### PR TITLE
Allow resuming sessions across gateway credentials

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
@@ -174,10 +174,10 @@ resolveSavedModelTarget
         , targetDialect = dialect
         }
 
--- | Refuse to carry provider-visible conversation history across gateway
--- routing boundaries. This check is independent of model overrides: changing
--- the selected alias must never authorize a local or differently-routed
--- session to enter the currently connected organization.
+-- | Keep direct-provider and organization-gateway sessions on their
+-- respective routes. Gateway credentials are deliberately interchangeable
+-- here: locally owned conversation history remains resumable after credential
+-- rotation or when the user connects another organization gateway.
 validateResumedGatewayBoundary
     :: Maybe Text
     -- ^ Identity of the currently connected gateway credential.
@@ -198,20 +198,12 @@ validateResumedGatewayBoundary currentIdentity connection savedIdentity =
                     "This session has inconsistent organization gateway \
                     \routing metadata and cannot be resumed."
             | otherwise -> Right ()
-        Just current
+        Just _
             | connection /= organizationGatewayConnectionId ->
                 Left
                     "This session was created outside the connected \
                     \organization gateway. Start a new session or disconnect \
                     \the gateway before resuming it."
-            | savedIdentity == Nothing ->
-                Left
-                    "This gateway session predates organization identity \
-                    \binding and cannot be resumed safely. Start a new session."
-            | savedIdentity /= Just current ->
-                Left
-                    "This session belongs to a different organization gateway \
-                    \credential and cannot be resumed. Start a new session."
             | otherwise -> Right ()
 
 catalogModelIds :: ModelCatalog -> [Text]

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayBoundarySpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayBoundarySpec.hs
@@ -48,14 +48,22 @@ spec = describe "GatewayBoundary" do
         firstBoundary `shouldNotBe` replacementBoundary
         gatewayBoundariesMatch firstBoundary firstBoundary `shouldBe` True
 
-    it "validates persisted sessions against the exact current route" do
+    it "keeps persisted sessions route-bound across gateway credentials" do
         let credential = testCredential "secret"
+            replacement = testCredential "replacement-secret"
             boundary = gatewayBoundaryFromCredential (Just credential)
+            replacementBoundary =
+                gatewayBoundaryFromCredential (Just replacement)
             identity = boundary.gatewayBoundaryIdentity
         validateGatewaySessionBoundary
-            boundary
+            replacementBoundary
             organizationGatewayConnectionId
             identity
+            `shouldBe` Right ()
+        validateGatewaySessionBoundary
+            replacementBoundary
+            organizationGatewayConnectionId
+            Nothing
             `shouldBe` Right ()
         validateGatewaySessionBoundary
             (gatewayBoundaryFromCredential Nothing)

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -253,24 +253,26 @@ spec = do
                     (Just "gateway-a")
                     `shouldBe` Right ()
 
-            it "rejects local and legacy sessions entering a gateway" do
+            it "rejects local sessions entering a gateway" do
                 validateResumedGatewayBoundary
                     (Just "gateway-a")
                     "local-openai"
                     Nothing
                     `shouldSatisfy` isLeft
+
+            it "allows gateway sessions across credentials and legacy metadata" do
                 validateResumedGatewayBoundary
                     (Just "gateway-a")
                     organizationGatewayConnectionId
                     Nothing
-                    `shouldSatisfy` isLeft
-
-            it "rejects sessions crossing gateway credentials or disconnecting" do
+                    `shouldBe` Right ()
                 validateResumedGatewayBoundary
                     (Just "gateway-b")
                     organizationGatewayConnectionId
                     (Just "gateway-a")
-                    `shouldSatisfy` isLeft
+                    `shouldBe` Right ()
+
+            it "rejects gateway sessions while disconnected" do
                 validateResumedGatewayBoundary
                     Nothing
                     organizationGatewayConnectionId

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -157,8 +157,8 @@ resumeEntriesFrom = map (uncurry entryFrom)
 resumeEntryFromMeta :: SessionMeta -> ResumeEntry
 resumeEntryFromMeta meta = entryFromWith False meta []
 
