### PR TITLE
Refactor oversized dispatch and reducer functions

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -238,244 +238,166 @@ parseSlash catalog raw line = case Text.words line of
             Just skill ->
                 ReplInvokeSkill
                     skill.skillCommandName
-                    (Text.strip (Text.drop (Text.length command) line))
+                    (slashCommandTail command line)
             Nothing -> unknownCommand command
-        Just spec -> case spec.slashName of
-            "help" -> parseHelpCommand catalog args
-            "init" ->
-                if null args
-                    then ReplInit
-                    else ReplCommandError "usage: /init"
-            "review" ->
-                let instructions =
-                        Text.strip (Text.drop (Text.length command) line)
-                in ReplReview
-                    (if Text.null instructions then Nothing else Just instructions)
-            "diff" ->
-                if null args
-                    then ReplDiff
-                    else ReplCommandError "usage: /diff"
-            "fork" ->
-                parseForkCommand
-                    (Text.strip (Text.drop (Text.length command) line))
-            "export" ->
-                let path = Text.strip (Text.drop (Text.length command) line)
-                in ReplExport
-                    (if Text.null path then Nothing else Just path)
-            "history" ->
-                if null args
-                    then ReplHistory
-                    else ReplCommandError "usage: /history"
-            "find" ->
-                ReplFind
-                    (nonEmptyText
-                        (Text.strip (Text.drop (Text.length command) line)))
-            "permissions" ->
-                if null args
-                    then ReplPermissions
-                    else ReplCommandError "usage: /permissions"
-            "effort" -> parseEffortCommand args
-            "fast" ->
-                if null args
-                    then ReplToggleFast
-                    else ReplCommandError "usage: /fast"
-            "model" -> parseModelCommand args
-            "theme" -> parseThemeCommand args
-            "plan" ->
-                let description =
-                        Text.strip (Text.drop (Text.length command) line)
-                in ReplPlan
-                    (if Text.null description then Nothing else Just description)
-            "view-plan" ->
-                if null args
-                    then ReplViewPlan
-                    else ReplCommandError "usage: /view-plan"
-            "queue" ->
-                if null args
-                    then ReplQueue
-                    else ReplCommandError "usage: /queue"
-            "transcript" ->
-                if null args
-                    then ReplTranscript
-                    else ReplCommandError "usage: /transcript"
-            "edit-prompt" ->
-                if null args
-                    then ReplEditPrompt
-                    else ReplCommandError "usage: /edit-prompt"
-            "context" ->
-                if null args
-                    then ReplContext
-                    else ReplCommandError "usage: /context"
-            "btw" ->
-                let question =
-                        Text.strip (Text.drop (Text.length command) line)
-                in if Text.null question
-                    then ReplCommandError "usage: /btw <QUESTION>"
-                    else ReplBtw question
-            "meta" ->
-                let request =
-                        Text.strip (Text.drop (Text.length command) line)
-                in if Text.null request
-                    then ReplCommandError "usage: /meta <REQUEST>"
-                    else ReplMetaConsole request
-            "recap" ->
-                if null args
-                    then ReplRecap
-                    else ReplCommandError "usage: /recap"
-            "retry" ->
-                if null args
-                    then ReplRetry
-                    else ReplCommandError "usage: /retry"
-            "session" ->
-                if null args
-                    then ReplShowSession
-                    else ReplCommandError "usage: /session"
-            "session-info" ->
-                if null args
-                    then ReplShowSessionInfo
-                    else ReplCommandError "usage: /session-info"
-            "desktop" ->
-                if null args
-                    then ReplDesktop
-                    else ReplCommandError "usage: /desktop"
-            "afk" -> case args of
-                [] -> ReplAfk Nothing
-                [target] -> ReplAfk (Just target)
-                _ -> ReplCommandError "usage: /afk [HOST:PATH]"
-            "worktree" ->
-                if null args
-                    then ReplWorktree
-                    else ReplCommandError "usage: /worktree"
-            "rename" ->
-                let title = Text.strip (Text.drop (Text.length command) line)
-                in if title == "--auto"
-                    then ReplRenameAuto
-                    else if Text.null title
-                        then ReplCommandError "usage: /rename <TITLE>|--auto"
-                        else if Text.length title > 100
-                            then ReplCommandError
-                                "session titles must be at most 100 characters"
-                            else ReplRename title
-            "login" ->
-                if null args
-                    then ReplLogin
-                    else ReplCommandError "usage: /login"
-            "resume" -> parseResumeCommand args
-            "home" ->
-                if null args
-                    then ReplHome
-                    else ReplCommandError "usage: /home"
-            "search" ->
-                let query =
-                        Text.strip (Text.drop (Text.length command) line)
-                in if Text.null query
-                    then ReplCommandError "usage: /search <QUERY>"
-                    else ReplSearch query
-            "compact" ->
-                let focus =
-                        Text.strip (Text.drop (Text.length command) line)
-                in ReplCompact
-                    (if Text.null focus then Nothing else Just focus)
-            "rewind" ->
-                if null args
-                    then ReplRewind
-                    else ReplCommandError "usage: /rewind"
-            "clear" ->
-                if null args
-                    then ReplClear
-                    else ReplCommandError "usage: /clear"
-            "new" ->
-                if null args
-                    then ReplNew
-                    else ReplCommandError "usage: /new"
-            "delete" ->
-                if null args
-                    then ReplDelete
-                    else ReplCommandError "usage: /delete"
-            "usage" ->
-                if null args
-                    then ReplUsage
-                    else ReplCommandError "usage: /usage"
-            "reload-auth" ->
-                if null args
-                    then ReplReloadAuth
-                    else ReplCommandError "usage: /reload-auth"
-            "paste" ->
-                parsePasteCommand (Text.strip (Text.drop (Text.length command) line))
-            "attachments" ->
-                if null args
-                    then ReplShowAttachments
-                    else ReplCommandError "usage: /attachments"
-            "clear-attachments" ->
-                if null args
-                    then ReplClearAttachments
-                    else ReplCommandError "usage: /clear-attachments"
-            "copy" ->
-                parseCopyCommand
-                    (Text.strip (Text.drop (Text.length command) line))
-            "copy-code" -> parseCopyCodeCommand args
-            "copy-diff" ->
-                if null args
-                    then ReplCopyDiff
-                    else ReplCommandError "usage: /copy-diff"
-            "copy-path" ->
-                if null args
-                    then ReplCopyPath
-                    else ReplCommandError "usage: /copy-path"
-            "copy-session" ->
-                if null args
-                    then ReplCopySession
-                    else ReplCommandError "usage: /copy-session"
-            "terminal" ->
-                if null args
-                    then ReplShowTerminal
-                    else ReplCommandError "usage: /terminal"
-            "changelog" ->
-                if null args
-                    then ReplChangelog
-                    else ReplCommandError "usage: /changelog"
-            "agents" -> parseAgentsCommand args
-            "mcp" -> case args of
-                [] -> ReplMcp
-                ("prompt" : server : name : rest) ->
-                    ReplMcpPrompt server name (map parsePromptArgument rest)
-                _ ->
-                    ReplCommandError
-                        "usage: /mcp [prompt <server> <prompt> [key=value ...]]"
-            "loop" ->
-                parseLoopCommand raw
-                    (Text.strip (Text.drop (Text.length command) line))
-            "goal" ->
-                parseGoalCommand raw
-                    (Text.strip (Text.drop (Text.length command) line))
-            "workflow" ->
-                parseWorkflowCommand raw
-                    (Text.strip (Text.drop (Text.length command) line))
-            "deep-research" ->
-                parseDeepResearchCommand raw
-                    (Text.strip (Text.drop (Text.length command) line))
-            "skills" -> case args of
-                [] -> ReplSkills False
-                ["reload"] -> ReplSkills True
-                _ -> ReplCommandError "usage: /skills [reload]"
-            "shell" -> parseShellCommand args
-            "codemod" ->
-                if null args
-                    then ReplEnableCodeMode
-                    else ReplCommandError "usage: /codemod"
-            "always-approve" ->
-                if null args
-                    then ReplToggleAlwaysApprove
-                    else ReplCommandError "usage: /always-approve"
-            "update-and-restart" ->
-                if null args
-                    then ReplUpdateAndRestart
-                    else ReplCommandError "usage: /update-and-restart"
-            "quit" ->
-                if null args
-                    then ReplQuit
-                    else ReplCommandError "usage: /quit"
-            other -> unknownCommand ("/" <> other)
+        Just spec ->
+            case Map.lookup spec.slashName simpleSlashCommands of
+                Just action ->
+                    parseNoArgumentCommand spec action args
+                Nothing ->
+                    parseSpecializedSlashCommand
+                        catalog
+                        raw
+                        spec
+                        args
+                        (slashCommandTail command line)
+
+simpleSlashCommands :: Map Text ReplAction
+simpleSlashCommands =
+    Map.fromList
+        [ ("init", ReplInit)
+        , ("diff", ReplDiff)
+        , ("history", ReplHistory)
+        , ("permissions", ReplPermissions)
+        , ("fast", ReplToggleFast)
+        , ("view-plan", ReplViewPlan)
+        , ("queue", ReplQueue)
+        , ("transcript", ReplTranscript)
+        , ("edit-prompt", ReplEditPrompt)
+        , ("context", ReplContext)
+        , ("recap", ReplRecap)
+        , ("retry", ReplRetry)
+        , ("session", ReplShowSession)
+        , ("session-info", ReplShowSessionInfo)
+        , ("desktop", ReplDesktop)
+        , ("worktree", ReplWorktree)
+        , ("login", ReplLogin)
+        , ("home", ReplHome)
+        , ("rewind", ReplRewind)
+        , ("clear", ReplClear)
+        , ("new", ReplNew)
+        , ("delete", ReplDelete)
+        , ("usage", ReplUsage)
+        , ("reload-auth", ReplReloadAuth)
+        , ("attachments", ReplShowAttachments)
+        , ("clear-attachments", ReplClearAttachments)
+        , ("copy-diff", ReplCopyDiff)
+        , ("copy-path", ReplCopyPath)
+        , ("copy-session", ReplCopySession)
+        , ("terminal", ReplShowTerminal)
+        , ("changelog", ReplChangelog)
+        , ("codemod", ReplEnableCodeMode)
+        , ("always-approve", ReplToggleAlwaysApprove)
+        , ("update-and-restart", ReplUpdateAndRestart)
+        , ("quit", ReplQuit)
+        ]
+
+parseNoArgumentCommand :: SlashCommand -> ReplAction -> [Text] -> ReplAction
+parseNoArgumentCommand spec action args
+    | null args = action
+    | otherwise = slashUsageError spec
+
+slashUsageError :: SlashCommand -> ReplAction
+slashUsageError spec =
+    ReplCommandError ("usage: " <> usage)
+  where
+    -- Parsing has historically used the built-in command's canonical usage
+    -- text, even when callers supply a catalog with different display text.
+    usage =
+        maybe spec.slashUsage
+            (.slashUsage)
+            (lookupSlashCommand spec.slashName)
+
+slashCommandTail :: Text -> Text -> Text
+slashCommandTail command =
+    Text.strip . Text.drop (Text.length command)
+
+parseSpecializedSlashCommand
+    :: SlashCatalog
+    -> Text
+    -> SlashCommand
+    -> [Text]
+    -> Text
+    -> ReplAction
+parseSpecializedSlashCommand catalog raw spec args commandTail =
+    case spec.slashName of
+        "help" -> parseHelpCommand catalog args
+        "review" -> parseOptionalTextCommand ReplReview commandTail
+        "fork" -> parseForkCommand commandTail
+        "export" -> parseOptionalTextCommand ReplExport commandTail
+        "find" -> ReplFind (nonEmptyText commandTail)
+        "effort" -> parseEffortCommand args
+        "model" -> parseModelCommand args
+        "theme" -> parseThemeCommand args
+        "plan" -> parseOptionalTextCommand ReplPlan commandTail
+        "btw" ->
+            parseRequiredTextCommand
+                ReplBtw
+                spec
+                commandTail
+        "meta" ->
+            parseRequiredTextCommand
+                ReplMetaConsole
+                spec
+                commandTail
+        "afk" -> case args of
+            [] -> ReplAfk Nothing
+            [target] -> ReplAfk (Just target)
+            _ -> slashUsageError spec
+        "rename" ->
+            if commandTail == "--auto"
+                then ReplRenameAuto
+                else if Text.null commandTail
+                    then slashUsageError spec
+                    else if Text.length commandTail > 100
+                        then ReplCommandError
+                            "session titles must be at most 100 characters"
+                        else ReplRename commandTail
+        "resume" -> parseResumeCommand args
+        "search" ->
+            parseRequiredTextCommand
+                ReplSearch
+                spec
+                commandTail
+        "compact" -> parseOptionalTextCommand ReplCompact commandTail
+        "paste" -> parsePasteCommand commandTail
+        "copy" -> parseCopyCommand commandTail
+        "copy-code" -> parseCopyCodeCommand args
+        "agents" -> parseAgentsCommand args
+        "mcp" -> case args of
+            [] -> ReplMcp
+            ("prompt" : server : name : rest) ->
+                ReplMcpPrompt server name (map parsePromptArgument rest)
+            _ ->
+                ReplCommandError
+                    "usage: /mcp [prompt <server> <prompt> [key=value ...]]"
+        "loop" ->
+            parseLoopCommand raw commandTail
+        "goal" ->
+            parseGoalCommand raw commandTail
+        "workflow" ->
+            parseWorkflowCommand raw commandTail
+        "deep-research" ->
+            parseDeepResearchCommand raw commandTail
+        "skills" -> case args of
+            [] -> ReplSkills False
+            ["reload"] -> ReplSkills True
+            _ -> slashUsageError spec
+        "shell" -> parseShellCommand args
+        other -> unknownCommand ("/" <> other)
+
+parseOptionalTextCommand :: (Maybe Text -> ReplAction) -> Text -> ReplAction
+parseOptionalTextCommand action =
+    action . nonEmptyText
+
+parseRequiredTextCommand
+    :: (Text -> ReplAction)
+    -> SlashCommand
+    -> Text
+    -> ReplAction
+parseRequiredTextCommand action spec value
+    | Text.null value = slashUsageError spec
+    | otherwise = action value
 
 unknownCommand :: Text -> ReplAction
 unknownCommand command =

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -109,111 +109,192 @@ emptyOutputItemStore = OutputItemStore
 
 applyStreamEvent :: StreamAssemblyState -> ResponseStreamEvent -> StreamAssemblyState
 applyStreamEvent state = \case
