### PR TITLE
Paint Markdown diff fences with semantic add/remove colors

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -104,12 +104,12 @@ import Agent.CLI.TUI.ImagePreview ( NativePreviewPlacement(..)
     , renderTuiImagePreview
     , sameNativePreviewLayout
     )
-import Agent.TUI.Markdown ( codeWidgetWithSyntaxHighlighting , diffSyntaxLanguages , markdownWidgetWithLinks , markdownWidgetWithSyntaxHighlightingAndLinks )
+import Agent.TUI.Markdown ( codeWidgetWithSyntaxHighlighting , diffSyntaxLanguages , markdownFenceSyntaxLanguages , markdownWidgetWithLinks , markdownWidgetWithSyntaxHighlightingAndLinks )
 import Agent.TUI.FencedCode ( FencedBlock(..)
     , fencedBlocks
     )
 import Agent.TUI.TextWidth ( clampGraphemeCursor , displayTerminalText , nextGraphemeBoundary , previousGraphemeBoundary )
-import Agent.Syntax ( SyntaxHighlighter , loadSyntaxLanguage , newSyntaxHighlighter , resolveFenceLanguage )
+import Agent.Syntax ( SyntaxHighlighter , loadSyntaxLanguage , newSyntaxHighlighter )
 import qualified Agent.CLI.TUI.Scroll as Scroll
 import qualified Agent.CLI.TUI.Transcript as Transcript
 import Agent.CLI.TUI.Types
@@ -609,8 +609,11 @@ syntaxLanguagesForBlock :: UiBlock -> [Text]
 syntaxLanguagesForBlock block =
     case block.blockKind of
         BlockAssistant ->
-            mapMaybe
-                (resolveFenceLanguage . (.fencedInfo))
+            concatMap
+                (\fence ->
+                    markdownFenceSyntaxLanguages
+                        fence.fencedInfo
+                        fence.fencedBody)
                 (fencedBlocks block.blockBody)
         BlockShell
             | Just language <- blockCodeLanguage block ->

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -302,6 +302,17 @@ spec = do
             syntaxLanguagesForBlocks (toList conversation.uiBlocks)
                 `shouldBe` Set.fromList ["haskell", "python"]
 
+        it "requests source grammars from Markdown diff fences" do
+            let conversation =
+                    reduceUi
+                        (UiAssistantHistory
+                            "```diff\n--- a/src/Agent/Syntax.hs\n\
+                            \+++ b/src/Agent/Syntax.hs\n\
+                            \@@ -1 +1 @@\n-old\n+new\n```")
+                        initialUiState
+            syntaxLanguagesForBlocks (toList conversation.uiBlocks)
+                `shouldBe` Set.singleton "haskell"
+
         it "requests the JavaScript grammar for exec source" do
             let conversation =
                     reduceUi

--- a/packages/agent-syntax/src/Agent/Syntax.hs
+++ b/packages/agent-syntax/src/Agent/Syntax.hs
@@ -645,6 +645,7 @@ languageAliases =
         , ("shell", "bash")
         , ("ts", "typescript")
         , ("tsx", "jsx")
+        , ("udiff", "diff")
         , ("yml", "yaml")
         ]
 

--- a/packages/agent-syntax/test/Agent/SyntaxSpec.hs
+++ b/packages/agent-syntax/test/Agent/SyntaxSpec.hs
@@ -15,6 +15,7 @@ spec = describe "syntax highlighting" do
             resolveFenceLanguage "py linenums" `shouldBe` Just "python"
             resolveFenceLanguage "c++" `shouldBe` Just "cpp"
             resolveFenceLanguage "PATCH" `shouldBe` Just "diff"
+            resolveFenceLanguage "udiff" `shouldBe` Just "diff"
 
         it "resolves Grok line-range file paths by extension" do
             resolveFenceLanguage "12:40:src/Agent/TUI/Markdown.hs"

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -60,6 +60,7 @@ import qualified Data.List as List
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Text.Read (readMaybe)
 import qualified Data.Text.Lazy as LazyText
 import qualified Data.Text.Lazy.Builder as Builder
 import qualified Graphics.Vty as V
@@ -292,42 +293,89 @@ data StyledDiffRow = StyledDiffRow
     , styledDiffFragments :: ![(V.Attr, Text)]
     }
 
