### PR TITLE
Extract agent tools runtime phases

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -93,7 +93,8 @@ import Agent.CLI.Options
       CliOptions(optYolo, optModel, optEffort, optMaxConcurrentAgents,
                  optGhci, optBash, optComputerUse, optNoYolo, optSkills) )
 import Agent.CLI.PendingInputs
-    ( PendingNoticeKind(..)
+    ( PendingInputs
+    , PendingNoticeKind(..)
     , enqueuePendingInput
     , enqueuePendingNotice
     , newPendingInputs
@@ -158,6 +159,7 @@ import Agent.CLI.Session
       sessionLegacySubagentTarget,
       taskPlanHooksForPersistence,
       SessionTempCleanupReport(..),
+      LegacySubagentTarget,
       Persistence(PersistenceDisabled),
       SessionHandle(sessionDir, sessionMeta),
       SessionMeta(metaId, metaTransportModel, metaProvider,
@@ -193,6 +195,10 @@ import Agent.CLI.Subagents.Runtime
       persistAndEvictSubagentSessionWithStatus,
       prepareCollaborationSpawn,
       restoreAgentFromDisk )
+import Agent.CLI.Subagents.Runtime.Types
+    ( SubagentSession
+    , SubagentStoreRoot
+    )
 import Agent.CLI.TUI.App
     ( FullscreenRuntime,
       clearFullscreenHistorySource,
@@ -219,20 +225,25 @@ import Agent.CLI.Worktree
 import Agent.Cancel ()
 import Agent.Claude ()
 import Agent.Dialect
-    ( dialectForId
+    ( Dialect
+    , dialectForId
     , DialectId(CodexDialect, GrokBuildDialect)
     )
 import Agent.Error (ApiError)
 import Agent.GrokBuild.Dialect.Goal ()
 import Agent.GrokBuild.Dialect.Runtime ()
-import Agent.GrokBuild.Dialect.Task ( grokRootChildModels )
+import Agent.GrokBuild.Dialect.Task
+    ( GrokSubagentSpecs
+    , grokRootChildModels
+    )
 import Agent.GrokBuild.Dialect.Workflow ()
 import Agent.Loop
     ( TurnInput(UserMessage, AgentMessage),
       LoopError(LoopNoResponseId) )
 import Agent.OpenAI.Compaction ()
 import Agent.OpenAI.ImageGeneration
-    ( clearImageGenerationHistory
+    ( ImageGenerationHistory
+    , clearImageGenerationHistory
     , imageGenerationTool
     , newImageGenerationHistory
     , recordImageGenerationImages
@@ -252,7 +263,10 @@ import Agent.ReasoningEffort
 import Agent.Responses.GenericBackend ()
 import Agent.Responses.GenericClient ( GenericClientOptions(..) )
 import Agent.Responses.Types ( ResponseItem )
-import Agent.Skills ( SkillCatalog(SkillCatalog) )
+import Agent.Skills
+    ( SkillCatalog(SkillCatalog)
+    , SkillInvocation
+    )
 import Agent.Store.Postgres ( trustedPool )
 import Agent.Store.Types ()
 import Agent.Subagents
@@ -265,7 +279,9 @@ import Agent.Subagents
       interruptActiveSubagents,
       defaultMaxConcurrent,
       defaultSubagentConfig,
-      SubagentConfig(maxConcurrent) )
+      SubagentConfig(maxConcurrent),
+      SubagentId,
+      SubagentRegistry )
 import Agent.Subagents.TaskPath ( taskPathRoot )
 import Agent.TUI.Model ( UiEvent(UiSetNotice) )
 import Agent.TUI.Motion ()
@@ -285,9 +301,10 @@ import Agent.Tools.Secret
     ( SecretPrompt(..), SecretPromptHooks(..) )
 import Agent.Tools.ShowImage
     ( ImageDisplayHooks(..), ImageDisplayRequest(..) )
-import Agent.Tools.TaskPlan (newTaskPlanEnv)
+import Agent.Tools.TaskPlan (TaskPlanEnv, newTaskPlanEnv)
 import Agent.Tools.Types
-    ( AppToolGroup(..)
+    ( AppTool
+    , AppToolGroup(..)
     , ToolEnv(..)
     , appToolsFromGroups
     , setToolSessionTmp
@@ -306,6 +323,7 @@ import Data.Functor ()
 import Data.IORef
     (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
 import Data.List ()
+import Data.Map.Strict (Map)
 import Data.Maybe ( isNothing, fromMaybe, isJust )
 import Data.Set (Set)
 import Data.Text (Text)
@@ -341,7 +359,10 @@ import qualified Data.Map.Strict as Map
     ( toAscList, empty, lookup, notMember )
 import qualified Agent.OpenAI.Auth as OpenAI ()
 import qualified Agent.OpenRouter as OpenRouter
-    ( clientOptionsFromEnv, mapModel )
+    ( ClientOptions
+    , clientOptionsFromEnv
+    , mapModel
+    )
 import qualified Agent.OpenRouter.Usage as OpenRouterUsage ()
 import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
@@ -353,6 +374,158 @@ import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Client as XAIClient ()
 import qualified Agent.XAI.Request as XAIRequest ()
 import qualified Agent.XAI.Usage as XAIUsage ()
+
+data AgentToolsRequest windowTitleResult = AgentToolsRequest
+    { runAgentChild :: AgentRunMode -> CliOptions -> IO DevResult
+    , loaded :: LoadedAuth
+    , connectedGateway :: Maybe GatewayCredential
+    , learnAboutUserRequested :: Bool
+    , customBearerToken :: Maybe Text
+    , activeAccountIdRef :: IORef Text
+    , activeAccountRef :: IORef Text
+    , activeSelectionRef :: IORef Text
+    , baseToolEnv :: ToolEnv
+    , catalog :: ModelCatalog
+    , gatewayModelsRef :: IORef (Maybe GatewayModelAccess)
+    , gatewayIdentity :: Maybe Text
+    , checkStartupUsageInBackground :: Bool
+    , configuredOptionTarget :: Maybe ModelTarget
+    , customResponses :: Maybe (Text, ResponsesConnection)
+    , cwd :: OsPath
+    , databaseScopes :: DatabaseScopes
+    , escPaused :: IORef Bool
+    , fullscreen :: Maybe FullscreenRuntime
+    , home :: OsPath
+    , interrupt :: InterruptState
+    , isTty :: Bool
+    , mcpSupervisor :: MCP.McpSupervisor
+    , options :: CliOptions
+    , pendingTurn :: Maybe PendingTurn
+    , preferredOpenAiAccountRef :: IORef (Maybe Text)
+    , processRuntime :: AgentProcessRuntime
+    , projectRoot :: OsPath
+    , projectSettings :: ProjectSettings
+    , projectTarget :: Maybe ModelTarget
+    , resolveActiveAccountLabel :: Credential -> IO Text
+    , resumeLock :: Maybe SessionLock
+    , resumed :: Maybe (SessionMeta, [SessionTurn])
+    , resumedTarget :: Maybe ModelTarget
+    , root :: OsPath
+    , selectHttpAccount :: Text -> IO (Either ApiError Text)
+    , selectableTokenProvider :: TokenProvider
+    , setWindowTitle :: Text -> IO windowTitleResult
+    , startup :: StartupRuntime
+    , stateDirectory :: FilePath
+    , stderrHandle :: Handle
+    , targetHint :: Maybe ModelTarget
+    , tokenProvider :: TokenProvider
+    , transition :: Maybe ProviderTransition
+    , transitionTarget :: Maybe ModelTarget
+    , uiRuntimeRef :: IORef (Maybe FullscreenRuntime)
+    , unavailableProviders :: Set Provider
+    }
+
+data ToolStartup = ToolStartup
+    { toolNativeCapabilities :: NativeRunCapabilities
+    , toolOpenRouterOptions :: OpenRouter.ClientOptions
+    , toolHarnessConfig :: HarnessConfig
+    , toolGatewaySelection :: Maybe ModelOption
+    , toolGatewayAllowedChildModels :: Maybe [Text]
+    }
+
+data ToolHostHooks = ToolHostHooks
+    { toolPlanHooks :: PlanModeHooks
+    , toolSecretHooks :: Maybe SecretPromptHooks
+    , toolImageHooks :: Maybe ImageDisplayHooks
+    }
+
+data ToolModelRuntime = ToolModelRuntime
+    { toolProvider :: Provider
+    , toolModel :: Text
+    , toolTransportModel :: Text -> Text
+    , toolInferredTarget :: ModelTarget
+    , toolCustomGenericOptions :: Maybe GenericClientOptions
+    , toolDialectId :: DialectId
+    , toolDialect :: Dialect
+    , toolResumeTargetChanged :: Bool
+    , toolRefreshDialectContext :: Bool
+    , toolLegacySubagentTarget :: Maybe LegacySubagentTarget
+    , toolEffortText :: Text
+    , toolPolicy :: ApprovalPolicy
+    , toolClaudeBypassEnabled :: Bool
+    }
+
+data CollaborationRuntime = CollaborationRuntime
+    { collaborationActiveSessionLock :: IORef (Maybe SessionLock)
+    , collaborationPersistSlotRef :: IORef Persistence
+    , collaborationSubagentSessions
+        :: IORef (Map SubagentId SubagentSession)
+    , collaborationSubagentStoreRoot :: SubagentStoreRoot
+    , collaborationSubagentForkSource
+        :: IORef (Maybe (IO [ResponseItem]))
+    , collaborationPendingNotices :: PendingInputs
+    , collaborationRegistry :: SubagentRegistry
+    , collaborationRootTurnRef :: IORef (Maybe RootTurnId)
+    , collaborationAgentTypes :: GrokSubagentSpecs
+    , collaborationOpenAiChild :: Maybe TokenProvider
+    , collaborationAllowedChildModels :: Maybe [Text]
+    , collaborationChildModelAllowed :: Maybe (Text -> IO Bool)
+    , collaborationResolveChildModel
+        :: Maybe (Text -> IO (Maybe CollaborationModelTarget))
+    , collaborationGatewayChildModelOption
+        :: Maybe (Text -> IO (Maybe ModelOption))
+    , collaborationCreateWorktree
+        :: OsPath -> IO (Either Text SubagentWorktree)
+    , collaborationContext :: Maybe MultiAgentContext
+    , collaborationCloseAgents :: IO ()
+    }
+
+data ScratchRuntime = ScratchRuntime
+    { scratchPromptRequest :: Maybe ManagedTurnRequest
+    , scratchPersistence :: Persistence
+    , scratchTaskPlan :: TaskPlanEnv
+    , scratchSessionTmp :: OsPath
+    , scratchImageGenerationHistory :: ImageGenerationHistory
+    , scratchExternalSessionTools :: [AppTool]
+    , scratchCleanup :: IO ()
+    }
+
+data McpRuntime = McpRuntime
+    { runtimeMcpServerConfigs :: [MCP.McpServerConfig]
+    , runtimeProgressiveMcp :: Bool
+    , runtimeMcpLease :: MCP.McpFleetLease
+    , runtimeMcpFleet :: MCP.McpFleet
+    , runtimeMcpInstructions :: [(Text, Text)]
+    }
+
+data CodingRuntime = CodingRuntime
+    { runtimeCoding :: CodingTools
+    , runtimeExtraTools :: [AppTool]
+    , runtimeCloseExtraTools :: IO ()
+    }
+
+data SessionControlRuntime = SessionControlRuntime
+    { controlGhciEnabledRef :: IORef Bool
+    , controlBashEnabledRef :: IORef Bool
+    , controlSkillsRef :: IORef SkillCatalog
+    , controlSkillInvocationsRef :: IORef [SkillInvocation]
+    , controlCodeModeCloseRef :: IORef (IO ())
+    , controlClaimCurrentSession :: SessionHandle -> IO ()
+    , controlSessionTools :: [AppTool]
+    }
+
+data SessionToolsRuntime = SessionToolsRuntime
+    { sessionAllTools :: [AppTool]
+    , sessionTools :: [AppTool]
+    , sessionMcpTools :: [AppTool]
+    , sessionDatabaseTools :: [AppTool]
+    , sessionLearnedSkillTools :: [AppTool]
+    , sessionGatewayTools :: [AppTool]
+    , sessionPlanMode :: PlanModeEnv
+    , sessionNoteDirectory :: OsPath -> IO ()
+    , sessionCloseAll :: IO ()
+    , sessionResumedPlanPending :: Bool
+    }
 
 runAgentTools
     :: (AgentRunMode -> CliOptions -> IO DevResult)
@@ -451,13 +624,87 @@ runAgentTools
     transitionTarget
     uiRuntimeRef
     unavailableProviders
-    = do
-    let nativeCapabilities =
+    =
+    runAgentToolsRequest AgentToolsRequest{..}
+
+runAgentToolsRequest
+    :: AgentToolsRequest windowTitleResult
+    -> IO RunResult
+runAgentToolsRequest request = do
+    toolStartup <- loadToolStartup request
+    let toolModelRuntime = resolveToolModel request toolStartup
+        toolHostHooks =
+            buildToolHostHooks request toolStartup toolModelRuntime
+    collaborationRuntime <-
+        newCollaborationRuntime request toolStartup toolModelRuntime
+    scratchRuntime <-
+        prepareScratchRuntime
+            request
+            toolStartup
+            toolModelRuntime
+            collaborationRuntime
+    mcpRuntime <-
+        acquireMcpRuntime
+            request
+            toolStartup
+            toolModelRuntime
+            collaborationRuntime
+            scratchRuntime
+    codingRuntime <-
+        acquireCodingRuntime
+            request
+            toolStartup
+            toolModelRuntime
+            toolHostHooks
+            collaborationRuntime
+            scratchRuntime
+            mcpRuntime
+    installCollaborationCallbacks request collaborationRuntime
+    sessionControlRuntime <-
+        newSessionControlRuntime
+            request
+            toolStartup
+            toolModelRuntime
+            collaborationRuntime
+    sessionToolsRuntime <-
+        assembleSessionToolsRuntime
+            request
+            toolStartup
+            toolModelRuntime
+            toolHostHooks
+            collaborationRuntime
+            scratchRuntime
+            mcpRuntime
+            codingRuntime
+            sessionControlRuntime
+    launchAgentToolsSession
+        request
+        toolStartup
+        toolModelRuntime
+        toolHostHooks
+        collaborationRuntime
+        scratchRuntime
+        mcpRuntime
+        codingRuntime
+        sessionControlRuntime
+        sessionToolsRuntime
+
+loadToolStartup
+    :: AgentToolsRequest windowTitleResult
+    -> IO ToolStartup
+loadToolStartup request@AgentToolsRequest
+    { loaded
+    , connectedGateway
+    , gatewayIdentity
+    , home
+    , startup
+    } = do
+    let toolNativeCapabilities =
             maybe
                 fullNativeRunCapabilities
                 (.nativeCapabilities)
                 startup.startupNativeHooks
-    openRouterOptions <- OpenRouter.clientOptionsFromEnv
+    toolOpenRouterOptions <- OpenRouter.clientOptionsFromEnv
     markStartupStage startup "Loading tools…"
     when (isGatewayLoadedAuth loaded /= isJust gatewayIdentity) $
         startupDie startup
@@ -465,248 +712,314 @@ runAgentTools
     when ((gatewayCredentialIdentity <$> connectedGateway) /= gatewayIdentity) $
         startupDie startup
             "gateway credential snapshot and session binding disagree"
-    harnessConfig <-
+    toolHarnessConfig <-
         loadHarnessConfig home >>= \case
             Left err -> startupDie startup (Text.unpack err)
             Right config -> pure config
-    (gatewaySelection, gatewayAllowedChildModels) <-
-        if not (isGatewayLoadedAuth loaded)
-            then pure (Nothing, Nothing)
-            else do
-                access <-
-                    readIORef gatewayModelsRef >>= \case
-                        Nothing ->
-                            startupDie startup
-                                "The organization gateway model catalog is unavailable."
-                        Just value -> pure value
-                cachedGatewayModels access >>= \case
-                    Nothing ->
-                        startupDie startup
-                            "The organization gateway model catalog is unavailable."
-                    Just models ->
-                        case
-                            modelOptionsForGatewayModels catalog models
-                            of
-                            [] ->
-                                startupDie startup
-                                    "The organization gateway does not offer any models."
-                            firstAvailable : remainingAvailable -> do
-                                let available =
-                                        firstAvailable : remainingAvailable
-                                    resolveTarget target =
-                                        resolveModelOptionById
-                                            available
-                                            target.targetModelId
-                                selected <- case options.optModel of
-                                    Just requested ->
-                                        case
-                                            resolveModelOptionById
-                                                available
-                                                requested
-                                            of
-                                            Nothing ->
-                                                startupDie startup $
-                                                    "Model '"
-                                                        <> Text.unpack requested
-                                                        <> "' is not available through your organization gateway."
-                                            Just selected ->
-                                                pure selected
-                                    Nothing ->
-                                        pure $
-                                            fromMaybe firstAvailable $
-                                                ( transitionTarget
-                                                    >>= resolveTarget
-                                                )
-                                                    <|> ( configuredOptionTarget
-                                                            >>= resolveTarget
-                                                        )
-                                                    <|> ( resumedTarget
-                                                            >>= resolveTarget
-                                                        )
-                                                    <|> ( projectTarget
-                                                            >>= resolveTarget
-                                                        )
-                                                    <|> ( targetHint
-                                                            >>= resolveTarget
-                                                        )
-                                pure
-                                    ( Just selected
-                                    , Just
-                                        (map
-                                            (.modelTarget.targetModelId)
-                                            available)
-                                    )
-    let basePlanHooks
-            | Just hooks <- startup.startupNativeHooks =
-                hooks.nativePlanHooks
-            | startup.startupBackground =
-                PlanModeHooks
-                    { planConfirmEnter = \_ -> pure False
-                    , planDecideExit = \_ -> pure PlanCancel
-                    , planAskQuestion = \_ _ -> pure Nothing
-                    }
-            | otherwise =
-                cliPlanHooks
-                    provider interrupt escPaused (resolveColor stderrHandle)
-        planHooks = fullscreenAwarePlanHooks uiRuntimeRef basePlanHooks
-        baseSecretHooks = SecretPromptHooks \request ->
-            Right <$> promptSecretLine
-                escPaused
-                request.secretPromptMessage
-                request.secretPromptPurpose
-        secretHooks
-            | not nativeCapabilities.nativeHostExtensions
-                || isOneShot options || not isTty = Nothing
-            | otherwise =
-                Just (fullscreenAwareSecretHooks uiRuntimeRef baseSecretHooks)
-        -- Outside the retained TUI, agent-displayed images print inline with
-        -- the same graphics path as pasted attachments.
-        baseImageHooks = ImageDisplayHooks \request -> do
-            color <- resolveColor stderrHandle
-            putImagePreview
-                startup.startupSessionState.sessionPreviewId
-                color
-                [request.displayImage]
-            pure (Right ())
-        imageHooks
-            | not nativeCapabilities.nativeHostExtensions || not isTty =
-                Nothing
-            | otherwise =
-                Just (fullscreenAwareImageHooks uiRuntimeRef baseImageHooks)
-        provider = loaded.loadedProvider
-        fallbackModel =
-            fromMaybe
-                (error "validated default model is missing")
-                (defaultModelFor catalog provider)
-        unrestrictedModel =
-            fromMaybe
-                (maybe fallbackModel (.targetModelId) targetHint)
-                options.optModel
-        model =
-            maybe
-                unrestrictedModel
-                (.modelTarget.targetModelId)
-                gatewaySelection
-        rawTarget = (rawModelOption provider model).modelTarget
-        inferredTarget0 =
-            maybe
-                (fromMaybe rawTarget targetHint)
-                (.modelTarget)
-                gatewaySelection
-        transportModel = case customResponses of
-            Just _ ->
-                \name ->
-                    case resolveConfiguredModel catalog name of
-                        Just option
-                            | option.modelTarget.targetConnectionId
-                                == inferredTarget0.targetConnectionId ->
-                                option.modelTarget.targetWireModelId
-                        _
-                            | name == model ->
-                                inferredTarget0.targetWireModelId
-                            | otherwise -> name
-            _ -> case provider of
-                OpenRouterProvider -> OpenRouter.mapModel openRouterOptions
-                _ -> id
-        inferredTarget =
-            inferredTarget0
-                { targetWireModelId =
-                    if inferredTarget0.targetConnectionId
-                        == builtinConnectionId OpenRouterProvider
-                        && inferredTarget0.targetWireModelId
-                            == inferredTarget0.targetModelId
-                        then transportModel model
-                        else inferredTarget0.targetWireModelId
-                }
-        customGenericOptions = do
-            (_, responses) <- customResponses
-            pure GenericClientOptions
-                { baseUrl = Text.unpack responses.responsesBaseUrl
-                , model = inferredTarget.targetWireModelId
-                , bearerToken = customBearerToken
-                , requestTimeoutSeconds =
-                    responses.responsesRequestTimeoutSeconds
-                }
-        persistedTarget = case fst <$> resumed of
-            Just meta ->
-                Just
-                    ( meta.metaDialect
-                    , meta.metaTransportModel
-                    )
-            Nothing -> do
-                remembered <- projectSettings.settingsLastModel
-                let target = remembered.projectModelTarget
-                if target.targetProvider == provider
-                    then Just
-                        ( target.targetDialect
-                        , Just target.targetWireModelId
-                        )
-                    else Nothing
-        resolvedPersistedTarget =
-            (\(storedDialect, storedTransportModel) ->
-                resolvePersistedDialect
-                    storedDialect
-                    storedTransportModel
-                    inferredTarget)
-                <$> persistedTarget
-        mappedTargetChanged =
-            maybe False snd resolvedPersistedTarget
-        dialectId = case gatewaySelection of
-            Just selected -> selected.modelTarget.targetDialect
-            Nothing -> case transitionTarget of
-                Just target -> target.targetDialect
-                Nothing -> case options.optModel of
-                    Just _ -> inferredTarget.targetDialect
-                    Nothing
-                        | mappedTargetChanged -> inferredTarget.targetDialect
-                        | otherwise ->
-                            maybe
-                                inferredTarget.targetDialect
-                                fst
-                                resolvedPersistedTarget
-        dialect = dialectForId dialectId
-        resumeTargetChanged = case fst <$> resumed of
-            Just meta ->
-                provider /= meta.metaProvider
-                    || inferredTarget.targetConnectionId /= meta.metaConnection
-                    || model /= meta.metaModel
-                    || mappedTargetChanged
-                    || dialectId /= meta.metaDialect
-            Nothing -> False
-        refreshDialectContext = case fst <$> resumed of
-            Just meta -> dialectId /= meta.metaDialect
-            Nothing -> False
-        legacySubagentTarget =
-            sessionLegacySubagentTarget . fst <$> resumed
-        effort =
-            normalizeReasoningEffortForDialect dialectId $
-                fromMaybe
-                    (maybe
-                        (defaultEffortFor provider)
-                        (either
-                            (const (defaultEffortFor provider))
-                            id
-                            . parseReasoningEffort
-                            . (.metaEffort))
-                        (fst <$> resumed))
-                    options.optEffort
-        effortText = reasoningEffortText effort
-        policy = case startup.startupNativeHooks of
-            Just hooks -> case hooks.nativeInteractionMode of
-                NativeYolo -> ApproveAll
-                NativeAsk -> PromptMutating
-                NativePlan -> PromptMutating
-            Nothing ->
-                resolveApprovalPolicy options isTty
-                    projectSettings.settingsAutoApprove
-        claudeBypassEnabled =
-            case startup.startupNativeHooks of
-                Just hooks ->
-                    hooks.nativeInteractionMode == NativeYolo
+    (toolGatewaySelection, toolGatewayAllowedChildModels) <-
+        selectGatewayModels request
+    pure ToolStartup{..}
+
+selectGatewayModels
+    :: AgentToolsRequest windowTitleResult
+    -> IO (Maybe ModelOption, Maybe [Text])
+selectGatewayModels AgentToolsRequest
+    { loaded
+    , catalog
+    , gatewayModelsRef
+    , options
+    , transitionTarget
+    , configuredOptionTarget
+    , resumedTarget
+    , projectTarget
+    , targetHint
+    , startup
+    }
+    | not (isGatewayLoadedAuth loaded) = pure (Nothing, Nothing)
+    | otherwise = do
+        access <-
+            readIORef gatewayModelsRef >>= \case
                 Nothing ->
-                    not options.optNoYolo
-                        && (options.optYolo
-                            || projectSettings.settingsAutoApprove)
+                    startupDie startup
+                        "The organization gateway model catalog is unavailable."
+                Just value -> pure value
+        cachedGatewayModels access >>= \case
+            Nothing ->
+                startupDie startup
+                    "The organization gateway model catalog is unavailable."
+            Just models ->
+                case modelOptionsForGatewayModels catalog models of
+                    [] ->
+                        startupDie startup
+                            "The organization gateway does not offer any models."
+                    firstAvailable : remainingAvailable -> do
+                        let available = firstAvailable : remainingAvailable
+                            resolveTarget target =
+                                resolveModelOptionById
+                                    available
+                                    target.targetModelId
+                        selected <- case options.optModel of
+                            Just requested ->
+                                case resolveModelOptionById available requested of
+                                    Nothing ->
+                                        startupDie startup $
+                                            "Model '"
+                                                <> Text.unpack requested
+                                                <> "' is not available through your organization gateway."
+                                    Just selected -> pure selected
+                            Nothing ->
+                                pure $
+                                    fromMaybe firstAvailable $
+                                        (transitionTarget >>= resolveTarget)
+                                            <|> (configuredOptionTarget >>= resolveTarget)
+                                            <|> (resumedTarget >>= resolveTarget)
+                                            <|> (projectTarget >>= resolveTarget)
+                                            <|> (targetHint >>= resolveTarget)
+                        pure
+                            ( Just selected
+                            , Just (map (.modelTarget.targetModelId) available)
+                            )
+
+resolveToolModel
+    :: AgentToolsRequest windowTitleResult
+    -> ToolStartup
+    -> ToolModelRuntime
+resolveToolModel AgentToolsRequest
+    { loaded
+    , catalog
+    , targetHint
+    , options
+    , customResponses
+    , customBearerToken
+    , resumed
+    , projectSettings
+    , transitionTarget
+    , isTty
+    , startup
+    } ToolStartup
+    { toolOpenRouterOptions = openRouterOptions
+    , toolGatewaySelection = gatewaySelection
+    } =
+    ToolModelRuntime{..}
+  where
+    toolProvider = loaded.loadedProvider
+    fallbackModel =
+        fromMaybe
+            (error "validated default model is missing")
+            (defaultModelFor catalog toolProvider)
+    unrestrictedModel =
+        fromMaybe
+            (maybe fallbackModel (.targetModelId) targetHint)
+            options.optModel
+    toolModel =
+        maybe
+            unrestrictedModel
+            (.modelTarget.targetModelId)
+            gatewaySelection
+    rawTarget = (rawModelOption toolProvider toolModel).modelTarget
+    inferredTarget0 =
+        maybe
+            (fromMaybe rawTarget targetHint)
+            (.modelTarget)
+            gatewaySelection
+    toolTransportModel = case customResponses of
+        Just _ ->
+            \name ->
+                case resolveConfiguredModel catalog name of
+                    Just option
+                        | option.modelTarget.targetConnectionId
+                            == inferredTarget0.targetConnectionId ->
+                            option.modelTarget.targetWireModelId
+                    _
+                        | name == toolModel ->
+                            inferredTarget0.targetWireModelId
+                        | otherwise -> name
+        _ -> case toolProvider of
+            OpenRouterProvider -> OpenRouter.mapModel openRouterOptions
+            _ -> id
+    toolInferredTarget =
+        inferredTarget0
+            { targetWireModelId =
+                if inferredTarget0.targetConnectionId
+                    == builtinConnectionId OpenRouterProvider
+                    && inferredTarget0.targetWireModelId
+                        == inferredTarget0.targetModelId
+                    then toolTransportModel toolModel
+                    else inferredTarget0.targetWireModelId
+            }
+    toolCustomGenericOptions = do
+        (_, responses) <- customResponses
+        pure GenericClientOptions
+            { baseUrl = Text.unpack responses.responsesBaseUrl
+            , model = toolInferredTarget.targetWireModelId
+            , bearerToken = customBearerToken
+            , requestTimeoutSeconds =
+                responses.responsesRequestTimeoutSeconds
+            }
+    persistedTarget = case fst <$> resumed of
+        Just meta ->
+            Just
+                ( meta.metaDialect
+                , meta.metaTransportModel
+                )
+        Nothing -> do
+            remembered <- projectSettings.settingsLastModel
+            let target = remembered.projectModelTarget
+            if target.targetProvider == toolProvider
+                then Just
+                    ( target.targetDialect
+                    , Just target.targetWireModelId
+                    )
+                else Nothing
+    resolvedPersistedTarget =
+        (\(storedDialect, storedTransportModel) ->
+            resolvePersistedDialect
+                storedDialect
+                storedTransportModel
+                toolInferredTarget)
+            <$> persistedTarget
+    mappedTargetChanged = maybe False snd resolvedPersistedTarget
+    toolDialectId = case gatewaySelection of
+        Just selected -> selected.modelTarget.targetDialect
+        Nothing -> case transitionTarget of
+            Just target -> target.targetDialect
+            Nothing -> case options.optModel of
+                Just _ -> toolInferredTarget.targetDialect
+                Nothing
+                    | mappedTargetChanged -> toolInferredTarget.targetDialect
+                    | otherwise ->
+                        maybe
+                            toolInferredTarget.targetDialect
+                            fst
+                            resolvedPersistedTarget
+    toolDialect = dialectForId toolDialectId
+    toolResumeTargetChanged = case fst <$> resumed of
+        Just meta ->
+            toolProvider /= meta.metaProvider
+                || toolInferredTarget.targetConnectionId /= meta.metaConnection
+                || toolModel /= meta.metaModel
+                || mappedTargetChanged
+                || toolDialectId /= meta.metaDialect
+        Nothing -> False
+    toolRefreshDialectContext = case fst <$> resumed of
+        Just meta -> toolDialectId /= meta.metaDialect
+        Nothing -> False
+    toolLegacySubagentTarget =
+        sessionLegacySubagentTarget . fst <$> resumed
+    effort =
+        normalizeReasoningEffortForDialect toolDialectId $
+            fromMaybe
+                (maybe
+                    (defaultEffortFor toolProvider)
+                    (either
+                        (const (defaultEffortFor toolProvider))
+                        id
+                        . parseReasoningEffort
+                        . (.metaEffort))
+                    (fst <$> resumed))
+                options.optEffort
+    toolEffortText = reasoningEffortText effort
+    toolPolicy = case startup.startupNativeHooks of
+        Just hooks -> case hooks.nativeInteractionMode of
+            NativeYolo -> ApproveAll
+            NativeAsk -> PromptMutating
+            NativePlan -> PromptMutating
+        Nothing ->
+            resolveApprovalPolicy options isTty
+                projectSettings.settingsAutoApprove
+    toolClaudeBypassEnabled =
+        case startup.startupNativeHooks of
+            Just hooks ->
+                hooks.nativeInteractionMode == NativeYolo
+            Nothing ->
+                not options.optNoYolo
+                    && (options.optYolo
+                        || projectSettings.settingsAutoApprove)
+
+buildToolHostHooks
+    :: AgentToolsRequest windowTitleResult
+    -> ToolStartup
+    -> ToolModelRuntime
+    -> ToolHostHooks
+buildToolHostHooks AgentToolsRequest
+    { interrupt
+    , escPaused
+    , stderrHandle
+    , uiRuntimeRef
+    , options
+    , isTty
+    , startup
+    } ToolStartup
+    { toolNativeCapabilities = nativeCapabilities
+    } ToolModelRuntime
+    { toolProvider = provider
+    } =
+    ToolHostHooks{..}
+  where
+    basePlanHooks
+        | Just hooks <- startup.startupNativeHooks =
+            hooks.nativePlanHooks
+        | startup.startupBackground =
+            PlanModeHooks
+                { planConfirmEnter = \_ -> pure False
+                , planDecideExit = \_ -> pure PlanCancel
+                , planAskQuestion = \_ _ -> pure Nothing
+                }
+        | otherwise =
+            cliPlanHooks
+                provider interrupt escPaused (resolveColor stderrHandle)
+    toolPlanHooks = fullscreenAwarePlanHooks uiRuntimeRef basePlanHooks
+    baseSecretHooks = SecretPromptHooks \request ->
+        Right <$> promptSecretLine
+            escPaused
+            request.secretPromptMessage
+            request.secretPromptPurpose
+    toolSecretHooks
+        | not nativeCapabilities.nativeHostExtensions
+            || isOneShot options || not isTty = Nothing
+        | otherwise =
+            Just (fullscreenAwareSecretHooks uiRuntimeRef baseSecretHooks)
+    -- Outside the retained TUI, agent-displayed images print inline with the
+    -- same graphics path as pasted attachments.
+    baseImageHooks = ImageDisplayHooks \request -> do
+        color <- resolveColor stderrHandle
+        putImagePreview
+            startup.startupSessionState.sessionPreviewId
+            color
+            [request.displayImage]
+        pure (Right ())
+    toolImageHooks
+        | not nativeCapabilities.nativeHostExtensions || not isTty =
+            Nothing
+        | otherwise =
+            Just (fullscreenAwareImageHooks uiRuntimeRef baseImageHooks)
+
+newCollaborationRuntime
+    :: AgentToolsRequest windowTitleResult
+    -> ToolStartup
+    -> ToolModelRuntime
+    -> IO CollaborationRuntime
+newCollaborationRuntime AgentToolsRequest
+    { resumeLock
+    , options
+    , projectSettings
+    , cwd
+    , gatewayModelsRef
+    , catalog
+    , home
+    , tokenProvider
+    } ToolStartup
+    { toolNativeCapabilities = nativeCapabilities
+    , toolHarnessConfig = harnessConfig
+    , toolGatewayAllowedChildModels = gatewayAllowedChildModels
+    } ToolModelRuntime
+    { toolProvider = provider
+    , toolTransportModel = transportModel
+    , toolInferredTarget = inferredTarget
+    , toolDialectId = dialectId
+    , toolLegacySubagentTarget = legacySubagentTarget
+    , toolEffortText = effortText
+    } = do
     -- Plan mode itself is process-local, while the assistant's proposed plan
     -- is durable in the session transcript. Reconstruct the approval phase
     -- before entering the REPL so a resumed Codex session cannot interpret
@@ -714,52 +1027,54 @@ runAgentTools
     -- Keep inferred startup, resume, and delegated-agent targets session-local.
     -- Live top-level model/provider switches persist their selection in
     -- Agent.CLI.Provider.Switch instead.
-    activeSessionLock <- newIORef resumeLock
-    persistSlotRef <- newIORef PersistenceDisabled
+    collaborationActiveSessionLock <- newIORef resumeLock
+    collaborationPersistSlotRef <- newIORef PersistenceDisabled
     -- Per-subagent transcripts / previous ids, shared across send_input / task.
-    subagentSessions <- newIORef Map.empty
-    subagentStoreRoot <- newIORef Nothing
-    subagentForkSource <- newIORef (Nothing :: Maybe (IO [ResponseItem]))
-    pendingNotices <- newPendingInputs
+    collaborationSubagentSessions <- newIORef Map.empty
+    collaborationSubagentStoreRoot <- newIORef Nothing
+    collaborationSubagentForkSource <-
+        newIORef (Nothing :: Maybe (IO [ResponseItem]))
+    collaborationPendingNotices <- newPendingInputs
     let maxConcurrentAgents =
             fromMaybe defaultMaxConcurrent $
                 options.optMaxConcurrentAgents
                     <|> projectSettings.settingsMaxConcurrentAgents
                     <|> harnessConfig.configMaxConcurrentAgents
-    registry <- newSubagentRegistry
+    collaborationRegistry <- newSubagentRegistry
         defaultSubagentConfig { maxConcurrent = maxConcurrentAgents }
         cwd
         (\_ _ _ _ -> pure $ Left LoopNoResponseId)
         (\_ _ -> pure ())
-    rootTurnRef <- newIORef (Nothing :: Maybe RootTurnId)
-    agentTypesRef <- newIORef Map.empty
-    openaiChild <- if not nativeCapabilities.nativeCollaboration
-        then pure Nothing
-        else case provider of
-            XAIProvider -> do
-                available <- hasOpenAiAuth
-                if not available
-                    then pure Nothing
-                    else loadAuth (Just OpenAIProvider) >>= \case
-                        Left _ -> pure Nothing
-                        Right openaiLoaded ->
-                            pure (Just openaiLoaded.loadedTokenProvider)
-            _ ->
-                pure Nothing
-    let allowedChildModels =
+    collaborationRootTurnRef <- newIORef (Nothing :: Maybe RootTurnId)
+    collaborationAgentTypes <- newIORef Map.empty
+    collaborationOpenAiChild <-
+        if not nativeCapabilities.nativeCollaboration
+            then pure Nothing
+            else case provider of
+                XAIProvider -> do
+                    available <- hasOpenAiAuth
+                    if not available
+                        then pure Nothing
+                        else loadAuth (Just OpenAIProvider) >>= \case
+                            Left _ -> pure Nothing
+                            Right openaiLoaded ->
+                                pure (Just openaiLoaded.loadedTokenProvider)
+                _ -> pure Nothing
+    let collaborationAllowedChildModels =
             case gatewayAllowedChildModels of
                 Just modelIds -> Just modelIds
                 Nothing -> case provider of
                     XAIProvider ->
-                        Just (grokRootChildModels (isJust openaiChild))
-                    _ ->
-                        Nothing
-        childModelAllowed
-            | Just resolve <- gatewayChildModelOption =
+                        Just
+                            (grokRootChildModels
+                                (isJust collaborationOpenAiChild))
+                    _ -> Nothing
+        collaborationChildModelAllowed
+            | Just resolve <- collaborationGatewayChildModelOption =
                 Just \modelId -> isJust <$> resolve modelId
             | otherwise = Nothing
-        resolveCollaborationChildModel
-            | Just resolve <- gatewayChildModelOption =
+        collaborationResolveChildModel
+            | Just resolve <- collaborationGatewayChildModelOption =
                 Just \modelId ->
                     fmap toCollaborationTarget <$> resolve modelId
             | otherwise = Nothing
@@ -772,7 +1087,7 @@ runAgentTools
                     target.targetWireModelId
                 , collaborationTargetDialect = target.targetDialect
                 }
-        gatewayChildModelOption
+        collaborationGatewayChildModelOption
             | isNothing gatewayAllowedChildModels = Nothing
             | otherwise =
                 Just \requested ->
@@ -788,10 +1103,12 @@ runAgentTools
                                                 catalog models)
                                             (Text.strip requested))
         sendToRoot message = do
-            enqueuePendingInput pendingNotices (AgentMessage message) >>= \case
-                Left err -> pure (Left err)
-                Right () -> pure (Right "queued")
-        createSubagentWorktree source =
+            enqueuePendingInput
+                collaborationPendingNotices
+                (AgentMessage message) >>= \case
+                    Left err -> pure (Left err)
+                    Right () -> pure (Right "queued")
+        collaborationCreateWorktree source =
             createManagedWorktree home source >>= \case
                 Left err -> pure (Left err)
                 Right path -> pure $ Right SubagentWorktree
@@ -801,74 +1118,125 @@ runAgentTools
                             Left err -> pure (Left err)
                             Right () -> pure (Right ())
                     }
-        multiCtx
+        collaborationContext
             | not nativeCapabilities.nativeCollaboration = Nothing
             | otherwise = Just MultiAgentContext
-            { multiRegistry = registry
-            , multiCwd = cwd
-            , multiSelfId = Nothing
-            , multiDepth = 0
-            , multiTaskPath = taskPathRoot
-            , multiRootTurnId = readIORef rootTurnRef
-            , multiResumeFromDisk = Just
-                (restoreAgentFromDisk
-                    provider
-                    inferredTarget.targetConnectionId
-                    transportModel
-                    inferredTarget.targetWireModelId
-                    dialectId
-                    legacySubagentTarget
-                    subagentStoreRoot
-                    registry
-                    subagentSessions
-                    resolveCollaborationChildModel
-                    agentTypesRef)
-            , multiCreateWorktree = Just createSubagentWorktree
-            , multiPrepareSpawn = Just
-                (prepareCollaborationSpawn
-                    provider
-                    inferredTarget.targetConnectionId
-                    transportModel
-                    inferredTarget.targetWireModelId
-                    effortText
-                    dialectId
-                    legacySubagentTarget
-                    subagentSessions subagentStoreRoot agentTypesRef
-                    subagentForkSource)
-            , multiSendToRoot = Just sendToRoot
-            , multiSpawnModelGuidance =
-                if isJust gatewayAllowedChildModels
-                    then Nothing
-                    else
-                        subscriptionSubagentModelGuidance
-                            provider
-                            (tokenProviderBillingMode tokenProvider)
-            , multiAllowedChildModels = allowedChildModels
-            , multiResolveChildModel = resolveCollaborationChildModel
-            , multiChildModelAllowed = childModelAllowed
-            }
-    promptRequest <- loadPrompt options
-    let promptText = fmap (\request -> request.managedTurnText) promptRequest
-    persist <-
+                { multiRegistry = collaborationRegistry
+                , multiCwd = cwd
+                , multiSelfId = Nothing
+                , multiDepth = 0
+                , multiTaskPath = taskPathRoot
+                , multiRootTurnId = readIORef collaborationRootTurnRef
+                , multiResumeFromDisk = Just
+                    (restoreAgentFromDisk
+                        provider
+                        inferredTarget.targetConnectionId
+                        transportModel
+                        inferredTarget.targetWireModelId
+                        dialectId
+                        legacySubagentTarget
+                        collaborationSubagentStoreRoot
+                        collaborationRegistry
+                        collaborationSubagentSessions
+                        collaborationResolveChildModel
+                        collaborationAgentTypes)
+                , multiCreateWorktree = Just collaborationCreateWorktree
+                , multiPrepareSpawn = Just
+                    (prepareCollaborationSpawn
+                        provider
+                        inferredTarget.targetConnectionId
+                        transportModel
+                        inferredTarget.targetWireModelId
+                        effortText
+                        dialectId
+                        legacySubagentTarget
+                        collaborationSubagentSessions
+                        collaborationSubagentStoreRoot
+                        collaborationAgentTypes
+                        collaborationSubagentForkSource)
+                , multiSendToRoot = Just sendToRoot
+                , multiSpawnModelGuidance =
+                    if isJust gatewayAllowedChildModels
+                        then Nothing
+                        else
+                            subscriptionSubagentModelGuidance
+                                provider
+                                (tokenProviderBillingMode tokenProvider)
+                , multiAllowedChildModels =
+                    collaborationAllowedChildModels
+                , multiResolveChildModel =
+                    collaborationResolveChildModel
+                , multiChildModelAllowed =
+                    collaborationChildModelAllowed
+                }
+        collaborationCloseAgents =
+            case collaborationContext of
+                Just ctx -> do
+                    interruptActiveSubagents ctx.multiRegistry
+                    flushAllSubagentSnapshots
+                        collaborationSubagentStoreRoot
+                        ctx.multiRegistry
+                        collaborationSubagentSessions
+                        collaborationAgentTypes
+                    closeSubagentRegistry ctx.multiRegistry
+                Nothing -> pure ()
+    pure CollaborationRuntime{..}
+
+prepareScratchRuntime
+    :: AgentToolsRequest windowTitleResult
+    -> ToolStartup
+    -> ToolModelRuntime
+    -> CollaborationRuntime
+    -> IO ScratchRuntime
+prepareScratchRuntime AgentToolsRequest
+    { options
+    , startup
+    , root
+    , gatewayIdentity
+    , transition
+    , cwd
+    , fullscreen
+    , baseToolEnv
+    , resumed
+    , home
+    } ToolStartup
+    { toolNativeCapabilities = nativeCapabilities
+    } ToolModelRuntime
+    { toolInferredTarget = inferredTarget
+    , toolDialectId = dialectId
+    , toolEffortText = effortText
+    } CollaborationRuntime
+    { collaborationPersistSlotRef = persistSlotRef
+    } = do
+    scratchPromptRequest <- loadPrompt options
+    let promptText =
+            fmap (\request -> request.managedTurnText) scratchPromptRequest
+    scratchPersistence <-
         preparePersistence
             (trustedPool startup.startupDatabaseStore)
-            startup options root
-                inferredTarget { targetDialect = dialectId }
-                gatewayIdentity
-                (isNothing transition) cwd effortText promptText resumed
-    writeIORef persistSlotRef persist
+            startup
+            options
+            root
+            inferredTarget { targetDialect = dialectId }
+            gatewayIdentity
+            (isNothing transition)
+            cwd
+            effortText
+            promptText
+            resumed
+    writeIORef persistSlotRef scratchPersistence
     initialTaskPlan <-
-        loadCurrentTaskPlan persist >>= \case
+        loadCurrentTaskPlan scratchPersistence >>= \case
             Left err ->
                 startupDie startup
                     ("Failed to load current task plan: " <> Text.unpack err)
             Right plan -> pure plan
-    taskPlan <-
+    scratchTaskPlan <-
         newTaskPlanEnv
             initialTaskPlan
-            (taskPlanHooksForPersistence persist)
+            (taskPlanHooksForPersistence scratchPersistence)
     forM_ fullscreen \runtime ->
-        reservedSessionId persist >>= \case
+        reservedSessionId scratchPersistence >>= \case
             Nothing ->
                 clearFullscreenHistorySource runtime
             Just sessionId ->
@@ -881,19 +1249,19 @@ runAgentTools
                         sessionId)
                     (emptyFullscreenHistoryPage
                         (HistoryGeneration 0))
-    (sessionTmp, ephemeralSessionId) <-
-        persistenceTempDir persist >>= \case
+    (scratchSessionTmp, ephemeralSessionId) <-
+        persistenceTempDir scratchPersistence >>= \case
             Just tempDir -> pure (tempDir, Nothing)
             Nothing -> do
                 (sessionId, tempDir) <- allocateSessionTemp root
                 pure (tempDir, Just sessionId)
-    setToolSessionTmp baseToolEnv (Just sessionTmp)
-    imageGenerationHistory <- newImageGenerationHistory
+    setToolSessionTmp baseToolEnv (Just scratchSessionTmp)
+    scratchImageGenerationHistory <- newImageGenerationHistory
     forM_ resumed \(_, turns) ->
         recordImageGenerationResponseItems
-            imageGenerationHistory
+            scratchImageGenerationHistory
             (foldSessionItems turns)
-    externalSessionAppTools <-
+    scratchExternalSessionTools <-
         if options.optSkills
             && nativeCapabilities.nativeHostExtensions
             then do
@@ -901,12 +1269,12 @@ runAgentTools
                     defaultExternalSessionEnv
                         baseToolEnv
                         (unsafeToFilePath cwd)
-                        (unsafeToFilePath sessionTmp)
+                        (unsafeToFilePath scratchSessionTmp)
                         (unsafeToFilePath home)
                 pure [externalSessionTool env]
             else pure []
     let cleanupAllocatedScratch = do
-            cleanupPendingPersistence persist
+            cleanupPendingPersistence scratchPersistence
             forM_ ephemeralSessionId \sessionId -> do
                 _ <- removeSessionTemp root sessionId
                 pure ()
@@ -917,7 +1285,7 @@ runAgentTools
                 startupDie startup (Text.unpack err)
             Right lease -> pure lease
     sessionTempLease <-
-        (acquireSessionTempLease root sessionTmp
+        (acquireSessionTempLease root scratchSessionTmp
             `onException`
                 (mapM_ releaseWorktreeLease worktreeLease
                     >> cleanupAllocatedScratch)) >>= \case
@@ -926,44 +1294,77 @@ runAgentTools
                     cleanupAllocatedScratch
                     startupDie startup (Text.unpack err)
                 Right lease -> pure lease
-    let cleanupScratch =
+    let scratchCleanup =
             mapM_ releaseSessionTempLease sessionTempLease
                 `finally`
                     (mapM_ releaseWorktreeLease worktreeLease
                         `finally` cleanupAllocatedScratch)
-        toolEnv = baseToolEnv
-        mcpServerConfigs =
-            [ MCP.McpServerConfig
-                { MCP.mcpServerName = label
-                , MCP.mcpServerUrl = config.mcpUrl
-                , MCP.mcpServerCommand = Text.unpack config.mcpCommand
-                , MCP.mcpServerArgs = map Text.unpack config.mcpArgs
-                , MCP.mcpServerCwd =
-                    Just $
-                        maybe (unsafeToFilePath cwd) Text.unpack config.mcpCwd
-                , MCP.mcpServerEnv =
-                    [ (Text.unpack name, Text.unpack value)
-                    | (name, value) <- Map.toAscList config.mcpEnv
-                    ] <> case config.mcpUrl of
-                        Just url
-                            | Map.notMember "MCP_OAUTH_TOKEN_FILE" config.mcpEnv ->
-                                [("MCP_OAUTH_TOKEN_FILE", unsafeToFilePath (mcpOAuthStorePath home url))]
-                        _ -> []
-                , MCP.mcpServerStartupTimeoutSeconds =
-                    config.mcpStartupTimeoutSeconds
-                , MCP.mcpServerRequestTimeoutSeconds =
-                    config.mcpRequestTimeoutSeconds
-                , MCP.mcpServerProtocol = config.mcpProtocol
-                }
-            | (label, config) <-
-                Map.toAscList harnessConfig.configMcpServers
-            , config.mcpEnabled
-            , nativeCapabilities.nativeHostExtensions
-            ]
-        progressiveMcp =
-            useProgressiveMcp
-                harnessConfig.configMcpInitStrategy
-                (isOneShot options)
+    pure ScratchRuntime{..}
+
+mcpConfiguration
+    :: AgentToolsRequest windowTitleResult
+    -> ToolStartup
+    -> ([MCP.McpServerConfig], Bool)
+mcpConfiguration AgentToolsRequest
+    { cwd
+    , home
+    , options
+    } ToolStartup
+    { toolNativeCapabilities = nativeCapabilities
+    , toolHarnessConfig = harnessConfig
+    } =
+    ( serverConfigs
+    , useProgressiveMcp
+        harnessConfig.configMcpInitStrategy
+        (isOneShot options)
+    )
+  where
+    serverConfigs =
+        [ MCP.McpServerConfig
+            { MCP.mcpServerName = label
+            , MCP.mcpServerUrl = config.mcpUrl
+            , MCP.mcpServerCommand = Text.unpack config.mcpCommand
+            , MCP.mcpServerArgs = map Text.unpack config.mcpArgs
+            , MCP.mcpServerCwd =
+                Just $
+                    maybe (unsafeToFilePath cwd) Text.unpack config.mcpCwd
+            , MCP.mcpServerEnv =
+                [ (Text.unpack name, Text.unpack value)
+                | (name, value) <- Map.toAscList config.mcpEnv
+                ] <> case config.mcpUrl of
+                    Just url
+                        | Map.notMember
+                            "MCP_OAUTH_TOKEN_FILE"
+                            config.mcpEnv ->
+                            [ ( "MCP_OAUTH_TOKEN_FILE"
+                              , unsafeToFilePath
+                                    (mcpOAuthStorePath home url)
+                              )
+                            ]
+                    _ -> []
+            , MCP.mcpServerStartupTimeoutSeconds =
+                config.mcpStartupTimeoutSeconds
+            , MCP.mcpServerRequestTimeoutSeconds =
+                config.mcpRequestTimeoutSeconds
+            , MCP.mcpServerProtocol = config.mcpProtocol
+            }
+        | (label, config) <-
+            Map.toAscList harnessConfig.configMcpServers
+        , config.mcpEnabled
+        , nativeCapabilities.nativeHostExtensions
+        ]
+
+startStaleResourceCleanup
+    :: AgentToolsRequest windowTitleResult
+    -> OsPath
+    -> IO ()
+startStaleResourceCleanup AgentToolsRequest
+    { processRuntime
+    , startup
+    , root
+    , cwd
+    , home
+    } sessionTmp = do
     -- Housekeeping may inspect hundreds of worktrees and invoke Git for each
     -- candidate. It must never delay interactive startup.
     _ <- processRuntime.processStartCleanup do
@@ -1009,6 +1410,34 @@ runAgentTools
                             <> Text.pack (unsafeToFilePath path)
                             <> ": "
                             <> err)
+    pure ()
+
+acquireMcpRuntime
+    :: AgentToolsRequest windowTitleResult
+    -> ToolStartup
+    -> ToolModelRuntime
+    -> CollaborationRuntime
+    -> ScratchRuntime
+    -> IO McpRuntime
+acquireMcpRuntime request@AgentToolsRequest
+    { processRuntime
+    , startup
+    , options
+    , isTty
+    , escPaused
+    , uiRuntimeRef
+    , mcpSupervisor
+    } toolStartup ToolModelRuntime
+    { toolDialectId = dialectId
+    } CollaborationRuntime
+    { collaborationPendingNotices = pendingNotices
+    } ScratchRuntime
+    { scratchSessionTmp = sessionTmp
+    , scratchCleanup = cleanupScratch
+    } = do
+    let (runtimeMcpServerConfigs, runtimeProgressiveMcp) =
+            mcpConfiguration request toolStartup
+    startStaleResourceCleanup request sessionTmp
     mcpStatusPhaseRef <- newIORef (Nothing :: Maybe Bool)
     mcpFleetRef <- newIORef (Nothing :: Maybe MCP.McpFleet)
     writeIORef processRuntime.processMcpElicitation
@@ -1042,14 +1471,14 @@ runAgentTools
                 atomicModifyIORef' mcpStatusPhaseRef \previous ->
                     (Just isConnecting, previous == Just True && not isConnecting)
             when settled (enqueueMcpSnapshot statuses)
-    mcpLease <-
+    runtimeMcpLease <-
         try @_ @SomeException
-            (if progressiveMcp
+            (if runtimeProgressiveMcp
                 then
                     MCP.acquireMcpFleetProgressive
                         mcpSupervisor
                         reportProgressiveMcp
-                        mcpServerConfigs
+                        runtimeMcpServerConfigs
                 else
                     MCP.acquireMcpFleetWithProgress
                         mcpSupervisor
@@ -1061,32 +1490,67 @@ runAgentTools
                                         "Loading tools: "
                                             <> Text.intercalate ", " names
                                             <> "…"))
-                        mcpServerConfigs)
+                        runtimeMcpServerConfigs)
             >>= \case
