### PR TITLE
refactor(responses): thread stream projection and retry state

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -523,50 +523,29 @@ openAiBackendWithTransportFallback fallbackActive primary fallback =
             else tryPrimary state legacyPreviousResponseId inputs onEvent
   where
     tryPrimary state legacyPreviousResponseId inputs onEvent = do
-        emittedModelOutput <- newIORef False
-        announcedToolCall <- newIORef False
-        let resetAttempt = do
-                writeIORef emittedModelOutput False
-                writeIORef announcedToolCall False
+        observationRef <- newIORef emptyAttemptObservation
         result <-
             primary.submitTurn state legacyPreviousResponseId inputs \event -> do
-                case event of
-                    -- The primary already closed that attempt; only activity
-                    -- from its newest attempt still needs a boundary before a
-                    -- replay.
-                    ResponseRestarted _ -> resetAttempt
-                    ResponseAttemptDiscarded -> resetAttempt
-                    _ -> do
-                        when (isModelOutput event) $
-                            writeIORef emittedModelOutput True
-                        when (isToolAnnouncement event) $
-                            writeIORef announcedToolCall True
+                -- Commit before forwarding so exceptions from the outer
+                -- callback cannot leave retry bookkeeping stale.
+                atomicModifyIORef' observationRef \observation ->
+                    (observeFallbackLoopEvent event observation, ())
                 onEvent event
         case result of
             Left err
                 | isOpenAiWebSocketTransportFailure err -> do
                     writeIORef fallbackActive True
-                    emitted <- readIORef emittedModelOutput
-                    announced <- readIORef announcedToolCall
-                    if emitted
+                    observation <- readIORef observationRef
+                    if observation.observedVisibleOutput
                         then onEvent (ResponseRestarted fallbackRestartMessage)
                         else
                             -- A tool block the dead socket announced must not
                             -- linger as running next to the replayed attempt.
-                            when announced (onEvent ResponseAttemptDiscarded)
+                            when observation.observedToolOutput
+                                (onEvent ResponseAttemptDiscarded)
                     fallback.submitTurn
                         state legacyPreviousResponseId inputs onEvent
             _ -> pure result
-
-    isModelOutput = \case
-        TextDelta {} -> True
-        ReasoningDelta {} -> True
-        _ -> False
-
-    isToolAnnouncement = \case
-        ToolStarted {} -> True
-        ToolUpdated {} -> True
-        _ -> False
 
 hasLegacyComputerContinuation :: [ResponseItem] -> [TurnInput] -> Bool
 hasLegacyComputerContinuation history inputs =
@@ -772,27 +751,34 @@ openAiBackendWithRetryPoliciesAndReasoningVisibility
                     }
   where
     sendRetrying onLoopEvent request previousResponseId = do
-        emittedRawOutput <- newIORef False
-        emittedVisibleOutput <- newIORef False
-        go emittedRawOutput emittedVisibleOutput
-            defaultRetryStatus defaultRetryStatus
+        go defaultRetryStatus defaultRetryStatus
       where
-        go emittedRawOutput emittedVisibleOutput transientStatus
-                reconnectStatus = do
+        go transientStatus reconnectStatus = do
             -- One projector per attempt: argument-progress counters must
             -- describe a single provider sample, not the whole retry chain.
-            projectEvent <-
-                Responses.newStreamEventToLoopEvents showRawReasoning
+            attemptState <- newIORef OpenAiAttemptState
+                { attemptProjection = Responses.emptyStreamProjectionState
+                , attemptObservation = emptyAttemptObservation
+                }
             result <- send request previousResponseId \event -> do
