### PR TITLE
Reject malformed Gemini function arguments

### DIFF
--- a/packages/agent-gemini/src/Agent/Gemini/Request.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Request.hs
@@ -39,7 +39,9 @@ buildRequest
 buildRequest fallbackModel params = do
     (tools, customToolNames) <-
         projectTools (enabledTools params.toolChoice params.tools)
-    projection <- projectInput customToolNames params.input
+    projection <- projectInput
+        (declaredCustomToolNames params.tools)
+        params.input
     let model = normalizeModelId
             (fromMaybe fallbackModel params.model)
         systemTexts =
@@ -77,6 +79,16 @@ enabledTools
     -> Maybe [ResponseTool]
 enabledTools (Just (ToolChoiceMode ToolChoiceNone)) _ = Nothing
 enabledTools _ tools = tools
+
+declaredCustomToolNames :: Maybe [ResponseTool] -> Set Text
+declaredCustomToolNames =
+    maybe Set.empty (Set.unions . map customNames)
+  where
+    customNames = \case
+        CustomToolValue tool -> Set.singleton tool.name
+        NamespaceToolValue namespace ->
+            Set.unions (map customNames namespace.tools)
+        _ -> Set.empty
 
 data Projection = Projection
     { systemTexts :: ![Text]

--- a/packages/agent-gemini/src/Agent/Gemini/Request.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Request.hs
@@ -114,11 +114,11 @@ projectItem projection = \case
     ReasoningItemValue reasoning ->
         pure (projectReasoning projection reasoning)
     FunctionCallItem call ->
-        pure (projectFunctionCall projection call)
+        projectFunctionCall projection call
     FunctionCallOutputItem callOutput ->
         pure (projectFunctionOutput projection callOutput)
     CustomToolCallItem call ->
-        pure (projectCustomToolCall projection call)
+        projectCustomToolCall projection call
     CustomToolCallOutputItem callOutput ->
         pure (projectCustomToolOutput projection callOutput)
     -- Local compaction snapshots are represented by ordinary messages. The
@@ -200,32 +200,41 @@ projectReasoning projection reasoning
         reasoning.encryptedContent
             <|> projection.pendingThoughtSignature
 
-projectFunctionCall :: Projection -> FunctionCall -> Projection
-projectFunctionCall projection call =
-    appendContent "model" [part] projection
+projectFunctionCall
+    :: Projection
+    -> FunctionCall
+    -> Either ApiError Projection
+projectFunctionCall projection call = do
+    args <-
+        if call.name `Set.member` projection.customToolNames
+            then pure (object ["input" .= call.arguments])
+            else case Aeson.eitherDecodeStrict' (encodeUtf8 call.arguments) of
+                Right value -> pure value
+                Left _ -> Left $ ProviderError InvalidRequestError
+                    ( "Gemini function call `" <> call.name
+                        <> "` arguments must be valid JSON"
+                    )
+                    Nothing
+    pure $ appendContent "model" [part args] projection
         { callNames = Map.insert call.callId call.name projection.callNames
         , pendingThoughtSignature = Nothing
         }
   where
-    args
-        | call.name `Set.member` projection.customToolNames =
-            object ["input" .= call.arguments]
-        | otherwise =
-            case Aeson.eitherDecodeStrict' (encodeUtf8 call.arguments) of
-                Right value -> value
-                Left _ -> Object KeyMap.empty
-    functionCall = object
+    functionCall args = object
         [ "id" .= call.callId
         , "name" .= call.name
         , "args" .= args
         ]
-    part = object $
-        ["functionCall" .= functionCall]
+    part args = object $
+        ["functionCall" .= functionCall args]
             <> maybe []
                 (\signature -> ["thoughtSignature" .= signature])
                 projection.pendingThoughtSignature
 
-projectCustomToolCall :: Projection -> CustomToolCall -> Projection
+projectCustomToolCall
+    :: Projection
+    -> CustomToolCall
+    -> Either ApiError Projection
 projectCustomToolCall projection call =
     projectFunctionCall projection FunctionCall
         { itemId = call.itemId

--- a/packages/agent-gemini/test/Agent/Gemini/RequestSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/RequestSpec.hs
@@ -1,5 +1,6 @@
 module Agent.Gemini.RequestSpec (spec) where
 
+import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Gemini.Request
 import Agent.Responses.Types
 import Data.Aeson (Value(..), object, (.=))
@@ -78,6 +79,47 @@ spec = describe "Gemini request projection" do
             `shouldBe`
                 Right (object ["contents" .= ([] :: [Value])])
 
+    it "projects valid JSON arguments for ordinary function calls" do
+        let params :: ResponseCreateParams
+            params = withInput
+                (Just (ResponseInputItems
+                    [functionCall "lookup" "{\"query\":\"weather\"}"]))
+                defaultResponseCreateParams
+        fmap (.requestBody) (buildRequest "gemini-test" params)
+            `shouldBe`
+                Right
+                    (object
+                        [ "contents" .=
+                            [ object
+                                [ "role" .= ("model" :: Text)
+                                , "parts" .=
+                                    [ object
+                                        [ "functionCall" .= object
+                                            [ "id" .= ("call-1" :: Text)
+                                            , "name" .= ("lookup" :: Text)
+                                            , "args" .= object
+                                                [ "query" .= ("weather" :: Text)
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ])
+
+    it "rejects malformed JSON arguments for ordinary function calls" do
+        let params :: ResponseCreateParams
+            params = withInput
+                (Just (ResponseInputItems
+                    [functionCall "lookup" "{not json"]))
+                defaultResponseCreateParams
+        buildRequest "gemini-test" params
+            `shouldBe`
+                Left
+                    (ProviderError InvalidRequestError
+                        "Gemini function call `lookup` arguments must be valid JSON"
+                        Nothing)
+
     it "adapts freeform custom tools and preserves raw replay input" do
         let patch = "*** Begin Patch\n*** End Patch"
             custom = CustomToolValue CustomTool
@@ -85,16 +127,7 @@ spec = describe "Gemini request projection" do
                 , description = Just "Apply a patch."
                 , format = Nothing
                 }
-            call = FunctionCallItem FunctionCall
-                { itemId = Just "item-1"
-                , callId = "call-1"
-                , name = "apply_patch"
-                , namespace = Nothing
-                , provider = Just "gemini"
-                , arguments = patch
-                , encryptedFunctionArgs = Nothing
-                , status = Just ItemCompleted
-                }
+            call = functionCall "apply_patch" patch
             params = defaultResponseCreateParams
                 { tools = Just [custom]
                 , input = Just (ResponseInputItems [call])
@@ -189,10 +222,23 @@ spec = describe "Gemini request projection" do
         , content = MessageContentText text, status = Nothing
         , phase = Nothing, passthrough = Nothing
         }
+    functionCall callName callArguments = FunctionCallItem FunctionCall
+        { itemId = Just "item-1"
+        , callId = "call-1"
+        , name = callName
+        , namespace = Nothing
+        , provider = Just "gemini"
+        , arguments = callArguments
+        , encryptedFunctionArgs = Nothing
+        , status = Just ItemCompleted
+        }
     member key objectValue = KeyMap.member (Key.fromText key) objectValue
 
     withTools value ResponseCreateParams{..} =
         ResponseCreateParams { tools = value, .. }
+
+    withInput value ResponseCreateParams{..} =
+        ResponseCreateParams { input = value, .. }
 
     withToolChoice value ResponseCreateParams{..} =
         ResponseCreateParams { toolChoice = value, .. }

--- a/packages/agent-gemini/test/Agent/Gemini/RequestSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/RequestSpec.hs
@@ -183,6 +183,42 @@ spec = describe "Gemini request projection" do
                         ]
                     ]
 
+    it "preserves custom replay input when tools are disabled" do
+        let patch = "*** Begin Patch\n*** End Patch"
+            custom = CustomToolValue CustomTool
+                { name = "apply_patch"
+                , description = Just "Apply a patch."
+                , format = Nothing
+                }
+            params = defaultResponseCreateParams
+                { tools = Just [custom]
+                , toolChoice = Just (ToolChoiceMode ToolChoiceNone)
+                , input = Just
+                    (ResponseInputItems [functionCall "apply_patch" patch])
+                }
+        case buildRequest "gemini-test" params of
+            Left err -> expectationFailure
+                ("unexpected request error: " <> show err)
+            Right request -> do
+                request.requestCustomToolNames `shouldBe` Set.empty
+                request.requestBody `shouldBe` object
+                    [ "contents" .=
+                        [ object
+                            [ "role" .= ("model" :: Text)
+                            , "parts" .=
+                                [ object
+                                    [ "functionCall" .= object
+                                        [ "id" .= ("call-1" :: Text)
+                                        , "name" .= ("apply_patch" :: Text)
+                                        , "args" .= object
+                                            ["input" .= (patch :: Text)]
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+
     it "maps disabled reasoning to the model's minimum thinking level" do
         let params :: ResponseCreateParams
             params = withReasoning


### PR DESCRIPTION
## Summary
- propagate ordinary Gemini function-call JSON decoding through request projection
- return an `InvalidRequestError` instead of silently replacing malformed arguments with `{}`
- preserve raw `input` wrapping for declared custom tools
- cover valid JSON, malformed JSON, and custom-tool raw input projection

## Deliberate behavior change
Malformed JSON in ordinary function-call arguments now fails request construction with ``Gemini function call `<name>` arguments must be valid JSON`` rather than sending an empty argument object. Custom-tool inputs remain raw strings wrapped in the Gemini `input` field.

## Tests
- `TMPDIR="$PWD/.test-tmp" nix develop -c cabal repl agent-gemini:test:agent-gemini-test` then `:main` (50 examples, 0 failures)