-            Left exception -> do
-                cleanupScratch
-                startupDie startup
-                    ("Failed to initialize MCP tools: " <> show exception)
-            Right lease -> pure lease
-    let mcpFleet = mcpLease.mcpLeaseFleet
-    writeIORef mcpFleetRef (Just mcpFleet)
-    when progressiveMcp $
-        MCP.mcpFleetStatuses mcpFleet >>= enqueueMcpSnapshot
-    currentMcpInstructions <- MCP.mcpFleetInstructions mcpFleet
-    let mcpInstructions =
+                Left exception -> do
+                    cleanupScratch
+                    startupDie startup
+                        ("Failed to initialize MCP tools: " <> show exception)
+                Right lease -> pure lease
+    let runtimeMcpFleet = runtimeMcpLease.mcpLeaseFleet
+    writeIORef mcpFleetRef (Just runtimeMcpFleet)
+    when runtimeProgressiveMcp $
+        MCP.mcpFleetStatuses runtimeMcpFleet >>= enqueueMcpSnapshot
+    currentMcpInstructions <- MCP.mcpFleetInstructions runtimeMcpFleet
+    let runtimeMcpInstructions =
             mcpInstructionsForRequest
-                progressiveMcp
+                runtimeProgressiveMcp
                 currentMcpInstructions
