### PR TITLE
Render streamed tool arguments in the TUI

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -448,6 +448,8 @@ pendingEventCoalesceKey = \case
         case loopEvent of
             ActivityUpdated _ -> Just CoalesceActivity
             ToolUpdated call -> Just (CoalesceToolUpdate call.callId)
+            ToolArgumentsUpdated call ->
+                Just (CoalesceToolUpdate call.callId)
             ToolOutputUpdated callId _ ->
                 Just (CoalesceToolOutput callId)
             _ -> Nothing
@@ -479,6 +481,7 @@ pendingEventBarrier event =
                 ReasoningDelta _ -> False
                 ActivityUpdated _ -> False
                 ToolUpdated _ -> False
+                ToolArgumentsUpdated _ -> False
                 ToolOutputUpdated _ _ -> False
                 _ -> True
         PendingUi (PendingExactUi _) -> True

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -39,7 +39,7 @@ import Agent.TUI.Presentation
 import Agent.Loop (ImageAttachment(..), LoopEvent(..), emptyTurnOutput)
 import Agent.Provider (Provider(XAIProvider))
 import Agent.Subagents (SubagentId(..))
-import Agent.ToolDispatch (functionToolCall)
+import Agent.ToolDispatch (ToolCall(..), functionToolCall)
 import Agent.TUI.Motion (MotionMode(..))
 import Control.Concurrent.Async (wait, withAsync)
 import Control.Concurrent.STM (readTVarIO)
@@ -179,6 +179,38 @@ spec = describe "fullscreen TUI bridge" do
                         any isNewestOutput rest
                     _ -> False
         newestFollowsBoundary `shouldBe` True
+
+    it "coalesces live tool arguments and lets the canonical call replace them" do
+        runtime <- newBridgeTestRuntime
+        let call arguments =
+                functionToolCall "c1" "apply_patch" arguments
+        emitUiEvent runtime
+            (UiLoop (ToolArgumentsUpdated (call "old")))
+        emitUiEvent runtime (UiLoop (TextDelta "text"))
+        emitUiEvent runtime
+            (UiLoop (ToolArgumentsUpdated (call "latest")))
+        emitUiEvent runtime (UiLoop TurnStarted)
+        emitUiEvent runtime
+            (UiLoop (ToolArgumentsUpdated (call "next")))
+        emitUiEvent runtime
+            (UiLoop (ToolUpdated (call "canonical")))
+        let AppEventMailbox stateRef = runtime.runtimeMailbox
+        pending <- (.mailboxPendingEvents) <$> readTVarIO stateRef
+        [ arguments
+            | PendingUi
+                (PendingExactUi
+                    (UiLoop (ToolArgumentsUpdated toolCall))) <-
+                toList pending
+            , let arguments = toolCall.arguments
+            ]
+            `shouldBe` ["latest"]
+        [ arguments
+            | PendingUi
+                (PendingExactUi (UiLoop (ToolUpdated toolCall))) <-
+                toList pending
+            , let arguments = toolCall.arguments
+            ]
+            `shouldBe` ["canonical"]
 
     it "backpressures a single streaming mailbox node by payload bytes" do
         runtime <- newBridgeTestRuntime

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -1021,6 +1021,7 @@ visibleResponseActivity = \case
 data LoopEventCoalescingKey
     = AssistantTextDelta
     | AssistantReasoningDelta
+    | ToolArgumentsSnapshot !Text
     | ToolOutputSnapshot !Text
     | NativeAgentOutputDelta !Text
     deriving (Eq)
@@ -1033,6 +1034,13 @@ emitLoopEvent pump = \case
         emitAppendedText pump AssistantTextDelta TextDelta text
     ReasoningDelta text ->
         emitAppendedText pump AssistantReasoningDelta ReasoningDelta text
