### PR TITLE
Refactor MCP client request pipelines with ExceptT

### DIFF
--- a/packages/agent-mcp/agent-mcp.cabal
+++ b/packages/agent-mcp/agent-mcp.cabal
@@ -67,6 +67,7 @@ library
                     , stm
                     , text
                     , time
+                    , transformers
                     , unix
                     , vector
 

--- a/packages/agent-mcp/package.nix
+++ b/packages/agent-mcp/package.nix
@@ -2,7 +2,7 @@
 , base, base64-bytestring, bytestring, containers, directory
 , filelock, filepath, hspec, http-client, http-client-tls
 , http-types, lib, process, QuickCheck, safe-exceptions, scientific
-, stm, text, time, unix, vector
+, stm, text, time, transformers, unix, vector
 }:
 mkDerivation {
   pname = "agent-mcp";
@@ -12,7 +12,7 @@ mkDerivation {
     aeson agent-core agent-json agent-process async base
     base64-bytestring bytestring containers directory filelock filepath
     http-client http-client-tls http-types process safe-exceptions
-    scientific stm text time unix vector
+    scientific stm text time transformers unix vector
   ];
   testHaskellDepends = [
     aeson agent-core agent-json async base bytestring containers

--- a/packages/agent-mcp/src/Agent/MCP/Client.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Client.hs
@@ -63,6 +63,12 @@ import Control.Exception.Safe
     , tryAny
     )
 import Control.Monad (forM, forM_, unless, void, when)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except
+    ( ExceptT(..)
+    , runExceptT
+    , throwE
+    )
 import Data.Aeson
     ( Series
     , ToJSON(toJSON)
@@ -615,6 +621,44 @@ startupFailure client err = do
 
 -- * Discovery
 
+-- | Private error effect used to keep request/decode pipelines linear. Public
+-- entry points continue to return their existing @Either@ types.
+type McpCall = ExceptT McpError IO
+
+requestMcpT :: McpClient -> McpRequest -> McpCall RawJson
+requestMcpT client = ExceptT . requestMcpFull client
+
+decodeMcpPayload
+    :: Text
+    -> Json.Decoder a
+    -> RawJson
+    -> McpCall a
+decodeMcpPayload context decoder raw =
+    case Json.decodeEither decoder (rawJsonBytes raw) of
+        Left err ->
+            throwE . McpTransportError $
+                "invalid " <> context <> ": " <> err.jsonErrorMessage
+        Right value -> pure value
+
+requestAndDecode
+    :: McpClient
+    -> McpRequest
+    -> Text
+    -> Json.Decoder a
+    -> McpCall a
+requestAndDecode client request context decoder =
+    requestMcpT client request >>= decodeMcpPayload context decoder
+
+-- | Preserve the historical error text of APIs which predate 'McpError':
+-- decode errors were already labelled but RPC/transport errors were rendered.
+renderTextMcpResult :: Text -> Either McpError a -> Either Text a
+renderTextMcpResult decodeContext = \case
+    Left (McpTransportError err)
+        | ("invalid " <> decodeContext <> ": ") `Text.isPrefixOf` err ->
+            Left err
+    Left err -> Left (renderMcpError err)
+    Right value -> Right value
+
 discoverMcpTools :: McpClient -> IO ([McpTool], [Text])
 discoverMcpTools client = do
     tools <- paginate client "tools/list" "tools" mcpToolDecoder
@@ -641,23 +685,20 @@ paginate
     -> Text
     -> Json.Decoder a
     -> IO (Either McpError [a])
-paginate client method key itemDecoder = go Nothing []
+paginate client method key itemDecoder = runExceptT (go Nothing [])
   where
     go cursor collected = do
         let parameters = maybe mempty
                 (\value -> AesonEncoding.pair "cursor" (rawJsonEncoding value))
                 cursor
-        requestMcpFull client (clientRequest client method parameters) >>= \case
-            Left err -> pure (Left err)
-            Right result ->
-                case Json.decodeEither pageDecoder (rawJsonBytes result) of
-                    Left err ->
-                        pure . Left . McpTransportError $
-                            "invalid " <> method <> " response: " <> err.jsonErrorMessage
-                    Right (items, nextCursor) ->
-                        case nextCursor of
-                            Just next -> go (Just next) (collected <> items)
-                            Nothing -> pure (Right (collected <> items))
+        (items, nextCursor) <-
+            requestAndDecode client
+                (clientRequest client method parameters)
+                (method <> " response")
+                pageDecoder
+        case nextCursor of
+            Just next -> go (Just next) (collected <> items)
+            Nothing -> pure (collected <> items)
 
     pageDecoder = Json.object $
         (,)
@@ -674,6 +715,8 @@ discoverMcpSkills client = do
         Nothing -> pure []
         Just _ -> go Nothing []
   where
+    -- Skill discovery is deliberately not expressed as one McpCall: catalog
+    -- failures are warnings and already decoded pages remain usable.
     go cursor warnings = do
         let parameters = maybe mempty
                 (\value -> AesonEncoding.pair "cursor" (rawJsonEncoding value))
@@ -722,36 +765,29 @@ getMcpSkill client uri = do
         Nothing -> pure (Left ("MCP server "
             <> client.clientConfig.mcpServerName
             <> " does not support io.modelcontextprotocol/skills"))
-        Just _ ->
-            requestMcpFull client (clientRequest client "skills/get" ("uri" .= uri)) >>= \case
-                Left err -> pure (Left (renderMcpError err))
-                Right result ->
-                    case Json.decodeEither
-                            (Json.object (Json.atKey "skill" mcpSkillEntryDecoder))
-                            (rawJsonBytes result) of
-                        Left err -> pure (Left ("invalid skills/get response: "
-                            <> err.jsonErrorMessage))
-                        Right skill -> pure (Right skill)
+        Just _ -> do
+            result <- runExceptT $
+                requestAndDecode client
+                    (clientRequest client "skills/get" ("uri" .= uri))
+                    "skills/get response"
+                    (Json.object (Json.atKey "skill" mcpSkillEntryDecoder))
+            pure (renderTextMcpResult "skills/get response" result)
 
 -- | Read one or more resource contents using the standard MCP resources/read
 -- method.  This does not activate a skill; callers must perform their own
 -- approval, frontmatter, and manifest verification.
 readMcpResource :: McpClient -> Text -> IO (Either Text [McpResourceContent])
-readMcpResource client uri =
-    invokeWithInputRounds client
-        (clientRequest client "resources/read" ("uri" .= uri))
-            { requestName = Just uri }
-        >>= \case
-        Left err -> pure (Left (renderMcpError err))
-        Right result ->
-            case Json.decodeEither
-                    (Json.object
-                        (Json.defaultKey [] "contents"
-                            (Json.list mcpResourceContentDecoder)))
-                    (rawJsonBytes result) of
-                Left err -> pure (Left ("invalid resources/read response: "
-                    <> err.jsonErrorMessage))
-                Right contents -> pure (Right contents)
+readMcpResource client uri = do
+    result <- runExceptT do
+        raw <- invokeWithInputRoundsT client
+            (clientRequest client "resources/read" ("uri" .= uri))
+                { requestName = Just uri }
+        decodeMcpPayload "resources/read response"
+            (Json.object
+                (Json.defaultKey [] "contents"
+                    (Json.list mcpResourceContentDecoder)))
+            raw
+    pure (renderTextMcpResult "resources/read response" result)
 
 listMcpResources :: McpClient -> IO (Either McpError [McpResource])
 listMcpResources client =
@@ -773,18 +809,14 @@ getMcpPrompt
     -> [(Text, Text)]
     -> IO (Either McpError McpPromptResult)
 getMcpPrompt client name arguments =
-    invokeWithInputRounds client
-        (clientRequest client "prompts/get"
-            ("name" .= name
-                <> "arguments" .= object [Key.fromText key .= value | (key, value) <- arguments]))
-            { requestName = Just name }
-        >>= \case
-        Left err -> pure (Left err)
-        Right result ->
-            pure . either
-                (\err -> Left (McpTransportError ("invalid prompts/get response: " <> err.jsonErrorMessage)))
-                Right $
-                Json.decodeEither mcpPromptResultDecoder (rawJsonBytes result)
+    runExceptT do
+        raw <- invokeWithInputRoundsT client
+            (clientRequest client "prompts/get"
+                ("name" .= name
+                    <> "arguments" .= object
+                        [Key.fromText key .= value | (key, value) <- arguments]))
+                { requestName = Just name }
+        decodeMcpPayload "prompts/get response" mcpPromptResultDecoder raw
 
 data McpCompletionRef
     = McpCompletePrompt !Text
@@ -814,13 +846,11 @@ completeMcpArgument client ref argumentName partial context = do
                             [ "arguments" .= object
                                 [Key.fromText key .= value | (key, value) <- context]
                             ])
-    requestMcpFull client (clientRequest client "completion/complete" parameters) >>= \case
-        Left err -> pure (Left err)
-        Right result ->
-            pure . either
-                (\err -> Left (McpTransportError ("invalid completion/complete response: " <> err.jsonErrorMessage)))
-                Right $
-                Json.decodeEither mcpCompletionDecoder (rawJsonBytes result)
+    runExceptT $
+        requestAndDecode client
+            (clientRequest client "completion/complete" parameters)
+            "completion/complete response"
+            mcpCompletionDecoder
 
 -- * Tools
 
@@ -1348,36 +1378,37 @@ resultKind raw =
 -- | Issue a request that may return @input_required@ or @task@ results and
 -- drive it to completion.
 invokeWithInputRounds :: McpClient -> McpRequest -> IO (Either McpError RawJson)
-invokeWithInputRounds client request = go (0 :: Int) mempty
+invokeWithInputRounds client request =
+    runExceptT (invokeWithInputRoundsT client request)
+
+invokeWithInputRoundsT :: McpClient -> McpRequest -> McpCall RawJson
+invokeWithInputRoundsT client request = go (0 :: Int) mempty
   where
-    go rounds extra =
-        requestMcpFull client request { requestParams = request.requestParams <> extra }
-            >>= \case
-            Left err -> pure (Left err)
-            Right raw -> case resultKind raw of
-                ResultComplete -> pure (Right raw)
-                ResultTask -> awaitTask client request raw
-                ResultUnknown kind ->
-                    pure (Left (McpTransportError ("unrecognized resultType \"" <> kind <> "\"")))
-                ResultInputRequired
-                    | rounds >= maxInputRounds ->
-                        pure (Left (McpTransportError
-                            ("MCP server kept requesting input after "
-                                <> Text.pack (show maxInputRounds) <> " rounds")))
-                    | otherwise ->
-                        case Json.decodeEither inputRequiredDecoder (rawJsonBytes raw) of
-                            Left err ->
-                                pure (Left (McpTransportError
-                                    ("invalid input_required result: " <> err.jsonErrorMessage)))
-                            Right (requests, requestState) ->
-                                fulfilInputRequests client requests >>= \case
-                                    Left err -> pure (Left err)
-                                    Right responses ->
-                                        go (rounds + 1)
-                                            (inputResponsesSeries responses
-                                                <> maybe mempty
-                                                    (\state -> AesonEncoding.pair "requestState" (rawJsonEncoding state))
-                                                    requestState)
+    go rounds extra = do
+        raw <- requestMcpT client
+            request { requestParams = request.requestParams <> extra }
+        case resultKind raw of
+            ResultComplete -> pure raw
+            ResultTask -> awaitTaskT client request raw
+            ResultUnknown kind ->
+                throwE (McpTransportError
+                    ("unrecognized resultType \"" <> kind <> "\""))
+            ResultInputRequired
+                | rounds >= maxInputRounds ->
+                    throwE (McpTransportError
+                        ("MCP server kept requesting input after "
+                            <> Text.pack (show maxInputRounds) <> " rounds"))
+                | otherwise -> do
+                    (requests, requestState) <-
+                        decodeMcpPayload "input_required result"
+                            inputRequiredDecoder raw
+                    responses <- ExceptT (fulfilInputRequests client requests)
+                    go (rounds + 1)
+                        (inputResponsesSeries responses
+                            <> maybe mempty
+                                (\state -> AesonEncoding.pair
+                                    "requestState" (rawJsonEncoding state))
+                                requestState)
 
 inputResponsesSeries :: [(Text, RawJson)] -> Series
 inputResponsesSeries responses =
@@ -1457,14 +1488,14 @@ decodeElicitRequest serverName raw =
 
 -- | Poll a task returned by a task-augmented request until it settles.
 awaitTask :: McpClient -> McpRequest -> RawJson -> IO (Either McpError RawJson)
-awaitTask client request raw =
-    case Json.decodeEither taskDecoder (rawJsonBytes raw) of
-        Left err ->
-            pure (Left (McpTransportError ("invalid task result: " <> err.jsonErrorMessage)))
-        Right task -> do
-            start <- getMonotonicTimeNSec
-            report 0 task
-            poll' start (1 :: Int) task.taskPollIntervalMs
+awaitTask client request raw = runExceptT (awaitTaskT client request raw)
+
+awaitTaskT :: McpClient -> McpRequest -> RawJson -> McpCall RawJson
+awaitTaskT client request raw = do
+    task <- decodeMcpPayload "task result" taskDecoder raw
+    start <- lift getMonotonicTimeNSec
+    lift (report 0 task)
+    poll' start (1 :: Int) task.taskPollIntervalMs
   where
     slice = max 1 request.requestTimeoutMicros
     report :: Int -> TaskState -> IO ()
@@ -1478,52 +1509,50 @@ awaitTask client request raw =
                         <> maybe "" (": " <>) task.taskStatusMessage)
                 }
     poll' start count intervalMs = do