-    ResponseCreatedEvent { responseValue } -> lifecycle responseValue
-    ResponseInProgressEvent { responseValue } -> lifecycle responseValue
-    ResponseQueuedEvent { responseValue } -> lifecycle responseValue
-    ResponseCompletedEvent { responseValue } -> lifecycle responseValue
-    ResponseDoneEvent { responseValue } -> lifecycle responseValue
-    ResponseFailedEvent { responseValue } -> lifecycle responseValue
-    ResponseIncompleteEvent { responseValue } -> lifecycle responseValue
+    ResponseCreatedEvent { responseValue } ->
+        mergeLifecycleResponse responseValue state
+    ResponseInProgressEvent { responseValue } ->
+        mergeLifecycleResponse responseValue state
+    ResponseQueuedEvent { responseValue } ->
+        mergeLifecycleResponse responseValue state
+    ResponseCompletedEvent { responseValue } ->
+        mergeLifecycleResponse responseValue state
+    ResponseDoneEvent { responseValue } ->
+        mergeLifecycleResponse responseValue state
+    ResponseFailedEvent { responseValue } ->
+        mergeLifecycleResponse responseValue state
+    ResponseIncompleteEvent { responseValue } ->
+        mergeLifecycleResponse responseValue state
     ResponseOutputItemAddedEvent { item, outputIndex } ->
         updateItem outputIndex False item state
     ResponseOutputItemDoneEvent { item, outputIndex } ->
         updateItem outputIndex True item state
     ResponseFunctionCallArgumentsDeltaEvent
         { delta = Just value, streamItemId, streamOutputIndex } ->
