### PR TITLE
refactor(cli): pass immutable snapshots to side calls

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Btw.hs
+++ b/packages/agent-cli/src/Agent/CLI/Btw.hs
@@ -2,8 +2,12 @@
 module Agent.CLI.Btw
     ( BtwBackendFactory
     , BtwError(..)
+    , SideCallSnapshot
     , formatBtwError
     , runBtwWithCancel
+    , sideCallSnapshotParams
+    , sideCallSnapshot
+    , sideCallSnapshotTranscript
     , sideQuestionPrompt
     , trimDanglingToolSuffix
     ) where
@@ -31,7 +35,6 @@ import Agent.Responses.Types
     , ToolChoiceMode(..)
     )
 import Control.Concurrent.Async (race)
-import Data.IORef (IORef, readIORef)
 import Data.List (findIndex)
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -41,6 +44,33 @@ import qualified Data.Text as Text
 -- | Construct a provider backend over private request parameters and transcript.
 type BtwBackendFactory =
     ResponseCreateParams -> Backend
+
+-- | Immutable provider parameters and transcript used by a one-shot side call.
+--
+-- Constructing the snapshot also removes request fields that belong to the
+-- parent turn and trims any incomplete live tool-call suffix.
+data SideCallSnapshot = SideCallSnapshot
+    { sideCallParams :: !ResponseCreateParams
+    , sideCallTranscript :: ![ResponseItem]
+    }
+
+sideCallSnapshot
+    :: ResponseCreateParams
+    -> [ResponseItem]
+    -> SideCallSnapshot
+sideCallSnapshot params transcript =
+    SideCallSnapshot
+        { sideCallParams = clearTurnSpecificParams params
+        , sideCallTranscript = trimDanglingToolSuffix transcript
+        }
+
+sideCallSnapshotParams :: SideCallSnapshot -> ResponseCreateParams
+sideCallSnapshotParams SideCallSnapshot{sideCallParams = params} = params
+
+sideCallSnapshotTranscript :: SideCallSnapshot -> [ResponseItem]
+sideCallSnapshotTranscript
+        SideCallSnapshot{sideCallTranscript = transcript} =
+    transcript
 
 data BtwError
     = BtwTransport !ApiError
@@ -161,13 +191,17 @@ runBtwWithCancel
         -> IO (Either BtwError Text)
         -> IO (Either BtwError Text))
     -> BtwBackendFactory
-    -> IORef ResponseCreateParams
-    -> IORef [ResponseItem]
+    -> SideCallSnapshot
     -> Text
     -> IO (Either BtwError Text)
-runBtwWithCancel withCancelScope makeBackend paramsRef transcriptRef question = do
-    params <- clearTurnSpecificParams <$> readIORef paramsRef
-    transcript <- trimDanglingToolSuffix <$> readIORef transcriptRef
+runBtwWithCancel
+        withCancelScope
+        makeBackend
+        SideCallSnapshot
+            { sideCallParams = params
+            , sideCallTranscript = transcript
+            }
+        question = do
     cancel <- newCancelFlag
     let Backend submit = makeBackend params
         request =

--- a/packages/agent-cli/src/Agent/CLI/Recap.hs
+++ b/packages/agent-cli/src/Agent/CLI/Recap.hs
@@ -32,7 +32,9 @@ module Agent.CLI.Recap
 import Agent.Cancel (CancelFlag, newCancelFlag, waitCancel)
 import Agent.CLI.Btw
     ( BtwBackendFactory
-    , trimDanglingToolSuffix
+    , SideCallSnapshot
+    , sideCallSnapshotParams
+    , sideCallSnapshotTranscript
     )
 import Agent.CLI.Error (formatApiErrorInline)
 import Agent.Loop
@@ -45,16 +47,12 @@ import Agent.Loop
 import Agent.Responses.Types
     ( MessageContent(..)
     , ResponseContentPart(..)
-    , ResponseCreateParams(..)
     , ResponseItem(..)
     , ResponseMessage(..)
     , ResponseRole(..)
-    , ToolChoice(..)
-    , ToolChoiceMode(..)
     )
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async (race)
-import Data.IORef (IORef, readIORef)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -245,17 +243,15 @@ runRecapWithCancel
         -> IO (Either RecapError Text)
         -> IO (Either RecapError Text))
     -> BtwBackendFactory
-    -> IORef ResponseCreateParams
-    -> IORef [ResponseItem]
+    -> SideCallSnapshot
     -> RecapKind
     -> IO (Either RecapError RecapOutcome)
-runRecapWithCancel withCancelScope makeBackend paramsRef transcriptRef kind = do
+runRecapWithCancel withCancelScope makeBackend snapshot kind = do
     result <-
         runSideCallWithCancel
             withCancelScope
             makeBackend
