### PR TITLE
Split agent session orchestration

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -12,7 +12,10 @@ import Agent.CLI.Auth
     , isGatewayLoadedAuth
     )
 import Agent.CLI.Clipboard ()
-import Agent.CLI.Claude (newClaudeSessionRuntimeSlot)
+import Agent.CLI.Claude
+    ( ClaudeSessionRuntimeSlot
+    , newClaudeSessionRuntimeSlot
+    )
 import Agent.CLI.CodeModeRuntime
     ( CodeModeSessionRuntime(..),
       CodexCatalogSession(..),
@@ -21,7 +24,11 @@ import Agent.CLI.CodeModeRuntime
       loadCodexCatalogModelInfo )
 import Agent.CLI.Command ()
 import Agent.CLI.Compaction
-    ( CompactionInstall(CompactionNotInstalled) )
+    ( AutomaticCompactionBoundary
+    , CompactOutcome
+    , CompactionInstall(CompactionNotInstalled)
+    , OccupancySnapshot
+    )
 import Agent.CLI.Config ()
 import Agent.Connectivity ()
 import Agent.CLI.Database ()
@@ -117,7 +124,8 @@ import Agent.CLI.Session
 import Agent.CLI.Session.Attachments ()
 import Agent.CLI.Session.Choices ()
 import Agent.CLI.Session.History
