### PR TITLE
Refactor REPL transcript command handling

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -100,8 +100,10 @@ library
                     , Agent.CLI.Runtime.Repl
                     , Agent.CLI.Runtime.Repl.Attachments
                     , Agent.CLI.Runtime.Repl.Commands
+                    , Agent.CLI.Runtime.Repl.Context
                     , Agent.CLI.Runtime.Repl.Selection
                     , Agent.CLI.Runtime.Repl.Session
+                    , Agent.CLI.Runtime.Repl.Transcript
                     , Agent.CLI.Runtime.Repl.Workflow
                     , Agent.CLI.Runtime.Types
                     , Agent.CLI.Render.MarkdownStream

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -13,13 +13,11 @@ import Agent.CLI.AgentViewport
     ( AgentViewportEnv(viewportSelect, viewportEntries,
                        viewportSelected) )
 import Agent.CLI.Approval ( setApprovalPolicy, toggleAlwaysApprove )
-import Agent.CLI.Artifact ( fencedCodeBlock, lastDiffBlock )
 import Agent.CLI.Auth ()
 import Agent.CLI.Changelog (loadReleaseNotes)
 import Agent.CLI.Clipboard ( loadImagesFromPastedText )
 import Agent.CLI.Command
-    ( CopyRequest(..),
-      formatSlashHelpWithCatalog,
+    ( formatSlashHelpWithCatalog,
       parseReplLineWithCatalog,
       ReplAction(ReplCommandError, ReplQuit, ReplReload,
                  ReplUpdateAndRestart, ReplPrompt, ReplExpandedPrompt,
@@ -57,11 +55,6 @@ import Agent.CLI.Config
     , updateHarnessConfig
     )
 import Agent.CLI.Context ( formatContextReport )
-import Agent.CLI.Transcript
-    ( assistantResponseBodies
-    , foldTranscriptTurns
-    )
-import qualified Agent.CLI.Transcript as Transcript
 import Agent.Connectivity ()
 import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
@@ -84,9 +77,7 @@ import Agent.CLI.Input
     ( formatPasteChip,
       readApprovalLine,
       readChoiceSelection,
-      readChoiceSelectionAt,
       readReplHistory,
-      readModalText,
       submissionPromptText,
       truncateDisplayText,
       ReplLine(ReplText, ReplMeta, ReplEof, ReplQuitInterrupt, ReplCycleMode,
@@ -163,9 +154,19 @@ import Agent.CLI.Runtime.Persistence ()
 import Agent.CLI.Runtime.Recap ( runSessionRecap )
 import Agent.CLI.Runtime.Repl.Attachments
     ( handleAttachmentAction, handleClipboardInput )
+import Agent.CLI.Runtime.Repl.Context
+    ( ReplHandlerContext(..)
+    , displayReplError
+    , displayReplInfo
+    , requestReplChoice
+    , requestReplText
+    , withReplSuspended
+    )
 import Agent.CLI.Runtime.Repl.Selection
     ( handleSelectionAction, handleSelectionInput, selectRequestedAccount )
 import Agent.CLI.Runtime.Repl.Session ( handleSessionAction )
+import Agent.CLI.Runtime.Repl.Transcript
+    ( TranscriptAction(..), handleTranscriptAction )
 import Agent.CLI.Runtime.Repl.Workflow ( handleWorkflowAction )
 import Agent.CLI.Runtime.Types
     ( RunResult(RunEnableCodeMode, RunFreshSession, RunRestart, RunUpdateAndRestart,
@@ -175,10 +176,8 @@ import Agent.CLI.Session
     ( TranscriptEffect(TranscriptReplace),
       appendTurnWithMetaUpdateIndexed,
       ensureSession,
-      loadSession,
       Persistence(..),
-      PersistenceState(PersistenceActive, PersistencePending),
-      sessionsRoot,
+      PersistenceState(PersistenceActive),
       SessionHandle(sessionMeta, sessionDir),
       SessionMeta(metaId, metaLastResponseId),
       SessionTurn(turnUsage, SessionTurn, turnAt, turnUserText,
@@ -221,25 +220,16 @@ import Agent.CLI.TUI.App
       requestFullscreenSecret,
       requestFullscreenText,
       queuedFullscreenInputDisplays,
-      setFullscreenImagePreviews,
-      withFullscreenSuspended )
+      setFullscreenImagePreviews )
 import Agent.CLI.TUI.SessionHistory ( sessionHistoryTurn )
 import Agent.CLI.TUI.Types
     ( FullscreenRuntime(runtimeInput)
     , HistoryCommit(..)
     )
 import Agent.CLI.Terminal
-    ( copyTerminalClipboard
-    , formatTerminalCapabilities
+    ( formatTerminalCapabilities
     , resolveColor
     )
-import Agent.CLI.TranscriptExport
-    ( defaultExportFileName
-    , resolveExportPath
-    , saveCopyText
-    , saveTranscriptNoClobber
-    )
-import qualified Agent.CLI.TranscriptExport as TranscriptExport
 import Agent.CLI.Tools ()
 import Agent.CLI.Turn ( runOneTurn )
 import Agent.CLI.Usage ()
@@ -298,10 +288,10 @@ import Control.Concurrent.STM ()
 import Control.Exception ( AsyncException(UserInterrupt) )
 import Control.Exception.Safe
     ( displayException, finally, throwIO, tryAny, tryIO )
-import Control.Monad ( foldM, forM_, unless, when )
+import Control.Monad ( foldM, forM_, when )
 import Data.Foldable ( toList )
 import Data.IORef ( newIORef, readIORef, writeIORef )
-import Data.List ( elemIndex, findIndex )
+import Data.List ( findIndex )
 import Data.Maybe ( fromMaybe, isNothing )
 import Data.Text ( Text )
 import Data.Time.Clock ( getCurrentTime )
@@ -359,11 +349,9 @@ handleReplLine
             , sessionProvider = provider
             , sessionPolicy = policyRef
             , sessionPersist = persist
-            , sessionDatabasePool = databasePool
             , sessionPlanMode = planMode
             , sessionProjectRoot = projectRoot
             , sessionCwd = cwd
-            , sessionHome = home
             , sessionTokenProvider = tokenProvider
             , sessionOpenAiPool = openAiPool
             , sessionGatewayModels = gatewayModelsRef
@@ -372,8 +360,6 @@ handleReplLine
             , sessionRefreshSkills = refreshSkills
             , sessionDraft = draftRef
             , sessionPreviewId = previewIdRef
-            , sessionInterrupt = interrupt
-            , sessionLastAssistant = lastAssistantRef
             , sessionTerminal = terminal
             , sessionFullscreen = fullscreen
             , sessionAgentViewport = agentViewport
@@ -456,6 +442,12 @@ handleReplLine
         submitLine slashCatalog skillInvocations
             continue stdoutColor False line
   where
+    handlerContext =
+        ReplHandlerContext
+            { handlerSessionEnv = env
+            , handlerContinueWith = continueWith
+            , handlerStdoutColor = stdoutColor
+            }
     submitLine
             slashCatalog skillInvocations
             continue color pasted line = do
@@ -599,9 +591,9 @@ handleReplLine
                                         Text.putStrLn
                                             (colorizeGitDiff color diff)
                                     continue
-                    ReplExport maybePath -> do
-                        exportTranscript maybePath
-                        continue
+                    ReplExport maybePath ->
+                        handleTranscriptAction handlerContext
+                            (ExportTranscript maybePath)
                     ReplPermissions
                         | provider == ClaudeCodeProvider -> do
                             let message =
@@ -761,70 +753,18 @@ handleReplLine
                     action@ReplGoalSet{} -> handleWorkflowAction env submitExpandedTurn color continue action
                     action@ReplWorkflowRuns -> handleWorkflowAction env submitExpandedTurn color continue action
                     action@ReplWorkflowManage{} -> handleWorkflowAction env submitExpandedTurn color continue action
-                    ReplCopy request -> do
-                        loadAssistantResponses >>= \case
-                            Left err ->
-                                displayError err do
-                                    color <- resolveColor stderr
-                                    Text.hPutStrLn stderr
-                                        (roleError color err)
-                            Right responses ->
-                                case listAt
-                                    (request.copyResponseIndex - 1)
-                                    responses of
-                                    Nothing -> do
-                                        let available = length responses
-                                            responseNoun
-                                                | available == 1 =
-                                                    "response is"
-                                                | otherwise =
-                                                    "responses are"
-                                            message
-                                                | available == 0 =
-                                                    "no assistant response to copy"
-                                                | otherwise =
-                                                    "only "
-                                                        <> Text.pack
-                                                            (show available)
-                                                        <> " assistant "
-                                                        <> responseNoun
-                                                        <> " available to copy"
-                                        displayError message do
-                                            color <- resolveColor stderr
-                                            Text.hPutStrLn stderr
-                                                (roleError color message)
-                                    Just answer ->
-                                        copyAssistantResponse request answer
-                        continue
-                    ReplCopyCode index -> do
-                        answer <- readIORef lastAssistantRef
-                        let label =
-                                "code block " <> Text.pack (show index)
-                        copyCommand
-                            label
-                            (label <> " was not found")
-                            (answer >>= fencedCodeBlock index)
-                        continue
-                    ReplCopyDiff -> do
-                        answer <- readIORef lastAssistantRef
-                        copyCommand
-                            "diff block"
-                            "no diff block was found"
-                            (answer >>= lastDiffBlock)
-                        continue
-                    ReplCopyPath -> do
-                        copyCommand
-                            "worktree path"
-                            "worktree path is unavailable"
-                            (Just (toText cwd))
-                        continue
-                    ReplCopySession -> do
-                        sessionId <- currentSessionId persist
-                        copyCommand
-                            "session id"
-                            "this session has no persisted id yet"
-                            sessionId
-                        continue
+                    ReplCopy request ->
+                        handleTranscriptAction handlerContext
+                            (CopyResponse request)
+                    ReplCopyCode index ->
+                        handleTranscriptAction handlerContext
+                            (CopyCodeBlock index)
+                    ReplCopyDiff ->
+                        handleTranscriptAction handlerContext CopyDiffBlock
+                    ReplCopyPath ->
+                        handleTranscriptAction handlerContext CopyWorktreePath
+                    ReplCopySession ->
+                        handleTranscriptAction handlerContext CopySessionId
                     ReplDesktop -> do
                         currentSessionId persist >>= \case
                             Nothing -> do
@@ -1042,85 +982,11 @@ handleReplLine
                                                     (historyLabel prompt))
                                             prompts
                                 maybe continue continueWith selected
-                    ReplTranscript -> do
-                        outcome <- case persist of
-                            PersistenceDisabled ->
-                                pure (Right "No conversation transcript is available yet.")
-                            PersistenceEnabled slotRef ->
-                                readIORef slotRef >>= \case
-                                    PersistencePending _ _ _ ->
-                                        pure (Right "No conversation transcript is available yet.")
-                                    PersistenceActive handle ->
-                                        loadSession
-                                            env.sessionDatabasePool
-                                            (sessionsRoot env.sessionHome)
-                                            handle.sessionMeta.metaId
-                                            >>= \case
-                                                Left err -> pure (Left err)
-                                                Right (meta, turns) ->
-                                                    let blocks =
-                                                            foldTranscriptTurns
-                                                                (zip [0 ..] turns)
-                                                    in if null blocks
-                                                        then pure (Right "No conversation transcript is available yet.")
-                                                        else
-                                                            legacy
-                                                                (openPager
-                                                                    (Transcript.renderTranscriptMarkdown
-                                                                        meta
-                                                                        blocks))
-                                                                >>= \case
-                                                                    Left err -> pure (Left err)
-                                                                    Right () -> pure (Right "")
-                        case outcome of
-                            Left err -> do
-                                displayError err $
-                                    Text.hPutStrLn stderr
-                                        (roleError color err)
-                            Right message
-                                | Text.null message -> pure ()
-                                | otherwise ->
-                                    displayInfo message (Text.putStrLn message)
-                        continue
+                    ReplTranscript ->
+                        handleTranscriptAction handlerContext ShowTranscript
                     ReplFind maybeQuery ->
-                        loadPersistedTranscript >>= \case
-                            Left err -> do
-                                displayError err $
-                                    Text.hPutStrLn stderr
-                                        (roleError color err)
-                                continue
-                            Right Nothing -> do
-                                let message =
-                                        "No conversation transcript is available yet."
-                                displayInfo message (Text.putStrLn message)
-                                continue
-                            Right (Just (meta, blocks)) -> do
-                                let query = fromMaybe "" maybeQuery
-                                    matches =
-                                        Transcript.searchTranscriptBlocks
-                                            query
-                                            blocks
-                                if null matches
-                                    then do
-                                        let message =
-                                                "No transcript blocks matched “"
-                                                    <> query
-                                                    <> "”."
-                                        displayInfo message
-                                            (Text.putStrLn message)
-                                    else
-                                        legacy
-                                            (openPager
-                                                (Transcript.renderTranscriptMarkdown
-                                                    meta
-                                                    matches))
-                                            >>= \case
-                                                Left err ->
-                                                    displayError err $
-                                                        Text.hPutStrLn stderr
-                                                            (roleError color err)
-                                                Right () -> pure ()
-                                continue
+                        handleTranscriptAction handlerContext
+                            (FindTranscript maybeQuery)
                     ReplEditPrompt -> do
                         legacy editPrompt >>= \case
                             Left err -> do
@@ -1659,134 +1525,8 @@ handleReplLine
                                     (Right
                                         (ReviewCustom
                                             <$> nonBlank instructions))
-    exportTranscript maybePath =
-        loadActiveTranscript >>= \case
-            Left err ->
-                displayError err $
-                    Text.hPutStrLn stderr (roleError stdoutColor err)
-            Right (sessionId, turns) -> do
-                let markdown = TranscriptExport.renderTranscriptMarkdown turns
-                    defaultPath = defaultExportFileName sessionId
-                case maybePath of
-                    Just path -> saveExport markdown path
-                    Nothing ->
-                        requestChoice
-                            "Export conversation"
-                            "Copy the visible conversation or save it as Markdown."
-                            0
-                            [ ( "Copy Markdown to clipboard"
-                              , "Copy the current visible transcript"
-                              )
-                            , ( "Save Markdown to a file"
-                              , "Create a new file without overwriting"
-                              )
-                            ] >>= \case
-                                Nothing -> pure ()
-                                Just 0 ->
-                                    copyCommand
-                                        "conversation Markdown"
-                                        "conversation is unavailable"
-                                        (Just markdown)
-                                Just _ ->
-                                    requestText
-                                        "Export path"
-                                        "Relative paths use the current working directory. Existing files are never replaced."
-                                        defaultPath >>= mapM_
-                                            (\entered ->
-                                                forM_
-                                                    (nonBlank entered)
-                                                    (saveExport markdown))
-    loadActiveTranscript =
-        case persist of
-            PersistenceDisabled ->
-                pure
-                    (Left
-                        "transcript export requires a persisted session")
-            PersistenceEnabled slotRef ->
-                readIORef slotRef >>= \case
-                    PersistencePending{} ->
-                        pure
-                            (Left
-                                "transcript export requires an active persisted session")
-                    PersistenceActive handle ->
-                        loadSession
-                            databasePool
-                            (sessionsRoot home)
-                            handle.sessionMeta.metaId >>= \case
-                                Left err -> pure (Left err)
-                                Right (_, turns) ->
-                                    pure
-                                        (Right
-                                            ( handle.sessionMeta.metaId
-                                            , turns
-                                            ))
-    saveExport markdown rawPath =
-        resolveExportPath cwd rawPath >>= \case
-            Left err ->
-                displayError err $
-                    Text.hPutStrLn stderr
-                        (roleError stdoutColor err)
-            Right path ->
-                saveTranscriptNoClobber path markdown >>= \case
-                    Left err -> do
-                        let message =
-                                "could not export to "
-                                    <> toText path
-                                    <> ": "
-                                    <> err
-                        displayError message $
-                            Text.hPutStrLn stderr
-                                (roleError stdoutColor message)
-                    Right () -> do
-                        let message =
-                                "exported conversation to " <> toText path
-                        displayInfo message $
-                            Text.hPutStrLn stderr
-                                (roleSuccess stdoutColor
-                                    (glyphOk <> message))
-    requestChoice title body initial rows
-        | null rows = pure Nothing
-        | otherwise =
-            case fullscreen of
-                Just runtime ->
-                    requestFullscreenChoiceWithBody
-                        runtime
-                        title
-                        body
-                        (max 0 (min (length rows - 1) initial))
-                        rows
-                Nothing -> do
-                    color <- resolveColor stderr
-                    Text.hPutStrLn stderr
-                        (roleMuted color
-                            (Text.intercalate
-                                "\n"
-                                (filter
-                                    (not . Text.null)
-                                    [title, body])))
-                    let labels =
-                            [ if Text.null detail
-                                then label
-                                else label <> " — " <> detail
-                            | (label, detail) <- rows
-                            ]
-                    selected <-
-                        readChoiceSelectionAt initial
-                            (\active label ->
-                                if active
-                                    then roleSuccess color label
-                                    else roleMuted color label)
-                            labels
-                    pure (selected >>= (`elemIndex` labels))
-    requestText title body initial =
-        case fullscreen of
-            Just runtime ->
-                requestFullscreenText runtime title body initial
-            Nothing -> do
-                color <- resolveColor stderr
-                unless (Text.null (Text.strip body)) $
-                    Text.hPutStrLn stderr (roleMuted color body)
-                readModalText interrupt (title <> ": ") initial
+    requestChoice = requestReplChoice handlerContext
+    requestText = requestReplText handlerContext
     approvalPolicyRows =
         [ (label, detail)
         | (_, label, detail) <- approvalPolicyOptions
@@ -1811,9 +1551,7 @@ handleReplLine
         | otherwise = Just stripped
       where
         stripped = Text.strip value
-    legacy action = case fullscreen of
-        Nothing -> action
-        Just runtime -> withFullscreenSuspended runtime action
+    legacy = withReplSuspended handlerContext
     fullscreenEvent event = case fullscreen of
         Nothing -> pure ()
         Just runtime -> emitUiEvent runtime event
@@ -1821,12 +1559,8 @@ handleReplLine
         forM_ fullscreen \runtime ->
             readLiveAttachments conversationRef
                 >>= setFullscreenImagePreviews runtime
-    displayInfo message minimalAction = case fullscreen of
-        Nothing -> minimalAction
-        Just runtime -> emitUiEvent runtime (UiSystemMessage message)
-    displayError message minimalAction = case fullscreen of
-        Nothing -> minimalAction
-        Just runtime -> emitUiEvent runtime (UiErrorMessage message)
+    displayInfo = displayReplInfo handlerContext
+    displayError = displayReplError handlerContext
     withReplActivity message action = do
         case fullscreen of
             Nothing ->
@@ -1838,78 +1572,6 @@ handleReplLine
             case fullscreen of
                 Nothing -> clearThinking render
                 Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
-    loadAssistantResponses =
-        loadPersistedTranscript >>= \case
-            Left err -> pure (Left err)
-            Right persisted -> do
-                latest <- readIORef lastAssistantRef
-                let responses =
-                        maybe
-                            []
-                            (assistantResponseBodies . snd)
-                            persisted
-                pure $
-                    Right $
-                        if null responses
-                            then maybe [] pure latest
-                            else responses
-    copyAssistantResponse request answer = do
-        let index = request.copyResponseIndex
-            label
-                | index == 1 = "last response"
-                | otherwise =
-                    "response " <> Text.pack (show index)
-        case request.copyDestination of
-            Nothing ->
-                copyCommand
-                    label
-                    "no assistant response to copy"
-                    (Just answer)
-            Just rawPath ->
-                resolveExportPath cwd rawPath >>= \case
-                    Left err ->
-                        displayError err do
-                            color <- resolveColor stderr
-                            Text.hPutStrLn stderr
-                                (roleError color err)
-                    Right path ->
-                        saveCopyText path answer >>= \case
-                            Left err ->
-                                displayError err do
-                                    color <- resolveColor stderr
-                                    Text.hPutStrLn stderr
-                                        (roleError color err)
-                            Right () -> do
-                                let message =
-                                        "copied "
-                                            <> label
-                                            <> " to "
-                                            <> toText path
-                                displayInfo message do
-                                    color <- resolveColor stderr
-                                    Text.hPutStrLn stderr
-                                        (roleSuccess color
-                                            (glyphOk <> message))
-    copyCommand label missing payload = case payload of
-        Nothing ->
-            displayError missing do
-                color <- resolveColor stderr
-                Text.hPutStrLn stderr (roleError color missing)
-        Just value -> do
-            copied <- copyTerminalClipboard terminal stdout value
-            if copied
-                then
-                    let message = "copied " <> label
-                    in displayInfo message do
-                        color <- resolveColor stderr
-                        Text.hPutStrLn stderr
-                            (roleSuccess color (glyphOk <> message))
-                else
-                    displayError "terminal clipboard is unavailable" do
-                        color <- resolveColor stderr
-                        Text.hPutStrLn stderr
-                            (roleError color
-                                "terminal clipboard is unavailable")
     editPrompt = do
         initialDraft <- readIORef draftRef
         outcome <- tryAny do
@@ -1931,45 +1593,6 @@ handleReplLine
             Left exception ->
                 Left
                     ( "could not edit prompt: "
-                        <> Text.pack (show exception)
-                    )
-            Right result -> result
-
-    loadPersistedTranscript =
-        case persist of
-            PersistenceDisabled -> pure (Right Nothing)
-            PersistenceEnabled slotRef ->
-                readIORef slotRef >>= \case
-                    PersistencePending{} -> pure (Right Nothing)
-                    PersistenceActive handle ->
-                        loadSession
-                            databasePool
-                            (sessionsRoot home)
-                            handle.sessionMeta.metaId
-                            >>= pure . fmap
-                                (\(meta, turns) ->
-                                    let blocks =
-                                            foldTranscriptTurns
-                                                (zip [0 ..] turns)
-                                    in if null blocks
-                                        then Nothing
-                                        else Just (meta, blocks))
-
-    openPager markdown = do
-        outcome <- tryAny do
-            resolveExternalProgram
-                [("PAGER", "$PAGER")]
-                "less -R" >>= \case
-                    Left err -> pure (Left err)
-                    Right program ->
-                        withTemporaryTextFile
-                            "agent-transcript-"
-                            markdown
-                            (runExternalProgramOnFile program)
-        pure $ case outcome of
-            Left exception ->
-                Left
-                    ( "could not open transcript: "
                         <> Text.pack (show exception)
                     )
             Right result -> result

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Context.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Context.hs
@@ -1,0 +1,121 @@
+-- | Shared dependencies for REPL command-domain handlers.
+module Agent.CLI.Runtime.Repl.Context
+    ( ReplHandlerContext(..)
+    , continueRepl
+    , displayReplError
+    , displayReplInfo
+    , requestReplChoice
+    , requestReplText
+    , withReplSuspended
+    ) where
+
+import Agent.CLI.Input ( readChoiceSelectionAt, readModalText )
+import Agent.CLI.Runtime.Types ( RunResult )
+import Agent.CLI.SessionEnv ( SessionEnv(..) )
+import Agent.CLI.Style ( roleMuted, roleSuccess )
+import Agent.CLI.Terminal ( resolveColor )
+import Agent.CLI.TUI.App
+    ( emitUiEvent
+    , requestFullscreenChoiceWithBody
+    , requestFullscreenText
+    , withFullscreenSuspended
+    )
+import Agent.TUI.Model
+    ( UiEvent(UiErrorMessage, UiSystemMessage) )
+import Control.Monad ( unless )
+import Data.List ( elemIndex )
+import Data.Text ( Text )
+import qualified Data.Text as Text
+    ( intercalate, null, strip )
+import qualified Data.Text.IO as Text ( hPutStrLn )
+import System.IO ( stderr )
+
+data ReplHandlerContext = ReplHandlerContext
+    { handlerSessionEnv :: !SessionEnv
+    , handlerContinueWith :: Text -> IO RunResult
+    , handlerStdoutColor :: !Bool
+    }
+
+continueRepl :: ReplHandlerContext -> IO RunResult
+continueRepl context = context.handlerContinueWith ""
+
+displayReplInfo :: ReplHandlerContext -> Text -> IO () -> IO ()
+displayReplInfo context message minimalAction =
+    case context.handlerSessionEnv.sessionFullscreen of
+        Nothing -> minimalAction
+        Just runtime ->
+            emitUiEvent runtime (UiSystemMessage message)
+
+displayReplError :: ReplHandlerContext -> Text -> IO () -> IO ()
+displayReplError context message minimalAction =
+    case context.handlerSessionEnv.sessionFullscreen of
+        Nothing -> minimalAction
+        Just runtime ->
+            emitUiEvent runtime (UiErrorMessage message)
+
+requestReplChoice
+    :: ReplHandlerContext
+    -> Text
+    -> Text
+    -> Int
+    -> [(Text, Text)]
+    -> IO (Maybe Int)
+requestReplChoice context title body initial rows
+    | null rows = pure Nothing
+    | otherwise =
+        case context.handlerSessionEnv.sessionFullscreen of
+            Just runtime ->
+                requestFullscreenChoiceWithBody
+                    runtime
+                    title
+                    body
+                    (max 0 (min (length rows - 1) initial))
+                    rows
+            Nothing -> do
+                color <- resolveColor stderr
+                Text.hPutStrLn stderr
+                    (roleMuted color
+                        (Text.intercalate
+                            "\n"
+                            (filter
+                                (not . Text.null)
+                                [title, body])))
+                let labels =
+                        [ if Text.null detail
+                            then label
+                            else label <> " — " <> detail
+                        | (label, detail) <- rows
+                        ]
+                selected <-
+                    readChoiceSelectionAt initial
+                        (\active label ->
+                            if active
+                                then roleSuccess color label
+                                else roleMuted color label)
+                        labels
+                pure (selected >>= (`elemIndex` labels))
+
+requestReplText
+    :: ReplHandlerContext
+    -> Text
+    -> Text
+    -> Text
+    -> IO (Maybe Text)
+requestReplText context title body initial =
+    case context.handlerSessionEnv.sessionFullscreen of
+        Just runtime ->
+            requestFullscreenText runtime title body initial
+        Nothing -> do
+            color <- resolveColor stderr
+            unless (Text.null (Text.strip body)) $
+                Text.hPutStrLn stderr (roleMuted color body)
+            readModalText
+                context.handlerSessionEnv.sessionInterrupt
+                (title <> ": ")
+                initial
+
+withReplSuspended :: ReplHandlerContext -> IO a -> IO a
+withReplSuspended context action =
+    case context.handlerSessionEnv.sessionFullscreen of
+        Nothing -> action
+        Just runtime -> withFullscreenSuspended runtime action

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Transcript.hs
@@ -1,0 +1,518 @@
+-- | Copying, exporting, and browsing conversation transcripts.
+module Agent.CLI.Runtime.Repl.Transcript
+    ( TranscriptAction(..)
+    , handleTranscriptAction
+    ) where
+
+import Agent.CLI.Artifact ( fencedCodeBlock, lastDiffBlock )
+import Agent.CLI.Command ( CopyRequest(..) )
+import Agent.CLI.ExternalProgram
+    ( resolveExternalProgram
+    , runExternalProgramOnFile
+    , withTemporaryTextFile
+    )
+import Agent.CLI.Runtime.Repl.Context
+    ( ReplHandlerContext(..)
+    , continueRepl
+    , displayReplError
+    , displayReplInfo
+    , requestReplChoice
+    , requestReplText
+    , withReplSuspended
+    )
+import Agent.CLI.Runtime.Types ( RunResult )
+import Agent.CLI.Session
+    ( Persistence(..)
+    , PersistenceState(..)
+    , SessionHandle(sessionMeta)
+    , SessionMeta(metaId)
+    , SessionTurn
+    , loadSession
+    , sessionsRoot
+    )
+import Agent.CLI.Session.Selection ( currentSessionId )
+import Agent.CLI.SessionEnv ( SessionEnv(..) )
+import Agent.CLI.Style
+    ( glyphOk, roleError, roleSuccess )
+import Agent.CLI.Terminal ( copyTerminalClipboard, resolveColor )
+import Agent.CLI.Transcript
+    ( assistantResponseBodies, foldTranscriptTurns )
+import qualified Agent.CLI.Transcript as Transcript
+import Agent.CLI.TranscriptExport
+    ( defaultExportFileName
+    , resolveExportPath
+    , saveCopyText
+    , saveTranscriptNoClobber
+    )
+import qualified Agent.CLI.TranscriptExport as TranscriptExport
+import Agent.OsPath ( toText )
+import Agent.TUI.Model ( UiBlock )
+import Control.Exception.Safe ( tryAny )
+import Control.Monad ( forM_ )
+import Data.IORef ( readIORef )
+import Data.Text ( Text )
+import qualified Data.Text as Text
+    ( null, pack, strip )
+import qualified Data.Text.IO as Text ( hPutStrLn, putStrLn )
+import System.IO ( stderr, stdout )
+
+data TranscriptAction
+    = ExportTranscript (Maybe Text)
+    | CopyResponse CopyRequest
+    | CopyCodeBlock Int
+    | CopyDiffBlock
+    | CopyWorktreePath
+    | CopySessionId
+    | ShowTranscript
+    | FindTranscript (Maybe Text)
+
+handleTranscriptAction
+    :: ReplHandlerContext
+    -> TranscriptAction
+    -> IO RunResult
+handleTranscriptAction context action = do
+    case action of
+        ExportTranscript maybePath ->
+            exportTranscript context maybePath
+        CopyResponse request ->
+            copyResponse context request
+        CopyCodeBlock index ->
+            copyCodeBlock context index
+        CopyDiffBlock ->
+            copyDiffBlock context
+        CopyWorktreePath ->
+            copyWorktreePath context
+        CopySessionId ->
+            copySessionId context
+        ShowTranscript ->
+            showTranscript context
+        FindTranscript maybeQuery ->
+            findTranscript context maybeQuery
+    continueRepl context
+
+exportTranscript
+    :: ReplHandlerContext
+    -> Maybe Text
+    -> IO ()
+exportTranscript context maybePath =
+    loadActiveTranscript context.handlerSessionEnv >>= \case
+        Left err ->
+            displayReplError context err $
+                Text.hPutStrLn stderr
+                    (roleError context.handlerStdoutColor err)
+        Right (sessionId, turns) -> do
+            let markdown =
+                    TranscriptExport.renderTranscriptMarkdown turns
+                defaultPath = defaultExportFileName sessionId
+            case maybePath of
+                Just path ->
+                    saveTranscriptExport context markdown path
+                Nothing ->
+                    requestReplChoice
+                        context
+                        "Export conversation"
+                        "Copy the visible conversation or save it as Markdown."
+                        0
+                        [ ( "Copy Markdown to clipboard"
+                          , "Copy the current visible transcript"
+                          )
+                        , ( "Save Markdown to a file"
+                          , "Create a new file without overwriting"
+                          )
+                        ] >>= \case
+                            Nothing -> pure ()
+                            Just 0 ->
+                                copyCommand
+                                    context
+                                    "conversation Markdown"
+                                    "conversation is unavailable"
+                                    (Just markdown)
+                            Just _ ->
+                                requestReplText
+                                    context
+                                    "Export path"
+                                    "Relative paths use the current working directory. Existing files are never replaced."
+                                    defaultPath >>= mapM_
+                                        (\entered ->
+                                            forM_
+                                                (nonBlank entered)
+                                                (saveTranscriptExport
+                                                    context
+                                                    markdown))
+
+loadActiveTranscript
+    :: SessionEnv
+    -> IO (Either Text (Text, [SessionTurn]))
+loadActiveTranscript
+        SessionEnv
+            { sessionDatabasePool = databasePool
+            , sessionHome = home
+            , sessionPersist = persist
+            } =
+    case persist of
+        PersistenceDisabled ->
+            pure
+                (Left
+                    "transcript export requires a persisted session")
+        PersistenceEnabled slotRef ->
+            readIORef slotRef >>= \case
+                PersistencePending{} ->
+                    pure
+                        (Left
+                            "transcript export requires an active persisted session")
+                PersistenceActive handle ->
+                    loadSession
+                        databasePool
+                        (sessionsRoot home)
+                        handle.sessionMeta.metaId >>= \case
+                            Left err -> pure (Left err)
+                            Right (_, turns) ->
+                                pure
+                                    (Right
+                                        ( handle.sessionMeta.metaId
+                                        , turns
+                                        ))
+
+saveTranscriptExport
+    :: ReplHandlerContext
+    -> Text
+    -> Text
+    -> IO ()
+saveTranscriptExport context markdown rawPath =
+    resolveExportPath
+        context.handlerSessionEnv.sessionCwd
+        rawPath >>= \case
+            Left err ->
+                displayReplError context err $
+                    Text.hPutStrLn stderr
+                        (roleError context.handlerStdoutColor err)
+            Right path ->
+                saveTranscriptNoClobber path markdown >>= \case
+                    Left err -> do
+                        let message =
+                                "could not export to "
+                                    <> toText path
+                                    <> ": "
+                                    <> err
+                        displayReplError context message $
+                            Text.hPutStrLn stderr
+                                (roleError
+                                    context.handlerStdoutColor
+                                    message)
+                    Right () -> do
+                        let message =
+                                "exported conversation to " <> toText path
+                        displayReplInfo context message $
+                            Text.hPutStrLn stderr
+                                (roleSuccess
+                                    context.handlerStdoutColor
+                                    (glyphOk <> message))
+
+copyResponse
+    :: ReplHandlerContext
+    -> CopyRequest
+    -> IO ()
+copyResponse context request =
+    loadAssistantResponses context.handlerSessionEnv >>= \case
+        Left err ->
+            displayReplError context err do
+                color <- resolveColor stderr
+                Text.hPutStrLn stderr (roleError color err)
+        Right responses ->
+            case listAt
+                (request.copyResponseIndex - 1)
+                responses of
+                Nothing -> do
+                    let available = length responses
+                        responseNoun
+                            | available == 1 = "response is"
+                            | otherwise = "responses are"
+                        message
+                            | available == 0 =
+                                "no assistant response to copy"
+                            | otherwise =
+                                "only "
+                                    <> Text.pack (show available)
+                                    <> " assistant "
+                                    <> responseNoun
+                                    <> " available to copy"
+                    displayReplError context message do
+                        color <- resolveColor stderr
+                        Text.hPutStrLn stderr
+                            (roleError color message)
+                Just answer ->
+                    copyAssistantResponse context request answer
+
+loadAssistantResponses
+    :: SessionEnv
+    -> IO (Either Text [Text])
+loadAssistantResponses env@SessionEnv{sessionLastAssistant = lastAssistantRef} =
+    loadPersistedTranscript env >>= \case
+        Left err -> pure (Left err)
+        Right persisted -> do
+            latest <- readIORef lastAssistantRef
+            let responses =
+                    maybe
+                        []
+                        (assistantResponseBodies . snd)
+                        persisted
+            pure $
+                Right $
+                    if null responses
+                        then maybe [] pure latest
+                        else responses
+
+copyAssistantResponse
+    :: ReplHandlerContext
+    -> CopyRequest
+    -> Text
+    -> IO ()
+copyAssistantResponse context request answer = do
+    let index = request.copyResponseIndex
+        label
+            | index == 1 = "last response"
+            | otherwise =
+                "response " <> Text.pack (show index)
+    case request.copyDestination of
+        Nothing ->
+            copyCommand
+                context
+                label
+                "no assistant response to copy"
+                (Just answer)
+        Just rawPath ->
+            resolveExportPath
+                context.handlerSessionEnv.sessionCwd
+                rawPath >>= \case
+                    Left err ->
+                        displayReplError context err do
+                            color <- resolveColor stderr
+                            Text.hPutStrLn stderr
+                                (roleError color err)
+                    Right path ->
+                        saveCopyText path answer >>= \case
+                            Left err ->
+                                displayReplError context err do
+                                    color <- resolveColor stderr
+                                    Text.hPutStrLn stderr
+                                        (roleError color err)
+                            Right () -> do
+                                let message =
+                                        "copied "
+                                            <> label
+                                            <> " to "
+                                            <> toText path
+                                displayReplInfo context message do
+                                    color <- resolveColor stderr
+                                    Text.hPutStrLn stderr
+                                        (roleSuccess color
+                                            (glyphOk <> message))
+
+copyCodeBlock
+    :: ReplHandlerContext
+    -> Int
+    -> IO ()
+copyCodeBlock context index = do
+    answer <-
+        readIORef context.handlerSessionEnv.sessionLastAssistant
+    let label = "code block " <> Text.pack (show index)
+    copyCommand
+        context
+        label
+        (label <> " was not found")
+        (answer >>= fencedCodeBlock index)
+
+copyDiffBlock :: ReplHandlerContext -> IO ()
+copyDiffBlock context = do
+    answer <-
+        readIORef context.handlerSessionEnv.sessionLastAssistant
+    copyCommand
+        context
+        "diff block"
+        "no diff block was found"
+        (answer >>= lastDiffBlock)
+
+copyWorktreePath :: ReplHandlerContext -> IO ()
+copyWorktreePath context =
+    copyCommand
+        context
+        "worktree path"
+        "worktree path is unavailable"
+        (Just (toText context.handlerSessionEnv.sessionCwd))
+
+copySessionId :: ReplHandlerContext -> IO ()
+copySessionId context = do
+    sessionId <-
+        currentSessionId context.handlerSessionEnv.sessionPersist
+    copyCommand
+        context
+        "session id"
+        "this session has no persisted id yet"
+        sessionId
+
+showTranscript :: ReplHandlerContext -> IO ()
+showTranscript context =
+    loadPersistedTranscript context.handlerSessionEnv >>= \case
+        Left err ->
+            displayReplError context err $
+                Text.hPutStrLn stderr
+                    (roleError context.handlerStdoutColor err)
+        Right Nothing ->
+            displayNoTranscript context
+        Right (Just (meta, blocks)) ->
+            withReplSuspended
+                context
+                (openPager
+                    (Transcript.renderTranscriptMarkdown
+                        meta
+                        blocks)) >>= \case
+                            Left err ->
+                                displayReplError context err $
+                                    Text.hPutStrLn stderr
+                                        (roleError
+                                            context.handlerStdoutColor
+                                            err)
+                            Right () -> pure ()
+
+findTranscript
+    :: ReplHandlerContext
+    -> Maybe Text
+    -> IO ()
+findTranscript context maybeQuery =
+    loadPersistedTranscript context.handlerSessionEnv >>= \case
+        Left err ->
+            displayReplError context err $
+                Text.hPutStrLn stderr
+                    (roleError context.handlerStdoutColor err)
+        Right Nothing ->
+            displayNoTranscript context
+        Right (Just (meta, blocks)) -> do
+            let query = maybe "" id maybeQuery
+                matches =
+                    Transcript.searchTranscriptBlocks
+                        query
+                        blocks
+            if null matches
+                then do
+                    let message =
+                            "No transcript blocks matched “"
+                                <> query
+                                <> "”."
+                    displayReplInfo context message
+                        (Text.putStrLn message)
+                else
+                    withReplSuspended
+                        context
+                        (openPager
+                            (Transcript.renderTranscriptMarkdown
+                                meta
+                                matches)) >>= \case
+                                    Left err ->
+                                        displayReplError context err $
+                                            Text.hPutStrLn stderr
+                                                (roleError
+                                                    context.handlerStdoutColor
+                                                    err)
+                                    Right () -> pure ()
+
+displayNoTranscript :: ReplHandlerContext -> IO ()
+displayNoTranscript context =
+    displayReplInfo context message (Text.putStrLn message)
+  where
+    message = "No conversation transcript is available yet."
+
+copyCommand
+    :: ReplHandlerContext
+    -> Text
+    -> Text
+    -> Maybe Text
+    -> IO ()
+copyCommand context label missing payload =
+    case payload of
+        Nothing ->
+            displayReplError context missing do
+                color <- resolveColor stderr
+                Text.hPutStrLn stderr (roleError color missing)
+        Just value -> do
+            copied <-
+                copyTerminalClipboard
+                    context.handlerSessionEnv.sessionTerminal
+                    stdout
+                    value
+            if copied
+                then
+                    let message = "copied " <> label
+                    in displayReplInfo context message do
+                        color <- resolveColor stderr
+                        Text.hPutStrLn stderr
+                            (roleSuccess color (glyphOk <> message))
+                else
+                    displayReplError
+                        context
+                        "terminal clipboard is unavailable" do
+                            color <- resolveColor stderr
+                            Text.hPutStrLn stderr
+                                (roleError color
+                                    "terminal clipboard is unavailable")
+
+loadPersistedTranscript
+    :: SessionEnv
+    -> IO (Either Text (Maybe (SessionMeta, [UiBlock])))
+loadPersistedTranscript
+        SessionEnv
+            { sessionDatabasePool = databasePool
+            , sessionHome = home
+            , sessionPersist = persist
+            } =
+    case persist of
+        PersistenceDisabled -> pure (Right Nothing)
+        PersistenceEnabled slotRef ->
+            readIORef slotRef >>= \case
+                PersistencePending{} -> pure (Right Nothing)
+                PersistenceActive handle ->
+                    loadSession
+                        databasePool
+                        (sessionsRoot home)
+                        handle.sessionMeta.metaId
+                        >>= pure . fmap
+                            (\(meta, turns) ->
+                                let blocks =
+                                        foldTranscriptTurns
+                                            (zip [0 ..] turns)
+                                in if null blocks
+                                    then Nothing
+                                    else Just (meta, blocks))
+
+openPager :: Text -> IO (Either Text ())
+openPager markdown = do
+    outcome <- tryAny do
+        resolveExternalProgram
+            [("PAGER", "$PAGER")]
+            "less -R" >>= \case
+                Left err -> pure (Left err)
+                Right program ->
+                    withTemporaryTextFile
+                        "agent-transcript-"
+                        markdown
+                        (runExternalProgramOnFile program)
+    pure $ case outcome of
+        Left exception ->
+            Left
+                ( "could not open transcript: "
+                    <> Text.pack (show exception)
+                )
+        Right result -> result
+
+nonBlank :: Text -> Maybe Text
+nonBlank value
+    | Text.null stripped = Nothing
+    | otherwise = Just stripped
+  where
+    stripped = Text.strip value
+
+listAt :: Int -> [a] -> Maybe a
+listAt index values
+    | index < 0 = Nothing
+    | otherwise = case drop index values of
+        value : _ -> Just value
+        [] -> Nothing


### PR DESCRIPTION
## Summary
- extract copy, export, transcript, and find handling from the oversized REPL dispatcher
- introduce a narrow shared handler context for continuation and minimal/fullscreen UI plumbing
- preserve persistence, clipboard, pager, and export behavior behind a small total action dispatcher

## Validation
- [x] object-code GHCi: `parseReplLine` (49 examples)
- [x] object-code GHCi: `renderTranscriptMarkdown` (1 example)
- [x] object-code GHCi: `path and save helpers` (3 examples)
- [x] object-code GHCi: `terminal protocol encoders` (8 examples)
- [x] `cabal build agent-cli:exe:agent-cli`
- [x] live tmux smoke for `/copy-path`, `/copy`, `/copy-code`, `/copy-diff`, `/copy-session`, `/transcript`, `/find`, `/export`, and clean `/quit`
- [x] independent semantic review found no blocking issues

## Notes
- An all-tests GHCi run did not complete in this environment: managed `AgentSessions` cases failed and GHCi later segfaulted. The focused affected suites and live command paths pass.