--- | Keep the resume surface on the same direct/gateway credential boundary
--- as the active session. Startup validates again before loading any history.
+-- | Keep the resume surface on the same direct/gateway route as the active
+-- session. Gateway sessions remain portable across gateway credentials.
 filterResumeSessionsForBoundary
     :: Maybe Text
     -> [SessionMeta]
@@ -181,9 +181,9 @@ validateResumeMetaForBoundary gatewayIdentity meta =
         meta.metaConnection
         meta.metaGatewayIdentity
 
--- | Keep transcript publication behind the same fail-closed boundary used by
--- startup. In particular, a fullscreen resume must not enqueue history before
--- startup has accepted the active gateway credential identity.
+-- | Keep transcript publication behind the same route validation used by
+-- startup. In particular, a fullscreen resume must not enqueue direct-provider
+-- history into a gateway-routed session (or vice versa).
 publishResumeHistoryAfterBoundary
     :: Either Text ()
     -> IO ()

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -251,7 +251,7 @@ spec = describe "Agent.CLI.AgentSessions" do
             selfResult `shouldSatisfy`
                 Text.isInfixOf "cannot message the current agent session"
 
-    it "does not expose or continue sessions across gateway boundaries" $
+    it "keeps gateway sessions private from direct mode but portable across gateways" $
         withTempEnv \env launched -> do
             let gatewayCreate =
                     (testCreate env.toolsPool env.toolsRoot)
@@ -302,12 +302,15 @@ spec = describe "Agent.CLI.AgentSessions" do
                 Text.isInfixOf "Reconnect the same gateway"
             otherRead <- runTool otherGateway "read_agent_session" payload
             otherRead `shouldSatisfy`
-                Text.isInfixOf "different organization gateway"
+                Text.isInfixOf "tenant A secret"
             otherSend <-
                 runTool otherGateway "send_agent_session_message" messagePayload
             otherSend `shouldSatisfy`
-                Text.isInfixOf "different organization gateway"
-            (null <$> readIORef launched) `shouldReturn` True
+                Text.isInfixOf "Status: running"
+            [(launchedHandle, message)] <- readIORef launched
+            launchedHandle.sessionMeta.metaId
+                `shouldBe` handle.sessionMeta.metaId
+            message `shouldBe` "continue"
             sameRead <- runTool sameGateway "read_agent_session" payload
             sameRead `shouldSatisfy` Text.isInfixOf "tenant A secret"
 

--- a/packages/agent-cli/test/Agent/CLI/MacOS/BridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MacOS/BridgeSpec.hs
@@ -244,7 +244,7 @@ nativeSessionBoundarySpec =
                 (Just "gateway-a")
                 `shouldBe` False
 
-        it "allows only the exact connected gateway identity" do
+        it "allows every gateway session while a gateway is connected" do
             nativeSessionRouteMatchesBoundary
                 (Just "gateway-a")
                 "organization-gateway"
@@ -254,7 +254,12 @@ nativeSessionBoundarySpec =
                 (Just "gateway-a")
                 "organization-gateway"
                 (Just "gateway-b")
-                `shouldBe` False
+                `shouldBe` True
+            nativeSessionRouteMatchesBoundary
+                (Just "gateway-a")
+                "organization-gateway"
+                Nothing
+                `shouldBe` True
             nativeSessionRouteMatchesBoundary
                 (Just "gateway-a")
                 "openai"

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -115,22 +115,18 @@ spec = do
                 (filterResumeSessionsForBoundary Nothing sessions)
                 `shouldBe` ["direct"]
 
-        it "offers only sessions from the exact gateway credential" do
+        it "offers sessions from every gateway credential" do
             map (.metaId)
                 (filterResumeSessionsForBoundary
                     (Just "gateway-a")
                     sessions)
-                `shouldBe` ["allowed"]
+                `shouldBe` ["allowed", "other", "legacy"]
 
