### PR TITLE
Refactor Claude query response orchestration

### DIFF
--- a/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
+++ b/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
@@ -68,6 +68,7 @@ library
                     , process               >= 1.6.26
                     , safe-exceptions
                     , text
+                    , transformers
                     , unix
                     , uuid-types
 

--- a/packages/claude-agent-sdk-haskell/package.nix
+++ b/packages/claude-agent-sdk-haskell/package.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, agent-json, agent-process, async, base
 , base64-bytestring, bytestring, containers, directory, entropy
 , filepath, hermes-json, hspec, lib, process, safe-exceptions, text
-, unix, uuid-types
+, transformers, unix, uuid-types
 }:
 mkDerivation {
   pname = "claude-agent-sdk-haskell";
@@ -10,7 +10,7 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-json agent-process async base base64-bytestring
     bytestring containers directory entropy hermes-json process
-    safe-exceptions text unix uuid-types
+    safe-exceptions text transformers unix uuid-types
   ];
   testHaskellDepends = [
     aeson agent-json base bytestring containers directory filepath

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
@@ -50,6 +50,13 @@ import Claude.Agent.SDK.Types
     , UserContentBlock(..)
     , messageSessionId
     )
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except
+    ( ExceptT(..)
+    , except
+    , runExceptT
+    , throwE
+    )
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Exit (ExitCode)
@@ -231,30 +238,25 @@ queryTurnContentWithMessageValidatorAndProgress
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 queryTurnContentWithMessageValidatorAndProgress
-    turn content validateMessage onProgress onMessage = do
-    completed <-
-        timeout
-            (max 1 (turnTimeoutMicros turn))
-            do
-                sendQueryContent turn content >>= \case
-                    Left err -> pure (Left err)
-                    Right () ->
-                        receiveResponseWithMessageValidatorAndProgress
-                            turn
-                            validateMessage
-                            onProgress
-                            onMessage
-    case completed of
-        Nothing ->
-            Left <$> timeoutError
-                turn
-                ( "did not complete within the turn timeout; it may already "
-                    <> "have changed files or created remote side effects, so "
-                    <> "inspect the workspace, Git history, and pull requests "
-                    <> "before retrying"
+    turn content validateMessage onProgress onMessage =
+        runExceptT $
+            withSDKTimeout
+                (turnTimeoutMicros turn)
+                ( timeoutError
+                    turn
+                    ( "did not complete within the turn timeout; it may already "
+                        <> "have changed files or created remote side effects, so "
+                        <> "inspect the workspace, Git history, and pull requests "
+                        <> "before retrying"
+                    )
                 )
-        Just result ->
-            pure result
+                do
+                    ExceptT (sendQueryContent turn content)
+                    receiveResponseT
+                        turn
+                        validateMessage
+                        onProgress
+                        onMessage
 
 -- | Receive messages until the matching successful 'ResultMessage'.
 receiveResponse
@@ -290,89 +292,128 @@ receiveResponseWithMessageValidatorAndProgress
     -> IO (Either ClaudeSDKError ResultMessage)
 receiveResponseWithMessageValidatorAndProgress
     turn validateMessage onProgress onMessage =
+        runExceptT $
+            receiveResponseT
+                turn
+                validateMessage
+                onProgress
+                onMessage
+
+receiveResponseT
+    :: ClaudeSDKTurn
+    -> (Message -> IO (Either ClaudeSDKError ()))
+    -> (QueryProgress -> IO ())
+    -> (Message -> IO ())
+    -> ExceptT ClaudeSDKError IO ResultMessage
+receiveResponseT turn validateMessage onProgress onMessage =
     go emptyQueryAccumulator False
   where
     go
         :: QueryAccumulator
         -> Bool
-        -> IO (Either ClaudeSDKError ResultMessage)
+        -> ExceptT ClaudeSDKError IO ResultMessage
     go accumulator sawOutput = do
-        maybeMessage <-
-            timeout
-                ( max 1 $
-                    if sawOutput
-                        then
-                            turnStreamInactivityTimeoutMicros turn
-                        else
-                            turnStreamStartupTimeoutMicros turn
+        outcome <- liftIO (receiveOutcome turn sawOutput)
+        message <- messageFromReceiveOutcome turn sawOutput outcome
+        ExceptT (validateMessage message)
+        responseStep <- except (consumeResponseMessage accumulator message)
+        case responseStep of
+            ResponseContinues nextAccumulator progress -> do
+                validateLiveProgressSession turn message progress
+                liftIO (mapM_ onProgress progress)
+                go
+                    nextAccumulator
+                    (sawOutput || hasOwnOutputProgress progress)
+            ResponseCompleted progress messages result -> do
+                ExceptT (acceptTurnSessionId turn result.sessionId)
+                liftIO (mapM_ onProgress progress)
+                liftIO (mapM_ onMessage messages)
+                pure result
+
+data ReceiveOutcome
+    = ReceiveTimedOut
+    | ReceiveEOF
+    | ReceiveTransportError !ClaudeSDKError
+    | ReceivedMessage !Message
+
+receiveOutcome
+    :: ClaudeSDKTurn
+    -> Bool
+    -> IO ReceiveOutcome
+receiveOutcome turn sawOutput = do
+    received <-
+        timeout
+            (max 1 (streamTimeoutMicros turn sawOutput))
+            (receiveMessage turn)
+    pure case received of
+        Nothing -> ReceiveTimedOut
+        Just (Left err) -> ReceiveTransportError err
+        Just (Right Nothing) -> ReceiveEOF
+        Just (Right (Just message)) -> ReceivedMessage message
+
+streamTimeoutMicros :: ClaudeSDKTurn -> Bool -> Int
+streamTimeoutMicros turn sawOutput
+    | sawOutput = turnStreamInactivityTimeoutMicros turn
+    | otherwise = turnStreamStartupTimeoutMicros turn
+
+messageFromReceiveOutcome
+    :: ClaudeSDKTurn
+    -> Bool
+    -> ReceiveOutcome
+    -> ExceptT ClaudeSDKError IO Message
+messageFromReceiveOutcome turn sawOutput = \case
+    ReceiveTimedOut ->
+        liftIO
+            ( timeoutError
+                turn
+                ( if sawOutput
+                    then "stopped producing structured output"
+                    else "did not produce structured output"
                 )
-                (receiveMessage turn)
-        case maybeMessage of
-            Nothing ->
-                Left <$> timeoutError
-                    turn
-                    ( if sawOutput
-                        then "stopped producing structured output"
-                        else "did not produce structured output"
-                    )
-            Just (Left err) ->
-                pure (Left err)
-            Just (Right Nothing) ->
-                Left <$> prematureExitError turn
-            Just (Right (Just message)) -> do
-                validated <- validateMessage message
-                case validated of
-                    Left err ->
-                        pure (Left err)
-                    Right () ->
-                        case
-                            consumeQueryMessageWithProgress
-                                accumulator
-                                message
-                        of
-                            Left err ->
-                                pure (Left err)
-                            Right (nextAccumulator, progress, Nothing) -> do
-                                sessionAccepted <-
-                                    validateLiveProgressSession
-                                        turn
-                                        message
-                                        progress
-                                case sessionAccepted of
-                                    Left err -> pure (Left err)
-                                    Right () -> do
-                                        mapM_ onProgress progress
-                                        go
-                                            nextAccumulator
-                                            (sawOutput
-                                                || hasOwnOutputProgress progress)
-                            Right (_, progress, Just (messages, result)) -> do
-                                accepted <-
-                                    acceptTurnSessionId
-                                        turn
-                                        result.sessionId
-                                case accepted of
-                                    Left err ->
-                                        pure (Left err)
-                                    Right () -> do
-                                        mapM_ onProgress progress
-                                        mapM_ onMessage messages
-                                        pure (Right result)
+            )
+            >>= throwE
+    ReceiveEOF ->
+        liftIO (prematureExitError turn) >>= throwE
+    ReceiveTransportError err ->
+        throwE err
+    ReceivedMessage message ->
+        pure message
+
+data ResponseStep
+    = ResponseContinues
+        !QueryAccumulator
+        ![QueryProgress]
+    | ResponseCompleted
+        ![QueryProgress]
+        ![Message]
+        !ResultMessage
+
+consumeResponseMessage
+    :: QueryAccumulator
+    -> Message
+    -> Either ClaudeSDKError ResponseStep
+consumeResponseMessage accumulator message = do
+    (nextAccumulator, progress, completion) <-
+        consumeQueryMessageWithProgress accumulator message
+    pure case completion of
+        Nothing ->
+            ResponseContinues nextAccumulator progress
+        Just (messages, result) ->
+            ResponseCompleted progress messages result
 
 validateLiveProgressSession
     :: ClaudeSDKTurn
     -> Message
     -> [QueryProgress]
-    -> IO (Either ClaudeSDKError ())
+    -> ExceptT ClaudeSDKError IO ()
 validateLiveProgressSession turn message progress
     | QueryConversationReset reset : _ <- progress = do
-        acceptConversationReset turn reset
-        pure (Right ())
-    | null progress = pure (Right ())
+        liftIO (acceptConversationReset turn reset)
+    | null progress = pure ()
     | otherwise =
         case messageSessionId message of
-            Nothing -> pure (Right ())
-            Just sessionId -> acceptTurnSessionId turn sessionId
+            Nothing -> pure ()
+            Just sessionId -> ExceptT (acceptTurnSessionId turn sessionId)
 
 hasOwnOutputProgress :: [QueryProgress] -> Bool
 hasOwnOutputProgress =
@@ -380,6 +421,21 @@ hasOwnOutputProgress =
         QueryMessageObserved{} -> True
         QueryMessagesRetracted{} -> True
         QueryConversationReset{} -> True
+
+withSDKTimeout
+    :: Int
+    -> IO ClaudeSDKError
+    -> ExceptT ClaudeSDKError IO a
+    -> ExceptT ClaudeSDKError IO a
+withSDKTimeout durationMicros timeoutFailure action =
+    ExceptT do
+        completed <-
+            timeout
+                (max 1 durationMicros)
+                (runExceptT action)
+        case completed of
+            Nothing -> Left <$> timeoutFailure
+            Just result -> pure result
 
 timeoutError :: ClaudeSDKTurn -> Text -> IO ClaudeSDKError
 timeoutError turn reason = do

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
@@ -479,6 +479,54 @@ spec = describe "query" do
                 [_] -> True
                 _ -> False
 
+    it "stops before progress and publication when live validation fails" $
+        withFakeClaude
+            (oneShotScript
+                [ assistantLine "validated" "accepted progress"
+                , assistantLine "rejected" "must remain hidden"
+                , successResult testSessionId
+                ])
+            \directory executable -> do
+                let options = testOptions executable directory
+                    validationError =
+                        CLIProtocolError "message rejected by the host"
+                progressRef <- newIORef []
+                messagesRef <- newIORef []
+                result <-
+                    withClaudeSDKClient options \client ->
+                        withClaudeSDKTurn
+                            client
+                            (pure True)
+                            Nothing
+                            options.model
+                            options.effort
+                            \turn -> do
+                                response <-
+                                    queryTurnContentWithMessageValidatorAndProgress
+                                        turn
+                                        [UserTextBlock "hello"]
+                                        ( \message ->
+                                            pure $
+                                                if messageUuid message
+                                                    == Just "rejected"
+                                                    then Left validationError
+                                                    else Right ()
+                                        )
+                                        (\progress ->
+                                            modifyIORef'
+                                                progressRef
+                                                (<> [progress]))
+                                        (\message ->
+                                            modifyIORef'
+                                                messagesRef
+                                                (<> [message]))
+                                pure ((, pure ()) <$> response)
+
+                result `shouldBe` Left validationError
+                map progressTag <$> readIORef progressRef
+                    `shouldReturn` ["message:validated"]
+                readIORef messagesRef `shouldReturn` []
+
     it "rejects mismatched live tool and nested-result messages without progress" do
         let wrongSessionId =
                 "123e4567-e89b-42d3-a456-426614174999"
@@ -596,6 +644,55 @@ spec = describe "query" do
                                     `Text.isInfixOf` message
                             _ -> False)
             [background, unknown]
+
+    it "switches to the inactivity timeout after submitted-turn progress" $
+        withFakeClaude
+            (Text.unpack $ Text.unlines
+                [ "#!/bin/sh"
+                , "IFS= read -r _query"
+                , "printf '%s\\n' "
+                    <> shellQuote
+                        (assistantLine "before-inactivity" "buffered answer")
+                , "while :; do :; done"
+                ])
+            \directory executable -> do
+                progressRef <- newIORef []
+                messagesRef <- newIORef []
+                result <-
+                    queryWithProgress
+                        ((testOptions executable directory)
+                            { streamStartupTimeoutMicros = 1_000_000
+                            , streamInactivityTimeoutMicros = 100_000
+                            , turnTimeoutMicros = 2_000_000
+                            })
+                        "hello"
+                        (\progress ->
+                            modifyIORef' progressRef (<> [progress]))
+                        (\message ->
+                            modifyIORef' messagesRef (<> [message]))
+                result `shouldSatisfy` \case
+                    Left (CLIConnectionError message) ->
+                        "stopped producing structured output"
+                            `Text.isInfixOf` message
+                    _ -> False
+                progress <- readIORef progressRef
+                progress `shouldSatisfy` any \case
+                    QueryMessageObserved QueryTopLevel message ->
+                        messageUuid message == Just "before-inactivity"
+                    _ -> False
+                readIORef messagesRef `shouldReturn` []
+
+    it "reports EOF as a premature process exit and keeps output buffered" do
+        (result, messages) <-
+            runQueryLines
+                [assistantLine "before-eof" "must remain buffered"]
+
+        result `shouldSatisfy` \case
+            Left ProcessError{message} ->
+                message
+                    == "Claude Code closed its structured output before completing the turn"
+            _ -> False
+        messages `shouldBe` []
 
     it "warns that a turn timeout may have left remote side effects" $
         withFakeClaude


### PR DESCRIPTION
## Summary
- run turn submission and response handling in `ExceptT ClaudeSDKError IO`
- classify receive results with an explicit ADT for timeout, EOF, transport failure, and parsed messages
- classify accumulator continuation/completion explicitly while preserving session validation, progress order, transactional publication, and timeout diagnostics
- add focused coverage for validator short-circuiting, inactivity timeout selection, and premature EOF

## Testing
- `nix develop -c cabal repl claude-agent-sdk-haskell:lib:claude-agent-sdk-haskell` (loads all 16 library modules)
- `nix develop -c cabal repl claude-agent-sdk-haskell:test:claude-agent-sdk-haskell-test`, then `:main` (98 examples, 0 failures)