-            updateResolvedProgress streamOutputIndex
-                [streamItemIdentity "function_call" streamItemId]
-                (\progress -> progress
-                    { functionArgumentChunks = Just
-                        (appendTextBuffer value
-                            (fromMaybe emptyTextBuffer
-                                progress.functionArgumentChunks))
-                    })
-                state
+            applyFunctionArgumentDelta
+                value streamItemId streamOutputIndex state
     ResponseFunctionCallArgumentsDoneEvent
         { arguments, functionName, streamItemId, streamOutputIndex } ->
-            updateResolvedProgress streamOutputIndex
-                [streamItemIdentity "function_call" streamItemId]
-                (\progress -> progress
-                    { itemValue = mapFunctionCall streamItemId
-                        (\call -> call
-                            { arguments =
-                                fromMaybe
-                                    (materializedFunctionArguments progress)
-                                    arguments
-                            , name = fromMaybe call.name functionName
-                            })
-                        progress.itemValue
-                    , functionArgumentChunks = Nothing
-                    })
-                state
+            applyFunctionArgumentDone
+                arguments functionName streamItemId streamOutputIndex state
     ResponseCustomToolInputDeltaEvent
         { delta = Just value, streamItemId, streamCallId
         , streamOutputIndex } ->
-            updateResolvedProgress streamOutputIndex
-                [ streamItemIdentity "custom_tool_call" streamItemId
-                , streamCallIdentity "custom_tool_call" streamCallId
-                ]
-                (\progress -> progress
-                    { customInputChunks = Just
-                        (appendTextBuffer value
-                            (fromMaybe emptyTextBuffer
-                                progress.customInputChunks))
-                    })
+            applyCustomToolInputDelta
+                value
+                streamItemId
+                streamCallId
+                streamOutputIndex
                 state
     ResponseCustomToolInputDoneEvent
         { inputText, streamItemId, streamCallId, streamOutputIndex } ->
