### PR TITLE
Bound subagent delegation and repair fork history

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Btw.hs
+++ b/packages/agent-cli/src/Agent/CLI/Btw.hs
@@ -71,12 +71,46 @@ sideQuestionPrompt question =
 -- that torn suffix in a fresh request produces invalid tool pairing.
 trimDanglingToolSuffix :: [ResponseItem] -> [ResponseItem]
 trimDanglingToolSuffix items =
-    case findIndex (isUnmatchedCall completed) suffix of
-        Nothing -> items
-        Just index -> prefix <> dropTrailingReasoning (take index suffix)
+    retainCompleteToolPairs $
+        case findIndex (isUnmatchedCall completed) suffix of
+            Nothing -> items
+            Just index -> prefix <> dropTrailingReasoning (take index suffix)
   where
     completed = outputCallIds items
     (prefix, suffix) = splitAfterLastMessage items
+
+data ToolCallKey
+    = FunctionCallKey !Text
+    | CustomToolCallKey !Text
+    deriving (Eq, Ord)
+
+-- A fresh request cannot rely on provider-side continuation state. Keep only
+-- tool calls whose matching output occurs later in the inherited transcript,
+-- and discard orphan outputs as well as old unmatched calls.
+retainCompleteToolPairs :: [ResponseItem] -> [ResponseItem]
+retainCompleteToolPairs items =
+    filter (belongsTo complete) items
+  where
+    complete = snd (foldl' collect (Set.empty, Set.empty) items)
+
+    collect (seen, paired) item = case itemKey item of
+        Just (True, key) -> (Set.insert key seen, paired)
+        Just (False, key)
+            | Set.member key seen -> (seen, Set.insert key paired)
+        _ -> (seen, paired)
+
+    belongsTo paired item = case itemKey item of
+        Just (_, key) -> Set.member key paired
+        Nothing -> True
+
+    itemKey = \case
+        FunctionCallItem call -> Just (True, FunctionCallKey call.callId)
+        FunctionCallOutputItem output ->
+            Just (False, FunctionCallKey output.callId)
+        CustomToolCallItem call -> Just (True, CustomToolCallKey call.callId)
+        CustomToolCallOutputItem output ->
+            Just (False, CustomToolCallKey output.callId)
+        _ -> Nothing
 
 splitAfterLastMessage :: [ResponseItem] -> ([ResponseItem], [ResponseItem])
 splitAfterLastMessage items =

--- a/packages/agent-cli/src/Agent/CLI/Btw.hs
+++ b/packages/agent-cli/src/Agent/CLI/Btw.hs
@@ -19,7 +19,9 @@ import Agent.Loop
     , initialBackendSnapshot
     )
 import Agent.Responses.Types
-    ( CustomToolCall(..)
+    ( ComputerCall(..)
+    , ComputerCallOutput(..)
+    , CustomToolCall(..)
     , CustomToolCallOutput(..)
     , FunctionCall(..)
     , FunctionCallOutput(..)
@@ -82,6 +84,7 @@ trimDanglingToolSuffix items =
 data ToolCallKey
     = FunctionCallKey !Text
     | CustomToolCallKey !Text
+    | ComputerCallKey !Text
     deriving (Eq, Ord)
 
 -- A fresh request cannot rely on provider-side continuation state. Keep only
@@ -110,6 +113,10 @@ retainCompleteToolPairs items =
         CustomToolCallItem call -> Just (True, CustomToolCallKey call.callId)
         CustomToolCallOutputItem output ->
             Just (False, CustomToolCallKey output.callId)
+        ComputerCallItem call ->
+            Just (True, ComputerCallKey call.computerCallId)
+        ComputerCallOutputItem output ->
+            Just (False, ComputerCallKey output.computerOutputCallId)
         _ -> Nothing
 
 splitAfterLastMessage :: [ResponseItem] -> ([ResponseItem], [ResponseItem])
@@ -130,12 +137,14 @@ outputCallIds :: [ResponseItem] -> Set Text
 outputCallIds = Set.fromList . foldMap \case
     FunctionCallOutputItem output -> [output.callId]
     CustomToolCallOutputItem output -> [output.callId]
+    ComputerCallOutputItem output -> [output.computerOutputCallId]
     _ -> []
 
 isUnmatchedCall :: Set Text -> ResponseItem -> Bool
 isUnmatchedCall completed = \case
     FunctionCallItem call -> Set.notMember call.callId completed
     CustomToolCallItem call -> Set.notMember call.callId completed
+    ComputerCallItem call -> Set.notMember call.computerCallId completed
     _ -> False
 
 dropTrailingReasoning :: [ResponseItem] -> [ResponseItem]

--- a/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
@@ -46,13 +46,29 @@ spec = do
                            ]
             trimDanglingToolSuffix items `shouldBe` prefix
 
-        it "does not truncate an old unmatched call before a later message" do
+        it "removes an old unmatched call before a later message" do
             let items =
                     [ userItem "before"
                     , functionCallItem "old-call"
                     , userItem "continued later"
                     ]
-            trimDanglingToolSuffix items `shouldBe` items
+            trimDanglingToolSuffix items
+                `shouldBe` [userItem "before", userItem "continued later"]
+
+        it "removes an orphan output without a preceding call" do
+            let items =
+                    [ functionOutputItem "orphan"
+                    , userItem "continued later"
+                    ]
+            trimDanglingToolSuffix items `shouldBe` [userItem "continued later"]
+
+        it "does not pair an output that precedes its call" do
+            let items =
+                    [ functionOutputItem "torn"
+                    , functionCallItem "torn"
+                    , userItem "continued later"
+                    ]
+            trimDanglingToolSuffix items `shouldBe` [userItem "continued later"]
 
     describe "runBtwWithCancel" do
         it "uses private state and preserves parent params including tools" do

--- a/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
@@ -62,6 +62,26 @@ spec = do
                     ]
             trimDanglingToolSuffix items `shouldBe` [userItem "continued later"]
 
