### PR TITLE
Enable Claude dictation via OpenAI or xAI accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,9 @@ Press `Ctrl+R` in the prompt composer, speak, and press `Enter` to stop
 (or `Esc` to cancel). Recording stays in the TUI; it does not suspend or close
 the session. On macOS, the resulting transcript is inserted at the cursor.
 Dictation follows the active model provider: OpenAI models use OpenAI and Grok
-models use xAI. ChatGPT/Codex OAuth uses the subscription-backed streaming
+models use xAI. Claude models have no transcription API, so they borrow a
+locally configured OpenAI account and fall back to an xAI account when no
+OpenAI credential exists. ChatGPT/Codex OAuth uses the subscription-backed streaming
 protocol used by the official desktop app and falls back to its buffered
 ChatGPT transcription route with the same recording if streaming fails. API
 keys use the public OpenAI Realtime API. Both OpenAI paths can update the
@@ -285,8 +287,7 @@ When an organization gateway is connected, the recording is sent only to the
 gateway's authenticated `/v1/audio/transcriptions` endpoint. The gateway uses
 its organization-managed transcription pool and returns a final transcript
 after recording stops; it never falls back to local provider credentials.
-Dictation is currently unavailable for providers without a speech-to-text
-integration.
+Dictation is currently unavailable for OpenRouter and Gemini models.
 
 ### Claude Code subscription
 

--- a/packages/agent-cli-runtime/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Auth.hs
@@ -177,13 +177,18 @@ loadDirectOpenAiAuth =
     runExceptT loadOpenAi
 
 -- | Dictation must not send an organization gateway bearer to a direct
--- provider transcription endpoint.
-loadOpenAiDictationAuth :: IO (Maybe LoadedAuth)
+-- provider transcription endpoint. Preserve OpenAI lookup failures so a
+-- borrowed Claude backend can still explain a broken local configuration.
+loadOpenAiDictationAuth :: IO (Either Text LoadedAuth)
 loadOpenAiDictationAuth =
     loadGatewayCredential >>= \case
-        Right Nothing -> OpenAIAuth.loadOpenAiDictationAuth
-        Right (Just _) -> pure Nothing
-        Left _ -> pure Nothing
+        Right Nothing ->
+            OpenAIAuth.loadOpenAiDictationAuth
+        Right (Just _) ->
+            pure $ Left
+                "No OpenAI credential found for OpenAI dictation"
+        Left gatewayErr ->
+            pure $ Left ("cannot load gateway credential: " <> gatewayErr)
 
 gatewayLoadedAuth :: GatewayCredential -> Either Text LoadedAuth
 gatewayLoadedAuth gateway = do

--- a/packages/agent-cli-runtime/src/Agent/CLI/Auth/OpenAI.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Auth/OpenAI.hs
@@ -151,21 +151,27 @@ preferredOpenAiTokenProvider preferredAccount pool fallback =
 -- | Load the best OpenAI credential for dictation. ChatGPT OAuth is preferred
 -- because the official desktop client transcribes subscription audio through
 -- the ChatGPT backend. API keys remain available for the public Realtime API.
-loadOpenAiDictationAuth :: IO (Maybe LoadedAuth)
+-- Lookup failures are preserved so callers can distinguish a missing account
+-- from a broken configuration.
+loadOpenAiDictationAuth :: IO (Either Text LoadedAuth)
 loadOpenAiDictationAuth =
     runExceptT loadOpenAi >>= \case
         Right loaded
             | tokenProviderBillingMode loaded.loadedTokenProvider
                 == SubscriptionBilled ->
-                pure (Just loaded)
+                pure (Right loaded)
             | otherwise ->
                 loadExternalOpenAiApiKeyDictationAuth >>= \case
                     Just external ->
-                        pure (Just external)
+                        pure (Right external)
                     Nothing ->
-                        pure (Just loaded)
-        Left _ ->
-            loadOpenAiApiKeyDictationAuth
+                        pure (Right loaded)
+        Left err ->
+            loadOpenAiApiKeyDictationAuth >>= \case
+                Just loaded ->
+                    pure (Right loaded)
+                Nothing ->
+                    pure (Left err)
 
 loadOpenAiApiKeyDictationAuth :: IO (Maybe LoadedAuth)
 loadOpenAiApiKeyDictationAuth =