-            paramsRef
-            transcriptRef
+            snapshot
             recapInstruction
     pure $ case result of
         Left err -> Left err
@@ -274,11 +270,12 @@ runTurnSummaryWithCancel
         -> IO (Either RecapError Text)
         -> IO (Either RecapError Text))
     -> BtwBackendFactory
-    -> IORef ResponseCreateParams
-    -> IORef [ResponseItem]
+    -> SideCallSnapshot
     -> IO (Either RecapError Text)
-runTurnSummaryWithCancel withCancelScope makeBackend paramsRef transcriptRef = do
-    transcript <- trimDanglingToolSuffix <$> readIORef transcriptRef
+runTurnSummaryWithCancel
+        withCancelScope
+        makeBackend
+        snapshot =
     case lastUserAnchor transcript of
         Nothing -> pure (Left RecapEmpty)
         Just anchor -> do
@@ -286,8 +283,7 @@ runTurnSummaryWithCancel withCancelScope makeBackend paramsRef transcriptRef = d
                 runSideCallWithCancel
                     withCancelScope
                     makeBackend
-                    paramsRef
-                    transcriptRef
+                    snapshot
                     (turnSummaryInstruction anchor)
             pure $ case result of
                 Left err -> Left err
@@ -296,19 +292,22 @@ runTurnSummaryWithCancel withCancelScope makeBackend paramsRef transcriptRef = d
                     in if Text.null summary
                         then Left RecapEmpty
                         else Right summary
+  where
+    transcript = sideCallSnapshotTranscript snapshot
 
 runSideCallWithCancel
     :: (CancelFlag
         -> IO (Either RecapError Text)
         -> IO (Either RecapError Text))
     -> BtwBackendFactory
-    -> IORef ResponseCreateParams
-    -> IORef [ResponseItem]
+    -> SideCallSnapshot
     -> Text
     -> IO (Either RecapError Text)
-runSideCallWithCancel withCancelScope makeBackend paramsRef transcriptRef instruction = do
-    params <- clearTurnSpecificParams <$> readIORef paramsRef
-    transcript <- trimDanglingToolSuffix <$> readIORef transcriptRef
+runSideCallWithCancel
+        withCancelScope
+        makeBackend
+        snapshot
+        instruction = do
     cancel <- newCancelFlag
     let Backend submit = makeBackend params
         request =
@@ -322,15 +321,9 @@ runSideCallWithCancel withCancelScope makeBackend paramsRef transcriptRef instru
                     Left (RecapTransport (formatApiErrorInline err))
                 Right (Right result) -> classifyTurn result.backendOutput
     withCancelScope cancel action
-
-clearTurnSpecificParams :: ResponseCreateParams -> ResponseCreateParams
-clearTurnSpecificParams ResponseCreateParams{..} =
-    ResponseCreateParams
-        { input = Nothing
-        , previousResponseId = Nothing
-        , toolChoice = Just (ToolChoiceMode ToolChoiceNone)
-        , ..
-        }
+  where
+    params = sideCallSnapshotParams snapshot
+    transcript = sideCallSnapshotTranscript snapshot
 
 classifyTurn :: TurnOutput -> Either RecapError Text
 classifyTurn turn

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Recap.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Recap.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Runtime.Recap
     , runSessionTurnSummary
     ) where
 
+import Agent.CLI.Btw (sideCallSnapshot)
 import Agent.CLI.CancelWatch (withEscCancel)
 import Agent.CLI.Interrupt (withTurnCancel)
 import Agent.CLI.Recap
@@ -35,7 +36,7 @@ import Agent.CLI.Terminal (resolveColor)
 import Agent.CLI.TUI.App (emitUiEvent)
 import Agent.TUI.Model (UiEvent(..))
 import Control.Monad (forM_, when)
-import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.IORef (readIORef, writeIORef)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
 import System.OsPath (takeDirectory)
@@ -44,9 +45,10 @@ runSessionRecap :: Bool -> SessionEnv -> RecapKind -> IO ()
 runSessionRecap registerCancel env kind = do
     let fullscreen = env.sessionFullscreen
         stdoutHandle = env.sessionRender.renderStdout
-    transcriptRef <- newIORef =<< readLiveTranscript env.sessionConversation
+    params <- readIORef env.sessionParams
+    transcript <- readLiveTranscript env.sessionConversation
+    let snapshot = sideCallSnapshot params transcript
     color <- resolveColor stdoutHandle
-    transcript <- readIORef transcriptRef
     let mainTurns = mainTurnCount transcript
         hasMessages = mainTurns > 0
     lastCommittedTurns <- recapWatermark env
