### PR TITLE
refactor(cli): thread state through JSONL imports

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/ExternalSession/JSONL.hs
+++ b/packages/agent-cli/src/Agent/CLI/ExternalSession/JSONL.hs
@@ -2,6 +2,7 @@ module Agent.CLI.ExternalSession.JSONL
     ( JsonlControl(..)
     , consumeJsonl
     , decodeBoundedJsonValue
+    , foldJsonl
     , readJsonFileValue
     , readJsonlValues
     ) where
@@ -22,7 +23,6 @@ import Control.Monad (unless, when)
 import Data.Aeson (Value, eitherDecodeStrict')
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
-import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8With)
@@ -60,7 +60,21 @@ consumeJsonl
     -> Maybe Int
     -> (Value -> IO JsonlControl)
     -> IO JsonlCounters
-consumeJsonl env path limit consume
+consumeJsonl env path limit consume =
+    snd <$> foldJsonl env path limit () consumeWithoutState
+  where
+    consumeWithoutState () value = do
+        control <- consume value
+        pure ((), control)
+
+foldJsonl
+    :: ExternalSessionEnv
+    -> FilePath
+    -> Maybe Int
+    -> state
+    -> (state -> Value -> IO (state, JsonlControl))
+    -> IO (state, JsonlCounters)
+foldJsonl env path limit initialState consume
     | ".jsonl.zst" `Text.isSuffixOf` Text.pack (takeFileName path) =
         consumeCompressed
     | otherwise = do
@@ -76,7 +90,12 @@ consumeJsonl env path limit consume
                     (pure handle)
                     hClose
                     \openedHandle ->
-                        fst <$> consumeHandle openedHandle limit consume
+                        (\(state, counters, _) -> (state, counters))
+                            <$> consumeHandle
+                                openedHandle
+                                limit
+                                initialState
+                                consume
   where
     consumeCompressed =
         withCreateProcess
@@ -90,8 +109,8 @@ consumeJsonl env path limit consume
                 case (maybeOutput, maybeErrors) of
                     (Just output, Just errors) ->
                         withAsync (drainStderr errors) \errorsTask -> do
-                            (counters, stopped) <-
-                                consumeHandle output limit consume
+                            (state, counters, stopped) <-
+                                consumeHandle output limit initialState consume
                             when stopped $ do
                                 _ <- tryIO (hClose output)
                                 _ <- tryIO (terminateProcess process)
@@ -108,7 +127,7 @@ consumeJsonl env path limit consume
                                                 then "unknown error"
                                                 else oneLine 300 details
                                         )
-                            pure counters
+                            pure (state, counters)
                     _ ->
                         throwIO $
                             ExternalSessionReadFailure
@@ -121,12 +140,10 @@ readJsonlValues
     -> Maybe Int
     -> IO ([Value], JsonlCounters)
 readJsonlValues env path limit = do
-    valuesRef <- newIORef []
-    counters <- consumeJsonl env path limit \value -> do
-        modifyIORef' valuesRef (value :)
-        pure JsonlContinue
-    values <- reverse <$> readIORef valuesRef
-    pure (values, counters)
+    (values, counters) <-
+        foldJsonl env path limit [] \collected value ->
+            pure (value : collected, JsonlContinue)
+    pure (reverse values, counters)
 
 readJsonFileValue :: FilePath -> IO (Maybe Value)
 readJsonFileValue path =
@@ -145,31 +162,33 @@ decodeBoundedJsonValue bytes
 consumeHandle
     :: Handle
     -> Maybe Int
-    -> (Value -> IO JsonlControl)
-    -> IO (JsonlCounters, Bool)
-consumeHandle handle limit consume = go emptyCounters 0
+    -> state
+    -> (state -> Value -> IO (state, JsonlControl))
+    -> IO (state, JsonlCounters, Bool)
+consumeHandle handle limit initialState consume =
+    go initialState emptyCounters 0
   where
-    go counters accepted
+    go state counters accepted
         | maybe False (accepted >=) limit =
-            pure (counters, True)
+            pure (state, counters, True)
         | otherwise = do
             lineResult <- tryIO (BS8.hGetLine handle)
             case lineResult of
                 Left exception
                     | isEndOfFileException exception ->
