### PR TITLE
Persist task plans across compaction

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session.hs
@@ -95,6 +95,8 @@ module Agent.CLI.Session
     , ensurePersistenceSessionId
     , ensurePersistenceSessionIdWithMaterializationHook
     , ensureSessionWithPromptSnapshot
+    , loadCurrentTaskPlan
+    , taskPlanHooksForPersistence
     , resumeHint
     , sessionUsageFromTurns
     ) where
@@ -152,6 +154,13 @@ import Agent.Store.Postgres (normalizePostgresTimestamp)
 import Agent.Store.Postgres.Connection (StorePool)
 import qualified Agent.Store.Postgres.Session as Store
 import Agent.Store.Types (StoreError, renderStoreError)
+import Agent.Tools.TaskPlan
+    ( CurrentTaskPlan(..)
+    , TaskPlan(..)
+    , TaskPlanHooks(..)
+    , TaskPlanItem(..)
+    , TaskPlanStatus(..)
+    )
 import Control.Applicative ((<|>))
 import Control.Exception.Safe
     ( SomeException
@@ -571,7 +580,18 @@ forkSessionAt root source turns requestedTitle targetCwd
                                         pure
                                             (Left
                                                 "could not allocate a unique PostgreSQL session id")
-                                    Right True -> pure (Right handle)
+                                    Right True -> do
+                                        copied <- restore
+                                            (Store.copySessionTaskPlan
+                                                source.sessionPool
+                                                source.sessionMeta.metaId
+                                                meta.metaId)
+                                            `onException` cleanupOwned
+                                        case copied of
+                                            Left err -> do
+                                                cleanupOwned
+                                                pure (Left (renderStoreError err))
+                                            Right _ -> pure (Right handle)
   where
     exceptionText = Text.pack . displayException
 
@@ -1013,6 +1033,88 @@ ensurePersistenceSessionIdWithMaterializationHook
     handle <- ensureSessionWithMaterializationHook afterStored slotRef
     pure (Just handle.sessionMeta.metaId)
 
+-- | Load the authoritative current plan for an already-active persistence
+-- slot. Pending sessions cannot yet have durable plan state.
+loadCurrentTaskPlan
+    :: Persistence
+    -> IO (Either Text (Maybe CurrentTaskPlan))
+loadCurrentTaskPlan PersistenceDisabled = pure (Right Nothing)
+loadCurrentTaskPlan (PersistenceEnabled slotRef) =
+    readIORef slotRef >>= \case
+        PersistencePending{} -> pure (Right Nothing)
+        PersistenceActive handle ->
+            mapStoreException "could not load session task plan" $
+                fmap (fmap (fmap fromStoredTaskPlan))
+                    (Store.loadSessionTaskPlan
+                        handle.sessionPool
+                        handle.sessionMeta.metaId)
+
+-- | Construct write-through hooks for the task-plan environment. A write
+-- materializes pending persistence before mutating plan state.
+taskPlanHooksForPersistence :: Persistence -> Maybe TaskPlanHooks
+taskPlanHooksForPersistence PersistenceDisabled = Nothing
+taskPlanHooksForPersistence (PersistenceEnabled slotRef) =
+    Just TaskPlanHooks
+        { taskPlanPersistReplace = \plan ->
+            mapStoreException "could not persist session task plan" do
+                handle <- ensureSession slotRef
+                Store.replaceSessionTaskPlan
+                    handle.sessionPool
+                    handle.sessionMeta.metaId
+                    plan.taskPlanExplanation
+                    (map toStoredTaskPlanItem plan.taskPlanItems) >>= \case
+                        Left err -> pure (Left err)
+                        Right Nothing ->
+                            fail
+                                ("session not found: "
+                                    <> Text.unpack handle.sessionMeta.metaId)
+                        Right (Just revision) -> pure (Right revision)
+        , taskPlanPersistClear =
+            mapStoreException "could not clear session task plan" do
+                handle <- ensureSession slotRef
+                Store.clearSessionTaskPlan
+                    handle.sessionPool
+                    handle.sessionMeta.metaId >>= \case
+                        Left err -> pure (Left err)
+                        Right _ -> pure (Right ())
+        }
+
+mapStoreException
+    :: Text
+    -> IO (Either StoreError a)
+    -> IO (Either Text a)
+mapStoreException label action =
+    tryAny action <&> \case
+        Left err -> Left (label <> ": " <> Text.pack (displayException err))
+        Right result -> either (Left . renderStoreError) Right result
+
+fromStoredTaskPlan :: Store.SessionTaskPlan -> CurrentTaskPlan
+fromStoredTaskPlan stored = CurrentTaskPlan
+    { currentTaskPlanRevision = stored.sessionTaskPlanRevision
+    , currentTaskPlanValue = TaskPlan
+        { taskPlanExplanation = stored.sessionTaskPlanExplanation
+        , taskPlanItems = map fromStoredTaskPlanItem stored.sessionTaskPlanItems
+        }
+    }
+
+fromStoredTaskPlanItem :: Store.SessionTaskPlanItem -> TaskPlanItem
+fromStoredTaskPlanItem stored = TaskPlanItem
+    { taskPlanStep = stored.sessionTaskPlanItemStep
+    , taskPlanStatus = case stored.sessionTaskPlanItemStatus of
+        Store.SessionTaskPlanPending -> TaskPlanPending
+        Store.SessionTaskPlanInProgress -> TaskPlanInProgress
+        Store.SessionTaskPlanCompleted -> TaskPlanCompleted
+    }
+
+toStoredTaskPlanItem :: TaskPlanItem -> Store.SessionTaskPlanItem
+toStoredTaskPlanItem item = Store.SessionTaskPlanItem
+    { Store.sessionTaskPlanItemStep = item.taskPlanStep
+    , Store.sessionTaskPlanItemStatus = case item.taskPlanStatus of
+        TaskPlanPending -> Store.SessionTaskPlanPending
+        TaskPlanInProgress -> Store.SessionTaskPlanInProgress
+        TaskPlanCompleted -> Store.SessionTaskPlanCompleted
+    }
+
 -- | Ensure the durable session exists and atomically persist the
 -- provider-visible request prefix before it can be sent. Subsequent calls only
 -- append an immutable epoch when the prefix or pending generated context
@@ -1353,7 +1455,7 @@ rewindSession handle retained = do
             , turnUsage = Nothing
             , turnProviderTelemetry = []
             }
-    Store.appendSessionTurns
+    Store.appendSessionTurnsClearingTaskPlan
         handle.sessionPool
         (map toStoredTurn (marker : retained))
         (toStoredMetadata meta) >>= \case
@@ -1706,7 +1808,8 @@ importSessionTransfer pool root cwd transfer = runExceptT do
     _ <- lift (ensureSessionTemp root sessionId) >>= except
     let meta = transfer.transferMeta
             { metaCwd = fromMaybe transfer.transferMeta.metaCwd cwd }
-        bytes = Aeson.encode (SessionTransfer meta transfer.transferTurns)
+        bytes = Aeson.encode
+            (SessionTransfer meta transfer.transferTaskPlan transfer.transferTurns)
         legacy = Store.LegacySession
             { legacySourcePath = "afk:" <> transfer.transferMeta.metaId
             , legacyContentHash = contentFingerprint bytes
@@ -1722,12 +1825,31 @@ importSessionTransfer pool root cwd transfer = runExceptT do
         Right False -> do
             lift (cleanupTransfer dir sessionId)
             throwE ("session already exists: " <> sessionId)
-        Right True -> pure sessionId
+        Right True -> do
+            case transfer.transferTaskPlan of
+                Nothing -> pure sessionId
+                Just plan ->
+                    lift (Store.replaceSessionTaskPlan
+                        pool
+                        sessionId
+                        plan.taskPlanExplanation
+                        (map toStoredTaskPlanItem plan.taskPlanItems)) >>= \case
+                            Left err -> do
+                                lift (cleanupImportedSession dir sessionId)
+                                throwE (renderStoreError err)
+                            Right Nothing -> do
+                                lift (cleanupImportedSession dir sessionId)
+                                throwE ("session not found: " <> sessionId)
+                            Right (Just _) -> pure sessionId
   where
     cleanupTransfer dir sessionId = do
         _ <- tryIO (removePathForcibly dir)
         _ <- removeSessionTemp root sessionId
         pure ()
+    cleanupImportedSession dir sessionId = do
+        now <- getCurrentTime
+        _ <- Store.deleteSession pool sessionId now
+        cleanupTransfer dir sessionId
 
 -- | Import a validated transfer as a new session. The source id is never
 -- reused, which makes importing the same file safe and preserves the source
@@ -1760,13 +1882,20 @@ exportSessionTransfer
     -> Text
     -> IO (Either Text SessionTransferEnvelope)
 exportSessionTransfer pool root sessionId =
-    loadSession pool root sessionId <&> \result -> do
-        (meta, turns) <- result
-        validateSessionTransferEnvelope SessionTransferEnvelope
-            { transferFormat = sessionTransferFormatName
-            , transferFormatVersion = sessionTransferFormatVersion
-            , transferSession = SessionTransfer meta turns
-            }
+    loadSession pool root sessionId >>= \case
+        Left err -> pure (Left err)
+        Right (meta, turns) ->
+            Store.loadSessionTaskPlan pool sessionId <&> \result -> do
+                storedPlan <- either (Left . renderStoreError) Right result
+                validateSessionTransferEnvelope SessionTransferEnvelope
+                    { transferFormat = sessionTransferFormatName
+                    , transferFormatVersion = sessionTransferFormatVersion
+                    , transferSession =
+                        SessionTransfer
+                            meta
+                            ((.currentTaskPlanValue) . fromStoredTaskPlan <$> storedPlan)
+                            turns
+                    }
 
 -- | Stream a transfer document in bounded turn pages. Callback bytes are
 -- valid only for the duration of the callback. The export captures the turn
@@ -1781,11 +1910,16 @@ streamSessionTransfer
 streamSessionTransfer pool root sessionId emit = runExceptT do
     (meta, snapshotStart, snapshotTotal) <-
         lift (loadSessionHistorySnapshot pool root sessionId) >>= except
+    storedPlan <- lift (Store.loadSessionTaskPlan pool sessionId)
+        >>= either (throwE . renderStoreError) pure
+    let taskPlan = ((.currentTaskPlanValue) . fromStoredTaskPlan) <$> storedPlan
     let snapshotEnd = snapshotStart + max 0 snapshotTotal
     lift $ emitLazy
         ("{\"format\":\"haskell-agent.session-transfer\","
             <> "\"version\":1,\"session\":{\"meta\":"
             <> Aeson.encode meta
+            <> ",\"currentTaskPlan\":"
+            <> Aeson.encode (fmap taskPlanTransferJson taskPlan)
             <> ",\"turns\":[")
     firstPage <- lift
         (loadSessionHistoryTurnsRangeBounded
@@ -1824,6 +1958,20 @@ streamSessionTransfer pool root sessionId emit = runExceptT do
                 when (next <= emitted) $
                     throwE "session export paging made no progress"
                 when (next < total) (streamRest snapshotEnd total next page)
+
+taskPlanTransferJson :: TaskPlan -> Aeson.Value
+taskPlanTransferJson plan = Aeson.object
+    [ "explanation" Aeson..= plan.taskPlanExplanation
+    , "plan" Aeson..= map itemJson plan.taskPlanItems
+    ]
+  where
+    itemJson item = Aeson.object
+        [ "step" Aeson..= item.taskPlanStep
+        , "status" Aeson..= case item.taskPlanStatus of
+            TaskPlanPending -> ("pending" :: Text)
+            TaskPlanInProgress -> "in_progress"
+            TaskPlanCompleted -> "completed"
+        ]
 
 -- | Fork a source session through an inclusive durable turn index. The source
 -- remains untouched. Transcript effects are copied verbatim, while derived
@@ -1865,7 +2013,7 @@ forkSessionAtTurn pool root sourceId throughIndex = runExceptT do
         envelope = SessionTransferEnvelope
             { transferFormat = sessionTransferFormatName
             , transferFormatVersion = sessionTransferFormatVersion
-            , transferSession = SessionTransfer meta turns
+            , transferSession = SessionTransfer meta Nothing turns
             }
     lift (importSessionTransferRemapped pool root Nothing envelope) >>= except
   where

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session.hs
@@ -36,6 +36,7 @@ module Agent.CLI.Session
     , appendTurnWithMetaUpdate
     , appendTurnWithMetaUpdateIndexed
     , appendTurnWithPromptResetIndexed
+    , appendTurnWithPromptResetAndTaskPlanClearIndexed
     , appendTurnKeepTitle
     , appendTurnKeepTitleIndexed
     , sessionRewindChoices
@@ -1071,12 +1072,14 @@ taskPlanHooksForPersistence (PersistenceEnabled slotRef) =
                         Right (Just revision) -> pure (Right revision)
         , taskPlanPersistClear =
             mapStoreException "could not clear session task plan" do
-                handle <- ensureSession slotRef
-                Store.clearSessionTaskPlan
-                    handle.sessionPool
-                    handle.sessionMeta.metaId >>= \case
-                        Left err -> pure (Left err)
-                        Right _ -> pure (Right ())
+                readIORef slotRef >>= \case
+                    PersistencePending{} -> pure (Right ())
+                    PersistenceActive handle ->
+                        Store.clearSessionTaskPlan
+                            handle.sessionPool
+                            handle.sessionMeta.metaId >>= \case
+                                Left err -> pure (Left err)
+                                Right _ -> pure (Right ())
         }
 
 mapStoreException
@@ -1265,6 +1268,23 @@ appendTurnWithPromptResetIndexed
 appendTurnWithPromptResetIndexed handle turn transition =
     appendTurnWithMetaTransitionIndexedUsing
         Store.appendSessionTurnIndexedWithPromptReset
+        handle
+        turn
+        (\meta ->
+            (transition meta)
+                { metaPromptSnapshot = Nothing
+                })
+
+-- | Append a reset turn while atomically retiring the prompt epoch and
+-- clearing the session's current task plan.
+appendTurnWithPromptResetAndTaskPlanClearIndexed
+    :: SessionHandle
+    -> SessionTurn
+    -> (SessionMeta -> SessionMeta)
+    -> IO (SessionHandle, Int64)
+appendTurnWithPromptResetAndTaskPlanClearIndexed handle turn transition =
+    appendTurnWithMetaTransitionIndexedUsing
+        Store.appendSessionTurnIndexedWithPromptResetAndTaskPlanClear
         handle
         turn
         (\meta ->

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session.hs
@@ -1837,6 +1837,16 @@ importSessionTransfer pool root cwd transfer = runExceptT do
             , legacyTurns = map toStoredTurn transfer.transferTurns
             , legacyPromptSnapshot =
                 toStoredPromptSnapshot <$> meta.metaPromptSnapshot
+            , legacyTaskPlan =
+                fmap
+                    (\plan ->
+                        Store.SessionTaskPlanSnapshot
+                            { Store.sessionTaskPlanSnapshotExplanation =
+                                plan.taskPlanExplanation
+                            , Store.sessionTaskPlanSnapshotItems =
+                                map toStoredTaskPlanItem plan.taskPlanItems
+                            })
+                    transfer.transferTaskPlan
             }
     lift (Store.importLegacySession pool legacy) >>= \case
         Left err -> do
@@ -1845,32 +1855,12 @@ importSessionTransfer pool root cwd transfer = runExceptT do
         Right False -> do
             lift (cleanupTransfer dir sessionId)
             throwE ("session already exists: " <> sessionId)
-        Right True -> do
-            case transfer.transferTaskPlan of
-                Nothing -> pure sessionId
-                Just plan ->
-                    lift (Store.replaceSessionTaskPlan
-                        pool
-                        sessionId
-                        plan.taskPlanExplanation
-                        (map toStoredTaskPlanItem plan.taskPlanItems)) >>= \case
-                            Left err -> do
-                                lift (cleanupImportedSession dir sessionId)
-                                throwE (renderStoreError err)
-                            Right Nothing -> do
-                                lift (cleanupImportedSession dir sessionId)
-                                throwE ("session not found: " <> sessionId)
-                            Right (Just _) -> pure sessionId
+        Right True -> pure sessionId
   where
     cleanupTransfer dir sessionId = do
         _ <- tryIO (removePathForcibly dir)
         _ <- removeSessionTemp root sessionId
         pure ()
-    cleanupImportedSession dir sessionId = do
-        now <- getCurrentTime
-        _ <- Store.deleteSession pool sessionId now
-        cleanupTransfer dir sessionId
-
 -- | Import a validated transfer as a new session. The source id is never
 -- reused, which makes importing the same file safe and preserves the source
 -- transcript as an immutable object.

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/Codec.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/Codec.hs
@@ -430,6 +430,7 @@ importLegacySession schemaVersion validId sessionDirForId pool sessionId = do
                     , legacyTurns = map toStoredTurn turns
                     , legacyPromptSnapshot =
                         toStoredPromptSnapshot <$> meta.metaPromptSnapshot
+                    , legacyTaskPlan = Nothing
                     }
             lift (Store.importLegacySession pool legacy) >>= \case
                 Left err -> throwE (renderStoreError err)

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/Types.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/Types.hs
@@ -52,6 +52,11 @@ import Agent.Responses.Types.Items (responseItemDecoder)
 import Agent.Responses.Types.Tools (ResponseTool, responseToolDecoder)
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Postgres.Session (TranscriptEffect(..))
+import Agent.Tools.TaskPlan
+    ( TaskPlan(..)
+    , TaskPlanItem(..)
+    , TaskPlanStatus(..)
+    )
 import Control.Monad (unless, when)
 import Data.Aeson (FromJSON(..), ToJSON(..), object, (.=))
 import qualified Data.Aeson as Aeson
@@ -166,12 +171,14 @@ sessionPromptSnapshotDecoder = Hermes.object do
 
 data SessionTransfer = SessionTransfer
     { transferMeta :: !SessionMeta
+    , transferTaskPlan :: !(Maybe TaskPlan)
     , transferTurns :: ![SessionTurn]
     } deriving (Eq, Show)
 
 instance ToJSON SessionTransfer where
     toJSON transfer = object
         [ "meta" .= transfer.transferMeta
+        , "currentTaskPlan" .= fmap taskPlanJson transfer.transferTaskPlan
         , "turns" .= transfer.transferTurns
         ]
 
@@ -187,7 +194,46 @@ sessionTransferDecoder :: Hermes.Decoder SessionTransfer
 sessionTransferDecoder = Hermes.object $
     SessionTransfer
         <$> Hermes.atKey "meta" sessionMetaDecoder
+        <*> optionalKey "currentTaskPlan" taskPlanDecoder
         <*> Hermes.atKey "turns" (Hermes.list sessionTurnDecoder)
+
+taskPlanJson :: TaskPlan -> Aeson.Value
+taskPlanJson plan = object
+    [ "explanation" .= plan.taskPlanExplanation
+    , "plan" .= map taskPlanItemJson plan.taskPlanItems
+    ]
+
+taskPlanItemJson :: TaskPlanItem -> Aeson.Value
+taskPlanItemJson item = object
+    [ "step" .= item.taskPlanStep
+    , "status" .= taskPlanStatusText item.taskPlanStatus
+    ]
+
+taskPlanDecoder :: Hermes.Decoder TaskPlan
+taskPlanDecoder = Hermes.object do
+    explanation <- optionalKey "explanation" Hermes.text
+    items <- Hermes.atKey "plan" (Hermes.list taskPlanItemDecoder)
+    when
+        (length (filter ((== TaskPlanInProgress) . (.taskPlanStatus)) items) > 1)
+        (fail "task plan has more than one in_progress item")
+    pure (TaskPlan explanation items)
+
+taskPlanItemDecoder :: Hermes.Decoder TaskPlanItem
+taskPlanItemDecoder = Hermes.object do
+    step <- Hermes.atKey "step" Hermes.text
+    statusText <- Hermes.atKey "status" Hermes.text
+    status <- case statusText of
+        "pending" -> pure TaskPlanPending
+        "in_progress" -> pure TaskPlanInProgress
+        "completed" -> pure TaskPlanCompleted
+        invalid -> fail ("unknown task plan status: " <> Text.unpack invalid)
+    pure (TaskPlanItem step status)
+
+taskPlanStatusText :: TaskPlanStatus -> Text
+taskPlanStatusText = \case
+    TaskPlanPending -> "pending"
+    TaskPlanInProgress -> "in_progress"
+    TaskPlanCompleted -> "completed"
 
 -- | Durable provenance for subagent transcripts written before child target
 -- metadata was persisted. Keeping this target separate from the mutable root

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
@@ -1641,6 +1641,43 @@ spec = describe "Agent.CLI.Session" do
                                         `shouldReturn`
                                             Right (Just sampleStoredTaskPlan)
 
