### PR TITLE
Fix duplicate sticky prompt after transcript reflow

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
@@ -634,16 +634,23 @@ reflowConversation = do
                 Just (VP _ top (_, height) (_, contentHeight)) -> do
                     renderedReserveRows <-
                         conversationRenderedReserveRows
+                    renderedAnchorTop <-
+                        conversationRenderedAnchorTop top anchor
                     let unpaddedContentHeight =
                             max 0
                                 (contentHeight - renderedReserveRows)
+                        alignedAnchor =
+                            maybe
+                                anchor
+                                (`Scroll.realignConversationAnchor` anchor)
+                                renderedAnchorTop
                         (next, scrollAction) =
                             Scroll.reflowConversationAnchor
                                 state.appUi.uiFollow
                                 top
                                 height
                                 unpaddedContentHeight
-                                anchor
+                                alignedAnchor
                     modify' \current ->
                         current { appConversationAnchor = Just next }
                     case scrollAction of
@@ -758,6 +765,46 @@ conversationRenderedReserveRows =
     lookupExtent ConversationReserve >>= \case
         Just (Extent _ _ (_, reserveRows)) -> pure reserveRows
         Nothing -> pure 0
+
+conversationRenderedAnchorTop
+    :: Int
+    -> Scroll.ConversationAnchor
+    -> EventM Name AppState (Maybe Int)
+conversationRenderedAnchorTop viewportTop anchor =
+    lookupExtent ConversationViewportExtent >>= \case
+        Nothing -> pure Nothing
+        Just viewportBounds ->
+            lookupExtent
+                (ConversationBlock AgentRoot anchor.anchorBlockId)
+                >>= \case
+                    Just blockBounds
+                        | extentTopRowInside viewportBounds blockBounds ->
+                            let
+                                Location (_, viewportRow) =
+                                    viewportBounds.extentUpperLeft
+                                Location (_, blockRow) =
+                                    blockBounds.extentUpperLeft
+                            in pure $
+                                Just $
+                                    max 0
+                                        (viewportTop
+                                            + blockRow
+                                            - viewportRow)
+                    _ -> pure Nothing
+
+-- Brick translates child extents by the viewport offset. Only a block whose
+-- top row is actually visible can safely repair the saved content position;
+-- an extent clipped above the viewport must retain sticky-prompt behavior.
+extentTopRowInside :: Extent Name -> Extent Name -> Bool
+extentTopRowInside outer inner =
+    innerRow >= outerRow
+        && innerRow < outerRow + outerHeight
+        && innerHeight > 0
+  where
+    Location (_, outerRow) = outer.extentUpperLeft
+    (_, outerHeight) = outer.extentSize
+    Location (_, innerRow) = inner.extentUpperLeft
+    (_, innerHeight) = inner.extentSize
 
 isSubmittedPrompt :: UiEvent -> Bool
 isSubmittedPrompt = \case

--- a/packages/agent-cli/src/Agent/CLI/TUI/Scroll.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Scroll.hs
@@ -8,6 +8,7 @@ module Agent.CLI.TUI.Scroll
     , conversationAnchorSticky
     , conversationFollowScroll
     , followConversationTail
+    , realignConversationAnchor
     , reconcileConversationFollow
     , reflowConversationAnchor
     , startConversationAnchor
@@ -109,6 +110,13 @@ startConversationAnchor blockId text top = ConversationAnchor
     , anchorViewportTop = max 0 top
     , anchorPhase = ConversationFillingPage
     }
+
+-- | Refresh the prompt's content row after rendered transcript geometry
+-- changes. The row captured at submission can become stale when earlier
+-- blocks are replaced, wrapped, or resized.
+realignConversationAnchor :: Int -> ConversationAnchor -> ConversationAnchor
+realignConversationAnchor top anchor =
+    anchor { anchorTop = max 0 top }
 
 -- | Recompute the virtual bottom reserve after a render.
 --

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -116,6 +116,12 @@ import Agent.CLI.TUI.ImagePreview
     ( NativePreviewPlacement(..)
     , TuiImagePreview(..)
     )