+        it "keeps complete native computer-call pairs" do
+            let items =
+                    [ userItem "before"
+                    , computerCallItem "computer-1"
+                    , computerOutputItem "computer-1"
+                    ]
+            trimDanglingToolSuffix items `shouldBe` items
+
+        it "drops reasoning and an unmatched native computer call" do
+            let prefix = [userItem "before"]
+                items = prefix <> [reasoningItem, computerCallItem "computer-live"]
+            trimDanglingToolSuffix items `shouldBe` prefix
+
+        it "removes an orphan native computer output" do
+            let items =
+                    [ computerOutputItem "computer-orphan"
+                    , userItem "continued later"
+                    ]
+            trimDanglingToolSuffix items `shouldBe` [userItem "continued later"]
+
         it "does not pair an output that precedes its call" do
             let items =
                     [ functionOutputItem "torn"
@@ -188,6 +208,27 @@ functionCallItem callId = FunctionCallItem FunctionCall
     , encryptedFunctionArgs = Nothing
     , status = Nothing
     }
+
+computerCallItem :: Text.Text -> ResponseItem
+computerCallItem computerCallId = ComputerCallItem ComputerCall
+    { computerCallItemId = Nothing
+    , computerCallId
+    , computerActions = []
+    , pendingSafetyChecks = []
+    , computerCallStatus = Nothing
+    , computerCallExtra = mempty
+    }
+
+computerOutputItem :: Text.Text -> ResponseItem
+computerOutputItem computerOutputCallId =
+    ComputerCallOutputItem ComputerCallOutput
+        { computerOutputItemId = Nothing
+        , computerOutputCallId
+        , screenshotDataUrl = ""
+        , acknowledgedChecks = []
+        , computerOutputStatus = Nothing
+        , computerOutputExtra = mempty
+        }
 
 functionOutputItem :: Text.Text -> ResponseItem
 functionOutputItem callId = FunctionCallOutputItem FunctionCallOutput

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal/Core.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal/Core.hs
@@ -72,6 +72,7 @@ newSubagentRegistry config cwd run onEvent = do
     agents <- newTVarIO Map.empty
     paths <- newTVarIO Map.empty
     live <- newTVarIO 0
+    rootTurnSpawnCounts <- newTVarIO Map.empty
     nextUpdateSeq <- newTVarIO 0
     waitCursors <- newTVarIO Map.empty
     activeWaits <- newTVarIO Map.empty
@@ -81,6 +82,7 @@ newSubagentRegistry config cwd run onEvent = do
     abortedRootTurns <- newTVarIO Set.empty
     configVar <- newTVarIO config
         { maxConcurrent = max 1 config.maxConcurrent
+        , maxSpawnedPerTurn = fmap (max 1) config.maxSpawnedPerTurn
         }
     lifecycle <- newMVar ()
     runRef <- newIORef run