+        it "rolls back failed task-plan imports so the transfer can be retried" $
+            withTempStore \store root -> do
+                let pool = trustedPool store
+                    sessionId = "session-atomic-transfer"
+                    invalidPlan = TaskPlan
+                        { taskPlanExplanation = Nothing
+                        , taskPlanItems =
+                            [ TaskPlanItem
+                                "first active step"
+                                TaskPlanInProgress
+                            , TaskPlanItem
+                                "second active step"
+                                TaskPlanInProgress
+                            ]
+                        }
+                    transfer = SessionTransfer
+                        { transferMeta = testMeta sessionId
+                        , transferTaskPlan = Just invalidPlan
+                        , transferTurns = []
+                        }
+                    sessionDir =
+                        root </> unsafeEncodeUtf (Text.unpack sessionId)
+                importSessionTransfer pool root Nothing transfer
+                    >>= (`shouldSatisfy` either (const True) (const False))
+                Store.loadSession pool sessionId
+                    `shouldReturn` Right Nothing
+                doesDirectoryExist sessionDir `shouldReturn` False
+
+                importSessionTransfer
+                    pool
+                    root
+                    Nothing
+                    (transfer { transferTaskPlan = Just sampleTaskPlan })
+                    `shouldReturn` Right sessionId
+                Store.loadSessionTaskPlan pool sessionId
+                    `shouldReturn` Right (Just sampleStoredTaskPlan)
+
         it "materializes pending persistence into a resumable session ID" $
             withTempStore \store root -> do
                 let pool = trustedPool store

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
@@ -988,6 +988,23 @@ spec = describe "Agent.CLI.Session" do
                 hooks.taskPlanPersistClear `shouldReturn` Right ()
                 loadCurrentTaskPlan persistence `shouldReturn` Right Nothing
 
+        it "does not materialize a pending session when clearing its task plan" $
+            withTempStore \store root -> do
+                PersistenceEnabled slot <-
+                    newPendingPersistence (testCreate (trustedPool store) root)
+                hooks <- case taskPlanHooksForPersistence
+                    (PersistenceEnabled slot) of
+                    Nothing ->
+                        expectationFailure "missing task-plan hooks"
+                            >> fail "hooks"
+                    Just value -> pure value
+                hooks.taskPlanPersistClear `shouldReturn` Right ()
+                readIORef slot >>= \case
+                    PersistencePending{} -> pure ()
+                    PersistenceActive{} ->
+                        expectationFailure
+                            "clearing an absent plan materialized the session"
+
         it "rejects inconsistent gateway identities at every creation boundary" $
             withTempStore \store root -> do
                 let pool = trustedPool store

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec.hs
@@ -35,6 +35,13 @@ import Agent.Store.Postgres.Managed (stopManagedPostgres)
 import Agent.Store.Postgres.Connection (StorePool)
 import qualified Agent.Store.Postgres.Session as Store
 import Agent.Store.Types (renderStoreError)
+import Agent.Tools.TaskPlan
+    ( CurrentTaskPlan(..)
+    , TaskPlan(..)
+    , TaskPlanHooks(..)
+    , TaskPlanItem(..)
+    , TaskPlanStatus(..)
+    )
 import Control.Concurrent (newEmptyMVar, putMVar, readMVar, takeMVar)
 import Control.Concurrent.Async
     ( cancelWith, concurrently, mapConcurrently, waitCatch, withAsync )
@@ -962,6 +969,25 @@ spec = describe "Agent.CLI.Session" do
                 storedContentPartRoundTrip
 
     describe "PostgreSQL session persistence" do
+        it "materializes and round-trips task plans through persistence hooks" $
+            withTempStore \store root -> do
+                persistence <-
+                    newPendingPersistence (testCreate (trustedPool store) root)
+                hooks <- case taskPlanHooksForPersistence persistence of
+                    Nothing -> expectationFailure "missing task-plan hooks" >> fail "hooks"
+                    Just value -> pure value
+                hooks.taskPlanPersistReplace sampleTaskPlan
+                    `shouldReturn` Right 1
+                loadCurrentTaskPlan persistence
+                    `shouldReturn`
+                        Right
+                            (Just CurrentTaskPlan
+                                { currentTaskPlanRevision = 1
+                                , currentTaskPlanValue = sampleTaskPlan
+                                })
+                hooks.taskPlanPersistClear `shouldReturn` Right ()
+                loadCurrentTaskPlan persistence `shouldReturn` Right Nothing
+
         it "rejects inconsistent gateway identities at every creation boundary" $
             withTempStore \store root -> do
                 let pool = trustedPool store
@@ -1026,6 +1052,12 @@ spec = describe "Agent.CLI.Session" do
                         { metaLastRecap = Just "recap"
                         , metaLastTurnSummary = Just "summary"
                         }
+                Store.replaceSessionTaskPlan
+                    pool
+                    source.sessionMeta.metaId
+                    sampleTaskPlan.taskPlanExplanation
+                    sampleStoredTaskPlanItems
+                    `shouldReturn` Right (Just 1)
                 let planPath = source.sessionDir </> unsafeEncodeUtf "plan.md"
                     agentsDir = source.sessionDir </> unsafeEncodeUtf "agents"
                     childDir = agentsDir </> unsafeEncodeUtf "child"
@@ -1065,6 +1097,10 @@ spec = describe "Agent.CLI.Session" do
                         loadSession pool root forked.sessionMeta.metaId
                             `shouldReturn`
                                 Right (forked.sessionMeta, [sourceTurn])
+                        Store.loadSessionTaskPlan
+                            pool
+                            forked.sessionMeta.metaId
+                            `shouldReturn` Right (Just sampleStoredTaskPlan)
                         doesFileExist
                             (forked.sessionDir </> unsafeEncodeUtf "plan.md")
                             `shouldReturn` True
@@ -1376,6 +1412,12 @@ spec = describe "Agent.CLI.Session" do
                         , metaLastTurnSummary = Just "stale summary"
                         , metaLastRecapMainTurns = 2
                         }
+                Store.replaceSessionTaskPlan
+                    pool
+                    final.sessionMeta.metaId
+                    sampleTaskPlan.taskPlanExplanation
+                    sampleStoredTaskPlanItems
+                    `shouldReturn` Right (Just 1)
 
                 rewound <- rewindSession final [first, checkpoint] >>= \case
                     Left err ->
@@ -1392,6 +1434,8 @@ spec = describe "Agent.CLI.Session" do
                 rewound.sessionMeta.metaInputTokens `shouldBe` 17
                 rewound.sessionMeta.metaOutputTokens `shouldBe` 7
                 rewound.sessionMeta.metaCachedTokens `shouldBe` 3
+                Store.loadSessionTaskPlan pool rewound.sessionMeta.metaId
+                    `shouldReturn` Right Nothing
 
                 loadSession pool root rewound.sessionMeta.metaId >>= \case
                     Left err -> expectationFailure (Text.unpack err)
@@ -1496,6 +1540,12 @@ spec = describe "Agent.CLI.Session" do
                 source4 <- appendTurnWithMetaUpdate source3 cleared
                     \meta -> meta { metaLastResponseId = Nothing }
                 _source5 <- appendTurn source4 fifth
+                Store.replaceSessionTaskPlan
+                    pool
+                    source0.sessionMeta.metaId
+                    sampleTaskPlan.taskPlanExplanation
+                    sampleStoredTaskPlanItems
+                    `shouldReturn` Right (Just 1)
 
                 loadSessionHistoryTurnsAround
                     pool root source0.sessionMeta.metaId 1 1 >>= \case
@@ -1519,6 +1569,8 @@ spec = describe "Agent.CLI.Session" do
                                     meta.metaLastResponseId `shouldBe` Nothing
                                     meta.metaInputTokens `shouldBe` 10
                                     meta.metaOutputTokens `shouldBe` 2
+                            Store.loadSessionTaskPlan pool forkId
+                                `shouldReturn` Right Nothing
                             loadSession pool root source0.sessionMeta.metaId
                                 >>= \case
                                     Left err ->
@@ -1534,7 +1586,6 @@ spec = describe "Agent.CLI.Session" do
                                                 , cleared
                                                 , fifth
                                                 ]
-
                 chunks <- newIORef []
                 streamSessionTransfer
                     pool root source0.sessionMeta.metaId
@@ -1549,6 +1600,8 @@ spec = describe "Agent.CLI.Session" do
                 envelope.transferSession.transferTurns
                     `shouldBe`
                         [first, compacted, third, cleared, fifth]
+                envelope.transferSession.transferTaskPlan
+                    `shouldBe` Just sampleTaskPlan
                 importSessionTransferRemapped pool root Nothing envelope
                     >>= \case
                         Left err -> expectationFailure (Text.unpack err)
@@ -1567,6 +1620,9 @@ spec = describe "Agent.CLI.Session" do
                                             , cleared
                                             , fifth
                                             ]
+                                    Store.loadSessionTaskPlan pool importedId
+                                        `shouldReturn`
+                                            Right (Just sampleStoredTaskPlan)
 
         it "materializes pending persistence into a resumable session ID" $
             withTempStore \store root -> do
@@ -1771,6 +1827,23 @@ spec = describe "Agent.CLI.Session" do
                 modeOf handle.sessionTempDir `shouldReturn` 0o700
 
     describe "json codec" do
+        it "round-trips an optional current task plan and accepts older transfers" do
+            let transfer = SessionTransfer
+                    { transferMeta = testMeta "session-plan"
+                    , transferTaskPlan = Just sampleTaskPlan
+                    , transferTurns = []
+                    }
+                encoded = Aeson.encode transfer
+            Hermes.decodeEither sessionTransferDecoder (LBS.toStrict encoded)
+                `shouldBe` Right transfer
+            let legacy = case Aeson.toJSON transfer of
+                    Aeson.Object object ->
+                        Aeson.Object (KeyMap.delete "currentTaskPlan" object)
+                    value -> value
+            Hermes.decodeEither sessionTransferDecoder
+                (LBS.toStrict (Aeson.encode legacy))
+                `shouldBe` Right transfer { transferTaskPlan = Nothing }
+
         it "encodes and decodes SessionTurn" do
             let turn = SessionTurn
                     { turnAt = fixedTime
@@ -1862,6 +1935,28 @@ spec = describe "Agent.CLI.Session" do
             effect "/compact focus"
                 `shouldBe` Right TranscriptReplace
             effect "/rewind" `shouldBe` Right TranscriptReset
+
+sampleTaskPlan :: TaskPlan
+sampleTaskPlan = TaskPlan
+    { taskPlanExplanation = Just "Keep durable progress."
+    , taskPlanItems =
+        [ TaskPlanItem "persist the plan" TaskPlanCompleted
+        , TaskPlanItem "resume the plan" TaskPlanInProgress
+        ]
+    }
+
+sampleStoredTaskPlanItems :: [Store.SessionTaskPlanItem]
+sampleStoredTaskPlanItems =
+    [ Store.SessionTaskPlanItem "persist the plan" Store.SessionTaskPlanCompleted
+    , Store.SessionTaskPlanItem "resume the plan" Store.SessionTaskPlanInProgress
+    ]
+
+sampleStoredTaskPlan :: Store.SessionTaskPlan
+sampleStoredTaskPlan = Store.SessionTaskPlan
+    { Store.sessionTaskPlanRevision = 1
+    , Store.sessionTaskPlanExplanation = Just "Keep durable progress."
+    , Store.sessionTaskPlanItems = sampleStoredTaskPlanItems
+    }
 
 testCreate :: StorePool -> OsPath -> SessionCreate
 testCreate pool root = SessionCreate

--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -38,6 +38,7 @@ import Agent.CLI.AgentViewport.Status
     ( agentStatusGlyph
     , formatAgentStatus
     )
+import Agent.Tools.TaskPlan (isTaskPlanContextText)
 import Agent.CLI.Picker (PickerKey(..), runOverlay)
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
 import Agent.CLI.TextLayout
@@ -587,9 +588,12 @@ responseItemFirstLine = go
 responseItemFirstItemLine :: ResponseItem -> Maybe Text
 responseItemFirstItemLine = \case
     MessageItem message ->
-        labelledFirst
-            (responseRoleLabel message.role)
-            (responseMessageText message.content)
+        if isTaskPlanContextMessage message
+            then Nothing
+            else
+                labelledFirst
+                    (responseRoleLabel message.role)
+                    (responseMessageText message.content)
     FunctionCallItem call ->
         Just ("tool: " <> call.name)
     CustomToolCallItem call ->
@@ -601,9 +605,12 @@ responseItemFirstItemLine = \case
 responseItemLineList :: ResponseItem -> [Text]
 responseItemLineList = \case
     MessageItem message ->
-        labelled
-            (responseRoleLabel message.role)
-            (responseMessageText message.content)
+        if isTaskPlanContextMessage message
+            then []
+            else
+                labelled
+                    (responseRoleLabel message.role)
+                    (responseMessageText message.content)
     FunctionCallItem call ->
         ["tool: " <> call.name]
     CustomToolCallItem call ->
@@ -628,6 +635,10 @@ responseMessageText = \case
     MessageContentParts parts ->
         Text.intercalate "\n" (concatMap responseContentText parts)
 
+isTaskPlanContextMessage :: ResponseMessage -> Bool
+isTaskPlanContextMessage message =
+    isTaskPlanContextText (responseMessageText message.content)
+
 responseContentText :: ResponseContentPart -> [Text]
 responseContentText = \case
     InputTextPart{text} -> [text]
@@ -645,7 +656,9 @@ responseContentText = \case
 appendResponseItem :: Bool -> UiState -> ResponseItem -> UiState
 appendResponseItem showRawReasoning state = \case
     MessageItem message ->
-        appendResponseMessage message state
+        if isTaskPlanContextMessage message
+            then state
+            else appendResponseMessage message state
     FunctionCallItem item ->
         maybe state
             (\call -> reduceUi (UiLoop (ToolStarted call)) state)

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -9,6 +9,7 @@ module Agent.CLI.Compaction
     , autoCompactOpenAiBackendWithThreshold
     , autoCompactOpenAiBackendWithSender
     , autoCompactOpenAiBackendWithSenderAndHook
+    , autoCompactOpenAiBackendWithSenderHookAndDecorator
     , autoCompactOpenAiBackendWith
     , autoCompactOpenAiBackendWithApi
     , autoCompactBackendWith
@@ -16,6 +17,8 @@ module Agent.CLI.Compaction
     , compactOpenAIWith
     , installCompactOutcome
     , installLiveCompactOutcome
+    , decorateCompactOutcomeWithTaskPlan
+    , decorateCompactOutcomeWithTaskPlanWithin
     , runProviderCompact
     , runProviderCompactWith
     , runProviderCompactWithContextWindow
@@ -61,6 +64,7 @@ import Agent.OpenAI.Compaction
     ( buildLocalCompactedHistoryToFit
     , buildRemoteCompactedHistory
     , buildRemoteCompactionRequest
+    , compactTranscriptAtLastCheckpoint
     , extractRemoteCompactionItem
     , estimateItemsTokens
     , estimateRequestTokensWithItems
@@ -83,6 +87,13 @@ import Agent.Responses.LoopBackend
     , withRequestInput
     )
 import Agent.Responses.Types
+import Agent.Tools.TaskPlan
+    ( CurrentTaskPlan
+    , TaskPlanEnv
+    , isTaskPlanContextText
+    , readTaskPlan
+    , taskPlanContextText
+    )
 import Agent.Provider
     ( Provider(..)
     , TokenProvider
@@ -532,6 +543,81 @@ installCompactionOutcome installState contextTokens runCompact focus =
                                 (length outcome.compactHistory)
         pure result
 
+-- | Add the authoritative database-backed task plan to a compacted context.
+-- Existing generated copies are removed first; the task-plan environment,
+-- rather than provider history, is the source of truth.
+decorateCompactOutcomeWithTaskPlan
+    :: Maybe TaskPlanEnv
+    -> CompactOutcome
+    -> IO CompactOutcome
+decorateCompactOutcomeWithTaskPlan taskPlanEnv outcome = do
+    current <- maybe (pure Nothing) readTaskPlan taskPlanEnv
+    let history =
+            filter (not . isTaskPlanContextItem) outcome.compactHistory
+                <> maybe [] (pure . taskPlanContextItem) current
+    pure outcome
+        { compactHistory = history
+        , compactAfterTokens = estimateItemsTokens history
+        }
+
+-- | Decorate a compacted snapshot, rejecting it rather than installing state
+-- that cannot fit in the next provider request.
+decorateCompactOutcomeWithTaskPlanWithin
+    :: Int
+    -> ResponseCreateParams
+    -> Maybe TaskPlanEnv
+    -> CompactOutcome
+    -> IO (Either Text CompactOutcome)
+decorateCompactOutcomeWithTaskPlanWithin
+        contextWindow params taskPlanEnv outcome = do
+    decorated <- decorateCompactOutcomeWithTaskPlan taskPlanEnv outcome
+    let requestTokens =
+            estimateRequestTokensWithItems params decorated.compactHistory
+    pure $
+        if requestTokens <= contextWindow
+            then Right decorated
+            else
+                Left
+                    ( "the authoritative task plan does not fit in the "
+                        <> "compacted model context ("
+                        <> Text.pack (show requestTokens)
+                        <> " tokens for a "
+                        <> Text.pack (show contextWindow)
+                        <> "-token context window)"
+                    )
+
+taskPlanContextItem :: CurrentTaskPlan -> ResponseItem
+taskPlanContextItem current =
+    MessageItem ResponseMessage
+        { messageId = Nothing
+        , content =
+            MessageContentParts
+                [InputTextPart (taskPlanContextText current) Nothing]
+        , role = RoleDeveloper
+        , status = Nothing
+        , phase = Nothing
+        , passthrough = Nothing
+        }
+
+isTaskPlanContextItem :: ResponseItem -> Bool
+isTaskPlanContextItem = \case
+    MessageItem message ->
+        any isTaskPlanContextText (taskPlanMessageTexts message.content)
+    _ -> False
+
+taskPlanMessageTexts :: MessageContent -> [Text]
+taskPlanMessageTexts = \case
+    MessageContentText text -> [text]
+    MessageContentParts parts ->
+        [ text
+        | part <- parts
+        , text <- case part of
+            InputTextPart{text} -> [text]
+            OutputTextPart{text} -> [text]
+            PlainTextPart{text} -> [text]
+            _ -> []
+        ]
+
 sendOpenAIRemoteCompaction
     :: TokenProvider
     -> ResponseCreateParams
@@ -880,6 +966,31 @@ autoCompactOpenAiBackendWithSenderAndHook
     -> Backend
 autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
         getParams onCompacted contextTokensRef backend =
+    autoCompactOpenAiBackendWithSenderHookAndDecorator
+        configuredThreshold
+        send
+        recordUsage
+        getParams
+        pure
+        onCompacted
+        contextTokensRef
+        backend
+
+-- | Variant whose decorator installs harness-owned state in the compacted
+-- history before size validation, durable publication, and continuation.
+autoCompactOpenAiBackendWithSenderHookAndDecorator
+    :: Maybe Int
+    -> OpenAiCompactionSender
+    -> (TokenUsage -> IO ())
+    -> IO ResponseCreateParams
+    -> (CompactOutcome -> IO CompactOutcome)
+    -> (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
+    -> IORef (Maybe OccupancySnapshot)
+    -> Backend
+    -> Backend
+autoCompactOpenAiBackendWithSenderHookAndDecorator
+        configuredThreshold send recordUsage getParams decorateOutcome
+        onCompacted contextTokensRef backend =
     rejectOversizedInitialRequest getParams $
         boundCompletedToolContinuations
             (codexEffectiveContextWindowFor . (.model))
@@ -913,8 +1024,6 @@ autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
             pendingItems = turnInputsToItems inputs
             contextWindow =
                 codexEffectiveContextWindowFor params.model
-            checkpointBaseTokens checkpoint =
-                estimateRequestTokensWithItems params [checkpoint]
             continuationBaseTokens checkpoint =
                 estimateRequestTokensWithItems
                     params
@@ -940,13 +1049,20 @@ autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
                 pure $ CompactAttempt emptyTokenUsage $
                     Left (thresholdError fixedRequestTokens)
             else do
-                attempt <-
+                rawAttempt <-
                     compactRemoteV2AttemptWithRetainedBudget
                         send
                         params
                         history
                         (estimateItemsTokens history)
                         retainedBudget
+                attempt <-
+                    case rawAttempt.compactAttemptResult of
+                        Left _ -> pure rawAttempt
+                        Right outcome -> do
+                            decorated <- decorateOutcome outcome
+                            pure rawAttempt
+                                { compactAttemptResult = Right decorated }
                 pure $
                     case attempt.compactAttemptResult of
                         Right outcome ->
@@ -954,17 +1070,24 @@ autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
                                     estimateRequestTokensWithItems
                                         params
                                         (outcome.compactHistory <> pendingItems)
+                                compactedBase =
+                                    compactTranscriptAtLastCheckpoint
+                                        outcome.compactHistory
                                 (baseTokens, baseWithPendingTokens) =
-                                    case reverse outcome.compactHistory of
-                                        checkpoint : _ ->
-                                            ( checkpointBaseTokens checkpoint
-                                            , continuationBaseTokens checkpoint
-                                            )
+                                    case compactedBase of
                                         [] ->
                                             ( fixedRequestTokens
                                             , estimateRequestTokensWithItems
                                                 params
                                                 pendingItems
+                                            )
+                                        fixedItems ->
+                                            ( estimateRequestTokensWithItems
+                                                params
+                                                fixedItems
+                                            , estimateRequestTokensWithItems
+                                                params
+                                                (fixedItems <> pendingItems)
                                             )
                             in if continuationTokens > contextWindow
                                 then

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -304,7 +304,7 @@ summarizeBackendLocalAttempt contextWindow makeBackend params history focus
     | contextWindow <= 0 =
         pure $ compactApiFailure
             "model context_window must be positive"
-    | null history =
+    | null sourceHistory =
         pure $ compactApiFailure "nothing to compact"
     | null summaryHistory =
         pure $ compactApiFailure "nothing compatible to compact"
@@ -375,7 +375,7 @@ summarizeBackendLocalAttempt contextWindow makeBackend params history focus
                                                 contextWindow
                                                 params
                                                 6
-                                                history
+                                                sourceHistory
                                                 summary
                                     if estimateRequestTokensWithItems params items
                                             > contextWindow
@@ -395,7 +395,8 @@ summarizeBackendLocalAttempt contextWindow makeBackend params history focus
                                 , compactAttemptResult = outcome
                                 }
   where
-    summaryHistory = filter isPortableLocalSummaryItem history
+    sourceHistory = stripTaskPlanContextItems history
+    summaryHistory = filter isPortableLocalSummaryItem sourceHistory
 
 compactApiFailure :: Text -> CompactAttempt ApiError
 compactApiFailure message =
@@ -553,7 +554,7 @@ decorateCompactOutcomeWithTaskPlan
 decorateCompactOutcomeWithTaskPlan taskPlanEnv outcome = do
     current <- maybe (pure Nothing) readTaskPlan taskPlanEnv
     let history =
-            filter (not . isTaskPlanContextItem) outcome.compactHistory
+            stripTaskPlanContextItems outcome.compactHistory
                 <> maybe [] (pure . taskPlanContextItem) current
     pure outcome
         { compactHistory = history
@@ -604,6 +605,12 @@ isTaskPlanContextItem = \case
     MessageItem message ->
         any isTaskPlanContextText (taskPlanMessageTexts message.content)
     _ -> False
+
+-- Task-plan messages are projections of mutable session state. Never let a
+-- compactor bake an obsolete projection into an opaque checkpoint or summary.
+stripTaskPlanContextItems :: [ResponseItem] -> [ResponseItem]
+stripTaskPlanContextItems =
+    filter (not . isTaskPlanContextItem)
 
 taskPlanMessageTexts :: MessageContent -> [Text]
 taskPlanMessageTexts = \case
@@ -682,7 +689,7 @@ compactRemoteV2AttemptWithRetainedBudget
     -> IO (CompactAttempt ApiError)
 compactRemoteV2AttemptWithRetainedBudget
         send params history before retainedBudgetFor
-    | null history =
+    | null sourceHistory =
         pure $ CompactAttempt emptyTokenUsage $
             Left (ProviderError InvalidRequestError "nothing to compact" Nothing)
     | otherwise = do
@@ -692,7 +699,7 @@ compactRemoteV2AttemptWithRetainedBudget
                 trimRemoteCompactionRequestToFit
                     contextWindow
                     params
-                    history
+                    sourceHistory
             request = buildRemoteCompactionRequest params requestHistory
         if estimateResponseCreateParamsTokens request > contextWindow
             then pure $ CompactAttempt emptyTokenUsage $
@@ -723,7 +730,7 @@ compactRemoteV2AttemptWithRetainedBudget
                                                     )
                                                 )
                                             )
