### PR TITLE
Highlight only the hovered transcript line

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -955,9 +955,9 @@ handleEventInner' event = case event of
         keepAgentHover target
     MouseUp AgentPane Nothing _ ->
         setHoveredControl Nothing
-    MouseUp name@(ConversationBlock _ _) Nothing _ -> do
+    MouseUp name@(ConversationBlock _ _) Nothing (Location (_, row)) -> do
         clearAgentHover
-        setHoveredControl (Just name)
+        setHoveredTranscriptLine name row
     MouseUp MarkdownLink{} Nothing _ -> do
         clearAgentHover
         setHoveredControl Nothing
@@ -974,18 +974,21 @@ handleEventInner' event = case event of
         modify' \state ->
             state
                 { appHoveredControl = Nothing
+                , appHoveredLine = Nothing
                 , appAgentHover = Nothing
                 }
     VtyEvent (V.EvMouseDown _ _ V.BLeft _) ->
         modify' \state ->
             state
                 { appHoveredControl = Nothing
+                , appHoveredLine = Nothing
                 , appAgentHover = Nothing
                 }
     VtyEvent (V.EvMouseUp _ _ _) ->
         modify' \state ->
             state
                 { appHoveredControl = Nothing
+                , appHoveredLine = Nothing
                 , appPressedControl = Nothing
                 , appAgentHover = Nothing
                 }
@@ -1125,7 +1128,19 @@ eventClearsMarkdownLinkCursor = \case
 -- extent.
 setHoveredControl :: Maybe Name -> EventM Name AppState ()
 setHoveredControl hovered =
-    modify' \state -> state{appHoveredControl = hovered}
+    modify' \state ->
+        state
+            { appHoveredControl = hovered
+            , appHoveredLine = Nothing
+            }
+
+setHoveredTranscriptLine :: Name -> Int -> EventM Name AppState ()
+setHoveredTranscriptLine name row =
+    modify' \state ->
+        state
+            { appHoveredControl = Just name
+            , appHoveredLine = Just (max 0 row)
+            }
 
 setMarkdownLinkCursor :: Bool -> EventM Name AppState ()
 setMarkdownLinkCursor hovered = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -997,6 +997,7 @@ openMetaConsole = do
                     }
             , appAgentHover = Nothing
             , appHoveredControl = Nothing
+            , appHoveredLine = Nothing
             , appPressedControl = Nothing
             }
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -447,6 +447,7 @@ noteTerminalFocusLost = do
             , appSyntaxHighlighter = Nothing
             , appSyntaxRequested = Set.empty
             , appHoveredControl = Nothing
+            , appHoveredLine = Nothing
             , appPressedControl = Nothing
             , appAgentHover = Nothing
             }

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -455,6 +455,7 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appAgentHover = Nothing
         , appMarkdownLinkHovered = False
         , appHoveredControl = Nothing
