### PR TITLE
Accumulate independent model config validation errors

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
@@ -42,7 +42,7 @@ import Agent.Json.Decode qualified as Hermes
 import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Provider (Provider(..), parseProvider, providerSlug)
 import Control.Exception.Safe (tryIO)
-import Control.Monad (unless, when)
+import Control.Monad (unless)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isAlpha, isAlphaNum, isSpace)
 import Data.Foldable (traverse_)
@@ -417,12 +417,52 @@ mergeConfigFiles defaults (Just user) = do
         , configModels = replacedDefaults <> appendedModels
         }
 
+-- | A deliberately small applicative validator. Configuration syntax and
+-- references still use 'Either' for dependent, fail-fast resolution; this is
+-- only for independent constraints that can be reported together.
+data Validation errors value
+    = ValidationFailure !errors
+    | ValidationSuccess !value
+
+instance Functor (Validation errors) where
+    fmap transform = \case
+        ValidationFailure errors -> ValidationFailure errors
+        ValidationSuccess value -> ValidationSuccess (transform value)
+
+instance Semigroup errors => Applicative (Validation errors) where
+    pure = ValidationSuccess
+    ValidationFailure left <*> ValidationFailure right =
+        ValidationFailure (left <> right)
+    ValidationFailure errors <*> _ = ValidationFailure errors
+    _ <*> ValidationFailure errors = ValidationFailure errors
+    ValidationSuccess transform <*> ValidationSuccess value =
+        ValidationSuccess (transform value)
+
+validationFailure :: Text -> Validation [Text] value
+validationFailure = ValidationFailure . pure
+
+validationFromEither :: Either Text value -> Validation [Text] value
+validationFromEither = \case
+    Left err -> validationFailure err
+    Right value -> pure value
+
+validationToEither :: Validation [Text] value -> Either Text value
+validationToEither = \case
+    ValidationFailure errors -> Left (Text.intercalate "\n" errors)
+    ValidationSuccess value -> Right value
+
+validationCheck :: Bool -> Text -> Validation [Text] ()
+validationCheck valid err
+    | valid = pure ()
+    | otherwise = validationFailure err
+
 validateConfig :: Text -> ConfigFile -> Either Text ModelCatalog
 validateConfig source config = do
     ensureUniqueModelRoutes source config.configModels
-    connections <- Map.traverseWithKey validateConnection
-        config.configConnections
-    models <- traverse (validateModel connections) config.configModels
+    connections <- validationToEither $
+        Map.traverseWithKey validateConnection config.configConnections
+    models <- validationToEither $
+        traverse (validateModel connections) config.configModels
     traverse_ (validateBuiltinDefault models) allBuiltinProviders
     pure ModelCatalog
         { catalogConnections = connections
@@ -443,70 +483,79 @@ validateConfig source config = do
                 ]
         }
   where