-                        pure (counters, False)
+                        pure (state, counters, False)
                     | otherwise -> throwIO exception
                 Right line
                     | BS.all isJsonWhitespace line ->
-                        go counters accepted
+                        go state counters accepted
                     | BS.length line > maxJsonRecordBytes ->
-                        go counters
+                        go state counters
                             { oversizedRecords =
                                 counters.oversizedRecords + 1
                             }
                             accepted
                     | jsonDepthExceeds maxJsonDepth line ->
-                        go counters
+                        go state counters
                             { deeplyNestedRecords =
                                 counters.deeplyNestedRecords + 1
                             }
@@ -177,16 +196,18 @@ consumeHandle handle limit consume = go emptyCounters 0
                     | otherwise ->
                         case eitherDecodeStrict' line of
                             Left _ ->
-                                go counters
+                                go state counters
                                     { malformedRecords =
                                         counters.malformedRecords + 1
                                     }
                                     accepted
-                            Right value ->
-                                consume value >>= \case
-                                    JsonlStop -> pure (counters, True)
+                            Right value -> do
+                                (nextState, control) <- consume state value
+                                nextState `seq` case control of
+                                    JsonlStop ->
+                                        pure (nextState, counters, True)
                                     JsonlContinue ->
-                                        go counters (accepted + 1)
+                                        go nextState counters (accepted + 1)
 
 emptyCounters :: JsonlCounters
 emptyCounters = JsonlCounters 0 0 0

--- a/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Claude.hs
+++ b/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Claude.hs
@@ -12,7 +12,7 @@ import Agent.CLI.ExternalSession.SQLite
 import Agent.CLI.ExternalSession.Types
 import Control.Applicative ((<|>))
 import Control.Exception.Safe (tryAny)