+data DiffParseState = DiffParseState
+    { parsePaths :: !DiffPaths
+    , parseHunk :: !(Maybe HunkRemaining)
+    }
+
+data HunkRemaining = HunkRemaining
+    { hunkOldLeft :: !Int
+    , hunkNewLeft :: !Int
+    }
+
 parseDiffLines :: Text -> Text -> [ParsedDiffLine]
 parseDiffLines initialPath =
-    go
-        (maybe emptyDiffPaths sameDiffPaths (nonEmptyText initialPath))
-        . Text.lines
+    go initialState . Text.lines
   where
+    initialState =
+        DiffParseState
+            { parsePaths =
+                maybe emptyDiffPaths sameDiffPaths (nonEmptyText initialPath)
+            , parseHunk = Nothing
+            }
+
     go _ [] = []
-    go currentPaths (line : rest)
+    go state (line : rest)
         | Just nextPaths <- diffHeaderPaths line =
             ParsedDiffLine DiffLineHeader nextPaths "" line
-                : go nextPaths rest
-        | Just nextPaths <- unifiedDiffHeaderPaths currentPaths line =
+                : go
+                    state { parsePaths = nextPaths, parseHunk = Nothing }
+                    rest
+        | Just hunk <- state.parseHunk =
+            parseInsideHunk state hunk line rest
+        | otherwise =
+            parseOutsideHunk state line rest
+
+    parseInsideHunk state hunk line rest
+        | Just nextPaths <- gitDiffFileStart line =
             ParsedDiffLine DiffLineMeta nextPaths "" line
-                : go nextPaths rest
+                : go
+                    state { parsePaths = nextPaths, parseHunk = Nothing }
+                    rest
+        | Just nextHunk <- parseHunkCounts line =
+            ParsedDiffLine DiffLineMeta state.parsePaths "" line
+                : go state { parseHunk = Just nextHunk } rest
+        | isNoNewlineMarker line =
+            ParsedDiffLine DiffLineMeta state.parsePaths "" line
+                : go state rest
+        | Just (kind, prefix, source) <- unifiedHunkLine line =
+            ParsedDiffLine kind state.parsePaths prefix source
+                : go
+                    state { parseHunk = advanceHunk hunk kind }
+                    rest
+        | otherwise =
+            ParsedDiffLine DiffLinePlain state.parsePaths "" line
+                : go state rest
+
+    parseOutsideHunk state line rest
+        | Just nextPaths <- unifiedDiffHeaderPaths state.parsePaths line =
+            ParsedDiffLine DiffLineMeta nextPaths "" line
+                : go state { parsePaths = nextPaths } rest
+        | Just hunk <- parseHunkCounts line =
+            ParsedDiffLine DiffLineMeta state.parsePaths "" line
+                : go state { parseHunk = Just hunk } rest
         | Just displayLine <- parseDiffDisplayLine line =
             ParsedDiffLine
                 (displayLineKind displayLine.diffDisplayKind)
-                currentPaths
+                state.parsePaths
                 ( displayLine.diffDisplayGutter
                     <> " │ "
                     <> displayLine.diffDisplayMarker
                 )
                 displayLine.diffDisplayCode
-                : go currentPaths rest
+                : go state rest
         | Just (kind, prefix, source) <- changedDiffLine line =
-            ParsedDiffLine kind currentPaths prefix source
-                : go currentPaths rest
+            ParsedDiffLine kind state.parsePaths prefix source
+                : go state rest
         | isDiffMetaLine line =
-            ParsedDiffLine DiffLineMeta currentPaths "" line
-                : go currentPaths rest
-        | Just (kind, prefix, source) <- unifiedDiffLine line =
-            ParsedDiffLine kind currentPaths prefix source
-                : go currentPaths rest
+            ParsedDiffLine DiffLineMeta state.parsePaths "" line
+                : go state rest
+        | Just (kind, prefix, source) <- unifiedHunkLine line =
+            ParsedDiffLine kind state.parsePaths prefix source
+                : go state rest
         | otherwise =
-            ParsedDiffLine DiffLinePlain currentPaths "" line
-                : go currentPaths rest
+            ParsedDiffLine DiffLinePlain state.parsePaths "" line
+                : go state rest
 
 displayLineKind :: Presentation.DiffLineKind -> DiffLineKind
 displayLineKind = \case