+import Agent.CLI.TUI.Scroll
+    ( ConversationAnchor(..)
+    , ConversationPhase(..)
+    , conversationAnchorSticky
+    , startConversationAnchor
+    )
 import Agent.CLI.Terminal
     ( TerminalCapabilities(..)
     , TerminalKind(..)
@@ -1706,6 +1712,11 @@ spec = do
                 (conversationScrollbarRenderer @()).renderVScrollbar
                 `shouldBe` V.char V.defAttr '┃'
 
+    describe "conversation prompt anchor" do
+        it "does not stick a stale prompt that is visible at the tail" do
+            timeout 2_000_000 visiblePromptRepairsStaleAnchor
+                `shouldReturn` Just True
+
     describe "history replacement viewport" do
         it "keeps startup system messages ahead of the first committed turn" do
             timeout 2_000_000 startupMessagesPrecedeFirstCommittedTurn
@@ -2791,6 +2802,41 @@ markerBlock blockId body = UiBlock
     , blockCallId = Nothing
     , blockInspectionGroupable = False
     }
+
+visiblePromptRepairsStaleAnchor :: IO Bool
+visiblePromptRepairsStaleAnchor = do
+    let prompt = "latest prompt"
+        ui =
+            reduceUi (UiUserSubmitted prompt) $
+                reduceUi
+                    (UiAssistantHistory
+                        (Text.unlines
+                            (replicate 30 "earlier transcript row")))
+                    initialUiState
+        promptBlockId = BlockId (ui.uiNextBlockId - 1)
+        staleAnchor =
+            (startConversationAnchor promptBlockId prompt 0)
+                { anchorViewportTop = 1
+                , anchorPhase = ConversationFollowingTail
+                }
+    runtime <- newScriptRuntime ui
+    let initialState =
+            (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                { appUi = ui
+                , appConversationAnchor = Just staleAnchor
+                }
+    (_, finalState) <-
+        runFullscreenScriptWithState
+            initialState
+            [ FullscreenScriptVty (V.EvKey V.KEnd [])
+            , FullscreenScriptApp AppConversationReflow
+            , FullscreenScriptHalt
+            ]
+    pure $
+        maybe
+            False
+            (not . conversationAnchorSticky)
+            finalState.appConversationAnchor
 
 renderedAppText :: (Int, Int) -> AppState -> Text
 renderedAppText size state =

--- a/packages/agent-cli/test/Agent/CLI/TUIScrollSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIScrollSpec.hs
@@ -55,6 +55,15 @@ spec = describe "fullscreen conversation scrolling" do
             conversationFollowScroll False
                 `shouldBe` KeepConversationPosition
 
+    it "realigns a stale prompt row before deciding whether it is sticky" do
+        let stale =
+                (startConversationAnchor (BlockId 7) "question" 40)
+                    { anchorViewportTop = 45 }
+            aligned = realignConversationAnchor 50 stale
+        conversationAnchorSticky stale `shouldBe` True
+        aligned.anchorTop `shouldBe` 50
+        conversationAnchorSticky aligned `shouldBe` False
+
     it "reserves the rest of the viewport below a submitted prompt" do
         let anchor = startConversationAnchor (BlockId 7) "question" 40
             (next, action) =


### PR DESCRIPTION
## Summary

- realign a submitted prompt's saved row from its rendered Brick extent after transcript reflow
- suppress the sticky overlay when that prompt is already visible, while preserving it when the prompt has genuinely scrolled offscreen
- cover the anchor policy and the full Brick event/render path with regressions

## Testing

- `cabal repl agent-cli:test:agent-cli-test --offline` in the Nix dev shell, then `hspec (Scroll.spec >> App.spec)` (140 examples, 0 failures)
- live tmux smoke check of the fullscreen TUI, including the local `/help` flow
- `git diff --check origin/master...HEAD`