-                if streamOutputObserved event
-                    then writeIORef emittedRawOutput True
-                    else pure ()
-                projectEvent event
-                    >>= mapM_ \loopEvent -> do
-                        when (isVisibleModelOutput loopEvent) $
-                            writeIORef emittedVisibleOutput True
-                        onLoopEvent loopEvent
-            emitted <- readIORef emittedRawOutput
+                loopEvents <- atomicModifyIORef' attemptState $
+                    openAiAttemptStep showRawReasoning event
+                mapM_ (\loopEvent -> do
+                    -- Observe only events that are about to be delivered:
+                    -- a failed callback must not pre-record later events in
+                    -- the same projected batch.
+                    atomicModifyIORef' attemptState \state ->
+                        ( state
+                            { attemptObservation =
+                                observeLoopEvent loopEvent
+                                    state.attemptObservation
+                            }
+                        , ()
+                        )
+                    onLoopEvent loopEvent
+                    ) loopEvents
+            observation <- (.attemptObservation) <$> readIORef attemptState
+            let emitted = observation.observedRawOutput
             case result of
                 Left apiError
                     -- A pre-output connection failure is handled by the
@@ -801,9 +787,8 @@ openAiBackendWithRetryPoliciesAndReasoningVisibility
                     | emitted
                     , isReconnectableTransportFailure apiError ->
                         applyPolicy reconnectPolicy reconnectStatus >>= \case
-                            Nothing -> settle apiError result
+                            Nothing -> settle observation apiError result
                             Just nextStatus -> do
-                                visible <- readIORef emittedVisibleOutput
                                 let delayMicros =
                                         fromMaybe 0 nextStatus.rsPreviousDelay
                                     attempt = nextStatus.rsIterNumber
@@ -816,7 +801,7 @@ openAiBackendWithRetryPoliciesAndReasoningVisibility
                                 -- partial output stays on screen marked as
                                 -- failed; hidden activity such as an announced
                                 -- tool call is removed.
-                                if visible
+                                if observation.observedVisibleOutput
                                     then onLoopEvent
                                         (ResponseRestarted
                                             connectionRestartMessage)
@@ -824,10 +809,7 @@ openAiBackendWithRetryPoliciesAndReasoningVisibility
                                 onLoopEvent $ ActivityUpdated $
                                     "Reconnecting to Codex (attempt "
                                         <> Text.pack (show attempt) <> ")…"
-                                writeIORef emittedRawOutput False
-                                writeIORef emittedVisibleOutput False
-                                go emittedRawOutput emittedVisibleOutput
-                                    transientStatus nextStatus
+                                go transientStatus nextStatus
                     | not emitted
                     , isInlineRetryableProviderResponseError apiError ->
                         applyPolicy transientPolicy transientStatus >>= \case
@@ -842,25 +824,94 @@ openAiBackendWithRetryPoliciesAndReasoningVisibility
                                 onLoopEvent $ ActivityUpdated $
                                     "Retrying Codex request (attempt "
                                         <> Text.pack (show attempt) <> ")…"
-                                go emittedRawOutput emittedVisibleOutput
-                                    nextStatus reconnectStatus
-                    | emitted -> settle apiError result
+                                go nextStatus reconnectStatus
+                    | emitted -> settle observation apiError result
                 _ -> pure result
           where
             -- The transport fallback may still replay a dropped connection
             -- after this backend gives up; every other failure after output
             -- is terminal because the provider may have committed the sample.
-            settle apiError result = do
-                visible <- readIORef emittedVisibleOutput
-                pure $ if visible || isReconnectableTransportFailure apiError
+            settle observation apiError result = do
+                pure $ if observation.observedVisibleOutput
+                        || isReconnectableTransportFailure apiError
                     then result
                     else Left (replayUnsafeError "model output" apiError)
 