+    ToolArgumentsUpdated call ->
+        emitLatestText
+            pump
+            (ToolArgumentsSnapshot call.callId)
+            (\arguments ->
+                ToolArgumentsUpdated (call { arguments = arguments }))
+            call.arguments
     ToolOutputUpdated callId output ->
         emitLatestText
             pump

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -482,6 +482,53 @@ spec = describe "runLoop" do
             , TurnFinished (emptyTurnOutput "resp-1" [] (Just "done"))
             ]
 
+    it "keeps only the latest adjacent tool-argument snapshot per call" do
+        sinkStarted <- newEmptyMVar
+        releaseSink <- newEmptyMVar
+        backendFinished <- newEmptyMVar
+        events <- newIORef []
+        let preview callId arguments =
+                ToolArgumentsUpdated
+                    (functionToolCall callId "apply_patch" arguments)
+            backend = Backend \_state _prev _inputs onEvent -> do
+                onEvent (preview "c1" "a")
+                onEvent (preview "c1" "ab")
+                onEvent (preview "c2" "x")
+                onEvent (preview "c2" "xy")
+                onEvent (preview "c1" "abc")
+                putMVar backendFinished ()
+                pure $ Right BackendResult
+                    { backendOutput =
+                        emptyTurnOutput "resp-1" [] (Just "done")
+                    , backendState = emptyBackendSnapshot
+                    }
+            onEvent event = do
+                modifyIORef' events (event :)
+                case event of
+                    TurnStarted -> do
+                        putMVar sinkStarted ()
+                        takeMVar releaseSink
+                    _ -> pure ()
+        config0 <- testConfig backend
+        let config = config0 { loopOnEvent = onEvent }
+        withAsync (runLoop config Nothing "go") \running -> do
+            takeMVar sinkStarted
+            takeMVar backendFinished
+            putMVar releaseSink ()
+            wait running `shouldReturn` Right LoopResult
+                { finalResponseId = "resp-1"
+                , finalText = Just "done"
+                , turnsUsed = 1
+                , tokenUsage = emptyTokenUsage
+                }
+        reverse <$> readIORef events `shouldReturn`
+            [ TurnStarted
+            , preview "c1" "ab"
+            , preview "c2" "xy"
+            , preview "c1" "abc"
+            , TurnFinished (emptyTurnOutput "resp-1" [] (Just "done"))
+            ]
+
     it "bounds a single oversized live tool-output snapshot" do
         delivered <- newIORef Nothing
         let oversized =

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -859,6 +859,7 @@ openAiBackendWithRetryPoliciesAndReasoningVisibility
     isVisibleModelOutput = \case
         TextDelta{} -> True
         ReasoningDelta{} -> True
+        ToolArgumentsUpdated{} -> True
         _ -> False
 
 transientStreamingResultPolicy :: RetryPolicyM IO

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1037,6 +1037,53 @@ spec = do
                 , ActivityUpdated "Reconnecting to Codex (attempt 1)…"
                 ]
 