--- a/packages/agent-cli/src/Agent/CLI/Dictation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dictation.hs
@@ -21,7 +21,6 @@ module Agent.CLI.Dictation
 
 import Agent.CLI.Auth
     ( LoadedAuth(..)
-    , authErrorNeedsOnboarding
     , loadAuth
     , loadOpenAiDictationAuth
     )
@@ -163,25 +162,44 @@ loadDictationBackendAuth
     -> IO (Either DictationAuthError LoadedAuth)
 loadDictationBackendAuth = \case
     OpenAIDictation ->
-        loadOpenAiDictationAuth >>= \case
-            Nothing ->
-                pure $ Left $ DictationCredentialMissing
-                    "No OpenAI credential found for OpenAI dictation"
-            Just loaded ->
-                pure (Right loaded)
+        classifyOpenAiDictationAuth <$> loadOpenAiDictationAuth
     XAIDictation ->
         loadAuth (Just XAIProvider) >>= \case
-            Left err
-                | authErrorNeedsOnboarding err ->
-                    pure (Left (DictationCredentialMissing err))
-                | otherwise ->
-                    pure (Left (DictationCredentialInvalid err))
+            Left err ->
+                pure (Left (classifyDictationLookupError err))
             Right loaded
                 | loaded.loadedProvider /= XAIProvider ->
                     pure $ Left $ DictationCredentialInvalid
                         "xAI dictation requires direct xAI credentials"
                 | otherwise ->
                     pure (Right loaded)
+
+classifyOpenAiDictationAuth
+    :: Either Text LoadedAuth
+    -> Either DictationAuthError LoadedAuth
+classifyOpenAiDictationAuth = \case
+    Right loaded ->
+        Right loaded
+    Left err ->
+        Left $ case classifyDictationLookupError err of
+            DictationCredentialMissing _ ->
+                DictationCredentialMissing
+                    "No OpenAI credential found for OpenAI dictation"
+            invalid ->
+                invalid
+
+-- | Treat only a true absence as missing. Errors such as
+-- @no valid OpenAI credentials found@ are broken configuration, even when
+-- first-start onboarding would offer a fresh login.
+classifyDictationLookupError :: Text -> DictationAuthError
+classifyDictationLookupError err
+    | dictationCredentialAbsent err = DictationCredentialMissing err
+    | otherwise = DictationCredentialInvalid err
+
+dictationCredentialAbsent :: Text -> Bool
+dictationCredentialAbsent message =
+    "no credentials found." `Text.isPrefixOf` message
+        || message == "No OpenAI credential found for OpenAI dictation"
 
 -- | Pick the first allowed backend that has a usable credential. Only the
 -- credential lookup participates in the fallback; once a backend is chosen,

--- a/packages/agent-cli/src/Agent/CLI/Dictation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dictation.hs
@@ -1,6 +1,7 @@
 -- | Terminal microphone recording and provider transcription.
 module Agent.CLI.Dictation