-    validateConnection connectionId raw = do
-        validateConnectionId connectionId
-        kind <- case Text.toLower (Text.strip raw.connectionApi) of
-            "builtin" -> do
-                providerText <- maybe
-                    (Left ("connection " <> connectionId
-                        <> " with api=builtin requires provider"))
-                    Right
-                    raw.connectionProvider
-                provider <- maybe
-                    (Left ("connection " <> connectionId
-                        <> " has unknown provider " <> providerText))
-                    Right
-                    (parseProvider (Text.toLower (Text.strip providerText)))
-                when (connectionId /= builtinConnectionId provider) $
-                    Left
-                        ( "builtin connection " <> connectionId
-                            <> " must use its provider id "
-                            <> builtinConnectionId provider
-                        )
-                pure (BuiltinConnection provider)
-            "responses" -> do
-                baseUrl <- maybe
-                    (Left ("connection " <> connectionId
-                        <> " with api=responses requires base_url"))
-                    (validateBaseUrl connectionId)
-                    raw.connectionBaseUrl
-                when
-                    ( raw.connectionApiKeyEnv == Nothing
-                        && not raw.connectionApiKeyOptional
-                    ) $
-                    Left
-                        ( "connection " <> connectionId
-                            <> " requires api_key_env unless "
-                            <> "api_key_optional is true"
-                        )
-                when (raw.connectionRequestTimeoutSeconds <= 0) $
-                    Left ("connection " <> connectionId
-                        <> " request_timeout_seconds must be positive")
-                traverse_ (validateEnvName connectionId)
-                    raw.connectionApiKeyEnv
-                pure $ CustomResponsesConnection ResponsesConnection
-                    { responsesBaseUrl = baseUrl
-                    , responsesApiKeyEnv =
-                        nonEmptyText =<< raw.connectionApiKeyEnv
-                    , responsesApiKeyOptional =
-                        raw.connectionApiKeyOptional
-                    , responsesRequestTimeoutSeconds =
-                        raw.connectionRequestTimeoutSeconds
-                    }
-            "gateway" -> do
-                when (connectionId /= organizationGatewayConnectionId) $
-                    Left
+    validateConnection connectionId raw =
+        case validateConnectionId connectionId of
+            Left err -> validationFailure err
+            Right () ->
+                ModelConnection connectionId
+                    <$> validateConnectionKind connectionId raw
+
+    validateConnectionKind connectionId raw =
+        case Text.toLower (Text.strip raw.connectionApi) of
+            "builtin" ->
+                case raw.connectionProvider of
+                    Nothing ->
+                        validationFailure ("connection " <> connectionId
+                            <> " with api=builtin requires provider")
+                    Just providerText ->
+                        case parseProvider
+                            (Text.toLower (Text.strip providerText)) of
+                            Nothing ->
+                                validationFailure ("connection " <> connectionId
+                                    <> " has unknown provider " <> providerText)
+                            Just provider ->
+                                BuiltinConnection provider
+                                    <$ validationCheck
+                                        (connectionId == builtinConnectionId provider)
+                                        ( "builtin connection " <> connectionId
+                                            <> " must use its provider id "
+                                            <> builtinConnectionId provider
+                                        )
+            "responses" ->
+                CustomResponsesConnection
+                    <$> ( ResponsesConnection
+                            <$> maybe
+                                (validationFailure
+                                    ("connection " <> connectionId
+                                        <> " with api=responses requires base_url"))
+                                (validationFromEither . validateBaseUrl connectionId)
+                                raw.connectionBaseUrl
+                            <*> pure (nonEmptyText =<< raw.connectionApiKeyEnv)
+                            <*> pure raw.connectionApiKeyOptional
+                            <*> ( raw.connectionRequestTimeoutSeconds
+                                <$ ( validationCheck
+                                        ( raw.connectionApiKeyEnv /= Nothing
+                                            || raw.connectionApiKeyOptional
+                                        )
+                                        ( "connection " <> connectionId
+                                            <> " requires api_key_env unless "
+                                            <> "api_key_optional is true"
+                                        )
+                                    *> validationCheck
+                                        (raw.connectionRequestTimeoutSeconds > 0)
+                                        ( "connection " <> connectionId
+                                            <> " request_timeout_seconds must be positive"
+                                        )
+                                    *> maybe
+                                        (pure ())
+                                        (validationFromEither . validateEnvName connectionId)
+                                        raw.connectionApiKeyEnv
+                                )
+                            )
+                    )
+            "gateway" ->
+                OrganizationGatewayConnection
+                    <$ validationCheck
+                        (connectionId == organizationGatewayConnectionId)
                         ( "gateway connection " <> connectionId
                             <> " must use the reserved id "
                             <> organizationGatewayConnectionId
                         )
-                pure OrganizationGatewayConnection
             other ->