@@ -90,6 +92,7 @@ newSubagentRegistry config cwd run onEvent = do
         { registryAgents = agents
         , registryPaths = paths
         , registryLiveCount = live
+        , registryRootTurnSpawnCounts = rootTurnSpawnCounts
         , registryNextUpdateSeq = nextUpdateSeq
         , registryWaitCursors = waitCursors
         , registryActiveWaits = activeWaits
@@ -173,6 +176,7 @@ resetSubagentRegistry registry =
             writeTVar registry.registryAgents Map.empty
             writeTVar registry.registryPaths Map.empty
             writeTVar registry.registryLiveCount 0
+            writeTVar registry.registryRootTurnSpawnCounts Map.empty
             writeTVar registry.registryNextUpdateSeq 0
             writeTVar registry.registryWaitCursors Map.empty
             writeTVar registry.registryActiveWaits Map.empty
@@ -357,8 +361,22 @@ spawnSubagentAtWithIdPreparedForTurn
                         Left err -> pure (Left err)
                         Right (parentPath, nextDepth) -> do
                             config <- readTVar registry.registryConfig
-                            case config.maxDepth of
-                                Just limit | nextDepth > limit ->
+                            budgetExceeded <- case
+                                    (rootTurnId, config.maxSpawnedPerTurn) of
+                                (Just turnId, Just limit) -> do
+                                    counts <- readTVar
+                                        registry.registryRootTurnSpawnCounts
+                                    pure $
+                                        if Map.findWithDefault 0 turnId counts >= limit
+                                            then Just limit
+                                            else Nothing
+                                _ -> pure Nothing
+                            case (budgetExceeded, config.maxDepth) of
+                                (Just limit, _) -> pure $ Left
+                                    ("Subagent budget reached for this turn (maximum "
+                                        <> Text.pack (show limit)
+                                        <> "). Solve the remaining task yourself.")
+                                (_, Just limit) | nextDepth > limit ->
                                     pure $ Left
                                         ("Agent depth limit reached (maximum depth "
                                             <> Text.pack (show limit)
@@ -409,6 +427,12 @@ spawnSubagentAtWithIdPreparedForTurn
                                                                 }
                                                         modifyTVar'
                                                             registry.registryLiveCount (+ 1)
+                                                        case rootTurnId of
+                                                            Just turnId ->
+                                                                modifyTVar'
+                                                                    registry.registryRootTurnSpawnCounts
+                                                                    (Map.insertWith (+) turnId 1)
+                                                            Nothing -> pure ()
                                                         writeTVar registry.registryAgents
                                                             (Map.insert agentId record agents)
                                                         writeTVar registry.registryPaths

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal/Types.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal/Types.hs
@@ -99,6 +99,7 @@ data SubagentRegistry = SubagentRegistry
     { registryAgents :: !(TVar (Map SubagentId SubagentRecord))
     , registryPaths :: !(TVar (Map TaskPath SubagentId))
     , registryLiveCount :: !(TVar Int)
+    , registryRootTurnSpawnCounts :: !(TVar (Map RootTurnId Int))
     , registryNextUpdateSeq :: !(TVar Int)
     , registryWaitCursors :: !(TVar (Map (Maybe SubagentId) Int))
     , registryActiveWaits :: !(TVar (Map (Maybe SubagentId) [SubagentId]))

--- a/packages/agent-core/src/Agent/Subagents/Types.hs
+++ b/packages/agent-core/src/Agent/Subagents/Types.hs
@@ -11,6 +11,7 @@ module Agent.Subagents.Types
     , defaultSubagentConfig
     , defaultMaxConcurrent
     , defaultMaxDepth
+    , defaultMaxSpawnedPerTurn
     , defaultWaitTimeoutMs
     , minWaitTimeoutMs
     , maxWaitTimeoutMs
@@ -59,18 +60,25 @@ data SubagentConfig = SubagentConfig
     { maxConcurrent :: !Int
       -- | 'Nothing' means unlimited nesting depth.
     , maxDepth :: !(Maybe Int)
+      -- | Cumulative new-agent admissions owned by one root turn.
+      -- 'Nothing' disables the budget.
+    , maxSpawnedPerTurn :: !(Maybe Int)
     } deriving (Eq, Show)
 
 defaultMaxConcurrent :: Int
-defaultMaxConcurrent = 32
+defaultMaxConcurrent = 8
 
 defaultMaxDepth :: Int
-defaultMaxDepth = 4
+defaultMaxDepth = 1
+
+defaultMaxSpawnedPerTurn :: Int
+defaultMaxSpawnedPerTurn = 16
 
 defaultSubagentConfig :: SubagentConfig
 defaultSubagentConfig = SubagentConfig
     { maxConcurrent = defaultMaxConcurrent
     , maxDepth = Just defaultMaxDepth
+    , maxSpawnedPerTurn = Just defaultMaxSpawnedPerTurn
     }
 
 minWaitTimeoutMs :: Int

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -231,13 +231,13 @@ spec = describe "Agent.Subagents" do
             `shouldReturn` Right replacement
         closeSubagentRegistry registry
 
-    it "allows 32 concurrent agents by default" do
+    it "allows eight concurrent agents by default" do
         defaultSubagentConfig.maxConcurrent `shouldBe` defaultMaxConcurrent
-        defaultMaxConcurrent `shouldBe` 32
+        defaultMaxConcurrent `shouldBe` 8
 
-    it "allows four nested levels by default and rejects depth five" do
+    it "allows one delegated level by default and rejects nested delegation" do
         defaultSubagentConfig.maxDepth `shouldBe` Just defaultMaxDepth
-        defaultMaxDepth `shouldBe` 4
+        defaultMaxDepth `shouldBe` 1
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ _ _ -> pure $ Right LoopResult
                 { finalResponseId = "x"
@@ -248,16 +248,31 @@ spec = describe "Agent.Subagents" do
             (\_ _ -> pure ())
         Right level1 <- spawnSubagent registry Nothing 0 "one" Nothing
         _ <- waitSubagents registry [level1] 15000
-        Right level2 <- spawnSubagent registry (Just level1) 1 "two" Nothing
-        _ <- waitSubagents registry [level2] 15000
-        Right level3 <- spawnSubagent registry (Just level2) 2 "three" Nothing
-        _ <- waitSubagents registry [level3] 15000
-        Right level4 <- spawnSubagent registry (Just level3) 3 "four" Nothing
-        _ <- waitSubagents registry [level4] 15000
-        result <- spawnSubagent registry (Just level4) 4 "five" Nothing
+        result <- spawnSubagent registry (Just level1) 1 "two" Nothing
         result `shouldBe`
             Left
-                "Agent depth limit reached (maximum depth 4). Solve the task yourself."
+                "Agent depth limit reached (maximum depth 1). Solve the task yourself."
+
+    it "caps cumulative new agents per root turn after agents finish" do
+        let config = defaultSubagentConfig
+                { maxSpawnedPerTurn = Just 2
+                }
+        registry <- newSubagentRegistry config (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure (completedResult "done"))
+            (\_ _ -> pure ())
+        rootTurnId <- beginRootTurn registry
+        let spawnForTurn name =
+                spawnSubagentWithCwdForTurn registry (Just rootTurnId)
+                    (fromFilePath "/tmp") Nothing 0 name Nothing
+        Right first <- spawnForTurn "first"
+        _ <- waitSubagents registry [first] 15000
+        Right second <- spawnForTurn "second"
+        _ <- waitSubagents registry [second] 15000
+        third <- spawnForTurn "third"
+        third `shouldBe`
+            Left
+                "Subagent budget reached for this turn (maximum 2). Solve the remaining task yourself."
+        closeSubagentRegistry registry
 
     it "releases maxConcurrent capacity when agents finish" do
         gate <- newTVarIO False
@@ -303,7 +318,9 @@ spec = describe "Agent.Subagents" do
         closeSubagentRegistry registry
 
     it "supports nested spawn when depth is unlimited" do
-        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+        registry <- newSubagentRegistry
+            (defaultSubagentConfig { maxDepth = Nothing })
+            (fromFilePath "/tmp")
             (\_ _ _ _ -> pure $ Left LoopNoResponseId)
             (\_ _ -> pure ())
         setSubagentRunner registry \env _previous prompt _ ->
@@ -542,7 +559,9 @@ spec = describe "Agent.Subagents" do
         noticeSeen <- newEmptyTMVarIO
         rootNotices <- newIORef ([] :: [SubagentId])
         settled <- newIORef ([] :: [(SubagentId, SubagentStatus)])
-        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+        registry <- newSubagentRegistry
+            (defaultSubagentConfig { maxDepth = Just 2 })
+            (fromFilePath "/tmp")
             (\_ _ _ _ -> pure (Left LoopNoResponseId))
             (\_ _ -> pure ())
         setSubagentOnComplete registry \agentId _ ->

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -832,7 +832,9 @@ spec = describe "Agent.Subagents" do
 
     it "releases nested subagent resources before their parent's resources" do
         released <- newIORef ([] :: [Text])
-        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+        registry <- newSubagentRegistry
+            (defaultSubagentConfig { maxDepth = Just 2 })
+            (fromFilePath "/tmp")
             (\_ _ prompt _ -> pure (completedResult (messagePayload prompt)))
             (\_ _ -> pure ())
         Right parent <- spawnSubagentWithCwdPrepared registry (fromFilePath "/tmp")

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -150,27 +150,18 @@ spec = describe "Agent.Tools.MultiAgents" do
             }
         closeSubagentRegistry registry
 
-    it "spawns canonical paths through depth four and rejects depth five" do
+    it "spawns one delegated level and rejects nested delegation" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\env _ _ _ -> pure (resultWithText env.subId.unSubagentId))
             (\_ _ -> pure ())
         level1 <- spawnFrom (rootContext registry Nothing) "level1"
         level1Context <- childContext registry level1 1
-        level2 <- spawnFrom level1Context "level2"
-        level2Context <- childContext registry level2 2
-        level3 <- spawnFrom level2Context "level3"
-        level3Context <- childContext registry level3 3
-        level4 <- spawnFrom level3Context "level4"
-        level4Path <- fromMaybe taskPathRoot <$> getTaskPath registry level4
-        taskPathText level4Path
-            `shouldBe` "/root/level1/level2/level3/level4"
-        level4Context <- childContext registry level4 4
         rejected <- dispatchToolCall defaultLoopDispatch
             (appToolHandlers
-                (multiAgentTools level4Context))
-            (spawnCall "level5")
+                (multiAgentTools level1Context))
+            (spawnCall "level2")
         rejected.output `shouldSatisfy`