-    mapM_ (reportStartupWarning startup) mcpFleet.mcpFleetWarnings
+    mapM_
+        (reportStartupWarning startup)
+        runtimeMcpFleet.mcpFleetWarnings
     setStartupNotice startup.startupFullscreen "Loading built-in tools…"
+    pure McpRuntime{..}
+
+acquireCodingRuntime
+    :: AgentToolsRequest windowTitleResult
+    -> ToolStartup
+    -> ToolModelRuntime
+    -> ToolHostHooks
+    -> CollaborationRuntime
+    -> ScratchRuntime
+    -> McpRuntime
+    -> IO CodingRuntime
+acquireCodingRuntime AgentToolsRequest
+    { startup
+    , baseToolEnv
+    } ToolStartup
+    { toolNativeCapabilities = nativeCapabilities
+    , toolHarnessConfig = harnessConfig
+    } ToolModelRuntime
+    { toolDialectId = dialectId
+    , toolDialect = dialect
+    } ToolHostHooks
+    { toolPlanHooks = planHooks
+    , toolSecretHooks = secretHooks
+    , toolImageHooks = imageHooks
+    } CollaborationRuntime
+    { collaborationContext = multiCtx
+    , collaborationAgentTypes = agentTypesRef
+    } ScratchRuntime
+    { scratchTaskPlan = taskPlan
+    , scratchCleanup = cleanupScratch
+    } McpRuntime
+    { runtimeMcpLease = mcpLease
+    } = do
     let codingToolEnv =
             case startup.startupNativeHooks
                 >>= nativePreparedDiscovery . (.nativeWorkspaceDiscovery) of
                 Just context ->
-                    toolEnv
+                    baseToolEnv
                         { toolCwd = context.nativeDiscoveryProjectRoot }
-                Nothing -> toolEnv
-    coding <-
+                Nothing -> baseToolEnv
+    runtimeCoding <-
         codingToolsForWithTypes
             dialect
             codingToolEnv
@@ -1099,7 +1563,7 @@ runAgentTools
             `onException`
                 (MCP.releaseMcpFleetLease mcpLease >> cleanupScratch)
     let closeBeforeSession =
-            coding.codingClose
+            runtimeCoding.codingClose
                 `finally`
                     (MCP.releaseMcpFleetLease mcpLease
                         `finally` cleanupScratch)
@@ -1117,26 +1581,41 @@ runAgentTools
                 concurrentlyAcquire
                     (newWebFetchRuntime
                         harnessConfig.configWebFetch
-                        toolEnv >>= \case
+                        baseToolEnv >>= \case
                             Left err ->
                                 startupDie startup
                                     ("Failed to initialize web_fetch: "
                                         <> Text.unpack err)
                             Right runtime -> pure runtime)
                     (mapM_ closeWebFetchRuntime)
-                    (newLspRuntime harnessConfig.configLsp toolEnv)
+                    (newLspRuntime harnessConfig.configLsp baseToolEnv)
                     (mapM_ closeLspRuntime . (.lspStartupRuntime))
     (webFetchRuntime, lspStartup) <-
         acquireGrokExtras `onException` closeBeforeSession
     mapM_ (reportStartupWarning startup) lspStartup.lspStartupWarnings
     let lspRuntime = lspStartup.lspStartupRuntime
-        extraTools =
+        runtimeExtraTools =
             maybe [] (pure . webFetchRuntimeTool) webFetchRuntime
                 <> maybe [] (pure . lspRuntimeTool) lspRuntime
-        closeExtraTools =
+        runtimeCloseExtraTools =
             concurrently_
                 (mapM_ closeLspRuntime lspRuntime)
                 (mapM_ closeWebFetchRuntime webFetchRuntime)
+    pure CodingRuntime{..}
+
+installCollaborationCallbacks
+    :: AgentToolsRequest windowTitleResult
+    -> CollaborationRuntime
+    -> IO ()
+installCollaborationCallbacks AgentToolsRequest
+    { startup
+    } CollaborationRuntime
+    { collaborationContext = multiCtx
+    , collaborationPendingNotices = pendingNotices
+    , collaborationSubagentSessions = subagentSessions
+    , collaborationSubagentStoreRoot = subagentStoreRoot
+    , collaborationAgentTypes = agentTypesRef
+    } =
     case multiCtx of
         Just ctx -> do
             setSubagentOnComplete ctx.multiRegistry \agentId status -> do
@@ -1149,17 +1628,51 @@ runAgentTools
                     Just session -> do
                         _ <-
                             persistAndEvictSubagentSessionWithStatus
-                                subagentStoreRoot ctx.multiRegistry agentTypesRef
-                                agentId status session
+                                subagentStoreRoot
+                                ctx.multiRegistry
+                                agentTypesRef
+                                agentId
+                                status
+                                session
                         pure ()
                     Nothing -> pure ()
         Nothing -> pure ()
-    ghciEnabledRef <- newIORef options.optGhci
-    bashEnabledRef <- newIORef options.optBash
-    skillsRef <- newIORef (SkillCatalog [] [])
-    skillInvocationsRef <- newIORef []
-    codeModeCloseRef <- newIORef (pure ())
-    let claimCurrentSession handle = do
+
+newSessionControlRuntime
+    :: AgentToolsRequest windowTitleResult
+    -> ToolStartup
+    -> ToolModelRuntime
+    -> CollaborationRuntime
+    -> IO SessionControlRuntime
+newSessionControlRuntime AgentToolsRequest
+    { options
+    , startup
+    , root
+    , gatewayIdentity
+    , cwd
+    , runAgentChild
+    , processRuntime
+    } ToolStartup
+    { toolNativeCapabilities = nativeCapabilities
+    , toolGatewayAllowedChildModels = gatewayAllowedChildModels
+    } ToolModelRuntime
+    { toolProvider = provider
+    , toolInferredTarget = inferredTarget
+    , toolModel = model
+    , toolDialectId = dialectId
+    , toolEffortText = effortText
+    , toolPolicy = policy
+    } CollaborationRuntime
+    { collaborationActiveSessionLock = activeSessionLock
+    , collaborationPersistSlotRef = persistSlotRef
+    , collaborationGatewayChildModelOption = gatewayChildModelOption
+    } = do
+    controlGhciEnabledRef <- newIORef options.optGhci
+    controlBashEnabledRef <- newIORef options.optBash
+    controlSkillsRef <- newIORef (SkillCatalog [] [])
+    controlSkillInvocationsRef <- newIORef []
+    controlCodeModeCloseRef <- newIORef (pure ())
+    let controlClaimCurrentSession handle = do
             let desired = sessionLockPath handle.sessionDir
             readIORef activeSessionLock >>= \case
                 Just current
@@ -1168,7 +1681,8 @@ runAgentTools
                     acquireSessionLock
                         handle.sessionDir
                         handle.sessionMeta.metaId >>= \case
-                            Left err -> throwIO (userError (Text.unpack err))
+                            Left err ->
+                                throwIO (userError (Text.unpack err))
                             Right lock -> do
                                 writeIORef activeSessionLock (Just lock)
                                 mapM_ releaseSessionLock previous
@@ -1188,8 +1702,8 @@ runAgentTools
             , toolsCurrentSessionId =
                 readIORef persistSlotRef >>= currentSessionId
             , toolsLaunchTurn = \handle message -> do