-            updateResolvedProgress streamOutputIndex
-                [ streamItemIdentity "custom_tool_call" streamItemId
-                , streamCallIdentity "custom_tool_call" streamCallId
-                ]
-                (\progress -> progress
-                    { itemValue = mapCustomCall streamItemId streamCallId
-                        (setCustomToolInput
-                            (fromMaybe
-                                (materializedCustomInput progress)
-                                inputText))
-                        progress.itemValue
-                    , customInputChunks = Nothing
-                    })
+            applyCustomToolInputDone
+                inputText
+                streamItemId
+                streamCallId
+                streamOutputIndex
                 state
     ResponseReasoningSummaryTextDoneEvent
         { text = Just value, streamItemId, streamOutputIndex
         , summaryIndex = Just index } ->
-            updateResolvedProgress streamOutputIndex
-                [streamItemIdentity "reasoning" streamItemId]
-                (\progress -> progress
-                    { itemValue = mapReasoning streamItemId index
-                        (setReasoningPartText (Just value))
-                        progress.itemValue
-                    , reasoningTextChunks =
-                        IntMap.delete index progress.reasoningTextChunks
-                    })
-                state
+            applyReasoningSummaryDone
+                value streamItemId streamOutputIndex index state
     OtherResponseStreamEvent
         { otherEventType = EventReasoningSummaryTextDelta
         , eventDelta = Just value, streamItemId, streamOutputIndex
         , summaryIndex = Just index } ->
-            updateResolvedProgress streamOutputIndex
-                [streamItemIdentity "reasoning" streamItemId]
-                (\progress -> progress
-                    { reasoningTextChunks = IntMap.alter
-                        (Just . appendTextBuffer value
-                            . fromMaybe emptyTextBuffer)
-                        index
-                        progress.reasoningTextChunks
-                    })
-                state
+            applyReasoningSummaryDelta
+                value streamItemId streamOutputIndex index state
     _ -> state
+
+mergeLifecycleResponse
+    :: Response
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+mergeLifecycleResponse response state =
+    merged `seq` state { lifecycleResponse = Just merged }
   where