@@ -395,26 +443,22 @@ diffHeaderPaths line =
 
 -- | Git/unified headers update the current file paths so later +/- rows can
 -- pick a source grammar. They stay muted rather than using the compact
--- create/update chrome.
+-- create/update chrome. @---@/@+++@ are headers only when the payload looks
+-- like a git path; inside a hunk the first character is always the marker.
 unifiedDiffHeaderPaths :: DiffPaths -> Text -> Maybe DiffPaths
 unifiedDiffHeaderPaths current line
-    | Just rest <- Text.stripPrefix "diff --git " line =
-        case Text.words rest of
-            [source, destination] ->
-                Just
-                    DiffPaths
-                        { diffRemovedPath = gitDiffPath source
-                        , diffAddedPath = gitDiffPath destination
-                        }
-            _ -> Nothing
-    | Just rest <- Text.stripPrefix "--- " line =
+    | Just nextPaths <- gitDiffFileStart line =
+        Just nextPaths
+    | Just rest <- Text.stripPrefix "--- " line
+    , looksLikeGitHeaderPath rest =
         let removed = gitDiffPath rest
         in Just
             current
                 { diffRemovedPath = removed
                 , diffAddedPath = current.diffAddedPath <|> removed
                 }
-    | Just rest <- Text.stripPrefix "+++ " line =
+    | Just rest <- Text.stripPrefix "+++ " line
+    , looksLikeGitHeaderPath rest =
         let added = gitDiffPath rest
         in Just
             current
@@ -422,6 +466,27 @@ unifiedDiffHeaderPaths current line
                 , diffRemovedPath = current.diffRemovedPath <|> added
                 }
     | otherwise = Nothing
+
+gitDiffFileStart :: Text -> Maybe DiffPaths
+gitDiffFileStart line = do
+    rest <- Text.stripPrefix "diff --git " line
+    case Text.words rest of
+        [source, destination] ->
+            Just
+                DiffPaths
+                    { diffRemovedPath = gitDiffPath source
+                    , diffAddedPath = gitDiffPath destination
+                    }
+        _ -> Nothing
+
+looksLikeGitHeaderPath :: Text -> Bool
+looksLikeGitHeaderPath raw =
+    let trimmed = Text.strip (Text.takeWhile (/= '\t') raw)
+        unquoted = stripDiffQuotes trimmed
+    in unquoted == "/dev/null"
+        || "a/" `Text.isPrefixOf` unquoted
+        || "b/" `Text.isPrefixOf` unquoted
+        || Text.any (`elem` ['/', '\\']) unquoted
 
 gitDiffPath :: Text -> Maybe Text
 gitDiffPath raw =
@@ -444,24 +509,75 @@ stripDiffQuotes text =
                 Text.dropEnd 1 rest
         _ -> text
 