@@ -83,8 +85,7 @@ runSessionRecap registerCancel env kind = do
                                         Just _ -> action
                             else action)
                     env.sessionBtwBackend
-                    env.sessionParams
-                    transcriptRef
+                    snapshot
                     kind
             case result of
                 Left err ->
@@ -165,13 +166,14 @@ recapFailed env message = do
 
 runSessionTurnSummary :: SessionEnv -> IO ()
 runSessionTurnSummary env = do
-    transcriptRef <- newIORef =<< readLiveTranscript env.sessionConversation
+    params <- readIORef env.sessionParams
+    transcript <- readLiveTranscript env.sessionConversation
+    let snapshot = sideCallSnapshot params transcript
     result <-
         runTurnSummaryWithCancel
             (\_ action -> action)
             env.sessionBtwBackend
-            env.sessionParams
-            transcriptRef
+            snapshot
     case result of
         Left _ -> pure ()
         Right summary ->

--- a/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
@@ -11,6 +11,7 @@ module Agent.CLI.Session.Interaction
 import Agent.CLI.Btw
     ( formatBtwError
     , runBtwWithCancel
+    , sideCallSnapshot
     )
 import Agent.CLI.CancelWatch (withEscCancel)
 import Agent.CLI.Command
@@ -73,7 +74,6 @@ import Agent.TUI.Model
 import Control.Monad (forM_)
 import Data.IORef
     ( modifyIORef'
-    , newIORef
     , readIORef
     , writeIORef
     )
@@ -189,7 +189,9 @@ runBtwQuestion registerCancel env question = do
         stdoutHandle = env.sessionRender.renderStdout
         stderrHandle = env.sessionRender.renderStderr
     color <- resolveColor stdoutHandle
-    transcriptRef <- newIORef =<< readLiveTranscript env.sessionConversation
+    params <- readIORef env.sessionParams
+    transcript <- readLiveTranscript env.sessionConversation
+    let snapshot = sideCallSnapshot params transcript
     forM_ fullscreen \runtime ->
         emitUiEvent runtime
             (UiSetNotice (Just (progressNotice "btw · asking…")))
@@ -210,8 +212,7 @@ runBtwQuestion registerCancel env question = do
                                 Just _ -> action
                     else action)
             env.sessionBtwBackend
-            env.sessionParams
-            transcriptRef
+            snapshot
             question
     forM_ fullscreen \runtime ->
         emitUiEvent runtime (UiSetNotice Nothing)

--- a/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
@@ -102,8 +102,6 @@ spec = do
                         , tools = Just [tool]
                         , ..
                         }
-            mainParams <- newIORef originalParams
-            mainTranscript <- newIORef originalItems
             seenPrevious <- newIORef (Just "not-called")
             seenInputs <- newIORef []
             seenPrivateParams <- newIORef Nothing
@@ -121,7 +119,7 @@ spec = do
                             , backendState = privateTranscript
                             }
             result <- runBtwWithCancel (\_ action -> action)
-                factory mainParams mainTranscript "why?"
+                factory (sideCallSnapshot originalParams originalItems) "why?"
             result `shouldBe` Right "side answer"
             readIORef seenPrevious `shouldReturn` Nothing
             seen <- readIORef seenInputs
@@ -132,8 +130,6 @@ spec = do
                 _ -> False
             (.backendItems) <$> readIORef seenPrivateTranscript
                 `shouldReturn` originalItems
-            readIORef mainTranscript `shouldReturn` originalItems
-            readIORef mainParams `shouldReturn` originalParams
             captured <- readIORef seenPrivateParams
             fmap (.tools) captured `shouldBe` Just (Just [tool])
             fmap (.input) captured `shouldBe` Just Nothing
@@ -142,8 +138,6 @@ spec = do
                 `shouldBe` Just (Just (ToolChoiceMode ToolChoiceNone))
 
         it "rejects tool calls without a follow-up submission" do
-            params <- newIORef defaultResponseCreateParams
-            transcript <- newIORef []
             submissions <- newIORef (0 :: Int)
             let factory _ = Backend \state _ _ _ -> do
                     modifyIORef' submissions (+ 1)
@@ -153,13 +147,13 @@ spec = do
                         , backendState = state
                         }
             result <- runBtwWithCancel (\_ action -> action)
-                factory params transcript "do something"
+                factory
+                (sideCallSnapshot defaultResponseCreateParams [])
+                "do something"
             result `shouldBe` Left BtwUnexpectedToolCall
             readIORef submissions `shouldReturn` 1
 
         it "surfaces transport and empty-response failures" do
-            params <- newIORef defaultResponseCreateParams
-            transcript <- newIORef []
             let transport _ = Backend \_ _ _ _ ->
                     pure (Left (ConnectionError "offline"))
                 empty _ = Backend \state _ _ _ ->