-        it "rejects resume metadata before startup can use it" do
+        it "allows resume metadata from another gateway credential" do
             validateResumeMetaForBoundary
                 (Just "gateway-a")
                 (gateway "gateway-b" "other")
-                `shouldBe`
-                    Left
-                        "This session belongs to a different organization \
-                        \gateway credential and cannot be resumed. Start a new \
-                        \session."
+                `shouldBe` Right ()
 
     describe "resumeNeedsGeneratedContext" do
         it "requeues context after compact, clear, and new boundaries" do

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -1240,9 +1240,7 @@ validateLoadedMeta
     -> SessionMeta
     -> Either ApiError ()
 validateLoadedMeta boundary meta
-    | meta.metaGatewayIdentity
-        == boundary.accessGatewayBoundary.gatewayBoundaryIdentity
-        && case boundary.accessGatewayBoundary.gatewayBoundaryIdentity of
+    | case boundary.accessGatewayBoundary.gatewayBoundaryIdentity of
             Nothing ->
                 meta.metaConnection /= organizationGatewayConnectionId
             Just _ ->

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/Read.hs
@@ -167,9 +167,10 @@ loadSessionMetadata pool sessionKey =
         Transactions.transaction Transactions.RepeatableRead Transactions.Read $
             Transaction.statement sessionKey loadMetadataStatement
 
--- | Load metadata only when the row belongs to the caller's exact routing
--- boundary. The authorization predicate is part of the SQL statement, so an
--- unauthorized row is never returned to the application for post-filtering.
+-- | Load metadata only when the row belongs to the caller's direct or gateway
+-- route. Gateway credentials share locally owned gateway conversation history.
+-- The predicate is part of the SQL statement, so a row from the other route is
+-- never returned to the application for post-filtering.
 loadSessionMetadataForBoundary
     :: StorePool
     -> Text
@@ -445,13 +446,13 @@ listSessionMetadata pool =
         Transactions.transaction Transactions.RepeatableRead Transactions.Read $
             Transaction.statement () listMetadataStatement
 
--- | List sessions inside the caller's exact organization-gateway boundary.
+-- | List sessions inside the caller's direct or organization-gateway route.
 --
--- Gateway mode admits only rows for the reserved gateway connection whose
--- stored credential identity exactly matches the supplied identity. Direct
--- mode admits only identity-less rows outside the reserved gateway
--- connection. Both the boundary and cursor predicates are applied before
--- ordering and LIMIT so unauthorized rows cannot displace authorized results.
+-- Gateway mode admits every row for the reserved gateway connection,
+-- including rows written by another or legacy gateway credential. Direct mode
+-- admits only identity-less rows outside the reserved gateway connection.
+-- Both the route and cursor predicates are applied before ordering and LIMIT
+-- so rows from the other route cannot displace authorized results.
 listSessionMetadataForBoundary
     :: StorePool
     -> Text
@@ -568,9 +569,9 @@ searchNativeConversations pool query limit =
             )
             searchNativeConversationsStatement
 
--- | Native/sidebar search with the same exact credential boundary as CLI
+-- | Native/sidebar search with the same direct/gateway route boundary as CLI
 -- search. The predicate is part of both candidate branches before ordering
--- and LIMIT, so another organization cannot displace or expose results.
+-- and LIMIT, so rows from the other route cannot displace or expose results.
 searchNativeConversationsForBoundary
     :: StorePool
     -> Text
@@ -720,7 +721,7 @@ searchNativeConversationsStatement = mkStatement
     \ FROM harness.sessions s CROSS JOIN query WHERE s.deleted_at IS NULL\
     \ AND ($2 IS NULL OR (\
     \   ($3 IS NULL AND s.connection_id <> $2 AND s.gateway_identity IS NULL)\
-    \   OR ($3 IS NOT NULL AND s.connection_id = $2 AND s.gateway_identity = $3)))\
+    \   OR ($3 IS NOT NULL AND s.connection_id = $2)))\
     \ AND (\
     \ s.title ILIKE '%' || $1 || '%' OR s.cwd ILIKE '%' || $1 || '%' OR\
     \ s.provider ILIKE '%' || $1 || '%' OR s.model_id ILIKE '%' || $1 || '%')\