-unifiedDiffLine :: Text -> Maybe (DiffLineKind, Text, Text)
-unifiedDiffLine line
-    | "+" `Text.isPrefixOf` line
-    , not ("+++" `Text.isPrefixOf` line) =
-        Just (DiffLineAdded, "+", Text.drop 1 line)
-    | "-" `Text.isPrefixOf` line
-    , not ("---" `Text.isPrefixOf` line) =
-        Just (DiffLineRemoved, "-", Text.drop 1 line)
-    | " " `Text.isPrefixOf` line =
-        Just (DiffLineContext, " ", Text.drop 1 line)
-    | otherwise = Nothing
+-- | Inside a hunk only the first character is the marker, so added
+-- @++counter;@ (@+++counter;@) and removed @-- comment@ (@--- comment@) stay
+-- change rows instead of being mistaken for file headers.
+unifiedHunkLine :: Text -> Maybe (DiffLineKind, Text, Text)
+unifiedHunkLine line =
+    case Text.uncons line of
+        Just ('+', rest) -> Just (DiffLineAdded, "+", rest)
+        Just ('-', rest) -> Just (DiffLineRemoved, "-", rest)
+        Just (' ', rest) -> Just (DiffLineContext, " ", rest)
+        _ -> Nothing
+
+parseHunkCounts :: Text -> Maybe HunkRemaining
+parseHunkCounts line = do
+    afterOpen <- Text.stripPrefix "@@" (Text.stripStart line)
+    afterMinus <- Text.stripPrefix "-" (Text.strip afterOpen)
+    (oldCount, afterOld) <- hunkCount afterMinus
+    afterPlus <- Text.stripPrefix "+" (Text.strip afterOld)
+    (newCount, _) <- hunkCount afterPlus
+    pure
+        HunkRemaining
+            { hunkOldLeft = oldCount
+            , hunkNewLeft = newCount
+            }
+
+hunkCount :: Text -> Maybe (Int, Text)
+hunkCount text = do
+    let (startDigits, afterStart) = Text.span isDigit text
+    _start <- readNonEmptyDigits startDigits
+    case Text.uncons afterStart of
+        Just (',', rest) -> do
+            let (countDigits, afterCount) = Text.span isDigit rest
+            count <- readNonEmptyDigits countDigits
+            pure (count, afterCount)
+        _ ->
+            Just (1, afterStart)
+
+readNonEmptyDigits :: Text -> Maybe Int
+readNonEmptyDigits digits
+    | Text.null digits = Nothing
+    | otherwise = readMaybe (Text.unpack digits)
+
+advanceHunk :: HunkRemaining -> DiffLineKind -> Maybe HunkRemaining
+advanceHunk hunk kind =
+    let next = case kind of
+            DiffLineRemoved ->
+                hunk { hunkOldLeft = max 0 (hunk.hunkOldLeft - 1) }
+            DiffLineAdded ->
+                hunk { hunkNewLeft = max 0 (hunk.hunkNewLeft - 1) }
+            DiffLineContext ->
+                hunk
+                    { hunkOldLeft = max 0 (hunk.hunkOldLeft - 1)
+                    , hunkNewLeft = max 0 (hunk.hunkNewLeft - 1)
+                    }
+            _ -> hunk
+    in if next.hunkOldLeft == 0 && next.hunkNewLeft == 0
+        then Nothing
+        else Just next
+
+isNoNewlineMarker :: Text -> Bool
+isNoNewlineMarker line =
+    "\\ " `Text.isPrefixOf` line
+        || "\\ No newline" `Text.isPrefixOf` line
 
 isDiffMetaLine :: Text -> Bool
 isDiffMetaLine line =
     "  …" `Text.isPrefixOf` line
         || "… +" `Text.isPrefixOf` line
         || "@@" `Text.isPrefixOf` Text.stripStart line
-        || "\\ " `Text.isPrefixOf` line
+        || isNoNewlineMarker line
         || "index " `Text.isPrefixOf` line
         || "new file mode " `Text.isPrefixOf` line
         || "deleted file mode " `Text.isPrefixOf` line

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -8,6 +8,9 @@ module Agent.TUI.Markdown
     , diffWidgetWithSyntaxHighlighting
     , highlightDiffCodeRows
     , inlinePlainText
+    , isDiffFenceInfo
+    , looksLikeUnifiedDiff
+    , markdownFenceSyntaxLanguages
     , markdownWidget
     , markdownWidgetWithLinks
     , markdownWidgetWithCodeControls
@@ -32,6 +35,7 @@ import Agent.Syntax
     , SyntaxHighlighter
     , SyntaxSpan(..)
     , highlightCode
+    , resolveFenceLanguage
     , resolvePathLanguage
     )
 import Agent.TUI.Presentation
@@ -49,6 +53,7 @@ import Agent.TUI.TextWidth
 import qualified Agent.TUI.Theme as Theme
 import Brick
 import qualified Brick.Types as B
+import Control.Applicative ((<|>))
 import Data.Bits ((.|.))
 import Data.Char (isDigit, isSpace)
 import qualified Data.List as List
@@ -192,6 +197,32 @@ diffSyntaxLanguages initialPath body =
         , Just language <- [resolvePathLanguage path]
         ]
 