-                                            history
+                                            sourceHistory
                                             checkpoint
                                 if
                                     estimateRequestTokensWithItems params items
@@ -743,6 +750,7 @@ compactRemoteV2AttemptWithRetainedBudget
                                             }
                             }
   where
+    sourceHistory = stripTaskPlanContextItems history
     protocolError message =
         ProviderError ApiErrorType message Nothing
 
@@ -787,7 +795,7 @@ summarizeLocalAttemptWith
     -> IO (CompactAttempt ApiError)
 summarizeLocalAttemptWith contextWindow prepareHistory send params history
         before focus
-    | null history =
+    | null sourceHistory =
         pure $ CompactAttempt emptyTokenUsage $
             Left (ProviderError InvalidRequestError "nothing to compact" Nothing)
     | null summaryHistory =
@@ -859,7 +867,7 @@ summarizeLocalAttemptWith contextWindow prepareHistory send params history
                                                             contextWindow
                                                             params
                                                             6
-                                                            history
+                                                            sourceHistory
                                                             summary
                                                 in if
                                                     estimateRequestTokensWithItems
@@ -878,7 +886,8 @@ summarizeLocalAttemptWith contextWindow prepareHistory send params history
                                                         }
                             }
   where
-    summaryHistory = prepareHistory history
+    sourceHistory = stripTaskPlanContextItems history
+    summaryHistory = prepareHistory sourceHistory
 
 isPortableLocalSummaryItem :: ResponseItem -> Bool
 isPortableLocalSummaryItem = \case
@@ -1235,8 +1244,20 @@ autoCompactOpenAiBackendWithLimit getLimit absorbCompletedTools compactAction
                 contextState snapshot previous inputs onEvent
   where
     runCompaction history inputs =
-        (.compactAttemptResult)
-            <$> runAttemptAndRecord recordUsage (compactAction history inputs)
+        fmap
+            (fmap (deduplicatePendingTaskPlan inputs) . (.compactAttemptResult))
+            (runAttemptAndRecord
+                recordUsage
+                (compactAction (stripTaskPlanContextItems history) inputs))
+
+    deduplicatePendingTaskPlan inputs outcome
+        | any isTaskPlanContextItem (turnInputsToItems inputs) =
+            let history = stripTaskPlanContextItems outcome.compactHistory
+            in outcome
+                { compactHistory = history
+                , compactAfterTokens = estimateItemsTokens history
+                }
+        | otherwise = outcome
 
     isCompletedTool = \case
         CompletedTool{} -> True

--- a/packages/agent-cli/src/Agent/CLI/Dialects.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dialects.hs
@@ -17,7 +17,9 @@ import Agent.Codex.Dialect.ProjectInstructions (formatCodexAgentsMd)
 import Agent.Codex.Dialect.Runtime
     ( CodexCodingTools(..)
     , newCodexCodingTools
+    , newCodexCodingToolsWithTaskPlan
     )
+import Agent.Tools.TaskPlan (TaskPlanEnv)
 import Agent.Dialect
     ( Dialect
     , InstructionHomeStyle(..)
@@ -76,6 +78,7 @@ sanitizeTaskName =
 data CodingTools = CodingTools
     { codingAppTools :: ![AppTool]
     , codingPlanMode :: !PlanModeEnv
+    , codingTaskPlan :: !(Maybe TaskPlanEnv)
     , codingSuspendGhci :: !(IO ())
     , codingResetSessionTemp :: !(OsPath -> IO ())
     , codingClose :: !(IO ())
@@ -94,7 +97,7 @@ codingToolsFor
 codingToolsFor dialect env planHooks secretHooks imageHooks multi = do
     typesRef <- newIORef Map.empty
     codingToolsForWithTypes
-        dialect env planHooks secretHooks imageHooks multi typesRef
+        dialect env planHooks Nothing secretHooks imageHooks multi typesRef
 
 -- | Host-presented tools (@ask_secret@, @show_image@) are registered only
 -- when the host supplies the matching hooks, so headless and child sessions
@@ -103,13 +106,14 @@ codingToolsForWithTypes
     :: Dialect
     -> ToolEnv
     -> Maybe PlanModeHooks
+    -> Maybe TaskPlanEnv
     -> Maybe SecretPromptHooks
     -> Maybe ImageDisplayHooks
     -> Maybe MultiAgentContext
     -> GrokSubagentSpecs
     -> IO CodingTools
 codingToolsForWithTypes
-        dialect env planHooks secretHooks imageHooks multi typesRef = do
+        dialect env planHooks taskPlan secretHooks imageHooks multi typesRef = do
     secretStore <- traverse (newSecretStore env) secretHooks
     let closeSecrets = mapM_ closeSecretStore secretStore
         analysisSpawner =
@@ -139,7 +143,7 @@ codingToolsForWithTypes
                 _ -> Nothing
         secretTools = maybe [] (pure . askSecretTool) secretStore
         imageTools = maybe [] (pure . showImageTool env) imageHooks
-        finish tools includeArtifacts plan suspendGhci resetSessionTemp
+        finish tools includeArtifacts plan currentTaskPlan suspendGhci resetSessionTemp
                 close agentTypes grokRuntime =
             CodingTools
                 { codingAppTools =
@@ -150,6 +154,7 @@ codingToolsForWithTypes
                         <> secretTools
                         <> imageTools
                 , codingPlanMode = plan
+                , codingTaskPlan = currentTaskPlan
                 , codingSuspendGhci = suspendGhci
                 , codingResetSessionTemp = resetSessionTemp
                 , codingClose = close `finally` closeSecrets
@@ -158,12 +163,17 @@ codingToolsForWithTypes
                 }
     flip onException closeSecrets $ case dialectToolSurface dialect of
         CodexToolSurface -> do
-            coding <- newCodexCodingTools env planHooks multi
+            coding <- case taskPlan of
+                Nothing -> newCodexCodingTools env planHooks multi
+                Just current ->
+                    newCodexCodingToolsWithTaskPlan
+                        env planHooks current multi
             pure $
                 finish
                     coding.codexAppTools
                     True
                     coding.codexPlanMode
+                    (Just coding.codexTaskPlan)
                     coding.codexSuspendGhci
                     coding.codexResetSessionTemp
                     coding.codexClose
@@ -176,6 +186,7 @@ codingToolsForWithTypes
                     coding.grokAppTools
                     True
                     coding.grokPlanMode
+                    taskPlan
                     coding.grokSuspendGhci
                     coding.grokResetSessionTemp
                     coding.grokClose
@@ -188,6 +199,7 @@ codingToolsForWithTypes
                     [askUserQuestionTool plan]
                     False
                     plan
+                    taskPlan
                     (pure ())
                     (\_tempDir -> pure ())
                     (pure ())

--- a/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
@@ -9,7 +9,7 @@ import Agent.CLI.Compaction
     , CompactionInstall
     , OccupancySnapshot
     , OpenAiCompactionSender
-    , autoCompactOpenAiBackendWithSenderAndHook
+    , autoCompactOpenAiBackendWithSenderHookAndDecorator
     )
 import Agent.Connectivity (withConnectionRecoveryOn)
 import Agent.Connectivity.NetworkPath (NetworkRecovery)
@@ -72,12 +72,13 @@ lockedOpenAiSession
     -> IO ResponseCreateParams
     -> IORef (Maybe OccupancySnapshot)
     -> (TokenUsage -> IO ())
+    -> (CompactOutcome -> IO CompactOutcome)
     -> (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
     -> (OpenAiCompactionSender, Backend)
 lockedOpenAiSession networkRecovery gatewayOnly compactThreshold
         showRawReasoning wsLock fallbackActive provider activeConnection
         getParams contextTokens
-        recordCompactionUsage onCompacted =
+        recordCompactionUsage decorateCompaction onCompacted =
     let sendResponse request previousResponseId onEvent = do
             OpenAiPersistentConnection
                 credential
@@ -163,11 +164,12 @@ lockedOpenAiSession networkRecovery gatewayOnly compactThreshold
                                 sendHttpCompaction request
                         _ -> pure result
         compactingBackend =
-            autoCompactOpenAiBackendWithSenderAndHook
+            autoCompactOpenAiBackendWithSenderHookAndDecorator
                 compactThreshold
                 compactSender
                 recordCompactionUsage
                 getParams
+                decorateCompaction
                 onCompacted
                 contextTokens
                 baseBackend

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -22,6 +22,8 @@ import Agent.CLI.Compaction
       OccupancySnapshot,
       autoCompactBackendWith,
       boundCompletedToolContinuations,
+      decorateCompactOutcomeWithTaskPlan,
+      decorateCompactOutcomeWithTaskPlanWithin,
       installLiveCompactOutcome,
       runProviderCompactWith,
       runBackendCompactHistoryWithContextWindow,
@@ -60,6 +62,7 @@ import Agent.CLI.ProviderFallback ( isProviderUnavailable )
 import Agent.CLI.ProviderTransition
     ( ProviderTransition(transitionCause),
       TransitionCause(AutomaticFallback) )
+import Agent.Tools.TaskPlan (TaskPlanEnv)
 import Agent.CLI.Recap ()
 import Agent.CLI.Render ( putTextLn )
 import Agent.CLI.ReplMode ()
@@ -139,7 +142,7 @@ import Agent.Claude.Control
     , defaultClaudeCodeHostHandlers
     )
 import Agent.Dialect (Dialect)
-import Agent.Error ( ApiError(..) )
+import Agent.Error ( ApiError(..), ErrorType(InvalidRequestError) )
 import Agent.GrokBuild.Dialect.Goal ()
 import Agent.GrokBuild.Dialect.Runtime ()
 import Agent.GrokBuild.Dialect.Task ()
@@ -155,6 +158,7 @@ import Agent.Loop
     )
 import Agent.OpenAI.Auth (Pool)
 import Agent.OpenAI.Compaction ()