-    lifecycle response =
-        merged `seq` state { lifecycleResponse = Just merged }
-      where
-        merged =
-            maybe response
-                (`mergeResponseFragment` response)
-                state.lifecycleResponse
+    merged =
+        maybe response
+            (`mergeResponseFragment` response)
+            state.lifecycleResponse
+
+applyFunctionArgumentDelta
+    :: Text
+    -> Maybe Text
+    -> Maybe Int
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+applyFunctionArgumentDelta value streamItemId streamOutputIndex =
+    updateResolvedProgress streamOutputIndex
+        [streamItemIdentity "function_call" streamItemId]
+        (\progress -> progress
+            { functionArgumentChunks = Just
+                (appendTextBuffer value
+                    (fromMaybe emptyTextBuffer
+                        progress.functionArgumentChunks))
+            })
+
+applyFunctionArgumentDone
+    :: Maybe Text
+    -> Maybe Text
+    -> Maybe Text
+    -> Maybe Int
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+applyFunctionArgumentDone
+        arguments functionName streamItemId streamOutputIndex =
+    updateResolvedProgress streamOutputIndex
+        [streamItemIdentity "function_call" streamItemId]
+        (\progress -> progress
+            { itemValue = mapFunctionCall streamItemId
+                (\call -> call
+                    { arguments =
+                        fromMaybe
+                            (materializedFunctionArguments progress)
+                            arguments
+                    , name = fromMaybe call.name functionName
+                    })
+                progress.itemValue
+            , functionArgumentChunks = Nothing
+            })
+
+applyCustomToolInputDelta
+    :: Text
+    -> Maybe Text
+    -> Maybe Text
+    -> Maybe Int
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+applyCustomToolInputDelta
+        value streamItemId streamCallId streamOutputIndex =
+    updateResolvedProgress streamOutputIndex
+        [ streamItemIdentity "custom_tool_call" streamItemId
+        , streamCallIdentity "custom_tool_call" streamCallId
+        ]
+        (\progress -> progress
+            { customInputChunks = Just
+                (appendTextBuffer value
+                    (fromMaybe emptyTextBuffer progress.customInputChunks))
+            })
+
+applyCustomToolInputDone
+    :: Maybe Text
+    -> Maybe Text
+    -> Maybe Text
+    -> Maybe Int
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+applyCustomToolInputDone
+        inputText streamItemId streamCallId streamOutputIndex =
+    updateResolvedProgress streamOutputIndex
+        [ streamItemIdentity "custom_tool_call" streamItemId
+        , streamCallIdentity "custom_tool_call" streamCallId
+        ]
+        (\progress -> progress
+            { itemValue = mapCustomCall streamItemId streamCallId
+                (setCustomToolInput
+                    (fromMaybe
+                        (materializedCustomInput progress)
+                        inputText))
+                progress.itemValue
+            , customInputChunks = Nothing
+            })
+
+applyReasoningSummaryDone
+    :: Text
+    -> Maybe Text
+    -> Maybe Int
+    -> Int
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+applyReasoningSummaryDone
+        value streamItemId streamOutputIndex summaryIndex =
+    updateResolvedProgress streamOutputIndex
+        [streamItemIdentity "reasoning" streamItemId]
+        (\progress -> progress
+            { itemValue = mapReasoning streamItemId summaryIndex
+                (setReasoningPartText (Just value))
+                progress.itemValue
+            , reasoningTextChunks =
+                IntMap.delete summaryIndex progress.reasoningTextChunks
+            })
+
+applyReasoningSummaryDelta
+    :: Text
+    -> Maybe Text
+    -> Maybe Int
+    -> Int
+    -> StreamAssemblyState
+    -> StreamAssemblyState
+applyReasoningSummaryDelta
+        value streamItemId streamOutputIndex summaryIndex =
+    updateResolvedProgress streamOutputIndex
+        [streamItemIdentity "reasoning" streamItemId]
+        (\progress -> progress
+            { reasoningTextChunks = IntMap.alter
+                (Just . appendTextBuffer value . fromMaybe emptyTextBuffer)
+                summaryIndex
+                progress.reasoningTextChunks
+            })
 
 stepStreamResponse
     :: StreamAssemblyConfig

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -169,17 +169,7 @@ reduceUi event state = case event of
             { uiContextTokens = tokens
             , uiContextWindow = contextWindow
             }
-    UiSetAwaitingInput awaiting ->
-        (if awaiting then finalizeStreams state else state)
-            { uiAwaitingInput = awaiting
-            , uiRunning = if awaiting then False else state.uiRunning
-            , uiGenerating =
-                if awaiting then False else state.uiGenerating
-            , uiActivity =
-                if awaiting && state.uiCompletionRemainingMillis == 0
-                    then "Ready"
-                    else state.uiActivity
-            }
+    UiSetAwaitingInput awaiting -> setAwaitingInput awaiting state
     UiSetRepository branch cwd workspace ->
         state { uiBranch = branch, uiCwd = cwd, uiWorkspaceRoot = workspace }
     UiSetNotice notice ->
@@ -230,114 +220,134 @@ reduceUi event state = case event of
         replaceOrAppendRecap "Generating recap…" BlockRunning state
     UiRecapReady summary ->
         replaceOrAppendRecap summary BlockComplete state
-    UiRecapUnavailable message ->
-        case latestRecapIndex state of
-            Just index ->
-                (removeBlockAt index state)
-                    { uiNotice = Just (warningNotice message)
-                    , uiNoticeElapsedMillis = 0
-                    }
-            Nothing ->
-                state
-                    { uiNotice = Just (warningNotice message)
-                    , uiNoticeElapsedMillis = 0
-                    }
+    UiRecapUnavailable message -> recapUnavailable message state
     UiErrorMessage message ->
         (appendBlock BlockError "Error" message "" BlockFailed Nothing state)
             { uiRetryCountdown = Nothing }
     UiRetryCountdown prefix remainingMillis suffix ->
