### PR TITLE
refactor(mcp): atomically register request ids and waiters

### DIFF
--- a/packages/agent-mcp/src/Agent/MCP/Client.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Client.hs
@@ -251,8 +251,7 @@ newClientRecord
     -> McpClientTransport
     -> IO McpClient
 newClientRecord hooks eraHint config transport = do
-    nextId <- newIORef 1
-    pending <- newTVarIO IntMap.empty
+    requestRegistry <- newTVarIO emptyRequestRegistry
     failure <- newTVarIO Nothing
     closed <- newMVar False
     lifecycle <- newTVarIO ClientPending
@@ -264,8 +263,7 @@ newClientRecord hooks eraHint config transport = do
         { clientConfig = config
         , clientHooks = hooks
         , clientTransport = transport
-        , clientNextId = nextId
-        , clientPending = pending
+        , clientRequestRegistry = requestRegistry
         , clientFailure = failure
         , clientWorkers = workers
         , clientClosed = closed
@@ -1211,18 +1209,23 @@ requestMcp client timeoutMicros method parameters =
 
 requestMcpFull :: McpClient -> McpRequest -> IO (Either McpError RawJson)
 requestMcpFull client request = do
-    failed <- readTVarIO client.clientFailure
-    case failed of
-        Just err -> pure (Left (McpTransportError err))
-        Nothing -> do
-            era <- case request.requestEra of
-                Just era -> pure (Just era)
-                Nothing -> mcpClientEra client
-            requestId <- atomicModifyIORef' client.clientNextId \current ->
-                (current + 1, current)
-            pending <- newPendingRequest request
-            atomically $
-                modifyTVar' client.clientPending (IntMap.insert requestId pending)
+    era <- case request.requestEra of
+        Just era -> pure (Just era)
+        Nothing -> mcpClientEra client
+    pending <- newPendingRequest request
+    registration <- atomically do
+        failed <- readTVar client.clientFailure
+        case failed of
+            Just err -> pure (Left err)
+            Nothing -> do
+                registry <- readTVar client.clientRequestRegistry
+                let (nextRegistry, requestId) =
+                        registerPending pending registry
+                writeTVar client.clientRequestRegistry nextRegistry
+                pure (Right requestId)
+    case registration of
+        Left err -> pure (Left (McpTransportError err))
+        Right requestId -> do
             elicitEnabled <-
                 if request.requestMeta && era == Just McpEraModern
                     then isJust <$> client.clientHooks.mcpHostElicit
@@ -1245,7 +1248,36 @@ requestMcpFull client request = do
                                 `finally` unregister requestId
   where
     unregister requestId =
-        atomically $ modifyTVar' client.clientPending (IntMap.delete requestId)
+        atomically do
+            registry <- readTVar client.clientRequestRegistry
+            writeTVar client.clientRequestRegistry
+                (registry
+                    { requestRegistryPending =
+                        IntMap.delete requestId registry.requestRegistryPending
+                    })
+
+emptyRequestRegistry :: RequestRegistry
+emptyRequestRegistry = RequestRegistry
+    { requestRegistryNextId = 1
+    , requestRegistryPending = IntMap.empty
+    }
+
+-- | Allocate an id and install its response destination as one pure state
+-- transition. The caller applies it to 'clientRequestRegistry' atomically.
+registerPending
+    :: PendingRequest
+    -> RequestRegistry
+    -> (RequestRegistry, Int)
+registerPending pending registry =
+    ( registry
+        { requestRegistryNextId = requestId + 1
+        , requestRegistryPending =
+            IntMap.insert requestId pending registry.requestRegistryPending
+        }
+    , requestId
+    )
+  where
+    requestId = registry.requestRegistryNextId
 
 newPendingRequest :: McpRequest -> IO PendingRequest
 newPendingRequest request = do
@@ -1651,14 +1683,14 @@ sendMessage client transport message =
         >>= \case
             Left exception -> do
                 let err = "MCP write failed: " <> exceptionSummary exception
-                failPending client.clientPending client.clientFailure err
+                failPending client.clientRequestRegistry client.clientFailure err
                 pure (Left err)
             Right () -> pure (Right ())
 
 readerLoop :: McpClient -> Handle -> IO ()
 readerLoop client output =
     loop `finally`
-        failPending client.clientPending client.clientFailure
+        failPending client.clientRequestRegistry client.clientFailure
             "MCP server stdout closed"
   where
     loop = do
@@ -1666,7 +1698,7 @@ readerLoop client output =
         unless (BS.null (BS8.strip line)) $
             case Json.decodeEither inboundDecoder line of
                 Left err ->
-                    failPending client.clientPending client.clientFailure
+                    failPending client.clientRequestRegistry client.clientFailure
                         ("Invalid MCP JSON message: " <> err.jsonErrorMessage)
                 Right inbound ->
                     handleInbound client inbound
@@ -1705,9 +1737,14 @@ routeResponse client inbound =
         Nothing -> pure ()
         Just ident -> do
             destination <- atomically do
-                current <- readTVar client.clientPending
-                writeTVar client.clientPending (IntMap.delete ident current)
-                pure (IntMap.lookup ident current)
+                registry <- readTVar client.clientRequestRegistry
+                let pending = registry.requestRegistryPending
+                writeTVar client.clientRequestRegistry
+                    (registry
+                        { requestRegistryPending =
+                            IntMap.delete ident pending
+                        })
+                pure (IntMap.lookup ident pending)
             forM_ destination \pending ->
                 atomically . void . tryPutTMVar pending.pendingResponse $
                     case inbound.inboundError of
@@ -1765,7 +1802,9 @@ handleNotification client method params =
     case method of
         "notifications/progress" ->
             forM_ (params >>= decodeProgress) \(token, progress) -> do
-                pending <- IntMap.lookup token <$> readTVarIO client.clientPending
+                registry <- readTVarIO client.clientRequestRegistry
+                let pending =
+                        IntMap.lookup token registry.requestRegistryPending
                 forM_ pending \entry -> do
                     atomically $ modifyTVar' entry.pendingActivity (+ 1)
                     void (tryAny (entry.pendingOnProgress progress))
@@ -2235,14 +2274,14 @@ capturedStderrText captured =
 -- * Failure and shutdown
 
 failClient
-    :: TVar (IntMap.IntMap PendingRequest)
+    :: TVar RequestRegistry
     -> TVar (Maybe Text)
     -> Text
     -> IO ()
 failClient = failPending
 
 failPending
-    :: TVar (IntMap.IntMap PendingRequest)
+    :: TVar RequestRegistry
     -> TVar (Maybe Text)
     -> Text
     -> IO ()
@@ -2250,8 +2289,10 @@ failPending pending failure err =
     atomically do
         existing <- readTVar failure
         when (existing == Nothing) (writeTVar failure (Just err))
-        requests <- readTVar pending
-        writeTVar pending IntMap.empty
+        registry <- readTVar pending
+        let requests = registry.requestRegistryPending
+        writeTVar pending
+            (registry { requestRegistryPending = IntMap.empty })
         mapM_ (\entry -> void (tryPutTMVar entry.pendingResponse (Left (McpTransportError err))))
             (IntMap.elems requests)
 
@@ -2285,7 +2326,7 @@ closeMcpClient client =
                         readIORef transport.stdioStderrReader >>= mapM_ stopWorker
                     McpClientHttp transport ->
                         closeHttpSession client transport
-                failClient client.clientPending client.clientFailure
+                failClient client.clientRequestRegistry client.clientFailure
                     "MCP server closed"
                 pure True
 

--- a/packages/agent-mcp/src/Agent/MCP/Fleet.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Fleet.hs
@@ -609,7 +609,8 @@ refreshServerTools fleet client =
   where
     serverName = client.clientConfig.mcpServerName
     sameClient :: McpClient -> McpClient -> Bool
-    sameClient left right = left.clientNextId == right.clientNextId
+    sameClient left right =
+        left.clientRequestRegistry == right.clientRequestRegistry
 
 -- * Meta-tools
 

--- a/packages/agent-mcp/src/Agent/MCP/Types.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Types.hs
@@ -295,6 +295,13 @@ data PendingRequest = PendingRequest
     , pendingOnProgress :: !(McpProgress -> IO ())
     }
 
