### PR TITLE
Refactor image generation error flow

### DIFF
--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -108,6 +108,7 @@ library
                     , directory
                     , filepath
                     , template-haskell
+                    , transformers
                     , unix
 
 executable agent-openai-login

--- a/packages/agent-openai/package.nix
+++ b/packages/agent-openai/package.nix
@@ -4,7 +4,7 @@
 , HsOpenSSL, hspec, http-client, http-conduit, http-streams
 , http-types, io-streams, lib, network, network-uri, retry
 , safe-exceptions, scientific, template-haskell, temporary, text
-, time, unix, vector, wai, warp, websockets, wuss
+, time, transformers, unix, vector, wai, warp, websockets, wuss
 }:
 mkDerivation {
   pname = "agent-openai";
@@ -17,7 +17,7 @@ mkDerivation {
     async base base64-bytestring bytestring containers directory
     exceptions filepath HsOpenSSL http-client http-conduit http-streams
     io-streams network-uri retry safe-exceptions scientific
-    template-haskell text time unix vector websockets wuss
+    template-haskell text time transformers unix vector websockets wuss
   ];
   executableHaskellDepends = [
     agent-core base directory filepath text

--- a/packages/agent-openai/src/Agent/OpenAI/ImageGeneration.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/ImageGeneration.hs
@@ -62,6 +62,14 @@ import Control.Exception.Safe
     , tryAny
     )
 import Control.Monad (unless)
+import Control.Monad.Trans.Except
+    ( ExceptT(..)
+    , except
+    , runExceptT
+    , throwE
+    , withExceptT
+    )
+import Data.Bifunctor (first)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as AesonKey
 import qualified Data.Aeson.KeyMap as AesonKeyMap
@@ -275,55 +283,55 @@ runImageGeneration
     -> RawJson
     -> IO (Either Text ToolHandlerResult)
 runImageGeneration baseUrl tokenProvider env history displayHooks call raw =
-    case Aeson.eitherDecodeStrict' (rawJsonBytes raw) of
-        Left err ->
-            pure (Left ("invalid imagegen arguments: " <> Text.pack err))
-        Right args ->
-            validateArgs args >>= \case
-                Left err -> pure (Left err)
-                Right () ->
-                    selectReferenceImages env history args >>= \case
-                        Left err -> pure (Left err)
-                        Right references -> do
-                            let (endpoint, requestBody) =
-                                    imageRequest args.prompt references
-                            response <- runWithTokenProvider tokenProvider \credential ->
-                                if credential.provider /= OpenAIProvider
-                                    then pure $ Left $ ProviderError
-                                        InvalidRequestError
-                                        "Image generation requires an OpenAI credential."
-                                        Nothing
-                                    else postCodexJson
-                                        baseUrl
-                                        endpoint
-                                        credential.accessToken
-                                        credential.accountId
-                                        (imageRequestHeaders call.callId)
-                                        requestBody
-                                        imageResponseHandler
-                            case response of
-                                Left err -> pure (Left (renderApiError err))
-                                Right encoded ->
-                                    finishGeneratedImage
-                                        env
-                                        history
-                                        displayHooks
-                                        call
-                                        encoded
+    runExceptT do
+        args <- except $
+            first
+                (("invalid imagegen arguments: " <>) . Text.pack)
+                (Aeson.eitherDecodeStrict' (rawJsonBytes raw))
+        except (validateArgs args)
+        references <- liftTextError (selectReferenceImages env history args)
+        let (endpoint, requestBody) = imageRequest args.prompt references
+        encoded <- liftApiError $
+            runWithTokenProvider tokenProvider \credential ->
+                if credential.provider /= OpenAIProvider
+                    then pure $ Left $ ProviderError
+                        InvalidRequestError
+                        "Image generation requires an OpenAI credential."
+                        Nothing
+                    else postCodexJson
+                        baseUrl
+                        endpoint
+                        credential.accessToken
+                        credential.accountId
+                        (imageRequestHeaders call.callId)
+                        requestBody
+                        imageResponseHandler
+        liftTextError $
+            finishGeneratedImage
+                env
+                history
+                displayHooks
+                call
+                encoded
 
-validateArgs :: ImageGenerationArgs -> IO (Either Text ())
+liftTextError :: IO (Either Text value) -> ExceptT Text IO value
+liftTextError = ExceptT
+
+liftApiError :: IO (Either ApiError value) -> ExceptT Text IO value
+liftApiError = withExceptT renderApiError . ExceptT
+
+validateArgs :: ImageGenerationArgs -> Either Text ()
 validateArgs args
     | maybe False ((> maxSelectableImages) . length) args.referencedImagePaths =
-        pure $ Left "`referenced_image_paths` must contain at most 5 paths"
+        Left "`referenced_image_paths` must contain at most 5 paths"
     | maybe False (\count -> count < 1 || count > maxSelectableImages)
             args.numLastImagesToInclude =
-        pure $ Left
-            "`num_last_images_to_include` must be between 1 and 5"
+        Left "`num_last_images_to_include` must be between 1 and 5"
     | maybe False (not . null) args.referencedImagePaths
         && maybe False (const True) args.numLastImagesToInclude =
-            pure $ Left
+            Left
                 "provide only one of `referenced_image_paths` or `num_last_images_to_include`"
-    | otherwise = pure (Right ())
+    | otherwise = Right ()
 
 selectReferenceImages
     :: ToolEnv
@@ -352,22 +360,17 @@ loadReferencedImages
     :: ToolEnv
     -> [Text]
     -> IO (Either Text [ImageAttachment])
-loadReferencedImages env = go []
+loadReferencedImages env paths =
+    runExceptT (traverse loadReferencedImage paths)
   where
-    go reversed = \case
-        [] -> pure (Right (reverse reversed))
-        pathText : rest ->
-            let requested = fromText pathText
-            in if not (isAbsolute requested)
-                then pure $ Left $
-                    "`referenced_image_paths` entries must be absolute paths: "
-                        <> pathText
-                else resolveForRead env requested >>= \case
-                    Left err -> pure (Left err)
-                    Right path ->
-                        readReferencedImage pathText path >>= \case
-                            Left err -> pure (Left err)
-                            Right image -> go (image : reversed) rest
+    loadReferencedImage pathText = do
+        let requested = fromText pathText
+        unless (isAbsolute requested) $
+            throwE $
+                "`referenced_image_paths` entries must be absolute paths: "
+                    <> pathText
+        path <- liftTextError (resolveForRead env requested)
+        liftTextError (readReferencedImage pathText path)
 
 readReferencedImage
     :: Text

--- a/packages/agent-openai/test/Agent/OpenAI/ImageGenerationSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ImageGenerationSpec.hs
@@ -182,7 +182,7 @@ spec = describe "image generation tool" do
                 , "size" .= ("auto" :: Text)
                 ]
 
-    it "rejects conflicting image selectors before making a request" do
+    it "rejects invalid image selectors before making a request" do
         withSystemTempDirectory "agent-imagegen-invalid" \cwd -> do
             env <- defaultToolEnv (fromText (Text.pack cwd))
             history <- newImageGenerationHistory
@@ -192,19 +192,19 @@ spec = describe "image generation tool" do
                     env
                     history
                     Nothing
-            result <- dispatchToolCall
-                defaultLoopDispatch
-                (appToolHandlers [tool])
-                (functionToolCall
-                    "invalid-1"
-                    "imagegen"
-                    "{\"prompt\":\"edit\",\
-                    \\"referenced_image_paths\":[\"/tmp/a.png\"],\
-                    \\"num_last_images_to_include\":1}")
-            result.output `shouldSatisfy`
-                Text.isInfixOf
-                    "provide only one of `referenced_image_paths` or `num_last_images_to_include`"
-            toolCallResultImages result `shouldBe` []
+            mapM_
+                (\(index, (arguments, expectedError)) -> do
+                    result <- dispatchToolCall
+                        defaultLoopDispatch
+                        (appToolHandlers [tool])
+                        (functionToolCall
+                            ("invalid-" <> Text.pack (show index))
+                            "imagegen"
+                            arguments)
+                    result.output `shouldSatisfy`
+                        Text.isInfixOf expectedError
+                    toolCallResultImages result `shouldBe` [])
+                (zip [1 :: Int ..] invalidSelectorCases)
 
 openAiProvider =
     tokenProvider SubscriptionBilled \_ ->
@@ -280,3 +280,24 @@ generatedPng =
 
 jpegBytes :: BS.ByteString
 jpegBytes = BS.pack [0xff, 0xd8, 0xff, 0x00]
+
+invalidSelectorCases :: [(Text, Text)]
+invalidSelectorCases =
+    [ ( "{\"prompt\":\"edit\",\
+        \\"referenced_image_paths\":[\"/tmp/a.png\"],\
+        \\"num_last_images_to_include\":1}"
+      , "provide only one of `referenced_image_paths` or `num_last_images_to_include`"
+      )
+    , ( "{\"prompt\":\"edit\",\
+        \\"referenced_image_paths\":[\
+        \\"/a.png\",\"/b.png\",\"/c.png\",\"/d.png\",\"/e.png\",\"/f.png\"]}"
+      , "`referenced_image_paths` must contain at most 5 paths"
+      )
+    , ( "{\"prompt\":\"edit\",\"num_last_images_to_include\":0}"
+      , "`num_last_images_to_include` must be between 1 and 5"
+      )
+    , ( "{\"prompt\":\"edit\",\
+        \\"referenced_image_paths\":[\"relative.png\"]}"
+      , "`referenced_image_paths` entries must be absolute paths: relative.png"
+      )
+    ]


### PR DESCRIPTION
## Summary
- express the image generation handler as an `ExceptT Text IO` pipeline with typed error lifting
- make argument validation pure and simplify referenced-image loading with `traverse`
- add focused invalid-selector coverage and declare/regenerate the `transformers` dependency metadata

## Testing
- `nix develop -c true`
- `printf ':load Agent.OpenAI.ImageGeneration\n:quit\n' | env TMPDIR="$PWD/.tmp-agent" HASKELL_AGENT_TMPDIR="$PWD/.tmp-agent" cabal repl agent-openai:lib:agent-openai`
- `env TMPDIR="$PWD/.tmp-agent" HASKELL_AGENT_TMPDIR="$PWD/.tmp-agent" cabal test agent-openai:agent-openai-test --test-option=--match --test-option='image generation tool'`
- `git diff --check`