+        it "keeps a streamed apply_patch preview across reconnects" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            events <- newIORef []
+            let patch = "*** Begin Patch\n"
+                send _request _previous onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    attempt <- readIORef attempts
+                    if attempt == 1
+                        then do
+                            onEvent ResponseOutputItemAddedEvent
+                                { item =
+                                    customCallItem
+                                        "patch-1"
+                                        "apply_patch"
+                                        ""
+                                , outputIndex = Just 0
+                                , sequenceNumber = Nothing
+                                }
+                            onEvent ResponseCustomToolInputDeltaEvent
+                                { delta = Just patch
+                                , streamItemId = Nothing
+                                , streamCallId = Just "patch-1"
+                                , streamOutputIndex = Just 0
+                                , sequenceNumber = Nothing
+                                }
+                            pure (Left (ConnectionError "socket closed"))
+                        else pure (Right
+                            (testResponse "resp-replayed" [assistantItem "ok"]))
+                backend = openAiBackendWithRetryPolicies
+                    (constantDelay 0 <> limitRetries 3)
+                    (constantDelay 0 <> limitRetries 5)
+                    send
+                    (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-replayed" [] (Just "ok"))
+            readIORef attempts `shouldReturn` 2
+            recorded <- reverse <$> readIORef events
+            let previews =
+                    [call | ToolArgumentsUpdated call <- recorded]
+            previews `shouldBe`
+                [customToolCall "patch-1" "apply_patch" patch]
+            length [() | ResponseRestarted _ <- recorded] `shouldBe` 1
+            [() | ResponseAttemptDiscarded <- recorded] `shouldBe` []
+
         it "reports the transport failure once the reconnect policy is exhausted" do
             attempts <- newIORef (0 :: Int)
             transcript <- newIORef []

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -937,8 +937,8 @@ codexRateLimitsWarning limits =
 
 -- | Stateful projection of one streamed response attempt into loop events.
 --
--- On top of 'streamEventToLoopEventWithRawReasoning' this surfaces streamed
--- shell arguments as a repaintable command preview and reports coarse activity
+-- On top of 'streamEventToLoopEventWithRawReasoning' this surfaces selected
+-- streamed arguments as repaintable tool previews and reports coarse activity
 -- for other tools. It also warns when a model gets stuck in a degenerate
 -- repetition loop inside one call (observed as multi-minute 128k-output-token
 -- samples whose arguments repeat @\\u0000@ or a hallucinated path segment).
@@ -994,10 +994,18 @@ data ToolArgumentStreamState = ToolArgumentStreamState
     , toolCallsById :: !(Map Text ToolCall)
     , currentToolCall :: !(Maybe ToolCall)
     , shellPreviewsByCallId :: !(Map Text Text)
+    , rawPreviewsByCallId :: !(Map Text RawArgumentPreview)
     , currentToolName :: !(Maybe Text)
     , streamedArgumentChars :: !Int
     , announcedArgumentChars :: !Int
     , warnedArgumentChars :: !Int
+    }
+
+data RawArgumentPreview = RawArgumentPreview
+    { publishedRawArguments :: !Text
+    , pendingRawArgumentChunks :: ![Text]
+    , pendingRawArgumentChars :: !Int
+    , retainedRawArgumentChars :: !Int
     }
 
 emptyToolArgumentStreamState :: ToolArgumentStreamState
@@ -1006,6 +1014,7 @@ emptyToolArgumentStreamState = ToolArgumentStreamState
     , toolCallsById = Map.empty
     , currentToolCall = Nothing
     , shellPreviewsByCallId = Map.empty
+    , rawPreviewsByCallId = Map.empty
     , currentToolName = Nothing
     , streamedArgumentChars = 0
     , announcedArgumentChars = 0
@@ -1065,7 +1074,7 @@ announceToolCall maybeCall name identities state =
         , currentToolName = Just name
         }
     , [ ActivityUpdated (writingToolCallActivity name Nothing)
-      | not (isLiveShellTool name)
+      | not (isLiveArgumentTool name)
       ]
     )
 
@@ -1092,10 +1101,20 @@ resolveToolCall identities state =
   where
     firstJust = foldr (<|>) Nothing
 
--- Keep enough raw arguments to render a useful one-line shell preview without
--- accumulating an unbounded repeated strict Text value for runaway calls.
-liveToolArgumentPrefixChars :: Int
-liveToolArgumentPrefixChars = 4096
+-- Keep live previews useful without retaining unbounded repeated strict Text
+-- values for runaway calls. Shell previews only need one command line, while
+-- apply_patch needs enough source to show a representative multi-file diff.
+liveShellArgumentPrefixChars :: Int
+liveShellArgumentPrefixChars = 4096
+
+liveRawArgumentPrefixChars :: Int
+liveRawArgumentPrefixChars = 64 * 1024
+
+-- Publish the first raw fragment immediately, then batch very small provider
+-- deltas. Rebuilding a cumulative strict Text for every token is quadratic
+-- and can also make terminal repainting dominate a long patch stream.
+liveRawArgumentPublishChunkChars :: Int
+liveRawArgumentPublishChunkChars = 256
 
 updateToolArguments
     :: [Maybe Text]