+-- | Fence info that should be painted as a unified/edit diff rather than
+-- tokenized with Skylighting's @diff@ grammar. That grammar maps removed
+-- lines to strings (green) and added lines to variables (cyan).
+isDiffFenceInfo :: Text -> Bool
+isDiffFenceInfo info =
+    resolveFenceLanguage info == Just "diff"
+
+-- | Conservative detection for unlabeled unified diffs. A hunk header at the
+-- start of a line is distinctive enough that ordinary source is unlikely to
+-- match.
+looksLikeUnifiedDiff :: Text -> Bool
+looksLikeUnifiedDiff =
+    any ("@@" `Text.isPrefixOf`) . Text.lines
+
+-- | Grammars to load for one Markdown fence. Diff fences contribute the
+-- languages of the files they name rather than the @diff@ grammar itself.
+markdownFenceSyntaxLanguages :: Text -> Text -> [Text]
+markdownFenceSyntaxLanguages info body =
+    case resolveFenceLanguage info of
+        Just "diff" -> diffSyntaxLanguages "" body
+        Just language -> [language]
+        Nothing
+            | looksLikeUnifiedDiff body ->
+                diffSyntaxLanguages "" body
+            | otherwise -> []
+
 -- | Render a compact edit preview with token-level syntax foregrounds over
 -- full-width added/removed backgrounds.
 diffWidgetWithSyntaxHighlighting
@@ -272,6 +303,9 @@ parseDiffLines initialPath =
         | Just nextPaths <- diffHeaderPaths line =
             ParsedDiffLine DiffLineHeader nextPaths "" line
                 : go nextPaths rest
+        | Just nextPaths <- unifiedDiffHeaderPaths currentPaths line =
+            ParsedDiffLine DiffLineMeta nextPaths "" line
+                : go nextPaths rest
         | Just displayLine <- parseDiffDisplayLine line =
             ParsedDiffLine
                 (displayLineKind displayLine.diffDisplayKind)
@@ -285,9 +319,11 @@ parseDiffLines initialPath =
         | Just (kind, prefix, source) <- changedDiffLine line =
             ParsedDiffLine kind currentPaths prefix source
                 : go currentPaths rest
-        | "  …" `Text.isPrefixOf` line
-            || "… +" `Text.isPrefixOf` line =
+        | isDiffMetaLine line =
             ParsedDiffLine DiffLineMeta currentPaths "" line
+                : go currentPaths rest
+        | Just (kind, prefix, source) <- unifiedDiffLine line =
+            ParsedDiffLine kind currentPaths prefix source
                 : go currentPaths rest
         | otherwise =
             ParsedDiffLine DiffLinePlain currentPaths "" line
@@ -356,6 +392,87 @@ diffHeaderPaths line =
                         , diffAddedPath = Just destinationPath
                         })
             Nothing -> pure (sameDiffPaths sourcePath)