@@ -169,10 +163,12 @@ spec = do
                         , backendState = state
                         }
             runBtwWithCancel (\_ action -> action)
-                transport params transcript "why?"
+                transport (sideCallSnapshot defaultResponseCreateParams [])
+                "why?"
                 `shouldReturn` Left (BtwTransport (ConnectionError "offline"))
             runBtwWithCancel (\_ action -> action)
-                empty params transcript "why?"
+                empty (sideCallSnapshot defaultResponseCreateParams [])
+                "why?"
                 `shouldReturn` Left BtwEmptyResponse
 
     describe "formatBtwError" do

--- a/packages/agent-cli/test/Agent/CLI/RecapSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RecapSpec.hs
@@ -1,9 +1,11 @@
 module Agent.CLI.RecapSpec (spec) where
 
+import Agent.CLI.Btw (sideCallSnapshot)
 import Agent.CLI.Recap
 import Agent.Loop
     ( Backend(..)
     , BackendResult(..)
+    , BackendSnapshot(..)
     , TurnInput(..)
     , emptyTurnOutput
     )
@@ -62,8 +64,6 @@ spec = describe "Agent.CLI.Recap" do
                         , passthrough = Nothing
                         }
                     ]
-            params <- newIORef defaultResponseCreateParams
-            transcript <- newIORef original
             seenInputs <- newIORef []
             let factory _ = Backend \state _ inputs _ -> do
                     writeIORef seenInputs inputs
@@ -75,13 +75,14 @@ spec = describe "Agent.CLI.Recap" do
                         }
             result <-
                 runRecapWithCancel (\_ action -> action)
-                    factory params transcript RecapManual
+                    factory
+                    (sideCallSnapshot defaultResponseCreateParams original)
+                    RecapManual
             result
                 `shouldBe`
                     Right
                         (RecapShown
                             "We fixed auth retries in billing/retry.rs.")
-            readIORef transcript `shouldReturn` original
             seen <- readIORef seenInputs
             seen `shouldSatisfy` \case
                 [UserMessage text] ->
@@ -89,8 +90,6 @@ spec = describe "Agent.CLI.Recap" do
                 _ -> False
 
         it "rejects tool calls" do
-            params <- newIORef defaultResponseCreateParams
-            transcript <- newIORef []
             let factory _ = Backend \state _ _ _ ->
                     pure $ Right BackendResult
                         { backendOutput =
@@ -100,5 +99,38 @@ spec = describe "Agent.CLI.Recap" do
                         , backendState = state
                         }
             runRecapWithCancel (\_ action -> action)
-                factory params transcript RecapManual
+                factory
+                (sideCallSnapshot defaultResponseCreateParams [])
+                RecapManual
                 >>= (`shouldBe` Left RecapUnexpectedToolCall)
+
+    describe "runTurnSummaryWithCancel" do
+        it "uses the same immutable transcript for its anchor and request" do
+            let original =
+                    [ MessageItem ResponseMessage
+                        { messageId = Just "u1"
+                        , content = MessageContentText "snapshot question"
+                        , role = RoleUser
+                        , status = Just ItemCompleted
+                        , phase = Nothing
+                        , passthrough = Nothing
+                        }
+                    ]
+            seenInputs <- newIORef []
+            seenTranscript <- newIORef []
+            let factory _ = Backend \state _ inputs _ -> do
+                    writeIORef seenInputs inputs
+                    writeIORef seenTranscript state.backendItems
+                    pure $ Right BackendResult
+                        { backendOutput =
+                            emptyTurnOutput "summary-1" [] (Just "snapshot answer")
+                        , backendState = state
+                        }
+            runTurnSummaryWithCancel
+                (\_ action -> action)
+                factory
+                (sideCallSnapshot defaultResponseCreateParams original)
+                `shouldReturn` Right "snapshot answer"
+            readIORef seenTranscript `shouldReturn` original
+            readIORef seenInputs `shouldReturn`
+                [UserMessage (turnSummaryInstruction "snapshot question")]


### PR DESCRIPTION
## Summary
- replace Btw/recap helper `IORef` inputs with an immutable side-call snapshot
- centralize request sanitization and dangling tool-suffix trimming in the snapshot constructor
- capture params and transcript once so turn-summary anchors and provider requests use identical context

## Tests
- `TMPDIR="$HOME/.cache/haskell-agent-tmp" nix develop -c cabal repl agent-cli:test:agent-cli-test --jobs=1 --repl-options=-fobject-code`
- focused Hspec filters: `sideQuestionPrompt`, `trimDanglingToolSuffix`, `runBtwWithCancel`, `formatBtwError`, `Agent.CLI.Recap` (21 examples, 0 failures)