@@ -1109,6 +1128,8 @@ updateToolArguments identities delta state =
             Just call
                 | isLiveShellTool call.name ->
                     updateLiveShellCall call delta state
+                | isLiveRawArgumentTool call.name ->
+                    updateLiveRawCall call delta state
             _ -> (state, [])
         (counted, activityEvents) =
             countToolArgumentChars name (Text.length delta) withDraft
@@ -1121,13 +1142,11 @@ updateLiveShellCall
     -> (ToolArgumentStreamState, [LoopEvent])
 updateLiveShellCall call delta state =
     let rawArguments =
-            Text.take liveToolArgumentPrefixChars (call.arguments <> delta)
+            appendArgumentPrefix
+                liveShellArgumentPrefixChars
+                call.arguments
+                delta
         updatedCall = withToolArguments call rawArguments
-        updatedCalls =
-            Map.map
-                (\known ->
-                    if known.callId == call.callId then updatedCall else known)
-                state.toolCallsById
         maybeCommand = jsonTextFieldPartial "command" rawArguments
         preview = Text.takeWhile (/= '\n') <$> maybeCommand
         previousPreview = Map.lookup call.callId state.shellPreviewsByCallId
@@ -1139,10 +1158,8 @@ updateLiveShellCall call delta state =
                 Text.decodeUtf8
                     (LBS.toStrict
                         (Aeson.encode (Aeson.object ["command" Aeson..= command])))
-        next = state
-            { toolCallsById = updatedCalls
-            , currentToolCall = Just updatedCall
-            , shellPreviewsByCallId =
+        next = (trackUpdatedToolCall updatedCall state)
+            { shellPreviewsByCallId =
                 maybe state.shellPreviewsByCallId
                     (\value -> Map.insert call.callId value
                         state.shellPreviewsByCallId)
@@ -1155,6 +1172,103 @@ updateLiveShellCall call delta state =
       , command <- maybeToList preview
       ]
     )
