### PR TITLE
Allow resuming sessions across gateway routes

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayBoundary.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayBoundary.hs
@@ -100,11 +100,10 @@ validateGatewayBoundary expected current
     | gatewayBoundariesMatch expected current = Right ()
     | otherwise = Left GatewayBoundaryChanged
 
--- | Validate persisted session routing metadata against the current boundary.
+-- | Admit persisted session history at the current boundary.
 --
--- This preserves the stricter distinction between a direct connection,
--- a gateway connection without legacy identity binding, and an exact gateway
--- credential identity.
+-- Session history is portable across direct and gateway routes. Startup
+-- retargets the resumed session before making another provider request.
 validateGatewaySessionBoundary
     :: GatewayBoundary
     -> Text

--- a/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
@@ -174,10 +174,9 @@ resolveSavedModelTarget
         , targetDialect = dialect
         }
 
--- | Keep direct-provider and organization-gateway sessions on their
--- respective routes. Gateway credentials are deliberately interchangeable
--- here: locally owned conversation history remains resumable after credential
--- rotation or when the user connects another organization gateway.
+-- | Persisted conversation history is portable across routing modes. Startup
+-- retargets a resumed session to the currently active direct or organization
+-- gateway route before the next turn.
 validateResumedGatewayBoundary
     :: Maybe Text
     -- ^ Identity of the currently connected gateway credential.
@@ -186,25 +185,7 @@ validateResumedGatewayBoundary
     -> Maybe Text
     -- ^ Persisted gateway identity.
     -> Either Text ()
-validateResumedGatewayBoundary currentIdentity connection savedIdentity =
-    case currentIdentity of
-        Nothing
-            | connection == organizationGatewayConnectionId ->
-                Left
-                    "This session belongs to an organization gateway. \
-                    \Reconnect the same gateway before resuming it."
-            | savedIdentity /= Nothing ->
-                Left
-                    "This session has inconsistent organization gateway \
-                    \routing metadata and cannot be resumed."
-            | otherwise -> Right ()
-        Just _
-            | connection /= organizationGatewayConnectionId ->
-                Left
-                    "This session was created outside the connected \
-                    \organization gateway. Start a new session or disconnect \
-                    \the gateway before resuming it."
-            | otherwise -> Right ()
+validateResumedGatewayBoundary _ _ _ = Right ()
 
 catalogModelIds :: ModelCatalog -> [Text]
 catalogModelIds =

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayBoundarySpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayBoundarySpec.hs
@@ -48,7 +48,7 @@ spec = describe "GatewayBoundary" do
         firstBoundary `shouldNotBe` replacementBoundary
         gatewayBoundariesMatch firstBoundary firstBoundary `shouldBe` True
 
-    it "keeps persisted sessions route-bound across gateway credentials" do
+    it "allows persisted sessions to move across gateway routes" do
         let credential = testCredential "secret"
             replacement = testCredential "replacement-secret"
             boundary = gatewayBoundaryFromCredential (Just credential)
@@ -69,7 +69,7 @@ spec = describe "GatewayBoundary" do
             (gatewayBoundaryFromCredential Nothing)
             organizationGatewayConnectionId
             identity
-            `shouldSatisfy` isSessionRejection
+            `shouldBe` Right ()
 
     it "rejects stale turn admission without executing the turn" $
         withTempHome \home -> do
@@ -155,11 +155,6 @@ spec = describe "GatewayBoundary" do
                 (writeIORef emitted True)
                 `shouldReturn` Left GatewayBoundaryChanged
             readIORef emitted `shouldReturn` False
-
-isSessionRejection :: Either GatewayBoundaryError () -> Bool
-isSessionRejection = \case
-    Left (GatewayBoundarySessionRejected _) -> True
-    _ -> False
 
 testCredential :: String -> GatewayCredential
 testCredential secret =

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -21,7 +21,6 @@ import Agent.Provider (Provider(..))
 import Control.Exception.Safe (bracket)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as LBS8
-import Data.Either (isLeft)
 import Data.List (find, nub)
 import Data.Maybe (fromMaybe, listToMaybe)
 import qualified Data.Text as Text