@@ -736,7 +737,7 @@ searchNativeConversationsStatement = mkStatement
     \ CROSS JOIN query WHERE s.deleted_at IS NULL\
     \ AND ($2 IS NULL OR (\
     \   ($3 IS NULL AND s.connection_id <> $2 AND s.gateway_identity IS NULL)\
-    \   OR ($3 IS NOT NULL AND s.connection_id = $2 AND s.gateway_identity = $3)))\
+    \   OR ($3 IS NOT NULL AND s.connection_id = $2)))\
     \ AND (\
     \ t.search_vector @@ query.ts OR t.user_text ILIKE '%' || $1 || '%' OR\
     \ t.assistant_text ILIKE '%' || $1 || '%'))\
@@ -841,8 +842,7 @@ loadMetadataForBoundaryStatement = mkStatement
            \     AND connection_id <> $2\
            \     AND gateway_identity IS NULL)\
            \   OR ($3 IS NOT NULL\
-           \     AND connection_id = $2\
-           \     AND gateway_identity = $3)\
+           \     AND connection_id = $2)\
            \ )")
     ( ((\(sessionKey, _, _) -> sessionKey)
         >$< Encoders.param (Encoders.nonNullable Encoders.text))
@@ -875,8 +875,7 @@ listMetadataForBoundaryStatement = mkStatement
            \     AND connection_id <> $1\
            \     AND gateway_identity IS NULL)\
            \   OR ($2 IS NOT NULL\
-           \     AND connection_id = $1\
-           \     AND gateway_identity = $2)\
+           \     AND connection_id = $1)\
            \ )\
            \ AND (\
            \   ($3 = 'active' AND archived_at IS NULL)\
@@ -1289,8 +1288,7 @@ searchTurnsForBoundaryStatement = mkStatement
     \     AND s.connection_id <> $2\
     \     AND s.gateway_identity IS NULL)\
     \   OR ($3 IS NOT NULL\
-    \     AND s.connection_id = $2\
-    \     AND s.gateway_identity = $3)\
+    \     AND s.connection_id = $2)\
     \ )\
     \ AND (\
     \   t.search_vector @@ query.value\

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -597,7 +597,7 @@ spec = describe "PostgreSQL session schema" do
                                 1 >>= \case
                                     Right [match] ->
                                         match.searchSessionId
-                                            `shouldBe` "boundary-authorized"
+                                            `shouldBe` "boundary-unauthorized"
                                     other ->
                                         expectationFailure
                                             ("unexpected gateway-bound search: "
@@ -623,7 +623,7 @@ spec = describe "PostgreSQL session schema" do
                                 1 >>= \case
                                     Right [match] ->
                                         match.nativeSearchSessionId
-                                            `shouldBe` "boundary-authorized"
+                                            `shouldBe` "boundary-unauthorized"
                                     other ->
                                         expectationFailure
                                             ("unexpected native gateway search: "
@@ -724,8 +724,14 @@ spec = describe "PostgreSQL session schema" do
                                 pool
                                 pageGateway
                                 otherPageIdentity
-                                "page-authorized-a"
-                                `shouldReturn` Right Nothing
+                                "page-authorized-a" >>= \case
+                                    Right (Just loaded) ->
+                                        loaded.sessionListEntryMetadata.sessionMetadataKey
+                                            `shouldBe` "page-authorized-a"
+                                    other ->
+                                        expectationFailure
+                                            ("expected portable gateway metadata: "
+                                                <> show other)
                             loadSessionMetadataForBoundary
                                 pool
                                 pageGateway
@@ -744,51 +750,25 @@ spec = describe "PostgreSQL session schema" do
                                 pageIdentity
                                 SessionAll
                                 Nothing
-                                2 >>= \case
+                                10 >>= \case
                                     Left err ->
                                         expectationFailure
-                                            ("could not list first boundary page: "
+                                            ("could not list gateway sessions: "
                                                 <> show err)
-                                    Right firstPage -> do
+                                    Right gatewayPage -> do
                                         map
                                             (\entry ->
                                                 entry.sessionListEntryMetadata.sessionMetadataKey)
-                                            firstPage.sessionListPageSessions
+                                            gatewayPage.sessionListPageSessions
                                             `shouldBe`
-                                                [ "page-authorized-a"
+                                                [ "page-other-newer"
+                                                , "page-authorized-a"
                                                 , "page-authorized-b"
+                                                , "page-other-between"
+                                                , "page-authorized-c"
                                                 ]
-                                        firstPage.sessionListPageNextCursor
-                                            `shouldBe`
-                                                Just SessionListCursor
-                                                    { sessionListCursorUpdatedAt =
-                                                        pageTieTime
-                                                    , sessionListCursorKey =
-                                                        "page-authorized-b"
-                                                    }
-                                        listSessionMetadataForBoundary
-                                            pool
-                                            pageGateway
-                                            pageIdentity
-                                            SessionAll
-                                            firstPage.sessionListPageNextCursor
-                                            2 >>= \case
-                                                Left err ->
-                                                    expectationFailure
-                                                        ( "could not list second "
-                                                            <> "boundary page: "
-                                                            <> show err
-                                                        )
-                                                Right secondPage -> do
-                                                    map
-                                                        (\entry ->
-                                                            entry.sessionListEntryMetadata.sessionMetadataKey)
-                                                        secondPage.sessionListPageSessions
-                                                        `shouldBe`
-                                                            [ "page-authorized-c"
-                                                            ]
-                                                    secondPage.sessionListPageNextCursor
-                                                        `shouldBe` Nothing
+                                        gatewayPage.sessionListPageNextCursor
+                                            `shouldBe` Nothing
                             listSessionMetadataForBoundary
                                 pool
                                 pageGateway
@@ -807,7 +787,10 @@ spec = describe "PostgreSQL session schema" do
                                             otherPage.sessionListPageSessions
                                             `shouldBe`
                                                 [ "page-other-newer"
+                                                , "page-authorized-a"
+                                                , "page-authorized-b"
                                                 , "page-other-between"
+                                                , "page-authorized-c"
                                                 ]
                             let
                                 directTieTime = addUTCTime 500 now
@@ -900,7 +883,10 @@ spec = describe "PostgreSQL session schema" do
                                                     `shouldBe` expected
                             expectFilteredPage
                                 SessionActive
-                                [ "page-authorized-b"
+                                [ "page-gateway-without-identity"
+                                , "page-other-newer"
+                                , "page-authorized-b"
+                                , "page-other-between"
                                 , "page-authorized-c"
                                 ]
                             expectFilteredPage
@@ -908,8 +894,11 @@ spec = describe "PostgreSQL session schema" do
                                 ["page-authorized-a"]
                             expectFilteredPage
                                 SessionAll
-                                [ "page-authorized-a"
+                                [ "page-gateway-without-identity"
+                                , "page-other-newer"
+                                , "page-authorized-a"
                                 , "page-authorized-b"
+                                , "page-other-between"
                                 , "page-authorized-c"
                                 ]
                             setSessionArchived pool "session-2" True now


### PR DESCRIPTION
## Summary
- authorize locally persisted conversation history by direct-vs-gateway route instead of exact gateway credential fingerprint
- allow resume, search, listing, session tools, native bridge access, and server forks across gateway credential rotation, including legacy gateway sessions
- retain direct/gateway isolation and exact credential binding for queued and running work

## Tests
- `cabal repl agent-cli-runtime:test:agent-cli-runtime-test --repl-options=-fobject-code` focused boundary specs
- `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code` focused resume, agent-session, and macOS bridge specs
- `cabal repl agent-store:test:agent-store-test --repl-options=-fobject-code` focused PostgreSQL session spec
- `cabal repl agent-server:lib:agent-server` module load
- `git diff --check`
