### PR TITLE
Make agent-server turns durable and idempotent

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -25,6 +25,7 @@ packages:
     packages/agent-claude
     packages/agent-runtime-daemon
     packages/agent-server
+    packages/agent-server-client
 
 tests: True
 multi-repl: True

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,16 @@
                     ];
                 };
 
+                agentServerClientSource = nix-filter.lib {
+                    root = ./packages/agent-server-client;
+                    include = [
+                        "src"
+                        "test"
+                        "agent-server-client.cabal"
+                        "LICENSE"
+                    ];
+                };
+
                 agentGeminiSource = nix-filter.lib {
                     root = ./packages/agent-gemini;
                     include = [
@@ -687,6 +697,14 @@
                                     src = agentStoreSource;
                                 })
                             [ pkgs.postgresql_18 ]);
+                        agent-server-client = localPackage
+                            (pkgs.haskell.lib.overrideSrc
+                                (final.callPackage
+                                    ./packages/agent-server-client/package.nix
+                                    { })
+                                {
+                                    src = agentServerClientSource;
+                                });
                         agent-cli-runtime = localPackage
                             (pkgs.haskell.lib.addTestToolDepends
                             (pkgs.haskell.lib.overrideSrc
@@ -859,6 +877,8 @@
                     productionHaskellPackages.agent-native-bridge;
                 agentTelegramPackage = productionHaskellPackages.agent-telegram;
                 agentServerPackage = productionHaskellPackages.agent-server;
+                agentServerClientPackage =
+                    productionHaskellPackages.agent-server-client;
                 # Exercise these packages' own test suites against the
                 # production dependency graph. Referencing the all-check
                 # package set here would also rerun every transitive local
@@ -1221,6 +1241,7 @@
                 packages.agent-cli = agentCliExecutable;
                 packages.agent-telegram = agentTelegramExecutable;
                 packages.agent-server = agentServerExecutable;
+                packages.agent-server-client = agentServerClientPackage;
                 packages.${if pkgs.stdenv.hostPlatform.isLinux
                     then "agent-sandbox-runner" else null} = agentSandboxRunner;
                 packages.${if pkgs.stdenv.hostPlatform.isDarwin
@@ -1373,6 +1394,8 @@
                         '';
                     agent-telegram = agentTelegramCheckPackage;
                     agent-server = agentServerCheckPackage;
+                    agent-server-client =
+                        haskellPackages.agent-server-client;
                     agent-core = haskellPackages.agent-core;
                     agent-mcp = haskellPackages.agent-mcp;
                     agent-json = haskellPackages.agent-json;

--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -70,6 +70,7 @@ library
                     , Agent.CLI.SessionLock
                     , Agent.CLI.Transcription
     build-depends:    agent-claude >= 0.1 && < 0.2
+                    , agent-server-client
                     , agent-core >= 0.1 && < 0.2
                     , agent-gemini >= 0.1 && < 0.2
                     , agent-json >= 0.1 && < 0.2

--- a/packages/agent-cli-runtime/package.nix
+++ b/packages/agent-cli-runtime/package.nix
@@ -1,11 +1,11 @@
 { mkDerivation, aeson, agent-claude, agent-core, agent-gemini
 , agent-json, agent-openai, agent-openrouter, agent-process
-, agent-responses-types, agent-store, agent-xai, async, base
-, base64-bytestring, bytestring, containers, crypton, directory
-, entropy, filelock, filepath, hspec, http-client, http-client-tls
-, http-types, lib, memory, network, network-uri, process
-, QuickCheck, safe-exceptions, scientific, stm, text, time
-, transformers, unix, vector, wai, warp
+, agent-responses-types, agent-server-client, agent-store
+, agent-xai, async, base, base64-bytestring, bytestring, containers
+, crypton, directory, entropy, filelock, filepath, hspec
+, http-client, http-client-tls, http-types, lib, memory, network
+, network-uri, process, QuickCheck, safe-exceptions, scientific
+, stm, text, time, transformers, unix, vector, wai, warp
 }:
 mkDerivation {
   pname = "agent-cli-runtime";
@@ -14,12 +14,12 @@ mkDerivation {
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [
     aeson agent-claude agent-core agent-gemini agent-json agent-openai
-    agent-openrouter agent-process agent-responses-types agent-store
-    agent-xai async base base64-bytestring bytestring containers
-    crypton directory entropy filelock filepath http-client
-    http-client-tls http-types memory network network-uri process
-    safe-exceptions scientific stm text time transformers unix vector
-    wai warp
+    agent-openrouter agent-process agent-responses-types
+    agent-server-client agent-store agent-xai async base
+    base64-bytestring bytestring containers crypton directory entropy
+    filelock filepath http-client http-client-tls http-types memory
+    network network-uri process safe-exceptions scientific stm text
+    time transformers unix vector wai warp
   ];
   testHaskellDepends = [
     aeson agent-core agent-json agent-responses-types agent-store async

--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -79,6 +79,10 @@ import Agent.Json.Decode qualified as Hermes
 import Agent.OpenAI.Usage (UsageSnapshot, decodeUsageResponse)
 import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
 import Agent.OsPath (unsafeToFilePath)
+import Agent.Server.Client.GatewayIdentity
+    ( GatewayCredential(..)
+    , gatewayCredentialIdentity
+    )
 import Control.Concurrent (ThreadId, myThreadId, threadDelay)
 import Control.Concurrent.Async (race)
 import Control.Concurrent.MVar
@@ -179,13 +183,6 @@ import System.Process (rawSystem)
 import System.Timeout (timeout)
 import Text.Read (readMaybe)
 
-data GatewayCredential = GatewayCredential
-    { gatewayBaseUrl :: !Text
-    , gatewayWebSocketUrl :: !Text
-    , gatewayAccessToken :: !Text
-    }
-    deriving (Eq)
-
 data GatewayModelProtocol
     = GatewayResponsesProtocol
     | GatewayAnthropicProtocol
@@ -196,60 +193,6 @@ data GatewayModel = GatewayModel
     , gatewayModelProtocol :: !GatewayModelProtocol
     }
     deriving (Eq, Show)
-
--- | Stable, non-secret binding for sessions created with one exact gateway
--- credential. Reauthorization deliberately produces a different identity:
--- without a gateway-issued organization identifier, treating a replacement
--- bearer as the same routing boundary could send prior context to another
--- organization.
-gatewayCredentialIdentity :: GatewayCredential -> Text
-gatewayCredentialIdentity credential =
-    "gateway-sha256:"
-        <> TextEncoding.decodeUtf8
-            (Base64Url.encodeUnpadded
-                (ByteArray.convert
-                    (hash material :: Digest SHA256)))
-  where
-    material =
-        TextEncoding.encodeUtf8 $
-            Text.intercalate
-                "\NUL"
-                [ "haskell-agent gateway session binding v1"
-                , canonicalGatewayIdentityUrl
-                    ""
-                    credential.gatewayBaseUrl
-                , canonicalGatewayIdentityUrl
-                    "/v1/responses"
-                    credential.gatewayWebSocketUrl
-                , credential.gatewayAccessToken
-                ]
-
-canonicalGatewayIdentityUrl :: Text -> Text -> Text
-canonicalGatewayIdentityUrl defaultPath raw =
-    case URI.parseURI (Text.unpack (Text.strip raw)) of
-        Just uri
-            | Just authority <- URI.uriAuthority uri
-            , let scheme = Text.toLower (Text.pack (URI.uriScheme uri))
-            , Right port <-
-                gatewayOriginPort
-                    "invalid gateway identity URL"
-                    scheme
-                    (URI.uriPort authority) ->
-                let host =
-                        Text.toLower (Text.pack (URI.uriRegName authority))
-                    rawPath = Text.pack (URI.uriPath uri)
-                    path
-                        | Text.null rawPath = defaultPath
-                        | Text.null defaultPath =
-                            Text.dropWhileEnd (== '/') rawPath
-                        | otherwise = rawPath
-                in scheme
-                    <> "//"
-                    <> host
-                    <> ":"
-                    <> Text.pack (show port)
-                    <> path
-        _ -> Text.strip raw
 
 newtype GatewayModelCatalogResponse = GatewayModelCatalogResponse
     { gatewayModelCatalogData :: [GatewayModel]
@@ -319,23 +262,6 @@ instance Show GatewayAuthorization where
         "GatewayAuthorization { authorizationBaseUrl = "
             <> show authorization.authorizationBaseUrl
             <> ", authorizationDevice = <redacted> }"
-
-instance Show GatewayCredential where
-    show credential =
-        "GatewayCredential { gatewayBaseUrl = "
-            <> show credential.gatewayBaseUrl
-            <> ", gatewayWebSocketUrl = "
-            <> show credential.gatewayWebSocketUrl
-            <> ", gatewayAccessToken = <redacted> }"
-
-instance Aeson.ToJSON GatewayCredential where
-    toJSON credential =
-        Aeson.object
-            [ "version" .= (1 :: Int)
-            , "base_url" .= credential.gatewayBaseUrl
-            , "websocket_url" .= credential.gatewayWebSocketUrl
-            , "access_token" .= credential.gatewayAccessToken
-            ]
 
 data GatewayAuthorizationCodeResponse = GatewayAuthorizationCodeResponse
     { authorizationAccessToken :: !Text

--- a/packages/agent-server-client/LICENSE
+++ b/packages/agent-server-client/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 digitally induced GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agent-server-client/agent-server-client.cabal
+++ b/packages/agent-server-client/agent-server-client.cabal
@@ -1,0 +1,76 @@
+cabal-version:      3.0
+name:               agent-server-client
+version:            0.1.0.0
+synopsis:           Typed REST and SSE client for agent-server
+description:        Lightweight client and public wire protocol for the versioned agent-server API.
+build-type:         Simple
+license:            MIT
+license-file:       LICENSE
+author:             digitally induced GmbH
+maintainer:         marc@digitallyinduced.com
+category:           Web
+
+common common-options
+    default-language: GHC2021
+    default-extensions:
+        BlockArguments
+      , DuplicateRecordFields
+      , LambdaCase
+      , NamedFieldPuns
+      , NoFieldSelectors
+      , OverloadedRecordDot
+      , OverloadedStrings
+      , ScopedTypeVariables
+      , TypeApplications
+    ghc-options:
+        -Wall
+        -Wcompat
+        -Werror=incomplete-patterns
+        -Werror=missing-fields
+
+library
+    import:           common-options
+    exposed-modules:
+        Agent.Server.Client
+      , Agent.Server.Client.GatewayIdentity
+      , Agent.Server.Client.Protocol
+    hs-source-dirs:   src
+    build-depends:
+        aeson >=2.0
+      , async
+      , base >=4.17 && <5
+      , base64-bytestring
+      , bytestring
+      , crypton
+      , http-client
+      , http-client-tls
+      , http-types
+      , network-uri
+      , safe-exceptions
+      , text >=2.0
+      , time
+      , unix
+      , uuid
+
+test-suite agent-server-client-tests
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    other-modules:
+        Agent.Server.ClientSpec
+      , Agent.Server.Client.GatewayIdentitySpec
+      , Agent.Server.Client.ProtocolSpec
+    hs-source-dirs:   test
+    ghc-options:      -threaded
+    build-depends:
+        agent-server-client
+      , aeson
+      , base >=4.17 && <5
+      , bytestring
+      , directory
+      , hspec >=2.11 && <2.12
+      , http-types
+      , text
+      , unix
+      , wai
+      , warp

--- a/packages/agent-server-client/package.nix
+++ b/packages/agent-server-client/package.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, aeson, async, base, base64-bytestring, bytestring, crypton
+, directory, hspec, http-client, http-client-tls, http-types, lib
+, network-uri, safe-exceptions, text, time, unix, uuid, wai, warp
+}:
+mkDerivation {
+  pname = "agent-server-client";
+  version = "0.1.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson async base base64-bytestring bytestring crypton http-client
+    http-client-tls http-types network-uri safe-exceptions text time unix uuid
+  ];
+  testHaskellDepends = [
+    aeson base bytestring directory hspec http-types text unix wai warp
+  ];
+  description = "Typed REST and SSE client for agent-server";
+  license = lib.meta.getLicenseFromSpdxId "MIT";
+}

--- a/packages/agent-server-client/src/Agent/Server/Client.hs
+++ b/packages/agent-server-client/src/Agent/Server/Client.hs
@@ -1,26 +1,26 @@
 {- | Bounded, redirect-free HTTP and SSE client for the versioned agent-server
 API. Deployment-specific routing and authorization policy belong to callers.
 -}
-module Agent.Server.Client
-    ( module Agent.Server.Client.GatewayIdentity
-    , module Agent.Server.Client.Protocol
-    , AgentServerClient
-    , AgentServerClientConfig (..)
-    , AgentServerClientError (..)
-    , AgentServerStreamResult (..)
-    , newAgentServerClient
-    , createAgentServerSession
-    , createAgentServerTurn
-    , getAgentServerTurn
-    , getAgentServerTurnResult
-    , listAgentServerTurns
-    , cancelAgentServerTurn
-    , listAgentServerRequests
-    , listAgentServerRequestsForTurn
-    , resolveAgentServerRequest
-    , getAgentServerHistory
-    , streamAgentServerTurn
-    )
+module Agent.Server.Client (
+    module Agent.Server.Client.GatewayIdentity,
+    module Agent.Server.Client.Protocol,
+    AgentServerClient,
+    AgentServerClientConfig (..),
+    AgentServerClientError (..),
+    AgentServerStreamResult (..),
+    newAgentServerClient,
+    createAgentServerSession,
+    createAgentServerTurn,
+    getAgentServerTurn,
+    getAgentServerTurnResult,
+    listAgentServerTurns,
+    cancelAgentServerTurn,
+    listAgentServerRequests,
+    listAgentServerRequestsForTurn,
+    resolveAgentServerRequest,
+    getAgentServerHistory,
+    streamAgentServerTurn,
+)
 where
 
 import Agent.Server.Client.GatewayIdentity
@@ -46,27 +46,27 @@ import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TextEncoding
 import Network.HTTP.Client
 import Network.HTTP.Client.TLS (tlsManagerSettings)
-import Network.HTTP.Types.Header
-    ( hAccept
-    , hAuthorization
-    , hContentType
-    )
+import Network.HTTP.Types.Header (
+    hAccept,
+    hAuthorization,
+    hContentType,
+ )
 import Network.HTTP.Types.Status (statusCode)
 import Network.HTTP.Types.URI (urlEncode)
 import System.IO.Error (isEOFError)
-import System.Posix.Files
-    ( fileMode
-    , fileOwner
-    , getFdStatus
-    , isRegularFile
-    )
-import System.Posix.IO
-    ( OpenFileFlags (..)
-    , OpenMode (ReadOnly)
-    , closeFd
-    , defaultFileFlags
-    , openFd
-    )
+import System.Posix.Files (
+    fileMode,
+    fileOwner,
+    getFdStatus,
+    isRegularFile,
+ )
+import System.Posix.IO (
+    OpenFileFlags (..),
+    OpenMode (ReadOnly),
+    closeFd,
+    defaultFileFlags,
+    openFd,
+ )
 import System.Posix.IO.ByteString qualified as Posix
 import System.Posix.Types (Fd)
 import System.Posix.User (getEffectiveUserID)
@@ -295,6 +295,8 @@ streamAgentServerTurn client expectedTurnId lastEventId onEvent =
             Right turn
                 | isTerminalTurnStatus turn.agentServerTurnStatus ->
                     pure (Right AgentServerStreamNeedsRefetch)
+            Left (AgentServerHttpError 404 _ _) ->
+                pure (Right AgentServerStreamNeedsRefetch)
             _ ->
                 listAgentServerRequestsForTurn client expectedTurnId >>= \case
                     Right requests
@@ -485,23 +487,27 @@ validateAgentServerBaseUrl raw = do
     pure case parsed of
         Left _ ->
             Left
-                (AgentServerProtocolError
-                    "agent-server base URL is invalid")
+                ( AgentServerProtocolError
+                    "agent-server base URL is invalid"
+                )
         Right request
             | request.path /= "/"
                 || not (ByteString.null request.queryString) ->
                 Left
-                    (AgentServerProtocolError
-                        "agent-server base URL must not contain a path or query")
+                    ( AgentServerProtocolError
+                        "agent-server base URL must not contain a path or query"
+                    )
             | lookup hAuthorization request.requestHeaders /= Nothing ->
                 Left
-                    (AgentServerProtocolError
-                        "agent-server base URL must not contain user info")
+                    ( AgentServerProtocolError
+                        "agent-server base URL must not contain user info"
+                    )
             | not request.secure
                 && not (isLiteralLoopback request.host) ->
                 Left
-                    (AgentServerProtocolError
-                        "plaintext agent-server URLs must use a literal loopback host")
+                    ( AgentServerProtocolError
+                        "plaintext agent-server URLs must use a literal loopback host"
+                    )
             | otherwise ->
                 Right (Text.dropWhileEnd (== '/') (Text.strip raw))
 

--- a/packages/agent-server-client/src/Agent/Server/Client.hs
+++ b/packages/agent-server-client/src/Agent/Server/Client.hs
@@ -1,0 +1,721 @@
+{- | Bounded, redirect-free HTTP and SSE client for the versioned agent-server
+API. Deployment-specific routing and authorization policy belong to callers.
+-}
+module Agent.Server.Client
+    ( module Agent.Server.Client.GatewayIdentity
+    , module Agent.Server.Client.Protocol
+    , AgentServerClient
+    , AgentServerClientConfig (..)
+    , AgentServerClientError (..)
+    , AgentServerStreamResult (..)
+    , newAgentServerClient
+    , createAgentServerSession
+    , createAgentServerTurn
+    , getAgentServerTurn
+    , getAgentServerTurnResult
+    , listAgentServerTurns
+    , cancelAgentServerTurn
+    , listAgentServerRequests
+    , listAgentServerRequestsForTurn
+    , resolveAgentServerRequest
+    , getAgentServerHistory
+    , streamAgentServerTurn
+    )
+where
+
+import Agent.Server.Client.GatewayIdentity
+import Agent.Server.Client.Protocol
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (race)
+import Control.Exception (IOException)
+import Control.Exception.Safe qualified as Exception
+import Control.Monad (when)
+import Data.Aeson (FromJSON)
+import Data.Aeson qualified as Aeson
+import Data.Bifunctor qualified as Bifunctor
+import Data.Bits qualified as Bits
+import Data.ByteString qualified as ByteString
+import Data.ByteString.Char8 qualified as ByteString8
+import Data.ByteString.Lazy qualified as LazyByteString
+import Data.Char (toLower)
+import Data.Int (Int64)
+import Data.List (minimumBy)
+import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as TextEncoding
+import Network.HTTP.Client
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types.Header
+    ( hAccept
+    , hAuthorization
+    , hContentType
+    )
+import Network.HTTP.Types.Status (statusCode)
+import Network.HTTP.Types.URI (urlEncode)
+import System.IO.Error (isEOFError)
+import System.Posix.Files
+    ( fileMode
+    , fileOwner
+    , getFdStatus
+    , isRegularFile
+    )
+import System.Posix.IO
+    ( OpenFileFlags (..)
+    , OpenMode (ReadOnly)
+    , closeFd
+    , defaultFileFlags
+    , openFd
+    )
+import System.Posix.IO.ByteString qualified as Posix
+import System.Posix.Types (Fd)
+import System.Posix.User (getEffectiveUserID)
+
+data AgentServerClientConfig = AgentServerClientConfig
+    { agentServerBaseUrl :: !Text
+    , agentServerCredentialFile :: !FilePath
+    }
+    deriving (Eq, Show)
+
+data AgentServerClient = AgentServerClient
+    { clientManager :: !Manager
+    , clientBaseUrl :: !Text
+    , clientBearerToken :: !ByteString.ByteString
+    }
+
+data AgentServerClientError
+    = AgentServerCredentialError !Text
+    | AgentServerTransportError !Text
+    | AgentServerHttpError !Int !(Maybe Text) !Text
+    | AgentServerDecodeError !Text
+    | AgentServerProtocolError !Text
+    deriving (Eq, Show)
+
+data AgentServerStreamResult
+    = AgentServerStreamCompleted
+    | AgentServerStreamFailed !(Maybe Text)
+    | AgentServerStreamCancelled
+    | AgentServerStreamNeedsRefetch
+    deriving (Eq, Show)
+
+newAgentServerClient ::
+    AgentServerClientConfig ->
+    IO (Either AgentServerClientError AgentServerClient)
+newAgentServerClient config =
+    validateAgentServerBaseUrl config.agentServerBaseUrl >>= \case
+        Left err -> pure (Left err)
+        Right baseUrl ->
+            readPrivateBearerToken config.agentServerCredentialFile >>= \case
+                Left err -> pure (Left err)
+                Right token -> do
+                    manager <- newManager tlsManagerSettings
+                    pure . Right $
+                        AgentServerClient
+                            { clientManager = manager
+                            , clientBaseUrl = baseUrl
+                            , clientBearerToken = token
+                            }
+
+createAgentServerSession ::
+    AgentServerClient ->
+    AgentServerCreateSessionRequest ->
+    IO (Either AgentServerClientError AgentServerSession)
+createAgentServerSession client =
+    performJsonRequest client "POST" "/v1/sessions" [201]
+        . Just
+        . Aeson.encode
+
+createAgentServerTurn ::
+    AgentServerClient ->
+    Text ->
+    AgentServerCreateTurnRequest ->
+    IO (Either AgentServerClientError AgentServerTurn)
+createAgentServerTurn client sessionId =
+    performJsonRequest
+        client
+        "POST"
+        ("/v1/sessions/" <> encodePathSegment sessionId <> "/turns")
+        [202]
+        . Just
+        . Aeson.encode
+
+getAgentServerTurn ::
+    AgentServerClient ->
+    Text ->
+    IO (Either AgentServerClientError AgentServerTurn)
+getAgentServerTurn client turnId =
+    performJsonRequest
+        client
+        "GET"
+        ("/v1/turns/" <> encodePathSegment turnId)
+        [200]
+        Nothing
+
+getAgentServerTurnResult ::
+    AgentServerClient ->
+    Text ->
+    IO (Either AgentServerClientError AgentServerTurnResult)
+getAgentServerTurnResult client turnId =
+    performJsonRequest
+        client
+        "GET"
+        ("/v1/turns/" <> encodePathSegment turnId <> "/result")
+        [200]
+        Nothing
+
+listAgentServerTurns ::
+    AgentServerClient ->
+    Text ->
+    IO (Either AgentServerClientError AgentServerTurnList)
+listAgentServerTurns client sessionId =
+    performJsonRequestWithLimit
+        maximumTurnListResponseBytes
+        client
+        "GET"
+        ("/v1/turns?sessionId=" <> encodeQueryValue sessionId)
+        [200]
+        Nothing
+
+cancelAgentServerTurn ::
+    AgentServerClient ->
+    Text ->
+    IO (Either AgentServerClientError AgentServerTurn)
+cancelAgentServerTurn client turnId =
+    performJsonRequest
+        client
+        "POST"
+        ("/v1/turns/" <> encodePathSegment turnId <> "/cancel")
+        [200, 202]
+        Nothing
+
+listAgentServerRequests ::
+    AgentServerClient ->
+    IO (Either AgentServerClientError AgentServerRequestList)
+listAgentServerRequests client =
+    performJsonRequestWithLimit
+        maximumRequestListResponseBytes
+        client
+        "GET"
+        "/v1/requests"
+        [200]
+        Nothing
+
+listAgentServerRequestsForTurn ::
+    AgentServerClient ->
+    Text ->
+    IO (Either AgentServerClientError AgentServerRequestList)
+listAgentServerRequestsForTurn client turnId =
+    performJsonRequestWithLimit
+        maximumRequestListResponseBytes
+        client
+        "GET"
+        ("/v1/requests?turnId=" <> encodeQueryValue turnId)
+        [200]
+        Nothing
+
+resolveAgentServerRequest ::
+    AgentServerClient ->
+    Text ->
+    AgentServerResolveRequest ->
+    IO (Either AgentServerClientError AgentServerHumanRequest)
+resolveAgentServerRequest client requestId =
+    performJsonRequest
+        client
+        "POST"
+        ("/v1/requests/" <> encodePathSegment requestId <> "/resolve")
+        [200]
+        . Just
+        . Aeson.encode
+
+getAgentServerHistory ::
+    AgentServerClient ->
+    Text ->
+    IO (Either AgentServerClientError AgentServerHistory)
+-- The current turn is always in the recent page. Twenty maximally projected
+-- turns can exceed the default JSON response limit, so history has its own
+-- bound sized for the server's per-turn projection budget.
+getAgentServerHistory client sessionId =
+    performJsonRequestWithLimit
+        maximumHistoryResponseBytes
+        client
+        "GET"
+        ( "/v1/sessions/"
+            <> encodePathSegment sessionId
+            <> "/history?limit=20"
+        )
+        [200]
+        Nothing
+
+streamAgentServerTurn ::
+    AgentServerClient ->
+    Text ->
+    Maybe Int64 ->
+    (AgentServerEvent -> IO (Either AgentServerClientError ())) ->
+    IO (Either AgentServerClientError AgentServerStreamResult)
+streamAgentServerTurn client expectedTurnId lastEventId onEvent =
+    race consumeStream monitorDurableTurn >>= pure . either id id
+  where
+    consumeStream = do
+        outcome <- Exception.try @IO @HttpException do
+            request <- authenticatedRequest client "GET" "/v1/events"
+            let cursor = maybe 0 id lastEventId
+                eventRequest =
+                    request
+                        { requestHeaders =
+                            (hAccept, "text/event-stream")
+                                : ( "Last-Event-ID"
+                                  , ByteString8.pack (show cursor)
+                                  )
+                                : filter
+                                    ( \header ->
+                                        fst header /= hAccept
+                                            && fst header /= "Last-Event-ID"
+                                    )
+                                    request.requestHeaders
+                        , responseTimeout = responseTimeoutNone
+                        }
+            withResponse eventRequest client.clientManager \response ->
+                if statusCode response.responseStatus /= 200
+                    then decodeErrorResponse response
+                    else
+                        consumeEventStream
+                            ByteString.empty
+                            response.responseBody
+        pure case outcome of
+            Left _ ->
+                Left
+                    ( AgentServerTransportError
+                        "agent-server event stream request failed"
+                    )
+            Right result -> result
+
+    monitorDurableTurn = do
+        threadDelay durableTurnPollIntervalMicros
+        getAgentServerTurn client expectedTurnId >>= \case
+            Right turn
+                | isTerminalTurnStatus turn.agentServerTurnStatus ->
+                    pure (Right AgentServerStreamNeedsRefetch)
+            _ ->
+                listAgentServerRequestsForTurn client expectedTurnId >>= \case
+                    Right requests
+                        | any
+                            ( (== expectedTurnId)
+                                . (.agentServerRequestTurnId)
+                            )
+                            requests.agentServerRequests ->
+                            pure (Right AgentServerStreamNeedsRefetch)
+                    _ -> monitorDurableTurn
+
+    consumeEventStream buffered bodyReader = do
+        chunk <- brRead bodyReader
+        if ByteString.null chunk
+            then
+                pure
+                    ( Left
+                        ( AgentServerProtocolError
+                            "agent-server closed the event stream before the turn finished"
+                        )
+                    )
+            else do
+                let combined = buffered <> chunk
+                if ByteString.length combined > maximumSseBufferBytes
+                    then
+                        pure
+                            ( Left
+                                ( AgentServerProtocolError
+                                    "agent-server SSE frame exceeded the size limit"
+                                )
+                            )
+                    else
+                        processFrames combined >>= \case
+                            Left err -> pure (Left err)
+                            Right (remaining, Nothing) ->
+                                consumeEventStream remaining bodyReader
+                            Right (_, Just terminal) ->
+                                pure (Right terminal)
+
+    processFrames buffered =
+        case takeSseFrame buffered of
+            Nothing -> pure (Right (buffered, Nothing))
+            Just (frame, rest) ->
+                case parseAgentServerSseFrame frame of
+                    Left message ->
+                        pure (Left (AgentServerProtocolError message))
+                    Right Nothing -> processFrames rest
+                    Right (Just (AgentServerSseReplayReset _)) ->
+                        pure
+                            ( Right
+                                (rest, Just AgentServerStreamNeedsRefetch)
+                            )
+                    Right (Just (AgentServerSseEvent event))
+                        | event.agentServerEventTurnId
+                            /= Just expectedTurnId ->
+                            processFrames rest
+                        | otherwise ->
+                            onEvent event >>= \case
+                                Left err -> pure (Left err)
+                                Right () ->
+                                    case event.agentServerEventPayload of
+                                        AgentServerTurnCompletedEvent ->
+                                            pure
+                                                ( Right
+                                                    ( rest
+                                                    , Just
+                                                        AgentServerStreamCompleted
+                                                    )
+                                                )
+                                        AgentServerTurnFailedEvent message ->
+                                            pure
+                                                ( Right
+                                                    ( rest
+                                                    , Just
+                                                        ( AgentServerStreamFailed
+                                                            message
+                                                        )
+                                                    )
+                                                )
+                                        AgentServerTurnCancelledEvent ->
+                                            pure
+                                                ( Right
+                                                    ( rest
+                                                    , Just
+                                                        AgentServerStreamCancelled
+                                                    )
+                                                )
+                                        _ -> processFrames rest
+
+isTerminalTurnStatus :: AgentServerTurnStatus -> Bool
+isTerminalTurnStatus = \case
+    AgentServerTurnQueued -> False
+    AgentServerTurnRunning -> False
+    AgentServerTurnWaitingForInput -> False
+    AgentServerTurnCompleted -> True
+    AgentServerTurnFailed -> True
+    AgentServerTurnCancelled -> True
+
+performJsonRequest ::
+    (FromJSON responseBody) =>
+    AgentServerClient ->
+    ByteString.ByteString ->
+    Text ->
+    [Int] ->
+    Maybe LazyByteString.ByteString ->
+    IO (Either AgentServerClientError responseBody)
+performJsonRequest =
+    performJsonRequestWithLimit maximumJsonResponseBytes
+
+performJsonRequestWithLimit ::
+    (FromJSON responseBody) =>
+    Int ->
+    AgentServerClient ->
+    ByteString.ByteString ->
+    Text ->
+    [Int] ->
+    Maybe LazyByteString.ByteString ->
+    IO (Either AgentServerClientError responseBody)
+performJsonRequestWithLimit
+    maximumResponseBytes
+    client
+    method
+    path
+    expectedStatuses
+    requestBody = do
+        outcome <- Exception.try @IO @HttpException do
+            baseRequest <- authenticatedRequest client method path
+            let request = case requestBody of
+                    Nothing -> baseRequest
+                    Just body ->
+                        baseRequest
+                            { requestHeaders =
+                                (hContentType, "application/json")
+                                    : baseRequest.requestHeaders
+                            , requestBody = RequestBodyLBS body
+                            }
+            withResponse request client.clientManager \response ->
+                if statusCode response.responseStatus `elem` expectedStatuses
+                    then
+                        readBoundedBody
+                            maximumResponseBytes
+                            response.responseBody
+                            >>= \case
+                                Left err -> pure (Left err)
+                                Right bytes ->
+                                    pure $
+                                        Bifunctor.first
+                                            (AgentServerDecodeError . Text.pack)
+                                            (Aeson.eitherDecodeStrict' bytes)
+                    else decodeErrorResponse response
+        pure case outcome of
+            Left _ ->
+                Left
+                    ( AgentServerTransportError
+                        "agent-server HTTP request failed"
+                    )
+            Right result -> result
+
+authenticatedRequest ::
+    AgentServerClient ->
+    ByteString.ByteString ->
+    Text ->
+    IO Request
+authenticatedRequest client method path = do
+    request <- parseRequest (Text.unpack (client.clientBaseUrl <> path))
+    pure
+        request
+            { method = method
+            , requestHeaders =
+                [
+                    ( hAuthorization
+                    , "Bearer " <> client.clientBearerToken
+                    )
+                , (hAccept, "application/json")
+                ]
+            , redirectCount = 0
+            , responseTimeout = responseTimeoutMicro 30_000_000
+            , checkResponse = \_ _ -> pure ()
+            }
+
+validateAgentServerBaseUrl ::
+    Text ->
+    IO (Either AgentServerClientError Text)
+validateAgentServerBaseUrl raw = do
+    parsed <-
+        Exception.try @IO @HttpException $
+            parseRequest (Text.unpack raw)
+    pure case parsed of
+        Left _ ->
+            Left
+                (AgentServerProtocolError
+                    "agent-server base URL is invalid")
+        Right request
+            | request.path /= "/"
+                || not (ByteString.null request.queryString) ->
+                Left
+                    (AgentServerProtocolError
+                        "agent-server base URL must not contain a path or query")
+            | lookup hAuthorization request.requestHeaders /= Nothing ->
+                Left
+                    (AgentServerProtocolError
+                        "agent-server base URL must not contain user info")
+            | not request.secure
+                && not (isLiteralLoopback request.host) ->
+                Left
+                    (AgentServerProtocolError
+                        "plaintext agent-server URLs must use a literal loopback host")
+            | otherwise ->
+                Right (Text.dropWhileEnd (== '/') (Text.strip raw))
+
+isLiteralLoopback :: ByteString.ByteString -> Bool
+isLiteralLoopback rawHost =
+    ByteString8.map toLower rawHost
+        `elem` ["127.0.0.1", "::1"]
+
+decodeErrorResponse ::
+    Response BodyReader ->
+    IO (Either AgentServerClientError value)
+decodeErrorResponse response = do
+    body <- readBoundedBody maximumJsonResponseBytes response.responseBody
+    pure case body of
+        Left err -> Left err
+        Right bytes ->
+            case Aeson.eitherDecodeStrict' bytes of
+                Right envelope ->
+                    let serverError =
+                            ( envelope ::
+                                AgentServerErrorEnvelope
+                            ).agentServerError
+                     in Left
+                            ( AgentServerHttpError
+                                (statusCode response.responseStatus)
+                                ( Just
+                                    ( Text.take
+                                        128
+                                        serverError.agentServerErrorCode
+                                    )
+                                )
+                                ( Text.take
+                                    1000
+                                    serverError.agentServerErrorMessage
+                                )
+                            )
+                Left _ ->
+                    Left
+                        ( AgentServerHttpError
+                            (statusCode response.responseStatus)
+                            Nothing
+                            "agent-server returned a non-success response"
+                        )
+
+readBoundedBody ::
+    Int ->
+    BodyReader ->
+    IO (Either AgentServerClientError ByteString.ByteString)
+readBoundedBody maximumBytes = go 0 []
+  where
+    go total chunks bodyReader = do
+        chunk <- brRead bodyReader
+        if ByteString.null chunk
+            then pure (Right (ByteString.concat (reverse chunks)))
+            else do
+                let nextTotal = total + ByteString.length chunk
+                if nextTotal > maximumBytes
+                    then
+                        pure
+                            ( Left
+                                ( AgentServerProtocolError
+                                    "agent-server response exceeded the size limit"
+                                )
+                            )
+                    else go nextTotal (chunk : chunks) bodyReader
+
+readPrivateBearerToken ::
+    FilePath ->
+    IO (Either AgentServerClientError ByteString.ByteString)
+readPrivateBearerToken path = do
+    inspected <- Exception.try @IO @IOException do
+        Exception.bracket
+            ( openFd
+                path
+                ReadOnly
+                defaultFileFlags
+                    { nofollow = True
+                    , cloexec = True
+                    }
+            )
+            closeFd
+            \descriptor -> do
+                status <- getFdStatus descriptor
+                effectiveUser <- getEffectiveUserID
+                if not (isRegularFile status)
+                    then pure (Left "credential path is not a regular file")
+                    else
+                        if fileOwner status /= effectiveUser
+                            then
+                                pure
+                                    ( Left
+                                        "credential file is not owned by this process"
+                                    )
+                            else
+                                if fileMode status Bits..&. 0o077 /= 0
+                                    then
+                                        pure
+                                            ( Left
+                                                "credential file permissions are too broad"
+                                            )
+                                    else
+                                        validateBearerToken
+                                            <$> readFdBytes
+                                                (maximumCredentialBytes + 1)
+                                                descriptor
+    pure case inspected of
+        Left _ ->
+            Left
+                ( AgentServerCredentialError
+                    "could not securely read the agent-server credential"
+                )
+        Right result ->
+            Bifunctor.first AgentServerCredentialError result
+
+validateBearerToken ::
+    ByteString.ByteString ->
+    Either Text ByteString.ByteString
+validateBearerToken raw = do
+    when (ByteString.length raw > maximumCredentialBytes) $
+        Left "agent-server credential is too large"
+    let token = stripAsciiWhitespace raw
+    when (ByteString.length token < 32) $
+        Left "agent-server credential is too short"
+    when (ByteString.any (\byte -> byte < 33 || byte > 126) token) $
+        Left "agent-server credential contains invalid header bytes"
+    pure token
+
+readFdBytes :: Int -> Fd -> IO ByteString.ByteString
+readFdBytes maximumBytes = go maximumBytes []
+  where
+    go remaining chunks descriptor
+        | remaining <= 0 =
+            pure (ByteString.concat (reverse chunks))
+        | otherwise =
+            Exception.tryIO
+                (Posix.fdRead descriptor (fromIntegral remaining))
+                >>= \case
+                    Left err
+                        | isEOFError err ->
+                            pure (ByteString.concat (reverse chunks))
+                        | otherwise -> Exception.throwIO err
+                    Right chunk
+                        | ByteString.null chunk ->
+                            pure (ByteString.concat (reverse chunks))
+                        | otherwise ->
+                            go
+                                (remaining - ByteString.length chunk)
+                                (chunk : chunks)
+                                descriptor
+
+encodePathSegment :: Text -> Text
+encodePathSegment =
+    TextEncoding.decodeUtf8
+        . urlEncode False
+        . TextEncoding.encodeUtf8
+
+encodeQueryValue :: Text -> Text
+encodeQueryValue =
+    TextEncoding.decodeUtf8
+        . urlEncode True
+        . TextEncoding.encodeUtf8
+
+stripAsciiWhitespace ::
+    ByteString.ByteString ->
+    ByteString.ByteString
+stripAsciiWhitespace =
+    ByteString8.dropWhileEnd isSpaceByte
+        . ByteString8.dropWhile isSpaceByte
+  where
+    isSpaceByte character =
+        character == ' '
+            || character == '\t'
+            || character == '\r'
+            || character == '\n'
+
+takeSseFrame ::
+    ByteString.ByteString ->
+    Maybe (ByteString.ByteString, ByteString.ByteString)
+takeSseFrame bytes =
+    case catMaybes [candidate "\n\n", candidate "\r\n\r\n"] of
+        [] -> Nothing
+        candidates ->
+            let (offset, separatorLength) =
+                    minimumBy
+                        (\left right -> compare (fst left) (fst right))
+                        candidates
+             in Just
+                    ( ByteString.take offset bytes
+                    , ByteString.drop (offset + separatorLength) bytes
+                    )
+  where
+    candidate separator =
+        let (prefix, suffix) = ByteString.breakSubstring separator bytes
+         in if ByteString.null suffix
+                then Nothing
+                else Just (ByteString.length prefix, ByteString.length separator)
+
+maximumJsonResponseBytes :: Int
+maximumJsonResponseBytes = 1024 * 1024
+
+maximumHistoryResponseBytes :: Int
+maximumHistoryResponseBytes = 16 * 1024 * 1024
+
+maximumTurnListResponseBytes :: Int
+maximumTurnListResponseBytes = 32 * 1024 * 1024
+
+maximumRequestListResponseBytes :: Int
+maximumRequestListResponseBytes = 16 * 1024 * 1024
+
+maximumSseBufferBytes :: Int
+maximumSseBufferBytes = 1024 * 1024
+
+durableTurnPollIntervalMicros :: Int
+durableTurnPollIntervalMicros = 1000 * 1000
+
+maximumCredentialBytes :: Int
+maximumCredentialBytes = 4096

--- a/packages/agent-server-client/src/Agent/Server/Client/GatewayIdentity.hs
+++ b/packages/agent-server-client/src/Agent/Server/Client/GatewayIdentity.hs
@@ -1,0 +1,155 @@
+-- | Stable gateway credential identity shared by runtimes and API clients.
+module Agent.Server.Client.GatewayIdentity
+    ( GatewayCredential (..)
+    , gatewayCredentialIdentity
+    )
+where
+
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.Aeson
+    ( FromJSON (..)
+    , ToJSON (..)
+    , Value (String)
+    , encode
+    , object
+    , withObject
+    , (.:)
+    , (.=)
+    )
+import Data.Bits ((.|.), shiftL)
+import Data.ByteString qualified as ByteString
+import Data.ByteString.Base64.URL qualified as Base64Url
+import Data.ByteString.Lazy qualified as LazyByteString
+import Data.Char (digitToInt, isDigit)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as TextEncoding
+import Network.URI qualified as URI
+import Text.Read (readMaybe)
+
+{- | Private gateway connection material.
+
+The custom 'Show' instance never renders the bearer.
+-}
+data GatewayCredential = GatewayCredential
+    { gatewayBaseUrl :: !Text
+    , gatewayWebSocketUrl :: !Text
+    , gatewayAccessToken :: !Text
+    }
+    deriving (Eq)
+
+instance Show GatewayCredential where
+    show credential =
+        "GatewayCredential { gatewayBaseUrl = "
+            <> show credential.gatewayBaseUrl
+            <> ", gatewayWebSocketUrl = "
+            <> show credential.gatewayWebSocketUrl
+            <> ", gatewayAccessToken = <redacted> }"
+
+instance FromJSON GatewayCredential where
+    parseJSON = withObject "GatewayCredential" \value ->
+        GatewayCredential
+            <$> value .: "base_url"
+            <*> value .: "websocket_url"
+            <*> value .: "access_token"
+
+instance ToJSON GatewayCredential where
+    toJSON credential =
+        object
+            [ "version" .= (1 :: Int)
+            , "base_url" .= credential.gatewayBaseUrl
+            , "websocket_url" .= credential.gatewayWebSocketUrl
+            , "access_token" .= credential.gatewayAccessToken
+            ]
+
+{- | Stable, non-secret binding for one exact gateway credential.
+
+Reauthorization deliberately produces a different identity: without a
+gateway-issued organization identifier, treating a replacement bearer as
+the same routing boundary could send prior context to another organization.
+-}
+gatewayCredentialIdentity :: GatewayCredential -> Text
+gatewayCredentialIdentity credential =
+    "gateway-sha256:"
+        <> TextEncoding.decodeUtf8
+            ( Base64Url.encodeUnpadded
+                (digestBytes (hash material :: Digest SHA256))
+            )
+  where
+    fields =
+        [ canonicalGatewayIdentityUrl
+            ""
+            credential.gatewayBaseUrl
+        , canonicalGatewayIdentityUrl
+            "/v1/responses"
+            credential.gatewayWebSocketUrl
+        , credential.gatewayAccessToken
+        ]
+    material
+        -- Preserve identities produced by existing installations for valid
+        -- credentials. Invalid NUL-bearing material uses explicit JSON
+        -- framing so distinct fields cannot alias.
+        | any (Text.any (== '\NUL')) fields =
+            LazyByteString.toStrict . encode $
+                String "haskell-agent gateway session binding v2"
+                    : map String fields
+        | otherwise =
+            TextEncoding.encodeUtf8 $
+                Text.intercalate
+                    "\NUL"
+                    ( "haskell-agent gateway session binding v1"
+                        : fields
+                    )
+
+digestBytes :: Digest SHA256 -> ByteString.ByteString
+digestBytes = ByteString.pack . decodeHex . show
+  where
+    decodeHex (high : low : rest) =
+        fromIntegral
+            (digitToInt high `shiftL` 4 .|. digitToInt low)
+            : decodeHex rest
+    decodeHex [] = []
+    decodeHex _ = error "SHA-256 digest rendered an odd number of hex digits"
+
+canonicalGatewayIdentityUrl :: Text -> Text -> Text
+canonicalGatewayIdentityUrl defaultPath raw =
+    case URI.parseURI (Text.unpack (Text.strip raw)) of
+        Just uri
+            | Just authority <- URI.uriAuthority uri
+            , let scheme = Text.toLower (Text.pack (URI.uriScheme uri))
+            , Right port <-
+                gatewayOriginPort scheme (URI.uriPort authority) ->
+                let host =
+                        Text.toLower (Text.pack (URI.uriRegName authority))
+                    userInfo = Text.pack (URI.uriUserInfo authority)
+                    rawPath = Text.pack (URI.uriPath uri)
+                    path
+                        | Text.null rawPath = defaultPath
+                        | Text.null defaultPath =
+                            Text.dropWhileEnd (== '/') rawPath
+                        | otherwise = rawPath
+                 in scheme
+                        <> "//"
+                        <> userInfo
+                        <> host
+                        <> ":"
+                        <> Text.pack (show port)
+                        <> path
+                        <> Text.pack (URI.uriQuery uri)
+                        <> Text.pack (URI.uriFragment uri)
+        _ -> Text.strip raw
+
+gatewayOriginPort :: Text -> String -> Either Text Int
+gatewayOriginPort "https:" "" = Right 443
+gatewayOriginPort "http:" "" = Right 80
+gatewayOriginPort "wss:" "" = Right 443
+gatewayOriginPort "ws:" "" = Right 80
+gatewayOriginPort scheme (':' : digits)
+    | scheme `elem` ["https:", "http:", "wss:", "ws:"]
+    , not (null digits)
+    , all isDigit digits
+    , Just port <- readMaybe digits
+    , port > 0
+    , port <= (65535 :: Int) =
+        Right port
+gatewayOriginPort _ _ = Left "invalid gateway identity URL"

--- a/packages/agent-server-client/src/Agent/Server/Client/Protocol.hs
+++ b/packages/agent-server-client/src/Agent/Server/Client/Protocol.hs
@@ -1,0 +1,568 @@
+-- | Named wire types and strict SSE decoding for the public agent-server API.
+module Agent.Server.Client.Protocol
+    ( AgentServerCreateSessionRequest (..)
+    , AgentServerSession (..)
+    , AgentServerCreateTurnRequest (..)
+    , AgentServerTurnStatus (..)
+    , AgentServerTurn (..)
+    , AgentServerTurnList (..)
+    , AgentServerTurnCompletion (..)
+    , AgentServerTurnOutput (..)
+    , AgentServerTurnResult (..)
+    , AgentServerHumanRequestKind (..)
+    , AgentServerHumanRequest (..)
+    , AgentServerRequestList (..)
+    , AgentServerResolveRequest (..)
+    , AgentServerEventPayload (..)
+    , AgentServerEvent (..)
+    , AgentServerReplayReset (..)
+    , AgentServerSseMessage (..)
+    , AgentServerHistoryTurn (..)
+    , AgentServerHistoryItem (..)
+    , AgentServerHistory (..)
+    , AgentServerErrorBody (..)
+    , AgentServerErrorEnvelope (..)
+    , parseAgentServerSseFrame
+    )
+where
+
+import Control.Monad (foldM, when)
+import Data.Aeson
+import Data.Aeson.Types (Parser)
+import Data.Bifunctor qualified as Bifunctor
+import Data.ByteString qualified as ByteString
+import Data.Foldable (forM_)
+import Data.Int (Int64)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as TextEncoding
+import Data.Time.Clock (UTCTime)
+import Data.UUID qualified as UUID
+import Text.Read (readMaybe)
+
+data AgentServerCreateSessionRequest = AgentServerCreateSessionRequest
+    { createSessionModel :: !(Maybe Text)
+    , createSessionCwd :: !(Maybe FilePath)
+    , createSessionEffort :: !(Maybe Text)
+    , createSessionTitle :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+instance ToJSON AgentServerCreateSessionRequest where
+    toJSON request =
+        object
+            [ "model" .= request.createSessionModel
+            , "cwd" .= request.createSessionCwd
+            , "effort" .= request.createSessionEffort
+            , "title" .= request.createSessionTitle
+            ]
+
+newtype AgentServerSession = AgentServerSession
+    { agentServerSessionId :: Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerSession where
+    parseJSON = withObject "AgentServerSession" \value ->
+        AgentServerSession
+            <$> (value .: "id" >>= parseSessionIdentifier)
+
+data AgentServerCreateTurnRequest = AgentServerCreateTurnRequest
+    { createTurnClientRequestId :: !Text
+    , createTurnInput :: !Text
+    }
+    deriving (Eq, Show)
+
+instance ToJSON AgentServerCreateTurnRequest where
+    toJSON request =
+        object
+            [ "clientRequestId" .= request.createTurnClientRequestId
+            , "input" .= request.createTurnInput
+            ]
+
+data AgentServerTurnStatus
+    = AgentServerTurnQueued
+    | AgentServerTurnRunning
+    | AgentServerTurnWaitingForInput
+    | AgentServerTurnCompleted
+    | AgentServerTurnFailed
+    | AgentServerTurnCancelled
+    deriving (Eq, Show)
+
+data AgentServerTurn = AgentServerTurn
+    { agentServerTurnId :: !Text
+    , agentServerTurnSessionId :: !Text
+    , agentServerTurnClientRequestId :: !Text
+    , agentServerTurnStatus :: !AgentServerTurnStatus
+    , agentServerTurnCreatedAt :: !UTCTime
+    , agentServerTurnStartedAt :: !(Maybe UTCTime)
+    , agentServerTurnFinishedAt :: !(Maybe UTCTime)
+    , agentServerTurnError :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerTurn where
+    parseJSON = withObject "AgentServerTurn" parseTurn
+
+newtype AgentServerTurnList = AgentServerTurnList
+    { agentServerTurns :: [AgentServerTurn]
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerTurnList where
+    parseJSON = withObject "AgentServerTurnList" \value ->
+        AgentServerTurnList <$> value .: "data"
+
+data AgentServerTurnCompletion
+    = AgentServerTurnComplete
+    | AgentServerTurnIncomplete !Text !(Maybe Int)
+    deriving (Eq, Show)
+
+data AgentServerTurnOutput = AgentServerTurnOutput
+    { agentServerOutputResponseId :: !Text
+    , agentServerOutputAssistantText :: !(Maybe Text)
+    , agentServerOutputAssistantTextTruncated :: !Bool
+    , agentServerOutputCompletion :: !AgentServerTurnCompletion
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerTurnOutput where
+    parseJSON = withObject "AgentServerTurnOutput" \value ->
+        AgentServerTurnOutput
+            <$> value .: "responseId"
+            <*> value .: "assistantText"
+            <*> value .: "assistantTextTruncated"
+            <*> (value .: "completion" >>= parseCompletion)
+
+data AgentServerTurnResult = AgentServerTurnResult
+    { agentServerResultTurn :: !AgentServerTurn
+    , agentServerResultOutput :: !(Maybe AgentServerTurnOutput)
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerTurnResult where
+    parseJSON = withObject "AgentServerTurnResult" \value ->
+        AgentServerTurnResult
+            <$> value .: "turn"
+            <*> value .: "output"
+
+data AgentServerHumanRequestKind
+    = AgentServerToolApproval
+    | AgentServerRootAccess
+    | AgentServerPlanEnter
+    | AgentServerPlanExit
+    | AgentServerPlanQuestion
+    deriving (Eq, Show)
+
+data AgentServerHumanRequest = AgentServerHumanRequest
+    { agentServerRequestId :: !Text
+    , agentServerRequestTurnId :: !Text
+    , agentServerRequestSessionId :: !Text
+    , agentServerRequestKind :: !AgentServerHumanRequestKind
+    , agentServerRequestPrompt :: !Text
+    , agentServerRequestOptions :: ![Text]
+    , agentServerRequestCreatedAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerHumanRequest where
+    parseJSON = withObject "AgentServerHumanRequest" parseHumanRequest
+
+newtype AgentServerRequestList = AgentServerRequestList
+    { agentServerRequests :: [AgentServerHumanRequest]
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerRequestList where
+    parseJSON = withObject "AgentServerRequestList" \value ->
+        AgentServerRequestList <$> value .: "data"
+
+data AgentServerResolveRequest = AgentServerResolveRequest
+    { resolveRequestDecision :: !Text
+    , resolveRequestValue :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+instance ToJSON AgentServerResolveRequest where
+    toJSON request =
+        object
+            [ "decision" .= request.resolveRequestDecision
+            , "value" .= request.resolveRequestValue
+            ]
+
+data AgentServerEventPayload
+    = AgentServerResponseTextDelta !Text
+    | AgentServerAgentTurnFinished
+        !(Maybe Text)
+        !Bool
+        !AgentServerTurnCompletion
+    | AgentServerToolStarted !Text !Text
+    | AgentServerToolFinished !Text
+    | AgentServerRequestCreated !AgentServerHumanRequest
+    | AgentServerRequestResolved !Text
+    | AgentServerTurnQueuedEvent
+    | AgentServerTurnStartedEvent
+    | AgentServerTurnCompletedEvent
+    | AgentServerTurnFailedEvent !(Maybe Text)
+    | AgentServerTurnCancelledEvent
+    | AgentServerOtherEvent !Text
+    deriving (Eq, Show)
+
+data AgentServerEvent = AgentServerEvent
+    { agentServerEventId :: !Int64
+    , agentServerEventType :: !Text
+    , agentServerEventTurnId :: !(Maybe Text)
+    , agentServerEventSessionId :: !(Maybe Text)
+    , agentServerEventPayload :: !AgentServerEventPayload
+    , agentServerEventAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerEvent where
+    parseJSON = withObject "AgentServerEvent" \value -> do
+        eventId <- value .: "id"
+        when (eventId < 1) (fail "event id must be positive")
+        eventType <- value .: "type"
+        eventTurnId <-
+            traverse
+                (parseIdentifier "event turn id")
+                =<< value .:? "turnId"
+        eventSessionId <-
+            traverse
+                parseSessionIdentifier
+                =<< value .:? "sessionId"
+        eventData <- value .: "data"
+        eventPayload <- parseEventPayload eventType eventData
+        eventAt <- value .: "at"
+        pure
+            AgentServerEvent
+                { agentServerEventId = eventId
+                , agentServerEventType = eventType
+                , agentServerEventTurnId = eventTurnId
+                , agentServerEventSessionId = eventSessionId
+                , agentServerEventPayload = eventPayload
+                , agentServerEventAt = eventAt
+                }
+
+newtype AgentServerReplayReset = AgentServerReplayReset
+    { replayResetReason :: Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerReplayReset where
+    parseJSON = withObject "AgentServerReplayReset" \value ->
+        AgentServerReplayReset <$> value .: "reason"
+
+data AgentServerSseMessage
+    = AgentServerSseEvent !AgentServerEvent
+    | AgentServerSseReplayReset !AgentServerReplayReset
+    deriving (Eq, Show)
+
+data AgentServerHistoryTurn = AgentServerHistoryTurn
+    { historyTurnUserText :: !Text
+    , historyTurnAssistantText :: !(Maybe Text)
+    , historyTurnError :: !(Maybe Text)
+    , historyTurnProjectionTruncated :: !Bool
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerHistoryTurn where
+    parseJSON = withObject "AgentServerHistoryTurn" \value ->
+        AgentServerHistoryTurn
+            <$> value .: "userText"
+            <*> value .:? "assistantText"
+            <*> value .:? "error"
+            <*> value .:? "projectionTruncated" .!= False
+
+data AgentServerHistoryItem = AgentServerHistoryItem
+    { historyItemIndex :: !Int64
+    , historyItemTurn :: !AgentServerHistoryTurn
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerHistoryItem where
+    parseJSON = withObject "AgentServerHistoryItem" \value ->
+        AgentServerHistoryItem
+            <$> value .: "index"
+            <*> value .: "turn"
+
+newtype AgentServerHistory = AgentServerHistory
+    { agentServerHistoryItems :: [AgentServerHistoryItem]
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerHistory where
+    parseJSON = withObject "AgentServerHistory" \value ->
+        AgentServerHistory <$> value .: "data"
+
+data AgentServerErrorBody = AgentServerErrorBody
+    { agentServerErrorCode :: !Text
+    , agentServerErrorMessage :: !Text
+    , agentServerErrorRequestId :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerErrorBody where
+    parseJSON = withObject "AgentServerErrorBody" \value ->
+        AgentServerErrorBody
+            <$> value .: "code"
+            <*> value .: "message"
+            <*> value .: "requestId"
+
+newtype AgentServerErrorEnvelope = AgentServerErrorEnvelope
+    { agentServerError :: AgentServerErrorBody
+    }
+    deriving (Eq, Show)
+
+instance FromJSON AgentServerErrorEnvelope where
+    parseJSON = withObject "AgentServerErrorEnvelope" \value ->
+        AgentServerErrorEnvelope <$> value .: "error"
+
+{- | Decode one complete SSE block (without the terminating blank line).
+Heartbeat/comment-only blocks intentionally produce 'Nothing'.
+-}
+parseAgentServerSseFrame ::
+    ByteString.ByteString ->
+    Either Text (Maybe AgentServerSseMessage)
+parseAgentServerSseFrame rawFrame = do
+    fields <- foldM parseLine (Nothing, Nothing, []) normalizedLines
+    case fields of
+        (_, _, []) -> Right Nothing
+        (eventName, sseId, reversedData) -> do
+            let eventType = fromMaybe "message" eventName
+                payload = ByteString.intercalate "\n" (reverse reversedData)
+            if eventType == "replay.reset"
+                then do
+                    reset <-
+                        Bifunctor.first
+                            Text.pack
+                            (eitherDecodeStrict' payload)
+                    pure (Just (AgentServerSseReplayReset reset))
+                else do
+                    event <-
+                        Bifunctor.first
+                            Text.pack
+                            (eitherDecodeStrict' payload)
+                    when (event.agentServerEventType /= eventType) $
+                        Left "SSE event type does not match its JSON envelope"
+                    forM_ sseId \identifier ->
+                        when (identifier /= event.agentServerEventId) $
+                            Left "SSE event id does not match its JSON envelope"
+                    pure (Just (AgentServerSseEvent event))
+  where
+    normalizedLines =
+        map stripCarriageReturn (ByteString.split 10 rawFrame)
+
+    parseLine fields line
+        | ByteString.null line = Right fields
+        | ByteString.head line == 58 = Right fields
+        | otherwise =
+            case ByteString.break (== 58) line of
+                (name, rest) ->
+                    let value = stripOneSpace (ByteString.drop 1 rest)
+                     in case name of
+                            "event" -> do
+                                decoded <- decodeUtf8Field "SSE event name" value
+                                pure
+                                    ( Just decoded
+                                    , secondOf fields
+                                    , thirdOf fields
+                                    )
+                            "id" -> do
+                                identifier <- parseEventId value
+                                pure
+                                    ( firstOf fields
+                                    , Just identifier
+                                    , thirdOf fields
+                                    )
+                            "data" ->
+                                pure
+                                    ( firstOf fields
+                                    , secondOf fields
+                                    , value : thirdOf fields
+                                    )
+                            _ -> Right fields
+
+parseTurn :: Object -> Parser AgentServerTurn
+parseTurn value =
+    AgentServerTurn
+        <$> (value .: "id" >>= parseIdentifier "turn id")
+        <*> (value .: "sessionId" >>= parseSessionIdentifier)
+        <*> ( value .: "clientRequestId"
+                >>= parseIdentifier "client request id"
+            )
+        <*> (value .: "status" >>= parseTurnStatus)
+        <*> value .: "createdAt"
+        <*> value .: "startedAt"
+        <*> value .: "finishedAt"
+        <*> value .: "error"
+
+parseEventPayload :: Text -> Value -> Parser AgentServerEventPayload
+parseEventPayload eventType eventData =
+    case eventType of
+        "response.text.delta" ->
+            withObject
+                "ResponseTextDelta"
+                (\value -> AgentServerResponseTextDelta <$> value .: "text")
+                eventData
+        "agent.turn.finished" ->
+            withObject
+                "AgentTurnFinished"
+                ( \value ->
+                    AgentServerAgentTurnFinished
+                        <$> value .: "assistantText"
+                        <*> value .: "assistantTextTruncated"
+                        <*> (value .: "completion" >>= parseCompletion)
+                )
+                eventData
+        "tool.started" ->
+            withObject
+                "ToolStarted"
+                ( \value ->
+                    AgentServerToolStarted
+                        <$> value .: "callId"
+                        <*> value .: "name"
+                )
+                eventData
+        "tool.finished" ->
+            withObject
+                "ToolFinished"
+                (\value -> AgentServerToolFinished <$> value .: "callId")
+                eventData
+        "request.created" ->
+            withObject
+                "RequestCreated"
+                ( \value ->
+                    AgentServerRequestCreated
+                        <$> (value .: "request" >>= parseJSON)
+                )
+                eventData
+        "request.resolved" ->
+            withObject
+                "RequestResolved"
+                ( \value ->
+                    AgentServerRequestResolved
+                        <$> ( value .: "requestId"
+                                >>= parseIdentifier "resolved request id"
+                            )
+                )
+                eventData
+        "turn.queued" -> pure AgentServerTurnQueuedEvent
+        "turn.started" -> pure AgentServerTurnStartedEvent
+        "turn.completed" -> pure AgentServerTurnCompletedEvent
+        "turn.failed" ->
+            withObject
+                "TurnFailed"
+                (\value -> AgentServerTurnFailedEvent <$> value .:? "error")
+                eventData
+        "turn.cancelled" -> pure AgentServerTurnCancelledEvent
+        _ -> pure (AgentServerOtherEvent eventType)
+
+parseHumanRequest :: Object -> Parser AgentServerHumanRequest
+parseHumanRequest value =
+    AgentServerHumanRequest
+        <$> (value .: "id" >>= parseIdentifier "request id")
+        <*> (value .: "turnId" >>= parseIdentifier "request turn id")
+        <*> (value .: "sessionId" >>= parseSessionIdentifier)
+        <*> (value .: "kind" >>= parseHumanRequestKind)
+        <*> value .: "prompt"
+        <*> value .: "options"
+        <*> value .: "createdAt"
+
+parseTurnStatus :: Text -> Parser AgentServerTurnStatus
+parseTurnStatus = \case
+    "queued" -> pure AgentServerTurnQueued
+    "running" -> pure AgentServerTurnRunning
+    "waiting_for_input" -> pure AgentServerTurnWaitingForInput
+    "completed" -> pure AgentServerTurnCompleted
+    "failed" -> pure AgentServerTurnFailed
+    "cancelled" -> pure AgentServerTurnCancelled
+    other ->
+        fail ("unknown agent-server turn status: " <> Text.unpack other)
+
+parseHumanRequestKind :: Text -> Parser AgentServerHumanRequestKind
+parseHumanRequestKind = \case
+    "tool_approval" -> pure AgentServerToolApproval
+    "root_access" -> pure AgentServerRootAccess
+    "plan_enter" -> pure AgentServerPlanEnter
+    "plan_exit" -> pure AgentServerPlanExit
+    "plan_question" -> pure AgentServerPlanQuestion
+    other ->
+        fail ("unknown agent-server request kind: " <> Text.unpack other)
+
+parseCompletion :: Value -> Parser AgentServerTurnCompletion
+parseCompletion = withObject "AgentServerTurnCompletion" \value ->
+    value .: "status" >>= \case
+        ("completed" :: Text) -> pure AgentServerTurnComplete
+        "incomplete" ->
+            AgentServerTurnIncomplete
+                <$> value .: "reason"
+                <*> value .:? "reasoningTokens"
+        other ->
+            fail
+                ( "unknown agent-server completion status: "
+                    <> Text.unpack other
+                )
+
+parseIdentifier :: Text -> Text -> Parser Text
+parseIdentifier label raw =
+    case UUID.fromText raw of
+        Nothing -> fail (Text.unpack label <> " must be a UUID")
+        Just value -> pure (UUID.toText value)
+
+-- Session ids predate the UUID wire identifiers. They are opaque path
+-- components, and the server intentionally keeps accepting older allocator
+-- formats so persisted sessions remain resumable.
+parseSessionIdentifier :: Text -> Parser Text
+parseSessionIdentifier raw
+    | Text.null raw = fail "session id must not be empty"
+    | raw == "." || raw == ".." =
+        fail "session id must be a single path component"
+    | Text.any
+        ( \character ->
+            character == '/'
+                || character == '\\'
+                || character == '\NUL'
+        )
+        raw =
+        fail "session id must be a single path component"
+    | otherwise = pure raw
+
+parseEventId :: ByteString.ByteString -> Either Text Int64
+parseEventId bytes =
+    case readMaybe (Text.unpack decoded) of
+        Just value
+            | value >= 1 -> Right value
+        _ -> Left "SSE event id must be a positive integer"
+  where
+    decoded =
+        TextEncoding.decodeUtf8With (\_ _ -> Just '\xfffd') bytes
+
+decodeUtf8Field ::
+    Text ->
+    ByteString.ByteString ->
+    Either Text Text
+decodeUtf8Field label =
+    Bifunctor.first
+        (const (label <> " is not valid UTF-8"))
+        . TextEncoding.decodeUtf8'
+
+stripCarriageReturn :: ByteString.ByteString -> ByteString.ByteString
+stripCarriageReturn value =
+    case ByteString.unsnoc value of
+        Just (prefix, 13) -> prefix
+        _ -> value
+
+stripOneSpace :: ByteString.ByteString -> ByteString.ByteString
+stripOneSpace value =
+    fromMaybe value (ByteString.stripPrefix " " value)
+
+firstOf :: (a, b, c) -> a
+firstOf (value, _, _) = value
+
+secondOf :: (a, b, c) -> b
+secondOf (_, value, _) = value
+
+thirdOf :: (a, b, c) -> c
+thirdOf (_, _, value) = value

--- a/packages/agent-server-client/test/Agent/Server/Client/GatewayIdentitySpec.hs
+++ b/packages/agent-server-client/test/Agent/Server/Client/GatewayIdentitySpec.hs
@@ -1,0 +1,74 @@
+module Agent.Server.Client.GatewayIdentitySpec (spec) where
+
+import Agent.Server.Client.GatewayIdentity
+import Data.Aeson (eitherDecodeStrict')
+import Data.Text qualified as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "gateway credential identity" do
+    it "matches the stable public test vector" do
+        gatewayCredentialIdentity sampleCredential
+            `shouldBe` "gateway-sha256:Dpd-c7NJ8FNhmkgN6ohRz5X7k3fbLPxbm3fXQwlC5n8"
+
+    it "normalizes equivalent gateway origins" do
+        gatewayCredentialIdentity
+            sampleCredential
+                { gatewayBaseUrl = " HTTPS://GATEWAY.EXAMPLE:443/ "
+                , gatewayWebSocketUrl = "wss://GATEWAY.EXAMPLE:443"
+                }
+            `shouldBe` gatewayCredentialIdentity sampleCredential
+
+    it "changes with the private bearer without exposing it" do
+        let replacement =
+                gatewayCredentialIdentity
+                    sampleCredential
+                        { gatewayAccessToken = "replacement-secret"
+                        }
+            original = gatewayCredentialIdentity sampleCredential
+        replacement `shouldNotBe` original
+        original
+            `shouldNotSatisfy` Text.isInfixOf sampleCredential.gatewayAccessToken
+
+    it "binds query, user-info, and fragment URL material" do
+        let original = gatewayCredentialIdentity sampleCredential
+        gatewayCredentialIdentity
+            sampleCredential
+                { gatewayBaseUrl =
+                    "https://tenant@gateway.example?organization=one#route"
+                }
+            `shouldNotBe` original
+        gatewayCredentialIdentity
+            sampleCredential
+                { gatewayBaseUrl =
+                    "https://tenant@gateway.example?organization=two#route"
+                }
+            `shouldNotBe` original
+
+    it "uses unambiguous framing even when fields contain NUL" do
+        gatewayCredentialIdentity
+            sampleCredential
+                { gatewayBaseUrl = "a\NULb"
+                , gatewayWebSocketUrl = "c"
+                }
+            `shouldNotBe` gatewayCredentialIdentity
+                sampleCredential
+                    { gatewayBaseUrl = "a"
+                    , gatewayWebSocketUrl = "b\NULc"
+                    }
+
+    it "decodes the installed gateway credential shape" do
+        ( eitherDecodeStrict'
+                "{\"base_url\":\"https://gateway.example\",\"websocket_url\":\"wss://gateway.example/v1/responses\",\"access_token\":\"gateway-bearer-secret\"}" ::
+                Either String GatewayCredential
+            )
+            `shouldBe` Right sampleCredential
+
+sampleCredential :: GatewayCredential
+sampleCredential =
+    GatewayCredential
+        { gatewayBaseUrl = "https://gateway.example"
+        , gatewayWebSocketUrl =
+            "wss://gateway.example/v1/responses"
+        , gatewayAccessToken = "gateway-bearer-secret"
+        }

--- a/packages/agent-server-client/test/Agent/Server/Client/ProtocolSpec.hs
+++ b/packages/agent-server-client/test/Agent/Server/Client/ProtocolSpec.hs
@@ -1,0 +1,155 @@
+module Agent.Server.Client.ProtocolSpec (spec) where
+
+import Agent.Server.Client.Protocol
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "agent-server client protocol" do
+    it "decodes the server's opaque non-UUID session ids" do
+        Aeson.eitherDecodeStrict'
+            "{\"id\":\"2026-09-04-deadbeef\"}"
+            `shouldBe` Right
+                (AgentServerSession "2026-09-04-deadbeef")
+
+    it "encodes a turn with its required idempotency key" do
+        let request =
+                AgentServerCreateTurnRequest
+                    { createTurnClientRequestId =
+                        "01991f6d-7200-7000-8000-000000000003"
+                    , createTurnInput = "hello"
+                    }
+        ( Aeson.eitherDecode (Aeson.encode request) ::
+                Either String Aeson.Value
+            )
+            `shouldBe` Right
+                ( Aeson.object
+                    [ "clientRequestId"
+                        Aeson..= ( "01991f6d-7200-7000-8000-000000000003" ::
+                                    Text
+                                 )
+                    , "input" Aeson..= ("hello" :: Text)
+                    ]
+                )
+
+    it "decodes a queued turn with its client request id" do
+        let payload =
+                "{\"id\":\"01991f6d-7200-7000-8000-000000000001\","
+                    <> "\"sessionId\":\"2026-09-04-deadbeef\","
+                    <> "\"clientRequestId\":\"01991f6d-7200-7000-8000-000000000003\","
+                    <> "\"status\":\"queued\","
+                    <> "\"createdAt\":\"2026-09-03T00:00:00Z\","
+                    <> "\"startedAt\":null,\"finishedAt\":null,\"error\":null}"
+        case Aeson.eitherDecodeStrict' payload of
+            Left message -> expectationFailure message
+            Right (turn :: AgentServerTurn) -> do
+                turn.agentServerTurnStatus
+                    `shouldBe` AgentServerTurnQueued
+                turn.agentServerTurnClientRequestId
+                    `shouldBe` "01991f6d-7200-7000-8000-000000000003"
+
+    it "rejects missing required nullable turn fields" do
+        let payload =
+                "{\"id\":\"01991f6d-7200-7000-8000-000000000001\","
+                    <> "\"sessionId\":\"01991f6d-7200-7000-8000-000000000002\","
+                    <> "\"clientRequestId\":\"01991f6d-7200-7000-8000-000000000003\","
+                    <> "\"status\":\"queued\","
+                    <> "\"createdAt\":\"2026-09-03T00:00:00Z\","
+                    <> "\"finishedAt\":null,\"error\":null}"
+        (Aeson.eitherDecodeStrict' payload :: Either String AgentServerTurn)
+            `shouldSatisfy` isLeft
+
+    it "decodes the canonical terminal result" do
+        let payload =
+                "{\"turn\":{"
+                    <> "\"id\":\"01991f6d-7200-7000-8000-000000000001\","
+                    <> "\"sessionId\":\"01991f6d-7200-7000-8000-000000000002\","
+                    <> "\"clientRequestId\":\"01991f6d-7200-7000-8000-000000000003\","
+                    <> "\"status\":\"completed\","
+                    <> "\"createdAt\":\"2026-09-03T00:00:00Z\","
+                    <> "\"startedAt\":\"2026-09-03T00:00:01Z\","
+                    <> "\"finishedAt\":\"2026-09-03T00:00:02Z\","
+                    <> "\"error\":null},\"output\":{"
+                    <> "\"responseId\":\"resp_123\","
+                    <> "\"assistantText\":\"done\","
+                    <> "\"assistantTextTruncated\":true,"
+                    <> "\"completion\":{\"status\":\"completed\"}}}"
+        case Aeson.eitherDecodeStrict' payload of
+            Left message -> expectationFailure message
+            Right (result :: AgentServerTurnResult) ->
+                result.agentServerResultOutput
+                    `shouldBe` Just
+                        ( AgentServerTurnOutput
+                            "resp_123"
+                            (Just "done")
+                            True
+                            AgentServerTurnComplete
+                        )
+
+    it "rejects a result that omits its required nullable output" do
+        let payload =
+                "{\"turn\":{"
+                    <> "\"id\":\"01991f6d-7200-7000-8000-000000000001\","
+                    <> "\"sessionId\":\"01991f6d-7200-7000-8000-000000000002\","
+                    <> "\"clientRequestId\":\"01991f6d-7200-7000-8000-000000000003\","
+                    <> "\"status\":\"failed\","
+                    <> "\"createdAt\":\"2026-09-03T00:00:00Z\","
+                    <> "\"startedAt\":null,\"finishedAt\":\"2026-09-03T00:00:02Z\","
+                    <> "\"error\":\"failed\"}}"
+        ( Aeson.eitherDecodeStrict' payload ::
+                Either String AgentServerTurnResult
+            )
+            `shouldSatisfy` isLeft
+
+    it "decodes an SSE event and validates its envelope" do
+        let frame =
+                "id: 41\r\nevent: response.text.delta\r\n"
+                    <> "data: {\"id\":41,\"type\":\"response.text.delta\","
+                    <> "\"turnId\":\"01991f6d-7200-7000-8000-000000000001\","
+                    <> "\"sessionId\":\"2026-09-04-deadbeef\","
+                    <> "\"data\":{\"text\":\"Hallo\"},"
+                    <> "\"at\":\"2026-09-03T00:00:00Z\"}\r\n"
+        case parseAgentServerSseFrame frame of
+            Right
+                ( Just
+                        ( AgentServerSseEvent
+                                AgentServerEvent
+                                    { agentServerEventId = 41
+                                    , agentServerEventPayload =
+                                        AgentServerResponseTextDelta "Hallo"
+                                    }
+                            )
+                    ) ->
+                    pure ()
+            other ->
+                expectationFailure
+                    ("unexpected SSE result: " <> show other)
+
+    it "surfaces replay.reset separately from normal events" do
+        parseAgentServerSseFrame
+            ( "event: replay.reset\n"
+                <> "data: {\"reason\":\"event_gap\",\"refetch\":true}\n"
+            )
+            `shouldBe` Right
+                ( Just
+                    ( AgentServerSseReplayReset
+                        (AgentServerReplayReset "event_gap")
+                    )
+                )
+
+    it "rejects a wire event id that disagrees with the JSON body" do
+        let frame =
+                "id: 8\nevent: turn.completed\n"
+                    <> "data: {\"id\":9,\"type\":\"turn.completed\","
+                    <> "\"turnId\":\"01991f6d-7200-7000-8000-000000000001\","
+                    <> "\"sessionId\":\"01991f6d-7200-7000-8000-000000000002\","
+                    <> "\"data\":{},"
+                    <> "\"at\":\"2026-09-03T00:00:00Z\"}\n"
+        parseAgentServerSseFrame frame
+            `shouldBe` Left "SSE event id does not match its JSON envelope"
+
+isLeft :: Either left right -> Bool
+isLeft = \case
+    Left _ -> True
+    Right _ -> False

--- a/packages/agent-server-client/test/Agent/Server/ClientSpec.hs
+++ b/packages/agent-server-client/test/Agent/Server/ClientSpec.hs
@@ -92,8 +92,8 @@ spec = describe "agent-server HTTP client" do
                     }
         case result of
             Left (AgentServerProtocolError message) ->
-                message `shouldBe`
-                    "plaintext agent-server URLs must use a literal loopback host"
+                message
+                    `shouldBe` "plaintext agent-server URLs must use a literal loopback host"
             Left other ->
                 expectationFailure
                     ("unexpected plaintext URL error: " <> show other)
@@ -156,8 +156,7 @@ spec = describe "agent-server HTTP client" do
                     [ "id" Aeson..= validTurnId
                     , "sessionId" Aeson..= ("opaque-session" :: Text)
                     , "clientRequestId"
-                        Aeson..=
-                            ("01991f6d-7200-7000-8000-000000000003" :: Text)
+                        Aeson..= ("01991f6d-7200-7000-8000-000000000003" :: Text)
                     , "status" Aeson..= ("failed" :: Text)
                     , "createdAt"
                         Aeson..= ("2026-09-03T00:00:00Z" :: Text)
@@ -316,6 +315,36 @@ spec = describe "agent-server HTTP client" do
             result
                 `shouldBe` Just (Right AgentServerStreamNeedsRefetch)
 
+    it "refetches when another instance deletes the turn" do
+        let application request respond
+                | rawPathInfo request == "/v1/events" =
+                    respond $
+                        responseStream
+                            status200
+                            [(hContentType, "text/event-stream")]
+                            \write flush -> do
+                                write ": keepalive\n\n"
+                                flush
+                                threadDelay (10 * 1000 * 1000)
+                | otherwise =
+                    respond $
+                        responseLBS
+                            status404
+                            [(hContentType, "application/json")]
+                            ""
+        withTestClient application \client -> do
+            result <-
+                timeout
+                    (3 * 1000 * 1000)
+                    ( streamAgentServerTurn
+                        client
+                        validTurnId
+                        Nothing
+                        (\_ -> pure (Right ()))
+                    )
+            result
+                `shouldBe` Just (Right AgentServerStreamNeedsRefetch)
+
     it "refetches when another instance durably requests human input" do
         requestQuery <- newEmptyMVar
         let application request respond
@@ -355,8 +384,7 @@ spec = describe "agent-server HTTP client" do
             result
                 `shouldBe` Just (Right AgentServerStreamNeedsRefetch)
             takeMVar requestQuery
-                `shouldReturn`
-                    "?turnId=01991f6d-7200-7000-8000-000000000001"
+                `shouldReturn` "?turnId=01991f6d-7200-7000-8000-000000000001"
 
     it "bounds an unterminated SSE frame" do
         let application _ respond =

--- a/packages/agent-server-client/test/Agent/Server/ClientSpec.hs
+++ b/packages/agent-server-client/test/Agent/Server/ClientSpec.hs
@@ -1,0 +1,465 @@
+module Agent.Server.ClientSpec (spec) where
+
+import Agent.Server.Client
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.MVar
+import Control.Exception (bracket)
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as ByteString
+import Data.ByteString.Lazy qualified as LazyByteString
+import Data.IORef
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Network.HTTP.Types
+import Network.Wai
+import Network.Wai.Handler.Warp (testWithApplication)
+import System.Directory (getTemporaryDirectory, removeFile)
+import System.IO (hClose, openBinaryTempFile)
+import System.Posix.Files (setFileMode)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "agent-server HTTP client" do
+    it "authenticates requests and encodes query values" do
+        observed <- newEmptyMVar
+        let application request respond = do
+                putMVar
+                    observed
+                    ( rawQueryString request
+                    , lookup hAuthorization request.requestHeaders
+                    )
+                respond $
+                    responseLBS
+                        status200
+                        [(hContentType, "application/json")]
+                        "{\"data\":[]}"
+        withTestClient application \client -> do
+            listAgentServerTurns client "session/a&other=1"
+                `shouldReturn` Right (AgentServerTurnList [])
+            takeMVar observed
+                `shouldReturn` ( "?sessionId=session%2Fa%26other%3D1"
+                               , Just ("Bearer " <> testBearer)
+                               )
+
+    it "encodes opaque identifiers as single path segments" do
+        observed <- newEmptyMVar
+        let application request respond = do
+                putMVar observed (rawPathInfo request)
+                respond $
+                    responseLBS
+                        status200
+                        [(hContentType, "application/json")]
+                        turnPayload
+        withTestClient application \client -> do
+            result <- getAgentServerTurn client "turn/../?admin=true"
+            result `shouldSatisfy` isRight
+            takeMVar observed
+                `shouldReturn` "/v1/turns/turn%2F..%2F%3Fadmin=true"
+
+    it "does not follow redirects" do
+        redirectVisits <- newIORef (0 :: Int)
+        let application request respond =
+                if rawPathInfo request == "/redirect-target"
+                    then do
+                        modifyIORef' redirectVisits (+ 1)
+                        respond $
+                            responseLBS
+                                status200
+                                [(hContentType, "application/json")]
+                                turnPayload
+                    else
+                        respond $
+                            responseLBS
+                                status302
+                                [(hLocation, "/redirect-target")]
+                                ""
+        withTestClient application \client -> do
+            result <- getAgentServerTurn client validTurnId
+            case result of
+                Left (AgentServerHttpError 302 _ _) -> pure ()
+                other ->
+                    expectationFailure
+                        ("unexpected redirect result: " <> show other)
+            readIORef redirectVisits `shouldReturn` 0
+
+    it "rejects plaintext bearer transport beyond literal loopback" do
+        result <-
+            newAgentServerClient
+                AgentServerClientConfig
+                    { agentServerBaseUrl = "http://example.com:4096"
+                    , agentServerCredentialFile = "not-read"
+                    }
+        case result of
+            Left (AgentServerProtocolError message) ->
+                message `shouldBe`
+                    "plaintext agent-server URLs must use a literal loopback host"
+            Left other ->
+                expectationFailure
+                    ("unexpected plaintext URL error: " <> show other)
+            Right _ ->
+                expectationFailure "plaintext remote URL was accepted"
+
+    it "rejects oversized JSON responses" do
+        let application _ respond =
+                respond $
+                    responseLBS
+                        status200
+                        [(hContentType, "application/json")]
+                        (LazyByteString.replicate (1024 * 1024 + 1) 97)
+        withTestClient application \client -> do
+            result <- getAgentServerTurn client validTurnId
+            case result of
+                Left (AgentServerProtocolError message) ->
+                    message `shouldBe` "agent-server response exceeded the size limit"
+                other ->
+                    expectationFailure
+                        ("unexpected oversized response result: " <> show other)
+
+    it "accepts a full page of maximally projected history" do
+        let projectedText = Text.replicate (64 * 1024) "a"
+            historyItem index =
+                Aeson.object
+                    [ "index" Aeson..= (index :: Int)
+                    , "turn"
+                        Aeson..= Aeson.object
+                            [ "userText" Aeson..= projectedText
+                            , "assistantText" Aeson..= (Nothing :: Maybe Text)
+                            , "error" Aeson..= (Nothing :: Maybe Text)
+                            , "projectionTruncated" Aeson..= False
+                            ]
+                    ]
+            application _ respond =
+                respond $
+                    responseLBS
+                        status200
+                        [(hContentType, "application/json")]
+                        ( Aeson.encode
+                            ( Aeson.object
+                                ["data" Aeson..= map historyItem [1 .. 20]]
+                            )
+                        )
+        withTestClient application \client -> do
+            result <- getAgentServerHistory client "2026-09-04-deadbeef"
+            case result of
+                Right history ->
+                    length history.agentServerHistoryItems `shouldBe` 20
+                Left err ->
+                    expectationFailure
+                        ("unexpected history response error: " <> show err)
+
+    it "accepts a full page of maximally projected turns" do
+        let maximumEncodedError =
+                Text.replicate (16 * 1024 - 1) "\NUL" <> "…"
+            failedTurn =
+                Aeson.object
+                    [ "id" Aeson..= validTurnId
+                    , "sessionId" Aeson..= ("opaque-session" :: Text)
+                    , "clientRequestId"
+                        Aeson..=
+                            ("01991f6d-7200-7000-8000-000000000003" :: Text)
+                    , "status" Aeson..= ("failed" :: Text)
+                    , "createdAt"
+                        Aeson..= ("2026-09-03T00:00:00Z" :: Text)
+                    , "startedAt"
+                        Aeson..= (Nothing :: Maybe Text)
+                    , "finishedAt"
+                        Aeson..= (Just ("2026-09-03T00:00:01Z" :: Text))
+                    , "error"
+                        Aeson..= Just maximumEncodedError
+                    ]
+            application _ respond =
+                respond $
+                    responseLBS
+                        status200
+                        [(hContentType, "application/json")]
+                        ( Aeson.encode
+                            ( Aeson.object
+                                ["data" Aeson..= replicate 200 failedTurn]
+                            )
+                        )
+        withTestClient application \client -> do
+            result <- listAgentServerTurns client "opaque-session"
+            case result of
+                Right turns ->
+                    length turns.agentServerTurns `shouldBe` 200
+                Left err ->
+                    expectationFailure
+                        ("unexpected turn-list response error: " <> show err)
+
+    it "accepts a full page of transport-bounded human requests" do
+        let request =
+                humanRequestValue
+                    (Text.replicate (60 * 1024) "p")
+            application _ respond =
+                respond $
+                    responseLBS
+                        status200
+                        [(hContentType, "application/json")]
+                        ( Aeson.encode
+                            ( Aeson.object
+                                ["data" Aeson..= replicate 200 request]
+                            )
+                        )
+        withTestClient application \client -> do
+            result <- listAgentServerRequests client
+            case result of
+                Right requests ->
+                    length requests.agentServerRequests `shouldBe` 200
+                Left err ->
+                    expectationFailure
+                        ("unexpected request-list response error: " <> show err)
+
+    it "streams a transport-bounded human request frame" do
+        seenPromptLength <- newIORef Nothing
+        let prompt = Text.replicate (60 * 1024) "p"
+            requestPayload =
+                Aeson.encode
+                    ( Aeson.object
+                        [ "id" Aeson..= (1 :: Int)
+                        , "type" Aeson..= ("request.created" :: Text)
+                        , "turnId" Aeson..= validTurnId
+                        , "sessionId"
+                            Aeson..= ("opaque-session" :: Text)
+                        , "data"
+                            Aeson..= Aeson.object
+                                ["request" Aeson..= humanRequestValue prompt]
+                        , "at"
+                            Aeson..= ("2026-09-03T00:00:00Z" :: Text)
+                        ]
+                    )
+            requestEvent =
+                LazyByteString.concat
+                    [ "id: 1\nevent: request.created\ndata: "
+                    , requestPayload
+                    , "\n\n"
+                    ]
+            application _ respond =
+                respond $
+                    responseLBS
+                        status200
+                        [(hContentType, "text/event-stream")]
+                        (requestEvent <> completedEvent)
+        withTestClient application \client -> do
+            result <-
+                streamAgentServerTurn client validTurnId Nothing \event -> do
+                    case event.agentServerEventPayload of
+                        AgentServerRequestCreated request ->
+                            writeIORef
+                                seenPromptLength
+                                (Just (Text.length request.agentServerRequestPrompt))
+                        _ -> pure ()
+                    pure (Right ())
+            result `shouldBe` Right AgentServerStreamCompleted
+            readIORef seenPromptLength
+                `shouldReturn` Just (Text.length prompt)
+
+    it "streams terminal events without reconnecting" do
+        seen <- newIORef (0 :: Int)
+        cursor <- newEmptyMVar
+        let application request respond = do
+                putMVar cursor (lookup "Last-Event-ID" request.requestHeaders)
+                respond $
+                    responseLBS
+                        status200
+                        [(hContentType, "text/event-stream")]
+                        completedEvent
+        withTestClient application \client -> do
+            result <-
+                streamAgentServerTurn client validTurnId Nothing \_ -> do
+                    modifyIORef' seen (+ 1)
+                    pure (Right ())
+            result `shouldBe` Right AgentServerStreamCompleted
+            readIORef seen `shouldReturn` 1
+            takeMVar cursor `shouldReturn` Just "0"
+
+    it "surfaces replay resets from the live stream" do
+        let application _ respond =
+                respond $
+                    responseLBS
+                        status200
+                        [(hContentType, "text/event-stream")]
+                        ( "event: replay.reset\n"
+                            <> "data: {\"reason\":\"event_gap\",\"refetch\":true}\n\n"
+                        )
+        withTestClient application \client -> do
+            streamAgentServerTurn client validTurnId Nothing (\_ -> pure (Right ()))
+                `shouldReturn` Right AgentServerStreamNeedsRefetch
+
+    it "refetches when another instance durably finishes the turn" do
+        let application request respond
+                | rawPathInfo request == "/v1/events" =
+                    respond $
+                        responseStream
+                            status200
+                            [(hContentType, "text/event-stream")]
+                            \write flush -> do
+                                write ": keepalive\n\n"
+                                flush
+                                threadDelay (10 * 1000 * 1000)
+                | otherwise =
+                    respond $
+                        responseLBS
+                            status200
+                            [(hContentType, "application/json")]
+                            completedTurnPayload
+        withTestClient application \client -> do
+            result <-
+                timeout
+                    (3 * 1000 * 1000)
+                    ( streamAgentServerTurn
+                        client
+                        validTurnId
+                        Nothing
+                        (\_ -> pure (Right ()))
+                    )
+            result
+                `shouldBe` Just (Right AgentServerStreamNeedsRefetch)
+
+    it "refetches when another instance durably requests human input" do
+        requestQuery <- newEmptyMVar
+        let application request respond
+                | rawPathInfo request == "/v1/events" =
+                    respond $
+                        responseStream
+                            status200
+                            [(hContentType, "text/event-stream")]
+                            \write flush -> do
+                                write ": keepalive\n\n"
+                                flush
+                                threadDelay (10 * 1000 * 1000)
+                | rawPathInfo request == "/v1/requests" =
+                    do
+                        putMVar requestQuery (rawQueryString request)
+                        respond $
+                            responseLBS
+                                status200
+                                [(hContentType, "application/json")]
+                                pendingRequestPayload
+                | otherwise =
+                    respond $
+                        responseLBS
+                            status200
+                            [(hContentType, "application/json")]
+                            turnPayload
+        withTestClient application \client -> do
+            result <-
+                timeout
+                    (3 * 1000 * 1000)
+                    ( streamAgentServerTurn
+                        client
+                        validTurnId
+                        Nothing
+                        (\_ -> pure (Right ()))
+                    )
+            result
+                `shouldBe` Just (Right AgentServerStreamNeedsRefetch)
+            takeMVar requestQuery
+                `shouldReturn`
+                    "?turnId=01991f6d-7200-7000-8000-000000000001"
+
+    it "bounds an unterminated SSE frame" do
+        let application _ respond =
+                respond $
+                    responseLBS
+                        status200
+                        [(hContentType, "text/event-stream")]
+                        (LazyByteString.replicate (1024 * 1024 + 1) 97)
+        withTestClient application \client -> do
+            result <-
+                streamAgentServerTurn client validTurnId Nothing (\_ -> pure (Right ()))
+            case result of
+                Left (AgentServerProtocolError message) ->
+                    message `shouldBe` "agent-server SSE frame exceeded the size limit"
+                other ->
+                    expectationFailure
+                        ("unexpected oversized stream result: " <> show other)
+
+withTestClient :: Application -> (AgentServerClient -> IO value) -> IO value
+withTestClient application action =
+    testWithApplication (pure application) \port ->
+        withCredentialFile \credentialFile -> do
+            created <-
+                newAgentServerClient
+                    AgentServerClientConfig
+                        { agentServerBaseUrl =
+                            "http://127.0.0.1:" <> Text.pack (show port)
+                        , agentServerCredentialFile = credentialFile
+                        }
+            case created of
+                Left err ->
+                    expectationFailure
+                        ("could not create test client: " <> show err)
+                        >> fail "could not create test client"
+                Right client -> action client
+
+withCredentialFile :: (FilePath -> IO value) -> IO value
+withCredentialFile =
+    bracket createCredential removeFile
+  where
+    createCredential = do
+        temporaryDirectory <- getTemporaryDirectory
+        (path, handle) <-
+            openBinaryTempFile temporaryDirectory "agent-server-client-token"
+        ByteString.hPut handle testBearer
+        hClose handle
+        setFileMode path 0o600
+        pure path
+
+validTurnId :: Text
+validTurnId = "01991f6d-7200-7000-8000-000000000001"
+
+testBearer :: ByteString.ByteString
+testBearer = "01234567890123456789012345678901"
+
+turnPayload :: LazyByteString.ByteString
+turnPayload =
+    "{\"id\":\"01991f6d-7200-7000-8000-000000000001\",\
+    \\"sessionId\":\"01991f6d-7200-7000-8000-000000000002\",\
+    \\"clientRequestId\":\"01991f6d-7200-7000-8000-000000000003\",\
+    \\"status\":\"queued\",\"createdAt\":\"2026-09-03T00:00:00Z\",\
+    \\"startedAt\":null,\"finishedAt\":null,\"error\":null}"
+
+completedEvent :: LazyByteString.ByteString
+completedEvent =
+    "id: 1\nevent: turn.completed\n\
+    \data: {\"id\":1,\"type\":\"turn.completed\",\
+    \\"turnId\":\"01991f6d-7200-7000-8000-000000000001\",\
+    \\"sessionId\":\"01991f6d-7200-7000-8000-000000000002\",\
+    \\"data\":{},\"at\":\"2026-09-03T00:00:00Z\"}\n\n"
+
+completedTurnPayload :: LazyByteString.ByteString
+completedTurnPayload =
+    "{\"id\":\"01991f6d-7200-7000-8000-000000000001\",\
+    \\"sessionId\":\"01991f6d-7200-7000-8000-000000000002\",\
+    \\"clientRequestId\":\"01991f6d-7200-7000-8000-000000000003\",\
+    \\"status\":\"completed\",\"createdAt\":\"2026-09-03T00:00:00Z\",\
+    \\"startedAt\":\"2026-09-03T00:00:01Z\",\
+    \\"finishedAt\":\"2026-09-03T00:00:02Z\",\"error\":null}"
+
+pendingRequestPayload :: LazyByteString.ByteString
+pendingRequestPayload =
+    "{\"data\":[{\"id\":\"01991f6d-7200-7000-8000-000000000004\",\
+    \\"turnId\":\"01991f6d-7200-7000-8000-000000000001\",\
+    \\"sessionId\":\"opaque-session\",\
+    \\"kind\":\"tool_approval\",\"prompt\":\"Approve?\",\
+    \\"options\":[\"approve\",\"cancel\"],\
+    \\"createdAt\":\"2026-09-03T00:00:01Z\"}]}"
+
+humanRequestValue :: Text -> Aeson.Value
+humanRequestValue prompt =
+    Aeson.object
+        [ "id"
+            Aeson..= ("01991f6d-7200-7000-8000-000000000004" :: Text)
+        , "turnId" Aeson..= validTurnId
+        , "sessionId" Aeson..= ("opaque-session" :: Text)
+        , "kind" Aeson..= ("tool_approval" :: Text)
+        , "prompt" Aeson..= prompt
+        , "options" Aeson..= (["approve", "cancel"] :: [Text])
+        , "createdAt" Aeson..= ("2026-09-03T00:00:01Z" :: Text)
+        ]
+
+isRight :: Either left right -> Bool
+isRight = \case
+    Left _ -> False
+    Right _ -> True

--- a/packages/agent-server-client/test/Main.hs
+++ b/packages/agent-server-client/test/Main.hs
@@ -1,0 +1,12 @@
+module Main (main) where
+
+import Agent.Server.Client.GatewayIdentitySpec qualified as GatewayIdentitySpec
+import Agent.Server.Client.ProtocolSpec qualified as ProtocolSpec
+import Agent.Server.ClientSpec qualified as ClientSpec
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec do
+    ClientSpec.spec
+    GatewayIdentitySpec.spec
+    ProtocolSpec.spec

--- a/packages/agent-server/agent-server.cabal
+++ b/packages/agent-server/agent-server.cabal
@@ -49,6 +49,7 @@ library
                     , Agent.Server.Identifier
                     , Agent.Server.PrivateFile
                     , Agent.Server.Runtime
+                    , Agent.Server.Runtime.TurnStore
                     , Agent.Server.Sandbox
                     , Agent.Server.Sandbox.Worker
                     , Agent.Server.Supervisor

--- a/packages/agent-server/openapi.json
+++ b/packages/agent-server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "haskell-agent server API",
     "version": "1.0.0",
-    "description": "Local, versioned API for durable agent sessions and process-local turns. Default loopback mode requires an exact local Host header; configuring a token enables bearer mode on any bind. Remote mode requires --allow-remote, bearer authentication, and trusted TLS termination. Organization-gateway credentials form an exact isolation boundary for sessions, turns, requests, and events."
+    "description": "Local, versioned API for durable agent sessions and idempotently submitted turns. Default loopback mode requires an exact local Host header; configuring a token enables bearer mode on any bind. Remote mode requires --allow-remote, bearer authentication, and trusted TLS termination. Organization-gateway credentials form an exact isolation boundary for sessions, turns, requests, and events."
   },
   "servers": [
     {
@@ -43,8 +43,29 @@
               }
             }
           },
-          "429": {
-            "description": "The global or per-tenant event subscriber limit was reached.",
+          "default": { "$ref": "#/components/responses/Error" }
+        }
+      }
+    },
+    "/v1/turns/{turnId}/result": {
+      "parameters": [
+        { "$ref": "#/components/parameters/TurnId" }
+      ],
+      "get": {
+        "tags": ["turns"],
+        "operationId": "getTurnResult",
+        "description": "Returns the canonical durable result for a terminal turn. Active turns return 409.",
+        "responses": {
+          "200": {
+            "description": "Canonical terminal turn result.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TurnResult" }
+              }
+            }
+          },
+          "409": {
+            "description": "The turn is not terminal.",
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
@@ -313,7 +334,7 @@
       "post": {
         "tags": ["turns"],
         "operationId": "createTurn",
-        "description": "Queues one in-process agent turn. A session may have only one queued/running/waiting turn.",
+        "description": "Durably reserves and queues one agent turn. Reusing clientRequestId with identical input returns the original turn; reusing it with different input is rejected. Once reserved, an admission rejection is represented by the same durable failed turn. A session may have only one queued/running/waiting turn.",
         "requestBody": {
           "required": true,
           "content": {
@@ -324,7 +345,7 @@
         },
         "responses": {
           "202": {
-            "description": "Turn accepted.",
+            "description": "Turn durably accepted. Immediate admission failures are returned as a terminal failed turn.",
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/Turn" }
@@ -348,7 +369,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Process-local turn records.",
+            "description": "Durable turn records.",
             "content": {
               "application/json": {
                 "schema": {
@@ -404,6 +425,14 @@
               }
             }
           },
+          "202": {
+            "description": "Durable cancellation requested from the owning server instance.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Turn" }
+              }
+            }
+          },
           "default": { "$ref": "#/components/responses/Error" }
         }
       }
@@ -441,6 +470,15 @@
       "get": {
         "tags": ["requests"],
         "operationId": "listRequests",
+        "parameters": [
+          {
+            "name": "turnId",
+            "in": "query",
+            "required": false,
+            "description": "Restrict the bounded pending-request view to one turn.",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Pending approvals, root access prompts, and plan interactions.",
@@ -512,6 +550,14 @@
               }
             }
           },
+          "429": {
+            "description": "The global or per-tenant event subscriber limit was reached.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
           "default": { "$ref": "#/components/responses/Error" }
         }
       }
@@ -536,13 +582,13 @@
         "name": "turnId",
         "in": "path",
         "required": true,
-        "schema": { "type": "string" }
+        "schema": { "type": "string", "format": "uuid" }
       },
       "RequestId": {
         "name": "requestId",
         "in": "path",
         "required": true,
-        "schema": { "type": "string" }
+        "schema": { "type": "string", "format": "uuid" }
       }
     },
     "responses": {
@@ -669,6 +715,11 @@
       "CreateTurn": {
         "type": "object",
         "properties": {
+          "clientRequestId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional for legacy callers. Supplying a stable UUID makes turn creation idempotent."
+          },
           "input": { "type": "string", "minLength": 1 }
         },
         "required": ["input"],
@@ -677,8 +728,9 @@
       "Turn": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
+          "id": { "type": "string", "format": "uuid" },
           "sessionId": { "type": "string" },
+          "clientRequestId": { "type": "string", "format": "uuid" },
           "status": {
             "type": "string",
             "enum": ["queued", "running", "waiting_for_input", "completed", "failed", "cancelled"]
@@ -688,7 +740,42 @@
           "finishedAt": { "type": ["string", "null"], "format": "date-time" },
           "error": { "type": ["string", "null"] }
         },
-        "required": ["id", "sessionId", "status", "createdAt", "startedAt", "finishedAt", "error"]
+        "required": ["id", "sessionId", "clientRequestId", "status", "createdAt", "startedAt", "finishedAt", "error"]
+      },
+      "TurnCompletion": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": ["completed", "incomplete"]
+          },
+          "reason": { "type": "string" },
+          "reasoningTokens": { "type": ["integer", "null"], "minimum": 0 }
+        },
+        "required": ["status"]
+      },
+      "TurnOutput": {
+        "type": "object",
+        "properties": {
+          "responseId": { "type": "string" },
+          "assistantText": { "type": ["string", "null"] },
+          "assistantTextTruncated": { "type": "boolean" },
+          "completion": { "$ref": "#/components/schemas/TurnCompletion" }
+        },
+        "required": ["responseId", "assistantText", "assistantTextTruncated", "completion"]
+      },
+      "TurnResult": {
+        "type": "object",
+        "properties": {
+          "turn": { "$ref": "#/components/schemas/Turn" },
+          "output": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/TurnOutput" },
+              { "type": "null" }
+            ]
+          }
+        },
+        "required": ["turn", "output"]
       },
       "Agent": {
         "type": "object",
@@ -703,8 +790,8 @@
       "HumanRequest": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "turnId": { "type": "string" },
+          "id": { "type": "string", "format": "uuid" },
+          "turnId": { "type": "string", "format": "uuid" },
           "sessionId": { "type": "string" },
           "kind": {
             "type": "string",

--- a/packages/agent-server/openapi.json
+++ b/packages/agent-server/openapi.json
@@ -462,6 +462,14 @@
               }
             }
           },
+          "409": {
+            "description": "The turn exists, but its process-local agent snapshot is unavailable on this server instance.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorEnvelope" }
+              }
+            }
+          },
           "default": { "$ref": "#/components/responses/Error" }
         }
       }

--- a/packages/agent-server/src/Agent/Server.hs
+++ b/packages/agent-server/src/Agent/Server.hs
@@ -54,6 +54,8 @@ runServer = do
                                 Backend
                                     { backendTurnBoundaryGuard =
                                         turnBoundaryGuard
+                                    , backendTurnPersistence =
+                                        turnPersistence
                                     , backendRunTurn = runTurn
                                     } = backend
                                 supervisorConfig = SupervisorConfig
@@ -73,9 +75,10 @@ runServer = do
                                         config.resolvedEventReplayLimit
                                     }
                             bracket
-                                (newSupervisorWithBoundaryGuard
+                                (newSupervisorWithBoundaryGuardAndPersistence
                                     supervisorConfig
                                     turnBoundaryGuard
+                                    turnPersistence
                                     runTurn)
                                 closeSupervisor
                                 \supervisor -> do

--- a/packages/agent-server/src/Agent/Server/Application.hs
+++ b/packages/agent-server/src/Agent/Server/Application.hs
@@ -31,6 +31,7 @@ import Agent.Server.Supervisor
     , submitReservedTurnChecked
     , subscribeEvents
     , trySubmitReservedTurnChecked
+    , withSessionCleanup
     , withSessionMutation
     )
 import Agent.Server.Types
@@ -47,7 +48,7 @@ import Control.Exception.Safe
     , onException
     , tryAny
     )
-import Control.Monad (foldM)
+import Control.Monad (foldM, void)
 import Data.Aeson
     ( FromJSON
     , Value
@@ -528,18 +529,18 @@ turnAgentsResponse
     -> [Header]
     -> IO (Either ApiError Response)
 turnAgentsResponse supervisor boundary rawTurnId headers =
-    lookupTurnAgents
-        supervisor
-        boundary
-        (TurnId rawTurnId) >>= \case
-            Nothing -> pure (Left turnNotFound)
-            Just agents ->
-                pure $
-                    Right $
-                        jsonResponse
-                            status200
-                            headers
-                            (object ["data" .= agents])
+    case canonicalTurnId rawTurnId of
+        Nothing -> pure (Left turnNotFound)
+        Just turnId ->
+            lookupTurnAgents supervisor boundary turnId >>= \case
+                Nothing -> pure (Left turnNotFound)
+                Just agents ->
+                    pure $
+                        Right $
+                            jsonResponse
+                                status200
+                                headers
+                                (object ["data" .= agents])
 
 humanRequestsResponse
     :: Supervisor
@@ -592,7 +593,7 @@ resolveHumanRequestResponse
                 resolveHumanRequest
                     supervisor
                     boundary
-                    (RequestId rawRequestId)
+                    (RequestId (Text.toLower rawRequestId))
                     response >>= \case
                         Left message ->
                             pure $
@@ -715,21 +716,26 @@ createTurn backend supervisor boundary sessionId request
             >>= completeAdmission reserved
 
     abandonCreatedReservation reserved =
-        lookupTurn
-            supervisor
-            boundary
-            reserved.turnRecordId
-            >>= \case
-                Just _ -> pure ()
-                Nothing -> do
-                    cancelledAt <- getCurrentTime
-                    _ <-
-                        persistTurnTerminalEventually
-                            backend
-                            reserved
-                            cancelledAt
-                            TurnWasCancelled
-                    pure ()
+        void $
+            withSessionCleanup
+                supervisor
+                reserved.turnRecordBoundary
+                reserved.turnRecordSessionId
+                ( lookupTurn
+                    supervisor
+                    boundary
+                    reserved.turnRecordId
+                    >>= \case
+                        Just _ -> pure ()
+                        Nothing -> do
+                            cancelledAt <- getCurrentTime
+                            void $
+                                persistTurnTerminalEventually
+                                    backend
+                                    reserved
+                                    cancelledAt
+                                    TurnWasCancelled
+                )
 
     completeAdmission reserved result =
         case firstCheckedSubmitError result of
@@ -816,10 +822,9 @@ findTurn
     -> Text
     -> IO (Either ApiError TurnRecord)
 findTurn backend supervisor boundary rawTurnId = do
-    if not (isUUIDText rawTurnId)
-        then pure (Left turnNotFound)
-        else do
-            let turnId = TurnId rawTurnId
+    case canonicalTurnId rawTurnId of
+        Nothing -> pure (Left turnNotFound)
+        Just turnId -> do
             backend.backendLookupTurn boundary turnId >>= \case
                 Left err -> pure (Left err)
                 Right Nothing -> pure (Left turnNotFound)
@@ -874,9 +879,7 @@ cancelKnownTurn
     -> Text
     -> IO (Either ApiError (Status, TurnRecord))
 cancelKnownTurn backend supervisor boundary rawTurnId
-    | not (isUUIDText rawTurnId) =
-        pure (Left turnNotFound)
-    | otherwise =
+    | Just turnId <- canonicalTurnId rawTurnId =
         cancelTurn supervisor boundary turnId >>= \case
             Right turn -> pure (Right (status200, turn))
             Left "turn not found" ->
@@ -924,8 +927,9 @@ cancelKnownTurn backend supervisor boundary rawTurnId
                                                         )
             Left message ->
                 pure (Left (cancellationError message))
+    | otherwise =
+        pure (Left turnNotFound)
   where
-    turnId = TurnId rawTurnId
     cancellationError message =
         ApiError
             { apiErrorStatus = 503
@@ -940,12 +944,12 @@ findTurnResult
     -> Text
     -> IO (Either ApiError TurnResult)
 findTurnResult backend boundary rawTurnId =
-    if not (isUUIDText rawTurnId)
-        then pure (Left turnNotFound)
-        else
+    case canonicalTurnId rawTurnId of
+        Nothing -> pure (Left turnNotFound)
+        Just turnId ->
             backend.backendLookupTurnResult
                 boundary
-                (TurnId rawTurnId)
+                turnId
                 >>= \case
                     Left err -> pure (Left err)
                     Right Nothing -> pure (Left turnNotFound)
@@ -1415,7 +1419,7 @@ queryOptionalTurnId request =
     queryOptionalText "turnId" request >>= \case
         Nothing -> Right Nothing
         Just raw
-            | isUUIDText raw -> Right (Just (TurnId raw))
+            | Just turnId <- canonicalTurnId raw -> Right (Just turnId)
             | otherwise ->
                 Left ApiError
                     { apiErrorStatus = 400
@@ -1423,6 +1427,11 @@ queryOptionalTurnId request =
                     , apiErrorMessage = "turnId must be a UUID"
                     , apiErrorDetails = Nothing
                     }
+
+canonicalTurnId :: Text -> Maybe TurnId
+canonicalTurnId raw
+    | isUUIDText raw = Just (TurnId (Text.toLower raw))
+    | otherwise = Nothing
 
 queryOptionalInteger
     :: ByteString

--- a/packages/agent-server/src/Agent/Server/Application.hs
+++ b/packages/agent-server/src/Agent/Server/Application.hs
@@ -13,22 +13,24 @@ import Agent.Server.Auth
     , corsResponseHeaders
     , isCorsPreflight
     )
-import Agent.Server.Backend (Backend(..))
-import Agent.Server.Identifier (newUUIDv7Text)
+import Agent.Server.Backend (Backend(..), SessionMutationLease(..))
+import Agent.Server.Identifier (isUUIDText, newUUIDv7Text)
 import Agent.Server.Supervisor
     ( CheckedSubmitError(..)
     , EventSubscriptionError(..)
     , SubmitError(..)
     , SessionMutationError(..)
     , Supervisor
+    , TurnPersistence(..)
     , cancelTurn
     , listHumanRequests
     , listTurns
     , lookupTurn
     , lookupTurnAgents
     , resolveHumanRequest
-    , submitTurnChecked
+    , submitReservedTurnChecked
     , subscribeEvents
+    , trySubmitReservedTurnChecked
     , withSessionMutation
     )
 import Agent.Server.Types
@@ -41,6 +43,8 @@ import Control.Concurrent.STM
     )
 import Control.Exception.Safe
     ( finally
+    , mask
+    , onException
     , tryAny
     )
 import Control.Monad (foldM)
@@ -63,9 +67,14 @@ import Data.ByteString.Builder
     )
 import Data.ByteString.Char8 qualified as ByteString8
 import Data.ByteString.Lazy qualified as LazyByteString
+import Data.List (sortOn)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Ord (Down (..))
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TextEncoding
+import Data.Time.Clock (UTCTime, getCurrentTime)
 import Network.HTTP.Types
     ( Header
     , Status
@@ -255,16 +264,19 @@ dispatchBoundary
             createTurnResponse
                 config backend supervisor boundary sessionId headers request
         ("GET", ["v1", "turns"]) ->
-            listTurnsResponse supervisor boundary headers request
+            listTurnsResponse backend supervisor boundary headers request
         ("GET", ["v1", "turns", rawTurnId]) ->
-            findTurn supervisor boundary rawTurnId >>= pure
+            findTurn backend supervisor boundary rawTurnId >>= pure
+                . fmap (jsonResponse status200 headers . toJSONValue)
+        ("GET", ["v1", "turns", rawTurnId, "result"]) ->
+            findTurnResult backend boundary rawTurnId >>= pure
                 . fmap (jsonResponse status200 headers . toJSONValue)
         ("POST", ["v1", "turns", rawTurnId, "cancel"]) ->
-            cancelTurnResponse supervisor boundary rawTurnId headers
+            cancelTurnResponse backend supervisor boundary rawTurnId headers
         ("GET", ["v1", "turns", rawTurnId, "agents"]) ->
             turnAgentsResponse supervisor boundary rawTurnId headers
         ("GET", ["v1", "requests"]) ->
-            humanRequestsResponse supervisor boundary headers
+            humanRequestsResponse supervisor boundary headers request
         ("POST", ["v1", "requests", rawRequestId, "resolve"]) ->
             resolveHumanRequestResponse
                 config supervisor boundary rawRequestId headers request
@@ -358,6 +370,7 @@ patchSessionResponse
                             })
                 else
                     runSessionMutation
+                        backend
                         supervisor
                         boundary
                         sessionId
@@ -380,6 +393,7 @@ deleteSessionResponse
     -> IO (Either ApiError Response)
 deleteSessionResponse backend supervisor boundary sessionId headers =
     runSessionMutation
+        backend
         supervisor
         boundary
         sessionId
@@ -436,6 +450,7 @@ forkSessionResponse
         config backend supervisor boundary sessionId headers request =
     withJsonBody config request \body ->
         runSessionMutation
+            backend
             supervisor
             boundary
             sessionId
@@ -464,42 +479,47 @@ createTurnResponse
                 . fmap (jsonResponse status202 headers . toJSONValue)
 
 listTurnsResponse
-    :: Supervisor
+    :: Backend
+    -> Supervisor
     -> AccessBoundary
     -> [Header]
     -> Request
     -> IO (Either ApiError Response)
-listTurnsResponse supervisor boundary headers request =
+listTurnsResponse backend supervisor boundary headers request =
     case queryOptionalText "sessionId" request of
         Left err -> pure (Left err)
-        Right sessionId -> do
-            turns <- listTurns supervisor boundary sessionId
-            pure $
-                Right $
-                    jsonResponse
-                        status200
-                        headers
-                        (object ["data" .= turns])
+        Right sessionId ->
+            listKnownTurns
+                backend
+                supervisor
+                boundary
+                sessionId >>= pure
+                    . fmap
+                        (\turns ->
+                            jsonResponse
+                                status200
+                                headers
+                                (object ["data" .= turns]))
 
 cancelTurnResponse
-    :: Supervisor
+    :: Backend
+    -> Supervisor
     -> AccessBoundary
     -> Text
     -> [Header]
     -> IO (Either ApiError Response)
-cancelTurnResponse supervisor boundary rawTurnId headers =
-    cancelTurn
+cancelTurnResponse backend supervisor boundary rawTurnId headers =
+    cancelKnownTurn
+        backend
         supervisor
         boundary
-        (TurnId rawTurnId) >>= \case
-            Left _ -> pure (Left turnNotFound)
-            Right turn ->
-                pure $
-                    Right $
-                        jsonResponse
-                            status200
-                            headers
-                            (toJSONValue turn)
+        rawTurnId >>= pure
+            . fmap
+                (\(responseStatus, turn) ->
+                    jsonResponse
+                        responseStatus
+                        headers
+                        (toJSONValue turn))
 
 turnAgentsResponse
     :: Supervisor
@@ -525,15 +545,29 @@ humanRequestsResponse
     :: Supervisor
     -> AccessBoundary
     -> [Header]
+    -> Request
     -> IO (Either ApiError Response)
-humanRequestsResponse supervisor boundary headers = do
-    requests <- listHumanRequests supervisor boundary
-    pure $
-        Right $
-            jsonResponse
-                status200
-                headers
-                (object ["data" .= requests])
+humanRequestsResponse supervisor boundary headers request =
+    case queryOptionalTurnId request of
+        Left err -> pure (Left err)
+        Right turnId ->
+            listHumanRequests supervisor boundary turnId >>= \case
+                Left message ->
+                    pure $
+                        Left
+                            ApiError
+                                { apiErrorStatus = 503
+                                , apiErrorCode = "store_unavailable"
+                                , apiErrorMessage = message
+                                , apiErrorDetails = Nothing
+                                }
+                Right requests ->
+                    pure $
+                        Right $
+                            jsonResponse
+                                status200
+                                headers
+                                (object ["data" .= requests])
 
 resolveHumanRequestResponse
     :: ApplicationConfig
@@ -545,38 +579,41 @@ resolveHumanRequestResponse
     -> IO (Either ApiError Response)
 resolveHumanRequestResponse
         config supervisor boundary rawRequestId headers request =
-    withJsonBody config request \(body :: ResolveRequest) -> do
-        let response = HumanResponse
-                { humanResponseDecision =
-                    body.resolveRequestDecision
-                , humanResponseValue =
-                    body.resolveRequestValue
-                }
-        resolveHumanRequest
-            supervisor
-            boundary
-            (RequestId rawRequestId)
-            response >>= \case
-                Left message ->
-                    pure $
-                        Left ApiError
-                            { apiErrorStatus =
-                                if "not found"
-                                    `Text.isInfixOf`
-                                        Text.toLower message
-                                then 404
-                                else 409
-                            , apiErrorCode = "request_not_resolved"
-                            , apiErrorMessage = message
-                            , apiErrorDetails = Nothing
-                            }
-                Right resolved ->
-                    pure $
-                        Right $
-                            jsonResponse
-                                status200
-                                headers
-                                (toJSONValue resolved)
+    if not (isUUIDText rawRequestId)
+        then pure (Left humanRequestNotFound)
+        else
+            withJsonBody config request \(body :: ResolveRequest) -> do
+                let response = HumanResponse
+                        { humanResponseDecision =
+                            body.resolveRequestDecision
+                        , humanResponseValue =
+                            body.resolveRequestValue
+                        }
+                resolveHumanRequest
+                    supervisor
+                    boundary
+                    (RequestId rawRequestId)
+                    response >>= \case
+                        Left message ->
+                            pure $
+                                Left ApiError
+                                    { apiErrorStatus =
+                                        if "not found"
+                                            `Text.isInfixOf`
+                                                Text.toLower message
+                                        then 404
+                                        else 409
+                                    , apiErrorCode = "request_not_resolved"
+                                    , apiErrorMessage = message
+                                    , apiErrorDetails = Nothing
+                                    }
+                        Right resolved ->
+                            pure $
+                                Right $
+                                    jsonResponse
+                                        status200
+                                        headers
+                                        (toJSONValue resolved)
 
 createTurn
     :: Backend
@@ -594,20 +631,118 @@ createTurn backend supervisor boundary sessionId request
                 , apiErrorMessage = "turn input must not be empty"
                 , apiErrorDetails = Nothing
                 }
-    | otherwise =
-        let spec = TurnSpec
+    | otherwise = do
+        now <- getCurrentTime
+        turnId <- TurnId <$> newUUIDv7Text
+        let clientRequestId =
+                fromMaybe
+                    (ClientRequestId turnId.unTurnId)
+                    request.createTurnClientRequestId
+            spec = TurnSpec
                 { turnSpecSessionId = sessionId
+                , turnSpecClientRequestId = clientRequestId
                 , turnSpecPrompt = request.createTurnInput
                 , turnSpecBoundary = boundary
                 }
             validateSession =
                 fmap (fmap (const ())) $
                     backend.backendGetSession boundary sessionId
-        in
-            submitTurnChecked
-                supervisor
-                spec
-                validateSession >>= pure . firstCheckedSubmitError
+        validateSession >>= \case
+            Left err -> pure (Left err)
+            Right () ->
+                mask \restore -> do
+                    reservation <-
+                        restore $
+                            backend.backendReserveTurn
+                                boundary
+                                sessionId
+                                clientRequestId
+                                request.createTurnInput
+                                turnId
+                                now
+                    case reservation of
+                        Left err -> pure (Left err)
+                        Right (TurnReservationExisting existing) ->
+                            pure (Right existing)
+                        Right (TurnReservationExistingOwned existing)
+                            | existing.turnRecordStatus == TurnQueued ->
+                                restore $
+                                    lookupTurn
+                                        supervisor
+                                        boundary
+                                        existing.turnRecordId
+                                        >>= \case
+                                            Just admitted ->
+                                                pure (Right admitted)
+                                            Nothing ->
+                                                admitOwnedReservation
+                                                    existing
+                                                    spec
+                                                    validateSession
+                            | otherwise ->
+                                pure (Right existing)
+                        Right (TurnReservationCreated reserved) ->
+                            restore
+                                ( admitCreatedReservation
+                                    reserved
+                                    spec
+                                    validateSession
+                                )
+                                `onException`
+                                    abandonCreatedReservation reserved
+  where
+    admitOwnedReservation reserved spec validateSession =
+        trySubmitReservedTurnChecked
+            supervisor
+            spec
+            reserved
+            validateSession
+            >>= \case
+                Left (SubmitValidationRejected SubmitSessionBusy) ->
+                    lookupTurn
+                        supervisor
+                        boundary
+                        reserved.turnRecordId
+                        >>= pure . Right . fromMaybe reserved
+                result -> completeAdmission reserved result
+
+    admitCreatedReservation reserved spec validateSession =
+        submitReservedTurnChecked
+            supervisor
+            spec
+            reserved
+            validateSession
+            >>= completeAdmission reserved
+
+    abandonCreatedReservation reserved =
+        lookupTurn
+            supervisor
+            boundary
+            reserved.turnRecordId
+            >>= \case
+                Just _ -> pure ()
+                Nothing -> do
+                    cancelledAt <- getCurrentTime
+                    _ <-
+                        persistTurnTerminalEventually
+                            backend
+                            reserved
+                            cancelledAt
+                            TurnWasCancelled
+                    pure ()
+
+    completeAdmission reserved result =
+        case firstCheckedSubmitError result of
+            Right admitted ->
+                pure (Right admitted)
+            Left err -> do
+                rejectedAt <- getCurrentTime
+                Right
+                    <$> persistTurnTerminalEventually
+                        backend
+                        reserved
+                        rejectedAt
+                        (TurnErrored err.apiErrorMessage)
 
 firstCheckedSubmitError
     :: Either (CheckedSubmitError ApiError) TurnRecord
@@ -654,25 +789,201 @@ firstSubmitError = \case
             }
     Right turn -> Right turn
 
+persistTurnTerminalEventually
+    :: Backend
+    -> TurnRecord
+    -> UTCTime
+    -> TurnTerminalOutcome
+    -> IO TurnRecord
+persistTurnTerminalEventually backend record finishedAt outcome =
+    go 100_000
+  where
+    go retryDelay =
+        backend.backendTurnPersistence.turnPersistenceTerminal
+            record
+            finishedAt
+            outcome
+            >>= \case
+                Right canonical -> pure canonical
+                Left _ -> do
+                    threadDelay retryDelay
+                    go (min 2_000_000 (retryDelay * 2))
+
 findTurn
-    :: Supervisor
+    :: Backend
+    -> Supervisor
     -> AccessBoundary
     -> Text
     -> IO (Either ApiError TurnRecord)
-findTurn supervisor boundary rawTurnId =
-    lookupTurn supervisor boundary (TurnId rawTurnId) >>= \case
-        Nothing -> pure (Left turnNotFound)
-        Just turn -> pure (Right turn)
+findTurn backend supervisor boundary rawTurnId = do
+    if not (isUUIDText rawTurnId)
+        then pure (Left turnNotFound)
+        else do
+            let turnId = TurnId rawTurnId
+            backend.backendLookupTurn boundary turnId >>= \case
+                Left err -> pure (Left err)
+                Right Nothing -> pure (Left turnNotFound)
+                Right (Just durable)
+                    | isActiveTurn durable ->
+                        lookupTurn supervisor boundary turnId
+                            >>= pure . Right . maybe durable id
+                    | otherwise -> pure (Right durable)
+
+listKnownTurns
+    :: Backend
+    -> Supervisor
+    -> AccessBoundary
+    -> Maybe Text
+    -> IO (Either ApiError [TurnRecord])
+listKnownTurns backend supervisor boundary sessionId =
+    backend.backendListTurns boundary sessionId >>= \case
+        Left err -> pure (Left err)
+        Right durable -> do
+            active <- listTurns supervisor boundary sessionId
+            let activeById =
+                    Map.fromList
+                        [ (turn.turnRecordId, turn)
+                        | turn <- active
+                        ]
+                durableIds =
+                    Map.fromList
+                        [ (turn.turnRecordId, ())
+                        | turn <- durable
+                        ]
+                merged =
+                    [ if isActiveTurn turn
+                        then
+                            Map.findWithDefault
+                                turn
+                                turn.turnRecordId
+                                activeById
+                        else turn
+                    | turn <- durable
+                    ]
+                        <> [ turn
+                           | turn <- active
+                           , Map.notMember turn.turnRecordId durableIds
+                           ]
+            pure . Right $
+                sortOn (Down . (.turnRecordCreatedAt)) merged
+
+cancelKnownTurn
+    :: Backend
+    -> Supervisor
+    -> AccessBoundary
+    -> Text
+    -> IO (Either ApiError (Status, TurnRecord))
+cancelKnownTurn backend supervisor boundary rawTurnId
+    | not (isUUIDText rawTurnId) =
+        pure (Left turnNotFound)
+    | otherwise =
+        cancelTurn supervisor boundary turnId >>= \case
+            Right turn -> pure (Right (status200, turn))
+            Left "turn not found" ->
+                backend.backendLookupTurn boundary turnId >>= \case
+                    Left err -> pure (Left err)
+                    Right Nothing -> pure (Left turnNotFound)
+                    Right (Just turn)
+                        | not (isActiveTurn turn) ->
+                            pure (Right (status200, turn))
+                        | otherwise -> do
+                            requestedAt <- getCurrentTime
+                            backend.backendRequestTurnCancellation
+                                boundary
+                                turnId
+                                requestedAt
+                                >>= \case
+                                    Left err -> pure (Left err)
+                                    Right (Just (True, owned)) -> do
+                                        cancelledAt <- getCurrentTime
+                                        canonical <-
+                                            persistTurnTerminalEventually
+                                                backend
+                                                owned
+                                                cancelledAt
+                                                TurnWasCancelled
+                                        pure
+                                            (Right (status200, canonical))
+                                    Right (Just (False, requested)) ->
+                                        pure
+                                            (Right (status202, requested))
+                                    Right Nothing ->
+                                        backend.backendLookupTurn
+                                            boundary
+                                            turnId
+                                            >>= \case
+                                                Left err -> pure (Left err)
+                                                Right Nothing ->
+                                                    pure (Left turnNotFound)
+                                                Right (Just canonical) ->
+                                                    pure
+                                                        ( Right
+                                                            ( status200
+                                                            , canonical
+                                                            )
+                                                        )
+            Left message ->
+                pure (Left (cancellationError message))
+  where
+    turnId = TurnId rawTurnId
+    cancellationError message =
+        ApiError
+            { apiErrorStatus = 503
+            , apiErrorCode = "turn_cancellation_failed"
+            , apiErrorMessage = message
+            , apiErrorDetails = Nothing
+            }
+
+findTurnResult
+    :: Backend
+    -> AccessBoundary
+    -> Text
+    -> IO (Either ApiError TurnResult)
+findTurnResult backend boundary rawTurnId =
+    if not (isUUIDText rawTurnId)
+        then pure (Left turnNotFound)
+        else
+            backend.backendLookupTurnResult
+                boundary
+                (TurnId rawTurnId)
+                >>= \case
+                    Left err -> pure (Left err)
+                    Right Nothing -> pure (Left turnNotFound)
+                    Right (Just result)
+                        | isActiveTurn result.turnResultTurn ->
+                            pure . Left $
+                                ApiError
+                                    { apiErrorStatus = 409
+                                    , apiErrorCode = "turn_not_terminal"
+                                    , apiErrorMessage =
+                                        "the turn has not reached a terminal state"
+                                    , apiErrorDetails =
+                                        Just
+                                            ( toJSONValue
+                                                result.turnResultTurn
+                                            )
+                                    }
+                        | otherwise -> pure (Right result)
+
+isActiveTurn :: TurnRecord -> Bool
+isActiveTurn turn =
+    turn.turnRecordStatus
+        `elem` [TurnQueued, TurnRunning, TurnWaitingForInput]
 
 runSessionMutation
-    :: Supervisor
+    :: Backend
+    -> Supervisor
     -> AccessBoundary
     -> Text
     -> IO (Either ApiError value)
     -> IO (Either ApiError value)
-runSessionMutation supervisor boundary sessionId action =
+runSessionMutation backend supervisor boundary sessionId action =
     withSessionMutation
-        supervisor boundary sessionId action >>= \case
+        supervisor
+        boundary
+        sessionId
+        durableMutation
+        >>= \case
             Left SessionMutationBusy ->
                 pure $
                     Left ApiError
@@ -692,6 +1003,38 @@ runSessionMutation supervisor boundary sessionId action =
                         , apiErrorDetails = Nothing
                         }
             Right result -> pure result
+  where
+    durableMutation =
+        mask \restore -> do
+            now <- getCurrentTime
+            reservation <-
+                backend.backendReserveSessionMutation
+                    boundary
+                    sessionId
+                    now
+            case reservation of
+                Left err -> pure (Left err)
+                Right Nothing -> pure (Left sessionBusyError)
+                Right
+                    ( Just
+                            SessionMutationLease
+                                { runSessionMutationLease = runMutation
+                                , releaseSessionMutationLease = releaseMutation
+                                }
+                        ) -> do
+                        guarded <-
+                            restore (runMutation action)
+                                `finally` releaseMutation
+                        pure (guarded >>= id)
+
+    sessionBusyError =
+        ApiError
+            { apiErrorStatus = 409
+            , apiErrorCode = "session_busy"
+            , apiErrorMessage =
+                "the session has an active turn or mutation"
+            , apiErrorDetails = Nothing
+            }
 
 createEventResponse
     :: Backend
@@ -1067,6 +1410,20 @@ queryLimit name defaultValue maximum request =
                         , apiErrorDetails = Nothing
                         }
 
+queryOptionalTurnId :: Request -> Either ApiError (Maybe TurnId)
+queryOptionalTurnId request =
+    queryOptionalText "turnId" request >>= \case
+        Nothing -> Right Nothing
+        Just raw
+            | isUUIDText raw -> Right (Just (TurnId raw))
+            | otherwise ->
+                Left ApiError
+                    { apiErrorStatus = 400
+                    , apiErrorCode = "invalid_query"
+                    , apiErrorMessage = "turnId must be a UUID"
+                    , apiErrorDetails = Nothing
+                    }
+
 queryOptionalInteger
     :: ByteString
     -> Request
@@ -1182,6 +1539,14 @@ turnNotFound = ApiError
     { apiErrorStatus = 404
     , apiErrorCode = "turn_not_found"
     , apiErrorMessage = "turn not found"
+    , apiErrorDetails = Nothing
+    }
+
+humanRequestNotFound :: ApiError
+humanRequestNotFound = ApiError
+    { apiErrorStatus = 404
+    , apiErrorCode = "request_not_found"
+    , apiErrorMessage = "request not found"
     , apiErrorDetails = Nothing
     }
 

--- a/packages/agent-server/src/Agent/Server/Application.hs
+++ b/packages/agent-server/src/Agent/Server/Application.hs
@@ -882,8 +882,18 @@ listKnownTurns backend supervisor boundary sessionId =
                            | turn <- active
                            , Map.notMember turn.turnRecordId durableIds
                            ]
-            pure . Right $
-                sortOn (Down . (.turnRecordCreatedAt)) merged
+            pure . Right . take maximumTurnPageSize $
+                sortOn
+                    ( \turn ->
+                        Down
+                            ( turn.turnRecordCreatedAt
+                            , turn.turnRecordId
+                            )
+                    )
+                    merged
+
+maximumTurnPageSize :: Int
+maximumTurnPageSize = 200
 
 cancelKnownTurn
     :: Backend

--- a/packages/agent-server/src/Agent/Server/Application.hs
+++ b/packages/agent-server/src/Agent/Server/Application.hs
@@ -18,6 +18,7 @@ import Agent.Server.Identifier (isUUIDText, newUUIDv7Text)
 import Agent.Server.Supervisor
     ( CheckedSubmitError(..)
     , EventSubscriptionError(..)
+    , HumanRequestResolutionError(..)
     , SubmitError(..)
     , SessionMutationError(..)
     , Supervisor
@@ -275,7 +276,7 @@ dispatchBoundary
         ("POST", ["v1", "turns", rawTurnId, "cancel"]) ->
             cancelTurnResponse backend supervisor boundary rawTurnId headers
         ("GET", ["v1", "turns", rawTurnId, "agents"]) ->
-            turnAgentsResponse supervisor boundary rawTurnId headers
+            turnAgentsResponse backend supervisor boundary rawTurnId headers
         ("GET", ["v1", "requests"]) ->
             humanRequestsResponse supervisor boundary headers request
         ("POST", ["v1", "requests", rawRequestId, "resolve"]) ->
@@ -523,17 +524,23 @@ cancelTurnResponse backend supervisor boundary rawTurnId headers =
                         (toJSONValue turn))
 
 turnAgentsResponse
-    :: Supervisor
+    :: Backend
+    -> Supervisor
     -> AccessBoundary
     -> Text
     -> [Header]
     -> IO (Either ApiError Response)
-turnAgentsResponse supervisor boundary rawTurnId headers =
+turnAgentsResponse backend supervisor boundary rawTurnId headers =
     case canonicalTurnId rawTurnId of
         Nothing -> pure (Left turnNotFound)
         Just turnId ->
             lookupTurnAgents supervisor boundary turnId >>= \case
-                Nothing -> pure (Left turnNotFound)
+                Nothing ->
+                    backend.backendLookupTurn boundary turnId >>= \case
+                        Left err -> pure (Left err)
+                        Right Nothing -> pure (Left turnNotFound)
+                        Right (Just _) ->
+                            pure (Left turnAgentsUnavailable)
                 Just agents ->
                     pure $
                         Right $
@@ -595,15 +602,21 @@ resolveHumanRequestResponse
                     boundary
                     (RequestId (Text.toLower rawRequestId))
                     response >>= \case
-                        Left message ->
+                        Left HumanRequestResolutionNotFound ->
+                            pure (Left humanRequestNotFound)
+                        Left
+                            (HumanRequestResolutionStoreUnavailable message) ->
                             pure $
                                 Left ApiError
-                                    { apiErrorStatus =
-                                        if "not found"
-                                            `Text.isInfixOf`
-                                                Text.toLower message
-                                        then 404
-                                        else 409
+                                    { apiErrorStatus = 503
+                                    , apiErrorCode = "store_unavailable"
+                                    , apiErrorMessage = message
+                                    , apiErrorDetails = Nothing
+                                    }
+                        Left (HumanRequestResolutionConflict message) ->
+                            pure $
+                                Left ApiError
+                                    { apiErrorStatus = 409
                                     , apiErrorCode = "request_not_resolved"
                                     , apiErrorMessage = message
                                     , apiErrorDetails = Nothing
@@ -1548,6 +1561,15 @@ turnNotFound = ApiError
     { apiErrorStatus = 404
     , apiErrorCode = "turn_not_found"
     , apiErrorMessage = "turn not found"
+    , apiErrorDetails = Nothing
+    }
+
+turnAgentsUnavailable :: ApiError
+turnAgentsUnavailable = ApiError
+    { apiErrorStatus = 409
+    , apiErrorCode = "turn_agents_unavailable"
+    , apiErrorMessage =
+        "turn agent snapshot is unavailable on this server instance"
     , apiErrorDetails = Nothing
     }
 

--- a/packages/agent-server/src/Agent/Server/Backend.hs
+++ b/packages/agent-server/src/Agent/Server/Backend.hs
@@ -6,15 +6,24 @@
 -- 'backendContinueBoundary' before every write.
 module Agent.Server.Backend
     ( Backend(..)
+    , SessionMutationLease(..)
     ) where
 
 import Agent.Server.Supervisor
     ( TurnBoundaryGuard
     , TurnControl
+    , TurnPersistence
     )
 import Agent.Server.Types
 import Data.Aeson (Value)
 import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+
+data SessionMutationLease = SessionMutationLease
+    { runSessionMutationLease ::
+        forall value. IO value -> IO (Either ApiError value)
+    , releaseSessionMutationLease :: IO ()
+    }
 
 data Backend = Backend
     { backendAdmitBoundary
@@ -66,6 +75,46 @@ data Backend = Backend
             -> ForkSessionRequest
             -> IO (Either ApiError Value)
             )
+    , backendReserveSessionMutation
+        :: !( AccessBoundary
+            -> Text
+            -> UTCTime
+            -> IO (Either ApiError (Maybe SessionMutationLease))
+            )
+    , backendReserveTurn
+        :: !( AccessBoundary
+            -> Text
+            -> ClientRequestId
+            -> Text
+            -> TurnId
+            -> UTCTime
+            -> IO (Either ApiError TurnReservation)
+            )
+    , backendLookupTurn
+        :: !( AccessBoundary
+            -> TurnId
+            -> IO (Either ApiError (Maybe TurnRecord))
+            )
+    , backendListTurns
+        :: !( AccessBoundary
+            -> Maybe Text
+            -> IO (Either ApiError [TurnRecord])
+            )
+    , backendLookupTurnResult
+        :: !( AccessBoundary
+            -> TurnId
+            -> IO (Either ApiError (Maybe TurnResult))
+            )
+    , backendRequestTurnCancellation
+        :: !( AccessBoundary
+            -> TurnId
+            -> UTCTime
+            -> IO (Either ApiError (Maybe (Bool, TurnRecord)))
+            )
+    , backendTurnPersistence :: !TurnPersistence
     , backendRunTurn
-        :: !(TurnControl -> TurnSpec -> IO (Either Text ()))
+        :: !( TurnControl
+            -> TurnSpec
+            -> IO (Either Text TurnExecutionOutput)
+            )
     }

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -67,6 +67,7 @@ import Agent.CLI.Session
     )
 import Agent.CLI.Session.Codec (fromStoredMetadata)
 import Agent.Dialect (DialectId, dialectSlug)
+import Agent.Loop qualified as Loop
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider
     ( Provider(..)
@@ -91,12 +92,17 @@ import Agent.Server.Event
     , projectLoopEvent
     , projectPublicValue
     )
-import Agent.Server.Supervisor (TurnControl(..))
+import Agent.Server.Identifier (newUUIDv7Text)
+import Agent.Server.Runtime.TurnStore qualified as TurnStore
 import Agent.Server.Sandbox
     ( TenantSandbox
     , closeTenantSandbox
     , openTenantSandbox
     , composeSandboxTools
+    )
+import Agent.Server.Supervisor
+    ( TurnControl(..)
+    , TurnPersistence(..)
     )
 import Agent.Server.Tenant
     ( ResolvedTenant(..) )
@@ -118,7 +124,7 @@ import Agent.Store.Postgres.Tenant
     )
 import Agent.Store.Postgres.Session qualified as StoreSession
 import Agent.Store.Types
-    ( StoreError
+    ( StoreError(..)
     , renderStoreError
     )
 import Agent.ToolDispatch (ToolCall(..))
@@ -149,6 +155,7 @@ import Data.Aeson
     , (.=)
     )
 import Data.Bifunctor (first)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Int (Int64)
 import Data.List (find)
 import Data.Map.Strict (Map)
@@ -180,6 +187,7 @@ openServerRuntime
     :: ResolvedServerConfig
     -> IO (Either Text ServerRuntime)
 openServerRuntime config = mask \restore -> do
+    instanceId <- newUUIDv7Text
     case config.resolvedServerMode of
         MultiTenantMode multi -> do
             postgresConfig <-
@@ -191,11 +199,15 @@ openServerRuntime config = mask \restore -> do
                     Left err -> pure (Left (renderStoreError err))
                     Right stores -> do
                         manager <-
-                            newTenantRuntimeManager config multi stores
+                            newTenantRuntimeManager
+                                config
+                                multi
+                                stores
+                                instanceId
                         pure $
                             Right ServerRuntime
                                 { runtimeBackend =
-                                    multiTenantBackend manager
+                                    multiTenantBackend instanceId manager
                                 , runtimeClose =
                                     closeTenantRuntimeManager manager
                                         `finally`
@@ -206,36 +218,59 @@ openServerRuntime config = mask \restore -> do
                 managedPostgresConfigFromEnv config.resolvedStateDirectory
             restore (openStore postgresConfig) >>= \case
                 Left err -> pure (Left (renderStoreError err))
-                Right store -> do
-                    let root = sessionsRoot (unsafeEncodeUtf config.resolvedHome)
-                    nativeResult <-
-                        tryAny (restore (newNativeProcessRuntime root))
-                            `onException` closeStore store
-                    case nativeResult of
-                        Left _ -> do
-                            closeStore store
-                            pure
-                                (Left
-                                    "could not initialize the native agent runtime")
-                        Right native -> do
-                            let environment = RuntimeEnvironment
-                                    { environmentConfig = config
-                                    , environmentStore = store
-                                    , environmentNative = native
-                                    , environmentRoot = root
-                                    , environmentTenantId = localTenantId
-                                    , environmentHome =
-                                        config.resolvedHome
-                                    , environmentSandbox = Nothing
-                                    }
-                                backend = productionBackend environment
-                            pure $
-                                Right ServerRuntime
-                                    { runtimeBackend = backend
-                                    , runtimeClose =
-                                        closeNativeProcessRuntime native
+                Right store ->
+                    restore
+                        (TurnStore.openTurnStoreOwner store instanceId)
+                        >>= \case
+                            Left err -> do
+                                closeStore store
+                                pure (Left err)
+                            Right turnStoreOwner -> do
+                                let root =
+                                        sessionsRoot
+                                            (unsafeEncodeUtf config.resolvedHome)
+                                    closeOwnedStore =
+                                        TurnStore.closeTurnStoreOwner
+                                            turnStoreOwner
                                             `finally` closeStore store
-                                    }
+                                nativeResult <-
+                                    tryAny
+                                        (restore
+                                            (newNativeProcessRuntime root))
+                                        `onException` closeOwnedStore
+                                case nativeResult of
+                                    Left _ -> do
+                                        closeOwnedStore
+                                        pure
+                                            (Left
+                                                "could not initialize the native agent runtime")
+                                    Right native -> do
+                                        let environment = RuntimeEnvironment
+                                                { environmentConfig = config
+                                                , environmentStore = store
+                                                , environmentTurnStoreOwner =
+                                                    turnStoreOwner
+                                                , environmentNative = native
+                                                , environmentRoot = root
+                                                , environmentTenantId =
+                                                    localTenantId
+                                                , environmentHome =
+                                                    config.resolvedHome
+                                                , environmentSandbox = Nothing
+                                                }
+                                            backend =
+                                                productionBackend
+                                                    instanceId
+                                                    environment
+                                        pure $
+                                            Right ServerRuntime
+                                                { runtimeBackend = backend
+                                                , runtimeClose =
+                                                    closeRuntimeEnvironment
+                                                        environment
+                                                        `finally`
+                                                            closeStore store
+                                                }
 
 closeServerRuntime :: ServerRuntime -> IO ()
 closeServerRuntime = (.runtimeClose)
@@ -243,6 +278,7 @@ closeServerRuntime = (.runtimeClose)
 data RuntimeEnvironment = RuntimeEnvironment
     { environmentConfig :: !ResolvedServerConfig
     , environmentStore :: !Store
+    , environmentTurnStoreOwner :: !TurnStore.TurnStoreOwner
     , environmentNative :: !NativeProcessRuntime
     , environmentRoot :: !OsPath
     , environmentTenantId :: !TenantId
@@ -265,6 +301,7 @@ data TenantRuntimeManager = TenantRuntimeManager
     , tenantRuntimeMultiConfig :: !MultiTenantConfig
     , tenantRuntimeStores :: !TenantStoreManager
     , tenantRuntimeMaximum :: !Int
+    , tenantRuntimeInstanceId :: !Text
     , tenantRuntimeState :: !(MVar TenantRuntimeState)
     }
 
@@ -281,8 +318,9 @@ newTenantRuntimeManager
     :: ResolvedServerConfig
     -> MultiTenantConfig
     -> TenantStoreManager
+    -> Text
     -> IO TenantRuntimeManager
-newTenantRuntimeManager config multi stores = do
+newTenantRuntimeManager config multi stores instanceId = do
     state <- newMVar TenantRuntimeState
         { tenantRuntimeClosed = False
         , tenantRuntimeSlots = Map.empty
@@ -292,6 +330,7 @@ newTenantRuntimeManager config multi stores = do
         , tenantRuntimeMultiConfig = multi
         , tenantRuntimeStores = stores
         , tenantRuntimeMaximum = config.resolvedMaxActiveTenants
+        , tenantRuntimeInstanceId = instanceId
         , tenantRuntimeState = state
         }
 
@@ -459,20 +498,39 @@ createTenantRuntime manager tenant = mask \restore ->
                                             closeComponents
                                             pure (Left (storeApiError err))
                                         Right store ->
-                                            pure $
-                                                Right RuntimeEnvironment
-                                                    { environmentConfig =
-                                                        manager.tenantRuntimeConfig
-                                                    , environmentStore = store
-                                                    , environmentNative = native
-                                                    , environmentRoot = root
-                                                    , environmentTenantId =
-                                                        tenant.resolvedTenantId
-                                                    , environmentHome =
-                                                        tenant.resolvedTenantHome
-                                                    , environmentSandbox =
-                                                        Just sandbox
-                                                    }
+                                            restore
+                                                (TurnStore.openTurnStoreOwner
+                                                    store
+                                                    manager.tenantRuntimeInstanceId)
+                                                `onException` closeComponents
+                                                >>= \case
+                                                    Left err -> do
+                                                        closeComponents
+                                                        pure
+                                                            (Left
+                                                                (tenantRuntimeUnavailable
+                                                                    err))
+                                                    Right turnStoreOwner ->
+                                                        pure $
+                                                            Right
+                                                                RuntimeEnvironment
+                                                                    { environmentConfig =
+                                                                        manager.tenantRuntimeConfig
+                                                                    , environmentStore =
+                                                                        store
+                                                                    , environmentTurnStoreOwner =
+                                                                        turnStoreOwner
+                                                                    , environmentNative =
+                                                                        native
+                                                                    , environmentRoot =
+                                                                        root
+                                                                    , environmentTenantId =
+                                                                        tenant.resolvedTenantId
+                                                                    , environmentHome =
+                                                                        tenant.resolvedTenantHome
+                                                                    , environmentSandbox =
+                                                                        Just sandbox
+                                                                    }
 
 closeTenantRuntimeManager :: TenantRuntimeManager -> IO ()
 closeTenantRuntimeManager manager = mask \restore -> do
@@ -510,10 +568,14 @@ closeRuntimeEnvironment :: RuntimeEnvironment -> IO ()
 closeRuntimeEnvironment environment =
     closeNativeProcessRuntime environment.environmentNative
         `finally`
-            mapM_ closeTenantSandbox environment.environmentSandbox
+            ( mapM_ closeTenantSandbox environment.environmentSandbox
+                `finally`
+                    TurnStore.closeTurnStoreOwner
+                        environment.environmentTurnStoreOwner
+            )
 
-multiTenantBackend :: TenantRuntimeManager -> Backend
-multiTenantBackend manager = Backend
+multiTenantBackend :: Text -> TenantRuntimeManager -> Backend
+multiTenantBackend instanceId manager = Backend
     { backendAdmitBoundary = \principal action ->
         withTenantEnvironment manager principal.principalTenantId \environment ->
             first gatewayApiError
@@ -530,39 +592,73 @@ multiTenantBackend manager = Backend
     , backendTurnBoundaryGuard = \boundary action ->
         acquireTenantRuntime manager boundary.accessTenantId >>= \case
             Left err -> pure (Left err.apiErrorMessage)
-            Right environment ->
-                first gatewayTurnError
-                    <$> withGatewayTurnBoundaryAt
-                        (unsafeEncodeUtf environment.environmentHome)
-                        boundary.accessGatewayBoundary
-                        action
+            Right environment -> do
+                fenced <-
+                    TurnStore.withTurnStoreOwnerFence
+                        environment.environmentTurnStoreOwner
+                        $ first gatewayTurnError
+                            <$> withGatewayTurnBoundaryAt
+                                (unsafeEncodeUtf environment.environmentHome)
+                                boundary.accessGatewayBoundary
+                                action
+                pure (fenced >>= id)
     , backendCheckReady =
         first storeApiError
             <$> checkTenantStoreManager manager.tenantRuntimeStores
     , backendListModels = \boundary ->
-        withBoundaryBackend manager boundary \backend ->
+        withBoundaryBackend instanceId manager boundary \backend ->
             backend.backendListModels boundary
     , backendListSessions = \boundary archive cursor limit ->
-        withBoundaryBackend manager boundary \backend ->
+        withBoundaryBackend instanceId manager boundary \backend ->
             backend.backendListSessions boundary archive cursor limit
     , backendCreateSession = \boundary request ->
-        withBoundaryBackend manager boundary \backend ->
+        withBoundaryBackend instanceId manager boundary \backend ->
             backend.backendCreateSession boundary request
     , backendGetSession = \boundary sessionId ->
-        withBoundaryBackend manager boundary \backend ->
+        withBoundaryBackend instanceId manager boundary \backend ->
             backend.backendGetSession boundary sessionId
     , backendPatchSession = \boundary sessionId request ->
-        withBoundaryBackend manager boundary \backend ->
+        withBoundaryBackend instanceId manager boundary \backend ->
             backend.backendPatchSession boundary sessionId request
     , backendDeleteSession = \boundary sessionId ->
-        withBoundaryBackend manager boundary \backend ->
+        withBoundaryBackend instanceId manager boundary \backend ->
             backend.backendDeleteSession boundary sessionId
     , backendSessionHistory = \boundary sessionId before limit ->
-        withBoundaryBackend manager boundary \backend ->
+        withBoundaryBackend instanceId manager boundary \backend ->
             backend.backendSessionHistory boundary sessionId before limit
     , backendForkSession = \boundary sessionId request ->
-        withBoundaryBackend manager boundary \backend ->
+        withBoundaryBackend instanceId manager boundary \backend ->
             backend.backendForkSession boundary sessionId request
+    , backendReserveTurn =
+        \boundary sessionId clientRequestId prompt turnId now ->
+            withBoundaryBackend instanceId manager boundary \backend ->
+                backend.backendReserveTurn
+                    boundary
+                    sessionId
+                    clientRequestId
+                    prompt
+                    turnId
+                    now
+    , backendReserveSessionMutation = \boundary sessionId now ->
+        withBoundaryBackend instanceId manager boundary \backend ->
+            backend.backendReserveSessionMutation boundary sessionId now
+    , backendLookupTurn = \boundary turnId ->
+        withBoundaryBackend instanceId manager boundary \backend ->
+            backend.backendLookupTurn boundary turnId
+    , backendListTurns = \boundary sessionId ->
+        withBoundaryBackend instanceId manager boundary \backend ->
+            backend.backendListTurns boundary sessionId
+    , backendLookupTurnResult = \boundary turnId ->
+        withBoundaryBackend instanceId manager boundary \backend ->
+            backend.backendLookupTurnResult boundary turnId
+    , backendRequestTurnCancellation = \boundary turnId requestedAt ->
+        withBoundaryBackend instanceId manager boundary \backend ->
+            backend.backendRequestTurnCancellation
+                boundary
+                turnId
+                requestedAt
+    , backendTurnPersistence =
+        multiTenantTurnPersistence instanceId manager
     , backendRunTurn = \control spec ->
         acquireTenantRuntime
             manager
@@ -582,13 +678,26 @@ withTenantEnvironment manager tenantId action =
         Right environment -> action environment
 
 withBoundaryBackend
-    :: TenantRuntimeManager
+    :: Text
+    -> TenantRuntimeManager
     -> AccessBoundary
     -> (Backend -> IO (Either ApiError value))
     -> IO (Either ApiError value)
-withBoundaryBackend manager boundary action =
+withBoundaryBackend instanceId manager boundary action =
     withTenantEnvironment manager boundary.accessTenantId
-        (action . productionBackend)
+        (action . productionBackend instanceId)
+
+withBoundaryBackendText
+    :: Text
+    -> TenantRuntimeManager
+    -> AccessBoundary
+    -> (Backend -> IO (Either Text value))
+    -> IO (Either Text value)
+withBoundaryBackendText instanceId manager boundary action =
+    acquireTenantRuntime manager boundary.accessTenantId >>= \case
+        Left err -> pure (Left err.apiErrorMessage)
+        Right environment ->
+            action (productionBackend instanceId environment)
 
 tenantRuntimeUnavailable :: Text -> ApiError
 tenantRuntimeUnavailable message = ApiError
@@ -598,8 +707,8 @@ tenantRuntimeUnavailable message = ApiError
     , apiErrorDetails = Nothing
     }
 
-productionBackend :: RuntimeEnvironment -> Backend
-productionBackend environment = Backend
+productionBackend :: Text -> RuntimeEnvironment -> Backend
+productionBackend _instanceId environment = Backend
     { backendAdmitBoundary = \principal action ->
         first gatewayApiError
             <$> withCurrentGatewayBoundaryAt
@@ -611,10 +720,16 @@ productionBackend environment = Backend
                 home
                 boundary.accessGatewayBoundary
                 action
-    , backendTurnBoundaryGuard = \boundary action ->
-        first gatewayTurnError
-            <$> withGatewayTurnBoundaryAt
-                home boundary.accessGatewayBoundary action
+    , backendTurnBoundaryGuard = \boundary action -> do
+        fenced <-
+            TurnStore.withTurnStoreOwnerFence
+                environment.environmentTurnStoreOwner
+                $ first gatewayTurnError
+                    <$> withGatewayTurnBoundaryAt
+                        home
+                        boundary.accessGatewayBoundary
+                        action
+        pure (fenced >>= id)
     , backendCheckReady =
         fmap (first storeApiError . fmap (const ())) $
             StoreSession.loadSessionMetadata
@@ -628,10 +743,106 @@ productionBackend environment = Backend
     , backendDeleteSession = deleteSessionForBoundary environment
     , backendSessionHistory = sessionHistoryForBoundary environment
     , backendForkSession = forkSessionForBoundary environment
+    , backendReserveSessionMutation =
+        turnStore.turnStoreReserveSessionMutation
+    , backendReserveTurn = turnStore.turnStoreReserve
+    , backendLookupTurn = turnStore.turnStoreLookup
+    , backendListTurns = turnStore.turnStoreList
+    , backendLookupTurnResult = turnStore.turnStoreLookupResult
+    , backendRequestTurnCancellation =
+        turnStore.turnStoreRequestCancellation
+    , backendTurnPersistence = turnStore.turnStorePersistence
     , backendRunTurn = runTurn environment
     }
   where
     home = unsafeEncodeUtf environment.environmentHome
+    turnStore =
+        TurnStore.newTurnStoreBackend
+            environment.environmentStore
+            environment.environmentTenantId
+            environment.environmentTurnStoreOwner
+
+multiTenantTurnPersistence
+    :: Text
+    -> TenantRuntimeManager
+    -> TurnPersistence
+multiTenantTurnPersistence instanceId manager =
+    TurnPersistence
+        { turnPersistenceStarted = \record startedAt ->
+            withBoundaryBackendText
+                instanceId
+                manager
+                record.turnRecordBoundary
+                \backend ->
+                    backend.backendTurnPersistence.turnPersistenceStarted
+                        record
+                        startedAt
+        , turnPersistenceTerminal = \record finishedAt outcome ->
+            withBoundaryBackendText
+                instanceId
+                manager
+                record.turnRecordBoundary
+                \backend ->
+                    backend.backendTurnPersistence.turnPersistenceTerminal
+                        record
+                        finishedAt
+                        outcome
+        , turnPersistenceShouldCancel = \record ->
+            withBoundaryBackendText
+                instanceId
+                manager
+                record.turnRecordBoundary
+                \backend ->
+                    backend.backendTurnPersistence.turnPersistenceShouldCancel
+                        record
+        , turnPersistenceCreateHumanRequest = \record request ->
+            withBoundaryBackendText
+                instanceId
+                manager
+                record.turnRecordBoundary
+                \backend ->
+                    backend.backendTurnPersistence.turnPersistenceCreateHumanRequest
+                        record
+                        request
+        , turnPersistenceListHumanRequests = \boundary turnId ->
+            withBoundaryBackendText
+                instanceId
+                manager
+                boundary
+                \backend ->
+                    backend.backendTurnPersistence.turnPersistenceListHumanRequests
+                        boundary
+                        turnId
+        , turnPersistenceResolveHumanRequest =
+            \boundary requestId response ->
+                withBoundaryBackendText
+                    instanceId
+                    manager
+                    boundary
+                    \backend ->
+                        backend.backendTurnPersistence.turnPersistenceResolveHumanRequest
+                            boundary
+                            requestId
+                            response
+        , turnPersistenceLoadHumanResponse = \record requestId ->
+            withBoundaryBackendText
+                instanceId
+                manager
+                record.turnRecordBoundary
+                \backend ->
+                    backend.backendTurnPersistence.turnPersistenceLoadHumanResponse
+                        record
+                        requestId
+        , turnPersistenceDeleteHumanRequest = \record requestId ->
+            withBoundaryBackendText
+                instanceId
+                manager
+                record.turnRecordBoundary
+                \backend ->
+                    backend.backendTurnPersistence.turnPersistenceDeleteHumanRequest
+                        record
+                        requestId
+        }
 
 gatewayApiError :: GatewayBoundaryError -> ApiError
 gatewayApiError err =
@@ -964,7 +1175,7 @@ runTurn
     :: RuntimeEnvironment
     -> TurnControl
     -> TurnSpec
-    -> IO (Either Text ())
+    -> IO (Either Text TurnExecutionOutput)
 runTurn environment control spec =
     loadAuthorizedMeta
         environment
@@ -981,16 +1192,30 @@ runTurn environment control spec =
                             case parseReasoningEffort meta.metaEffort of
                                 Left err -> pure (Left err)
                                 Right effort ->
-                                    withFile "/dev/null" WriteMode \output ->
+                                    withFile "/dev/null" WriteMode \output -> do
+                                        finalOutput <- newIORef Nothing
+                                        let baseHooks =
+                                                nativeHooks
+                                                    environment
+                                                    control
+                                                    spec.turnSpecSessionId
+                                                    cwd
+                                                    meta.metaDialect
+                                            hooks =
+                                                baseHooks
+                                                    { nativeOnLoopEvent = \event -> do
+                                                        case event of
+                                                            Loop.TurnFinished value ->
+                                                                writeIORef
+                                                                    finalOutput
+                                                                    (Just value)
+                                                            _ -> pure ()
+                                                        baseHooks.nativeOnLoopEvent event
+                                                    }
                                         runNativeTurn
                                             environment.environmentNative
                                             output
-                                            (nativeHooks
-                                                environment
-                                                control
-                                                spec.turnSpecSessionId
-                                                cwd
-                                                meta.metaDialect)
+                                            hooks
                                             NativeTurnRequest
                                                 { nativeTurnPrompt =
                                                     spec.turnSpecPrompt
@@ -1008,6 +1233,35 @@ runTurn environment control spec =
                                                 , nativeTurnShellMode =
                                                     tenantShellMode environment
                                                 }
+                                            >>= \case
+                                                Left err -> pure (Left err)
+                                                Right () ->
+                                                    readIORef finalOutput
+                                                        >>= pure
+                                                            . maybe
+                                                                ( Left
+                                                                    "agent turn completed without a terminal output"
+                                                                )
+                                                                ( Right
+                                                                    . turnExecutionOutput
+                                                                )
+
+turnExecutionOutput :: Loop.TurnOutput -> TurnExecutionOutput
+turnExecutionOutput output =
+    let assistantText = boundedPublicText <$> output.assistantText
+     in TurnExecutionOutput
+            { turnExecutionResponseId = output.responseId
+            , turnExecutionAssistantText = fst <$> assistantText
+            , turnExecutionAssistantTextTruncated =
+                maybe False snd assistantText
+            , turnExecutionCompletion =
+                case output.completion of
+                    Loop.TurnCompleted -> TurnCompletionComplete
+                    Loop.TurnIncomplete reason reasoningTokens ->
+                        TurnCompletionIncomplete
+                            (fst (boundedPublicText reason))
+                            reasoningTokens
+            }
 
 nativeHooks
     :: RuntimeEnvironment

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -833,7 +833,7 @@ multiTenantTurnPersistence instanceId manager =
                     backend.backendTurnPersistence.turnPersistenceLoadHumanResponse
                         record
                         requestId
-        , turnPersistenceDeleteHumanRequest = \record requestId ->
+        , turnPersistenceDeleteHumanRequest = \record requestId disposition ->
             withBoundaryBackendText
                 instanceId
                 manager
@@ -842,6 +842,7 @@ multiTenantTurnPersistence instanceId manager =
                     backend.backendTurnPersistence.turnPersistenceDeleteHumanRequest
                         record
                         requestId
+                        disposition
         }
 
 gatewayApiError :: GatewayBoundaryError -> ApiError

--- a/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
@@ -1,45 +1,46 @@
 -- | Durable externally submitted turn storage for the production server.
-module Agent.Server.Runtime.TurnStore
-    ( TurnStoreBackend (..)
-    , TurnStoreOwner
-    , openTurnStoreOwner
-    , closeTurnStoreOwner
-    , withTurnStoreOwnerFence
-    , newTurnStoreBackend
-    )
+module Agent.Server.Runtime.TurnStore (
+    TurnStoreBackend (..),
+    TurnStoreOwner,
+    openTurnStoreOwner,
+    closeTurnStoreOwner,
+    withTurnStoreOwnerFence,
+    newTurnStoreBackend,
+    takeRotatingPendingBatch,
+)
 where
 
-import Agent.Server.Backend (SessionMutationLease(..))
+import Agent.Server.Backend (SessionMutationLease (..))
 import Agent.Server.Event (boundedPublicText)
-import Agent.Server.Supervisor
-    ( HumanRequestCleanup (..)
-    , HumanRequestPersistenceResolution (..)
-    , TurnPersistence (..)
-    )
+import Agent.Server.Supervisor (
+    HumanRequestCleanup (..),
+    HumanRequestPersistenceResolution (..),
+    TurnPersistence (..),
+ )
 import Agent.Server.Types
 import Agent.Store.Postgres (Store, trustedPool)
 import Agent.Store.Postgres.ServerHumanRequest qualified as HumanRequestStore
 import Agent.Store.Postgres.ServerTurn qualified as ServerTurnStore
 import Agent.Store.Types (StoreError (..), renderStoreError)
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async
-    ( Async
-    , async
-    , mapConcurrently_
-    , race
-    , waitCatch
-    , withAsync
-    )
-import Control.Concurrent.STM
-    ( TVar
-    , atomically
-    , check
-    , modifyTVar'
-    , newTVarIO
-    , readTVar
-    , readTVarIO
-    , writeTVar
-    )
+import Control.Concurrent.Async (
+    Async,
+    async,
+    mapConcurrently_,
+    race,
+    waitCatch,
+    withAsync,
+ )
+import Control.Concurrent.STM (
+    TVar,
+    atomically,
+    check,
+    modifyTVar',
+    newTVarIO,
+    readTVar,
+    readTVarIO,
+    writeTVar,
+ )
 import Control.Exception.Safe (finally, mask, onException, tryAny)
 import Control.Monad (void)
 import Crypto.Hash (Digest, SHA256, hash)
@@ -51,10 +52,10 @@ import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TextEncoding
-import Data.Time.Clock
-    ( UTCTime
-    , getCurrentTime
-    )
+import Data.Time.Clock (
+    UTCTime,
+    getCurrentTime,
+ )
 import System.Timeout (timeout)
 
 data TurnStoreOwner = TurnStoreOwner
@@ -66,8 +67,12 @@ data TurnStoreOwner = TurnStoreOwner
     , turnStoreOwnerLifecycle :: !(Async ())
     , turnStoreOwnerPendingMutationReleases ::
         !(TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation))
+    , turnStoreOwnerPendingMutationReleaseCursor ::
+        !(TVar (Maybe MutationReleaseKey))
     , turnStoreOwnerPendingHumanRequestCleanups ::
         !(TVar (Map HumanRequestCleanupKey PendingHumanRequestCleanup))
+    , turnStoreOwnerPendingHumanRequestCleanupCursor ::
+        !(TVar (Maybe HumanRequestCleanupKey))
     }
 
 type MutationReleaseKey = (Text, Maybe Text, Text)
@@ -95,7 +100,9 @@ openTurnStoreOwner store instanceId = mask \restore -> do
             healthy <- newTVarIO True
             stopping <- newTVarIO False
             pendingMutationReleases <- newTVarIO Map.empty
+            pendingMutationReleaseCursor <- newTVarIO Nothing
             pendingHumanRequestCleanups <- newTVarIO Map.empty
+            pendingHumanRequestCleanupCursor <- newTVarIO Nothing
             lifecycle <-
                 async
                     ( restore
@@ -105,7 +112,9 @@ openTurnStoreOwner store instanceId = mask \restore -> do
                             healthy
                             stopping
                             pendingMutationReleases
+                            pendingMutationReleaseCursor
                             pendingHumanRequestCleanups
+                            pendingHumanRequestCleanupCursor
                         )
                     )
                     `onException` ServerTurnStore.releaseServerTurnOwner lease
@@ -120,8 +129,12 @@ openTurnStoreOwner store instanceId = mask \restore -> do
                         , turnStoreOwnerLifecycle = lifecycle
                         , turnStoreOwnerPendingMutationReleases =
                             pendingMutationReleases
+                        , turnStoreOwnerPendingMutationReleaseCursor =
+                            pendingMutationReleaseCursor
                         , turnStoreOwnerPendingHumanRequestCleanups =
                             pendingHumanRequestCleanups
+                        , turnStoreOwnerPendingHumanRequestCleanupCursor =
+                            pendingHumanRequestCleanupCursor
                         }
 
 closeTurnStoreOwner :: TurnStoreOwner -> IO ()
@@ -140,7 +153,9 @@ ownerLifecycle ::
     TVar Bool ->
     TVar Bool ->
     TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation) ->
+    TVar (Maybe MutationReleaseKey) ->
     TVar (Map HumanRequestCleanupKey PendingHumanRequestCleanup) ->
+    TVar (Maybe HumanRequestCleanupKey) ->
     IO ()
 ownerLifecycle
     store
@@ -148,37 +163,41 @@ ownerLifecycle
     healthy
     stopping
     pendingMutationReleases
-    pendingHumanRequestCleanups =
-    ( withAsync
-        ( ownerHeartbeatLoop
-            store
-            lease
-            healthy
-            pendingMutationReleases
-            pendingHumanRequestCleanups
+    pendingMutationReleaseCursor
+    pendingHumanRequestCleanups
+    pendingHumanRequestCleanupCursor =
+        ( withAsync
+            ( ownerHeartbeatLoop
+                store
+                lease
+                healthy
+                pendingMutationReleases
+                pendingMutationReleaseCursor
+                pendingHumanRequestCleanups
+                pendingHumanRequestCleanupCursor
+            )
+            \heartbeat ->
+                void $
+                    race
+                        ( atomically do
+                            shouldStop <- readTVar stopping
+                            check shouldStop
+                        )
+                        (void (waitCatch heartbeat))
         )
-        \heartbeat ->
-            void $
-                race
-                    ( atomically do
-                        shouldStop <- readTVar stopping
-                        check shouldStop
-                    )
-                    (void (waitCatch heartbeat))
-    )
-        `finally` do
-            atomically (writeTVar healthy False)
-            retireTurnStoreOwnerLease lease
+            `finally` do
+                atomically (writeTVar healthy False)
+                retireTurnStoreOwnerLease lease
 
 retireTurnStoreOwnerLease ::
     ServerTurnStore.ServerTurnOwnerLease ->
     IO ()
 retireTurnStoreOwnerLease lease =
     ( void $
-            timeout ownerHeartbeatTimeoutMicroseconds $
-                ServerTurnStore.releaseServerTurnOwner
-                    lease
-        )
+        timeout ownerHeartbeatTimeoutMicroseconds $
+            ServerTurnStore.releaseServerTurnOwner
+                lease
+    )
         `finally` ServerTurnStore.abandonServerTurnOwnerLease
             lease
 
@@ -195,42 +214,50 @@ ownerHeartbeatLoop ::
     ServerTurnStore.ServerTurnOwnerLease ->
     TVar Bool ->
     TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation) ->
+    TVar (Maybe MutationReleaseKey) ->
     TVar (Map HumanRequestCleanupKey PendingHumanRequestCleanup) ->
+    TVar (Maybe HumanRequestCleanupKey) ->
     IO ()
 ownerHeartbeatLoop
     store
     lease
     healthy
     pendingMutationReleases
-    pendingHumanRequestCleanups = do
-    threadDelay ownerHeartbeatIntervalMicroseconds
-    result <-
-        tryAny do
-            heartbeat <- heartbeatOwnerWithinDeadline lease
-            case heartbeat of
-                Left err -> pure (Left err)
-                Right () -> do
-                    retryPendingMutationReleases
-                        store
-                        pendingMutationReleases
-                    retryPendingHumanRequestCleanups
-                        store
-                        pendingHumanRequestCleanups
-                    pure (Right ())
-    case result of
-        Right (Right ()) ->
-            ownerHeartbeatLoop
-                store
-                lease
-                healthy
-                pendingMutationReleases
-                pendingHumanRequestCleanups
-        _ -> do
-            -- Losing the connection-lifetime fence is irreversible for this
-            -- process identity. Never try to revive it after another server
-            -- may have recovered its turns.
-            atomically (writeTVar healthy False)
-            ServerTurnStore.abandonServerTurnOwnerLease lease
+    pendingMutationReleaseCursor
+    pendingHumanRequestCleanups
+    pendingHumanRequestCleanupCursor = do
+        threadDelay ownerHeartbeatIntervalMicroseconds
+        result <-
+            tryAny do
+                heartbeat <- heartbeatOwnerWithinDeadline lease
+                case heartbeat of
+                    Left err -> pure (Left err)
+                    Right () -> do
+                        retryPendingMutationReleases
+                            store
+                            pendingMutationReleases
+                            pendingMutationReleaseCursor
+                        retryPendingHumanRequestCleanups
+                            store
+                            pendingHumanRequestCleanups
+                            pendingHumanRequestCleanupCursor
+                        pure (Right ())
+        case result of
+            Right (Right ()) ->
+                ownerHeartbeatLoop
+                    store
+                    lease
+                    healthy
+                    pendingMutationReleases
+                    pendingMutationReleaseCursor
+                    pendingHumanRequestCleanups
+                    pendingHumanRequestCleanupCursor
+            _ -> do
+                -- Losing the connection-lifetime fence is irreversible for this
+                -- process identity. Never try to revive it after another server
+                -- may have recovered its turns.
+                atomically (writeTVar healthy False)
+                ServerTurnStore.abandonServerTurnOwnerLease lease
 
 heartbeatOwnerWithinDeadline ::
     ServerTurnStore.ServerTurnOwnerLease ->
@@ -636,9 +663,8 @@ withTurnStoreOwnerActionFence owner action = mask \restore ->
                         fence
                         action
                     )
-                    `finally`
-                        ServerTurnStore.closeServerTurnOwnerActionFence
-                            fence
+                    `finally` ServerTurnStore.closeServerTurnOwnerActionFence
+                        fence
 
 runWhileOwnerAndActionFenceHealthy ::
     TurnStoreOwner ->
@@ -703,12 +729,14 @@ requestSessionMutationRelease store owner mutation =
 retryPendingMutationReleases ::
     Store ->
     TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation) ->
+    TVar (Maybe MutationReleaseKey) ->
     IO ()
-retryPendingMutationReleases store pending = do
+retryPendingMutationReleases store pending cursor = do
     mutations <-
-        take maximumMutationReleaseBatch
-            . Map.elems
-            <$> readTVarIO pending
+        takeRotatingPendingBatch
+            maximumMutationReleaseBatch
+            pending
+            cursor
     mapConcurrently_
         (attemptPendingMutationRelease store pending)
         mutations
@@ -781,12 +809,14 @@ requestHumanRequestCleanup store owner record requestId disposition =
 retryPendingHumanRequestCleanups ::
     Store ->
     TVar (Map HumanRequestCleanupKey PendingHumanRequestCleanup) ->
+    TVar (Maybe HumanRequestCleanupKey) ->
     IO ()
-retryPendingHumanRequestCleanups store pending = do
+retryPendingHumanRequestCleanups store pending cursor = do
     cleanups <-
-        take maximumHumanRequestCleanupBatch
-            . Map.elems
-            <$> readTVarIO pending
+        takeRotatingPendingBatch
+            maximumHumanRequestCleanupBatch
+            pending
+            cursor
     mapConcurrently_
         (void . attemptPendingHumanRequestCleanup store pending)
         cleanups
@@ -865,6 +895,35 @@ humanRequestCleanupKey cleanup =
 
 maximumHumanRequestCleanupBatch :: Int
 maximumHumanRequestCleanupBatch = 4
+
+takeRotatingPendingBatch ::
+    (Ord key) =>
+    Int ->
+    TVar (Map key value) ->
+    TVar (Maybe key) ->
+    IO [value]
+takeRotatingPendingBatch limit pending cursor =
+    atomically do
+        entries <- readTVar pending
+        previous <- readTVar cursor
+        let ordered =
+                case previous of
+                    Nothing -> Map.toAscList entries
+                    Just previousKey ->
+                        let (before, atPrevious, after) =
+                                Map.splitLookup previousKey entries
+                            previousEntry =
+                                maybe [] (\value -> [(previousKey, value)]) atPrevious
+                         in Map.toAscList after
+                                <> Map.toAscList before
+                                <> previousEntry
+            selected = take limit ordered
+            nextCursor =
+                case reverse selected of
+                    [] -> Nothing
+                    (key, _) : _ -> Just key
+        writeTVar cursor nextCursor
+        pure (snd <$> selected)
 
 requestTurnCancellation ::
     Store ->
@@ -979,6 +1038,8 @@ reserveTurn store tenantId instanceId boundary sessionId clientRequestId prompt 
                             "the session has an active mutation"
                         , apiErrorDetails = Nothing
                         }
+            Right ServerTurnStore.ServerTurnSessionMissing ->
+                Left notFoundApiError
             Right ServerTurnStore.ServerTurnOwnerUnavailable ->
                 Left unhealthyOwnerApiError
             Right (ServerTurnStore.ServerTurnIdempotencyConflict _) ->
@@ -1085,10 +1146,12 @@ finishStoredTurn store instanceId record finishedAt outcome = do
         Left err -> pure (Left err)
         Right (Just stored) ->
             pure
-                (Right
-                    (storedTurnRecord
+                ( Right
+                    ( storedTurnRecord
                         record.turnRecordBoundary
-                        stored))
+                        stored
+                    )
+                )
         Right Nothing ->
             ServerTurnStore.loadServerTurn
                 (trustedPool store)
@@ -1102,9 +1165,10 @@ finishStoredTurn store instanceId record finishedAt outcome = do
                                 stored.storedServerTurnStatus
                             ) ->
                             Right
-                                (storedTurnRecord
+                                ( storedTurnRecord
                                     record.turnRecordBoundary
-                                    stored)
+                                    stored
+                                )
                     _ ->
                         Left
                             ( StoreDataError

--- a/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
@@ -12,7 +12,8 @@ where
 import Agent.Server.Backend (SessionMutationLease(..))
 import Agent.Server.Event (boundedPublicText)
 import Agent.Server.Supervisor
-    ( HumanRequestPersistenceResolution (..)
+    ( HumanRequestCleanup (..)
+    , HumanRequestPersistenceResolution (..)
     , TurnPersistence (..)
     )
 import Agent.Server.Types
@@ -340,14 +341,24 @@ productionTurnPersistence store owner =
                     instanceId
                     record
                     requestId
-        , turnPersistenceDeleteHumanRequest = \record requestId ->
-            first renderStoreError
-                <$> HumanRequestStore.deleteServerHumanRequest
-                    (trustedPool store)
-                    (storeBoundary record.turnRecordBoundary)
-                    instanceId
-                    record.turnRecordId.unTurnId
-                    requestId.unRequestId
+        , turnPersistenceDeleteHumanRequest =
+            \record requestId disposition ->
+                first renderStoreError
+                    <$> case disposition of
+                        HumanRequestAbandoned ->
+                            HumanRequestStore.deleteServerHumanRequest
+                                (trustedPool store)
+                                (storeBoundary record.turnRecordBoundary)
+                                instanceId
+                                record.turnRecordId.unTurnId
+                                requestId.unRequestId
+                        HumanResponseConsumed ->
+                            HumanRequestStore.deleteConsumedServerHumanRequest
+                                (trustedPool store)
+                                (storeBoundary record.turnRecordBoundary)
+                                instanceId
+                                record.turnRecordId.unTurnId
+                                requestId.unRequestId
         }
   where
     instanceId = owner.turnStoreOwnerInstanceId

--- a/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
@@ -66,9 +66,21 @@ data TurnStoreOwner = TurnStoreOwner
     , turnStoreOwnerLifecycle :: !(Async ())
     , turnStoreOwnerPendingMutationReleases ::
         !(TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation))
+    , turnStoreOwnerPendingHumanRequestCleanups ::
+        !(TVar (Map HumanRequestCleanupKey PendingHumanRequestCleanup))
     }
 
 type MutationReleaseKey = (Text, Maybe Text, Text)
+
+type HumanRequestCleanupKey = (AccessBoundary, TurnId, RequestId)
+
+data PendingHumanRequestCleanup = PendingHumanRequestCleanup
+    { pendingHumanRequestCleanupRecord :: !TurnRecord
+    , pendingHumanRequestCleanupRequestId :: !RequestId
+    , pendingHumanRequestCleanupDisposition :: !HumanRequestCleanup
+    , pendingHumanRequestCleanupOwnerInstanceId :: !Text
+    }
+    deriving (Eq)
 
 openTurnStoreOwner :: Store -> Text -> IO (Either Text TurnStoreOwner)
 openTurnStoreOwner store instanceId = mask \restore -> do
@@ -83,6 +95,7 @@ openTurnStoreOwner store instanceId = mask \restore -> do
             healthy <- newTVarIO True
             stopping <- newTVarIO False
             pendingMutationReleases <- newTVarIO Map.empty
+            pendingHumanRequestCleanups <- newTVarIO Map.empty
             lifecycle <-
                 async
                     ( restore
@@ -92,6 +105,7 @@ openTurnStoreOwner store instanceId = mask \restore -> do
                             healthy
                             stopping
                             pendingMutationReleases
+                            pendingHumanRequestCleanups
                         )
                     )
                     `onException` ServerTurnStore.releaseServerTurnOwner lease
@@ -106,6 +120,8 @@ openTurnStoreOwner store instanceId = mask \restore -> do
                         , turnStoreOwnerLifecycle = lifecycle
                         , turnStoreOwnerPendingMutationReleases =
                             pendingMutationReleases
+                        , turnStoreOwnerPendingHumanRequestCleanups =
+                            pendingHumanRequestCleanups
                         }
 
 closeTurnStoreOwner :: TurnStoreOwner -> IO ()
@@ -124,14 +140,22 @@ ownerLifecycle ::
     TVar Bool ->
     TVar Bool ->
     TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation) ->
+    TVar (Map HumanRequestCleanupKey PendingHumanRequestCleanup) ->
     IO ()
-ownerLifecycle store lease healthy stopping pendingMutationReleases =
+ownerLifecycle
+    store
+    lease
+    healthy
+    stopping
+    pendingMutationReleases
+    pendingHumanRequestCleanups =
     ( withAsync
         ( ownerHeartbeatLoop
             store
             lease
             healthy
             pendingMutationReleases
+            pendingHumanRequestCleanups
         )
         \heartbeat ->
             void $
@@ -171,8 +195,14 @@ ownerHeartbeatLoop ::
     ServerTurnStore.ServerTurnOwnerLease ->
     TVar Bool ->
     TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation) ->
+    TVar (Map HumanRequestCleanupKey PendingHumanRequestCleanup) ->
     IO ()
-ownerHeartbeatLoop store lease healthy pendingMutationReleases = do
+ownerHeartbeatLoop
+    store
+    lease
+    healthy
+    pendingMutationReleases
+    pendingHumanRequestCleanups = do
     threadDelay ownerHeartbeatIntervalMicroseconds
     result <-
         tryAny do
@@ -183,10 +213,18 @@ ownerHeartbeatLoop store lease healthy pendingMutationReleases = do
                     retryPendingMutationReleases
                         store
                         pendingMutationReleases
+                    retryPendingHumanRequestCleanups
+                        store
+                        pendingHumanRequestCleanups
                     pure (Right ())
     case result of
         Right (Right ()) ->
-            ownerHeartbeatLoop store lease healthy pendingMutationReleases
+            ownerHeartbeatLoop
+                store
+                lease
+                healthy
+                pendingMutationReleases
+                pendingHumanRequestCleanups
         _ -> do
             -- Losing the connection-lifetime fence is irreversible for this
             -- process identity. Never try to revive it after another server
@@ -343,22 +381,12 @@ productionTurnPersistence store owner =
                     requestId
         , turnPersistenceDeleteHumanRequest =
             \record requestId disposition ->
-                first renderStoreError
-                    <$> case disposition of
-                        HumanRequestAbandoned ->
-                            HumanRequestStore.deleteServerHumanRequest
-                                (trustedPool store)
-                                (storeBoundary record.turnRecordBoundary)
-                                instanceId
-                                record.turnRecordId.unTurnId
-                                requestId.unRequestId
-                        HumanResponseConsumed ->
-                            HumanRequestStore.deleteConsumedServerHumanRequest
-                                (trustedPool store)
-                                (storeBoundary record.turnRecordBoundary)
-                                instanceId
-                                record.turnRecordId.unTurnId
-                                requestId.unRequestId
+                requestHumanRequestCleanup
+                    store
+                    owner
+                    record
+                    requestId
+                    disposition
         }
   where
     instanceId = owner.turnStoreOwnerInstanceId
@@ -725,6 +753,118 @@ mutationReleaseKey mutation =
 
 maximumMutationReleaseBatch :: Int
 maximumMutationReleaseBatch = 4
+
+requestHumanRequestCleanup ::
+    Store ->
+    TurnStoreOwner ->
+    TurnRecord ->
+    RequestId ->
+    HumanRequestCleanup ->
+    IO (Either Text ())
+requestHumanRequestCleanup store owner record requestId disposition =
+    mask \restore -> do
+        let cleanup =
+                PendingHumanRequestCleanup
+                    { pendingHumanRequestCleanupRecord = record
+                    , pendingHumanRequestCleanupRequestId = requestId
+                    , pendingHumanRequestCleanupDisposition = disposition
+                    , pendingHumanRequestCleanupOwnerInstanceId =
+                        owner.turnStoreOwnerInstanceId
+                    }
+            pending = owner.turnStoreOwnerPendingHumanRequestCleanups
+        atomically $
+            modifyTVar'
+                pending
+                (Map.insert (humanRequestCleanupKey cleanup) cleanup)
+        restore (attemptPendingHumanRequestCleanup store pending cleanup)
+
+retryPendingHumanRequestCleanups ::
+    Store ->
+    TVar (Map HumanRequestCleanupKey PendingHumanRequestCleanup) ->
+    IO ()
+retryPendingHumanRequestCleanups store pending = do
+    cleanups <-
+        take maximumHumanRequestCleanupBatch
+            . Map.elems
+            <$> readTVarIO pending
+    mapConcurrently_
+        (void . attemptPendingHumanRequestCleanup store pending)
+        cleanups
+
+attemptPendingHumanRequestCleanup ::
+    Store ->
+    TVar (Map HumanRequestCleanupKey PendingHumanRequestCleanup) ->
+    PendingHumanRequestCleanup ->
+    IO (Either Text ())
+attemptPendingHumanRequestCleanup store pending cleanup = do
+    attempted <-
+        tryAny $
+            timeout ownerHeartbeatTimeoutMicroseconds $
+                performHumanRequestCleanup store cleanup
+    case attempted of
+        Right (Just (Right ())) -> do
+            atomically $
+                modifyTVar'
+                    pending
+                    ( Map.update
+                        ( \current ->
+                            if current == cleanup
+                                then Nothing
+                                else Just current
+                        )
+                        (humanRequestCleanupKey cleanup)
+                    )
+            pure (Right ())
+        Right (Just (Left err)) ->
+            pure (Left (renderStoreError err))
+        Right Nothing ->
+            pure (Left "human request cleanup timed out")
+        Left err ->
+            pure
+                ( Left
+                    ( "human request cleanup failed: "
+                        <> Text.pack (show err)
+                    )
+                )
+
+performHumanRequestCleanup ::
+    Store ->
+    PendingHumanRequestCleanup ->
+    IO (Either StoreError ())
+performHumanRequestCleanup store cleanup =
+    case cleanup.pendingHumanRequestCleanupDisposition of
+        HumanRequestAbandoned ->
+            HumanRequestStore.deleteServerHumanRequest
+                (trustedPool store)
+                boundary
+                cleanup.pendingHumanRequestCleanupOwnerInstanceId
+                record.turnRecordId.unTurnId
+                requestId.unRequestId
+        HumanResponseConsumed ->
+            HumanRequestStore.deleteConsumedServerHumanRequest
+                (trustedPool store)
+                boundary
+                cleanup.pendingHumanRequestCleanupOwnerInstanceId
+                record.turnRecordId.unTurnId
+                requestId.unRequestId
+  where
+    record = cleanup.pendingHumanRequestCleanupRecord
+    requestId = cleanup.pendingHumanRequestCleanupRequestId
+    boundary = storeBoundary record.turnRecordBoundary
+
+humanRequestCleanupKey ::
+    PendingHumanRequestCleanup ->
+    HumanRequestCleanupKey
+humanRequestCleanupKey cleanup =
+    ( record.turnRecordBoundary
+    , record.turnRecordId
+    , cleanup.pendingHumanRequestCleanupRequestId
+    )
+  where
+    record = cleanup.pendingHumanRequestCleanupRecord
+
+maximumHumanRequestCleanupBatch :: Int
+maximumHumanRequestCleanupBatch = 4
 
 requestTurnCancellation ::
     Store ->

--- a/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
@@ -24,10 +24,10 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
     ( Async
     , async
-    , cancel
     , mapConcurrently_
     , race
     , waitCatch
+    , withAsync
     )
 import Control.Concurrent.STM
     ( TVar
@@ -61,7 +61,8 @@ data TurnStoreOwner = TurnStoreOwner
     , turnStoreOwnerInstanceId :: !Text
     , turnStoreOwnerHealthy :: !(TVar Bool)
     , turnStoreOwnerLease :: !ServerTurnStore.ServerTurnOwnerLease
-    , turnStoreOwnerHeartbeat :: !(Async ())
+    , turnStoreOwnerStopping :: !(TVar Bool)
+    , turnStoreOwnerLifecycle :: !(Async ())
     , turnStoreOwnerPendingMutationReleases ::
         !(TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation))
     }
@@ -79,14 +80,16 @@ openTurnStoreOwner store instanceId = mask \restore -> do
         Left err -> pure (Left (renderStoreError err))
         Right lease -> do
             healthy <- newTVarIO True
+            stopping <- newTVarIO False
             pendingMutationReleases <- newTVarIO Map.empty
-            heartbeat <-
+            lifecycle <-
                 async
                     ( restore
-                        ( ownerHeartbeatLoop
+                        ( ownerLifecycle
                             store
                             lease
                             healthy
+                            stopping
                             pendingMutationReleases
                         )
                     )
@@ -98,23 +101,61 @@ openTurnStoreOwner store instanceId = mask \restore -> do
                         , turnStoreOwnerInstanceId = instanceId
                         , turnStoreOwnerHealthy = healthy
                         , turnStoreOwnerLease = lease
-                        , turnStoreOwnerHeartbeat = heartbeat
+                        , turnStoreOwnerStopping = stopping
+                        , turnStoreOwnerLifecycle = lifecycle
                         , turnStoreOwnerPendingMutationReleases =
                             pendingMutationReleases
                         }
 
 closeTurnStoreOwner :: TurnStoreOwner -> IO ()
 closeTurnStoreOwner owner = do
-    atomically (writeTVar owner.turnStoreOwnerHealthy False)
-    cancel owner.turnStoreOwnerHeartbeat
-    void (waitCatch owner.turnStoreOwnerHeartbeat)
+    -- The lifecycle owns heartbeat cancellation and lease retirement. Once
+    -- this atomic signal commits, an exception in the caller cannot strand a
+    -- live heartbeat between those cleanup steps.
+    atomically do
+        writeTVar owner.turnStoreOwnerHealthy False
+        writeTVar owner.turnStoreOwnerStopping True
+    void (waitCatch owner.turnStoreOwnerLifecycle)
+
+ownerLifecycle ::
+    Store ->
+    ServerTurnStore.ServerTurnOwnerLease ->
+    TVar Bool ->
+    TVar Bool ->
+    TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation) ->
+    IO ()
+ownerLifecycle store lease healthy stopping pendingMutationReleases =
+    ( withAsync
+        ( ownerHeartbeatLoop
+            store
+            lease
+            healthy
+            pendingMutationReleases
+        )
+        \heartbeat ->
+            void $
+                race
+                    ( atomically do
+                        shouldStop <- readTVar stopping
+                        check shouldStop
+                    )
+                    (void (waitCatch heartbeat))
+    )
+        `finally` do
+            atomically (writeTVar healthy False)
+            retireTurnStoreOwnerLease lease
+
+retireTurnStoreOwnerLease ::
+    ServerTurnStore.ServerTurnOwnerLease ->
+    IO ()
+retireTurnStoreOwnerLease lease =
     ( void $
             timeout ownerHeartbeatTimeoutMicroseconds $
                 ServerTurnStore.releaseServerTurnOwner
-                    owner.turnStoreOwnerLease
+                    lease
         )
         `finally` ServerTurnStore.abandonServerTurnOwnerLease
-            owner.turnStoreOwnerLease
+            lease
 
 withTurnStoreOwnerFence ::
     TurnStoreOwner ->
@@ -495,7 +536,7 @@ reserveSessionMutation store tenantId owner boundary sessionId now
                     owner.turnStoreOwnerInstanceId
         case fenceResult of
             Left err -> pure (Left (storeApiError err))
-            Right Nothing -> pure (Right Nothing)
+            Right Nothing -> pure (Left unhealthyOwnerApiError)
             Right (Just fence) -> do
                 let closeFence =
                         ServerTurnStore.closeServerTurnOwnerActionFence fence

--- a/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
@@ -679,35 +679,33 @@ runWhileOwnerAndActionFenceHealthy owner fence action = do
         Just (Right ()) ->
             readTVarIO owner.turnStoreOwnerHealthy >>= \case
                 False -> pure (Left unhealthyOwnerApiError)
-                True ->
-                    race waitUntilUnhealthy action >>= \case
-                        Left () -> pure (Left unhealthyOwnerApiError)
-                        Right value -> pure (Right value)
+                True -> do
+                    monitored <-
+                        ServerTurnStore.withServerTurnOwnerActionFenceMonitor
+                            fence
+                            \waitForActionFenceFailure ->
+                                race
+                                    ( waitUntilUnhealthy
+                                        waitForActionFenceFailure
+                                    )
+                                    action
+                                    >>= \case
+                                        Left () ->
+                                            pure (Left unhealthyOwnerApiError)
+                                        Right value -> pure (Right value)
+                    case monitored of
+                        Left _ -> pure (Left unhealthyOwnerApiError)
+                        Right result -> pure result
         _ -> pure (Left unhealthyOwnerApiError)
   where
-    waitUntilUnhealthy =
+    waitUntilUnhealthy waitForActionFenceFailure =
         void $
             race
                 ( atomically do
                     healthy <- readTVar owner.turnStoreOwnerHealthy
                     check (not healthy)
                 )
-                (waitUntilActionFenceFails fence)
-
-waitUntilActionFenceFails ::
-    ServerTurnStore.ServerTurnOwnerActionFence ->
-    IO ()
-waitUntilActionFenceFails fence = do
-    threadDelay actionFenceCheckIntervalMicroseconds
-    checked <-
-        timeout ownerHeartbeatTimeoutMicroseconds $
-            ServerTurnStore.checkServerTurnOwnerActionFence fence
-    case checked of
-        Just (Right ()) -> waitUntilActionFenceFails fence
-        _ -> pure ()
-
-actionFenceCheckIntervalMicroseconds :: Int
-actionFenceCheckIntervalMicroseconds = 1000 * 1000
+                waitForActionFenceFailure
 
 requestSessionMutationRelease ::
     Store ->

--- a/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
@@ -1,0 +1,1094 @@
+-- | Durable externally submitted turn storage for the production server.
+module Agent.Server.Runtime.TurnStore
+    ( TurnStoreBackend (..)
+    , TurnStoreOwner
+    , openTurnStoreOwner
+    , closeTurnStoreOwner
+    , withTurnStoreOwnerFence
+    , newTurnStoreBackend
+    )
+where
+
+import Agent.Server.Backend (SessionMutationLease(..))
+import Agent.Server.Event (boundedPublicText)
+import Agent.Server.Supervisor
+    ( HumanRequestPersistenceResolution (..)
+    , TurnPersistence (..)
+    )
+import Agent.Server.Types
+import Agent.Store.Postgres (Store, trustedPool)
+import Agent.Store.Postgres.ServerHumanRequest qualified as HumanRequestStore
+import Agent.Store.Postgres.ServerTurn qualified as ServerTurnStore
+import Agent.Store.Types (StoreError (..), renderStoreError)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async
+    ( Async
+    , async
+    , cancel
+    , mapConcurrently_
+    , race
+    , waitCatch
+    )
+import Control.Concurrent.STM
+    ( TVar
+    , atomically
+    , check
+    , modifyTVar'
+    , newTVarIO
+    , readTVar
+    , readTVarIO
+    , writeTVar
+    )
+import Control.Exception.Safe (finally, mask, onException, tryAny)
+import Control.Monad (void)
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.Aeson qualified as Aeson
+import Data.Bifunctor (first)
+import Data.ByteString.Lazy qualified as LazyByteString
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as TextEncoding
+import Data.Time.Clock
+    ( UTCTime
+    , getCurrentTime
+    )
+import System.Timeout (timeout)
+
+data TurnStoreOwner = TurnStoreOwner
+    { turnStoreOwnerStore :: !Store
+    , turnStoreOwnerInstanceId :: !Text
+    , turnStoreOwnerHealthy :: !(TVar Bool)
+    , turnStoreOwnerLease :: !ServerTurnStore.ServerTurnOwnerLease
+    , turnStoreOwnerHeartbeat :: !(Async ())
+    , turnStoreOwnerPendingMutationReleases ::
+        !(TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation))
+    }
+
+type MutationReleaseKey = (Text, Maybe Text, Text)
+
+openTurnStoreOwner :: Store -> Text -> IO (Either Text TurnStoreOwner)
+openTurnStoreOwner store instanceId = mask \restore -> do
+    leaseResult <-
+        restore $
+            ServerTurnStore.openServerTurnOwnerLease
+                (trustedPool store)
+                instanceId
+    case leaseResult of
+        Left err -> pure (Left (renderStoreError err))
+        Right lease -> do
+            healthy <- newTVarIO True
+            pendingMutationReleases <- newTVarIO Map.empty
+            heartbeat <-
+                async
+                    ( restore
+                        ( ownerHeartbeatLoop
+                            store
+                            lease
+                            healthy
+                            pendingMutationReleases
+                        )
+                    )
+                    `onException` ServerTurnStore.releaseServerTurnOwner lease
+            pure $
+                Right
+                    TurnStoreOwner
+                        { turnStoreOwnerStore = store
+                        , turnStoreOwnerInstanceId = instanceId
+                        , turnStoreOwnerHealthy = healthy
+                        , turnStoreOwnerLease = lease
+                        , turnStoreOwnerHeartbeat = heartbeat
+                        , turnStoreOwnerPendingMutationReleases =
+                            pendingMutationReleases
+                        }
+
+closeTurnStoreOwner :: TurnStoreOwner -> IO ()
+closeTurnStoreOwner owner = do
+    atomically (writeTVar owner.turnStoreOwnerHealthy False)
+    cancel owner.turnStoreOwnerHeartbeat
+    void (waitCatch owner.turnStoreOwnerHeartbeat)
+    ( void $
+            timeout ownerHeartbeatTimeoutMicroseconds $
+                ServerTurnStore.releaseServerTurnOwner
+                    owner.turnStoreOwnerLease
+        )
+        `finally` ServerTurnStore.abandonServerTurnOwnerLease
+            owner.turnStoreOwnerLease
+
+withTurnStoreOwnerFence ::
+    TurnStoreOwner ->
+    IO value ->
+    IO (Either Text value)
+withTurnStoreOwnerFence owner action =
+    first (.apiErrorMessage)
+        <$> withTurnStoreOwnerActionFence owner action
+
+ownerHeartbeatLoop ::
+    Store ->
+    ServerTurnStore.ServerTurnOwnerLease ->
+    TVar Bool ->
+    TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation) ->
+    IO ()
+ownerHeartbeatLoop store lease healthy pendingMutationReleases = do
+    threadDelay ownerHeartbeatIntervalMicroseconds
+    result <-
+        tryAny do
+            heartbeat <- heartbeatOwnerWithinDeadline lease
+            case heartbeat of
+                Left err -> pure (Left err)
+                Right () -> do
+                    retryPendingMutationReleases
+                        store
+                        pendingMutationReleases
+                    pure (Right ())
+    case result of
+        Right (Right ()) ->
+            ownerHeartbeatLoop store lease healthy pendingMutationReleases
+        _ -> do
+            -- Losing the connection-lifetime fence is irreversible for this
+            -- process identity. Never try to revive it after another server
+            -- may have recovered its turns.
+            atomically (writeTVar healthy False)
+            ServerTurnStore.abandonServerTurnOwnerLease lease
+
+heartbeatOwnerWithinDeadline ::
+    ServerTurnStore.ServerTurnOwnerLease ->
+    IO (Either StoreError ())
+heartbeatOwnerWithinDeadline lease =
+    timeout
+        ownerHeartbeatTimeoutMicroseconds
+        (ServerTurnStore.heartbeatServerTurnOwner lease)
+        >>= \case
+            Nothing ->
+                pure
+                    ( Left
+                        ( StoreConnectionError
+                            "server turn owner heartbeat timed out"
+                        )
+                    )
+            Just result -> pure result
+
+ownerHeartbeatIntervalMicroseconds :: Int
+ownerHeartbeatIntervalMicroseconds = 5 * 1000 * 1000
+
+ownerHeartbeatTimeoutMicroseconds :: Int
+ownerHeartbeatTimeoutMicroseconds = 5 * 1000 * 1000
+
+data TurnStoreBackend = TurnStoreBackend
+    { turnStoreReserve ::
+        !( AccessBoundary ->
+           Text ->
+           ClientRequestId ->
+           Text ->
+           TurnId ->
+           UTCTime ->
+           IO (Either ApiError TurnReservation)
+         )
+    , turnStoreLookup ::
+        !( AccessBoundary ->
+           TurnId ->
+           IO (Either ApiError (Maybe TurnRecord))
+         )
+    , turnStoreList ::
+        !( AccessBoundary ->
+           Maybe Text ->
+           IO (Either ApiError [TurnRecord])
+         )
+    , turnStoreLookupResult ::
+        !( AccessBoundary ->
+           TurnId ->
+           IO (Either ApiError (Maybe TurnResult))
+         )
+    , turnStoreReserveSessionMutation ::
+        !( AccessBoundary ->
+           Text ->
+           UTCTime ->
+           IO (Either ApiError (Maybe SessionMutationLease))
+         )
+    , turnStoreRequestCancellation ::
+        !( AccessBoundary ->
+           TurnId ->
+           UTCTime ->
+           IO (Either ApiError (Maybe (Bool, TurnRecord)))
+         )
+    , turnStorePersistence :: !TurnPersistence
+    }
+
+newTurnStoreBackend :: Store -> TenantId -> TurnStoreOwner -> TurnStoreBackend
+newTurnStoreBackend store tenantId owner =
+    TurnStoreBackend
+        { turnStoreReserve = \boundary sessionId clientRequestId prompt turnId now ->
+            let reserve =
+                    reserveTurn
+                        store
+                        tenantId
+                        instanceId
+                        boundary
+                        sessionId
+                        clientRequestId
+                        prompt
+                        turnId
+                        now
+             in if boundary.accessTenantId /= tenantId
+                    then reserve
+                    else
+                        readTVarIO owner.turnStoreOwnerHealthy >>= \case
+                            True -> reserve
+                            False -> pure (Left unhealthyOwnerApiError)
+        , turnStoreLookup =
+            lookupStoredTurn store tenantId instanceId
+        , turnStoreList =
+            listStoredTurns store tenantId instanceId
+        , turnStoreLookupResult =
+            lookupStoredTurnResult store tenantId instanceId
+        , turnStoreReserveSessionMutation =
+            reserveSessionMutation store tenantId owner
+        , turnStoreRequestCancellation =
+            requestTurnCancellation store tenantId instanceId
+        , turnStorePersistence =
+            productionTurnPersistence store owner
+        }
+  where
+    instanceId = owner.turnStoreOwnerInstanceId
+
+productionTurnPersistence :: Store -> TurnStoreOwner -> TurnPersistence
+productionTurnPersistence store owner =
+    TurnPersistence
+        { turnPersistenceStarted = \record startedAt ->
+            first renderStoreError
+                <$> markStoredTurnRunning
+                    store
+                    instanceId
+                    record
+                    startedAt
+        , turnPersistenceTerminal = \record finishedAt outcome ->
+            first renderStoreError
+                <$> finishStoredTurn
+                    store
+                    instanceId
+                    record
+                    finishedAt
+                    outcome
+        , turnPersistenceShouldCancel = \record ->
+            readTVarIO owner.turnStoreOwnerHealthy >>= \case
+                False -> pure (Right True)
+                True ->
+                    first renderStoreError
+                        <$> ServerTurnStore.shouldCancelServerTurn
+                            (trustedPool store)
+                            (storeBoundary record.turnRecordBoundary)
+                            instanceId
+                            record.turnRecordId.unTurnId
+        , turnPersistenceCreateHumanRequest = \record request ->
+            first renderStoreError
+                <$> createStoredHumanRequest
+                    store
+                    instanceId
+                    record
+                    request
+        , turnPersistenceListHumanRequests = \boundary turnId ->
+            first renderStoreError
+                <$> listStoredHumanRequests store boundary turnId
+        , turnPersistenceResolveHumanRequest =
+            resolveStoredHumanRequest store
+        , turnPersistenceLoadHumanResponse = \record requestId ->
+            first renderStoreError
+                <$> loadStoredHumanResponse
+                    store
+                    instanceId
+                    record
+                    requestId
+        , turnPersistenceDeleteHumanRequest = \record requestId ->
+            first renderStoreError
+                <$> HumanRequestStore.deleteServerHumanRequest
+                    (trustedPool store)
+                    (storeBoundary record.turnRecordBoundary)
+                    instanceId
+                    record.turnRecordId.unTurnId
+                    requestId.unRequestId
+        }
+  where
+    instanceId = owner.turnStoreOwnerInstanceId
+
+createStoredHumanRequest ::
+    Store ->
+    Text ->
+    TurnRecord ->
+    HumanRequest ->
+    IO (Either StoreError ())
+createStoredHumanRequest store instanceId record request =
+    fmap (>>= requireStoreTransition "human request creation") $
+        HumanRequestStore.createServerHumanRequest
+            (trustedPool store)
+            HumanRequestStore.CreateServerHumanRequest
+                { HumanRequestStore.createServerHumanRequestId =
+                    request.humanRequestId.unRequestId
+                , HumanRequestStore.createServerHumanRequestTurnId =
+                    record.turnRecordId.unTurnId
+                , HumanRequestStore.createServerHumanRequestBoundary =
+                    storeBoundary record.turnRecordBoundary
+                , HumanRequestStore.createServerHumanRequestOwnerInstanceId =
+                    instanceId
+                , HumanRequestStore.createServerHumanRequestKind =
+                    humanRequestKindText request.humanRequestKind
+                , HumanRequestStore.createServerHumanRequestPrompt =
+                    request.humanRequestPrompt
+                , HumanRequestStore.createServerHumanRequestOptionsJson =
+                    encodeHumanRequestOptions request.humanRequestOptions
+                , HumanRequestStore.createServerHumanRequestCreatedAt =
+                    request.humanRequestCreatedAt
+                }
+
+listStoredHumanRequests ::
+    Store ->
+    AccessBoundary ->
+    Maybe TurnId ->
+    IO (Either StoreError [HumanRequest])
+listStoredHumanRequests store boundary turnId = do
+    result <-
+        case turnId of
+            Nothing ->
+                HumanRequestStore.listServerHumanRequests
+                    (trustedPool store)
+                    (storeBoundary boundary)
+            Just expectedTurnId ->
+                HumanRequestStore.listServerHumanRequestsForTurn
+                    (trustedPool store)
+                    (storeBoundary boundary)
+                    expectedTurnId.unTurnId
+    pure $
+        result
+            >>= traverse (storedHumanRequest boundary)
+
+resolveStoredHumanRequest ::
+    Store ->
+    AccessBoundary ->
+    RequestId ->
+    HumanResponse ->
+    IO (Either Text HumanRequestPersistenceResolution)
+resolveStoredHumanRequest store boundary requestId response = do
+    now <- getCurrentTime
+    result <-
+        HumanRequestStore.resolveServerHumanRequest
+            (trustedPool store)
+            (storeBoundary boundary)
+            requestId.unRequestId
+            HumanRequestStore.ServerHumanResponse
+                { HumanRequestStore.serverHumanResponseDecision =
+                    response.humanResponseDecision
+                , HumanRequestStore.serverHumanResponseValue =
+                    response.humanResponseValue
+                }
+            now
+    pure case result of
+        Left err -> Left (renderStoreError err)
+        Right HumanRequestStore.ServerHumanRequestNotFound ->
+            Right HumanRequestNotFoundDurably
+        Right HumanRequestStore.ServerHumanRequestAlreadyResolved ->
+            Left "request has already been resolved"
+        Right HumanRequestStore.ServerHumanRequestInvalidDecision ->
+            Left "decision is not one of the allowed options"
+        Right (HumanRequestStore.ServerHumanRequestResolved request) ->
+            first renderStoreError $
+                HumanRequestResolvedDurably
+                    <$> storedHumanRequest boundary request
+
+loadStoredHumanResponse ::
+    Store ->
+    Text ->
+    TurnRecord ->
+    RequestId ->
+    IO (Either StoreError (Maybe HumanResponse))
+loadStoredHumanResponse store instanceId record requestId =
+    fmap (fmap (fmap storedHumanResponse)) $
+        HumanRequestStore.loadServerHumanResponse
+            (trustedPool store)
+            (storeBoundary record.turnRecordBoundary)
+            instanceId
+            record.turnRecordId.unTurnId
+            requestId.unRequestId
+
+storedHumanRequest ::
+    AccessBoundary ->
+    HumanRequestStore.StoredServerHumanRequest ->
+    Either StoreError HumanRequest
+storedHumanRequest boundary stored = do
+    kind <- decodeHumanRequestKind stored.storedServerHumanRequestKind
+    options <-
+        first
+            (StoreDataError . Text.pack)
+            ( Aeson.eitherDecodeStrict'
+                ( TextEncoding.encodeUtf8
+                    stored.storedServerHumanRequestOptionsJson
+                )
+            )
+    pure
+        HumanRequest
+            { humanRequestId =
+                RequestId stored.storedServerHumanRequestId
+            , humanRequestTurnId =
+                TurnId stored.storedServerHumanRequestTurnId
+            , humanRequestSessionId =
+                stored.storedServerHumanRequestSessionId
+            , humanRequestBoundary = boundary
+            , humanRequestKind = kind
+            , humanRequestPrompt =
+                stored.storedServerHumanRequestPrompt
+            , humanRequestOptions = options
+            , humanRequestCreatedAt =
+                stored.storedServerHumanRequestCreatedAt
+            }
+
+storedHumanResponse ::
+    HumanRequestStore.ServerHumanResponse ->
+    HumanResponse
+storedHumanResponse response =
+    HumanResponse
+        { humanResponseDecision =
+            response.serverHumanResponseDecision
+        , humanResponseValue =
+            response.serverHumanResponseValue
+        }
+
+decodeHumanRequestKind :: Text -> Either StoreError HumanRequestKind
+decodeHumanRequestKind = \case
+    "tool_approval" -> Right ToolApprovalRequest
+    "root_access" -> Right RootAccessRequest
+    "plan_enter" -> Right PlanEnterRequest
+    "plan_exit" -> Right PlanExitRequest
+    "plan_question" -> Right PlanQuestionRequest
+    other ->
+        Left
+            ( StoreDataError
+                ("invalid durable human request kind: " <> other)
+            )
+
+encodeHumanRequestOptions :: [Text] -> Text
+encodeHumanRequestOptions =
+    TextEncoding.decodeUtf8
+        . LazyByteString.toStrict
+        . Aeson.encode
+
+reserveSessionMutation ::
+    Store ->
+    TenantId ->
+    TurnStoreOwner ->
+    AccessBoundary ->
+    Text ->
+    UTCTime ->
+    IO (Either ApiError (Maybe SessionMutationLease))
+reserveSessionMutation store tenantId owner boundary sessionId now
+    | boundary.accessTenantId /= tenantId =
+        pure (Left notFoundApiError)
+    | otherwise = mask \restore -> do
+        let mutation =
+                sessionMutation
+                    boundary
+                    sessionId
+                    owner.turnStoreOwnerInstanceId
+                    now
+        fenceResult <-
+            restore $
+                ServerTurnStore.openServerTurnOwnerActionFence
+                    (trustedPool store)
+                    owner.turnStoreOwnerInstanceId
+        case fenceResult of
+            Left err -> pure (Left (storeApiError err))
+            Right Nothing -> pure (Right Nothing)
+            Right (Just fence) -> do
+                let closeFence =
+                        ServerTurnStore.closeServerTurnOwnerActionFence fence
+                    releaseReservation =
+                        requestSessionMutationRelease
+                            store
+                            owner
+                            mutation
+                            `finally` closeFence
+                reservation <-
+                    restore
+                        ( ServerTurnStore.reserveServerSessionMutation
+                            (trustedPool store)
+                            mutation
+                        )
+                        `onException` releaseReservation
+                case reservation of
+                    Left err -> do
+                        releaseReservation
+                        pure (Left (storeApiError err))
+                    Right ServerTurnStore.ServerSessionMutationReserved ->
+                        pure . Right . Just $
+                            SessionMutationLease
+                                { runSessionMutationLease =
+                                    runWhileOwnerAndActionFenceHealthy
+                                        owner
+                                        fence
+                                , releaseSessionMutationLease =
+                                    releaseReservation
+                                }
+                    Right ServerTurnStore.ServerSessionMutationBusy -> do
+                        closeFence
+                        pure (Right Nothing)
+                    Right
+                        ServerTurnStore.ServerSessionMutationSessionMissing -> do
+                            closeFence
+                            pure (Left notFoundApiError)
+                    Right
+                        ServerTurnStore.ServerSessionMutationOwnerUnavailable -> do
+                            closeFence
+                            pure (Left unhealthyOwnerApiError)
+
+withTurnStoreOwnerActionFence ::
+    TurnStoreOwner ->
+    IO value ->
+    IO (Either ApiError value)
+withTurnStoreOwnerActionFence owner action = mask \restore ->
+    ServerTurnStore.openServerTurnOwnerActionFence
+        (trustedPool owner.turnStoreOwnerStore)
+        owner.turnStoreOwnerInstanceId
+        >>= \case
+            Left err -> pure (Left (storeApiError err))
+            Right Nothing -> pure (Left unhealthyOwnerApiError)
+            Right (Just fence) ->
+                restore
+                    ( runWhileOwnerAndActionFenceHealthy
+                        owner
+                        fence
+                        action
+                    )
+                    `finally`
+                        ServerTurnStore.closeServerTurnOwnerActionFence
+                            fence
+
+runWhileOwnerAndActionFenceHealthy ::
+    TurnStoreOwner ->
+    ServerTurnStore.ServerTurnOwnerActionFence ->
+    IO value ->
+    IO (Either ApiError value)
+runWhileOwnerAndActionFenceHealthy owner fence action = do
+    fenceReady <-
+        timeout ownerHeartbeatTimeoutMicroseconds $
+            ServerTurnStore.checkServerTurnOwnerActionFence fence
+    case fenceReady of
+        Just (Right ()) ->
+            readTVarIO owner.turnStoreOwnerHealthy >>= \case
+                False -> pure (Left unhealthyOwnerApiError)
+                True ->
+                    race waitUntilUnhealthy action >>= \case
+                        Left () -> pure (Left unhealthyOwnerApiError)
+                        Right value -> pure (Right value)
+        _ -> pure (Left unhealthyOwnerApiError)
+  where
+    waitUntilUnhealthy =
+        void $
+            race
+                ( atomically do
+                    healthy <- readTVar owner.turnStoreOwnerHealthy
+                    check (not healthy)
+                )
+                (waitUntilActionFenceFails fence)
+
+waitUntilActionFenceFails ::
+    ServerTurnStore.ServerTurnOwnerActionFence ->
+    IO ()
+waitUntilActionFenceFails fence = do
+    threadDelay actionFenceCheckIntervalMicroseconds
+    checked <-
+        timeout ownerHeartbeatTimeoutMicroseconds $
+            ServerTurnStore.checkServerTurnOwnerActionFence fence
+    case checked of
+        Just (Right ()) -> waitUntilActionFenceFails fence
+        _ -> pure ()
+
+actionFenceCheckIntervalMicroseconds :: Int
+actionFenceCheckIntervalMicroseconds = 1000 * 1000
+
+requestSessionMutationRelease ::
+    Store ->
+    TurnStoreOwner ->
+    ServerTurnStore.ServerSessionMutation ->
+    IO ()
+requestSessionMutationRelease store owner mutation =
+    mask \restore -> do
+        atomically $
+            modifyTVar'
+                owner.turnStoreOwnerPendingMutationReleases
+                (Map.insert (mutationReleaseKey mutation) mutation)
+        restore $
+            attemptPendingMutationRelease
+                store
+                owner.turnStoreOwnerPendingMutationReleases
+                mutation
+
+retryPendingMutationReleases ::
+    Store ->
+    TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation) ->
+    IO ()
+retryPendingMutationReleases store pending = do
+    mutations <-
+        take maximumMutationReleaseBatch
+            . Map.elems
+            <$> readTVarIO pending
+    mapConcurrently_
+        (attemptPendingMutationRelease store pending)
+        mutations
+
+attemptPendingMutationRelease ::
+    Store ->
+    TVar (Map MutationReleaseKey ServerTurnStore.ServerSessionMutation) ->
+    ServerTurnStore.ServerSessionMutation ->
+    IO ()
+attemptPendingMutationRelease store pending mutation = do
+    released <-
+        tryAny $
+            timeout ownerHeartbeatTimeoutMicroseconds $
+                ServerTurnStore.releaseServerSessionMutation
+                    (trustedPool store)
+                    mutation
+    case released of
+        Right (Just (Right ())) ->
+            atomically $
+                modifyTVar'
+                    pending
+                    ( Map.update
+                        ( \current ->
+                            if current == mutation
+                                then Nothing
+                                else Just current
+                        )
+                        (mutationReleaseKey mutation)
+                    )
+        _ -> pure ()
+
+mutationReleaseKey ::
+    ServerTurnStore.ServerSessionMutation ->
+    MutationReleaseKey
+mutationReleaseKey mutation =
+    ( boundary.serverTurnTenantId
+    , boundary.serverTurnGatewayIdentity
+    , mutation.serverSessionMutationSessionId
+    )
+  where
+    boundary = mutation.serverSessionMutationBoundary
+
+maximumMutationReleaseBatch :: Int
+maximumMutationReleaseBatch = 4
+
+requestTurnCancellation ::
+    Store ->
+    TenantId ->
+    Text ->
+    AccessBoundary ->
+    TurnId ->
+    UTCTime ->
+    IO (Either ApiError (Maybe (Bool, TurnRecord)))
+requestTurnCancellation store tenantId instanceId boundary turnId requestedAt
+    | boundary.accessTenantId /= tenantId =
+        pure (Right Nothing)
+    | otherwise =
+        fmap
+            ( first storeApiError
+                . fmap
+                    ( fmap
+                        ( \stored ->
+                            ( stored.storedServerTurnOwnerInstanceId
+                                == instanceId
+                            , storedTurnRecord boundary stored
+                            )
+                        )
+                    )
+            )
+            $ ServerTurnStore.requestServerTurnCancellation
+                (trustedPool store)
+                (storeBoundary boundary)
+                turnId.unTurnId
+                requestedAt
+
+sessionMutation ::
+    AccessBoundary ->
+    Text ->
+    Text ->
+    UTCTime ->
+    ServerTurnStore.ServerSessionMutation
+sessionMutation boundary sessionId instanceId now =
+    ServerTurnStore.ServerSessionMutation
+        { ServerTurnStore.serverSessionMutationBoundary =
+            storeBoundary boundary
+        , ServerTurnStore.serverSessionMutationSessionId = sessionId
+        , ServerTurnStore.serverSessionMutationOwnerInstanceId =
+            instanceId
+        , ServerTurnStore.serverSessionMutationCreatedAt = now
+        }
+
+reserveTurn ::
+    Store ->
+    TenantId ->
+    Text ->
+    AccessBoundary ->
+    Text ->
+    ClientRequestId ->
+    Text ->
+    TurnId ->
+    UTCTime ->
+    IO (Either ApiError TurnReservation)
+reserveTurn store tenantId instanceId boundary sessionId clientRequestId prompt turnId now
+    | boundary.accessTenantId /= tenantId =
+        pure (Left notFoundApiError)
+    | otherwise = do
+        result <-
+            ServerTurnStore.reserveServerTurn
+                (trustedPool store)
+                ServerTurnStore.ReserveServerTurn
+                    { ServerTurnStore.reserveServerTurnId = turnId.unTurnId
+                    , ServerTurnStore.reserveServerTurnBoundary =
+                        storeBoundary boundary
+                    , ServerTurnStore.reserveServerTurnSessionId = sessionId
+                    , ServerTurnStore.reserveServerTurnClientRequestId =
+                        clientRequestId.unClientRequestId
+                    , ServerTurnStore.reserveServerTurnInputDigest =
+                        turnInputDigest prompt
+                    , ServerTurnStore.reserveServerTurnOwnerInstanceId =
+                        instanceId
+                    , ServerTurnStore.reserveServerTurnCreatedAt = now
+                    }
+        pure case result of
+            Left err -> Left (storeApiError err)
+            Right (ServerTurnStore.ServerTurnReserved stored) ->
+                Right
+                    ( TurnReservationCreated
+                        (storedTurnRecord boundary stored)
+                    )
+            Right (ServerTurnStore.ServerTurnAlreadyReserved stored) ->
+                Right
+                    ( if stored.storedServerTurnOwnerInstanceId
+                        == instanceId
+                        then
+                            TurnReservationExistingOwned
+                                (storedTurnRecord boundary stored)
+                        else
+                            TurnReservationExisting
+                                (storedTurnRecord boundary stored)
+                    )
+            Right (ServerTurnStore.ServerTurnSessionBusy _) ->
+                Left
+                    ApiError
+                        { apiErrorStatus = 409
+                        , apiErrorCode = "session_busy"
+                        , apiErrorMessage =
+                            "the session already has an active turn"
+                        , apiErrorDetails = Nothing
+                        }
+            Right ServerTurnStore.ServerTurnSessionMutating ->
+                Left
+                    ApiError
+                        { apiErrorStatus = 409
+                        , apiErrorCode = "session_busy"
+                        , apiErrorMessage =
+                            "the session has an active mutation"
+                        , apiErrorDetails = Nothing
+                        }
+            Right ServerTurnStore.ServerTurnOwnerUnavailable ->
+                Left unhealthyOwnerApiError
+            Right (ServerTurnStore.ServerTurnIdempotencyConflict _) ->
+                Left
+                    ApiError
+                        { apiErrorStatus = 409
+                        , apiErrorCode = "idempotency_conflict"
+                        , apiErrorMessage =
+                            "clientRequestId was already used with different input"
+                        , apiErrorDetails = Nothing
+                        }
+
+lookupStoredTurn ::
+    Store ->
+    TenantId ->
+    Text ->
+    AccessBoundary ->
+    TurnId ->
+    IO (Either ApiError (Maybe TurnRecord))
+lookupStoredTurn store tenantId _instanceId boundary turnId
+    | boundary.accessTenantId /= tenantId =
+        pure (Right Nothing)
+    | otherwise =
+        fmap
+            ( first storeApiError
+                . fmap (fmap (storedTurnRecord boundary))
+            )
+            $ ServerTurnStore.loadServerTurn
+                (trustedPool store)
+                (storeBoundary boundary)
+                turnId.unTurnId
+
+listStoredTurns ::
+    Store ->
+    TenantId ->
+    Text ->
+    AccessBoundary ->
+    Maybe Text ->
+    IO (Either ApiError [TurnRecord])
+listStoredTurns store tenantId _instanceId boundary sessionId
+    | boundary.accessTenantId /= tenantId =
+        pure (Right [])
+    | otherwise =
+        fmap
+            ( first storeApiError
+                . fmap (map (storedTurnRecord boundary))
+            )
+            $ ServerTurnStore.listServerTurns
+                (trustedPool store)
+                (storeBoundary boundary)
+                sessionId
+
+lookupStoredTurnResult ::
+    Store ->
+    TenantId ->
+    Text ->
+    AccessBoundary ->
+    TurnId ->
+    IO (Either ApiError (Maybe TurnResult))
+lookupStoredTurnResult store tenantId _instanceId boundary turnId
+    | boundary.accessTenantId /= tenantId =
+        pure (Right Nothing)
+    | otherwise =
+        fmap
+            ( first storeApiError
+                . fmap (fmap (storedTurnResult boundary))
+            )
+            $ ServerTurnStore.loadServerTurn
+                (trustedPool store)
+                (storeBoundary boundary)
+                turnId.unTurnId
+
+markStoredTurnRunning ::
+    Store ->
+    Text ->
+    TurnRecord ->
+    UTCTime ->
+    IO (Either StoreError ())
+markStoredTurnRunning store instanceId record startedAt =
+    fmap (>>= requireStoreTransition "start") $
+        ServerTurnStore.markServerTurnRunning
+            (trustedPool store)
+            (storeBoundary record.turnRecordBoundary)
+            instanceId
+            record.turnRecordId.unTurnId
+            startedAt
+
+finishStoredTurn ::
+    Store ->
+    Text ->
+    TurnRecord ->
+    UTCTime ->
+    TurnTerminalOutcome ->
+    IO (Either StoreError TurnRecord)
+finishStoredTurn store instanceId record finishedAt outcome = do
+    result <-
+        ServerTurnStore.finishServerTurn
+            (trustedPool store)
+            (storeBoundary record.turnRecordBoundary)
+            instanceId
+            record.turnRecordId.unTurnId
+            (storedTerminal finishedAt outcome)
+    case result of
+        Left err -> pure (Left err)
+        Right (Just stored) ->
+            pure
+                (Right
+                    (storedTurnRecord
+                        record.turnRecordBoundary
+                        stored))
+        Right Nothing ->
+            ServerTurnStore.loadServerTurn
+                (trustedPool store)
+                (storeBoundary record.turnRecordBoundary)
+                record.turnRecordId.unTurnId
+                >>= pure . \case
+                    Left err -> Left err
+                    Right (Just stored)
+                        | not
+                            ( isStoredTurnActive
+                                stored.storedServerTurnStatus
+                            ) ->
+                            Right
+                                (storedTurnRecord
+                                    record.turnRecordBoundary
+                                    stored)
+                    _ ->
+                        Left
+                            ( StoreDataError
+                                "server turn terminal transition was rejected"
+                            )
+
+storeBoundary :: AccessBoundary -> ServerTurnStore.ServerTurnBoundary
+storeBoundary boundary =
+    ServerTurnStore.ServerTurnBoundary
+        { ServerTurnStore.serverTurnTenantId =
+            renderTenantId boundary.accessTenantId
+        , ServerTurnStore.serverTurnGatewayIdentity =
+            boundary.accessGatewayBoundary.gatewayBoundaryIdentity
+        }
+
+storedTurnRecord ::
+    AccessBoundary ->
+    ServerTurnStore.StoredServerTurn ->
+    TurnRecord
+storedTurnRecord boundary stored =
+    TurnRecord
+        { turnRecordId = TurnId stored.storedServerTurnId
+        , turnRecordSessionId = stored.storedServerTurnSessionId
+        , turnRecordClientRequestId =
+            ClientRequestId stored.storedServerTurnClientRequestId
+        , turnRecordBoundary = boundary
+        , turnRecordStatus =
+            storedTurnStatus stored.storedServerTurnStatus
+        , turnRecordCreatedAt = stored.storedServerTurnCreatedAt
+        , turnRecordStartedAt = stored.storedServerTurnStartedAt
+        , turnRecordFinishedAt = stored.storedServerTurnFinishedAt
+        , turnRecordError = stored.storedServerTurnError
+        }
+
+storedTurnStatus :: ServerTurnStore.ServerTurnStatus -> TurnStatus
+storedTurnStatus = \case
+    ServerTurnStore.ServerTurnQueued -> TurnQueued
+    ServerTurnStore.ServerTurnRunning -> TurnRunning
+    ServerTurnStore.ServerTurnCompleted -> TurnCompleted
+    ServerTurnStore.ServerTurnFailed -> TurnFailed
+    ServerTurnStore.ServerTurnCancelled -> TurnCancelled
+
+isStoredTurnActive :: ServerTurnStore.ServerTurnStatus -> Bool
+isStoredTurnActive = \case
+    ServerTurnStore.ServerTurnQueued -> True
+    ServerTurnStore.ServerTurnRunning -> True
+    ServerTurnStore.ServerTurnCompleted -> False
+    ServerTurnStore.ServerTurnFailed -> False
+    ServerTurnStore.ServerTurnCancelled -> False
+
+storedTurnResult ::
+    AccessBoundary ->
+    ServerTurnStore.StoredServerTurn ->
+    TurnResult
+storedTurnResult boundary stored =
+    TurnResult
+        { turnResultTurn = storedTurnRecord boundary stored
+        , turnResultOutput =
+            if stored.storedServerTurnStatus
+                == ServerTurnStore.ServerTurnCompleted
+                then
+                    TurnExecutionOutput
+                        <$> stored.storedServerTurnResponseId
+                        <*> pure stored.storedServerTurnAssistantText
+                        <*> pure
+                            stored.storedServerTurnAssistantTextTruncated
+                        <*> pure
+                            ( case stored.storedServerTurnIncompleteReason of
+                                Nothing -> TurnCompletionComplete
+                                Just reason ->
+                                    TurnCompletionIncomplete
+                                        reason
+                                        ( fromIntegral
+                                            <$> stored.storedServerTurnIncompleteReasoningTokens
+                                        )
+                            )
+                else Nothing
+        }
+
+storedTerminal ::
+    UTCTime ->
+    TurnTerminalOutcome ->
+    ServerTurnStore.ServerTurnTerminal
+storedTerminal finishedAt = \case
+    TurnSucceeded output ->
+        let assistantText =
+                boundedPublicText <$> output.turnExecutionAssistantText
+         in ServerTurnStore.ServerTurnTerminal
+                { ServerTurnStore.terminalServerTurnStatus =
+                    ServerTurnStore.ServerTurnCompleted
+                , ServerTurnStore.terminalServerTurnFinishedAt = finishedAt
+                , ServerTurnStore.terminalServerTurnAssistantText =
+                    fst <$> assistantText
+                , ServerTurnStore.terminalServerTurnAssistantTextTruncated =
+                    output.turnExecutionAssistantTextTruncated
+                        || maybe False snd assistantText
+                , ServerTurnStore.terminalServerTurnResponseId =
+                    Just
+                        ( fst
+                            ( boundedPublicText
+                                output.turnExecutionResponseId
+                            )
+                        )
+                , ServerTurnStore.terminalServerTurnIncompleteReason =
+                    case output.turnExecutionCompletion of
+                        TurnCompletionComplete -> Nothing
+                        TurnCompletionIncomplete reason _ ->
+                            Just (fst (boundedPublicText reason))
+                , ServerTurnStore.terminalServerTurnIncompleteReasoningTokens =
+                    case output.turnExecutionCompletion of
+                        TurnCompletionComplete -> Nothing
+                        TurnCompletionIncomplete _ tokens ->
+                            fromIntegral <$> tokens
+                , ServerTurnStore.terminalServerTurnError = Nothing
+                }
+    TurnErrored err ->
+        failedTerminal
+            ServerTurnStore.ServerTurnFailed
+            (Just (fst (boundedPublicText err)))
+    TurnWasCancelled ->
+        failedTerminal ServerTurnStore.ServerTurnCancelled Nothing
+  where
+    failedTerminal status err =
+        ServerTurnStore.ServerTurnTerminal
+            { ServerTurnStore.terminalServerTurnStatus = status
+            , ServerTurnStore.terminalServerTurnFinishedAt = finishedAt
+            , ServerTurnStore.terminalServerTurnAssistantText = Nothing
+            , ServerTurnStore.terminalServerTurnAssistantTextTruncated =
+                False
+            , ServerTurnStore.terminalServerTurnResponseId = Nothing
+            , ServerTurnStore.terminalServerTurnIncompleteReason = Nothing
+            , ServerTurnStore.terminalServerTurnIncompleteReasoningTokens =
+                Nothing
+            , ServerTurnStore.terminalServerTurnError = err
+            }
+
+turnInputDigest :: Text -> Text
+turnInputDigest prompt =
+    Text.pack . show $
+        ( hash
+            ( TextEncoding.encodeUtf8
+                ("agent-server client request v1\NUL" <> prompt)
+            ) ::
+            Digest SHA256
+        )
+
+requireStoreTransition :: Text -> Bool -> Either StoreError ()
+requireStoreTransition label changed
+    | changed = Right ()
+    | otherwise =
+        Left (StoreDataError ("server turn " <> label <> " was rejected"))
+
+storeApiError :: StoreError -> ApiError
+storeApiError err =
+    ApiError
+        { apiErrorStatus = 503
+        , apiErrorCode = "store_unavailable"
+        , apiErrorMessage = renderStoreError err
+        , apiErrorDetails = Nothing
+        }
+
+unhealthyOwnerApiError :: ApiError
+unhealthyOwnerApiError =
+    ApiError
+        { apiErrorStatus = 503
+        , apiErrorCode = "turn_owner_unhealthy"
+        , apiErrorMessage =
+            "the server cannot confirm its durable turn-owner fence"
+        , apiErrorDetails = Nothing
+        }
+
+notFoundApiError :: ApiError
+notFoundApiError =
+    ApiError
+        { apiErrorStatus = 404
+        , apiErrorCode = "not_found"
+        , apiErrorMessage = "resource not found"
+        , apiErrorDetails = Nothing
+        }

--- a/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
@@ -493,9 +493,9 @@ resolveStoredHumanRequest store boundary requestId response = do
         Right HumanRequestStore.ServerHumanRequestNotFound ->
             Right HumanRequestNotFoundDurably
         Right HumanRequestStore.ServerHumanRequestAlreadyResolved ->
-            Left "request has already been resolved"
+            Right HumanRequestAlreadyResolvedDurably
         Right HumanRequestStore.ServerHumanRequestInvalidDecision ->
-            Left "decision is not one of the allowed options"
+            Right HumanRequestInvalidDecisionDurably
         Right (HumanRequestStore.ServerHumanRequestResolved request) ->
             first renderStoreError $
                 HumanRequestResolvedDurably

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -36,14 +36,16 @@ module Agent.Server.Supervisor
     , lookupTurnAgents
     , publishEvent
     , subscribeEvents
+    , deleteCancellationTaskIfOwned
     ) where
 
 import Agent.Server.Identifier (newUUIDv7Text)
 import Agent.Server.Types
-import Control.Concurrent (threadDelay)
+import Control.Concurrent (ThreadId, myThreadId, threadDelay)
 import Control.Concurrent.Async
     ( Async
     , async
+    , asyncThreadId
     , cancel
     , forConcurrently
     , mapConcurrently_
@@ -1186,7 +1188,8 @@ spawnCancellationTask :: Supervisor -> TurnRecord -> IO ()
 spawnCancellationTask supervisor record = mask \restore -> do
     start <- newEmptyMVar
     task <-
-        async $
+        async do
+            taskThreadId <- myThreadId
             (readMVar start >> restore cancelRecord)
                 `finally`
                     atomically
@@ -1195,8 +1198,9 @@ spawnCancellationTask supervisor record = mask \restore -> do
                             ( \state ->
                                 state
                                     { stateCancellationTasks =
-                                        Map.delete
+                                        deleteCancellationTaskIfOwned
                                             record.turnRecordId
+                                            taskThreadId
                                             state.stateCancellationTasks
                                     }
                             )
@@ -1234,6 +1238,22 @@ spawnCancellationTask supervisor record = mask \restore -> do
                         supervisor
                         record.turnRecordBoundary
                         record.turnRecordId
+
+-- | Delete only the task whose own finalizer is running. A rejected duplicate
+-- must leave the incumbent registered so shutdown can still cancel and join it.
+deleteCancellationTaskIfOwned
+    :: TurnId
+    -> ThreadId
+    -> Map TurnId (Async ())
+    -> Map TurnId (Async ())
+deleteCancellationTaskIfOwned turnId ownerThreadId =
+    Map.update
+        ( \registered ->
+            if asyncThreadId registered == ownerThreadId
+                then Nothing
+                else Just registered
+        )
+        turnId
 
 reserveRunnable :: Supervisor -> STM (Maybe (TurnId, TurnSpec))
 reserveRunnable supervisor = do

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -158,6 +158,8 @@ type TurnBoundaryGuard =
 data HumanRequestPersistenceResolution
     = HumanRequestResolvedDurably !HumanRequest
     | HumanRequestNotFoundDurably
+    | HumanRequestAlreadyResolvedDurably
+    | HumanRequestInvalidDecisionDurably
     | HumanRequestLocalOnly
     deriving (Eq, Show)
 
@@ -915,6 +917,20 @@ resolveHumanRequest supervisor boundary requestId response = do
             pure (Left (HumanRequestResolutionStoreUnavailable err))
         Right HumanRequestNotFoundDurably ->
             pure (Left HumanRequestResolutionNotFound)
+        Right HumanRequestAlreadyResolvedDurably ->
+            pure
+                ( Left
+                    ( HumanRequestResolutionConflict
+                        "request has already been resolved"
+                    )
+                )
+        Right HumanRequestInvalidDecisionDurably ->
+            pure
+                ( Left
+                    ( HumanRequestResolutionConflict
+                        "decision is not one of the allowed options"
+                    )
+                )
         Right (HumanRequestResolvedDurably request) ->
             resolveLocal (Just request)
         Right HumanRequestLocalOnly ->

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -12,11 +12,17 @@ module Agent.Server.Supervisor
     , TurnControl(..)
     , TurnRunner
     , TurnBoundaryGuard
+    , HumanRequestPersistenceResolution(..)
+    , TurnPersistence(..)
+    , inMemoryTurnPersistence
     , newSupervisor
     , newSupervisorWithBoundaryGuard
+    , newSupervisorWithBoundaryGuardAndPersistence
     , closeSupervisor
     , submitTurn
     , submitTurnChecked
+    , submitReservedTurnChecked
+    , trySubmitReservedTurnChecked
     , cancelTurn
     , lookupTurn
     , listTurns
@@ -29,12 +35,14 @@ module Agent.Server.Supervisor
     , subscribeEvents
     ) where
 
-import Agent.Server.Types
 import Agent.Server.Identifier (newUUIDv7Text)
+import Agent.Server.Types
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
     ( Async
     , async
     , cancel
+    , forConcurrently
     , mapConcurrently_
     , waitCatch
     )
@@ -68,11 +76,14 @@ import Control.Exception.Safe
     ( SomeException
     , finally
     , mask
+    , onException
     , tryAny
     )
 import Control.Monad (forM_, void, when)
-import Data.Aeson (Value, object, toJSON, (.=))
+import Data.Aeson (Value, encode, object, toJSON, (.=))
+import Data.ByteString.Lazy qualified as LazyByteString
 import Data.Foldable (toList)
+import Data.Int (Int64)
 import Data.List (sortOn)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -128,7 +139,8 @@ data TurnControl = TurnControl
     , turnControlSetAgents :: !(IO Value -> IO ())
     }
 
-type TurnRunner = TurnControl -> TurnSpec -> IO (Either Text ())
+type TurnRunner =
+    TurnControl -> TurnSpec -> IO (Either Text TurnExecutionOutput)
 
 -- | Run an action only while the exact admitted gateway boundary is leased.
 --
@@ -140,9 +152,66 @@ type TurnBoundaryGuard =
     IO value ->
     IO (Either Text value)
 
+data HumanRequestPersistenceResolution
+    = HumanRequestResolvedDurably !HumanRequest
+    | HumanRequestNotFoundDurably
+    | HumanRequestLocalOnly
+    deriving (Eq, Show)
+
+data TurnPersistence = TurnPersistence
+    { turnPersistenceStarted ::
+        !(TurnRecord -> UTCTime -> IO (Either Text ()))
+    , turnPersistenceTerminal ::
+        !( TurnRecord ->
+           UTCTime ->
+           TurnTerminalOutcome ->
+           IO (Either Text TurnRecord)
+         )
+    , turnPersistenceShouldCancel ::
+        !(TurnRecord -> IO (Either Text Bool))
+    , turnPersistenceCreateHumanRequest ::
+        !(TurnRecord -> HumanRequest -> IO (Either Text ()))
+    , turnPersistenceListHumanRequests ::
+        !(AccessBoundary -> Maybe TurnId -> IO (Either Text [HumanRequest]))
+    , turnPersistenceResolveHumanRequest ::
+        !( AccessBoundary ->
+           RequestId ->
+           HumanResponse ->
+           IO (Either Text HumanRequestPersistenceResolution)
+         )
+    , turnPersistenceLoadHumanResponse ::
+        !( TurnRecord ->
+           RequestId ->
+           IO (Either Text (Maybe HumanResponse))
+         )
+    , turnPersistenceDeleteHumanRequest ::
+        !(TurnRecord -> RequestId -> IO (Either Text ()))
+    }
+
+inMemoryTurnPersistence :: TurnPersistence
+inMemoryTurnPersistence =
+    TurnPersistence
+        { turnPersistenceStarted = \_ _ -> pure (Right ())
+        , turnPersistenceTerminal = \record finishedAt outcome ->
+            pure (Right (terminalRecord finishedAt outcome record))
+        , turnPersistenceShouldCancel = \_ ->
+            pure (Right False)
+        , turnPersistenceCreateHumanRequest = \_ _ ->
+            pure (Right ())
+        , turnPersistenceListHumanRequests = \_ _ ->
+            pure (Right [])
+        , turnPersistenceResolveHumanRequest = \_ _ _ ->
+            pure (Right HumanRequestLocalOnly)
+        , turnPersistenceLoadHumanResponse = \_ _ ->
+            pure (Right Nothing)
+        , turnPersistenceDeleteHumanRequest = \_ _ ->
+            pure (Right ())
+        }
+
 data TurnSlot = TurnSlot
     { turnSlotSpec :: !TurnSpec
     , turnSlotRecord :: !TurnRecord
+    , turnSlotCancelling :: !Bool
     , turnSlotCancel :: !(Maybe (IO ()))
     , turnSlotAgents :: !(IO Value)
     }
@@ -167,6 +236,7 @@ data SupervisorState = SupervisorState
     , stateTurns :: !(Map TurnId TurnSlot)
     , stateActiveSessions :: !(Set (AccessBoundary, Text))
     , stateWorkers :: !(Map TurnId (Async ()))
+    , stateCancellationTasks :: !(Map TurnId (Async ()))
     , statePendingInputs :: !(Map RequestId PendingInput)
     , stateEvents :: !(Map AccessBoundary EventBuffer)
     , stateNextSubscriberId :: !Integer
@@ -179,8 +249,10 @@ data Supervisor = Supervisor
     { supervisorConfig :: !SupervisorConfig
     , supervisorRunner :: !TurnRunner
     , supervisorBoundaryGuard :: !TurnBoundaryGuard
+    , supervisorPersistence :: !TurnPersistence
     , supervisorState :: !(TVar SupervisorState)
     , supervisorDispatcher :: !(MVar (Async ()))
+    , supervisorCancellationMonitor :: !(MVar (Async ()))
     }
 
 newSupervisor :: SupervisorConfig -> TurnRunner -> IO Supervisor
@@ -188,116 +260,133 @@ newSupervisor config =
     newSupervisorWithBoundaryGuard config
         (\_ action -> Right <$> action)
 
-newSupervisorWithBoundaryGuard
-    :: SupervisorConfig
-    -> TurnBoundaryGuard
-    -> TurnRunner
-    -> IO Supervisor
-newSupervisorWithBoundaryGuard config boundaryGuard runner
-    | config.supervisorMaxConcurrentTurns < 1 =
-        fail "supervisorMaxConcurrentTurns must be positive"
-    | config.supervisorMaxConcurrentTurnsPerTenant < 1 =
-        fail "supervisorMaxConcurrentTurnsPerTenant must be positive"
-    | config.supervisorMaxConcurrentTurnsPerTenant
-        > config.supervisorMaxConcurrentTurns =
-        fail
-            "supervisorMaxConcurrentTurnsPerTenant exceeds global concurrency"
-    | config.supervisorMaxQueuedTurns < 1 =
-        fail "supervisorMaxQueuedTurns must be positive"
-    | config.supervisorMaxQueuedTurnsPerTenant < 1 =
-        fail "supervisorMaxQueuedTurnsPerTenant must be positive"
-    | config.supervisorMaxQueuedTurnsPerTenant
-        > config.supervisorMaxQueuedTurns =
-        fail "supervisorMaxQueuedTurnsPerTenant exceeds global queue capacity"
-    | config.supervisorMaxEventSubscribers < 1 =
-        fail "supervisorMaxEventSubscribers must be positive"
-    | config.supervisorMaxEventSubscribersPerTenant < 1 =
-        fail "supervisorMaxEventSubscribersPerTenant must be positive"
-    | config.supervisorMaxEventSubscribersPerTenant
-        > config.supervisorMaxEventSubscribers =
-        fail
-            "supervisorMaxEventSubscribersPerTenant exceeds global capacity"
-    | config.supervisorEventReplayLimit < 1 =
-        fail "supervisorEventReplayLimit must be positive"
-    | otherwise = mask \restore -> do
-        state <- newTVarIO SupervisorState
-            { stateQueue = Seq.empty
-            , stateTurns = Map.empty
-            , stateActiveSessions = Set.empty
-            , stateWorkers = Map.empty
-            , statePendingInputs = Map.empty
-            , stateEvents = Map.empty
-            , stateNextSubscriberId = 1
-            , stateSubscribers = Map.empty
-            , stateLastScheduledTenant = Nothing
-            , stateClosed = False
-            }
-        dispatcherVar <- newEmptyMVar
-        let supervisor = Supervisor
-                { supervisorConfig = config
-                , supervisorRunner = runner
-                , supervisorBoundaryGuard = boundaryGuard
-                , supervisorState = state
-                , supervisorDispatcher = dispatcherVar
-                }
-        dispatcher <- async (restore (dispatcherLoop supervisor))
-        putMVar dispatcherVar dispatcher
-        pure supervisor
+newSupervisorWithBoundaryGuard ::
+    SupervisorConfig ->
+    TurnBoundaryGuard ->
+    TurnRunner ->
+    IO Supervisor
+newSupervisorWithBoundaryGuard config boundaryGuard runner =
+    newSupervisorWithBoundaryGuardAndPersistence
+        config
+        boundaryGuard
+        inMemoryTurnPersistence
+        runner
+
+newSupervisorWithBoundaryGuardAndPersistence ::
+    SupervisorConfig ->
+    TurnBoundaryGuard ->
+    TurnPersistence ->
+    TurnRunner ->
+    IO Supervisor
+newSupervisorWithBoundaryGuardAndPersistence
+    config
+    boundaryGuard
+    persistence
+    runner
+        | config.supervisorMaxConcurrentTurns < 1 =
+            fail "supervisorMaxConcurrentTurns must be positive"
+        | config.supervisorMaxConcurrentTurnsPerTenant < 1 =
+            fail "supervisorMaxConcurrentTurnsPerTenant must be positive"
+        | config.supervisorMaxConcurrentTurnsPerTenant
+            > config.supervisorMaxConcurrentTurns =
+            fail
+                "supervisorMaxConcurrentTurnsPerTenant exceeds global concurrency"
+        | config.supervisorMaxQueuedTurns < 1 =
+            fail "supervisorMaxQueuedTurns must be positive"
+        | config.supervisorMaxQueuedTurnsPerTenant < 1 =
+            fail "supervisorMaxQueuedTurnsPerTenant must be positive"
+        | config.supervisorMaxQueuedTurnsPerTenant
+            > config.supervisorMaxQueuedTurns =
+            fail "supervisorMaxQueuedTurnsPerTenant exceeds global queue capacity"
+        | config.supervisorMaxEventSubscribers < 1 =
+            fail "supervisorMaxEventSubscribers must be positive"
+        | config.supervisorMaxEventSubscribersPerTenant < 1 =
+            fail "supervisorMaxEventSubscribersPerTenant must be positive"
+        | config.supervisorMaxEventSubscribersPerTenant
+            > config.supervisorMaxEventSubscribers =
+            fail
+                "supervisorMaxEventSubscribersPerTenant exceeds global capacity"
+        | config.supervisorEventReplayLimit < 1 =
+            fail "supervisorEventReplayLimit must be positive"
+        | otherwise = mask \restore -> do
+            state <-
+                newTVarIO
+                    SupervisorState
+                        { stateQueue = Seq.empty
+                        , stateTurns = Map.empty
+                        , stateActiveSessions = Set.empty
+                        , stateWorkers = Map.empty
+                        , stateCancellationTasks = Map.empty
+                        , statePendingInputs = Map.empty
+                        , stateEvents = Map.empty
+                        , stateNextSubscriberId = 1
+                        , stateSubscribers = Map.empty
+                        , stateLastScheduledTenant = Nothing
+                        , stateClosed = False
+                        }
+            dispatcherVar <- newEmptyMVar
+            cancellationMonitorVar <- newEmptyMVar
+            let supervisor =
+                    Supervisor
+                        { supervisorConfig = config
+                        , supervisorRunner = runner
+                        , supervisorBoundaryGuard = boundaryGuard
+                        , supervisorPersistence = persistence
+                        , supervisorState = state
+                        , supervisorDispatcher = dispatcherVar
+                        , supervisorCancellationMonitor =
+                            cancellationMonitorVar
+                        }
+            dispatcher <- async (restore (dispatcherLoop supervisor))
+            cancellationMonitor <-
+                async (restore (cancellationMonitorLoop supervisor))
+                    `onException` do
+                        cancel dispatcher
+                        void (waitCatch dispatcher)
+            putMVar dispatcherVar dispatcher
+            putMVar cancellationMonitorVar cancellationMonitor
+            pure supervisor
 
 closeSupervisor :: Supervisor -> IO ()
 closeSupervisor supervisor = mask \restore -> do
     now <- getCurrentTime
-    (workers, cancellations, replies) <- atomically do
-        state <- readTVar supervisor.supervisorState
-        if state.stateClosed
-            then pure ([], [], [])
-            else do
-                let activeSlots =
-                        [ slot
-                        | slot <- Map.elems state.stateTurns
-                        , isActiveStatus slot.turnSlotRecord.turnRecordStatus
-                        ]
-                    cancellationActions =
-                        mapMaybe (.turnSlotCancel) activeSlots
-                    pendingReplies =
-                        map (.pendingInputReply)
-                            (Map.elems state.statePendingInputs)
-                    cancelledTurns =
-                        foldr
-                            (cancelSlot now)
-                            state.stateTurns
-                            activeSlots
-                    (events, state') = foldr
-                        (\slot (eventsAcc, stateAcc) ->
-                            let (event, nextState) =
-                                    appendEventToState
-                                        supervisor.supervisorConfig
-                                        now
-                                        slot.turnSlotRecord.turnRecordBoundary
-                                        "turn.cancelled"
-                                        (Just
-                                            slot.turnSlotRecord.turnRecordId)
-                                        (Just
-                                            slot.turnSlotRecord.turnRecordSessionId)
-                                        (object [])
-                                        stateAcc
-                            in (event : eventsAcc, nextState))
-                        ([], state
-                            { stateClosed = True
-                            , stateQueue = Seq.empty
-                            , stateTurns = cancelledTurns
-                            , statePendingInputs = Map.empty
-                            })
-                        activeSlots
-                writeTVar supervisor.supervisorState state'
-                forM_
-                    (sortOn (.serverEventId) events)
-                    (publishToSubscribers state')
-                pure
-                    ( Map.elems state.stateWorkers
-                    , cancellationActions
-                    , pendingReplies
-                    )
+    (workers, cancellationTasks, cancellations, replies, activeRecords) <-
+        atomically do
+            state <- readTVar supervisor.supervisorState
+            if state.stateClosed
+                then pure ([], [], [], [], [])
+                else do
+                    let activeSlots =
+                            [ slot
+                            | slot <- Map.elems state.stateTurns
+                            , isActiveStatus slot.turnSlotRecord.turnRecordStatus
+                            ]
+                        cancellationActions =
+                            mapMaybe (.turnSlotCancel) activeSlots
+                        pendingReplies =
+                            map (.pendingInputReply)
+                                (Map.elems state.statePendingInputs)
+                        cancelledTurns =
+                            foldr
+                                (cancelSlot now)
+                                state.stateTurns
+                                activeSlots
+                        state' =
+                            state
+                                { stateClosed = True
+                                , stateQueue = Seq.empty
+                                , stateTurns = cancelledTurns
+                                , stateCancellationTasks = Map.empty
+                                , statePendingInputs = Map.empty
+                                }
+                    writeTVar supervisor.supervisorState state'
+                    pure
+                        ( Map.elems state.stateWorkers
+                        , Map.elems state.stateCancellationTasks
+                        , cancellationActions
+                        , pendingReplies
+                        , map (.turnSlotRecord) activeSlots
+                        )
     forM_ replies \reply ->
         atomically (void (tryPutTMVar reply (Left "server is shutting down")))
     let interruptInBand =
@@ -307,19 +396,56 @@ closeSupervisor supervisor = mask \restore -> do
                         (void (tryAny (restore action)))
         stopWorkers =
             mapConcurrently_ cancel workers
-        stopDispatcher = do
+        stopBackground = do
             dispatcher <- readMVar supervisor.supervisorDispatcher
             cancel dispatcher
             void (waitCatch dispatcher)
+            cancellationMonitor <-
+                readMVar supervisor.supervisorCancellationMonitor
+            cancel cancellationMonitor
+            void (waitCatch cancellationMonitor)
+            forM_ cancellationTasks cancel
+            forM_ cancellationTasks (void . waitCatch)
     -- A stuck provider interrupt must not skip structured worker teardown.
     (interruptInBand `finally` stopWorkers)
-        `finally` stopDispatcher
+        `finally` stopBackground
+    persisted <-
+        timeout
+            terminalPersistenceShutdownTimeoutMicros
+            ( forConcurrently activeRecords \record ->
+                persistTerminalEventually
+                    supervisor
+                    record
+                    now
+                    TurnWasCancelled
+            )
+    forM_ persisted $
+        mapM_ \canonical ->
+            atomically $
+                publishTerminalRecord supervisor canonical
 
-submitTurn
-    :: Supervisor
-    -> TurnSpec
-    -> IO (Either SubmitError TurnRecord)
-submitTurn supervisor = enqueueTurn supervisor False
+submitTurn ::
+    Supervisor ->
+    TurnSpec ->
+    IO (Either SubmitError TurnRecord)
+submitTurn supervisor spec = do
+    now <- getCurrentTime
+    turnId <- TurnId <$> newUUIDv7Text
+    enqueueTurnRecord
+        supervisor
+        False
+        spec
+        TurnRecord
+            { turnRecordId = turnId
+            , turnRecordSessionId = spec.turnSpecSessionId
+            , turnRecordClientRequestId = spec.turnSpecClientRequestId
+            , turnRecordBoundary = spec.turnSpecBoundary
+            , turnRecordStatus = TurnQueued
+            , turnRecordCreatedAt = now
+            , turnRecordStartedAt = Nothing
+            , turnRecordFinishedAt = Nothing
+            , turnRecordError = Nothing
+            }
 
 -- | Validate a session while holding the same per-boundary reservation that
 -- is atomically converted into a queued turn. This prevents delete/patch/fork
@@ -351,83 +477,168 @@ submitTurnChecked supervisor spec validate = do
             Left (SubmitValidationRejected SubmitSupervisorClosed)
         Right result -> result
 
-enqueueTurn
-    :: Supervisor
-    -> Bool
+-- | Queue a newly reserved durable turn, waiting for an in-flight local
+-- mutation to release the session. The durable reservation makes that
+-- mutation unwind before the turn is admitted.
+submitReservedTurnChecked ::
+    Supervisor ->
+    TurnSpec ->
+    TurnRecord ->
+    IO (Either validationError ()) ->
+    IO (Either (CheckedSubmitError validationError) TurnRecord)
+submitReservedTurnChecked =
+    submitReservedTurnCheckedWith True
+
+-- | Try to admit an existing durable reservation without waiting for another
+-- process-local admission of the same session. The caller can return the
+-- durable reservation when an identical retry loses that race.
+trySubmitReservedTurnChecked ::
+    Supervisor ->
+    TurnSpec ->
+    TurnRecord ->
+    IO (Either validationError ()) ->
+    IO (Either (CheckedSubmitError validationError) TurnRecord)
+trySubmitReservedTurnChecked =
+    submitReservedTurnCheckedWith False
+
+submitReservedTurnCheckedWith
+    :: Bool
+    -> Supervisor
     -> TurnSpec
-    -> IO (Either SubmitError TurnRecord)
+    -> TurnRecord
+    -> IO (Either validationError ())
+    -> IO (Either (CheckedSubmitError validationError) TurnRecord)
+submitReservedTurnCheckedWith
+        waitForReservation supervisor spec record validate = do
+    reserved <-
+        withSessionReservation
+            waitForReservation
+            supervisor
+            spec.turnSpecBoundary
+            spec.turnSpecSessionId
+            ( validate >>= \case
+                Left err ->
+                    pure (Left (SubmitValidationFailed err))
+                Right () ->
+                    fmap
+                        ( either
+                            (Left . SubmitValidationRejected)
+                            Right
+                        )
+                        (enqueueTurnRecord supervisor True spec record)
+            )
+    pure case reserved of
+        Left SessionMutationBusy ->
+            Left (SubmitValidationRejected SubmitSessionBusy)
+        Left SessionMutationSupervisorClosed ->
+            Left (SubmitValidationRejected SubmitSupervisorClosed)
+        Right result -> result
+
+enqueueTurn ::
+    Supervisor ->
+    Bool ->
+    TurnSpec ->
+    IO (Either SubmitError TurnRecord)
 enqueueTurn supervisor reservationHeld spec = do
     now <- getCurrentTime
     turnId <- TurnId <$> newUUIDv7Text
-    atomically do
-        state <- readTVar supervisor.supervisorState
-        let key = (spec.turnSpecBoundary, spec.turnSpecSessionId)
-            reserved = Set.member key state.stateActiveSessions
-        if state.stateClosed
-            then pure (Left SubmitSupervisorClosed)
-            else if reservationHeld && not reserved
-                then pure (Left SubmitSessionBusy)
-            else if
-                (not reservationHeld && reserved)
-                    || sessionBusy
-                        spec.turnSpecBoundary
-                        spec.turnSpecSessionId
-                        state.stateTurns
-                then pure (Left SubmitSessionBusy)
-                else if Seq.length state.stateQueue
-                    >= supervisor.supervisorConfig.supervisorMaxQueuedTurns
-                    then pure (Left SubmitQueueFull)
-                else if
-                    queuedForTenant
-                        spec.turnSpecBoundary.accessTenantId
-                        state.stateTurns
-                        >= supervisor.supervisorConfig.supervisorMaxQueuedTurnsPerTenant
-                    then pure (Left SubmitTenantQueueFull)
-                    else do
-                        let record = TurnRecord
-                                { turnRecordId = turnId
-                                , turnRecordSessionId =
-                                    spec.turnSpecSessionId
-                                , turnRecordBoundary =
-                                    spec.turnSpecBoundary
-                                , turnRecordStatus = TurnQueued
-                                , turnRecordCreatedAt = now
-                                , turnRecordStartedAt = Nothing
-                                , turnRecordFinishedAt = Nothing
-                                , turnRecordError = Nothing
-                                }
-                            slot = TurnSlot
-                                { turnSlotSpec = spec
-                                , turnSlotRecord = record
-                                , turnSlotCancel = Nothing
-                                , turnSlotAgents = pure toJSONEmptyArray
-                                }
-                            withTurn = state
-                                { stateQueue = state.stateQueue |> turnId
-                                , stateTurns =
-                                    Map.insert
-                                        turnId
-                                        slot
-                                        (pruneTerminalTurns state.stateTurns)
-                                }
-                            (event, state') = appendEventToState
-                                supervisor.supervisorConfig
-                                now
-                                spec.turnSpecBoundary
-                                "turn.queued"
-                                (Just turnId)
-                                (Just spec.turnSpecSessionId)
-                                (object [])
-                                withTurn
-                        writeTVar supervisor.supervisorState state'
-                        publishToSubscribers state' event
-                        pure (Right record)
+    enqueueTurnRecord
+        supervisor
+        reservationHeld
+        spec
+        TurnRecord
+            { turnRecordId = turnId
+            , turnRecordSessionId = spec.turnSpecSessionId
+            , turnRecordClientRequestId = spec.turnSpecClientRequestId
+            , turnRecordBoundary = spec.turnSpecBoundary
+            , turnRecordStatus = TurnQueued
+            , turnRecordCreatedAt = now
+            , turnRecordStartedAt = Nothing
+            , turnRecordFinishedAt = Nothing
+            , turnRecordError = Nothing
+            }
 
-cancelTurn
-    :: Supervisor
-    -> AccessBoundary
-    -> TurnId
-    -> IO (Either Text TurnRecord)
+enqueueTurnRecord ::
+    Supervisor ->
+    Bool ->
+    TurnSpec ->
+    TurnRecord ->
+    IO (Either SubmitError TurnRecord)
+enqueueTurnRecord supervisor reservationHeld spec record
+    | record.turnRecordSessionId /= spec.turnSpecSessionId =
+        fail "reserved turn session does not match its specification"
+    | record.turnRecordClientRequestId /= spec.turnSpecClientRequestId =
+        fail "reserved turn client request does not match its specification"
+    | record.turnRecordBoundary /= spec.turnSpecBoundary =
+        fail "reserved turn boundary does not match its specification"
+    | record.turnRecordStatus /= TurnQueued =
+        fail "only a queued reserved turn can be admitted"
+    | otherwise =
+        atomically do
+            state <- readTVar supervisor.supervisorState
+            let now = record.turnRecordCreatedAt
+                key = (spec.turnSpecBoundary, spec.turnSpecSessionId)
+                reserved = Set.member key state.stateActiveSessions
+            if state.stateClosed
+                then pure (Left SubmitSupervisorClosed)
+                else
+                    if reservationHeld && not reserved
+                        then pure (Left SubmitSessionBusy)
+                        else
+                            if (not reservationHeld && reserved)
+                                || sessionBusy
+                                    spec.turnSpecBoundary
+                                    spec.turnSpecSessionId
+                                    state.stateTurns
+                                then pure (Left SubmitSessionBusy)
+                                else
+                                    if Seq.length state.stateQueue
+                                        >= supervisor.supervisorConfig.supervisorMaxQueuedTurns
+                                        then pure (Left SubmitQueueFull)
+                                        else
+                                            if queuedForTenant
+                                                spec.turnSpecBoundary.accessTenantId
+                                                state.stateTurns
+                                                >= supervisor.supervisorConfig.supervisorMaxQueuedTurnsPerTenant
+                                                then pure (Left SubmitTenantQueueFull)
+                                                else do
+                                                    let turnId = record.turnRecordId
+                                                        slot =
+                                                            TurnSlot
+                                                                { turnSlotSpec = spec
+                                                                , turnSlotRecord = record
+                                                                , turnSlotCancelling = False
+                                                                , turnSlotCancel = Nothing
+                                                                , turnSlotAgents = pure toJSONEmptyArray
+                                                                }
+                                                        withTurn =
+                                                            state
+                                                                { stateQueue = state.stateQueue |> turnId
+                                                                , stateTurns =
+                                                                    Map.insert
+                                                                        turnId
+                                                                        slot
+                                                                        (pruneTerminalTurns state.stateTurns)
+                                                                }
+                                                        (event, state') =
+                                                            appendEventToState
+                                                                supervisor.supervisorConfig
+                                                                now
+                                                                spec.turnSpecBoundary
+                                                                "turn.queued"
+                                                                (Just turnId)
+                                                                (Just spec.turnSpecSessionId)
+                                                                (object [])
+                                                                withTurn
+                                                    writeTVar supervisor.supervisorState state'
+                                                    publishToSubscribers state' event
+                                                    pure (Right record)
+
+cancelTurn ::
+    Supervisor ->
+    AccessBoundary ->
+    TurnId ->
+    IO (Either Text TurnRecord)
 cancelTurn supervisor boundary turnId = mask \restore -> do
     now <- getCurrentTime
     outcome <- atomically do
@@ -437,13 +648,23 @@ cancelTurn supervisor boundary turnId = mask \restore -> do
             Just slot
                 | slot.turnSlotRecord.turnRecordBoundary /= boundary ->
                     pure (Left "turn not found")
+                | slot.turnSlotCancelling ->
+                    pure (Left "turn cancellation is in progress")
                 | not
-                    (isActiveStatus
-                        slot.turnSlotRecord.turnRecordStatus) ->
-                    pure (Right (slot.turnSlotRecord, Nothing, Nothing))
+                    ( isActiveStatus
+                        slot.turnSlotRecord.turnRecordStatus
+                    ) ->
+                    pure
+                        ( Right
+                            ( slot.turnSlotRecord
+                            , Nothing
+                            , Nothing
+                            , False
+                            )
+                        )
                 | otherwise -> do
-                    let record = cancelledRecord now slot.turnSlotRecord
-                        slot' = slot { turnSlotRecord = record }
+                    let slot' =
+                            slot { turnSlotCancelling = True }
                         worker =
                             Map.lookup turnId state.stateWorkers
                         (inputs, retainedInputs) =
@@ -451,30 +672,13 @@ cancelTurn supervisor boundary turnId = mask \restore -> do
                                 ((== turnId)
                                     . (.pendingInputView.humanRequestTurnId))
                                 state.statePendingInputs
-                        (event, state') = appendEventToState
-                            supervisor.supervisorConfig
-                            now
-                            boundary
-                            "turn.cancelled"
-                            (Just turnId)
-                            (Just record.turnRecordSessionId)
-                            (object [])
+                        state' =
                             state
                                 { stateQueue =
                                     Seq.filter (/= turnId) state.stateQueue
                                 , stateTurns =
                                     Map.insert turnId slot' state.stateTurns
                                 , statePendingInputs = retainedInputs
-                                , stateActiveSessions =
-                                    case worker of
-                                        Nothing ->
-                                            Set.delete
-                                                ( boundary
-                                                , record.turnRecordSessionId
-                                                )
-                                                state.stateActiveSessions
-                                        Just _ ->
-                                            state.stateActiveSessions
                                 }
                     forM_ (Map.elems inputs) \input ->
                         void
@@ -482,16 +686,17 @@ cancelTurn supervisor boundary turnId = mask \restore -> do
                                 input.pendingInputReply
                                 (Left "turn cancelled"))
                     writeTVar supervisor.supervisorState state'
-                    publishToSubscribers state' event
                     pure
                         (Right
-                            ( record
+                            ( slot.turnSlotRecord
                             , slot.turnSlotCancel
                             , worker
-                            ))
+                            , True
+                            )
+                        )
     case outcome of
         Left err -> pure (Left err)
-        Right (record, cancellation, worker) -> do
+        Right (record, cancellation, worker, transitioned) -> do
             let stopWorker =
                     forM_ worker \running -> do
                         cancel running
@@ -504,7 +709,18 @@ cancelTurn supervisor boundary turnId = mask \restore -> do
             -- Preserve in-band cancellation when it is responsive, but always
             -- deliver and join the structured cancellation.
             interruptInBand `finally` stopWorker
-            pure (Right record)
+            if not transitioned
+                then pure (Right record)
+                else do
+                    canonical <-
+                        persistTerminalEventually
+                            supervisor
+                            record
+                            now
+                            TurnWasCancelled
+                    atomically $
+                        publishTerminalRecord supervisor canonical
+                    pure (Right canonical)
 
 lookupTurn
     :: Supervisor
@@ -567,17 +783,30 @@ withSessionMutation
     -> Text
     -> IO value
     -> IO (Either SessionMutationError value)
-withSessionMutation supervisor boundary sessionId action =
+withSessionMutation =
+    withSessionReservation False
+
+withSessionReservation
+    :: Bool
+    -> Supervisor
+    -> AccessBoundary
+    -> Text
+    -> IO value
+    -> IO (Either SessionMutationError value)
+withSessionReservation waitForReservation supervisor boundary sessionId action =
     mask \restore -> do
         acquired <- atomically do
             state <- readTVar supervisor.supervisorState
             let key = (boundary, sessionId)
             if state.stateClosed
                 then pure (Left SessionMutationSupervisorClosed)
-                else if
-                    Set.member key state.stateActiveSessions
-                        || sessionBusy boundary sessionId state.stateTurns
+                else if sessionBusy boundary sessionId state.stateTurns
                     then pure (Left SessionMutationBusy)
+                    else if Set.member key state.stateActiveSessions
+                        then
+                            if waitForReservation
+                                then retry
+                                else pure (Left SessionMutationBusy)
                     else do
                         writeTVar supervisor.supervisorState
                             state
@@ -604,17 +833,35 @@ withSessionMutation supervisor boundary sessionId action =
 listHumanRequests
     :: Supervisor
     -> AccessBoundary
-    -> IO [HumanRequest]
-listHumanRequests supervisor boundary =
-    atomically do
+    -> Maybe TurnId
+    -> IO (Either Text [HumanRequest])
+listHumanRequests supervisor boundary turnId = do
+    local <- atomically do
         state <- readTVar supervisor.supervisorState
+        pure
+            [ request
+            | pending <- Map.elems state.statePendingInputs
+            , let request = pending.pendingInputView
+            , request.humanRequestBoundary == boundary
+            , maybe
+                True
+                (== request.humanRequestTurnId)
+                turnId
+            ]
+    durable <-
+        supervisor.supervisorPersistence.turnPersistenceListHumanRequests
+            boundary
+            turnId
+    pure do
+        persisted <- durable
+        let combined = persisted <> local
         pure $
-            sortOn (Down . (.humanRequestCreatedAt))
-                [ request
-                | pending <- Map.elems state.statePendingInputs
-                , let request = pending.pendingInputView
-                , request.humanRequestBoundary == boundary
-                ]
+            sortOn (Down . (.humanRequestCreatedAt)) $
+                Map.elems $
+                    Map.fromList
+                        [ (request.humanRequestId, request)
+                        | request <- combined
+                        ]
 
 resolveHumanRequest
     :: Supervisor
@@ -623,51 +870,69 @@ resolveHumanRequest
     -> HumanResponse
     -> IO (Either Text HumanRequest)
 resolveHumanRequest supervisor boundary requestId response = do
-    now <- getCurrentTime
-    atomically do
-        state <- readTVar supervisor.supervisorState
-        case Map.lookup requestId state.statePendingInputs of
-            Nothing -> pure (Left "request not found")
-            Just pending
-                | pending.pendingInputView.humanRequestBoundary /= boundary ->
-                    pure (Left "request not found")
-                | not
-                    (validHumanAnswer
-                        pending.pendingInputView.humanRequestOptions
-                        response.humanResponseDecision) ->
-                    pure (Left "decision is not one of the allowed options")
-                | otherwise -> do
-                    accepted <-
-                        tryPutTMVar pending.pendingInputReply (Right response)
-                    if not accepted
-                        then pure (Left "request has already been resolved")
-                        else do
-                            let request = pending.pendingInputView
-                                turns' = Map.adjust
-                                    (resumeWaitingTurn now)
-                                    request.humanRequestTurnId
-                                    state.stateTurns
-                                (event, state') = appendEventToState
-                                    supervisor.supervisorConfig
-                                    now
-                                    boundary
-                                    "request.resolved"
-                                    (Just request.humanRequestTurnId)
-                                    (Just request.humanRequestSessionId)
-                                    (object
-                                        [ "requestId"
-                                            .= requestId.unRequestId
-                                        ])
-                                    state
-                                        { statePendingInputs =
-                                            Map.delete
-                                                requestId
-                                                state.statePendingInputs
-                                        , stateTurns = turns'
-                                        }
-                            writeTVar supervisor.supervisorState state'
-                            publishToSubscribers state' event
-                            pure (Right request)
+    durable <-
+        supervisor.supervisorPersistence.turnPersistenceResolveHumanRequest
+            boundary
+            requestId
+            response
+    case durable of
+        Left err -> pure (Left err)
+        Right HumanRequestNotFoundDurably ->
+            pure (Left "request not found")
+        Right (HumanRequestResolvedDurably request) ->
+            resolveLocal (Just request)
+        Right HumanRequestLocalOnly ->
+            resolveLocal Nothing
+  where
+    resolveLocal durableRequest = do
+        now <- getCurrentTime
+        atomically do
+            state <- readTVar supervisor.supervisorState
+            case Map.lookup requestId state.statePendingInputs of
+                Nothing ->
+                    pure $
+                        maybe
+                            (Left "request not found")
+                            Right
+                            durableRequest
+                Just pending
+                    | pending.pendingInputView.humanRequestBoundary /= boundary ->
+                        pure (Left "request not found")
+                    | durableRequest == Nothing
+                        && not
+                            ( validHumanAnswer
+                                pending.pendingInputView.humanRequestOptions
+                                response.humanResponseDecision
+                            ) ->
+                        pure
+                            ( Left
+                                "decision is not one of the allowed options"
+                            )
+                    | otherwise -> do
+                        accepted <-
+                            tryPutTMVar
+                                pending.pendingInputReply
+                                (Right response)
+                        if not accepted
+                            then
+                                pure
+                                    ( Left
+                                        "request has already been resolved"
+                                    )
+                            else
+                                case completePendingInputInState
+                                        supervisor.supervisorConfig
+                                        now
+                                        requestId
+                                        state of
+                                    Nothing ->
+                                        pure (Left "request not found")
+                                    Just (request, event, state') -> do
+                                        writeTVar
+                                            supervisor.supervisorState
+                                            state'
+                                        publishToSubscribers state' event
+                                        pure (Right request)
 
 lookupTurnAgents
     :: Supervisor
@@ -803,6 +1068,116 @@ dispatcherLoop supervisor = do
             spawnTrackedWorker supervisor turnId spec
             dispatcherLoop supervisor
 
+cancellationMonitorLoop :: Supervisor -> IO ()
+cancellationMonitorLoop supervisor = do
+    threadDelay cancellationPollIntervalMicros
+    pending <- atomically do
+        state <- readTVar supervisor.supervisorState
+        if state.stateClosed
+            then pure Nothing
+            else
+                pure . Just $
+                    [ slot.turnSlotRecord
+                    | slot <- Map.elems state.stateTurns
+                    , not slot.turnSlotCancelling
+                    , isActiveStatus
+                        slot.turnSlotRecord.turnRecordStatus
+                    ]
+    case pending of
+        Nothing -> pure ()
+        Just records -> do
+            checks <-
+                forConcurrentlyBatched
+                    cancellationCheckBatchSize
+                    records \record -> do
+                    result <-
+                        tryAny $
+                            timeout
+                                cancellationCheckTimeoutMicros
+                                (supervisor.supervisorPersistence.turnPersistenceShouldCancel record)
+                    pure (record, result)
+            forM_ checks \case
+                (_, Right (Just (Right False))) -> pure ()
+                (record, _) ->
+                    -- A process which cannot confirm its durable owner fence
+                    -- must stop local side effects before another instance can
+                    -- reclaim the expired turn. Terminal persistence continues
+                    -- independently so one unavailable tenant cannot stall
+                    -- ownership checks for every other tenant.
+                    spawnCancellationTask supervisor record
+            cancellationMonitorLoop supervisor
+
+forConcurrentlyBatched
+    :: Int
+    -> [input]
+    -> (input -> IO output)
+    -> IO [output]
+forConcurrentlyBatched batchSize values action
+    | batchSize <= 0 =
+        fail "concurrent batch size must be positive"
+    | otherwise =
+        go values
+  where
+    go [] = pure []
+    go remaining = do
+        let (batch, rest) = splitAt batchSize remaining
+        batchResults <- forConcurrently batch action
+        restResults <- go rest
+        pure (batchResults <> restResults)
+
+spawnCancellationTask :: Supervisor -> TurnRecord -> IO ()
+spawnCancellationTask supervisor record = mask \restore -> do
+    start <- newEmptyMVar
+    task <-
+        async $
+            (readMVar start >> restore cancelRecord)
+                `finally`
+                    atomically
+                        ( modifyTVar'
+                            supervisor.supervisorState
+                            ( \state ->
+                                state
+                                    { stateCancellationTasks =
+                                        Map.delete
+                                            record.turnRecordId
+                                            state.stateCancellationTasks
+                                    }
+                            )
+                        )
+    accepted <- atomically do
+        state <- readTVar supervisor.supervisorState
+        if
+            state.stateClosed
+                || Map.member
+                    record.turnRecordId
+                    state.stateCancellationTasks
+            then pure False
+            else do
+                writeTVar
+                    supervisor.supervisorState
+                    state
+                        { stateCancellationTasks =
+                            Map.insert
+                                record.turnRecordId
+                                task
+                                state.stateCancellationTasks
+                        }
+                pure True
+    if accepted
+        then putMVar start ()
+        else do
+            cancel task
+            void (waitCatch task)
+  where
+    cancelRecord =
+        void $
+            tryAny $
+                void $
+                    cancelTurn
+                        supervisor
+                        record.turnRecordBoundary
+                        record.turnRecordId
+
 reserveRunnable :: Supervisor -> STM (Maybe (TurnId, TurnSpec))
 reserveRunnable supervisor = do
     state <- readTVar supervisor.supervisorState
@@ -863,32 +1238,43 @@ markTurnStarted
     -> UTCTime
     -> TurnId
     -> TurnSpec
-    -> STM ()
-markTurnStarted supervisor now turnId spec =
-    do
-        state <- readTVar supervisor.supervisorState
-        let withStarted = state
-                { stateTurns = Map.adjust
-                    (\slot ->
-                        slot
-                            { turnSlotRecord =
-                                slot.turnSlotRecord
-                                    { turnRecordStartedAt = Just now }
-                            })
-                    turnId
-                    state.stateTurns
-                }
-            (event, state') = appendEventToState
-                supervisor.supervisorConfig
-                now
-                spec.turnSpecBoundary
-                "turn.started"
-                (Just turnId)
-                (Just spec.turnSpecSessionId)
-                (object [])
-                withStarted
-        writeTVar supervisor.supervisorState state'
-        publishToSubscribers state' event
+    -> STM Bool
+markTurnStarted supervisor now turnId spec = do
+    state <- readTVar supervisor.supervisorState
+    case Map.lookup turnId state.stateTurns of
+        Just slot
+            | slot.turnSlotRecord.turnRecordStatus == TurnRunning
+            , not slot.turnSlotCancelling
+            , slot.turnSlotRecord.turnRecordBoundary
+                == spec.turnSpecBoundary
+            , slot.turnSlotRecord.turnRecordSessionId
+                == spec.turnSpecSessionId -> do
+                let withStarted =
+                        state
+                            { stateTurns = Map.adjust
+                                (\slot ->
+                                    slot
+                                        { turnSlotRecord =
+                                            slot.turnSlotRecord
+                                                { turnRecordStartedAt = Just now
+                                                }
+                                        })
+                                turnId
+                                state.stateTurns
+                            }
+                    (event, state') = appendEventToState
+                        supervisor.supervisorConfig
+                        now
+                        spec.turnSpecBoundary
+                        "turn.started"
+                        (Just turnId)
+                        (Just spec.turnSpecSessionId)
+                        (object [])
+                        withStarted
+                writeTVar supervisor.supervisorState state'
+                publishToSubscribers state' event
+                pure True
+        _ -> pure False
 
 spawnTrackedWorker :: Supervisor -> TurnId -> TurnSpec -> IO ()
 spawnTrackedWorker supervisor turnId spec = mask \restore -> do
@@ -972,81 +1358,151 @@ executeTurn supervisor turnId spec =
 
     runAndFinalize = do
         startedAt <- getCurrentTime
-        atomically $
-            markTurnStarted supervisor startedAt turnId spec
-        outcome <-
-            tryAny (supervisor.supervisorRunner control spec)
-                :: IO (Either SomeException (Either Text ()))
-        let result = case outcome of
-                Left _ -> Left "agent turn terminated unexpectedly"
-                Right value -> value
-        finalizeTurn supervisor turnId spec result
+        current <- lookupTurn supervisor spec.turnSpecBoundary turnId
+        case current of
+            Nothing -> pure ()
+            Just record ->
+                supervisor.supervisorPersistence.turnPersistenceStarted
+                    record
+                    startedAt
+                    >>= \case
+                        Left err ->
+                            finalizeTurn
+                                supervisor
+                                turnId
+                                spec
+                                ( Left
+                                    ( "could not persist turn start: "
+                                        <> err
+                                    )
+                                )
+                        Right () -> do
+                            started <-
+                                atomically $
+                                    markTurnStarted
+                                        supervisor
+                                        startedAt
+                                        turnId
+                                        spec
+                            when started do
+                                outcome <-
+                                    tryAny
+                                        (supervisor.supervisorRunner control spec) ::
+                                        IO
+                                            ( Either
+                                                SomeException
+                                                (Either Text TurnExecutionOutput)
+                                            )
+                                let result = case outcome of
+                                        Left _ ->
+                                            Left
+                                                "agent turn terminated unexpectedly"
+                                        Right value -> value
+                                finalizeTurn supervisor turnId spec result
 
     finish =
         atomically $
             modifyTVar' supervisor.supervisorState \state ->
-                state
+                let cancellationOwnsTerminal =
+                        maybe
+                            False
+                            (.turnSlotCancelling)
+                            (Map.lookup turnId state.stateTurns)
+                 in state
                     { stateWorkers =
                         Map.delete turnId state.stateWorkers
                     , stateActiveSessions =
-                        Set.delete
-                            ( spec.turnSpecBoundary
-                            , spec.turnSpecSessionId
-                            )
-                            state.stateActiveSessions
+                        if cancellationOwnsTerminal
+                            then state.stateActiveSessions
+                            else
+                                Set.delete
+                                    ( spec.turnSpecBoundary
+                                    , spec.turnSpecSessionId
+                                    )
+                                    state.stateActiveSessions
                     }
 
-finalizeTurn
-    :: Supervisor
-    -> TurnId
-    -> TurnSpec
-    -> Either Text ()
-    -> IO ()
+finalizeTurn ::
+    Supervisor ->
+    TurnId ->
+    TurnSpec ->
+    Either Text TurnExecutionOutput ->
+    IO ()
 finalizeTurn supervisor turnId spec result = do
     now <- getCurrentTime
-    atomically do
+    current <- atomically do
         state <- readTVar supervisor.supervisorState
-        case Map.lookup turnId state.stateTurns of
-            Nothing -> pure ()
-            Just slot
-                | isTerminalStatus
-                    slot.turnSlotRecord.turnRecordStatus ->
-                    pure ()
-                | otherwise -> do
-                    let (status, eventType, turnError) = case result of
-                            Left err ->
-                                ( TurnFailed
-                                , "turn.failed"
-                                , Just (boundedSupervisorText err)
-                                )
-                            Right () ->
-                                (TurnCompleted, "turn.completed", Nothing)
-                        record =
-                            slot.turnSlotRecord
-                                { turnRecordStatus = status
-                                , turnRecordFinishedAt = Just now
-                                , turnRecordError = turnError
-                                }
-                        (event, state') = appendEventToState
-                            supervisor.supervisorConfig
-                            now
-                            spec.turnSpecBoundary
-                            eventType
-                            (Just turnId)
-                            (Just spec.turnSpecSessionId)
-                            (object ["error" .= turnError])
-                            state
-                                { stateTurns =
-                                    Map.insert
-                                        turnId
-                                        slot
-                                            { turnSlotRecord = record
-                                            , turnSlotCancel = Nothing
-                                            }
-                                        state.stateTurns
-                                }
-                    writeTVar supervisor.supervisorState state'
-                    publishToSubscribers state' event
+        pure do
+            slot <- Map.lookup turnId state.stateTurns
+            if slot.turnSlotRecord.turnRecordBoundary
+                == spec.turnSpecBoundary
+                && not slot.turnSlotCancelling
+                then Just slot.turnSlotRecord
+                else Nothing
+    case current of
+        Nothing -> pure ()
+        Just record
+            | isTerminalStatus record.turnRecordStatus ->
+                pure ()
+        Just record -> do
+            canonical <-
+                persistTerminalEventually
+                    supervisor
+                    record
+                    now
+                    (either TurnErrored TurnSucceeded result)
+            atomically $
+                publishTerminalRecord supervisor canonical
+
+publishTerminalRecord
+    :: Supervisor
+    -> TurnRecord
+    -> STM ()
+publishTerminalRecord supervisor canonical = do
+    state <- readTVar supervisor.supervisorState
+    case Map.lookup canonical.turnRecordId state.stateTurns of
+        Nothing -> pure ()
+        Just slot
+            | slot.turnSlotRecord == canonical ->
+                pure ()
+            | otherwise -> do
+                let eventType = case canonical.turnRecordStatus of
+                        TurnCompleted -> "turn.completed"
+                        TurnFailed -> "turn.failed"
+                        TurnCancelled -> "turn.cancelled"
+                        _ -> "turn.failed"
+                    eventAt =
+                        maybe
+                            canonical.turnRecordCreatedAt
+                            id
+                            canonical.turnRecordFinishedAt
+                    (event, state') = appendEventToState
+                        supervisor.supervisorConfig
+                        eventAt
+                        canonical.turnRecordBoundary
+                        eventType
+                        (Just canonical.turnRecordId)
+                        (Just canonical.turnRecordSessionId)
+                        (object ["error" .= canonical.turnRecordError])
+                        state
+                            { stateTurns =
+                                Map.insert
+                                    canonical.turnRecordId
+                                    slot
+                                        { turnSlotRecord = canonical
+                                        , turnSlotCancelling = False
+                                        , turnSlotCancel = Nothing
+                                        }
+                                    state.stateTurns
+                            , stateActiveSessions =
+                                Set.delete
+                                    ( canonical.turnRecordBoundary
+                                    , canonical.turnRecordSessionId
+                                    )
+                                    state.stateActiveSessions
+                            }
+                writeTVar supervisor.supervisorState state'
+                publishToSubscribers state' event
 
 -- A failed boundary guard must not invoke an event callback for the stale
 -- credential. Retain only a terminal in-memory state, still scoped to the
@@ -1058,107 +1514,241 @@ finalizeTurnStateOnly
     -> IO ()
 finalizeTurnStateOnly supervisor turnId err = do
     now <- getCurrentTime
-    atomically $
-        modifyTVar' supervisor.supervisorState \state ->
-            state
-                { stateTurns =
-                    Map.adjust
-                        (\slot ->
-                            if isTerminalStatus
-                                slot.turnSlotRecord.turnRecordStatus
-                                then slot
-                                else slot
-                                    { turnSlotRecord =
-                                        slot.turnSlotRecord
-                                            { turnRecordStatus = TurnFailed
-                                            , turnRecordFinishedAt = Just now
-                                            , turnRecordError =
-                                                Just
-                                                    (boundedSupervisorText err)
-                                            }
+    current <- atomically do
+        state <- readTVar supervisor.supervisorState
+        pure do
+            slot <- Map.lookup turnId state.stateTurns
+            if slot.turnSlotCancelling
+                then Nothing
+                else Just slot.turnSlotRecord
+    forM_ current \record -> do
+        canonical <-
+            persistTerminalEventually
+                supervisor
+                record
+                now
+                (TurnErrored err)
+        atomically $
+            modifyTVar' supervisor.supervisorState \state ->
+                state
+                    { stateTurns =
+                        Map.adjust
+                            (\slot ->
+                                slot
+                                    { turnSlotRecord = canonical
+                                    , turnSlotCancelling = False
                                     , turnSlotCancel = Nothing
                                     })
-                        turnId
-                        state.stateTurns
-                }
+                            turnId
+                            state.stateTurns
+                    }
 
-requestTurnInput
-    :: Supervisor
-    -> TurnId
-    -> TurnSpec
-    -> HumanRequestSpec
-    -> IO (Either Text HumanResponse)
-requestTurnInput supervisor turnId spec requestSpec = do
-    now <- getCurrentTime
-    requestId <- RequestId <$> newUUIDv7Text
-    reply <- atomically newEmptyTMVar
-    let boundedRequestSpec = HumanRequestSpec
-            { humanRequestSpecKind =
-                requestSpec.humanRequestSpecKind
-            , humanRequestSpecPrompt =
-                boundedSupervisorText
-                    requestSpec.humanRequestSpecPrompt
-            , humanRequestSpecOptions =
-                map boundedSupervisorText
-                    (take 100 requestSpec.humanRequestSpecOptions)
-            }
-    requestResult <- atomically do
-        state <- readTVar supervisor.supervisorState
-        case Map.lookup turnId state.stateTurns of
-            Nothing -> pure (Left "turn not found")
-            Just slot
-                | isTerminalStatus
-                    slot.turnSlotRecord.turnRecordStatus ->
-                    pure (Left "turn is no longer running")
-                | otherwise -> do
-                    let request = HumanRequest
-                            { humanRequestId = requestId
-                            , humanRequestTurnId = turnId
-                            , humanRequestSessionId =
-                                spec.turnSpecSessionId
-                            , humanRequestBoundary =
-                                spec.turnSpecBoundary
-                            , humanRequestKind =
-                                boundedRequestSpec.humanRequestSpecKind
-                            , humanRequestPrompt =
-                                boundedRequestSpec.humanRequestSpecPrompt
-                            , humanRequestOptions =
-                                boundedRequestSpec.humanRequestSpecOptions
-                            , humanRequestCreatedAt = now
-                            }
-                        pending = PendingInput
-                            { pendingInputView = request
-                            , pendingInputReply = reply
-                            }
-                        record =
-                            slot.turnSlotRecord
-                                { turnRecordStatus = TurnWaitingForInput }
-                        (event, state') = appendEventToState
-                            supervisor.supervisorConfig
-                            now
-                            spec.turnSpecBoundary
-                            "request.created"
-                            (Just turnId)
-                            (Just spec.turnSpecSessionId)
-                            (toJSONRequest request)
-                            state
-                                { statePendingInputs =
-                                    Map.insert
-                                        requestId
-                                        pending
-                                        state.statePendingInputs
-                                , stateTurns =
-                                    Map.insert
-                                        turnId
-                                        slot { turnSlotRecord = record }
-                                        state.stateTurns
+persistTerminalEventually ::
+    Supervisor ->
+    TurnRecord ->
+    UTCTime ->
+    TurnTerminalOutcome ->
+    IO TurnRecord
+persistTerminalEventually supervisor record finishedAt outcome =
+    go terminalPersistenceInitialRetryMicros
+  where
+    go retryDelay =
+        supervisor.supervisorPersistence.turnPersistenceTerminal
+            record
+            finishedAt
+            outcome
+            >>= \case
+                Right canonical -> pure canonical
+                Left _ -> do
+                    threadDelay retryDelay
+                    go
+                        ( min
+                            terminalPersistenceMaximumRetryMicros
+                            (retryDelay * 2)
+                        )
+
+requestTurnInput ::
+    Supervisor ->
+    TurnId ->
+    TurnSpec ->
+    HumanRequestSpec ->
+    IO (Either Text HumanResponse)
+requestTurnInput supervisor turnId spec requestSpec =
+    mask \restore -> do
+        now <- getCurrentTime
+        requestId <- RequestId <$> newUUIDv7Text
+        reply <- atomically newEmptyTMVar
+        let boundedRequestSpec = HumanRequestSpec
+                { humanRequestSpecKind =
+                    requestSpec.humanRequestSpecKind
+                , humanRequestSpecPrompt =
+                    boundedSupervisorText
+                        requestSpec.humanRequestSpecPrompt
+                , humanRequestSpecOptions =
+                    map boundedSupervisorText
+                        (take 100 requestSpec.humanRequestSpecOptions)
+                }
+            request = HumanRequest
+                { humanRequestId = requestId
+                , humanRequestTurnId = turnId
+                , humanRequestSessionId =
+                    spec.turnSpecSessionId
+                , humanRequestBoundary =
+                    spec.turnSpecBoundary
+                , humanRequestKind =
+                    boundedRequestSpec.humanRequestSpecKind
+                , humanRequestPrompt =
+                    boundedRequestSpec.humanRequestSpecPrompt
+                , humanRequestOptions =
+                    boundedRequestSpec.humanRequestSpecOptions
+                , humanRequestCreatedAt = now
+                }
+        if LazyByteString.length (encode request)
+            > maximumHumanRequestBytes
+            then
+                pure
+                    ( Left
+                        "human request exceeds the public size limit"
+                    )
+            else do
+                current <- atomically (currentTurnRecord supervisor turnId)
+                case current of
+                    Left err -> pure (Left err)
+                    Right record ->
+                        supervisor.supervisorPersistence.turnPersistenceCreateHumanRequest
+                            record
+                            request
+                            >>= \case
+                                Left err -> pure (Left err)
+                                Right () ->
+                                    restore
+                                        (installAndWait record request reply)
+                                        `finally` cleanup record requestId
+  where
+    cleanup record requestId =
+        void $
+            timeout humanRequestCleanupTimeoutMicros $
+                supervisor.supervisorPersistence.turnPersistenceDeleteHumanRequest
+                    record
+                    requestId
+
+    installAndWait record request reply = do
+        installed <- atomically do
+            state <- readTVar supervisor.supervisorState
+            case Map.lookup turnId state.stateTurns of
+                Nothing -> pure (Left "turn not found")
+                Just slot
+                    | slot.turnSlotCancelling
+                        || isTerminalStatus
+                            slot.turnSlotRecord.turnRecordStatus ->
+                        pure (Left "turn is no longer running")
+                    | otherwise -> do
+                        let pending = PendingInput
+                                { pendingInputView = request
+                                , pendingInputReply = reply
                                 }
-                    writeTVar supervisor.supervisorState state'
-                    publishToSubscribers state' event
-                    pure (Right ())
-    case requestResult of
-        Left err -> pure (Left err)
-        Right () -> atomically (takeTMVar reply)
+                            waitingRecord =
+                                slot.turnSlotRecord
+                                    { turnRecordStatus =
+                                        TurnWaitingForInput
+                                    }
+                            (event, state') = appendEventToState
+                                supervisor.supervisorConfig
+                                request.humanRequestCreatedAt
+                                spec.turnSpecBoundary
+                                "request.created"
+                                (Just turnId)
+                                (Just spec.turnSpecSessionId)
+                                (toJSONRequest request)
+                                state
+                                    { statePendingInputs =
+                                        Map.insert
+                                            request.humanRequestId
+                                            pending
+                                            state.statePendingInputs
+                                    , stateTurns =
+                                        Map.insert
+                                            turnId
+                                            slot
+                                                { turnSlotRecord =
+                                                    waitingRecord
+                                                }
+                                            state.stateTurns
+                                    }
+                        writeTVar supervisor.supervisorState state'
+                        publishToSubscribers state' event
+                        pure (Right ())
+        case installed of
+            Left err -> pure (Left err)
+            Right () ->
+                waitForHumanResponse
+                    supervisor
+                    record
+                    request
+                    reply
+
+currentTurnRecord ::
+    Supervisor ->
+    TurnId ->
+    STM (Either Text TurnRecord)
+currentTurnRecord supervisor turnId = do
+    state <- readTVar supervisor.supervisorState
+    case Map.lookup turnId state.stateTurns of
+        Nothing -> pure (Left "turn not found")
+        Just slot
+            | slot.turnSlotCancelling
+                || isTerminalStatus
+                    slot.turnSlotRecord.turnRecordStatus ->
+                pure (Left "turn is no longer running")
+            | otherwise -> pure (Right slot.turnSlotRecord)
+
+waitForHumanResponse ::
+    Supervisor ->
+    TurnRecord ->
+    HumanRequest ->
+    TMVar (Either Text HumanResponse) ->
+    IO (Either Text HumanResponse)
+waitForHumanResponse supervisor record request reply =
+    timeout
+        humanResponsePollIntervalMicros
+        (atomically (takeTMVar reply))
+        >>= \case
+            Just response -> pure response
+            Nothing ->
+                supervisor.supervisorPersistence.turnPersistenceLoadHumanResponse
+                    record
+                    request.humanRequestId
+                    >>= \case
+                        Left err -> pure (Left err)
+                        Right Nothing ->
+                            waitForHumanResponse
+                                supervisor
+                                record
+                                request
+                                reply
+                        Right (Just response) -> do
+                            now <- getCurrentTime
+                            completed <- atomically do
+                                state <- readTVar supervisor.supervisorState
+                                case completePendingInputInState
+                                        supervisor.supervisorConfig
+                                        now
+                                        request.humanRequestId
+                                        state of
+                                    Nothing -> pure False
+                                    Just (_, event, state') -> do
+                                        writeTVar
+                                            supervisor.supervisorState
+                                            state'
+                                        publishToSubscribers state' event
+                                        pure True
+                            pure
+                                ( if completed
+                                    then Right response
+                                    else
+                                        Left
+                                            "turn is no longer waiting for input"
+                                )
 
 setTurnCancellation :: TurnId -> IO () -> SupervisorState -> SupervisorState
 setTurnCancellation turnId action state =
@@ -1166,7 +1756,9 @@ setTurnCancellation turnId action state =
         { stateTurns =
             Map.adjust
                 (\slot ->
-                    if isActiveStatus slot.turnSlotRecord.turnRecordStatus
+                    if
+                        isActiveStatus slot.turnSlotRecord.turnRecordStatus
+                            && not slot.turnSlotCancelling
                         then slot { turnSlotCancel = Just action }
                         else slot)
                 turnId
@@ -1253,6 +1845,7 @@ publishTurnEvent
         case Map.lookup turnId state.stateTurns of
             Just slot
                 | not state.stateClosed
+                , not slot.turnSlotCancelling
                 , slot.turnSlotRecord.turnRecordBoundary == boundary
                 , slot.turnSlotRecord.turnRecordSessionId == sessionId
                 , isActiveStatus slot.turnSlotRecord.turnRecordStatus -> do
@@ -1377,12 +1970,11 @@ cancelSlot
     -> TurnSlot
     -> Map TurnId TurnSlot
     -> Map TurnId TurnSlot
-cancelSlot now slot =
+cancelSlot _now slot =
     Map.insert
         slot.turnSlotRecord.turnRecordId
         slot
-            { turnSlotRecord =
-                cancelledRecord now slot.turnSlotRecord
+            { turnSlotCancelling = True
             , turnSlotCancel = Nothing
             }
 
@@ -1397,6 +1989,28 @@ cancelledRecord now record =
         , turnRecordError = Nothing
         }
 
+terminalRecord
+    :: UTCTime
+    -> TurnTerminalOutcome
+    -> TurnRecord
+    -> TurnRecord
+terminalRecord finishedAt outcome record =
+    case outcome of
+        TurnSucceeded _ ->
+            record
+                { turnRecordStatus = TurnCompleted
+                , turnRecordFinishedAt = Just finishedAt
+                , turnRecordError = Nothing
+                }
+        TurnErrored err ->
+            record
+                { turnRecordStatus = TurnFailed
+                , turnRecordFinishedAt = Just finishedAt
+                , turnRecordError = Just (boundedSupervisorText err)
+                }
+        TurnWasCancelled ->
+            cancelledRecord finishedAt record
+
 resumeWaitingTurn
     :: UTCTime
     -> TurnSlot
@@ -1410,6 +2024,38 @@ resumeWaitingTurn _now slot
             }
     | otherwise = slot
 
+completePendingInputInState ::
+    SupervisorConfig ->
+    UTCTime ->
+    RequestId ->
+    SupervisorState ->
+    Maybe (HumanRequest, ServerEvent, SupervisorState)
+completePendingInputInState config now requestId state = do
+    pending <- Map.lookup requestId state.statePendingInputs
+    let request = pending.pendingInputView
+        turns' =
+            Map.adjust
+                (resumeWaitingTurn now)
+                request.humanRequestTurnId
+                state.stateTurns
+        withoutPending =
+            state
+                { statePendingInputs =
+                    Map.delete requestId state.statePendingInputs
+                , stateTurns = turns'
+                }
+        (event, state') =
+            appendEventToState
+                config
+                now
+                request.humanRequestBoundary
+                "request.resolved"
+                (Just request.humanRequestTurnId)
+                (Just request.humanRequestSessionId)
+                (object ["requestId" .= requestId.unRequestId])
+                withoutPending
+    pure (request, event, state')
+
 validHumanAnswer :: [Text] -> Text -> Bool
 validHumanAnswer options answer =
     null options || answer `elem` options
@@ -1418,6 +2064,33 @@ boundedSupervisorText :: Text -> Text
 boundedSupervisorText value
     | Text.length value <= 16384 = value
     | otherwise = Text.take 16383 value <> "…"
+
+terminalPersistenceInitialRetryMicros :: Int
+terminalPersistenceInitialRetryMicros = 100 * 1000
+
+terminalPersistenceMaximumRetryMicros :: Int
+terminalPersistenceMaximumRetryMicros = 2 * 1000 * 1000
+
+cancellationPollIntervalMicros :: Int
+cancellationPollIntervalMicros = 100 * 1000
+
+cancellationCheckTimeoutMicros :: Int
+cancellationCheckTimeoutMicros = 5 * 1000 * 1000
+
+cancellationCheckBatchSize :: Int
+cancellationCheckBatchSize = 4
+
+humanResponsePollIntervalMicros :: Int
+humanResponsePollIntervalMicros = 100 * 1000
+
+humanRequestCleanupTimeoutMicros :: Int
+humanRequestCleanupTimeoutMicros = 1000 * 1000
+
+maximumHumanRequestBytes :: Int64
+maximumHumanRequestBytes = 64 * 1024
+
+terminalPersistenceShutdownTimeoutMicros :: Int
+terminalPersistenceShutdownTimeoutMicros = 5 * 1000 * 1000
 
 cancelHookTimeoutMicros :: Int
 cancelHookTimeoutMicros = 1000 * 1000

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -13,6 +13,7 @@ module Agent.Server.Supervisor
     , TurnRunner
     , TurnBoundaryGuard
     , HumanRequestPersistenceResolution(..)
+    , HumanRequestResolutionError(..)
     , HumanRequestCleanup(..)
     , TurnPersistence(..)
     , inMemoryTurnPersistence
@@ -158,6 +159,12 @@ data HumanRequestPersistenceResolution
     = HumanRequestResolvedDurably !HumanRequest
     | HumanRequestNotFoundDurably
     | HumanRequestLocalOnly
+    deriving (Eq, Show)
+
+data HumanRequestResolutionError
+    = HumanRequestResolutionNotFound
+    | HumanRequestResolutionConflict !Text
+    | HumanRequestResolutionStoreUnavailable !Text
     deriving (Eq, Show)
 
 data HumanRequestCleanup
@@ -896,7 +903,7 @@ resolveHumanRequest
     -> AccessBoundary
     -> RequestId
     -> HumanResponse
-    -> IO (Either Text HumanRequest)
+    -> IO (Either HumanRequestResolutionError HumanRequest)
 resolveHumanRequest supervisor boundary requestId response = do
     durable <-
         supervisor.supervisorPersistence.turnPersistenceResolveHumanRequest
@@ -904,9 +911,10 @@ resolveHumanRequest supervisor boundary requestId response = do
             requestId
             response
     case durable of
-        Left err -> pure (Left err)
+        Left err ->
+            pure (Left (HumanRequestResolutionStoreUnavailable err))
         Right HumanRequestNotFoundDurably ->
-            pure (Left "request not found")
+            pure (Left HumanRequestResolutionNotFound)
         Right (HumanRequestResolvedDurably request) ->
             resolveLocal (Just request)
         Right HumanRequestLocalOnly ->
@@ -920,12 +928,12 @@ resolveHumanRequest supervisor boundary requestId response = do
                 Nothing ->
                     pure $
                         maybe
-                            (Left "request not found")
+                            (Left HumanRequestResolutionNotFound)
                             Right
                             durableRequest
                 Just pending
                     | pending.pendingInputView.humanRequestBoundary /= boundary ->
-                        pure (Left "request not found")
+                        pure (Left HumanRequestResolutionNotFound)
                     | durableRequest == Nothing
                         && not
                             ( validHumanAnswer
@@ -934,7 +942,9 @@ resolveHumanRequest supervisor boundary requestId response = do
                             ) ->
                         pure
                             ( Left
-                                "decision is not one of the allowed options"
+                                ( HumanRequestResolutionConflict
+                                    "decision is not one of the allowed options"
+                                )
                             )
                     | otherwise -> do
                         accepted <-
@@ -945,7 +955,9 @@ resolveHumanRequest supervisor boundary requestId response = do
                             then
                                 pure
                                     ( Left
-                                        "request has already been resolved"
+                                        ( HumanRequestResolutionConflict
+                                            "request has already been resolved"
+                                        )
                                     )
                             else
                                 case completePendingInputInState
@@ -954,7 +966,8 @@ resolveHumanRequest supervisor boundary requestId response = do
                                         requestId
                                         state of
                                     Nothing ->
-                                        pure (Left "request not found")
+                                        pure
+                                            (Left HumanRequestResolutionNotFound)
                                     Just (request, event, state') -> do
                                         writeTVar
                                             supervisor.supervisorState

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -28,6 +28,7 @@ module Agent.Server.Supervisor
     , lookupTurn
     , listTurns
     , sessionHasActiveTurn
+    , withSessionCleanup
     , withSessionMutation
     , listHumanRequests
     , resolveHumanRequest
@@ -795,6 +796,18 @@ withSessionMutation
     -> IO (Either SessionMutationError value)
 withSessionMutation =
     withSessionReservation False
+
+-- | Wait behind a transient reservation before cleaning up durable state.
+--
+-- An admitted turn still rejects cleanup so its live execution wins.
+withSessionCleanup
+    :: Supervisor
+    -> AccessBoundary
+    -> Text
+    -> IO value
+    -> IO (Either SessionMutationError value)
+withSessionCleanup =
+    withSessionReservation True
 
 withSessionReservation
     :: Bool

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -894,13 +894,23 @@ listHumanRequests supervisor boundary turnId = do
     pure do
         persisted <- durable
         let combined = persisted <> local
+            sorted =
+                sortOn
+                    ( \request ->
+                        ( Down request.humanRequestCreatedAt
+                        , Down request.humanRequestId
+                        )
+                    )
+                    ( Map.elems $
+                        Map.fromList
+                            [ (request.humanRequestId, request)
+                            | request <- combined
+                            ]
+                    )
         pure $
-            sortOn (Down . (.humanRequestCreatedAt)) $
-                Map.elems $
-                    Map.fromList
-                        [ (request.humanRequestId, request)
-                        | request <- combined
-                        ]
+            case turnId of
+                Nothing -> take maximumHumanRequestPageSize sorted
+                Just _ -> sorted
 
 resolveHumanRequest
     :: Supervisor
@@ -2199,6 +2209,9 @@ humanRequestCleanupTimeoutMicros = 1000 * 1000
 
 maximumHumanRequestBytes :: Int64
 maximumHumanRequestBytes = 64 * 1024
+
+maximumHumanRequestPageSize :: Int
+maximumHumanRequestPageSize = 200
 
 terminalPersistenceShutdownTimeoutMicros :: Int
 terminalPersistenceShutdownTimeoutMicros = 5 * 1000 * 1000

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -717,21 +717,26 @@ cancelTurn supervisor boundary turnId = mask \restore -> do
                         void $
                             timeout cancelHookTimeoutMicros
                                 (void (tryAny (restore action)))
-            -- Preserve in-band cancellation when it is responsive, but always
-            -- deliver and join the structured cancellation.
-            interruptInBand `finally` stopWorker
-            if not transitioned
-                then pure (Right record)
-                else do
-                    canonical <-
-                        persistTerminalEventually
-                            supervisor
-                            record
-                            now
-                            TurnWasCancelled
-                    atomically $
-                        publishTerminalRecord supervisor canonical
-                    pure (Right canonical)
+                completeCancellation = do
+                    -- Preserve in-band cancellation when it is responsive, but
+                    -- always deliver and join the structured cancellation.
+                    interruptInBand `finally` stopWorker
+                    if not transitioned
+                        then pure (Right record)
+                        else do
+                            canonical <-
+                                persistTerminalEventually
+                                    supervisor
+                                    record
+                                    now
+                                    TurnWasCancelled
+                            atomically $
+                                publishTerminalRecord supervisor canonical
+                            pure (Right canonical)
+            completeCancellation
+                `onException`
+                    when transitioned
+                        (atomically (releaseCancellationClaim supervisor record))
 
 lookupTurn
     :: Supervisor
@@ -1526,6 +1531,27 @@ publishTerminalRecord supervisor canonical = do
                             }
                 writeTVar supervisor.supervisorState state'
                 publishToSubscribers state' event
+
+releaseCancellationClaim :: Supervisor -> TurnRecord -> STM ()
+releaseCancellationClaim supervisor record =
+    modifyTVar' supervisor.supervisorState \state ->
+        state
+            { stateTurns =
+                Map.adjust
+                    ( \slot ->
+                        if
+                            slot.turnSlotCancelling
+                                && slot.turnSlotRecord == record
+                            then
+                                slot
+                                    { turnSlotCancelling = False
+                                    , turnSlotCancel = Nothing
+                                    }
+                            else slot
+                    )
+                    record.turnRecordId
+                    state.stateTurns
+            }
 
 -- A failed boundary guard must not invoke an event callback for the stale
 -- credential. Retain only a terminal in-memory state, still scoped to the

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -13,6 +13,7 @@ module Agent.Server.Supervisor
     , TurnRunner
     , TurnBoundaryGuard
     , HumanRequestPersistenceResolution(..)
+    , HumanRequestCleanup(..)
     , TurnPersistence(..)
     , inMemoryTurnPersistence
     , newSupervisor
@@ -158,6 +159,11 @@ data HumanRequestPersistenceResolution
     | HumanRequestLocalOnly
     deriving (Eq, Show)
 
+data HumanRequestCleanup
+    = HumanRequestAbandoned
+    | HumanResponseConsumed
+    deriving (Eq, Show)
+
 data TurnPersistence = TurnPersistence
     { turnPersistenceStarted ::
         !(TurnRecord -> UTCTime -> IO (Either Text ()))
@@ -185,7 +191,11 @@ data TurnPersistence = TurnPersistence
            IO (Either Text (Maybe HumanResponse))
          )
     , turnPersistenceDeleteHumanRequest ::
-        !(TurnRecord -> RequestId -> IO (Either Text ()))
+        !( TurnRecord ->
+           RequestId ->
+           HumanRequestCleanup ->
+           IO (Either Text ())
+         )
     }
 
 inMemoryTurnPersistence :: TurnPersistence
@@ -204,7 +214,7 @@ inMemoryTurnPersistence =
             pure (Right HumanRequestLocalOnly)
         , turnPersistenceLoadHumanResponse = \_ _ ->
             pure (Right Nothing)
-        , turnPersistenceDeleteHumanRequest = \_ _ ->
+        , turnPersistenceDeleteHumanRequest = \_ _ _ ->
             pure (Right ())
         }
 
@@ -1620,17 +1630,30 @@ requestTurnInput supervisor turnId spec requestSpec =
                             request
                             >>= \case
                                 Left err -> pure (Left err)
-                                Right () ->
-                                    restore
-                                        (installAndWait record request reply)
-                                        `finally` cleanup record requestId
+                                Right () -> do
+                                    result <-
+                                        restore
+                                            (installAndWait record request reply)
+                                            `onException` cleanup
+                                                record
+                                                requestId
+                                                HumanRequestAbandoned
+                                    cleanup
+                                        record
+                                        requestId
+                                        ( case result of
+                                            Left _ -> HumanRequestAbandoned
+                                            Right _ -> HumanResponseConsumed
+                                        )
+                                    pure result
   where
-    cleanup record requestId =
+    cleanup record requestId disposition =
         void $
             timeout humanRequestCleanupTimeoutMicros $
                 supervisor.supervisorPersistence.turnPersistenceDeleteHumanRequest
                     record
                     requestId
+                    disposition
 
     installAndWait record request reply = do
         installed <- atomically do

--- a/packages/agent-server/src/Agent/Server/Types.hs
+++ b/packages/agent-server/src/Agent/Server/Types.hs
@@ -13,11 +13,17 @@ module Agent.Server.Types
     , AccessBoundary(..)
     , accessBoundary
     , TurnId(..)
+    , ClientRequestId(..)
     , RequestId(..)
     , TurnStatus(..)
     , turnStatusText
     , TurnSpec(..)
     , TurnRecord(..)
+    , TurnReservation(..)
+    , TurnCompletionResult(..)
+    , TurnExecutionOutput(..)
+    , TurnTerminalOutcome(..)
+    , TurnResult(..)
     , HumanRequestKind(..)
     , humanRequestKindText
     , HumanRequestSpec(..)
@@ -116,6 +122,9 @@ accessBoundary principal gateway = AccessBoundary
 newtype TurnId = TurnId { unTurnId :: Text }
     deriving (Eq, Ord, Show)
 
+newtype ClientRequestId = ClientRequestId { unClientRequestId :: Text }
+    deriving (Eq, Ord, Show)
+
 newtype RequestId = RequestId { unRequestId :: Text }
     deriving (Eq, Ord, Show)
 
@@ -139,14 +148,26 @@ turnStatusText = \case
 
 data TurnSpec = TurnSpec
     { turnSpecSessionId :: !Text
+    , turnSpecClientRequestId :: !ClientRequestId
     , turnSpecPrompt :: !Text
     , turnSpecBoundary :: !AccessBoundary
     }
     deriving (Eq, Show)
 
+instance ToJSON TurnExecutionOutput where
+    toJSON output =
+        object
+            [ "responseId" .= output.turnExecutionResponseId
+            , "assistantText" .= output.turnExecutionAssistantText
+            , "assistantTextTruncated"
+                .= output.turnExecutionAssistantTextTruncated
+            , "completion" .= output.turnExecutionCompletion
+            ]
+
 data TurnRecord = TurnRecord
     { turnRecordId :: !TurnId
     , turnRecordSessionId :: !Text
+    , turnRecordClientRequestId :: !ClientRequestId
     , turnRecordBoundary :: !AccessBoundary
     , turnRecordStatus :: !TurnStatus
     , turnRecordCreatedAt :: !UTCTime
@@ -157,15 +178,67 @@ data TurnRecord = TurnRecord
     deriving (Eq, Show)
 
 instance ToJSON TurnRecord where
-    toJSON turn = object
-        [ "id" .= turn.turnRecordId.unTurnId
-        , "sessionId" .= turn.turnRecordSessionId
-        , "status" .= turnStatusText turn.turnRecordStatus
-        , "createdAt" .= turn.turnRecordCreatedAt
-        , "startedAt" .= turn.turnRecordStartedAt
-        , "finishedAt" .= turn.turnRecordFinishedAt
-        , "error" .= turn.turnRecordError
-        ]
+    toJSON turn =
+        object
+            [ "id" .= turn.turnRecordId.unTurnId
+            , "sessionId" .= turn.turnRecordSessionId
+            , "clientRequestId"
+                .= turn.turnRecordClientRequestId.unClientRequestId
+            , "status" .= turnStatusText turn.turnRecordStatus
+            , "createdAt" .= turn.turnRecordCreatedAt
+            , "startedAt" .= turn.turnRecordStartedAt
+            , "finishedAt" .= turn.turnRecordFinishedAt
+            , "error" .= turn.turnRecordError
+            ]
+
+data TurnReservation
+    = TurnReservationCreated !TurnRecord
+    | TurnReservationExistingOwned !TurnRecord
+    | TurnReservationExisting !TurnRecord
+    deriving (Eq, Show)
+
+data TurnCompletionResult
+    = TurnCompletionComplete
+    | TurnCompletionIncomplete !Text !(Maybe Int)
+    deriving (Eq, Show)
+
+instance ToJSON TurnCompletionResult where
+    toJSON = \case
+        TurnCompletionComplete ->
+            object ["status" .= ("completed" :: Text)]
+        TurnCompletionIncomplete reason reasoningTokens ->
+            object
+                [ "status" .= ("incomplete" :: Text)
+                , "reason" .= reason
+                , "reasoningTokens" .= reasoningTokens
+                ]
+
+data TurnExecutionOutput = TurnExecutionOutput
+    { turnExecutionResponseId :: !Text
+    , turnExecutionAssistantText :: !(Maybe Text)
+    , turnExecutionAssistantTextTruncated :: !Bool
+    , turnExecutionCompletion :: !TurnCompletionResult
+    }
+    deriving (Eq, Show)
+
+data TurnTerminalOutcome
+    = TurnSucceeded !TurnExecutionOutput
+    | TurnErrored !Text
+    | TurnWasCancelled
+    deriving (Eq, Show)
+
+data TurnResult = TurnResult
+    { turnResultTurn :: !TurnRecord
+    , turnResultOutput :: !(Maybe TurnExecutionOutput)
+    }
+    deriving (Eq, Show)
+
+instance ToJSON TurnResult where
+    toJSON result =
+        object
+            [ "turn" .= result.turnResultTurn
+            , "output" .= result.turnResultOutput
+            ]
 
 data HumanRequestKind
     = ToolApprovalRequest
@@ -310,15 +383,29 @@ instance FromJSON ForkSessionRequest where
             <*> value .:? "title"
             <*> value .:? "cwd"
 
-newtype CreateTurnRequest = CreateTurnRequest
-    { createTurnInput :: Text
+data CreateTurnRequest = CreateTurnRequest
+    { createTurnClientRequestId :: !(Maybe ClientRequestId)
+    , createTurnInput :: !Text
     }
     deriving (Eq, Show)
 
 instance FromJSON CreateTurnRequest where
     parseJSON = withObject "CreateTurnRequest" \value -> do
-        rejectUnknownFields "CreateTurnRequest" ["input"] value
-        CreateTurnRequest <$> value .: "input"
+        rejectUnknownFields
+            "CreateTurnRequest"
+            ["clientRequestId", "input"]
+            value
+        rawRequestId <- value .:? "clientRequestId"
+        requestId <- case rawRequestId of
+            Nothing -> pure Nothing
+            Just candidate
+                | isUUIDText candidate ->
+                    pure
+                        (Just
+                            (ClientRequestId
+                                (Text.toLower candidate)))
+                | otherwise -> fail "clientRequestId must be a UUID"
+        CreateTurnRequest requestId <$> value .: "input"
 
 data ResolveRequest = ResolveRequest
     { resolveRequestDecision :: !Text

--- a/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
@@ -1,25 +1,25 @@
 module Agent.Server.ApplicationSpec (spec) where
 
-import Agent.Server.Application
-    ( ApplicationConfig (..)
-    , newApplication
-    )
+import Agent.Server.Application (
+    ApplicationConfig (..),
+    newApplication,
+ )
 import Agent.Server.Auth
-import Agent.Server.Backend (Backend(..), SessionMutationLease(..))
+import Agent.Server.Backend (Backend (..), SessionMutationLease (..))
 import Agent.Server.Supervisor
 import Agent.Server.Types
 import Control.Concurrent.Async (cancel, wait, waitCatch, withAsync)
-import Control.Concurrent.MVar
-    ( MVar
-    , modifyMVar
-    , modifyMVar_
-    , newEmptyMVar
-    , newMVar
-    , putMVar
-    , readMVar
-    , takeMVar
-    , tryPutMVar
-    )
+import Control.Concurrent.MVar (
+    MVar,
+    modifyMVar,
+    modifyMVar_,
+    newEmptyMVar,
+    newMVar,
+    putMVar,
+    readMVar,
+    takeMVar,
+    tryPutMVar,
+ )
 import Control.Exception.Safe (bracket, finally)
 import Control.Monad (void)
 import Data.Aeson (Value (..), eitherDecode, object, (.=))
@@ -31,37 +31,37 @@ import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Time.Clock (getCurrentTime)
-import Network.HTTP.Types
-    ( Header
-    , Method
-    , methodGet
-    , methodPatch
-    , methodPost
-    , status200
-    , status202
-    , status400
-    , status403
-    , status404
-    , status409
-    , status413
-    , status415
-    , status422
-    , status503
-    )
-import Network.Wai
-    ( Application
-    , defaultRequest
-    , pathInfo
-    , queryString
-    , requestHeaders
-    , requestMethod
-    )
-import Network.Wai.Test
-    ( SRequest (..)
-    , SResponse (..)
-    , runSession
-    , srequest
-    )
+import Network.HTTP.Types (
+    Header,
+    Method,
+    methodGet,
+    methodPatch,
+    methodPost,
+    status200,
+    status202,
+    status400,
+    status403,
+    status404,
+    status409,
+    status413,
+    status415,
+    status422,
+    status503,
+ )
+import Network.Wai (
+    Application,
+    defaultRequest,
+    pathInfo,
+    queryString,
+    requestHeaders,
+    requestMethod,
+ )
+import Network.Wai.Test (
+    SRequest (..),
+    SResponse (..),
+    runSession,
+    srequest,
+ )
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -69,31 +69,36 @@ spec :: Spec
 spec = describe "agent-server WAI application" do
     it "rejects requests without the strict loopback Host" do
         withApplication immediateRunner \application -> do
-            response <- perform application
-                methodGet
-                ["healthz"]
-                []
-                ""
+            response <-
+                perform
+                    application
+                    methodGet
+                    ["healthz"]
+                    []
+                    ""
             response.simpleStatus `shouldBe` status403
             LBS8.unpack response.simpleBody
                 `shouldContain` "\"requestId\":\""
 
     it "keeps allowed CORS headers on authentication failures" do
-        let auth = AuthConfig
-                { authMode =
-                    LoopbackHostAuth
-                        (Set.fromList ["127.0.0.1:4096"])
-                , authCorsOrigins =
-                    Set.fromList ["https://client.example"]
-                }
+        let auth =
+                AuthConfig
+                    { authMode =
+                        LoopbackHostAuth
+                            (Set.fromList ["127.0.0.1:4096"])
+                    , authCorsOrigins =
+                        Set.fromList ["https://client.example"]
+                    }
         withApplicationAuth auth immediateRunner \application -> do
-            response <- perform application
-                methodGet
-                ["healthz"]
-                [ ("Host", "attacker.example")
-                , ("Origin", "https://client.example")
-                ]
-                ""
+            response <-
+                perform
+                    application
+                    methodGet
+                    ["healthz"]
+                    [ ("Host", "attacker.example")
+                    , ("Origin", "https://client.example")
+                    ]
+                    ""
             response.simpleStatus `shouldBe` status403
             lookup
                 "Access-Control-Allow-Origin"
@@ -102,11 +107,13 @@ spec = describe "agent-server WAI application" do
 
     it "serves health and attaches a request id" do
         withApplication immediateRunner \application -> do
-            response <- perform application
-                methodGet
-                ["healthz"]
-                validHeaders
-                ""
+            response <-
+                perform
+                    application
+                    methodGet
+                    ["healthz"]
+                    validHeaders
+                    ""
             response.simpleStatus `shouldBe` status200
             lookup "X-Request-ID" response.simpleHeaders
                 `shouldSatisfy` (/= Nothing)
@@ -124,22 +131,26 @@ spec = describe "agent-server WAI application" do
 
     it "rejects media types that only prefix-match application/json" do
         withApplication immediateRunner \application -> do
-            response <- perform application
-                methodPost
-                ["v1", "sessions"]
-                [ ("Host", "127.0.0.1:4096")
-                , ("Content-Type", "application/json-patch")
-                ]
-                "{}"
+            response <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions"]
+                    [ ("Host", "127.0.0.1:4096")
+                    , ("Content-Type", "application/json-patch")
+                    ]
+                    "{}"
             response.simpleStatus `shouldBe` status415
 
     it "rejects request fields outside the published schema" do
         withApplication immediateRunner \application -> do
-            response <- perform application
-                methodPost
-                ["v1", "sessions"]
-                validHeaders
-                "{\"unexpected\":true}"
+            response <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions"]
+                    validHeaders
+                    "{\"unexpected\":true}"
             response.simpleStatus `shouldBe` status400
 
     it "filters pending human requests by turn id" do
@@ -159,20 +170,23 @@ spec = describe "agent-server WAI application" do
         withBackendApplication backend immediateRunner \application -> do
             response <-
                 runSession
-                    (srequest
-                        (SRequest
+                    ( srequest
+                        ( SRequest
                             defaultRequest
                                 { requestMethod = methodGet
                                 , pathInfo = ["v1", "requests"]
                                 , queryString =
-                                    [ ( "turnId"
-                                      , Just
+                                    [
+                                        ( "turnId"
+                                        , Just
                                             "01999999-1111-7111-8111-111111111120"
-                                      )
+                                        )
                                     ]
                                 , requestHeaders = validHeaders
                                 }
-                            ""))
+                            ""
+                        )
+                    )
                     application
             response.simpleStatus `shouldBe` status200
             takeMVar observed `shouldReturn` Just expectedTurnId
@@ -201,9 +215,11 @@ spec = describe "agent-server WAI application" do
                     { backendReserveTurn =
                         \boundary _ _ _ _ _ ->
                             pure
-                                (Right
-                                    (TurnReservationExistingOwned
-                                        (reserved boundary)))
+                                ( Right
+                                    ( TurnReservationExistingOwned
+                                        (reserved boundary)
+                                    )
+                                )
                     }
             runner _ _ =
                 putMVar ran () >> pure (Right successfulOutput)
@@ -431,13 +447,45 @@ spec = describe "agent-server WAI application" do
             LBS8.unpack response.simpleBody
                 `shouldContain` "\"clientRequestId\":"
 
+    it "returns 404 when a session disappears before turn reservation" do
+        ran <- newEmptyMVar
+        let backend =
+                fakeBackend
+                    { backendReserveTurn =
+                        \_ _ _ _ _ _ ->
+                            pure . Left $
+                                ApiError
+                                    { apiErrorStatus = 404
+                                    , apiErrorCode = "not_found"
+                                    , apiErrorMessage = "resource not found"
+                                    , apiErrorDetails = Nothing
+                                    }
+                    }
+            runner _ _ =
+                putMVar ran () >> pure (Right successfulOutput)
+        withBackendApplication backend runner \application -> do
+            response <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    "{\"input\":\"hello\"}"
+            response.simpleStatus `shouldBe` status404
+            LBS8.unpack response.simpleBody
+                `shouldContain` "\"code\":\"not_found\""
+            timeout (100 * 1000) (takeMVar ran)
+                `shouldReturn` Nothing
+
     it "rejects a non-atomic multi-field session patch" do
         withApplication immediateRunner \application -> do
-            response <- perform application
-                methodPatch
-                ["v1", "sessions", "session-a"]
-                validHeaders
-                "{\"title\":\"new\",\"archived\":true}"
+            response <-
+                perform
+                    application
+                    methodPatch
+                    ["v1", "sessions", "session-a"]
+                    validHeaders
+                    "{\"title\":\"new\",\"archived\":true}"
             response.simpleStatus `shouldBe` status422
 
     it "returns 409 for mutation while a session turn is active" do
@@ -457,11 +505,13 @@ spec = describe "agent-server WAI application" do
                     "{\"clientRequestId\":\"01999999-1111-7111-8111-111111111111\",\"input\":\"hello\"}"
             created.simpleStatus `shouldBe` status202
             takeMVar started
-            patched <- perform application
-                methodPatch
-                ["v1", "sessions", "session-a"]
-                validHeaders
-                "{\"title\":\"new title\"}"
+            patched <-
+                perform
+                    application
+                    methodPatch
+                    ["v1", "sessions", "session-a"]
+                    validHeaders
+                    "{\"title\":\"new title\"}"
             patched.simpleStatus `shouldBe` status409
             putMVar release ()
 
@@ -810,12 +860,13 @@ withApplication ::
     IO value
 withApplication = withApplicationAuth auth
   where
-    auth = AuthConfig
-        { authMode =
-            LoopbackHostAuth
-                (Set.fromList ["127.0.0.1:4096"])
-        , authCorsOrigins = Set.empty
-        }
+    auth =
+        AuthConfig
+            { authMode =
+                LoopbackHostAuth
+                    (Set.fromList ["127.0.0.1:4096"])
+            , authCorsOrigins = Set.empty
+            }
 
 withDurableApplication ::
     TurnRunner ->
@@ -928,15 +979,16 @@ withApplicationAuth auth runner action =
                     supervisor
             action application
   where
-    supervisorConfig = SupervisorConfig
-        { supervisorMaxConcurrentTurns = 1
-        , supervisorMaxConcurrentTurnsPerTenant = 1
-        , supervisorMaxQueuedTurns = 10
-        , supervisorMaxQueuedTurnsPerTenant = 10
-        , supervisorMaxEventSubscribers = 10
-        , supervisorMaxEventSubscribersPerTenant = 5
-        , supervisorEventReplayLimit = 10
-        }
+    supervisorConfig =
+        SupervisorConfig
+            { supervisorMaxConcurrentTurns = 1
+            , supervisorMaxConcurrentTurnsPerTenant = 1
+            , supervisorMaxQueuedTurns = 10
+            , supervisorMaxQueuedTurnsPerTenant = 10
+            , supervisorMaxEventSubscribers = 10
+            , supervisorMaxEventSubscribersPerTenant = 5
+            , supervisorEventReplayLimit = 10
+            }
 
 fakeBackend :: Backend
 fakeBackend =
@@ -971,13 +1023,15 @@ fakeBackend =
         , backendReserveSessionMutation =
             \_ _ _ ->
                 pure
-                    (Right
-                        (Just
+                    ( Right
+                        ( Just
                             SessionMutationLease
                                 { runSessionMutationLease =
                                     \action -> Right <$> action
                                 , releaseSessionMutationLease = pure ()
-                                }))
+                                }
+                        )
+                    )
         , backendReserveTurn =
             \boundary sessionId clientRequestId _ turnId createdAt ->
                 pure . Right . TurnReservationCreated $
@@ -1001,9 +1055,10 @@ fakeBackend =
         , backendRunTurn = immediateRunner
         }
   where
-    sessionValue = object
-        [ "id" .= ("session-a" :: String)
-        ]
+    sessionValue =
+        object
+            [ "id" .= ("session-a" :: String)
+            ]
 
 data TestStoredTurn = TestStoredTurn
     { testStoredInput :: !Text
@@ -1129,9 +1184,9 @@ durableBackend ledger terminal runner =
                                 }
                     updateStoredTurn ledger record.turnRecordId \entry ->
                         entry
-                                { testStoredRecord = canonical
-                                , testStoredOutput = output
-                                }
+                            { testStoredRecord = canonical
+                            , testStoredOutput = output
+                            }
                     void (tryPutMVar terminal ())
                     pure (Right canonical)
                 , turnPersistenceShouldCancel = \_ ->
@@ -1184,23 +1239,25 @@ successfulOutput =
         , turnExecutionCompletion = TurnCompletionComplete
         }
 
-perform
-    :: Application
-    -> Method
-    -> [Text]
-    -> [Header]
-    -> LBS8.ByteString
-    -> IO SResponse
+perform ::
+    Application ->
+    Method ->
+    [Text] ->
+    [Header] ->
+    LBS8.ByteString ->
+    IO SResponse
 perform application method path headers body =
     runSession
-        (srequest
-            (SRequest
+        ( srequest
+            ( SRequest
                 defaultRequest
                     { requestMethod = method
                     , pathInfo = path
                     , requestHeaders = headers
                     }
-                body))
+                body
+            )
+        )
         application
 
 responseTurnId :: SResponse -> IO Text

--- a/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
@@ -30,7 +30,7 @@ import Data.List (find)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Data.Time.Clock (getCurrentTime)
+import Data.Time.Clock (addUTCTime, getCurrentTime)
 import Network.HTTP.Types (
     Header,
     Method,
@@ -247,6 +247,59 @@ spec = describe "agent-server WAI application" do
                     LBS8.unpack response.simpleBody
                         `shouldContain` expectedMessage
         mapM_ assertConflict cases
+
+    it "bounds merged turn pages after adding local history" do
+        createdAt <- addUTCTime (-60) <$> getCurrentTime
+        let durableTurn :: AccessBoundary -> Int -> TurnRecord
+            durableTurn boundary index =
+                TurnRecord
+                    { turnRecordId =
+                        TurnId
+                            ( "01999999-1111-7111-8111-"
+                                <> Text.justifyRight
+                                    12
+                                    '0'
+                                    (Text.pack (show index))
+                            )
+                    , turnRecordSessionId = "session-a"
+                    , turnRecordClientRequestId =
+                        ClientRequestId
+                            "01999999-1111-7111-8111-222222222222"
+                    , turnRecordBoundary = boundary
+                    , turnRecordStatus = TurnCompleted
+                    , turnRecordCreatedAt = createdAt
+                    , turnRecordStartedAt = Just createdAt
+                    , turnRecordFinishedAt = Just createdAt
+                    , turnRecordError = Nothing
+                    }
+            backend =
+                fakeBackend
+                    { backendListTurns = \boundary _ ->
+                        pure . Right $
+                            map (durableTurn boundary) [1 .. 200]
+                    }
+        withBackendApplication backend immediateRunner \application -> do
+            created <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    "{\"clientRequestId\":\"01999999-1111-7111-8111-333333333333\",\"input\":\"hello\"}"
+            created.simpleStatus `shouldBe` status202
+            localTurnId <- responseTurnId created
+
+            listed <-
+                perform
+                    application
+                    methodGet
+                    ["v1", "turns"]
+                    validHeaders
+                    ""
+            listed.simpleStatus `shouldBe` status200
+            turnIds <- responseTurnIds listed
+            length turnIds `shouldBe` 200
+            turnIds `shouldSatisfy` elem localTurnId
 
     it "distinguishes a remote turn from an unavailable agent snapshot" do
         createdAt <- getCurrentTime
@@ -1367,6 +1420,35 @@ responseTurnId response =
         decoded ->
             expectationFailure
                 ("could not decode turn response: " <> show decoded)
+                >> fail "unreachable"
+
+responseTurnIds :: SResponse -> IO [Text]
+responseTurnIds response =
+    case eitherDecode response.simpleBody of
+        Right (Object value) ->
+            case KeyMap.lookup "data" value of
+                Just (Array turns) ->
+                    mapM extractTurnId (foldr (:) [] turns)
+                other ->
+                    expectationFailure
+                        ("turn list response has no data array: " <> show other)
+                        >> fail "unreachable"
+        decoded ->
+            expectationFailure
+                ("could not decode turn list response: " <> show decoded)
+                >> fail "unreachable"
+  where
+    extractTurnId = \case
+        Object turn ->
+            case KeyMap.lookup "id" turn of
+                Just (String turnId) -> pure turnId
+                other ->
+                    expectationFailure
+                        ("turn list entry has no text id: " <> show other)
+                        >> fail "unreachable"
+        other ->
+            expectationFailure
+                ("turn list entry is not an object: " <> show other)
                 >> fail "unreachable"
 
 validHeaders :: [Header]

--- a/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
@@ -20,7 +20,7 @@ import Control.Concurrent.MVar
     , takeMVar
     , tryPutMVar
     )
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, finally)
 import Control.Monad (void)
 import Data.Aeson (Value (..), eitherDecode, object, (.=))
 import Data.Aeson.KeyMap qualified as KeyMap
@@ -29,6 +29,7 @@ import Data.IORef (atomicModifyIORef', newIORef, readIORef)
 import Data.List (find)
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Data.Text qualified as Text
 import Data.Time.Clock (getCurrentTime)
 import Network.HTTP.Types
     ( Header
@@ -318,6 +319,94 @@ spec = describe "agent-server WAI application" do
                 LBS8.unpack retry.simpleBody
                     `shouldContain` "\"status\":\"cancelled\""
 
+    it "fences interrupted reservation cleanup against an identical retry" do
+        ledger <- newMVar []
+        terminal <- newEmptyMVar
+        checkedValidationStarted <- newEmptyMVar
+        neverValidation <- newEmptyMVar
+        cleanupStarted <- newEmptyMVar
+        releaseCleanup <- newEmptyMVar
+        ran <- newEmptyMVar
+        neverRunner <- newEmptyMVar
+        validationCalls <- newIORef (0 :: Int)
+        let runner _ _ =
+                putMVar ran ()
+                    >> takeMVar neverRunner
+                    >> pure (Right successfulOutput)
+            baseBackend = durableBackend ledger terminal runner
+            basePersistence = baseBackend.backendTurnPersistence
+            backend =
+                baseBackend
+                    { backendGetSession = \_ _ -> do
+                        call <-
+                            atomicModifyIORef' validationCalls \count ->
+                                let next = count + 1
+                                 in (next, next)
+                        if call == 2
+                            then
+                                putMVar checkedValidationStarted ()
+                                    >> takeMVar neverValidation
+                            else pure ()
+                        pure
+                            ( Right
+                                (object ["id" .= ("session-a" :: String)])
+                            )
+                    , backendTurnPersistence =
+                        basePersistence
+                            { turnPersistenceTerminal =
+                                \record finishedAt outcome ->
+                                    case outcome of
+                                        TurnWasCancelled -> do
+                                            void (tryPutMVar cleanupStarted ())
+                                            takeMVar releaseCleanup
+                                            basePersistence.turnPersistenceTerminal
+                                                record
+                                                finishedAt
+                                                outcome
+                                        _ ->
+                                            basePersistence.turnPersistenceTerminal
+                                                record
+                                                finishedAt
+                                                outcome
+                            }
+                    }
+            body =
+                "{\"clientRequestId\":\"01999999-1111-7111-8111-111111111121\",\"input\":\"hello\"}"
+            create application =
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    body
+        withBackendApplication backend runner \application ->
+            withAsync (create application) \original -> do
+                takeMVar checkedValidationStarted
+                withAsync (cancel original) \canceller -> do
+                    takeMVar cleanupStarted
+
+                    duplicate <- create application
+                    duplicate.simpleStatus `shouldBe` status202
+                    LBS8.unpack duplicate.simpleBody
+                        `shouldContain` "\"status\":\"queued\""
+                    timeout (250 * 1000) (takeMVar ran)
+                        `shouldReturn` Nothing
+
+                    putMVar releaseCleanup ()
+                    wait canceller
+                void (waitCatch original)
+
+                stored <- readMVar ledger
+                case stored of
+                    [entry] ->
+                        entry.testStoredRecord.turnRecordStatus
+                            `shouldBe` TurnCancelled
+                    entries ->
+                        expectationFailure
+                            ( "expected one durable turn, got "
+                                <> show (length entries)
+                            )
+
     it "rejects malformed turn identifiers before storage lookup" do
         withApplication immediateRunner \application -> do
             response <-
@@ -581,6 +670,90 @@ spec = describe "agent-server WAI application" do
             cancelled.simpleStatus `shouldBe` status200
             LBS8.unpack cancelled.simpleBody
                 `shouldContain` "\"status\":\"cancelled\""
+
+    it "canonicalizes an uppercase turn id before local cancellation" do
+        createdAt <- getCurrentTime
+        started <- newEmptyMVar
+        stopped <- newEmptyMVar
+        never <- newEmptyMVar
+        fallbackCalls <- newIORef (0 :: Int)
+        let turnId =
+                TurnId "0199abcd-abcd-7abc-8abc-abcdefabcdef"
+            reserved boundary sessionId clientRequestId =
+                TurnRecord
+                    { turnRecordId = turnId
+                    , turnRecordSessionId = sessionId
+                    , turnRecordClientRequestId = clientRequestId
+                    , turnRecordBoundary = boundary
+                    , turnRecordStatus = TurnQueued
+                    , turnRecordCreatedAt = createdAt
+                    , turnRecordStartedAt = Nothing
+                    , turnRecordFinishedAt = Nothing
+                    , turnRecordError = Nothing
+                    }
+            runner _ _ =
+                (putMVar started () >> takeMVar never)
+                    `finally` putMVar stopped ()
+                    >> pure (Right successfulOutput)
+            storedRecord boundary =
+                reserved
+                    boundary
+                    "session-a"
+                    ( ClientRequestId
+                        "01999999-1111-7111-8111-111111111122"
+                    )
+            lookupRecord boundary requestedId =
+                storedRecord boundary <$ guardTurnId requestedId
+            backend =
+                fakeBackend
+                    { backendReserveTurn =
+                        \boundary sessionId clientRequestId _ _ _ ->
+                            pure . Right . TurnReservationCreated $
+                                reserved boundary sessionId clientRequestId
+                    , backendLookupTurn =
+                        \boundary requestedId ->
+                            pure (Right (lookupRecord boundary requestedId))
+                    , backendRequestTurnCancellation =
+                        \boundary requestedId _ -> do
+                            atomicModifyIORef' fallbackCalls \count ->
+                                (count + 1, ())
+                            pure . Right $
+                                fmap
+                                    (\record -> (True, record))
+                                    (lookupRecord boundary requestedId)
+                    }
+            body =
+                "{\"clientRequestId\":\"01999999-1111-7111-8111-111111111122\",\"input\":\"hello\"}"
+            guardTurnId requestedId
+                | Text.toLower requestedId.unTurnId == turnId.unTurnId =
+                    Just ()
+                | otherwise = Nothing
+        withBackendApplication backend runner \application -> do
+            created <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    body
+            created.simpleStatus `shouldBe` status202
+            takeMVar started
+
+            cancelled <-
+                perform
+                    application
+                    methodPost
+                    [ "v1"
+                    , "turns"
+                    , Text.toUpper turnId.unTurnId
+                    , "cancel"
+                    ]
+                    validHeaders
+                    ""
+            cancelled.simpleStatus `shouldBe` status200
+            timeout (2 * 1000 * 1000) (takeMVar stopped)
+                `shouldReturn` Just ()
+            readIORef fallbackCalls `shouldReturn` 0
 
     it "durably requests cancellation from another owning instance" do
         createdAt <- getCurrentTime

--- a/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
@@ -214,6 +214,40 @@ spec = describe "agent-server WAI application" do
             LBS8.unpack response.simpleBody
                 `shouldContain` "\"code\":\"store_unavailable\""
 
+    it "preserves durable human request conflicts as 409" do
+        let requestId = "01999999-1111-7111-8111-111111111124"
+            cases =
+                [ ( HumanRequestAlreadyResolvedDurably
+                  , "request has already been resolved"
+                  )
+                , ( HumanRequestInvalidDecisionDurably
+                  , "decision is not one of the allowed options"
+                  )
+                ]
+            assertConflict (resolution, expectedMessage) = do
+                let backend =
+                        fakeBackend
+                            { backendTurnPersistence =
+                                inMemoryTurnPersistence
+                                    { turnPersistenceResolveHumanRequest =
+                                        \_ _ _ -> pure (Right resolution)
+                                    }
+                            }
+                withBackendApplication backend immediateRunner \application -> do
+                    response <-
+                        perform
+                            application
+                            methodPost
+                            ["v1", "requests", requestId, "resolve"]
+                            validHeaders
+                            "{\"decision\":\"approve\"}"
+                    response.simpleStatus `shouldBe` status409
+                    LBS8.unpack response.simpleBody
+                        `shouldContain` "\"code\":\"request_not_resolved\""
+                    LBS8.unpack response.simpleBody
+                        `shouldContain` expectedMessage
+        mapM_ assertConflict cases
+
     it "distinguishes a remote turn from an unavailable agent snapshot" do
         createdAt <- getCurrentTime
         let turnId = TurnId "01999999-1111-7111-8111-111111111122"

--- a/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
@@ -191,6 +191,66 @@ spec = describe "agent-server WAI application" do
             response.simpleStatus `shouldBe` status200
             takeMVar observed `shouldReturn` Just expectedTurnId
 
+    it "returns 503 when durable human request resolution loses the store" do
+        let requestId = "01999999-1111-7111-8111-111111111121"
+            backend =
+                fakeBackend
+                    { backendTurnPersistence =
+                        inMemoryTurnPersistence
+                            { turnPersistenceResolveHumanRequest =
+                                \_ _ _ ->
+                                    pure (Left "PostgreSQL is unavailable")
+                            }
+                    }
+        withBackendApplication backend immediateRunner \application -> do
+            response <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "requests", requestId, "resolve"]
+                    validHeaders
+                    "{\"decision\":\"approve\"}"
+            response.simpleStatus `shouldBe` status503
+            LBS8.unpack response.simpleBody
+                `shouldContain` "\"code\":\"store_unavailable\""
+
+    it "distinguishes a remote turn from an unavailable agent snapshot" do
+        createdAt <- getCurrentTime
+        let turnId = TurnId "01999999-1111-7111-8111-111111111122"
+            remoteTurn boundary =
+                TurnRecord
+                    { turnRecordId = turnId
+                    , turnRecordSessionId = "session-a"
+                    , turnRecordClientRequestId =
+                        ClientRequestId
+                            "01999999-1111-7111-8111-111111111123"
+                    , turnRecordBoundary = boundary
+                    , turnRecordStatus = TurnRunning
+                    , turnRecordCreatedAt = createdAt
+                    , turnRecordStartedAt = Just createdAt
+                    , turnRecordFinishedAt = Nothing
+                    , turnRecordError = Nothing
+                    }
+            backend =
+                fakeBackend
+                    { backendLookupTurn = \boundary requestedTurnId ->
+                        pure . Right $
+                            if requestedTurnId == turnId
+                                then Just (remoteTurn boundary)
+                                else Nothing
+                    }
+        withBackendApplication backend immediateRunner \application -> do
+            response <-
+                perform
+                    application
+                    methodGet
+                    ["v1", "turns", turnId.unTurnId, "agents"]
+                    validHeaders
+                    ""
+            response.simpleStatus `shouldBe` status409
+            LBS8.unpack response.simpleBody
+                `shouldContain` "\"code\":\"turn_agents_unavailable\""
+
     it "re-admits an owned queued reservation missing from memory" do
         createdAt <- getCurrentTime
         ran <- newEmptyMVar

--- a/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
@@ -1,23 +1,35 @@
 module Agent.Server.ApplicationSpec (spec) where
 
 import Agent.Server.Application
-    ( ApplicationConfig(..)
+    ( ApplicationConfig (..)
     , newApplication
     )
 import Agent.Server.Auth
-import Agent.Server.Backend (Backend(..))
+import Agent.Server.Backend (Backend(..), SessionMutationLease(..))
 import Agent.Server.Supervisor
 import Agent.Server.Types
+import Control.Concurrent.Async (cancel, wait, waitCatch, withAsync)
 import Control.Concurrent.MVar
-    ( newEmptyMVar
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newEmptyMVar
+    , newMVar
     , putMVar
+    , readMVar
     , takeMVar
+    , tryPutMVar
     )
 import Control.Exception.Safe (bracket)
-import Data.Aeson (object, (.=))
+import Control.Monad (void)
+import Data.Aeson (Value (..), eitherDecode, object, (.=))
+import Data.Aeson.KeyMap qualified as KeyMap
 import Data.ByteString.Lazy.Char8 qualified as LBS8
+import Data.IORef (atomicModifyIORef', newIORef, readIORef)
+import Data.List (find)
 import Data.Set qualified as Set
 import Data.Text (Text)
+import Data.Time.Clock (getCurrentTime)
 import Network.HTTP.Types
     ( Header
     , Method
@@ -28,24 +40,28 @@ import Network.HTTP.Types
     , status202
     , status400
     , status403
+    , status404
     , status409
     , status413
     , status415
     , status422
+    , status503
     )
 import Network.Wai
     ( Application
     , defaultRequest
     , pathInfo
+    , queryString
     , requestHeaders
     , requestMethod
     )
 import Network.Wai.Test
-    ( SRequest(..)
-    , SResponse(..)
+    ( SRequest (..)
+    , SResponse (..)
     , runSession
     , srequest
     )
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -96,11 +112,13 @@ spec = describe "agent-server WAI application" do
 
     it "rejects an oversized body before JSON decoding" do
         withApplication immediateRunner \application -> do
-            response <- perform application
-                methodPost
-                ["v1", "sessions"]
-                validHeaders
-                (LBS8.replicate 65 'x')
+            response <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions"]
+                    validHeaders
+                    (LBS8.replicate 257 'x')
             response.simpleStatus `shouldBe` status413
 
     it "rejects media types that only prefix-match application/json" do
@@ -123,6 +141,207 @@ spec = describe "agent-server WAI application" do
                 "{\"unexpected\":true}"
             response.simpleStatus `shouldBe` status400
 
+    it "filters pending human requests by turn id" do
+        observed <- newEmptyMVar
+        let expectedTurnId =
+                TurnId "01999999-1111-7111-8111-111111111120"
+            backend =
+                fakeBackend
+                    { backendTurnPersistence =
+                        inMemoryTurnPersistence
+                            { turnPersistenceListHumanRequests =
+                                \_ turnId -> do
+                                    putMVar observed turnId
+                                    pure (Right [])
+                            }
+                    }
+        withBackendApplication backend immediateRunner \application -> do
+            response <-
+                runSession
+                    (srequest
+                        (SRequest
+                            defaultRequest
+                                { requestMethod = methodGet
+                                , pathInfo = ["v1", "requests"]
+                                , queryString =
+                                    [ ( "turnId"
+                                      , Just
+                                            "01999999-1111-7111-8111-111111111120"
+                                      )
+                                    ]
+                                , requestHeaders = validHeaders
+                                }
+                            ""))
+                    application
+            response.simpleStatus `shouldBe` status200
+            takeMVar observed `shouldReturn` Just expectedTurnId
+
+    it "re-admits an owned queued reservation missing from memory" do
+        createdAt <- getCurrentTime
+        ran <- newEmptyMVar
+        let clientRequestId =
+                ClientRequestId
+                    "01999999-1111-7111-8111-111111111115"
+            reserved boundary =
+                TurnRecord
+                    { turnRecordId =
+                        TurnId "01999999-1111-7111-8111-111111111116"
+                    , turnRecordSessionId = "session-a"
+                    , turnRecordClientRequestId = clientRequestId
+                    , turnRecordBoundary = boundary
+                    , turnRecordStatus = TurnQueued
+                    , turnRecordCreatedAt = createdAt
+                    , turnRecordStartedAt = Nothing
+                    , turnRecordFinishedAt = Nothing
+                    , turnRecordError = Nothing
+                    }
+            backend =
+                fakeBackend
+                    { backendReserveTurn =
+                        \boundary _ _ _ _ _ ->
+                            pure
+                                (Right
+                                    (TurnReservationExistingOwned
+                                        (reserved boundary)))
+                    }
+            runner _ _ =
+                putMVar ran () >> pure (Right successfulOutput)
+        withBackendApplication backend runner \application -> do
+            response <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    "{\"clientRequestId\":\"01999999-1111-7111-8111-111111111115\",\"input\":\"hello\"}"
+            response.simpleStatus `shouldBe` status202
+            takeMVar ran
+
+    it "does not fail an owned reservation when an identical retry loses admission" do
+        ledger <- newMVar []
+        terminal <- newEmptyMVar
+        checkedValidationStarted <- newEmptyMVar
+        releaseCheckedValidation <- newEmptyMVar
+        validationCalls <- newIORef (0 :: Int)
+        let backend =
+                (durableBackend ledger terminal immediateRunner)
+                    { backendGetSession = \_ _ -> do
+                        call <-
+                            atomicModifyIORef' validationCalls \count ->
+                                let next = count + 1
+                                 in (next, next)
+                        if call == 2
+                            then do
+                                putMVar checkedValidationStarted ()
+                                takeMVar releaseCheckedValidation
+                            else pure ()
+                        pure
+                            ( Right
+                                (object ["id" .= ("session-a" :: String)])
+                            )
+                    }
+            body =
+                "{\"clientRequestId\":\"01999999-1111-7111-8111-111111111117\",\"input\":\"hello\"}"
+            create application =
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    body
+        withBackendApplication backend immediateRunner \application ->
+            withAsync (create application) \original -> do
+                takeMVar checkedValidationStarted
+
+                duplicate <- create application
+                duplicate.simpleStatus `shouldBe` status202
+                LBS8.unpack duplicate.simpleBody
+                    `shouldContain` "\"status\":\"queued\""
+
+                putMVar releaseCheckedValidation ()
+                originalResponse <- wait original
+                originalResponse.simpleStatus `shouldBe` status202
+
+    it "terminalizes a created reservation when admission is interrupted" do
+        ledger <- newMVar []
+        terminal <- newEmptyMVar
+        checkedValidationStarted <- newEmptyMVar
+        never <- newEmptyMVar
+        validationCalls <- newIORef (0 :: Int)
+        let backend =
+                (durableBackend ledger terminal immediateRunner)
+                    { backendGetSession = \_ _ -> do
+                        call <-
+                            atomicModifyIORef' validationCalls \count ->
+                                let next = count + 1
+                                 in (next, next)
+                        if call == 2
+                            then
+                                putMVar checkedValidationStarted ()
+                                    >> takeMVar never
+                            else pure ()
+                        pure
+                            ( Right
+                                (object ["id" .= ("session-a" :: String)])
+                            )
+                    }
+            body =
+                "{\"clientRequestId\":\"01999999-1111-7111-8111-111111111118\",\"input\":\"hello\"}"
+            create application =
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    body
+        withBackendApplication backend immediateRunner \application ->
+            withAsync (create application) \request -> do
+                takeMVar checkedValidationStarted
+                cancel request
+                void (waitCatch request)
+                timeout (2 * 1000 * 1000) (takeMVar terminal)
+                    `shouldReturn` Just ()
+
+                stored <- readMVar ledger
+                case stored of
+                    [entry] ->
+                        entry.testStoredRecord.turnRecordStatus
+                            `shouldBe` TurnCancelled
+                    entries ->
+                        expectationFailure
+                            ( "expected one durable turn, got "
+                                <> show (length entries)
+                            )
+
+                retry <- create application
+                retry.simpleStatus `shouldBe` status202
+                LBS8.unpack retry.simpleBody
+                    `shouldContain` "\"status\":\"cancelled\""
+
+    it "rejects malformed turn identifiers before storage lookup" do
+        withApplication immediateRunner \application -> do
+            response <-
+                perform
+                    application
+                    methodGet
+                    ["v1", "turns", "not-a-uuid"]
+                    validHeaders
+                    ""
+            response.simpleStatus `shouldBe` status404
+
+    it "keeps legacy turn creation working without an idempotency key" do
+        withApplication immediateRunner \application -> do
+            response <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    "{\"input\":\"hello\"}"
+            response.simpleStatus `shouldBe` status202
+            LBS8.unpack response.simpleBody
+                `shouldContain` "\"clientRequestId\":"
+
     it "rejects a non-atomic multi-field session patch" do
         withApplication immediateRunner \application -> do
             response <- perform application
@@ -135,14 +354,18 @@ spec = describe "agent-server WAI application" do
     it "returns 409 for mutation while a session turn is active" do
         release <- newEmptyMVar
         started <- newEmptyMVar
-        let runner _ _ = putMVar started () >> takeMVar release
-                >> pure (Right ())
+        let runner _ _ =
+                putMVar started ()
+                    >> takeMVar release
+                    >> pure (Right successfulOutput)
         withApplication runner \application -> do
-            created <- perform application
-                methodPost
-                ["v1", "sessions", "session-a", "turns"]
-                validHeaders
-                "{\"input\":\"hello\"}"
+            created <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    "{\"clientRequestId\":\"01999999-1111-7111-8111-111111111111\",\"input\":\"hello\"}"
             created.simpleStatus `shouldBe` status202
             takeMVar started
             patched <- perform application
@@ -153,10 +376,265 @@ spec = describe "agent-server WAI application" do
             patched.simpleStatus `shouldBe` status409
             putMVar release ()
 
-withApplication
-    :: TurnRunner
-    -> (Application -> IO value)
-    -> IO value
+    it "honors a durable mutation reservation held by another instance" do
+        patchCalls <- newIORef (0 :: Int)
+        let backend =
+                fakeBackend
+                    { backendReserveSessionMutation =
+                        \_ _ _ -> pure (Right Nothing)
+                    , backendPatchSession = \_ _ _ -> do
+                        atomicModifyIORef' patchCalls \count ->
+                            (count + 1, ())
+                        pure (Right (object []))
+                    }
+        withBackendApplication backend immediateRunner \application -> do
+            patched <-
+                perform
+                    application
+                    methodPatch
+                    ["v1", "sessions", "session-a"]
+                    validHeaders
+                    "{\"title\":\"new title\"}"
+            patched.simpleStatus `shouldBe` status409
+            readIORef patchCalls `shouldReturn` 0
+
+    it "does not run a mutation after its owner fence is lost" do
+        patchCalls <- newIORef (0 :: Int)
+        releaseCalls <- newIORef (0 :: Int)
+        let ownerLost =
+                ApiError
+                    { apiErrorStatus = 503
+                    , apiErrorCode = "turn_owner_unavailable"
+                    , apiErrorMessage =
+                        "the durable server owner fence is unavailable"
+                    , apiErrorDetails = Nothing
+                    }
+            backend =
+                fakeBackend
+                    { backendReserveSessionMutation =
+                        \_ _ _ ->
+                            pure . Right . Just $
+                                SessionMutationLease
+                                    { runSessionMutationLease =
+                                        \_ -> pure (Left ownerLost)
+                                    , releaseSessionMutationLease =
+                                        atomicModifyIORef'
+                                            releaseCalls
+                                            (\count -> (count + 1, ()))
+                                    }
+                    , backendPatchSession = \_ _ _ -> do
+                        atomicModifyIORef' patchCalls \count ->
+                            (count + 1, ())
+                        pure (Right (object []))
+                    }
+        withBackendApplication backend immediateRunner \application -> do
+            patched <-
+                perform
+                    application
+                    methodPatch
+                    ["v1", "sessions", "session-a"]
+                    validHeaders
+                    "{\"title\":\"new title\"}"
+            patched.simpleStatus `shouldBe` status503
+            readIORef patchCalls `shouldReturn` 0
+            readIORef releaseCalls `shouldReturn` 1
+
+    it "deduplicates turn retries and exposes their terminal output" do
+        release <- newEmptyMVar
+        started <- newEmptyMVar
+        runCount <- newIORef (0 :: Int)
+        let runner _ _ = do
+                atomicModifyIORef' runCount \count -> (count + 1, ())
+                putMVar started ()
+                takeMVar release
+                pure (Right successfulOutput)
+            body =
+                "{\"clientRequestId\":\"01999999-1111-7111-8111-111111111112\",\"input\":\"hello\"}"
+        withDurableApplication runner \application terminal -> do
+            created <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    body
+            created.simpleStatus `shouldBe` status202
+            takeMVar started
+
+            duplicate <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    body
+            duplicate.simpleStatus `shouldBe` status202
+            duplicateTurnId <- responseTurnId duplicate
+            originalTurnId <- responseTurnId created
+            duplicateTurnId `shouldBe` originalTurnId
+
+            conflict <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    "{\"clientRequestId\":\"01999999-1111-7111-8111-111111111112\",\"input\":\"different\"}"
+            conflict.simpleStatus `shouldBe` status409
+
+            activeResult <-
+                perform
+                    application
+                    methodGet
+                    ["v1", "turns", originalTurnId, "result"]
+                    validHeaders
+                    ""
+            activeResult.simpleStatus `shouldBe` status409
+
+            putMVar release ()
+            takeMVar terminal
+            result <-
+                perform
+                    application
+                    methodGet
+                    ["v1", "turns", originalTurnId, "result"]
+                    validHeaders
+                    ""
+            result.simpleStatus `shouldBe` status200
+            LBS8.unpack result.simpleBody
+                `shouldContain` "\"assistantText\":\"done\""
+            LBS8.unpack result.simpleBody
+                `shouldContain` "\"assistantTextTruncated\":false"
+            readIORef runCount `shouldReturn` 1
+
+    it "durably cancels a reserved turn before local admission" do
+        createdAt <- getCurrentTime
+        let boundary =
+                accessBoundary localPrincipal (GatewayBoundary Nothing)
+            turnId = TurnId "01999999-1111-7111-8111-111111111113"
+            record =
+                TurnRecord
+                    { turnRecordId = turnId
+                    , turnRecordSessionId = "session-a"
+                    , turnRecordClientRequestId =
+                        ClientRequestId
+                            "01999999-1111-7111-8111-111111111114"
+                    , turnRecordBoundary = boundary
+                    , turnRecordStatus = TurnQueued
+                    , turnRecordCreatedAt = createdAt
+                    , turnRecordStartedAt = Nothing
+                    , turnRecordFinishedAt = Nothing
+                    , turnRecordError = Nothing
+                    }
+        stored <- newMVar record
+        let persistence =
+                inMemoryTurnPersistence
+                    { turnPersistenceStarted = \_ _ -> pure (Right ())
+                    , turnPersistenceTerminal =
+                        \_ finishedAt outcome ->
+                            case outcome of
+                                TurnWasCancelled -> do
+                                    canonical <-
+                                        modifyMVar stored \current ->
+                                            let updated =
+                                                    current
+                                                        { turnRecordStatus =
+                                                            TurnCancelled
+                                                        , turnRecordFinishedAt =
+                                                            Just finishedAt
+                                                        }
+                                             in pure (updated, updated)
+                                    pure (Right canonical)
+                                _ -> pure (Left "unexpected terminal outcome")
+                    , turnPersistenceShouldCancel = \_ ->
+                        pure (Right False)
+                    }
+            backend =
+                fakeBackend
+                    { backendLookupTurn = \requestedBoundary requestedId -> do
+                        current <- readMVar stored
+                        pure . Right $
+                            if current.turnRecordBoundary == requestedBoundary
+                                && current.turnRecordId == requestedId
+                                then Just current
+                                else Nothing
+                    , backendTurnPersistence = persistence
+                    , backendRequestTurnCancellation =
+                        \requestedBoundary requestedId _ -> do
+                            current <- readMVar stored
+                            pure . Right $
+                                if current.turnRecordBoundary
+                                    == requestedBoundary
+                                    && current.turnRecordId
+                                        == requestedId
+                                    then Just (True, current)
+                                    else Nothing
+                    }
+        withBackendApplication backend immediateRunner \application -> do
+            cancelled <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "turns", turnId.unTurnId, "cancel"]
+                    validHeaders
+                    ""
+            cancelled.simpleStatus `shouldBe` status200
+            LBS8.unpack cancelled.simpleBody
+                `shouldContain` "\"status\":\"cancelled\""
+
+    it "durably requests cancellation from another owning instance" do
+        createdAt <- getCurrentTime
+        requested <- newEmptyMVar
+        let boundary =
+                accessBoundary localPrincipal (GatewayBoundary Nothing)
+            turnId = TurnId "01999999-1111-7111-8111-111111111119"
+            record =
+                TurnRecord
+                    { turnRecordId = turnId
+                    , turnRecordSessionId = "session-a"
+                    , turnRecordClientRequestId =
+                        ClientRequestId
+                            "01999999-1111-7111-8111-111111111120"
+                    , turnRecordBoundary = boundary
+                    , turnRecordStatus = TurnRunning
+                    , turnRecordCreatedAt = createdAt
+                    , turnRecordStartedAt = Just createdAt
+                    , turnRecordFinishedAt = Nothing
+                    , turnRecordError = Nothing
+                    }
+            backend =
+                fakeBackend
+                    { backendLookupTurn =
+                        \requestedBoundary requestedId ->
+                            pure . Right $
+                                if requestedBoundary == boundary
+                                    && requestedId == turnId
+                                    then Just record
+                                    else Nothing
+                    , backendRequestTurnCancellation =
+                        \requestedBoundary requestedId _ -> do
+                            putMVar
+                                requested
+                                (requestedBoundary, requestedId)
+                            pure (Right (Just (False, record)))
+                    }
+        withBackendApplication backend immediateRunner \application -> do
+            response <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "turns", turnId.unTurnId, "cancel"]
+                    validHeaders
+                    ""
+            response.simpleStatus `shouldBe` status202
+            takeMVar requested `shouldReturn` (boundary, turnId)
+            LBS8.unpack response.simpleBody
+                `shouldContain` "\"status\":\"running\""
+
+withApplication ::
+    TurnRunner ->
+    (Application -> IO value) ->
+    IO value
 withApplication = withApplicationAuth auth
   where
     auth = AuthConfig
@@ -166,23 +644,115 @@ withApplication = withApplicationAuth auth
         , authCorsOrigins = Set.empty
         }
 
-withApplicationAuth
-    :: AuthConfig
-    -> TurnRunner
-    -> (Application -> IO value)
-    -> IO value
+withDurableApplication ::
+    TurnRunner ->
+    (Application -> MVar () -> IO value) ->
+    IO value
+withDurableApplication runner action = do
+    ledger <- newMVar []
+    terminal <- newEmptyMVar
+    let backend = durableBackend ledger terminal runner
+    bracket
+        ( newSupervisorWithBoundaryGuardAndPersistence
+            supervisorConfig
+            (\_ guarded -> Right <$> guarded)
+            backend.backendTurnPersistence
+            runner
+        )
+        closeSupervisor
+        \supervisor -> do
+            application <-
+                newApplication
+                    ApplicationConfig
+                        { applicationMaximumRequestBytes = 256
+                        , applicationOpenApiDocument = "{}"
+                        }
+                    auth
+                    backend
+                    supervisor
+            action application terminal
+  where
+    auth =
+        AuthConfig
+            { authMode =
+                LoopbackHostAuth
+                    (Set.fromList ["127.0.0.1:4096"])
+            , authCorsOrigins = Set.empty
+            }
+    supervisorConfig =
+        SupervisorConfig
+            { supervisorMaxConcurrentTurns = 1
+            , supervisorMaxConcurrentTurnsPerTenant = 1
+            , supervisorMaxQueuedTurns = 10
+            , supervisorMaxQueuedTurnsPerTenant = 10
+            , supervisorMaxEventSubscribers = 10
+            , supervisorMaxEventSubscribersPerTenant = 5
+            , supervisorEventReplayLimit = 10
+            }
+
+withBackendApplication ::
+    Backend ->
+    TurnRunner ->
+    (Application -> IO value) ->
+    IO value
+withBackendApplication backend runner action =
+    bracket
+        ( newSupervisorWithBoundaryGuardAndPersistence
+            supervisorConfig
+            (\_ guarded -> Right <$> guarded)
+            backend.backendTurnPersistence
+            runner
+        )
+        closeSupervisor
+        \supervisor -> do
+            application <-
+                newApplication
+                    ApplicationConfig
+                        { applicationMaximumRequestBytes = 256
+                        , applicationOpenApiDocument = "{}"
+                        }
+                    auth
+                    backend
+                    supervisor
+            action application
+  where
+    auth =
+        AuthConfig
+            { authMode =
+                LoopbackHostAuth
+                    (Set.fromList ["127.0.0.1:4096"])
+            , authCorsOrigins = Set.empty
+            }
+    supervisorConfig =
+        SupervisorConfig
+            { supervisorMaxConcurrentTurns = 1
+            , supervisorMaxConcurrentTurnsPerTenant = 1
+            , supervisorMaxQueuedTurns = 10
+            , supervisorMaxQueuedTurnsPerTenant = 10
+            , supervisorMaxEventSubscribers = 10
+            , supervisorMaxEventSubscribersPerTenant = 5
+            , supervisorEventReplayLimit = 10
+            }
+
+withApplicationAuth ::
+    AuthConfig ->
+    TurnRunner ->
+    (Application -> IO value) ->
+    IO value
 withApplicationAuth auth runner action =
     bracket
         (newSupervisor supervisorConfig runner)
-        closeSupervisor \supervisor -> do
-            application <- newApplication
-                ApplicationConfig
-                    { applicationMaximumRequestBytes = 64
-                    , applicationOpenApiDocument = "{}"
-                    }
-                auth
-                fakeBackend
-                supervisor
+        closeSupervisor
+        \supervisor -> do
+            application <-
+                newApplication
+                    ApplicationConfig
+                        { applicationMaximumRequestBytes = 256
+                        , applicationOpenApiDocument = "{}"
+                        }
+                    auth
+                    fakeBackend
+                    supervisor
             action application
   where
     supervisorConfig = SupervisorConfig
@@ -196,42 +766,250 @@ withApplicationAuth auth runner action =
         }
 
 fakeBackend :: Backend
-fakeBackend = Backend
-    { backendAdmitBoundary = \principal action ->
-        Right <$> action
-            (accessBoundary principal (GatewayBoundary Nothing))
-    , backendContinueBoundary = \_ action ->
-        Right <$> action
-    , backendTurnBoundaryGuard = \_ action ->
-        Right <$> action
-    , backendCheckReady = pure (Right ())
-    , backendListModels =
-        \_ -> pure (Right (object ["models" .= ([] :: [Int])]))
-    , backendListSessions =
-        \_ _ _ _ ->
-            pure (Right (object ["sessions" .= ([] :: [Int])]))
-    , backendCreateSession =
-        \_ _ -> pure (Right sessionValue)
-    , backendGetSession =
-        \_ _ -> pure (Right sessionValue)
-    , backendPatchSession =
-        \_ _ _ -> pure (Right sessionValue)
-    , backendDeleteSession =
-        \_ _ -> pure (Right ())
-    , backendSessionHistory =
-        \_ _ _ _ ->
-            pure (Right (object ["turns" .= ([] :: [Int])]))
-    , backendForkSession =
-        \_ _ _ -> pure (Right sessionValue)
-    , backendRunTurn = immediateRunner
-    }
+fakeBackend =
+    Backend
+        { backendAdmitBoundary = \principal action ->
+            Right
+                <$> action
+                    (accessBoundary principal (GatewayBoundary Nothing))
+        , backendContinueBoundary = \_ action ->
+            Right <$> action
+        , backendTurnBoundaryGuard = \_ action ->
+            Right <$> action
+        , backendCheckReady = pure (Right ())
+        , backendListModels =
+            \_ -> pure (Right (object ["models" .= ([] :: [Int])]))
+        , backendListSessions =
+            \_ _ _ _ ->
+                pure (Right (object ["sessions" .= ([] :: [Int])]))
+        , backendCreateSession =
+            \_ _ -> pure (Right sessionValue)
+        , backendGetSession =
+            \_ _ -> pure (Right sessionValue)
+        , backendPatchSession =
+            \_ _ _ -> pure (Right sessionValue)
+        , backendDeleteSession =
+            \_ _ -> pure (Right ())
+        , backendSessionHistory =
+            \_ _ _ _ ->
+                pure (Right (object ["turns" .= ([] :: [Int])]))
+        , backendForkSession =
+            \_ _ _ -> pure (Right sessionValue)
+        , backendReserveSessionMutation =
+            \_ _ _ ->
+                pure
+                    (Right
+                        (Just
+                            SessionMutationLease
+                                { runSessionMutationLease =
+                                    \action -> Right <$> action
+                                , releaseSessionMutationLease = pure ()
+                                }))
+        , backendReserveTurn =
+            \boundary sessionId clientRequestId _ turnId createdAt ->
+                pure . Right . TurnReservationCreated $
+                    TurnRecord
+                        { turnRecordId = turnId
+                        , turnRecordSessionId = sessionId
+                        , turnRecordClientRequestId = clientRequestId
+                        , turnRecordBoundary = boundary
+                        , turnRecordStatus = TurnQueued
+                        , turnRecordCreatedAt = createdAt
+                        , turnRecordStartedAt = Nothing
+                        , turnRecordFinishedAt = Nothing
+                        , turnRecordError = Nothing
+                        }
+        , backendLookupTurn = \_ _ -> pure (Right Nothing)
+        , backendListTurns = \_ _ -> pure (Right [])
+        , backendLookupTurnResult = \_ _ -> pure (Right Nothing)
+        , backendRequestTurnCancellation =
+            \_ _ _ -> pure (Right Nothing)
+        , backendTurnPersistence = inMemoryTurnPersistence
+        , backendRunTurn = immediateRunner
+        }
   where
     sessionValue = object
         [ "id" .= ("session-a" :: String)
         ]
 
+data TestStoredTurn = TestStoredTurn
+    { testStoredInput :: !Text
+    , testStoredRecord :: !TurnRecord
+    , testStoredOutput :: !(Maybe TurnExecutionOutput)
+    }
+
+durableBackend ::
+    MVar [TestStoredTurn] ->
+    MVar () ->
+    TurnRunner ->
+    Backend
+durableBackend ledger terminal runner =
+    fakeBackend
+        { backendReserveTurn =
+            \boundary sessionId clientRequestId input turnId createdAt ->
+                modifyMVar ledger \stored ->
+                    case find
+                        ( matchesRequest
+                            boundary
+                            sessionId
+                            clientRequestId
+                        )
+                        stored of
+                        Just existing
+                            | existing.testStoredInput == input ->
+                                pure
+                                    ( stored
+                                    , Right
+                                        ( TurnReservationExistingOwned
+                                            existing.testStoredRecord
+                                        )
+                                    )
+                            | otherwise ->
+                                pure
+                                    ( stored
+                                    , Left
+                                        ApiError
+                                            { apiErrorStatus = 409
+                                            , apiErrorCode =
+                                                "idempotency_conflict"
+                                            , apiErrorMessage =
+                                                "clientRequestId was already used with different input"
+                                            , apiErrorDetails = Nothing
+                                            }
+                                    )
+                        Nothing ->
+                            let record =
+                                    TurnRecord
+                                        { turnRecordId = turnId
+                                        , turnRecordSessionId = sessionId
+                                        , turnRecordClientRequestId =
+                                            clientRequestId
+                                        , turnRecordBoundary = boundary
+                                        , turnRecordStatus = TurnQueued
+                                        , turnRecordCreatedAt = createdAt
+                                        , turnRecordStartedAt = Nothing
+                                        , turnRecordFinishedAt = Nothing
+                                        , turnRecordError = Nothing
+                                        }
+                                entry =
+                                    TestStoredTurn
+                                        { testStoredInput = input
+                                        , testStoredRecord = record
+                                        , testStoredOutput = Nothing
+                                        }
+                             in pure
+                                    ( entry : stored
+                                    , Right (TurnReservationCreated record)
+                                    )
+        , backendLookupTurn = \boundary turnId -> do
+            stored <- readMVar ledger
+            pure . Right $
+                (.testStoredRecord)
+                    <$> find (matchesTurn boundary turnId) stored
+        , backendListTurns = \boundary sessionId -> do
+            stored <- readMVar ledger
+            pure . Right $
+                [ entry.testStoredRecord
+                | entry <- stored
+                , entry.testStoredRecord.turnRecordBoundary == boundary
+                , maybe
+                    True
+                    (== entry.testStoredRecord.turnRecordSessionId)
+                    sessionId
+                ]
+        , backendLookupTurnResult = \boundary turnId -> do
+            stored <- readMVar ledger
+            pure . Right $
+                ( \entry ->
+                    TurnResult
+                        { turnResultTurn = entry.testStoredRecord
+                        , turnResultOutput = entry.testStoredOutput
+                        }
+                )
+                    <$> find (matchesTurn boundary turnId) stored
+        , backendTurnPersistence =
+            inMemoryTurnPersistence
+                { turnPersistenceStarted = \record startedAt -> do
+                    updateStoredTurn ledger record.turnRecordId \entry ->
+                        entry
+                            { testStoredRecord =
+                                entry.testStoredRecord
+                                    { turnRecordStatus = TurnRunning
+                                    , turnRecordStartedAt = Just startedAt
+                                    }
+                            }
+                    pure (Right ())
+                , turnPersistenceTerminal = \record finishedAt outcome -> do
+                    let (status, err, output) =
+                            case outcome of
+                                TurnSucceeded result ->
+                                    (TurnCompleted, Nothing, Just result)
+                                TurnErrored message ->
+                                    (TurnFailed, Just message, Nothing)
+                                TurnWasCancelled ->
+                                    (TurnCancelled, Nothing, Nothing)
+                        canonical =
+                            record
+                                { turnRecordStatus = status
+                                , turnRecordFinishedAt = Just finishedAt
+                                , turnRecordError = err
+                                }
+                    updateStoredTurn ledger record.turnRecordId \entry ->
+                        entry
+                                { testStoredRecord = canonical
+                                , testStoredOutput = output
+                                }
+                    void (tryPutMVar terminal ())
+                    pure (Right canonical)
+                , turnPersistenceShouldCancel = \_ ->
+                    pure (Right False)
+                }
+        , backendRunTurn = runner
+        }
+
+matchesRequest ::
+    AccessBoundary ->
+    Text ->
+    ClientRequestId ->
+    TestStoredTurn ->
+    Bool
+matchesRequest boundary sessionId clientRequestId entry =
+    let record = entry.testStoredRecord
+     in record.turnRecordBoundary == boundary
+            && record.turnRecordSessionId == sessionId
+            && record.turnRecordClientRequestId == clientRequestId
+
+matchesTurn :: AccessBoundary -> TurnId -> TestStoredTurn -> Bool
+matchesTurn boundary turnId entry =
+    entry.testStoredRecord.turnRecordBoundary == boundary
+        && entry.testStoredRecord.turnRecordId == turnId
+
+updateStoredTurn ::
+    MVar [TestStoredTurn] ->
+    TurnId ->
+    (TestStoredTurn -> TestStoredTurn) ->
+    IO ()
+updateStoredTurn ledger turnId update =
+    modifyMVar_ ledger $
+        pure
+            . map
+                ( \entry ->
+                    if entry.testStoredRecord.turnRecordId == turnId
+                        then update entry
+                        else entry
+                )
+
 immediateRunner :: TurnRunner
-immediateRunner _ _ = pure (Right ())
+immediateRunner _ _ = pure (Right successfulOutput)
+
+successfulOutput :: TurnExecutionOutput
+successfulOutput =
+    TurnExecutionOutput
+        { turnExecutionResponseId = "response-test"
+        , turnExecutionAssistantText = Just "done"
+        , turnExecutionAssistantTextTruncated = False
+        , turnExecutionCompletion = TurnCompletionComplete
+        }
 
 perform
     :: Application
@@ -251,6 +1029,21 @@ perform application method path headers body =
                     }
                 body))
         application
+
+responseTurnId :: SResponse -> IO Text
+responseTurnId response =
+    case eitherDecode response.simpleBody of
+        Right (Object value) ->
+            case KeyMap.lookup "id" value of
+                Just (String turnId) -> pure turnId
+                other ->
+                    expectationFailure
+                        ("turn response has no text id: " <> show other)
+                        >> fail "unreachable"
+        decoded ->
+            expectationFailure
+                ("could not decode turn response: " <> show decoded)
+                >> fail "unreachable"
 
 validHeaders :: [Header]
 validHeaders =

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -98,6 +98,31 @@ spec = describe "turn supervisor" do
             putMVar release ()
             wait mutation `shouldReturn` Right ()
 
+    it "waits to clean up behind a transient session reservation" do
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        cleaned <- newEmptyMVar
+        withSupervisor (\_ _ -> pure (Right testOutput)) \supervisor -> do
+            mutation <-
+                async $
+                    withSessionMutation
+                        supervisor
+                        localAccessBoundary
+                        "session-a"
+                        (putMVar entered () >> takeMVar release)
+            takeWithin entered
+            cleanup <-
+                async $
+                    withSessionCleanup
+                        supervisor
+                        localAccessBoundary
+                        "session-a"
+                        (putMVar cleaned ())
+            timeout 50000 (takeMVar cleaned) `shouldReturn` Nothing
+            putMVar release ()
+            wait mutation `shouldReturn` Right ()
+            wait cleanup `shouldReturn` Right ()
+
     it "admits a durable winner after a losing local mutation unwinds" do
         entered <- newEmptyMVar
         release <- newEmptyMVar

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -34,7 +34,7 @@ import Data.IORef (atomicModifyIORef', newIORef, readIORef)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Data.Time.Clock (UTCTime, getCurrentTime)
+import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -716,6 +716,85 @@ spec = describe "turn supervisor" do
             listHumanRequests supervisor localAccessBoundary Nothing
                 `shouldReturn` Right []
 
+    it "bounds merged human request pages without truncating a turn lookup" do
+        now <- getCurrentTime
+        let durableTurnId =
+                TurnId "01999999-3333-7333-8333-333333333333"
+            durableRequests =
+                [ HumanRequest
+                    { humanRequestId =
+                        RequestId
+                            ( "01999999-4444-7444-8444-"
+                                <> Text.justifyRight
+                                    12
+                                    '0'
+                                    (Text.pack (show index))
+                            )
+                    , humanRequestTurnId = durableTurnId
+                    , humanRequestSessionId = "durable-session"
+                    , humanRequestBoundary = localAccessBoundary
+                    , humanRequestKind = ToolApprovalRequest
+                    , humanRequestPrompt = "Approve durable request?"
+                    , humanRequestOptions = ["approve", "cancel"]
+                    , humanRequestCreatedAt = addUTCTime (-3600) now
+                    }
+                | index <- [1 .. 201 :: Int]
+                ]
+            persistence =
+                inMemoryTurnPersistence
+                    { turnPersistenceListHumanRequests =
+                        \boundary turnId ->
+                            pure . Right $
+                                [ request
+                                | request <- durableRequests
+                                , request.humanRequestBoundary == boundary
+                                , maybe
+                                    True
+                                    (== request.humanRequestTurnId)
+                                    turnId
+                                ]
+                    }
+            runner control _ = do
+                void $
+                    control.turnControlRequestInput
+                        HumanRequestSpec
+                            { humanRequestSpecKind = PlanQuestionRequest
+                            , humanRequestSpecPrompt = "Choose"
+                            , humanRequestSpecOptions = ["continue"]
+                            }
+                pure (Right testOutput)
+        bracket
+            ( newSupervisorWithBoundaryGuardAndPersistence
+                defaultConfig
+                (\_ action -> Right <$> action)
+                persistence
+                runner
+            )
+            closeSupervisor
+            \supervisor -> do
+                localTurn <-
+                    submitTurn supervisor (turnSpec "session-a")
+                        >>= expectRight
+                localRequest <-
+                    awaitRequestForTurn
+                        supervisor
+                        localTurn.turnRecordId
+                globalRequests <-
+                    listHumanRequests
+                        supervisor
+                        localAccessBoundary
+                        Nothing
+                        >>= expectRight
+                length globalRequests `shouldBe` 200
+                localRequest `elem` globalRequests `shouldBe` True
+                exactRequests <-
+                    listHumanRequests
+                        supervisor
+                        localAccessBoundary
+                        (Just durableTurnId)
+                        >>= expectRight
+                exactRequests `shouldMatchList` durableRequests
+
     it "hands human input across supervisor instances" do
         sharedRequests <- newTVarIO Map.empty
         resolved <- newEmptyMVar
@@ -994,7 +1073,14 @@ awaitTurnStatus supervisor turnId expected =
                 >> awaitTurnStatus supervisor turnId expected
 
 awaitRequest :: Supervisor -> IO HumanRequest
-awaitRequest supervisor = go (100 :: Int)
+awaitRequest supervisor = awaitRequestMatching supervisor Nothing
+
+awaitRequestForTurn :: Supervisor -> TurnId -> IO HumanRequest
+awaitRequestForTurn supervisor turnId =
+    awaitRequestMatching supervisor (Just turnId)
+
+awaitRequestMatching :: Supervisor -> Maybe TurnId -> IO HumanRequest
+awaitRequestMatching supervisor turnId = go (100 :: Int)
   where
     go attempts
         | attempts <= 0 =
@@ -1004,7 +1090,7 @@ awaitRequest supervisor = go (100 :: Int)
             listHumanRequests
                 supervisor
                 localAccessBoundary
-                Nothing
+                turnId
                 >>= \case
                     Right (request : _) -> pure request
                     Right [] -> threadDelay 10000 >> go (attempts - 1)

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -6,6 +6,7 @@ import Agent.Server.Types
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (
     async,
+    asyncThreadId,
     cancel,
     wait,
     waitCatch,
@@ -322,6 +323,25 @@ spec = describe "turn supervisor" do
                     localAccessBoundary
                     "session-a"
                     `shouldReturn` False
+
+    it "preserves the incumbent cancellation task when a duplicate loses" do
+        never <- newEmptyMVar
+        let turnId = TurnId "01999999-3333-7333-8333-333333333333"
+        withAsync (takeMVar never) \incumbent ->
+            withAsync (takeMVar never) \duplicate -> do
+                let registered = Map.singleton turnId incumbent
+                    afterDuplicate =
+                        deleteCancellationTaskIfOwned
+                            turnId
+                            (asyncThreadId duplicate)
+                            registered
+                    afterIncumbent =
+                        deleteCancellationTaskIfOwned
+                            turnId
+                            (asyncThreadId incumbent)
+                            registered
+                Map.member turnId afterDuplicate `shouldBe` True
+                Map.member turnId afterIncumbent `shouldBe` False
 
     it "cancels active workers concurrently during shutdown" do
         firstStarted <- newEmptyMVar

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -1,28 +1,29 @@
 module Agent.Server.SupervisorSpec (spec) where
 
+import Agent.Server.Runtime.TurnStore (takeRotatingPendingBatch)
 import Agent.Server.Supervisor
 import Agent.Server.Types
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async
-    ( async
-    , wait
-    , withAsync
-    )
-import Control.Concurrent.MVar
-    ( MVar
-    , newEmptyMVar
-    , putMVar
-    , takeMVar
-    , tryPutMVar
-    )
-import Control.Concurrent.STM
-    ( atomically
-    , modifyTVar'
-    , newTVarIO
-    , readTBQueue
-    , readTVar
-    , writeTVar
-    )
+import Control.Concurrent.Async (
+    async,
+    wait,
+    withAsync,
+ )
+import Control.Concurrent.MVar (
+    MVar,
+    newEmptyMVar,
+    putMVar,
+    takeMVar,
+    tryPutMVar,
+ )
+import Control.Concurrent.STM (
+    atomically,
+    modifyTVar',
+    newTVarIO,
+    readTBQueue,
+    readTVar,
+    writeTVar,
+ )
 import Control.Exception.Safe (bracket, finally)
 import Control.Monad (forM_, void)
 import Data.Aeson (object)
@@ -36,6 +37,26 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "turn supervisor" do
+    it "rotates bounded durable cleanup retry batches" do
+        let entries :: Map.Map Int Int
+            entries =
+                Map.fromList
+                    [ (1, 1)
+                    , (2, 2)
+                    , (3, 3)
+                    , (4, 4)
+                    , (5, 5)
+                    ]
+        pending <- newTVarIO entries
+        cursor <- newTVarIO Nothing
+        takeRotatingPendingBatch 4 pending cursor
+            `shouldReturn` [1, 2, 3, 4]
+        takeRotatingPendingBatch 4 pending cursor
+            `shouldReturn` [5, 1, 2, 3]
+        atomically (modifyTVar' pending (Map.delete 3))
+        takeRotatingPendingBatch 4 pending cursor
+            `shouldReturn` [4, 5, 1, 2]
+
     it "enforces one active turn per session" do
         release <- newEmptyMVar
         let runner _ _ = takeMVar release >> pure (Right testOutput)
@@ -63,13 +84,16 @@ spec = describe "turn supervisor" do
                 { supervisorMaxConcurrentTurns = 2
                 , supervisorMaxConcurrentTurnsPerTenant = 2
                 }
-            runner \supervisor -> do
+            runner
+            \supervisor -> do
                 first <-
-                    submitTurn supervisor
+                    submitTurn
+                        supervisor
                         (turnSpecFor tenantA "same-session")
                 first `shouldSatisfy` isRight
                 second <-
-                    submitTurn supervisor
+                    submitTurn
+                        supervisor
                         (turnSpecFor tenantB "same-session")
                 second `shouldSatisfy` isRight
                 takeWithin firstStarted
@@ -205,12 +229,14 @@ spec = describe "turn supervisor" do
                         >> fail "unreachable"
                 Right accepted -> pure accepted
             takeWithin started
-            cancelled <- timeout
-                (2 * 1000 * 1000)
-                (cancelTurn
-                    supervisor
-                    localAccessBoundary
-                    turn.turnRecordId)
+            cancelled <-
+                timeout
+                    (2 * 1000 * 1000)
+                    ( cancelTurn
+                        supervisor
+                        localAccessBoundary
+                        turn.turnRecordId
+                    )
             case cancelled of
                 Just (Right record) ->
                     record.turnRecordStatus `shouldBe` TurnCancelled
@@ -238,14 +264,14 @@ spec = describe "turn supervisor" do
                         | otherwise =
                             (secondStarted, secondCancelled, releaseSecond)
                 (putMVar started () >> takeMVar never)
-                    `finally`
-                        (putMVar cancelled () >> takeMVar release)
+                    `finally` (putMVar cancelled () >> takeMVar release)
         withSupervisorConfig
             defaultConfig
                 { supervisorMaxConcurrentTurns = 2
                 , supervisorMaxConcurrentTurnsPerTenant = 2
                 }
-            runner \supervisor -> do
+            runner
+            \supervisor -> do
                 void (submitTurn supervisor (turnSpec "session-a"))
                 void (submitTurn supervisor (turnSpec "session-b"))
                 takeWithin firstStarted
@@ -253,7 +279,7 @@ spec = describe "turn supervisor" do
 
                 withAsync (closeSupervisor supervisor) \shutdown ->
                     finally
-                        (do
+                        ( do
                             cancelledTogether <-
                                 timeout 500_000 do
                                     takeMVar firstCancelled
@@ -264,7 +290,7 @@ spec = describe "turn supervisor" do
 
                             cancelledTogether `shouldBe` Just ()
                         )
-                        (do
+                        ( do
                             void (tryPutMVar releaseFirst ())
                             void (tryPutMVar releaseSecond ())
                         )
@@ -283,11 +309,13 @@ spec = describe "turn supervisor" do
                     , turnPersistenceTerminal = \record finishedAt outcome -> do
                         putMVar terminal (record.turnRecordId, outcome)
                         pure
-                            (Right
-                                (testTerminalRecord
+                            ( Right
+                                ( testTerminalRecord
                                     finishedAt
                                     outcome
-                                    record))
+                                    record
+                                )
+                            )
                     , turnPersistenceShouldCancel = \_ ->
                         pure (Right False)
                     }
@@ -364,8 +392,9 @@ spec = describe "turn supervisor" do
         terminal <- newEmptyMVar
         failControlCheck <- newIORef False
         let runner control _ = do
-                _ <- control.turnControlRegisterCancel
-                    (void (tryPutMVar cancellationDelivered ()))
+                _ <-
+                    control.turnControlRegisterCancel
+                        (void (tryPutMVar cancellationDelivered ()))
                 putMVar started ()
                 _ <- takeMVar never
                 pure (Right testOutput)
@@ -484,11 +513,13 @@ spec = describe "turn supervisor" do
                             else do
                                 putMVar persisted ()
                                 pure
-                                    (Right
-                                        (testTerminalRecord
+                                    ( Right
+                                        ( testTerminalRecord
                                             finishedAt
                                             outcome
-                                            record))
+                                            record
+                                        )
+                                    )
                     , turnPersistenceShouldCancel = \_ ->
                         pure (Right False)
                     }
@@ -529,7 +560,8 @@ spec = describe "turn supervisor" do
                 { supervisorMaxConcurrentTurns = 2
                 , supervisorMaxConcurrentTurnsPerTenant = 2
                 }
-            runner \supervisor -> do
+            runner
+            \supervisor -> do
                 void (submitTurn supervisor (turnSpec "session-a"))
                 takeWithin firstStarted
                 void (submitTurn supervisor (turnSpec "session-b"))
@@ -539,12 +571,14 @@ spec = describe "turn supervisor" do
     it "waits for and resolves structured human input" do
         resolved <- newEmptyMVar
         let runner control _ = do
-                answer <- control.turnControlRequestInput HumanRequestSpec
-                    { humanRequestSpecKind = PlanExitRequest
-                    , humanRequestSpecPrompt = "Approve?"
-                    , humanRequestSpecOptions =
-                        ["approve", "request_changes", "cancel"]
-                    }
+                answer <-
+                    control.turnControlRequestInput
+                        HumanRequestSpec
+                            { humanRequestSpecKind = PlanExitRequest
+                            , humanRequestSpecPrompt = "Approve?"
+                            , humanRequestSpecOptions =
+                                ["approve", "request_changes", "cancel"]
+                            }
                 putMVar resolved answer
                 pure (Right testOutput)
         withSupervisor runner \supervisor -> do
@@ -560,8 +594,8 @@ spec = describe "turn supervisor" do
                     }
                 `shouldReturn` Right request
             takeWithin resolved
-                `shouldReturn`
-                    Right HumanResponse
+                `shouldReturn` Right
+                    HumanResponse
                         { humanResponseDecision = "request_changes"
                         , humanResponseValue = Just "add tests"
                         }
@@ -570,21 +604,21 @@ spec = describe "turn supervisor" do
         result <- newEmptyMVar
         let runner control _ = do
                 answer <-
-                    control.turnControlRequestInput HumanRequestSpec
-                        { humanRequestSpecKind = PlanQuestionRequest
-                        , humanRequestSpecPrompt = "Choose"
-                        , humanRequestSpecOptions =
-                            replicate
-                                100
-                                (Text.replicate (16 * 1024) "x")
-                        }
+                    control.turnControlRequestInput
+                        HumanRequestSpec
+                            { humanRequestSpecKind = PlanQuestionRequest
+                            , humanRequestSpecPrompt = "Choose"
+                            , humanRequestSpecOptions =
+                                replicate
+                                    100
+                                    (Text.replicate (16 * 1024) "x")
+                            }
                 putMVar result answer
                 pure (Right testOutput)
         withSupervisor runner \supervisor -> do
             void (submitTurn supervisor (turnSpec "session-a"))
             takeWithin result
-                `shouldReturn`
-                    Left "human request exceeds the public size limit"
+                `shouldReturn` Left "human request exceeds the public size limit"
             listHumanRequests supervisor localAccessBoundary Nothing
                 `shouldReturn` Right []
 
@@ -659,11 +693,13 @@ spec = describe "turn supervisor" do
                             pure (Right ())
                     }
             ownerRunner control _ = do
-                answer <- control.turnControlRequestInput HumanRequestSpec
-                    { humanRequestSpecKind = ToolApprovalRequest
-                    , humanRequestSpecPrompt = "Run the tool?"
-                    , humanRequestSpecOptions = ["approve", "cancel"]
-                    }
+                answer <-
+                    control.turnControlRequestInput
+                        HumanRequestSpec
+                            { humanRequestSpecKind = ToolApprovalRequest
+                            , humanRequestSpecPrompt = "Run the tool?"
+                            , humanRequestSpecOptions = ["approve", "cancel"]
+                            }
                 putMVar resolved answer
                 pure (Right testOutput)
             newWith runner =
@@ -692,12 +728,11 @@ spec = describe "turn supervisor" do
                                 }
                             `shouldReturn` Right request
                         takeWithin resolved
-                            `shouldReturn`
-                                Right
-                                    HumanResponse
-                                        { humanResponseDecision = "approve"
-                                        , humanResponseValue = Nothing
-                                        }
+                            `shouldReturn` Right
+                                HumanResponse
+                                    { humanResponseDecision = "approve"
+                                    , humanResponseValue = Nothing
+                                    }
                         atomically (readTVar sharedRequests)
                             `shouldReturn` Map.empty
 
@@ -722,10 +757,11 @@ spec = describe "turn supervisor" do
             subscription.subscriptionClose
 
     it "bounds event subscribers globally and by tenant" do
-        let config = defaultConfig
-                { supervisorMaxEventSubscribers = 2
-                , supervisorMaxEventSubscribersPerTenant = 1
-                }
+        let config =
+                defaultConfig
+                    { supervisorMaxEventSubscribers = 2
+                    , supervisorMaxEventSubscribersPerTenant = 1
+                    }
             tenantA = testBoundary tenantAId (Just "gateway-a")
             tenantAOtherGateway =
                 testBoundary tenantAId (Just "gateway-b")
@@ -759,16 +795,25 @@ spec = describe "turn supervisor" do
                 | otherwise =
                     putMVar staleRan () >> pure (Right testOutput)
         bracket
-            (newSupervisorWithBoundaryGuard
+            ( newSupervisorWithBoundaryGuard
                 defaultConfig
-                    { supervisorMaxConcurrentTurns = 1 }
+                    { supervisorMaxConcurrentTurns = 1
+                    }
                 guard
-                runner)
-            closeSupervisor \supervisor -> do
-                void (submitTurn supervisor
-                    (turnSpecFor tenantA "first"))
-                void (submitTurn supervisor
-                    (turnSpecFor tenantA "stale"))
+                runner
+            )
+            closeSupervisor
+            \supervisor -> do
+                void
+                    ( submitTurn
+                        supervisor
+                        (turnSpecFor tenantA "first")
+                    )
+                void
+                    ( submitTurn
+                        supervisor
+                        (turnSpecFor tenantA "stale")
+                    )
                 _ <- takeMVar current
                 putMVar current tenantB
                 putMVar releaseFirst ()
@@ -776,30 +821,31 @@ spec = describe "turn supervisor" do
                 timeout 50000 (takeMVar staleRan)
                     `shouldReturn` Nothing
 
-withSupervisor
-    :: TurnRunner
-    -> (Supervisor -> IO value)
-    -> IO value
+withSupervisor ::
+    TurnRunner ->
+    (Supervisor -> IO value) ->
+    IO value
 withSupervisor = withSupervisorConfig defaultConfig
 
-withSupervisorConfig
-    :: SupervisorConfig
-    -> TurnRunner
-    -> (Supervisor -> IO value)
-    -> IO value
+withSupervisorConfig ::
+    SupervisorConfig ->
+    TurnRunner ->
+    (Supervisor -> IO value) ->
+    IO value
 withSupervisorConfig config runner =
     bracket (newSupervisor config runner) closeSupervisor
 
 defaultConfig :: SupervisorConfig
-defaultConfig = SupervisorConfig
-    { supervisorMaxConcurrentTurns = 1
-    , supervisorMaxConcurrentTurnsPerTenant = 1
-    , supervisorMaxQueuedTurns = 10
-    , supervisorMaxQueuedTurnsPerTenant = 10
-    , supervisorMaxEventSubscribers = 10
-    , supervisorMaxEventSubscribersPerTenant = 5
-    , supervisorEventReplayLimit = 2
-    }
+defaultConfig =
+    SupervisorConfig
+        { supervisorMaxConcurrentTurns = 1
+        , supervisorMaxConcurrentTurnsPerTenant = 1
+        , supervisorMaxQueuedTurns = 10
+        , supervisorMaxQueuedTurnsPerTenant = 10
+        , supervisorMaxEventSubscribers = 10
+        , supervisorMaxEventSubscribersPerTenant = 5
+        , supervisorEventReplayLimit = 2
+        }
 
 turnSpec :: Text -> TurnSpec
 turnSpec = turnSpecFor localAccessBoundary
@@ -864,7 +910,8 @@ awaitRequest supervisor = go (100 :: Int)
             listHumanRequests
                 supervisor
                 localAccessBoundary
-                Nothing >>= \case
+                Nothing
+                >>= \case
                     Right (request : _) -> pure request
                     Right [] -> threadDelay 10000 >> go (attempts - 1)
                     Left err ->
@@ -883,7 +930,7 @@ isRight = \case
     Right _ -> True
     Left _ -> False
 
-expectRight :: Show left => Either left right -> IO right
+expectRight :: (Show left) => Either left right -> IO right
 expectRight = \case
     Right value -> pure value
     Left err ->

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -616,12 +616,22 @@ spec = describe "turn supervisor" do
                             pure . Right $
                                 Map.lookup requestId requests
                                     >>= snd
-                    , turnPersistenceDeleteHumanRequest = \_ requestId -> do
-                        atomically $
-                            modifyTVar'
-                                sharedRequests
-                                (Map.delete requestId)
-                        pure (Right ())
+                    , turnPersistenceDeleteHumanRequest =
+                        \_ requestId disposition -> do
+                            atomically $
+                                modifyTVar'
+                                    sharedRequests
+                                    ( case disposition of
+                                        HumanRequestAbandoned ->
+                                            Map.update
+                                                ( \entry@(_, response) ->
+                                                    entry <$ response
+                                                )
+                                                requestId
+                                        HumanResponseConsumed ->
+                                            Map.delete requestId
+                                    )
+                            pure (Right ())
                     }
             ownerRunner control _ = do
                 answer <- control.turnControlRequestInput HumanRequestSpec
@@ -663,6 +673,8 @@ spec = describe "turn supervisor" do
                                         { humanResponseDecision = "approve"
                                         , humanResponseValue = Nothing
                                         }
+                        atomically (readTVar sharedRequests)
+                            `shouldReturn` Map.empty
 
     it "isolates replay buffers by exact access boundary and signals gaps" do
         withSupervisor (\_ _ -> pure (Right testOutput)) \supervisor -> do

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -6,7 +6,9 @@ import Agent.Server.Types
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (
     async,
+    cancel,
     wait,
+    waitCatch,
     withAsync,
  )
 import Control.Concurrent.MVar (
@@ -248,6 +250,78 @@ spec = describe "turn supervisor" do
                 localAccessBoundary
                 "session-a"
                 `shouldReturn` False
+
+    it "makes an interrupted cancellation retryable" do
+        started <- newEmptyMVar
+        terminalEntered <- newEmptyMVar
+        never <- newEmptyMVar
+        attempts <- newIORef (0 :: Int)
+        let runner _ _ =
+                putMVar started ()
+                    >> takeMVar never
+                    >> pure (Right testOutput)
+            persistence =
+                inMemoryTurnPersistence
+                    { turnPersistenceStarted = \_ _ -> pure (Right ())
+                    , turnPersistenceTerminal = \record finishedAt outcome -> do
+                        attempt <-
+                            atomicModifyIORef' attempts \count ->
+                                let next = count + 1
+                                 in (next, next)
+                        if attempt == 1
+                            then putMVar terminalEntered () >> takeMVar never
+                            else
+                                pure
+                                    ( Right
+                                        ( testTerminalRecord
+                                            finishedAt
+                                            outcome
+                                            record
+                                        )
+                                    )
+                    , turnPersistenceShouldCancel = \_ ->
+                        pure (Right False)
+                    }
+        bracket
+            ( newSupervisorWithBoundaryGuardAndPersistence
+                defaultConfig
+                (\_ action -> Right <$> action)
+                persistence
+                runner
+            )
+            closeSupervisor
+            \supervisor -> do
+                submitted <-
+                    submitTurn supervisor (turnSpec "session-a")
+                        >>= expectRight
+                takeWithin started
+                firstCancellation <-
+                    async $
+                        cancelTurn
+                            supervisor
+                            localAccessBoundary
+                            submitted.turnRecordId
+                takeWithin terminalEntered
+                cancel firstCancellation
+                firstResult <- waitCatch firstCancellation
+                firstResult `shouldSatisfy` \case
+                    Left _ -> True
+                    Right _ -> False
+                retried <-
+                    cancelTurn
+                        supervisor
+                        localAccessBoundary
+                        submitted.turnRecordId
+                retried `shouldSatisfy` \case
+                    Right record ->
+                        record.turnRecordStatus == TurnCancelled
+                    Left _ -> False
+                readIORef attempts `shouldReturn` 2
+                sessionHasActiveTurn
+                    supervisor
+                    localAccessBoundary
+                    "session-a"
+                    `shouldReturn` False
 
     it "cancels active workers concurrently during shutdown" do
         firstStarted <- newEmptyMVar

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -3,6 +3,11 @@ module Agent.Server.SupervisorSpec (spec) where
 import Agent.Server.Supervisor
 import Agent.Server.Types
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async
+    ( async
+    , wait
+    , withAsync
+    )
 import Control.Concurrent.MVar
     ( MVar
     , newEmptyMVar
@@ -12,17 +17,20 @@ import Control.Concurrent.MVar
     )
 import Control.Concurrent.STM
     ( atomically
+    , modifyTVar'
+    , newTVarIO
     , readTBQueue
-    )
-import Control.Concurrent.Async
-    ( async
-    , wait
-    , withAsync
+    , readTVar
+    , writeTVar
     )
 import Control.Exception.Safe (bracket, finally)
-import Control.Monad (void)
+import Control.Monad (forM_, void)
 import Data.Aeson (object)
+import Data.IORef (atomicModifyIORef', newIORef, readIORef)
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Time.Clock (UTCTime, getCurrentTime)
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -30,7 +38,7 @@ spec :: Spec
 spec = describe "turn supervisor" do
     it "enforces one active turn per session" do
         release <- newEmptyMVar
-        let runner _ _ = takeMVar release >> pure (Right ())
+        let runner _ _ = takeMVar release >> pure (Right testOutput)
         withSupervisor runner \supervisor -> do
             first <- submitTurn supervisor (turnSpec "session-a")
             first `shouldSatisfy` isRight
@@ -49,7 +57,7 @@ spec = describe "turn supervisor" do
                     then putMVar firstStarted ()
                     else putMVar secondStarted ()
                 takeMVar release
-                pure (Right ())
+                pure (Right testOutput)
         withSupervisorConfig
             defaultConfig
                 { supervisorMaxConcurrentTurns = 2
@@ -76,30 +84,75 @@ spec = describe "turn supervisor" do
     it "atomically excludes turn admission for a session mutation" do
         entered <- newEmptyMVar
         release <- newEmptyMVar
-        withSupervisor (\_ _ -> pure (Right ())) \supervisor -> do
-            mutation <- async $
-                withSessionMutation
-                    supervisor
-                    localAccessBoundary
-                    "session-a"
-                    (putMVar entered () >> takeMVar release)
+        withSupervisor (\_ _ -> pure (Right testOutput)) \supervisor -> do
+            mutation <-
+                async $
+                    withSessionMutation
+                        supervisor
+                        localAccessBoundary
+                        "session-a"
+                        (putMVar entered () >> takeMVar release)
             takeWithin entered
             submitTurn supervisor (turnSpec "session-a")
                 `shouldReturn` Left SubmitSessionBusy
             putMVar release ()
             wait mutation `shouldReturn` Right ()
 
+    it "admits a durable winner after a losing local mutation unwinds" do
+        entered <- newEmptyMVar
+        release <- newEmptyMVar
+        withSupervisor (\_ _ -> pure (Right testOutput)) \supervisor -> do
+            mutation <-
+                async $
+                    withSessionMutation
+                        supervisor
+                        localAccessBoundary
+                        "session-a"
+                        (putMVar entered () >> takeMVar release)
+            takeWithin entered
+            createdAt <- getCurrentTime
+            let spec' = turnSpec "session-a"
+                reserved =
+                    TurnRecord
+                        { turnRecordId =
+                            TurnId
+                                "01999999-2222-7222-8222-222222222222"
+                        , turnRecordSessionId = spec'.turnSpecSessionId
+                        , turnRecordClientRequestId =
+                            spec'.turnSpecClientRequestId
+                        , turnRecordBoundary = spec'.turnSpecBoundary
+                        , turnRecordStatus = TurnQueued
+                        , turnRecordCreatedAt = createdAt
+                        , turnRecordStartedAt = Nothing
+                        , turnRecordFinishedAt = Nothing
+                        , turnRecordError = Nothing
+                        }
+            admission <-
+                async $
+                    submitReservedTurnChecked
+                        supervisor
+                        spec'
+                        reserved
+                        (pure (Right () :: Either Text ()))
+            timeout 50000 (wait admission) `shouldReturn` Nothing
+            putMVar release ()
+            wait mutation `shouldReturn` Right ()
+            admitted <- wait admission
+            admitted `shouldSatisfy` isRight
+
     it "holds the session reservation across checked turn validation" do
         entered <- newEmptyMVar
         release <- newEmptyMVar
-        withSupervisor (\_ _ -> pure (Right ())) \supervisor -> do
-            admission <- async $
-                submitTurnChecked
-                    supervisor
-                    (turnSpec "session-a")
-                    (putMVar entered ()
-                        >> takeMVar release
-                        >> pure (Right () :: Either Text ()))
+        withSupervisor (\_ _ -> pure (Right testOutput)) \supervisor -> do
+            admission <-
+                async $
+                    submitTurnChecked
+                        supervisor
+                        (turnSpec "session-a")
+                        ( putMVar entered ()
+                            >> takeMVar release
+                            >> pure (Right () :: Either Text ())
+                        )
             takeWithin entered
             withSessionMutation
                 supervisor
@@ -118,7 +171,7 @@ spec = describe "turn supervisor" do
                 _ <- control.turnControlRegisterCancel (takeMVar never)
                 putMVar started ()
                 takeMVar never
-                pure (Right ())
+                pure (Right testOutput)
         withSupervisor runner \supervisor -> do
             submitted <- submitTurn supervisor (turnSpec "session-a")
             turn <- case submitted of
@@ -191,6 +244,249 @@ spec = describe "turn supervisor" do
                             void (tryPutMVar releaseSecond ())
                         )
 
+    it "persists active turns as cancelled during graceful shutdown" do
+        started <- newEmptyMVar
+        never <- newEmptyMVar
+        terminal <- newEmptyMVar
+        let runner _ _ =
+                putMVar started ()
+                    >> takeMVar never
+                    >> pure (Right testOutput)
+            persistence =
+                inMemoryTurnPersistence
+                    { turnPersistenceStarted = \_ _ -> pure (Right ())
+                    , turnPersistenceTerminal = \record finishedAt outcome -> do
+                        putMVar terminal (record.turnRecordId, outcome)
+                        pure
+                            (Right
+                                (testTerminalRecord
+                                    finishedAt
+                                    outcome
+                                    record))
+                    , turnPersistenceShouldCancel = \_ ->
+                        pure (Right False)
+                    }
+        bracket
+            ( newSupervisorWithBoundaryGuardAndPersistence
+                defaultConfig
+                (\_ action -> Right <$> action)
+                persistence
+                runner
+            )
+            closeSupervisor
+            \supervisor -> do
+                submitted <-
+                    submitTurn supervisor (turnSpec "session-a")
+                        >>= expectRight
+                takeWithin started
+                closeSupervisor supervisor
+                takeWithin terminal
+                    `shouldReturn` (submitted.turnRecordId, TurnWasCancelled)
+
+    it "observes durable cancellation requested by another instance" do
+        started <- newEmptyMVar
+        never <- newEmptyMVar
+        terminal <- newEmptyMVar
+        requested <- newIORef False
+        let runner _ _ =
+                putMVar started ()
+                    >> takeMVar never
+                    >> pure (Right testOutput)
+            persistence =
+                inMemoryTurnPersistence
+                    { turnPersistenceStarted = \_ _ -> pure (Right ())
+                    , turnPersistenceTerminal = \record finishedAt outcome -> do
+                        putMVar terminal outcome
+                        pure
+                            ( Right
+                                ( testTerminalRecord
+                                    finishedAt
+                                    outcome
+                                    record
+                                )
+                            )
+                    , turnPersistenceShouldCancel = \_ ->
+                        Right <$> readIORef requested
+                    }
+        bracket
+            ( newSupervisorWithBoundaryGuardAndPersistence
+                defaultConfig
+                (\_ action -> Right <$> action)
+                persistence
+                runner
+            )
+            closeSupervisor
+            \supervisor -> do
+                submitted <-
+                    submitTurn supervisor (turnSpec "session-a")
+                        >>= expectRight
+                takeWithin started
+                atomicModifyIORef' requested (const (True, ()))
+                takeWithin terminal `shouldReturn` TurnWasCancelled
+                fmap
+                    (.turnRecordStatus)
+                    ( awaitTurnStatus
+                        supervisor
+                        submitted.turnRecordId
+                        TurnCancelled
+                    )
+                    `shouldReturn` TurnCancelled
+
+    it "stops a worker when its durable owner fence cannot be confirmed" do
+        started <- newEmptyMVar
+        never <- newEmptyMVar
+        cancellationDelivered <- newEmptyMVar
+        terminal <- newEmptyMVar
+        failControlCheck <- newIORef False
+        let runner control _ = do
+                _ <- control.turnControlRegisterCancel
+                    (void (tryPutMVar cancellationDelivered ()))
+                putMVar started ()
+                _ <- takeMVar never
+                pure (Right testOutput)
+            persistence =
+                inMemoryTurnPersistence
+                    { turnPersistenceStarted = \_ _ -> pure (Right ())
+                    , turnPersistenceTerminal = \record finishedAt outcome -> do
+                        putMVar terminal outcome
+                        pure
+                            ( Right
+                                ( testTerminalRecord
+                                    finishedAt
+                                    outcome
+                                    record
+                                )
+                            )
+                    , turnPersistenceShouldCancel = \_ -> do
+                        failing <- readIORef failControlCheck
+                        pure
+                            ( if failing
+                                then Left "owner lease unavailable"
+                                else Right False
+                            )
+                    }
+        bracket
+            ( newSupervisorWithBoundaryGuardAndPersistence
+                defaultConfig
+                (\_ action -> Right <$> action)
+                persistence
+                runner
+            )
+            closeSupervisor
+            \supervisor -> do
+                submitted <-
+                    submitTurn supervisor (turnSpec "session-a")
+                        >>= expectRight
+                takeWithin started
+                atomicModifyIORef' failControlCheck (const (True, ()))
+                takeWithin cancellationDelivered
+                takeWithin terminal `shouldReturn` TurnWasCancelled
+                fmap
+                    (.turnRecordStatus)
+                    ( awaitTurnStatus
+                        supervisor
+                        submitted.turnRecordId
+                        TurnCancelled
+                    )
+                    `shouldReturn` TurnCancelled
+
+    it "bounds concurrent durable cancellation checks" do
+        never <- newEmptyMVar
+        concurrency <- newIORef (0 :: Int, 0 :: Int)
+        let runner _ _ =
+                takeMVar never >> pure (Right testOutput)
+            persistence =
+                inMemoryTurnPersistence
+                    { turnPersistenceShouldCancel = \_ -> do
+                        atomicModifyIORef' concurrency \(active, peak) ->
+                            let active' = active + 1
+                             in ((active', max peak active'), ())
+                        threadDelay 50000
+                        atomicModifyIORef' concurrency \(active, peak) ->
+                            ((active - 1, peak), ())
+                        pure (Right False)
+                    }
+            config =
+                defaultConfig
+                    { supervisorMaxQueuedTurns = 20
+                    , supervisorMaxQueuedTurnsPerTenant = 20
+                    }
+        bracket
+            ( newSupervisorWithBoundaryGuardAndPersistence
+                config
+                (\_ action -> Right <$> action)
+                persistence
+                runner
+            )
+            closeSupervisor
+            \supervisor -> do
+                forM_
+                    [ "session-01"
+                    , "session-02"
+                    , "session-03"
+                    , "session-04"
+                    , "session-05"
+                    , "session-06"
+                    , "session-07"
+                    , "session-08"
+                    , "session-09"
+                    , "session-10"
+                    , "session-11"
+                    , "session-12"
+                    ]
+                    \sessionId ->
+                        void $
+                            submitTurn supervisor (turnSpec sessionId)
+                                >>= expectRight
+                threadDelay 400000
+                (_, peak) <- readIORef concurrency
+                peak `shouldSatisfy` \value ->
+                    value > 0 && value <= 4
+
+    it "retries terminal persistence before exposing completion" do
+        attempts <- newIORef (0 :: Int)
+        persisted <- newEmptyMVar
+        let persistence =
+                inMemoryTurnPersistence
+                    { turnPersistenceStarted = \_ _ -> pure (Right ())
+                    , turnPersistenceTerminal = \record finishedAt outcome -> do
+                        attempt <-
+                            atomicModifyIORef' attempts \count ->
+                                let next = count + 1
+                                 in (next, next)
+                        if attempt < 3
+                            then pure (Left "database unavailable")
+                            else do
+                                putMVar persisted ()
+                                pure
+                                    (Right
+                                        (testTerminalRecord
+                                            finishedAt
+                                            outcome
+                                            record))
+                    , turnPersistenceShouldCancel = \_ ->
+                        pure (Right False)
+                    }
+        bracket
+            ( newSupervisorWithBoundaryGuardAndPersistence
+                defaultConfig
+                (\_ action -> Right <$> action)
+                persistence
+                (\_ _ -> pure (Right testOutput))
+            )
+            closeSupervisor
+            \supervisor -> do
+                submitted <-
+                    submitTurn supervisor (turnSpec "session-a")
+                        >>= expectRight
+                takeWithin persisted
+                completed <-
+                    timeout
+                        (2 * 1000 * 1000)
+                        (awaitCompleted supervisor submitted.turnRecordId)
+                completed `shouldSatisfy` (/= Nothing)
+                readIORef attempts `shouldReturn` 3
+
     it "keeps queued turns from blocking work in another session" do
         firstStarted <- newEmptyMVar
         releaseFirst <- newEmptyMVar
@@ -199,10 +495,10 @@ spec = describe "turn supervisor" do
                 | spec.turnSpecSessionId == "session-a" = do
                     void (tryPutMVar firstStarted ())
                     takeMVar releaseFirst
-                    pure (Right ())
+                    pure (Right testOutput)
                 | otherwise = do
                     void (tryPutMVar secondStarted ())
-                    pure (Right ())
+                    pure (Right testOutput)
         withSupervisorConfig
             defaultConfig
                 { supervisorMaxConcurrentTurns = 2
@@ -225,7 +521,7 @@ spec = describe "turn supervisor" do
                         ["approve", "request_changes", "cancel"]
                     }
                 putMVar resolved answer
-                pure (Right ())
+                pure (Right testOutput)
         withSupervisor runner \supervisor -> do
             void (submitTurn supervisor (turnSpec "session-a"))
             request <- awaitRequest supervisor
@@ -245,8 +541,131 @@ spec = describe "turn supervisor" do
                         , humanResponseValue = Just "add tests"
                         }
 
+    it "rejects human input too large for the public transport" do
+        result <- newEmptyMVar
+        let runner control _ = do
+                answer <-
+                    control.turnControlRequestInput HumanRequestSpec
+                        { humanRequestSpecKind = PlanQuestionRequest
+                        , humanRequestSpecPrompt = "Choose"
+                        , humanRequestSpecOptions =
+                            replicate
+                                100
+                                (Text.replicate (16 * 1024) "x")
+                        }
+                putMVar result answer
+                pure (Right testOutput)
+        withSupervisor runner \supervisor -> do
+            void (submitTurn supervisor (turnSpec "session-a"))
+            takeWithin result
+                `shouldReturn`
+                    Left "human request exceeds the public size limit"
+            listHumanRequests supervisor localAccessBoundary Nothing
+                `shouldReturn` Right []
+
+    it "hands human input across supervisor instances" do
+        sharedRequests <- newTVarIO Map.empty
+        resolved <- newEmptyMVar
+        let persistence =
+                inMemoryTurnPersistence
+                    { turnPersistenceCreateHumanRequest = \_ request -> do
+                        atomically $
+                            modifyTVar'
+                                sharedRequests
+                                (Map.insert request.humanRequestId (request, Nothing))
+                        pure (Right ())
+                    , turnPersistenceListHumanRequests = \boundary turnId -> do
+                        requests <- atomically (readTVar sharedRequests)
+                        pure . Right $
+                            [ request
+                            | (request, response) <- Map.elems requests
+                            , request.humanRequestBoundary == boundary
+                            , maybe
+                                True
+                                (== request.humanRequestTurnId)
+                                turnId
+                            , response == Nothing
+                            ]
+                    , turnPersistenceResolveHumanRequest =
+                        \boundary requestId response ->
+                            atomically do
+                                requests <- readTVar sharedRequests
+                                case Map.lookup requestId requests of
+                                    Just (request, Nothing)
+                                        | request.humanRequestBoundary
+                                            == boundary -> do
+                                            writeTVar
+                                                sharedRequests
+                                                ( Map.insert
+                                                    requestId
+                                                    (request, Just response)
+                                                    requests
+                                                )
+                                            pure
+                                                ( Right
+                                                    ( HumanRequestResolvedDurably
+                                                        request
+                                                    )
+                                                )
+                                    _ ->
+                                        pure
+                                            (Right HumanRequestNotFoundDurably)
+                    , turnPersistenceLoadHumanResponse = \_ requestId ->
+                        atomically do
+                            requests <- readTVar sharedRequests
+                            pure . Right $
+                                Map.lookup requestId requests
+                                    >>= snd
+                    , turnPersistenceDeleteHumanRequest = \_ requestId -> do
+                        atomically $
+                            modifyTVar'
+                                sharedRequests
+                                (Map.delete requestId)
+                        pure (Right ())
+                    }
+            ownerRunner control _ = do
+                answer <- control.turnControlRequestInput HumanRequestSpec
+                    { humanRequestSpecKind = ToolApprovalRequest
+                    , humanRequestSpecPrompt = "Run the tool?"
+                    , humanRequestSpecOptions = ["approve", "cancel"]
+                    }
+                putMVar resolved answer
+                pure (Right testOutput)
+            newWith runner =
+                newSupervisorWithBoundaryGuardAndPersistence
+                    defaultConfig
+                    (\_ action -> Right <$> action)
+                    persistence
+                    runner
+        bracket
+            (newWith ownerRunner)
+            closeSupervisor
+            \owner ->
+                bracket
+                    (newWith (\_ _ -> pure (Right testOutput)))
+                    closeSupervisor
+                    \other -> do
+                        void (submitTurn owner (turnSpec "session-a"))
+                        request <- awaitRequest other
+                        resolveHumanRequest
+                            other
+                            localAccessBoundary
+                            request.humanRequestId
+                            HumanResponse
+                                { humanResponseDecision = "approve"
+                                , humanResponseValue = Nothing
+                                }
+                            `shouldReturn` Right request
+                        takeWithin resolved
+                            `shouldReturn`
+                                Right
+                                    HumanResponse
+                                        { humanResponseDecision = "approve"
+                                        , humanResponseValue = Nothing
+                                        }
+
     it "isolates replay buffers by exact access boundary and signals gaps" do
-        withSupervisor (\_ _ -> pure (Right ())) \supervisor -> do
+        withSupervisor (\_ _ -> pure (Right testOutput)) \supervisor -> do
             let tenantA = testBoundary tenantAId (Just "gateway")
                 tenantB = testBoundary tenantBId (Just "gateway")
             publishEvent supervisor tenantA "a.one" Nothing Nothing (object [])
@@ -274,7 +693,7 @@ spec = describe "turn supervisor" do
             tenantAOtherGateway =
                 testBoundary tenantAId (Just "gateway-b")
             tenantB = testBoundary tenantBId Nothing
-        withSupervisorConfig config (\_ _ -> pure (Right ())) \supervisor -> do
+        withSupervisorConfig config (\_ _ -> pure (Right testOutput)) \supervisor -> do
             first <- subscribeEvents supervisor tenantA Nothing >>= expectRight
             subscribeEvents supervisor tenantAOtherGateway Nothing
                 >>= expectLeft EventSubscriberTenantLimitReached
@@ -299,9 +718,9 @@ spec = describe "turn supervisor" do
                     else pure (Left "boundary changed")
             runner _ spec
                 | spec.turnSpecSessionId == "first" =
-                    takeMVar releaseFirst >> pure (Right ())
+                    takeMVar releaseFirst >> pure (Right testOutput)
                 | otherwise =
-                    putMVar staleRan () >> pure (Right ())
+                    putMVar staleRan () >> pure (Right testOutput)
         bracket
             (newSupervisorWithBoundaryGuard
                 defaultConfig
@@ -349,11 +768,53 @@ turnSpec :: Text -> TurnSpec
 turnSpec = turnSpecFor localAccessBoundary
 
 turnSpecFor :: AccessBoundary -> Text -> TurnSpec
-turnSpecFor boundary sessionId = TurnSpec
-    { turnSpecSessionId = sessionId
-    , turnSpecPrompt = "hello"
-    , turnSpecBoundary = boundary
-    }
+turnSpecFor boundary sessionId =
+    TurnSpec
+        { turnSpecSessionId = sessionId
+        , turnSpecClientRequestId =
+            ClientRequestId "01999999-1111-7111-8111-111111111111"
+        , turnSpecPrompt = "hello"
+        , turnSpecBoundary = boundary
+        }
+
+testOutput :: TurnExecutionOutput
+testOutput =
+    TurnExecutionOutput
+        { turnExecutionResponseId = "response-test"
+        , turnExecutionAssistantText = Just "done"
+        , turnExecutionAssistantTextTruncated = False
+        , turnExecutionCompletion = TurnCompletionComplete
+        }
+
+testTerminalRecord ::
+    UTCTime ->
+    TurnTerminalOutcome ->
+    TurnRecord ->
+    TurnRecord
+testTerminalRecord finishedAt outcome record =
+    record
+        { turnRecordStatus = case outcome of
+            TurnSucceeded _ -> TurnCompleted
+            TurnErrored _ -> TurnFailed
+            TurnWasCancelled -> TurnCancelled
+        , turnRecordFinishedAt = Just finishedAt
+        , turnRecordError = case outcome of
+            TurnErrored err -> Just err
+            _ -> Nothing
+        }
+
+awaitCompleted :: Supervisor -> TurnId -> IO TurnRecord
+awaitCompleted supervisor turnId =
+    awaitTurnStatus supervisor turnId TurnCompleted
+
+awaitTurnStatus :: Supervisor -> TurnId -> TurnStatus -> IO TurnRecord
+awaitTurnStatus supervisor turnId expected =
+    lookupTurn supervisor localAccessBoundary turnId >>= \case
+        Just record
+            | record.turnRecordStatus == expected -> pure record
+        _ ->
+            threadDelay 10000
+                >> awaitTurnStatus supervisor turnId expected
 
 awaitRequest :: Supervisor -> IO HumanRequest
 awaitRequest supervisor = go (100 :: Int)
@@ -365,9 +826,14 @@ awaitRequest supervisor = go (100 :: Int)
         | otherwise =
             listHumanRequests
                 supervisor
-                localAccessBoundary >>= \case
-                    request : _ -> pure request
-                    [] -> threadDelay 10000 >> go (attempts - 1)
+                localAccessBoundary
+                Nothing >>= \case
+                    Right (request : _) -> pure request
+                    Right [] -> threadDelay 10000 >> go (attempts - 1)
+                    Left err ->
+                        expectationFailure
+                            ("could not list human requests: " <> show err)
+                            >> fail "unreachable"
 
 takeWithin :: MVar value -> IO value
 takeWithin value =

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -63,6 +63,7 @@ library
                     , Agent.Store.Postgres.Session.Write
                     , Agent.Store.Postgres.Hasql
                     , Agent.Store.Postgres.Sql
+                    , Agent.Store.Postgres.ServerTurn.OwnerFence
                     , Agent.Store.Postgres.SessionItem
                     , Agent.Store.Postgres.SessionItem.Mapping.Statements.BaseRows
                     , Agent.Store.Postgres.SessionItem.Mapping.Statements.ContentParts
@@ -177,6 +178,7 @@ test-suite agent-store-test
                     , Agent.Store.Postgres.ManagedSpec
                     , Agent.Store.PoolCacheSpec
                     , Agent.Store.Postgres.ScopeSpec
+                    , Agent.Store.Postgres.ServerTurnRecoverySpec
                     , Agent.Store.Postgres.ServerTurnSpec
                     , Agent.Store.Postgres.SessionSpec
                     , Agent.Store.Postgres.SkillSpec

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -102,6 +102,7 @@ library
                     , hasql
                     , hasql-pool
                     , hasql-transaction
+                    , pqi
                     , pqi-ffi
                     , process
                     , safe-exceptions

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -46,6 +46,8 @@ library
                     , Agent.Store.Postgres.Managed
                     , Agent.Store.Postgres.Migrations
                     , Agent.Store.Postgres.Scope
+                    , Agent.Store.Postgres.ServerTurn
+                    , Agent.Store.Postgres.ServerHumanRequest
                     , Agent.Store.Postgres.Session
                     , Agent.Store.Postgres.Skill
                     , Agent.Store.Postgres.Tenant
@@ -89,6 +91,7 @@ library
                     , Agent.Store.Postgres.Skill.Mapping.Statements.UpdateSkill
     hs-source-dirs:   src
     build-depends:    base >= 4.14 && < 5
+                    , aeson
                     , async >= 2.2.6 && < 2.3
                     , bytestring
                     , containers
@@ -173,6 +176,7 @@ test-suite agent-store-test
                     , Agent.Store.Postgres.ManagedSpec
                     , Agent.Store.PoolCacheSpec
                     , Agent.Store.Postgres.ScopeSpec
+                    , Agent.Store.Postgres.ServerTurnSpec
                     , Agent.Store.Postgres.SessionSpec
                     , Agent.Store.Postgres.SkillSpec
                     , Agent.Store.Postgres.TenantSpec

--- a/packages/agent-store/package.nix
+++ b/packages/agent-store/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, async, base, bytestring, containers, contravariant
 , directory, filelock, filepath, hasql, hasql-pool
-, hasql-transaction, hspec, lib, pqi-ffi, process, safe-exceptions
+, hasql-transaction, hspec, lib, pqi, pqi-ffi, process, safe-exceptions
 , stm, temporary, text, time, unix, uuid-types, vector
 }:
 mkDerivation {
@@ -9,7 +9,7 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson async base bytestring containers contravariant directory filelock
-    filepath hasql hasql-pool hasql-transaction pqi-ffi process
+    filepath hasql hasql-pool hasql-transaction pqi pqi-ffi process
     safe-exceptions stm text time unix uuid-types vector
   ];
   testHaskellDepends = [

--- a/packages/agent-store/package.nix
+++ b/packages/agent-store/package.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, async, base, bytestring, containers, contravariant
+{ mkDerivation, aeson, async, base, bytestring, containers, contravariant
 , directory, filelock, filepath, hasql, hasql-pool
 , hasql-transaction, hspec, lib, pqi-ffi, process, safe-exceptions
 , stm, temporary, text, time, unix, uuid-types, vector
@@ -8,7 +8,7 @@ mkDerivation {
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    async base bytestring containers contravariant directory filelock
+    aeson async base bytestring containers contravariant directory filelock
     filepath hasql hasql-pool hasql-transaction pqi-ffi process
     safe-exceptions stm text time unix uuid-types vector
   ];

--- a/packages/agent-store/src/Agent/Store/Postgres/Config.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Config.hs
@@ -8,6 +8,7 @@ module Agent.Store.Postgres.Config
     , ManagedPostgresConfig(..)
     , defaultManagedPostgresConfig
     , managedPostgresConfigFromEnv
+    , serverTurnActionLockDirectory
     , postgresExecutable
     , socketHost
     , postgresqlConf
@@ -15,10 +16,12 @@ module Agent.Store.Postgres.Config
     ) where
 
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Data.Word (Word16)
+import Numeric (showHex)
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
 import Text.Read (readMaybe)
@@ -83,6 +86,20 @@ managedPostgresConfigFromEnv stateDirectory = do
     pure case portValue >>= readMaybe of
         Just port -> config { postgresPort = port }
         Nothing -> config
+
+-- | Isolate host-level owner fences by the exact database in one cluster.
+serverTurnActionLockDirectory :: ManagedPostgresConfig -> FilePath
+serverTurnActionLockDirectory config =
+    config.postgresPaths.postgresServerTurnActionLockDirectory
+        </> "database-" <> databaseNameHex
+  where
+    databaseNameHex =
+        concatMap
+            encodeByte
+            (ByteString.unpack (Text.encodeUtf8 config.postgresDatabase))
+    encodeByte byte
+        | byte < 16 = '0' : showHex byte ""
+        | otherwise = showHex byte ""
 
 postgresExecutable :: ManagedPostgresConfig -> FilePath -> FilePath
 postgresExecutable config executable

--- a/packages/agent-store/src/Agent/Store/Postgres/Config.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Config.hs
@@ -29,6 +29,7 @@ data ManagedPostgresPaths = ManagedPostgresPaths
     , postgresSocketDirectory :: !FilePath
     , postgresLogFile :: !FilePath
     , postgresLifecycleLockFile :: !FilePath
+    , postgresServerTurnActionLockDirectory :: !FilePath
     }
     deriving (Eq, Show)
 
@@ -58,6 +59,8 @@ defaultManagedPostgresConfig stateDirectory binDirectory =
             , postgresSocketDirectory = root </> "run"
             , postgresLogFile = root </> "postgres.log"
             , postgresLifecycleLockFile = root </> "lifecycle.lock"
+            , postgresServerTurnActionLockDirectory =
+                root </> "server-turn-actions"
             }
         , postgresBinDirectory = binDirectory
         , postgresPort = 55432

--- a/packages/agent-store/src/Agent/Store/Postgres/Connection.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Connection.hs
@@ -139,7 +139,7 @@ openRoleStorePool config role options = mask \restore -> do
             { storePoolInternal = pool
             , storePoolConnectionSettings = settings
             , storePoolServerTurnActionLockDirectoryInternal =
-                config.postgresPaths.postgresServerTurnActionLockDirectory
+                serverTurnActionLockDirectory config
             }
 
 closeStorePool :: StorePool -> IO ()

--- a/packages/agent-store/src/Agent/Store/Postgres/Connection.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Connection.hs
@@ -7,12 +7,16 @@
 module Agent.Store.Postgres.Connection
     ( StorePool
     , storePool
+    , StoreConnection
     , PoolConfig(..)
     , defaultPoolConfig
     , connectionSettingsForRole
     , openStorePool
     , openRoleStorePool
     , closeStorePool
+    , openStoreConnection
+    , closeStoreConnection
+    , withConnectionSession
     , withStorePool
     , withSession
     , runSession
@@ -23,6 +27,7 @@ import Control.Exception.Safe (bracket, mask, onException)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (DiffTime)
+import qualified Hasql.Connection as Connection
 import qualified Hasql.Connection.Settings as ConnectionSettings
 import qualified Hasql.Pool as Pool
 import qualified Hasql.Pool.Config as PoolConfig
@@ -34,10 +39,15 @@ import qualified Pqi.Ffi as Pqi
 import Agent.Store.Postgres.Config
 import Agent.Store.Types
 
-newtype StorePool = StorePool Pool.Pool
+data StorePool = StorePool
+    { storePoolInternal :: !Pool.Pool
+    , storePoolConnectionSettings :: !ConnectionSettings.Settings
+    }
 
 storePool :: StorePool -> Pool.Pool
-storePool (StorePool pool) = pool
+storePool = (.storePoolInternal)
+
+newtype StoreConnection = StoreConnection Connection.Connection
 
 data PoolConfig = PoolConfig
     { poolSize :: !Int
@@ -81,13 +91,13 @@ openRoleStorePool
     -> PoolConfig
     -> IO (Either StoreError StorePool)
 openRoleStorePool config role options = mask \restore -> do
+    let settings = connectionSettingsForRole config role
     pool <- Pool.acquire Pqi.adapter $ PoolConfig.settings
         [ PoolConfig.size options.poolSize
         , PoolConfig.acquisitionTimeout options.poolAcquisitionTimeout
         , PoolConfig.agingTimeout options.poolAgingTimeout
         , PoolConfig.idlenessTimeout options.poolIdlenessTimeout
-        , PoolConfig.staticConnectionSettings
-            (connectionSettingsForRole config role)
+        , PoolConfig.staticConnectionSettings settings
         ]
     validationResult <-
         restore (Pool.use pool (pure ()))
@@ -98,10 +108,48 @@ openRoleStorePool config role options = mask \restore -> do
             pure $ Left $ StoreConnectionError $
                 "Could not connect to managed PostgreSQL: "
                     <> Text.pack (show err)
-        Right () -> pure (Right (StorePool pool))
+        Right () -> pure $ Right StorePool
+            { storePoolInternal = pool
+            , storePoolConnectionSettings = settings
+            }
 
 closeStorePool :: StorePool -> IO ()
 closeStorePool = Pool.release . storePool
+
+{- | Open a connection outside the reusable pool.
+
+This is reserved for connection-lifetime PostgreSQL leases. A session-level
+advisory lock must never be returned to the pool where another request
+could inherit it.
+-}
+openStoreConnection :: StorePool -> IO (Either StoreError StoreConnection)
+openStoreConnection pool =
+    Connection.acquire
+        Pqi.adapter
+        pool.storePoolConnectionSettings
+        >>= \case
+            Left err ->
+                pure . Left . StoreConnectionError $
+                    "Could not open dedicated PostgreSQL connection: "
+                        <> Text.pack (show err)
+            Right connection ->
+                pure (Right (StoreConnection connection))
+
+closeStoreConnection :: StoreConnection -> IO ()
+closeStoreConnection (StoreConnection connection) =
+    Connection.release connection
+
+withConnectionSession ::
+    StoreConnection ->
+    Session.Session a ->
+    IO (Either StoreError a)
+withConnectionSession (StoreConnection connection) session =
+    Connection.use connection session >>= \case
+        Left err ->
+            pure . Left . StoreConnectionError $
+                "Dedicated PostgreSQL session failed: "
+                    <> Text.pack (show err)
+        Right value -> pure (Right value)
 
 withStorePool
     :: ManagedPostgresConfig

--- a/packages/agent-store/src/Agent/Store/Postgres/Connection.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Connection.hs
@@ -16,6 +16,8 @@ module Agent.Store.Postgres.Connection
     , closeStorePool
     , openStoreConnection
     , closeStoreConnection
+    , withStoreConnectionFailureMonitor
+    , waitForStoreConnectionFailure
     , withConnectionSession
     , withStorePool
     , withSession
@@ -23,10 +25,25 @@ module Agent.Store.Postgres.Connection
     , runTransaction
     ) where
 
-import Control.Exception.Safe (bracket, mask, onException)
+import Control.Concurrent.MVar
+    ( newEmptyMVar
+    , putMVar
+    , takeMVar
+    , tryTakeMVar
+    )
+import Control.Concurrent.STM (atomically, orElse)
+import Control.Exception.Safe
+    ( bracket
+    , displayException
+    , finally
+    , mask
+    , onException
+    , tryAny
+    )
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (DiffTime)
+import GHC.Conc (threadWaitReadSTM)
 import qualified Hasql.Connection as Connection
 import qualified Hasql.Connection.Settings as ConnectionSettings
 import qualified Hasql.Pool as Pool
@@ -34,7 +51,8 @@ import qualified Hasql.Pool.Config as PoolConfig
 import qualified Hasql.Session as Session
 import qualified Hasql.Transaction as Transaction
 import qualified Hasql.Transaction.Sessions as Transactions
-import qualified Pqi.Ffi as Pqi
+import qualified Pqi
+import qualified Pqi.Ffi as PqiFfi
 
 import Agent.Store.Postgres.Config
 import Agent.Store.Types
@@ -47,7 +65,10 @@ data StorePool = StorePool
 storePool :: StorePool -> Pool.Pool
 storePool = (.storePoolInternal)
 
-newtype StoreConnection = StoreConnection Connection.Connection
+data StoreConnection = StoreConnection
+    { storeConnectionHasql :: !Connection.Connection
+    , storeConnectionDriver :: !Pqi.Connection
+    }
 
 data PoolConfig = PoolConfig
     { poolSize :: !Int
@@ -92,7 +113,7 @@ openRoleStorePool
     -> IO (Either StoreError StorePool)
 openRoleStorePool config role options = mask \restore -> do
     let settings = connectionSettingsForRole config role
-    pool <- Pool.acquire Pqi.adapter $ PoolConfig.settings
+    pool <- Pool.acquire PqiFfi.adapter $ PoolConfig.settings
         [ PoolConfig.size options.poolSize
         , PoolConfig.acquisitionTimeout options.poolAcquisitionTimeout
         , PoolConfig.agingTimeout options.poolAgingTimeout
@@ -123,28 +144,108 @@ advisory lock must never be returned to the pool where another request
 could inherit it.
 -}
 openStoreConnection :: StorePool -> IO (Either StoreError StoreConnection)
-openStoreConnection pool =
-    Connection.acquire
-        Pqi.adapter
-        pool.storePoolConnectionSettings
-        >>= \case
-            Left err ->
-                pure . Left . StoreConnectionError $
-                    "Could not open dedicated PostgreSQL connection: "
-                        <> Text.pack (show err)
-            Right connection ->
-                pure (Right (StoreConnection connection))
+openStoreConnection pool = mask \restore -> do
+    capturedConnection <- newEmptyMVar
+    let baseAdapter = PqiFfi.adapter
+        capturingAdapter =
+            baseAdapter
+                { Pqi.connectdb = \settings -> mask \restoreConnect -> do
+                    connection <-
+                        restoreConnect (Pqi.connectdb baseAdapter settings)
+                    putMVar capturedConnection connection
+                    pure connection
+                }
+        closeCapturedConnection =
+            tryTakeMVar capturedConnection >>= \case
+                Nothing -> pure ()
+                Just connection -> Pqi.finish connection
+    acquired <-
+        restore
+            (Connection.acquire capturingAdapter pool.storePoolConnectionSettings)
+            `onException` closeCapturedConnection
+    case acquired of
+        Left err -> do
+            closeCapturedConnection
+            pure . Left . StoreConnectionError $
+                "Could not open dedicated PostgreSQL connection: "
+                    <> Text.pack (show err)
+        Right connection -> do
+            driverConnection <- takeMVar capturedConnection
+            pure $ Right StoreConnection
+                { storeConnectionHasql = connection
+                , storeConnectionDriver = driverConnection
+                }
 
 closeStoreConnection :: StoreConnection -> IO ()
-closeStoreConnection (StoreConnection connection) =
-    Connection.release connection
+closeStoreConnection connection =
+    Connection.release connection.storeConnectionHasql
 
-withConnectionSession ::
+{- | Arm a monitor for the exact PostgreSQL socket underlying this connection
+before invoking the supplied action.
+
+A dedicated idle lease connection receives no application data, so socket
+readiness means PostgreSQL has closed or invalidated the connection. The GHC
+event-manager registration is installed synchronously before the action starts.
+The supplied wait is asynchronously interruptible and may therefore be raced
+against the guarded action without delaying normal completion.
+-}
+withStoreConnectionFailureMonitor ::
     StoreConnection ->
-    Session.Session a ->
+    (IO () -> IO a) ->
     IO (Either StoreError a)
-withConnectionSession (StoreConnection connection) session =
-    Connection.use connection session >>= \case
+withStoreConnectionFailureMonitor connection action =
+    mask \restore -> do
+        prepared <- tryAny prepareMonitor
+        case prepared of
+            Left err ->
+                pure . Left . StoreConnectionError $
+                    "PostgreSQL connection monitor failed: "
+                        <> Text.pack (displayException err)
+            Right (Left err) -> pure (Left err)
+            Right (Right (waitForFailure, unregister)) -> do
+                alreadyFailed <-
+                    atomically $
+                        (True <$ waitForFailure)
+                            `orElse` pure False
+                if alreadyFailed
+                    then do
+                        unregister
+                        pure . Left . StoreConnectionError $
+                            "PostgreSQL connection socket was already readable"
+                    else
+                        restore (Right <$> action (atomically waitForFailure))
+                            `finally` unregister
+  where
+    driverConnection = connection.storeConnectionDriver
+    prepareMonitor =
+        Pqi.status driverConnection >>= \case
+            Pqi.ConnectionOk ->
+                Pqi.socket driverConnection >>= \case
+                    Nothing ->
+                        pure . Left . StoreConnectionError $
+                            "PostgreSQL connection has no monitorable socket"
+                    Just socket -> do
+                        (waitForFailure, unregister) <-
+                            threadWaitReadSTM socket
+                        pure (Right (waitForFailure, unregister))
+            status ->
+                pure . Left . StoreConnectionError $
+                    "PostgreSQL connection is unavailable: "
+                        <> Text.pack (show status)
+
+-- | Wait until the monitored PostgreSQL connection fails.
+waitForStoreConnectionFailure ::
+    StoreConnection ->
+    IO (Either StoreError ())
+waitForStoreConnectionFailure connection =
+    withStoreConnectionFailureMonitor connection id
+
+withConnectionSession
+    :: StoreConnection
+    -> Session.Session a
+    -> IO (Either StoreError a)
+withConnectionSession connection session =
+    Connection.use connection.storeConnectionHasql session >>= \case
         Left err ->
             pure . Left . StoreConnectionError $
                 "Dedicated PostgreSQL session failed: "

--- a/packages/agent-store/src/Agent/Store/Postgres/Connection.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Connection.hs
@@ -7,6 +7,7 @@
 module Agent.Store.Postgres.Connection
     ( StorePool
     , storePool
+    , storePoolServerTurnActionLockDirectory
     , StoreConnection
     , PoolConfig(..)
     , defaultPoolConfig
@@ -60,10 +61,15 @@ import Agent.Store.Types
 data StorePool = StorePool
     { storePoolInternal :: !Pool.Pool
     , storePoolConnectionSettings :: !ConnectionSettings.Settings
+    , storePoolServerTurnActionLockDirectoryInternal :: !FilePath
     }
 
 storePool :: StorePool -> Pool.Pool
 storePool = (.storePoolInternal)
+
+storePoolServerTurnActionLockDirectory :: StorePool -> FilePath
+storePoolServerTurnActionLockDirectory =
+    (.storePoolServerTurnActionLockDirectoryInternal)
 
 data StoreConnection = StoreConnection
     { storeConnectionHasql :: !Connection.Connection
@@ -132,6 +138,8 @@ openRoleStorePool config role options = mask \restore -> do
         Right () -> pure $ Right StorePool
             { storePoolInternal = pool
             , storePoolConnectionSettings = settings
+            , storePoolServerTurnActionLockDirectoryInternal =
+                config.postgresPaths.postgresServerTurnActionLockDirectory
             }
 
 closeStorePool :: StorePool -> IO ()

--- a/packages/agent-store/src/Agent/Store/Postgres/Managed.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Managed.hs
@@ -159,6 +159,8 @@ prepareDirectories :: ManagedPostgresConfig -> IO ()
 prepareDirectories config = do
     createPrivateDirectory config.postgresPaths.postgresRootDirectory
     createPrivateDirectory config.postgresPaths.postgresSocketDirectory
+    createPrivateDirectory
+        config.postgresPaths.postgresServerTurnActionLockDirectory
 
 createPrivateDirectory :: FilePath -> IO ()
 createPrivateDirectory path = do

--- a/packages/agent-store/src/Agent/Store/Postgres/Managed.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Managed.hs
@@ -161,6 +161,7 @@ prepareDirectories config = do
     createPrivateDirectory config.postgresPaths.postgresSocketDirectory
     createPrivateDirectory
         config.postgresPaths.postgresServerTurnActionLockDirectory
+    createPrivateDirectory (serverTurnActionLockDirectory config)
 
 createPrivateDirectory :: FilePath -> IO ()
 createPrivateDirectory path = do

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -296,6 +296,183 @@ coreMigrations =
               \ $ha$"
             ]
         }
+    , Migration
+        { migrationVersion = 111
+        , migrationName = "durable externally submitted turns"
+        , migrationStatements =
+            [ "CREATE TABLE IF NOT EXISTS harness.server_turn_owners (\
+              \ instance_id uuid PRIMARY KEY,\
+              \ last_heartbeat_at timestamptz NOT NULL\
+              \ )"
+            , "CREATE TABLE IF NOT EXISTS harness.server_turns (\
+              \ turn_id uuid PRIMARY KEY,\
+              \ tenant_id text NOT NULL,\
+              \ gateway_identity text,\
+              \ session_key text NOT NULL,\
+              \ client_request_id uuid NOT NULL,\
+              \ input_digest text NOT NULL CHECK (length(input_digest) = 64),\
+              \ owner_instance_id uuid NOT NULL,\
+              \ status text NOT NULL\
+              \   CHECK (status IN ('queued', 'running', 'completed', 'failed', 'cancelled')),\
+              \ created_at timestamptz NOT NULL,\
+              \ started_at timestamptz,\
+              \ finished_at timestamptz,\
+              \ assistant_text text,\
+              \ assistant_text_truncated boolean NOT NULL DEFAULT FALSE,\
+              \ response_id text,\
+              \ incomplete_reason text,\
+              \ incomplete_reasoning_tokens bigint\
+              \   CHECK (incomplete_reasoning_tokens IS NULL\
+              \     OR incomplete_reasoning_tokens >= 0),\
+              \ error_text text,\
+              \ UNIQUE NULLS NOT DISTINCT\
+              \   (tenant_id, gateway_identity, session_key, client_request_id),\
+              \ CHECK ((status IN ('completed', 'failed', 'cancelled'))\
+              \   = (finished_at IS NOT NULL)),\
+              \ CHECK (status <> 'completed' OR started_at IS NOT NULL),\
+              \ CHECK ((status = 'completed') = (response_id IS NOT NULL)),\
+              \ CHECK (status = 'completed'\
+              \   OR (assistant_text IS NULL\
+              \     AND assistant_text_truncated = FALSE\
+              \     AND incomplete_reason IS NULL\
+              \     AND incomplete_reasoning_tokens IS NULL)),\
+              \ CHECK (assistant_text IS NOT NULL\
+              \   OR assistant_text_truncated = FALSE),\
+              \ CHECK ((status = 'failed') = (error_text IS NOT NULL)),\
+              \ CHECK (incomplete_reason IS NOT NULL\
+              \   OR incomplete_reasoning_tokens IS NULL)\
+              \ )"
+            , "DO $ha$\
+              \ BEGIN\
+              \   IF EXISTS (\
+              \     SELECT 1\
+              \       FROM information_schema.columns\
+              \      WHERE table_schema = 'harness'\
+              \        AND table_name = 'sessions'\
+              \        AND column_name = 'session_key'\
+              \   ) AND NOT EXISTS (\
+              \     SELECT 1\
+              \       FROM pg_constraint\
+              \      WHERE conname = 'server_turns_session_key_fkey'\
+              \        AND conrelid = 'harness.server_turns'::regclass\
+              \   ) THEN\
+              \     ALTER TABLE harness.server_turns\
+              \       ADD CONSTRAINT server_turns_session_key_fkey\
+              \       FOREIGN KEY (session_key)\
+              \       REFERENCES harness.sessions(session_key)\
+              \       ON DELETE CASCADE;\
+              \   END IF;\
+              \ END\
+              \ $ha$"
+            , "CREATE INDEX IF NOT EXISTS server_turns_boundary_created_idx\
+              \ ON harness.server_turns\
+              \ (tenant_id, gateway_identity, created_at DESC)"
+            , "CREATE UNIQUE INDEX IF NOT EXISTS server_turns_active_session_idx\
+              \ ON harness.server_turns\
+              \ (tenant_id, gateway_identity, session_key)\
+              \ NULLS NOT DISTINCT\
+              \ WHERE status IN ('queued', 'running')"
+            , "GRANT SELECT, INSERT, UPDATE, DELETE\
+              \ ON harness.server_turn_owners TO ha_runtime"
+            , "GRANT SELECT, INSERT, UPDATE\
+              \ ON harness.server_turns TO ha_runtime"
+            ]
+        }
+    , Migration
+        { migrationVersion = 112
+        , migrationName = "cross-instance server coordination"
+        , migrationStatements =
+            [ "ALTER TABLE harness.server_turn_owners\
+              \ ADD COLUMN IF NOT EXISTS revoked_at timestamptz"
+            , "ALTER TABLE harness.server_turns\
+              \ ADD COLUMN IF NOT EXISTS cancellation_requested_at timestamptz"
+            , "ALTER TABLE harness.server_turns\
+              \ ADD COLUMN IF NOT EXISTS teardown_pending boolean\
+              \ NOT NULL DEFAULT FALSE"
+            , "DROP INDEX IF EXISTS harness.server_turns_active_session_idx"
+            , "CREATE UNIQUE INDEX server_turns_active_session_idx\
+              \ ON harness.server_turns\
+              \ (tenant_id, gateway_identity, session_key)\
+              \ NULLS NOT DISTINCT\
+              \ WHERE status IN ('queued', 'running') OR teardown_pending"
+            , "CREATE TABLE IF NOT EXISTS harness.server_session_mutations (\
+              \ tenant_id text NOT NULL,\
+              \ gateway_identity text,\
+              \ session_key text NOT NULL,\
+              \ owner_instance_id uuid NOT NULL\
+              \   REFERENCES harness.server_turn_owners(instance_id) ON DELETE CASCADE,\
+              \ created_at timestamptz NOT NULL\
+              \ )"
+            , "CREATE UNIQUE INDEX IF NOT EXISTS server_session_mutations_boundary_idx\
+              \ ON harness.server_session_mutations\
+              \ (tenant_id, gateway_identity, session_key)\
+              \ NULLS NOT DISTINCT"
+            , "DO $ha$\
+              \ BEGIN\
+              \   IF EXISTS (\
+              \     SELECT 1\
+              \       FROM information_schema.columns\
+              \      WHERE table_schema = 'harness'\
+              \        AND table_name = 'sessions'\
+              \        AND column_name = 'session_key'\
+              \   ) AND NOT EXISTS (\
+              \     SELECT 1\
+              \       FROM pg_constraint\
+              \      WHERE conname = 'server_session_mutations_session_key_fkey'\
+              \        AND conrelid = 'harness.server_session_mutations'::regclass\
+              \   ) THEN\
+              \     ALTER TABLE harness.server_session_mutations\
+              \       ADD CONSTRAINT server_session_mutations_session_key_fkey\
+              \       FOREIGN KEY (session_key)\
+              \       REFERENCES harness.sessions(session_key)\
+              \       ON DELETE CASCADE;\
+              \   END IF;\
+              \ END\
+              \ $ha$"
+            , "CREATE TABLE IF NOT EXISTS harness.server_human_requests (\
+              \ request_id uuid PRIMARY KEY,\
+              \ turn_id uuid NOT NULL\
+              \   REFERENCES harness.server_turns(turn_id) ON DELETE CASCADE,\
+              \ kind text NOT NULL\
+              \   CHECK (kind IN ('tool_approval', 'root_access',\
+              \     'plan_enter', 'plan_exit', 'plan_question')),\
+              \ prompt text NOT NULL,\
+              \ options_json jsonb NOT NULL\
+              \   CHECK (jsonb_typeof(options_json) = 'array'),\
+              \ created_at timestamptz NOT NULL,\
+              \ response_decision text,\
+              \ response_value text,\
+              \ resolved_at timestamptz,\
+              \ CHECK ((response_decision IS NULL) = (resolved_at IS NULL))\
+              \ )"
+            , "CREATE UNIQUE INDEX IF NOT EXISTS\
+              \ server_human_requests_unresolved_turn_idx\
+              \ ON harness.server_human_requests (turn_id)\
+              \ WHERE resolved_at IS NULL"
+            , "CREATE INDEX IF NOT EXISTS\
+              \ server_human_requests_unresolved_created_idx\
+              \ ON harness.server_human_requests (created_at DESC)\
+              \ WHERE resolved_at IS NULL"
+            , "GRANT SELECT, INSERT, DELETE\
+              \ ON harness.server_session_mutations TO ha_runtime"
+            , "GRANT SELECT, INSERT, UPDATE, DELETE\
+              \ ON harness.server_human_requests TO ha_runtime"
+            ]
+        }
+    , Migration
+        { migrationVersion = 113
+        , migrationName = "recoverable server owner fencing"
+        , migrationStatements =
+            [ "DROP INDEX IF EXISTS harness.server_turns_active_session_idx"
+            , "ALTER TABLE harness.server_turns\
+              \ DROP COLUMN IF EXISTS teardown_pending"
+            , "CREATE UNIQUE INDEX server_turns_active_session_idx\
+              \ ON harness.server_turns\
+              \ (tenant_id, gateway_identity, session_key)\
+              \ NULLS NOT DISTINCT\
+              \ WHERE status IN ('queued', 'running')"
+            ]
+        }
     ]
 
 -- | Specialize all runtime grants for a validated cluster-global role.

--- a/packages/agent-store/src/Agent/Store/Postgres/ServerHumanRequest.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/ServerHumanRequest.hs
@@ -16,6 +16,7 @@ module Agent.Store.Postgres.ServerHumanRequest
     , resolveServerHumanRequest
     , loadServerHumanResponse
     , deleteServerHumanRequest
+    , deleteConsumedServerHumanRequest
     )
 where
 
@@ -184,6 +185,28 @@ deleteServerHumanRequest pool boundary ownerInstanceId turnId requestId =
             Transaction.statement
                 (boundary, ownerInstanceId, turnId, requestId)
                 deleteServerHumanRequestStatement
+
+deleteConsumedServerHumanRequest ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Text ->
+    Text ->
+    Text ->
+    IO (Either StoreError ())
+deleteConsumedServerHumanRequest
+    pool
+    boundary
+    ownerInstanceId
+    turnId
+    requestId =
+        withSession pool $
+            Transactions.transaction
+                Transactions.ReadCommitted
+                Transactions.Write
+                ( Transaction.statement
+                    (boundary, ownerInstanceId, turnId, requestId)
+                    deleteConsumedServerHumanRequestStatement
+                )
 
 resolvedRequest ::
     ServerHumanResponse ->
@@ -468,6 +491,33 @@ deleteServerHumanRequestStatement =
         \ AND server_turn.turn_id = $4::uuid\
         \ AND server_request.request_id = $5::uuid\
         \ AND server_request.resolved_at IS NULL"
+        ( boundaryEncoder (\(boundary, _, _, _) -> boundary)
+            <> ( (\(_, ownerInstanceId, _, _) -> ownerInstanceId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (\(_, _, turnId, _) -> turnId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (\(_, _, _, requestId) -> requestId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+        )
+        Decoders.noResult
+        True
+
+deleteConsumedServerHumanRequestStatement ::
+    Statement (ServerTurnBoundary, Text, Text, Text) ()
+deleteConsumedServerHumanRequestStatement =
+    mkStatement
+        "DELETE FROM harness.server_human_requests server_request\
+        \ USING harness.server_turns server_turn\
+        \ WHERE server_turn.turn_id = server_request.turn_id\
+        \ AND server_turn.tenant_id = $1\
+        \ AND server_turn.gateway_identity IS NOT DISTINCT FROM $2\
+        \ AND server_turn.owner_instance_id = $3::uuid\
+        \ AND server_turn.turn_id = $4::uuid\
+        \ AND server_request.request_id = $5::uuid\
+        \ AND server_request.resolved_at IS NOT NULL"
         ( boundaryEncoder (\(boundary, _, _, _) -> boundary)
             <> ( (\(_, ownerInstanceId, _, _) -> ownerInstanceId)
                     >$< Encoders.param (Encoders.nonNullable Encoders.text)

--- a/packages/agent-store/src/Agent/Store/Postgres/ServerHumanRequest.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/ServerHumanRequest.hs
@@ -363,7 +363,7 @@ listServerHumanRequestsStatement =
                \ AND ($3::uuid IS NULL OR server_request.turn_id = $3::uuid)\
                \ ORDER BY server_request.created_at DESC,\
                \ server_request.request_id DESC\
-               \ LIMIT 200"
+               \ LIMIT CASE WHEN $3::uuid IS NULL THEN 200 END"
         )
         ( boundaryEncoder fst
             <> ( snd

--- a/packages/agent-store/src/Agent/Store/Postgres/ServerHumanRequest.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/ServerHumanRequest.hs
@@ -1,0 +1,483 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+-- | Durable human-input handoff for externally submitted turns.
+module Agent.Store.Postgres.ServerHumanRequest
+    ( StoredServerHumanRequest (..)
+    , CreateServerHumanRequest (..)
+    , ServerHumanResponse (..)
+    , ServerHumanRequestResolution (..)
+    , createServerHumanRequest
+    , listServerHumanRequests
+    , listServerHumanRequestsForTurn
+    , resolveServerHumanRequest
+    , loadServerHumanResponse
+    , deleteServerHumanRequest
+    )
+where
+
+import Agent.Store.Postgres.Connection (StorePool, withSession)
+import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Postgres.ServerTurn (ServerTurnBoundary (..))
+import Agent.Store.Types (StoreError)
+import Data.Functor.Contravariant ((>$<))
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+import qualified Data.Vector as Vector
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
+import Hasql.Statement (Statement)
+import qualified Hasql.Transaction as Transaction
+import qualified Hasql.Transaction.Sessions as Transactions
+
+data StoredServerHumanRequest = StoredServerHumanRequest
+    { storedServerHumanRequestId :: !Text
+    , storedServerHumanRequestTurnId :: !Text
+    , storedServerHumanRequestBoundary :: !ServerTurnBoundary
+    , storedServerHumanRequestSessionId :: !Text
+    , storedServerHumanRequestKind :: !Text
+    , storedServerHumanRequestPrompt :: !Text
+    , storedServerHumanRequestOptionsJson :: !Text
+    , storedServerHumanRequestCreatedAt :: !UTCTime
+    , storedServerHumanRequestResponseDecision :: !(Maybe Text)
+    , storedServerHumanRequestResponseValue :: !(Maybe Text)
+    , storedServerHumanRequestResolvedAt :: !(Maybe UTCTime)
+    }
+    deriving (Eq, Show)
+
+data CreateServerHumanRequest = CreateServerHumanRequest
+    { createServerHumanRequestId :: !Text
+    , createServerHumanRequestTurnId :: !Text
+    , createServerHumanRequestBoundary :: !ServerTurnBoundary
+    , createServerHumanRequestOwnerInstanceId :: !Text
+    , createServerHumanRequestKind :: !Text
+    , createServerHumanRequestPrompt :: !Text
+    , createServerHumanRequestOptionsJson :: !Text
+    , createServerHumanRequestCreatedAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+data ServerHumanResponse = ServerHumanResponse
+    { serverHumanResponseDecision :: !Text
+    , serverHumanResponseValue :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+data ServerHumanRequestResolution
+    = ServerHumanRequestResolved !StoredServerHumanRequest
+    | ServerHumanRequestNotFound
+    | ServerHumanRequestAlreadyResolved
+    | ServerHumanRequestInvalidDecision
+    deriving (Eq, Show)
+
+createServerHumanRequest ::
+    StorePool ->
+    CreateServerHumanRequest ->
+    IO (Either StoreError Bool)
+createServerHumanRequest pool request =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Write $
+            Transaction.statement request createServerHumanRequestStatement
+
+listServerHumanRequests ::
+    StorePool ->
+    ServerTurnBoundary ->
+    IO (Either StoreError [StoredServerHumanRequest])
+listServerHumanRequests pool boundary =
+    listServerHumanRequestsMatching pool boundary Nothing
+
+listServerHumanRequestsForTurn ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Text ->
+    IO (Either StoreError [StoredServerHumanRequest])
+listServerHumanRequestsForTurn pool boundary turnId =
+    listServerHumanRequestsMatching pool boundary (Just turnId)
+
+listServerHumanRequestsMatching ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Maybe Text ->
+    IO (Either StoreError [StoredServerHumanRequest])
+listServerHumanRequestsMatching pool boundary turnId =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Read do
+            Vector.toList
+                <$> Transaction.statement
+                    (boundary, turnId)
+                    listServerHumanRequestsStatement
+
+resolveServerHumanRequest ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Text ->
+    ServerHumanResponse ->
+    UTCTime ->
+    IO (Either StoreError ServerHumanRequestResolution)
+resolveServerHumanRequest pool boundary requestId response resolvedAt =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Write do
+            Transaction.statement
+                (boundary, requestId)
+                loadServerHumanRequestForUpdateStatement
+                >>= \case
+                    Nothing ->
+                        pure ServerHumanRequestNotFound
+                    Just request
+                        | request.storedServerHumanRequestResolvedAt
+                            /= Nothing ->
+                            pure ServerHumanRequestAlreadyResolved
+                        | otherwise -> do
+                            valid <-
+                                Transaction.statement
+                                    ( response.serverHumanResponseDecision
+                                    , request.storedServerHumanRequestOptionsJson
+                                    )
+                                    validServerHumanDecisionStatement
+                            if not valid
+                                then pure ServerHumanRequestInvalidDecision
+                                else do
+                                    changed <-
+                                        Transaction.statement
+                                            (requestId, response, resolvedAt)
+                                            resolveServerHumanRequestStatement
+                                    pure
+                                        ( if changed
+                                            then
+                                                ServerHumanRequestResolved
+                                                    ( resolvedRequest
+                                                        response
+                                                        resolvedAt
+                                                        request
+                                                    )
+                                            else
+                                                ServerHumanRequestAlreadyResolved
+                                        )
+
+loadServerHumanResponse ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Text ->
+    Text ->
+    Text ->
+    IO (Either StoreError (Maybe ServerHumanResponse))
+loadServerHumanResponse pool boundary ownerInstanceId turnId requestId =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Read $
+            Transaction.statement
+                (boundary, ownerInstanceId, turnId, requestId)
+                loadServerHumanResponseStatement
+
+deleteServerHumanRequest ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Text ->
+    Text ->
+    Text ->
+    IO (Either StoreError ())
+deleteServerHumanRequest pool boundary ownerInstanceId turnId requestId =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Write $
+            Transaction.statement
+                (boundary, ownerInstanceId, turnId, requestId)
+                deleteServerHumanRequestStatement
+
+resolvedRequest ::
+    ServerHumanResponse ->
+    UTCTime ->
+    StoredServerHumanRequest ->
+    StoredServerHumanRequest
+resolvedRequest response resolvedAt request =
+    request
+        { storedServerHumanRequestResponseDecision =
+            Just response.serverHumanResponseDecision
+        , storedServerHumanRequestResponseValue =
+            response.serverHumanResponseValue
+        , storedServerHumanRequestResolvedAt = Just resolvedAt
+        }
+
+data RawServerHumanRequest = RawServerHumanRequest
+    { rawRequestId :: !Text
+    , rawTurnId :: !Text
+    , rawTenantId :: !Text
+    , rawGatewayIdentity :: !(Maybe Text)
+    , rawSessionId :: !Text
+    , rawKind :: !Text
+    , rawPrompt :: !Text
+    , rawOptionsJson :: !Text
+    , rawCreatedAt :: !UTCTime
+    , rawResponseDecision :: !(Maybe Text)
+    , rawResponseValue :: !(Maybe Text)
+    , rawResolvedAt :: !(Maybe UTCTime)
+    }
+
+decodeServerHumanRequest ::
+    RawServerHumanRequest ->
+    StoredServerHumanRequest
+decodeServerHumanRequest raw =
+    StoredServerHumanRequest
+        { storedServerHumanRequestId = raw.rawRequestId
+        , storedServerHumanRequestTurnId = raw.rawTurnId
+        , storedServerHumanRequestBoundary =
+            ServerTurnBoundary
+                { serverTurnTenantId = raw.rawTenantId
+                , serverTurnGatewayIdentity = raw.rawGatewayIdentity
+                }
+        , storedServerHumanRequestSessionId = raw.rawSessionId
+        , storedServerHumanRequestKind = raw.rawKind
+        , storedServerHumanRequestPrompt = raw.rawPrompt
+        , storedServerHumanRequestOptionsJson = raw.rawOptionsJson
+        , storedServerHumanRequestCreatedAt = raw.rawCreatedAt
+        , storedServerHumanRequestResponseDecision = raw.rawResponseDecision
+        , storedServerHumanRequestResponseValue = raw.rawResponseValue
+        , storedServerHumanRequestResolvedAt = raw.rawResolvedAt
+        }
+
+serverHumanRequestColumns :: Text
+serverHumanRequestColumns =
+    "server_request.request_id::text, server_request.turn_id::text,\
+    \ server_turn.tenant_id, server_turn.gateway_identity,\
+    \ server_turn.session_key, server_request.kind, server_request.prompt,\
+    \ server_request.options_json::text, server_request.created_at,\
+    \ server_request.response_decision, server_request.response_value,\
+    \ server_request.resolved_at"
+
+serverHumanRequestDecoder :: Decoders.Row StoredServerHumanRequest
+serverHumanRequestDecoder =
+    decodeServerHumanRequest
+        <$> ( RawServerHumanRequest
+                <$> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
+                <*> Decoders.column (Decoders.nullable Decoders.text)
+                <*> Decoders.column (Decoders.nullable Decoders.text)
+                <*> Decoders.column (Decoders.nullable Decoders.timestamptz)
+            )
+
+boundaryEncoder ::
+    (input -> ServerTurnBoundary) ->
+    Encoders.Params input
+boundaryEncoder select =
+    ( ((.serverTurnTenantId) . select)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text)
+    )
+        <> ( ((.serverTurnGatewayIdentity) . select)
+                >$< Encoders.param (Encoders.nullable Encoders.text)
+           )
+
+createServerHumanRequestStatement ::
+    Statement CreateServerHumanRequest Bool
+createServerHumanRequestStatement =
+    mkStatement
+        "WITH owned_turn AS (\
+        \ SELECT server_turn.turn_id\
+        \ FROM harness.server_turns server_turn\
+        \ WHERE server_turn.turn_id = $2::uuid\
+        \ AND server_turn.tenant_id = $3\
+        \ AND server_turn.gateway_identity IS NOT DISTINCT FROM $4\
+        \ AND server_turn.owner_instance_id = $5::uuid\
+        \ AND server_turn.status IN ('queued', 'running')\
+        \ FOR UPDATE\
+        \ ), inserted AS (\
+        \ INSERT INTO harness.server_human_requests\
+        \ (request_id, turn_id, kind, prompt, options_json, created_at)\
+        \ SELECT $1::uuid, owned_turn.turn_id, $6, $7, $8::jsonb, $9\
+        \ FROM owned_turn\
+        \ ON CONFLICT DO NOTHING\
+        \ RETURNING 1)\
+        \ SELECT EXISTS (SELECT 1 FROM inserted)"
+        ( ( (.createServerHumanRequestId)
+                >$< Encoders.param (Encoders.nonNullable Encoders.text)
+          )
+            <> ( (.createServerHumanRequestTurnId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> boundaryEncoder (.createServerHumanRequestBoundary)
+            <> ( (.createServerHumanRequestOwnerInstanceId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (.createServerHumanRequestKind)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (.createServerHumanRequestPrompt)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (.createServerHumanRequestOptionsJson)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (.createServerHumanRequestCreatedAt)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz)
+               )
+        )
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+listServerHumanRequestsStatement ::
+    Statement
+        (ServerTurnBoundary, Maybe Text)
+        (Vector.Vector StoredServerHumanRequest)
+listServerHumanRequestsStatement =
+    mkStatement
+        ( "SELECT "
+            <> serverHumanRequestColumns
+            <> "\
+               \ FROM harness.server_human_requests server_request\
+               \ JOIN harness.server_turns server_turn\
+               \ ON server_turn.turn_id = server_request.turn_id\
+               \ WHERE server_turn.tenant_id = $1\
+               \ AND server_turn.gateway_identity IS NOT DISTINCT FROM $2\
+               \ AND server_turn.status IN ('queued', 'running')\
+               \ AND server_request.resolved_at IS NULL\
+               \ AND ($3::uuid IS NULL OR server_request.turn_id = $3::uuid)\
+               \ ORDER BY server_request.created_at DESC,\
+               \ server_request.request_id DESC\
+               \ LIMIT 200"
+        )
+        ( boundaryEncoder fst
+            <> ( snd
+                    >$< Encoders.param (Encoders.nullable Encoders.text)
+               )
+        )
+        (Decoders.rowVector serverHumanRequestDecoder)
+        True
+
+loadServerHumanRequestForUpdateStatement ::
+    Statement
+        (ServerTurnBoundary, Text)
+        (Maybe StoredServerHumanRequest)
+loadServerHumanRequestForUpdateStatement =
+    mkStatement
+        ( "SELECT "
+            <> serverHumanRequestColumns
+            <> "\
+               \ FROM harness.server_human_requests server_request\
+               \ JOIN harness.server_turns server_turn\
+               \ ON server_turn.turn_id = server_request.turn_id\
+               \ WHERE server_turn.tenant_id = $1\
+               \ AND server_turn.gateway_identity IS NOT DISTINCT FROM $2\
+               \ AND server_request.request_id = $3::uuid\
+               \ AND server_turn.status IN ('queued', 'running')\
+               \ FOR UPDATE OF server_request, server_turn"
+        )
+        ( boundaryEncoder fst
+            <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        )
+        (Decoders.rowMaybe serverHumanRequestDecoder)
+        True
+
+validServerHumanDecisionStatement ::
+    Statement (Text, Text) Bool
+validServerHumanDecisionStatement =
+    mkStatement
+        "SELECT jsonb_array_length($2::jsonb) = 0 OR EXISTS (\
+        \ SELECT 1 FROM jsonb_array_elements_text($2::jsonb) allowed(value)\
+        \ WHERE allowed.value = $1)"
+        ( (fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+            <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.text))
+        )
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+resolveServerHumanRequestStatement ::
+    Statement (Text, ServerHumanResponse, UTCTime) Bool
+resolveServerHumanRequestStatement =
+    mkStatement
+        "WITH changed AS (\
+        \ UPDATE harness.server_human_requests\
+        \ SET response_decision = $2, response_value = $3,\
+        \ resolved_at = $4\
+        \ WHERE request_id = $1::uuid AND resolved_at IS NULL\
+        \ RETURNING 1)\
+        \ SELECT EXISTS (SELECT 1 FROM changed)"
+        ( ( (\(requestId, _, _) -> requestId)
+                >$< Encoders.param (Encoders.nonNullable Encoders.text)
+          )
+            <> ( ( (.serverHumanResponseDecision)
+                    . (\(_, response, _) -> response)
+                 )
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( ( (.serverHumanResponseValue)
+                    . (\(_, response, _) -> response)
+                 )
+                    >$< Encoders.param (Encoders.nullable Encoders.text)
+               )
+            <> ( (\(_, _, resolvedAt) -> resolvedAt)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz)
+               )
+        )
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+loadServerHumanResponseStatement ::
+    Statement
+        (ServerTurnBoundary, Text, Text, Text)
+        (Maybe ServerHumanResponse)
+loadServerHumanResponseStatement =
+    mkStatement
+        "SELECT server_request.response_decision,\
+        \ server_request.response_value\
+        \ FROM harness.server_human_requests server_request\
+        \ JOIN harness.server_turns server_turn\
+        \ ON server_turn.turn_id = server_request.turn_id\
+        \ WHERE server_turn.tenant_id = $1\
+        \ AND server_turn.gateway_identity IS NOT DISTINCT FROM $2\
+        \ AND server_turn.owner_instance_id = $3::uuid\
+        \ AND server_turn.turn_id = $4::uuid\
+        \ AND server_request.request_id = $5::uuid\
+        \ AND server_turn.status IN ('queued', 'running')\
+        \ AND server_request.resolved_at IS NOT NULL"
+        ( boundaryEncoder (\(boundary, _, _, _) -> boundary)
+            <> ( (\(_, ownerInstanceId, _, _) -> ownerInstanceId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (\(_, _, turnId, _) -> turnId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (\(_, _, _, requestId) -> requestId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+        )
+        ( Decoders.rowMaybe
+            ( ServerHumanResponse
+                <$> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nullable Decoders.text)
+            )
+        )
+        True
+
+deleteServerHumanRequestStatement ::
+    Statement (ServerTurnBoundary, Text, Text, Text) ()
+deleteServerHumanRequestStatement =
+    mkStatement
+        "DELETE FROM harness.server_human_requests server_request\
+        \ USING harness.server_turns server_turn\
+        \ WHERE server_turn.turn_id = server_request.turn_id\
+        \ AND server_turn.tenant_id = $1\
+        \ AND server_turn.gateway_identity IS NOT DISTINCT FROM $2\
+        \ AND server_turn.owner_instance_id = $3::uuid\
+        \ AND server_turn.turn_id = $4::uuid\
+        \ AND server_request.request_id = $5::uuid\
+        \ AND server_request.resolved_at IS NULL"
+        ( boundaryEncoder (\(boundary, _, _, _) -> boundary)
+            <> ( (\(_, ownerInstanceId, _, _) -> ownerInstanceId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (\(_, _, turnId, _) -> turnId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (\(_, _, _, requestId) -> requestId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+        )
+        Decoders.noResult
+        True

--- a/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
@@ -1,0 +1,1310 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+-- | Durable admission and terminal results for externally submitted turns.
+module Agent.Store.Postgres.ServerTurn
+    ( ServerTurnBoundary (..)
+    , ServerTurnStatus (..)
+    , StoredServerTurn (..)
+    , ReserveServerTurn (..)
+    , ServerTurnReservation (..)
+    , ServerTurnTerminal (..)
+    , ServerSessionMutation (..)
+    , ServerSessionMutationReservation (..)
+    , ServerTurnOwnerLease
+    , ServerTurnOwnerActionFence
+    , openServerTurnOwnerLease
+    , abandonServerTurnOwnerLease
+    , openServerTurnOwnerActionFence
+    , checkServerTurnOwnerActionFence
+    , closeServerTurnOwnerActionFence
+    , reserveServerTurn
+    , reserveServerSessionMutation
+    , releaseServerSessionMutation
+    , requestServerTurnCancellation
+    , shouldCancelServerTurn
+    , markServerTurnRunning
+    , finishServerTurn
+    , heartbeatServerTurnOwner
+    , releaseServerTurnOwner
+    , loadServerTurn
+    , listServerTurns
+    )
+where
+
+import Agent.Store.Postgres.Connection (
+    StoreConnection,
+    StorePool,
+    closeStoreConnection,
+    openStoreConnection,
+    withConnectionSession,
+    withSession,
+ )
+import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Types (StoreError (..))
+import Control.Concurrent.MVar (
+    MVar,
+    modifyMVar,
+    modifyMVar_,
+    newMVar,
+    withMVar,
+ )
+import Control.Exception.Safe (mask, onException)
+import Data.Functor.Contravariant ((>$<))
+import Data.Int (Int64)
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+import qualified Data.Vector as Vector
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Session as Session
+import Hasql.Statement (Statement)
+import qualified Hasql.Transaction as Transaction
+import qualified Hasql.Transaction.Sessions as Transactions
+
+data ServerTurnBoundary = ServerTurnBoundary
+    { serverTurnTenantId :: !Text
+    , serverTurnGatewayIdentity :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+data ServerTurnStatus
+    = ServerTurnQueued
+    | ServerTurnRunning
+    | ServerTurnCompleted
+    | ServerTurnFailed
+    | ServerTurnCancelled
+    deriving (Eq, Show)
+
+data StoredServerTurn = StoredServerTurn
+    { storedServerTurnId :: !Text
+    , storedServerTurnBoundary :: !ServerTurnBoundary
+    , storedServerTurnSessionId :: !Text
+    , storedServerTurnClientRequestId :: !Text
+    , storedServerTurnInputDigest :: !Text
+    , storedServerTurnOwnerInstanceId :: !Text
+    , storedServerTurnStatus :: !ServerTurnStatus
+    , storedServerTurnCreatedAt :: !UTCTime
+    , storedServerTurnStartedAt :: !(Maybe UTCTime)
+    , storedServerTurnFinishedAt :: !(Maybe UTCTime)
+    , storedServerTurnAssistantText :: !(Maybe Text)
+    , storedServerTurnAssistantTextTruncated :: !Bool
+    , storedServerTurnResponseId :: !(Maybe Text)
+    , storedServerTurnIncompleteReason :: !(Maybe Text)
+    , storedServerTurnIncompleteReasoningTokens :: !(Maybe Int64)
+    , storedServerTurnError :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+data ReserveServerTurn = ReserveServerTurn
+    { reserveServerTurnId :: !Text
+    , reserveServerTurnBoundary :: !ServerTurnBoundary
+    , reserveServerTurnSessionId :: !Text
+    , reserveServerTurnClientRequestId :: !Text
+    , reserveServerTurnInputDigest :: !Text
+    , reserveServerTurnOwnerInstanceId :: !Text
+    , reserveServerTurnCreatedAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+data ServerTurnReservation
+    = ServerTurnReserved !StoredServerTurn
+    | ServerTurnAlreadyReserved !StoredServerTurn
+    | ServerTurnIdempotencyConflict !StoredServerTurn
+    | ServerTurnSessionBusy !StoredServerTurn
+    | ServerTurnSessionMutating
+    | ServerTurnOwnerUnavailable
+    deriving (Eq, Show)
+
+data ServerTurnTerminal = ServerTurnTerminal
+    { terminalServerTurnStatus :: !ServerTurnStatus
+    , terminalServerTurnFinishedAt :: !UTCTime
+    , terminalServerTurnAssistantText :: !(Maybe Text)
+    , terminalServerTurnAssistantTextTruncated :: !Bool
+    , terminalServerTurnResponseId :: !(Maybe Text)
+    , terminalServerTurnIncompleteReason :: !(Maybe Text)
+    , terminalServerTurnIncompleteReasoningTokens :: !(Maybe Int64)
+    , terminalServerTurnError :: !(Maybe Text)
+    }
+    deriving (Eq, Show)
+
+data ServerSessionMutation = ServerSessionMutation
+    { serverSessionMutationBoundary :: !ServerTurnBoundary
+    , serverSessionMutationSessionId :: !Text
+    , serverSessionMutationOwnerInstanceId :: !Text
+    , serverSessionMutationCreatedAt :: !UTCTime
+    }
+    deriving (Eq, Show)
+
+data ServerSessionMutationReservation
+    = ServerSessionMutationReserved
+    | ServerSessionMutationBusy
+    | ServerSessionMutationSessionMissing
+    | ServerSessionMutationOwnerUnavailable
+    deriving (Eq, Show)
+
+data ServerTurnOwnerLease = ServerTurnOwnerLease
+    { serverTurnOwnerLeaseInstanceId :: !Text
+    , serverTurnOwnerLeaseState :: !(MVar ServerTurnOwnerLeaseState)
+    }
+
+data ServerTurnOwnerLeaseState
+    = ServerTurnOwnerLeaseOpen !StoreConnection
+    | ServerTurnOwnerLeaseClosed
+
+newtype ServerTurnOwnerActionFence
+    = ServerTurnOwnerActionFence (MVar ServerTurnOwnerActionFenceState)
+
+data ServerTurnOwnerActionFenceState
+    = ServerTurnOwnerActionFenceOpen !StoreConnection
+    | ServerTurnOwnerActionFenceClosed
+
+{- | Register one server process behind a connection-lifetime PostgreSQL lock.
+
+Unlike a timestamp lease, the lock survives arbitrary scheduler pauses.
+PostgreSQL releases it automatically when the process or connection dies,
+which lets another live owner recover its durable turns without trusting a
+wall-clock timeout.
+-}
+openServerTurnOwnerLease ::
+    StorePool ->
+    Text ->
+    IO (Either StoreError ServerTurnOwnerLease)
+openServerTurnOwnerLease pool instanceId = mask \restore ->
+    openStoreConnection pool >>= \case
+        Left err -> pure (Left err)
+        Right connection -> do
+            locked <-
+                restore
+                    ( withConnectionSession connection $
+                        Session.statement
+                            instanceId
+                            acquireServerTurnOwnerLockStatement
+                    )
+                    `onException` closeStoreConnection connection
+            case locked of
+                Left err -> do
+                    closeStoreConnection connection
+                    pure (Left err)
+                Right False -> do
+                    closeStoreConnection connection
+                    pure . Left . StoreDataError $
+                        "server turn owner identity is already active"
+                Right True -> do
+                    state <- newMVar (ServerTurnOwnerLeaseOpen connection)
+                    let lease =
+                            ServerTurnOwnerLease
+                                { serverTurnOwnerLeaseInstanceId = instanceId
+                                , serverTurnOwnerLeaseState = state
+                                }
+                    registered <-
+                        restore (heartbeatServerTurnOwner lease)
+                            `onException` abandonServerTurnOwnerLease lease
+                    case registered of
+                        Left err -> do
+                            abandonServerTurnOwnerLease lease
+                            pure (Left err)
+                        Right () -> pure (Right lease)
+
+{- | Drop the liveness connection without acknowledging local worker teardown.
+
+Production uses this after an irreversible owner-connection failure. It is
+also the crash boundary exercised by the store tests.
+-}
+abandonServerTurnOwnerLease :: ServerTurnOwnerLease -> IO ()
+abandonServerTurnOwnerLease lease =
+    modifyMVar_ lease.serverTurnOwnerLeaseState \case
+        ServerTurnOwnerLeaseClosed ->
+            pure ServerTurnOwnerLeaseClosed
+        ServerTurnOwnerLeaseOpen connection -> do
+            closeStoreConnection connection
+            pure ServerTurnOwnerLeaseClosed
+
+{- | Hold a shared action fence while this owner can still produce effects.
+
+The reaper needs the exclusive form of this lock before revoking an owner.
+Acquiring the shared lock before validating the durable owner makes action
+start and owner revocation linearizable even if the liveness connection is
+lost between those operations.
+-}
+openServerTurnOwnerActionFence ::
+    StorePool ->
+    Text ->
+    IO (Either StoreError (Maybe ServerTurnOwnerActionFence))
+openServerTurnOwnerActionFence pool instanceId = mask \restore ->
+    openStoreConnection pool >>= \case
+        Left err -> pure (Left err)
+        Right connection -> do
+            locked <-
+                restore
+                    ( withConnectionSession connection $
+                        Session.statement
+                            instanceId
+                            acquireServerTurnOwnerActionFenceStatement
+                    )
+                    `onException` closeStoreConnection connection
+            case locked of
+                Left err -> do
+                    closeStoreConnection connection
+                    pure (Left err)
+                Right False -> do
+                    closeStoreConnection connection
+                    pure (Right Nothing)
+                Right True -> do
+                    valid <-
+                        restore
+                            ( withConnectionSession connection $
+                                Transactions.transaction
+                                    Transactions.ReadCommitted
+                                    Transactions.Read
+                                    ( Transaction.statement
+                                        instanceId
+                                        validateServerTurnOwnerActionFenceStatement
+                                    )
+                            )
+                            `onException` closeStoreConnection connection
+                    case valid of
+                        Left err -> do
+                            closeStoreConnection connection
+                            pure (Left err)
+                        Right False -> do
+                            closeStoreConnection connection
+                            pure (Right Nothing)
+                        Right True -> do
+                            state <-
+                                newMVar
+                                    (ServerTurnOwnerActionFenceOpen connection)
+                            pure . Right . Just $
+                                ServerTurnOwnerActionFence state
+
+checkServerTurnOwnerActionFence ::
+    ServerTurnOwnerActionFence ->
+    IO (Either StoreError ())
+checkServerTurnOwnerActionFence
+        (ServerTurnOwnerActionFence state) =
+    withMVar state \case
+        ServerTurnOwnerActionFenceClosed ->
+            pure . Left . StoreDataError $
+                "server turn owner action fence is closed"
+        ServerTurnOwnerActionFenceOpen connection ->
+            withConnectionSession connection $
+                Session.statement () checkServerTurnOwnerActionFenceStatement
+
+closeServerTurnOwnerActionFence :: ServerTurnOwnerActionFence -> IO ()
+closeServerTurnOwnerActionFence
+        (ServerTurnOwnerActionFence state) =
+    modifyMVar_ state \case
+        ServerTurnOwnerActionFenceClosed ->
+            pure ServerTurnOwnerActionFenceClosed
+        ServerTurnOwnerActionFenceOpen connection -> do
+            closeStoreConnection connection
+            pure ServerTurnOwnerActionFenceClosed
+
+reserveServerTurn ::
+    StorePool ->
+    ReserveServerTurn ->
+    IO (Either StoreError ServerTurnReservation)
+reserveServerTurn pool request = do
+    result <- withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Write do
+            Transaction.statement request lockServerTurnSessionStatement
+            ownerAvailable <-
+                Transaction.statement
+                    request
+                    lockServerTurnOwnerStatement
+            if not ownerAvailable
+                then pure (Just ServerTurnOwnerUnavailable)
+                else
+                    Transaction.statement
+                        request
+                        loadServerTurnByClientRequestStatement
+                        >>= \case
+                            Just existing
+                                | existing.storedServerTurnInputDigest
+                                    /= request.reserveServerTurnInputDigest ->
+                                    pure . Just $
+                                        ServerTurnIdempotencyConflict existing
+                                | otherwise ->
+                                    pure . Just $
+                                        ServerTurnAlreadyReserved existing
+                            Nothing ->
+                                Transaction.statement
+                                    request
+                                    serverSessionMutationExistsForTurnStatement
+                                    >>= \case
+                                        True ->
+                                            pure (Just ServerTurnSessionMutating)
+                                        False ->
+                                            Transaction.statement
+                                                request
+                                                insertServerTurnStatement
+                                                >>= \case
+                                                    Just inserted ->
+                                                        pure . Just $
+                                                            ServerTurnReserved inserted
+                                                    Nothing ->
+                                                        fmap ServerTurnSessionBusy
+                                                            <$> Transaction.statement
+                                                                request
+                                                                loadActiveServerTurnStatement
+    pure $
+        result
+            >>= maybe
+                ( Left
+                    ( StoreDataError
+                        "server turn reservation did not find its session"
+                    )
+                )
+                Right
+
+reserveServerSessionMutation ::
+    StorePool ->
+    ServerSessionMutation ->
+    IO (Either StoreError ServerSessionMutationReservation)
+reserveServerSessionMutation pool request =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Write do
+            Transaction.statement
+                request
+                lockServerSessionMutationStatement
+            ownerAvailable <-
+                Transaction.statement
+                    request
+                    lockServerSessionMutationOwnerStatement
+            if not ownerAvailable
+                then pure ServerSessionMutationOwnerUnavailable
+                else do
+                    exists <-
+                        Transaction.statement
+                            request
+                            serverSessionExistsForMutationStatement
+                    if not exists
+                        then pure ServerSessionMutationSessionMissing
+                        else do
+                            active <-
+                                Transaction.statement
+                                    request
+                                    activeServerTurnExistsForMutationStatement
+                            if active
+                                then pure ServerSessionMutationBusy
+                                else do
+                                    acquired <-
+                                        Transaction.statement
+                                            request
+                                            insertServerSessionMutationStatement
+                                    pure
+                                        ( if acquired
+                                            then ServerSessionMutationReserved
+                                            else ServerSessionMutationBusy
+                                        )
+
+releaseServerSessionMutation ::
+    StorePool ->
+    ServerSessionMutation ->
+    IO (Either StoreError ())
+releaseServerSessionMutation pool request =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Write do
+            Transaction.statement
+                request
+                lockServerSessionMutationStatement
+            Transaction.statement
+                request
+                deleteServerSessionMutationStatement
+
+requestServerTurnCancellation ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Text ->
+    UTCTime ->
+    IO (Either StoreError (Maybe StoredServerTurn))
+requestServerTurnCancellation pool boundary turnId requestedAt =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Write $
+            Transaction.statement
+                (turnId, boundary, requestedAt)
+                requestServerTurnCancellationStatement
+
+shouldCancelServerTurn ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Text ->
+    Text ->
+    IO (Either StoreError Bool)
+shouldCancelServerTurn pool boundary instanceId turnId =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Read do
+            Transaction.statement
+                (turnId, boundary, instanceId)
+                shouldCancelServerTurnStatement
+
+{- | Refresh one process registration and recover owners whose liveness
+connection has disappeared.
+
+A disconnected owner is terminalized only after this transaction acquires
+its advisory lock. A merely paused owner still holds that lock, so neither
+its turns nor its session mutations expire with wall-clock time.
+-}
+heartbeatServerTurnOwner ::
+    ServerTurnOwnerLease ->
+    IO (Either StoreError ())
+heartbeatServerTurnOwner lease =
+    withMVar lease.serverTurnOwnerLeaseState \case
+        ServerTurnOwnerLeaseClosed ->
+            pure . Left . StoreDataError $
+                "server turn owner liveness connection is closed"
+        ServerTurnOwnerLeaseOpen connection -> do
+            accepted <-
+                withConnectionSession connection $
+                    Transactions.transaction
+                        Transactions.ReadCommitted
+                        Transactions.Write
+                        do
+                            live <-
+                                Transaction.statement
+                                    lease.serverTurnOwnerLeaseInstanceId
+                                    heartbeatServerTurnOwnerStatement
+                            if live
+                                then do
+                                    Transaction.statement
+                                        lease.serverTurnOwnerLeaseInstanceId
+                                        interruptDisconnectedServerTurnsStatement
+                                    pure True
+                                else pure False
+            pure (accepted >>= ensureAccepted)
+  where
+    ensureAccepted True = Right ()
+    ensureAccepted False =
+        Left
+            ( StoreDataError
+                "server turn owner lease has been revoked"
+            )
+
+-- | Retire an owner during an orderly shutdown.
+--
+-- The supervisor normally terminalizes all admitted turns first. This final
+-- fence covers reservations which were persisted but never admitted locally.
+releaseServerTurnOwner ::
+    ServerTurnOwnerLease ->
+    IO (Either StoreError ())
+releaseServerTurnOwner lease =
+    modifyMVar lease.serverTurnOwnerLeaseState \case
+        ServerTurnOwnerLeaseClosed ->
+            pure (ServerTurnOwnerLeaseClosed, Right ())
+        ServerTurnOwnerLeaseOpen connection -> do
+            released <-
+                withConnectionSession connection $
+                    Transactions.transaction
+                        Transactions.ReadCommitted
+                        Transactions.Write
+                        do
+                            actionFenceAvailable <-
+                                Transaction.statement
+                                    lease.serverTurnOwnerLeaseInstanceId
+                                    acquireServerTurnOwnerReleaseFenceStatement
+                            if actionFenceAvailable
+                                then do
+                                    Transaction.statement
+                                        lease.serverTurnOwnerLeaseInstanceId
+                                        interruptReleasedServerTurnsStatement
+                                    Transaction.statement
+                                        lease.serverTurnOwnerLeaseInstanceId
+                                        deleteServerTurnOwnerStatement
+                                    pure True
+                                else pure False
+            closeStoreConnection connection
+            pure
+                ( ServerTurnOwnerLeaseClosed
+                , released >>= \case
+                    True -> Right ()
+                    False ->
+                        Left
+                            ( StoreDataError
+                                "server turn owner still has active actions"
+                            )
+                )
+
+markServerTurnRunning ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Text ->
+    Text ->
+    UTCTime ->
+    IO (Either StoreError Bool)
+markServerTurnRunning pool boundary instanceId turnId startedAt =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Write $
+            Transaction.statement
+                (startedAt, turnId, boundary, instanceId)
+                markServerTurnRunningStatement
+
+finishServerTurn ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Text ->
+    Text ->
+    ServerTurnTerminal ->
+    IO (Either StoreError (Maybe StoredServerTurn))
+finishServerTurn pool boundary instanceId turnId terminal
+    | not (isTerminal terminal.terminalServerTurnStatus) =
+        pure $
+            Left
+                ( StoreDataError
+                    "server turn terminal transition requires a terminal status"
+                )
+    | otherwise =
+        withSession pool
+            $ Transactions.transaction
+                Transactions.ReadCommitted
+                Transactions.Write
+            $ Transaction.statement
+                (turnId, boundary, instanceId, terminal)
+                finishServerTurnStatement
+
+loadServerTurn ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Text ->
+    IO (Either StoreError (Maybe StoredServerTurn))
+loadServerTurn pool boundary turnId =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Read $
+            Transaction.statement
+                (turnId, boundary)
+                loadServerTurnStatement
+
+listServerTurns ::
+    StorePool ->
+    ServerTurnBoundary ->
+    Maybe Text ->
+    IO (Either StoreError [StoredServerTurn])
+listServerTurns pool boundary sessionId =
+    withSession pool $
+        Transactions.transaction Transactions.ReadCommitted Transactions.Read do
+            Vector.toList
+                <$> Transaction.statement
+                    (boundary, sessionId)
+                    listServerTurnsStatement
+
+data RawServerTurn = RawServerTurn
+    { rawTurnId :: !Text
+    , rawTenantId :: !Text
+    , rawGatewayIdentity :: !(Maybe Text)
+    , rawSessionId :: !Text
+    , rawClientRequestId :: !Text
+    , rawInputDigest :: !Text
+    , rawOwnerInstanceId :: !Text
+    , rawStatus :: !Text
+    , rawCreatedAt :: !UTCTime
+    , rawStartedAt :: !(Maybe UTCTime)
+    , rawFinishedAt :: !(Maybe UTCTime)
+    , rawAssistantText :: !(Maybe Text)
+    , rawAssistantTextTruncated :: !Bool
+    , rawResponseId :: !(Maybe Text)
+    , rawIncompleteReason :: !(Maybe Text)
+    , rawIncompleteReasoningTokens :: !(Maybe Int64)
+    , rawError :: !(Maybe Text)
+    }
+
+decodeServerTurn :: RawServerTurn -> StoredServerTurn
+decodeServerTurn raw =
+    StoredServerTurn
+        { storedServerTurnId = raw.rawTurnId
+        , storedServerTurnBoundary =
+            ServerTurnBoundary
+                { serverTurnTenantId = raw.rawTenantId
+                , serverTurnGatewayIdentity = raw.rawGatewayIdentity
+                }
+        , storedServerTurnSessionId = raw.rawSessionId
+        , storedServerTurnClientRequestId = raw.rawClientRequestId
+        , storedServerTurnInputDigest = raw.rawInputDigest
+        , storedServerTurnOwnerInstanceId = raw.rawOwnerInstanceId
+        , storedServerTurnStatus = decodeStatus raw.rawStatus
+        , storedServerTurnCreatedAt = raw.rawCreatedAt
+        , storedServerTurnStartedAt = raw.rawStartedAt
+        , storedServerTurnFinishedAt = raw.rawFinishedAt
+        , storedServerTurnAssistantText = raw.rawAssistantText
+        , storedServerTurnAssistantTextTruncated =
+            raw.rawAssistantTextTruncated
+        , storedServerTurnResponseId = raw.rawResponseId
+        , storedServerTurnIncompleteReason = raw.rawIncompleteReason
+        , storedServerTurnIncompleteReasoningTokens =
+            raw.rawIncompleteReasoningTokens
+        , storedServerTurnError = raw.rawError
+        }
+
+decodeStatus :: Text -> ServerTurnStatus
+decodeStatus = \case
+    "queued" -> ServerTurnQueued
+    "running" -> ServerTurnRunning
+    "completed" -> ServerTurnCompleted
+    "failed" -> ServerTurnFailed
+    "cancelled" -> ServerTurnCancelled
+    _ -> ServerTurnFailed
+
+encodeStatus :: ServerTurnStatus -> Text
+encodeStatus = \case
+    ServerTurnQueued -> "queued"
+    ServerTurnRunning -> "running"
+    ServerTurnCompleted -> "completed"
+    ServerTurnFailed -> "failed"
+    ServerTurnCancelled -> "cancelled"
+
+isActive :: ServerTurnStatus -> Bool
+isActive = \case
+    ServerTurnQueued -> True
+    ServerTurnRunning -> True
+    ServerTurnCompleted -> False
+    ServerTurnFailed -> False
+    ServerTurnCancelled -> False
+
+isTerminal :: ServerTurnStatus -> Bool
+isTerminal = not . isActive
+
+serverTurnColumns :: Text
+serverTurnColumns =
+    "turn_id::text, tenant_id, gateway_identity,\
+    \ session_key, client_request_id::text, input_digest,\
+    \ owner_instance_id::text, status, server_turn.created_at,\
+    \ started_at, finished_at, assistant_text, assistant_text_truncated,\
+    \ response_id,\
+    \ incomplete_reason, incomplete_reasoning_tokens, error_text"
+
+serverTurnDecoder :: Decoders.Row StoredServerTurn
+serverTurnDecoder =
+    decodeServerTurn
+        <$> ( RawServerTurn
+                <$> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
+                <*> Decoders.column (Decoders.nullable Decoders.timestamptz)
+                <*> Decoders.column (Decoders.nullable Decoders.timestamptz)
+                <*> Decoders.column (Decoders.nullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.bool)
+                <*> Decoders.column (Decoders.nullable Decoders.text)
+                <*> Decoders.column (Decoders.nullable Decoders.text)
+                <*> Decoders.column (Decoders.nullable Decoders.int8)
+                <*> Decoders.column (Decoders.nullable Decoders.text)
+            )
+
+boundaryEncoder :: (input -> ServerTurnBoundary) -> Encoders.Params input
+boundaryEncoder select =
+    ( ((.serverTurnTenantId) . select)
+        >$< Encoders.param (Encoders.nonNullable Encoders.text)
+    )
+        <> ( ((.serverTurnGatewayIdentity) . select)
+                >$< Encoders.param (Encoders.nullable Encoders.text)
+           )
+
+lockServerTurnSessionStatement :: Statement ReserveServerTurn Bool
+lockServerTurnSessionStatement =
+    mkStatement
+        "SELECT pg_advisory_xact_lock(\
+        \ hashtextextended(\
+        \   jsonb_build_array($1::text, $2::text, $3::text)::text,\
+        \   0)) IS NULL"
+        ( boundaryEncoder (.reserveServerTurnBoundary)
+            <> ( (.reserveServerTurnSessionId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+        )
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+lockServerTurnOwnerStatement :: Statement ReserveServerTurn Bool
+lockServerTurnOwnerStatement =
+    mkStatement
+        "SELECT COALESCE((\
+        \ SELECT revoked_at IS NULL\
+        \ FROM harness.server_turn_owners\
+        \ WHERE instance_id = $1::uuid\
+        \ FOR SHARE), FALSE)\
+        \ AND NOT pg_try_advisory_xact_lock(\
+        \   hashtextextended(\
+        \     'haskell-agent:server-turn-owner:' || $1::text,\
+        \     0))"
+        ( (.reserveServerTurnOwnerInstanceId)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text)
+        )
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+serverSessionMutationExistsForTurnStatement ::
+    Statement ReserveServerTurn Bool
+serverSessionMutationExistsForTurnStatement =
+    mkStatement
+        "SELECT EXISTS (\
+        \ SELECT 1 FROM harness.server_session_mutations\
+        \ WHERE tenant_id = $1\
+        \ AND gateway_identity IS NOT DISTINCT FROM $2\
+        \ AND session_key = $3)"
+        ( boundaryEncoder (.reserveServerTurnBoundary)
+            <> ( (.reserveServerTurnSessionId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+        )
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+serverSessionMutationKeyEncoder ::
+    Encoders.Params ServerSessionMutation
+serverSessionMutationKeyEncoder =
+    boundaryEncoder (.serverSessionMutationBoundary)
+        <> ( (.serverSessionMutationSessionId)
+                >$< Encoders.param (Encoders.nonNullable Encoders.text)
+           )
+
+serverSessionMutationEncoder ::
+    Encoders.Params ServerSessionMutation
+serverSessionMutationEncoder =
+    serverSessionMutationKeyEncoder
+        <> ( (.serverSessionMutationOwnerInstanceId)
+                >$< Encoders.param (Encoders.nonNullable Encoders.text)
+           )
+        <> ( (.serverSessionMutationCreatedAt)
+                >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz)
+           )
+
+lockServerSessionMutationStatement ::
+    Statement ServerSessionMutation Bool
+lockServerSessionMutationStatement =
+    mkStatement
+        "SELECT pg_advisory_xact_lock(\
+        \ hashtextextended(\
+        \   jsonb_build_array($1::text, $2::text, $3::text)::text,\
+        \   0)) IS NULL"
+        serverSessionMutationKeyEncoder
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+acquireServerTurnOwnerActionFenceStatement ::
+    Statement Text Bool
+acquireServerTurnOwnerActionFenceStatement =
+    mkStatement
+        "WITH locked AS MATERIALIZED (\
+        \ SELECT pg_advisory_lock_shared(\
+        \   hashtextextended(\
+        \     'haskell-agent:server-turn-owner-action:' || $1::text,\
+        \     0)))\
+        \ SELECT TRUE FROM locked"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+validateServerTurnOwnerActionFenceStatement ::
+    Statement Text Bool
+validateServerTurnOwnerActionFenceStatement =
+    mkStatement
+        "SELECT COALESCE((\
+        \ SELECT revoked_at IS NULL\
+        \ FROM harness.server_turn_owners\
+        \ WHERE instance_id = $1::uuid), FALSE)\
+        \ AND NOT pg_try_advisory_xact_lock(\
+        \   hashtextextended(\
+        \     'haskell-agent:server-turn-owner:' || $1::text,\
+        \     0))"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+checkServerTurnOwnerActionFenceStatement :: Statement () ()
+checkServerTurnOwnerActionFenceStatement =
+    mkStatement
+        "SELECT 1"
+        Encoders.noParams
+        ( const ()
+            <$> Decoders.singleRow
+                (Decoders.column (Decoders.nonNullable Decoders.int4))
+        )
+        True
+
+lockServerSessionMutationOwnerStatement ::
+    Statement ServerSessionMutation Bool
+lockServerSessionMutationOwnerStatement =
+    mkStatement
+        "SELECT COALESCE((\
+        \ SELECT revoked_at IS NULL\
+        \ FROM harness.server_turn_owners\
+        \ WHERE instance_id = $1::uuid\
+        \ FOR SHARE), FALSE)\
+        \ AND NOT pg_try_advisory_xact_lock(\
+        \   hashtextextended(\
+        \     'haskell-agent:server-turn-owner:' || $1::text,\
+        \     0))"
+        ( (.serverSessionMutationOwnerInstanceId)
+            >$< Encoders.param (Encoders.nonNullable Encoders.text)
+        )
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+serverSessionExistsForMutationStatement ::
+    Statement ServerSessionMutation Bool
+serverSessionExistsForMutationStatement =
+    mkStatement
+        "SELECT EXISTS (\
+        \ SELECT 1 FROM harness.sessions\
+        \ WHERE $1::text IS NOT NULL\
+        \ AND gateway_identity IS NOT DISTINCT FROM $2\
+        \ AND session_key = $3\
+        \ AND deleted_at IS NULL)"
+        serverSessionMutationKeyEncoder
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+activeServerTurnExistsForMutationStatement ::
+    Statement ServerSessionMutation Bool
+activeServerTurnExistsForMutationStatement =
+    mkStatement
+        "SELECT EXISTS (\
+        \ SELECT 1 FROM harness.server_turns\
+        \ WHERE tenant_id = $1\
+        \ AND gateway_identity IS NOT DISTINCT FROM $2\
+        \ AND session_key = $3\
+        \ AND status IN ('queued', 'running'))"
+        serverSessionMutationKeyEncoder
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+insertServerSessionMutationStatement ::
+    Statement ServerSessionMutation Bool
+insertServerSessionMutationStatement =
+    mkStatement
+        "WITH inserted AS (\
+        \ INSERT INTO harness.server_session_mutations\
+        \ (tenant_id, gateway_identity, session_key,\
+        \  owner_instance_id, created_at)\
+        \ VALUES ($1, $2, $3, $4::uuid, $5)\
+        \ ON CONFLICT DO NOTHING\
+        \ RETURNING 1)\
+        \ SELECT EXISTS (SELECT 1 FROM inserted)"
+        serverSessionMutationEncoder
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+deleteServerSessionMutationStatement ::
+    Statement ServerSessionMutation ()
+deleteServerSessionMutationStatement =
+    mkStatement
+        "DELETE FROM harness.server_session_mutations\
+        \ WHERE tenant_id = $1\
+        \ AND gateway_identity IS NOT DISTINCT FROM $2\
+        \ AND session_key = $3\
+        \ AND owner_instance_id = $4::uuid\
+        \ AND created_at = $5"
+        serverSessionMutationEncoder
+        Decoders.noResult
+        True
+
+insertServerTurnStatement ::
+    Statement ReserveServerTurn (Maybe StoredServerTurn)
+insertServerTurnStatement =
+    mkStatement
+        ( "INSERT INTO harness.server_turns AS server_turn\
+          \ (turn_id, tenant_id, gateway_identity, session_key,\
+          \ client_request_id, input_digest, owner_instance_id, status, created_at)\
+          \ SELECT $1::uuid, $2, $3, session.session_key,\
+          \ $5::uuid, $6, $7::uuid, 'queued', $8\
+          \ FROM harness.sessions session\
+          \ WHERE session.session_key = $4 AND session.deleted_at IS NULL\
+          \ AND session.gateway_identity IS NOT DISTINCT FROM $3\
+          \ ON CONFLICT DO NOTHING\
+          \ RETURNING "
+            <> serverTurnColumns
+        )
+        ( ( (.reserveServerTurnId)
+                >$< Encoders.param (Encoders.nonNullable Encoders.text)
+          )
+            <> boundaryEncoder (.reserveServerTurnBoundary)
+            <> ( (.reserveServerTurnSessionId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (.reserveServerTurnClientRequestId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (.reserveServerTurnInputDigest)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (.reserveServerTurnOwnerInstanceId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (.reserveServerTurnCreatedAt)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz)
+               )
+        )
+        (Decoders.rowMaybe serverTurnDecoder)
+        True
+
+loadServerTurnByClientRequestStatement ::
+    Statement ReserveServerTurn (Maybe StoredServerTurn)
+loadServerTurnByClientRequestStatement =
+    mkStatement
+        ( "SELECT "
+            <> serverTurnColumns
+            <> "\
+               \ FROM harness.server_turns server_turn\
+               \ WHERE tenant_id = $1\
+               \ AND gateway_identity IS NOT DISTINCT FROM $2\
+               \ AND session_key = $3\
+               \ AND client_request_id = $4::uuid\
+               \ FOR UPDATE OF server_turn"
+        )
+        ( ( ((.serverTurnTenantId) . (.reserveServerTurnBoundary))
+                >$< Encoders.param (Encoders.nonNullable Encoders.text)
+          )
+            <> ( ((.serverTurnGatewayIdentity) . (.reserveServerTurnBoundary))
+                    >$< Encoders.param (Encoders.nullable Encoders.text)
+               )
+            <> ( (.reserveServerTurnSessionId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (.reserveServerTurnClientRequestId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+        )
+        (Decoders.rowMaybe serverTurnDecoder)
+        True
+
+loadActiveServerTurnStatement ::
+    Statement ReserveServerTurn (Maybe StoredServerTurn)
+loadActiveServerTurnStatement =
+    mkStatement
+        ( "SELECT "
+            <> serverTurnColumns
+            <> "\
+               \ FROM harness.server_turns server_turn\
+               \ WHERE tenant_id = $1\
+               \ AND gateway_identity IS NOT DISTINCT FROM $2\
+               \ AND session_key = $3\
+               \ AND status IN ('queued', 'running')\
+               \ ORDER BY created_at, turn_id\
+               \ LIMIT 1\
+               \ FOR UPDATE OF server_turn"
+        )
+        ( ( ((.serverTurnTenantId) . (.reserveServerTurnBoundary))
+                >$< Encoders.param (Encoders.nonNullable Encoders.text)
+          )
+            <> ( ((.serverTurnGatewayIdentity) . (.reserveServerTurnBoundary))
+                    >$< Encoders.param (Encoders.nullable Encoders.text)
+               )
+            <> ( (.reserveServerTurnSessionId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+        )
+        (Decoders.rowMaybe serverTurnDecoder)
+        True
+
+markServerTurnRunningStatement ::
+    Statement (UTCTime, Text, ServerTurnBoundary, Text) Bool
+markServerTurnRunningStatement =
+    mkStatement
+        "WITH changed AS (\
+        \ UPDATE harness.server_turns\
+        \ SET status = 'running', started_at = COALESCE(started_at, $1)\
+        \ WHERE turn_id = $2::uuid AND tenant_id = $3\
+        \ AND gateway_identity IS NOT DISTINCT FROM $4\
+        \ AND owner_instance_id = $5::uuid AND status IN ('queued', 'running')\
+        \ RETURNING 1)\
+        \ SELECT EXISTS (SELECT 1 FROM changed)"
+        ( ( (\(startedAt, _, _, _) -> startedAt)
+                >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz)
+          )
+            <> ( (\(_, turnId, _, _) -> turnId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> boundaryEncoder (\(_, _, boundary, _) -> boundary)
+            <> ( (\(_, _, _, instanceId) -> instanceId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+        )
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+finishServerTurnStatement ::
+    Statement
+        (Text, ServerTurnBoundary, Text, ServerTurnTerminal)
+        (Maybe StoredServerTurn)
+finishServerTurnStatement =
+    mkStatement
+        ( "UPDATE harness.server_turns AS server_turn\
+          \ SET status = CASE WHEN status IN ('queued', 'running')\
+          \   THEN $5 ELSE status END,\
+          \ finished_at = CASE WHEN status IN ('queued', 'running')\
+          \   THEN $6 ELSE finished_at END,\
+          \ assistant_text = CASE WHEN status IN ('queued', 'running')\
+          \   THEN $7 ELSE assistant_text END,\
+          \ assistant_text_truncated = CASE\
+          \   WHEN status IN ('queued', 'running') THEN $8\
+          \   ELSE assistant_text_truncated END,\
+          \ response_id = CASE WHEN status IN ('queued', 'running')\
+          \   THEN $9 ELSE response_id END,\
+          \ incomplete_reason = CASE WHEN status IN ('queued', 'running')\
+          \   THEN $10 ELSE incomplete_reason END,\
+          \ incomplete_reasoning_tokens = CASE\
+          \   WHEN status IN ('queued', 'running') THEN $11\
+          \   ELSE incomplete_reasoning_tokens END,\
+          \ error_text = CASE WHEN status IN ('queued', 'running')\
+          \   THEN $12 ELSE error_text END\
+          \ WHERE turn_id = $1::uuid AND tenant_id = $2\
+          \ AND gateway_identity IS NOT DISTINCT FROM $3\
+          \ AND owner_instance_id = $4::uuid\
+          \ RETURNING "
+            <> serverTurnColumns
+        )
+        ( ( (\(turnId, _, _, _) -> turnId)
+                >$< Encoders.param (Encoders.nonNullable Encoders.text)
+          )
+            <> boundaryEncoder (\(_, boundary, _, _) -> boundary)
+            <> ( (\(_, _, instanceId, _) -> instanceId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( ( encodeStatus
+                    . (.terminalServerTurnStatus)
+                    . (\(_, _, _, terminal) -> terminal)
+                 )
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( ( (.terminalServerTurnFinishedAt)
+                    . (\(_, _, _, terminal) -> terminal)
+                 )
+                    >$< Encoders.param (Encoders.nonNullable Encoders.timestamptz)
+               )
+            <> ( ( (.terminalServerTurnAssistantText)
+                    . (\(_, _, _, terminal) -> terminal)
+                 )
+                    >$< Encoders.param (Encoders.nullable Encoders.text)
+               )
+            <> ( ( (.terminalServerTurnAssistantTextTruncated)
+                    . (\(_, _, _, terminal) -> terminal)
+                 )
+                    >$< Encoders.param (Encoders.nonNullable Encoders.bool)
+               )
+            <> ( ( (.terminalServerTurnResponseId)
+                    . (\(_, _, _, terminal) -> terminal)
+                 )
+                    >$< Encoders.param (Encoders.nullable Encoders.text)
+               )
+            <> ( ( (.terminalServerTurnIncompleteReason)
+                    . (\(_, _, _, terminal) -> terminal)
+                 )
+                    >$< Encoders.param (Encoders.nullable Encoders.text)
+               )
+            <> ( ( (.terminalServerTurnIncompleteReasoningTokens)
+                    . (\(_, _, _, terminal) -> terminal)
+                 )
+                    >$< Encoders.param (Encoders.nullable Encoders.int8)
+               )
+            <> ( ( (.terminalServerTurnError)
+                    . (\(_, _, _, terminal) -> terminal)
+                 )
+                    >$< Encoders.param (Encoders.nullable Encoders.text)
+               )
+        )
+        (Decoders.rowMaybe serverTurnDecoder)
+        True
+
+requestServerTurnCancellationStatement ::
+    Statement
+        (Text, ServerTurnBoundary, UTCTime)
+        (Maybe StoredServerTurn)
+requestServerTurnCancellationStatement =
+    mkStatement
+        ( "UPDATE harness.server_turns AS server_turn\
+          \ SET cancellation_requested_at =\
+          \   COALESCE(cancellation_requested_at, $4)\
+          \ WHERE turn_id = $1::uuid AND tenant_id = $2\
+          \ AND gateway_identity IS NOT DISTINCT FROM $3\
+          \ AND status IN ('queued', 'running')\
+          \ RETURNING "
+            <> serverTurnColumns
+        )
+        ( ( (\(turnId, _, _) -> turnId)
+                >$< Encoders.param (Encoders.nonNullable Encoders.text)
+          )
+            <> boundaryEncoder (\(_, boundary, _) -> boundary)
+            <> ( (\(_, _, requestedAt) -> requestedAt)
+                    >$< Encoders.param
+                        (Encoders.nonNullable Encoders.timestamptz)
+               )
+        )
+        (Decoders.rowMaybe serverTurnDecoder)
+        True
+
+shouldCancelServerTurnStatement ::
+    Statement (Text, ServerTurnBoundary, Text) Bool
+shouldCancelServerTurnStatement =
+    mkStatement
+        "SELECT COALESCE((\
+        \ SELECT cancellation_requested_at IS NOT NULL\
+        \ FROM harness.server_turns\
+        \ WHERE turn_id = $1::uuid AND tenant_id = $2\
+        \ AND gateway_identity IS NOT DISTINCT FROM $3\
+        \ AND owner_instance_id = $4::uuid\
+        \ AND status IN ('queued', 'running')),\
+        \ TRUE)"
+        ( ( (\(turnId, _, _) -> turnId)
+                >$< Encoders.param (Encoders.nonNullable Encoders.text)
+          )
+            <> boundaryEncoder (\(_, boundary, _) -> boundary)
+            <> ( (\(_, _, instanceId) -> instanceId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+        )
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+loadServerTurnStatement ::
+    Statement (Text, ServerTurnBoundary) (Maybe StoredServerTurn)
+loadServerTurnStatement =
+    mkStatement
+        ( "SELECT "
+            <> serverTurnColumns
+            <> "\
+               \ FROM harness.server_turns server_turn\
+               \ WHERE turn_id = $1::uuid AND tenant_id = $2\
+               \ AND gateway_identity IS NOT DISTINCT FROM $3"
+        )
+        ( (fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+            <> boundaryEncoder snd
+        )
+        (Decoders.rowMaybe serverTurnDecoder)
+        True
+
+heartbeatServerTurnOwnerStatement ::
+    Statement Text Bool
+heartbeatServerTurnOwnerStatement =
+    mkStatement
+        "WITH heartbeat AS (\
+        \ INSERT INTO harness.server_turn_owners AS owner\
+        \ (instance_id, last_heartbeat_at)\
+        \ VALUES ($1::uuid, clock_timestamp())\
+        \ ON CONFLICT (instance_id) DO UPDATE\
+        \ SET last_heartbeat_at = EXCLUDED.last_heartbeat_at\
+        \ WHERE owner.revoked_at IS NULL\
+        \ RETURNING 1)\
+        \ SELECT EXISTS (SELECT 1 FROM heartbeat)"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+acquireServerTurnOwnerLockStatement :: Statement Text Bool
+acquireServerTurnOwnerLockStatement =
+    mkStatement
+        "SELECT pg_try_advisory_lock(\
+        \ hashtextextended(\
+        \   'haskell-agent:server-turn-owner:' || $1::text,\
+        \   0))"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+interruptDisconnectedServerTurnsStatement ::
+    Statement Text ()
+interruptDisconnectedServerTurnsStatement =
+    mkStatement
+        "WITH action_unfenced_owner AS MATERIALIZED (\
+        \ SELECT owner.instance_id\
+        \ FROM harness.server_turn_owners AS owner\
+        \ WHERE owner.instance_id <> $1::uuid\
+        \ AND owner.revoked_at IS NULL\
+        \ AND pg_try_advisory_xact_lock(\
+        \   hashtextextended(\
+        \     'haskell-agent:server-turn-owner-action:'\
+        \       || owner.instance_id::text,\
+        \     0))\
+        \ FOR UPDATE OF owner SKIP LOCKED\
+        \ ), disconnected_owner AS MATERIALIZED (\
+        \ SELECT owner.instance_id\
+        \ FROM action_unfenced_owner AS candidate\
+        \ JOIN harness.server_turn_owners AS owner\
+        \   ON owner.instance_id = candidate.instance_id\
+        \ AND pg_try_advisory_xact_lock(\
+        \   hashtextextended(\
+        \     'haskell-agent:server-turn-owner:'\
+        \       || owner.instance_id::text,\
+        \     0))\
+        \ ), revoked_owner AS (\
+        \ UPDATE harness.server_turn_owners AS owner\
+        \ SET revoked_at = clock_timestamp()\
+        \ FROM disconnected_owner AS disconnected\
+        \ WHERE owner.instance_id = disconnected.instance_id\
+        \ RETURNING owner.instance_id\
+        \ ), released_mutation AS (\
+        \ DELETE FROM harness.server_session_mutations AS mutation\
+        \ USING revoked_owner AS owner\
+        \ WHERE mutation.owner_instance_id = owner.instance_id\
+        \ )\
+        \ UPDATE harness.server_turns AS turn\
+        \ SET status = 'failed', finished_at = clock_timestamp(),\
+        \ error_text =\
+        \   'agent server owner disconnected before the turn completed'\
+        \ WHERE status IN ('queued', 'running')\
+        \ AND owner_instance_id IN (SELECT instance_id FROM revoked_owner)"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        Decoders.noResult
+        True
+
+interruptReleasedServerTurnsStatement ::
+    Statement Text ()
+interruptReleasedServerTurnsStatement =
+    mkStatement
+        "UPDATE harness.server_turns\
+        \ SET status = 'failed', finished_at = clock_timestamp(),\
+        \ error_text = CASE WHEN status IN ('queued', 'running')\
+        \   THEN 'agent server stopped before the turn completed'\
+        \   ELSE error_text END\
+        \ WHERE owner_instance_id = $1::uuid\
+        \ AND status IN ('queued', 'running')"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        Decoders.noResult
+        True
+
+acquireServerTurnOwnerReleaseFenceStatement :: Statement Text Bool
+acquireServerTurnOwnerReleaseFenceStatement =
+    mkStatement
+        "SELECT pg_try_advisory_xact_lock(\
+        \ hashtextextended(\
+        \   'haskell-agent:server-turn-owner-action:' || $1::text,\
+        \   0))"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+deleteServerTurnOwnerStatement :: Statement Text ()
+deleteServerTurnOwnerStatement =
+    mkStatement
+        "DELETE FROM harness.server_turn_owners\
+        \ WHERE instance_id = $1::uuid"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        Decoders.noResult
+        True
+
+listServerTurnsStatement ::
+    Statement
+        (ServerTurnBoundary, Maybe Text)
+        (Vector.Vector StoredServerTurn)
+listServerTurnsStatement =
+    mkStatement
+        ( "SELECT "
+            <> serverTurnColumns
+            <> "\
+               \ FROM harness.server_turns server_turn\
+               \ WHERE tenant_id = $1\
+               \ AND gateway_identity IS NOT DISTINCT FROM $2\
+               \ AND ($3::text IS NULL OR session_key = $3)\
+               \ ORDER BY server_turn.created_at DESC, server_turn.turn_id DESC\
+               \ LIMIT 200"
+        )
+        ( boundaryEncoder fst
+            <> (snd >$< Encoders.param (Encoders.nullable Encoders.text))
+        )
+        (Decoders.rowVector serverTurnDecoder)
+        True

--- a/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
@@ -20,6 +20,8 @@ module Agent.Store.Postgres.ServerTurn (
     abandonServerTurnOwnerLease,
     openServerTurnOwnerActionFence,
     checkServerTurnOwnerActionFence,
+    withServerTurnOwnerActionFenceMonitor,
+    waitForServerTurnOwnerActionFenceFailure,
     closeServerTurnOwnerActionFence,
     reserveServerTurn,
     reserveServerSessionMutation,
@@ -42,6 +44,7 @@ import Agent.Store.Postgres.Connection (
     openStoreConnection,
     withConnectionSession,
     withSession,
+    withStoreConnectionFailureMonitor,
  )
 import Agent.Store.Postgres.Hasql (mkStatement)
 import Agent.Store.Types (StoreError (..))
@@ -293,6 +296,33 @@ checkServerTurnOwnerActionFence
             ServerTurnOwnerActionFenceOpen connection ->
                 withConnectionSession connection $
                     Session.statement () checkServerTurnOwnerActionFenceStatement
+
+{- | Arm the dedicated action-fence monitor before invoking an action.
+
+The event manager watches the exact idle socket which holds the advisory lock,
+so a server restart or socket failure wakes the caller without a timer-based
+polling window. The callback receives an interruptible wait for that failure.
+-}
+withServerTurnOwnerActionFenceMonitor ::
+    ServerTurnOwnerActionFence ->
+    (IO () -> IO a) ->
+    IO (Either StoreError a)
+withServerTurnOwnerActionFenceMonitor
+    (ServerTurnOwnerActionFence state)
+    action =
+        withMVar state \case
+            ServerTurnOwnerActionFenceClosed ->
+                pure . Left . StoreDataError $
+                    "server turn owner action fence is closed"
+            ServerTurnOwnerActionFenceOpen connection ->
+                withStoreConnectionFailureMonitor connection action
+
+-- | Wait for the dedicated action-fence connection to fail.
+waitForServerTurnOwnerActionFenceFailure ::
+    ServerTurnOwnerActionFence ->
+    IO (Either StoreError ())
+waitForServerTurnOwnerActionFenceFailure fence =
+    withServerTurnOwnerActionFenceMonitor fence id
 
 closeServerTurnOwnerActionFence :: ServerTurnOwnerActionFence -> IO ()
 closeServerTurnOwnerActionFence

--- a/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
@@ -1034,7 +1034,8 @@ finishServerTurnStatement ::
         (Maybe StoredServerTurn)
 finishServerTurnStatement =
     mkStatement
-        ( "UPDATE harness.server_turns AS server_turn\
+        ( "WITH finished_turn AS (\
+          \ UPDATE harness.server_turns AS server_turn\
           \ SET status = CASE WHEN status IN ('queued', 'running')\
           \   THEN $5 ELSE status END,\
           \ finished_at = CASE WHEN status IN ('queued', 'running')\
@@ -1056,8 +1057,16 @@ finishServerTurnStatement =
           \ WHERE turn_id = $1::uuid AND tenant_id = $2\
           \ AND gateway_identity IS NOT DISTINCT FROM $3\
           \ AND owner_instance_id = $4::uuid\
-          \ RETURNING "
+          \ RETURNING turn_id AS durable_turn_id, "
             <> serverTurnColumns
+            <> "\
+               \ ), deleted_request AS (\
+               \ DELETE FROM harness.server_human_requests AS request\
+               \ USING finished_turn\
+               \ WHERE request.turn_id = finished_turn.durable_turn_id)\
+               \ SELECT "
+            <> serverTurnColumns
+            <> " FROM finished_turn AS server_turn"
         )
         ( ( (\(turnId, _, _, _) -> turnId)
                 >$< Encoders.param (Encoders.nonNullable Encoders.text)
@@ -1241,13 +1250,17 @@ interruptDisconnectedServerTurnsStatement =
         \ DELETE FROM harness.server_session_mutations AS mutation\
         \ USING revoked_owner AS owner\
         \ WHERE mutation.owner_instance_id = owner.instance_id\
-        \ )\
+        \ ), interrupted_turn AS (\
         \ UPDATE harness.server_turns AS turn\
         \ SET status = 'failed', finished_at = clock_timestamp(),\
         \ error_text =\
         \   'agent server owner disconnected before the turn completed'\
         \ WHERE status IN ('queued', 'running')\
-        \ AND owner_instance_id IN (SELECT instance_id FROM revoked_owner)"
+        \ AND owner_instance_id IN (SELECT instance_id FROM revoked_owner)\
+        \ RETURNING turn.turn_id)\
+        \ DELETE FROM harness.server_human_requests AS request\
+        \ USING interrupted_turn AS turn\
+        \ WHERE request.turn_id = turn.turn_id"
         (Encoders.param (Encoders.nonNullable Encoders.text))
         Decoders.noResult
         True
@@ -1256,13 +1269,18 @@ interruptReleasedServerTurnsStatement ::
     Statement Text ()
 interruptReleasedServerTurnsStatement =
     mkStatement
-        "UPDATE harness.server_turns\
+        "WITH interrupted_turn AS (\
+        \ UPDATE harness.server_turns AS turn\
         \ SET status = 'failed', finished_at = clock_timestamp(),\
         \ error_text = CASE WHEN status IN ('queued', 'running')\
         \   THEN 'agent server stopped before the turn completed'\
         \   ELSE error_text END\
         \ WHERE owner_instance_id = $1::uuid\
-        \ AND status IN ('queued', 'running')"
+        \ AND status IN ('queued', 'running')\
+        \ RETURNING turn.turn_id)\
+        \ DELETE FROM harness.server_human_requests AS request\
+        \ USING interrupted_turn AS turn\
+        \ WHERE request.turn_id = turn.turn_id"
         (Encoders.param (Encoders.nonNullable Encoders.text))
         Decoders.noResult
         True

--- a/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
@@ -5,34 +5,34 @@
 {-# LANGUAGE NoFieldSelectors #-}
 
 -- | Durable admission and terminal results for externally submitted turns.
-module Agent.Store.Postgres.ServerTurn
-    ( ServerTurnBoundary (..)
-    , ServerTurnStatus (..)
-    , StoredServerTurn (..)
-    , ReserveServerTurn (..)
-    , ServerTurnReservation (..)
-    , ServerTurnTerminal (..)
-    , ServerSessionMutation (..)
-    , ServerSessionMutationReservation (..)
-    , ServerTurnOwnerLease
-    , ServerTurnOwnerActionFence
-    , openServerTurnOwnerLease
-    , abandonServerTurnOwnerLease
-    , openServerTurnOwnerActionFence
-    , checkServerTurnOwnerActionFence
-    , closeServerTurnOwnerActionFence
-    , reserveServerTurn
-    , reserveServerSessionMutation
-    , releaseServerSessionMutation
-    , requestServerTurnCancellation
-    , shouldCancelServerTurn
-    , markServerTurnRunning
-    , finishServerTurn
-    , heartbeatServerTurnOwner
-    , releaseServerTurnOwner
-    , loadServerTurn
-    , listServerTurns
-    )
+module Agent.Store.Postgres.ServerTurn (
+    ServerTurnBoundary (..),
+    ServerTurnStatus (..),
+    StoredServerTurn (..),
+    ReserveServerTurn (..),
+    ServerTurnReservation (..),
+    ServerTurnTerminal (..),
+    ServerSessionMutation (..),
+    ServerSessionMutationReservation (..),
+    ServerTurnOwnerLease,
+    ServerTurnOwnerActionFence,
+    openServerTurnOwnerLease,
+    abandonServerTurnOwnerLease,
+    openServerTurnOwnerActionFence,
+    checkServerTurnOwnerActionFence,
+    closeServerTurnOwnerActionFence,
+    reserveServerTurn,
+    reserveServerSessionMutation,
+    releaseServerSessionMutation,
+    requestServerTurnCancellation,
+    shouldCancelServerTurn,
+    markServerTurnRunning,
+    finishServerTurn,
+    heartbeatServerTurnOwner,
+    releaseServerTurnOwner,
+    loadServerTurn,
+    listServerTurns,
+)
 where
 
 import Agent.Store.Postgres.Connection (
@@ -116,6 +116,7 @@ data ServerTurnReservation
     | ServerTurnIdempotencyConflict !StoredServerTurn
     | ServerTurnSessionBusy !StoredServerTurn
     | ServerTurnSessionMutating
+    | ServerTurnSessionMissing
     | ServerTurnOwnerUnavailable
     deriving (Eq, Show)
 
@@ -284,24 +285,24 @@ checkServerTurnOwnerActionFence ::
     ServerTurnOwnerActionFence ->
     IO (Either StoreError ())
 checkServerTurnOwnerActionFence
-        (ServerTurnOwnerActionFence state) =
-    withMVar state \case
-        ServerTurnOwnerActionFenceClosed ->
-            pure . Left . StoreDataError $
-                "server turn owner action fence is closed"
-        ServerTurnOwnerActionFenceOpen connection ->
-            withConnectionSession connection $
-                Session.statement () checkServerTurnOwnerActionFenceStatement
+    (ServerTurnOwnerActionFence state) =
+        withMVar state \case
+            ServerTurnOwnerActionFenceClosed ->
+                pure . Left . StoreDataError $
+                    "server turn owner action fence is closed"
+            ServerTurnOwnerActionFenceOpen connection ->
+                withConnectionSession connection $
+                    Session.statement () checkServerTurnOwnerActionFenceStatement
 
 closeServerTurnOwnerActionFence :: ServerTurnOwnerActionFence -> IO ()
 closeServerTurnOwnerActionFence
-        (ServerTurnOwnerActionFence state) =
-    modifyMVar_ state \case
-        ServerTurnOwnerActionFenceClosed ->
-            pure ServerTurnOwnerActionFenceClosed
-        ServerTurnOwnerActionFenceOpen connection -> do
-            closeStoreConnection connection
-            pure ServerTurnOwnerActionFenceClosed
+    (ServerTurnOwnerActionFence state) =
+        modifyMVar_ state \case
+            ServerTurnOwnerActionFenceClosed ->
+                pure ServerTurnOwnerActionFenceClosed
+            ServerTurnOwnerActionFenceOpen connection -> do
+                closeStoreConnection connection
+                pure ServerTurnOwnerActionFenceClosed
 
 reserveServerTurn ::
     StorePool ->
@@ -346,10 +347,23 @@ reserveServerTurn pool request = do
                                                         pure . Just $
                                                             ServerTurnReserved inserted
                                                     Nothing ->
-                                                        fmap ServerTurnSessionBusy
-                                                            <$> Transaction.statement
-                                                                request
-                                                                loadActiveServerTurnStatement
+                                                        Transaction.statement
+                                                            request
+                                                            loadActiveServerTurnStatement
+                                                            >>= \case
+                                                                Just active ->
+                                                                    pure . Just $
+                                                                        ServerTurnSessionBusy active
+                                                                Nothing ->
+                                                                    Transaction.statement
+                                                                        request
+                                                                        serverSessionExistsForTurnStatement
+                                                                        >>= \case
+                                                                            False ->
+                                                                                pure
+                                                                                    (Just ServerTurnSessionMissing)
+                                                                            True ->
+                                                                                pure Nothing
     pure $
         result
             >>= maybe
@@ -483,10 +497,11 @@ heartbeatServerTurnOwner lease =
                 "server turn owner lease has been revoked"
             )
 
--- | Retire an owner during an orderly shutdown.
---
--- The supervisor normally terminalizes all admitted turns first. This final
--- fence covers reservations which were persisted but never admitted locally.
+{- | Retire an owner during an orderly shutdown.
+
+The supervisor normally terminalizes all admitted turns first. This final
+fence covers reservations which were persisted but never admitted locally.
+-}
 releaseServerTurnOwner ::
     ServerTurnOwnerLease ->
     IO (Either StoreError ())
@@ -748,6 +763,25 @@ serverSessionMutationExistsForTurnStatement =
         \ AND gateway_identity IS NOT DISTINCT FROM $2\
         \ AND session_key = $3)"
         ( boundaryEncoder (.reserveServerTurnBoundary)
+            <> ( (.reserveServerTurnSessionId)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+        )
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+        True
+
+serverSessionExistsForTurnStatement ::
+    Statement ReserveServerTurn Bool
+serverSessionExistsForTurnStatement =
+    mkStatement
+        "SELECT EXISTS (\
+        \ SELECT 1 FROM harness.sessions\
+        \ WHERE gateway_identity IS NOT DISTINCT FROM $1\
+        \ AND session_key = $2\
+        \ AND deleted_at IS NULL)"
+        ( ( ((.serverTurnGatewayIdentity) . (.reserveServerTurnBoundary))
+                >$< Encoders.param (Encoders.nullable Encoders.text)
+          )
             <> ( (.reserveServerTurnSessionId)
                     >$< Encoders.param (Encoders.nonNullable Encoders.text)
                )

--- a/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
@@ -42,11 +42,13 @@ import Agent.Store.Postgres.Connection (
     StorePool,
     closeStoreConnection,
     openStoreConnection,
+    storePoolServerTurnActionLockDirectory,
     withConnectionSession,
     withSession,
     withStoreConnectionFailureMonitor,
  )
 import Agent.Store.Postgres.Hasql (mkStatement)
+import qualified Agent.Store.Postgres.ServerTurn.OwnerFence as OwnerFence
 import Agent.Store.Types (StoreError (..))
 import Control.Concurrent.MVar (
     MVar,
@@ -55,7 +57,7 @@ import Control.Concurrent.MVar (
     newMVar,
     withMVar,
  )
-import Control.Exception.Safe (mask, onException)
+import Control.Exception.Safe (finally, mask, onException)
 import Data.Functor.Contravariant ((>$<))
 import Data.Int (Int64)
 import Data.Text (Text)
@@ -152,6 +154,7 @@ data ServerSessionMutationReservation
 
 data ServerTurnOwnerLease = ServerTurnOwnerLease
     { serverTurnOwnerLeaseInstanceId :: !Text
+    , serverTurnOwnerLeaseActionLockDirectory :: !FilePath
     , serverTurnOwnerLeaseState :: !(MVar ServerTurnOwnerLeaseState)
     }
 
@@ -163,7 +166,9 @@ newtype ServerTurnOwnerActionFence
     = ServerTurnOwnerActionFence (MVar ServerTurnOwnerActionFenceState)
 
 data ServerTurnOwnerActionFenceState
-    = ServerTurnOwnerActionFenceOpen !StoreConnection
+    = ServerTurnOwnerActionFenceOpen
+        !StoreConnection
+        !OwnerFence.OwnerActionFileLock
     | ServerTurnOwnerActionFenceClosed
 
 {- | Register one server process behind a connection-lifetime PostgreSQL lock.
@@ -177,41 +182,48 @@ openServerTurnOwnerLease ::
     StorePool ->
     Text ->
     IO (Either StoreError ServerTurnOwnerLease)
-openServerTurnOwnerLease pool instanceId = mask \restore ->
-    openStoreConnection pool >>= \case
+openServerTurnOwnerLease pool rawInstanceId =
+    case OwnerFence.canonicalOwnerInstanceId rawInstanceId of
         Left err -> pure (Left err)
-        Right connection -> do
-            locked <-
-                restore
-                    ( withConnectionSession connection $
-                        Session.statement
-                            instanceId
-                            acquireServerTurnOwnerLockStatement
-                    )
-                    `onException` closeStoreConnection connection
-            case locked of
-                Left err -> do
-                    closeStoreConnection connection
-                    pure (Left err)
-                Right False -> do
-                    closeStoreConnection connection
-                    pure . Left . StoreDataError $
-                        "server turn owner identity is already active"
-                Right True -> do
-                    state <- newMVar (ServerTurnOwnerLeaseOpen connection)
-                    let lease =
-                            ServerTurnOwnerLease
-                                { serverTurnOwnerLeaseInstanceId = instanceId
-                                , serverTurnOwnerLeaseState = state
-                                }
-                    registered <-
-                        restore (heartbeatServerTurnOwner lease)
-                            `onException` abandonServerTurnOwnerLease lease
-                    case registered of
+        Right instanceId -> mask \restore ->
+            openStoreConnection pool >>= \case
+                Left err -> pure (Left err)
+                Right connection -> do
+                    locked <-
+                        restore
+                            ( withConnectionSession connection $
+                                Session.statement
+                                    instanceId
+                                    acquireServerTurnOwnerLockStatement
+                            )
+                            `onException` closeStoreConnection connection
+                    case locked of
                         Left err -> do
-                            abandonServerTurnOwnerLease lease
+                            closeStoreConnection connection
                             pure (Left err)
-                        Right () -> pure (Right lease)
+                        Right False -> do
+                            closeStoreConnection connection
+                            pure . Left . StoreDataError $
+                                "server turn owner identity is already active"
+                        Right True -> do
+                            state <- newMVar (ServerTurnOwnerLeaseOpen connection)
+                            let lease =
+                                    ServerTurnOwnerLease
+                                        { serverTurnOwnerLeaseInstanceId =
+                                            instanceId
+                                        , serverTurnOwnerLeaseActionLockDirectory =
+                                            storePoolServerTurnActionLockDirectory
+                                                pool
+                                        , serverTurnOwnerLeaseState = state
+                                        }
+                            registered <-
+                                restore (heartbeatServerTurnOwner lease)
+                                    `onException` abandonServerTurnOwnerLease lease
+                            case registered of
+                                Left err -> do
+                                    abandonServerTurnOwnerLease lease
+                                    pure (Left err)
+                                Right () -> pure (Right lease)
 
 {- | Drop the liveness connection without acknowledging local worker teardown.
 
@@ -238,51 +250,78 @@ openServerTurnOwnerActionFence ::
     StorePool ->
     Text ->
     IO (Either StoreError (Maybe ServerTurnOwnerActionFence))
-openServerTurnOwnerActionFence pool instanceId = mask \restore ->
-    openStoreConnection pool >>= \case
+openServerTurnOwnerActionFence pool rawInstanceId =
+    case OwnerFence.canonicalOwnerInstanceId rawInstanceId of
         Left err -> pure (Left err)
-        Right connection -> do
-            locked <-
-                restore
-                    ( withConnectionSession connection $
-                        Session.statement
-                            instanceId
-                            acquireServerTurnOwnerActionFenceStatement
-                    )
-                    `onException` closeStoreConnection connection
-            case locked of
-                Left err -> do
-                    closeStoreConnection connection
-                    pure (Left err)
-                Right False -> do
-                    closeStoreConnection connection
-                    pure (Right Nothing)
-                Right True -> do
-                    valid <-
-                        restore
-                            ( withConnectionSession connection $
-                                Transactions.transaction
-                                    Transactions.ReadCommitted
-                                    Transactions.Read
-                                    ( Transaction.statement
-                                        instanceId
-                                        validateServerTurnOwnerActionFenceStatement
-                                    )
-                            )
-                            `onException` closeStoreConnection connection
-                    case valid of
-                        Left err -> do
-                            closeStoreConnection connection
-                            pure (Left err)
-                        Right False -> do
-                            closeStoreConnection connection
-                            pure (Right Nothing)
-                        Right True -> do
-                            state <-
-                                newMVar
-                                    (ServerTurnOwnerActionFenceOpen connection)
-                            pure . Right . Just $
-                                ServerTurnOwnerActionFence state
+        Right instanceId -> mask \restore ->
+            restore
+                ( OwnerFence.acquireSharedActionLock
+                    (storePoolServerTurnActionLockDirectory pool)
+                    instanceId
+                )
+                >>= \case
+                    Left err -> pure (Left err)
+                    Right actionLock -> do
+                        let releaseActionLock =
+                                OwnerFence.releaseActionLock actionLock
+                            closeFenceConnection connection =
+                                closeStoreConnection connection
+                                    `finally` releaseActionLock
+                        connectionResult <-
+                            restore (openStoreConnection pool)
+                                `onException` releaseActionLock
+                        case connectionResult of
+                            Left err -> do
+                                releaseActionLock
+                                pure (Left err)
+                            Right connection -> do
+                                locked <-
+                                    restore
+                                        ( withConnectionSession connection $
+                                            Session.statement
+                                                instanceId
+                                                acquireServerTurnOwnerActionFenceStatement
+                                        )
+                                        `onException` closeFenceConnection
+                                            connection
+                                case locked of
+                                    Left err -> do
+                                        closeFenceConnection connection
+                                        pure (Left err)
+                                    Right False -> do
+                                        closeFenceConnection connection
+                                        pure (Right Nothing)
+                                    Right True -> do
+                                        valid <-
+                                            restore
+                                                ( withConnectionSession connection $
+                                                    Transactions.transaction
+                                                        Transactions.ReadCommitted
+                                                        Transactions.Read
+                                                        ( Transaction.statement
+                                                            instanceId
+                                                            validateServerTurnOwnerActionFenceStatement
+                                                        )
+                                                )
+                                                `onException` closeFenceConnection
+                                                    connection
+                                        case valid of
+                                            Left err -> do
+                                                closeFenceConnection connection
+                                                pure (Left err)
+                                            Right False -> do
+                                                closeFenceConnection connection
+                                                pure (Right Nothing)
+                                            Right True -> do
+                                                state <-
+                                                    newMVar
+                                                        ( ServerTurnOwnerActionFenceOpen
+                                                            connection
+                                                            actionLock
+                                                        )
+                                                pure . Right . Just $
+                                                    ServerTurnOwnerActionFence
+                                                        state
 
 checkServerTurnOwnerActionFence ::
     ServerTurnOwnerActionFence ->
@@ -293,7 +332,7 @@ checkServerTurnOwnerActionFence
             ServerTurnOwnerActionFenceClosed ->
                 pure . Left . StoreDataError $
                     "server turn owner action fence is closed"
-            ServerTurnOwnerActionFenceOpen connection ->
+            ServerTurnOwnerActionFenceOpen connection _ ->
                 withConnectionSession connection $
                     Session.statement () checkServerTurnOwnerActionFenceStatement
 
@@ -301,7 +340,9 @@ checkServerTurnOwnerActionFence
 
 The event manager watches the exact idle socket which holds the advisory lock,
 so a server restart or socket failure wakes the caller without a timer-based
-polling window. The callback receives an interruptible wait for that failure.
+polling window. The independent shared host lock remains held until the caller
+has cancelled and joined the guarded action and closes this fence. The callback
+receives an interruptible wait for the socket failure.
 -}
 withServerTurnOwnerActionFenceMonitor ::
     ServerTurnOwnerActionFence ->
@@ -314,7 +355,7 @@ withServerTurnOwnerActionFenceMonitor
             ServerTurnOwnerActionFenceClosed ->
                 pure . Left . StoreDataError $
                     "server turn owner action fence is closed"
-            ServerTurnOwnerActionFenceOpen connection ->
+            ServerTurnOwnerActionFenceOpen connection _ ->
                 withStoreConnectionFailureMonitor connection action
 
 -- | Wait for the dedicated action-fence connection to fail.
@@ -324,15 +365,29 @@ waitForServerTurnOwnerActionFenceFailure ::
 waitForServerTurnOwnerActionFenceFailure fence =
     withServerTurnOwnerActionFenceMonitor fence id
 
+{- | Drop the database monitor and host lock after the action is quiescent.
+
+The caller must not close this fence until the guarded action has completed or
+has been cancelled and joined.
+-}
 closeServerTurnOwnerActionFence :: ServerTurnOwnerActionFence -> IO ()
 closeServerTurnOwnerActionFence
     (ServerTurnOwnerActionFence state) =
-        modifyMVar_ state \case
-            ServerTurnOwnerActionFenceClosed ->
-                pure ServerTurnOwnerActionFenceClosed
-            ServerTurnOwnerActionFenceOpen connection -> do
-                closeStoreConnection connection
-                pure ServerTurnOwnerActionFenceClosed
+        mask \restore -> do
+            resources <-
+                modifyMVar state \case
+                    ServerTurnOwnerActionFenceClosed ->
+                        pure (ServerTurnOwnerActionFenceClosed, Nothing)
+                    ServerTurnOwnerActionFenceOpen connection actionLock ->
+                        pure
+                            ( ServerTurnOwnerActionFenceClosed
+                            , Just (connection, actionLock)
+                            )
+            case resources of
+                Nothing -> pure ()
+                Just (connection, actionLock) ->
+                    restore (closeStoreConnection connection)
+                        `finally` OwnerFence.releaseActionLock actionLock
 
 reserveServerTurn ::
     StorePool ->
@@ -488,9 +543,11 @@ shouldCancelServerTurn pool boundary instanceId turnId =
 {- | Refresh one process registration and recover owners whose liveness
 connection has disappeared.
 
-A disconnected owner is terminalized only after this transaction acquires
-its advisory lock. A merely paused owner still holds that lock, so neither
-its turns nor its session mutations expire with wall-clock time.
+A disconnected owner is terminalized only while the reaper holds its exclusive
+host action lock and this transaction's defensive advisory lock. A merely
+paused owner or action still holds the shared host lock, including across a
+PostgreSQL restart, so neither its turns nor its session mutations expire with
+wall-clock time.
 -}
 heartbeatServerTurnOwner ::
     ServerTurnOwnerLease ->
@@ -501,23 +558,36 @@ heartbeatServerTurnOwner lease =
             pure . Left . StoreDataError $
                 "server turn owner liveness connection is closed"
         ServerTurnOwnerLeaseOpen connection -> do
-            accepted <-
+            recoveryCandidates <-
                 withConnectionSession connection $
-                    Transactions.transaction
-                        Transactions.ReadCommitted
-                        Transactions.Write
-                        do
-                            live <-
-                                Transaction.statement
-                                    lease.serverTurnOwnerLeaseInstanceId
-                                    heartbeatServerTurnOwnerStatement
-                            if live
-                                then do
-                                    Transaction.statement
-                                        lease.serverTurnOwnerLeaseInstanceId
-                                        interruptDisconnectedServerTurnsStatement
-                                    pure True
-                                else pure False
+                    Session.statement
+                        lease.serverTurnOwnerLeaseInstanceId
+                        listServerTurnOwnerRecoveryCandidatesStatement
+            accepted <- case recoveryCandidates of
+                Left err -> pure (Left err)
+                Right candidates ->
+                    OwnerFence.withAvailableExclusiveActionLocks
+                        lease.serverTurnOwnerLeaseActionLockDirectory
+                        candidates
+                        \recoverableOwners ->
+                            withConnectionSession connection $
+                                Transactions.transaction
+                                    Transactions.ReadCommitted
+                                    Transactions.Write
+                                    do
+                                        live <-
+                                            Transaction.statement
+                                                lease.serverTurnOwnerLeaseInstanceId
+                                                heartbeatServerTurnOwnerStatement
+                                        if live
+                                            then do
+                                                Transaction.statement
+                                                    ( lease.serverTurnOwnerLeaseInstanceId
+                                                    , recoverableOwners
+                                                    )
+                                                    interruptDisconnectedServerTurnsStatement
+                                                pure True
+                                            else pure False
             pure (accepted >>= ensureAccepted)
   where
     ensureAccepted True = Right ()
@@ -536,41 +606,62 @@ releaseServerTurnOwner ::
     ServerTurnOwnerLease ->
     IO (Either StoreError ())
 releaseServerTurnOwner lease =
-    modifyMVar lease.serverTurnOwnerLeaseState \case
-        ServerTurnOwnerLeaseClosed ->
-            pure (ServerTurnOwnerLeaseClosed, Right ())
-        ServerTurnOwnerLeaseOpen connection -> do
-            released <-
-                withConnectionSession connection $
-                    Transactions.transaction
-                        Transactions.ReadCommitted
-                        Transactions.Write
-                        do
-                            actionFenceAvailable <-
-                                Transaction.statement
-                                    lease.serverTurnOwnerLeaseInstanceId
-                                    acquireServerTurnOwnerReleaseFenceStatement
-                            if actionFenceAvailable
-                                then do
-                                    Transaction.statement
-                                        lease.serverTurnOwnerLeaseInstanceId
-                                        interruptReleasedServerTurnsStatement
-                                    Transaction.statement
-                                        lease.serverTurnOwnerLeaseInstanceId
-                                        deleteServerTurnOwnerStatement
-                                    pure True
-                                else pure False
-            closeStoreConnection connection
-            pure
-                ( ServerTurnOwnerLeaseClosed
-                , released >>= \case
-                    True -> Right ()
-                    False ->
-                        Left
-                            ( StoreDataError
-                                "server turn owner still has active actions"
+    mask \restore -> do
+        connection <-
+            modifyMVar lease.serverTurnOwnerLeaseState \case
+                ServerTurnOwnerLeaseClosed ->
+                    pure (ServerTurnOwnerLeaseClosed, Nothing)
+                ServerTurnOwnerLeaseOpen openConnection ->
+                    pure (ServerTurnOwnerLeaseClosed, Just openConnection)
+        case connection of
+            Nothing -> pure (Right ())
+            Just openConnection -> do
+                releaseFence <-
+                    OwnerFence.tryAcquireExclusiveActionLock
+                        lease.serverTurnOwnerLeaseActionLockDirectory
+                        lease.serverTurnOwnerLeaseInstanceId
+                released <- case releaseFence of
+                    Left err -> do
+                        closeStoreConnection openConnection
+                        pure (Left err)
+                    Right Nothing -> do
+                        closeStoreConnection openConnection
+                        pure (Right False)
+                    Right (Just actionLock) ->
+                        restore
+                            ( withConnectionSession
+                                openConnection
+                                ( Transactions.transaction
+                                    Transactions.ReadCommitted
+                                    Transactions.Write
+                                    do
+                                        actionFenceAvailable <-
+                                            Transaction.statement
+                                                lease.serverTurnOwnerLeaseInstanceId
+                                                acquireServerTurnOwnerReleaseFenceStatement
+                                        if actionFenceAvailable
+                                            then do
+                                                Transaction.statement
+                                                    lease.serverTurnOwnerLeaseInstanceId
+                                                    interruptReleasedServerTurnsStatement
+                                                Transaction.statement
+                                                    lease.serverTurnOwnerLeaseInstanceId
+                                                    deleteServerTurnOwnerStatement
+                                                pure True
+                                            else pure False
+                                )
                             )
-                )
+                            `finally` ( closeStoreConnection openConnection
+                                            `finally` OwnerFence.releaseActionLock actionLock
+                                      )
+                pure $
+                    released >>= \case
+                        True -> Right ()
+                        False ->
+                            Left
+                                ( StoreDataError
+                                    "server turn owner still has active actions"
+                                )
 
 markServerTurnRunning ::
     StorePool ->
@@ -1279,8 +1370,20 @@ acquireServerTurnOwnerLockStatement =
         (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
         True
 
+listServerTurnOwnerRecoveryCandidatesStatement :: Statement Text [Text]
+listServerTurnOwnerRecoveryCandidatesStatement =
+    mkStatement
+        "SELECT instance_id::text\
+        \ FROM harness.server_turn_owners\
+        \ WHERE instance_id <> $1::uuid\
+        \ AND revoked_at IS NULL\
+        \ ORDER BY instance_id"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        (Decoders.rowList (Decoders.column (Decoders.nonNullable Decoders.text)))
+        True
+
 interruptDisconnectedServerTurnsStatement ::
-    Statement Text ()
+    Statement (Text, [Text]) ()
 interruptDisconnectedServerTurnsStatement =
     mkStatement
         "WITH action_unfenced_owner AS MATERIALIZED (\
@@ -1288,6 +1391,7 @@ interruptDisconnectedServerTurnsStatement =
         \ FROM harness.server_turn_owners AS owner\
         \ WHERE owner.instance_id <> $1::uuid\
         \ AND owner.revoked_at IS NULL\
+        \ AND owner.instance_id::text = ANY($2::text[])\
         \ AND pg_try_advisory_xact_lock(\
         \   hashtextextended(\
         \     'haskell-agent:server-turn-owner-action:'\
@@ -1325,7 +1429,15 @@ interruptDisconnectedServerTurnsStatement =
         \ DELETE FROM harness.server_human_requests AS request\
         \ USING interrupted_turn AS turn\
         \ WHERE request.turn_id = turn.turn_id"
-        (Encoders.param (Encoders.nonNullable Encoders.text))
+        ( (fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+            <> ( snd
+                    >$< Encoders.param
+                        ( Encoders.nonNullable $
+                            Encoders.foldableArray
+                                (Encoders.nonNullable Encoders.text)
+                        )
+               )
+        )
         Decoders.noResult
         True
 

--- a/packages/agent-store/src/Agent/Store/Postgres/ServerTurn/OwnerFence.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/ServerTurn/OwnerFence.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Host-level action locks which survive managed PostgreSQL restarts.
+
+The managed database is reachable only through its private local Unix socket,
+so every server process shares this lock directory. Lock files deliberately
+remain in place: replacing an inode while another process holds it would split
+the lock domain.
+-}
+module Agent.Store.Postgres.ServerTurn.OwnerFence (
+    OwnerActionFileLock,
+    canonicalOwnerInstanceId,
+    acquireSharedActionLock,
+    tryAcquireExclusiveActionLock,
+    releaseActionLock,
+    withAvailableExclusiveActionLocks,
+) where
+
+import Agent.Store.Types (StoreError (..))
+import Control.Exception.Safe (displayException, finally, mask, mask_, tryAny)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.UUID.Types as UUID
+import qualified System.FileLock as FileLock
+import System.FilePath ((</>))
+
+data OwnerActionFileLock = OwnerActionFileLock
+    { ownerActionFileLockInstanceId :: !Text
+    , ownerActionFileLockHandle :: !FileLock.FileLock
+    }
+
+canonicalOwnerInstanceId :: Text -> Either StoreError Text
+canonicalOwnerInstanceId raw =
+    case UUID.fromText raw of
+        Nothing ->
+            Left . StoreDataError $
+                "server turn owner instance id is not a UUID"
+        Just ownerId -> Right (UUID.toText ownerId)
+
+acquireSharedActionLock ::
+    FilePath ->
+    Text ->
+    IO (Either StoreError OwnerActionFileLock)
+acquireSharedActionLock directory rawInstanceId =
+    mask_ $
+        case canonicalOwnerInstanceId rawInstanceId of
+            Left err -> pure (Left err)
+            Right instanceId ->
+                fmap (fmap (OwnerActionFileLock instanceId)) $
+                    captureLockFailure "acquire shared server action lock" $
+                        FileLock.lockFile
+                            (actionLockPath directory instanceId)
+                            FileLock.Shared
+
+tryAcquireExclusiveActionLock ::
+    FilePath ->
+    Text ->
+    IO (Either StoreError (Maybe OwnerActionFileLock))
+tryAcquireExclusiveActionLock directory rawInstanceId =
+    mask_ $
+        case canonicalOwnerInstanceId rawInstanceId of
+            Left err -> pure (Left err)
+            Right instanceId ->
+                fmap (fmap (fmap (OwnerActionFileLock instanceId))) $
+                    captureLockFailure "acquire exclusive server action lock" $
+                        FileLock.tryLockFile
+                            (actionLockPath directory instanceId)
+                            FileLock.Exclusive
+
+releaseActionLock :: OwnerActionFileLock -> IO ()
+releaseActionLock actionLock =
+    mask_ $
+        FileLock.unlockFile actionLock.ownerActionFileLockHandle
+
+withAvailableExclusiveActionLocks ::
+    FilePath ->
+    [Text] ->
+    ([Text] -> IO (Either StoreError value)) ->
+    IO (Either StoreError value)
+withAvailableExclusiveActionLocks directory instanceIds action =
+    mask \restore ->
+        acquireAll [] instanceIds >>= \case
+            Left err -> pure (Left err)
+            Right locks ->
+                restore
+                    (action (map (.ownerActionFileLockInstanceId) locks))
+                    `finally` mapM_ releaseActionLock locks
+  where
+    acquireAll acquired = \case
+        [] -> pure (Right (reverse acquired))
+        instanceId : remaining ->
+            tryAcquireExclusiveActionLock directory instanceId >>= \case
+                Left err -> do
+                    mapM_ releaseActionLock acquired
+                    pure (Left err)
+                Right Nothing -> acquireAll acquired remaining
+                Right (Just actionLock) ->
+                    acquireAll (actionLock : acquired) remaining
+
+actionLockPath :: FilePath -> Text -> FilePath
+actionLockPath directory instanceId =
+    directory </> Text.unpack instanceId <> ".lock"
+
+captureLockFailure :: Text -> IO value -> IO (Either StoreError value)
+captureLockFailure operation action =
+    tryAny action >>= \case
+        Left err ->
+            pure . Left . StoreProcessError $
+                "Could not "
+                    <> operation
+                    <> ": "
+                    <> Text.pack (displayException err)
+        Right value -> pure (Right value)

--- a/packages/agent-store/test/Agent/Store/Postgres/ConfigSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ConfigSpec.hs
@@ -28,3 +28,17 @@ spec = do
             rendered `shouldSatisfy` Text.isInfixOf "listen_addresses = ''"
             rendered `shouldSatisfy`
                 Text.isInfixOf "unix_socket_permissions = 0700"
+
+        it "isolates server action locks by exact database" do
+            let config = defaultManagedPostgresConfig "/tmp/agent" ""
+                lockDirectory database =
+                    serverTurnActionLockDirectory
+                        config { postgresDatabase = database }
+            lockDirectory "tenant-a"
+                `shouldBe`
+                    "/tmp/agent/postgres/server-turn-actions/database-74656e616e742d61"
+            lockDirectory "tenant-a"
+                `shouldNotBe` lockDirectory "tenant-b"
+            lockDirectory "../tenant"
+                `shouldBe`
+                    "/tmp/agent/postgres/server-turn-actions/database-2e2e2f74656e616e74"

--- a/packages/agent-store/test/Agent/Store/Postgres/ConfigSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ConfigSpec.hs
@@ -17,6 +17,8 @@ spec = do
                 `shouldBe` "/tmp/agent/postgres/data"
             config.postgresPaths.postgresSocketDirectory
                 `shouldBe` "/tmp/agent/postgres/run"
+            config.postgresPaths.postgresServerTurnActionLockDirectory
+                `shouldBe` "/tmp/agent/postgres/server-turn-actions"
             postgresExecutable config "initdb"
                 `shouldBe` "/pg/bin/initdb"
 

--- a/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
@@ -131,6 +131,44 @@ spec =
                                 (closeStorePool ownerPool)
                     ) `finally` cleanup
 
+        it "upgrades the published server-turn migration in place" $
+            withSystemTempDirectory "ha" \stateDirectory -> do
+                let
+                    config = defaultManagedPostgresConfig stateDirectory ""
+                    cleanup = do
+                        _ <- stopManagedPostgres config
+                        pure ()
+                    publishedMigrations =
+                        takeWhile
+                            ((<= 111) . (.migrationVersion))
+                            coreMigrations
+                (do
+                    ensureManagedPostgres config
+                        >>= (`shouldSatisfy` isRight)
+                    openStorePool config defaultPoolConfig >>= \case
+                        Left err ->
+                            expectationFailure
+                                ("could not open migration pool: " <> show err)
+                        Right ownerPool ->
+                            finally
+                                (do
+                                    runMigrations
+                                        ownerPool
+                                        publishedMigrations
+                                        `shouldReturn` Right ()
+                                    runMigrations ownerPool coreMigrations
+                                        `shouldReturn` Right ()
+                                    withSession ownerPool
+                                        ( Session.statement
+                                            ()
+                                            serverCoordinationSchemaStatement
+                                        )
+                                        `shouldReturn`
+                                            Right (True, True, True, True, True)
+                                )
+                                (closeStorePool ownerPool)
+                    ) `finally` cleanup
+
         it "upgrades an empty normalized session schema in place" $
             withSystemTempDirectory "ha" \stateDirectory -> do
                 let
@@ -556,6 +594,39 @@ providerTelemetryColumnStatement = Statement.preparable
     Encoders.noParams
     (Decoders.singleRow $
         Decoders.column (Decoders.nonNullable Decoders.bool))
+
+serverCoordinationSchemaStatement ::
+    Statement () (Bool, Bool, Bool, Bool, Bool)
+serverCoordinationSchemaStatement = Statement.preparable
+    "SELECT\
+    \ to_regclass('harness.server_session_mutations') IS NOT NULL,\
+    \ EXISTS (\
+    \   SELECT 1 FROM information_schema.columns\
+    \   WHERE table_schema = 'harness'\
+    \     AND table_name = 'server_turns'\
+    \     AND column_name = 'cancellation_requested_at'\
+    \ ),\
+    \ NOT EXISTS (\
+    \   SELECT 1 FROM information_schema.columns\
+    \   WHERE table_schema = 'harness'\
+    \     AND table_name = 'server_turns'\
+    \     AND column_name = 'teardown_pending'\
+    \ ),\
+    \ EXISTS (\
+    \   SELECT 1 FROM information_schema.columns\
+    \   WHERE table_schema = 'harness'\
+    \     AND table_name = 'server_turn_owners'\
+    \     AND column_name = 'revoked_at'\
+    \ ),\
+    \ to_regclass('harness.server_human_requests') IS NOT NULL"
+    Encoders.noParams
+    (Decoders.singleRow $
+        (,,,,)
+            <$> Decoders.column (Decoders.nonNullable Decoders.bool)
+            <*> Decoders.column (Decoders.nonNullable Decoders.bool)
+            <*> Decoders.column (Decoders.nonNullable Decoders.bool)
+            <*> Decoders.column (Decoders.nonNullable Decoders.bool)
+            <*> Decoders.column (Decoders.nonNullable Decoders.bool))
 
 migratedOpaqueFieldsStatement :: Statement () (Bool, Bool, Bool)
 migratedOpaqueFieldsStatement = Statement.preparable

--- a/packages/agent-store/test/Agent/Store/Postgres/ServerTurnRecoverySpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ServerTurnRecoverySpec.hs
@@ -1,0 +1,199 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Agent.Store.Postgres.ServerTurnRecoverySpec (spec) where
+
+import Agent.Store.Postgres (
+    ManagedPostgresConfig,
+    Store,
+    closeStore,
+    defaultManagedPostgresConfig,
+    openStore,
+    trustedPool,
+ )
+import Agent.Store.Postgres.Connection (StorePool)
+import Agent.Store.Postgres.Managed (stopManagedPostgres)
+import Agent.Store.Postgres.ServerTurn
+import Agent.Store.Postgres.Session (SessionMetadata (..), createSession)
+import Control.Exception.Safe (bracket, finally)
+import Control.Monad (void)
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+spec :: Spec
+spec =
+    describe "PostgreSQL server turn store" do
+        it "keeps disconnected actions fenced across a PostgreSQL restart" $
+            withSystemTempDirectory "ha-reap" \stateDirectory -> do
+                let config = defaultManagedPostgresConfig stateDirectory ""
+                    run =
+                        withStore config \firstStore ->
+                            withAbandonedOwner
+                                (trustedPool firstStore)
+                                instanceOne
+                                \_ ->
+                                    withActionFence
+                                        (trustedPool firstStore)
+                                        instanceOne
+                                        \fence ->
+                                            exerciseRestartFence
+                                                config
+                                                (trustedPool firstStore)
+                                                fence
+                run `finally` void (stopManagedPostgres config)
+
+exerciseRestartFence ::
+    ManagedPostgresConfig ->
+    StorePool ->
+    ServerTurnOwnerActionFence ->
+    IO ()
+exerciseRestartFence config firstPool fence = do
+    let createdAt = read "2026-09-03 08:00:00 UTC"
+        boundary =
+            ServerTurnBoundary
+                { serverTurnTenantId = "tenant-a"
+                , serverTurnGatewayIdentity =
+                    Just "gateway-sha256:generation-a"
+                }
+        request =
+            ReserveServerTurn
+                { reserveServerTurnId =
+                    "01999999-0000-7000-8000-000000000031"
+                , reserveServerTurnBoundary = boundary
+                , reserveServerTurnSessionId = "session-restart-fence"
+                , reserveServerTurnClientRequestId =
+                    "01999999-0000-7000-8000-000000000032"
+                , reserveServerTurnInputDigest =
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                , reserveServerTurnOwnerInstanceId = instanceOne
+                , reserveServerTurnCreatedAt = createdAt
+                }
+
+    createSession firstPool (testMetadata createdAt)
+        `shouldReturn` Right True
+    reserveServerTurn firstPool request >>= \result ->
+        result `shouldSatisfy` \case
+            Right (ServerTurnReserved _) -> True
+            _ -> False
+    stopManagedPostgres config `shouldReturn` Right ()
+
+    withStore config \secondStore ->
+        withOwner (trustedPool secondStore) instanceTwo \ownerTwo -> do
+            let secondPool = trustedPool secondStore
+            loadServerTurn
+                secondPool
+                boundary
+                request.reserveServerTurnId
+                >>= \result ->
+                    result `shouldSatisfy` \case
+                        Right (Just stored) ->
+                            stored.storedServerTurnStatus == ServerTurnQueued
+                        _ -> False
+
+            closeServerTurnOwnerActionFence fence
+            heartbeatServerTurnOwner ownerTwo `shouldReturn` Right ()
+            loadServerTurn
+                secondPool
+                boundary
+                request.reserveServerTurnId
+                >>= \result ->
+                    result `shouldSatisfy` \case
+                        Right (Just stored) ->
+                            stored.storedServerTurnStatus == ServerTurnFailed
+                                && stored.storedServerTurnFinishedAt /= Nothing
+                                && stored.storedServerTurnError
+                                    == Just
+                                        "agent server owner disconnected before the turn completed"
+                        _ -> False
+
+withStore ::
+    ManagedPostgresConfig ->
+    (Store -> IO value) ->
+    IO value
+withStore config =
+    bracket
+        ( openStore config >>= \case
+            Left err -> fail ("could not open store: " <> show err)
+            Right store -> pure store
+        )
+        closeStore
+
+withAbandonedOwner ::
+    StorePool ->
+    Text ->
+    (ServerTurnOwnerLease -> IO value) ->
+    IO value
+withAbandonedOwner pool instanceId =
+    bracket
+        (requireOwner pool instanceId)
+        abandonServerTurnOwnerLease
+
+withOwner ::
+    StorePool ->
+    Text ->
+    (ServerTurnOwnerLease -> IO value) ->
+    IO value
+withOwner pool instanceId =
+    bracket
+        (requireOwner pool instanceId)
+        (void . releaseServerTurnOwner)
+
+requireOwner :: StorePool -> Text -> IO ServerTurnOwnerLease
+requireOwner pool instanceId =
+    openServerTurnOwnerLease pool instanceId >>= \case
+        Left err -> fail ("could not open server turn owner: " <> show err)
+        Right owner -> pure owner
+
+withActionFence ::
+    StorePool ->
+    Text ->
+    (ServerTurnOwnerActionFence -> IO value) ->
+    IO value
+withActionFence pool instanceId =
+    bracket
+        ( openServerTurnOwnerActionFence pool instanceId >>= \case
+            Left err -> fail ("could not open owner action fence: " <> show err)
+            Right Nothing -> fail "server turn owner was unavailable"
+            Right (Just fence) -> pure fence
+        )
+        closeServerTurnOwnerActionFence
+
+instanceOne :: Text
+instanceOne = "01999999-0000-7000-8000-000000000033"
+
+instanceTwo :: Text
+instanceTwo = "01999999-0000-7000-8000-000000000034"
+
+testMetadata :: UTCTime -> SessionMetadata
+testMetadata now =
+    SessionMetadata
+        { sessionMetadataKey = "session-restart-fence"
+        , sessionMetadataVersion = 1
+        , sessionMetadataCreatedAt = now
+        , sessionMetadataUpdatedAt = now
+        , sessionMetadataProvider = "openai"
+        , sessionMetadataConnection = "organization-gateway"
+        , sessionMetadataGatewayIdentity =
+            Just "gateway-sha256:generation-a"
+        , sessionMetadataModel = "gpt-test"
+        , sessionMetadataTransportModel = Just "gpt-test"
+        , sessionMetadataDialect = "openai"
+        , sessionMetadataLegacyTarget = Nothing
+        , sessionMetadataCwd = "/tmp/project"
+        , sessionMetadataEffort = "medium"
+        , sessionMetadataTitle = "test"
+        , sessionMetadataTitleIsManual = False
+        , sessionMetadataTitleRefreshIndex = 0
+        , sessionMetadataTitleUserTurns = 0
+        , sessionMetadataLastResponseId = Nothing
+        , sessionMetadataInputTokens = 0
+        , sessionMetadataOutputTokens = 0
+        , sessionMetadataCachedTokens = 0
+        , sessionMetadataLastRecap = Nothing
+        , sessionMetadataLastTurnSummary = Nothing
+        , sessionMetadataLastRecapMainTurns = 0
+        }

--- a/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
@@ -42,6 +42,55 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "PostgreSQL server turn store" do
+    it "wakes the action fence monitor when PostgreSQL disconnects" $
+        withSystemTempDirectory "ha-fence" \stateDirectory -> do
+            let config = defaultManagedPostgresConfig stateDirectory ""
+                cleanup = void (stopManagedPostgres config)
+            ( openStore config >>= \case
+                    Left err ->
+                        expectationFailure ("could not open store: " <> show err)
+                    Right store ->
+                        finally
+                            ( withServerTurnOwner
+                                (trustedPool store)
+                                instanceOne
+                                \_ -> do
+                                    withServerTurnOwnerActionFence
+                                        (trustedPool store)
+                                        instanceOne
+                                        \fence -> do
+                                            monitored <-
+                                                withServerTurnOwnerActionFenceMonitor
+                                                    fence
+                                                    (timeout 100000)
+                                            monitored `shouldSatisfy` \case
+                                                Right Nothing -> True
+                                                _ -> False
+                                    withServerTurnOwnerActionFence
+                                        (trustedPool store)
+                                        instanceOne
+                                        \fence -> do
+                                            disconnected <-
+                                                withServerTurnOwnerActionFenceMonitor
+                                                    fence
+                                                    \waitForFailure -> do
+                                                        timeout
+                                                            100000
+                                                            waitForFailure
+                                                            `shouldReturn` Nothing
+                                                        timeout 5000000 do
+                                                            stopManagedPostgres
+                                                                config
+                                                                `shouldReturn` Right ()
+                                                            waitForFailure
+                                            disconnected `shouldSatisfy` \case
+                                                Right (Just ()) -> True
+                                                _ -> False
+                            )
+                            (closeStore store)
+                )
+                `finally` cleanup
+
     it "keeps admission idempotent and terminal output restart-safe" $
         withSystemTempDirectory "ha-server-turn" \stateDirectory -> do
             let config = defaultManagedPostgresConfig stateDirectory ""

--- a/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
@@ -27,6 +27,7 @@ import Agent.Store.Postgres.Session (
     createSession,
     deleteSession,
  )
+import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (bracket, finally)
 import Control.Monad (void)
 import Data.Text (Text)
@@ -595,15 +596,17 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
         releaseServerSessionMutation pool protectedMutation
             `shouldReturn` Right ()
 
-    heartbeatServerTurnOwner ownerTwo
-        `shouldReturn` Right ()
     interrupted <-
-        loadServerTurn
-            pool
-            boundary
-            interruptedRequest.reserveServerTurnId
+        timeout
+            (5 * 1000 * 1000)
+            ( waitForInterruptedTurn
+                pool
+                ownerTwo
+                boundary
+                interruptedRequest.reserveServerTurnId
+            )
     interrupted `shouldSatisfy` \case
-        Right (Just stored) ->
+        Just (Right (Just stored)) ->
             stored.storedServerTurnStatus == ServerTurnFailed
                 && stored.storedServerTurnFinishedAt /= Nothing
                 && stored.storedServerTurnError
@@ -715,6 +718,25 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
     listed `shouldSatisfy` \case
         Right turns -> length turns == 3
         Left _ -> False
+
+waitForInterruptedTurn ::
+    StorePool ->
+    ServerTurnOwnerLease ->
+    ServerTurnBoundary ->
+    Text ->
+    IO (Either StoreError (Maybe StoredServerTurn))
+waitForInterruptedTurn pool owner boundary turnId =
+    heartbeatServerTurnOwner owner >>= \case
+        Left err -> pure (Left err)
+        Right () ->
+            loadServerTurn pool boundary turnId >>= \case
+                loaded@(Right (Just stored))
+                    | stored.storedServerTurnStatus == ServerTurnFailed ->
+                        pure loaded
+                Left err -> pure (Left err)
+                _ -> do
+                    threadDelay 10000
+                    waitForInterruptedTurn pool owner boundary turnId
 
 instanceOne :: Text
 instanceOne = "01999999-0000-7000-8000-000000000003"

--- a/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
@@ -5,24 +5,28 @@
 
 module Agent.Store.Postgres.ServerTurnSpec (spec) where
 
-import Agent.Store.Postgres
-    ( StoreError (..)
-    , closeStore
-    , defaultManagedPostgresConfig
-    , openStore
-    , trustedPool
-    )
-import Agent.Store.Postgres.Connection
-    ( StorePool
-    , closeStoreConnection
-    , openStoreConnection
-    , withConnectionSession
-    , withSession
-    )
+import Agent.Store.Postgres (
+    StoreError (..),
+    closeStore,
+    defaultManagedPostgresConfig,
+    openStore,
+    trustedPool,
+ )
+import Agent.Store.Postgres.Connection (
+    StorePool,
+    closeStoreConnection,
+    openStoreConnection,
+    withConnectionSession,
+    withSession,
+ )
 import Agent.Store.Postgres.Managed (stopManagedPostgres)
 import qualified Agent.Store.Postgres.ServerHumanRequest as HumanRequest
 import Agent.Store.Postgres.ServerTurn
-import Agent.Store.Postgres.Session (SessionMetadata (..), createSession)
+import Agent.Store.Postgres.Session (
+    SessionMetadata (..),
+    createSession,
+    deleteSession,
+ )
 import Control.Exception.Safe (bracket, finally)
 import Control.Monad (void)
 import Data.Text (Text)
@@ -119,8 +123,36 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
                     "01999999-0000-7000-8000-000000000010"
                 }
     wrongBoundaryReservation `shouldSatisfy` \case
-        Left (StoreDataError _) -> True
+        Right ServerTurnSessionMissing -> True
         _ -> False
+
+    let deletedSessionId = "session-deleted-before-turn"
+        deletedMutation =
+            mutation
+                { serverSessionMutationSessionId = deletedSessionId
+                }
+        deletedRequest =
+            request
+                { reserveServerTurnId =
+                    "01999999-0000-7000-8000-000000000023"
+                , reserveServerTurnSessionId = deletedSessionId
+                , reserveServerTurnClientRequestId =
+                    "01999999-0000-7000-8000-000000000024"
+                }
+    createSession
+        pool
+        (testMetadata createdAt)
+            { sessionMetadataKey = deletedSessionId
+            }
+        `shouldReturn` Right True
+    reserveServerSessionMutation pool deletedMutation
+        `shouldReturn` Right ServerSessionMutationReserved
+    deleteSession pool deletedSessionId (addUTCTime 1 createdAt)
+        `shouldReturn` Right True
+    releaseServerSessionMutation pool deletedMutation
+        `shouldReturn` Right ()
+    reserveServerTurn pool deletedRequest
+        `shouldReturn` Right ServerTurnSessionMissing
 
     shouldCancelServerTurn
         pool

--- a/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
@@ -1,0 +1,694 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Agent.Store.Postgres.ServerTurnSpec (spec) where
+
+import Agent.Store.Postgres
+    ( StoreError (..)
+    , closeStore
+    , defaultManagedPostgresConfig
+    , openStore
+    , trustedPool
+    )
+import Agent.Store.Postgres.Connection
+    ( StorePool
+    , closeStoreConnection
+    , openStoreConnection
+    , withConnectionSession
+    , withSession
+    )
+import Agent.Store.Postgres.Managed (stopManagedPostgres)
+import qualified Agent.Store.Postgres.ServerHumanRequest as HumanRequest
+import Agent.Store.Postgres.ServerTurn
+import Agent.Store.Postgres.Session (SessionMetadata (..), createSession)
+import Control.Exception.Safe (bracket, finally)
+import Control.Monad (void)
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime, addUTCTime)
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Session as Session
+import Hasql.Statement (Statement)
+import qualified Hasql.Statement as Statement
+import System.IO.Temp (withSystemTempDirectory)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "PostgreSQL server turn store" do
+    it "keeps admission idempotent and terminal output restart-safe" $
+        withSystemTempDirectory "ha-server-turn" \stateDirectory -> do
+            let config = defaultManagedPostgresConfig stateDirectory ""
+                cleanup = do
+                    _ <- stopManagedPostgres config
+                    pure ()
+            ( openStore config >>= \case
+                    Left err ->
+                        expectationFailure ("could not open store: " <> show err)
+                    Right store ->
+                        finally
+                            (exerciseTurnStore (trustedPool store))
+                            (closeStore store)
+                )
+                `finally` cleanup
+
+exerciseTurnStore :: StorePool -> IO ()
+exerciseTurnStore pool =
+    withServerTurnOwner pool instanceOne \ownerOne ->
+        withServerTurnOwner pool instanceTwo \ownerTwo ->
+            exerciseTurnStoreWithOwners pool ownerOne ownerTwo
+
+exerciseTurnStoreWithOwners ::
+    StorePool ->
+    ServerTurnOwnerLease ->
+    ServerTurnOwnerLease ->
+    IO ()
+exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
+    let createdAt = read "2026-09-03 08:00:00 UTC"
+        startedAt = addUTCTime 1 createdAt
+        finishedAt = addUTCTime 2 createdAt
+        boundary =
+            ServerTurnBoundary
+                { serverTurnTenantId = "tenant-a"
+                , serverTurnGatewayIdentity =
+                    Just "gateway-sha256:generation-a"
+                }
+        otherBoundary =
+            boundary
+                { serverTurnGatewayIdentity =
+                    Just "gateway-sha256:generation-b"
+                }
+        request =
+            ReserveServerTurn
+                { reserveServerTurnId =
+                    "01999999-0000-7000-8000-000000000001"
+                , reserveServerTurnBoundary = boundary
+                , reserveServerTurnSessionId = "session-a"
+                , reserveServerTurnClientRequestId =
+                    "01999999-0000-7000-8000-000000000002"
+                , reserveServerTurnInputDigest =
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                , reserveServerTurnOwnerInstanceId = instanceOne
+                , reserveServerTurnCreatedAt = createdAt
+                }
+        mutation =
+            ServerSessionMutation
+                { serverSessionMutationBoundary = boundary
+                , serverSessionMutationSessionId = "session-a"
+                , serverSessionMutationOwnerInstanceId =
+                    request.reserveServerTurnOwnerInstanceId
+                , serverSessionMutationCreatedAt = createdAt
+                }
+
+    createSession pool (testMetadata createdAt)
+        `shouldReturn` Right True
+    heartbeatServerTurnOwner
+        ownerOne
+        `shouldReturn` Right ()
+
+    wrongBoundaryReservation <-
+        reserveServerTurn
+            pool
+            request
+                { reserveServerTurnId =
+                    "01999999-0000-7000-8000-000000000009"
+                , reserveServerTurnBoundary = otherBoundary
+                , reserveServerTurnClientRequestId =
+                    "01999999-0000-7000-8000-000000000010"
+                }
+    wrongBoundaryReservation `shouldSatisfy` \case
+        Left (StoreDataError _) -> True
+        _ -> False
+
+    shouldCancelServerTurn
+        pool
+        boundary
+        request.reserveServerTurnOwnerInstanceId
+        request.reserveServerTurnId
+        `shouldReturn` Right True
+
+    reserveServerSessionMutation pool mutation
+        `shouldReturn` Right ServerSessionMutationReserved
+    reserveServerTurn pool request
+        `shouldReturn` Right ServerTurnSessionMutating
+    releaseServerSessionMutation
+        pool
+        mutation
+            { serverSessionMutationCreatedAt =
+                addUTCTime 1 createdAt
+            }
+        `shouldReturn` Right ()
+    reserveServerSessionMutation pool mutation
+        `shouldReturn` Right ServerSessionMutationBusy
+    releaseServerSessionMutation pool mutation
+        `shouldReturn` Right ()
+
+    first <- reserveServerTurn pool request
+    first `shouldSatisfy` \case
+        Right (ServerTurnReserved stored) ->
+            stored.storedServerTurnId == request.reserveServerTurnId
+                && stored.storedServerTurnStatus == ServerTurnQueued
+        _ -> False
+
+    reserveServerSessionMutation pool mutation
+        `shouldReturn` Right ServerSessionMutationBusy
+
+    reserveServerTurn
+        pool
+        request
+            { reserveServerTurnId =
+                "01999999-0000-7000-8000-000000000005"
+            }
+        `shouldReturn` fmap
+            ( \case
+                ServerTurnReserved stored ->
+                    ServerTurnAlreadyReserved stored
+                other -> other
+            )
+            first
+
+    conflict <-
+        reserveServerTurn
+            pool
+            request
+                { reserveServerTurnId =
+                    "01999999-0000-7000-8000-000000000006"
+                , reserveServerTurnInputDigest =
+                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                }
+    conflict `shouldSatisfy` \case
+        Right (ServerTurnIdempotencyConflict stored) ->
+            stored.storedServerTurnId == request.reserveServerTurnId
+        _ -> False
+
+    sessionBusy <-
+        reserveServerTurn
+            pool
+            request
+                { reserveServerTurnId =
+                    "01999999-0000-7000-8000-000000000011"
+                , reserveServerTurnClientRequestId =
+                    "01999999-0000-7000-8000-000000000012"
+                , reserveServerTurnOwnerInstanceId =
+                    request.reserveServerTurnOwnerInstanceId
+                }
+    sessionBusy `shouldSatisfy` \case
+        Right (ServerTurnSessionBusy stored) ->
+            stored.storedServerTurnId == request.reserveServerTurnId
+        _ -> False
+
+    loadServerTurn
+        pool
+        otherBoundary
+        request.reserveServerTurnId
+        `shouldReturn` Right Nothing
+
+    markServerTurnRunning
+        pool
+        boundary
+        request.reserveServerTurnOwnerInstanceId
+        request.reserveServerTurnId
+        startedAt
+        `shouldReturn` Right True
+
+    shouldCancelServerTurn
+        pool
+        boundary
+        request.reserveServerTurnOwnerInstanceId
+        request.reserveServerTurnId
+        `shouldReturn` Right False
+
+    let humanRequest =
+            HumanRequest.CreateServerHumanRequest
+                { HumanRequest.createServerHumanRequestId =
+                    "01999999-0000-7000-8000-000000000013"
+                , HumanRequest.createServerHumanRequestTurnId =
+                    request.reserveServerTurnId
+                , HumanRequest.createServerHumanRequestBoundary = boundary
+                , HumanRequest.createServerHumanRequestOwnerInstanceId =
+                    request.reserveServerTurnOwnerInstanceId
+                , HumanRequest.createServerHumanRequestKind = "tool_approval"
+                , HumanRequest.createServerHumanRequestPrompt = "Approve?"
+                , HumanRequest.createServerHumanRequestOptionsJson =
+                    "[\"approve\",\"cancel\"]"
+                , HumanRequest.createServerHumanRequestCreatedAt = startedAt
+                }
+        approval =
+            HumanRequest.ServerHumanResponse
+                { HumanRequest.serverHumanResponseDecision = "approve"
+                , HumanRequest.serverHumanResponseValue = Just "once"
+                }
+    HumanRequest.createServerHumanRequest pool humanRequest
+        `shouldReturn` Right True
+    HumanRequest.listServerHumanRequests pool otherBoundary
+        `shouldReturn` Right []
+    pendingRequests <-
+        HumanRequest.listServerHumanRequests pool boundary
+    pendingRequests `shouldSatisfy` \case
+        Right [pending] ->
+            pending.storedServerHumanRequestId
+                == humanRequest.createServerHumanRequestId
+                && pending.storedServerHumanRequestOptionsJson
+                    == "[\"approve\", \"cancel\"]"
+        _ -> False
+    HumanRequest.listServerHumanRequestsForTurn
+        pool
+        boundary
+        request.reserveServerTurnId
+        `shouldReturn` pendingRequests
+    HumanRequest.listServerHumanRequestsForTurn
+        pool
+        boundary
+        "01999999-0000-7000-8000-000000000099"
+        `shouldReturn` Right []
+    HumanRequest.resolveServerHumanRequest
+        pool
+        boundary
+        humanRequest.createServerHumanRequestId
+        approval
+            { HumanRequest.serverHumanResponseDecision = "deny"
+            }
+        finishedAt
+        `shouldReturn` Right HumanRequest.ServerHumanRequestInvalidDecision
+    resolvedRequest <-
+        HumanRequest.resolveServerHumanRequest
+            pool
+            boundary
+            humanRequest.createServerHumanRequestId
+            approval
+            finishedAt
+    resolvedRequest `shouldSatisfy` \case
+        Right (HumanRequest.ServerHumanRequestResolved resolved) ->
+            resolved.storedServerHumanRequestResponseDecision
+                == Just "approve"
+                && resolved.storedServerHumanRequestResponseValue
+                    == Just "once"
+        _ -> False
+    HumanRequest.loadServerHumanResponse
+        pool
+        boundary
+        instanceTwo
+        request.reserveServerTurnId
+        humanRequest.createServerHumanRequestId
+        `shouldReturn` Right Nothing
+    HumanRequest.loadServerHumanResponse
+        pool
+        boundary
+        request.reserveServerTurnOwnerInstanceId
+        request.reserveServerTurnId
+        humanRequest.createServerHumanRequestId
+        `shouldReturn` Right (Just approval)
+    HumanRequest.deleteServerHumanRequest
+        pool
+        boundary
+        request.reserveServerTurnOwnerInstanceId
+        request.reserveServerTurnId
+        humanRequest.createServerHumanRequestId
+        `shouldReturn` Right ()
+    HumanRequest.listServerHumanRequests pool boundary
+        `shouldReturn` Right []
+
+    requestedCancellation <-
+        requestServerTurnCancellation
+            pool
+            boundary
+            request.reserveServerTurnId
+            startedAt
+    requestedCancellation `shouldSatisfy` \case
+        Right (Just stored) ->
+            stored.storedServerTurnStatus == ServerTurnRunning
+        _ -> False
+    shouldCancelServerTurn
+        pool
+        boundary
+        request.reserveServerTurnOwnerInstanceId
+        request.reserveServerTurnId
+        `shouldReturn` Right True
+    shouldCancelServerTurn
+        pool
+        boundary
+        instanceTwo
+        request.reserveServerTurnId
+        `shouldReturn` Right True
+
+    completed <-
+        finishServerTurn
+            pool
+            boundary
+            request.reserveServerTurnOwnerInstanceId
+            request.reserveServerTurnId
+            ServerTurnTerminal
+                { terminalServerTurnStatus = ServerTurnCompleted
+                , terminalServerTurnFinishedAt = finishedAt
+                , terminalServerTurnAssistantText = Just "hello"
+                , terminalServerTurnAssistantTextTruncated = False
+                , terminalServerTurnResponseId = Just "response-a"
+                , terminalServerTurnIncompleteReason = Nothing
+                , terminalServerTurnIncompleteReasoningTokens = Nothing
+                , terminalServerTurnError = Nothing
+                }
+    completed `shouldSatisfy` \case
+        Right (Just stored) ->
+            stored.storedServerTurnStatus == ServerTurnCompleted
+                && stored.storedServerTurnAssistantText == Just "hello"
+                && not stored.storedServerTurnAssistantTextTruncated
+                && stored.storedServerTurnResponseId == Just "response-a"
+        _ -> False
+
+    -- Wall-clock staleness cannot revoke a process which still owns its
+    -- connection-lifetime advisory lock. In particular, a paused mutation
+    -- remains exclusive and its handler may safely resume.
+    reserveServerSessionMutation pool mutation
+        `shouldReturn` Right ServerSessionMutationReserved
+    ageServerTurnOwner pool instanceOne
+        `shouldReturn` Right ()
+    heartbeatServerTurnOwner ownerTwo
+        `shouldReturn` Right ()
+    let instanceTwoMutation =
+            mutation
+                { serverSessionMutationOwnerInstanceId = instanceTwo
+                , serverSessionMutationCreatedAt = addUTCTime 3 finishedAt
+                }
+    reserveServerSessionMutation pool instanceTwoMutation
+        `shouldReturn` Right ServerSessionMutationBusy
+    reserveServerTurn
+        pool
+        request
+            { reserveServerTurnId =
+                "01999999-0000-7000-8000-000000000020"
+            , reserveServerTurnClientRequestId =
+                "01999999-0000-7000-8000-000000000021"
+            }
+        `shouldReturn` Right ServerTurnSessionMutating
+    releaseServerSessionMutation pool mutation
+        `shouldReturn` Right ()
+
+    -- Reaping must not wait behind the owner-row share lock held by an
+    -- in-flight admission. Waiting would retain an old READ COMMITTED snapshot
+    -- and can also make the healthy reaper miss its heartbeat deadline.
+    withServerTurnOwnerRowLocked pool instanceOne do
+        timeout
+            (2 * 1000 * 1000)
+            (heartbeatServerTurnOwner ownerTwo)
+            `shouldReturn` Just (Right ())
+
+    let interruptedRequest =
+            request
+                { reserveServerTurnId =
+                    "01999999-0000-7000-8000-000000000007"
+                , reserveServerTurnClientRequestId =
+                    "01999999-0000-7000-8000-000000000008"
+                }
+    interruptedReservation <- reserveServerTurn pool interruptedRequest
+    interruptedReservation `shouldSatisfy` \case
+        Right (ServerTurnReserved _) -> True
+        _ -> False
+
+    -- Another live instance may inspect and heartbeat without changing a
+    -- paused owner's turn, even though its timestamp is arbitrarily old.
+    observedByOther <-
+        loadServerTurn
+            pool
+            boundary
+            interruptedRequest.reserveServerTurnId
+    observedByOther `shouldSatisfy` \case
+        Right (Just stored) ->
+            stored.storedServerTurnStatus == ServerTurnQueued
+        _ -> False
+    heartbeatServerTurnOwner ownerTwo
+        `shouldReturn` Right ()
+    stillQueued <-
+        loadServerTurn
+            pool
+            boundary
+            interruptedRequest.reserveServerTurnId
+    stillQueued `shouldSatisfy` \case
+        Right (Just stored) ->
+            stored.storedServerTurnStatus == ServerTurnQueued
+        _ -> False
+
+    -- A real crash closes the liveness connection. The next owner can then
+    -- recover the turn and session. A shared owner-action fence delays that
+    -- recovery while a turn or mutation can still produce effects.
+    createSession
+        pool
+        (testMetadata createdAt)
+            { sessionMetadataKey = "session-b"
+            }
+        `shouldReturn` Right True
+    let protectedMutation =
+            mutation
+                { serverSessionMutationSessionId = "session-b"
+                , serverSessionMutationCreatedAt =
+                    addUTCTime 4 finishedAt
+                }
+    withServerTurnOwnerActionFence pool instanceOne \_ -> do
+        reserveServerSessionMutation pool protectedMutation
+            `shouldReturn` Right ServerSessionMutationReserved
+        abandonServerTurnOwnerLease ownerOne
+        reserveServerTurn pool interruptedRequest
+            `shouldReturn` Right ServerTurnOwnerUnavailable
+        reserveServerSessionMutation pool mutation
+            `shouldReturn` Right ServerSessionMutationOwnerUnavailable
+        heartbeatServerTurnOwner ownerTwo
+            `shouldReturn` Right ()
+        stillProtected <-
+            loadServerTurn
+                pool
+                boundary
+                interruptedRequest.reserveServerTurnId
+        stillProtected `shouldSatisfy` \case
+            Right (Just stored) ->
+                stored.storedServerTurnStatus == ServerTurnQueued
+            _ -> False
+        reserveServerSessionMutation
+            pool
+            protectedMutation
+                { serverSessionMutationOwnerInstanceId = instanceTwo
+                }
+            `shouldReturn` Right ServerSessionMutationBusy
+        releaseServerSessionMutation pool protectedMutation
+            `shouldReturn` Right ()
+
+    heartbeatServerTurnOwner ownerTwo
+        `shouldReturn` Right ()
+    interrupted <-
+        loadServerTurn
+            pool
+            boundary
+            interruptedRequest.reserveServerTurnId
+    interrupted `shouldSatisfy` \case
+        Right (Just stored) ->
+            stored.storedServerTurnStatus == ServerTurnFailed
+                && stored.storedServerTurnFinishedAt /= Nothing
+                && stored.storedServerTurnError
+                    == Just
+                        "agent server owner disconnected before the turn completed"
+        _ -> False
+    replay <-
+        reserveServerTurn
+            pool
+            interruptedRequest
+                { reserveServerTurnOwnerInstanceId = instanceTwo
+                , reserveServerTurnCreatedAt = addUTCTime 1 finishedAt
+                }
+    replay `shouldSatisfy` \case
+        Right (ServerTurnAlreadyReserved stored) ->
+            stored.storedServerTurnStatus == ServerTurnFailed
+        _ -> False
+
+    reserveServerSessionMutation pool instanceTwoMutation
+        `shouldReturn` Right ServerSessionMutationReserved
+    releaseServerSessionMutation pool instanceTwoMutation
+        `shouldReturn` Right ()
+
+    let recoveredRequest =
+            request
+                { reserveServerTurnId =
+                    "01999999-0000-7000-8000-000000000016"
+                , reserveServerTurnClientRequestId =
+                    "01999999-0000-7000-8000-000000000017"
+                , reserveServerTurnOwnerInstanceId = instanceTwo
+                , reserveServerTurnCreatedAt = addUTCTime 4 finishedAt
+                }
+    recovered <- reserveServerTurn pool recoveredRequest
+    recovered `shouldSatisfy` \case
+        Right (ServerTurnReserved _) -> True
+        _ -> False
+
+    -- The abandoned identity cannot heartbeat, reserve, or be reopened after
+    -- its durable tombstone has fenced it.
+    abandonedHeartbeat <- heartbeatServerTurnOwner ownerOne
+    abandonedHeartbeat `shouldSatisfy` \case
+        Left (StoreDataError _) -> True
+        _ -> False
+    reopen <- openServerTurnOwnerLease pool instanceOne
+    case reopen of
+        Left (StoreDataError _) -> pure ()
+        Left err ->
+            expectationFailure
+                ("unexpected owner reopen error: " <> show err)
+        Right lease -> do
+            void (releaseServerTurnOwner lease)
+            expectationFailure "revoked owner identity was reopened"
+    reserveServerTurn
+        pool
+        recoveredRequest
+            { reserveServerTurnId =
+                "01999999-0000-7000-8000-000000000018"
+            , reserveServerTurnClientRequestId =
+                "01999999-0000-7000-8000-000000000019"
+            , reserveServerTurnOwnerInstanceId = instanceOne
+            }
+        `shouldReturn` Right ServerTurnOwnerUnavailable
+    reserveServerSessionMutation
+        pool
+        instanceTwoMutation
+            { serverSessionMutationOwnerInstanceId = instanceOne
+            }
+        `shouldReturn` Right ServerSessionMutationOwnerUnavailable
+
+    listed <-
+        listServerTurns
+            pool
+            boundary
+            (Just "session-a")
+    listed `shouldSatisfy` \case
+        Right turns -> length turns == 3
+        Left _ -> False
+
+instanceOne :: Text
+instanceOne = "01999999-0000-7000-8000-000000000003"
+
+instanceTwo :: Text
+instanceTwo = "01999999-0000-7000-8000-000000000004"
+
+withServerTurnOwner ::
+    StorePool ->
+    Text ->
+    (ServerTurnOwnerLease -> IO value) ->
+    IO value
+withServerTurnOwner pool instanceId =
+    bracket
+        ( openServerTurnOwnerLease pool instanceId >>= \case
+            Left err ->
+                fail ("could not open server turn owner: " <> show err)
+            Right lease -> pure lease
+        )
+        (void . releaseServerTurnOwner)
+
+withServerTurnOwnerActionFence ::
+    StorePool ->
+    Text ->
+    (ServerTurnOwnerActionFence -> IO value) ->
+    IO value
+withServerTurnOwnerActionFence pool instanceId =
+    bracket
+        ( openServerTurnOwnerActionFence pool instanceId >>= \case
+            Left err ->
+                fail ("could not open owner action fence: " <> show err)
+            Right Nothing ->
+                fail "server turn owner was unavailable"
+            Right (Just fence) -> pure fence
+        )
+        closeServerTurnOwnerActionFence
+
+withServerTurnOwnerRowLocked ::
+    StorePool ->
+    Text ->
+    IO value ->
+    IO value
+withServerTurnOwnerRowLocked pool instanceId action =
+    bracket
+        ( openStoreConnection pool >>= \case
+            Left err ->
+                fail ("could not open owner row lock connection: " <> show err)
+            Right connection -> pure connection
+        )
+        closeStoreConnection
+        \connection ->
+            bracket
+                ( do
+                    withConnectionSession connection (Session.script "BEGIN")
+                        >>= either
+                            (fail . ("could not begin owner row lock: " <>) . show)
+                            pure
+                    withConnectionSession
+                        connection
+                        ( Session.statement
+                            instanceId
+                            lockServerTurnOwnerRowStatement
+                        )
+                        >>= \case
+                            Left err ->
+                                fail
+                                    ( "could not lock server turn owner row: "
+                                        <> show err
+                                    )
+                            Right True -> pure ()
+                            Right False ->
+                                fail "server turn owner row was missing"
+                )
+                ( \() ->
+                    void $
+                        withConnectionSession
+                            connection
+                            (Session.script "ROLLBACK")
+                )
+                (const action)
+
+lockServerTurnOwnerRowStatement :: Statement Text Bool
+lockServerTurnOwnerRowStatement =
+    Statement.preparable
+        "SELECT TRUE\
+        \ FROM harness.server_turn_owners\
+        \ WHERE instance_id = $1::uuid\
+        \ FOR SHARE"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
+
+ageServerTurnOwner :: StorePool -> Text -> IO (Either StoreError ())
+ageServerTurnOwner pool instanceId =
+    withSession pool $
+        Session.statement instanceId ageServerTurnOwnerStatement
+
+ageServerTurnOwnerStatement :: Statement Text ()
+ageServerTurnOwnerStatement =
+    Statement.preparable
+        "UPDATE harness.server_turn_owners\
+        \ SET last_heartbeat_at = clock_timestamp() - interval '1 day'\
+        \ WHERE instance_id = $1::uuid"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        Decoders.noResult
+
+testMetadata :: UTCTime -> SessionMetadata
+testMetadata now =
+    SessionMetadata
+        { sessionMetadataKey = "session-a"
+        , sessionMetadataVersion = 1
+        , sessionMetadataCreatedAt = now
+        , sessionMetadataUpdatedAt = now
+        , sessionMetadataProvider = "openai"
+        , sessionMetadataConnection = "organization-gateway"
+        , sessionMetadataGatewayIdentity =
+            Just "gateway-sha256:generation-a"
+        , sessionMetadataModel = "gpt-test"
+        , sessionMetadataTransportModel = Just "gpt-test"
+        , sessionMetadataDialect = "openai"
+        , sessionMetadataLegacyTarget = Nothing
+        , sessionMetadataCwd = "/tmp/project"
+        , sessionMetadataEffort = "medium"
+        , sessionMetadataTitle = "test"
+        , sessionMetadataTitleIsManual = False
+        , sessionMetadataTitleRefreshIndex = 0
+        , sessionMetadataTitleUserTurns = 0
+        , sessionMetadataLastResponseId = Nothing
+        , sessionMetadataInputTokens = 0
+        , sessionMetadataOutputTokens = 0
+        , sessionMetadataCachedTokens = 0
+        , sessionMetadataLastRecap = Nothing
+        , sessionMetadataLastTurnSummary = Nothing
+        , sessionMetadataLastRecapMainTurns = 0
+        }

--- a/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
@@ -331,6 +331,14 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
     HumanRequest.listServerHumanRequests pool boundary
         `shouldReturn` Right []
 
+    let terminalHumanRequest =
+            humanRequest
+                { HumanRequest.createServerHumanRequestId =
+                    "01999999-0000-7000-8000-000000000014"
+                }
+    HumanRequest.createServerHumanRequest pool terminalHumanRequest
+        `shouldReturn` Right True
+
     requestedCancellation <-
         requestServerTurnCancellation
             pool
@@ -377,6 +385,10 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
                 && not stored.storedServerTurnAssistantTextTruncated
                 && stored.storedServerTurnResponseId == Just "response-a"
         _ -> False
+    humanRequestExists
+        pool
+        terminalHumanRequest.createServerHumanRequestId
+        `shouldReturn` Right False
 
     -- Wall-clock staleness cannot revoke a process which still owns its
     -- connection-lifetime advisory lock. In particular, a paused mutation
@@ -426,6 +438,15 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
     interruptedReservation `shouldSatisfy` \case
         Right (ServerTurnReserved _) -> True
         _ -> False
+    let interruptedHumanRequest =
+            humanRequest
+                { HumanRequest.createServerHumanRequestId =
+                    "01999999-0000-7000-8000-000000000015"
+                , HumanRequest.createServerHumanRequestTurnId =
+                    interruptedRequest.reserveServerTurnId
+                }
+    HumanRequest.createServerHumanRequest pool interruptedHumanRequest
+        `shouldReturn` Right True
 
     -- Another live instance may inspect and heartbeat without changing a
     -- paused owner's turn, even though its timestamp is arbitrarily old.
@@ -508,6 +529,10 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
                     == Just
                         "agent server owner disconnected before the turn completed"
         _ -> False
+    humanRequestExists
+        pool
+        interruptedHumanRequest.createServerHumanRequestId
+        `shouldReturn` Right False
     replay <-
         reserveServerTurn
             pool
@@ -570,6 +595,36 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
             { serverSessionMutationOwnerInstanceId = instanceOne
             }
         `shouldReturn` Right ServerSessionMutationOwnerUnavailable
+
+    let releasedHumanRequest =
+            humanRequest
+                { HumanRequest.createServerHumanRequestId =
+                    "01999999-0000-7000-8000-000000000022"
+                , HumanRequest.createServerHumanRequestTurnId =
+                    recoveredRequest.reserveServerTurnId
+                , HumanRequest.createServerHumanRequestOwnerInstanceId =
+                    instanceTwo
+                }
+    HumanRequest.createServerHumanRequest pool releasedHumanRequest
+        `shouldReturn` Right True
+    releaseServerTurnOwner ownerTwo
+        `shouldReturn` Right ()
+    released <-
+        loadServerTurn
+            pool
+            boundary
+            recoveredRequest.reserveServerTurnId
+    released `shouldSatisfy` \case
+        Right (Just stored) ->
+            stored.storedServerTurnStatus == ServerTurnFailed
+                && stored.storedServerTurnError
+                    == Just
+                        "agent server stopped before the turn completed"
+        _ -> False
+    humanRequestExists
+        pool
+        releasedHumanRequest.createServerHumanRequestId
+        `shouldReturn` Right False
 
     listed <-
         listServerTurns
@@ -683,6 +738,21 @@ ageServerTurnOwnerStatement =
         \ WHERE instance_id = $1::uuid"
         (Encoders.param (Encoders.nonNullable Encoders.text))
         Decoders.noResult
+
+humanRequestExists :: StorePool -> Text -> IO (Either StoreError Bool)
+humanRequestExists pool requestId =
+    withSession pool $
+        Session.statement requestId humanRequestExistsStatement
+
+humanRequestExistsStatement :: Statement Text Bool
+humanRequestExistsStatement =
+    Statement.preparable
+        "SELECT EXISTS (\
+        \ SELECT 1\
+        \ FROM harness.server_human_requests\
+        \ WHERE request_id = $1::uuid)"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
 
 testMetadata :: UTCTime -> SessionMetadata
 testMetadata now =

--- a/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
@@ -307,6 +307,27 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
         request.reserveServerTurnId
         humanRequest.createServerHumanRequestId
         `shouldReturn` Right ()
+    HumanRequest.loadServerHumanResponse
+        pool
+        boundary
+        request.reserveServerTurnOwnerInstanceId
+        request.reserveServerTurnId
+        humanRequest.createServerHumanRequestId
+        `shouldReturn` Right (Just approval)
+    HumanRequest.deleteConsumedServerHumanRequest
+        pool
+        boundary
+        request.reserveServerTurnOwnerInstanceId
+        request.reserveServerTurnId
+        humanRequest.createServerHumanRequestId
+        `shouldReturn` Right ()
+    HumanRequest.loadServerHumanResponse
+        pool
+        boundary
+        request.reserveServerTurnOwnerInstanceId
+        request.reserveServerTurnId
+        humanRequest.createServerHumanRequestId
+        `shouldReturn` Right Nothing
     HumanRequest.listServerHumanRequests pool boundary
         `shouldReturn` Right []
 

--- a/packages/agent-store/test/Spec.hs
+++ b/packages/agent-store/test/Spec.hs
@@ -9,6 +9,7 @@ import qualified Agent.Store.Postgres.CustomSpec as CustomSpec
 import qualified Agent.Store.Postgres.ManagedSpec as ManagedSpec
 import qualified Agent.Store.PoolCacheSpec as PoolCacheSpec
 import qualified Agent.Store.Postgres.ScopeSpec as ScopeSpec
+import qualified Agent.Store.Postgres.ServerTurnRecoverySpec as ServerTurnRecoverySpec
 import qualified Agent.Store.Postgres.ServerTurnSpec as ServerTurnSpec
 import qualified Agent.Store.Postgres.SessionSpec as SessionSpec
 import qualified Agent.Store.Postgres.SkillSpec as SkillSpec
@@ -20,6 +21,7 @@ main = hspec do
     ConfigSpec.spec
     ScopeSpec.spec
     CustomSpec.spec
+    ServerTurnRecoverySpec.spec
     ServerTurnSpec.spec
     SessionSpec.spec
     SkillSpec.spec

--- a/packages/agent-store/test/Spec.hs
+++ b/packages/agent-store/test/Spec.hs
@@ -9,6 +9,7 @@ import qualified Agent.Store.Postgres.CustomSpec as CustomSpec
 import qualified Agent.Store.Postgres.ManagedSpec as ManagedSpec
 import qualified Agent.Store.PoolCacheSpec as PoolCacheSpec
 import qualified Agent.Store.Postgres.ScopeSpec as ScopeSpec
+import qualified Agent.Store.Postgres.ServerTurnSpec as ServerTurnSpec
 import qualified Agent.Store.Postgres.SessionSpec as SessionSpec
 import qualified Agent.Store.Postgres.SkillSpec as SkillSpec
 import qualified Agent.Store.Postgres.TenantSpec as TenantSpec
@@ -19,6 +20,7 @@ main = hspec do
     ConfigSpec.spec
     ScopeSpec.spec
     CustomSpec.spec
+    ServerTurnSpec.spec
     SessionSpec.spec
     SkillSpec.spec
     TenantSpec.spec


### PR DESCRIPTION
## Summary
- persist agent-server turns and terminal results in PostgreSQL with owner leases
- make turn admission idempotent through stable client request IDs
- add a shared typed REST/SSE client package and canonical result endpoint
- preserve legacy raw turn creation while hardening cancellation, replay, and boundary checks

## Validation
- `nix build --no-link .#checks.aarch64-darwin.agent-server .#checks.aarch64-darwin.agent-server-client .#checks.aarch64-darwin.agent-store`
- full `agent-server-test` and `agent-server-client-tests` suites