### PR TITLE
refactor(core): make task plan memory transitions atomic

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -156,6 +156,7 @@ import Agent.Tools.PlanMode
 import Agent.Tools.TaskPlan
     ( restoreTaskPlanReminder
     , takeTaskPlanReminder
+    , taskPlanReminderText
     )
 import Agent.OsPath (toText, unsafeToFilePath)
 import Control.Monad (forM_, when)
@@ -311,7 +312,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv
         turnInputs0 =
             turnInputsWithContext
                 planReminder
-                taskPlanReminder
+                (taskPlanReminderText <$> taskPlanReminder)
                 pendingStartup
                 inputs
     (conversationStartedAt, previousActivityAt) <-
@@ -357,8 +358,9 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                         Nothing -> Just consumed
                         Just _ -> current
                     , ())
-            forM_ taskPlanReminder \_ ->
-                mapM_ restoreTaskPlanReminder taskPlan
+            forM_ taskPlanReminder \reminder ->
+                forM_ taskPlan \env ->
+                    restoreTaskPlanReminder env reminder
         persistPromptSnapshot = case persist of
             PersistenceDisabled -> pure ()
             PersistenceEnabled slotRef -> do
@@ -462,8 +464,9 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                     (rebasePreparedTurn boundary prepared)
                     ConversationInterrupted)
                 >> when (isNothing boundary)
-                    (forM_ taskPlanReminder \_ ->
-                        mapM_ restoreTaskPlanReminder taskPlan)
+                    (forM_ taskPlanReminder \reminder ->
+                        forM_ taskPlan \env ->
+                            restoreTaskPlanReminder env reminder)
                 >> restorePlanStateAfterIncomplete planMode initialPlanState
                 >> abortSubagentTurn rootTurnId
             )
@@ -525,8 +528,9 @@ runOneTurnBusy includeTurnContext env@SessionEnv
             commitConversationPatch
                 (finishConversation committedPrepared ConversationRestarted)
             when (isNothing automaticCompaction) $
-                forM_ taskPlanReminder \_ ->
-                    mapM_ restoreTaskPlanReminder taskPlan
+                forM_ taskPlanReminder \reminder ->
+                    forM_ taskPlan \env ->
+                        restoreTaskPlanReminder env reminder
             planState <- readIORef planMode.planStateRef
             case fullscreen of
                 Just runtime ->
@@ -585,8 +589,9 @@ runOneTurnBusy includeTurnContext env@SessionEnv
                                 committedPrepared
                                 ConversationProviderUnavailable)
                         when (isNothing automaticCompaction) $
-                            forM_ taskPlanReminder \_ ->
-                                mapM_ restoreTaskPlanReminder taskPlan
+                            forM_ taskPlanReminder \reminder ->
+                                forM_ taskPlan \env ->
+                                    restoreTaskPlanReminder env reminder
                         case fullscreen of
                             Nothing -> pure ()
                             Just runtime ->

--- a/packages/agent-core/src/Agent/Tools/TaskPlan.hs
+++ b/packages/agent-core/src/Agent/Tools/TaskPlan.hs
@@ -82,10 +82,13 @@ data TaskPlanReminderState
     | TaskPlanReminderConsumed
 
 data TaskPlanMemory
-    = TaskPlanEmpty
-    | TaskPlanPresent !CurrentTaskPlan !TaskPlanReminderState
+    = TaskPlanEmpty !Integer
+    | TaskPlanPresent
+        !Integer
+        !CurrentTaskPlan
+        !TaskPlanReminderState
 
-newtype TaskPlanReminder = TaskPlanReminder CurrentTaskPlan
+data TaskPlanReminder = TaskPlanReminder !Integer !CurrentTaskPlan
     deriving (Eq, Show)
 
 data TaskPlanEnv = TaskPlanEnv
@@ -149,7 +152,7 @@ newTaskPlanEnv
     -> Maybe TaskPlanHooks
     -> IO TaskPlanEnv
 newTaskPlanEnv initial hooks = do
