### PR TITLE
Reserve headroom for Claude compaction

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -5,6 +5,8 @@ module Agent.CLI.Compaction
     , CompactionInstall(..)
     , OpenAiCompactionSender
     , codexAutoCompactTokenLimit
+    , claudeAutoCompactTokenLimit
+    , claudeCompactionInputLimit
     , autoCompactOpenAiBackend
     , autoCompactOpenAiBackendWithThreshold
     , autoCompactOpenAiBackendWithSender
@@ -26,6 +28,8 @@ module Agent.CLI.Compaction
     , runResponsesCompactWithContextWindow
     , runBackendCompactWithContextWindow
     , runBackendCompactHistoryWithContextWindow
+    , runBackendCompactWithLimits
+    , runBackendCompactHistoryWithLimits
     , OccupancyKind(..)
     , OccupancySnapshot(..)
     , estimatedOccupancy
@@ -118,6 +122,41 @@ import qualified Data.Text as Text
 
 codexAutoCompactTokenLimit :: Int
 codexAutoCompactTokenLimit = defaultCodexAutoCompactTokenLimit
+
+-- | Claude Code reserves up to 20k tokens for model output, begins preparing
+-- compaction at 80% of that effective window, and keeps a further 13k-token
+-- margin before a compaction prompt may fill the window. Scale both fixed
+-- reserves down for synthetic small windows used by tests and custom models.
+claudeAutoCompactTokenLimit :: Int -> Int
+claudeAutoCompactTokenLimit contextWindow =
+    max 1 $
+        min
+            (claudeCompactionInputLimit contextWindow)
+            (claudeEffectiveContextWindow contextWindow * 4 `div` 5)
+
+-- | Maximum estimated input size for an isolated Claude summary request.
+-- The Responses estimator cannot see Claude Code's own prompt framing, so this
+-- hard limit deliberately leaves the same output and safety headroom used by
+-- Claude Code instead of spending the model's complete context window.
+claudeCompactionInputLimit :: Int -> Int
+claudeCompactionInputLimit contextWindow =
+    max 1
+        ( effectiveWindow
+            - boundedClaudeReserve 13_000 effectiveWindow
+        )
+  where
+    effectiveWindow = claudeEffectiveContextWindow contextWindow
+
+claudeEffectiveContextWindow :: Int -> Int
+claudeEffectiveContextWindow contextWindow =
+    max 1
+        ( max 1 contextWindow
+            - boundedClaudeReserve 20_000 (max 1 contextWindow)
+        )
+
+boundedClaudeReserve :: Int -> Int -> Int
+boundedClaudeReserve maximumReserve window =
+    min maximumReserve (max 0 window `div` 5)
 
 data CompactAttempt error = CompactAttempt
     { compactAttemptUsage :: !TokenUsage
@@ -268,13 +307,27 @@ runBackendCompactWithContextWindow
     -> IORef [ResponseItem]
     -> Maybe Text
     -> IO (Either Text CompactOutcome)
-runBackendCompactWithContextWindow contextWindow makeBackend recordUsage
+runBackendCompactWithContextWindow contextWindow =
+    runBackendCompactWithLimits contextWindow contextWindow
+
+-- | Variant with a provider-specific input limit for the isolated summary
+-- request. The full context window still governs the installed checkpoint.
+runBackendCompactWithLimits
+    :: Int
+    -> Int
+    -> (ResponseCreateParams -> Backend)
+    -> (TokenUsage -> IO ())
+    -> IORef ResponseCreateParams
+    -> IORef [ResponseItem]
+    -> Maybe Text
+    -> IO (Either Text CompactOutcome)
+runBackendCompactWithLimits contextWindow inputLimit makeBackend recordUsage
         paramsRef transcriptRef focus = do
     params <- readIORef paramsRef
     history <- readIORef transcriptRef
     either (Left . formatApiError) Right
-        <$> runBackendCompactHistoryWithContextWindow
-        contextWindow makeBackend recordUsage params history focus
+        <$> runBackendCompactHistoryWithLimits
+        contextWindow inputLimit makeBackend recordUsage params history focus
 
 -- | History-taking variant used by automatic compaction wrappers, where the
 -- exact checkpoint being compacted is already available.
@@ -286,24 +339,42 @@ runBackendCompactHistoryWithContextWindow
     -> [ResponseItem]
     -> Maybe Text
     -> IO (Either ApiError CompactOutcome)
-runBackendCompactHistoryWithContextWindow contextWindow makeBackend recordUsage
+runBackendCompactHistoryWithContextWindow contextWindow =
+    runBackendCompactHistoryWithLimits contextWindow contextWindow
+
+runBackendCompactHistoryWithLimits
+    :: Int
+    -> Int
+    -> (ResponseCreateParams -> Backend)
+    -> (TokenUsage -> IO ())
+    -> ResponseCreateParams
+    -> [ResponseItem]
+    -> Maybe Text
+    -> IO (Either ApiError CompactOutcome)
+runBackendCompactHistoryWithLimits contextWindow inputLimit makeBackend
+        recordUsage
         params history focus = do
     attempt <- runAttemptAndRecord recordUsage $
         summarizeBackendLocalAttempt
-            contextWindow makeBackend params history focus
+            contextWindow inputLimit makeBackend params history focus
     pure attempt.compactAttemptResult
 
 summarizeBackendLocalAttempt
     :: Int
+    -> Int
     -> (ResponseCreateParams -> Backend)
     -> ResponseCreateParams
     -> [ResponseItem]
     -> Maybe Text
     -> IO (CompactAttempt ApiError)
-summarizeBackendLocalAttempt contextWindow makeBackend params history focus
+summarizeBackendLocalAttempt contextWindow inputLimit makeBackend params
+        history focus
     | contextWindow <= 0 =
         pure $ compactApiFailure
             "model context_window must be positive"
+    | inputLimit <= 0 =
+        pure $ compactApiFailure
+            "compaction input limit must be positive"
     | null sourceHistory =
         pure $ compactApiFailure "nothing to compact"
     | null summaryHistory =
@@ -326,7 +397,7 @@ summarizeBackendLocalAttempt contextWindow makeBackend params history focus
             promptItem = userTextItem summaryPrompt
             requestHistory =
                 trimResponseHistoryToFit
-                    contextWindow
+                    summaryInputLimit
                     summaryParams
                     [promptItem]
                     summaryHistory
@@ -334,7 +405,7 @@ summarizeBackendLocalAttempt contextWindow makeBackend params history focus
         if estimateRequestTokensWithItems
                 summaryParams
                 (requestHistory <> [promptItem])
-                > contextWindow
+                > summaryInputLimit
             then pure $ CompactAttempt emptyTokenUsage $
                 Left (requestTooLargeError "local compaction")
             else
@@ -395,6 +466,7 @@ summarizeBackendLocalAttempt contextWindow makeBackend params history focus
                                 , compactAttemptResult = outcome
                                 }
   where