@@ -241,7 +240,7 @@ spec = do
                         "saved model organization-gateway/company-private requires an active organization gateway"
 
         describe "validateResumedGatewayBoundary" do
-            it "allows sessions that stay on their original routing boundary" do
+            it "allows resume across direct and gateway routing modes" do
                 validateResumedGatewayBoundary
                     Nothing
                     "local-openai"
@@ -252,15 +251,11 @@ spec = do
                     organizationGatewayConnectionId
                     (Just "gateway-a")
                     `shouldBe` Right ()
-
-            it "rejects local sessions entering a gateway" do
                 validateResumedGatewayBoundary
                     (Just "gateway-a")
                     "local-openai"
                     Nothing
-                    `shouldSatisfy` isLeft
-
-            it "allows gateway sessions across credentials and legacy metadata" do
+                    `shouldBe` Right ()
                 validateResumedGatewayBoundary
                     (Just "gateway-a")
                     organizationGatewayConnectionId
@@ -271,18 +266,16 @@ spec = do
                     organizationGatewayConnectionId
                     (Just "gateway-a")
                     `shouldBe` Right ()
-
-            it "rejects gateway sessions while disconnected" do
                 validateResumedGatewayBoundary
                     Nothing
                     organizationGatewayConnectionId
                     (Just "gateway-a")
-                    `shouldSatisfy` isLeft
+                    `shouldBe` Right ()
                 validateResumedGatewayBoundary
                     Nothing
                     "local-openai"
                     (Just "gateway-a")
-                    `shouldSatisfy` isLeft
+                    `shouldBe` Right ()
 
         it "loads only valid gateway-scoped alias metadata" do
             defaults <- readPackagedDefaults

--- a/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
@@ -1,7 +1,8 @@
 -- | Load the authoritative model options exposed by a connected organization
 -- gateway for native clients that do not own a long-running CLI session.
 module Agent.CLI.GatewayModels
-    ( loadGatewayModelOptionsAt
+    ( gatewayProviderForStartup
+    , loadGatewayModelOptionsAt
     , loadGatewayModelOptionsWithCredentialAt
     , modelOptionsForGatewayModels
     , modelOptionsForGatewayState
@@ -21,14 +22,28 @@ import Agent.CLI.ModelConfig
     )
 import Agent.CLI.Models
     ( ModelOption
+    , ModelTarget(targetProvider)
     , gatewayModelOptions
     , modelCatalog
     )
 import Agent.Provider
     ( Provider (ClaudeCodeProvider, OpenAIProvider) )
+import Control.Applicative ((<|>))
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import System.OsPath (OsPath)
+
+gatewayProviderForStartup
+    :: Maybe ModelTarget
+    -> Maybe Provider
+    -> Maybe Provider
+    -> Provider
+gatewayProviderForStartup targetHint requestedProvider resumedProvider =
+    fromMaybe OpenAIProvider $
+        (.targetProvider) <$> targetHint
+            <|> requestedProvider
+            <|> resumedProvider
 
 loadGatewayModelOptionsAt
     :: OsPath

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -157,8 +157,8 @@ resumeEntriesFrom = map (uncurry entryFrom)
 resumeEntryFromMeta :: SessionMeta -> ResumeEntry
 resumeEntryFromMeta meta = entryFromWith False meta []
 
--- | Keep the resume surface on the same direct/gateway route as the active
--- session. Gateway sessions remain portable across gateway credentials.
+-- | Conversation history is portable across direct and gateway routes. The
+-- selected session is retargeted to the active route during startup.
 filterResumeSessionsForBoundary
     :: Maybe Text
     -> [SessionMeta]
@@ -169,8 +169,8 @@ filterResumeSessionsForBoundary gatewayIdentity =
             Right () -> True
             Left _ -> False
 
--- | Validate loaded resume metadata before any of its cwd, repository, model,
--- or transcript state is allowed to reach startup surfaces.
+-- | Apply the resume admission policy before loaded metadata reaches startup
+-- surfaces.
 validateResumeMetaForBoundary
     :: Maybe Text
     -> SessionMeta
@@ -181,9 +181,8 @@ validateResumeMetaForBoundary gatewayIdentity meta =
         meta.metaConnection
         meta.metaGatewayIdentity
 
--- | Keep transcript publication behind the same route validation used by
--- startup. In particular, a fullscreen resume must not enqueue direct-provider
--- history into a gateway-routed session (or vice versa).
+-- | Keep transcript publication behind the same admission hook used by
+-- startup.
 publishResumeHistoryAfterBoundary
     :: Either Text ()
     -> IO ()

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -46,6 +46,7 @@ import Agent.CLI.GatewayClient
     , newGatewayModelAccess
     , refreshGatewayModels
     )