-        threadDelay (max 100 intervalMs * 1000)
-        now <- getMonotonicTimeNSec
+        lift (threadDelay (max 100 intervalMs * 1000))
+        now <- lift getMonotonicTimeNSec
         if request.requestTimeoutMicros > 0 && pastHardDeadline start now slice
             then do
-                _ <- requestMcpFull client
+                -- Cancellation is best-effort; preserve the timeout as the
+                -- primary error if the server rejects the cancel request.
+                _ <- lift $ requestMcpFull client
                     (clientRequest client "tasks/cancel" ("taskId" .= taskIdOf))
-                pure (Left (timeoutError (request.requestMethod <> " task") slice))
-            else
-                requestMcpFull client
+                throwE (timeoutError (request.requestMethod <> " task") slice)
+            else do
+                task <- requestAndDecode client
                     (clientRequest client "tasks/get" ("taskId" .= taskIdOf))
-                    >>= \case
-                    Left err -> pure (Left err)
-                    Right state ->
-                        case Json.decodeEither taskDecoder (rawJsonBytes state) of
-                            Left err ->
-                                pure (Left (McpTransportError
-                                    ("invalid tasks/get result: " <> err.jsonErrorMessage)))
-                            Right task -> do
-                                report count task
-                                case task.taskStatus of
-                                    "completed" -> case task.taskResult of
-                                        Just result -> pure (Right result)
-                                        Nothing -> legacyTaskResult
-                                    "failed" ->
-                                        pure . Left $ fromMaybe
-                                            (McpTransportError "MCP task failed")
-                                            (task.taskError >>= decodeRpcError)
-                                    "cancelled" ->
-                                        pure (Left (McpTransportError "MCP task was cancelled"))
-                                    "input_required" ->
-                                        fulfilInputRequests client task.taskInputRequests
-                                            >>= \case
-                                            Left err -> pure (Left err)
-                                            Right responses -> do
-                                                _ <- requestMcpFull client
-                                                    (clientRequest client "tasks/update"
-                                                        ("taskId" .= taskIdOf
-                                                            <> inputResponsesSeries responses))
-                                                poll' start (count + 1) task.taskPollIntervalMs
-                                    _ -> poll' start (count + 1) task.taskPollIntervalMs
+                    "tasks/get result"
+                    taskDecoder
+                lift (report count task)
+                case task.taskStatus of
+                    "completed" -> case task.taskResult of
+                        Just result -> pure result
+                        Nothing -> legacyTaskResult
+                    "failed" ->
+                        throwE $ fromMaybe
+                            (McpTransportError "MCP task failed")
+                            (task.taskError >>= decodeRpcError)
+                    "cancelled" ->
+                        throwE (McpTransportError "MCP task was cancelled")
+                    "input_required" -> do
+                        responses <-
+                            ExceptT (fulfilInputRequests client task.taskInputRequests)
+                        -- A tasks/update RPC error means the input was not
+                        -- accepted and must stop the task instead of being
+                        -- silently discarded. Its successful payload is only
+                        -- an acknowledgement; the next tasks/get is canonical.
+                        void $ requestMcpT client
+                            (clientRequest client "tasks/update"
+                                ("taskId" .= taskIdOf
+                                    <> inputResponsesSeries responses))
+                        poll' start (count + 1) task.taskPollIntervalMs
+                    _ -> poll' start (count + 1) task.taskPollIntervalMs
       where
         taskIdOf = initialTaskId
     initialTaskId =
         projectRawOr "" (Json.object (Json.defaultKey "" "taskId" Json.text)) raw
     legacyTaskResult =