+    summaryInputLimit = min contextWindow inputLimit
     sourceHistory = stripTaskPlanContextItems history
     summaryHistory = filter isPortableLocalSummaryItem sourceHistory
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -22,12 +22,14 @@ import Agent.CLI.Compaction
       OccupancySnapshot,
       autoCompactBackendWith,
       boundCompletedToolContinuations,
+      claudeAutoCompactTokenLimit,
+      claudeCompactionInputLimit,
       decorateCompactOutcomeWithTaskPlan,
       decorateCompactOutcomeWithTaskPlanWithin,
       installLiveCompactOutcome,
       runProviderCompactWith,
-      runBackendCompactHistoryWithContextWindow,
-      runBackendCompactWithContextWindow,
+      runBackendCompactHistoryWithLimits,
+      runBackendCompactWithLimits,
       runResponsesCompactWithContextWindow )
 import Agent.CLI.Config ()
 import Agent.Connectivity ( withConnectionRecoveryOn )
@@ -888,12 +890,18 @@ runAgentProviders
                                         currentParams
                             claudeCompactThreshold = do
                                 contextWindow <- claudeContextWindow
+                                let hardLimit =
+                                        claudeCompactionInputLimit contextWindow
                                 pure $
                                     max 1 $
-                                        min contextWindow $
+                                        min hardLimit $
                                             fromMaybe
-                                                (contextWindow * 4 `div` 5)
+                                                (claudeAutoCompactTokenLimit
+                                                    contextWindow)
                                                 options.optCompactThreshold
+                            claudeSummaryInputLimit =
+                                claudeCompactionInputLimit
+                                    <$> claudeContextWindow
                             btwBackend privateParams =
                                 Backend \state previous inputs onEvent -> do
                                     privateTranscript <-
@@ -913,6 +921,7 @@ runAgentProviders
                                         onEvent
                             compactRunner focus = do
                                 contextWindow <- claudeContextWindow
