### PR TITLE
refactor(claude): return accumulated query state

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -91,7 +91,6 @@ import qualified Data.Char as Char
 import Data.IORef
     ( IORef
     , atomicModifyIORef'
-    , modifyIORef'
     , newIORef
     , readIORef
     , writeIORef
@@ -110,7 +109,8 @@ import Claude.Agent.SDK.Errors
     , renderClaudeSDKError
     )
 import Claude.Agent.SDK.Query
-    ( queryTurnContentWithMessageValidatorAndProgress
+    ( QueryResult(..)
+    , queryTurnContentWithMessageValidatorAndProgress
     )
 import Claude.Agent.SDK.Types
     ( ClaudeAgentOptions(..)
@@ -361,7 +361,6 @@ submitClaudeCodeTurn
                         -- transcript reference aligned after compaction/reset
                         -- before its successful-turn callback appends.
                         writeIORef transcript history
-                        messages <- newIORef []
                         eventState <- newIORef emptyClaudeEventState
                         let prompt =
                                 buildClaudePrompt
@@ -387,13 +386,14 @@ submitClaudeCodeTurn
                                                 progress
                                     writeIORef eventState nextState
                                     mapM_ onEvent events)
-                                (\message ->
-                                    modifyIORef' messages (message :))
+                                (const (pure ()))
                         case awaitResult of
                             Left sdkError ->
                                 pure (Left sdkError)
-                            Right result -> do
-                                turnMessages <- reverse <$> readIORef messages
+                            Right QueryResult
+                                { queryMessages = turnMessages
+                                , queryResultMessage = result
+                                } -> do
                                 case
                                     interpretClaudeTurnWithCredentialValidation
                                         (transport == ClaudeCodeLocalSubscription)

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Query.hs
@@ -1,7 +1,8 @@
 -- | One-shot and per-turn query functions, analogous to the official SDK's
 -- top-level @query()@ API.
 module Claude.Agent.SDK.Query
-    ( query
+    ( QueryResult(..)
+    , query
     , queryWithProgress
     , queryContent
     , queryContentWithProgress
@@ -55,6 +56,13 @@ import qualified Data.Text as Text
 import System.Exit (ExitCode)
 import System.Timeout (timeout)
 
+-- | A completed query together with the canonical message sequence that
+-- produced its terminal result.
+data QueryResult = QueryResult
+    { queryMessages :: ![Message]
+    , queryResultMessage :: !ResultMessage
+    } deriving (Eq, Show)
+
 -- | Run a self-contained query and close its client afterward.
 query
     :: ClaudeAgentOptions
@@ -84,12 +92,13 @@ queryTurnContentWithProgress
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 queryTurnContentWithProgress turn content onProgress onMessage =
-    queryTurnContentWithMessageValidatorAndProgress
-        turn
-        content
-        (const (pure (Right ())))
-        onProgress
-        onMessage
+    fmap queryResultOnly $
+        queryTurnContentWithMessageValidatorAndProgress
+            turn
+            content
+            (const (pure (Right ())))
+            onProgress
+            onMessage
 
 -- | Run a self-contained query with structured user content.
 queryContent
@@ -212,12 +221,13 @@ queryTurnContentWithMessageValidator
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 queryTurnContentWithMessageValidator turn content validateMessage onMessage = do
-    queryTurnContentWithMessageValidatorAndProgress
-        turn
-        content
-        validateMessage
-        (const (pure ()))
-        onMessage
+    fmap queryResultOnly $
+        queryTurnContentWithMessageValidatorAndProgress
+            turn
+            content
+            validateMessage
+            (const (pure ()))
+            onMessage
 
 -- | Like 'queryTurnContentWithMessageValidator', with a live observer that
 -- runs after query routing and canonicalization state updates. It sees only
@@ -229,7 +239,7 @@ queryTurnContentWithMessageValidatorAndProgress
     -> (Message -> IO (Either ClaudeSDKError ()))
     -> (QueryProgress -> IO ())
     -> (Message -> IO ())
-    -> IO (Either ClaudeSDKError ResultMessage)
+    -> IO (Either ClaudeSDKError QueryResult)
 queryTurnContentWithMessageValidatorAndProgress
     turn content validateMessage onProgress onMessage = do
     completed <-
@@ -275,11 +285,12 @@ receiveResponseWithMessageValidator
     -> (Message -> IO ())
     -> IO (Either ClaudeSDKError ResultMessage)
 receiveResponseWithMessageValidator turn validateMessage onMessage =
-    receiveResponseWithMessageValidatorAndProgress
-        turn
-        validateMessage
-        (const (pure ()))
-        onMessage
+    fmap queryResultOnly $
+        receiveResponseWithMessageValidatorAndProgress
+            turn
+            validateMessage
+            (const (pure ()))
+            onMessage
 
 -- | Receive a response with classified live query progress.
 receiveResponseWithMessageValidatorAndProgress
@@ -287,7 +298,7 @@ receiveResponseWithMessageValidatorAndProgress
     -> (Message -> IO (Either ClaudeSDKError ()))
     -> (QueryProgress -> IO ())
     -> (Message -> IO ())
-    -> IO (Either ClaudeSDKError ResultMessage)
+    -> IO (Either ClaudeSDKError QueryResult)
 receiveResponseWithMessageValidatorAndProgress
     turn validateMessage onProgress onMessage =
     go emptyQueryAccumulator False
@@ -295,7 +306,7 @@ receiveResponseWithMessageValidatorAndProgress
     go
         :: QueryAccumulator
         -> Bool
-        -> IO (Either ClaudeSDKError ResultMessage)
+        -> IO (Either ClaudeSDKError QueryResult)
     go accumulator sawOutput = do
         maybeMessage <-
             timeout
@@ -357,7 +368,16 @@ receiveResponseWithMessageValidatorAndProgress
                                     Right () -> do
                                         mapM_ onProgress progress
                                         mapM_ onMessage messages
-                                        pure (Right result)
+                                        pure $ Right QueryResult
+                                            { queryMessages = messages
+                                            , queryResultMessage = result
+                                            }
+
+queryResultOnly
+    :: Either ClaudeSDKError QueryResult
+    -> Either ClaudeSDKError ResultMessage
+queryResultOnly =
+    fmap \QueryResult{queryResultMessage} -> queryResultMessage
 
 validateLiveProgressSession
     :: ClaudeSDKTurn

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/QuerySpec.hs
@@ -53,6 +53,19 @@ spec = describe "query" do
         messages `shouldSatisfy` any hasCanonicalAssistant
         messages `shouldSatisfy` all (not . hasRetractedContent)
 
+    it "returns the canonical messages with the terminal query result" do
+        completed <- expectRight
+            =<< runQueryResultLines canonicalResponseLines
+        map messageUuid completed.queryMessages
+            `shouldBe`
+                [ Just "system-init"
+                , Just "assistant-replacement"
+                , Just "fallback"
+                , Just "result"
+                ]
+        completed.queryResultMessage.result
+            `shouldBe` Just "canonical answer"
+
     it "renders structured tool_result content and retains its raw JSON" do
         (result, messages) <- runQueryLines
             [ structuredToolResultUser
@@ -852,6 +865,29 @@ runQueryLines linesToEmit =
                     modifyIORef' messagesRef (<> [message]))
         messages <- readIORef messagesRef
         pure (result, messages)
+
+runQueryResultLines
+    :: [Text]
+    -> IO (Either ClaudeSDKError QueryResult)
+runQueryResultLines linesToEmit =
+    withFakeClaude (oneShotScript linesToEmit) \directory executable -> do
+        let options = testOptions executable directory
+        withClaudeSDKClient options \client ->
+            withClaudeSDKTurn
+                client
+                (pure True)
+                Nothing
+                options.model
+                options.effort
+                \turn -> do
+                    result <-
+                        queryTurnContentWithMessageValidatorAndProgress
+                            turn
+                            [UserTextBlock "hello"]
+                            (const (pure (Right ())))
+                            (const (pure ()))
+                            (const (pure ()))
+                    pure ((, pure ()) <$> result)
 
 runQueryProgress
     :: [Text]


### PR DESCRIPTION
## Summary
- return the canonical Claude message sequence alongside the terminal SDK result
- remove the LoopBackend message-collection `IORef` and consume that immutable query outcome
- preserve the existing result-only SDK entry points as compatibility projections
- cover canonical deduplication/retraction order in the SDK

## Tests
- SDK query suite: 33 examples, 0 failures
- explicit `QueryResult` regression: 1 example, 0 failures
- Claude loop-backend suite: 31 examples, 0 failures
- `git diff --check`
