### PR TITLE
Refactor LSP error workflows

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Lsp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Lsp.hs
@@ -77,6 +77,12 @@ import Control.Monad
     , void
     , when
     )
+import Control.Monad.Trans.Except
+    ( ExceptT(..)
+    , runExceptT
+    , throwE
+    , withExceptT
+    )
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import qualified Data.ByteString as BS
@@ -393,7 +399,7 @@ spawnClient name config workspace logHandle = mask \restore -> do
                 `onException` stopAsync stderrWorker)
         `onException` closePartial
 initializeClient :: LspClient -> IO (Either Text ())
-initializeClient client = do
+initializeClient client = runExceptT do
     let rootUri = fileUri client.clientWorkspace
         rootName =
             Text.pack
@@ -416,41 +422,29 @@ initializeClient client = do
                 , "initializationOptions"
                     .= client.clientConfig.lspInitializationOptions
                 ]
-    requestClient
-        client
-        client.clientConfig.lspStartupTimeoutMilliseconds
-        "initialize"
-        params >>= \case
-            Left err -> pure (Left ("initialize failed: " <> err))
-            Right _ -> do
-                initialized <-
+        startupTimeout =
+            client.clientConfig.lspStartupTimeoutMilliseconds
+    void $
+        withExceptT ("initialize failed: " <>) $
+            ExceptT $
+                requestClient client startupTimeout "initialize" params
+    withExceptT ("post-initialize notification failed: " <>) $
+        ExceptT $
+            sendNotificationWithin
+                client
+                startupTimeout
+                "initialized"
+                (Aeson.object [])
+    case client.clientConfig.lspSettings of
+        Nothing -> pure ()
+        Just settings ->
+            withExceptT ("settings notification failed: " <>) $
+                ExceptT $
                     sendNotificationWithin
                         client
-                        client.clientConfig.lspStartupTimeoutMilliseconds
-                        "initialized"
-                        (Aeson.object [])
-                case initialized of
-                    Left err ->
-                        pure
-                            (Left
-                                ("post-initialize notification failed: "
-                                    <> err))
-                    Right () ->
-                        case client.clientConfig.lspSettings of
-                            Nothing -> pure (Right ())
-                            Just settings ->
-                                sendNotificationWithin
-                                    client
-                                    client.clientConfig.lspStartupTimeoutMilliseconds
-                                    "workspace/didChangeConfiguration"
-                                    (Aeson.object
-                                        ["settings" .= settings]) >>= \case
-                                            Left err ->
-                                                pure
-                                                    (Left
-                                                        ("settings notification failed: "
-                                                            <> err))
-                                            Right () -> pure (Right ())
+                        startupTimeout
+                        "workspace/didChangeConfiguration"
+                        (Aeson.object ["settings" .= settings])
 
 runLsp :: LspRuntime -> LspRequest -> IO (Either Text Text)
 runLsp runtime = \case
@@ -505,69 +499,48 @@ runFileOperation
     -> Text
     -> (LspClient -> Text -> IO (Either Text Text))
     -> IO (Either Text Text)
-runFileOperation runtime rawPath operation =
-    prepareFileRequest runtime rawPath >>= \case
-        Left err -> pure (Left err)
-        Right (client, path, uri) ->
-            withMVar client.clientOperationLock \() ->
-                synchronizeDocument client path uri >>= \case
-                    Left err -> pure (Left err)
-                    Right () -> operation client uri
+runFileOperation runtime rawPath operation = runExceptT do
+    (client, path, uri) <- ExceptT (prepareFileRequest runtime rawPath)
+    ExceptT $
+        withMVar client.clientOperationLock \() ->
+            runExceptT do
+                ExceptT (synchronizeDocument client path uri)
+                ExceptT (operation client uri)
 
 prepareFileRequest
     :: LspRuntime
     -> Text
     -> IO (Either Text (LspClient, FilePath, Text))
-prepareFileRequest runtime rawPath = do
+prepareFileRequest runtime rawPath = runExceptT do
     let path = Text.unpack rawPath