+        , appHoveredLine = Nothing
         , appPressedControl = Nothing
         , appWorkerStopped = False
         , appConversationAnchor = Nothing

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -236,6 +236,7 @@ handleControlMouseDown name =
     modify' \state ->
         state
             { appHoveredControl = Just name
+            , appHoveredLine = Nothing
             , appPressedControl = case state.appPressedControl of
                 Nothing -> Just name
                 pressed -> pressed
@@ -252,6 +253,7 @@ handleControlMouseUp name action = do
         current
             { appHoveredControl =
                 if activate then Nothing else Just name
+            , appHoveredLine = Nothing
             , appPressedControl = Nothing
             }
     when activate action

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -30,12 +30,12 @@ import Agent.CLI.TUI.ImagePreview
 import Agent.CLI.TUI.LambdaArt ()
 import Agent.CLI.TUI.Motion
     ( motionModeForTerminalFocus, userActionPending )
-import Agent.TUI.Accent ( accentRail, waveHeader )
+import Agent.TUI.Accent ( accentRail, highlightWidgetRow, waveHeader )
 import Agent.CLI.TUI.Types
     ( AppState(appSubmittedImagePreviews, appTerminalFocus,
                appHistorySelectedBlock, appUi, appAgentSelected,
                appSyntaxHighlighter, appCompletionFlashes, appMotionElapsedMillis,
-               appHoveredControl, appPressedControl, appRuntime),
+               appHoveredControl, appHoveredLine, appPressedControl, appRuntime),
       FullscreenRuntime(runtimeWaveTrough, runtimeMotionMode,
                         runtimeNativeImagePreviews, runtimeColor),
       activeTheme,
@@ -97,7 +97,6 @@ import Brick
       vBox,
       vLimit,
       withAttr,
-      withDefAttr,
       withBorderStyle,
       AttrName,
       Context(availWidth),
@@ -162,21 +161,15 @@ import qualified Data.Text.Encoding as TextEncoding ()
 import qualified Agent.TUI.Theme as Theme
     ( assistantAttr,
       borderActiveAttr,
-      borderAttr,
       completionFlashAttr,
       controlLinkAttr,
-      dimAttr,
       errorAttr,
       inspectAttr,
       mutedAttr,
       successAttr,
-      syntaxCommentAttr,
       thinkingAttr,
       thinkingBodyAttr,
       transcriptHoverAttr,
-      transcriptHoverMutedAttr,
-      transcriptHoverMutedCancelledAttr,
-      transcriptHoverMutedItalicAttr,
       todoCancelledAttr,
       todoCompletedAttr,
       todoInProgressAttr,
@@ -185,7 +178,6 @@ import qualified Agent.TUI.Theme as Theme
       toolPathAttr,
       userAttr,
       userMutedAttr,
-      waitingDimAttr,
       waveTroughForTheme )
 import qualified Agent.CLI.TUI.Transcript as Transcript ()
 import qualified Graphics.Vty as V ()
@@ -366,8 +358,9 @@ drawBlock state target ui block =
         hoveredRow =
             (if hovered
                 then
-                    withDefAttr Theme.transcriptHoverAttr
-                        . hoverReadableAttrs
+                    highlightWidgetRow
+                        Theme.transcriptHoverAttr
+                        (fromMaybe 0 state.appHoveredLine)
                 else id) $
                 padRight Max blockRow
         rendered =
@@ -385,29 +378,6 @@ drawBlock state target ui block =
                 (codeCopyCacheState state target block.blockId))
             rendered
         else rendered
-
--- The hover band occupies palette bright-black, so semantic gray foregrounds
--- inherit dimmed terminal text instead of disappearing into the background.
-hoverReadableAttrs :: Widget Name -> Widget Name
-hoverReadableAttrs =
-    overrideAttr Theme.mutedAttr Theme.transcriptHoverMutedAttr
-        . overrideAttr Theme.inspectAttr Theme.transcriptHoverMutedAttr
-        . overrideAttr
-            Theme.thinkingBodyAttr
-            Theme.transcriptHoverMutedItalicAttr
-        . overrideAttr
-            Theme.todoCompletedAttr
-            Theme.transcriptHoverMutedAttr
-        . overrideAttr
-            Theme.todoCancelledAttr
-            Theme.transcriptHoverMutedCancelledAttr
-        . overrideAttr
-            Theme.syntaxCommentAttr
-            Theme.transcriptHoverMutedItalicAttr
-        . overrideAttr Theme.dimAttr Theme.transcriptHoverMutedAttr
-        . overrideAttr Theme.waitingDimAttr Theme.transcriptHoverMutedAttr
-        . overrideAttr Theme.borderAttr Theme.transcriptHoverMutedAttr
-        . overrideAttr Theme.controlLinkAttr Theme.transcriptHoverMutedAttr
 
 submittedUserMessage
     :: AppState

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -487,6 +487,8 @@ data AppState = AppState
     , appAgentHover :: !(Maybe AgentHover)
     , appMarkdownLinkHovered :: !Bool
     , appHoveredControl :: !(Maybe Name)
+      -- | Local row inside `appHoveredControl` for line-level transcript hover.
+    , appHoveredLine :: !(Maybe Int)
     , appPressedControl :: !(Maybe Name)
     , appWorkerStopped :: !Bool
     , appConversationAnchor :: !(Maybe Scroll.ConversationAnchor)

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1131,10 +1131,27 @@ spec = do
             (_, hovered) <-
                 runFullscreenScriptWithState
                     initialState