+import Agent.OpenAI.ModelMetadata (codexEffectiveContextWindowFor)
 import Agent.OpenAI.Usage ()
 import Agent.OpenAI.WebSocketClient
     ( CodexAuthFailed(..),
@@ -276,6 +280,7 @@ runAgentProviders
     -> Dialect
     -> Maybe FullscreenRuntime
     -> IORef (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
+    -> Maybe TaskPlanEnv
     -> OsPath
     -> Maybe Text
     -> Text
@@ -322,6 +327,7 @@ runAgentProviders
     dialect
     fullscreen
     automaticCompactionHookRef
+    taskPlan
     home
     initialPrevious
     model
@@ -582,6 +588,8 @@ runAgentProviders
                                             (readIORef paramsRef)
                                             contextTokensRef
                                             recordCompactionUsage
+                                            (decorateCompactOutcomeWithTaskPlan
+                                                taskPlan)
                                             (\outcome inputs ->
                                                 readIORef
                                                     automaticCompactionHookRef
@@ -611,13 +619,18 @@ runAgentProviders
                                                     installLiveCompactOutcome
                                                         conversationRef
                                                         (Just contextTokensRef)
-                                                        (runProviderCompactWith
-                                                            (Just compactSender)
-                                                            recordCompactionUsage
-                                                            provider
-                                                            (Just tokenProvider)
-                                                            paramsRef
-                                                            historyRef)
+                                                        (\requestedFocus ->
+                                                            runProviderCompactWith
+                                                                (Just compactSender)
+                                                                recordCompactionUsage
+                                                                provider
+                                                                (Just tokenProvider)
+                                                                paramsRef
+                                                                historyRef
+                                                                requestedFocus
+                                                                >>= decorateManualCompact
+                                                                    (codexEffectiveContextWindowFor
+                                                                        . (.model)))
                                                         focus
                                             resetCodexTurnState turnState
                                             runCompact `finally`
@@ -724,18 +737,22 @@ runAgentProviders
                                 historyRef <-
                                     newIORef =<< readLiveTranscript conversationRef
                                 installLiveCompactOutcome conversationRef Nothing
-                                    (runResponsesCompactWithContextWindow
-                                        contextWindow
-                                        (\request ->
-                                            runWithTokenProvider tokenProvider
-                                                \credential ->
-                                                    XAIClient.createResponseWith
-                                                        xaiOptions
-                                                        credential
-                                                        request)
-                                        recordCompactionUsage
-                                        paramsRef
-                                        historyRef)
+                                    (\requestedFocus ->
+                                        runResponsesCompactWithContextWindow
+                                            contextWindow
+                                            (\request ->
+                                                runWithTokenProvider tokenProvider
+                                                    \credential ->
+                                                        XAIClient.createResponseWith
+                                                            xaiOptions
+                                                            credential
+                                                            request)
+                                            recordCompactionUsage
+                                            paramsRef
+                                            historyRef
+                                            requestedFocus
+                                            >>= decorateManualCompact
+                                                xaiContextWindow)
                                     focus
                         activeBackend <-
                             prepareTransitionBackend
@@ -808,18 +825,22 @@ runAgentProviders
                                 historyRef <-
                                     newIORef =<< readLiveTranscript conversationRef
                                 installLiveCompactOutcome conversationRef Nothing
-                                    (runResponsesCompactWithContextWindow
-                                        contextWindow
-                                        (\request ->
-                                            runWithTokenProvider tokenProvider
-                                                \credential ->
-                                                    GeminiClient.createResponseWith
-                                                        geminiOptions
-                                                        credential
-                                                        request)
-                                        recordCompactionUsage
-                                        paramsRef
-                                        historyRef)
+                                    (\requestedFocus ->
+                                        runResponsesCompactWithContextWindow
+                                            contextWindow
+                                            (\request ->
+                                                runWithTokenProvider tokenProvider
+                                                    \credential ->
+                                                        GeminiClient.createResponseWith
+                                                            geminiOptions
+                                                            credential
+                                                            request)
+                                            recordCompactionUsage
+                                            paramsRef
+                                            historyRef
+                                            requestedFocus
+                                            >>= decorateManualCompact
+                                                geminiContextWindow)
                                     focus
                         activeBackend <-
                             prepareTransitionBackend
@@ -898,12 +919,16 @@ runAgentProviders
                                 installLiveCompactOutcome
                                     conversationRef
                                     (Just contextTokensRef)
-                                    (runBackendCompactWithContextWindow
-                                        contextWindow
-                                        btwBackend
-                                        recordCompactionUsage
-                                        paramsRef
-                                        historyRef)
+                                    (\requestedFocus ->
+                                        runBackendCompactWithContextWindow
+                                            contextWindow
+                                            btwBackend
+                                            recordCompactionUsage
+                                            paramsRef
+                                            historyRef
+                                            requestedFocus
+                                            >>= decorateManualCompact
+                                                (const contextWindow))
                                     focus
                             claudeRequest =
                                 sessionRequest
@@ -984,6 +1009,8 @@ runAgentProviders
                                             currentParams
                                             history
                                             Nothing
+                                            >>= decorateAutomaticCompact
+                                                (const contextWindow)
                                     compactingBackend =
                                         autoCompactBackendWith
                                             claudeCompactThreshold
@@ -1072,37 +1099,41 @@ runAgentProviders
                                 historyRef <-
                                     newIORef =<< readLiveTranscript conversationRef
                                 installLiveCompactOutcome conversationRef Nothing
-                                    (case customGenericOptions of
-                                        Just genericOptions ->
-                                            runResponsesCompactWithContextWindow
-                                                contextWindow
-                                                (\request ->
-                                                    GenericResponses.createResponseWith
-                                                        genericOptions
-                                                            { GenericResponses.model =
-                                                                transportModel
-                                                                    (fromMaybe
-                                                                        model
-                                                                        request.model)
-                                                            }
-                                                        request)
-                                                recordCompactionUsage
-                                                paramsRef
-                                                historyRef
-                                        Nothing ->
-                                            runResponsesCompactWithContextWindow
-                                                contextWindow
-                                                (\request ->
-                                                    runWithTokenProvider
-                                                        tokenProvider
-                                                        \credential ->
-                                                            OpenRouter.createResponseWith
-                                                                openRouterOptions
-                                                                credential
-                                                                request)
-                                                recordCompactionUsage
-                                                paramsRef
-                                                historyRef)
+                                    (\requestedFocus ->
+                                        (case customGenericOptions of
+                                            Just genericOptions ->
+                                                runResponsesCompactWithContextWindow
+                                                    contextWindow
+                                                    (\request ->
+                                                        GenericResponses.createResponseWith
+                                                            genericOptions
+                                                                { GenericResponses.model =
+                                                                    transportModel
+                                                                        (fromMaybe
+                                                                            model
+                                                                            request.model)
+                                                                }
+                                                            request)
+                                                    recordCompactionUsage
+                                                    paramsRef
+                                                    historyRef
+                                            Nothing ->
+                                                runResponsesCompactWithContextWindow
+                                                    contextWindow
+                                                    (\request ->
+                                                        runWithTokenProvider
+                                                            tokenProvider
+                                                            \credential ->
+                                                                OpenRouter.createResponseWith
+                                                                    openRouterOptions
+                                                                    credential
+                                                                    request)
+                                                    recordCompactionUsage
+                                                    paramsRef
+                                                    historyRef)
+                                            requestedFocus
+                                            >>= decorateManualCompact
+                                                openRouterContextWindow)
                                     focus
                         activeBackend <-
                             prepareTransitionBackend
@@ -1126,6 +1157,28 @@ runAgentProviders
                                 , resetBackendState = pure ()
                                 }
           where
+            decorateManualCompact contextWindowForResult = \case
+                Left err -> pure (Left err)
+                Right outcome -> do
+                    currentParams <- readIORef paramsRef
+                    decorateCompactOutcomeWithTaskPlanWithin
+                        (contextWindowForResult currentParams)
+                        currentParams
+                        taskPlan
+                        outcome
+            decorateAutomaticCompact contextWindowForResult = \case
+                Left err -> pure (Left err)
+                Right outcome ->
+                    decorateManualCompact
+                        contextWindowForResult
+                        (Right outcome) >>= pure . \case
+                            Left message ->
+                                Left
+                                    (ProviderError
+                                        InvalidRequestError
+                                        message
+                                        Nothing)
+                            Right decorated -> Right decorated
             startupFailure err = do
                 now <- getCurrentTime
                 startupDie startup

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -129,7 +129,8 @@ import Agent.CLI.Session.Runtime.Types
                      suspendGhci, resetToolSessionTemp, grokRuntime,
                      mcpRegistrations, mcpWarnings,
                      mcpInstructions, mcpFleet,
-                     ghciEnabledRef, bashEnabledRef, toolEnv, planMode, startup,
+                     ghciEnabledRef, bashEnabledRef, toolEnv, planMode, taskPlan,
+                     startup,
                      learnAboutUserRequested, databaseScopes, promptRequest,
                      pendingTurn, unavailableProviders, startupUnavailable, paramsRef,
                      conversationRef, needsInitialContext, queueInitialContext,
@@ -781,6 +782,7 @@ runAgentSession
                                 , bashEnabledRef
                                 , toolEnv
                                 , planMode
+                                , taskPlan = coding.codingTaskPlan
                                 , startup
                                 , learnAboutUserRequested
                                 , databaseScopes
@@ -875,6 +877,7 @@ runAgentSession
                         dialect
                         fullscreen
                         automaticCompactionHookRef
+                        coding.codingTaskPlan
                         home
                         initialPrevious
                         model

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -147,7 +147,9 @@ import Agent.CLI.Session
       persistenceTempDir,
       releaseSessionTempLease,
       removeSessionTemp,
+      loadCurrentTaskPlan,
       sessionLegacySubagentTarget,
+      taskPlanHooksForPersistence,
       SessionTempCleanupReport(..),
       Persistence(PersistenceDisabled),
       SessionHandle(sessionDir, sessionMeta),
@@ -276,6 +278,7 @@ import Agent.Tools.Secret
     ( SecretPrompt(..), SecretPromptHooks(..) )
 import Agent.Tools.ShowImage
     ( ImageDisplayHooks(..), ImageDisplayRequest(..) )
+import Agent.Tools.TaskPlan (newTaskPlanEnv)
 import Agent.Tools.Types (ToolEnv, setToolSessionTmp)
 import Agent.XAI.LoopBackend ()
 import Control.Applicative ( (<|>) )
@@ -831,6 +834,16 @@ runAgentTools
                 gatewayIdentity
                 (isNothing transition) cwd effortText promptText resumed
     writeIORef persistSlotRef persist
+    initialTaskPlan <-
+        loadCurrentTaskPlan persist >>= \case
+            Left err ->
+                startupDie startup
+                    ("Failed to load current task plan: " <> Text.unpack err)
+            Right plan -> pure plan
+    taskPlan <-
+        newTaskPlanEnv
+            initialTaskPlan
+            (taskPlanHooksForPersistence persist)
     forM_ fullscreen \runtime ->
         reservedSessionId persist >>= \case
             Nothing ->
@@ -1036,6 +1049,7 @@ runAgentTools
             dialect
             toolEnv
             (Just planHooks)
+            (Just taskPlan)
             secretHooks
             imageHooks
             multiCtx

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -70,9 +70,10 @@ import Agent.CLI.Secret ()
 import Agent.CLI.Session
     ( TranscriptEffect(TranscriptReset),
       appendTurnKeepTitleIndexed,
-      appendTurnWithPromptResetIndexed,
+      appendTurnWithPromptResetAndTaskPlanClearIndexed,
       createSession,
       forkSessionAt,
+      loadCurrentTaskPlan,
       loadSession,
       rewindSession,
       removeSessionTemp,
@@ -92,7 +93,8 @@ import Agent.CLI.Session
                   metaInputTokens, metaOutputTokens, metaCachedTokens, metaLastRecap,
                   metaLastTurnSummary, metaLastRecapMainTurns, metaTransportModel,
                   metaTitleUserTurns, metaId, metaCwd, metaGatewayIdentity),
-      SessionTransfer(transferTurns, SessionTransfer, transferMeta),
+      SessionTransfer(transferTurns, SessionTransfer, transferMeta,
+                      transferTaskPlan),
       SessionTurn(turnUsage, SessionTurn, turnAt, turnUserText,
                   turnAssistantText, turnError, turnResponseId, turnEffect,
                   turnItems, turnDisplayItems, turnProviderTelemetry) )
@@ -168,6 +170,10 @@ import Agent.ToolDispatch ()
 import Agent.Tools.MultiAgents ()
 import Agent.Tools.PlanMode ( PlanModeEnv(planSessionDir) )
 import Agent.Tools.Secret ()
+import Agent.Tools.TaskPlan
+    ( CurrentTaskPlan(currentTaskPlanValue)
+    , resetTaskPlanState
+    )
 import Agent.Tools.Types ()
 import Agent.XAI.LoopBackend ()
 import Control.Applicative ()
@@ -176,7 +182,8 @@ import Control.Concurrent.Chan ()
 import Control.Concurrent.MVar ()
 import Control.Concurrent.STM ()
 import Control.Exception ()
-import Control.Exception.Safe ( finally, mask, onException )
+import Control.Exception.Safe
+    ( displayException, finally, mask, onException, tryAny )
 import Control.Monad ( forM_, void )
 import Data.IORef ( readIORef, writeIORef )
 import Data.List ()
@@ -228,6 +235,7 @@ handleSessionAction
             , sessionGatewayIdentity = gatewayIdentity
             , sessionDialect = dialect
             , sessionPlanMode = planMode
+            , sessionTaskPlan = taskPlan
             , sessionStoreRoot = storeRoot
             , sessionSetWindowTitle = setWindowTitle
             , sessionUsage = usageRef
@@ -318,18 +326,17 @@ handleSessionAction
                                                                             (RunRestart
                                                                                 updated.sessionMeta.metaId)
     ReplClear -> do
-        sessionReset
-        fullscreenEvent UiConversationCleared
         color <- resolveColor stderr
-        message <- case persist of
-            PersistenceDisabled ->
-                pure "conversation cleared"
+        clearResult <- mask \restore -> case persist of
+            PersistenceDisabled -> do
+                resetCurrentTaskPlan
+                pure (Right ("conversation cleared", Nothing))
             PersistenceEnabled slotRef -> do
                 now <- getCurrentTime
-                slot <- readIORef slotRef
-                case slot of
-                    PersistencePending _ _ _ ->
-                        pure "conversation cleared"
+                readIORef slotRef >>= \case
+                    PersistencePending{} -> do
+                        resetCurrentTaskPlan
+                        pure (Right ("conversation cleared", Nothing))
                     PersistenceActive handle -> do
                         let turn = SessionTurn
                                 { turnAt = now
@@ -344,39 +351,63 @@ handleSessionAction
                                 , turnUsage = Nothing
                                 , turnProviderTelemetry = []
                                 }
-                        (handle', turnIndex) <-
-                            appendTurnWithPromptResetIndexed handle turn \meta ->
-                                meta
-                                    { metaLastResponseId = Nothing
-                                    , metaInputTokens = 0
-                                    , metaOutputTokens = 0
-                                    , metaCachedTokens = 0
-                                    , metaLastRecap = Nothing
-                                    , metaLastTurnSummary = Nothing
-                                    , metaLastRecapMainTurns = 0
-                                    }
-                        let meta = handle'.sessionMeta
-                        writeIORef slotRef
-                            (PersistenceActive handle')
-                        forM_ fullscreen \runtime ->
-                            commitFullscreenHistoryTurn
-                                runtime
-                                (sessionHistoryTurn turnIndex turn)
-                                HistoryCommitReset
-                        pure
-                            ("conversation cleared (session "
-                                <> meta.metaId
-                                <> ")")
-        displayInfo message $
-            Text.hPutStrLn stderr
-                (roleMuted color (glyphOk <> message))
-        continue
+                        tryAny
+                            (restore
+                                (appendTurnWithPromptResetAndTaskPlanClearIndexed
+                                    handle
+                                    turn
+                                    \meta ->
+                                        meta
+                                            { metaLastResponseId = Nothing
+                                            , metaInputTokens = 0
+                                            , metaOutputTokens = 0
+                                            , metaCachedTokens = 0
+                                            , metaLastRecap = Nothing
+                                            , metaLastTurnSummary = Nothing
+                                            , metaLastRecapMainTurns = 0
+                                            })) >>= \case
+                            Left err ->
+                                pure $
+                                    Left
+                                        ("could not clear conversation: "
+                                            <> Text.pack (displayException err))
+                            Right (handle', turnIndex) -> do
+                                let meta = handle'.sessionMeta
+                                writeIORef slotRef
+                                    (PersistenceActive handle')
+                                resetCurrentTaskPlan
+                                pure $
+                                    Right
+                                        ( "conversation cleared (session "
+                                            <> meta.metaId
+                                            <> ")"
+                                        , Just (turnIndex, turn)
+                                        )
+        case clearResult of
+            Left err -> do
+                displayError err $
+                    putTextLn stderr (roleError color err)
+                continue
+            Right (message, committedTurn) -> do
+                sessionReset
+                fullscreenEvent UiConversationCleared
+                forM_ committedTurn \(turnIndex, turn) ->
+                    forM_ fullscreen \runtime ->
+                        commitFullscreenHistoryTurn
+                            runtime
+                            (sessionHistoryTurn turnIndex turn)
+                            HistoryCommitReset
+                displayInfo message $
+                    Text.hPutStrLn stderr
+                        (roleMuted color (glyphOk <> message))
+                continue
     ReplNew -> do
         sessionReset
         fullscreenEvent UiConversationCleared
         color <- resolveColor stderr
         case persist of
             PersistenceDisabled -> do
+                resetCurrentTaskPlan
                 displayInfo "started a fresh conversation" $
                     Text.hPutStrLn stderr
                         (roleMuted color
@@ -452,6 +483,7 @@ handleSessionAction
                 env.sessionSetTempDir handle'.sessionTempDir
                 writeIORef slotRef
                     (PersistenceActive handle')
+                resetCurrentTaskPlan
                 writeIORef env.sessionTitleTurnCount 0
                 writeIORef planMode.planSessionDir
                     (Just handle'.sessionDir)
@@ -702,18 +734,29 @@ handleSessionAction
                                         >>= \case
                                             Left err -> failAfk err
                                             Right (meta, turns) ->
-                                                handoffRemote
-                                                    host
-                                                    path
-                                                    handle.sessionDir
-                                                    SessionTransfer
-                                                        { transferMeta = meta
-                                                        , transferTurns = turns
-                                                        }
+                                                loadCurrentTaskPlan persist
                                                     >>= \case
                                                         Left err -> failAfk err
-                                                        Right message ->
-                                                            finishAfk message
+                                                        Right currentPlan ->
+                                                            handoffRemote
+                                                                host
+                                                                path
+                                                                handle.sessionDir
+                                                                SessionTransfer
+                                                                    { transferMeta =
+                                                                        meta
+                                                                    , transferTaskPlan =
+                                                                        (.currentTaskPlanValue)
+                                                                            <$> currentPlan
+                                                                    , transferTurns =
+                                                                        turns
+                                                                    }
+                                                                >>= \case
+                                                                    Left err ->
+                                                                        failAfk err
+                                                                    Right message ->
+                                                                        finishAfk
+                                                                            message
     ReplWorktree -> do
         result <- withReplActivity \report ->
             createManagedWorktreeWithProgress
@@ -851,6 +894,8 @@ handleSessionAction
     displayError message minimalAction = case fullscreen of
         Nothing -> minimalAction
         Just runtime -> emitUiEvent runtime (UiErrorMessage message)
+    resetCurrentTaskPlan =
+        mapM_ (\current -> resetTaskPlanState current Nothing) taskPlan
     shellModeText = \case
         ShellGhci -> "ghci"
         ShellBash -> "bash"

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -920,6 +920,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             , sessionTitleManager = titleManager
             , sessionTitleTurnCount = titleTurnCount
             , sessionPlanMode = planMode
+            , sessionTaskPlan = taskPlan
             , sessionProjectRoot = projectRoot
             , sessionCwd = cwd
             , sessionHome = home

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -79,6 +79,7 @@ import Agent.Subagents
     )
 import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode (PlanModeEnv)
+import Agent.Tools.TaskPlan (TaskPlanEnv)
 import Agent.Tools.Types
     ( AppTool
     , ToolEnv
@@ -129,6 +130,7 @@ data SessionRequest = SessionRequest
     , bashEnabledRef :: !(IORef Bool)
     , toolEnv :: !ToolEnv
     , planMode :: !PlanModeEnv
+    , taskPlan :: !(Maybe TaskPlanEnv)
     , startup :: !StartupRuntime
     , learnAboutUserRequested :: !Bool
     , databaseScopes :: !DatabaseScopes

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -37,6 +37,7 @@ import Agent.CLI.ProviderTransition (PendingTurn)
 import Agent.Skills (SkillCatalog, SkillInvocation)
 import Agent.Subagents (RootTurnId)
 import Agent.Tools.PlanMode (PlanModeEnv)
+import Agent.Tools.TaskPlan (TaskPlanEnv)
 import Agent.Store.Postgres.Connection (StorePool)
 import Data.IORef (IORef)
 import Data.Set (Set)
@@ -72,6 +73,7 @@ data SessionEnv = SessionEnv
     , sessionTitleManager :: !SessionTitleManager
     , sessionTitleTurnCount :: !(IORef Int)
     , sessionPlanMode :: !PlanModeEnv
+    , sessionTaskPlan :: !(Maybe TaskPlanEnv)
     , sessionProjectRoot :: !OsPath
     , sessionCwd :: !OsPath
     , sessionHome :: !OsPath

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -13,7 +13,10 @@ module Agent.CLI.Subagents.Runtime
 import Agent.CLI.Approval (childApprove)
 import Agent.CLI.Btw (trimDanglingToolSuffix)
 import Agent.CLI.Compaction
-    ( autoCompactOpenAiBackendWithSender )
+    ( CompactionInstall(..)
+    , autoCompactOpenAiBackendWithSenderHookAndDecorator
+    , decorateCompactOutcomeWithTaskPlan
+    )
 import Agent.Connectivity (withConnectionRecoveryOn)
 import Agent.CLI.Options (CliOptions(..), defaultEffortFor)
 import Agent.CLI.Prompt (sessionTempGuidance, systemPrompt, systemPromptForTools)
@@ -688,11 +691,14 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                                         tokenProvider
                                         request
                         compactingBackend =
-                            autoCompactOpenAiBackendWithSender
+                            autoCompactOpenAiBackendWithSenderHookAndDecorator
                                 runtime.subagentOptions.optCompactThreshold
                                 compactSender
                                 (const (pure ()))
                                 (pure childParams)
+                                (decorateCompactOutcomeWithTaskPlan
+                                    coding.codingTaskPlan)
+                                (\_ _ -> pure CompactionNotInstalled)
                                 prepared.preparedSession.subSessionContextTokens
                                 baseBackend
                         backend =

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -150,6 +150,10 @@ import Agent.Tools.PlanMode
     , planModeReminder
     , writePlanMarkdown
     )
+import Agent.Tools.TaskPlan
+    ( restoreTaskPlanReminder
+    , takeTaskPlanReminder
+    )
 import Agent.OsPath (toText, unsafeToFilePath)
 import Control.Monad (forM_, when)
 import Control.Exception.Safe (bracket_, finally, onException, tryAny)
@@ -242,6 +246,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
     , sessionConversation = conversationRef
     , sessionPersist = persist
     , sessionPlanMode = planMode
+    , sessionTaskPlan = taskPlan
     , sessionStartupContext = startupContext
     , sessionGrokFirstTurnContext = grokFirstTurnContext
     , sessionBackground = background
@@ -295,9 +300,17 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                                 planPath
                         else Nothing
             else pure Nothing
+    taskPlanReminder <-
+        if includeTurnContext
+            then maybe (pure Nothing) takeTaskPlanReminder taskPlan
+            else pure Nothing
     let
         turnInputs0 =
-            turnInputsWithContext planReminder pendingStartup inputs
+            turnInputsWithContext
+                planReminder
+                taskPlanReminder
+                pendingStartup
+                inputs
     (conversationStartedAt, previousActivityAt) <-
         timestampConversationBounds persist
     stampedInputs <-
@@ -308,7 +321,11 @@ runOneTurnBusy includeTurnContext env@SessionEnv
     sentStartupContext <- case pendingStartup of
         Nothing -> pure Nothing
         Just _ ->
-            case drop (if isJust planReminder then 1 else 0) stampedInputs of
+            case drop
+                    ( (if isJust planReminder then 1 else 0)
+                        + (if isJust taskPlanReminder then 1 else 0)
+                    )
+                    stampedInputs of
                 UserMessage context : _ -> pure (Just context)
                 _ -> fail "startup context did not produce a user message"
     (turnInputs, pendingGrokContext) <-
@@ -335,6 +352,8 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                         Nothing -> Just consumed
                         Just _ -> current
                     , ())
+            forM_ taskPlanReminder \_ ->
+                mapM_ restoreTaskPlanReminder taskPlan
         persistPromptSnapshot = case persist of
             PersistenceDisabled -> pure ()
             PersistenceEnabled slotRef -> do
@@ -437,6 +456,9 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                 (finishConversation
                     (rebasePreparedTurn boundary prepared)
                     ConversationInterrupted)
+                >> when (isNothing boundary)
+                    (forM_ taskPlanReminder \_ ->
+                        mapM_ restoreTaskPlanReminder taskPlan)
                 >> restorePlanStateAfterIncomplete planMode initialPlanState
                 >> abortSubagentTurn rootTurnId
             )
@@ -497,6 +519,9 @@ runOneTurnBusy includeTurnContext env@SessionEnv
             abortSubagentTurn rootTurnId
             commitConversationPatch
                 (finishConversation committedPrepared ConversationRestarted)
+            when (isNothing automaticCompaction) $
+                forM_ taskPlanReminder \_ ->
+                    mapM_ restoreTaskPlanReminder taskPlan
             planState <- readIORef planMode.planStateRef
             case fullscreen of
                 Just runtime ->
@@ -554,6 +579,9 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                             (finishConversation
                                 committedPrepared
                                 ConversationProviderUnavailable)
+                        when (isNothing automaticCompaction) $
+                            forM_ taskPlanReminder \_ ->
+                                mapM_ restoreTaskPlanReminder taskPlan
                         case fullscreen of
                             Nothing -> pure ()
                             Just runtime ->

--- a/packages/agent-cli/src/Agent/CLI/TurnState.hs
+++ b/packages/agent-cli/src/Agent/CLI/TurnState.hs
@@ -383,10 +383,12 @@ data TurnAbort
 turnInputsWithContext
     :: Maybe Text
     -> Maybe Text
+    -> Maybe Text
     -> [TurnInput]
     -> [TurnInput]
-turnInputsWithContext planReminder startup inputs =
+turnInputsWithContext planReminder taskPlanReminder startup inputs =
     contextInput planReminder
+        <> contextInput taskPlanReminder
         <> contextInput startup
         <> inputs
   where

--- a/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentViewportSpec.hs
@@ -5,6 +5,13 @@ import Agent.Json (rawJsonFromEncoding)
 import Agent.CLI.Picker (PickerKey(..))
 import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentStatus(..))
+import Agent.Tools.TaskPlan
+    ( CurrentTaskPlan(..)
+    , TaskPlan(..)
+    , TaskPlanItem(..)
+    , TaskPlanStatus(..)
+    , taskPlanContextText
+    )
 import Agent.TUI.Model
     ( BlockKind(..)
     , BlockState(..)
@@ -240,6 +247,22 @@ spec = do
                 , messageItem RoleAssistant "answer"
                 ]
                 `shouldBe` ["user: request"]
+
+        it "hides generated task-plan context but keeps ordinary developer text" do
+            let context =
+                    taskPlanContextText $
+                        CurrentTaskPlan 2 $
+                            TaskPlan Nothing
+                                [TaskPlanItem "implement" TaskPlanInProgress]
+                items =
+                    [ messageItem RoleDeveloper context
+                    , messageItem RoleUser context
+                    , messageItem RoleDeveloper "ordinary instruction"
+                    ]
+            responseItemLines items
+                `shouldBe` ["developer: ordinary instruction"]
+            responseItemPreviewLines 4 items
+                `shouldBe` ["developer: ordinary instruction"]
 
     describe "responseItemsToUiState" do
         it "replays child messages, reasoning, and tools into retained blocks" do

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -8,9 +8,12 @@ import Agent.CLI.Compaction
     , autoCompactOpenAiBackendWithApi
     , autoCompactOpenAiBackendWithSender
     , autoCompactOpenAiBackendWithSenderAndHook
+    , autoCompactOpenAiBackendWithSenderHookAndDecorator
     , autoCompactOpenAiBackendWithThreshold
     , codexAutoCompactTokenLimit
     , compactOpenAIWith
+    , decorateCompactOutcomeWithTaskPlan
+    , decorateCompactOutcomeWithTaskPlanWithin
     , estimatedOccupancy
     , installCompactOutcome
     , reportedOccupancy
@@ -40,6 +43,16 @@ import Agent.ToolDispatch
     )
 import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Responses.Types
+import Agent.Tools.TaskPlan
+    ( CurrentTaskPlan(..)
+    , TaskPlan(..)
+    , TaskPlanItem(..)
+    , TaskPlanStatus(..)
+    , isTaskPlanContextText
+    , newTaskPlanEnv
+    , replaceTaskPlan
+    , taskPlanContextText
+    )
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import Agent.Provider
@@ -1198,7 +1211,132 @@ spec = do
                 Right _ ->
                     expectationFailure "expected compaction to fail"
 
+    describe "task-plan compaction context" do
+        it "replaces stale generated copies from authoritative state" do
+            let stale =
+                    taskPlanContextText $
+                        CurrentTaskPlan 8 $
+                            TaskPlan Nothing
+                                [TaskPlanItem "stale" TaskPlanPending]
+                plan = TaskPlan
+                    (Just "continue here")
+                    [TaskPlanItem "current" TaskPlanInProgress]
+                current = CurrentTaskPlan 1 plan
+                outcome = CompactOutcome
+                    { compactBeforeTokens = 20
+                    , compactAfterTokens = 10
+                    , compactHistory =
+                        [userTextItem stale, userTextItem "retained"]
+                    , compactSummary = "summary"
+                    }
+            env <- newTaskPlanEnv Nothing Nothing
+            replaceTaskPlan env plan `shouldReturn` Right current
+            decorated <-
+                decorateCompactOutcomeWithTaskPlan (Just env) outcome
+            filter responseItemHasTaskPlan decorated.compactHistory
+                `shouldSatisfy` \case
+                    [MessageItem message] ->
+                        message.role == RoleDeveloper
+                            && responseMessageHasText
+                                (taskPlanContextText current)
+                                message
+                    _ -> False
+
+        it "does not reconstruct a plan from pre-compaction history" do
+            let stale =
+                    taskPlanContextText $
+                        CurrentTaskPlan 8 $
+                            TaskPlan Nothing
+                                [TaskPlanItem "stale" TaskPlanInProgress]
+                outcome = CompactOutcome
+                    { compactBeforeTokens = 20
+                    , compactAfterTokens = 10
+                    , compactHistory =
+                        [userTextItem stale, userTextItem "retained"]
+                    , compactSummary = "summary"
+                    }
+            env <- newTaskPlanEnv Nothing Nothing
+            decorated <-
+                decorateCompactOutcomeWithTaskPlan (Just env) outcome
+            decorated.compactHistory
+                `shouldBe` [userTextItem "retained"]
+
+        it "rejects a generated plan that cannot fit the compacted request" do
+            let plan = TaskPlan Nothing
+                    [TaskPlanItem "current" TaskPlanInProgress]
+                outcome = CompactOutcome
+                    { compactBeforeTokens = 20
+                    , compactAfterTokens = 1
+                    , compactHistory = []
+                    , compactSummary = "summary"
+                    }
+                rawLimit =
+                    estimateRequestTokensWithItems
+                        defaultResponseCreateParams
+                        outcome.compactHistory
+            env <- newTaskPlanEnv Nothing Nothing
+            _ <- replaceTaskPlan env plan
+            result <-
+                decorateCompactOutcomeWithTaskPlanWithin
+                    rawLimit
+                    defaultResponseCreateParams
+                    (Just env)
+                    outcome
+            result `shouldSatisfy` \case
+                Left message ->
+                    "authoritative task plan does not fit"
+                        `Text.isInfixOf` message
+                Right _ -> False
+
     describe "autoCompactOpenAiBackendWith" do
+        it "decorates before publishing and continuing automatic compaction" do
+            let history = [userTextItem "old"]
+                threshold = 2_000
+                plan = TaskPlan Nothing
+                    [TaskPlanItem "continue implementation" TaskPlanInProgress]
+            taskPlanEnv <- newTaskPlanEnv Nothing Nothing
+            _ <- replaceTaskPlan taskPlanEnv plan
+            contextState <- newIORef
+                (Just (reportedOccupancy threshold (length history)))
+            hookHistory <- newIORef []
+            continuationHistory <- newIORef []
+            let sender _request =
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _previous _inputs _onEvent -> do
+                    writeIORef continuationHistory state.backendItems
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        , providerTelemetry = Nothing
+                        , completion = TurnCompleted
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSenderHookAndDecorator
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure defaultResponseCreateParams)
+                        (decorateCompactOutcomeWithTaskPlan
+                            (Just taskPlanEnv))
+                        (\outcome _inputs -> do
+                            writeIORef hookHistory outcome.compactHistory
+                            pure CompactionInstalled)
+                        contextState
+                        base
+            result <-
+                backend.submitTurn
+                    (initialBackendSnapshot history)
+                    Nothing
+                    [UserMessage "new"]
+                    (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef hookHistory
+                >>= (`shouldSatisfy` any responseItemHasTaskPlan)
+            readIORef continuationHistory
+                >>= (`shouldSatisfy` any responseItemHasTaskPlan)
+
         it "compacts at a configured threshold below the model default" do
             let history = [userTextItem "old"]
                 threshold = 20
@@ -2137,6 +2275,30 @@ spec = do
                 (const (pure ()))
             result `shouldSatisfy` either (const False) (const True)
             readIORef compactCalls `shouldReturn` 1
+
+responseItemHasTaskPlan :: ResponseItem -> Bool
+responseItemHasTaskPlan = \case
+    MessageItem message ->
+        any isTaskPlanContextText (responseMessageTexts message)
+    _ -> False
+
+responseMessageHasText :: Text -> ResponseMessage -> Bool
+responseMessageHasText expected =
+    elem expected . responseMessageTexts
+
+responseMessageTexts :: ResponseMessage -> [Text]
+responseMessageTexts message =
+    case message.content of
+        MessageContentText text -> [text]
+        MessageContentParts parts ->
+            [ text
+            | part <- parts
+            , text <- case part of
+                InputTextPart{text} -> [text]
+                OutputTextPart{text} -> [text]
+                PlainTextPart{text} -> [text]
+                _ -> []
+            ]
 
 successful
     :: BackendSnapshot

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -1212,6 +1212,73 @@ spec = do
                     expectationFailure "expected compaction to fail"
 
     describe "task-plan compaction context" do
+        it "removes generated task plans before remote compaction" do
+            let stale =
+                    taskPlanContextText $
+                        CurrentTaskPlan 8 $
+                            TaskPlan Nothing
+                                [TaskPlanItem "stale" TaskPlanInProgress]
+                history =
+                    [ taskPlanMessage RoleDeveloper stale
+                    , userTextItem stale
+                    , userTextItem "retained"
+                    ]
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef history
+            requests <- newIORef []
+            result <-
+                runProviderCompactWith
+                    (Just \request -> do
+                        modifyIORef' requests (<> [request])
+                        pure (Right remoteCompactionResponse))
+                    (const (pure ()))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    Nothing
+            result `shouldSatisfy` either (const False) (const True)
+            map requestItems <$> readIORef requests
+                `shouldReturn`
+                    [ [ userTextItem "retained"
+                      , compactionTriggerItem
+                      ]
+                    ]
+
+        it "removes generated task plans before local summarization" do
+            let stale =
+                    taskPlanContextText $
+                        CurrentTaskPlan 8 $
+                            TaskPlan Nothing
+                                [TaskPlanItem "stale" TaskPlanInProgress]
+                history =
+                    [ taskPlanMessage RoleDeveloper stale
+                    , userTextItem stale
+                    , userTextItem "retained"
+                    ]
+                focus = Just "focus on the remaining work"
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef history
+            requests <- newIORef []
+            result <-
+                runProviderCompactWith
+                    (Just \request -> do
+                        modifyIORef' requests (<> [request])
+                        pure (Right (summaryResponse "local summary")))
+                    (const (pure ()))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    focus
+            result `shouldSatisfy` either (const False) (const True)
+            map requestItems <$> readIORef requests
+                `shouldReturn`
+                    [ [ userTextItem "retained"
+                      , userTextItem (summarizationPrompt focus)
+                      ]
+                    ]
+
         it "replaces stale generated copies from authoritative state" do
             let stale =
                     taskPlanContextText $
@@ -1336,6 +1403,58 @@ spec = do
                 >>= (`shouldSatisfy` any responseItemHasTaskPlan)
             readIORef continuationHistory
                 >>= (`shouldSatisfy` any responseItemHasTaskPlan)
+
+        it "does not duplicate a pending task-plan reminder after compaction" do
+            let history = [userTextItem "old"]
+                threshold = 2_000
+                plan = TaskPlan Nothing
+                    [TaskPlanItem "continue implementation" TaskPlanInProgress]
+            taskPlanEnv <- newTaskPlanEnv Nothing Nothing
+            current <- replaceTaskPlan taskPlanEnv plan >>= \case
+                Left err -> expectationFailure (Text.unpack err) >> fail "plan"
+                Right value -> pure value
+            contextState <- newIORef
+                (Just (reportedOccupancy threshold (length history)))
+            hookHistory <- newIORef []
+            continuationHistory <- newIORef []
+            let sender _request =
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _previous _inputs _onEvent -> do
+                    writeIORef continuationHistory state.backendItems
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        , providerTelemetry = Nothing
+                        , completion = TurnCompleted
+                        }
+                backend =
+                    autoCompactOpenAiBackendWithSenderHookAndDecorator
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure defaultResponseCreateParams)
+                        (decorateCompactOutcomeWithTaskPlan
+                            (Just taskPlanEnv))
+                        (\outcome _inputs -> do
+                            writeIORef hookHistory outcome.compactHistory
+                            pure CompactionInstalled)
+                        contextState
+                        base
+                reminder = taskPlanContextText current
+            result <-
+                backend.submitTurn
+                    (initialBackendSnapshot history)
+                    Nothing
+                    [UserMessage reminder, UserMessage "new"]
+                    (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef hookHistory
+                >>= (`shouldSatisfy` all (not . responseItemHasTaskPlan))
+            readIORef continuationHistory
+                >>= (`shouldSatisfy`
+                    ((== 1) . length . filter responseItemHasTaskPlan))
 
         it "compacts at a configured threshold below the model default" do
             let history = [userTextItem "old"]
@@ -2281,6 +2400,17 @@ responseItemHasTaskPlan = \case
     MessageItem message ->
         any isTaskPlanContextText (responseMessageTexts message)
     _ -> False
+
+taskPlanMessage :: ResponseRole -> Text -> ResponseItem
+taskPlanMessage role text =
+    MessageItem ResponseMessage
+        { messageId = Nothing
+        , content = MessageContentParts [InputTextPart text Nothing]
+        , role = role
+        , status = Nothing
+        , phase = Nothing
+        , passthrough = Nothing
+        }
 
 responseMessageHasText :: Text -> ResponseMessage -> Bool
 responseMessageHasText expected =

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -56,13 +56,15 @@ import Test.Hspec
 spec :: Spec
 spec = do
     describe "turnInputsWithContext" do
-        it "orders plan, startup, and submitted inputs" do
+        it "orders plan-mode, task-plan, startup, and submitted inputs" do
             turnInputsWithContext
                 (Just "plan reminder")
+                (Just "task plan")
                 (Just "startup instructions")
                 [UserMessage "fix it"]
                 `shouldBe`
                     [ UserMessage "plan reminder"
+                    , UserMessage "task plan"
                     , UserMessage "startup instructions"
                     , UserMessage "fix it"
                     ]

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Runtime.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Runtime.hs
@@ -1,6 +1,7 @@
 module Agent.Codex.Dialect.Runtime
     ( CodexCodingTools(..)
     , newCodexCodingTools
+    , newCodexCodingToolsWithTaskPlan
     ) where
 
 import Agent.Codex.Dialect.Shell
@@ -21,6 +22,7 @@ import Agent.Tools.Ghci
     )
 import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks, newPlanModeEnv)
