### PR TITLE
perf(cli): speed up repository service tests

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-cli/src/Agent/CLI/RepositoryDelivery.hs
@@ -33,6 +33,7 @@ import Control.Exception.Safe
     , tryAny
     )
 import Control.Monad (forever, unless, when)
+import Crypto.Hash (Digest, SHA1, SHA256, hash)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
@@ -592,7 +593,7 @@ statusAtSnapshot snapshot =
                                         finishStatus upstreamOid ahead behind
       where
         finishStatus upstreamOid ahead behind =
-            readValidatedRemote root remote >>= \case
+            readValidatedRemote root headOid remote >>= \case
                 Left err -> pure (Left err)
                 Right validatedRemote ->
                     pure
@@ -648,8 +649,9 @@ readUpstream root fullBranch =
 readValidatedRemote
     :: FilePath
     -> Text
+    -> Text
     -> IO (Either DeliveryError ValidatedRemote)
-readValidatedRemote root remote =
+readValidatedRemote root headOid remote =
     readLocalConfig >>= \case
         Left err -> pure (Left err)
         Right entries ->
@@ -661,22 +663,15 @@ readValidatedRemote root remote =
     finish fetchUrl pushUrl
         | fetchUrl == pushUrl
             && validRemoteUrl pushUrl =
-                runGit
-                    root
-                    ["hash-object", "--stdin"]
-                    pushUrl
-                    localTimeoutMicros >>= \case
-                        Left err -> pure (Left err)
-                        Right fingerprint ->
-                            pure
-                                (Right
-                                    ValidatedRemote
-                                        { validatedRemoteUrl = pushUrl
-                                        , validatedRemoteFingerprint =
-                                            decodeTrimmed fingerprint
-                                        , validatedGitHubRepository =
-                                            githubRepositoryFromUrl pushUrl
-                                        })
+                pure do
+                    fingerprint <- gitBlobHashForOid headOid pushUrl
+                    pure
+                        ValidatedRemote
+                            { validatedRemoteUrl = pushUrl
+                            , validatedRemoteFingerprint = fingerprint
+                            , validatedGitHubRepository =
+                                githubRepositoryFromUrl pushUrl
+                            }
         | otherwise = invalid
     readLocalConfig =
         runGit
@@ -727,7 +722,10 @@ validatedRemoteForStatus
     :: DeliveryStatus
     -> IO (Either DeliveryError ValidatedRemote)
 validatedRemoteForStatus status =
-    readValidatedRemote status.deliveryRoot status.deliveryRemote >>= \case
+    readValidatedRemote
+        status.deliveryRoot
+        status.deliveryHeadOid
+        status.deliveryRemote >>= \case
         Left _ ->
             pure
                 (Left
@@ -741,6 +739,27 @@ validatedRemoteForStatus status =
                             (DeliveryStale
                                 "the remote destination changed"))
             | otherwise -> pure (Right remote)
+
+gitBlobHashForOid
+    :: Text
+    -> BS.ByteString
+    -> Either DeliveryError Text
+gitBlobHashForOid oid bytes =
+    let material =
+            BS8.pack ("blob " <> show (BS.length bytes) <> "\NUL") <> bytes
+    in case Text.length oid of
+        40 ->
+            Right
+                (Text.pack
+                    (show (hash material :: Digest SHA1)))
+        64 ->
+            Right
+                (Text.pack
+                    (show (hash material :: Digest SHA256)))
+        _ ->
+            Left
+                (DeliveryCommandFailed
+                    "Git returned an unsupported object format")
 
 queryRemoteHead
     :: DeliveryStatus

--- a/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -628,8 +628,9 @@ withDeliveryRepositoryWithFormat objectFormat action =
             (["init", "-q", "--bare"] <> formatArguments <> [remote])
         _ <- git root
             (["init", "-q", "-b", "main"] <> formatArguments)