+import Agent.CLI.GatewayModels (gatewayProviderForStartup)
 import Agent.CLI.GatewayBridge ()
 import Agent.CLI.Input ()
 import Agent.CLI.Interrupt ()
@@ -511,7 +512,11 @@ runAgentInitializedWithLock
                     else Nothing
         requestedProvider
             | isJust connectedGateway =
-                options.optProvider <|> Just OpenAIProvider
+                Just $
+                    gatewayProviderForStartup
+                        targetHint
+                        options.optProvider
+                        ((.metaProvider) . fst <$> resumed)
             | otherwise =
                 (.targetProvider) <$> targetHint
                     <|> options.optProvider

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -434,6 +434,16 @@ runAgentInitializedWithLock
                 Right Nothing
             | otherwise = case fst <$> resumed of
             Nothing -> Right Nothing
+            Just meta
+                | isNothing connectedGateway
+                , meta.metaConnection == organizationGatewayConnectionId ->
+                    Right $
+                        case resolveConfiguredModel catalog meta.metaModel of
+                            Just option
+                                | option.modelTarget.targetConnectionId
+                                    /= organizationGatewayConnectionId ->
+                                    Just option.modelTarget
+                            _ -> Nothing
             Just meta ->
                 Just <$> resolveSavedModelTarget
                     catalog
@@ -505,6 +515,7 @@ runAgentInitializedWithLock
             | otherwise =
                 (.targetProvider) <$> targetHint
                     <|> options.optProvider
+                    <|> ((.metaProvider) . fst <$> resumed)
                     <|> if isNothing options.optModel
                         then projectModelProvider projectSettings
                         else Nothing
@@ -684,13 +695,6 @@ runAgentInitializedWithLock
             , loaded.loadedProvider /= target.targetProvider ->
                 startupDie startup $ "provider transition requested "
                     <> Text.unpack (providerSlug target.targetProvider)