+
+-- | Git/unified headers update the current file paths so later +/- rows can
+-- pick a source grammar. They stay muted rather than using the compact
+-- create/update chrome.
+unifiedDiffHeaderPaths :: DiffPaths -> Text -> Maybe DiffPaths
+unifiedDiffHeaderPaths current line
+    | Just rest <- Text.stripPrefix "diff --git " line =
+        case Text.words rest of
+            [source, destination] ->
+                Just
+                    DiffPaths
+                        { diffRemovedPath = gitDiffPath source
+                        , diffAddedPath = gitDiffPath destination
+                        }
+            _ -> Nothing
+    | Just rest <- Text.stripPrefix "--- " line =
+        let removed = gitDiffPath rest
+        in Just
+            current
+                { diffRemovedPath = removed
+                , diffAddedPath = current.diffAddedPath <|> removed
+                }
+    | Just rest <- Text.stripPrefix "+++ " line =
+        let added = gitDiffPath rest
+        in Just
+            current
+                { diffAddedPath = added
+                , diffRemovedPath = current.diffRemovedPath <|> added
+                }
+    | otherwise = Nothing
+
+gitDiffPath :: Text -> Maybe Text
+gitDiffPath raw =
+    let trimmed = Text.strip (Text.takeWhile (/= '\t') raw)
+        unquoted = stripDiffQuotes trimmed
+        withoutPrefix
+            | "a/" `Text.isPrefixOf` unquoted
+                || "b/" `Text.isPrefixOf` unquoted =
+                Text.drop 2 unquoted
+            | otherwise = unquoted
+    in if Text.null withoutPrefix || withoutPrefix == "/dev/null"
+        then Nothing
+        else Just withoutPrefix
+
+stripDiffQuotes :: Text -> Text
+stripDiffQuotes text =
+    case Text.uncons text of
+        Just ('"', rest)
+            | Text.isSuffixOf "\"" rest && not (Text.null rest) ->
+                Text.dropEnd 1 rest
+        _ -> text
+
+unifiedDiffLine :: Text -> Maybe (DiffLineKind, Text, Text)
+unifiedDiffLine line
+    | "+" `Text.isPrefixOf` line
+    , not ("+++" `Text.isPrefixOf` line) =
+        Just (DiffLineAdded, "+", Text.drop 1 line)
+    | "-" `Text.isPrefixOf` line
+    , not ("---" `Text.isPrefixOf` line) =
+        Just (DiffLineRemoved, "-", Text.drop 1 line)
+    | " " `Text.isPrefixOf` line =
+        Just (DiffLineContext, " ", Text.drop 1 line)
+    | otherwise = Nothing
+
+isDiffMetaLine :: Text -> Bool
+isDiffMetaLine line =
+    "  …" `Text.isPrefixOf` line
+        || "… +" `Text.isPrefixOf` line
+        || "@@" `Text.isPrefixOf` Text.stripStart line
+        || "\\ " `Text.isPrefixOf` line
+        || "index " `Text.isPrefixOf` line
+        || "new file mode " `Text.isPrefixOf` line
+        || "deleted file mode " `Text.isPrefixOf` line
+        || "old mode " `Text.isPrefixOf` line
+        || "new mode " `Text.isPrefixOf` line
+        || "similarity index " `Text.isPrefixOf` line
+        || "rename from " `Text.isPrefixOf` line
+        || "rename to " `Text.isPrefixOf` line
+        || "copy from " `Text.isPrefixOf` line
+        || "copy to " `Text.isPrefixOf` line
+        || "Binary files " `Text.isPrefixOf` line
 
 emptyDiffPaths :: DiffPaths
 emptyDiffPaths =
@@ -705,11 +822,26 @@ renderChunk syntaxHighlighter _ cacheCode codeHeader (FenceBlock block) =
         else bodyWidget
     ]
   where
-    bodyWidget =
-        renderCodeBody
-            (if block.fencedClosed then syntaxHighlighter else Nothing)
-            block.fencedInfo
-            (codeBodyLines block.fencedBody)
+    highlighter =
+        if block.fencedClosed then syntaxHighlighter else Nothing
+    bodyWidget
+        | shouldRenderFenceAsDiff block =
+            diffWidgetWithSyntaxHighlighting
+                highlighter
+                ""
+                block.fencedBody
+        | otherwise =
+            renderCodeBody
+                highlighter
+                block.fencedInfo
+                (codeBodyLines block.fencedBody)
+
+shouldRenderFenceAsDiff :: FencedBlock -> Bool
+shouldRenderFenceAsDiff block =
+    isDiffFenceInfo block.fencedInfo
+        || ( Text.null (Text.strip block.fencedInfo)
+            && looksLikeUnifiedDiff block.fencedBody
+           )
 
 renderLines
     :: Ord n

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -338,6 +338,37 @@ spec = describe "fullscreen Markdown rendering" do
                 ])
             `shouldBe` ["haskell", "typescript", "python", "rust"]
 
+    it "discovers languages from unified diff headers" do
+        diffSyntaxLanguages
+            ""
+            (Text.unlines
+                [ "diff --git a/src/Main.hs b/src/Main.hs"
+                , "--- a/src/Main.hs"
+                , "+++ b/src/Main.hs"
+                , "@@ -1,2 +1,2 @@"
+                , " context"
+                , "-old"
+                , "+new"
+                ])
+            `shouldBe` ["haskell"]
+
+    it "loads source grammars for Markdown diff fences" do
+        markdownFenceSyntaxLanguages
+            "diff"
+            "--- a/src/Main.hs\n+++ b/src/Main.hs\n@@ -1 +1 @@\n-old\n+new\n"
+            `shouldBe` ["haskell"]
+        markdownFenceSyntaxLanguages "PATCH" "-old\n+new\n"
+            `shouldBe` []
+        markdownFenceSyntaxLanguages
+            ""
+            "@@ -1 +1 @@\n-old\n+new\n"
+            `shouldBe` []
+        markdownFenceSyntaxLanguages "haskell" "main = pure ()"
+            `shouldBe` ["haskell"]
+        isDiffFenceInfo "udiff" `shouldBe` True
+        looksLikeUnifiedDiff "@@ -1 +1 @@\n-old\n+new\n" `shouldBe` True
+        looksLikeUnifiedDiff "main = pure ()" `shouldBe` False
+
     it "syntax-highlights edit lines over full-width diff backgrounds" do
         syntaxDirectory <- sourceSyntaxDirectory
         loadSyntaxHighlighterFrom syntaxDirectory >>= \case
