### PR TITLE
Split initialized runtime orchestration

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -36,7 +36,10 @@ import Agent.CLI.Compaction ()
 import Agent.CLI.Config ()
 import Agent.Connectivity ()
 import Agent.CLI.Database ()
-import Agent.CLI.Database.Store ( deriveDatabaseScopesWithNamespace )
+import Agent.CLI.Database.Store
+    ( DatabaseScopes
+    , deriveDatabaseScopesWithNamespace
+    )
 import Agent.CLI.Dialects ()
 import Agent.CLI.Error ()
 import Agent.CLI.GatewayClient
@@ -57,7 +60,8 @@ import Agent.CLI.ManagedTurn ()
 import Agent.CLI.McpManager ()
 import Agent.CLI.McpStatus ()
 import Agent.CLI.ModelConfig
-    ( catalogConnection,
+    ( ModelCatalog
+    , catalogConnection,
       loadModelCatalogAt,
       organizationGatewayConnectionId,
       ConnectionKind(BuiltinConnection, CustomResponsesConnection,
@@ -205,7 +209,8 @@ import Control.Concurrent.Async
     ( Async, cancel, concurrently, poll, wait, withAsync )
 import Control.Concurrent.Chan ()
 import Control.Concurrent.MVar
-    ( modifyMVar_
+    ( MVar
+    , modifyMVar_
     , newEmptyMVar
     , newMVar
     , readMVar
@@ -256,6 +261,72 @@ data PreparedStartupAuth = PreparedStartupAuth
 data PreparedStartupAuthWorker = PreparedStartupAuthWorker
     { preparedStartupAsync :: !(Async PreparedStartupAuth)
     , retirePreparedStartup :: !(IO ())
+    }
+
+data InitializedRequest = InitializedRequest
+    { initializedRunAgentChild :: AgentRunMode -> CliOptions -> IO DevResult
+    , initializedProcessRuntime :: AgentProcessRuntime
+    , initializedOptions :: CliOptions
+    , initializedTransition :: Maybe ProviderTransition
+    , initializedHome :: OsPath
+    , initializedRoot :: OsPath
+    , initializedResumed :: Maybe (SessionMeta, [SessionTurn])
+    , initializedResumeLock :: Maybe SessionLock
+    , initializedCwd :: OsPath
+    , initializedStartup :: StartupRuntime
+    , initializedConnectedGateway :: Maybe GatewayCredential
+    , initializedPreparedAuth :: Maybe PreparedStartupAuthWorker
+    }
+
+data InitializedWorkspace = InitializedWorkspace
+    { initializedProjectRoot :: OsPath
+    , initializedStateDirectory :: FilePath
+    , initializedDatabaseScopes :: DatabaseScopes
+    , initializedProjectSettings :: ProjectSettings
+    , initializedCatalog :: ModelCatalog
+    }
+
+data InitializedTargets = InitializedTargets
+    { initializedGatewayIdentity :: Maybe Text
+    , initializedTransitionTarget :: Maybe ModelTarget
+    , initializedConfiguredTarget :: Maybe ModelTarget
+    , initializedResumedTarget :: Maybe ModelTarget
+    , initializedProjectTarget :: Maybe ModelTarget
+    , initializedTargetHint :: Maybe ModelTarget
+    , initializedRequestedProvider :: Maybe Provider
+    , initializedCustomResponses :: Maybe (Text, ResponsesConnection)
+    , initializedCheckStartupUsageInBackground :: Bool
+    }
+
+data RoutedStartupAuth = RoutedStartupAuth
+    { routedInitialLoaded :: LoadedAuth
+    , routedLearnAboutUserRequested :: Bool
+    , routedPreparedAccountUsage :: Maybe PreparedProviderAccounts
+    , routedCustomBearerToken :: Maybe Text
+    }
+
+data InitializedAuth = InitializedAuth
+    { initializedLoaded :: LoadedAuth
+    , initializedLearnAboutUserRequested :: Bool
+    , initializedPreparedAccountUsage :: Maybe PreparedProviderAccounts
+    , initializedCustomBearerToken :: Maybe Text
+    , initializedStartupAccountIds :: Maybe (Text, Text)
+    }
+
+data InitializedAccountRefs = InitializedAccountRefs
+    { initializedGatewayModelsRef :: IORef (Maybe GatewayModelAccess)
+    , initializedActiveAccountIdRef :: IORef Text
+    , initializedActiveAccountRef :: IORef Text
+    , initializedActiveSelectionRef :: IORef Text
+    , initializedPreferredOpenAiAccountRef :: IORef (Maybe Text)
+    , initializedSelectableTokenProvider :: TokenProvider
+    }
+
+data InitializedHttpRuntime = InitializedHttpRuntime
+    { initializedResolveActiveAccountLabel :: Credential -> IO Text
+    , initializedTokenProvider :: TokenProvider
+    , initializedSelectHttpAccount ::
+        Text -> IO (Either ApiError Text)
     }
 
 prepareStartupAuth :: Bool -> Maybe Provider -> IO PreparedStartupAuth
@@ -350,22 +421,31 @@ runAgentInitializedWithLock
 runAgentInitializedWithLock
         runAgentChild processRuntime
         options transition home root resumed resumeLock cwd startup
-        connectedGateway preparedAuth = do
-    let baseToolEnv = startup.startupToolEnv
-        mcpSupervisor = processRuntime.processMcpSupervisor
-        interrupt = startup.startupInterrupt
-        escPaused = startup.startupEscPaused
-        uiRuntimeRef = startup.startupUiRuntimeRef
+        connectedGateway preparedAuth =
+    runInitialized InitializedRequest
+        { initializedRunAgentChild = runAgentChild
+        , initializedProcessRuntime = processRuntime
+        , initializedOptions = options
+        , initializedTransition = transition
+        , initializedHome = home
+        , initializedRoot = root
+        , initializedResumed = resumed
+        , initializedResumeLock = resumeLock
+        , initializedCwd = cwd
+        , initializedStartup = startup
+        , initializedConnectedGateway = connectedGateway
+        , initializedPreparedAuth = preparedAuth
+        }
+
+prepareInitializedWorkspace
+    :: InitializedRequest
+    -> IO InitializedWorkspace
+prepareInitializedWorkspace request = do
+    let startup = request.initializedStartup
+        home = request.initializedHome
+        cwd = request.initializedCwd
         fullscreen = startup.startupFullscreen
-        isTty = startup.startupStdinTty
-        stdoutTty = startup.startupStdoutTty
-        stdoutHandle = startup.startupStdout
-        stderrHandle = startup.startupStderr
-        setWindowTitle title =
-            case fullscreen of
-                Just runtime -> setFullscreenWindowTitle runtime title
-                Nothing -> setCliWindowTitle stdoutTty stdoutHandle title
-    let preparedDiscovery =
+        preparedDiscovery =
             nativePreparedDiscovery . (.nativeWorkspaceDiscovery)
                 =<< startup.startupNativeHooks
     projectRoot <-
@@ -410,12 +490,30 @@ runAgentInitializedWithLock
         catalogResult
     setStartupRepository fullscreen home branch cwd
     markStartupStage startup "Loading credentials…"
-    let connectedGatewayIdentity =
+    pure InitializedWorkspace
+        { initializedProjectRoot = projectRoot
+        , initializedStateDirectory = stateDirectory
+        , initializedDatabaseScopes = databaseScopes
+        , initializedProjectSettings = projectSettings
+        , initializedCatalog = catalog
+        }
+
+resolveInitializedTargets
+    :: InitializedRequest
+    -> InitializedWorkspace
+    -> IO InitializedTargets
+resolveInitializedTargets request workspace = do
+    let startup = request.initializedStartup
+        options = request.initializedOptions
+        transition = request.initializedTransition
+        resumed = request.initializedResumed
+        connectedGateway = request.initializedConnectedGateway
+        fullscreen = startup.startupFullscreen
+        catalog = workspace.initializedCatalog
+        projectSettings = workspace.initializedProjectSettings
+        connectedGatewayIdentity =
             gatewayCredentialIdentity <$> connectedGateway
         transitionTarget = (.transitionTarget) <$> transition
-        pendingTurn = transition >>= (.transitionPendingTurn)
-        unavailableProviders =
-            maybe Set.empty (.transitionUnavailableProviders) transition
         configuredOptionTarget =
             (.modelTarget)
                 <$> (options.optModel >>= resolveConfiguredModel catalog)
@@ -433,44 +531,44 @@ runAgentInitializedWithLock
             | isJust transitionTarget || isJust options.optModel =
                 Right Nothing
             | otherwise = case fst <$> resumed of
-            Nothing -> Right Nothing
-            Just meta ->
-                Just <$> resolveSavedModelTarget
-                    catalog
-                    (isJust connectedGateway)
-                    meta.metaProvider
-                    meta.metaConnection
-                    meta.metaModel
-                    meta.metaTransportModel
-                    meta.metaDialect
+                Nothing -> Right Nothing
+                Just meta ->
+                    Just <$> resolveSavedModelTarget
+                        catalog
+                        (isJust connectedGateway)
+                        meta.metaProvider
+                        meta.metaConnection
+                        meta.metaModel
+                        meta.metaTransportModel
+                        meta.metaDialect
         projectTargetResult
             | isJust transitionTarget
                 || isJust options.optModel
                 || isJust resumed =
                     Right Nothing
             | otherwise = case projectSettings.settingsLastModel of
-            Nothing -> Right Nothing
-            Just remembered ->
-                let target = remembered.projectModelTarget
-                in if isJust connectedGateway
-                then Right (Just target)
-                else if target.targetConnectionId
-                    == organizationGatewayConnectionId
-                then Right Nothing
-                else
-                    Just <$> savedTarget
-                        target.targetProvider
-                        target.targetConnectionId
-                        target.targetModelId
-                        (Just target.targetWireModelId)
-                        target.targetDialect
+                Nothing -> Right Nothing
+                Just remembered ->
+                    let target = remembered.projectModelTarget
+                    in if isJust connectedGateway
+                    then Right (Just target)
+                    else if target.targetConnectionId
+                        == organizationGatewayConnectionId
+                    then Right Nothing
+                    else
+                        Just <$> savedTarget
+                            target.targetProvider
+                            target.targetConnectionId
+                            target.targetModelId
+                            (Just target.targetWireModelId)
+                            target.targetDialect
     resumedHistoryResult <-
         publishResumeHistoryAfterBoundary resumedBoundaryResult $
             forM_ fullscreen \runtime ->
                 forM_ resumed \(meta, _) ->
                     loadRecentSessionTurns
                         (trustedPool startup.startupDatabaseStore)
-                        root
+                        request.initializedRoot
                         meta.metaId
                         sessionUiPageSize >>= \case
                             Left err ->
@@ -480,8 +578,9 @@ runAgentInitializedWithLock
                                     runtime
                                     meta.metaId
                                     (loadFullscreenHistoryPage
-                                        (trustedPool startup.startupDatabaseStore)
-                                        root
+                                        (trustedPool
+                                            startup.startupDatabaseStore)
+                                        request.initializedRoot
                                         meta.metaId)
                                     (sessionHistoryPage
                                         (HistoryGeneration 0)
@@ -526,159 +625,242 @@ runAgentInitializedWithLock
                 && isNothing resumed
                 && isNothing options.optProvider
                 && isNothing options.optModel
-    ( ( initialLoaded
-      , learnAboutUserRequested
-      , preparedAccountUsage
-      )
-      , customBearerToken
-      ) <-
-        case (connectedGateway, customResponses) of
-            (Just gateway, Nothing) -> do
-                mapM_ (.retirePreparedStartup) preparedAuth
-                exactLoaded <-
-                    either
-                        (startupDie startup . Text.unpack)
-                        pure
-                        (gatewayLoadedAuthForProvider requestedProvider gateway)
-                pure ((exactLoaded, False, Nothing), Nothing)
-            (Nothing, Nothing) -> do
-                (startupAuth, accountUsage) <- loadPreparedOrStartupAuth
-                    preparedAuth
-                    (options.optYolo && checkStartupUsageInBackground)
-                    startup
-                    transition
-                    requestedProvider
-                pure
-                    ( ( fst startupAuth
-                      , snd startupAuth
-                      , accountUsage
-                      )
-                    , Nothing
-                    )
-            (Nothing, Just (connectionId, responses)) -> do
-                token <- case responses.responsesApiKeyEnv of
-                    Nothing
-                        | responses.responsesApiKeyOptional -> pure ""
-                        | otherwise ->
-                            startupDie startup $
-                                "custom connection "
-                                    <> Text.unpack connectionId
-                                    <> " requires api_key_env or api_key_optional=true"
-                    Just envName ->
-                        lookupEnv (Text.unpack envName) >>= \case
-                            Just value
-                                | not (null value) -> pure (Text.pack value)
-                            _
-                                | responses.responsesApiKeyOptional -> pure ""
-                                | otherwise ->
-                                    startupDie startup $
-                                        "custom connection "
-                                            <> Text.unpack connectionId
-                                            <> " requires environment variable "
-                                            <> Text.unpack envName
-                let credential = Credential
-                        { accessToken = token
-                        , accountId = connectionId
-                        , leaseId = Nothing
-                        , provider = OpenRouterProvider
-                        }
-                pure
-                    ( ( LoadedAuth
-                            { loadedProvider = OpenRouterProvider
-                            , loadedTokenProvider =
-                                staticCredentialProvider ApiBilled credential
-                            , loadedAccountLabel = const (pure connectionId)
-                            , loadedSelectionId = Nothing
-                            , loadedOpenAiPool = Nothing
-                            }
-                      , False
-                      , Nothing
-                      )
-                    , if Text.null token then Nothing else Just token
-                    )
-            (Just _, Just _) ->
-                startupDie startup
-                    "gateway and custom connection routing cannot both be active"
-    (loaded, startupAccountIds) <- case customResponses of
-        Just _ -> pure (initialLoaded, Nothing)
+    pure InitializedTargets
+        { initializedGatewayIdentity = connectedGatewayIdentity
+        , initializedTransitionTarget = transitionTarget
+        , initializedConfiguredTarget = configuredOptionTarget
+        , initializedResumedTarget = resumedTarget
+        , initializedProjectTarget = projectTarget
+        , initializedTargetHint = targetHint
+        , initializedRequestedProvider = requestedProvider
+        , initializedCustomResponses = customResponses
+        , initializedCheckStartupUsageInBackground =
+            checkStartupUsageInBackground
+        }
+
+loadInitializedAuth
+    :: InitializedRequest
+    -> InitializedTargets
+    -> IO RoutedStartupAuth
+loadInitializedAuth request targets =
+    case
+        ( request.initializedConnectedGateway
+        , targets.initializedCustomResponses
+        )
+    of
+        (Just gateway, Nothing) -> do
+            mapM_
+                (.retirePreparedStartup)
+                request.initializedPreparedAuth
+            exactLoaded <-
+                either
+                    (startupDie startup . Text.unpack)
+                    pure
+                    (gatewayLoadedAuthForProvider requestedProvider gateway)
+            pure RoutedStartupAuth
+                { routedInitialLoaded = exactLoaded
+                , routedLearnAboutUserRequested = False
+                , routedPreparedAccountUsage = Nothing
+                , routedCustomBearerToken = Nothing
+                }
+        (Nothing, Nothing) -> do
+            (startupAuth, accountUsage) <- loadPreparedOrStartupAuth
+                request.initializedPreparedAuth
+                (options.optYolo
+                    && targets.initializedCheckStartupUsageInBackground)
+                startup
+                request.initializedTransition
+                requestedProvider
+            pure RoutedStartupAuth
+                { routedInitialLoaded = fst startupAuth
+                , routedLearnAboutUserRequested = snd startupAuth
+                , routedPreparedAccountUsage = accountUsage
+                , routedCustomBearerToken = Nothing
+                }
+        (Nothing, Just (connectionId, responses)) -> do
+            (loaded, bearerToken) <-
+                loadCustomResponsesAuth startup connectionId responses
+            pure RoutedStartupAuth
+                { routedInitialLoaded = loaded
+                , routedLearnAboutUserRequested = False
+                , routedPreparedAccountUsage = Nothing
+                , routedCustomBearerToken = bearerToken
+                }
+        (Just _, Just _) ->
+            startupDie startup
+                "gateway and custom connection routing cannot both be active"
+  where
+    startup = request.initializedStartup
+    options = request.initializedOptions
+    requestedProvider = targets.initializedRequestedProvider
+
+loadCustomResponsesAuth
+    :: StartupRuntime
+    -> Text
+    -> ResponsesConnection
+    -> IO (LoadedAuth, Maybe Text)
+loadCustomResponsesAuth startup connectionId responses = do
+    token <- case responses.responsesApiKeyEnv of
         Nothing
-            | not (isGatewayLoadedAuth initialLoaded)
-            , Just active <- transition
-            , Just selectionId <- active.transitionAccountSelectionId ->
-                pure
-                    ( initialLoaded
-                    , Just
-                        ( selectionId
-                        , fromMaybe selectionId active.transitionAccountId
+            | responses.responsesApiKeyOptional -> pure ""
+            | otherwise ->
+                startupDie startup $
+                    "custom connection "
+                        <> Text.unpack connectionId
+                        <> " requires api_key_env or api_key_optional=true"
+        Just envName ->
+            lookupEnv (Text.unpack envName) >>= \case
+                Just value
+                    | not (null value) -> pure (Text.pack value)
+                _
+                    | responses.responsesApiKeyOptional -> pure ""
+                    | otherwise ->
+                        startupDie startup $
+                            "custom connection "
+                                <> Text.unpack connectionId
+                                <> " requires environment variable "
+                                <> Text.unpack envName
+    let credential = Credential
+            { accessToken = token
+            , accountId = connectionId
+            , leaseId = Nothing
+            , provider = OpenRouterProvider
+            }
+        loaded = LoadedAuth
+            { loadedProvider = OpenRouterProvider
+            , loadedTokenProvider =
+                staticCredentialProvider ApiBilled credential
+            , loadedAccountLabel = const (pure connectionId)
+            , loadedSelectionId = Nothing
+            , loadedOpenAiPool = Nothing
+            }
+    pure
+        ( loaded
+        , if Text.null token then Nothing else Just token
+        )
+
+selectInitializedStartupAccount
+    :: InitializedRequest
+    -> InitializedWorkspace
+    -> InitializedTargets
+    -> RoutedStartupAuth
+    -> IO InitializedAuth
+selectInitializedStartupAccount request workspace targets routed = do
+    (loaded, startupAccountIds) <-
+        case targets.initializedCustomResponses of
+            Just _ -> pure (initialLoaded, Nothing)
+            Nothing
+                | not (isGatewayLoadedAuth initialLoaded)
+                , Just active <- request.initializedTransition
+                , Just selectionId <-
+                    active.transitionAccountSelectionId ->
+                    pure
+                        ( initialLoaded
+                        , Just
+                            ( selectionId
+                            , fromMaybe
+                                selectionId
+                                active.transitionAccountId
+                            )
                         )
-                    )
-            | not
-                (loadedAuthSupportsUsageAccountSelection initialLoaded) ->
-                    pure (initialLoaded, Nothing)
-            | checkStartupUsageInBackground
-            , isNothing preparedAccountUsage -> do
-                -- Make the remembered model/account usable immediately. The
-                -- scoped availability worker below checks the account pool
-                -- after the prompt is ready and triggers startup fallback if
-                -- every credential is exhausted.
-                let provider = initialLoaded.loadedProvider
-                case projectAccountFor provider projectSettings of
-                    Nothing -> pure (initialLoaded, Nothing)
-                    Just remembered ->
-                        loadSelectedAccountAuth
-                            provider
-                            remembered.projectAccountSelectionId
-                            remembered.projectAccountId >>= \case
-                                Left _ -> pure (initialLoaded, Nothing)
-                                Right selectedLoaded ->
-                                    pure
-                                        ( selectedLoaded
-                                        , Just
-                                            ( remembered.projectAccountSelectionId
-                                            , remembered.projectAccountId
-                                            )
-                                        )
-            | otherwise -> do
-                let provider = initialLoaded.loadedProvider
-                    rememberedIds = fmap
-                        (\account ->
-                            ( account.projectAccountSelectionId
-                            , account.projectAccountId
-                            ))
-                        (projectAccountFor provider projectSettings)
-                let selectStartupAccount = case preparedAccountUsage of
-                        Just accountUsage ->
-                            pure $ selectPreparedProviderAccount
-                                rememberedIds
-                                accountUsage
-                        Nothing ->
-                            selectProviderAccount
-                                provider
-                                Nothing
-                                rememberedIds
-                selectStartupAccount >>= \case
-                        Left err ->
-                            startupDie startup (Text.unpack err)
-                        Right selected ->
-                            loadSelectedAccountAuth
-                                provider
-                                selected.selectedSelectionId
-                                selected.selectedAccountId
-                                >>= either
-                                    (startupDie startup . Text.unpack)
-                                    (\selectedLoaded ->
-                                        pure
-                                            ( selectedLoaded
-                                            , Just
-                                                ( selected.selectedSelectionId
-                                                , selected.selectedAccountId
-                                                )
-                                            ))
-    when (isJust connectedGateway /= isGatewayLoadedAuth loaded) $
+                | not
+                    (loadedAuthSupportsUsageAccountSelection initialLoaded) ->
+                        pure (initialLoaded, Nothing)
+                | targets.initializedCheckStartupUsageInBackground
+                , isNothing preparedAccountUsage ->
+                    selectRememberedAccount initialLoaded
+                | otherwise ->
+                    selectUsableAccount initialLoaded
+    pure InitializedAuth
+        { initializedLoaded = loaded
+        , initializedLearnAboutUserRequested =
+            routed.routedLearnAboutUserRequested
+        , initializedPreparedAccountUsage = preparedAccountUsage
+        , initializedCustomBearerToken =
+            routed.routedCustomBearerToken
+        , initializedStartupAccountIds = startupAccountIds
+        }
+  where
+    initialLoaded = routed.routedInitialLoaded
+    preparedAccountUsage = routed.routedPreparedAccountUsage
+    projectSettings = workspace.initializedProjectSettings
+    startup = request.initializedStartup
+
+    selectRememberedAccount loaded = do
+        -- Make the remembered model/account usable immediately. The scoped
+        -- availability worker later checks the pool and triggers startup
+        -- fallback if every credential is exhausted.
+        let provider = loaded.loadedProvider
+        case projectAccountFor provider projectSettings of
+            Nothing -> pure (loaded, Nothing)
+            Just remembered ->
+                loadSelectedAccountAuth
+                    provider
+                    remembered.projectAccountSelectionId
+                    remembered.projectAccountId >>= \case
+                        Left _ -> pure (loaded, Nothing)
+                        Right selectedLoaded ->
+                            pure
+                                ( selectedLoaded
+                                , Just
+                                    ( remembered.projectAccountSelectionId
+                                    , remembered.projectAccountId
+                                    )
+                                )
+
+    selectUsableAccount loaded = do
+        let provider = loaded.loadedProvider
+            rememberedIds = fmap
+                (\account ->
+                    ( account.projectAccountSelectionId
+                    , account.projectAccountId
+                    ))
+                (projectAccountFor provider projectSettings)
+            selectStartupAccount = case preparedAccountUsage of
+                Just accountUsage ->
+                    pure $ selectPreparedProviderAccount
+                        rememberedIds
+                        accountUsage
+                Nothing ->
+                    selectProviderAccount
+                        provider
+                        Nothing
+                        rememberedIds
+        selectStartupAccount >>= \case
+            Left err ->
+                startupDie startup (Text.unpack err)
+            Right selected ->
+                loadSelectedAccountAuth
+                    provider
+                    selected.selectedSelectionId
+                    selected.selectedAccountId
+                    >>= either
+                        (startupDie startup . Text.unpack)
+                        (\selectedLoaded ->
+                            pure
+                                ( selectedLoaded
+                                , Just
+                                    ( selected.selectedSelectionId
+                                    , selected.selectedAccountId
+                                    )
+                                ))
+
+validateInitializedAuth
+    :: InitializedRequest
+    -> InitializedTargets
+    -> LoadedAuth
+    -> IO ()
+validateInitializedAuth request targets loaded = do
+    when
+        ( isJust request.initializedConnectedGateway
+            /= isGatewayLoadedAuth loaded
+        ) $
         startupDie startup
             "gateway model routing and loaded credentials disagree; refusing \
             \to start with an unsafe transport configuration"
-    case (transitionTarget, resumed) of
+    case ( targets.initializedTransitionTarget
+        , request.initializedResumed
+        ) of
         (Just target, _)
             | not (isGatewayLoadedAuth loaded)
             , loaded.loadedProvider /= target.targetProvider ->
@@ -694,7 +876,8 @@ runAgentInitializedWithLock
                     <> " but auth resolved "
                     <> Text.unpack (providerSlug loaded.loadedProvider)
         _ -> pure ()
-    case transition >>= (.transitionAutomaticBilling) of
+    case request.initializedTransition
+        >>= (.transitionAutomaticBilling) of
         Just sourceBilling
             | not
                 (allowsAutomaticBillingFallback
@@ -704,10 +887,22 @@ runAgentInitializedWithLock
                     "automatic provider fallback would cross from subscription \
                     \billing to API-credit billing"
         _ -> pure ()
+  where
+    startup = request.initializedStartup
+
+newInitializedAccountRefs
+    :: InitializedRequest
+    -> InitializedAuth
+    -> IO InitializedAccountRefs
+newInitializedAccountRefs request auth = do
+    let loaded = auth.initializedLoaded
+        startupAccountIds = auth.initializedStartupAccountIds
     initialGatewayModels <-
-        loadGatewayModelAccess connectedGateway loaded >>= either
-            (startupDie startup . Text.unpack)
-            pure
+        loadGatewayModelAccess
+            request.initializedConnectedGateway
+            loaded >>= either
+                (startupDie request.initializedStartup . Text.unpack)
+                pure
     gatewayModelsRef <- newIORef initialGatewayModels
     activeAccountRef <- newIORef ""
     activeAccountIdRef <-
@@ -735,10 +930,28 @@ runAgentInitializedWithLock
                     loaded.loadedTokenProvider
         selectableTokenProvider
             | isGatewayLoadedAuth loaded =
-                gatewayRouterTokenProvider unguardedSelectableTokenProvider
+                gatewayRouterTokenProvider
+                    unguardedSelectableTokenProvider
             | otherwise =
                 unguardedSelectableTokenProvider
-    initialHttp <- case customResponses of
+    pure InitializedAccountRefs
+        { initializedGatewayModelsRef = gatewayModelsRef
+        , initializedActiveAccountIdRef = activeAccountIdRef
+        , initializedActiveAccountRef = activeAccountRef
+        , initializedActiveSelectionRef = activeSelectionRef
+        , initializedPreferredOpenAiAccountRef =
+            preferredOpenAiAccountRef
+        , initializedSelectableTokenProvider =
+            selectableTokenProvider
+        }
+
+initializeActiveHttpAuth
+    :: InitializedTargets
+    -> InitializedAuth
+    -> InitializedAccountRefs
+    -> IO (MVar ActiveHttpAuth)
+initializeActiveHttpAuth targets auth refs = do
+    initialHttp <- case targets.initializedCustomResponses of
         Just (connectionId, _) -> do
             writeIORef activeAccountRef connectionId
             pure
@@ -775,7 +988,8 @@ runAgentInitializedWithLock
                                 OpenRouterProvider -> "OpenRouter"
                                 GeminiProvider -> "Google Gemini"
                                 ClaudeCodeProvider -> "Claude Code"
-                            selectionId = fromMaybe "" loaded.loadedSelectionId
+                            selectionId =
+                                fromMaybe "" loaded.loadedSelectionId
                         writeIORef activeAccountRef fallback
                         writeIORef activeSelectionRef selectionId
                         pure
@@ -788,183 +1002,297 @@ runAgentInitializedWithLock
             , initialHttpResolver
             , initialHttpAccountId
             ) = initialHttp
-    activeHttpAuth <- newMVar ActiveHttpAuth
+    newMVar ActiveHttpAuth
         { activeHttpGeneration = 0
         , activeHttpProvider = initialHttpProvider
         , activeHttpResolveLabel = initialHttpResolver
         , activeHttpAccountId = initialHttpAccountId
         }
-    let switchableTokenProvider =
-            Provider.tokenProvider
-                (tokenProviderBillingMode selectableTokenProvider)
-                \failed -> do
-                    snapshot <- readMVar activeHttpAuth
-                    let routedFailure = case failed of
+  where
+    loaded = auth.initializedLoaded
+    activeAccountRef = refs.initializedActiveAccountRef
+    activeAccountIdRef = refs.initializedActiveAccountIdRef
+    activeSelectionRef = refs.initializedActiveSelectionRef
+    selectableTokenProvider =
+        refs.initializedSelectableTokenProvider
+
+makeSwitchableTokenProvider
+    :: InitializedAccountRefs
+    -> MVar ActiveHttpAuth
+    -> TokenProvider
+makeSwitchableTokenProvider refs activeHttpAuth =
+    Provider.tokenProvider
+        (tokenProviderBillingMode selectableTokenProvider)
+        \failed -> do
+            snapshot <- readMVar activeHttpAuth
+            let routedFailure = case failed of
+                    Just reported
+                        | reported.credential.accountId
+                            == snapshot.activeHttpAccountId ->
                             Just reported
-                                | reported.credential.accountId
-                                    == snapshot.activeHttpAccountId ->
-                                    Just reported
-                            _ -> Nothing
-                    getNextToken
-                        snapshot.activeHttpProvider
-                        routedFailure
-                        >>= \case
-                            Left err -> pure (Left err)
-                            Right credential -> do
-                                label <-
-                                    snapshot.activeHttpResolveLabel credential
-                                modifyMVar_ activeHttpAuth \current ->
-                                    if current.activeHttpGeneration
-                                        == snapshot.activeHttpGeneration
-                                        then do
+                    _ -> Nothing
+            getNextToken
+                snapshot.activeHttpProvider
+                routedFailure
+                >>= \case
+                    Left err -> pure (Left err)
+                    Right credential -> do
+                        label <-
+                            snapshot.activeHttpResolveLabel credential
+                        modifyMVar_ activeHttpAuth \current ->
+                            if current.activeHttpGeneration
+                                == snapshot.activeHttpGeneration
+                                then do
+                                    writeIORef
+                                        refs.initializedActiveAccountIdRef
+                                        credential.accountId
+                                    writeIORef
+                                        refs.initializedActiveAccountRef
+                                        label
+                                    pure current
+                                        { activeHttpAccountId =
+                                            credential.accountId
+                                        }
+                                else pure current
+                        pure (Right credential)
+  where
+    selectableTokenProvider =
+        refs.initializedSelectableTokenProvider
+
+resolveInitializedActiveAccountLabel
+    :: LoadedAuth
+    -> MVar ActiveHttpAuth
+    -> Credential
+    -> IO Text
+resolveInitializedActiveAccountLabel loaded activeHttpAuth credential =
+    case loaded.loadedProvider of
+        OpenAIProvider ->
+            loaded.loadedAccountLabel credential
+        _ -> do
+            active <- readMVar activeHttpAuth
+            active.activeHttpResolveLabel credential
+
+selectInitializedHttpAccount
+    :: LoadedAuth
+    -> InitializedAccountRefs
+    -> MVar ActiveHttpAuth
+    -> Text
+    -> IO (Either ApiError Text)
+selectInitializedHttpAccount
+        loaded refs activeHttpAuth selectedSelectionId
+    | isGatewayLoadedAuth loaded =
+        pure $ Left $ CredentialError
+            "Account switching is unavailable while connected to the organization gateway. Disconnect the gateway first."
+    | otherwise =
+        loadAuthForAccount loaded.loadedProvider selectedSelectionId
+            >>= \case
+                Left err ->
+                    pure (Left (CredentialError err))
+                Right selected
+                    | selected.loadedProvider /= loaded.loadedProvider ->
+                        pure $ Left $ CredentialError
+                            "selected account belongs to a different provider"
+                    | tokenProviderBillingMode
+                        selected.loadedTokenProvider
+                        /= tokenProviderBillingMode selectableTokenProvider ->
+                        pure $ Left $ CredentialError
+                            "selected account uses a different billing mode"
+                    | otherwise ->
+                        loadGatewayModelAccess Nothing selected >>= \case
+                            Left err ->
+                                pure (Left (CredentialError err))
+                            Right selectedGatewayModels ->
+                                probeLoadedAuthCredential selected >>= \case
+                                    Left err -> pure (Left err)
+                                    Right (credential, usable) -> do
+                                        label <-
+                                            usable.loadedAccountLabel credential
+                                        when
+                                            (loaded.loadedProvider
+                                                == OpenAIProvider) $
                                             writeIORef
-                                                activeAccountIdRef
+                                                preferredOpenAiAccountRef
+                                                (if selectedSelectionId
+                                                        == gatewayAuthSelectionId
+                                                    then Nothing
+                                                    else
+                                                        Just
+                                                            credential.accountId)
+                                        let selectionId =
+                                                fromMaybe
+                                                    selectedSelectionId
+                                                    usable.loadedSelectionId
+                                        modifyMVar_ activeHttpAuth \current -> do
+                                            writeIORef
+                                                refs.initializedGatewayModelsRef
+                                                selectedGatewayModels
+                                            writeIORef
+                                                refs.initializedActiveAccountIdRef
                                                 credential.accountId
-                                            writeIORef activeAccountRef label
-                                            pure current
-                                                { activeHttpAccountId =
+                                            writeIORef
+                                                refs.initializedActiveSelectionRef
+                                                selectionId
+                                            writeIORef
+                                                refs.initializedActiveAccountRef
+                                                label
+                                            pure ActiveHttpAuth
+                                                { activeHttpGeneration =
+                                                    current.activeHttpGeneration
+                                                        + 1
+                                                , activeHttpProvider =
+                                                    usable.loadedTokenProvider
+                                                , activeHttpResolveLabel =
+                                                    usable.loadedAccountLabel
+                                                , activeHttpAccountId =
                                                     credential.accountId
                                                 }
-                                        else pure current
-                                pure (Right credential)
-        resolveActiveAccountLabel credential =
-            case loaded.loadedProvider of
-                OpenAIProvider ->
-                    loaded.loadedAccountLabel credential
-                _ -> do
-                    active <- readMVar activeHttpAuth
-                    active.activeHttpResolveLabel credential
-        tokenProvider =
-            case loaded.loadedProvider of
-                OpenAIProvider ->
-                    trackCredentialAccount
-                        activeAccountRef
-                        activeAccountIdRef
-                        activeSelectionRef
-                        resolveActiveAccountLabel
-                        selectableTokenProvider
-                _ -> switchableTokenProvider
-        selectHttpAccount selectedSelectionId
-            | isGatewayLoadedAuth loaded =
-                pure $ Left $ CredentialError
-                    "Account switching is unavailable while connected to the organization gateway. Disconnect the gateway first."
-            | otherwise =
-                loadAuthForAccount loaded.loadedProvider selectedSelectionId
-                    >>= \case
-                    Left err ->
-                        pure (Left (CredentialError err))
-                    Right selected
-                        | selected.loadedProvider /= loaded.loadedProvider ->
-                            pure $ Left $ CredentialError
-                                "selected account belongs to a different provider"
-                        | tokenProviderBillingMode
-                            selected.loadedTokenProvider
-                            /= tokenProviderBillingMode
-                                selectableTokenProvider ->
-                            pure $ Left $ CredentialError
-                                "selected account uses a different billing mode"
-                        | otherwise ->
-                            loadGatewayModelAccess Nothing selected >>= \case
-                                Left err ->
-                                    pure (Left (CredentialError err))
-                                Right selectedGatewayModels ->
-                                    probeLoadedAuthCredential selected >>= \case
-                                        Left err -> pure (Left err)
-                                        Right (credential, usable) -> do
-                                            label <-
-                                                usable.loadedAccountLabel
-                                                    credential
-                                            when
-                                                (loaded.loadedProvider
-                                                    == OpenAIProvider) $
-                                                writeIORef
-                                                    preferredOpenAiAccountRef
-                                                    (if selectedSelectionId
-                                                            == gatewayAuthSelectionId
-                                                        then Nothing
-                                                        else
-                                                            Just
-                                                                credential.accountId)
-                                            let selectionId =
-                                                    fromMaybe
-                                                        selectedSelectionId
-                                                        usable.loadedSelectionId
-                                            modifyMVar_
-                                                activeHttpAuth
-                                                \current -> do
-                                                    writeIORef
-                                                        gatewayModelsRef
-                                                        selectedGatewayModels
-                                                    writeIORef
-                                                        activeAccountIdRef
-                                                        credential.accountId
-                                                    writeIORef
-                                                        activeSelectionRef
-                                                        selectionId
-                                                    writeIORef
-                                                        activeAccountRef
-                                                        label
-                                                    pure ActiveHttpAuth
-                                                        { activeHttpGeneration =
-                                                            current.activeHttpGeneration
-                                                                + 1
-                                                        , activeHttpProvider =
-                                                            usable.loadedTokenProvider
-                                                        , activeHttpResolveLabel =
-                                                            usable.loadedAccountLabel
-                                                        , activeHttpAccountId =
-                                                            credential.accountId
-                                                        }
-                                            pure (Right label)
+                                        pure (Right label)
+  where
+    selectableTokenProvider =
+        refs.initializedSelectableTokenProvider
+    preferredOpenAiAccountRef =
+        refs.initializedPreferredOpenAiAccountRef
 
+newInitializedHttpRuntime
+    :: InitializedAuth
+    -> InitializedAccountRefs
+    -> MVar ActiveHttpAuth
+    -> InitializedHttpRuntime
+newInitializedHttpRuntime auth refs activeHttpAuth =
+    InitializedHttpRuntime
+        { initializedResolveActiveAccountLabel =
+            resolveActiveAccountLabel
+        , initializedTokenProvider = tokenProvider
+        , initializedSelectHttpAccount =
+            selectInitializedHttpAccount loaded refs activeHttpAuth
+        }
+  where
+    loaded = auth.initializedLoaded
+    selectableTokenProvider =
+        refs.initializedSelectableTokenProvider
+    resolveActiveAccountLabel =
+        resolveInitializedActiveAccountLabel loaded activeHttpAuth
+    switchableTokenProvider =
+        makeSwitchableTokenProvider refs activeHttpAuth
+    tokenProvider =
+        case loaded.loadedProvider of
+            OpenAIProvider ->
+                trackCredentialAccount
+                    refs.initializedActiveAccountRef
+                    refs.initializedActiveAccountIdRef
+                    refs.initializedActiveSelectionRef
+                    resolveActiveAccountLabel
+                    selectableTokenProvider
+            _ -> switchableTokenProvider
+
+runInitialized :: InitializedRequest -> IO RunResult
+runInitialized request = do
+    workspace <- prepareInitializedWorkspace request
+    targets <- resolveInitializedTargets request workspace
+    routedAuth <- loadInitializedAuth request targets
+    initializedAuth <-
+        selectInitializedStartupAccount
+            request
+            workspace
+            targets
+            routedAuth
+    validateInitializedAuth
+        request
+        targets
+        initializedAuth.initializedLoaded
+    accountRefs <- newInitializedAccountRefs request initializedAuth
+    activeHttpAuth <-
+        initializeActiveHttpAuth
+            targets
+            initializedAuth
+            accountRefs
+    let httpRuntime =
+            newInitializedHttpRuntime
+                initializedAuth
+                accountRefs
+                activeHttpAuth
+    launchInitializedTools
+        request
+        workspace
+        targets
+        initializedAuth
+        accountRefs
+        httpRuntime
+
+launchInitializedTools
+    :: InitializedRequest
+    -> InitializedWorkspace
+    -> InitializedTargets
+    -> InitializedAuth
+    -> InitializedAccountRefs
+    -> InitializedHttpRuntime
+    -> IO RunResult
+launchInitializedTools request workspace targets auth refs httpRuntime =
     runAgentTools
-        runAgentChild
-        loaded
-        connectedGateway
-        learnAboutUserRequested
-        customBearerToken
-        activeAccountIdRef
-        activeAccountRef
-        activeSelectionRef
-        baseToolEnv
-        catalog
-        gatewayModelsRef
-        connectedGatewayIdentity
-        (checkStartupUsageInBackground && isNothing preparedAccountUsage)
-        configuredOptionTarget
-        customResponses
-        cwd
-        databaseScopes
-        escPaused
+        request.initializedRunAgentChild
+        auth.initializedLoaded
+        request.initializedConnectedGateway
+        auth.initializedLearnAboutUserRequested
+        auth.initializedCustomBearerToken
+        refs.initializedActiveAccountIdRef
+        refs.initializedActiveAccountRef
+        refs.initializedActiveSelectionRef
+        startup.startupToolEnv
+        workspace.initializedCatalog
+        refs.initializedGatewayModelsRef
+        targets.initializedGatewayIdentity
+        ( targets.initializedCheckStartupUsageInBackground
+            && isNothing auth.initializedPreparedAccountUsage
+        )
+        targets.initializedConfiguredTarget
+        targets.initializedCustomResponses
+        request.initializedCwd
+        workspace.initializedDatabaseScopes
+        startup.startupEscPaused
         fullscreen
-        home
-        interrupt
-        isTty
-        mcpSupervisor
-        options
+        request.initializedHome
+        startup.startupInterrupt
+        startup.startupStdinTty
+        request.initializedProcessRuntime.processMcpSupervisor
+        request.initializedOptions
         pendingTurn
-        preferredOpenAiAccountRef
-        processRuntime
-        projectRoot
-        projectSettings
-        projectTarget
-        resolveActiveAccountLabel
-        resumeLock
-        resumed
-        resumedTarget
-        root
-        selectHttpAccount
-        selectableTokenProvider
+        refs.initializedPreferredOpenAiAccountRef
+        request.initializedProcessRuntime
+        workspace.initializedProjectRoot
+        workspace.initializedProjectSettings
+        targets.initializedProjectTarget
+        httpRuntime.initializedResolveActiveAccountLabel
+        request.initializedResumeLock
+        request.initializedResumed
+        targets.initializedResumedTarget
+        request.initializedRoot
+        httpRuntime.initializedSelectHttpAccount
+        refs.initializedSelectableTokenProvider
         setWindowTitle
         startup
-        stateDirectory
-        stderrHandle
-        targetHint
-        tokenProvider
+        workspace.initializedStateDirectory
+        startup.startupStderr
+        targets.initializedTargetHint
+        httpRuntime.initializedTokenProvider
         transition
-        transitionTarget
-        uiRuntimeRef
+        targets.initializedTransitionTarget
+        startup.startupUiRuntimeRef
         unavailableProviders
+  where
+    startup = request.initializedStartup
+    fullscreen = startup.startupFullscreen
+    transition = request.initializedTransition
+    pendingTurn = transition >>= (.transitionPendingTurn)
+    unavailableProviders =
+        maybe Set.empty (.transitionUnavailableProviders) transition
+    setWindowTitle title =
+        case fullscreen of
+            Just runtime -> setFullscreenWindowTitle runtime title
+            Nothing ->
+                setCliWindowTitle
+                    startup.startupStdoutTty
+                    startup.startupStdout
+                    title
 
 loadPreparedOrStartupAuth
     :: Maybe PreparedStartupAuthWorker


### PR DESCRIPTION
## Summary
- replace the monolithic initialized-runtime body with typed workspace, target, authentication, account, and HTTP-runtime phases
- isolate resume-boundary publication, startup account selection, credential validation, and switchable token state
- preserve concurrent startup loading, prepared-auth retirement, generation checks, callback write order, and final tool-launch wiring

## Validation
- `cabal repl agent-cli:lib:agent-cli` (`Agent.CLI.Runtime.Orchestration.Initialized`, 200 modules loaded)
- focused object-code specs covering account pools/selection, gateway routing, usage availability, provider fallback/transitions, resume boundaries, project settings, and managed agent sessions
- 112 examples, 0 failures
- `git diff --check`
- independent behavior-preservation review: no issues found