+
+updateLiveRawCall
+    :: ToolCall
+    -> Text
+    -> ToolArgumentStreamState
+    -> (ToolArgumentStreamState, [LoopEvent])
+updateLiveRawCall call delta state =
+    let preview = Map.findWithDefault
+            (initialRawArgumentPreview call)
+            call.callId
+            state.rawPreviewsByCallId
+        room =
+            liveRawArgumentPrefixChars - preview.retainedRawArgumentChars
+        retainedDelta = Text.copy (Text.take room delta)
+        retainedDeltaChars = Text.length retainedDelta
+        pendingChars =
+            preview.pendingRawArgumentChars + retainedDeltaChars
+        withDelta = preview
+            { pendingRawArgumentChunks =
+                [retainedDelta | retainedDeltaChars > 0]
+                    <> preview.pendingRawArgumentChunks
+            , pendingRawArgumentChars = pendingChars
+            , retainedRawArgumentChars =
+                preview.retainedRawArgumentChars + retainedDeltaChars
+            }
+        shouldPublish =
+            retainedDeltaChars > 0
+                && ( Text.null preview.publishedRawArguments
+                    || pendingChars >= liveRawArgumentPublishChunkChars
+                    || withDelta.retainedRawArgumentChars
+                        == liveRawArgumentPrefixChars
+                   )
+        rawArguments =
+            preview.publishedRawArguments
+                <> Text.concat (reverse withDelta.pendingRawArgumentChunks)
+        published = withDelta
+            { publishedRawArguments = rawArguments
+            , pendingRawArgumentChunks = []
+            , pendingRawArgumentChars = 0
+            }
+        nextPreview = if shouldPublish then published else withDelta
+        withPreview = state
+            { rawPreviewsByCallId =
+                Map.insert call.callId nextPreview state.rawPreviewsByCallId
+            }
+        updatedCall = withToolArguments call rawArguments
+    in if shouldPublish
+        then
+            ( trackUpdatedToolCall updatedCall withPreview
+            , [ToolArgumentsUpdated updatedCall]
+            )
+        else (withPreview, [])
+
+initialRawArgumentPreview :: ToolCall -> RawArgumentPreview
+initialRawArgumentPreview call =
+    let initial =
+            Text.copy
+                (Text.take liveRawArgumentPrefixChars call.arguments)
+    in RawArgumentPreview
+        { publishedRawArguments = initial
+        , pendingRawArgumentChunks = []
+        , pendingRawArgumentChars = 0
+        , retainedRawArgumentChars = Text.length initial
+        }
+
+trackUpdatedToolCall
+    :: ToolCall
+    -> ToolArgumentStreamState
+    -> ToolArgumentStreamState
+trackUpdatedToolCall updatedCall state =
+    state
+        { toolCallsById =
+            Map.map
+                (\known ->
+                    if known.callId == updatedCall.callId
+                        then updatedCall
+                        else known)
+                state.toolCallsById
+        , currentToolCall = Just updatedCall
+        }
+
+appendArgumentPrefix :: Int -> Text -> Text -> Text
+appendArgumentPrefix limit previous delta
+    | room <= 0 = previous
+    | Text.null previous = retainedDelta
+    | otherwise = previous <> retainedDelta
+  where
+    room = limit - Text.length previous
+    retainedDelta = Text.copy (Text.take room delta)
+
+isLiveArgumentTool :: Text -> Bool
+isLiveArgumentTool name =
+    isLiveShellTool name || isLiveRawArgumentTool name
+
+isLiveRawArgumentTool :: Text -> Bool
+isLiveRawArgumentTool name =
+    canonicalToolName name `elem` ["apply_patch"]
 
 isLiveShellTool :: Text -> Bool
 isLiveShellTool name =