+-- | Request ids and their response destinations. Keeping both values in one
+-- STM cell makes id allocation and waiter registration one atomic transition.
+data RequestRegistry = RequestRegistry
+    { requestRegistryNextId :: !Int
+    , requestRegistryPending :: !(IntMap.IntMap PendingRequest)
+    }
+
 mcpSkillEntryDecoder :: Json.Decoder McpSkillEntry
 mcpSkillEntryDecoder = Json.object do
     mcpSkillUri <- Json.atKey "uri" Json.text
@@ -414,8 +421,7 @@ data McpClient = McpClient
     { clientConfig :: !McpServerConfig
     , clientHooks :: !McpHostHooks
     , clientTransport :: !McpClientTransport
-    , clientNextId :: !(IORef Int)
-    , clientPending :: !(TVar (IntMap.IntMap PendingRequest))
+    , clientRequestRegistry :: !(TVar RequestRegistry)
     , clientFailure :: !(TVar (Maybe Text))
     , clientWorkers :: !(TVar [Async ()])
     -- ^ Background work owned by the client: handlers for server-initiated

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -8,8 +8,10 @@ import Agent.MCP.Client
     , closeMcpClient
     , classifyProbe
     , encodeHeaderValue
+    , emptyRequestRegistry
     , headerParamValues
     , readBounded
+    , registerPending
     , spawnClientWorker
     , splitSseChunk
     , splitLines
@@ -22,6 +24,8 @@ import Agent.MCP.Types
     , McpHttpTransport(..)
     , McpStdioTransport(..)
     , McpTool(..)
+    , PendingRequest(..)
+    , RequestRegistry(..)
     )
 import Agent.Json (RawJson, rawJsonBytes, rawJsonDecoder, rawJsonFromEncoding)
 import qualified Agent.Json.Decode as Json