-    ( currentLiveTranscriptGeneration,
+    ( LiveConversation
+    , currentLiveTranscriptGeneration,
       durableTranscriptCheckpoint,
       evictLiveTranscript,
       foldSessionItems,
@@ -197,12 +205,18 @@ import Agent.GrokBuild.Dialect.Goal ()
 import Agent.GrokBuild.Dialect.Runtime ()
 import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs)
 import Agent.GrokBuild.Dialect.Workflow ()
-import Agent.Loop (ImageAttachment, addTokenUsage, emptyTokenUsage)
+import Agent.Loop
+    ( ImageAttachment
+    , TokenUsage
+    , TurnInput
+    , addTokenUsage
+    , emptyTokenUsage
+    )
 import Agent.OpenAI.Compaction ()
 import Agent.OpenAI.ImageGeneration ( imageGenerationToolName )
 import Agent.OpenAI.Usage ()
 import Agent.OpenAI.WebSocketClient ()
-import Agent.OpenAI.Models.Types ( resolvedContextWindow )
+import Agent.OpenAI.Models.Types ( ModelInfo, resolvedContextWindow )
 import Agent.OpenRouter.LoopBackend ()
 import Agent.OpenRouter.Options (ClientOptions)
 import Agent.OsPath ()
@@ -237,7 +251,7 @@ import Control.Applicative ( (<|>) )
 import Control.Concurrent.Async ( waitSTM, withAsync )
 import Control.Concurrent.Chan ()
 import Control.Concurrent.MVar ()
-import Control.Concurrent.STM ( retry )
+import Control.Concurrent.STM ( STM, retry )
 import Control.Exception ()
 import Control.Exception.Safe ( mask_, finally )
 import Control.Monad ( forM_, void, when )
@@ -267,7 +281,7 @@ import qualified Agent.Responses.GenericClient as GenericResponses
     ()
 import qualified Agent.MCP as MCP
 import qualified Data.Map.Strict as Map ()
-import qualified Agent.OpenAI.Auth as OpenAI ()
+import qualified Agent.OpenAI.Auth as OpenAI (Pool)
 import qualified Agent.OpenRouter as OpenRouter ()
 import qualified Agent.OpenRouter.Usage as OpenRouterUsage ()
 import qualified Agent.Provider as Provider ()
@@ -280,6 +294,136 @@ import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Client as XAIClient ()
 import qualified Agent.XAI.Request as XAIRequest ()
 import qualified Agent.XAI.Usage as XAIUsage ()
+
+data AgentSessionRequest closeResult windowTitleResult = AgentSessionRequest
+    { loaded :: LoadedAuth
+    , connectedGateway :: Maybe GatewayCredential
+    , learnAboutUserRequested :: Bool
+    , sessionTmp :: OsPath
+    , activeAccountIdRef :: IORef Text
+    , activeAccountRef :: IORef Text
+    , activeSelectionRef :: IORef Text
+    , agentTypesRef :: GrokSubagentSpecs
+    , allTools :: [AppTool]
+    , recordImageGenerationInputs :: [ImageAttachment] -> IO ()
+    , clearImageGenerationHistory :: IO ()
+    , bashEnabledRef :: IORef Bool
+    , catalog :: ModelCatalog
+    , gatewayModelsRef :: IORef (Maybe GatewayModelAccess)
+    , checkStartupUsageInBackground :: Bool
+    , claimCurrentSession :: SessionHandle -> IO ()
+    , claudeBypassEnabled :: Bool
+    , closeAll :: IO closeResult
+    , codeModeCloseRef :: IORef (IO ())
+    , coding :: CodingTools
+    , createSubagentWorktree
+        :: OsPath -> IO (Either Text SubagentWorktree)
+    , customGenericOptions :: Maybe GenericClientOptions
+    , cwd :: OsPath
+    , databaseAppTools :: [AppTool]
+    , databaseScopes :: DatabaseScopes
+    , dialect :: Dialect
+    , effortText :: Text
+    , escPaused :: IORef Bool
+    , extraTools :: [AppTool]
+    , fullscreen :: Maybe FullscreenRuntime
+    , gatewayTools :: [AppTool]
+    , ghciEnabledRef :: IORef Bool
+    , allowedChildModels :: Maybe [Text]
+    , resolveChildModel
+        :: Maybe (Text -> IO (Maybe CollaborationModelTarget))
+    , childModelAllowed :: Maybe (Text -> IO Bool)
+    , home :: OsPath
+    , inferredTarget :: ModelTarget
+    , interrupt :: InterruptState
+    , learnedSkillAppTools :: [AppTool]
+    , legacySubagentTarget :: Maybe LegacySubagentTarget
+    , mcpFleet :: MCP.McpFleet
+    , mcpInstructions :: [(Text, Text)]
+    , mcpTools :: [AppTool]
+    , model :: Text
+    , multiCtx :: Maybe MultiAgentContext
+    , noteSessionDir :: OsPath -> IO ()
+    , openRouterOptions :: ClientOptions
+    , openaiChild :: Maybe TokenProvider
+    , options :: CliOptions
+    , pendingNotices :: PendingInputs
+    , pendingTurn :: Maybe PendingTurn
+    , persist :: Persistence
+    , planHooks :: PlanModeHooks
+    , planMode :: PlanModeEnv
+    , policy :: ApprovalPolicy
+    , preferredOpenAiAccountRef :: IORef (Maybe Text)
+    , projectRoot :: OsPath
+    , promptRequest :: Maybe ManagedTurnRequest
+    , provider :: Provider
+    , refreshDialectContext :: Bool
+    , registry :: SubagentRegistry
+    , resolveActiveAccountLabel :: Credential -> IO Text
+    , resumeTargetChanged :: Bool
+    , resumed :: Maybe (SessionMeta, [SessionTurn])
+    , root :: OsPath
+    , rootTurnRef :: IORef (Maybe RootTurnId)
+    , selectHttpAccount :: Text -> IO (Either ApiError Text)
+    , selectableTokenProvider :: TokenProvider
+    , sessionTools :: [AppTool]
+    , setWindowTitle :: Text -> IO windowTitleResult
+    , skillInvocationsRef :: IORef [SkillInvocation]
+    , skillsRef :: IORef SkillCatalog
+    , startup :: StartupRuntime
+    , stateDirectory :: FilePath
+    , stderrHandle :: Handle
+    , subagentForkSource :: IORef (Maybe (IO [ResponseItem]))
+    , subagentSessions :: IORef (Map SubagentId SubagentSession)
+    , subagentStoreRoot :: SubagentStoreRoot
+    , tokenProvider :: TokenProvider
+    , toolEnv :: ToolEnv
+    , tools :: [AppTool]
+    , transition :: Maybe ProviderTransition
+    , transportModel :: Text -> Text
+    , unavailableProviders :: Set Provider
+    }
+
+data SessionCodeRuntime = SessionCodeRuntime
+    { sessionModelInfo :: Maybe ModelInfo
+    , sessionLoadsHostWorkspaceContext :: Bool
+    , sessionCodeModeRuntime :: Maybe CodeModeSessionRuntime
+    , sessionCatalogSession :: Maybe CodexCatalogSession
+    , sessionRegistryTools :: [AppTool]
+    , sessionBaseParams :: ResponseCreateParams
+    , sessionReservedId :: Maybe Text
+    , sessionEnvironmentContext :: Maybe Text
+    }
+
+data SessionPromptRuntime = SessionPromptRuntime
+    { sessionCodeRuntime :: SessionCodeRuntime
+    , sessionParams :: ResponseCreateParams
+    , sessionParamsRef :: IORef ResponseCreateParams
+    , sessionPolicyRef :: IORef ApprovalPolicy
+    , sessionClaudeRuntimeSlot :: ClaudeSessionRuntimeSlot
+    , sessionClaudeBridgeTools :: [AppTool]
+    , sessionAutomaticCompactionRef
+        :: IORef (Maybe AutomaticCompactionBoundary)
+    , sessionAutomaticCompactionHookRef
+        :: IORef
+            (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
+    , sessionInitialItems :: [ResponseItem]
+    , sessionResumeNeedsFreshContext :: Bool
+    , sessionInitialPrevious :: Maybe Text
+    , sessionNeedsInitialContext :: Bool
+    , sessionRestoredPromptSnapshot :: Maybe SessionPromptSnapshot
+    , sessionQueueInitialContext :: Bool
+    }
+
+data SessionLiveRuntime = SessionLiveRuntime
+    { sessionConversationRef :: IORef LiveConversation
+    , sessionContextTokensRef :: IORef (Maybe OccupancySnapshot)
+    , sessionStartupContext :: IORef (Maybe Text)
+    , sessionUsageRef :: IORef TokenUsage
+    , sessionStartupWindowTitle :: Text
+    , sessionRecordCompactionUsage :: TokenUsage -> IO ()
+    , sessionSubagentRuntime :: SubagentRuntime
+    }
 
 runAgentSession
     :: LoadedAuth
@@ -452,492 +596,757 @@ runAgentSession
     transition
     transportModel
     unavailableProviders
-    = do
+    =
+    runAgentSessionRequest AgentSessionRequest{..}
+
+runAgentSessionRequest
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> IO RunResult
+runAgentSessionRequest request@AgentSessionRequest{closeAll} =
     flip finally closeAll do
-        case
-                mcpToolCollision
-                    ( coding.codingAppTools
-                        ++ extraTools
-                        ++ sessionTools
-                        ++ gatewayTools
-                        ++ databaseAppTools
-                        ++ learnedSkillAppTools
-                    )
-                    mcpFleet.mcpFleetRegistrations
-            of
-                Just err ->
-                    startupDie startup
-                        ("Failed to initialize MCP tools: " <> Text.unpack err)
-                Nothing -> pure ()
-        today <- utctDay <$> getCurrentTime
-        -- Catalog models provide the per-model instructions template. Full
-        -- code mode remains opt-in, but code_mode_only models still route the
-        -- reserved image-generation tool through exec because Responses Lite
-        -- rejects its direct namespace. The offline lookup never blocks
-        -- startup on the network.
-        codexModelInfo <-
-            loadCodexCatalogModelInfo
-                stateDirectory
-                provider
-                dialect
-                (if isGatewayLoadedAuth loaded
-                    then Nothing
-                    else Just selectableTokenProvider)
-                model
-        let nativeCapabilities =
-                maybe
-                    fullNativeRunCapabilities
-                    (.nativeCapabilities)
-                    startup.startupNativeHooks
-            loadsHostWorkspaceContext =
-                maybe
-                    True
-                    (nativeLoadsHostWorkspaceContext
-                        . (.nativeWorkspaceDiscovery))
-                    startup.startupNativeHooks
-            includeHostedSearch =
-                nativeCapabilities.nativeProviderHostedTools
-            initializeCodeMode
-                | not nativeCapabilities.nativeHostExtensions =
-                    pure (Right Nothing)
-                | options.optCodeMode =
-                    codeModeSessionRuntimeFor codexModelInfo tools
-                | otherwise =
-                    imageGenerationCodeModeRuntimeFor codexModelInfo tools
-            codeModeFallbackWarning
-                | options.optCodeMode =
-                    "code mode unavailable; falling back to compatible \
-                    \direct tools: "
-                | otherwise =
-                    "image generation code mode unavailable; \
-                    \disabling image generation: "
-        (codeModeRuntime, suppressDirectImageGeneration) <-
-            initializeCodeMode >>= \case
-                Left err -> do
-                    reportStartupWarning startup
-                        (codeModeFallbackWarning <> err)
-                    pure (Nothing, True)
-                Right runtime -> pure (runtime, False)
-        writeIORef codeModeCloseRef
-            (maybe (pure ()) (.codeModeClose) codeModeRuntime)
-        sessionId <- reservedSessionId persist
-        let providerTools
-                | suppressDirectImageGeneration =
-                    filter
-                        ((/= imageGenerationToolName) . (.appToolName))
-                        tools
-                | otherwise = tools
-            catalogSession = codexModelInfo <&> \info ->
-                CodexCatalogSession
-                    { catalogInstructionsFor = \toolNames sessionTmpDir ->
-                        systemPromptForCatalogModelWithHostedSearch
-                            includeHostedSearch
-                            dialect
-                            info
-                            toolNames
-                            sessionTmpDir
-                    , catalogEnvironmentContext =
-                        codexEnvironmentContext cwd today Nothing Nothing
-                    }
-            instructions =
-                appendMcpInstructions mcpInstructions case catalogSession of
-                    Just catalog ->
-                        catalog.catalogInstructionsFor
-                            (map (.appToolName) providerTools)
-                            (Just sessionTmp)
-                    Nothing ->
-                        systemPromptForToolsWithHostedSearch
-                            includeHostedSearch
-                            dialect
-                            (map (.appToolName) providerTools)
-                            cwd
-                            (Just sessionTmp)
-                            today
-                            (isOneShot options)
-            wireSchemas = case codeModeRuntime of
-                Just codeMode ->
-                    schemasFromAppToolsCodeModeWithHostedSearch
+        validateSessionMcpTools request
+        codeRuntime <- prepareSessionCodeRuntime request
+        promptRuntime <- prepareSessionPromptRuntime request codeRuntime
+        liveRuntime <- prepareSessionLiveRuntime request promptRuntime
+        launchPreparedSession request promptRuntime liveRuntime
+
+validateSessionMcpTools
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> IO ()
+validateSessionMcpTools AgentSessionRequest
+    { coding
+    , extraTools
+    , sessionTools
+    , gatewayTools
+    , databaseAppTools
+    , learnedSkillAppTools
+    , mcpFleet
+    , startup
+    } =
+    case
+            mcpToolCollision
+                ( coding.codingAppTools
+                    ++ extraTools
+                    ++ sessionTools
+                    ++ gatewayTools
+                    ++ databaseAppTools
+                    ++ learnedSkillAppTools
+                )
+                mcpFleet.mcpFleetRegistrations
+        of
+            Just err ->
+                startupDie startup
+                    ("Failed to initialize MCP tools: " <> Text.unpack err)
+            Nothing -> pure ()
+
+prepareSessionCodeRuntime
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> IO SessionCodeRuntime
+prepareSessionCodeRuntime AgentSessionRequest
+    { loaded
+    , stateDirectory
+    , provider
+    , dialect
+    , selectableTokenProvider
+    , model
+    , startup
+    , options
+    , tools
+    , codeModeCloseRef
+    , allTools
+    , effortText
+    , cwd
+    , sessionTmp
+    , persist
+    , mcpInstructions
+    } = do
+    today <- utctDay <$> getCurrentTime
+    -- Catalog models provide the per-model instructions template. Full code
+    -- mode remains opt-in, while code_mode_only models still route the
+    -- reserved image-generation tool through exec.
+    sessionModelInfo <-
+        loadCodexCatalogModelInfo
+            stateDirectory
+            provider
+            dialect
+            (if isGatewayLoadedAuth loaded
+                then Nothing
+                else Just selectableTokenProvider)
+            model
+    let nativeCapabilities =
+            maybe
+                fullNativeRunCapabilities
+                (.nativeCapabilities)
+                startup.startupNativeHooks
+        sessionLoadsHostWorkspaceContext =
+            maybe
+                True
+                (nativeLoadsHostWorkspaceContext
+                    . (.nativeWorkspaceDiscovery))
+                startup.startupNativeHooks
+        includeHostedSearch =
+            nativeCapabilities.nativeProviderHostedTools
+        initializeCodeMode
+            | not nativeCapabilities.nativeHostExtensions =
+                pure (Right Nothing)
+            | options.optCodeMode =
+                codeModeSessionRuntimeFor sessionModelInfo tools
+            | otherwise =
+                imageGenerationCodeModeRuntimeFor sessionModelInfo tools
+        codeModeFallbackWarning
+            | options.optCodeMode =
+                "code mode unavailable; falling back to compatible \
+                \direct tools: "
+            | otherwise =
+                "image generation code mode unavailable; \
+                \disabling image generation: "
+    (sessionCodeModeRuntime, suppressDirectImageGeneration) <-
+        initializeCodeMode >>= \case
+            Left err -> do
+                reportStartupWarning startup
+                    (codeModeFallbackWarning <> err)
+                pure (Nothing, True)
+            Right runtime -> pure (runtime, False)
+    writeIORef codeModeCloseRef
+        (maybe (pure ()) (.codeModeClose) sessionCodeModeRuntime)
+    sessionReservedId <- reservedSessionId persist
+    let providerTools
+            | suppressDirectImageGeneration =
+                filter
+                    ((/= imageGenerationToolName) . (.appToolName))
+                    tools
+            | otherwise = tools
+        sessionCatalogSession = sessionModelInfo <&> \info ->
+            CodexCatalogSession
+                { catalogInstructionsFor = \toolNames sessionTmpDir ->
+                    systemPromptForCatalogModelWithHostedSearch
                         includeHostedSearch
                         dialect
-                        ( codeMode.codeModeWireTools
-                            <> codeMode.codeModeDirectTools
-                        )
-                Nothing ->
-                    schemasFromAppToolsWithHostedSearch
-                        includeHostedSearch
-                        dialect
-                        providerTools
-            environmentContextBlock =
-                (.catalogEnvironmentContext) <$> catalogSession
-            registryTools =
-                allTools
-                    <> maybe [] (.codeModeWireTools) codeModeRuntime
-            baseParams = requestParams provider model instructions
-                wireSchemas effortText
-            compatiblePromptSnapshot =
-                compatibleSessionPromptSnapshot
-                    provider
-                    inferredTarget.targetConnectionId
-                    (dialectId dialect)
-                    cwd
-                    sessionId
-                    baseParams
-                    (resumed >>= \(meta, _) -> meta.metaPromptSnapshot)
-            params = case compatiblePromptSnapshot of
-                Just snapshot ->
-                    setRequestPromptCacheKey
-                        snapshot.promptSnapshotCacheKey
-                        (setRequestInstructionsAndTools
-                            snapshot.promptSnapshotInstructions
-                            (Just snapshot.promptSnapshotTools)
-                            baseParams)
-                Nothing ->
-                    maybe baseParams
-                        (`setRequestPromptCacheKey` baseParams)
-                        sessionId
-            initialItems = maybe [] (foldSessionItems . snd) resumed
-            initialTurns = maybe [] snd resumed
-            resumeNeedsFreshContext =
-                resumeNeedsGeneratedContext initialTurns
-            initialPrevious = case transition of
-                Just _ -> Nothing
-                Nothing
-                    | resumeTargetChanged -> Nothing
-                    | otherwise ->
-                        resumed >>= \(meta, _) -> meta.metaLastResponseId
-            needsInitialContext =
-                resumeNeedsFreshContext
-                    || (null initialTurns && isNothing initialPrevious)
-            restoredInitialPromptSnapshot
-                | null initialTurns && isNothing initialPrevious =
-                    compatiblePromptSnapshot
-                | otherwise = Nothing
-            queueInitialContext =
-                needsInitialContext && isNothing restoredInitialPromptSnapshot
-        paramsRef <- newIORef params
-        policyRef <- newIORef policy
-        claudeRuntimeSlot <- newClaudeSessionRuntimeSlot
-        let claudeBridgeTools =
-                filter isClaudeBridgeTool allTools
-            isClaudeBridgeTool tool =
-                canonicalToolName tool.appToolName
-                    `notElem`
-                        [ "shell_command", "run_terminal_cmd"
-                        , "read_file", "write_file", "grep", "glob"
-                        , "search_replace", "apply_patch", "write_stdin"
-                        , "web_fetch", "web_search"
-                        ]
-                    && case tool.appToolSchema of
-                        JsonFunctionSchema{} -> True
-                        RawJsonFunctionSchema{} -> True
-                        _ -> False
-        automaticCompactionRef <- newIORef Nothing
-        automaticCompactionHookRef <-
-            newIORef
-                (\_outcome _inputs -> pure CompactionNotInstalled)
-        let currentModelContextWindow mapTransportModel = do
-                currentParams <- readIORef paramsRef
-                pure $
-                    catalogContextWindowForParams
-                        mapTransportModel
-                        currentParams
-            catalogContextWindowForParams mapTransportModel params = do
-                currentModel <- params.model
-                catalogContextWindowForTransport
-                    catalog
-                    inferredTarget.targetConnectionId
-                    currentModel
-                    (mapTransportModel currentModel)
-            contextWindowForParams mapTransportModel fallback params =
-                fromMaybe fallback
-                    (catalogContextWindowForParams mapTransportModel params)
-            subagentRuntime = SubagentRuntime
-                { subagentOptions = options
-                , subagentNetworkRecovery =
-                    startup.startupNetworkRecovery
-                , subagentGhciEnabled = ghciEnabledRef
-                , subagentBashEnabled = bashEnabledRef
-                , subagentPolicy = policyRef
-                , subagentPlanHooks = planHooks
-                , subagentSkillRoots = toolEnv.toolSkillRoots
-                , subagentAllowedRoots = toolEnv.toolAllowedRoots
-                , subagentRootAccessRequest = toolEnv.toolRootAccessRequest
-                , subagentParams = paramsRef
-                , subagentMcpTools = mcpTools
-                , subagentRegistry = registry
-                , subagentSessions = subagentSessions
-                , subagentStoreRoot = subagentStoreRoot
-                , subagentTypes = agentTypesRef
-                , subagentLegacyTarget = legacySubagentTarget
-                , subagentConnection = inferredTarget.targetConnectionId
-                , subagentMapModel = transportModel
-                , subagentCreateWorktree = Just createSubagentWorktree
-                , subagentSessionTmp = toolEnv.toolSessionTmp
-                , subagentSpawnModelGuidance =
-                    if provider == OpenAIProvider
-                        && isJust allowedChildModels
-                        then Nothing
-                        else
-                            subscriptionSubagentModelGuidance
-                                provider
-                                (tokenProviderBillingMode tokenProvider)
-                , subagentAllowedChildModels = allowedChildModels
-                , subagentResolveChildModel = resolveChildModel
-                , subagentChildModelAllowed = childModelAllowed
-                , subagentOpenAiChild = openaiChild
+                        info
+                        toolNames
+                        sessionTmpDir
+                , catalogEnvironmentContext =
+                    codexEnvironmentContext cwd today Nothing Nothing
                 }
-        let conversationRef = startup.startupSessionState.sessionConversation
-        void $
-            replaceLiveConversation
-                conversationRef initialPrevious initialItems
-        contextTokensRef <- newIORef Nothing
-        writeIORef subagentForkSource (Just (readLiveTranscript conversationRef))
-        let titleHint = case resumed of
-                Just (meta, _) -> Just meta.metaTitle
+        instructions =
+            appendMcpInstructions mcpInstructions case sessionCatalogSession of
+                Just catalogSession ->
+                    catalogSession.catalogInstructionsFor
+                        (map (.appToolName) providerTools)
+                        (Just sessionTmp)
                 Nothing ->
-                    fmap (\request -> sessionTitleFromPrompt request.managedTurnText)
-                        promptRequest
-            startupWindowTitle = cliWindowTitle cwd titleHint
-        _ <- setWindowTitle startupWindowTitle
-        markStartupStage startup "Loading instructions…"
-        let agentsContextNotice
-                | isNothing resumed && isNothing transition =
-                    ReportAgentsContextLoaded
-                | otherwise =
-                    SuppressAgentsContextLoaded
-        startupContext <- case restoredInitialPromptSnapshot of
-            Just snapshot ->
-                newIORef snapshot.promptSnapshotGeneratedContext
-            Nothing ->
-                if not loadsHostWorkspaceContext
-                    then newIORef environmentContextBlock
-                    else
-                        loadAgentsContext
-                            stderrHandle
-                            fullscreen
-                            agentsContextNotice
-                            options
-                            dialect
-                            home
-                            cwd
-                            (if refreshDialectContext || resumeNeedsFreshContext
-                                then []
-                                else initialItems)
-                            (if refreshDialectContext || resumeNeedsFreshContext
-                                then Nothing
-                                else initialPrevious)
-                            environmentContextBlock
-        -- Fullscreen sessions load skills after Brick has taken over the
-        -- terminal, so filesystem discovery cannot delay the first frame.
-        -- Minimal and one-shot sessions still initialize them synchronously
-        -- before their first prompt/turn below.
-        usageRef <- newIORef $ case resumed of
-            Just (meta, turns) -> sessionUsageFromTurns meta turns
-            Nothing -> emptyTokenUsage
-        forM_ resumed \(meta, _) -> do
-            generation <-
-                currentLiveTranscriptGeneration conversationRef
-            evicted <-
-                evictLiveTranscript
-                    conversationRef
-                    generation
-                    (durableTranscriptCheckpoint
-                        (trustedPool startup.startupDatabaseStore)
-                        root
-                        meta.metaId)
-            when evicted performMajorGC
-        let recordCompactionUsage usage =
-                when (usage /= emptyTokenUsage) $
-                    mask_ do
-                        case persist of
-                            PersistenceDisabled -> pure ()
-                            PersistenceEnabled slotRef -> do
-                                handle <- ensureSession slotRef
-                                claimCurrentSession handle
-                                updated <- addSessionUsage usage handle
-                                writeIORef slotRef (PersistenceActive updated)
-                        modifyIORef' usageRef (`addTokenUsage` usage)
-        case persist of
-            PersistenceEnabled slotRef -> do
-                slot <- readIORef slotRef
-                case slot of
-                    PersistenceActive handle -> do
-                        claimCurrentSession handle
-                        noteSessionDir handle.sessionDir
-                    PersistencePending _ _ _ -> pure ()
-            PersistenceDisabled -> pure ()
-        progName <- getProgName
-        markStartupStage startup "Connecting to provider…"
-        let runWithInterruptHandling action
-                | startup.startupBackground = action
-                | otherwise =
-                    withCtrlCHandler interrupt $
-                        withResumeHintOnQuit
-                            fullscreen progName persist action
-        runWithInterruptHandling do
-                let shouldProbeAtStartup =
-                        checkStartupUsageInBackground
-                            && isNothing promptRequest
-                    sessionRequest
-                        startupUnavailable
-                        sessionTokenProvider
-                        sessionOpenAiPool
-                        sessionSelectAccount
-                        sessionContextWindow
-                        sessionCompactRunner =
-                            SessionRequest
-                                { catalog
-                                , gatewayModelsRef
-                                , claudeRuntimeSlot
-                                , claudeBridgeTools
-                                , modelInfo = codexModelInfo
-                                , connectionId =
-                                    inferredTarget.targetConnectionId
-                                , gatewayIdentity =
-                                    gatewayCredentialIdentity
-                                        <$> connectedGateway
-                                , options
-                                , provider
-                                , dialect
-                                , policyRef
-                                , allTools = registryTools
-                                , recordImageGenerationInputs
-                                , clearImageGenerationHistory
-                                , suspendGhci = coding.codingSuspendGhci
-                                , resetToolSessionTemp =
-                                    coding.codingResetSessionTemp
-                                , grokRuntime = coding.codingGrokRuntime
-                                , mcpRegistrations =
-                                    mcpFleet.mcpFleetRegistrations
-                                , mcpWarnings = mcpFleet.mcpFleetWarnings
-                                , mcpInstructions
-                                , mcpFleet = Just mcpFleet
-                                , ghciEnabledRef
-                                , bashEnabledRef
-                                , toolEnv
-                                , planMode
-                                , taskPlan = coding.codingTaskPlan
-                                , startup
-                                , learnAboutUserRequested
-                                , databaseScopes
-                                , promptRequest
-                                , pendingTurn
-                                , unavailableProviders
-                                , startupUnavailable
-                                , paramsRef
-                                , conversationRef
-                                , contextOccupancyRef = contextTokensRef
-                                , currentContextWindow = do
-                                    configured <- sessionContextWindow
-                                    pure $
-                                        configured
-                                            <|> (resolvedContextWindow
-                                                =<< codexModelInfo)
-                                , automaticCompactionRef
-                                , needsInitialContext
-                                , queueInitialContext
-                                , initialGrokContext =
-                                    restoredInitialPromptSnapshot
-                                        >>= (.promptSnapshotGrokContext)
-                                , persist
-                                , startupWindowTitle
-                                , projectRoot
-                                , home
-                                , cwd
-                                , tokenProvider = sessionTokenProvider
-                                , openAiPool = sessionOpenAiPool
-                                , startupContext
-                                , automaticCompactionHookRef
-                                , skillsRef
-                                , skillInvocationsRef
-                                , escPaused
-                                , interrupt
-                                , multiCtx
-                                , rootTurnRef
-                                , subagentSessions
-                                , pendingNotices
-                                , storeRoot = subagentStoreRoot
-                                , agentTypes = agentTypesRef
-                                , legacyTarget = legacySubagentTarget
-                                , usageRef
-                                , accountRef = activeAccountRef
-                                , accountIdRef = activeAccountIdRef
-                                , selectionRef = activeSelectionRef
-                                , accountLabel = resolveActiveAccountLabel
-                                , selectAccount = sessionSelectAccount
-                                , onPersisted = claimCurrentSession
-                                , compactRunner = sessionCompactRunner
-                                , codeModeNestedSlot =
-                                    (.codeModeNestedSlot) <$> codeModeRuntime
-                                , codexCatalogSession = catalogSession
-                                }
-                    withStartupAvailability action
-                        | shouldProbeAtStartup
-                        , not (isGatewayLoadedAuth loaded) =
-                            withAsync
-                                (probeLoadedAvailability
-                                    loaded
-                                        { loadedTokenProvider =
-                                            tokenProvider
-                                        })
-                                \availability -> do
-                                    let startupUnavailable =
-                                            waitSTM availability >>= \case
-                                                Left err
-                                                    | isProviderUnavailable err ->
-                                                        pure err
-                                                _ -> retry
-                                    action (Just startupUnavailable)
-                        | otherwise = action Nothing
-                withStartupAvailability \startupUnavailable ->
-                    runAgentProviders
-                        (if startup.startupBackground
-                            then SessionLocalSwitch
-                            else TopLevelSwitch)
-                        loaded
-                        connectedGateway
-                        sessionRequest
-                        activeAccountIdRef
-                        activeAccountRef
-                        activeSelectionRef
-                        catalog
-                        claudeBypassEnabled
-                        contextTokensRef
-                        contextWindowForParams
-                        conversationRef
-                        currentModelContextWindow
-                        customGenericOptions
-                        cwd
+                    systemPromptForToolsWithHostedSearch
+                        includeHostedSearch
                         dialect
-                        fullscreen
-                        automaticCompactionHookRef
-                        coding.codingTaskPlan
-                        home
-                        initialPrevious
-                        model
-                        multiCtx
-                        openRouterOptions
-                        options
-                        params
-                        paramsRef
-                        pendingNotices
-                        persist
-                        preferredOpenAiAccountRef
-                        projectRoot
+                        (map (.appToolName) providerTools)
+                        cwd
+                        (Just sessionTmp)
+                        today
+                        (isOneShot options)
+        wireSchemas = case sessionCodeModeRuntime of
+            Just codeMode ->
+                schemasFromAppToolsCodeModeWithHostedSearch
+                    includeHostedSearch
+                    dialect
+                    ( codeMode.codeModeWireTools
+                        <> codeMode.codeModeDirectTools
+                    )
+            Nothing ->
+                schemasFromAppToolsWithHostedSearch
+                    includeHostedSearch
+                    dialect
+                    providerTools
+        sessionEnvironmentContext =
+            (.catalogEnvironmentContext) <$> sessionCatalogSession
+        sessionRegistryTools =
+            allTools
+                <> maybe [] (.codeModeWireTools) sessionCodeModeRuntime
+        sessionBaseParams =
+            requestParams provider model instructions wireSchemas effortText
+    pure SessionCodeRuntime{..}
+
+prepareSessionPromptRuntime
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> SessionCodeRuntime
+    -> IO SessionPromptRuntime
+prepareSessionPromptRuntime AgentSessionRequest
+    { provider
+    , inferredTarget
+    , dialect
+    , cwd
+    , resumed
+    , transition
+    , resumeTargetChanged
+    , policy
+    , allTools
+    } sessionCodeRuntime = do
+    let compatiblePromptSnapshot =
+            compatibleSessionPromptSnapshot
+                provider
+                inferredTarget.targetConnectionId
+                (dialectId dialect)
+                cwd
+                sessionCodeRuntime.sessionReservedId
+                sessionCodeRuntime.sessionBaseParams
+                (resumed >>= \(meta, _) -> meta.metaPromptSnapshot)
+        sessionParams = case compatiblePromptSnapshot of
+            Just snapshot ->
+                setRequestPromptCacheKey
+                    snapshot.promptSnapshotCacheKey
+                    (setRequestInstructionsAndTools
+                        snapshot.promptSnapshotInstructions
+                        (Just snapshot.promptSnapshotTools)
+                        sessionCodeRuntime.sessionBaseParams)
+            Nothing ->
+                maybe sessionCodeRuntime.sessionBaseParams
+                    (`setRequestPromptCacheKey`
+                        sessionCodeRuntime.sessionBaseParams)
+                    sessionCodeRuntime.sessionReservedId
+        sessionInitialItems = maybe [] (foldSessionItems . snd) resumed
+        initialTurns = maybe [] snd resumed
+        sessionResumeNeedsFreshContext =
+            resumeNeedsGeneratedContext initialTurns
+        sessionInitialPrevious = case transition of
+            Just _ -> Nothing
+            Nothing
+                | resumeTargetChanged -> Nothing
+                | otherwise ->
+                    resumed >>= \(meta, _) -> meta.metaLastResponseId
+        sessionNeedsInitialContext =
+            sessionResumeNeedsFreshContext
+                || (null initialTurns && isNothing sessionInitialPrevious)
+        sessionRestoredPromptSnapshot
+            | null initialTurns && isNothing sessionInitialPrevious =
+                compatiblePromptSnapshot
+            | otherwise = Nothing
+        sessionQueueInitialContext =
+            sessionNeedsInitialContext
+                && isNothing sessionRestoredPromptSnapshot
+        sessionClaudeBridgeTools =
+            filter isClaudeBridgeTool allTools
+    sessionParamsRef <- newIORef sessionParams
+    sessionPolicyRef <- newIORef policy
+    sessionClaudeRuntimeSlot <- newClaudeSessionRuntimeSlot
+    sessionAutomaticCompactionRef <- newIORef Nothing
+    sessionAutomaticCompactionHookRef <-
+        newIORef (\_outcome _inputs -> pure CompactionNotInstalled)
+    pure SessionPromptRuntime{..}
+
+isClaudeBridgeTool :: AppTool -> Bool
+isClaudeBridgeTool tool =
+    canonicalToolName tool.appToolName
+        `notElem`
+            [ "shell_command", "run_terminal_cmd"
+            , "read_file", "write_file", "grep", "glob"
+            , "search_replace", "apply_patch", "write_stdin"
+            , "web_fetch", "web_search"
+            ]
+        && case tool.appToolSchema of
+            JsonFunctionSchema{} -> True
+            RawJsonFunctionSchema{} -> True
+            _ -> False
+
+sessionCatalogContextWindowForParams
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> (Text -> Text)
+    -> ResponseCreateParams
+    -> Maybe Int
+sessionCatalogContextWindowForParams AgentSessionRequest
+    { catalog
+    , inferredTarget
+    } mapTransportModel params = do
+    currentModel <- params.model
+    catalogContextWindowForTransport
+        catalog
+        inferredTarget.targetConnectionId
+        currentModel
+        (mapTransportModel currentModel)
+
+sessionCurrentModelContextWindow
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> SessionPromptRuntime
+    -> (Text -> Text)
+    -> IO (Maybe Int)
+sessionCurrentModelContextWindow request promptRuntime mapTransportModel = do
+    currentParams <- readIORef promptRuntime.sessionParamsRef
+    pure $
+        sessionCatalogContextWindowForParams
+            request
+            mapTransportModel
+            currentParams
+
+sessionContextWindowForParams
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> (Text -> Text)
+    -> Int
+    -> ResponseCreateParams
+    -> Int
+sessionContextWindowForParams request mapTransportModel fallback params =
+    fromMaybe fallback
+        (sessionCatalogContextWindowForParams
+            request
+            mapTransportModel
+            params)
+
+buildSessionSubagentRuntime
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> SessionPromptRuntime
+    -> SubagentRuntime
+buildSessionSubagentRuntime AgentSessionRequest
+    { options
+    , startup
+    , ghciEnabledRef
+    , bashEnabledRef
+    , planHooks
+    , toolEnv
+    , mcpTools
+    , registry
+    , subagentSessions
+    , subagentStoreRoot
+    , agentTypesRef
+    , legacySubagentTarget
+    , inferredTarget
+    , transportModel
+    , createSubagentWorktree
+    , provider
+    , allowedChildModels
+    , tokenProvider
+    , resolveChildModel
+    , childModelAllowed
+    , openaiChild
+    } promptRuntime =
+    SubagentRuntime
+        { subagentOptions = options
+        , subagentNetworkRecovery = startup.startupNetworkRecovery
+        , subagentGhciEnabled = ghciEnabledRef
+        , subagentBashEnabled = bashEnabledRef
+        , subagentPolicy = promptRuntime.sessionPolicyRef
+        , subagentPlanHooks = planHooks
+        , subagentSkillRoots = toolEnv.toolSkillRoots
+        , subagentAllowedRoots = toolEnv.toolAllowedRoots
+        , subagentRootAccessRequest = toolEnv.toolRootAccessRequest
+        , subagentParams = promptRuntime.sessionParamsRef
+        , subagentMcpTools = mcpTools
+        , subagentRegistry = registry
+        , subagentSessions = subagentSessions
+        , subagentStoreRoot = subagentStoreRoot
+        , subagentTypes = agentTypesRef
+        , subagentLegacyTarget = legacySubagentTarget
+        , subagentConnection = inferredTarget.targetConnectionId
+        , subagentMapModel = transportModel
+        , subagentCreateWorktree = Just createSubagentWorktree
+        , subagentSessionTmp = toolEnv.toolSessionTmp
+        , subagentSpawnModelGuidance =
+            if provider == OpenAIProvider && isJust allowedChildModels
+                then Nothing
+                else
+                    subscriptionSubagentModelGuidance
                         provider
-                        recordCompactionUsage
-                        resolveActiveAccountLabel
-                        selectHttpAccount
-                        selectableTokenProvider
-                        shouldProbeAtStartup
-                        startup
-                        startupUnavailable
-                        stderrHandle
-                        subagentRuntime
-                        tokenProvider
-                        transition
-                        transportModel
-                        unavailableProviders
+                        (tokenProviderBillingMode tokenProvider)
+        , subagentAllowedChildModels = allowedChildModels
+        , subagentResolveChildModel = resolveChildModel
+        , subagentChildModelAllowed = childModelAllowed
+        , subagentOpenAiChild = openaiChild
+        }
+
+prepareSessionLiveRuntime
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> SessionPromptRuntime
+    -> IO SessionLiveRuntime
+prepareSessionLiveRuntime request@AgentSessionRequest
+    { startup
+    , subagentForkSource
+    , setWindowTitle
+    , resumed
+    } promptRuntime = do
+    let sessionConversationRef =
+            startup.startupSessionState.sessionConversation
+    void $
+        replaceLiveConversation
+            sessionConversationRef
+            promptRuntime.sessionInitialPrevious
+            promptRuntime.sessionInitialItems
+    sessionContextTokensRef <- newIORef Nothing
+    writeIORef subagentForkSource
+        (Just (readLiveTranscript sessionConversationRef))
+    let sessionStartupWindowTitle = sessionWindowTitle request
+    _ <- setWindowTitle sessionStartupWindowTitle
+    markStartupStage startup "Loading instructions…"
+    sessionStartupContext <-
+        loadSessionStartupContext request promptRuntime
+    -- Fullscreen sessions load skills after Brick has taken over the
+    -- terminal. Minimal and one-shot sessions initialize them synchronously
+    -- before their first prompt or turn.
+    sessionUsageRef <- newIORef $ case resumed of
+        Just (meta, turns) -> sessionUsageFromTurns meta turns
+        Nothing -> emptyTokenUsage
+    evictResumedConversation
+        request
+        sessionConversationRef
+    claimPersistedSession request
+    let sessionRecordCompactionUsage =
+            recordSessionCompactionUsage request sessionUsageRef
+        sessionSubagentRuntime =
+            buildSessionSubagentRuntime request promptRuntime
+    pure SessionLiveRuntime{..}
+
+sessionWindowTitle
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> Text
+sessionWindowTitle AgentSessionRequest
+    { resumed
+    , promptRequest
+    , cwd
+    } =
+    cliWindowTitle cwd titleHint
+  where
+    titleHint = case resumed of
+        Just (meta, _) -> Just meta.metaTitle
+        Nothing ->
+            fmap
+                (\request ->
+                    sessionTitleFromPrompt request.managedTurnText)
+                promptRequest
+
+loadSessionStartupContext
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> SessionPromptRuntime
+    -> IO (IORef (Maybe Text))
+loadSessionStartupContext AgentSessionRequest
+    { resumed
+    , transition
+    , stderrHandle
+    , fullscreen
+    , options
+    , dialect
+    , home
+    , cwd
+    , refreshDialectContext
+    } promptRuntime =
+    case promptRuntime.sessionRestoredPromptSnapshot of
+        Just snapshot ->
+            newIORef snapshot.promptSnapshotGeneratedContext
+        Nothing
+            | not
+                promptRuntime.sessionCodeRuntime.sessionLoadsHostWorkspaceContext ->
+                newIORef
+                    promptRuntime.sessionCodeRuntime.sessionEnvironmentContext
+            | otherwise ->
+                loadAgentsContext
+                    stderrHandle
+                    fullscreen
+                    agentsContextNotice
+                    options
+                    dialect
+                    home
+                    cwd
+                    initialItems
+                    initialPrevious
+                    promptRuntime.sessionCodeRuntime.sessionEnvironmentContext
+  where
+    agentsContextNotice
+        | isNothing resumed && isNothing transition =
+            ReportAgentsContextLoaded
+        | otherwise =
+            SuppressAgentsContextLoaded
+    refreshContext =
+        refreshDialectContext
+            || promptRuntime.sessionResumeNeedsFreshContext
+    initialItems
+        | refreshContext = []
+        | otherwise = promptRuntime.sessionInitialItems
+    initialPrevious
+        | refreshContext = Nothing
+        | otherwise = promptRuntime.sessionInitialPrevious
+
+evictResumedConversation
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> IORef LiveConversation
+    -> IO ()
+evictResumedConversation AgentSessionRequest
+    { resumed
+    , startup
+    , root
+    } conversationRef =
+    forM_ resumed \(meta, _) -> do
+        generation <-
+            currentLiveTranscriptGeneration conversationRef
+        evicted <-
+            evictLiveTranscript
+                conversationRef
+                generation
+                (durableTranscriptCheckpoint
+                    (trustedPool startup.startupDatabaseStore)
+                    root
+                    meta.metaId)
+        when evicted performMajorGC
+
+recordSessionCompactionUsage
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> IORef TokenUsage
+    -> TokenUsage
+    -> IO ()
+recordSessionCompactionUsage AgentSessionRequest
+    { persist
+    , claimCurrentSession
+    } usageRef usage =
+    when (usage /= emptyTokenUsage) $
+        mask_ do
+            case persist of
+                PersistenceDisabled -> pure ()
+                PersistenceEnabled slotRef -> do
+                    handle <- ensureSession slotRef
+                    claimCurrentSession handle
+                    updated <- addSessionUsage usage handle
+                    writeIORef slotRef (PersistenceActive updated)
+            modifyIORef' usageRef (`addTokenUsage` usage)
+
+claimPersistedSession
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> IO ()
+claimPersistedSession AgentSessionRequest
+    { persist
+    , claimCurrentSession
+    , noteSessionDir
+    } =
+    case persist of
+        PersistenceEnabled slotRef ->
+            readIORef slotRef >>= \case
+                PersistenceActive handle -> do
+                    claimCurrentSession handle
+                    noteSessionDir handle.sessionDir
+                PersistencePending _ _ _ -> pure ()
+        PersistenceDisabled -> pure ()
+
+buildProviderSessionRequest
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> SessionPromptRuntime
+    -> SessionLiveRuntime
+    -> Maybe (STM ApiError)
+    -> Maybe TokenProvider
+    -> Maybe OpenAI.Pool
+    -> Maybe (Text -> IO (Either ApiError Text))
+    -> IO (Maybe Int)
+    -> (Maybe Text -> IO (Either Text CompactOutcome))
+    -> SessionRequest
+buildProviderSessionRequest
+    request
+    promptRuntime
+    liveRuntime
+    startupUnavailable
+    sessionTokenProvider
+    sessionOpenAiPool
+    sessionSelectAccount
+    sessionContextWindow
+    sessionCompactRunner =
+        SessionRequest
+            { catalog = request.catalog
+            , gatewayModelsRef = request.gatewayModelsRef
+            , claudeRuntimeSlot =
+                promptRuntime.sessionClaudeRuntimeSlot
+            , claudeBridgeTools =
+                promptRuntime.sessionClaudeBridgeTools
+            , modelInfo =
+                promptRuntime.sessionCodeRuntime.sessionModelInfo
+            , connectionId =
+                request.inferredTarget.targetConnectionId
+            , gatewayIdentity =
+                gatewayCredentialIdentity <$> request.connectedGateway
+            , options = request.options
+            , provider = request.provider
+            , dialect = request.dialect
+            , policyRef = promptRuntime.sessionPolicyRef
+            , allTools =
+                promptRuntime.sessionCodeRuntime.sessionRegistryTools
+            , recordImageGenerationInputs =
+                request.recordImageGenerationInputs
+            , clearImageGenerationHistory =
+                request.clearImageGenerationHistory
+            , suspendGhci = request.coding.codingSuspendGhci
+            , resetToolSessionTemp =
+                request.coding.codingResetSessionTemp
+            , grokRuntime = request.coding.codingGrokRuntime
+            , mcpRegistrations =
+                request.mcpFleet.mcpFleetRegistrations
+            , mcpWarnings = request.mcpFleet.mcpFleetWarnings
+            , mcpInstructions = request.mcpInstructions
+            , mcpFleet = Just request.mcpFleet
+            , ghciEnabledRef = request.ghciEnabledRef
+            , bashEnabledRef = request.bashEnabledRef
+            , toolEnv = request.toolEnv
+            , planMode = request.planMode
+            , taskPlan = request.coding.codingTaskPlan
+            , startup = request.startup
+            , learnAboutUserRequested =
+                request.learnAboutUserRequested
+            , databaseScopes = request.databaseScopes
+            , promptRequest = request.promptRequest
+            , pendingTurn = request.pendingTurn
+            , unavailableProviders = request.unavailableProviders
+            , startupUnavailable
+            , paramsRef = promptRuntime.sessionParamsRef
+            , conversationRef = liveRuntime.sessionConversationRef
+            , contextOccupancyRef =
+                liveRuntime.sessionContextTokensRef
+            , currentContextWindow = do
+                configured <- sessionContextWindow
+                pure $
+                    configured
+                        <|> (resolvedContextWindow
+                            =<< promptRuntime.sessionCodeRuntime.sessionModelInfo)
+            , automaticCompactionRef =
+                promptRuntime.sessionAutomaticCompactionRef
+            , needsInitialContext =
+                promptRuntime.sessionNeedsInitialContext
+            , queueInitialContext =
+                promptRuntime.sessionQueueInitialContext
+            , initialGrokContext =
+                promptRuntime.sessionRestoredPromptSnapshot
+                    >>= (.promptSnapshotGrokContext)
+            , persist = request.persist
+            , startupWindowTitle =
+                liveRuntime.sessionStartupWindowTitle
+            , projectRoot = request.projectRoot
+            , home = request.home
+            , cwd = request.cwd
+            , tokenProvider = sessionTokenProvider
+            , openAiPool = sessionOpenAiPool
+            , startupContext = liveRuntime.sessionStartupContext
+            , automaticCompactionHookRef =
+                promptRuntime.sessionAutomaticCompactionHookRef
+            , skillsRef = request.skillsRef
+            , skillInvocationsRef = request.skillInvocationsRef
+            , escPaused = request.escPaused
+            , interrupt = request.interrupt
+            , multiCtx = request.multiCtx
+            , rootTurnRef = request.rootTurnRef
+            , subagentSessions = request.subagentSessions
+            , pendingNotices = request.pendingNotices
+            , storeRoot = request.subagentStoreRoot
+            , agentTypes = request.agentTypesRef
+            , legacyTarget = request.legacySubagentTarget
+            , usageRef = liveRuntime.sessionUsageRef
+            , accountRef = request.activeAccountRef
+            , accountIdRef = request.activeAccountIdRef
+            , selectionRef = request.activeSelectionRef
+            , accountLabel = request.resolveActiveAccountLabel
+            , selectAccount = sessionSelectAccount
+            , onPersisted = request.claimCurrentSession
+            , compactRunner = sessionCompactRunner
+            , codeModeNestedSlot =
+                (.codeModeNestedSlot)
+                    <$> promptRuntime.sessionCodeRuntime.sessionCodeModeRuntime
+            , codexCatalogSession =
+                promptRuntime.sessionCodeRuntime.sessionCatalogSession
+            }
+
+withSessionStartupAvailability
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> Bool
+    -> (Maybe (STM ApiError) -> IO result)
+    -> IO result
+withSessionStartupAvailability AgentSessionRequest
+    { loaded
+    , tokenProvider
+    } shouldProbeAtStartup action
+        | shouldProbeAtStartup
+        , not (isGatewayLoadedAuth loaded) =
+            withAsync
+                (probeLoadedAvailability
+                    loaded{loadedTokenProvider = tokenProvider})
+                \availability -> do
+                    let startupUnavailable =
+                            waitSTM availability >>= \case
+                                Left err
+                                    | isProviderUnavailable err ->
+                                        pure err
+                                _ -> retry
+                    action (Just startupUnavailable)
+        | otherwise = action Nothing
+
+runSessionWithInterruptHandling
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> String
+    -> IO RunResult
+    -> IO RunResult
+runSessionWithInterruptHandling AgentSessionRequest
+    { startup
+    , interrupt
+    , fullscreen
+    , persist
+    } progName action
+        | startup.startupBackground = action
+        | otherwise =
+            withCtrlCHandler interrupt $
+                withResumeHintOnQuit fullscreen progName persist action
+
+launchPreparedSession
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> SessionPromptRuntime
+    -> SessionLiveRuntime
+    -> IO RunResult
+launchPreparedSession request promptRuntime liveRuntime = do
+    progName <- getProgName
+    markStartupStage request.startup "Connecting to provider…"
+    let shouldProbeAtStartup =
+            request.checkStartupUsageInBackground
+                && isNothing request.promptRequest
+    runSessionWithInterruptHandling request progName $
+        withSessionStartupAvailability request shouldProbeAtStartup
+            \startupUnavailable ->
+                runAgentProviders
+                    (if request.startup.startupBackground
+                        then SessionLocalSwitch
+                        else TopLevelSwitch)
+                    request.loaded
+                    request.connectedGateway
+                    (buildProviderSessionRequest
+                        request
+                        promptRuntime
+                        liveRuntime)
+                    request.activeAccountIdRef
+                    request.activeAccountRef
+                    request.activeSelectionRef
+                    request.catalog
+                    request.claudeBypassEnabled
+                    liveRuntime.sessionContextTokensRef
+                    (sessionContextWindowForParams request)
+                    liveRuntime.sessionConversationRef
+                    (sessionCurrentModelContextWindow
+                        request
+                        promptRuntime)
+                    request.customGenericOptions
+                    request.cwd
+                    request.dialect
+                    request.fullscreen
+                    promptRuntime.sessionAutomaticCompactionHookRef
+                    request.coding.codingTaskPlan
+                    request.home
+                    promptRuntime.sessionInitialPrevious
+                    request.model
+                    request.multiCtx
+                    request.openRouterOptions
+                    request.options
+                    promptRuntime.sessionParams
+                    promptRuntime.sessionParamsRef
+                    request.pendingNotices
+                    request.persist
+                    request.preferredOpenAiAccountRef
+                    request.projectRoot
+                    request.provider
+                    liveRuntime.sessionRecordCompactionUsage
+                    request.resolveActiveAccountLabel
+                    request.selectHttpAccount
+                    request.selectableTokenProvider
+                    shouldProbeAtStartup
+                    request.startup
+                    startupUnavailable
+                    request.stderrHandle
+                    liveRuntime.sessionSubagentRuntime
+                    request.tokenProvider
+                    request.transition
+                    request.transportModel
+                    request.unavailableProviders
 
 -- | Print a copy-pasteable --resume line whenever the CLI session quits.
 -- Ctrl-C is normalized to the same graceful 'RunQuit' result as :q/Ctrl-D so


### PR DESCRIPTION
## Summary
- replace the monolithic `runAgentSession` body with a typed request and focused lifecycle phases
- isolate code-mode setup, prompt/context preparation, live conversation state, and provider request construction
- preserve cleanup, persistence, startup availability probing, compaction, and session launch ordering

## Validation
- `cabal repl agent-cli:lib:agent-cli` (`Agent.CLI.Runtime.Orchestration.Session`, 187 modules loaded)
- focused object-code specs covering dialect/tool wiring, permissions, MCP, pending inputs, live/session state, resume context, compaction, availability/fallback, subagents, viewport, prompts, managed agent sessions, and provider compaction
- 161 examples, 0 failures (AgentSessions rerun with a short TMPDIR for PostgreSQL socket limits)
- `git diff --check`
- independent behavior-preservation review: no issues found