-    isVisibleModelOutput = \case
-        TextDelta{} -> True
-        ReasoningDelta{} -> True
-        ToolArgumentsUpdated{} -> True
-        _ -> False
+data AttemptObservation = AttemptObservation
+    { observedRawOutput :: !Bool
+    , observedVisibleOutput :: !Bool
+    , observedToolOutput :: !Bool
+    }
+
+emptyAttemptObservation :: AttemptObservation
+emptyAttemptObservation = AttemptObservation
+    { observedRawOutput = False
+    , observedVisibleOutput = False
+    , observedToolOutput = False
+    }
+
+observeRawOutput
+    :: ResponseStreamEvent
+    -> AttemptObservation
+    -> AttemptObservation
+observeRawOutput event observation
+    | streamOutputObserved event =
+        observation { observedRawOutput = True }
+    | otherwise = observation
+
+observeLoopEvent :: LoopEvent -> AttemptObservation -> AttemptObservation
+observeLoopEvent event observation = case event of
+    TextDelta{} -> observation { observedVisibleOutput = True }
+    ReasoningDelta{} -> observation { observedVisibleOutput = True }
+    ToolArgumentsUpdated{} ->
+        observation { observedVisibleOutput = True }
+    ToolStarted{} -> observation { observedToolOutput = True }
+    ToolUpdated{} -> observation { observedToolOutput = True }
+    ResponseRestarted{} -> emptyAttemptObservation
+    ResponseAttemptDiscarded -> emptyAttemptObservation
+    _ -> observation
+
+-- The outer transport fallback only distinguishes durable model deltas from
+-- an in-flight tool block. Argument previews belong to the latter and are
+-- removed rather than retained when HTTP replays the attempt.
+observeFallbackLoopEvent
+    :: LoopEvent
+    -> AttemptObservation
+    -> AttemptObservation
+observeFallbackLoopEvent event observation = case event of
+    TextDelta{} -> observation { observedVisibleOutput = True }
+    ReasoningDelta{} -> observation { observedVisibleOutput = True }
+    ToolStarted{} -> observation { observedToolOutput = True }
+    ToolUpdated{} -> observation { observedToolOutput = True }
+    ResponseRestarted{} -> emptyAttemptObservation
+    ResponseAttemptDiscarded -> emptyAttemptObservation
+    _ -> observation
+
+data OpenAiAttemptState = OpenAiAttemptState
+    { attemptProjection :: !Responses.StreamProjectionState
+    , attemptObservation :: !AttemptObservation
+    }
+
+openAiAttemptStep
+    :: Bool
+    -> ResponseStreamEvent
+    -> OpenAiAttemptState
+    -> (OpenAiAttemptState, [LoopEvent])
+openAiAttemptStep showRawReasoning event state =
+    ( OpenAiAttemptState
+        { attemptProjection = nextProjection
+        , attemptObservation = nextObservation
+        }
+    , loopEvents
+    )
+  where
+    (nextProjection, loopEvents) =
+        Responses.streamEventToLoopEventsStep
+            showRawReasoning
+            state.attemptProjection
+            event
+    nextObservation =
+        observeRawOutput event state.attemptObservation
 
 transientStreamingResultPolicy :: RetryPolicyM IO
 transientStreamingResultPolicy =

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -9,6 +9,9 @@ module Agent.Responses.LoopBackend
     , responseTokenUsage
     , streamEventToLoopEvent
     , streamEventToLoopEventWithRawReasoning
+    , StreamProjectionState
+    , emptyStreamProjectionState
+    , streamEventToLoopEventsStep
     , newStreamEventToLoopEvents
     , toolArgumentActivityChunkChars
     , runawayToolArgumentWarningChars
@@ -949,15 +952,41 @@ newStreamEventToLoopEvents
     :: Bool
     -> IO (ResponseStreamEvent -> IO [LoopEvent])
 newStreamEventToLoopEvents showRawReasoning = do