@@ -29,6 +33,7 @@ import Control.Concurrent.STM
     ( TMVar
     , atomically
     , newEmptyTMVarIO
+    , newTVarIO
     , readTMVar
     , readTVarIO
     , tryPutTMVar
@@ -64,6 +69,7 @@ import Data.IORef
     , readIORef
     )
 import Data.List (find)
+import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Text as Text
 import System.Directory
     ( createDirectory
@@ -89,6 +95,16 @@ import Test.QuickCheck
     , (===)
     )
 
+testPendingRequest :: IO PendingRequest
+testPendingRequest = do
+    response <- newEmptyTMVarIO
+    activity <- newTVarIO 0
+    pure PendingRequest
+        { pendingResponse = response
+        , pendingActivity = activity
+        , pendingOnProgress = const (pure ())
+        }
+
 spec :: Spec
 spec = describe "Agent.MCP" do
     it "redacts configured environment values from Show" do
@@ -106,6 +122,30 @@ spec = describe "Agent.MCP" do
         rendered `shouldContain` "API_TOKEN"
         rendered `shouldContain` "<redacted>"
         rendered `shouldNotContain` "super-secret"
+
+    describe "request registry" do
+        it "allocates sequential ids while installing each waiter" do
+            first <- testPendingRequest
+            second <- testPendingRequest
+            let (afterFirst, firstId) =
+                    registerPending first emptyRequestRegistry
+                (afterSecond, secondId) =
+                    registerPending second afterFirst
+            firstId `shouldBe` 1
+            secondId `shouldBe` 2
+            afterSecond.requestRegistryNextId `shouldBe` 3
+            IntMap.keys afterSecond.requestRegistryPending
+                `shouldBe` [1, 2]
+            case IntMap.lookup firstId afterSecond.requestRegistryPending of
+                Nothing -> expectationFailure "first waiter was not registered"
+                Just registered ->
+                    registered.pendingResponse == first.pendingResponse
+                        `shouldBe` True
+            case IntMap.lookup secondId afterSecond.requestRegistryPending of
+                Nothing -> expectationFailure "second waiter was not registered"
+                Just registered ->
+                    registered.pendingResponse == second.pendingResponse
+                        `shouldBe` True
 
     describe "client transport" do
         it "stores only HTTP state for an HTTP client" $


### PR DESCRIPTION
## Summary
- combine MCP request IDs and pending waiters into one strict `RequestRegistry` TVar
- use a pure `registerPending` transition so failure checks, ID allocation, and waiter installation happen atomically
- preserve response/progress routing, shutdown cleanup, and the next request ID while adding sequential-allocation coverage

## Tests
- `agent-mcp:test:agent-mcp-test` focused `request registry`: 1 example, 0 failures
- all affected `agent-mcp` production and test modules compiled