-                ghciEnabled <- readIORef ghciEnabledRef
-                bashEnabled <- readIORef bashEnabledRef
+                ghciEnabled <- readIORef controlGhciEnabledRef
+                bashEnabled <- readIORef controlBashEnabledRef
                 let action =
                         runInProcessSessionTurn
                             runAgentChild
@@ -1217,7 +1731,67 @@ runAgentTools
             , toolsSessionStatus =
                 sessionThreadStatus processRuntime.processSessionThreads
             }
-        mcpTools =
+        -- Persisted agent-session tools recursively start another native
+        -- runtime, so they require an explicit collaboration capability from
+        -- the embedding.
+        controlSessionTools
+            | not nativeCapabilities.nativeCollaboration = []
+            | otherwise = agentSessionTools sessionToolsEnv
+    pure SessionControlRuntime{..}
+
+assembleSessionToolsRuntime
+    :: AgentToolsRequest windowTitleResult
+    -> ToolStartup
+    -> ToolModelRuntime
+    -> ToolHostHooks
+    -> CollaborationRuntime
+    -> ScratchRuntime
+    -> McpRuntime
+    -> CodingRuntime
+    -> SessionControlRuntime
+    -> IO SessionToolsRuntime
+assembleSessionToolsRuntime AgentToolsRequest
+    { startup
+    , databaseScopes
+    , gatewayIdentity
+    , options
+    , loaded
+    , tokenProvider
+    , baseToolEnv
+    , resumed
+    } ToolStartup
+    { toolNativeCapabilities = nativeCapabilities
+    } ToolModelRuntime
+    { toolProvider = provider
+    , toolDialectId = dialectId
+    , toolInferredTarget = inferredTarget
+    } ToolHostHooks
+    { toolImageHooks = imageHooks
+    } CollaborationRuntime
+    { collaborationPersistSlotRef = persistSlotRef
+    , collaborationSubagentStoreRoot = subagentStoreRoot
+    , collaborationActiveSessionLock = activeSessionLock
+    , collaborationCloseAgents = closeAgents
+    } ScratchRuntime
+    { scratchPromptRequest = promptRequest
+    , scratchImageGenerationHistory = imageGenerationHistory
+    , scratchExternalSessionTools = externalSessionAppTools
+    , scratchCleanup = cleanupScratch
+    } McpRuntime
+    { runtimeMcpServerConfigs = mcpServerConfigs
+    , runtimeProgressiveMcp = progressiveMcp
+    , runtimeMcpLease = mcpLease
+    , runtimeMcpFleet = mcpFleet
+    } CodingRuntime
+    { runtimeCoding = coding
+    , runtimeExtraTools = extraTools
+    , runtimeCloseExtraTools = closeExtraTools
+    } SessionControlRuntime
+    { controlSkillInvocationsRef = skillInvocationsRef
+    , controlCodeModeCloseRef = codeModeCloseRef
+    , controlSessionTools = persistedSessionTools
+    } = do
+    let sessionMcpTools =
             if null mcpServerConfigs
                 then []
                 else
@@ -1238,15 +1812,9 @@ runAgentTools
                 startup.startupDatabaseStore
                 databaseScopes
                 (readIORef persistSlotRef >>= reservedSessionId)
-        -- Persisted agent-session tools recursively start another native
-        -- runtime, so they require an explicit collaboration capability from
-        -- the embedding.
-        sessionTools
-            | not nativeCapabilities.nativeCollaboration = []
-            | otherwise = agentSessionTools sessionToolsEnv
-        gatewayTools = maybe [] managedGatewayTools promptRequest
-        databaseAppTools = databaseTools databaseToolsEnv
-        learnedSkillAppTools =
+        sessionGatewayTools = maybe [] managedGatewayTools promptRequest
+        sessionDatabaseTools = databaseTools databaseToolsEnv
+        sessionLearnedSkillTools =
             learnedSkillTools skillInvocationsRef learnedSkillToolsEnv
         nativeToolGroups =
             maybe [] (.nativeToolGroups) startup.startupNativeHooks
@@ -1259,7 +1827,7 @@ runAgentTools
         imageGenerationTools =
             [ imageGenerationTool
                 tokenProvider
-                toolEnv
+                baseToolEnv
                 imageGenerationHistory
                 imageHooks
             | provider == OpenAIProvider
@@ -1271,11 +1839,11 @@ runAgentTools
             ]
         surroundingToolGroups =
             [ ExecutionToolGroup extraTools
-            , ExecutionToolGroup mcpTools
-            , HostToolGroup sessionTools
-            , HostToolGroup gatewayTools
-            , HostToolGroup databaseAppTools
-            , HostToolGroup learnedSkillAppTools
+            , ExecutionToolGroup sessionMcpTools
+            , HostToolGroup persistedSessionTools
+            , HostToolGroup sessionGatewayTools
+            , HostToolGroup sessionDatabaseTools
+            , HostToolGroup sessionLearnedSkillTools
             , HostToolGroup externalSessionAppTools
             ]
                 <> nativeToolGroups
@@ -1297,26 +1865,18 @@ runAgentTools
             case startup.startupNativeHooks of
                 Nothing -> appToolsFromGroups groups
                 Just hooks -> hooks.nativeComposeTools groups
-        planMode = coding.codingPlanMode
-        resumedPlanPending =
+        sessionPlanMode = coding.codingPlanMode
+        sessionResumedPlanPending =
             case resumed of
                 Just (_, turns) ->
                     resumedPlanNeedsApproval
                         (map (.turnAssistantText) turns)
                 Nothing -> False
         -- Keep planSessionDir and subagent store root in sync.
-        noteSessionDir dir = do
-            writeIORef planMode.planSessionDir (Just dir)
+        sessionNoteDirectory dir = do
+            writeIORef sessionPlanMode.planSessionDir (Just dir)
             writeIORef subagentStoreRoot (Just dir)
-        closeAgents =
-            case multiCtx of
-                Just ctx -> do
-                    interruptActiveSubagents ctx.multiRegistry
-                    flushAllSubagentSnapshots subagentStoreRoot ctx.multiRegistry
-                        subagentSessions agentTypesRef
-                    closeSubagentRegistry ctx.multiRegistry
-                Nothing -> pure ()
-        closeAll =
+        sessionCloseAll =
             closeAgents
                 `finally`
                     ((readIORef activeSessionLock
@@ -1328,11 +1888,89 @@ runAgentTools
                                         `finally`
                                             (coding.codingClose
                                                 `finally`
-                                                    (join (readIORef codeModeCloseRef)
+                                                    (join
+                                                        (readIORef
+                                                            codeModeCloseRef)
                                                         `finally`
                                                             cleanupScratch)))))
-    let allTools = composeToolGroups allToolGroups
-        tools = composeToolGroups activeToolGroups
+        sessionAllTools = composeToolGroups allToolGroups
+        sessionTools = composeToolGroups activeToolGroups
+    pure SessionToolsRuntime{..}
+
+launchAgentToolsSession
+    :: AgentToolsRequest windowTitleResult
+    -> ToolStartup
+    -> ToolModelRuntime
+    -> ToolHostHooks
+    -> CollaborationRuntime
+    -> ScratchRuntime
+    -> McpRuntime
+    -> CodingRuntime
+    -> SessionControlRuntime
+    -> SessionToolsRuntime
+    -> IO RunResult
+launchAgentToolsSession AgentToolsRequest{..} ToolStartup
+    { toolOpenRouterOptions = openRouterOptions
+    } ToolModelRuntime
+    { toolProvider = provider
+    , toolModel = model
+    , toolTransportModel = transportModel
+    , toolInferredTarget = inferredTarget
+    , toolCustomGenericOptions = customGenericOptions
+    , toolDialect = dialect
+    , toolResumeTargetChanged = resumeTargetChanged
+    , toolRefreshDialectContext = refreshDialectContext
+    , toolLegacySubagentTarget = legacySubagentTarget
+    , toolEffortText = effortText
+    , toolPolicy = policy
+    , toolClaudeBypassEnabled = claudeBypassEnabled
+    } ToolHostHooks
+    { toolPlanHooks = planHooks
+    } CollaborationRuntime
+    { collaborationSubagentSessions = subagentSessions
+    , collaborationSubagentStoreRoot = subagentStoreRoot
+    , collaborationSubagentForkSource = subagentForkSource
+    , collaborationPendingNotices = pendingNotices
+    , collaborationRegistry = registry
+    , collaborationRootTurnRef = rootTurnRef
+    , collaborationAgentTypes = agentTypesRef
+    , collaborationOpenAiChild = openaiChild
+    , collaborationAllowedChildModels = allowedChildModels
+    , collaborationChildModelAllowed = childModelAllowed
+    , collaborationResolveChildModel = resolveCollaborationChildModel
+    , collaborationCreateWorktree = createSubagentWorktree
+    , collaborationContext = multiCtx
+    } ScratchRuntime
+    { scratchPromptRequest = promptRequest
+    , scratchPersistence = persist
+    , scratchSessionTmp = sessionTmp
+    , scratchImageGenerationHistory = imageGenerationHistory
+    } McpRuntime
+    { runtimeMcpFleet = mcpFleet
+    , runtimeMcpInstructions = mcpInstructions
+    } CodingRuntime
+    { runtimeCoding = coding
+    , runtimeExtraTools = extraTools
+    } SessionControlRuntime
+    { controlGhciEnabledRef = ghciEnabledRef
+    , controlBashEnabledRef = bashEnabledRef
+    , controlSkillsRef = skillsRef
+    , controlSkillInvocationsRef = skillInvocationsRef
+    , controlCodeModeCloseRef = codeModeCloseRef
+    , controlClaimCurrentSession = claimCurrentSession
+    , controlSessionTools = agentSessionAppTools
+    } SessionToolsRuntime
+    { sessionAllTools = allTools
+    , sessionTools = tools
+    , sessionMcpTools = mcpTools
+    , sessionDatabaseTools = databaseAppTools
+    , sessionLearnedSkillTools = learnedSkillAppTools
+    , sessionGatewayTools = gatewayTools
+    , sessionPlanMode = planMode
+    , sessionNoteDirectory = noteSessionDir
+    , sessionCloseAll = closeAll
+    , sessionResumedPlanPending = resumedPlanPending
+    } = do
     when resumedPlanPending (activatePlanMode planMode)
     forM_ startup.startupNativeHooks \hooks ->
         when (hooks.nativeInteractionMode == NativePlan) $
@@ -1406,7 +2044,7 @@ runAgentTools
         rootTurnRef
         selectHttpAccount
         selectableTokenProvider
-        sessionTools
+        agentSessionAppTools
         setWindowTitle
         skillInvocationsRef
         skillsRef
@@ -1417,7 +2055,7 @@ runAgentTools
         subagentSessions
         subagentStoreRoot
         tokenProvider
-        toolEnv
+        baseToolEnv
         tools
         transition
         transportModel

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -121,6 +121,7 @@ import qualified Data.Text as Text
 import qualified Data.Set as Set
 import Data.Time.Clock (getCurrentTime, utctDay)
 import System.IO (Handle)
+import System.OsPath (OsPath)
 
 formatQueuedPrompts :: [Text.Text] -> Text.Text
 formatQueuedPrompts [] = "No prompts are queued."
@@ -647,6 +648,483 @@ buildSkillContextRuntime
         callbacks.runnerFinishStartup startup
         pure learnedSkills
 
+data SessionLoopEventRuntime = SessionLoopEventRuntime
+    { loopEventRender :: !RenderConfig
+    , loopEventEmit :: !(LoopEvent -> IO ())
+    }
+
+buildSessionLoopEventRuntime
+    :: SessionHostRuntime
+    -> SessionControlRuntime
+    -> SessionRequest
+    -> (LoopEvent -> IO ())
+    -> SessionLoopEventRuntime
+buildSessionLoopEventRuntime
+        host controls SessionRequest{..} managedLoopPublisher =
+    SessionLoopEventRuntime
+        { loopEventRender = render
+        , loopEventEmit = emitLoop
+        }
+  where
+    fullscreen = host.hostFullscreen
+    terminal = host.hostTerminal
+    renderStateRef = controls.controlRenderStateRef
+    agentViewportRuntime = controls.controlAgentViewportRuntime
+    render = RenderConfig
+        { renderShowThinking = host.hostStderrTty
+        , renderThinkingSpinner = controls.controlSpinnerRef
+        , renderState = renderStateRef
+        , renderColor = host.hostUseColor
+        , renderLock = host.hostIoLock
+        , renderStdout = host.hostStdoutHandle
+        , renderStderr = host.hostStderrHandle
+        , renderModelRef = controls.controlModelRef
+        , renderNativeProgress =
+            host.hostStderrTty
+                && terminal.terminalNativeProgress
+                && nativeProgressAnimationEnabled options.optMotionMode
+        , renderMotionMode = options.optMotionMode
+        , renderWorkspace = toText cwd
+        }
+    emitLoop event = do
+        recordAgentViewportEvent agentViewportRuntime event
+        forM_ startup.startupNativeHooks \hooks ->
+            hooks.nativeOnLoopEvent event
+        managedLoopPublisher event
+        case event of
+            TurnFinished turn -> do
+                history <- readLiveTranscript conversationRef
+                forM_ (reportedContextTokens turn.tokenUsage) \tokens ->
+                    writeIORef contextOccupancyRef $
+                        Just (reportedOccupancy tokens (length history))
+            _ -> pure ()
+        case fullscreen of
+            Nothing -> renderEvent render event
+            Just runtime -> do
+                now <- getCurrentTime
+                modifyIORef' renderStateRef \state ->
+                    case event of
+                        TurnStarted -> beginRenderTurn now state
+                        TextDelta delta ->
+                            countGenerationChars delta
+                                state{statePrintedText = True}
+                        ReasoningDelta delta ->
+                            countGenerationChars delta state
+                        ResponseRestarted _ ->
+                            resetRenderGeneration now state
+                        ToolStarted _ ->
+                            state{stateActivity = "Running tool…"}
+                        TurnFinished turn ->
+                            recordRenderTurnRate now turn state
+                        _ -> state
+                emitUiEvent runtime (UiLoop event)
+                case event of
+                    TurnFinished _ -> do
+                        occupancy <- readIORef contextOccupancyRef
+                        params <- readIORef paramsRef
+                        history <- readLiveTranscript conversationRef
+                        contextWindow <- currentContextWindow
+                        emitUiEvent runtime $
+                            UiSetContextUsage
+                                (Just
+                                    (contextUsageTokens
+                                        occupancy
+                                        params
+                                        history))
+                                contextWindow
+                    _ -> pure ()
+
+data SessionApprovalRuntime = SessionApprovalRuntime
+    { approvalApproveClassified
+        :: !(Maybe Bool -> ToolCall -> IO (Either Text.Text Bool))
+    , approvalApproveRegistered
+        :: !(ToolCall -> IO (Either Text.Text Bool))
+    }
+
+buildSessionApprovalRuntime
+    :: SessionHostRuntime
+    -> SessionControlRuntime
+    -> SessionRequest
+    -> SessionApprovalRuntime
+buildSessionApprovalRuntime host controls SessionRequest{..} =
+    SessionApprovalRuntime
+        { approvalApproveClassified = approveToolWithClassification
+        , approvalApproveRegistered = approveRegisteredTool
+        }
+  where
+    approveToolWithClassification classifiedReadOnly call =
+        withMVar host.hostIoLock \_ ->
+            let classify = const (pure classifiedReadOnly)
+            in case startup.startupNativeHooks of
+                Just hooks ->
+                    approveToolDecisionWithReporterAndPersistenceClassified
+                        classify
+                        hooks.nativeRequestApproval
+                        (const (pure ()))
+                        (pure ())
+                        policyRef
+                        controls.controlAllowedToolsRef
+                        controls.controlToolRegistry
+                        planMode
+                        call
+                Nothing -> case promptRequest of
+                    Just request
+                        | isJust request.managedTurnBridgeDirectory ->
+                            approveToolDecisionWithReporterAndPersistenceClassified
+                                classify
+                                (requestManagedApproval request)
+                                (const (pure ()))
+                                (pure ())
+                                policyRef
+                                controls.controlAllowedToolsRef
+                                controls.controlToolRegistry
+                                planMode
+                                call
+                    _ -> case host.hostFullscreen of
+                        Nothing ->
+                            withStdinPaused escPaused $
+                                approveToolDecisionClassified
+                                    classify
+                                    policyRef
+                                    controls.controlAllowedToolsRef
+                                    controls.controlToolRegistry
+                                    planMode
+                                    projectRoot
+                                    cwd
+                                    call
+                        Just runtime ->
+                            approveToolDecisionWithReporterAndPersistenceClassified
+                                classify
+                                (requestFullscreenPermission
+                                    runtime
+                                    (toText cwd))
+                                (\case
+                                    ApprovalWarning _ -> pure ()
+                                    ApprovalSuccess message ->
+                                        emitUiEvent runtime
+                                            (UiSetNotice
+                                                (Just
+                                                    (successNotice
+                                                        message))))
+                                (saveProjectAutoApprove projectRoot True)
+                                policyRef
+                                controls.controlAllowedToolsRef
+                                controls.controlToolRegistry
+                                planMode
+                                call
+    approveRegisteredTool =
+        approveToolWithClassification Nothing
+
+data SessionShellRuntime = SessionShellRuntime
+    { shellToolAllowed :: !(ToolCall -> IO Bool)
+    , shellActiveToolNames :: !(IO [Text.Text])
+    , shellCurrentMode :: !(IO ShellMode)
+    , shellSetMode :: !(ShellMode -> IO Text.Text)
+    , shellSetTempDir :: !(OsPath -> IO ())
+    }
+
+buildSessionShellRuntime
+    :: SessionHostRuntime
+    -> SessionRequest
+    -> SessionShellRuntime
+buildSessionShellRuntime host SessionRequest{..} =
+    SessionShellRuntime
+        { shellToolAllowed = shellToolAllowed
+        , shellActiveToolNames = currentActiveToolNames
+        , shellCurrentMode = currentShellMode
+        , shellSetMode = setShellMode
+        , shellSetTempDir = setSessionTempDir
+        }
+  where
+    nativeCapabilities = host.hostNativeCapabilities
+    shellToolAllowed call = do
+        ghciEnabled <- readIORef ghciEnabledRef
+        bashEnabled <- readIORef bashEnabledRef
+        let toolName = canonicalToolName call.name
+        pure $
+            (not (isGhciToolName toolName) || ghciEnabled)
+                && (not (isBashToolName toolName) || bashEnabled)
+    activeShellTools ghciEnabled bashEnabled =
+        filterGhciTools ghciEnabled
+            (filterBashTools bashEnabled allTools)
+    currentShellMode = do
+        ghciEnabled <- readIORef ghciEnabledRef
+        bashEnabled <- readIORef bashEnabledRef
+        pure $ case (ghciEnabled, bashEnabled) of
+            (True, False) -> ShellGhci
+            (False, True) -> ShellBash
+            (True, True) -> ShellBoth
+            (False, False) -> ShellNone
+    currentActiveToolNames = do
+        ghciEnabled <- readIORef ghciEnabledRef
+        bashEnabled <- readIORef bashEnabledRef
+        let active =
+                activeShellTools ghciEnabled bashEnabled
+            internalNames = map (.appToolName) active
+            projectedNames =
+                case dialectToolLayout dialect of
+                    NoHostToolLayout -> []
+                    FlatToolLayout
+                        | dialectId dialect == GrokBuildDialect ->
+                            map grokBuildPublicToolName internalNames
+                        | otherwise -> internalNames
+                    CollaborationNamespaceLayout ->
+                        filter (`notElem` multiAgentToolNames) internalNames
+                            <> if any
+                                (`elem` multiAgentToolNames)
+                                internalNames
+                                then ["collaboration"]
+                                else []
+        pure $
+            case dialectToolLayout dialect of
+                NoHostToolLayout -> []
+                _ ->
+                    hostedSearchToolNamesWhen
+                        nativeCapabilities.nativeProviderHostedTools
+                        dialect
+                        ++ projectedNames
+    shellModeFlags = \case
+        ShellGhci -> (True, False)
+        ShellBash -> (False, True)
+        ShellBoth -> (True, True)
+        ShellNone -> (False, False)
+    shellModeLabel = \case
+        ShellGhci -> "ghci"
+        ShellBash -> "bash"
+        ShellBoth -> "ghci + bash"
+        ShellNone -> "none"
+    refreshShellParams ghciEnabled bashEnabled
+        | isJust codeModeNestedSlot = pure ()
+        | otherwise = do
+            sessionTmp <- readIORef toolEnv.toolSessionTmp
+            today <- utctDay <$> getCurrentTime
+            let enabledTools = activeShellTools ghciEnabled bashEnabled
+                enabledNames = map (.appToolName) enabledTools
+                instructionText =
+                    appendMcpInstructions mcpInstructions case codexCatalogSession of
+                        Just catalog ->
+                            catalog.catalogInstructionsFor
+                                enabledNames sessionTmp
+                        Nothing ->
+                            systemPromptForToolsWithHostedSearch
+                                nativeCapabilities.nativeProviderHostedTools
+                                dialect
+                                enabledNames
+                                cwd
+                                sessionTmp
+                                today
+                                (isOneShot options)
+                toolSchemas =
+                    schemasFromAppToolsWithHostedSearch
+                        nativeCapabilities.nativeProviderHostedTools
+                        dialect
+                        enabledTools
+            modifyIORef' paramsRef
+                (setRequestInstructionsAndTools
+                    instructionText
+                    (Just toolSchemas))
+    setShellMode mode = do
+        let (ghciEnabled, bashEnabled) = shellModeFlags mode
+        writeIORef ghciEnabledRef ghciEnabled
+        writeIORef bashEnabledRef bashEnabled
+        unless ghciEnabled suspendGhci
+        refreshShellParams ghciEnabled bashEnabled
+        pure ("shell tools: " <> shellModeLabel mode)
+    setSessionTempDir tempDir = do
+        -- Persistent tool runtimes capture temp-backed state at startup.
+        -- Reset them before publishing the new root so no process or state
+        -- file remains attached to the previous session.
+        resetToolSessionTemp tempDir
+        setToolSessionTmp toolEnv (Just tempDir)
+        ghciEnabled <- readIORef ghciEnabledRef
+        bashEnabled <- readIORef bashEnabledRef
+        refreshShellParams ghciEnabled bashEnabled
+
+data SessionSubagentRuntime = SessionSubagentRuntime
+    { subagentBeginTurn :: !(IO (Maybe RootTurnId))
+    , subagentFinishTurn :: !(Maybe RootTurnId -> IO ())
+    , subagentAbortTurn :: !(Maybe RootTurnId -> IO ())
+    , subagentConcurrentLimit :: !(IO Int)
+    , subagentSetConcurrentLimit :: !(Int -> IO Text.Text)
+    }
+
+buildSessionSubagentRuntime :: SessionRequest -> SessionSubagentRuntime
+buildSessionSubagentRuntime SessionRequest{..} =
+    SessionSubagentRuntime
+        { subagentBeginTurn = beginSubagentTurn
+        , subagentFinishTurn = finishSubagentTurn
+        , subagentAbortTurn = abortSubagentTurn
+        , subagentConcurrentLimit = currentConcurrentLimit
+        , subagentSetConcurrentLimit = setConcurrentLimit
+        }
+  where
+    beginSubagentTurn =
+        case multiCtx of
+            Nothing -> pure Nothing
+            Just ctx -> do
+                rootTurnId <- beginRootTurn ctx.multiRegistry
+                writeIORef rootTurnRef (Just rootTurnId)
+                pure (Just rootTurnId)
+    finishSubagentTurn rootTurnId =
+        atomicModifyIORef' rootTurnRef \current ->
+            (if current == rootTurnId then Nothing else current, ())
+    abortSubagentTurn rootTurnId = do
+        case rootTurnId of
+            Just owned -> case multiCtx of
+                Just ctx -> abortRootTurn ctx.multiRegistry owned
+                Nothing -> pure ()
+            Nothing -> pure ()
+        finishSubagentTurn rootTurnId
+    currentConcurrentLimit = case multiCtx of
+        Nothing ->
+            pure defaultSubagentConfig.maxConcurrent
+        Just ctx ->
+            (.maxConcurrent) <$> subagentConfig ctx.multiRegistry
+    setConcurrentLimit limit = do
+        let next = max 1 limit
+        case multiCtx of
+            Just ctx -> setMaxConcurrent ctx.multiRegistry next
+            Nothing -> pure ()
+        saveProjectMaxConcurrentAgents projectRoot next
+        pure ("concurrent agent limit: " <> Text.pack (show next))
+
+buildSessionLoopConfig
+    :: SessionControlRuntime
+    -> SessionRequest
+    -> SessionBackend
+    -> SessionLoopEventRuntime
+    -> SessionShellRuntime
+    -> SessionApprovalRuntime
+    -> LoopConfig
+buildSessionLoopConfig
+        controls SessionRequest{..} SessionBackend{..}
+        eventRuntime shellRuntime approvalRuntime =
+    LoopConfig
+        { loopBackend = backend
+        , loopBackendState = BackendStateStore
+            { readBackendState =
+                withLiveBackendState conversationRef pure
+            , commitBackendState =
+                commitLiveBackendState conversationRef
+            }
+        , loopTools = controls.controlToolRegistry
+        , loopDispatch =
+            defaultLoopDispatch
+                { toolDispatchFinalizeOutput = \call output ->
+                    if isComputerToolCallKind call.callKind
+                        then pure output
+                        else finalizeToolOutput toolEnv call output
+                }
+        , loopMaxTurns = options.optMaxTurns
+        , loopOnEvent = eventRuntime.loopEventEmit
+        , loopApprove = \call ->
+            shellRuntime.shellToolAllowed call >>= \case
+                False ->
+                    pure (Left
+                        ("Tool " <> call.name
+                            <> " is disabled by the current /shell setting."))
+                True -> approvalRuntime.approvalApproveRegistered call
+        , loopReadSteering =
+            readSteeringInputs controls.controlSteeringInputs
+        , loopCommitSteering = \count ->
+            commitSteeringInputs controls.controlSteeringInputs count
+        , loopInterrupt = interruptBackend
+        , loopCancel = toolEnv.toolCancel
+        }
+
+installSessionToolRuntimes
+    :: SessionHostRuntime
+    -> SessionControlRuntime
+    -> SessionRequest
+    -> SessionLoopEventRuntime
+    -> SessionShellRuntime
+    -> SessionApprovalRuntime
+    -> LoopConfig
+    -> IO ()
+installSessionToolRuntimes
+        host controls SessionRequest{..}
+        eventRuntime shellRuntime approvalRuntime config = do
+    installClaudeSessionRuntime claudeRuntimeSlot ClaudeSessionRuntime
+        { approveNativeTool = \call readOnly ->
+            approvalRuntime.approvalApproveClassified readOnly call
+        , approveRegisteredTool =
+            approvalRuntime.approvalApproveRegistered
+        , planMode
+        , providerNativeToolsEnabled =
+            host.hostNativeCapabilities.nativeProviderNativeTools
+        }
+    forM_ codeModeNestedSlot \slot ->
+        setCodeModeNestedInvoke slot \call -> do
+            allowed <- shellRuntime.shellToolAllowed call
+            if not allowed
+                then pure $ Left $
+                    "Tool " <> call.name
+                        <> " is disabled by the current /shell setting."
+                else
+                    approvalRuntime.approvalApproveRegistered call >>= \case
+                        Left denial -> pure (Left denial)
+                        Right False ->
+                            pure (Left "Tool call rejected by user.")
+                        Right True -> do
+                            eventRuntime.loopEventEmit (ToolStarted call)
+                            result <- dispatchRegisteredToolCall
+                                config.loopDispatch
+                                controls.controlToolRegistry
+                                call
+                            eventRuntime.loopEventEmit (ToolFinished result)
+                            pure (Right result)
+
+data SessionLoopRuntime = SessionLoopRuntime
+    { loopRuntimeConfig :: !LoopConfig
+    , loopRuntimeRender :: !RenderConfig
+    , loopRuntimeShell :: !SessionShellRuntime
+    , loopRuntimeSubagents :: !SessionSubagentRuntime
+    }
+
+newSessionLoopRuntime
+    :: SessionHostRuntime
+    -> SessionControlRuntime
+    -> SessionRequest
+    -> SessionBackend
+    -> IO SessionLoopRuntime
+newSessionLoopRuntime host controls request@SessionRequest{..} sessionBackend = do
+    managedLoopPublisher <-
+        maybe
+            (pure (const (pure ())))
+            newManagedLoopEventPublisher
+            promptRequest
+    sessionDir <- readIORef planMode.planSessionDir
+    forM_ sessionDir (writeIORef storeRoot . Just)
+    let eventRuntime =
+            buildSessionLoopEventRuntime
+                host controls request managedLoopPublisher
+        shellRuntime = buildSessionShellRuntime host request
+        approvalRuntime =
+            buildSessionApprovalRuntime host controls request
+        subagentRuntime = buildSessionSubagentRuntime request
+        config =
+            buildSessionLoopConfig
+                controls
+                request
+                sessionBackend
+                eventRuntime
+                shellRuntime
+                approvalRuntime
+    installSessionToolRuntimes
+        host
+        controls
+        request
+        eventRuntime
+        shellRuntime
+        approvalRuntime
+        config
+    pure SessionLoopRuntime
+        { loopRuntimeConfig = config
+        , loopRuntimeRender = eventRuntime.loopEventRender
+        , loopRuntimeShell = shellRuntime
+        , loopRuntimeSubagents = subagentRuntime
+        }
+
 runSession
     :: SessionRunnerContinuation
     -> SessionRequest