-        _ <- git root ["config", "user.name", "Repository Delivery Test"]
-        _ <- git root ["config", "user.email", "delivery@example.test"]
+        appendFile
+            (root <> "/.git/config")
+            "\n[user]\n\tname = Repository Delivery Test\n\temail = delivery@example.test\n"
         writeFile (root <> "/tracked.txt") "first\n"
         _ <- git root ["add", "tracked.txt"]
         _ <- git root ["commit", "-q", "-m", "initial"]

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -41,7 +41,6 @@ import System.Process
     , createProcess
     , proc
     , readCreateProcessWithExitCode
-    , terminateProcess
     , waitForProcess
     )
 import System.Timeout (timeout)
@@ -284,12 +283,15 @@ spec = describe "repository review service" do
                     root
                         <> "/.git/haskell-agent-worktree.lock"
                 readyPath = root <> "/advisory-lock-ready"
+                releasePath = root <> "/advisory-lock-release"
                 script =
-                    "import fcntl,time;"
-                        <> "f=open(" <> show lockPath <> ",'w');"
-                        <> "fcntl.flock(f,fcntl.LOCK_EX);"
-                        <> "open(" <> show readyPath <> ",'w').close();"
-                        <> "time.sleep(30)"
+                    "import fcntl,os,time\n"
+                        <> "f=open(" <> show lockPath <> ",'w')\n"
+                        <> "fcntl.flock(f,fcntl.LOCK_EX)\n"
+                        <> "open(" <> show readyPath <> ",'w').close()\n"
+                        <> "while not os.path.exists("
+                        <> show releasePath
+                        <> "):\n time.sleep(0.01)\n"
             (_, _, _, locker) <-
                 createProcess (proc pythonExecutable ["-c", script])
             _ <- awaitFileContents readyPath 200
@@ -298,7 +300,7 @@ spec = describe "repository review service" do
             blocked `shouldSatisfy` \case
                 Nothing -> True
                 Just _ -> False
-            terminateProcess locker
+            writeFile releasePath ""
             _ <- waitForProcess locker
             waitCatch pending `shouldReturnSatisfying` \case
                 Right (Right _) -> True
@@ -737,8 +739,9 @@ spec = describe "repository review service" do
 withRepository :: (FilePath -> IO value) -> IO value
 withRepository action = withTempDirectory "repository-review" \root -> do
     _ <- git root ["init", "-q"]
-    _ <- git root ["config", "user.name", "Repository Review Test"]
-    _ <- git root ["config", "user.email", "review@example.test"]
+    appendFile
+        (root <> "/.git/config")
+        "\n[user]\n\tname = Repository Review Test\n\temail = review@example.test\n"
     writeFile (root <> "/tracked.txt") "first\n"
     _ <- git root ["add", "tracked.txt"]
     _ <- git root ["commit", "-q", "-m", "initial"]


### PR DESCRIPTION
## Summary

- release the cross-process repository-review advisory lock cooperatively instead of leaving a fixed 30-second sleeper to be terminated
- avoid per-fixture Git identity configuration subprocesses while keeping every test commit hermetic
- calculate delivery remote URL Git blob fingerprints in-process for SHA-1 and SHA-256 repositories instead of spawning `git hash-object`

## Performance

Benchmarked optimized test executables with three interleaved old/new samples per suite on macOS. Each sample used:

```sh
/usr/bin/time -lp "$bin" --format=failed-examples --match '<suite>'
```

Median results:

| Suite | Before | After | Elapsed | Median RSS |
| --- | ---: | ---: | ---: | ---: |
| repository review service | 79.71s | 49.22s | 38.2% faster | 229.5 MB -> 213.7 MB |
| repository delivery service | 79.02s | 76.88s | 2.7% faster | 212.8 MB -> 208.6 MB |
| combined | 158.73s | 126.10s | 20.6% faster | |

## Validation

- optimized focused runs: 26 review examples and 25 delivery examples, all passing
- three repeated post-change runs of each focused suite, all passing
- `git diff --check`
- rebased onto current `origin/master`; `git range-diff` confirms the patch is unchanged
- post-rebase `cabal build --offline -j1 agent-cli:test:agent-cli-test` compiled both changed spec modules, then hit unrelated existing compile failures in `TUIBridgeSpec`, `TUIComposerSpec`, and `TUIScrollSpec` on current master