-        let
-            ident = BlockId state.uiNextBlockId
-            remaining = max 0 remainingMillis
-            withBlock =
-                appendBlock
-                    BlockError
-                    "Error"
-                    (retryCountdownText prefix remaining suffix)
-                    ""
-                    BlockFailed
-                    Nothing
-                    state
-        in withBlock
-            { uiRetryCountdown =
-                if remaining == 0
-                    then Nothing
-                    else Just RetryCountdown
-                        { retryCountdownBlockId = ident
-                        , retryCountdownPrefix = prefix
-                        , retryCountdownRemainingMillis = remaining
-                        , retryCountdownSuffix = suffix
-                        }
-            }
-    UiConversationCleared ->
-        state
-            { uiBlocks = Seq.empty
-            , uiSelectedBlock = Nothing
-            , uiSelectedBlockIndex = Nothing
-            , uiBlockIndices = Map.empty
-            , uiNextBlockId = 1
-            , uiTurnStartBlock = 0
-            , uiAttemptStartBlock = 0
-            , uiToolCalls = Map.empty
-            , uiInspectionGroups = Map.empty
-            , uiShellProcesses = Map.empty
-            , uiShellPolls = Map.empty
-            , uiRetryCountdown = Nothing
-            , uiTodos = []
-            , uiGenerating = False
-            , uiGenerationChars = 0
-            , uiGenerationMillis = 0
-            , uiGenerationLastDeltaMillis = 0
-            , uiResponseMillis = 0
-            , uiLastTokensPerSecond = Nothing
-            }
-    UiSetFollow follow ->
-        state
-            { uiFollow = follow
-            , uiSelectedBlock =
-                if follow
-                    then (.blockId) <$> Seq.lookup
-                        (Seq.length state.uiBlocks - 1)
-                        state.uiBlocks
-                    else state.uiSelectedBlock
-            , uiSelectedBlockIndex =
-                if follow
-                    then
-                        if Seq.null state.uiBlocks
-                            then Nothing
-                            else Just (Seq.length state.uiBlocks - 1)
-                    else state.uiSelectedBlockIndex
-            }
+        setRetryCountdown prefix remainingMillis suffix state
+    UiConversationCleared -> clearConversation state
+    UiSetFollow follow -> setFollow follow state
     UiTurnEnded terminalState ->
         finalizeTurn terminalState state