+import Agent.Tools.TaskPlan (TaskPlanEnv, newTaskPlanEnv)
 import Agent.Tools.Types (AppTool, ToolEnv(..))
 import Control.Exception.Safe (onException)
 import System.OsPath (OsPath)
@@ -28,6 +30,7 @@ import System.OsPath (OsPath)
 data CodexCodingTools = CodexCodingTools
     { codexAppTools :: ![AppTool]
     , codexPlanMode :: !PlanModeEnv
+    , codexTaskPlan :: !TaskPlanEnv
     , codexSuspendGhci :: !(IO ())
     , codexResetSessionTemp :: !(OsPath -> IO ())
     , codexClose :: !(IO ())
@@ -39,6 +42,16 @@ newCodexCodingTools
     -> Maybe MultiAgentContext
     -> IO CodexCodingTools
 newCodexCodingTools env hooks multi = do
+    taskPlan <- newTaskPlanEnv Nothing Nothing
+    newCodexCodingToolsWithTaskPlan env hooks taskPlan multi
+
+newCodexCodingToolsWithTaskPlan
+    :: ToolEnv
+    -> Maybe PlanModeHooks
+    -> TaskPlanEnv
+    -> Maybe MultiAgentContext
+    -> IO CodexCodingTools
+newCodexCodingToolsWithTaskPlan env hooks taskPlan multi = do
     resources <- newResourceScope
     flip onException (closeResourceScope resources) do
         plan <- newPlanModeEnv env.toolCwd hooks
@@ -48,10 +61,11 @@ newCodexCodingTools env hooks multi = do
         (_, ghci) <- allocateResource resources
             (newGhciSession env)
             closeGhciSession
-        tools <- codexTools env shellSession ghci plan multi
+        tools <- codexTools env shellSession ghci plan taskPlan multi
         pure CodexCodingTools
             { codexAppTools = tools
             , codexPlanMode = plan
+            , codexTaskPlan = taskPlan
             , codexSuspendGhci = suspendGhciSession ghci
             , codexResetSessionTemp = \_tempDir -> do
                 suspendGhciSession ghci

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -55,6 +55,14 @@ import Agent.Tools.PlanMode
     , isPlanModeActive
     , writePlanTool
     )
+import Agent.Tools.TaskPlan
+    ( TaskPlanEnv
+    , TaskPlanUpdate
+    , renderTaskPlanUpdate
+    , replaceTaskPlan
+    , taskPlanUpdateDecoder
+    , validateTaskPlanUpdate
+    )
 import Agent.Tools.Scheduling
     ( ToolAccess(..)
     , ToolResource(..)
@@ -83,9 +91,10 @@ codexTools
     -> CodexShellSession
     -> GhciSession
     -> PlanModeEnv
+    -> TaskPlanEnv
     -> Maybe MultiAgentContext
     -> IO [AppTool]
-codexTools env shellSession ghci planMode multi =
+codexTools env shellSession ghci planMode taskPlan multi =
     pure $
         [ runGhciTool ghci
         , viewImageTool env
@@ -93,7 +102,7 @@ codexTools env shellSession ghci planMode multi =
         , grepTool env
         , listDirTool env
         , applyPatchTool env
-        , updatePlanTool planMode
+        , updatePlanTool planMode taskPlan
         , enterCodexPlanModeTool planMode
         , writePlanTool planMode
         , askUserQuestionTool planMode
@@ -418,30 +427,8 @@ decodeApplyPatchArguments call = case call.callKind of
 -- update_plan
 --------------------------------------------------------------------------------
 
-data PlanItem = PlanItem
-    { step :: Text
-    , status :: Text
-    } deriving (Eq, Show)
-
-planItemDecoder :: Json.Decoder PlanItem
-planItemDecoder = Json.object $
-    PlanItem
-        <$> Json.atKey "step" Json.text
-        <*> Json.atKey "status" Json.text
-
-data UpdatePlanArgs = UpdatePlanArgs
-    { explanation :: Maybe Text
-    , plan :: [PlanItem]
-    }
-
-updatePlanArgsDecoder :: Json.Decoder UpdatePlanArgs
-updatePlanArgsDecoder = Json.object $
-    UpdatePlanArgs
-        <$> optionalText "explanation"
-        <*> Json.atKey "plan" (Json.list planItemDecoder)
-
-updatePlanTool :: PlanModeEnv -> AppTool
-updatePlanTool planMode = jsonTool "update_plan" updatePlanDescription
+updatePlanTool :: PlanModeEnv -> TaskPlanEnv -> AppTool
+updatePlanTool planMode taskPlan = jsonTool "update_plan" updatePlanDescription
     [ PropertySchema "explanation" PropertyString False $ Just
         "Optional explanation for this plan update."
     , PropertySchema "plan" (PropertyArray (PropertyObject
@@ -452,7 +439,7 @@ updatePlanTool planMode = jsonTool "update_plan" updatePlanDescription
     ]
     True
     TurnSequential
-    (typedTool "update_plan" updatePlanArgsDecoder (runUpdatePlan planMode))
+    (typedTool "update_plan" taskPlanUpdateDecoder (runUpdatePlan planMode taskPlan))
 
 updatePlanDescription :: Text
 updatePlanDescription =
@@ -461,30 +448,19 @@ updatePlanDescription =
     \At most one step can be in_progress at a time.\n\
     \This is a progress checklist, not Plan Mode. It errors while Plan Mode is active."
 
-runUpdatePlan :: PlanModeEnv -> UpdatePlanArgs -> IO (Either Text Text)
-runUpdatePlan planMode args = do
+runUpdatePlan :: PlanModeEnv -> TaskPlanEnv -> TaskPlanUpdate -> IO (Either Text Text)
+runUpdatePlan planMode taskPlan update = do
     active <- isPlanModeActive planMode
     if active
         then pure $ Left
             "update_plan is unavailable in Plan Mode. Write the design to plan.md \
             \and present it with a <proposed_plan> block when ready."
-        else pure (runUpdatePlanBody args)
-
-runUpdatePlanBody :: UpdatePlanArgs -> Either Text Text
-runUpdatePlanBody args
-    | any (\item -> item.status `notElem` ["pending", "in_progress", "completed"]) args.plan =
-        Left "Each plan status must be pending, in_progress, or completed."
-    | length (filter (\item -> item.status == "in_progress") args.plan) > 1 =
-        Left "At most one step can be in_progress at a time."
-    | otherwise =
-        let rendered = Text.unlines (map renderItem args.plan)
-            header = case args.explanation of
-                Nothing -> "Plan updated:\n"
-                Just explanation -> explanation <> "\nPlan updated:\n"
-        in Right (header <> rendered)
-  where
-    renderItem :: PlanItem -> Text
-    renderItem item = "- [" <> item.status <> "] " <> item.step
+        else case validateTaskPlanUpdate update of
+            Left err -> pure (Left err)
+            Right plan ->
+                replaceTaskPlan taskPlan plan >>= \case
+                    Left err -> pure (Left err)
+                    Right _ -> pure (Right (renderTaskPlanUpdate plan))
 
 optionalText :: Text -> Json.FieldsDecoder (Maybe Text)
 optionalText key =

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -9,6 +9,7 @@ import Agent.Codex.Dialect.Prompt
 import Agent.Codex.Dialect.Runtime
     ( CodexCodingTools(..)
     , newCodexCodingTools
+    , newCodexCodingToolsWithTaskPlan
     )
 import Agent.Codex.Dialect.Shell
     ( CodexShellResult(..)
@@ -30,6 +31,15 @@ import Agent.ToolDispatch
     , functionToolCall
     )
 import Agent.Tools.Scheduling (schedulingPlansConflict)
+import Agent.Tools.TaskPlan
+    ( CurrentTaskPlan(..)
+    , TaskPlan(..)
+    , TaskPlanHooks(..)
+    , TaskPlanItem(..)
+    , TaskPlanStatus(..)
+    , newTaskPlanEnv
+    , readTaskPlan
+    )
 import Agent.Tools.Types
     ( AppTool(..)
     , BackgroundTaskHooks(..)
@@ -108,6 +118,49 @@ spec = describe "Codex dialect" do
                 `shouldBe` replicate 5 True
             names `shouldNotContain` ["run_terminal_cmd", "search_replace"]
             coding.codexClose
+
+    it "persists update_plan before reporting success" do
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            taskPlan <- newTaskPlanEnv Nothing $ Just TaskPlanHooks
+                { taskPlanPersistReplace = \_ -> pure (Right 9)
+                , taskPlanPersistClear = pure (Right ())
+                }
+            bracket
+                (newCodexCodingToolsWithTaskPlan env Nothing taskPlan Nothing)
+                (.codexClose)
+                \coding -> do
+                    result <- dispatchToolCall
+                        testDispatchConfig
+                        (appToolHandlers coding.codexAppTools)
+                        (functionToolCall "plan-1" "update_plan"
+                            "{\"explanation\":\"Next\",\"plan\":[{\"step\":\"Implement\",\"status\":\"in_progress\"}]}")
+                    result.output `shouldBe`
+                        "Next\nPlan updated:\n- [in_progress] Implement\n"
+                    readTaskPlan taskPlan `shouldReturn` Just
+                        (CurrentTaskPlan 9
+                            (TaskPlan (Just "Next")
+                                [TaskPlanItem "Implement" TaskPlanInProgress]))
+
+    it "does not publish update_plan when persistence fails" do
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            taskPlan <- newTaskPlanEnv Nothing $ Just TaskPlanHooks
+                { taskPlanPersistReplace = \_ -> pure (Left "database unavailable")
+                , taskPlanPersistClear = pure (Right ())
+                }
+            bracket
+                (newCodexCodingToolsWithTaskPlan env Nothing taskPlan Nothing)
+                (.codexClose)
+                \coding -> do
+                    result <- dispatchToolCall
+                        testDispatchConfig
+                        (appToolHandlers coding.codexAppTools)
+                        (functionToolCall "plan-2" "update_plan"
+                            "{\"plan\":[{\"step\":\"Implement\",\"status\":\"pending\"}]}")
+                    result.output `shouldSatisfy`
+                        Text.isInfixOf "database unavailable"
+                    readTaskPlan taskPlan `shouldReturn` Nothing
 
     it "defaults shell_command to the turn cwd when workdir is omitted" do
         withTempDir \dir -> do

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -87,6 +87,7 @@ library
                     , Agent.Tools.MultiAgents
                     , Agent.Tools.OutputArtifact
                     , Agent.Tools.PlanMode
+                    , Agent.Tools.TaskPlan
                     , Agent.Tools.Secret
                     , Agent.Tools.Scheduling
                     , Agent.Tools.ShowImage
@@ -268,6 +269,7 @@ test-suite agent-core-test
                     , Agent.Tools.MultiAgentsSpec
                     , Agent.Tools.OutputArtifactSpec
                     , Agent.Tools.PlanModeSpec
+                    , Agent.Tools.TaskPlanSpec
                     , Agent.Tools.SecretSpec
                     , Agent.Tools.ShowImageSpec
                     , Agent.Tools.ViewImageSpec

--- a/packages/agent-core/src/Agent/Tools/TaskPlan.hs
+++ b/packages/agent-core/src/Agent/Tools/TaskPlan.hs
@@ -1,0 +1,241 @@
+-- | Durable, session-scoped progress-plan state.
+--
+-- The current plan is authoritative state rather than something reconstructed
+-- from model history.  Persistence hooks are deliberately small so callers can
+-- back the state with a database without coupling agent-core to a store.
+module Agent.Tools.TaskPlan
+    ( TaskPlanStatus(..)
+    , TaskPlanItem(..)
+    , TaskPlan(..)
+    , CurrentTaskPlan(..)
+    , TaskPlanInputItem(..)
+    , TaskPlanUpdate(..)
+    , TaskPlanHooks(..)
+    , TaskPlanEnv
+    , taskPlanUpdateDecoder
+    , validateTaskPlanUpdate
+    , renderTaskPlanUpdate
+    , newTaskPlanEnv
+    , readTaskPlan
+    , replaceTaskPlan
+    , clearTaskPlan
+    , taskPlanContextText
+    , currentTaskPlanContextText
+    , takeTaskPlanReminder
+    , isTaskPlanContextText
+    , taskPlanContextMarker
+    ) where
+
+import qualified Agent.Json.Decode as Json
+import Control.Concurrent.MVar (MVar, modifyMVar, newMVar)
+import Control.Exception.Safe (mask)
+import Data.Int (Int64)
+import Data.IORef
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+data TaskPlanStatus
+    = TaskPlanPending
+    | TaskPlanInProgress
+    | TaskPlanCompleted
+    deriving (Eq, Show)
+
+data TaskPlanItem = TaskPlanItem
+    { taskPlanStep :: !Text
+    , taskPlanStatus :: !TaskPlanStatus
+    } deriving (Eq, Show)
+
+data TaskPlan = TaskPlan
+    { taskPlanExplanation :: !(Maybe Text)
+    , taskPlanItems :: ![TaskPlanItem]
+    } deriving (Eq, Show)
+
+data CurrentTaskPlan = CurrentTaskPlan
+    { currentTaskPlanRevision :: !Int64
+    , currentTaskPlanValue :: !TaskPlan
+    } deriving (Eq, Show)
+
+-- | Wire representation.  Status remains textual until validation so invalid
+-- calls retain the established, useful validation error.
+data TaskPlanInputItem = TaskPlanInputItem
+    { taskPlanInputStep :: !Text
+    , taskPlanInputStatus :: !Text
+    } deriving (Eq, Show)
+
+data TaskPlanUpdate = TaskPlanUpdate
+    { taskPlanUpdateExplanation :: !(Maybe Text)
+    , taskPlanUpdateItems :: ![TaskPlanInputItem]
+    } deriving (Eq, Show)
+
+data TaskPlanHooks = TaskPlanHooks
+    { taskPlanPersistReplace :: !(TaskPlan -> IO (Either Text Int64))
+    , taskPlanPersistClear :: !(IO (Either Text ()))
+    }
+
+data TaskPlanEnv = TaskPlanEnv
+    { taskPlanStateRef :: !(IORef (Maybe CurrentTaskPlan))
+    , taskPlanReminderPendingRef :: !(IORef Bool)
+    , taskPlanHooks :: !(Maybe TaskPlanHooks)
+    , taskPlanMutationLock :: !(MVar ())
+    }
+
+taskPlanUpdateDecoder :: Json.Decoder TaskPlanUpdate
+taskPlanUpdateDecoder = Json.object $
+    TaskPlanUpdate
+        <$> optionalNonEmptyText "explanation"
+        <*> Json.atKey "plan" (Json.list inputItemDecoder)
+  where
+    inputItemDecoder = Json.object $
+        TaskPlanInputItem
+            <$> Json.atKey "step" Json.text
+            <*> Json.atKey "status" Json.text
+
+optionalNonEmptyText :: Text -> Json.FieldsDecoder (Maybe Text)
+optionalNonEmptyText key =
+    fmap (>>= nonEmpty) (Json.optionalKey key Json.text)
+  where
+    nonEmpty value
+        | Text.null value = Nothing
+        | otherwise = Just value
+
+validateTaskPlanUpdate :: TaskPlanUpdate -> Either Text TaskPlan
+validateTaskPlanUpdate update = do
+    items <- traverse validateItem update.taskPlanUpdateItems
+    if length (filter (\item -> item.taskPlanStatus == TaskPlanInProgress) items) > 1
+        then Left "At most one step can be in_progress at a time."
+        else Right TaskPlan
+            { taskPlanExplanation = update.taskPlanUpdateExplanation
+            , taskPlanItems = items
+            }
+  where
+    validateItem :: TaskPlanInputItem -> Either Text TaskPlanItem
+    validateItem item = TaskPlanItem item.taskPlanInputStep
+        <$> case item.taskPlanInputStatus of
+            "pending" -> Right TaskPlanPending
+            "in_progress" -> Right TaskPlanInProgress
+            "completed" -> Right TaskPlanCompleted
+            _ -> Left "Each plan status must be pending, in_progress, or completed."
+
+renderTaskPlanUpdate :: TaskPlan -> Text
+renderTaskPlanUpdate plan =
+    header <> Text.unlines (map renderItem plan.taskPlanItems)
+  where
+    header = case plan.taskPlanExplanation of
+        Nothing -> "Plan updated:\n"
+        Just explanation -> explanation <> "\nPlan updated:\n"
+    renderItem :: TaskPlanItem -> Text
+    renderItem item =
+        "- [" <> renderStatus item.taskPlanStatus <> "] " <> item.taskPlanStep
+
+-- | Construct an environment.  A supplied initial plan is considered resumed
+-- durable state and therefore produces one reminder when next requested.
+newTaskPlanEnv
+    :: Maybe CurrentTaskPlan
+    -> Maybe TaskPlanHooks
+    -> IO TaskPlanEnv
+newTaskPlanEnv initial hooks = do
+    stateRef <- newIORef initial
+    reminderRef <- newIORef (maybe False (const True) initial)
+    mutationLock <- newMVar ()
+    pure TaskPlanEnv
+        { taskPlanStateRef = stateRef
+        , taskPlanReminderPendingRef = reminderRef
+        , taskPlanHooks = hooks
+        , taskPlanMutationLock = mutationLock
+        }
+
+readTaskPlan :: TaskPlanEnv -> IO (Maybe CurrentTaskPlan)
+readTaskPlan env = readIORef env.taskPlanStateRef
+
+-- | Persist first, then publish in memory.  Async exceptions may interrupt the
+-- persistence operation, but cannot land between its success and publication.
+replaceTaskPlan
+    :: TaskPlanEnv
+    -> TaskPlan
+    -> IO (Either Text CurrentTaskPlan)
+replaceTaskPlan env plan =
+    mask \restore -> modifyMVar env.taskPlanMutationLock \lock -> do
+        persisted <- restore $ case env.taskPlanHooks of
+            Just hooks -> hooks.taskPlanPersistReplace plan
+            Nothing -> do
+                current <- readIORef env.taskPlanStateRef
+                pure $ Right $ maybe 1 (\value -> value.currentTaskPlanRevision + 1) current
+        case persisted of
+            Left err -> pure (lock, Left err)
+            Right revision -> do
+                let current = CurrentTaskPlan revision plan
+                writeIORef env.taskPlanStateRef (Just current)
+                writeIORef env.taskPlanReminderPendingRef False
+                pure (lock, Right current)
+
+-- | Clear durable state before clearing the in-memory projection.
+clearTaskPlan :: TaskPlanEnv -> IO (Either Text ())
+clearTaskPlan env =
+    mask \restore -> modifyMVar env.taskPlanMutationLock \lock -> do
+        persisted <- restore $ case env.taskPlanHooks of
+            Just hooks -> hooks.taskPlanPersistClear
+            Nothing -> pure (Right ())
+        case persisted of
+            Left err -> pure (lock, Left err)
+            Right () -> do
+                writeIORef env.taskPlanStateRef Nothing
+                writeIORef env.taskPlanReminderPendingRef False
+                pure (lock, Right ())
+
+taskPlanContextMarker :: Text
+taskPlanContextMarker = "<task-plan-state"
+
+taskPlanContextLimit :: Int
+taskPlanContextLimit = 12000
+
+taskPlanContextText :: CurrentTaskPlan -> Text
+taskPlanContextText current =
+    boundContext $
+        "<task-plan-state revision=\""
+            <> Text.pack (show current.currentTaskPlanRevision)
+            <> "\">\n"
+            <> "This is the authoritative current task plan. Continue from it; do not reconstruct a plan from earlier messages.\n"
+            <> explanation
+            <> Text.concat (map renderItem plan.taskPlanItems)
+            <> "</task-plan-state>"
+  where
+    plan = current.currentTaskPlanValue
+    explanation = case plan.taskPlanExplanation of
+        Nothing -> ""
+        Just value -> "Explanation: " <> neutralize value <> "\n"
+    renderItem :: TaskPlanItem -> Text
+    renderItem item =
+        "- [" <> renderStatus item.taskPlanStatus <> "] "
+            <> neutralize item.taskPlanStep <> "\n"
+
+currentTaskPlanContextText :: TaskPlanEnv -> IO (Maybe Text)
+currentTaskPlanContextText env =
+    fmap taskPlanContextText <$> readTaskPlan env
+
+-- | Consume the one-shot reminder used when a runtime resumes persisted state.
+takeTaskPlanReminder :: TaskPlanEnv -> IO (Maybe Text)
+takeTaskPlanReminder env = do
+    pending <- atomicModifyIORef' env.taskPlanReminderPendingRef (\value -> (False, value))
+    if pending then currentTaskPlanContextText env else pure Nothing
+
+isTaskPlanContextText :: Text -> Bool
+isTaskPlanContextText =
+    Text.isPrefixOf taskPlanContextMarker . Text.stripStart
+
+renderStatus :: TaskPlanStatus -> Text
+renderStatus = \case
+    TaskPlanPending -> "pending"
+    TaskPlanInProgress -> "in_progress"
+    TaskPlanCompleted -> "completed"
+
+-- Prevent user-controlled text from closing or opening our context element.
+neutralize :: Text -> Text
+neutralize = Text.replace ">" "›" . Text.replace "<" "‹"
+
+boundContext :: Text -> Text
+boundContext text
+    | Text.length text <= taskPlanContextLimit = text
+    | otherwise =
+        Text.take (taskPlanContextLimit - Text.length suffix) text <> suffix
+  where
+    suffix = "\n[task plan context truncated]\n</task-plan-state>"

--- a/packages/agent-core/src/Agent/Tools/TaskPlan.hs
+++ b/packages/agent-core/src/Agent/Tools/TaskPlan.hs
@@ -19,9 +19,11 @@ module Agent.Tools.TaskPlan
     , readTaskPlan
     , replaceTaskPlan
     , clearTaskPlan
+    , resetTaskPlanState
     , taskPlanContextText
     , currentTaskPlanContextText
     , takeTaskPlanReminder
+    , restoreTaskPlanReminder
     , isTaskPlanContextText
     , taskPlanContextMarker
     ) where
@@ -29,6 +31,7 @@ module Agent.Tools.TaskPlan
 import qualified Agent.Json.Decode as Json
 import Control.Concurrent.MVar (MVar, modifyMVar, newMVar)
 import Control.Exception.Safe (mask)
+import Control.Monad (when)
 import Data.Int (Int64)
 import Data.IORef
 import Data.Text (Text)
@@ -182,6 +185,20 @@ clearTaskPlan env =
                 writeIORef env.taskPlanReminderPendingRef False
                 pure (lock, Right ())
 
+-- | Replace only the in-memory projection after the host switches the
+-- persistence hooks to a different session. The supplied value must already
+-- reflect that session's authoritative database state.
+resetTaskPlanState
+    :: TaskPlanEnv
+    -> Maybe CurrentTaskPlan
+    -> IO ()
+resetTaskPlanState env current =
+    modifyMVar env.taskPlanMutationLock \lock -> do
+        writeIORef env.taskPlanStateRef current
+        writeIORef env.taskPlanReminderPendingRef
+            (maybe False (const True) current)
+        pure (lock, ())
+
 taskPlanContextMarker :: Text
 taskPlanContextMarker = "<task-plan-state"
 
@@ -217,6 +234,14 @@ takeTaskPlanReminder :: TaskPlanEnv -> IO (Maybe Text)
 takeTaskPlanReminder env = do
     pending <- atomicModifyIORef' env.taskPlanReminderPendingRef (\value -> (False, value))
     if pending then currentTaskPlanContextText env else pure Nothing
+
+-- | Requeue a consumed resume reminder when prompt preparation fails before
+-- the corresponding input can become part of canonical history.
+restoreTaskPlanReminder :: TaskPlanEnv -> IO ()
+restoreTaskPlanReminder env = do
+    current <- readTaskPlan env
+    when (maybe False (const True) current) $
+        writeIORef env.taskPlanReminderPendingRef True
 
 isTaskPlanContextText :: Text -> Bool
 isTaskPlanContextText =

--- a/packages/agent-core/test/Agent/Tools/TaskPlanSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/TaskPlanSpec.hs
@@ -60,6 +60,25 @@ spec = describe "task plans" do
         Text.count "<task-plan-state" reminder `shouldBe` 1
         reminder `shouldSatisfy` Text.isInfixOf "‹evil›"
         takeTaskPlanReminder env `shouldReturn` Nothing
+        restoreTaskPlanReminder env
+        takeTaskPlanReminder env `shouldReturn` Just reminder
+
+    it "resets the in-memory projection when the host changes sessions" do
+        let oldPlan = TaskPlan Nothing
+                [TaskPlanItem "old session" TaskPlanInProgress]
+            newPlan = TaskPlan (Just "resumed")
+                [TaskPlanItem "new session" TaskPlanPending]
+            current = CurrentTaskPlan 4 newPlan
+        env <- newTaskPlanEnv
+            (Just (CurrentTaskPlan 9 oldPlan))
+            Nothing
+        resetTaskPlanState env Nothing
+        readTaskPlan env `shouldReturn` Nothing
+        takeTaskPlanReminder env `shouldReturn` Nothing
+        resetTaskPlanState env (Just current)
+        readTaskPlan env `shouldReturn` Just current
+        takeTaskPlanReminder env
+            `shouldReturn` Just (taskPlanContextText current)
 
     it "bounds rendered context" do
         let plan = TaskPlan Nothing

--- a/packages/agent-core/test/Agent/Tools/TaskPlanSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/TaskPlanSpec.hs
@@ -1,0 +1,72 @@
+module Agent.Tools.TaskPlanSpec (spec) where
+
+import Agent.Tools.TaskPlan
+import Data.IORef
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "task plans" do
+    it "validates statuses and the single in-progress invariant" do
+        validateTaskPlanUpdate (update [item "one" "unknown"])
+            `shouldBe` Left "Each plan status must be pending, in_progress, or completed."
+        validateTaskPlanUpdate
+            (update [item "one" "in_progress", item "two" "in_progress"])
+            `shouldBe` Left "At most one step can be in_progress at a time."
+
+    it "writes through before changing memory" do
+        writes <- newIORef ([] :: [TaskPlan])
+        env <- newTaskPlanEnv Nothing $ Just TaskPlanHooks
+            { taskPlanPersistReplace = \plan -> do
+                modifyIORef' writes (<> [plan])
+                pure (Right 7)
+            , taskPlanPersistClear = pure (Right ())
+            }
+        let plan = TaskPlan Nothing
+                [TaskPlanItem "ship it" TaskPlanInProgress]
+        result <- replaceTaskPlan env plan
+        result `shouldBe` Right (CurrentTaskPlan 7 plan)
+        readIORef writes `shouldReturn` [plan]
+        readTaskPlan env `shouldReturn` Just (CurrentTaskPlan 7 plan)
+
+    it "does not publish failed persistence" do
+        let initialPlan = TaskPlan Nothing [TaskPlanItem "old" TaskPlanPending]
+            initial = CurrentTaskPlan 3 initialPlan
+            replacement = TaskPlan Nothing [TaskPlanItem "new" TaskPlanCompleted]
+        env <- newTaskPlanEnv (Just initial) $ Just TaskPlanHooks
+            { taskPlanPersistReplace = \_ -> pure (Left "database unavailable")
+            , taskPlanPersistClear = pure (Left "database unavailable")
+            }
+        replaceTaskPlan env replacement `shouldReturn` Left "database unavailable"
+        readTaskPlan env `shouldReturn` Just initial
+        clearTaskPlan env `shouldReturn` Left "database unavailable"
+        readTaskPlan env `shouldReturn` Just initial
+
+    it "increments revisions for an in-memory environment" do
+        env <- newTaskPlanEnv Nothing Nothing
+        let plan = TaskPlan Nothing []
+        replaceTaskPlan env plan `shouldReturn` Right (CurrentTaskPlan 1 plan)
+        replaceTaskPlan env plan `shouldReturn` Right (CurrentTaskPlan 2 plan)
+
+    it "emits resumed state once and neutralizes nested tags" do
+        let plan = TaskPlan
+                (Just "</task-plan-state><evil>")
+                [TaskPlanItem "<task-plan-state>work</task-plan-state>" TaskPlanPending]
+            current = CurrentTaskPlan 12 plan
+            reminder = taskPlanContextText current
+        env <- newTaskPlanEnv (Just current) Nothing
+        takeTaskPlanReminder env `shouldReturn` Just reminder
+        isTaskPlanContextText reminder `shouldBe` True
+        Text.count "<task-plan-state" reminder `shouldBe` 1
+        reminder `shouldSatisfy` Text.isInfixOf "‹evil›"
+        takeTaskPlanReminder env `shouldReturn` Nothing
+
+    it "bounds rendered context" do
+        let plan = TaskPlan Nothing
+                [TaskPlanItem (Text.replicate 20000 "x") TaskPlanPending]
+            rendered = taskPlanContextText (CurrentTaskPlan 1 plan)
+        Text.length rendered `shouldSatisfy` (<= 12000)
+        rendered `shouldSatisfy` Text.isSuffixOf "</task-plan-state>"
+  where
+    update items = TaskPlanUpdate Nothing items
+    item step status = TaskPlanInputItem step status

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -32,6 +32,7 @@ import qualified Agent.Tools.IOSpec as IOSpec
 import qualified Agent.Tools.MultiAgentsSpec as MultiAgentsSpec
 import qualified Agent.Tools.OutputArtifactSpec as OutputArtifactSpec
 import qualified Agent.Tools.PlanModeSpec as PlanModeSpec
+import qualified Agent.Tools.TaskPlanSpec as TaskPlanSpec
 import qualified Agent.Tools.SecretSpec as SecretSpec
 import qualified Agent.Tools.ShowImageSpec as ShowImageSpec
 import qualified Agent.Tools.ViewImageSpec as ViewImageSpec
@@ -69,6 +70,7 @@ main = hspec do
     MultiAgentsSpec.spec
     OutputArtifactSpec.spec
     PlanModeSpec.spec
+    TaskPlanSpec.spec
     SecretSpec.spec
     ShowImageSpec.spec
     ViewImageSpec.spec

--- a/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Compaction.hs
@@ -56,6 +56,7 @@ import Agent.OpenAI.Compaction.Commands
     , rewindSessionUserText
     )
 import Agent.Responses.Types
+import Agent.Tools.TaskPlan (isTaskPlanContextText)
 import Agent.Json (RawJson, rawJsonFromEncoding)
 import qualified Data.Aeson as Aeson
 import Data.Maybe (listToMaybe, mapMaybe)
@@ -732,6 +733,7 @@ isImageResizeNotice = \case
 isGeneratedContextUserText :: Text -> Bool
 isGeneratedContextUserText text =
     isReloadedGeneratedContextUserText text
+        || isTaskPlanContextText text
         || any (`Text.isPrefixOf` Text.stripStart text)
             [ "# Skill instructions: "
             , "Plan mode is active. Do not make any edits or writes to the system except for the plan file."

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -10,6 +10,13 @@ import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import Agent.Provider
 import Agent.Responses.Types
+import Agent.Tools.TaskPlan
+    ( CurrentTaskPlan(..)
+    , TaskPlan(..)
+    , TaskPlanItem(..)
+    , TaskPlanStatus(..)
+    , taskPlanContextText
+    )
 import qualified Agent.Responses.Codec as ResponsesCodec
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
@@ -555,6 +562,7 @@ spec = do
                     , user "<learned-skills>\nThese are durable, reusable instructions learned from earlier sessions.\n"
                     , user "<system-reminder>\nAs you answer the user's questions, you can use the following context\n"
                     , user "<subagent_notification>\nstatus: completed\n</subagent_notification>"
+                    , user generatedTaskPlanContext
                     , user "real user request"
                     ]
             buildRemoteCompactedHistory 64_000 history opaque
@@ -1090,6 +1098,7 @@ spec = do
                     , user "## Skills\nThe following reusable skills are available in this session.\nrules"
                     , user "<learned-skills>\nThese are durable, reusable instructions learned from earlier sessions.\nrules"
                     , user "<system-reminder>\nAs you answer the user's questions, you can use the following context\nrules"
+                    , user generatedTaskPlanContext
                     , user "old request"
                     , user "new request"
                     ]
@@ -1227,6 +1236,11 @@ spec = do
                     "Codex compaction requires an OpenAI credential" Nothing)
 
   where
+    generatedTaskPlanContext =
+        taskPlanContextText $
+            CurrentTaskPlan 3 $
+                TaskPlan Nothing
+                    [TaskPlanItem "keep working" TaskPlanInProgress]
     naiveEncodedTokens :: Aeson.ToJSON a => a -> Int
     naiveEncodedTokens value =
         Text.length

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -55,6 +55,7 @@ library
                     , Agent.Store.Postgres.Skill.Types
                     , Agent.Store.Postgres.Session.Read
                     , Agent.Store.Postgres.Session.Schema
+                    , Agent.Store.Postgres.Session.TaskPlan
                     , Agent.Store.Postgres.Session.Types
                     , Agent.Store.Postgres.Session.Write
                     , Agent.Store.Postgres.Hasql

--- a/packages/agent-store/package.nix
+++ b/packages/agent-store/package.nix
@@ -21,5 +21,5 @@ mkDerivation {
     text time vector
   ];
   description = "PostgreSQL persistence for the agent harness";
-  license = lib.licenses.mit;
+  license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -34,6 +34,7 @@ import Agent.Store.Postgres.Session
     ( sessionSchemaStatements
     , sessionSearchIndexStatements
     , sessionPromptEpochSchemaStatements
+    , sessionTaskPlanSchemaStatements
     )
 import Agent.Store.Postgres.Skill
     ( learnedSkillRuntimeGrantStatements
@@ -59,6 +60,17 @@ coreMigrations =
         , migrationStatements =
             customSchemaStatements
             <> sessionSchemaStatements
+        }
+    , Migration
+        { migrationVersion = 109
+        , migrationName = "durable session task plans"
+        , migrationStatements =
+            sessionTaskPlanSchemaStatements
+            <> [ "GRANT SELECT, INSERT, UPDATE, DELETE\
+                 \ ON harness.session_task_plans TO ha_runtime"
+               , "GRANT SELECT, INSERT, DELETE\
+                 \ ON harness.session_task_plan_items TO ha_runtime"
+               ]
         }
     , Migration
         { migrationVersion = 2
@@ -574,6 +586,10 @@ sessionRuntimeGrantStatements =
       \ ON harness.session_response_content_parts TO ha_runtime"
     , "GRANT SELECT, INSERT\
       \ ON harness.session_prompt_epochs TO ha_runtime"
+    , "GRANT SELECT, INSERT, UPDATE, DELETE\
+      \ ON harness.session_task_plans TO ha_runtime"
+    , "GRANT SELECT, INSERT, DELETE\
+      \ ON harness.session_task_plan_items TO ha_runtime"
     ]
 
 runCoreMigrations :: StorePool -> IO (Either StoreError ())

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -62,17 +62,6 @@ coreMigrations =
             <> sessionSchemaStatements
         }
     , Migration
-        { migrationVersion = 109
-        , migrationName = "durable session task plans"
-        , migrationStatements =
-            sessionTaskPlanSchemaStatements
-            <> [ "GRANT SELECT, INSERT, UPDATE, DELETE\
-                 \ ON harness.session_task_plans TO ha_runtime"
-               , "GRANT SELECT, INSERT, DELETE\
-                 \ ON harness.session_task_plan_items TO ha_runtime"
-               ]
-        }
-    , Migration
         { migrationVersion = 2
         , migrationName = "restricted harness runtime role"
         , migrationStatements =
@@ -270,6 +259,17 @@ coreMigrations =
             [ "ALTER TABLE IF EXISTS harness.sessions\
               \ ADD COLUMN IF NOT EXISTS gateway_identity text"
             ]
+        }
+    , Migration
+        { migrationVersion = 109
+        , migrationName = "durable session task plans"
+        , migrationStatements =
+            sessionTaskPlanSchemaStatements
+            <> [ "GRANT SELECT, INSERT, UPDATE, DELETE\
+                 \ ON harness.session_task_plans TO ha_runtime"
+               , "GRANT SELECT, INSERT, DELETE\
+                 \ ON harness.session_task_plan_items TO ha_runtime"
+               ]
         }
     ]
 

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -17,6 +17,7 @@ module Agent.Store.Postgres.Session
     , sessionSchemaStatements
     , sessionSearchIndexStatements
     , sessionPromptEpochSchemaStatements