@@ -659,15 +1137,10 @@ runSession
   host <- newSessionHostRuntime request
   let initialPrevious = host.hostInitialPrevious
       grokFirstTurnContextRef = host.hostGrokFirstTurnContextRef
-      ioLock = host.hostIoLock
       fullscreen = host.hostFullscreen
       nativeCapabilities = host.hostNativeCapabilities
       preparedWorkspaceEnvironment = host.hostPreparedWorkspaceEnvironment
       terminal = host.hostTerminal
-      stdoutHandle = host.hostStdoutHandle
-      stderrHandle = host.hostStderrHandle
-      useColor = host.hostUseColor
-      stderrTty = host.hostStderrTty
       reportSessionError = host.hostReportSessionError
       setWindowTitle = host.hostWindowTitle.windowTitleSet
       beginWindowTitleBusy = host.hostWindowTitle.windowTitleBeginBusy
@@ -676,19 +1149,13 @@ runSession
   withSessionTitleRuntime host request sessionBackend \titleManager -> do
     controls <- newSessionControlRuntime host request
     let previewIdRef = startup.startupSessionState.sessionPreviewId
-        toolRegistry = controls.controlToolRegistry
         steeringInputs = controls.controlSteeringInputs
-        spinnerRef = controls.controlSpinnerRef
-        renderStateRef = controls.controlRenderStateRef
-        allowedToolsRef = controls.controlAllowedToolsRef
         lastAssistantRef = controls.controlLastAssistantRef
-        modelRef = controls.controlModelRef
         unavailableProvidersRef = controls.controlUnavailableProvidersRef
         startupUnavailableRef = controls.controlStartupUnavailableRef
         restartEffortRef = controls.controlRestartEffortRef
         lastFailedTurnRef = controls.controlLastFailedTurnRef
         titleTurnCount = controls.controlTitleTurnCount
-        agentViewportRuntime = controls.controlAgentViewportRuntime
         agentViewport = controls.controlAgentViewport
         skillsRuntime =
             buildSkillContextRuntime
@@ -697,338 +1164,21 @@ runSession
             skillsRuntime.skillReloadGeneratedContext
         sessionReset = skillsRuntime.skillResetSession
         refreshSkills = skillsRuntime.skillRefresh
-    managedLoopPublisher <-
-        maybe
-            (pure (const (pure ())))
-            newManagedLoopEventPublisher
-            promptRequest
-    let syncStore = do
-            sessionDir <- readIORef planMode.planSessionDir
-            case sessionDir of
-                Just dir -> writeIORef storeRoot (Just dir)
-                Nothing -> pure ()
-    syncStore
-    let render = RenderConfig
-            { renderShowThinking = stderrTty
-            , renderThinkingSpinner = spinnerRef
-            , renderState = renderStateRef
-            , renderColor = useColor
-            , renderLock = ioLock
-            , renderStdout = stdoutHandle
-            , renderStderr = stderrHandle
-            , renderModelRef = modelRef
-            , renderNativeProgress =
-                stderrTty
-                    && terminal.terminalNativeProgress
-                    && nativeProgressAnimationEnabled
-                        options.optMotionMode
-            , renderMotionMode = options.optMotionMode
-            , renderWorkspace = toText cwd
-            }
-        emitLoop event = do
-            recordAgentViewportEvent agentViewportRuntime event
-            forM_ startup.startupNativeHooks \hooks ->
-                hooks.nativeOnLoopEvent event
-            managedLoopPublisher event
-            case event of
-                TurnFinished turn -> do
-                    history <- readLiveTranscript conversationRef
-                    forM_ (reportedContextTokens turn.tokenUsage) \tokens ->
-                        writeIORef contextOccupancyRef $
-                            Just (reportedOccupancy tokens (length history))
-                _ -> pure ()
-            case fullscreen of
-                Nothing -> renderEvent render event
-                Just runtime -> do
-                    now <- getCurrentTime
-                    modifyIORef' renderStateRef \state ->
-                        case event of
-                            TurnStarted -> beginRenderTurn now state
-                            TextDelta delta ->
-                                countGenerationChars delta
-                                    state{statePrintedText = True}
-                            ReasoningDelta delta ->
-                                countGenerationChars delta state
-                            ResponseRestarted _ ->
-                                resetRenderGeneration now state
-                            ToolStarted _ ->
-                                state{stateActivity = "Running tool…"}
-                            TurnFinished turn ->
-                                recordRenderTurnRate now turn state
-                            _ -> state
-                    emitUiEvent runtime (UiLoop event)
-                    case event of
-                        TurnFinished _ -> do
-                            occupancy <- readIORef contextOccupancyRef
-                            params <- readIORef paramsRef
-                            history <- readLiveTranscript conversationRef
-                            contextWindow <- currentContextWindow
-                            emitUiEvent runtime $
-                                UiSetContextUsage
-                                    (Just
-                                        (contextUsageTokens
-                                            occupancy
-                                            params
-                                            history))
-                                    contextWindow
-                        _ -> pure ()
-        shellToolAllowed call = do
-            ghciEnabled <- readIORef ghciEnabledRef
-            bashEnabled <- readIORef bashEnabledRef
-            let toolName = canonicalToolName call.name
-            pure $
-                (not (isGhciToolName toolName) || ghciEnabled)
-                    && (not (isBashToolName toolName) || bashEnabled)
-        approveToolWithClassification classifiedReadOnly call =
-            withMVar ioLock \_ ->
-                let classify = const (pure classifiedReadOnly)
-                in case startup.startupNativeHooks of
-                    Just hooks ->
-                        approveToolDecisionWithReporterAndPersistenceClassified
-                            classify
-                            hooks.nativeRequestApproval
-                            (const (pure ()))
-                            (pure ())
-                            policyRef
-                            allowedToolsRef
-                            toolRegistry
-                            planMode
-                            call
-                    Nothing -> case promptRequest of
-                        Just request
-                            | isJust request.managedTurnBridgeDirectory ->
-                                approveToolDecisionWithReporterAndPersistenceClassified
-                                    classify
-                                    (requestManagedApproval request)
-                                    (const (pure ()))
-                                    (pure ())
-                                    policyRef
-                                    allowedToolsRef
-                                    toolRegistry
-                                    planMode
-                                    call
-                        _ -> case fullscreen of
-                            Nothing ->
-                                withStdinPaused escPaused $
-                                    approveToolDecisionClassified
-                                        classify
-                                        policyRef
-                                        allowedToolsRef
-                                        toolRegistry
-                                        planMode
-                                        projectRoot
-                                        cwd
-                                        call
-                            Just runtime ->
-                                approveToolDecisionWithReporterAndPersistenceClassified
-                                    classify
-                                    (requestFullscreenPermission
-                                        runtime
-                                        (toText cwd))
-                                    (\case
-                                        ApprovalWarning _ -> pure ()
-                                        ApprovalSuccess message ->
-                                            emitUiEvent runtime
-                                                (UiSetNotice
-                                                    (Just
-                                                        (successNotice
-                                                            message))))
-                                    (saveProjectAutoApprove projectRoot True)
-                                    policyRef
-                                    allowedToolsRef
-                                    toolRegistry
-                                    planMode
-                                    call
-        approveRegisteredTool =
-            approveToolWithClassification Nothing
-        config = LoopConfig
-            { loopBackend = backend
-            , loopBackendState = BackendStateStore
-                { readBackendState =
-                    withLiveBackendState conversationRef pure
-                , commitBackendState =
-                    commitLiveBackendState conversationRef
-                }
-            , loopTools = toolRegistry
-            , loopDispatch =
-                defaultLoopDispatch
-                    { toolDispatchFinalizeOutput = \call output ->
-                        if isComputerToolCallKind call.callKind
-                            then pure output
-                            else finalizeToolOutput toolEnv call output
-                    }
-            , loopMaxTurns = options.optMaxTurns
-            , loopOnEvent = emitLoop
-            , loopApprove = \call ->
-                shellToolAllowed call >>= \case
-                    False ->
-                        pure (Left
-                            ("Tool " <> call.name
-                                <> " is disabled by the current /shell setting."))
-                    True -> approveRegisteredTool call
-            , loopReadSteering =
-                readSteeringInputs steeringInputs
-            , loopCommitSteering = \count ->
-                commitSteeringInputs steeringInputs count
-            , loopInterrupt = interruptBackend
-            , loopCancel = toolEnv.toolCancel
-            }
-        beginSubagentTurn = do
-            case multiCtx of
-                Nothing -> pure Nothing
-                Just ctx -> do
-                    rootTurnId <- beginRootTurn ctx.multiRegistry
-                    writeIORef rootTurnRef (Just rootTurnId)
-                    pure (Just rootTurnId)
-        finishSubagentTurn rootTurnId =
-            atomicModifyIORef' rootTurnRef \current ->
-                (if current == rootTurnId then Nothing else current, ())
-        abortSubagentTurn rootTurnId = do
-            case rootTurnId of
-                Just owned -> case multiCtx of
-                    Just ctx -> abortRootTurn ctx.multiRegistry owned
-                    Nothing -> pure ()
-                Nothing -> pure ()
-            finishSubagentTurn rootTurnId
-        activeShellTools ghciEnabled bashEnabled =
-            filterGhciTools ghciEnabled
-                (filterBashTools bashEnabled allTools)
-        currentShellMode = do
-            ghciEnabled <- readIORef ghciEnabledRef
-            bashEnabled <- readIORef bashEnabledRef
-            pure $ case (ghciEnabled, bashEnabled) of
-                (True, False) -> ShellGhci
-                (False, True) -> ShellBash
-                (True, True) -> ShellBoth
-                (False, False) -> ShellNone
-        currentActiveToolNames = do
-            ghciEnabled <- readIORef ghciEnabledRef
-            bashEnabled <- readIORef bashEnabledRef
-            let active =
-                    activeShellTools ghciEnabled bashEnabled
-                internalNames = map (.appToolName) active
-                projectedNames =
-                    case dialectToolLayout dialect of
-                        NoHostToolLayout -> []
-                        FlatToolLayout
-                            | dialectId dialect
-                                == GrokBuildDialect ->
-                                    map
-                                        grokBuildPublicToolName
-                                        internalNames
-                            | otherwise -> internalNames
-                        CollaborationNamespaceLayout ->
-                            filter
-                                (`notElem` multiAgentToolNames)
-                                internalNames
-                                <> if any
-                                    (`elem` multiAgentToolNames)
-                                    internalNames
-                                    then ["collaboration"]
-                                    else []
-            pure $
-                case dialectToolLayout dialect of
-                    NoHostToolLayout -> []
-                    _ ->
-                        hostedSearchToolNamesWhen
-                            nativeCapabilities.nativeProviderHostedTools
-                            dialect
-                            ++ projectedNames
-        shellModeFlags = \case
-            ShellGhci -> (True, False)
-            ShellBash -> (False, True)
-            ShellBoth -> (True, True)
-            ShellNone -> (False, False)
-        shellModeLabel = \case
-            ShellGhci -> "ghci"
-            ShellBash -> "bash"
-            ShellBoth -> "ghci + bash"
-            ShellNone -> "none"
-        refreshShellParams ghciEnabled bashEnabled
-            | isJust codeModeNestedSlot = pure ()
-            | otherwise = do
-                sessionTmp <- readIORef toolEnv.toolSessionTmp
-                today <- utctDay <$> getCurrentTime
-                let enabledTools = activeShellTools ghciEnabled bashEnabled
-                    enabledNames = map (.appToolName) enabledTools
-                    instructionText =
-                        appendMcpInstructions mcpInstructions case codexCatalogSession of
-                            Just catalog ->
-                                catalog.catalogInstructionsFor
-                                    enabledNames sessionTmp
-                            Nothing ->
-                                systemPromptForToolsWithHostedSearch
-                                    nativeCapabilities.nativeProviderHostedTools
-                                    dialect
-                                    enabledNames
-                                    cwd
-                                    sessionTmp
-                                    today
-                                    (isOneShot options)
-                    toolSchemas =
-                        schemasFromAppToolsWithHostedSearch
-                            nativeCapabilities.nativeProviderHostedTools
-                            dialect
-                            enabledTools
-                modifyIORef' paramsRef
-                    (setRequestInstructionsAndTools
-                        instructionText
-                        (Just toolSchemas))
-        setShellMode mode = do
-            let (ghciEnabled, bashEnabled) = shellModeFlags mode
-            writeIORef ghciEnabledRef ghciEnabled
-            writeIORef bashEnabledRef bashEnabled
-            unless ghciEnabled suspendGhci
-            refreshShellParams ghciEnabled bashEnabled
-            pure ("shell tools: " <> shellModeLabel mode)
-        setSessionTempDir tempDir = do
-            -- Persistent tool runtimes capture temp-backed state at startup.
-            -- Reset them before publishing the new root so no process or
-            -- state file remains attached to the previous session.
-            resetToolSessionTemp tempDir
-            setToolSessionTmp toolEnv (Just tempDir)
-            ghciEnabled <- readIORef ghciEnabledRef
-            bashEnabled <- readIORef bashEnabledRef
-            refreshShellParams ghciEnabled bashEnabled
-        currentConcurrentLimit = case multiCtx of
-            Nothing ->
-                pure defaultSubagentConfig.maxConcurrent
-            Just ctx ->
-                (.maxConcurrent) <$> subagentConfig ctx.multiRegistry
-        setConcurrentLimit limit = do
-            let next = max 1 limit
-            case multiCtx of
-                Just ctx -> setMaxConcurrent ctx.multiRegistry next
-                Nothing -> pure ()
-            saveProjectMaxConcurrentAgents projectRoot next
-            pure ("concurrent agent limit: " <> Text.pack (show next))
-    installClaudeSessionRuntime claudeRuntimeSlot ClaudeSessionRuntime
-        { approveNativeTool = \call readOnly ->
-            approveToolWithClassification readOnly call
-        , approveRegisteredTool
-        , planMode
-        , providerNativeToolsEnabled =
-            nativeCapabilities.nativeProviderNativeTools
-        }
-    forM_ codeModeNestedSlot \slot ->
-        setCodeModeNestedInvoke slot \call -> do
-            allowed <- shellToolAllowed call
-            if not allowed
-                then pure $ Left $
-                    "Tool " <> call.name
-                        <> " is disabled by the current /shell setting."
-                else approveRegisteredTool call >>= \case
-                    Left denial -> pure (Left denial)
-                    Right False ->
-                        pure (Left "Tool call rejected by user.")
-                    Right True -> do
-                        emitLoop (ToolStarted call)
-                        result <- dispatchRegisteredToolCall
-                            config.loopDispatch
-                            toolRegistry
-                            call
-                        emitLoop (ToolFinished result)
-                        pure (Right result)
+    loopRuntime <-
+        newSessionLoopRuntime host controls request sessionBackend
+    let config = loopRuntime.loopRuntimeConfig
+        render = loopRuntime.loopRuntimeRender
+        shellRuntime = loopRuntime.loopRuntimeShell
+        subagentRuntime = loopRuntime.loopRuntimeSubagents
+        setSessionTempDir = shellRuntime.shellSetTempDir
+        currentActiveToolNames = shellRuntime.shellActiveToolNames
+        currentShellMode = shellRuntime.shellCurrentMode
+        setShellMode = shellRuntime.shellSetMode
+        beginSubagentTurn = subagentRuntime.subagentBeginTurn
+        finishSubagentTurn = subagentRuntime.subagentFinishTurn
+        abortSubagentTurn = subagentRuntime.subagentAbortTurn
+        currentConcurrentLimit = subagentRuntime.subagentConcurrentLimit
+        setConcurrentLimit = subagentRuntime.subagentSetConcurrentLimit
     btwRequests <- newChan
     recapRequests <- newChan
     turnActivityRef <- newIORef Nothing

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -103,7 +103,7 @@ import Agent.Tools.Types
 import Agent.OsPath
 import Control.Concurrent (ThreadId)
 import Control.Concurrent.Async (withAsync)