-    ( DictationBackend(..)
+    ( DictationAuthError(..)
+    , DictationBackend(..)
     , DictationControl(..)
     , DictationResult(..)
     , DictationTarget(..)
@@ -10,13 +11,17 @@ module Agent.CLI.Dictation
     , dictateWith
     , dictateWithTarget
     , dictationTargetForSession
-    , dictationBackendForProvider
+    , dictationBackendsForProvider
+    , dictationBackendUnavailable
     , insertDictation
+    , loadDictationBackendAuth
+    , selectDictationBackend
     , transcribeAudio
     ) where
 
 import Agent.CLI.Auth
     ( LoadedAuth(..)
+    , authErrorNeedsOnboarding
     , loadAuth
     , loadOpenAiDictationAuth
     )
@@ -54,6 +59,9 @@ import Control.Exception (AsyncException(UserInterrupt))
 import Control.Monad (unless, void)
 import qualified Data.ByteString as BS
 import Data.Char (isSpace)
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -113,18 +121,123 @@ dictationTargetForSession
 dictationTargetForSession provider =
     maybe (DirectDictation provider) GatewayDictation
 
--- | Select dictation from the active model provider. Providers without a
--- speech-to-text integration fail explicitly rather than spending credentials
--- from an unrelated provider.
-dictationBackendForProvider :: Provider -> Either Text DictationBackend
-dictationBackendForProvider = \case
-    OpenAIProvider -> Right OpenAIDictation
-    XAIProvider -> Right XAIDictation
+-- | Select the dictation backends allowed for the active model provider, in
+-- preference order. Providers with their own speech-to-text integration only
+-- ever transcribe with their own credentials. Claude has no transcription
+-- API, so Claude sessions borrow whichever OpenAI or xAI account is
+-- configured locally; OpenAI is tried first because ChatGPT subscriptions
+-- stream partial transcripts. Remaining providers fail explicitly rather than
+-- spending credentials from an unrelated provider.
+dictationBackendsForProvider
+    :: Provider
+    -> Either Text (NonEmpty DictationBackend)
+dictationBackendsForProvider = \case
+    OpenAIProvider -> Right (OpenAIDictation :| [])
+    XAIProvider -> Right (XAIDictation :| [])
+    ClaudeCodeProvider -> Right (OpenAIDictation :| [XAIDictation])
     provider ->
         Left $
             "Dictation is not supported for "
                 <> providerSlug provider
                 <> " models"
+
+-- | Why a backend cannot supply a credential. Distinguishing a plain absence
+-- from a broken configuration lets borrowed-backend errors stay short while
+-- still surfacing anything the user should fix.
+data DictationAuthError
+    = DictationCredentialMissing !Text
+    -- ^ Nothing is configured for this backend.
+    | DictationCredentialInvalid !Text
+    -- ^ Something is configured but could not be loaded.
+    deriving (Eq, Show)
+
+dictationAuthErrorText :: DictationAuthError -> Text
+dictationAuthErrorText = \case
+    DictationCredentialMissing err -> err
+    DictationCredentialInvalid err -> err
+
+-- | Load the direct credential a backend transcribes with, without recording
+-- any audio.
+loadDictationBackendAuth
+    :: DictationBackend
+    -> IO (Either DictationAuthError LoadedAuth)
+loadDictationBackendAuth = \case
+    OpenAIDictation ->
+        loadOpenAiDictationAuth >>= \case
+            Nothing ->
+                pure $ Left $ DictationCredentialMissing
+                    "No OpenAI credential found for OpenAI dictation"
+            Just loaded ->
+                pure (Right loaded)
+    XAIDictation ->
+        loadAuth (Just XAIProvider) >>= \case
+            Left err
+                | authErrorNeedsOnboarding err ->
+                    pure (Left (DictationCredentialMissing err))
+                | otherwise ->
+                    pure (Left (DictationCredentialInvalid err))
+            Right loaded
+                | loaded.loadedProvider /= XAIProvider ->
+                    pure $ Left $ DictationCredentialInvalid
+                        "xAI dictation requires direct xAI credentials"
+                | otherwise ->
+                    pure (Right loaded)
+
+-- | Pick the first allowed backend that has a usable credential. Only the
+-- credential lookup participates in the fallback; once a backend is chosen,
+-- its transcription errors surface directly instead of silently retrying
+-- with another account.
+selectDictationBackend
+    :: Provider
+    -> (DictationBackend -> IO (Either DictationAuthError LoadedAuth))
+    -> IO (Either Text (DictationBackend, LoadedAuth))
+selectDictationBackend provider loadBackendAuth =
+    case dictationBackendsForProvider provider of
+        Left err ->
+            pure (Left err)
+        Right backends ->
+            go [] (NonEmpty.toList backends)
+  where
+    go failures = \case
+        [] ->
+            pure $ Left $
+                dictationBackendUnavailable provider (reverse failures)
+        backend : remaining ->
+            loadBackendAuth backend >>= \case
+                Right loaded ->
+                    pure (Right (backend, loaded))
+                Left err ->
+                    go ((backend, err) : failures) remaining
+
+-- | Explain why no allowed backend could transcribe. A provider with a single
+-- native backend reports that backend's error verbatim. Borrowed backends
+-- summarize which accounts would work and only repeat lookup errors that
+-- describe a broken configuration, so a Claude user is not shown every
+-- provider's generic sign-in hint.
+dictationBackendUnavailable
+    :: Provider
+    -> [(DictationBackend, DictationAuthError)]
+    -> Text
+dictationBackendUnavailable provider failures =
+    case failures of
+        [(_, err)] -> dictationAuthErrorText err
+        _ ->
+            "Dictation for "
+                <> providerSlug provider
+                <> " models requires an OpenAI or xAI account; connect one \
+                   \with /login"
+                <> case mapMaybe detail failures of
+                    [] -> ""
+                    details ->
+                        " (" <> Text.intercalate "; " details <> ")"
+  where
+    detail (backend, err) = case err of
+        DictationCredentialMissing _ -> Nothing
+        DictationCredentialInvalid message ->
+            Just (backendLabel backend <> ": " <> message)
+    backendLabel = \case
+        OpenAIDictation -> "openai"
+        XAIDictation -> "xai"
 
 -- | Legacy standalone entry point. The inline model-aware REPL and fullscreen
 -- composer use 'dictateForProvider'; this preserves the original xAI default
@@ -175,11 +288,12 @@ dictateWithTarget target control =
         requireExecutable "ffmpeg"
         case target of
             DirectDictation provider ->
-                case dictationBackendForProvider provider of
-                    Left err ->
-                        pure (DictationFailed err)
-                    Right backend ->
-                        runBackend backend
+                selectDictationBackend provider loadDictationBackendAuth
+                    >>= \case
+                        Left err ->
+                            pure (DictationFailed err)
+                        Right (backend, loaded) ->
+                            runBackend backend loaded
             GatewayDictation gateway ->
                 transcribeGatewayPcm
                     gateway
@@ -192,36 +306,23 @@ dictateWithTarget target control =
                             pure
                                 (DictationTranscript
                                     (Text.strip transcript))
-    runBackend = \case
+    runBackend backend loaded = case backend of
         OpenAIDictation ->
-            loadOpenAiDictationAuth >>= \case
-                Nothing ->
-                    pure $ DictationFailed
-                        "No OpenAI credential found for OpenAI dictation"
-                Just loaded ->
-                    finish =<<
-                        transcribePcmWithOpenAI
-                            loaded.loadedTokenProvider
-                            (streamMicrophone
-                                openAITranscriptionSampleRate
-                                control.dictationWaitForStop)
-                            control.dictationOnTranscript
+            finish =<<
+                transcribePcmWithOpenAI
+                    loaded.loadedTokenProvider
+                    (streamMicrophone
+                        openAITranscriptionSampleRate
+                        control.dictationWaitForStop)
+                    control.dictationOnTranscript
         XAIDictation ->
-            loadAuth (Just XAIProvider) >>= \case
-                Left err ->
-                    pure (DictationFailed err)
-                Right loaded
-                    | loaded.loadedProvider /= XAIProvider ->
-                        pure $ DictationFailed
-                            "xAI dictation requires direct xAI credentials"
-                    | otherwise ->
-                        finish =<<
-                            transcribePcmWithXAI
-                                loaded.loadedTokenProvider
-                                (streamMicrophone
-                                    16_000
-                                    control.dictationWaitForStop)
-                                control.dictationOnTranscript
+            finish =<<
+                transcribePcmWithXAI
+                    loaded.loadedTokenProvider
+                    (streamMicrophone
+                        16_000
+                        control.dictationWaitForStop)
+                    control.dictationOnTranscript
     finish = \case
         Left err ->
             pure (DictationFailed (Text.pack (show err)))

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -2,6 +2,11 @@ module Agent.CLI.AuthSpec (spec) where
 
 import Agent.CLI.Auth
 import Agent.CLI.CredentialStore
+import Agent.CLI.Dictation
+    ( DictationAuthError(..)
+    , DictationBackend(..)
+    , loadDictationBackendAuth
+    )
 import Agent.CLI.GatewayClient
     ( GatewayCredential(..)
     , gatewayCredentialPath
@@ -492,6 +497,80 @@ spec = do
                             SubscriptionBilled
                             "e30.eyJleHAiOjQxMDI0NDQ4MDB9."
                             "account-home"
+
+        it "preserves an unreadable credential store instead of returning nothing" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    let storeDirectory =
+                            toFilePath home
+                                </> ".haskell-agent"
+                                </> "credentials"
+                    createDirectoryIfMissing True storeDirectory
+                    writeFile
+                        (storeDirectory </> "accounts.json")
+                        "{not-json"
+                    loadOpenAiDictationAuth >>= \case
+                        Right _ ->
+                            expectationFailure
+                                "expected invalid OpenAI dictation auth"
+                        Left err -> do
+                            err
+                                `shouldSatisfy`
+                                    ("no valid OpenAI credentials found:"
+                                        `Text.isPrefixOf`)
+                            err
+                                `shouldSatisfy`
+                                    ("invalid credential store" `Text.isInfixOf`)
+
+        it "preserves invalid managed OpenAI auth JSON instead of returning nothing" $
+            withTempHome \_ ->
+                withCleanOpenAiEnv do
+                    upsertManagedCredential
+                        (openAiMetadata
+                            SubscriptionBilled
+                            "broken-openai"
+                            "broken-account"
+                            True)
+                        (ManagedSecret "broken-openai" "{not-json")
+                        `shouldReturn` Right ()
+                    loadOpenAiDictationAuth >>= \case
+                        Right _ ->
+                            expectationFailure
+                                "expected invalid OpenAI dictation auth"
+                        Left err ->
+                            err
+                                `shouldBe`
+                                    "no valid OpenAI credentials found: \
+                                    \managed OpenAI OAuth credential \
+                                    \broken-openai contains invalid auth JSON"
+
+        it "classifies an unreadable OpenAI store as an invalid dictation credential" $
+            withTempHome \home ->
+                withCleanOpenAiEnv do
+                    let storeDirectory =
+                            toFilePath home
+                                </> ".haskell-agent"
+                                </> "credentials"
+                    createDirectoryIfMissing True storeDirectory
+                    writeFile
+                        (storeDirectory </> "accounts.json")
+                        "{not-json"
+                    loadDictationBackendAuth OpenAIDictation >>= \case
+                        Left (DictationCredentialInvalid err) -> do
+                            err
+                                `shouldSatisfy`
+                                    ("no valid OpenAI credentials found:"
+                                        `Text.isPrefixOf`)
+                            err
+                                `shouldSatisfy`
+                                    ("invalid credential store" `Text.isInfixOf`)
+                        Left (DictationCredentialMissing err) ->
+                            expectationFailure
+                                ("expected invalid OpenAI dictation auth, got missing: "
+                                    <> Text.unpack err)
+                        Right _ ->
+                            expectationFailure
+                                "expected invalid OpenAI dictation auth"
     describe "Gemini loadAuth" do
         it "loads Google AI Studio keys with GOOGLE_API_KEY precedence" $
             withTempHome \_ ->
@@ -2113,9 +2192,11 @@ shouldLoadOpenAiDictationCredential
     -> Expectation
 shouldLoadOpenAiDictationCredential billing expected expectedAccount =
     loadOpenAiDictationAuth >>= \case
-        Nothing ->
-            expectationFailure "expected an OpenAI dictation credential"
-        Just loaded -> do
+        Left err ->
+            expectationFailure
+                ("expected an OpenAI dictation credential, got "
+                    <> Text.unpack err)
+        Right loaded -> do
             loaded.loadedProvider `shouldBe` OpenAIProvider
             tokenProviderBillingMode loaded.loadedTokenProvider
                 `shouldBe` billing

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -314,6 +314,19 @@ spec = describe "fullscreen composer" do
         fmap fst selected `shouldBe` Right XAIDictation
         readIORef attempted `shouldReturn` [OpenAIDictation, XAIDictation]
 
+    it "falls back to xAI when Claude's OpenAI credential is invalid" do
+        attempted <- newIORef []
+        let loadBackend backend = do
+                modifyIORef' attempted (<> [backend])
+                pure case backend of
+                    OpenAIDictation ->
+                        Left (DictationCredentialInvalid "invalid auth JSON")
+                    XAIDictation ->
+                        Right (fakeLoadedAuth backend)
+        selected <- selectDictationBackend ClaudeCodeProvider loadBackend
+        fmap fst selected `shouldBe` Right XAIDictation
+        readIORef attempted `shouldReturn` [OpenAIDictation, XAIDictation]
+
     it "never borrows another provider's account for native dictation" do
         attempted <- newIORef []
         let loadBackend backend = do
@@ -345,9 +358,39 @@ spec = describe "fullscreen composer" do
                 "Dictation for claude-code models requires an OpenAI or xAI \
                 \account; connect one with /login (xai: invalid auth JSON)"
         dictationBackendUnavailable
+            ClaudeCodeProvider
+            [ ( OpenAIDictation
+              , DictationCredentialInvalid
+                    "no valid OpenAI credentials found: \
+                    \credential store is unreadable"
+              )
+            , (XAIDictation, DictationCredentialMissing "no credentials found.")
+            ]
+            `shouldBe`
+                "Dictation for claude-code models requires an OpenAI or xAI \
+                \account; connect one with /login (openai: no valid OpenAI \
+                \credentials found: credential store is unreadable)"
+        dictationBackendUnavailable
             XAIProvider
             [(XAIDictation, DictationCredentialInvalid "invalid auth JSON")]
             `shouldBe` "invalid auth JSON"
+
+    it "keeps invalid OpenAI lookup errors when Claude has no xAI account" do
+        selected <-
+            selectDictationBackend ClaudeCodeProvider \case
+                OpenAIDictation ->
+                    pure $ Left $ DictationCredentialInvalid
+                        "no valid OpenAI credentials found: \
+                        \credential store is unreadable"
+                XAIDictation ->
+                    pure $ Left $ DictationCredentialMissing
+                        "no credentials found."
+        fmap fst selected
+            `shouldBe`
+                Left
+                    "Dictation for claude-code models requires an OpenAI or xAI \
+                    \account; connect one with /login (openai: no valid OpenAI \
+                    \credentials found: credential store is unreadable)"
 
     it "keeps organization-gateway dictation inside the gateway boundary" do
         case dictationTargetForSession XAIProvider Nothing of

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -1,15 +1,23 @@
 module Agent.CLI.TUIComposerSpec (spec) where
 
+import Agent.CLI.Auth (LoadedAuth(..), staticCredentialProvider)
 import Agent.CLI.Dictation
-    ( DictationBackend(..)
+    ( DictationAuthError(..)
+    , DictationBackend(..)
     , DictationTarget(..)
-    , dictationBackendForProvider
+    , dictationBackendsForProvider
+    , dictationBackendUnavailable
     , dictationTargetForSession
     , insertDictation
+    , selectDictationBackend
     )
 import Agent.CLI.GatewayClient (newGatewayModelAccessWith)
 import Agent.CLI.Command (CopyRequest(..), ReplAction(..))
-import Agent.Provider (Provider(..))
+import Agent.Provider
+    ( BillingMode(..)
+    , Credential(..)
+    , Provider(..)
+    )
 import Agent.CLI.Input
     ( ReplLine(..)
     , displayEditorText
@@ -34,6 +42,8 @@ import Control.Concurrent.STM (atomically)
 import qualified Data.ByteString as ByteString
 import Data.Char (isControl)
 import Data.Foldable (toList)
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -269,16 +279,75 @@ spec = describe "fullscreen composer" do
             `shouldBe` ("hello, world", 12)
 
     it "routes dictation through the active model provider" do
-        dictationBackendForProvider OpenAIProvider
-            `shouldBe` Right OpenAIDictation
-        dictationBackendForProvider XAIProvider
-            `shouldBe` Right XAIDictation
-        dictationBackendForProvider OpenRouterProvider
+        dictationBackendsForProvider OpenAIProvider
+            `shouldBe` Right (OpenAIDictation :| [])
+        dictationBackendsForProvider XAIProvider
+            `shouldBe` Right (XAIDictation :| [])
+        dictationBackendsForProvider OpenRouterProvider
             `shouldBe` Left
                 "Dictation is not supported for openrouter models"
-        dictationBackendForProvider ClaudeCodeProvider
+        dictationBackendsForProvider GeminiProvider
             `shouldBe` Left
-                "Dictation is not supported for claude-code models"
+                "Dictation is not supported for gemini models"
+
+    it "borrows an OpenAI account before an xAI account for Claude" do
+        dictationBackendsForProvider ClaudeCodeProvider
+            `shouldBe` Right (OpenAIDictation :| [XAIDictation])
+        attempted <- newIORef []
+        let loadBackend backend = do
+                modifyIORef' attempted (<> [backend])
+                pure $ Right (fakeLoadedAuth backend)
+        selected <- selectDictationBackend ClaudeCodeProvider loadBackend
+        fmap fst selected `shouldBe` Right OpenAIDictation
+        readIORef attempted `shouldReturn` [OpenAIDictation]
+
+    it "falls back to xAI when Claude has no OpenAI credential" do
+        attempted <- newIORef []
+        let loadBackend backend = do
+                modifyIORef' attempted (<> [backend])
+                pure case backend of
+                    OpenAIDictation ->
+                        Left (DictationCredentialMissing "no openai")
+                    XAIDictation ->
+                        Right (fakeLoadedAuth backend)
+        selected <- selectDictationBackend ClaudeCodeProvider loadBackend
+        fmap fst selected `shouldBe` Right XAIDictation
+        readIORef attempted `shouldReturn` [OpenAIDictation, XAIDictation]
+
+    it "never borrows another provider's account for native dictation" do
+        attempted <- newIORef []
+        let loadBackend backend = do
+                modifyIORef' attempted (<> [backend])
+                pure (Left (DictationCredentialMissing "no credential"))
+        selected <- selectDictationBackend XAIProvider loadBackend
+        fmap fst selected `shouldBe` Left "no credential"
+        readIORef attempted `shouldReturn` [XAIDictation]
+        rejected <-
+            selectDictationBackend OpenRouterProvider loadBackend
+        fmap fst rejected
+            `shouldBe` Left "Dictation is not supported for openrouter models"
+
+    it "summarizes missing borrowed accounts without provider sign-in hints" do
+        dictationBackendUnavailable
+            ClaudeCodeProvider
+            [ (OpenAIDictation, DictationCredentialMissing "no openai")
+            , (XAIDictation, DictationCredentialMissing "no credentials found.")
+            ]
+            `shouldBe`
+                "Dictation for claude-code models requires an OpenAI or xAI \
+                \account; connect one with /login"
+        dictationBackendUnavailable
+            ClaudeCodeProvider
+            [ (OpenAIDictation, DictationCredentialMissing "no openai")
+            , (XAIDictation, DictationCredentialInvalid "invalid auth JSON")
+            ]
+            `shouldBe`
+                "Dictation for claude-code models requires an OpenAI or xAI \
+                \account; connect one with /login (xai: invalid auth JSON)"
+        dictationBackendUnavailable
+            XAIProvider
+            [(XAIDictation, DictationCredentialInvalid "invalid auth JSON")]
+            `shouldBe` "invalid auth JSON"
 
     it "keeps organization-gateway dictation inside the gateway boundary" do
         case dictationTargetForSession XAIProvider Nothing of
@@ -485,3 +554,25 @@ genDraftAtom =
         , Text.pack ['\x1f44d', '\x1f3fd']
         , Text.pack ['1', '\xfe0f', '\x20e3']
         ]
+
+fakeLoadedAuth :: DictationBackend -> LoadedAuth
+fakeLoadedAuth backend =
+    LoadedAuth
+        { loadedProvider = provider
+        , loadedTokenProvider =
+            staticCredentialProvider ApiBilled credential
+        , loadedAccountLabel = const (pure "fake")
+        , loadedSelectionId = Nothing
+        , loadedOpenAiPool = Nothing
+        }
+  where
+    provider = case backend of
+        OpenAIDictation -> OpenAIProvider
+        XAIDictation -> XAIProvider
+    credential =
+        Credential
+            { accessToken = "token"
+            , accountId = "account"
+            , leaseId = Nothing
+            , provider
+            }


### PR DESCRIPTION
## Summary
- let Claude sessions use Ctrl+R dictation by borrowing a locally configured OpenAI account, then falling back to xAI when no OpenAI credential exists
- keep native OpenAI and xAI dictation on their own credentials only, so Grok/OpenAI sessions never spend an unrelated provider account
- keep a connected organization gateway as the only dictation transport when one is in use
- report a short `/login` hint when Claude has no transcription account, and only append broken-configuration details

## Testing
- `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`
  - `:main --match dictation` — 6 examples, 0 failures (97 modules loaded)
  - `:main --match "Claude" --match "borrow" --match "summarizes missing" --match "routes dictation"` — composer cases for OpenAI-first selection, xAI fallback, native-only backends, and the shared login hint all passed
- live GHCi credential lookup: `selectDictationBackend ClaudeCodeProvider loadDictationBackendAuth` selected `OpenAIDictation` from local accounts
- `git diff --check`

## Notes
- Transcription still happens after a backend is chosen; a failed OpenAI stream does not silently retry with xAI.
- OpenRouter and Gemini remain without dictation.