### PR TITLE
refactor(claude): simplify capability probes with ExceptT

### DIFF
--- a/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
+++ b/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
@@ -68,6 +68,7 @@ library
                     , process               >= 1.6.26
                     , safe-exceptions
                     , text
+                    , transformers
                     , unix
                     , uuid-types
 

--- a/packages/claude-agent-sdk-haskell/package.nix
+++ b/packages/claude-agent-sdk-haskell/package.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, agent-json, agent-process, async, base
 , base64-bytestring, bytestring, containers, directory, entropy
 , filepath, hermes-json, hspec, lib, process, safe-exceptions, text
-, unix, uuid-types
+, transformers, unix, uuid-types
 }:
 mkDerivation {
   pname = "claude-agent-sdk-haskell";
@@ -10,7 +10,7 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-json agent-process async base base64-bytestring
     bytestring containers directory entropy hermes-json process
-    safe-exceptions text unix uuid-types
+    safe-exceptions text transformers unix uuid-types
   ];
   testHaskellDepends = [
     aeson agent-json base bytestring containers directory filepath

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Capabilities.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Capabilities.hs
@@ -27,6 +27,8 @@ import Control.Exception.Safe
     , tryAny
     )
 import Control.Monad (when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except (ExceptT(..), runExceptT, throwE, withExceptT)
 import qualified Data.ByteString as ByteString
 import Data.IORef (IORef, newIORef, readIORef, atomicModifyIORef')
 import qualified Data.Map.Strict as Map
@@ -178,48 +180,49 @@ probeClaudeCapabilities :: FilePath -> IO (Either Text ClaudeAgentCapabilities)
 probeClaudeCapabilities executable = getCurrentDirectory >>= probeClaudeCapabilitiesIn executable
 
 probeClaudeCapabilitiesIn :: FilePath -> FilePath -> IO (Either Text ClaudeAgentCapabilities)
-probeClaudeCapabilitiesIn executable cwd = do
-    versionResult <- runProbe executable cwd ["--version"]
-    case versionResult of
-        Left err -> pure (Left err)
-        Right (exitCode, _, _)
-            | exitCode /= ExitSuccess ->
-                pure
-                    (Left
-                        "Claude Code --version probe exited unsuccessfully.")
-        Right (_, versionOutput, versionErr) ->
-            case parseClaudeVersion (versionOutput <> "\n" <> versionErr) of
-                Nothing -> pure (Left "Unable to parse Claude Code version output.")
-                Just version -> do
-                    let key = executable <> "\0" <> Text.unpack version
-                    cached <- readIORef capabilityCache
-                    case Map.lookup key cached of
-                        Just result -> pure (Right result)
-                        Nothing -> do
-                            helpResult <- runProbe executable cwd ["--help"]
-                            case helpResult of
-                                Left err ->
-                                    pure
-                                        (Left
-                                            ("Claude Code --help probe failed: " <> err))
-                                Right (helpExit, _, _)
-                                    | helpExit /= ExitSuccess ->
-                                        pure
-                                            (Left
-                                                "Claude Code --help probe exited unsuccessfully.")
-                                Right (_, helpOutput, helpErr) -> do
-                                    let parsed = parseClaudeHelp helpOutput
-                                        failures =
-                                            [ "Claude Code probe stderr: " <> helpErr
-                                            | not (Text.null (Text.strip helpErr))
-                                            ]
-                                        result = parsed
-                                            { capabilityVersion = Just version
-                                            , warnings = failures <> parsed.warnings
-                                            }
-                                    atomicModifyIORef' capabilityCache
-                                        \m -> (Map.insert key result m, ())
-                                    pure (Right result)
+probeClaudeCapabilitiesIn executable cwd = runExceptT do
+    versionProbe <- ExceptT $ runProbe executable cwd ["--version"]
+    (versionOutput, versionErr) <- requireSuccessfulProbe "--version" versionProbe
+    version <- parseProbeVersion versionOutput versionErr
+    let key = executable <> "\0" <> Text.unpack version
+    cached <- liftIO $ Map.lookup key <$> readIORef capabilityCache
+    case cached of
+        -- A cached result is a successful capability discovery for this
+        -- executable/version pair, so avoid a redundant help probe.
+        Just result -> pure result
+        Nothing -> do
+            helpProbe <- withExceptT
+                ("Claude Code --help probe failed: " <>)
+                (ExceptT $ runProbe executable cwd ["--help"])
+            (helpOutput, helpErr) <- requireSuccessfulProbe "--help" helpProbe
+            let parsed = parseClaudeHelp helpOutput
+                failures =
+                    [ "Claude Code probe stderr: " <> helpErr
+                    | not (Text.null (Text.strip helpErr))
+                    ]
+                result = parsed
+                    { capabilityVersion = Just version
+                    , warnings = failures <> parsed.warnings
+                    }
+            liftIO $ atomicModifyIORef' capabilityCache
+                \m -> (Map.insert key result m, ())
+            pure result
+
+requireSuccessfulProbe
+    :: Text
+    -> (ExitCode, Text, Text)
+    -> ExceptT Text IO (Text, Text)
+requireSuccessfulProbe name (exitCode, output, errorOutput)
+    | exitCode == ExitSuccess = pure (output, errorOutput)
+    | otherwise =
+        throwE ("Claude Code " <> name <> " probe exited unsuccessfully.")
+
+parseProbeVersion :: Text -> Text -> ExceptT Text IO Text
+parseProbeVersion output errorOutput =
+    case parseClaudeVersion (output <> "\n" <> errorOutput) of
+        Just version -> pure version
+        Nothing -> throwE "Unable to parse Claude Code version output."
+
 capabilityCache :: IORef (Map.Map String ClaudeAgentCapabilities)
 capabilityCache = unsafePerformIO (newIORef Map.empty)
 {-# NOINLINE capabilityCache #-}

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/CapabilitiesSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/CapabilitiesSpec.hs
@@ -59,6 +59,15 @@ spec = describe "Claude Code capabilities" do
                     capabilities.supportsStreaming
                 Left _ -> False
 
+    it "returns a cached successful capability probe without re-running help" $
+        withFakeClaude cacheHitProbeScript \directory executable -> do
+            first <- probeClaudeCapabilitiesIn executable directory
+            first `shouldSatisfy` \case
+                Right capabilities -> capabilities.supportsStreaming
+                Left _ -> False
+            second <- probeClaudeCapabilitiesIn executable directory
+            second `shouldBe` first
+
     it "fails the probe when a descendant keeps stdout open" $
         withFakeClaude heldOpenHelpOutputScript \directory executable -> do
             result <-
@@ -137,6 +146,32 @@ failFirstHelpProbeScript =
         , "      printf 'failed' > \"$0.help-probed\""
         , "      exit 1"
         , "    fi"
+        , "    printf '%s\\n' \\"
+        , "      'Usage: claude [options]' \\"
+        , "      '  -p, --print' \\"
+        , "      '  --input-format <format> (choices: text, stream-json)' \\"
+        , "      '  --output-format <format> (choices: text, json, stream-json)' \\"
+        , "      '  --verbose' \\"
+        , "      '  --safe-mode' \\"
+        , "      '  --strict-mcp-config' \\"
+        , "      '  --permission-mode <mode> (choices: acceptEdits, auto, bypassPermissions, manual, dontAsk, plan)'"
+        , "    ;;"
+        , "esac"
+        ]
+
+cacheHitProbeScript :: String
+cacheHitProbeScript =
+    unlines
+        [ "#!/bin/sh"
+        , "case \"$1\" in"
+        , "  --version)"
+        , "    printf '%s\\n' '2.1.254 (Claude Code)'"
+        , "    ;;"
+        , "  --help)"
+        , "    if [ -e \"$0.help-probed\" ]; then"
+        , "      exit 1"
+        , "    fi"
+        , "    printf 'succeeded' > \"$0.help-probed\""
         , "    printf '%s\\n' \\"
         , "      'Usage: claude [options]' \\"
         , "      '  -p, --print' \\"


### PR DESCRIPTION
## Summary
- linearize Claude capability probe orchestration with `ExceptT Text IO`
- keep cache hits as explicit successful branches and centralize probe exit/version checks
- cover successful cache reuse without another help probe

## Validation
- focused `CapabilitiesSpec`: 7 examples, 0 failures

The low-level `runProbe` process cleanup and cancellation machinery is unchanged.