-import Control.Concurrent.Chan (newChan, readChan, writeChan)
+import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM (STM)
 import Control.Exception.Safe
@@ -1125,67 +1125,27 @@ newSessionLoopRuntime host controls request@SessionRequest{..} sessionBackend = 
         , loopRuntimeSubagents = subagentRuntime
         }
 
-runSession
-    :: SessionRunnerContinuation
+data SessionPersistenceRuntime = SessionPersistenceRuntime
+    { persistenceBeginTurnActivity :: !(IO ())
+    , persistenceEndTurnActivity :: !(IO ())
+    , persistenceOnPersisted :: !(SessionHandle -> IO ())
+    , persistenceCommitAutomaticCompaction
+        :: !(CompactOutcome -> [TurnInput] -> IO CompactionInstall)
+    , persistenceCompact
+        :: !(Maybe Text.Text -> IO (Either Text.Text CompactOutcome))
+    }
+
+newSessionPersistenceRuntime
+    :: SessionHostRuntime
+    -> SkillContextRuntime
     -> SessionRequest
-    -> SessionBackend
-    -> IO RunResult
-runSession
-        callbacks
-        request@SessionRequest{..}
-        sessionBackend@SessionBackend{..} = do
-  host <- newSessionHostRuntime request
-  let initialPrevious = host.hostInitialPrevious
-      grokFirstTurnContextRef = host.hostGrokFirstTurnContextRef
-      fullscreen = host.hostFullscreen
-      nativeCapabilities = host.hostNativeCapabilities
-      preparedWorkspaceEnvironment = host.hostPreparedWorkspaceEnvironment
-      terminal = host.hostTerminal
-      reportSessionError = host.hostReportSessionError
-      setWindowTitle = host.hostWindowTitle.windowTitleSet
-      beginWindowTitleBusy = host.hostWindowTitle.windowTitleBeginBusy
-      endWindowTitleBusy = host.hostWindowTitle.windowTitleEndBusy
-      windowTitleWorker = host.hostWindowTitle.windowTitleWorker
-  withSessionTitleRuntime host request sessionBackend \titleManager -> do
-    controls <- newSessionControlRuntime host request
-    let previewIdRef = startup.startupSessionState.sessionPreviewId
-        steeringInputs = controls.controlSteeringInputs
-        lastAssistantRef = controls.controlLastAssistantRef
-        unavailableProvidersRef = controls.controlUnavailableProvidersRef
-        startupUnavailableRef = controls.controlStartupUnavailableRef
-        restartEffortRef = controls.controlRestartEffortRef
-        lastFailedTurnRef = controls.controlLastFailedTurnRef
-        titleTurnCount = controls.controlTitleTurnCount
-        agentViewport = controls.controlAgentViewport
-        skillsRuntime =
-            buildSkillContextRuntime
-                callbacks host controls request sessionBackend
-        reloadGeneratedContext =
-            skillsRuntime.skillReloadGeneratedContext
-        sessionReset = skillsRuntime.skillResetSession
-        refreshSkills = skillsRuntime.skillRefresh
-    loopRuntime <-
-        newSessionLoopRuntime host controls request sessionBackend
-    let config = loopRuntime.loopRuntimeConfig
-        render = loopRuntime.loopRuntimeRender
-        shellRuntime = loopRuntime.loopRuntimeShell
-        subagentRuntime = loopRuntime.loopRuntimeSubagents
-        setSessionTempDir = shellRuntime.shellSetTempDir
-        currentActiveToolNames = shellRuntime.shellActiveToolNames
-        currentShellMode = shellRuntime.shellCurrentMode
-        setShellMode = shellRuntime.shellSetMode
-        beginSubagentTurn = subagentRuntime.subagentBeginTurn
-        finishSubagentTurn = subagentRuntime.subagentFinishTurn
-        abortSubagentTurn = subagentRuntime.subagentAbortTurn
-        currentConcurrentLimit = subagentRuntime.subagentConcurrentLimit
-        setConcurrentLimit = subagentRuntime.subagentSetConcurrentLimit
-    btwRequests <- newChan
-    recapRequests <- newChan
+    -> IO SessionPersistenceRuntime
+newSessionPersistenceRuntime
+        host skillsRuntime SessionRequest{..} = do
     turnActivityRef <- newIORef Nothing
     turnIsActiveRef <- newIORef False
     nativeSessionIdRef <- newIORef Nothing
-    let
-        acquireTurnActivity handle = mask_ do
+    let acquireTurnActivity handle = mask_ do
             current <- readIORef turnActivityRef
             if isNothing current
                 then
@@ -1208,7 +1168,8 @@ runSession
                 PersistenceEnabled slotRef ->
                     readIORef slotRef >>= \case
                         PersistencePending{} -> pure ()
-                        PersistenceActive handle -> void (acquireTurnActivity handle)
+                        PersistenceActive handle ->
+                            void (acquireTurnActivity handle)
         endTurnActivity = do
             writeIORef turnIsActiveRef False
             atomicModifyIORef' turnActivityRef
@@ -1242,8 +1203,8 @@ runSession
                 `onException`
                     when acquired endTurnActivity
         reloadGeneratedContextSafely =
-            reloadGeneratedContext `catchAny` \err ->
-                reportSessionError
+            skillsRuntime.skillReloadGeneratedContext `catchAny` \err ->
+                host.hostReportSessionError
                     ("failed to reload generated context: "
                         <> formatException err)
         -- The durable replace, pending input, and in-memory publication form
@@ -1301,97 +1262,168 @@ runSession
                 Left _ -> pure ()
                 Right _ -> reloadGeneratedContextSafely
             pure result
-        env = SessionEnv
-            { sessionLoop = config
-            , sessionSteeringInputs = steeringInputs
-            , sessionModelInfo = modelInfo
-            , sessionBtwBackend = btwBackend
-            , sessionQueueRecap = writeChan recapRequests
-            , sessionCompact = compactRunnerWithContext
-            , sessionRender = render
-            , sessionProvider = provider
-            , sessionConnection = connectionId
-            , sessionGatewayIdentity = gatewayIdentity
-            , sessionModelCatalog = catalog
-            , sessionGatewayModels = gatewayModelsRef
-            , sessionDialect = dialect
-            , sessionRecordImageGenerationInputs =
-                recordImageGenerationInputs
-            , sessionUnavailableProviders = unavailableProvidersRef
-            , sessionStartupUnavailable = startupUnavailableRef
-            , sessionConversation = conversationRef
-            , sessionAutomaticCompaction = automaticCompactionRef
-            , sessionParams = paramsRef
-            , sessionContextOccupancy = contextOccupancyRef
-            , sessionContextWindow = currentContextWindow
-            , sessionPolicy = policyRef
-            , sessionPersist = persist
-            , sessionDatabasePool =
-                trustedPool startup.startupDatabaseStore
-            , sessionTitleManager = titleManager
-            , sessionTitleTurnCount = titleTurnCount
-            , sessionPlanMode = planMode
-            , sessionTaskPlan = taskPlan
-            , sessionProjectRoot = projectRoot
-            , sessionCwd = cwd
-            , sessionProviderFallback =
-                nativeCapabilities.nativeProviderFallback
-            , sessionPreparedWorkspaceEnvironment =
-                preparedWorkspaceEnvironment
-            , sessionHome = home
-            , sessionMcpRegistrations = mcpRegistrations
-            , sessionMcpWarnings = mcpWarnings
-            , sessionMcpFleet = mcpFleet
-            , sessionSetTempDir = setSessionTempDir
-            , sessionTokenProvider = tokenProvider
-            , sessionOpenAiPool = openAiPool
-            , sessionStartupContext = startupContext
-            , sessionGrokFirstTurnContext = grokFirstTurnContextRef
-            , sessionSkills = skillsRef
-            , sessionSkillInvocations = skillInvocationsRef
-            , sessionRefreshSkills = refreshSkills
-            , sessionActiveToolNames = currentActiveToolNames
-            , sessionGrokRuntime = grokRuntime
-            , sessionShellMode = currentShellMode
-            , sessionSetShellMode = setShellMode
-            , sessionBackground = startup.startupBackground
-            , sessionEscPaused = escPaused
-            , sessionDraft = startup.startupSessionState.sessionDraft
-            , sessionPreviewId = previewIdRef
-            , sessionInterrupt = interrupt
-            , sessionRestartEffort = restartEffortRef
-            , sessionLastFailedTurn = lastFailedTurnRef
-            , sessionStoreRoot = storeRoot
-            , sessionUsage = usageRef
-            , sessionAccount = accountRef
-            , sessionAccountId = accountIdRef
-            , sessionAccountSelectionId = selectionRef
-            , sessionAccountLabel = accountLabel
-            , sessionSelectAccount = selectAccount
-            , sessionLastAssistant = lastAssistantRef
-            , sessionTerminal = terminal
-            , sessionFullscreen = fullscreen
-            , sessionSetWindowTitle = setWindowTitle
-            , sessionBeginWindowTitleBusy = beginWindowTitleBusy
-            , sessionEndWindowTitleBusy = endWindowTitleBusy
-            , sessionBeginTurnActivity = beginTurnActivity
-            , sessionEndTurnActivity = endTurnActivity
-            , sessionAgentViewport = Just agentViewport
-            , sessionBeginSubagentTurn = beginSubagentTurn
-            , sessionFinishSubagentTurn = finishSubagentTurn
-            , sessionAbortSubagentTurn = abortSubagentTurn
-            , sessionConcurrentLimit = currentConcurrentLimit
-            , sessionSetConcurrentLimit = setConcurrentLimit
-            , sessionOnPersisted = onPersistedWithActivity
-            , sessionReset = sessionReset
-            }
-    writeIORef automaticCompactionHookRef commitAutomaticCompaction
+    pure SessionPersistenceRuntime
+        { persistenceBeginTurnActivity = beginTurnActivity
+        , persistenceEndTurnActivity = endTurnActivity
+        , persistenceOnPersisted = onPersistedWithActivity
+        , persistenceCommitAutomaticCompaction =
+            commitAutomaticCompaction
+        , persistenceCompact = compactRunnerWithContext
+        }
+
+buildSessionEnv
+    :: SessionHostRuntime
+    -> SessionControlRuntime
+    -> SkillContextRuntime
+    -> SessionLoopRuntime
+    -> SessionPersistenceRuntime
+    -> SessionRequest
+    -> SessionBackend
+    -> SessionTitleManager
+    -> Chan RecapRequest
+    -> SessionEnv
+buildSessionEnv
+        host
+        controls
+        skillsRuntime
+        loopRuntime
+        persistenceRuntime
+        SessionRequest{..}
+        SessionBackend{..}
+        titleManager
+        recapRequests =
+    SessionEnv
+        { sessionLoop = loopRuntime.loopRuntimeConfig
+        , sessionSteeringInputs = controls.controlSteeringInputs
+        , sessionModelInfo = modelInfo
+        , sessionBtwBackend = btwBackend
+        , sessionQueueRecap = writeChan recapRequests
+        , sessionCompact = persistenceRuntime.persistenceCompact
+        , sessionRender = loopRuntime.loopRuntimeRender
+        , sessionProvider = provider
+        , sessionConnection = connectionId
+        , sessionGatewayIdentity = gatewayIdentity
+        , sessionModelCatalog = catalog
+        , sessionGatewayModels = gatewayModelsRef
+        , sessionDialect = dialect
+        , sessionRecordImageGenerationInputs =
+            recordImageGenerationInputs
+        , sessionUnavailableProviders =
+            controls.controlUnavailableProvidersRef
+        , sessionStartupUnavailable =
+            controls.controlStartupUnavailableRef
+        , sessionConversation = conversationRef
+        , sessionAutomaticCompaction = automaticCompactionRef
+        , sessionParams = paramsRef
+        , sessionContextOccupancy = contextOccupancyRef
+        , sessionContextWindow = currentContextWindow
+        , sessionPolicy = policyRef
+        , sessionPersist = persist
+        , sessionDatabasePool =
+            trustedPool startup.startupDatabaseStore
+        , sessionTitleManager = titleManager
+        , sessionTitleTurnCount = controls.controlTitleTurnCount
+        , sessionPlanMode = planMode
+        , sessionTaskPlan = taskPlan
+        , sessionProjectRoot = projectRoot
+        , sessionCwd = cwd
+        , sessionProviderFallback =
+            host.hostNativeCapabilities.nativeProviderFallback
+        , sessionPreparedWorkspaceEnvironment =
+            host.hostPreparedWorkspaceEnvironment
+        , sessionHome = home
+        , sessionMcpRegistrations = mcpRegistrations
+        , sessionMcpWarnings = mcpWarnings
+        , sessionMcpFleet = mcpFleet
+        , sessionSetTempDir =
+            loopRuntime.loopRuntimeShell.shellSetTempDir
+        , sessionTokenProvider = tokenProvider
+        , sessionOpenAiPool = openAiPool
+        , sessionStartupContext = startupContext
+        , sessionGrokFirstTurnContext =
+            host.hostGrokFirstTurnContextRef
+        , sessionSkills = skillsRef
+        , sessionSkillInvocations = skillInvocationsRef
+        , sessionRefreshSkills = skillsRuntime.skillRefresh
+        , sessionActiveToolNames =
+            loopRuntime.loopRuntimeShell.shellActiveToolNames
+        , sessionGrokRuntime = grokRuntime
+        , sessionShellMode =
+            loopRuntime.loopRuntimeShell.shellCurrentMode
+        , sessionSetShellMode =
+            loopRuntime.loopRuntimeShell.shellSetMode
+        , sessionBackground = startup.startupBackground
+        , sessionEscPaused = escPaused
+        , sessionDraft = startup.startupSessionState.sessionDraft
+        , sessionPreviewId =
+            startup.startupSessionState.sessionPreviewId
+        , sessionInterrupt = interrupt
+        , sessionRestartEffort = controls.controlRestartEffortRef
+        , sessionLastFailedTurn = controls.controlLastFailedTurnRef
+        , sessionStoreRoot = storeRoot
+        , sessionUsage = usageRef
+        , sessionAccount = accountRef
+        , sessionAccountId = accountIdRef
+        , sessionAccountSelectionId = selectionRef
+        , sessionAccountLabel = accountLabel
+        , sessionSelectAccount = selectAccount
+        , sessionLastAssistant = controls.controlLastAssistantRef
+        , sessionTerminal = host.hostTerminal
+        , sessionFullscreen = host.hostFullscreen
+        , sessionSetWindowTitle =
+            host.hostWindowTitle.windowTitleSet
+        , sessionBeginWindowTitleBusy =
+            host.hostWindowTitle.windowTitleBeginBusy
+        , sessionEndWindowTitleBusy =
+            host.hostWindowTitle.windowTitleEndBusy
+        , sessionBeginTurnActivity =
+            persistenceRuntime.persistenceBeginTurnActivity
+        , sessionEndTurnActivity =
+            persistenceRuntime.persistenceEndTurnActivity
+        , sessionAgentViewport = Just controls.controlAgentViewport
+        , sessionBeginSubagentTurn =
+            loopRuntime.loopRuntimeSubagents.subagentBeginTurn
+        , sessionFinishSubagentTurn =
+            loopRuntime.loopRuntimeSubagents.subagentFinishTurn
+        , sessionAbortSubagentTurn =
+            loopRuntime.loopRuntimeSubagents.subagentAbortTurn
+        , sessionConcurrentLimit =
+            loopRuntime.loopRuntimeSubagents.subagentConcurrentLimit
+        , sessionSetConcurrentLimit =
+            loopRuntime.loopRuntimeSubagents.subagentSetConcurrentLimit
+        , sessionOnPersisted =
+            persistenceRuntime.persistenceOnPersisted
+        , sessionReset = skillsRuntime.skillResetSession
+        }
+
+installSessionActions
+    :: SessionRunnerContinuation
+    -> SessionHostRuntime
+    -> SessionControlRuntime
+    -> SessionPersistenceRuntime
+    -> SessionRequest
+    -> SessionEnv
+    -> Chan Text.Text
+    -> Chan RecapRequest
+    -> IO ()
+installSessionActions
+        callbacks
+        host
+        controls
+        persistenceRuntime
+        SessionRequest{..}
+        env
+        btwRequests
+        recapRequests = do
+    writeIORef
+        automaticCompactionHookRef
+        persistenceRuntime.persistenceCommitAutomaticCompaction
     writeIORef startup.startupRestartEffort \level -> do
         setSessionEffortText env level
-        writeIORef restartEffortRef (Just level)
+        writeIORef controls.controlRestartEffortRef (Just level)
         requestCancel toolEnv.toolCancel
     gatewayAccess <- readIORef gatewayModelsRef
-    forM_ fullscreen \runtime ->
+    forM_ host.hostFullscreen \runtime ->
         setFullscreenSessionActions
             runtime
             (Just (dictationTargetForSession provider gatewayAccess))
@@ -1410,16 +1442,21 @@ runSession
                             emitUiEvent runtime (UiErrorMessage err)
                                 >> pure (Left err)
                         Right inputs ->