-    UiTurnRestarted ->
-        let blocks = Seq.take state.uiTurnStartBlock state.uiBlocks
-            selected =
-                selectionAfterTruncate
-                    blocks
-                    state.uiSelectedBlockIndex
-            processes =
-                retainShellProcesses blocks state.uiShellProcesses
-        in state
-            { uiBlocks = blocks
-            , uiSelectedBlock = (.blockId) . snd <$> selected
-            , uiSelectedBlockIndex = fst <$> selected
-            , uiBlockIndices =
-                Map.filter (< Seq.length blocks) state.uiBlockIndices
-            , uiRunning = False
-            , uiGenerating = False
-            , uiActivity = "Restarting…"
-            , uiNotice =
-                Just (progressNotice "Restarting current turn…")
+    UiTurnRestarted -> restartTurn state
+
+setAwaitingInput :: Bool -> UiState -> UiState
+setAwaitingInput awaiting state =
+    (if awaiting then finalizeStreams state else state)
+        { uiAwaitingInput = awaiting
+        , uiRunning = if awaiting then False else state.uiRunning
+        , uiGenerating = if awaiting then False else state.uiGenerating
+        , uiActivity =
+            if awaiting && state.uiCompletionRemainingMillis == 0
+                then "Ready"
+                else state.uiActivity
+        }
+
+recapUnavailable :: Text -> UiState -> UiState
+recapUnavailable message state =
+    withNotice
+        (maybe state (`removeBlockAt` state) (latestRecapIndex state))
+  where
+    withNotice current =
+        current
+            { uiNotice = Just (warningNotice message)
             , uiNoticeElapsedMillis = 0
-            , uiCompletionRemainingMillis = 0
-            , uiToolCalls = Map.empty
-            , uiInspectionGroups = Map.empty
-            , uiShellProcesses = processes
-            , uiShellPolls =
-                retainShellPolls processes state.uiShellPolls
-            , uiAttemptStartBlock = state.uiTurnStartBlock
             }
+
+setRetryCountdown :: Text -> Int -> Text -> UiState -> UiState
+setRetryCountdown prefix remainingMillis suffix state =
+    withBlock
+        { uiRetryCountdown =
+            if remaining == 0
+                then Nothing
+                else Just RetryCountdown
+                    { retryCountdownBlockId = ident
+                    , retryCountdownPrefix = prefix
+                    , retryCountdownRemainingMillis = remaining
+                    , retryCountdownSuffix = suffix
+                    }
+        }
+  where
+    ident = BlockId state.uiNextBlockId
+    remaining = max 0 remainingMillis
+    withBlock =
+        appendBlock
+            BlockError
+            "Error"
+            (retryCountdownText prefix remaining suffix)
+            ""
+            BlockFailed
+            Nothing
+            state
+
+clearConversation :: UiState -> UiState
+clearConversation state =
+    state
+        { uiBlocks = Seq.empty
+        , uiSelectedBlock = Nothing
+        , uiSelectedBlockIndex = Nothing
+        , uiBlockIndices = Map.empty
+        , uiNextBlockId = 1
+        , uiTurnStartBlock = 0
+        , uiAttemptStartBlock = 0
+        , uiToolCalls = Map.empty
+        , uiInspectionGroups = Map.empty
+        , uiShellProcesses = Map.empty
+        , uiShellPolls = Map.empty
+        , uiRetryCountdown = Nothing
+        , uiTodos = []
+        , uiGenerating = False
+        , uiGenerationChars = 0
+        , uiGenerationMillis = 0
+        , uiGenerationLastDeltaMillis = 0
+        , uiResponseMillis = 0
+        , uiLastTokensPerSecond = Nothing
+        }
+
+setFollow :: Bool -> UiState -> UiState
+setFollow follow state =
+    state
+        { uiFollow = follow
+        , uiSelectedBlock =
+            if follow
+                then (.blockId) <$> Seq.lookup lastIndex state.uiBlocks
+                else state.uiSelectedBlock
+        , uiSelectedBlockIndex =
+            if follow
+                then
+                    if Seq.null state.uiBlocks
+                        then Nothing
+                        else Just lastIndex
+                else state.uiSelectedBlockIndex
+        }
+  where
+    lastIndex = Seq.length state.uiBlocks - 1
+
+restartTurn :: UiState -> UiState
+restartTurn state =
+    state
+        { uiBlocks = blocks
+        , uiSelectedBlock = (.blockId) . snd <$> selected
+        , uiSelectedBlockIndex = fst <$> selected
+        , uiBlockIndices =
+            Map.filter (< Seq.length blocks) state.uiBlockIndices
+        , uiRunning = False
+        , uiGenerating = False
+        , uiActivity = "Restarting…"
+        , uiNotice = Just (progressNotice "Restarting current turn…")
+        , uiNoticeElapsedMillis = 0
+        , uiCompletionRemainingMillis = 0
+        , uiToolCalls = Map.empty
+        , uiInspectionGroups = Map.empty
+        , uiShellProcesses = processes
+        , uiShellPolls = retainShellPolls processes state.uiShellPolls
+        , uiAttemptStartBlock = state.uiTurnStartBlock
+        }
+  where
+    blocks = Seq.take state.uiTurnStartBlock state.uiBlocks
+    selected = selectionAfterTruncate blocks state.uiSelectedBlockIndex
+    processes = retainShellProcesses blocks state.uiShellProcesses
 
 resetGeneration :: UiState -> UiState
 resetGeneration state =
@@ -377,21 +387,7 @@ snapshotGenerationRate usage state =
 
 reduceLoop :: LoopEvent -> UiState -> UiState
 reduceLoop event state = case event of
-    TurnStarted ->
-        resetGeneration
-            state
-                { uiRunning = True
-                , uiAwaitingInput = False
-                , uiActivity = "Thinking…"
-                , uiNotice = Nothing
-                , uiNoticeElapsedMillis = 0
-                , uiElapsedMillis = 0
-                , uiCompletionRemainingMillis = 0
-                , uiTurnStartBlock = Seq.length state.uiBlocks
-                , uiAttemptStartBlock = Seq.length state.uiBlocks
-                , uiToolCalls = Map.empty
-                , uiInspectionGroups = Map.empty
-                }
+    TurnStarted -> startTurn state
     ReasoningDelta delta ->
         appendOrExtend BlockThinking "Thought" delta BlockStreaming $
             appendGenerationChars delta state
@@ -407,48 +403,14 @@ reduceLoop event state = case event of
     ProviderLimitUpdated
         { providerLimitText = text
         , providerLimitWarning = warning
-        } ->
-        state
-            { uiPrompt =
-                state.uiPrompt
-                    { promptLimitStatus =
-                        Just PromptLimitStatus
-                            { promptLimitText = text
-                            , promptLimitWarning = warning
-                            }
-                    }
-            }
+        } -> setProviderLimit text warning state
     WarningRaised warning ->
         state
             { uiNotice = Just (warningNotice warning)
             , uiNoticeElapsedMillis = 0
             }
-    ResponseRestarted message ->
-        let finalized =
-                finalizeAttempt BlockFailed (finalizeStreams state)
-        in resetGeneration
-            finalized
-                { uiRunning = True
-                , uiActivity = "Retrying response…"
-                , uiNotice = Just (warningNotice message)
-                , uiNoticeElapsedMillis = 0
-                , uiAttemptStartBlock = Seq.length finalized.uiBlocks
-                , uiToolCalls = Map.empty
-                , uiInspectionGroups = Map.empty
-                }
-    ToolStarted call
-        | Map.member call.callId state.uiToolCalls
-            || Map.member call.callId state.uiShellPolls ->
-            -- A streaming backend may announce the call before execution;
-            -- the core loop announces it again once the response is complete.
-            -- Refresh the canonical metadata without adding another block.
-            updateToolCall call
-                state
-                    { uiRunning = True
-                    , uiGenerating = False
-                    , uiAwaitingInput = False
-                    }
-        | otherwise -> startToolCall call state
+    ResponseRestarted message -> restartResponse message state
+    ToolStarted call -> startOrUpdateToolCall call state
     ToolUpdated call ->
         updateToolCall call state
     ToolArgumentsUpdated call ->