-            Text.isInfixOf "maximum depth 4"
+            Text.isInfixOf "maximum depth 1"
         closeSubagentRegistry registry
 
     it "adds host-provided model guidance to spawn_agent" do
@@ -586,7 +577,9 @@ spec = describe "Agent.Tools.MultiAgents" do
 
     it "wait_agent excludes the calling child" do
         parentGate <- newTVarIO False
-        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+        registry <- newSubagentRegistry
+            (defaultSubagentConfig { maxDepth = Just 2 })
+            (fromFilePath "/tmp")
             (\_ _ message _ ->
                 if message.messageRecipient == "/root/parent"
                     then do

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Task.hs
@@ -275,7 +275,8 @@ taskDescription allowedModels =
     \- subagent_type defaults to general-purpose when omitted.\n\
     \- Nested delegation is limited to "
     <> Text.pack (show defaultMaxDepth)
-    <> " levels below the root agent. At the limit, complete the assigned task directly.\n\
+    <> (if defaultMaxDepth == 1 then " level" else " levels")
+    <> " below the root agent. At the limit, complete the assigned task directly.\n\
     \- When launching independent subagents, you MUST incorporate the results into the task based on requirements BEFORE concluding.\n\n\
     \Resuming a previous agent (resume_from):\n\
     \- Use resume_from to continue a previously completed subagent's conversation. Pass the subagent_id returned by a prior spawn_subagent call. A resumed agent keeps its transcript, so only describe what changed since the last run.\n\

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/TaskSpec.hs
@@ -66,7 +66,7 @@ spec = describe "Agent.GrokBuild.Dialect.Task" do
         tool.appToolDescription `shouldSatisfy`
             Text.isInfixOf "subagent_type defaults to general-purpose"
         tool.appToolDescription `shouldSatisfy`
-            Text.isInfixOf "limited to 4 levels"
+            Text.isInfixOf "limited to 1 level"
         tool.appToolDescription `shouldNotSatisfy`
             Text.isInfixOf "must specify a subagent_type"
         expectAlwaysPrompt tool.appToolApproval


### PR DESCRIPTION
## Summary

- reduce default subagent concurrency from 32 to 8 and default nesting depth from 4 to 1
- add a cumulative 16-agent admission budget per root turn, shared by Codex- and Grok-style collaboration tools
- sanitize forked transcripts so unmatched calls and orphan or misordered tool outputs are not replayed
- add focused registry, dialect, and transcript regression coverage

## Motivation

Historical session analysis showed that deep, high-fan-out delegation amplified provider failures and cancellation cascades. The largest explicit failure class was invalid tool continuation history, including outputs without matching calls and calls without outputs.

## Validation

- `cabal repl agent-core:test:agent-core-test`
  - six focused subagent admission, nesting, routing, and dialect examples: 0 failures
- `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`
  - `trimDanglingToolSuffix`: 5 examples, 0 failures
- `git diff --check`