-    stateRef <- newIORef emptyToolArgumentStreamState
-    pure \event -> do
-        argumentEvents <- atomicModifyIORef' stateRef \state ->
-            toolArgumentStreamStep event state
-        pure $
-            maybeToList
-                (streamEventToLoopEventWithRawReasoning showRawReasoning event)
-                <> maybeToList (codexRateLimitsUpdate event)
-                <> argumentEvents
+    stateRef <- newIORef emptyStreamProjectionState
+    pure \event ->
+        atomicModifyIORef' stateRef \state ->
+            streamEventToLoopEventsStep showRawReasoning state event
+
+-- | Immutable state for projecting one response attempt.
+--
+-- The constructor is intentionally private so callers cannot accidentally
+-- carry only part of the projection state across an attempt boundary.
+data StreamProjectionState = StreamProjectionState
+    { streamToolArguments :: !ToolArgumentStreamState
+    }
+
+emptyStreamProjectionState :: StreamProjectionState
+emptyStreamProjectionState =
+    StreamProjectionState emptyToolArgumentStreamState
+
+-- | Pure projection of one provider event. The returned state belongs to the
+-- same response attempt; start from 'emptyStreamProjectionState' when a retry
+-- or reconnect begins a new sample.
+streamEventToLoopEventsStep
+    :: Bool
+    -> StreamProjectionState
+    -> ResponseStreamEvent
+    -> (StreamProjectionState, [LoopEvent])
+streamEventToLoopEventsStep showRawReasoning state event =
+    ( StreamProjectionState nextArguments
+    , maybeToList
+        (streamEventToLoopEventWithRawReasoning showRawReasoning event)
+        <> maybeToList (codexRateLimitsUpdate event)
+        <> argumentEvents
+    )
+  where
+    (nextArguments, argumentEvents) =
+        toolArgumentStreamStep event state.streamToolArguments
 
 codexRateLimitsUpdate :: ResponseStreamEvent -> Maybe LoopEvent
 codexRateLimitsUpdate = \case

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -21,7 +21,8 @@ import Agent.Provider
 import Agent.Json (rawJsonFromEncoding)
 import qualified Agent.Json.Decode as Json
 import Agent.Responses.LoopBackend
-    ( newStreamEventToLoopEvents
+    ( emptyStreamProjectionState
+    , newStreamEventToLoopEvents
     , statelessResponsesBackend
     , statelessResponsesBackendWithRawReasoning
     , tokenProviderStatelessResponsesBackend
@@ -29,6 +30,7 @@ import Agent.Responses.LoopBackend
     , responseItemToToolCall
     , toolResultToItem
     , withRequestInput
+    , streamEventToLoopEventsStep
     )
 import Agent.Responses.Types
     ( MessageContent(..)
@@ -817,6 +819,33 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
 -- repaint the call, while other tools retain coarse activity updates.
 streamProjectionSpec :: Spec
 streamProjectionSpec = describe "newStreamEventToLoopEvents" do
+    it "starts a pure projection attempt without retaining reused tool ids" do
+        let (firstState, _) =
+                streamEventToLoopEventsStep False
+                    emptyStreamProjectionState
+                    (functionCallAdded "fc-1" "call-1" "shell_command")
+            (_, firstEvents) =
+                streamEventToLoopEventsStep False firstState
+                    (argumentsDelta "fc-1" "{\"command\":\"pwd\"}")
+            (secondState, _) =
+                streamEventToLoopEventsStep False
+                    emptyStreamProjectionState
+                    (functionCallAdded "fc-1" "call-2" "apply_patch")
+            (_, secondEvents) =
+                streamEventToLoopEventsStep False secondState
+                    (argumentsDelta "fc-1" "{}")
+        firstEvents `shouldBe`
+            [ ToolArgumentsUpdated
+                (functionToolCall
+                    "call-1"
+                    "shell_command"
+                    "{\"command\":\"pwd\"}")
+            ]
+        secondEvents `shouldSatisfy` \case
+            [ToolArgumentsUpdated call] ->
+                call.callId == "call-2" && call.name == "apply_patch"
+            _ -> False
+
     it "publishes Codex weekly capacity updates for retained prompt chrome" do
         projectEvent <- newStreamEventToLoopEvents False
         events <- projectEvent ResponseCodexRateLimitsEvent


### PR DESCRIPTION
## Summary
- expose a strict, abstract response-stream projection state with a pure transition
- keep callback compatibility behind one mutable boundary and start each retry from fresh projection state
- consolidate OpenAI retry/fallback observations into strict pure reducers while preserving callback and replay ordering
- cover reused tool IDs across independent attempts

## Tests
- `agent-responses-test`: 96 examples, 0 failures
- `agent-openai-test`: 346 examples, 0 failures, 1 pending live functional test
- post-order `openAiBackendWith` subset: 44 examples, 0 failures
- post-order transport-fallback subset: 10 examples, 0 failures
- `git diff --check`