+    , sessionTaskPlanSchemaStatements
     , createSession
     , createSessionWithInitialPromptEpoch
     , createSessionFromSnapshot
@@ -28,6 +29,7 @@ module Agent.Store.Postgres.Session
     , appendSessionTurnIndexed
     , appendSessionTurnIndexedWithPromptReset
     , appendSessionTurns
+    , appendSessionTurnsClearingTaskPlan
     , loadSession
     , loadSessionWithImplementation
     , loadSessions
@@ -39,6 +41,9 @@ module Agent.Store.Postgres.Session
     , SessionTurnPage(..)
     , SessionHistorySnapshot(..)
     , SessionResumeStats(..)
+    , SessionTaskPlanStatus(..)
+    , SessionTaskPlanItem(..)
+    , SessionTaskPlan(..)
     , loadRecentSessionTurns
     , loadRecentSessionHistoryTurns
     , loadSessionTurnsBefore
@@ -59,9 +64,14 @@ module Agent.Store.Postgres.Session
     , deleteSession
     , importLegacySession
     , withSessionAdvisoryLock
+    , loadSessionTaskPlan
+    , replaceSessionTaskPlan
+    , clearSessionTaskPlan
+    , copySessionTaskPlan
     ) where
 
 import Agent.Store.Postgres.Session.Read
 import Agent.Store.Postgres.Session.Schema