@@ -1198,7 +1312,7 @@ countToolArgumentChars name deltaChars state =
         }
     , [ ActivityUpdated (writingToolCallActivity name (Just total))
       | announce
-      , not (isLiveShellTool name)
+      , not (isLiveArgumentTool name)
       ]
         <> [ WarningRaised (runawayToolArgumentWarning name total)
            | warn

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -61,7 +61,6 @@ import Agent.Responses.Types
 import Agent.Responses.Types.Items (responseItemDecoder)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Aeson.Key as Key
 import Data.IORef
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Either (isLeft)
@@ -814,9 +813,8 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
         map encodedField (requestInputItems request) !! 1
             `shouldBe` Just (Aeson.String "opaque")
 
--- | Streamed tool calls are announced immediately. Shell argument deltas
--- repaint that call with the partial command, while other tools retain coarse
--- activity updates.
+-- | Streamed tool calls are announced immediately. Selected argument deltas
+-- repaint the call, while other tools retain coarse activity updates.
 streamProjectionSpec :: Spec
 streamProjectionSpec = describe "newStreamEventToLoopEvents" do
     it "publishes Codex weekly capacity updates for retained prompt chrome" do
@@ -888,15 +886,65 @@ streamProjectionSpec = describe "newStreamEventToLoopEvents" do
         events <- projectEvent
             (customToolCallAdded "ct-1" "call-9" "apply_patch")
         events `shouldBe`
-            [ ToolStarted ToolCall
-                { callId = "call-9"
-                , name = "apply_patch"
-                , arguments = ""
-                , callKind = CustomCallKind
-                , argumentsEncrypted = False
-                }
-            , ActivityUpdated "Writing apply_patch call…"
+            [ToolStarted (customToolCall "call-9" "apply_patch" "")]
+
+    it "repaints streamed apply_patch input as it arrives" do
+        projectEvent <- newStreamEventToLoopEvents False
+        _ <- projectEvent
+            (customToolCallAdded "ct-1" "call-9" "apply_patch")
+        let prefix = "*** Begin Patch\n*** Update File: A.hs\n"
+        first <- projectEvent
+            (customInputDelta "ct-1" "call-9" prefix)
+        first `shouldBe`
+            [ ToolArgumentsUpdated
+                (customToolCall
+                    "call-9"
+                    "apply_patch"
+                    prefix)
             ]
+        let continuation =
+                "@@\n-old\n+new\n" <> Text.replicate 256 "x"
+        second <- projectEvent
+            (customInputDelta "ct-1" "call-9" continuation)
+        second `shouldBe`
+            [ ToolArgumentsUpdated
+                (customToolCall
+                    "call-9"
+                    "apply_patch"
+                    (prefix <> continuation))
+            ]
+
+    it "batches tiny apply_patch deltas without losing their content" do
+        projectEvent <- newStreamEventToLoopEvents False
+        _ <- projectEvent
+            (customToolCallAdded "ct-1" "call-9" "apply_patch")
+        batches <- mapM
+            (\_ -> projectEvent (customInputDelta "ct-1" "call-9" "x"))
+            [1 :: Int .. 8193]
+        let previews =
+                [ call.arguments
+                | ToolArgumentsUpdated call <- concat batches
+                ]
+        length previews `shouldSatisfy` (< 40)
+        last previews `shouldBe` Text.replicate 8193 "x"
+
+    it "bounds a live apply_patch preview" do
+        projectEvent <- newStreamEventToLoopEvents False
+        _ <- projectEvent
+            (customToolCallAdded "ct-1" "call-9" "apply_patch")
+        let retained = Text.replicate (64 * 1024) "p"
+        first <- projectEvent
+            (customInputDelta
+                "ct-1"
+                "call-9"
+                (retained <> "not retained"))
+        first `shouldBe`
+            [ ToolArgumentsUpdated
+                (customToolCall "call-9" "apply_patch" retained)
+            ]
+        second <- projectEvent
+            (customInputDelta "ct-1" "call-9" "still not retained")
+        second `shouldBe` []
 
     it "updates a streamed custom tool from its done item" do
         projectEvent <- newStreamEventToLoopEvents False
@@ -909,13 +957,8 @@ streamProjectionSpec = describe "newStreamEventToLoopEvents" do
                 "apply_patch"
                 "*** Begin Patch")
         events `shouldBe`
-            [ ToolUpdated ToolCall
-                { callId = "call-9"
-                , name = "apply_patch"
-                , arguments = "*** Begin Patch"
-                , callKind = CustomCallKind
-                , argumentsEncrypted = False
-                }
+            [ ToolUpdated
+                (customToolCall "call-9" "apply_patch" "*** Begin Patch")
             ]
 
     it "does not replace a shell preview with coarse argument activity" do
@@ -946,11 +989,12 @@ streamProjectionSpec = describe "newStreamEventToLoopEvents" do
 
     it "counts custom tool input as argument streaming" do
         projectEvent <- newStreamEventToLoopEvents False
-        _ <- projectEvent (customToolCallAdded "ct-1" "call-9" "apply_patch")
+        _ <- projectEvent
+            (customToolCallAdded "ct-1" "call-9" "large_custom_tool")
         loud <- projectEvent
             (customInputDelta "ct-1" "call-9" (Text.replicate 10000 "p"))
         loud `shouldBe`
-            [ActivityUpdated "Writing apply_patch call… (10k chars)"]
+            [ActivityUpdated "Writing large_custom_tool call… (10k chars)"]
 
     it "keeps plain deltas mapped through the pure projection" do
         projectEvent <- newStreamEventToLoopEvents False
@@ -974,6 +1018,15 @@ functionToolCall functionCallId functionName functionArguments = ToolCall
     , argumentsEncrypted = False
     }
 
+customToolCall :: Text.Text -> Text.Text -> Text.Text -> ToolCall
+customToolCall customCallId customName customInput = ToolCall
+    { callId = customCallId
+    , name = customName
+    , arguments = customInput
+    , callKind = CustomCallKind
+    , argumentsEncrypted = False
+    }
+
 functionCallAdded :: Text.Text -> Text.Text -> Text.Text -> ResponseStreamEvent
 functionCallAdded functionItemId functionCallId functionName =
     ResponseOutputItemAddedEvent
@@ -992,7 +1045,6 @@ functionCallAdded functionItemId functionCallId functionName =
         , sequenceNumber = Just 1
 
         }