-        requestMcpFull client
+        requestMcpT client
             (clientRequest client "tasks/result" ("taskId" .= initialTaskId))
 
 data TaskState = TaskState

--- a/packages/agent-mcp/src/Agent/MCP/Client.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Client.hs
@@ -1537,11 +1537,10 @@ awaitTaskT client request raw = do
                     "input_required" -> do
                         responses <-
                             ExceptT (fulfilInputRequests client task.taskInputRequests)
-                        -- A tasks/update RPC error means the input was not
-                        -- accepted and must stop the task instead of being
-                        -- silently discarded. Its successful payload is only
-                        -- an acknowledgement; the next tasks/get is canonical.
-                        void $ requestMcpT client
+                        -- tasks/update is best-effort: its successful response
+                        -- body is only an acknowledgement, and RPC errors are
+                        -- deliberately ignored. The next tasks/get is canonical.
+                        _ <- lift $ requestMcpFull client
                             (clientRequest client "tasks/update"
                                 ("taskId" .= taskIdOf
                                     <> inputResponsesSeries responses))

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -661,7 +661,7 @@ spec = describe "Agent.MCP" do
                 task.output `shouldBe` "task done"
                 waitForLog log "listen"
 
-    it "uses task updates as acknowledgements and propagates their RPC errors" $
+    it "treats task update responses and errors as best-effort acknowledgements" $
         withBodyServer "agent-mcp-task-update.sh" taskUpdateServer \script -> do
             let hooks = defaultMcpHostHooks
                     { mcpHostElicit = pure $ Just \_ ->
@@ -678,8 +678,7 @@ spec = describe "Agent.MCP" do
             accepted <- run "accept"
             accepted.output `shouldBe` "task updated"
             rejected <- run "reject"
-            rejected.output `shouldSatisfy`
-                Text.isInfixOf "input rejected"
+            rejected.output `shouldBe` "task updated"
 
     it "answers pings, extends timeouts on progress, refreshes changed tool lists, and cancels timeouts" $
         withCountingServer legacyEventsServer \script log -> do

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -299,6 +299,20 @@ spec = describe "Agent.MCP" do
                     other -> expectationFailure
                         ("unexpected skill registrations: " <> show other)
 
+    it "keeps discovered tools when optional Skills discovery fails" $
+        withBodyServer "agent-mcp-skills-warning.sh" skillsWarningServer \script -> do
+            fleet <- startMcpFleet [baseConfig "partial" script]
+            bracket (pure fleet) closeMcpFleet \_ -> do
+                map (.appToolName) (mcpFleetTools fleet)
+                    `shouldBe` ["partial__read", "partial__second_read"]
+                mcpFleetStatuses fleet `shouldReturn`
+                    [McpServerStatus "partial" McpReady 2]
+                fleet.mcpFleetWarnings `shouldSatisfy` \case
+                    [warning] ->
+                        "skills/list failed" `Text.isInfixOf` warning
+                            && "catalog unavailable" `Text.isInfixOf` warning
+                    _ -> False
+
     it "starts servers concurrently and preserves configured tool order" $
         withConcurrentFakeServer \script barrier -> do
             progress <- newIORef []
@@ -647,6 +661,26 @@ spec = describe "Agent.MCP" do
                 task.output `shouldBe` "task done"
                 waitForLog log "listen"
 
+    it "uses task updates as acknowledgements and propagates their RPC errors" $
+        withBodyServer "agent-mcp-task-update.sh" taskUpdateServer \script -> do
+            let hooks = defaultMcpHostHooks
+                    { mcpHostElicit = pure $ Just \_ ->
+                        pure (McpElicitAccept (Just (raw "{\"answer\":\"yes\"}")))
+                    }
+                run mode =
+                    bracket
+                        (startMcpFleetWithProgressHooks hooks (const (pure ()))
+                            [ (baseConfig "task-update" script)
+                                { mcpServerArgs = [mode] }
+                            ])
+                        closeMcpFleet
+                        \fleet -> callFleetTool fleet "task-update__input_task" "{}"
+            accepted <- run "accept"
+            accepted.output `shouldBe` "task updated"
+            rejected <- run "reject"
+            rejected.output `shouldSatisfy`
+                Text.isInfixOf "input rejected"
+
     it "answers pings, extends timeouts on progress, refreshes changed tool lists, and cancels timeouts" $
         withCountingServer legacyEventsServer \script log -> do
             fleet <- startMcpFleet
@@ -887,25 +921,23 @@ waitForConcurrentStarts barrier = go (300 :: Int)
             else threadDelay 10000 >> go (remaining - 1)
 
 withFakeServer :: (FilePath -> IO a) -> IO a
-withFakeServer action = do
-    temporary <- getTemporaryDirectory
-    bracket
-        (do
-            (path, handle) <- openTempFile temporary "agent-mcp-fake.sh"
-            LBS.hPutStr handle fakeServer
-            hClose handle
-            setFileMode path 0o700
-            pure path)
-        removeFile
-        action
+withFakeServer = withBodyServer "agent-mcp-fake.sh" fakeServer
 
 withSkillsFakeServer :: (FilePath -> IO a) -> IO a
-withSkillsFakeServer action = do
+withSkillsFakeServer =
+    withBodyServer "agent-mcp-skills.sh" skillsFakeServer
+
+withBodyServer
+    :: String
+    -> LBS.ByteString
+    -> (FilePath -> IO a)
+    -> IO a
+withBodyServer template body action = do
     temporary <- getTemporaryDirectory
     bracket
         (do
-            (path, handle) <- openTempFile temporary "agent-mcp-skills.sh"
-            LBS.hPutStr handle skillsFakeServer
+            (path, handle) <- openTempFile temporary template
+            LBS.hPutStr handle body
             hClose handle
             setFileMode path 0o700
             pure path)
@@ -1122,6 +1154,65 @@ fakeServer =
     \      else\n\
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"second response\"}]}}'\n\
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$first_id\"',\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"first response\"}]}}'\n\
+    \      fi\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+skillsWarningServer :: LBS.ByteString
+skillsWarningServer =
+    "#!/bin/sh\n\
+    \tool_pages=0\n\
+    \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"supportedVersions\":[\"2026-07-28\"],\"capabilities\":{\"tools\":{},\"extensions\":{\"io.modelcontextprotocol/skills\":{}}}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      tool_pages=$((tool_pages+1))\n\
+    \      if [ \"$tool_pages\" -eq 1 ]; then\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[{\"name\":\"read\",\"description\":\"Read.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}],\"nextCursor\":\"next\"}}'\n\
+    \      else\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[{\"name\":\"second_read\",\"description\":\"Read another page.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}]}}'\n\
+    \      fi\n\
+    \      ;;\n\
+    \    *'\"method\":\"skills/list\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32000,\"message\":\"catalog unavailable\"}}'\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+taskUpdateServer :: LBS.ByteString
+taskUpdateServer =
+    "#!/bin/sh\n\
+    \mode=\"$1\"\n\
+    \polls=0\n\
+    \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"supportedVersions\":[\"2026-07-28\"],\"capabilities\":{\"tools\":{}}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[{\"name\":\"input_task\",\"description\":\"Task.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}]}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"tools/call\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"resultType\":\"task\",\"taskId\":\"input-1\",\"status\":\"working\",\"pollIntervalMs\":1}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"tasks/get\"'*)\n\
+    \      polls=$((polls+1))\n\
+    \      if [ \"$polls\" -eq 1 ]; then\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"taskId\":\"input-1\",\"status\":\"input_required\",\"pollIntervalMs\":1,\"inputRequests\":{\"answer\":{\"method\":\"elicitation/create\",\"params\":{\"message\":\"Continue?\"}}}}}'\n\
+    \      else\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"taskId\":\"input-1\",\"status\":\"completed\",\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"task updated\"}]}}}'\n\
+    \      fi\n\
+    \      ;;\n\
+    \    *'\"method\":\"tasks/update\"'*)\n\
+    \      if [ \"$mode\" = reject ]; then\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32000,\"message\":\"input rejected\"}}'\n\
+    \      else\n\
+    \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"acknowledged\":true,\"ignoredPayload\":\"deliberate\"}}'\n\
     \      fi\n\
     \      ;;\n\
     \  esac\n\


### PR DESCRIPTION
## Summary
- centralize MCP request and payload-decoding flows behind a private `ExceptT McpError IO` effect
- simplify pagination, resource/prompt resolution, multi-round input, and task polling while preserving existing public result types and error text
- keep Skills discovery warning-based and partial-successful rather than fail-fast
- preserve best-effort `tasks/update` semantics: successful bodies are acknowledgements and JSON-RPC errors are deliberately ignored before the next canonical `tasks/get`

## Tests
- `printf ":main\n:quit\n" | cabal repl agent-mcp:test:agent-mcp-test` (98 examples, 0 failures)
- `cabal test agent-mcp:test:agent-mcp-test` (98 examples, 0 failures)
- `nix-instantiate --parse packages/agent-mcp/package.nix`
- `git diff --check`