-    if not (FilePath.isAbsolute path)
-        then pure (Left "lsp file_path must be absolute")
-        else do
-            canonicalResult <-
+    unless (FilePath.isAbsolute path) $
+        throwE "lsp file_path must be absolute"
+    (workspace, canonical) <-
+        withExceptT
+            ( \exception ->
+                "lsp could not resolve file_path: "
+                    <> exceptionText exception
+            )
+            (ExceptT $
                 tryAny $
                     (,)
                         <$> canonicalizePath runtime.runtimeWorkspace
-                        <*> canonicalizePath path
-            case canonicalResult of
-                Left exception ->
-                    pure . Left $
-                        "lsp could not resolve file_path: "
-                            <> exceptionText exception
-                Right (workspace, canonical)
-                    | not
-                        (pathWithin
-                            workspace
-                            canonical) ->
-                        pure
-                            (Left
-                                "lsp file_path must be inside the \
-                                \active workspace")
-                    | otherwise ->
-                        case clientForPath
-                            runtime.runtimeClients canonical
-                        of
-                            Nothing ->
-                                pure . Left $
-                                    "No initialized LSP server is \
-                                    \configured for "
-                                        <> Text.pack
-                                            (FilePath.takeExtension canonical)
-                            Just client
-                                | not
-                                    (pathWithin
-                                        client.clientWorkspace
-                                        canonical) ->
-                                    pure . Left $
-                                        "lsp file_path is outside the \
-                                        \configured server workspace for "
-                                            <> client.clientName
-                            Just client ->
-                                pure
-                                    (Right
-                                        ( client
-                                        , canonical
-                                        , fileUri canonical
-                                        ))
+                        <*> canonicalizePath path)
+    unless (pathWithin workspace canonical) $
+        throwE
+            "lsp file_path must be inside the active workspace"
+    client <-
+        maybe
+            (throwE $
+                "No initialized LSP server is configured for "
+                    <> Text.pack (FilePath.takeExtension canonical))
+            pure
+            (clientForPath runtime.runtimeClients canonical)
+    unless (pathWithin client.clientWorkspace canonical) $
+        throwE $
+            "lsp file_path is outside the configured server workspace for "
+                <> client.clientName
+    pure (client, canonical, fileUri canonical)
 
 runDocumentSymbols
     :: LspClient

--- a/packages/agent-cli/test/Agent/CLI/WebLspSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WebLspSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.WebLspSpec (spec) where
 import Agent.CLI.Config
 import Agent.CLI.Lsp
 import Agent.CLI.WebFetch
+import Agent.Json (rawJsonFromEncoding)
 import Agent.Loop (defaultLoopDispatch)
 import Agent.OsPath (unsafeToFilePath)
 import Agent.ToolDispatch
@@ -161,8 +162,10 @@ spec = describe "web_fetch and LSP runtime support" do
                 script = directory FilePath.</> "mock-lsp.sh"
                 trace = directory FilePath.</> "mock-lsp-requests.log"
                 source = directory FilePath.</> "Test.hs"
+                unsupportedSource = directory FilePath.</> "Test.txt"
             writeFile script mockLspScript
             writeFile source "module Test where\nmain = pure ()\n"
+            writeFile unsupportedSource "not handled by the mock server\n"
             env <- defaultToolEnv root
             setToolSessionTmp env (Just root)
             let server = LspServerConfig
@@ -171,8 +174,17 @@ spec = describe "web_fetch and LSP runtime support" do
                     , lspEnv = Map.empty
                     , lspExtensionToLanguage =
                         Map.singleton ".hs" "haskell"
-                    , lspInitializationOptions = Nothing
-                    , lspSettings = Nothing
+                    , lspInitializationOptions =
+                        Just . rawJsonFromEncoding . Aeson.toEncoding $
+                            object ["feature" .= True]
+                    , lspSettings =
+                        Just . rawJsonFromEncoding . Aeson.toEncoding $
+                            object
+                                [ "haskell" .= object
+                                    [ "formattingProvider"
+                                        .= ("ormolu" :: Text.Text)
+                                    ]
+                                ]
                     , lspWorkspaceFolder = Nothing
                     , lspStartupTimeoutMilliseconds = 3000
                     , lspShutdownTimeoutMilliseconds = 3000
@@ -187,14 +199,31 @@ spec = describe "web_fetch and LSP runtime support" do
                 Nothing -> expectationFailure "expected initialized LSP runtime"
                 Just runtime -> do
                     let tool = lspRuntimeTool runtime