-    memoryRef <- newIORef (resumeTaskPlanMemory initial)
+    memoryRef <- newIORef (initialTaskPlanMemory initial)
     mutationLock <- newMVar ()
     pure TaskPlanEnv
         { taskPlanMemoryRef = memoryRef
@@ -178,7 +181,7 @@ replaceTaskPlan env plan =
             Left err -> pure (lock, Left err)
             Right revision -> do
                 let current = CurrentTaskPlan revision plan
-                writeIORef env.taskPlanMemoryRef
+                modifyIORef' env.taskPlanMemoryRef
                     (publishTaskPlanMemory current)
                 pure (lock, Right current)
 
@@ -192,7 +195,7 @@ clearTaskPlan env =
         case persisted of
             Left err -> pure (lock, Left err)
             Right () -> do
-                writeIORef env.taskPlanMemoryRef TaskPlanEmpty
+                modifyIORef' env.taskPlanMemoryRef clearTaskPlanMemory
                 pure (lock, Right ())
 
 -- | Replace only the in-memory projection after the host switches the
@@ -204,7 +207,8 @@ resetTaskPlanState
     -> IO ()
 resetTaskPlanState env current =
     modifyMVar env.taskPlanMutationLock \lock -> do
-        writeIORef env.taskPlanMemoryRef (resumeTaskPlanMemory current)
+        modifyIORef' env.taskPlanMemoryRef
+            (resumeTaskPlanMemory current)
         pure (lock, ())
 
 taskPlanContextMarker :: Text
@@ -238,7 +242,7 @@ currentTaskPlanContextText env =
     fmap taskPlanContextText <$> readTaskPlan env
 
 taskPlanReminderText :: TaskPlanReminder -> Text
-taskPlanReminderText (TaskPlanReminder current) =
+taskPlanReminderText (TaskPlanReminder _ current) =
     taskPlanContextText current
 
 -- | Consume the one-shot reminder used when a runtime resumes persisted state.
@@ -248,34 +252,69 @@ takeTaskPlanReminder env =
 
 -- | Requeue a consumed resume reminder when prompt preparation fails before
 -- the corresponding input can become part of canonical history.  The token
--- identifies the plan that was consumed, so a delayed failure cannot requeue
--- a replacement plan.
+-- identifies both the plan and its installation generation, so a delayed
+-- failure cannot requeue a replacement plan or an identical plan from a
+-- different session.
 restoreTaskPlanReminder :: TaskPlanEnv -> TaskPlanReminder -> IO ()
 restoreTaskPlanReminder env reminder =
     atomicModifyIORef' env.taskPlanMemoryRef \memory ->
         (restoreTaskPlanReminderStep reminder memory, ())
 
-resumeTaskPlanMemory :: Maybe CurrentTaskPlan -> TaskPlanMemory
-resumeTaskPlanMemory = \case
-    Nothing -> TaskPlanEmpty
-    Just current -> TaskPlanPresent current TaskPlanReminderPending
+initialTaskPlanMemory :: Maybe CurrentTaskPlan -> TaskPlanMemory
+initialTaskPlanMemory = \case
+    Nothing -> TaskPlanEmpty 0
+    Just current ->
+        TaskPlanPresent 0 current TaskPlanReminderPending
 
-publishTaskPlanMemory :: CurrentTaskPlan -> TaskPlanMemory
-publishTaskPlanMemory current =
-    TaskPlanPresent current TaskPlanReminderInactive
+resumeTaskPlanMemory
+    :: Maybe CurrentTaskPlan
+    -> TaskPlanMemory
+    -> TaskPlanMemory
+resumeTaskPlanMemory current memory =
+    let generation = nextTaskPlanGeneration memory
+    in case current of
+        Nothing -> TaskPlanEmpty generation
+        Just value ->
+            TaskPlanPresent generation value TaskPlanReminderPending
+
+publishTaskPlanMemory
+    :: CurrentTaskPlan
+    -> TaskPlanMemory
+    -> TaskPlanMemory
+publishTaskPlanMemory current memory =
+    TaskPlanPresent
+        (nextTaskPlanGeneration memory)
+        current
+        TaskPlanReminderInactive
+
+clearTaskPlanMemory :: TaskPlanMemory -> TaskPlanMemory
+clearTaskPlanMemory memory =
+    TaskPlanEmpty (nextTaskPlanGeneration memory)
+
+nextTaskPlanGeneration :: TaskPlanMemory -> Integer
+nextTaskPlanGeneration memory =
+    taskPlanGeneration memory + 1
+
+taskPlanGeneration :: TaskPlanMemory -> Integer
+taskPlanGeneration = \case
+    TaskPlanEmpty generation -> generation
+    TaskPlanPresent generation _ _ -> generation
 
 currentTaskPlan :: TaskPlanMemory -> Maybe CurrentTaskPlan
 currentTaskPlan = \case
-    TaskPlanEmpty -> Nothing
-    TaskPlanPresent current _ -> Just current
+    TaskPlanEmpty _ -> Nothing
+    TaskPlanPresent _ current _ -> Just current
 
 takeTaskPlanReminderStep
     :: TaskPlanMemory
     -> (TaskPlanMemory, Maybe TaskPlanReminder)
 takeTaskPlanReminderStep = \case
-    TaskPlanPresent current TaskPlanReminderPending ->
-        ( TaskPlanPresent current TaskPlanReminderConsumed
-        , Just (TaskPlanReminder current)
+    TaskPlanPresent generation current TaskPlanReminderPending ->
+        ( TaskPlanPresent
+            generation
+            current
+            TaskPlanReminderConsumed
+        , Just (TaskPlanReminder generation current)
         )
     memory -> (memory, Nothing)
 
@@ -283,10 +322,15 @@ restoreTaskPlanReminderStep
     :: TaskPlanReminder
     -> TaskPlanMemory
     -> TaskPlanMemory
-restoreTaskPlanReminderStep (TaskPlanReminder consumed) = \case
-    TaskPlanPresent current TaskPlanReminderConsumed
-        | current == consumed ->
-            TaskPlanPresent current TaskPlanReminderPending
+restoreTaskPlanReminderStep
+        (TaskPlanReminder consumedGeneration consumed) = \case
+    TaskPlanPresent generation current TaskPlanReminderConsumed
+        | generation == consumedGeneration
+        , current == consumed ->
+            TaskPlanPresent
+                generation
+                current
+                TaskPlanReminderPending
     memory -> memory
 
 isTaskPlanContextText :: Text -> Bool

--- a/packages/agent-core/src/Agent/Tools/TaskPlan.hs
+++ b/packages/agent-core/src/Agent/Tools/TaskPlan.hs
@@ -12,6 +12,8 @@ module Agent.Tools.TaskPlan
     , TaskPlanUpdate(..)
     , TaskPlanHooks(..)
     , TaskPlanEnv
+    , TaskPlanReminder
+    , taskPlanReminderText
     , taskPlanUpdateDecoder
     , validateTaskPlanUpdate
     , renderTaskPlanUpdate
@@ -31,7 +33,6 @@ module Agent.Tools.TaskPlan
 import qualified Agent.Json.Decode as Json
 import Control.Concurrent.MVar (MVar, modifyMVar, newMVar)
 import Control.Exception.Safe (mask)
-import Control.Monad (when)
 import Data.Int (Int64)
 import Data.IORef
 import Data.Text (Text)
@@ -75,9 +76,20 @@ data TaskPlanHooks = TaskPlanHooks
     , taskPlanPersistClear :: !(IO (Either Text ()))
     }
 
+data TaskPlanReminderState
+    = TaskPlanReminderInactive
+    | TaskPlanReminderPending
+    | TaskPlanReminderConsumed
+
+data TaskPlanMemory
+    = TaskPlanEmpty
+    | TaskPlanPresent !CurrentTaskPlan !TaskPlanReminderState
+
+newtype TaskPlanReminder = TaskPlanReminder CurrentTaskPlan
+    deriving (Eq, Show)
+
 data TaskPlanEnv = TaskPlanEnv
-    { taskPlanStateRef :: !(IORef (Maybe CurrentTaskPlan))
-    , taskPlanReminderPendingRef :: !(IORef Bool)
+    { taskPlanMemoryRef :: !(IORef TaskPlanMemory)
     , taskPlanHooks :: !(Maybe TaskPlanHooks)
     , taskPlanMutationLock :: !(MVar ())
     }
@@ -137,18 +149,17 @@ newTaskPlanEnv
     -> Maybe TaskPlanHooks
     -> IO TaskPlanEnv
 newTaskPlanEnv initial hooks = do
-    stateRef <- newIORef initial
-    reminderRef <- newIORef (maybe False (const True) initial)
+    memoryRef <- newIORef (resumeTaskPlanMemory initial)
     mutationLock <- newMVar ()
     pure TaskPlanEnv
-        { taskPlanStateRef = stateRef
-        , taskPlanReminderPendingRef = reminderRef
+        { taskPlanMemoryRef = memoryRef
         , taskPlanHooks = hooks
         , taskPlanMutationLock = mutationLock
         }
 
 readTaskPlan :: TaskPlanEnv -> IO (Maybe CurrentTaskPlan)
-readTaskPlan env = readIORef env.taskPlanStateRef
+readTaskPlan env =
+    currentTaskPlan <$> readIORef env.taskPlanMemoryRef
 
 -- | Persist first, then publish in memory.  Async exceptions may interrupt the
 -- persistence operation, but cannot land between its success and publication.
@@ -161,14 +172,14 @@ replaceTaskPlan env plan =
         persisted <- restore $ case env.taskPlanHooks of
             Just hooks -> hooks.taskPlanPersistReplace plan
             Nothing -> do
-                current <- readIORef env.taskPlanStateRef
+                current <- readTaskPlan env
                 pure $ Right $ maybe 1 (\value -> value.currentTaskPlanRevision + 1) current
         case persisted of
             Left err -> pure (lock, Left err)
             Right revision -> do
                 let current = CurrentTaskPlan revision plan
-                writeIORef env.taskPlanStateRef (Just current)
-                writeIORef env.taskPlanReminderPendingRef False
+                writeIORef env.taskPlanMemoryRef
+                    (publishTaskPlanMemory current)
                 pure (lock, Right current)
 
 -- | Clear durable state before clearing the in-memory projection.
@@ -181,8 +192,7 @@ clearTaskPlan env =
         case persisted of
             Left err -> pure (lock, Left err)
             Right () -> do
-                writeIORef env.taskPlanStateRef Nothing
-                writeIORef env.taskPlanReminderPendingRef False
+                writeIORef env.taskPlanMemoryRef TaskPlanEmpty
                 pure (lock, Right ())
 
 -- | Replace only the in-memory projection after the host switches the
@@ -194,9 +204,7 @@ resetTaskPlanState
     -> IO ()
 resetTaskPlanState env current =
     modifyMVar env.taskPlanMutationLock \lock -> do
-        writeIORef env.taskPlanStateRef current
-        writeIORef env.taskPlanReminderPendingRef
-            (maybe False (const True) current)
+        writeIORef env.taskPlanMemoryRef (resumeTaskPlanMemory current)
         pure (lock, ())
 
 taskPlanContextMarker :: Text
@@ -229,19 +237,57 @@ currentTaskPlanContextText :: TaskPlanEnv -> IO (Maybe Text)
 currentTaskPlanContextText env =
     fmap taskPlanContextText <$> readTaskPlan env
 
+taskPlanReminderText :: TaskPlanReminder -> Text
+taskPlanReminderText (TaskPlanReminder current) =
+    taskPlanContextText current
+
 -- | Consume the one-shot reminder used when a runtime resumes persisted state.
-takeTaskPlanReminder :: TaskPlanEnv -> IO (Maybe Text)
-takeTaskPlanReminder env = do
-    pending <- atomicModifyIORef' env.taskPlanReminderPendingRef (\value -> (False, value))
-    if pending then currentTaskPlanContextText env else pure Nothing
+takeTaskPlanReminder :: TaskPlanEnv -> IO (Maybe TaskPlanReminder)
+takeTaskPlanReminder env =
+    atomicModifyIORef' env.taskPlanMemoryRef takeTaskPlanReminderStep
 
 -- | Requeue a consumed resume reminder when prompt preparation fails before
--- the corresponding input can become part of canonical history.
-restoreTaskPlanReminder :: TaskPlanEnv -> IO ()
-restoreTaskPlanReminder env = do
-    current <- readTaskPlan env
-    when (maybe False (const True) current) $
-        writeIORef env.taskPlanReminderPendingRef True
+-- the corresponding input can become part of canonical history.  The token
+-- identifies the plan that was consumed, so a delayed failure cannot requeue
+-- a replacement plan.
+restoreTaskPlanReminder :: TaskPlanEnv -> TaskPlanReminder -> IO ()
+restoreTaskPlanReminder env reminder =
+    atomicModifyIORef' env.taskPlanMemoryRef \memory ->
+        (restoreTaskPlanReminderStep reminder memory, ())
+
+resumeTaskPlanMemory :: Maybe CurrentTaskPlan -> TaskPlanMemory
+resumeTaskPlanMemory = \case
+    Nothing -> TaskPlanEmpty
+    Just current -> TaskPlanPresent current TaskPlanReminderPending
+
+publishTaskPlanMemory :: CurrentTaskPlan -> TaskPlanMemory
+publishTaskPlanMemory current =
+    TaskPlanPresent current TaskPlanReminderInactive
+
+currentTaskPlan :: TaskPlanMemory -> Maybe CurrentTaskPlan
+currentTaskPlan = \case
+    TaskPlanEmpty -> Nothing
+    TaskPlanPresent current _ -> Just current
+
+takeTaskPlanReminderStep
+    :: TaskPlanMemory
+    -> (TaskPlanMemory, Maybe TaskPlanReminder)
+takeTaskPlanReminderStep = \case
+    TaskPlanPresent current TaskPlanReminderPending ->
+        ( TaskPlanPresent current TaskPlanReminderConsumed
+        , Just (TaskPlanReminder current)
+        )
+    memory -> (memory, Nothing)
+
+restoreTaskPlanReminderStep
+    :: TaskPlanReminder
+    -> TaskPlanMemory
+    -> TaskPlanMemory
+restoreTaskPlanReminderStep (TaskPlanReminder consumed) = \case
+    TaskPlanPresent current TaskPlanReminderConsumed
+        | current == consumed ->
+            TaskPlanPresent current TaskPlanReminderPending
+    memory -> memory
 
 isTaskPlanContextText :: Text -> Bool
 isTaskPlanContextText =

--- a/packages/agent-core/test/Agent/Tools/TaskPlanSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/TaskPlanSpec.hs
@@ -82,6 +82,20 @@ spec = describe "task plans" do
         taskPlanReminderText <$> restored
             `shouldBe` Just (taskPlanContextText replacement)
 
+    it "rejects a reminder token from an identical prior session" do
+        let current = CurrentTaskPlan 1 $
+                TaskPlan Nothing [TaskPlanItem "same" TaskPlanPending]
+        env <- newTaskPlanEnv (Just current) Nothing
+        Just oldReminder <- takeTaskPlanReminder env
+        resetTaskPlanState env (Just current)
+        Just currentReminder <- takeTaskPlanReminder env
+        restoreTaskPlanReminder env oldReminder
+        takeTaskPlanReminder env `shouldReturn` Nothing
+        restoreTaskPlanReminder env currentReminder
+        restored <- takeTaskPlanReminder env
+        taskPlanReminderText <$> restored
+            `shouldBe` Just (taskPlanContextText current)
+
     it "does not make a freshly published plan into a resume reminder" do
         let resumed = CurrentTaskPlan 4 $
                 TaskPlan Nothing [TaskPlanItem "resumed" TaskPlanPending]

--- a/packages/agent-core/test/Agent/Tools/TaskPlanSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/TaskPlanSpec.hs
@@ -55,13 +55,44 @@ spec = describe "task plans" do
             current = CurrentTaskPlan 12 plan
             reminder = taskPlanContextText current
         env <- newTaskPlanEnv (Just current) Nothing
-        takeTaskPlanReminder env `shouldReturn` Just reminder
+        consumed <- takeTaskPlanReminder env
+        taskPlanReminderText <$> consumed `shouldBe` Just reminder
         isTaskPlanContextText reminder `shouldBe` True
         Text.count "<task-plan-state" reminder `shouldBe` 1
         reminder `shouldSatisfy` Text.isInfixOf "‹evil›"
         takeTaskPlanReminder env `shouldReturn` Nothing
-        restoreTaskPlanReminder env
-        takeTaskPlanReminder env `shouldReturn` Just reminder
+        mapM_ (restoreTaskPlanReminder env) consumed
+        restored <- takeTaskPlanReminder env
+        taskPlanReminderText <$> restored `shouldBe` Just reminder
+
+    it "does not let a stale restore requeue a replacement plan" do
+        let old = CurrentTaskPlan 1 $
+                TaskPlan Nothing [TaskPlanItem "old" TaskPlanPending]
+            replacement = CurrentTaskPlan 1 $
+                TaskPlan Nothing
+                    [TaskPlanItem "replacement" TaskPlanInProgress]
+        env <- newTaskPlanEnv (Just old) Nothing
+        Just oldReminder <- takeTaskPlanReminder env
+        resetTaskPlanState env (Just replacement)
+        Just replacementReminder <- takeTaskPlanReminder env
+        restoreTaskPlanReminder env oldReminder
+        takeTaskPlanReminder env `shouldReturn` Nothing
+        restoreTaskPlanReminder env replacementReminder
+        restored <- takeTaskPlanReminder env
+        taskPlanReminderText <$> restored
+            `shouldBe` Just (taskPlanContextText replacement)
+
+    it "does not make a freshly published plan into a resume reminder" do
+        let resumed = CurrentTaskPlan 4 $
+                TaskPlan Nothing [TaskPlanItem "resumed" TaskPlanPending]
+            fresh = TaskPlan Nothing
+                [TaskPlanItem "fresh" TaskPlanInProgress]
+        env <- newTaskPlanEnv (Just resumed) Nothing
+        Just consumed <- takeTaskPlanReminder env
+        replaceTaskPlan env fresh
+            `shouldReturn` Right (CurrentTaskPlan 5 fresh)
+        restoreTaskPlanReminder env consumed
+        takeTaskPlanReminder env `shouldReturn` Nothing
 
     it "resets the in-memory projection when the host changes sessions" do
         let oldPlan = TaskPlan Nothing
@@ -77,8 +108,9 @@ spec = describe "task plans" do
         takeTaskPlanReminder env `shouldReturn` Nothing
         resetTaskPlanState env (Just current)
         readTaskPlan env `shouldReturn` Just current
-        takeTaskPlanReminder env
-            `shouldReturn` Just (taskPlanContextText current)
+        reminder <- takeTaskPlanReminder env
+        taskPlanReminderText <$> reminder
+            `shouldBe` Just (taskPlanContextText current)
 
     it "bounds rendered context" do
         let plan = TaskPlan Nothing


### PR DESCRIPTION
## Summary
- replace separate task-plan and reminder refs with one strict task-plan memory state
- express resume, publish, consume, restore, and clear as explicit state transitions
- carry an opaque generation-tagged reminder token so delayed restores cannot requeue replacement or identical plans from a different session
- preserve nonblocking reads, mutation serialization, and persistence-before-publication ordering

## Tests
- `agent-core` task-plan tests: 10 examples, 0 failures
- `agent-cli:lib:agent-cli`: all 212 modules compiled
- `git diff --check`