-                    <> " but auth resolved "
-                    <> Text.unpack (providerSlug loaded.loadedProvider)
-        (Nothing, Just (meta, _))
-            | not (isGatewayLoadedAuth loaded)
-            , loaded.loadedProvider /= meta.metaProvider ->
-                startupDie startup $ "session provider is "
-                    <> Text.unpack (providerSlug meta.metaProvider)
                     <> " but auth resolved "
                     <> Text.unpack (providerSlug loaded.loadedProvider)
         _ -> pure ()

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Persistence.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Persistence.hs
@@ -72,6 +72,7 @@ preparePersistence
                 metadataChanged =
                     retargetResumed
                         && ( targetChanged
+                            || meta.metaGatewayIdentity /= gatewayIdentity
                             || meta.metaTransportModel
                                 /= Just target.targetWireModelId
                             || isNothing meta.metaLegacySubagentTarget
@@ -81,6 +82,7 @@ preparePersistence
                         meta
                             { metaProvider = target.targetProvider
                             , metaConnection = target.targetConnectionId
+                            , metaGatewayIdentity = gatewayIdentity
                             , metaModel = target.targetModelId
                             , metaTransportModel =
                                 Just target.targetWireModelId

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -251,7 +251,7 @@ spec = describe "Agent.CLI.AgentSessions" do
             selfResult `shouldSatisfy`
                 Text.isInfixOf "cannot message the current agent session"
 
-    it "keeps gateway sessions private from direct mode but portable across gateways" $
+    it "keeps persisted gateway sessions portable across direct and gateway modes" $
         withTempEnv \env launched -> do
             let gatewayCreate =
                     (testCreate env.toolsPool env.toolsRoot)
@@ -299,7 +299,11 @@ spec = describe "Agent.CLI.AgentSessions" do
                         }
             directRead <- runTool env "read_agent_session" payload
             directRead `shouldSatisfy`
-                Text.isInfixOf "Reconnect the same gateway"
+                Text.isInfixOf "tenant A secret"
+            directSend <-
+                runTool env "send_agent_session_message" messagePayload
+            directSend `shouldSatisfy`
+                Text.isInfixOf "Status: running"
             otherRead <- runTool otherGateway "read_agent_session" payload
             otherRead `shouldSatisfy`
                 Text.isInfixOf "tenant A secret"
@@ -307,10 +311,14 @@ spec = describe "Agent.CLI.AgentSessions" do
                 runTool otherGateway "send_agent_session_message" messagePayload
             otherSend `shouldSatisfy`
                 Text.isInfixOf "Status: running"
-            [(launchedHandle, message)] <- readIORef launched
-            launchedHandle.sessionMeta.metaId
+            [(directHandle, directMessage), (gatewayHandle, gatewayMessage)] <-
+                readIORef launched
+            directHandle.sessionMeta.metaId
                 `shouldBe` handle.sessionMeta.metaId
-            message `shouldBe` "continue"
+            directMessage `shouldBe` "continue"
+            gatewayHandle.sessionMeta.metaId
+                `shouldBe` handle.sessionMeta.metaId
+            gatewayMessage `shouldBe` "continue"
             sameRead <- runTool sameGateway "read_agent_session" payload
             sameRead `shouldSatisfy` Text.isInfixOf "tenant A secret"
 

--- a/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
@@ -54,6 +54,24 @@ spec = describe "Agent.CLI.GatewayModels" do
         map (.modelTarget.targetDialect) options
             `shouldBe` [GenericResponsesDialect, ClaudeCodeDialect]
 
+    it "aligns gateway auth with a resumed Claude model target" do
+        let options =
+                modelOptionsForGatewayModels
+                    testCatalog
+                    [GatewayModel "sonnet" GatewayAnthropicProtocol]
+        case options of
+            [option] ->
+                gatewayProviderForStartup
+                    (Just option.modelTarget)
+                    Nothing
+                    (Just OpenAIProvider)
+                    `shouldBe` ClaudeCodeProvider
+            _ -> expectationFailure "expected one Claude gateway model"
+
+    it "defaults gateway auth to OpenAI without a target or provider hint" $
+        gatewayProviderForStartup Nothing Nothing Nothing
+            `shouldBe` OpenAIProvider
+
 testCatalog :: ModelCatalog
 testCatalog =
     ModelCatalog

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -110,17 +110,17 @@ spec = do
                 , legacyGateway
                 ]
 
-        it "offers direct sessions only while disconnected" do
+        it "offers every session while disconnected" do
             map (.metaId)
                 (filterResumeSessionsForBoundary Nothing sessions)
-                `shouldBe` ["direct"]
+                `shouldBe` ["direct", "allowed", "other", "legacy"]
 
-        it "offers sessions from every gateway credential" do
+        it "offers every session while connected to a gateway" do
             map (.metaId)
                 (filterResumeSessionsForBoundary
                     (Just "gateway-a")
                     sessions)
-                `shouldBe` ["allowed", "other", "legacy"]
+                `shouldBe` ["direct", "allowed", "other", "legacy"]
 
         it "allows resume metadata from another gateway credential" do
             validateResumeMetaForBoundary


### PR DESCRIPTION
## Summary
- allow locally persisted sessions to resume across direct and organization-gateway routes
- retarget resumed sessions to the active route and refresh persisted routing metadata
- expose all local sessions in the resume picker while keeping live turns bound to the current gateway state

## Testing
- `nix develop -c cabal repl agent-cli-runtime:test:agent-cli-runtime-test` (focused gateway-resume tests: 2 examples, 0 failures)
- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code` (focused resume-picker tests: 3 examples, 0 failures)