-                        fileRequest operation =
+                        fileRequestFor operation file =
                             object
                                 [ "operation" .= (operation :: Text.Text)
-                                , "file_path" .= Text.pack source
+                                , "file_path" .= Text.pack file
                                 , "line" .= (0 :: Int)
                                 , "character" .= (1 :: Int)
                                 ]
+                        fileRequest operation =
+                            fileRequestFor operation source
                     tool.appToolName `shouldBe` "lsp"
+                    relative <- callLsp tool
+                        (fileRequestFor "hover" "Test.hs")
+                    relative.output `shouldSatisfy`
+                        Text.isInfixOf
+                            "lsp file_path must be absolute"
+                    outside <- callLsp tool
+                        (fileRequestFor "hover" "/etc/hosts")
+                    outside.output `shouldSatisfy`
+                        Text.isInfixOf
+                            "lsp file_path must be inside the active workspace"
+                    unsupported <- callLsp tool
+                        (fileRequestFor "hover" unsupportedSource)
+                    unsupported.output `shouldSatisfy`
+                        Text.isInfixOf
+                            "No initialized LSP server is configured for .txt"
                     definition <- callLsp tool
                         (fileRequest "goToDefinition")
                     definition.output `shouldSatisfy`
@@ -233,6 +262,7 @@ spec = describe "web_fetch and LSP runtime support" do
                                     ("\"method\":\"" <> method <> "\""))
                         [ "textDocument/didOpen"
                         , "textDocument/didChange"
+                        , "workspace/didChangeConfiguration"
                         , "textDocument/definition"
                         , "textDocument/references"
                         , "textDocument/hover"
@@ -242,6 +272,13 @@ spec = describe "web_fetch and LSP runtime support" do
                         , "shutdown"
                         , "exit"
                         ]
+                    take 4 (Text.lines requests)
+                        `shouldSatisfy` initializationOrder
+                    requests `shouldSatisfy`
+                        Text.isInfixOf "\"feature\":true"
+                    requests `shouldSatisfy`
+                        Text.isInfixOf
+                            "\"formattingProvider\":\"ormolu\""
                     requests `shouldSatisfy`
                         Text.isInfixOf
                             "\"id\":\"configuration-1\""
@@ -371,6 +408,7 @@ mockLspScript =
         , "read_frame"
         , "read_frame"
         , "read_frame"
+        , "read_frame"
         , "send_frame '{\"jsonrpc\":\"2.0\",\"id\":\"configuration-1\",\"method\":\"workspace/configuration\",\"params\":{\"items\":[{},{}]}}'"
         , "read_frame"
         , "send_frame '{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"uri\":\"file:///mock/Test.hs\",\"range\":{\"start\":{\"line\":0,\"character\":1}}}}'"
@@ -391,6 +429,25 @@ mockLspScript =
         , "read_frame"
         , "send_frame '{\"jsonrpc\":\"2.0\",\"id\":8,\"result\":null}'"
         , "read_frame"
+        ]
+
+initializationOrder :: [Text.Text] -> Bool
+initializationOrder requests =
+    length requests == length methods
+        && and
+            (zipWith
+                (\request method ->
+                    ("\"method\":\"" <> method <> "\"")
+                        `Text.isInfixOf`
+                            request)
+                requests
+                methods)
+  where
+    methods =
+        [ "initialize"
+        , "initialized"
+        , "workspace/didChangeConfiguration"
+        , "textDocument/didOpen"
         ]
 
 blockingLspScript :: FilePath -> FilePath -> String


### PR DESCRIPTION
## Summary
- express LSP initialization and file-request validation as linear `ExceptT Text IO` workflows
- preserve notification ordering, optional settings, path canonicalization, client selection, and per-client synchronization
- extend the mock-LSP integration test to cover initialization payload/order and early file-path validation failures

## Tests
- `printf ':load Agent.CLI.Lsp\n:q\n' | cabal repl agent-cli:lib:agent-cli`
- `printf ':load Agent.CLI.WebLspSpec\nimport Test.Hspec\nhspec Agent.CLI.WebLspSpec.spec\n:q\n' | cabal repl agent-cli:test:agent-cli-test --repl-no-load` (10 examples, 0 failures)
- `git diff --check`