+                                inputLimit <- claudeSummaryInputLimit
                                 historyRef <-
                                     newIORef =<< readLiveTranscript
                                         conversationRef
@@ -920,8 +929,9 @@ runAgentProviders
                                     conversationRef
                                     (Just contextTokensRef)
                                     (\requestedFocus ->
-                                        runBackendCompactWithContextWindow
+                                        runBackendCompactWithLimits
                                             contextWindow
+                                            inputLimit
                                             btwBackend
                                             recordCompactionUsage
                                             paramsRef
@@ -1001,9 +1011,11 @@ runAgentProviders
                             \handle -> do
                                 let compactHistory history _inputs = do
                                         contextWindow <- claudeContextWindow
+                                        inputLimit <- claudeSummaryInputLimit
                                         currentParams <- readIORef paramsRef
-                                        runBackendCompactHistoryWithContextWindow
+                                        runBackendCompactHistoryWithLimits
                                             contextWindow
+                                            inputLimit
                                             btwBackend
                                             recordCompactionUsage
                                             currentParams

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -12,6 +12,8 @@ import Agent.CLI.Compaction
     , autoCompactOpenAiBackendWithThreshold
     , codexAutoCompactTokenLimit
     , compactOpenAIWith
+    , claudeAutoCompactTokenLimit
+    , claudeCompactionInputLimit
     , decorateCompactOutcomeWithTaskPlan
     , decorateCompactOutcomeWithTaskPlanWithin
     , estimatedOccupancy
@@ -20,6 +22,7 @@ import Agent.CLI.Compaction
     , runProviderCompact
     , runProviderCompactWith
     , runBackendCompactWithContextWindow
+    , runBackendCompactWithLimits
     , runResponsesCompactWith
     , runResponsesCompactWithContextWindow
     )
@@ -591,6 +594,10 @@ spec = do
             readIORef recordedUsage `shouldReturn` [compactionUsage]
 
     describe "runBackendCompactWithContextWindow" do
+        it "matches Claude Code headroom for a 200k context window" do
+            claudeAutoCompactTokenLimit 200_000 `shouldBe` 144_000
+            claudeCompactionInputLimit 200_000 `shouldBe` 167_000
+
         it "uses an isolated fresh backend and records summary usage" do
             let history = [userTextItem "old context"]
                 paramsValue =
@@ -645,6 +652,46 @@ spec = do
                     inputs `shouldBe`
                         [UserMessage (summarizationPrompt (Just "focus"))]
                 _ -> expectationFailure "expected one isolated backend request"
+
+        it "applies a separate summary input limit" do
+            let history =
+                    [ userTextItem (Text.replicate 20_000 "old")
+                    , userTextItem "recent"
+                    ]
+                inputLimit = 2_000
+            params <- newIORef defaultResponseCreateParams
+            transcript <- newIORef history
+            requests <- newIORef []
+            let makeBackend summaryParams =
+                    Backend \snapshot _previous _inputs _onEvent -> do
+                        modifyIORef' requests
+                            (<> [(summaryParams, snapshot.backendItems)])
+                        pure $ successful snapshot TurnOutput
+                            { responseId = "claude-summary-session"
+                            , toolCalls = []
+                            , assistantText = Just "portable summary"
+                            , tokenUsage = compactionUsage
+                            , providerTelemetry = Nothing
+                            , completion = TurnCompleted
+                            }
+            result <-
+                runBackendCompactWithLimits
+                    200_000
+                    inputLimit
+                    makeBackend
+                    (const (pure ()))
+                    params
+                    transcript
+                    Nothing
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef requests >>= \case
+                [(summaryParams, requestHistory)] ->
+                    estimateRequestTokensWithItems
+                        summaryParams
+                        (requestHistory
+                            <> [userTextItem (summarizationPrompt Nothing)])
+                        `shouldSatisfy` (<= inputLimit)
+                _ -> expectationFailure "expected one bounded summary request"
 
         it "clears a provider continuation before automatic continuation" do
             let oldHistory = [userTextItem "old context"]


### PR DESCRIPTION
## Summary
- mirror Claude Code's effective-context and early-compaction headroom for Claude sessions
- cap isolated Claude summary requests separately from the final compacted transcript budget
- cover the 200k-window thresholds and bounded summary request behavior

For a 200k context window, automatic compaction now starts at 144k tokens and the summary request is capped at 167k tokens.

## Test plan
- `cabal test agent-cli-test --test-options="--match runBackendCompactWithContextWindow"` (4 examples, 0 failures)