-                            enqueueSteeringInputs steeringInputs inputs >>= \case
-                                Left err -> pure (Left err)
-                                Right () -> do
-                                    emitUiEvent runtime (UiInputSteered text)
-                                    pure (Right ()))
+                            enqueueSteeringInputs
+                                controls.controlSteeringInputs
+                                inputs >>= \case
+                                    Left err -> pure (Left err)
+                                    Right () -> do
+                                        emitUiEvent
+                                            runtime
+                                            (UiInputSteered text)
+                                        pure (Right ()))
             (writeChan btwRequests)
             (\command -> do
                 let copyImmediate label missing payload =
                         case payload of
-                            Nothing -> emitUiEvent runtime (UiErrorMessage missing)
+                            Nothing ->
+                                emitUiEvent runtime (UiErrorMessage missing)
                             Just value -> do
                                 copied <- runtime.runtimeCopy value
                                 emitUiEvent runtime $
@@ -1433,11 +1470,13 @@ runSession
                     ReplCopy request
                         | request.copyResponseIndex == 1
                         , Nothing <- request.copyDestination ->
-                        readIORef lastAssistantRef >>= copyImmediate
-                            "last response"
-                            "no assistant response to copy"
+                        readIORef controls.controlLastAssistantRef
+                            >>= copyImmediate
+                                "last response"
+                                "no assistant response to copy"
                     ReplCopyCode index -> do
-                        answer <- readIORef lastAssistantRef
+                        answer <-
+                            readIORef controls.controlLastAssistantRef
                         let label =
                                 "code block " <> Text.pack (show index)
                         copyImmediate
@@ -1445,7 +1484,8 @@ runSession
                             (label <> " was not found")
                             (answer >>= fencedCodeBlock index)
                     ReplCopyDiff -> do
-                        answer <- readIORef lastAssistantRef
+                        answer <-
+                            readIORef controls.controlLastAssistantRef
                         copyImmediate
                             "diff block"
                             "no diff block was found"
@@ -1487,75 +1527,99 @@ runSession
             (readIORef startup.startupAgentSnapshot >>= id)
             (\target ->
                 readIORef startup.startupAgentSelect >>= ($ target))
-    let sessionAction = do
-            learnedSkills <- skillsRuntime.skillInitialize
-            case pendingTurn of
-                Just pending ->
-                    callbacks.runnerRunPendingTurn
-                        (if startup.startupFullscreenReused
-                            then ContinuePendingTurn
-                            else SubmitPendingTurn)
+
+runSessionInteraction
+    :: SessionRunnerContinuation
+    -> SessionHostRuntime
+    -> SkillContextRuntime
+    -> SessionRequest
+    -> SessionEnv
+    -> IO RunResult
+runSessionInteraction
+        callbacks host skillsRuntime SessionRequest{..} env = do
+    learnedSkills <- skillsRuntime.skillInitialize
+    case pendingTurn of
+        Just pending ->
+            callbacks.runnerRunPendingTurn
+                (if startup.startupFullscreenReused
+                    then ContinuePendingTurn
+                    else SubmitPendingTurn)
+                env
+                pending
+        Nothing -> case promptRequest of
+            Just request -> do
+                inputs <- managedTurnInputs cwd request
+                skillInputs <-
+                    callbacks.runnerPreparePromptSkillInputs
                         env
-                        pending
-                Nothing -> case promptRequest of
-                    Just request -> do
-                        inputs <- managedTurnInputs cwd request
-                        skillInputs <-
-                            callbacks.runnerPreparePromptSkillInputs
-                                env
-                                False
-                                request.managedTurnText
-                                inputs
-                                >>= either
-                                    (startupDie startup . Text.unpack)
-                                    pure
-                        result <- runOneTurn env request.managedTurnText skillInputs
-                        callbacks.runnerFinishTurn env True result
-                    Nothing -> do
-                        initialPrompt <-
-                            atomicModifyIORef'
-                                startup.startupSessionState.sessionInitialPrompt
-                                (\pending -> (Nothing, pending))
-                        case initialPrompt of
-                            Just text -> runInteractiveInitialPrompt env text
-                            Nothing ->
-                                case learnAboutUserOnboardingPrompt learnedSkills of
-                                    Just onboardingPrompt
-                                        | learnAboutUserRequested
-                                        , isNothing initialPrevious ->
-                                            runInteractiveInitialPrompt
-                                                env
-                                                onboardingPrompt
-                                    _ ->
-                                        readIORef
-                                            startup.startupSessionState.sessionDraft
-                                            >>= callbacks.runnerReplWithDraft env
-        runInteractiveInitialPrompt env text = do
-            skillInputs <-
-                callbacks.runnerPreparePromptSkillInputs
-                    env
-                    False
-                    text
-                    [UserMessage text]
-                    >>= either
-                        (startupDie startup . Text.unpack)
-                        pure
-            forM_ fullscreen \runtime ->
-                emitUiEvent runtime (UiUserSubmitted text)
-            result <- runOneTurn env text skillInputs
-            callbacks.runnerFinishTurn env False result
-        btwWorker = do
+                        False
+                        request.managedTurnText
+                        inputs
+                        >>= either
+                            (startupDie startup . Text.unpack)
+                            pure
+                result <- runOneTurn env request.managedTurnText skillInputs
+                callbacks.runnerFinishTurn env True result
+            Nothing -> do
+                initialPrompt <-
+                    atomicModifyIORef'
+                        startup.startupSessionState.sessionInitialPrompt
+                        (\pending -> (Nothing, pending))
+                case initialPrompt of
+                    Just text -> runInteractiveInitialPrompt text
+                    Nothing ->
+                        case learnAboutUserOnboardingPrompt learnedSkills of
+                            Just onboardingPrompt
+                                | learnAboutUserRequested
+                                , isNothing host.hostInitialPrevious ->
+                                    runInteractiveInitialPrompt
+                                        onboardingPrompt
+                            _ ->
+                                readIORef
+                                    startup.startupSessionState.sessionDraft
+                                    >>= callbacks.runnerReplWithDraft env
+  where
+    runInteractiveInitialPrompt text = do
+        skillInputs <-
+            callbacks.runnerPreparePromptSkillInputs
+                env
+                False
+                text
+                [UserMessage text]
+                >>= either
+                    (startupDie startup . Text.unpack)
+                    pure
+        forM_ host.hostFullscreen \runtime ->
+            emitUiEvent runtime (UiUserSubmitted text)
+        result <- runOneTurn env text skillInputs
+        callbacks.runnerFinishTurn env False result
+
+runSessionWorkers
+    :: SessionRunnerContinuation
+    -> SessionHostRuntime
+    -> SessionTitleManager
+    -> SessionEnv
+    -> Chan Text.Text
+    -> Chan RecapRequest
+    -> IO RunResult
+    -> IO RunResult
+runSessionWorkers
+        callbacks host titleManager env
+        btwRequests recapRequests sessionAction = do
+    let btwWorker = do
             question <- readChan btwRequests
             runBtwQuestion False env question
             btwWorker
         recapWorker = do
             request <- readChan recapRequests
             case request of
-                RecapSession kind -> callbacks.runnerRunSessionRecap False env kind
-                RecapTurnSummary -> callbacks.runnerRunSessionTurnSummary env
+                RecapSession kind ->
+                    callbacks.runnerRunSessionRecap False env kind
+                RecapTurnSummary ->
+                    callbacks.runnerRunSessionTurnSummary env
             recapWorker
-    result <- withAsync windowTitleWorker \_ ->
-        case fullscreen of
+    result <- withAsync host.hostWindowTitle.windowTitleWorker \_ ->
+        case host.hostFullscreen of
             Just _ ->
                 withAsync btwWorker \_ ->
                     withAsync recapWorker (const sessionAction)
@@ -1564,3 +1628,51 @@ runSession
     _ <- waitForSessionTitleResults 5000000 titleManager
     applyPendingSessionTitles env
     pure result
+
+runSession
+    :: SessionRunnerContinuation
+    -> SessionRequest
+    -> SessionBackend
+    -> IO RunResult
+runSession callbacks request sessionBackend = do
+    host <- newSessionHostRuntime request
+    withSessionTitleRuntime host request sessionBackend \titleManager -> do
+        controls <- newSessionControlRuntime host request
+        let skillsRuntime =
+                buildSkillContextRuntime
+                    callbacks host controls request sessionBackend
+        loopRuntime <-
+            newSessionLoopRuntime host controls request sessionBackend
+        btwRequests <- newChan
+        recapRequests <- newChan
+        persistenceRuntime <-
+            newSessionPersistenceRuntime host skillsRuntime request
+        let env =
+                buildSessionEnv
+                    host
+                    controls
+                    skillsRuntime
+                    loopRuntime
+                    persistenceRuntime
+                    request
+                    sessionBackend
+                    titleManager
+                    recapRequests
+        installSessionActions
+            callbacks
+            host
+            controls
+            persistenceRuntime
+            request
+            env
+            btwRequests
+            recapRequests
+        runSessionWorkers
+            callbacks
+            host
+            titleManager
+            env
+            btwRequests
+            recapRequests
+            (runSessionInteraction
+                callbacks host skillsRuntime request env)

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -22,6 +22,7 @@ import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Responses.Types (ResponseCreateParams(model))
 import Agent.CLI.Session.Runner.Types
     ( SessionRunnerContinuation(..) )
+import Agent.CLI.AgentViewport (AgentViewportEnv)
 import Agent.CLI.AgentViewport.Runtime
 import Agent.Tools.OutputArtifact
 import Agent.Tools.Background
@@ -35,6 +36,7 @@ import Agent.CLI.Notification
     )
 import Agent.CLI.Approval
 import Agent.CLI.Permission (promptRootAccess)
+import Agent.CLI.ProviderTransition (PendingTurn)
 import Agent.CLI.Recap
 import Agent.CLI.CancelWatch
 import Agent.CLI.Clipboard
@@ -88,7 +90,10 @@ import Agent.CLI.Turn
 import Agent.Cancel
 import Agent.Loop
 import Agent.Dialect
+import Agent.Error (ApiError)
+import Agent.Provider (Provider)
 import Agent.Skills
+import Agent.Store.Postgres.Skill (LearnedSkill)
 import Agent.Subagents
 import Agent.Subagents.TaskPath
 import Agent.ToolDispatch
@@ -96,9 +101,11 @@ import Agent.Tools.MultiAgents
 import Agent.Tools.PlanMode
 import Agent.Tools.Types
 import Agent.OsPath
+import Control.Concurrent (ThreadId)
 import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.Chan (newChan, readChan, writeChan)
-import Control.Concurrent.MVar (newMVar, withMVar)
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
+import Control.Concurrent.STM (STM)
 import Control.Exception.Safe
     ( catchAny
     , mask_
@@ -113,6 +120,7 @@ import Data.Maybe (isJust, isNothing)
 import qualified Data.Text as Text
 import qualified Data.Set as Set
 import Data.Time.Clock (getCurrentTime, utctDay)
+import System.IO (Handle)
 
 formatQueuedPrompts :: [Text.Text] -> Text.Text
 formatQueuedPrompts [] = "No prompts are queued."
@@ -127,121 +135,195 @@ formatQueuedPrompts prompts =
             <> ". "
             <> Text.replace "\n" "\n   " prompt
 
-runSession
-    :: SessionRunnerContinuation
+-- | Host-facing session resources that are established before the title and
+-- turn runtimes. Keeping these together makes the outer session runner a
+-- lifecycle coordinator instead of a second implementation of each host
+-- concern.
+data SessionHostRuntime = SessionHostRuntime
+    { hostInitialPrevious :: !(Maybe Text.Text)
+    , hostGrokFirstTurnContextRef :: !(IORef (Maybe Text.Text))
+    , hostIoLock :: !(MVar ())
+    , hostNativeCapabilities :: !NativeRunCapabilities
+    , hostLoadsWorkspaceContext :: !Bool
+    , hostPreparedWorkspaceEnvironment
+        :: !(Maybe PreparedWorkspaceEnvironment)
+    , hostTerminal :: !TerminalCapabilities
+    , hostStdoutHandle :: !Handle
+    , hostStderrHandle :: !Handle
+    , hostUseColor :: !Bool
+    , hostStderrTty :: !Bool
+    , hostReportSessionError :: !(Text.Text -> IO ())
+    , hostWindowTitle :: !WindowTitleController
+    , hostTitleEvent :: !(SessionTitleEvent -> IO ())
+    , hostFullscreen :: !(Maybe FullscreenRuntime)
+    }
+
+newSessionHostRuntime :: SessionRequest -> IO SessionHostRuntime
+newSessionHostRuntime SessionRequest{..} = do
+    initialPrevious <- readLivePreviousResponseId conversationRef
+    grokFirstTurnContextRef <- newIORef initialGrokContext
+    ioLock <- newMVar ()
+    let fullscreen = startup.startupFullscreen
+        nativeCapabilities =
+            maybe
+                fullNativeRunCapabilities
+                (.nativeCapabilities)
+                startup.startupNativeHooks
+        preparedDiscovery =
+            startup.startupNativeHooks
+                >>= nativePreparedDiscovery . (.nativeWorkspaceDiscovery)
+        loadsHostWorkspaceContext = isNothing preparedDiscovery
+        preparedWorkspaceEnvironment =
+            (\context ->
+                PreparedWorkspaceEnvironment
+                    context.nativeDiscoveryOperatingSystem
+                    context.nativeDiscoveryShell)
+                <$> preparedDiscovery
+        terminal = startup.startupTerminal
+        stdoutHandle = startup.startupStdout
+        stderrHandle = startup.startupStderr
+        useColor = startup.startupUseColor
+        stderrTty = startup.startupStderrTty
+        stdoutTty = startup.startupStdoutTty
+        writeWindowTitle title =
+            case fullscreen of
+                Just runtime -> setFullscreenWindowTitle runtime title
+                Nothing -> setCliWindowTitle stdoutTty stdoutHandle title
+        withIoLock action = withMVar ioLock (const action)
+        requestRootAccess root =
+            approveFilesystemRootAccess policyRef $
+                case startup.startupNativeHooks of
+                    Just hooks -> hooks.nativeRequestRootAccess root
+                    Nothing -> withMVar ioLock \_ ->
+                        case promptRequest of
+                            Just request
+                                | isJust request.managedTurnBridgeDirectory ->
+                                    requestManagedRootAccess request root
+                            _ -> case fullscreen of
+                                Just runtime -> do
+                                    notifyAttention
+                                        stderrHandle
+                                        PermissionRequested
+                                    maybe False (== 0)
+                                        <$> requestFullscreenChoiceWithBody
+                                            runtime
+                                            "Filesystem access requested"
+                                            ("Allow access to " <> toText root
+                                                <> " for this session?")
+                                            0
+                                            [ ( "Allow directory for this session"
+                                              , ""
+                                              )
+                                            , ("Deny", "")
+                                            ]
+                                Nothing ->
+                                    withStdinPaused escPaused
+                                        (promptRootAccess useColor root)
+        reportSessionError message =
+            case fullscreen of
+                Just runtime ->
+                    emitUiEvent runtime (UiErrorMessage message)
+                Nothing -> do
+                    color <- resolveColor stderrHandle
+                    putTextLn stderrHandle
+                        (roleWarn color (glyphWarn <> message))
+    windowTitle <- newWindowTitleController
+        options.optMotionMode
+        startupWindowTitle
+        withIoLock
+        writeWindowTitle
+    setToolRootAccessRequest toolEnv (Just requestRootAccess)
+    let showTitleEvent = \case
+            SessionTitleGenerated SessionTitleResult{..} ->
+                case persist of
+                    PersistenceDisabled -> pure ()
+                    PersistenceEnabled slotRef ->
+                        readIORef slotRef >>= \case
+                            PersistenceActive handle
+                                | handle.sessionMeta.metaId == resultSessionId
+                                , not handle.sessionMeta.metaTitleIsManual ->
+                                    windowTitle.windowTitleSet
+                                        (cliWindowTitle
+                                            handle.sessionMeta.metaCwd
+                                            (Just resultTitle))
+                            _ -> pure ()
+            SessionTitleFailed SessionTitleFailure{..} ->
+                case persist of
+                    PersistenceDisabled -> pure ()
+                    PersistenceEnabled slotRef ->
+                        readIORef slotRef >>= \case
+                            PersistenceActive handle
+                                | handle.sessionMeta.metaId == failureSessionId
+                                , not handle.sessionMeta.metaTitleIsManual ->
+                                    withMVar ioLock \_ -> do
+                                        let message =
+                                                "session title generation failed: "
+                                                    <> failureMessage
+                                        case fullscreen of
+                                            Just runtime ->
+                                                emitUiEvent runtime
+                                                    (UiErrorMessage message)
+                                            Nothing -> do
+                                                color <-
+                                                    resolveColor stderrHandle
+                                                putTextLn stderrHandle
+                                                    (roleWarn color
+                                                        (glyphWarn <> message))
+                            _ -> pure ()
+    pure SessionHostRuntime
+        { hostInitialPrevious = initialPrevious
+        , hostGrokFirstTurnContextRef = grokFirstTurnContextRef
+        , hostIoLock = ioLock
+        , hostNativeCapabilities = nativeCapabilities
+        , hostLoadsWorkspaceContext = loadsHostWorkspaceContext
+        , hostPreparedWorkspaceEnvironment = preparedWorkspaceEnvironment
+        , hostTerminal = terminal
+        , hostStdoutHandle = stdoutHandle
+        , hostStderrHandle = stderrHandle
+        , hostUseColor = useColor
+        , hostStderrTty = stderrTty
+        , hostReportSessionError = reportSessionError
+        , hostWindowTitle = windowTitle
+        , hostTitleEvent = showTitleEvent
+        , hostFullscreen = fullscreen
+        }
+
+withSessionTitleRuntime
+    :: SessionHostRuntime
     -> SessionRequest
     -> SessionBackend
-    -> IO RunResult
-runSession callbacks SessionRequest{..} SessionBackend{..} = do
-  initialPrevious <- readLivePreviousResponseId conversationRef
-  grokFirstTurnContextRef <- newIORef initialGrokContext
-  ioLock <- newMVar ()
-  let fullscreen = startup.startupFullscreen
-      nativeCapabilities =
-          maybe
-              fullNativeRunCapabilities
-              (.nativeCapabilities)
-              startup.startupNativeHooks
-      preparedDiscovery =
-          startup.startupNativeHooks
-              >>= nativePreparedDiscovery . (.nativeWorkspaceDiscovery)
-      loadsHostWorkspaceContext = isNothing preparedDiscovery
-      preparedWorkspaceEnvironment =
-          (\context ->
-              PreparedWorkspaceEnvironment
-                  context.nativeDiscoveryOperatingSystem
-                  context.nativeDiscoveryShell)
-              <$> preparedDiscovery
-      terminal = startup.startupTerminal
-      stdoutHandle = startup.startupStdout
-      stderrHandle = startup.startupStderr
-      useColor = startup.startupUseColor
-      stderrTty = startup.startupStderrTty
-      stdoutTty = startup.startupStdoutTty
-      writeWindowTitle title =
-          case fullscreen of
-              Just runtime -> setFullscreenWindowTitle runtime title
-              Nothing -> setCliWindowTitle stdoutTty stdoutHandle title
-      withIoLock action = withMVar ioLock (const action)
-      requestRootAccess root =
-          approveFilesystemRootAccess policyRef $
-              case startup.startupNativeHooks of
-                Just hooks -> hooks.nativeRequestRootAccess root
-                Nothing -> withMVar ioLock \_ ->
-                  case promptRequest of
-                      Just request
-                          | isJust request.managedTurnBridgeDirectory ->
-                              requestManagedRootAccess request root
-                      _ -> case fullscreen of
-                          Just runtime -> do
-                              notifyAttention stderrHandle PermissionRequested
-                              maybe False (== 0)
-                                  <$> requestFullscreenChoiceWithBody
-                                      runtime
-                                      "Filesystem access requested"
-                                      ("Allow access to " <> toText root
-                                          <> " for this session?")
-                                      0
-                                      [ ("Allow directory for this session", "")
-                                      , ("Deny", "")
-                                      ]
-                          Nothing ->
-                              withStdinPaused escPaused
-                                  (promptRootAccess useColor root)
-      reportSessionError message =
-          case fullscreen of
-              Just runtime ->
-                  emitUiEvent runtime (UiErrorMessage message)
-              Nothing -> do
-                  color <- resolveColor stderrHandle
-                  putTextLn stderrHandle
-                      (roleWarn color (glyphWarn <> message))
-  windowTitle <- newWindowTitleController
-      options.optMotionMode
-      startupWindowTitle
-      withIoLock
-      writeWindowTitle
-  setToolRootAccessRequest toolEnv (Just requestRootAccess)
-  let setWindowTitle = windowTitle.windowTitleSet
-      beginWindowTitleBusy = windowTitle.windowTitleBeginBusy
-      endWindowTitleBusy = windowTitle.windowTitleEndBusy
-      windowTitleWorker = windowTitle.windowTitleWorker
-      showTitleEvent = \case
-        SessionTitleGenerated SessionTitleResult{..} ->
-          case persist of
-              PersistenceDisabled -> pure ()
-              PersistenceEnabled slotRef ->
-                  readIORef slotRef >>= \case
-                      PersistenceActive handle
-                          | handle.sessionMeta.metaId == resultSessionId
-                          , not handle.sessionMeta.metaTitleIsManual ->
-                              setWindowTitle
-                                  (cliWindowTitle handle.sessionMeta.metaCwd
-                                      (Just resultTitle))
-                      _ -> pure ()
-        SessionTitleFailed SessionTitleFailure{..} ->
-          case persist of
-              PersistenceDisabled -> pure ()
-              PersistenceEnabled slotRef ->
-                  readIORef slotRef >>= \case
-                      PersistenceActive handle
-                          | handle.sessionMeta.metaId == failureSessionId
-                          , not handle.sessionMeta.metaTitleIsManual ->
-                              withMVar ioLock \_ -> do
-                                  let message =
-                                          "session title generation failed: "
-                                              <> failureMessage
-                                  case fullscreen of
-                                      Just runtime ->
-                                          emitUiEvent runtime
-                                              (UiErrorMessage message)
-                                      Nothing -> do
-                                          color <- resolveColor stderrHandle
-                                          putTextLn stderrHandle
-                                              (roleWarn color
-                                                  (glyphWarn <> message))
-                      _ -> pure ()
-  withSessionTitleManager btwBackend (readIORef paramsRef) showTitleEvent \titleManager -> do
+    -> (SessionTitleManager -> IO a)
+    -> IO a
+withSessionTitleRuntime host SessionRequest{..} SessionBackend{..} =
+    withSessionTitleManager
+        btwBackend
+        (readIORef paramsRef)
+        host.hostTitleEvent
+
+-- | Mutable controls shared by rendering, tools, persistence, and the agent
+-- viewport. Allocation and viewport registration form one startup phase.
+data SessionControlRuntime = SessionControlRuntime
+    { controlToolRegistry :: !ToolRegistry
+    , controlSteeringInputs :: !SteeringInputs
+    , controlSpinnerRef :: !(IORef (Maybe ThreadId))
+    , controlRenderStateRef :: !(IORef RenderState)
+    , controlAllowedToolsRef :: !(IORef (Set.Set Text.Text))
+    , controlLastAssistantRef :: !(IORef (Maybe Text.Text))
+    , controlModelRef :: !(IORef Text.Text)
+    , controlUnavailableProvidersRef :: !(IORef (Set.Set Provider))
+    , controlStartupUnavailableRef :: !(IORef (Maybe (STM ApiError)))
+    , controlRestartEffortRef :: !(IORef (Maybe Text.Text))
+    , controlLastFailedTurnRef :: !(IORef (Maybe PendingTurn))
+    , controlTitleTurnCount :: !(IORef Int)
+    , controlAgentViewportRuntime :: !AgentViewportRuntime
+    , controlAgentViewport :: !AgentViewportEnv
+    }
+
+newSessionControlRuntime
+    :: SessionHostRuntime
+    -> SessionRequest
+    -> IO SessionControlRuntime
+newSessionControlRuntime host SessionRequest{..} = do
     toolRegistry <- requireToolRegistry allTools
     steeringInputs <- newSteeringInputs
     setBackgroundTaskHooks toolEnv BackgroundTaskHooks
@@ -258,7 +340,6 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
         , backgroundTaskDismissed =
             dismissBackgroundCompletion steeringInputs
         }