-
 functionCallDone
     :: Text.Text
     -> Text.Text
@@ -1144,12 +1196,5 @@ developerMessage messageText contentItemKinds =
             , createTime = Nothing
             , contentItemKinds = Just contentItemKinds
             , executedToolCalls = Nothing
-
             }
-
         }
-
-jsonField :: Text.Text -> Aeson.Value -> Maybe Aeson.Value
-jsonField fieldName = \case
-    Aeson.Object object -> KeyMap.lookup (Key.fromText fieldName) object
-    _ -> Nothing

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1662,8 +1662,22 @@ spec = describe "fullscreen UI reducer" do
         map (.blockInspectionGroupable) blocks
             `shouldBe` [False, False]
 
-    it "shows an apply_patch diff while running and after completion" do
-        let call =
+    it "repaints an apply_patch diff while input streams" do
+        let early =
+                customToolCall
+                    "patch-1"
+                    "apply_patch"
+                    ""
+            preview =
+                customToolCall
+                    "patch-1"
+                    "apply_patch"
+                    "*** Begin Patch\n\
+                    \*** Update File: A.hs\n\
+                    \@@\n\
+                    \-old\n\
+                    \+ne"
+            canonical =
                 customToolCall
                     "patch-1"
                     "apply_patch"
@@ -1673,11 +1687,14 @@ spec = describe "fullscreen UI reducer" do
                     \-old\n\
                     \+new\n\
                     \*** End Patch"
-            started =
+            running =
                 apply
                     [ UiLoop TurnStarted
-                    , UiLoop (ToolStarted call)
+                    , UiLoop (ToolStarted early)
+                    , UiLoop (ToolArgumentsUpdated preview)
                     ]
+            updated =
+                reduceUi (UiLoop (ToolUpdated canonical)) running
             finished =
                 reduceUi
                     (UiLoop
@@ -1687,12 +1704,13 @@ spec = describe "fullscreen UI reducer" do
                                 , output = "Updated A.hs"
                                 , callKind = CustomCallKind
                                 }))
-                    started
-        case Foldable.toList started.uiBlocks of
+                    updated
+        case Foldable.toList running.uiBlocks of
             [block] -> do
                 block.blockKind `shouldBe` BlockEdit
                 block.blockBody `shouldSatisfy` Text.isInfixOf "-old"
-                block.blockBody `shouldSatisfy` Text.isInfixOf "+new"
+                block.blockBody `shouldSatisfy` Text.isInfixOf "+ne"
+                block.blockState `shouldBe` BlockRunning
             _ -> expectationFailure "expected one running edit block"
         case Foldable.toList finished.uiBlocks of
             [block] -> do


### PR DESCRIPTION
## Summary
- publish cumulative streamed tool-argument snapshots so `apply_patch` appears as soon as input begins
- coalesce bounded live previews by call id and replace them with the canonical completed tool call
- preserve streamed previews across OpenAI reconnects while keeping existing shell-command previews intact

## Testing
- focused GHCi tests across agent-responses, agent-core, agent-tui, agent-cli, and agent-openai (17 examples)
- live fullscreen tmux smoke with a 120-line `apply_patch`, confirming multiple incremental redraw states and the final canonical edit