@@ -424,6 +455,73 @@ spec = describe "fullscreen Markdown rendering" do
                 fmap (V.attrForeColor . spanAttr)
                     (find (containsText "destination comment") rows)
                     `shouldBe` Just commentForeground
+
+    it "paints Markdown diff fences with add/remove backgrounds" do
+        syntaxDirectory <- sourceSyntaxDirectory
+        loadSyntaxHighlighterFrom syntaxDirectory >>= \case
+            Left message -> expectationFailure (Text.unpack message)
+            Right highlighter -> do
+                let width = 40
+                    widget :: Widget ()
+                    widget =
+                        markdownWidgetWithSyntaxHighlighting
+                            (Just highlighter)
+                            (\_ body -> body)
+                            (\_ _ -> txt "")
+                            (Text.unlines
+                                [ "```diff"
+                                , "--- a/Main.hs"
+                                , "+++ b/Main.hs"
+                                , "@@ -1 +1 @@"
+                                , "-message = \"before\""
+                                , "+message = \"after\""
+                                , "```"
+                                ])
+                    picture =
+                        renderWidget
+                            (Just Theme.terminalDefault)
+                            [widget]
+                            (width, 8)
+                    rows =
+                        map toList $
+                            toList $
+                                displayOpsForPic picture (width, 8)
+                    findText expected =
+                        find (containsText expected) (concat rows)
+                    stringForeground =
+                        V.attrForeColor $
+                            attrMapLookup
+                                Theme.syntaxStringAttr
+                                Theme.terminalDefault
+                    removedBackground =
+                        V.attrBackColor $
+                            attrMapLookup
+                                Theme.diffRemovedAttr
+                                Theme.terminalDefault
+                    addedBackground =
+                        V.attrBackColor $
+                            attrMapLookup
+                                Theme.diffAddedAttr
+                                Theme.terminalDefault
+                    variableForeground =
+                        V.attrForeColor $
+                            attrMapLookup
+                                Theme.syntaxVariableAttr
+                                Theme.terminalDefault
+                V.imageWidth (V.picImage picture) `shouldBe` width
+                fmap (V.attrForeColor . spanAttr) (findText "\"before\"")
+                    `shouldBe` Just stringForeground
+                fmap (V.attrBackColor . spanAttr) (findText "\"before\"")
+                    `shouldBe` Just removedBackground
+                fmap (V.attrForeColor . spanAttr) (findText "\"after\"")
+                    `shouldBe` Just stringForeground
+                fmap (V.attrBackColor . spanAttr) (findText "\"after\"")
+                    `shouldBe` Just addedBackground
+                -- Skylighting's diff grammar would paint the whole added
+                -- line as a variable (cyan). Semantic rows keep string
+                -- tokens green on the added wash instead.
+                fmap (V.attrForeColor . spanAttr) (findText "\"after\"")
+                    `shouldNotBe` Just variableForeground
 
     it "renders terminal controls as inert visible glyphs" do
         let unsafe = "\ESC]0;owned\BEL\t\r"

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -523,6 +523,90 @@ spec = describe "fullscreen Markdown rendering" do
                 fmap (V.attrForeColor . spanAttr) (findText "\"after\"")
                     `shouldNotBe` Just variableForeground
 