+import Agent.Store.Postgres.Session.TaskPlan
 import Agent.Store.Postgres.Session.Types
 import Agent.Store.Postgres.Session.Write

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -28,6 +28,7 @@ module Agent.Store.Postgres.Session
     , appendSessionTurn
     , appendSessionTurnIndexed
     , appendSessionTurnIndexedWithPromptReset
+    , appendSessionTurnIndexedWithPromptResetAndTaskPlanClear
     , appendSessionTurns
     , appendSessionTurnsClearingTaskPlan
     , loadSession

--- a/packages/agent-store/src/Agent/Store/Postgres/Session.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session.hs
@@ -45,6 +45,7 @@ module Agent.Store.Postgres.Session
     , SessionTaskPlanStatus(..)
     , SessionTaskPlanItem(..)
     , SessionTaskPlan(..)
+    , SessionTaskPlanSnapshot(..)
     , loadRecentSessionTurns
     , loadRecentSessionHistoryTurns
     , loadSessionTurnsBefore

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Schema.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Schema.hs
@@ -181,6 +181,9 @@ sessionTaskPlanSchemaStatements =
       \   CHECK (status IN ('pending', 'in_progress', 'completed')),\
       \ PRIMARY KEY (session_id, item_index)\
       \ )"
+    , "CREATE UNIQUE INDEX IF NOT EXISTS session_task_plan_one_active_idx\
+      \ ON harness.session_task_plan_items (session_id)\
+      \ WHERE status = 'in_progress'"
     ]
 
 sessionPromptEpochSchemaStatements :: [ByteString]

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Schema.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Schema.hs
@@ -4,6 +4,7 @@ module Agent.Store.Postgres.Session.Schema
     ( sessionSchemaStatements
     , sessionSearchIndexStatements
     , sessionPromptEpochSchemaStatements
+    , sessionTaskPlanSchemaStatements
     ) where
 
 import Data.ByteString (ByteString)
@@ -160,6 +161,27 @@ sessionSchemaStatements =
        \ FOR EACH ROW EXECUTE FUNCTION harness.reject_session_fact_mutation()"
        ]
     <> sessionPromptEpochSchemaStatements