-                Left ("connection " <> connectionId
+                validationFailure ("connection " <> connectionId
                     <> " has unsupported api " <> other)
-        pure ModelConnection{connectionId, connectionKind = kind}
 
-    validateModel connections raw = do
+    validateModel connections raw =
         let modelId = Text.strip raw.modelFileId
             connectionId = Text.strip raw.modelFileConnection
             wireId = Text.strip (fromMaybe modelId raw.modelFileWireId)
@@ -516,117 +565,137 @@ validateConfig source config = do
             defaultReasoningEffort =
                 Text.toLower . Text.strip
                     <$> raw.modelFileDefaultReasoningEffort
-        when (Text.null modelId || Text.any isSpace modelId) $
-            Left ("model id must be nonempty and contain no whitespace: "
-                <> raw.modelFileId)
-        when (Text.null wireId) $
-            Left ("model " <> modelId <> " has an empty wire model name")
-        connection <- maybe
-            (Left ("model " <> modelId
-                <> " references unknown connection " <> connectionId))
-            Right
-            (Map.lookup connectionId connections)
-        dialect <- maybe
-            (Left ("model " <> modelId <> " has unknown dialect "
-                <> raw.modelFileDialect))
-            Right
-            (parseDialect raw.modelFileDialect)
-        case connection.connectionKind of
-            BuiltinConnection provider -> do
-                when (wireId /= modelId) $
-                    Left
+        in if Text.null modelId || Text.any isSpace modelId
+            then validationFailure
+                ("model id must be nonempty and contain no whitespace: "
+                    <> raw.modelFileId)
+            else if Text.null wireId
+                then validationFailure
+                    ("model " <> modelId <> " has an empty wire model name")
+            else case Map.lookup connectionId connections of
+                Nothing ->
+                    validationFailure ("model " <> modelId
+                        <> " references unknown connection " <> connectionId)
+                Just connection ->
+                    case parseDialect raw.modelFileDialect of
+                        Nothing ->
+                            validationFailure ("model " <> modelId
+                                <> " has unknown dialect "
+                                <> raw.modelFileDialect)
+                        Just dialect ->
+                            validateResolvedModel
+                                connection
+                                dialect
+                                modelId
+                                connectionId
+                                wireId
+                                reasoningEfforts
+                                defaultReasoningEffort
+      where
+        validateResolvedModel
+            connection
+            dialect
+            modelId
+            connectionId
+            wireId
+            reasoningEfforts
+            defaultReasoningEffort =
+            let connectionValidation =
+                    case connection.connectionKind of
+                        BuiltinConnection provider ->
+                            validationCheck
+                                (wireId == modelId)
+                                ( "model " <> modelId
+                                    <> " cannot override its wire model on built-in connection "
+                                    <> connectionId
+                                    <> "; use the wire model as id or define a custom responses connection"
+                                )
+                                *> validationCheck
+                                    (providerSupportsDialect provider dialect)
+                                    ( "model " <> modelId <> " uses dialect "
+                                        <> raw.modelFileDialect
+                                        <> " which is incompatible with connection "
+                                        <> connectionId
+                                    )
+                        CustomResponsesConnection _ -> pure ()
+                        OrganizationGatewayConnection ->
+                            validationCheck
+                                (wireId == modelId)
+                                ( "model " <> modelId
+                                    <> " cannot override its wire model on organization gateway connection "
+                                    <> connectionId
+                                )
+                                *> validationCheck
+                                    (connectionSupportsDialect
+                                        connectionId
+                                        OpenAIProvider
+                                        dialect
+                                        || connectionSupportsDialect
+                                            connectionId
+                                            ClaudeCodeProvider
+                                            dialect)
+                                    ( "model " <> modelId <> " uses dialect "
+                                        <> raw.modelFileDialect
+                                        <> " which is incompatible with connection "
+                                        <> connectionId
+                                    )
+                modelValidation =
+                    validationCheck
+                        (maybe True (>= 0) raw.modelFileFallbackPriority)
                         ( "model " <> modelId
-                            <> " cannot override its wire model on built-in connection "
-                            <> connectionId
-                            <> "; use the wire model as id or define a custom responses connection"
+                            <> " fallback_priority must not be negative"
                         )
-                unless (providerSupportsDialect provider dialect) $
-                    Left
-                        ( "model " <> modelId <> " uses dialect "
-                            <> raw.modelFileDialect
-                            <> " which is incompatible with connection "
-                            <> connectionId
-                        )
-            CustomResponsesConnection _ -> pure ()
-            OrganizationGatewayConnection -> do
-                when (wireId /= modelId) $
-                    Left
+                    *> validationCheck
+                        (maybe True (> 0) raw.modelFileContextWindow)
                         ( "model " <> modelId
-                            <> " cannot override its wire model on organization gateway connection "
-                            <> connectionId
+                            <> " context_window must be positive"
                         )
-                unless
-                    (connectionSupportsDialect
-                        connectionId
-                        OpenAIProvider
-                        dialect
-                        || connectionSupportsDialect
-                            connectionId
-                            ClaudeCodeProvider
-                            dialect) $
-                    Left
-                        ( "model " <> modelId <> " uses dialect "
-                            <> raw.modelFileDialect
-                            <> " which is incompatible with connection "
-                            <> connectionId
+                    *> validationCheck
+                        (maybe True
+                            (all (`elem` supportedReasoningEfforts))
+                            reasoningEfforts)
+                        ( "model " <> modelId
+                            <> " has unsupported reasoning_efforts; expected "
+                            <> Text.intercalate ", " supportedReasoningEfforts
                         )
-        traverse_
-            (\priority -> when (priority < 0) $
-                Left ("model " <> modelId
-                    <> " fallback_priority must not be negative"))
-            raw.modelFileFallbackPriority
-        traverse_
-            (\contextWindow -> when (contextWindow <= 0) $
-                Left ("model " <> modelId
-                    <> " context_window must be positive"))
-            raw.modelFileContextWindow
-        unless
-            ( maybe True
-                (all (`elem` supportedReasoningEfforts))
-                reasoningEfforts
-            ) $
-            Left
-                ( "model " <> modelId
-                    <> " has unsupported reasoning_efforts; expected "
-                    <> Text.intercalate ", " supportedReasoningEfforts
-                )
-        traverse_
-            (\efforts -> do
-                when (null efforts) $
-                    Left
+                    *> validationCheck
+                        (maybe True (not . null) reasoningEfforts)
                         ( "model " <> modelId
                             <> " reasoning_efforts must not be empty"
                         )
-                when (length efforts /= length (nub efforts)) $
-                    Left
+                    *> validationCheck
+                        (maybe True
+                            (\efforts -> length efforts == length (nub efforts))
+                            reasoningEfforts)
                         ( "model " <> modelId
                             <> " reasoning_efforts must not contain duplicates"
-                        ))
-            reasoningEfforts
-        traverse_
-            (\effort -> unless (maybe False (effort `elem`) reasoningEfforts) $
-                Left
-                    ( "model " <> modelId
-                        <> " default_reasoning_effort must be listed in "
-                        <> "reasoning_efforts"
-                    ))
-            defaultReasoningEffort
-        pure CatalogModel
-            { catalogModelId = modelId
-            , catalogModelConnectionId = connectionId
-            , catalogModelWireId = wireId
-            , catalogModelDialect = dialect
-            , catalogModelContextWindow =
-                raw.modelFileContextWindow
-            , catalogModelLabel =
-                nonEmptyText =<< raw.modelFileLabel
-            , catalogModelReasoningEfforts = reasoningEfforts
-            , catalogModelDefaultReasoningEffort =
-                defaultReasoningEffort
-            , catalogModelDefault = raw.modelFileDefault
-            , catalogModelFallbackPriority =
-                raw.modelFileFallbackPriority
-            }
+                        )
+                    *> validationCheck
+                        (maybe True
+                            (\effort ->
+                                maybe False (effort `elem`) reasoningEfforts)
+                            defaultReasoningEffort)
+                        ( "model " <> modelId
+                            <> " default_reasoning_effort must be listed in "
+                            <> "reasoning_efforts"
+                        )
+            in CatalogModel
+                { catalogModelId = modelId
+                , catalogModelConnectionId = connectionId
+                , catalogModelWireId = wireId
+                , catalogModelDialect = dialect
+                , catalogModelContextWindow =
+                    raw.modelFileContextWindow
+                , catalogModelLabel =
+                    nonEmptyText =<< raw.modelFileLabel
+                , catalogModelReasoningEfforts = reasoningEfforts
+                , catalogModelDefaultReasoningEffort =
+                    defaultReasoningEffort
+                , catalogModelDefault = raw.modelFileDefault
+                , catalogModelFallbackPriority =
+                    raw.modelFileFallbackPriority
+                }
+                <$ (connectionValidation *> modelValidation)
 
 supportedReasoningEfforts :: [Text]
 supportedReasoningEfforts =

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
@@ -279,6 +279,36 @@ spec = describe "Agent.CLI.ModelConfig" do
             (Just ("models.json", overlay))
             `shouldSatisfy` leftContains "invalid api_key_env"
 
+    it "reports independent connection validation errors together in check order" do
+        defaults <- readPackagedDefaults
+        let overlay =
+                "{\"version\":1,\"connections\":{\"local\":{\"api\":\"responses\",\"base_url\":\"ftp://localhost/v1\",\"api_key_env\":\"BAD-NAME\",\"request_timeout_seconds\":0}}}"
+        err <- expectLeft
+            (mergeModelConfigs
+                ("models.default.json", defaults)
+                (Just ("models.json", overlay)))
+        err `shouldBe` Text.intercalate "\n"
+            [ "connection local base_url must start with http:// or https://"
+            , "connection local request_timeout_seconds must be positive"
+            , "connection local has invalid api_key_env BAD-NAME"
+            ]
+
+    it "reports independent model validation errors together in check order" do
+        defaults <- readPackagedDefaults
+        let overlay =
+                "{\"version\":1,\"connections\":{\"local\":{\"api\":\"responses\",\"base_url\":\"http://localhost/v1\",\"api_key_optional\":true}},\"models\":[{\"id\":\"local-model\",\"connection\":\"local\",\"dialect\":\"generic-responses\",\"fallback_priority\":-1,\"context_window\":0,\"reasoning_efforts\":[\"turbo\",\"turbo\"],\"default_reasoning_effort\":\"high\"}]}"
+        err <- expectLeft
+            (mergeModelConfigs
+                ("models.default.json", defaults)
+                (Just ("models.json", overlay)))
+        err `shouldBe` Text.intercalate "\n"
+            [ "model local-model fallback_priority must not be negative"
+            , "model local-model context_window must be positive"
+            , "model local-model has unsupported reasoning_efforts; expected none, low, medium, high, xhigh, max"
+            , "model local-model reasoning_efforts must not contain duplicates"
+            , "model local-model default_reasoning_effort must be listed in reasoning_efforts"
+            ]
+
     it "requires an API-key environment variable unless auth is optional" do
         defaults <- readPackagedDefaults
         let overlay =
@@ -370,6 +400,13 @@ expectRight = \case
         expectationFailure (Text.unpack err)
         fail "expected Right"
     Right value -> pure value
+
+expectLeft :: Either Text value -> IO Text
+expectLeft = \case
+    Left err -> pure err
+    Right _ -> do
+        expectationFailure "expected Left"
+        fail "expected Left"
 
 readPackagedDefaults :: IO LBS.ByteString
 readPackagedDefaults =


### PR DESCRIPTION
## Summary
- collect independent connection and model validation failures in a small local applicative validator
- retain fail-fast behavior for parsing and reference resolution
- add ordered regression coverage for multi-error reports

## Validation
- `git diff --check`
- source/test syntax parsed with `ghc -fno-code` using package extensions
- `cabal repl agent-cli-runtime:lib:agent-cli-runtime` attempted but blocked before the target by missing `packages/agent-openai/data/prompt.md` in the existing worktree

No merge performed.