-    let previewIdRef = startup.startupSessionState.sessionPreviewId
     spinnerRef <- newIORef Nothing
     renderStateRef <- newIORef emptyRenderState
     allowedToolsRef <- newIORef Set.empty
@@ -287,7 +368,7 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
                 pinSubagentSession
                     storeRoot agentTypes legacyTarget agentId session)
                 `catchAny` \err ->
-                    reportSessionError
+                    host.hostReportSessionError
                         ("failed to select agent: "
                             <> formatException err)
         releaseChild agentId = do
@@ -344,161 +425,278 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             (snd <$> loadAgentSnapshot agentViewportRuntime False)
     writeIORef startup.startupAgentSelect
         (selectAgentViewport agentViewportRuntime)
-    let installSkills context queueContext skills = do
-            before <- readIORef context
-            installSkillToolRoots toolEnv skills
-            omitted <- installSkillCatalogWithOmissions
-                reservedSlashNames queueContext context
-                skillsRef skillInvocationsRef skills
-            after <- readIORef context
-            pure
-                ( omitted
-                , max 0 (contextLength after - contextLength before)
-                )
-        installLearnedSkills context maximum queueContext =
-            loadApplicableLearnedSkillsForStore
-                startup.startupDatabaseStore
-                databaseScopes >>= \case
-                    Left err -> do
+    pure SessionControlRuntime
+        { controlToolRegistry = toolRegistry
+        , controlSteeringInputs = steeringInputs
+        , controlSpinnerRef = spinnerRef
+        , controlRenderStateRef = renderStateRef
+        , controlAllowedToolsRef = allowedToolsRef
+        , controlLastAssistantRef = lastAssistantRef
+        , controlModelRef = modelRef
+        , controlUnavailableProvidersRef = unavailableProvidersRef
+        , controlStartupUnavailableRef = startupUnavailableRef
+        , controlRestartEffortRef = restartEffortRef
+        , controlLastFailedTurnRef = lastFailedTurnRef
+        , controlTitleTurnCount = titleTurnCount
+        , controlAgentViewportRuntime = agentViewportRuntime
+        , controlAgentViewport = agentViewport
+        }
+
+data SkillContextRuntime = SkillContextRuntime
+    { skillReloadGeneratedContext :: !(IO ())
+    , skillResetSession :: !(IO ())
+    , skillRefresh :: !(Bool -> IO ())
+    , skillInitialize :: !(IO [LearnedSkill])
+    }
+
+buildSkillContextRuntime
+    :: SessionRunnerContinuation
+    -> SessionHostRuntime
+    -> SessionControlRuntime
+    -> SessionRequest
+    -> SessionBackend
+    -> SkillContextRuntime
+buildSkillContextRuntime
+        callbacks host controls SessionRequest{..} SessionBackend{..} =
+    SkillContextRuntime
+        { skillReloadGeneratedContext = reloadGeneratedContext
+        , skillResetSession = sessionReset
+        , skillRefresh = refreshSkills
+        , skillInitialize = initializeSkills
+        }
+  where
+    fullscreen = host.hostFullscreen
+    stderrHandle = host.hostStderrHandle
+    loadsHostWorkspaceContext = host.hostLoadsWorkspaceContext
+    renderStateRef = controls.controlRenderStateRef
+    lastAssistantRef = controls.controlLastAssistantRef
+    steeringInputs = controls.controlSteeringInputs
+    agentViewportRuntime = controls.controlAgentViewportRuntime
+    installSkills context queueContext skills = do
+        before <- readIORef context
+        installSkillToolRoots toolEnv skills
+        omitted <- installSkillCatalogWithOmissions
+            reservedSlashNames queueContext context
+            skillsRef skillInvocationsRef skills
+        after <- readIORef context
+        pure
+            ( omitted
+            , max 0 (contextLength after - contextLength before)
+            )
+    installLearnedSkills context maximum queueContext =
+        loadApplicableLearnedSkillsForStore
+            startup.startupDatabaseStore
+            databaseScopes >>= \case
+                Left err -> do
+                    reportLearnedSkillWarning
+                        ("learned skills unavailable: " <> err)
+                    pure []
+                Right learnedSkills -> do
+                    omitted <-
+                        if queueContext
+                            then queueLearnedSkillContextWithOmissions
+                                maximum
+                                context
+                                learnedSkills
+                            else pure 0
+                    when (omitted > 0) $
                         reportLearnedSkillWarning
-                            ("learned skills unavailable: " <> err)
-                        pure []
-                    Right learnedSkills -> do
-                        omitted <-
-                            if queueContext
-                                then queueLearnedSkillContextWithOmissions
-                                    maximum
-                                    context
-                                    learnedSkills
-                                else pure 0
-                        when (omitted > 0) $
-                            reportLearnedSkillWarning
-                                ("learned skills: "
-                                    <> Text.pack (show omitted)
-                                    <> " omitted from model context due to the context budget")
-                        pure learnedSkills
-        reloadGeneratedContext = do
-            freshAgents <-
-                if loadsHostWorkspaceContext
-                    then
-                        loadAgentsContext
-                            stderrHandle
-                            fullscreen
-                            SuppressAgentsContextLoaded
-                            options
-                            dialect
-                            home
-                            cwd
-                            []
-                            Nothing
-                            ((.catalogEnvironmentContext)
-                                <$> codexCatalogSession)
-                    else
-                        newIORef
-                            ((.catalogEnvironmentContext)
-                                <$> codexCatalogSession)
-            freshSkills <-
-                if loadsHostWorkspaceContext
-                    then loadSkillsCatalogQuiet options home projectRoot cwd
-                    else pure (SkillCatalog [] [])
-            (omitted, _) <-
-                installSkills freshAgents True freshSkills
-            reportSkillCatalog True freshSkills omitted
-            void $ installLearnedSkills
-                freshAgents
-                defaultLearnedSkillContextMaxChars
-                True
-            fresh <- readIORef freshAgents
-            writeIORef startupContext fresh
-        sessionReset = do
-            resetLiveConversationWith
-                resetBackendState
-                conversationRef
-                planMode
-            clearImageGenerationHistory
-            writeIORef usageRef emptyTokenUsage
-            writeIORef contextOccupancyRef Nothing
-            modifyIORef' renderStateRef clearRenderTokenRate
-            writeIORef lastAssistantRef Nothing
-            writeIORef subagentSessions Map.empty
-            writeIORef grokFirstTurnContextRef Nothing
-            resetAgentViewport agentViewportRuntime
-            case multiCtx of
-                Just ctx -> resetSubagentRegistry ctx.multiRegistry
-                Nothing -> pure ()
-            clearPendingInputs pendingNotices
-            clearSteeringInputs steeringInputs
-            readIORef toolEnv.toolSessionTmp >>= mapM_ resetToolSessionTemp
-            reloadGeneratedContext
-        refreshSkills queueContext = do
-            refreshed <-
-                if loadsHostWorkspaceContext
-                    then loadSkillsCatalogQuiet options home projectRoot cwd
-                    else pure (SkillCatalog [] [])
-            (omitted, _) <-
-                installSkills startupContext queueContext refreshed
-            when queueContext $
-                reportSkillCatalog True refreshed omitted
-        contextLength = maybe 0 Text.length
-        formatSkillWarning warning =
-            "skill ignored: "
-                <> toText warning.skillWarningPath
-                <> ": "
-                <> warning.skillWarningMessage
-        formatSkillOmission omitted =
-            "skills: "
-                <> Text.pack (show omitted)
-                <> " omitted from model context due to the catalog budget"
-        reportLearnedSkillWarning message =
-            case fullscreen of
-                Nothing -> do
-                    color <- resolveColor stderrHandle
+                            ("learned skills: "
+                                <> Text.pack (show omitted)
+                                <> " omitted from model context due to the context budget")
+                    pure learnedSkills
+    reloadGeneratedContext = do
+        freshAgents <-
+            if loadsHostWorkspaceContext
+                then
+                    loadAgentsContext
+                        stderrHandle
+                        fullscreen
+                        SuppressAgentsContextLoaded
+                        options
+                        dialect
+                        home
+                        cwd
+                        []
+                        Nothing
+                        ((.catalogEnvironmentContext)
+                            <$> codexCatalogSession)
+                else
+                    newIORef
+                        ((.catalogEnvironmentContext)
+                            <$> codexCatalogSession)
+        freshSkills <-
+            if loadsHostWorkspaceContext
+                then loadSkillsCatalogQuiet options home projectRoot cwd
+                else pure (SkillCatalog [] [])
+        (omitted, _) <-
+            installSkills freshAgents True freshSkills
+        reportSkillCatalog True freshSkills omitted
+        void $ installLearnedSkills
+            freshAgents
+            defaultLearnedSkillContextMaxChars
+            True
+        fresh <- readIORef freshAgents
+        writeIORef startupContext fresh
+    sessionReset = do
+        resetLiveConversationWith
+            resetBackendState
+            conversationRef
+            planMode
+        clearImageGenerationHistory
+        writeIORef usageRef emptyTokenUsage
+        writeIORef contextOccupancyRef Nothing
+        modifyIORef' renderStateRef clearRenderTokenRate
+        writeIORef lastAssistantRef Nothing
+        writeIORef subagentSessions Map.empty
+        writeIORef host.hostGrokFirstTurnContextRef Nothing
+        resetAgentViewport agentViewportRuntime
+        case multiCtx of
+            Just ctx -> resetSubagentRegistry ctx.multiRegistry
+            Nothing -> pure ()
+        clearPendingInputs pendingNotices
+        clearSteeringInputs steeringInputs
+        readIORef toolEnv.toolSessionTmp >>= mapM_ resetToolSessionTemp
+        reloadGeneratedContext
+    refreshSkills queueContext = do
+        refreshed <-
+            if loadsHostWorkspaceContext
+                then loadSkillsCatalogQuiet options home projectRoot cwd
+                else pure (SkillCatalog [] [])
+        (omitted, _) <-
+            installSkills startupContext queueContext refreshed
+        when queueContext $
+            reportSkillCatalog True refreshed omitted
+    contextLength = maybe 0 Text.length
+    formatSkillWarning warning =
+        "skill ignored: "
+            <> toText warning.skillWarningPath
+            <> ": "
+            <> warning.skillWarningMessage
+    formatSkillOmission omitted =
+        "skills: "
+            <> Text.pack (show omitted)
+            <> " omitted from model context due to the catalog budget"
+    reportLearnedSkillWarning message =
+        case fullscreen of
+            Nothing -> do
+                color <- resolveColor stderrHandle
+                putTextLn stderrHandle $
+                    roleWarn color (glyphWarn <> message)
+            Just runtime ->
+                emitUiEvent runtime (UiSystemMessage message)
+    reportSkillCatalog includeSummary catalog omitted =
+        case fullscreen of
+            Nothing -> do
+                color <- resolveColor stderrHandle
+                when includeSummary do
+                    let count = length catalog.catalogSkills
                     putTextLn stderrHandle $
-                        roleWarn color (glyphWarn <> message)
-                Just runtime ->
-                    emitUiEvent runtime (UiSystemMessage message)
-        reportSkillCatalog includeSummary catalog omitted =
-            case fullscreen of
-                Nothing -> do
-                    color <- resolveColor stderrHandle
-                    when includeSummary do
-                        let count = length catalog.catalogSkills
-                        putTextLn stderrHandle $
-                            roleMuted color
-                                (glyphSession
-                                    <> "skills: loaded "
-                                    <> Text.pack (show count)
-                                    <> if count == 1
-                                        then " skill"
-                                        else " skills")
-                    mapM_
-                        (putTextLn stderrHandle
-                            . roleWarn color
-                            . (glyphWarn <>)
-                            . formatSkillWarning)
-                        catalog.catalogWarnings
-                    when (omitted > 0) $
-                        putTextLn stderrHandle $
-                            roleWarn color
-                                (glyphWarn <> formatSkillOmission omitted)
-                Just runtime -> do
-                    when includeSummary do
-                        let count = length catalog.catalogSkills
-                        emitUiEvent runtime $
-                            UiSystemMessage
-                                ("skills: loaded "
-                                    <> Text.pack (show count)
-                                    <> if count == 1
-                                        then " skill"
-                                        else " skills")
-                    mapM_
-                        (emitUiEvent runtime
-                            . UiSystemMessage
-                            . formatSkillWarning)
-                        catalog.catalogWarnings
-                    when (omitted > 0) $
-                        emitUiEvent runtime
-                            (UiSystemMessage (formatSkillOmission omitted))
+                        roleMuted color
+                            (glyphSession
+                                <> "skills: loaded "
+                                <> Text.pack (show count)
+                                <> if count == 1
+                                    then " skill"
+                                    else " skills")
+                mapM_
+                    (putTextLn stderrHandle
+                        . roleWarn color
+                        . (glyphWarn <>)
+                        . formatSkillWarning)
+                    catalog.catalogWarnings
+                when (omitted > 0) $
+                    putTextLn stderrHandle $
+                        roleWarn color
+                            (glyphWarn <> formatSkillOmission omitted)
+            Just runtime -> do
+                when includeSummary do
+                    let count = length catalog.catalogSkills
+                    emitUiEvent runtime $
+                        UiSystemMessage
+                            ("skills: loaded "
+                                <> Text.pack (show count)
+                                <> if count == 1
+                                    then " skill"
+                                    else " skills")
+                mapM_
+                    (emitUiEvent runtime
+                        . UiSystemMessage
+                        . formatSkillWarning)
+                    catalog.catalogWarnings
+                when (omitted > 0) $
+                    emitUiEvent runtime
+                        (UiSystemMessage (formatSkillOmission omitted))
+    initializeSkills = do
+        markStartupStage startup "Loading skills…"
+        skills <-
+            if loadsHostWorkspaceContext
+                then loadSkillsCatalogQuiet options home projectRoot cwd
+                else pure (SkillCatalog [] [])
+        (omitted, _) <- installSkills startupContext
+            queueInitialContext
+            skills
+        reportSkillCatalog (isNothing fullscreen) skills omitted
+        learnedSkills <-
+            if needsInitialContext
+                then installLearnedSkills
+                    startupContext
+                    defaultLearnedSkillContextMaxChars
+                    queueInitialContext
+                else pure []
+        callbacks.runnerFinishStartup startup
+        pure learnedSkills
+
+runSession
+    :: SessionRunnerContinuation
+    -> SessionRequest
+    -> SessionBackend
+    -> IO RunResult
+runSession
+        callbacks
+        request@SessionRequest{..}
+        sessionBackend@SessionBackend{..} = do
+  host <- newSessionHostRuntime request
+  let initialPrevious = host.hostInitialPrevious
+      grokFirstTurnContextRef = host.hostGrokFirstTurnContextRef
+      ioLock = host.hostIoLock
+      fullscreen = host.hostFullscreen
+      nativeCapabilities = host.hostNativeCapabilities
+      preparedWorkspaceEnvironment = host.hostPreparedWorkspaceEnvironment
+      terminal = host.hostTerminal
+      stdoutHandle = host.hostStdoutHandle
+      stderrHandle = host.hostStderrHandle
+      useColor = host.hostUseColor
+      stderrTty = host.hostStderrTty
+      reportSessionError = host.hostReportSessionError
+      setWindowTitle = host.hostWindowTitle.windowTitleSet
+      beginWindowTitleBusy = host.hostWindowTitle.windowTitleBeginBusy
+      endWindowTitleBusy = host.hostWindowTitle.windowTitleEndBusy
+      windowTitleWorker = host.hostWindowTitle.windowTitleWorker
+  withSessionTitleRuntime host request sessionBackend \titleManager -> do
+    controls <- newSessionControlRuntime host request
+    let previewIdRef = startup.startupSessionState.sessionPreviewId
+        toolRegistry = controls.controlToolRegistry
+        steeringInputs = controls.controlSteeringInputs
+        spinnerRef = controls.controlSpinnerRef
+        renderStateRef = controls.controlRenderStateRef
+        allowedToolsRef = controls.controlAllowedToolsRef
+        lastAssistantRef = controls.controlLastAssistantRef
+        modelRef = controls.controlModelRef
+        unavailableProvidersRef = controls.controlUnavailableProvidersRef
+        startupUnavailableRef = controls.controlStartupUnavailableRef
+        restartEffortRef = controls.controlRestartEffortRef
+        lastFailedTurnRef = controls.controlLastFailedTurnRef
+        titleTurnCount = controls.controlTitleTurnCount
+        agentViewportRuntime = controls.controlAgentViewportRuntime
+        agentViewport = controls.controlAgentViewport
+        skillsRuntime =
+            buildSkillContextRuntime
+                callbacks host controls request sessionBackend
+        reloadGeneratedContext =
+            skillsRuntime.skillReloadGeneratedContext
+        sessionReset = skillsRuntime.skillResetSession
+        refreshSkills = skillsRuntime.skillRefresh
     managedLoopPublisher <-
         maybe
             (pure (const (pure ())))
@@ -1139,27 +1337,8 @@ runSession callbacks SessionRequest{..} SessionBackend{..} = do
             (readIORef startup.startupAgentSnapshot >>= id)
             (\target ->
                 readIORef startup.startupAgentSelect >>= ($ target))
-    let initializeSkills = do
-            markStartupStage startup "Loading skills…"
-            skills <-
-                if loadsHostWorkspaceContext
-                    then loadSkillsCatalogQuiet options home projectRoot cwd
-                    else pure (SkillCatalog [] [])
-            (omitted, _) <- installSkills startupContext
-                queueInitialContext
-                skills
-            reportSkillCatalog (isNothing fullscreen) skills omitted
-            learnedSkills <-
-                if needsInitialContext
-                    then installLearnedSkills
-                        startupContext
-                        defaultLearnedSkillContextMaxChars
-                        queueInitialContext
-                    else pure []
-            callbacks.runnerFinishStartup startup
-            pure learnedSkills
-        sessionAction = do
-            learnedSkills <- initializeSkills
+    let sessionAction = do
+            learnedSkills <- skillsRuntime.skillInitialize
             case pendingTurn of
                 Just pending ->
                     callbacks.runnerRunPendingTurn


### PR DESCRIPTION
## Summary
- replace the monolithic `runAgentTools` body with typed startup/runtime phase records
- isolate gateway/model selection, collaboration setup, scratch ownership, and MCP/coding acquisition
- centralize tool assembly, callback installation, cleanup ordering, and final session launch

## Validation
- `cabal repl agent-cli:lib:agent-cli` (`Agent.CLI.Runtime.Orchestration.Tools`, 199 modules loaded)
- focused object-code specs: dialects (8), tool schemas (23), Claude permissions (11), MCP status (2), pending inputs (12), web/LSP (10), worktrees (22), subagent model inheritance (7)
- 95 examples, 0 failures
- `git diff --check`
- independent behavior-preservation review: no issues found