-                    [ FullscreenScriptMouseUp name
+                    [ FullscreenScriptMouseUp name (B.Location (0, 0))
                     , FullscreenScriptHalt
                     ]
             hovered.appHoveredControl `shouldBe` Just name
+            hovered.appHoveredLine `shouldBe` Just 0
+            hovered.appUi.uiSelectedBlock `shouldBe` Nothing
+
+        it "tracks the hovered transcript line inside a multi-line item" do
+            runtime <- newScriptRuntime initialUiState
+            let blockId = BlockId 42
+                name = ConversationBlock AgentRoot blockId
+                initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, hovered) <-
+                runFullscreenScriptWithState
+                    initialState
+                    [ FullscreenScriptMouseUp name (B.Location (4, 2))
+                    , FullscreenScriptHalt
+                    ]
+            hovered.appHoveredControl `shouldBe` Just name
+            hovered.appHoveredLine `shouldBe` Just 2
             hovered.appUi.uiSelectedBlock `shouldBe` Nothing
 
         it "clears the hovered transcript row after the pointer leaves" do
@@ -1145,11 +1162,12 @@ spec = do
             (_, finalState) <-
                 runFullscreenScriptWithState
                     initialState
-                    [ FullscreenScriptMouseUp name
-                    , FullscreenScriptMouseUp ConversationViewport
+                    [ FullscreenScriptMouseUp name (B.Location (0, 1))
+                    , FullscreenScriptMouseUp ConversationViewport (B.Location (0, 0))
                     , FullscreenScriptHalt
                     ]
             finalState.appHoveredControl `shouldBe` Nothing
+            finalState.appHoveredLine `shouldBe` Nothing
 
         it "clears the hovered transcript row when terminal focus is lost" do
             runtime <- newScriptRuntime initialUiState
@@ -1159,11 +1177,12 @@ spec = do
             (_, finalState) <-
                 runFullscreenScriptWithState
                     initialState
-                    [ FullscreenScriptMouseUp name
+                    [ FullscreenScriptMouseUp name (B.Location (0, 0))
                     , FullscreenScriptVty V.EvLostFocus
                     , FullscreenScriptHalt
                     ]
             finalState.appHoveredControl `shouldBe` Nothing
+            finalState.appHoveredLine `shouldBe` Nothing
 
     describe "fullscreen window title" do
         it "replays the stored session title as UTF-8 OSC bytes" do
@@ -2137,7 +2156,7 @@ spec = do
 data FullscreenScriptEvent
     = FullscreenScriptApp !AppEvent
     | FullscreenScriptVty !V.Event
-    | FullscreenScriptMouseUp !Name
+    | FullscreenScriptMouseUp !Name !B.Location
     | FullscreenScriptHalt
 
 data ReplacementScenario
@@ -2712,9 +2731,9 @@ runFullscreenScriptWithState initialState script = do
                     fullscreenApp.appHandleEvent (AppEvent event)
                 AppEvent (FullscreenScriptVty event) ->
                     fullscreenApp.appHandleEvent (VtyEvent event)
-                AppEvent (FullscreenScriptMouseUp name) ->
+                AppEvent (FullscreenScriptMouseUp name location) ->
                     fullscreenApp.appHandleEvent
-                        (MouseUp name Nothing (B.Location (0, 0)))
+                        (MouseUp name Nothing location)
                 AppEvent FullscreenScriptHalt ->
                     halt
                 VtyEvent event ->

--- a/packages/agent-tui/src/Agent/TUI/Accent.hs
+++ b/packages/agent-tui/src/Agent/TUI/Accent.hs
@@ -1,6 +1,8 @@
 -- | Full-height scrollback accent rail, including a traveling brightness wave.
 module Agent.TUI.Accent
     ( accentRail
+    , highlightImageRow
+    , highlightWidgetRow
     , waveHeader
     ) where
 
@@ -12,8 +14,10 @@ import Agent.TUI.Motion
     )
 import qualified Agent.TUI.Theme as Theme
 import Brick
+import Data.Bits ((.|.))
 import qualified Data.Text as Text
 import qualified Graphics.Vty as V
+import qualified Graphics.Vty.Image.Internal as ImageInternal
 
 -- | Paint a one-column rail beside @content@, matching that widget's height.
 --
@@ -89,3 +93,94 @@ accentBarChar glyphs =
     case Text.uncons (accentBarGlyph glyphs) of
         Just (character, _) -> character
         Nothing -> '|'
+
+-- | Tint one row of a child widget with a hover surface.
+--
+-- Collapsed transcript items can span several lines (title, preview, overflow).
+-- Hover paints only the row under the pointer, leaving semantic foregrounds
+-- in place.
+highlightWidgetRow :: AttrName -> Int -> Widget n -> Widget n
+highlightWidgetRow attrName row widget =
+    Widget Greedy Fixed do
+        result <- render widget
+        hoverAttr <- lookupAttrName attrName
+        pure result { image = highlightImageRow hoverAttr row result.image }
+
+-- | Apply a hover surface to a single row of a rendered image.
+--
+-- Background fills become spaces so the band is visible; existing foregrounds
+-- and styles are preserved unless they would vanish into the hover background.
+highlightImageRow :: V.Attr -> Int -> V.Image -> V.Image
+highlightImageRow attr row img
+    | height <= 0 || row < 0 || row >= height = img
+    | otherwise =
+        above V.<-> applyHoverSurface attr line V.<-> below
+  where
+    height = V.imageHeight img
+    above
+        | row == 0 = V.emptyImage
+        | otherwise = V.cropBottom row img
+    line = V.cropTop 1 (V.cropBottom (row + 1) img)
+    below =
+        let rest = height - row - 1
+        in if rest <= 0 then V.emptyImage else V.cropTop rest img
+
+applyHoverSurface :: V.Attr -> V.Image -> V.Image
+applyHoverSurface hover = \case
+    ImageInternal.HorizText attr txt outputWidth charWidth ->
+        ImageInternal.HorizText
+            (applyHoverAttr hover attr)
+            txt
+            outputWidth
+            charWidth
+    ImageInternal.HorizJoin partLeft partRight outputWidth outputHeight ->
+        ImageInternal.HorizJoin
+            (applyHoverSurface hover partLeft)
+            (applyHoverSurface hover partRight)
+            outputWidth
+            outputHeight
+    ImageInternal.VertJoin partTop partBottom outputWidth outputHeight ->
+        ImageInternal.VertJoin
+            (applyHoverSurface hover partTop)
+            (applyHoverSurface hover partBottom)
+            outputWidth
+            outputHeight
+    ImageInternal.BGFill width height ->
+        V.charFill (applyHoverAttr hover V.defAttr) ' ' width height
+    ImageInternal.Crop croppedImage leftSkip topSkip outputWidth outputHeight ->
+        ImageInternal.Crop
+            (applyHoverSurface hover croppedImage)
+            leftSkip
+            topSkip
+            outputWidth
+            outputHeight
+    ImageInternal.EmptyImage -> ImageInternal.EmptyImage
+
+applyHoverAttr :: V.Attr -> V.Attr -> V.Attr
+applyHoverAttr hover attr =
+    addHoverStyle hover (addHoverBackground hover attr)
+
+addHoverBackground :: V.Attr -> V.Attr -> V.Attr
+addHoverBackground hover attr =
+    case V.attrBackColor hover of
+        V.SetTo bg ->
+            let painted = attr `V.withBackColor` bg
+            in case V.attrForeColor attr of
+                V.SetTo fg | fg == bg ->
+                    painted
+                        `V.withForeColor` V.white
+                        `V.withStyle` mergeStyle V.dim (V.attrStyle painted)
+                _ -> painted
+        _ -> attr
+
+addHoverStyle :: V.Attr -> V.Attr -> V.Attr
+addHoverStyle hover attr =
+    case V.attrStyle hover of
+        V.SetTo extra ->
+            attr `V.withStyle` mergeStyle extra (V.attrStyle attr)
+        _ -> attr
+
+mergeStyle :: V.Style -> V.MaybeDefault V.Style -> V.Style
+mergeStyle extra = \case
+    V.SetTo existing -> extra .|. existing
+    _ -> extra

--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -116,6 +116,7 @@ data ThemeKind
 data ThemePalette = ThemePalette
     { themePaletteBackground :: !V.Color
     , themePaletteRaised :: !V.Color
+    , themePaletteHover :: !V.Color
     , themePaletteFocused :: !V.Color
     , themePaletteForeground :: !V.Color
     , themePaletteStrong :: !V.Color
@@ -185,6 +186,7 @@ fixedThemePalette = \case
     Midnight -> Just ThemePalette
         { themePaletteBackground = RGBColor 20 20 20
         , themePaletteRaised = RGBColor 36 36 36
+        , themePaletteHover = RGBColor 28 28 28
         , themePaletteFocused = RGBColor 44 44 44
         , themePaletteForeground = RGBColor 200 200 200
         , themePaletteStrong = RGBColor 225 225 225
@@ -202,6 +204,7 @@ fixedThemePalette = \case
     Daylight -> Just ThemePalette
         { themePaletteBackground = RGBColor 250 247 242
         , themePaletteRaised = RGBColor 255 255 255
+        , themePaletteHover = RGBColor 228 223 216
         , themePaletteFocused = RGBColor 242 237 230
         , themePaletteForeground = RGBColor 45 42 46
         , themePaletteStrong = RGBColor 30 28 31
@@ -219,6 +222,7 @@ fixedThemePalette = \case
     TokyoNight -> Just ThemePalette
         { themePaletteBackground = RGBColor 26 27 38
         , themePaletteRaised = RGBColor 36 40 59
+        , themePaletteHover = RGBColor 34 36 50
         , themePaletteFocused = RGBColor 47 53 73
         , themePaletteForeground = RGBColor 192 202 245
         , themePaletteStrong = RGBColor 218 224 255
@@ -236,6 +240,7 @@ fixedThemePalette = \case
     RosePineMoon -> Just ThemePalette
         { themePaletteBackground = RGBColor 25 23 36
         , themePaletteRaised = RGBColor 38 35 58
+        , themePaletteHover = RGBColor 33 31 48
         , themePaletteFocused = RGBColor 49 46 69
         , themePaletteForeground = RGBColor 224 222 244
         , themePaletteStrong = RGBColor 240 238 255
@@ -253,6 +258,7 @@ fixedThemePalette = \case
     OscuraMidnight -> Just ThemePalette
         { themePaletteBackground = RGBColor 8 12 18
         , themePaletteRaised = RGBColor 20 27 35
+        , themePaletteHover = RGBColor 16 20 26
         , themePaletteFocused = RGBColor 28 37 46
         , themePaletteForeground = RGBColor 220 235 245
         , themePaletteStrong = RGBColor 238 247 252
@@ -403,12 +409,24 @@ terminalDefault =
             palette V.brightGreen `V.withStyle` V.bold)
         , (selectedAttr, raisedPanelAttr `V.withStyle` V.bold)
         , (selectedMutedAttr, raisedPanelMutedAttr)
-        , (transcriptHoverAttr, raisedPanelMutedAttr)
-        , (transcriptHoverMutedAttr, V.defAttr `V.withStyle` V.dim)
+        -- Background-only: keep semantic foregrounds and avoid the strong
+        -- white-on-bright-black panel used for selection.
+        , (transcriptHoverAttr, V.defAttr `V.withBackColor` V.brightBlack)
+        , (transcriptHoverMutedAttr,
+            V.defAttr
+                `V.withForeColor` V.white
+                `V.withBackColor` V.brightBlack
+                `V.withStyle` V.dim)
         , (transcriptHoverMutedItalicAttr,
-            V.defAttr `V.withStyle` (V.dim .|. V.italic))
+            V.defAttr
+                `V.withForeColor` V.white
+                `V.withBackColor` V.brightBlack
+                `V.withStyle` (V.dim .|. V.italic))
         , (transcriptHoverMutedCancelledAttr,
-            V.defAttr `V.withStyle` (V.dim .|. V.strikethrough))
+            V.defAttr
+                `V.withForeColor` V.white
+                `V.withBackColor` V.brightBlack
+                `V.withStyle` (V.dim .|. V.strikethrough))
         , (borderAttr, palette V.brightBlack `V.withStyle` V.dim)
         , (borderActiveAttr, palette V.brightBlack)
         , (headingAttr, palette V.magenta `V.withStyle` V.bold)
@@ -575,13 +593,12 @@ mkTheme palette =
         , (completionFlashAttr, greenA `V.withStyle` V.bold)
         , (selectedAttr, focusedStrong `V.withStyle` V.bold)
         , (selectedMutedAttr, focusedMuted)
-        , (transcriptHoverAttr, focused)
-        , (transcriptHoverMutedAttr,
-            focusedMuted `V.withStyle` V.dim)
+        , (transcriptHoverAttr, hoverA)
+        , (transcriptHoverMutedAttr, hoverMuted `V.withStyle` V.dim)
         , (transcriptHoverMutedItalicAttr,
-            focusedMuted `V.withStyle` (V.dim .|. V.italic))
+            hoverMuted `V.withStyle` (V.dim .|. V.italic))
         , (transcriptHoverMutedCancelledAttr,
-            focusedMuted `V.withStyle` (V.dim .|. V.strikethrough))
+            hoverMuted `V.withStyle` (V.dim .|. V.strikethrough))
         , (borderAttr, borderA `V.withStyle` V.dim)
         , (borderActiveAttr, borderActiveA)
         , (headingAttr, accentA `V.withStyle` V.bold)
@@ -618,6 +635,7 @@ mkTheme palette =
   where
     background = palette.themePaletteBackground
     raised = palette.themePaletteRaised
+    hoverBackground = palette.themePaletteHover
     focusedBackground = palette.themePaletteFocused
     foreground = palette.themePaletteForeground
     strong = palette.themePaletteStrong
@@ -655,10 +673,12 @@ mkTheme palette =
         V.defAttr
             `V.withForeColor` secondary
             `V.withBackColor` raised
-    focused =
+    hoverA =
+        V.defAttr `V.withBackColor` hoverBackground
+    hoverMuted =
         V.defAttr
-            `V.withForeColor` foreground
-            `V.withBackColor` focusedBackground
+            `V.withForeColor` muted
+            `V.withBackColor` hoverBackground
     focusedStrong =
         V.defAttr
             `V.withForeColor` strong

--- a/packages/agent-tui/test/Agent/TUI/AccentSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/AccentSpec.hs
@@ -1,14 +1,16 @@
 module Agent.TUI.AccentSpec (spec) where
 
-import Agent.TUI.Accent (accentRail)
+import Agent.TUI.Accent (accentRail, highlightImageRow, highlightWidgetRow)
 import Agent.TUI.Motion (MotionGlyphSet(..), accentBarGlyph)
 import qualified Agent.TUI.Theme as Theme
 import Brick
     ( Widget
+    , padRight
     , renderWidget
     , str
     , vBox
     , viewport
+    , Padding(Max)
     )
 import Brick.Types (ViewportType(..))
 import Data.List (isInfixOf)
@@ -58,6 +60,59 @@ spec = describe "accent rail" do
                         [widget]
                         (20, 6)
         V.imageHeight image `shouldSatisfy` (> 0)
+
+    it "tints only the hovered image row" do
+        let hover = V.defAttr `V.withBackColor` V.brightBlack
+            img =
+                V.vertCat
+                    [ V.string V.defAttr "alpha"
+                    , V.string V.defAttr "bravo"
+                    , V.string V.defAttr "charlie"
+                    ]
+            tinted0 = highlightImageRow hover 0 img
+            tinted1 = highlightImageRow hover 1 img
+        V.imageHeight tinted1 `shouldBe` 3
+        highlightImageRow hover 5 img `shouldBe` img
+        tinted0 `shouldNotBe` img
+        tinted1 `shouldNotBe` img
+        tinted0 `shouldNotBe` tinted1
+        show tinted1 `shouldSatisfy` isInfixOf "ISOColor 8"
+
+    it "remaps colliding muted foregrounds on the hover band" do
+        let hover = V.defAttr `V.withBackColor` V.brightBlack
+            muted = V.defAttr `V.withForeColor` V.brightBlack
+            tinted = highlightImageRow hover 0 (V.string muted "dim")
+        -- V.white is ISO 7; V.brightBlack is ISO 8; style 16 is dim.
+        show tinted `shouldSatisfy` isInfixOf "ISOColor 7"
+        show tinted `shouldSatisfy` isInfixOf "ISOColor 8"
+        show tinted `shouldSatisfy` isInfixOf "SetTo 16"
+
+    it "paints a widget hover band on a single padded row" do
+        let hovered row =
+                highlightWidgetRow Theme.transcriptHoverAttr row $
+                    padRight Max $
+                        vBox [str "one", str "two", str "three"]
+            renderHover row =
+                V.picImage $
+                    renderWidget
+                        (Just Theme.terminalDefault)
+                        [hovered row :: Widget ()]
+                        (8, 3)
+            plain =
+                V.picImage $
+                    renderWidget
+                        (Just Theme.terminalDefault)
+                        [ padRight Max (vBox [str "one", str "two", str "three"])
+                            :: Widget ()
+                        ]
+                        (8, 3)
+            image0 = renderHover 0
+            image1 = renderHover 1
+        V.imageHeight image1 `shouldBe` 3
+        image0 `shouldNotBe` plain
+        image1 `shouldNotBe` plain
+        image0 `shouldNotBe` image1
+        show image1 `shouldSatisfy` isInfixOf "ISOColor 8"
 
 sampleRail :: Maybe Int -> Int -> Widget ()
 sampleRail waveElapsed rows =

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -69,14 +69,17 @@ spec = do
             V.attrForeColor activeBorder
                 `shouldBe` V.SetTo (RGBColor 60 60 65)
 
-        it "gives fixed-theme hover attributes explicit surfaces" do
+        it "gives fixed-theme hover attributes a weaker surface than selection" do
             let theme = Theme.themeAttrMap Theme.Midnight
                 hover = attrMapLookup Theme.transcriptHoverAttr theme
                 hoverMuted =
                     attrMapLookup Theme.transcriptHoverMutedAttr theme
-            V.attrBackColor hover `shouldBe` V.SetTo (RGBColor 44 44 44)
+                selected = attrMapLookup Theme.selectedAttr theme
+            V.attrBackColor hover `shouldBe` V.SetTo (RGBColor 28 28 28)
             V.attrBackColor hoverMuted
-                `shouldBe` V.SetTo (RGBColor 44 44 44)
+                `shouldBe` V.SetTo (RGBColor 28 28 28)
+            V.attrForeColor hover `shouldBe` V.Default
+            V.attrBackColor hover `shouldNotBe` V.attrBackColor selected
 
         it "keeps the daylight page background while dimming overlays" do
             V.attrBackColor
@@ -264,18 +267,15 @@ spec = do
                     attrMapLookup
                         Theme.transcriptHoverAttr
                         theme
-                hoveredTheme =
-                    mapAttrName
+                hoverMuted =
+                    attrMapLookup
                         Theme.transcriptHoverMutedAttr
-                        Theme.mutedAttr
-                        (setDefaultAttr hover theme)
-                hoveredMuted =
-                    attrMapLookup Theme.mutedAttr hoveredTheme
+                        theme
             V.attrBackColor hover `shouldBe` V.SetTo V.brightBlack
-            V.attrForeColor hover `shouldBe` V.SetTo V.white
-            V.attrForeColor hoveredMuted `shouldBe` V.SetTo V.white
-            V.attrBackColor hoveredMuted `shouldBe` V.SetTo V.brightBlack
-            V.attrStyle hoveredMuted `shouldBe` V.SetTo V.dim
+            V.attrForeColor hover `shouldBe` V.Default
+            V.attrForeColor hoverMuted `shouldBe` V.SetTo V.white
+            V.attrBackColor hoverMuted `shouldBe` V.SetTo V.brightBlack
+            V.attrStyle hoverMuted `shouldBe` V.SetTo V.dim
 
         it "does not introduce colors in monochrome mode" do
             map


### PR DESCRIPTION
## Summary

- paint transcript hover on the current line only, instead of the whole collapsed item
- keep a weaker background-only hover surface so tool and inspection colors stay readable
- track the pointer row from mouse motion and clear it when the pointer leaves or focus is lost

Collapsed items such as grouped inspections still expand and collapse as before. Keyboard selection is unchanged.

## Testing

- `cabal repl agent-tui:test:agent-tui-test`, then `:main --match "/accent rail/"` (6 examples) and `:main --match "/syntax theme attributes/"` (21 examples)
- `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`, then `:main --match "/fullscreen transcript hover/"` (4 examples)
- live tmux smoke check of the fullscreen TUI: started `cabal repl lib:agent-cli` in a 120x36 pane, ran `devMain`, submitted a prompt that produced a collapsed `Read 3 items` group with preview rows, then injected real SGR mouse-motion (`CSI < 35 ; col ; row M`) through `tmux send-keys -H`
  - hovering the title row (`Read 3 items`) painted only that row with Midnight hover `#1c1c1c` (`48;2;28;28;28`); preview and overflow rows stayed on the page background `#141414`
  - hovering `Read README.md` painted only that child row
  - hovering `… +670 lines` painted only the overflow row
  - moving the pointer onto the composer cleared the transcript hover band
- `git diff --check`