-import Control.Monad (filterM, when)
+import Control.Monad (filterM)
 import Data.Aeson (Value(..), decodeStrict', encode)
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
@@ -183,8 +183,9 @@ readClaude env candidate maxToolChars =
         "resume-claude-chain.sqlite"
         \database -> do
             initializeClaudeIndex database
-            ((_, unindexable), counters) <-
-                foldJsonl env candidate.candidatePath Nothing (0, 0)
+            (indexState, counters) <-
+                foldJsonl env candidate.candidatePath Nothing
+                    (ClaudeIndexState 0 0)
                     \indexState record -> do
                         nextState <-
                             indexClaudeRecord
@@ -198,7 +199,7 @@ readClaude env candidate maxToolChars =
                 { claudeTurnsFromLeaf = []
                 , claudeLastUser = Nothing
                 , claudeLastAssistant = Nothing
-                , claudeSkipped = unindexable
+                , claudeSkipped = indexState.claudeIndexUnindexable
                 , claudeOmissions = mempty
                 }
             mapM_ (walkClaudeChain database maxToolChars stateRef) leaf
@@ -236,19 +237,24 @@ initializeClaudeIndex database = do
         "CREATE TABLE claude_visited (uuid TEXT PRIMARY KEY)"
         []
 
+data ClaudeIndexState = ClaudeIndexState
+    { claudeIndexSequence :: !Int
+    , claudeIndexUnindexable :: !Int
+    }
+
 indexClaudeRecord
     :: Database
     -> ExternalCandidate
-    -> (Int, Int)
+    -> ClaudeIndexState
     -> Value
-    -> IO (Int, Int)
-indexClaudeRecord database candidate (sequenceNumber, unindexable) record =
+    -> IO ClaudeIndexState
+indexClaudeRecord database candidate state record =
     case externalTextValue "uuid" record of
         Just uuid
             | externalTextValue "type" record
                 `elem` map Just ["user", "assistant", "system", "attachment"]
             , not (truthy (externalObjectValue "isSidechain" record)) -> do
-                let nextSequence = sequenceNumber + 1
+                let nextSequence = state.claudeIndexSequence + 1
                     parent =
                         firstNonEmptyText
                             [ externalTextValue "parentUuid" record
@@ -273,10 +279,16 @@ indexClaudeRecord database candidate (sequenceNumber, unindexable) record =
                     , SQLFloat sortTime
                     , SQLBlob (LBS.toStrict (encode record))
                     ]
-                pure (nextSequence, unindexable)
-        _ -> pure (sequenceNumber, unindexable)
+                pure state
+                    { claudeIndexSequence = nextSequence
+                    }
+        _ -> pure state
   `catchAnyIndex` \_ ->
-        pure (sequenceNumber + 1, unindexable + 1)
+        pure ClaudeIndexState
+            { claudeIndexSequence = state.claudeIndexSequence + 1
+            , claudeIndexUnindexable =
+                state.claudeIndexUnindexable + 1
+            }
 
 catchAnyIndex :: IO value -> (Text -> IO value) -> IO value
 catchAnyIndex action handle =

--- a/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Claude.hs
+++ b/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Claude.hs
@@ -78,25 +78,29 @@ claudeMetadata
 claudeMetadata env path
     | not (isClaudeTranscript path) = pure Nothing
     | otherwise = do
-        stateRef <- newIORef ClaudeMetadataState
-            { metadataCwd = Nothing
-            , metadataSessionId = Text.pack (dropJsonl path)
-            , metadataFirstUser = ""
-            , metadataCustomTitle = ""
-            , metadataAiTitle = ""
-            , metadataSummary = ""
-            , metadataCreated = Nothing
-            , metadataUpdated = Nothing
-            }
         result <- tryAny $
-            consumeJsonl env path Nothing \record -> do
-                when (not (truthy (externalObjectValue "isSidechain" record))) $
-                    modifyIORef' stateRef (consumeClaudeMetadata record)
-                pure JsonlContinue
+            foldJsonl env path Nothing
+                ClaudeMetadataState
+                    { metadataCwd = Nothing
+                    , metadataSessionId = Text.pack (dropJsonl path)
+                    , metadataFirstUser = ""
+                    , metadataCustomTitle = ""
+                    , metadataAiTitle = ""
+                    , metadataSummary = ""
+                    , metadataCreated = Nothing
+                    , metadataUpdated = Nothing
+                    }
+                \state record ->
+                    pure
+                        ( if truthy
+                                (externalObjectValue "isSidechain" record)
+                            then state
+                            else consumeClaudeMetadata record state
+                        , JsonlContinue
+                        )
         case result of
             Left _ -> pure Nothing
-            Right _ -> do
-                state <- readIORef stateRef
+            Right (state, _) -> do
                 let title =
                         firstNonEmptyText
                             [ nonEmptyText state.metadataCustomTitle
@@ -179,14 +183,16 @@ readClaude env candidate maxToolChars =
         "resume-claude-chain.sqlite"
         \database -> do
             initializeClaudeIndex database
-            sequenceRef <- newIORef (0 :: Int)
-            unindexableRef <- newIORef (0 :: Int)
-            counters <- consumeJsonl env candidate.candidatePath Nothing
-                \record -> do
-                    indexClaudeRecord database candidate sequenceRef
-                        unindexableRef record
-                    pure JsonlContinue
-            unindexable <- readIORef unindexableRef
+            ((_, unindexable), counters) <-
+                foldJsonl env candidate.candidatePath Nothing (0, 0)
+                    \indexState record -> do
+                        nextState <-
+                            indexClaudeRecord
+                                database
+                                candidate
+                                indexState
+                                record
+                        pure (nextState, JsonlContinue)
             leaf <- claudeLeaf database
             stateRef <- newIORef ClaudeReadState
                 { claudeTurnsFromLeaf = []
@@ -233,19 +239,17 @@ initializeClaudeIndex database = do
 indexClaudeRecord
     :: Database
     -> ExternalCandidate
-    -> IORef Int
-    -> IORef Int
+    -> (Int, Int)
     -> Value
-    -> IO ()
-indexClaudeRecord database candidate sequenceRef unindexableRef record =
+    -> IO (Int, Int)
+indexClaudeRecord database candidate (sequenceNumber, unindexable) record =
     case externalTextValue "uuid" record of
         Just uuid
             | externalTextValue "type" record
                 `elem` map Just ["user", "assistant", "system", "attachment"]
             , not (truthy (externalObjectValue "isSidechain" record)) -> do
-                modifyIORef' sequenceRef (+ 1)
-                sequenceNumber <- readIORef sequenceRef
-                let parent =
+                let nextSequence = sequenceNumber + 1
+                    parent =
                         firstNonEmptyText
                             [ externalTextValue "parentUuid" record
                             , externalTextValue "logicalParentUuid" record
@@ -264,13 +268,15 @@ indexClaudeRecord database candidate sequenceRef unindexableRef record =
                     \sort_time = excluded.sort_time, \
                     \payload = excluded.payload"
                     [ SQLText uuid
-                    , SQLInteger (fromIntegral sequenceNumber)
+                    , SQLInteger (fromIntegral nextSequence)
                     , SQLText parent
                     , SQLFloat sortTime
                     , SQLBlob (LBS.toStrict (encode record))
                     ]
-        _ -> pure ()
-  `catchAnyIndex` \_ -> modifyIORef' unindexableRef (+ 1)
+                pure (nextSequence, unindexable)
+        _ -> pure (sequenceNumber, unindexable)
+  `catchAnyIndex` \_ ->
+        pure (sequenceNumber + 1, unindexable + 1)
 
 catchAnyIndex :: IO value -> (Text -> IO value) -> IO value
 catchAnyIndex action handle =

--- a/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Codex.hs
+++ b/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Codex.hs
@@ -12,7 +12,7 @@ import Agent.CLI.ExternalSession.SQLite
 import Agent.CLI.ExternalSession.Types
 import Control.Applicative ((<|>))
 import Control.Exception.Safe (tryAny)
-import Control.Monad (filterM, when)
+import Control.Monad (filterM, foldM, when)
 import Data.Aeson (Value(..), decodeStrict', encode)
 import qualified Data.Aeson.Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -322,9 +322,9 @@ processCodex
     -> TurnSink
     -> IO CodexProcessed
 processCodex env path maxToolChars sink = do
-    stateRef <- newIORef (0, mempty, False)
-    counters <- consumeJsonl env path Nothing \record -> do
-        (_, _, needsJournal) <- readIORef stateRef
+    ((skipped, omissions, needsJournal), counters) <-
+        foldJsonl env path Nothing (0, mempty, False)
+            \(count, total, needsJournal) record -> do
         let recordType = externalTextValue "type" record
             payload = externalObjectValue "payload" record
         case recordType of
@@ -332,34 +332,57 @@ processCodex env path maxToolChars sink = do
                 case payload >>= externalObjectValue "replacement_history" of
                     Just (Array values) -> do
                         sink.sinkClear
-                        writeIORef stateRef (0, mempty, False)
-                        Vector.forM_ values \replacement -> do
-                            let (turn, unsafe, replacementOmissions) =
-                                    codexTurn maxToolChars replacement
-                            modifyIORef' stateRef
-                                (\(count, total, _) ->
-                                    ( count + if unsafe then 1 else 0
-                                    , total <> replacementOmissions
-                                    , False
-                                    ))
-                            mapM_ sink.sinkAppend turn
-                    _ -> pure ()
+                        nextState <-
+                            foldM
+                                (\(replacementCount, replacementTotal, _)
+                                    replacement -> do
+                                    let
+                                        ( turn
+                                            , unsafe
+                                            , replacementOmissions
+                                            ) =
+                                                codexTurn
+                                                    maxToolChars
+                                                    replacement
+                                    mapM_ sink.sinkAppend turn
+                                    pure
+                                        ( replacementCount
+                                            + if unsafe then 1 else 0
+                                        , replacementTotal
+                                            <> replacementOmissions
+                                        , False
+                                        ))
+                                (0, mempty, False)
+                                values
+                        pure (nextState, JsonlContinue)
+                    _ ->
+                        pure
+                            ( (count, total, needsJournal)
+                            , JsonlContinue
+                            )
             _
-                | needsJournal -> pure ()
+                | needsJournal ->
+                    pure
+                        ( (count, total, needsJournal)
+                        , JsonlContinue
+                        )
             Just "response_item" -> case payload of
                 Just payloadValue -> do
                     let (turn, unsafe, recordOmissions) =
                             codexTurn maxToolChars payloadValue
-                    modifyIORef' stateRef
-                        (\(count, total, required) ->
-                            ( count + if unsafe then 1 else 0
-                            , total <> recordOmissions
-                            , required
-                            ))
                     mapM_ sink.sinkAppend turn
-                Nothing -> modifyIORef' stateRef
-                    (\(count, total, required) ->
-                        (count + 1, total, required))
+                    pure
+                        ( ( count + if unsafe then 1 else 0
+                          , total <> recordOmissions
+                          , needsJournal
+                          )
+                        , JsonlContinue
+                        )
+                Nothing ->
+                    pure
+                        ( (count + 1, total, needsJournal)
+                        , JsonlContinue
+                        )
             Just "event_msg"
                 | Just event <- payload
                 , externalTextValue "type" event
@@ -368,17 +391,25 @@ processCodex env path maxToolChars sink = do
                             externalObjectValue "num_turns" event
                                 >>= integralValue
                     applied <- sink.sinkDropUsers number
-                    when (not applied) $
-                        modifyIORef' stateRef
-                            (\(count, total, _) ->
-                                (count, total, True))
-            Just "session_meta" -> pure ()
-            Just "event_msg" -> pure ()
-            _ -> modifyIORef' stateRef
-                (\(count, total, required) ->
-                    (count + 1, total, required))
-        pure JsonlContinue
-    (skipped, omissions, needsJournal) <- readIORef stateRef
+                    pure
+                        ( (count, total, not applied)
+                        , JsonlContinue
+                        )
+            Just "session_meta" ->
+                pure
+                    ( (count, total, needsJournal)
+                    , JsonlContinue
+                    )
+            Just "event_msg" ->
+                pure
+                    ( (count, total, needsJournal)
+                    , JsonlContinue
+                    )
+            _ ->
+                pure
+                    ( (count + 1, total, needsJournal)
+                    , JsonlContinue
+                    )
     pure CodexProcessed
         { processedJsonl = counters
         , processedSkipped = skipped

--- a/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Codex.hs
+++ b/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Codex.hs
@@ -30,7 +30,6 @@ import Data.Scientific (fromFloatDigits)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Vector as Vector
 import Database.SQLite3 (Database, SQLData(..))
 import Data.Scientific (floatingOrInteger)
 import qualified Data.Text.Encoding

--- a/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Cursor.hs
+++ b/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Cursor.hs
@@ -203,12 +203,13 @@ cursorTranscriptTitle
 cursorTranscriptTitle env path = do
     titleRef <- newIORef Nothing
     _ <- tryAny $
-        consumeJsonl env path Nothing \record -> do
+        foldJsonl env path Nothing () \() record ->
             case cursorFirstUserTitle record of
                 Just title -> do
                     modifyIORef' titleRef (const (Just title))
-                    pure JsonlStop
-                Nothing -> pure JsonlContinue
+                    pure ((), JsonlStop)
+                Nothing ->
+                    pure ((), JsonlContinue)
     readIORef titleRef
 
 cursorProjectMatchesCwd
@@ -397,31 +398,32 @@ readCursor
     -> Int
     -> IO ExternalSession
 readCursor env candidate maxToolChars = do
-    stateRef <- newIORef (emptyBoundedTurns, mempty)
-    warningRef <- newIORef []
-    let consume value =
-            modifyIORef' stateRef \(bounded, omissions) ->
-                let (turns, addedOmissions) =
-                        cursorTurns maxToolChars value
-                in (foldl (flip appendBoundedTurn) bounded turns,
-                    omissions <> addedOmissions)
     transcript <- resolveCursorTranscript env candidate
-    case transcript of
+    ((bounded, omissions), warnings) <- case transcript of
         Just path -> do
-            counters <- consumeJsonl env path Nothing \value -> do
-                consume value
-                pure JsonlContinue
-            modifyIORef' warningRef (<> jsonlWarnings counters)
-        Nothing
-            | takeFileName candidate.candidatePath == "state.vscdb" ->
-                readDesktopRows candidate consume warningRef
-            | otherwise -> do
-                directory <- doesDirectoryExist candidate.candidatePath
-                if directory
-                    then readCursorStore candidate consume warningRef
-                    else readDesktopRows candidate consume warningRef
-    (bounded, omissions) <- readIORef stateRef
-    warnings <- readIORef warningRef
+            (state, counters) <-
+                foldJsonl env path Nothing (emptyBoundedTurns, mempty)
+                    \state value ->
+                        pure
+                            ( cursorStateStep maxToolChars state value
+                            , JsonlContinue
+                            )
+            pure (state, jsonlWarnings counters)
+        Nothing -> do
+            stateRef <- newIORef (emptyBoundedTurns, mempty)
+            warningRef <- newIORef []
+            let consume value =
+                    modifyIORef' stateRef \state ->
+                        cursorStateStep maxToolChars state value
+            if takeFileName candidate.candidatePath == "state.vscdb"
+                then readDesktopRows candidate consume warningRef
+                else do
+                    directory <-
+                        doesDirectoryExist candidate.candidatePath
+                    if directory
+                        then readCursorStore candidate consume warningRef
+                        else readDesktopRows candidate consume warningRef
+            (,) <$> readIORef stateRef <*> readIORef warningRef
     let turns = boundedRecent bounded
         unavailable =
             [ warning
@@ -436,6 +438,18 @@ readCursor env candidate maxToolChars = do
             (appendOmissionWarnings omissions (warnings <> unavailable))
             (boundedLastText "user" bounded)
             (boundedLastText "assistant" bounded)
+
+cursorStateStep
+    :: Int
+    -> (BoundedTurns, ContentOmissions)
+    -> Value
+    -> (BoundedTurns, ContentOmissions)
+cursorStateStep maxToolChars (bounded, omissions) value =
+    let (turns, addedOmissions) = cursorTurns maxToolChars value
+    in
+        ( foldl (flip appendBoundedTurn) bounded turns
+        , omissions <> addedOmissions
+        )
 
 resolveCursorTranscript
     :: ExternalSessionEnv

--- a/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Grok.hs
+++ b/packages/agent-cli/src/Agent/CLI/ExternalSession/Provider/Grok.hs
@@ -13,7 +13,6 @@ import Control.Applicative ((<|>))
 import Control.Monad (filterM)
 import Data.Aeson (Value(..))
 import qualified Data.Aeson.KeyMap as KeyMap
-import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -166,20 +165,25 @@ readGrok env candidate maxToolChars = do
             | plainSafe = Just plain
             | compressedSafe = Just compressed
             | otherwise = Nothing
-    stateRef <- newIORef (emptyBoundedTurns, 0, mempty)
-    counters <- case transcript of
-        Nothing -> pure (JsonlCounters 0 0 0)
+    ((bounded, skipped, omissions), counters) <- case transcript of
+        Nothing ->
+            pure
+                ( (emptyBoundedTurns, 0, mempty)
+                , JsonlCounters 0 0 0
+                )
         Just path ->
-            consumeJsonl env path Nothing \record -> do
+            foldJsonl env path Nothing
+                (emptyBoundedTurns, 0, mempty)
+                \(current, skippedTotal, totalOmissions) record -> do
                 let (turn, skipped, omissions) =
                         grokTurn maxToolChars record
-                modifyIORef' stateRef \(bounded, skippedTotal, totalOmissions) ->
-                    ( maybe bounded (`appendBoundedTurn` bounded) turn
+                pure
+                    ( ( maybe current (`appendBoundedTurn` current) turn
                     , skippedTotal + skipped
                     , totalOmissions <> omissions
                     )
-                pure JsonlContinue
-    (bounded, skipped, omissions) <- readIORef stateRef
+                    , JsonlContinue
+                    )
     let transcriptWarnings =
             [ warning
                 "grok_transcript_unavailable"


### PR DESCRIPTION
## Summary
- add a strict state-threaded JSONL fold while retaining the callback compatibility API
- use immutable cons/reverse accumulation for collected JSONL values
- migrate Claude, Codex, Cursor, and Grok JSONL-local accumulators to explicit fold state
- keep Claude indexing counters strict across caught row failures
- retain the Cursor title boundary cell where partial progress must survive a teardown exception

## Tests
- `Agent.CLI.ExternalSession`: 14 examples, 0 failures
- covers plain and compressed Codex JSONL plus Claude, Cursor, and Grok imports
- `git diff --check`