+    <> sessionTaskPlanSchemaStatements
+
+sessionTaskPlanSchemaStatements :: [ByteString]
+sessionTaskPlanSchemaStatements =
+    [ "CREATE TABLE IF NOT EXISTS harness.session_task_plans (\
+      \ session_id uuid PRIMARY KEY\
+      \   REFERENCES harness.sessions(session_id) ON DELETE CASCADE,\
+      \ revision bigint NOT NULL CHECK (revision > 0),\
+      \ updated_at timestamptz NOT NULL,\
+      \ explanation text\
+      \ )"
+    , "CREATE TABLE IF NOT EXISTS harness.session_task_plan_items (\
+      \ session_id uuid NOT NULL\
+      \   REFERENCES harness.session_task_plans(session_id) ON DELETE CASCADE,\
+      \ item_index bigint NOT NULL CHECK (item_index >= 0),\
+      \ step_text text NOT NULL,\
+      \ status text NOT NULL\
+      \   CHECK (status IN ('pending', 'in_progress', 'completed')),\
+      \ PRIMARY KEY (session_id, item_index)\
+      \ )"
+    ]
 
 sessionPromptEpochSchemaStatements :: [ByteString]
 sessionPromptEpochSchemaStatements =

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/TaskPlan.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/TaskPlan.hs
@@ -1,0 +1,205 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoFieldSelectors #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Mutable, revisioned task-plan state associated with a session.
+module Agent.Store.Postgres.Session.TaskPlan
+    ( loadSessionTaskPlan
+    , replaceSessionTaskPlan
+    , clearSessionTaskPlan
+    , copySessionTaskPlan
+    ) where
+
+import Data.Functor.Contravariant ((>$<))
+import Data.Int (Int64)
+import Data.Text (Text)
+import qualified Data.Vector as Vector
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Transaction as Transaction
+import qualified Hasql.Transaction.Sessions as Transactions
+import Hasql.Statement (Statement)
+
+import Agent.Store.Postgres.Connection (StorePool, withSession)
+import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Postgres.Session.Types
+import Agent.Store.Types (StoreError(..))
+
+loadSessionTaskPlan
+    :: StorePool
+    -> Text
+    -> IO (Either StoreError (Maybe SessionTaskPlan))
+loadSessionTaskPlan pool sessionKey = do
+    result <- withSession pool $
+        Transactions.transaction
+            Transactions.RepeatableRead
+            Transactions.Read do
+                Transaction.statement sessionKey loadPlanHeaderStatement >>= \case
+                    Nothing -> pure Nothing
+                    Just (sessionId, revision, explanation) -> do
+                        items <- Transaction.statement sessionId loadPlanItemsStatement
+                        pure (Just (revision, explanation, Vector.toList items))
+    pure (result >>= traverse decodePlan)
+
+replaceSessionTaskPlan
+    :: StorePool
+    -> Text
+    -> Maybe Text
+    -> [SessionTaskPlanItem]
+    -> IO (Either StoreError (Maybe Int64))
+replaceSessionTaskPlan pool sessionKey explanation items =
+    withSession pool $
+        Transactions.transaction Transactions.Serializable Transactions.Write do
+            Transaction.statement
+                (sessionKey, explanation)
+                replacePlanHeaderStatement >>= \case
+                    Nothing -> pure Nothing
+                    Just (sessionId, revision) -> do
+                        _ <- Transaction.statement sessionId deletePlanItemsStatement
+                        insertItems sessionId items
+                        pure (Just revision)
+
+clearSessionTaskPlan
+    :: StorePool
+    -> Text
+    -> IO (Either StoreError Bool)
+clearSessionTaskPlan pool sessionKey =
+    withSession pool $
+        Transactions.transaction Transactions.Serializable Transactions.Write $
+            Transaction.statement sessionKey clearPlanStatement
+
+-- | Copy the source's current plan into the target. Returns 'False' when the
+-- source has no plan or the target session does not exist.
+copySessionTaskPlan
+    :: StorePool
+    -> Text
+    -> Text
+    -> IO (Either StoreError Bool)
+copySessionTaskPlan pool sourceKey targetKey =
+    withSession pool $
+        Transactions.transaction Transactions.Serializable Transactions.Write do
+            Transaction.statement sourceKey loadPlanHeaderStatement >>= \case
+                Nothing -> pure False
+                Just (sourceId, _, explanation) -> do
+                    sourceItems <- Vector.toList
+                        <$> Transaction.statement sourceId loadPlanItemsStatement
+                    Transaction.statement
+                        (targetKey, explanation)
+                        replacePlanHeaderStatement >>= \case
+                            Nothing -> pure False
+                            Just (targetId, _) -> do
+                                _ <- Transaction.statement
+                                    targetId deletePlanItemsStatement
+                                case traverse decodeItem sourceItems of
+                                    Left _ -> Transaction.condemn >> pure False
+                                    Right items -> insertItems targetId items >> pure True
+
+insertItems :: Text -> [SessionTaskPlanItem] -> Transaction.Transaction ()
+insertItems sessionId items =
+    mapM_ (\(itemIndex, item) ->
+        Transaction.statement
+            (sessionId, itemIndex, item.sessionTaskPlanItemStep, encodeStatus item.sessionTaskPlanItemStatus)
+            insertPlanItemStatement)
+        (zip [0 :: Int64 ..] items)
+
+decodePlan
+    :: (Int64, Maybe Text, [(Text, Text)])
+    -> Either StoreError SessionTaskPlan
+decodePlan (revision, explanation, rawItems) =
+    SessionTaskPlan revision explanation <$> traverse decodeItem rawItems
+
+decodeItem :: (Text, Text) -> Either StoreError SessionTaskPlanItem
+decodeItem (step, status) =
+    SessionTaskPlanItem step <$> case status of
+        "pending" -> Right SessionTaskPlanPending
+        "in_progress" -> Right SessionTaskPlanInProgress
+        "completed" -> Right SessionTaskPlanCompleted
+        invalid -> Left (StoreDataError ("invalid task-plan status: " <> invalid))
+
+encodeStatus :: SessionTaskPlanStatus -> Text
+encodeStatus = \case
+    SessionTaskPlanPending -> "pending"
+    SessionTaskPlanInProgress -> "in_progress"
+    SessionTaskPlanCompleted -> "completed"
+
+loadPlanHeaderStatement :: Statement Text (Maybe (Text, Int64, Maybe Text))
+loadPlanHeaderStatement = mkStatement
+    "SELECT p.session_id::text, p.revision, p.explanation\
+    \ FROM harness.session_task_plans p\
+    \ JOIN harness.sessions s ON s.session_id = p.session_id\
+    \ WHERE s.session_key = $1 AND s.deleted_at IS NULL"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowMaybe $
+        (,,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.int8)
+            <*> Decoders.column (Decoders.nullable Decoders.text))
+    True
+
+loadPlanItemsStatement :: Statement Text (Vector.Vector (Text, Text))
+loadPlanItemsStatement = mkStatement
+    "SELECT step_text, status\
+    \ FROM harness.session_task_plan_items\
+    \ WHERE session_id = $1::uuid\
+    \ ORDER BY item_index"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.rowVector $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.text))
+    True
+
+replacePlanHeaderStatement
+    :: Statement (Text, Maybe Text) (Maybe (Text, Int64))
+replacePlanHeaderStatement = mkStatement
+    "INSERT INTO harness.session_task_plans\
+    \ (session_id, revision, updated_at, explanation)\
+    \ SELECT session_id, 1, now(), $2\
+    \ FROM harness.sessions\
+    \ WHERE session_key = $1 AND deleted_at IS NULL\
+    \ ON CONFLICT (session_id) DO UPDATE SET\
+    \ revision = harness.session_task_plans.revision + 1,\
+    \ updated_at = EXCLUDED.updated_at,\
+    \ explanation = EXCLUDED.explanation\
+    \ RETURNING session_id::text, revision"
+    ((fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> (snd >$< Encoders.param (Encoders.nullable Encoders.text)))
+    (Decoders.rowMaybe $
+        (,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.text)
+            <*> Decoders.column (Decoders.nonNullable Decoders.int8))
+    True
+
+deletePlanItemsStatement :: Statement Text ()
+deletePlanItemsStatement = mkStatement
+    "DELETE FROM harness.session_task_plan_items WHERE session_id = $1::uuid"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    Decoders.noResult
+    True
+
+insertPlanItemStatement :: Statement (Text, Int64, Text, Text) ()
+insertPlanItemStatement = mkStatement
+    "INSERT INTO harness.session_task_plan_items\
+    \ (session_id, item_index, step_text, status)\
+    \ VALUES ($1::uuid, $2, $3, $4)"
+    ( ((\(a, _, _, _) -> a)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((\(_, b, _, _) -> b) >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+        <> ((\(_, _, c, _) -> c) >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        <> ((\(_, _, _, d) -> d) >$< Encoders.param (Encoders.nonNullable Encoders.text)))
+    Decoders.noResult
+    True
+
+clearPlanStatement :: Statement Text Bool
+clearPlanStatement = mkStatement
+    "WITH deleted AS (\
+    \ DELETE FROM harness.session_task_plans p\
+    \ USING harness.sessions s\
+    \ WHERE p.session_id = s.session_id AND s.session_key = $1\
+    \ RETURNING 1)\
+    \ SELECT EXISTS (SELECT 1 FROM deleted)"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+    True

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/TaskPlan.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/TaskPlan.hs
@@ -8,6 +8,7 @@
 module Agent.Store.Postgres.Session.TaskPlan
     ( loadSessionTaskPlan
     , replaceSessionTaskPlan
+    , replaceSessionTaskPlanTransaction
     , clearSessionTaskPlan
     , copySessionTaskPlan
     ) where
@@ -51,15 +52,23 @@ replaceSessionTaskPlan
     -> IO (Either StoreError (Maybe Int64))
 replaceSessionTaskPlan pool sessionKey explanation items =
     withSession pool $
-        Transactions.transaction Transactions.Serializable Transactions.Write do
-            Transaction.statement
-                (sessionKey, explanation)
-                replacePlanHeaderStatement >>= \case
-                    Nothing -> pure Nothing
-                    Just (sessionId, revision) -> do
-                        _ <- Transaction.statement sessionId deletePlanItemsStatement
-                        insertItems sessionId items
-                        pure (Just revision)
+        Transactions.transaction Transactions.Serializable Transactions.Write $
+            replaceSessionTaskPlanTransaction sessionKey explanation items
+
+replaceSessionTaskPlanTransaction
+    :: Text
+    -> Maybe Text
+    -> [SessionTaskPlanItem]
+    -> Transaction.Transaction (Maybe Int64)
+replaceSessionTaskPlanTransaction sessionKey explanation items =
+    Transaction.statement
+        (sessionKey, explanation)
+        replacePlanHeaderStatement >>= \case
+            Nothing -> pure Nothing
+            Just (sessionId, revision) -> do
+                _ <- Transaction.statement sessionId deletePlanItemsStatement
+                insertItems sessionId items
+                pure (Just revision)
 
 clearSessionTaskPlan
     :: StorePool

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
@@ -17,6 +17,9 @@ module Agent.Store.Postgres.Session.Types
     , SessionTurnPage(..)
     , SessionHistorySnapshot(..)
     , SessionResumeStats(..)
+    , SessionTaskPlanStatus(..)
+    , SessionTaskPlanItem(..)
+    , SessionTaskPlan(..)
     ) where
 
 import Data.Int (Int32, Int64)
@@ -25,6 +28,26 @@ import Data.Time.Clock (UTCTime)
 import Data.Vector (Vector)
 
 import Agent.Store.SessionItem (StoredResponseItem)
+
+data SessionTaskPlanStatus
+    = SessionTaskPlanPending
+    | SessionTaskPlanInProgress
+    | SessionTaskPlanCompleted
+    deriving (Eq, Show)
+
+data SessionTaskPlanItem = SessionTaskPlanItem
+    { sessionTaskPlanItemStep :: !Text
+    , sessionTaskPlanItemStatus :: !SessionTaskPlanStatus
+    }
+    deriving (Eq, Show)
+
+-- | The current durable task plan for a session.
+data SessionTaskPlan = SessionTaskPlan
+    { sessionTaskPlanRevision :: !Int64
+    , sessionTaskPlanExplanation :: !(Maybe Text)
+    , sessionTaskPlanItems :: ![SessionTaskPlanItem]
+    }
+    deriving (Eq, Show)
 
 data SessionLegacyTarget = SessionLegacyTarget
     { sessionLegacyProvider :: !Text

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Types.hs
@@ -20,6 +20,7 @@ module Agent.Store.Postgres.Session.Types
     , SessionTaskPlanStatus(..)
     , SessionTaskPlanItem(..)
     , SessionTaskPlan(..)
+    , SessionTaskPlanSnapshot(..)
     ) where
 
 import Data.Int (Int32, Int64)
@@ -46,6 +47,13 @@ data SessionTaskPlan = SessionTaskPlan
     { sessionTaskPlanRevision :: !Int64
     , sessionTaskPlanExplanation :: !(Maybe Text)
     , sessionTaskPlanItems :: ![SessionTaskPlanItem]
+    }
+    deriving (Eq, Show)
+
+-- | An unversioned task plan imported together with a session snapshot.
+data SessionTaskPlanSnapshot = SessionTaskPlanSnapshot
+    { sessionTaskPlanSnapshotExplanation :: !(Maybe Text)
+    , sessionTaskPlanSnapshotItems :: ![SessionTaskPlanItem]
     }
     deriving (Eq, Show)
 
@@ -228,5 +236,6 @@ data LegacySession = LegacySession
     , legacyMetadata :: !SessionMetadata
     , legacyTurns :: ![SessionTurn]
     , legacyPromptSnapshot :: !(Maybe SessionPromptSnapshot)
+    , legacyTaskPlan :: !(Maybe SessionTaskPlanSnapshot)
     }
     deriving (Eq, Show)

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
@@ -16,6 +16,7 @@ module Agent.Store.Postgres.Session.Write
     , appendSessionTurnIndexed
     , appendSessionTurnIndexedWithPromptReset
     , appendSessionTurns
+    , appendSessionTurnsClearingTaskPlan
     , setSessionArchived
     , deleteSession
     , importLegacySession
@@ -324,17 +325,42 @@ appendSessionTurns
     -> SessionMetadata
     -> IO (Either StoreError Bool)
 appendSessionTurns pool turns metadata =
+    appendSessionTurnsWithTaskPlanClear False pool turns metadata
+
+-- | Append a transcript transition and clear its current task plan in the
+-- same serializable transaction.
+appendSessionTurnsClearingTaskPlan
+    :: StorePool
+    -> [SessionTurn]
+    -> SessionMetadata
+    -> IO (Either StoreError Bool)
+appendSessionTurnsClearingTaskPlan =
+    appendSessionTurnsWithTaskPlanClear True
+
+appendSessionTurnsWithTaskPlanClear
+    :: Bool
+    -> StorePool
+    -> [SessionTurn]
+    -> SessionMetadata
+    -> IO (Either StoreError Bool)
+appendSessionTurnsWithTaskPlanClear clearTaskPlan pool turns metadata =
     withSession pool $
         Transactions.transaction Transactions.Serializable Transactions.Write do
             _ <- Transaction.statement
                 metadata.sessionMetadataKey
                 blockingAdvisoryLockStatement
-            case turns of
+            appended <- case turns of
                 [] ->
                     Transaction.statement
                         metadata.sessionMetadataKey
                         sessionExistsStatement
                 _ -> appendAll turns
+            when (appended && clearTaskPlan) do
+                _ <- Transaction.statement
+                    metadata.sessionMetadataKey
+                    clearTaskPlanStatement
+                pure ()
+            pure appended
   where
     appendAll [] = pure True
     appendAll (turn : rest) = do
@@ -342,6 +368,15 @@ appendSessionTurns pool turns metadata =
         if appended
             then appendAll rest
             else Transaction.condemn >> pure False
+
+clearTaskPlanStatement :: Statement Text ()
+clearTaskPlanStatement = mkStatement
+    "DELETE FROM harness.session_task_plans p\
+    \ USING harness.sessions s\
+    \ WHERE p.session_id = s.session_id AND s.session_key = $1"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    Decoders.noResult
+    True
 
 setSessionArchived
     :: StorePool

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
@@ -15,6 +15,7 @@ module Agent.Store.Postgres.Session.Write
     , appendSessionTurn
     , appendSessionTurnIndexed
     , appendSessionTurnIndexedWithPromptReset
+    , appendSessionTurnIndexedWithPromptResetAndTaskPlanClear
     , appendSessionTurns
     , appendSessionTurnsClearingTaskPlan
     , setSessionArchived
@@ -256,7 +257,7 @@ appendSessionTurnIndexed
     -> SessionMetadata
     -> IO (Either StoreError (Maybe Int64))
 appendSessionTurnIndexed =
-    appendSessionTurnIndexedInternal False
+    appendSessionTurnIndexedInternal False False
 
 -- | Append a turn and retire the current provider-visible prompt prefix in
 -- the same transaction. The next request must establish a new prompt epoch.
@@ -266,15 +267,26 @@ appendSessionTurnIndexedWithPromptReset
     -> SessionMetadata
     -> IO (Either StoreError (Maybe Int64))
 appendSessionTurnIndexedWithPromptReset =
-    appendSessionTurnIndexedInternal True
+    appendSessionTurnIndexedInternal True False
+
+-- | Append a transcript reset while atomically retiring both the current
+-- provider-visible prompt prefix and current task plan.
+appendSessionTurnIndexedWithPromptResetAndTaskPlanClear
+    :: StorePool
+    -> SessionTurn
+    -> SessionMetadata
+    -> IO (Either StoreError (Maybe Int64))
+appendSessionTurnIndexedWithPromptResetAndTaskPlanClear =
+    appendSessionTurnIndexedInternal True True
 
 appendSessionTurnIndexedInternal
     :: Bool
+    -> Bool
     -> StorePool
     -> SessionTurn
     -> SessionMetadata
     -> IO (Either StoreError (Maybe Int64))
-appendSessionTurnIndexedInternal resetPrompt pool turn metadata =
+appendSessionTurnIndexedInternal resetPrompt clearTaskPlan pool turn metadata =
     withSession pool $
         Transactions.transaction Transactions.Serializable Transactions.Write do
             _ <- Transaction.statement
@@ -311,6 +323,11 @@ appendSessionTurnIndexedInternal resetPrompt pool turn metadata =
                             , turn.sessionTurnOccurredAt
                             )
                             invalidatePromptEpochStatement
+                        pure ()
+                    when clearTaskPlan do
+                        _ <- Transaction.statement
+                            metadata.sessionMetadataKey
+                            clearTaskPlanStatement
                         pure ()
                     pure (Just turnIndex)
 

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Write.hs
@@ -40,6 +40,9 @@ import Agent.Store.Postgres.Connection
     , withSession
     )
 import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Postgres.Session.TaskPlan
+    ( replaceSessionTaskPlanTransaction
+    )
 import Agent.Store.Postgres.Session.Types
 import Agent.Store.Postgres.SessionItem (insertResponseItems)
 import Agent.Store.Types (StoreError)
@@ -467,6 +470,14 @@ importLegacySession pool legacy =
                         "legacy.import_completed"
                         metadata
                         legacy.legacyTurns
+                    forM_ legacy.legacyTaskPlan \plan -> do
+                        revision <- replaceSessionTaskPlanTransaction
+                            sessionKey
+                            plan.sessionTaskPlanSnapshotExplanation
+                            plan.sessionTaskPlanSnapshotItems
+                        case revision of
+                            Just 1 -> pure ()
+                            _ -> Transaction.condemn
                     forM_ legacy.legacyPromptSnapshot \snapshot -> do
                         epoch <- Transaction.statement
                             (sessionKey, snapshot)

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -199,6 +199,7 @@ spec = describe "PostgreSQL session schema" do
                                     , legacyTurns = []
                                     , legacyPromptSnapshot =
                                         Just importedPrompt
+                                    , legacyTaskPlan = Nothing
                                     }
                             importLegacySession pool legacy
                                 `shouldReturn` Right True
@@ -210,6 +211,65 @@ spec = describe "PostgreSQL session schema" do
                                             { sessionPromptEpochIndex = 0
                                             , sessionPromptEpochSnapshot =
                                                 importedPrompt
+                                            })
+                            let atomicImportKey = "session-atomic-import"
+                                atomicMetadata = promptMetadata
+                                    { sessionMetadataKey = atomicImportKey
+                                    }
+                                invalidPlanItems =
+                                    [ SessionTaskPlanItem
+                                        "first active step"
+                                        SessionTaskPlanInProgress
+                                    , SessionTaskPlanItem
+                                        "second active step"
+                                        SessionTaskPlanInProgress
+                                    ]
+                                invalidLegacy = LegacySession
+                                    { legacySourcePath =
+                                        "afk:session-atomic-import"
+                                    , legacyContentHash = "invalid-plan"
+                                    , legacyMetadata = atomicMetadata
+                                    , legacyTurns = []
+                                    , legacyPromptSnapshot = Nothing
+                                    , legacyTaskPlan =
+                                        Just SessionTaskPlanSnapshot
+                                            { sessionTaskPlanSnapshotExplanation =
+                                                Nothing
+                                            , sessionTaskPlanSnapshotItems =
+                                                invalidPlanItems
+                                            }
+                                    }
+                            importLegacySession pool invalidLegacy
+                                >>= (`shouldSatisfy`
+                                    either (const True) (const False))
+                            loadSession pool atomicImportKey
+                                `shouldReturn` Right Nothing
+                            let validPlanItems =
+                                    [ SessionTaskPlanItem
+                                        "retry safely"
+                                        SessionTaskPlanInProgress
+                                    ]
+                                validLegacy = invalidLegacy
+                                    { legacyContentHash = "valid-plan"
+                                    , legacyTaskPlan =
+                                        Just SessionTaskPlanSnapshot
+                                            { sessionTaskPlanSnapshotExplanation =
+                                                Just "atomic import"
+                                            , sessionTaskPlanSnapshotItems =
+                                                validPlanItems
+                                            }
+                                    }
+                            importLegacySession pool validLegacy
+                                `shouldReturn` Right True
+                            loadSessionTaskPlan pool atomicImportKey
+                                `shouldReturn`
+                                    Right
+                                        (Just SessionTaskPlan
+                                            { sessionTaskPlanRevision = 1
+                                            , sessionTaskPlanExplanation =
+                                                Just "atomic import"
+                                            , sessionTaskPlanItems =
+                                                validPlanItems
                                             })
                             createSession pool metadata
                                 `shouldReturn` Right True

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -80,6 +80,7 @@ spec = describe "PostgreSQL session schema" do
             "CREATE TABLE IF NOT EXISTS harness.session_task_plan_items"
         ddl `shouldContainBytes`
             "status IN ('pending', 'in_progress', 'completed')"
+        ddl `shouldContainBytes` "session_task_plan_one_active_idx"
 
     it "tracks restart-safe legacy imports" do
         let ddl = ByteString.intercalate "\n" sessionSchemaStatements
@@ -252,6 +253,31 @@ spec = describe "PostgreSQL session schema" do
                                             , sessionTaskPlanItems =
                                                 replacementItems
                                             })
+                            replaceSessionTaskPlan
+                                pool
+                                "session-1"
+                                Nothing
+                                [ SessionTaskPlanItem
+                                    "one"
+                                    SessionTaskPlanInProgress
+                                , SessionTaskPlanItem
+                                    "two"
+                                    SessionTaskPlanInProgress
+                                ] >>= \case
+                                    Left _ -> pure ()
+                                    Right value ->
+                                        expectationFailure
+                                            ("accepted invalid task plan: "
+                                                <> show value)
+                            loadSessionTaskPlan pool "session-1"
+                                `shouldReturn`
+                                    Right
+                                        (Just SessionTaskPlan
+                                            { sessionTaskPlanRevision = 2
+                                            , sessionTaskPlanExplanation = Nothing
+                                            , sessionTaskPlanItems =
+                                                replacementItems
+                                            })
                             appendSessionTurn pool turn metadata
                                 `shouldReturn` Right True
                             loadSession pool "session-1" >>= \case
@@ -290,6 +316,24 @@ spec = describe "PostgreSQL session schema" do
                                             , sessionTaskPlanItems =
                                                 replacementItems
                                             })
+                            let clearMetadata = metadata
+                                    { sessionMetadataKey = "session-clear"
+                                    , sessionMetadataTitle = "clear"
+                                    }
+                                clearTurn = turn
+                                    { sessionTurnEffect = TranscriptReset
+                                    , sessionTurnUserText = "/clear"
+                                    }
+                            createSession pool clearMetadata
+                                `shouldReturn` Right True
+                            copySessionTaskPlan
+                                pool "session-1" "session-clear"
+                                `shouldReturn` Right True
+                            appendSessionTurnIndexedWithPromptResetAndTaskPlanClear
+                                pool clearTurn clearMetadata
+                                `shouldReturn` Right (Just 0)
+                            loadSessionTaskPlan pool "session-clear"
+                                `shouldReturn` Right Nothing
                             clearSessionTaskPlan pool "session-1"
                                 `shouldReturn` Right True
                             loadSessionTaskPlan pool "session-1"

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -74,6 +74,12 @@ spec = describe "PostgreSQL session schema" do
             "CREATE TABLE IF NOT EXISTS harness.session_prompt_epochs"
         ddl `shouldContainBytes` "is_active boolean NOT NULL DEFAULT TRUE"
         ddl `shouldContainBytes` "session_prompt_epochs_immutable"
+        ddl `shouldContainBytes`
+            "CREATE TABLE IF NOT EXISTS harness.session_task_plans"
+        ddl `shouldContainBytes`
+            "CREATE TABLE IF NOT EXISTS harness.session_task_plan_items"
+        ddl `shouldContainBytes`
+            "status IN ('pending', 'in_progress', 'completed')"
 
     it "tracks restart-safe legacy imports" do
         let ddl = ByteString.intercalate "\n" sessionSchemaStatements
@@ -206,6 +212,46 @@ spec = describe "PostgreSQL session schema" do
                                             })
                             createSession pool metadata
                                 `shouldReturn` Right True
+                            let initialPlanItems =
+                                    [ SessionTaskPlanItem
+                                        "inspect storage"
+                                        SessionTaskPlanCompleted
+                                    , SessionTaskPlanItem
+                                        "persist plan"
+                                        SessionTaskPlanInProgress
+                                    ]
+                            loadSessionTaskPlan pool "session-1"
+                                `shouldReturn` Right Nothing
+                            replaceSessionTaskPlan
+                                pool "session-1" (Just "first") initialPlanItems
+                                `shouldReturn` Right (Just 1)
+                            loadSessionTaskPlan pool "session-1"
+                                `shouldReturn`
+                                    Right
+                                        (Just SessionTaskPlan
+                                            { sessionTaskPlanRevision = 1
+                                            , sessionTaskPlanExplanation =
+                                                Just "first"
+                                            , sessionTaskPlanItems =
+                                                initialPlanItems
+                                            })
+                            let replacementItems =
+                                    [ SessionTaskPlanItem
+                                        "finish"
+                                        SessionTaskPlanPending
+                                    ]
+                            replaceSessionTaskPlan
+                                pool "session-1" Nothing replacementItems
+                                `shouldReturn` Right (Just 2)
+                            loadSessionTaskPlan pool "session-1"
+                                `shouldReturn`
+                                    Right
+                                        (Just SessionTaskPlan
+                                            { sessionTaskPlanRevision = 2
+                                            , sessionTaskPlanExplanation = Nothing
+                                            , sessionTaskPlanItems =
+                                                replacementItems
+                                            })
                             appendSessionTurn pool turn metadata
                                 `shouldReturn` Right True
                             loadSession pool "session-1" >>= \case
@@ -233,8 +279,28 @@ spec = describe "PostgreSQL session schema" do
                                     }
                             createSession pool metadata2
                                 `shouldReturn` Right True
-                            appendSessionTurns pool [turn2, turn3] metadata2
+                            copySessionTaskPlan pool "session-1" "session-2"
                                 `shouldReturn` Right True
+                            loadSessionTaskPlan pool "session-2"
+                                `shouldReturn`
+                                    Right
+                                        (Just SessionTaskPlan
+                                            { sessionTaskPlanRevision = 1
+                                            , sessionTaskPlanExplanation = Nothing
+                                            , sessionTaskPlanItems =
+                                                replacementItems
+                                            })
+                            clearSessionTaskPlan pool "session-1"
+                                `shouldReturn` Right True
+                            loadSessionTaskPlan pool "session-1"
+                                `shouldReturn` Right Nothing
+                            clearSessionTaskPlan pool "session-1"
+                                `shouldReturn` Right False
+                            appendSessionTurnsClearingTaskPlan
+                                pool [turn2, turn3] metadata2
+                                `shouldReturn` Right True
+                            loadSessionTaskPlan pool "session-2"
+                                `shouldReturn` Right Nothing
                             loadSessionMetadataMany
                                 pool
                                 ["session-2", "missing", "session-1"]


### PR DESCRIPTION
## Summary
- add a typed, validated, revisioned task-plan environment and make Codex `update_plan` persist before reporting success
- store each session's current plan in normalized PostgreSQL tables, preserving it through full forks and transfers while clearing it atomically for rewind, `/clear`, and historical forks
- rehydrate the authoritative plan after compaction and resume without scanning pre-compaction history, replacing stale generated copies and hiding the generated context from transcript previews

## Motivation
Long-running OpenAI sessions could lose their current checklist when compaction removed the relevant `update_plan` interaction. The session database is now the source of truth; compaction only projects that structured state back into model context.

## Validation
- loaded the full 516-module multi-package GHCi workspace after rebasing onto `origin/master`
- passed focused task-plan, Codex dialect, OpenAI compaction, CLI compaction/viewport, PostgreSQL migration, persistence, fork, rewind, and transfer tests
- exercised the live CLI in tmux
- `git diff --check origin/master...HEAD`