+    it "treats triple-prefix hunk lines as added and removed changes" do
+        let width = 40
+            widget :: Widget ()
+            widget =
+                diffWidgetWithSyntaxHighlighting
+                    Nothing
+                    "Main.hs"
+                    (Text.unlines
+                        [ "@@ -1,2 +1,2 @@"
+                        , "--- comment"
+                        , "+++counter;"
+                        ])
+            picture =
+                renderWidget
+                    (Just Theme.terminalDefault)
+                    [widget]
+                    (width, 4)
+            rows =
+                concat $
+                    map toList $
+                        toList $
+                            displayOpsForPic picture (width, 4)
+            findText expected = find (containsText expected) rows
+            removedBackground =
+                V.attrBackColor $
+                    attrMapLookup Theme.diffRemovedAttr Theme.terminalDefault
+            addedBackground =
+                V.attrBackColor $
+                    attrMapLookup Theme.diffAddedAttr Theme.terminalDefault
+        fmap (V.attrBackColor . spanAttr) (findText "-- comment")
+            `shouldBe` Just removedBackground
+        fmap (V.attrBackColor . spanAttr) (findText "++counter;")
+            `shouldBe` Just addedBackground
+
+    it "keeps unified YAML context from matching compact-edit removals" do
+        let width = 40
+            widget :: Widget ()
+            widget =
+                diffWidgetWithSyntaxHighlighting
+                    Nothing
+                    "items.yaml"
+                    (Text.unlines
+                        [ "@@ -1 +1 @@"
+                        , "  - item"
+                        ])
+            picture =
+                renderWidget
+                    (Just Theme.terminalDefault)
+                    [widget]
+                    (width, 3)
+            rows =
+                concat $
+                    map toList $
+                        toList $
+                            displayOpsForPic picture (width, 3)
+            removedBackground =
+                V.attrBackColor $
+                    attrMapLookup Theme.diffRemovedAttr Theme.terminalDefault
+            addedBackground =
+                V.attrBackColor $
+                    attrMapLookup Theme.diffAddedAttr Theme.terminalDefault
+        find (containsText "- item") rows `shouldSatisfy` isJust
+        fmap (V.attrBackColor . spanAttr) (find (containsText "- item") rows)
+            `shouldNotBe` Just removedBackground
+        fmap (V.attrBackColor . spanAttr) (find (containsText "- item") rows)
+            `shouldNotBe` Just addedBackground
+
+    it "keeps a following file header after a unified hunk is complete" do
+        diffSyntaxLanguages
+            ""
+            (Text.unlines
+                [ "--- a/src/Main.hs"
+                , "+++ b/src/Main.hs"
+                , "@@ -1 +1 @@"
+                , "-old"
+                , "+new"
+                , "--- a/web/app.ts"
+                , "+++ b/web/app.ts"
+                , "@@ -1 +1 @@"
+                , "-const oldValue = 1"
+                , "+const newValue = 2"
+                ])
+            `shouldBe` ["haskell", "typescript"]
+
     it "renders terminal controls as inert visible glyphs" do
         let unsafe = "\ESC]0;owned\BEL\t\r"
             prose = Text.concat (renderRows 40 unsafe)


### PR DESCRIPTION
## Summary

- render Markdown `diff`/`patch`/`udiff` fences with the same red/green add/remove washes used for tool edit previews
- parse unified diffs with hunk state so the first character is the marker inside a hunk (`+++counter;`, `--- comment`, YAML ` - item`)
- recognize `--- a/path` / `+++ b/path` / `diff --git` headers only outside the current hunk, then overlay the source-file grammar
- treat unlabeled fences that contain `@@` hunk headers the same way, and load those source languages for on-demand highlighting

Claude replies often wrap patches in ` ```diff `. Skylighting maps removed lines to strings (green) and added lines to variables (cyan), which made Claude sessions look wrong next to OpenAI and Grok.

## Testing

- `cabal repl agent-tui:test:agent-tui-test --repl-options=-fobject-code`, then `:main --match "fullscreen Markdown rendering"` (59 examples, 0 failures)
- `cabal repl agent-syntax:test:agent-syntax-test`, then `:main --match "fence language resolution"` (4 examples, 0 failures)
- `cabal repl agent-cli:lib:agent-cli --repl-options=-fobject-code` (199 modules loaded)
- live tmux TTY preview of a ` ```diff ` widget (`TERM=tmux-256color`, `capture-pane -e`):
  - headers stayed muted (`[90m`)
  - removed rows used `48;5;68` (Color240 52) including `-- comment`
  - added rows used `48;5;38` (Color240 22) including `++counter;`
  - gutters were red `-` / green `+`
- `git diff --check`