@@ -469,34 +431,98 @@ reduceLoop event state = case event of
         state
     NativeAgentFinished{} ->
         state
-    TurnFinished output ->
-        let finalized = finalizeStreams state
-            continuing = not (null output.toolCalls)
-            finishedActivity =
-                case telemetrySummary <$> output.providerTelemetry of
-                    Just summary
-                        | not (Text.null summary) ->
-                            "Finished · " <> summary
-                    _ -> "Finished"
-            withFallback = case output.assistantText of
-                Just text
-                    | not (Text.null (Text.strip text))
-                    , not
-                        (hasAssistantTextSince
-                            finalized.uiAttemptStartBlock
-                            finalized) ->
-                        appendBlock BlockAssistant "Assistant" text ""
-                            BlockComplete Nothing finalized
-                _ -> finalized
-        in snapshotGenerationRate output.tokenUsage withFallback
-            { uiRunning = continuing
-            , uiActivity =
-                if continuing
-                    then "Running tools…"
-                    else finishedActivity
-            , uiCompletionRemainingMillis =
-                if continuing then 0 else completionStatusDurationMillis
+    TurnFinished output -> finishLoopTurn output state
+
+startTurn :: UiState -> UiState
+startTurn state =
+    resetGeneration
+        state
+            { uiRunning = True
+            , uiAwaitingInput = False
+            , uiActivity = "Thinking…"
+            , uiNotice = Nothing
+            , uiNoticeElapsedMillis = 0
+            , uiElapsedMillis = 0
+            , uiCompletionRemainingMillis = 0
+            , uiTurnStartBlock = Seq.length state.uiBlocks
+            , uiAttemptStartBlock = Seq.length state.uiBlocks
+            , uiToolCalls = Map.empty
+            , uiInspectionGroups = Map.empty
             }
+
+setProviderLimit :: Text -> Bool -> UiState -> UiState
+setProviderLimit text warning state =
+    state
+        { uiPrompt =
+            state.uiPrompt
+                { promptLimitStatus =
+                    Just PromptLimitStatus
+                        { promptLimitText = text
+                        , promptLimitWarning = warning
+                        }
+                }
+        }
+
+restartResponse :: Text -> UiState -> UiState
+restartResponse message state =
+    resetGeneration
+        finalized
+            { uiRunning = True
+            , uiActivity = "Retrying response…"
+            , uiNotice = Just (warningNotice message)
+            , uiNoticeElapsedMillis = 0
+            , uiAttemptStartBlock = Seq.length finalized.uiBlocks
+            , uiToolCalls = Map.empty
+            , uiInspectionGroups = Map.empty
+            }
+  where
+    finalized = finalizeAttempt BlockFailed (finalizeStreams state)
+
+startOrUpdateToolCall :: ToolCall -> UiState -> UiState
+startOrUpdateToolCall call state
+    | Map.member call.callId state.uiToolCalls
+        || Map.member call.callId state.uiShellPolls =
+        -- A streaming backend may announce the call before execution;
+        -- the core loop announces it again once the response is complete.
+        -- Refresh the canonical metadata without adding another block.
+        updateToolCall call
+            state
+                { uiRunning = True
+                , uiGenerating = False
+                , uiAwaitingInput = False
+                }
+    | otherwise = startToolCall call state
+
+finishLoopTurn :: TurnOutput -> UiState -> UiState
+finishLoopTurn output state =
+    snapshotGenerationRate output.tokenUsage withFallback
+        { uiRunning = continuing
+        , uiActivity =
+            if continuing
+                then "Running tools…"
+                else finishedActivity
+        , uiCompletionRemainingMillis =
+            if continuing then 0 else completionStatusDurationMillis
+        }
+  where
+    finalized = finalizeStreams state
+    continuing = not (null output.toolCalls)
+    finishedActivity =
+        case telemetrySummary <$> output.providerTelemetry of
+            Just summary
+                | not (Text.null summary) ->
+                    "Finished · " <> summary
+            _ -> "Finished"
+    withFallback = case output.assistantText of
+        Just text
+            | not (Text.null (Text.strip text))
+            , not
+                (hasAssistantTextSince
+                    finalized.uiAttemptStartBlock
+                    finalized) ->
+                appendBlock BlockAssistant "Assistant" text ""
+                    BlockComplete Nothing finalized
+        _ -> finalized
 
 appendOrExtend
     :: BlockKind


### PR DESCRIPTION
## Summary

- replace the monolithic slash-command parser with a small dispatcher, a table for no-argument commands, and focused argument parsers
- decompose response stream assembly into named lifecycle, tool-input, argument, and reasoning transitions
- extract cohesive UI and loop state transitions from the oversized fullscreen reducers
- preserve existing command usage text and reducer/event ordering semantics

## Testing

- `parseReplLine`: 49 examples, 0 failures
- `buildStreamResponse`: 28 examples, 0 failures, including 1,100 property-test cases
- fullscreen TUI suites: 142 examples, 0 failures, including 1,500 generated reducer traces
- exercised the live TUI startup and keyboard selection path in tmux
- `git diff --check`
