### PR TITLE
Preload skills during workspace startup

### DIFF
--- a/packages/agent-cli/benchmark/Concurrency.hs
+++ b/packages/agent-cli/benchmark/Concurrency.hs
@@ -2,14 +2,17 @@ module Main (main) where
 
 import Agent.CLI.Dialects (CodingTools(..), codingToolsFor)
 import Agent.CLI.Options (defaultCliOptions)
-import Agent.CLI.Skills (loadSkillsCatalogQuiet)
-import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.CLI.PendingInputs
     ( PendingInputs
     , enqueuePendingInput
     , newPendingInputs
     , withPendingInputs
     )
+import Agent.CLI.ModelConfig (loadModelCatalogAt)
+import Agent.CLI.Project (loadProjectSettings, loadUserSettings)
+import Agent.CLI.Session.History (detectGitBranch)
+import Agent.CLI.Skills (loadSkillsCatalogQuiet)
+import Agent.Concurrent (mapConcurrentlyBounded)
 import Agent.Dialect (DialectId(CodexDialect), dialectForId)
 import Agent.Loop
     ( Backend(..)
@@ -25,23 +28,23 @@ import Agent.MCP
     , McpProtocolPreference(..)
     , McpServerConfig(..)
     , McpSupervisor
-    , acquireMcpFleetWithProgress
+    , acquireMcpFleet
+    , acquireMcpFleetProgressive
     , closeMcpSupervisor
+    , mcpFleetStatuses
     , mcpFleetTools
     , newMcpSupervisor
     , releaseMcpFleetLease
     )
 import Agent.ResourceScope
-    ( ResourceKey
-    , allocateResource
+    ( allocateResource
     , allocateResourcesConcurrently
-    , releaseResource
     , withResourceScope
     )
 import Agent.Skills (Skill(..), SkillCatalog(..))
 import Agent.Tools.Types (ToolEnv, defaultToolEnv)
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (poll, withAsync)
+import Control.Concurrent.Async (concurrently, poll, withAsync)
 import Control.Exception.Safe
     ( SomeException
     , bracket
@@ -50,10 +53,10 @@ import Control.Exception.Safe
     , onException
     )
 import qualified Control.Exception.Safe as Exception
-import Control.Monad (forM_, unless, when)
+import Control.Monad (forM, forM_, unless, when)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
-import Data.Char (ord)
+import Data.Char (isDigit, isSpace, ord)
 import Data.IORef
     ( IORef
     , atomicModifyIORef'
@@ -99,6 +102,11 @@ data LocalToolStartup = LocalToolStartup
     , localSkills :: !SkillCatalog
     }
 
+data ToolStartupStrategy
+    = StartupSerial
+    | StartupParentFullOverlap
+    | StartupPreloadSkills
+
 main :: IO ()
 main = do
     args <- getArgs
@@ -125,14 +133,28 @@ main = do
                 (read samples)
         ["startup-tools-serial", servers, mcpDelayMillis, skills, samples] ->
             benchmarkStartupTools
-                False
+                StartupSerial
                 (read servers)
                 (read mcpDelayMillis)
                 (read skills)
                 (read samples)
-        ["startup-tools-overlap", servers, mcpDelayMillis, skills, samples] ->
+        ["startup-tools-parent", servers, mcpDelayMillis, skills, samples] ->
             benchmarkStartupTools
-                True
+                StartupParentFullOverlap
+                (read servers)
+                (read mcpDelayMillis)
+                (read skills)
+                (read samples)
+        ["startup-tools-preload-skills",
+            servers, mcpDelayMillis, skills, samples] ->
+            benchmarkStartupTools
+                StartupPreloadSkills
+                (read servers)
+                (read mcpDelayMillis)
+                (read skills)
+                (read samples)
+        ["startup-tools-paired", servers, mcpDelayMillis, skills, samples] ->
+            benchmarkStartupToolsPaired
                 (read servers)
                 (read mcpDelayMillis)
                 (read skills)
@@ -234,16 +256,17 @@ overlapStartup worktreeMillis accountMillis =
                 Just (Left err) -> Exception.throwIO err
                 Just (Right accountResult) -> pure (1 + accountResult)
 
-benchmarkStartupTools :: Bool -> Int -> Int -> Int -> Int -> IO ()
 benchmarkStartupTools
-        useOverlap serverCount mcpDelayMillis skillCount sampleCount = do
+    :: ToolStartupStrategy -> Int -> Int -> Int -> Int -> IO ()
+benchmarkStartupTools
+        strategy serverCount mcpDelayMillis skillCount sampleCount = do
     statsEnabled <- getRTSStatsEnabled
     when (not statsEnabled) $
         fail "run with +RTS -T"
     executable <- getExecutablePath
-    let normalizedServers = max 1 serverCount
+    let normalizedServers = max 0 serverCount
         normalizedDelay = max 0 mcpDelayMillis
-        normalizedSkills = max 1 skillCount
+        normalizedSkills = max 0 skillCount
         normalizedSamples = max 1 sampleCount
     withToolStartupFixture
         executable
@@ -251,22 +274,24 @@ benchmarkStartupTools
         normalizedDelay
         normalizedSkills
         \fixture -> do
-            serialChecksum <- runToolStartup False fixture
-            overlapChecksum <- runToolStartup True fixture
-            when (serialChecksum /= overlapChecksum) $
+            validateMcpFixture fixture
+            serialChecksum <- runToolStartup StartupSerial fixture
+            selectedChecksum <- runToolStartup strategy fixture
+            when (serialChecksum /= selectedChecksum) $
                 fail "startup tool implementations disagree on checksum"
-            let label =
-                    if useOverlap
-                        then "startup-tools-overlap"
-                        else "startup-tools-serial"
+            let label = case strategy of
+                    StartupSerial -> "startup-tools-serial"
+                    StartupParentFullOverlap -> "startup-tools-parent"
+                    StartupPreloadSkills -> "startup-tools-preload-skills"
             samples <-
                 mapM
-                    (const (measureToolStartup useOverlap fixture))
+                    (const (measureToolStartup strategy fixture))
                     [1 .. normalizedSamples]
             let sample = medianSample samples
             putStrLn
                 ( label
-                    <> " servers=" <> show normalizedServers
+                    <> " mcp-mode=progressive"
+                    <> " mcp-servers=" <> show normalizedServers
                     <> " mcp-delay-ms=" <> show normalizedDelay
                     <> " skills=" <> show normalizedSkills
                     <> " samples=" <> show normalizedSamples
@@ -275,110 +300,234 @@ benchmarkStartupTools
                     <> " allocated-bytes=" <> show sample.sampleAllocatedBytes
                 )
 
-runToolStartup :: Bool -> ToolStartupFixture -> IO Int
-runToolStartup useOverlap fixture = do
+benchmarkStartupToolsPaired :: Int -> Int -> Int -> Int -> IO ()
+benchmarkStartupToolsPaired
+        serverCount mcpDelayMillis skillCount sampleCount = do
+    statsEnabled <- getRTSStatsEnabled
+    when (not statsEnabled) $
+        fail "run with +RTS -T"
+    executable <- getExecutablePath
+    let normalizedServers = max 0 serverCount
+        normalizedDelay = max 0 mcpDelayMillis
+        normalizedSkills = max 0 skillCount
+        normalizedSamples = max 1 sampleCount
+    withToolStartupFixture
+        executable
+        normalizedServers
+        normalizedDelay
+        normalizedSkills
+        \fixture -> do
+            validateMcpFixture fixture
+            parentChecksum <-
+                runToolStartup StartupParentFullOverlap fixture
+            currentChecksum <- runToolStartup StartupPreloadSkills fixture
+            when (parentChecksum /= currentChecksum) $
+                fail "startup tool implementations disagree on checksum"
+            pairedSamples <-
+                forM [1 .. normalizedSamples] \index ->
+                    if odd index
+                        then do
+                            parentSample <-
+                                measureToolStartup
+                                    StartupParentFullOverlap
+                                    fixture
+                            currentSample <-
+                                measureToolStartup StartupPreloadSkills fixture
+                            pure (parentSample, currentSample)
+                        else do
+                            currentSample <-
+                                measureToolStartup StartupPreloadSkills fixture
+                            parentSample <-
+                                measureToolStartup
+                                    StartupParentFullOverlap
+                                    fixture
+                            pure (parentSample, currentSample)
+            let parentSample = medianSample (map fst pairedSamples)
+                currentSample = medianSample (map snd pairedSamples)
+                elapsedDelta =
+                    median
+                        [ current.sampleElapsedMillis
+                            - parent.sampleElapsedMillis
+                        | (parent, current) <- pairedSamples
+                        ]
+                cpuDelta =
+                    median
+                        [ current.sampleCpuMillis - parent.sampleCpuMillis
+                        | (parent, current) <- pairedSamples
+                        ]
+                allocationDelta =
+                    median
+                        [ toInteger current.sampleAllocatedBytes
+                            - toInteger parent.sampleAllocatedBytes
+                        | (parent, current) <- pairedSamples
+                        ]
+                printSample label sample =
+                    putStrLn
+                        ( label
+                            <> " mcp-mode=progressive"
+                            <> " pairing=alternating"
+                            <> " mcp-servers=" <> show normalizedServers
+                            <> " mcp-delay-ms=" <> show normalizedDelay
+                            <> " skills=" <> show normalizedSkills
+                            <> " samples=" <> show normalizedSamples
+                            <> " elapsed-ms="
+                            <> show sample.sampleElapsedMillis
+                            <> " cpu-ms=" <> show sample.sampleCpuMillis
+                            <> " allocated-bytes="
+                            <> show sample.sampleAllocatedBytes
+                        )
+            printSample "startup-tools-paired-parent" parentSample
+            printSample "startup-tools-paired-current" currentSample
+            putStrLn
+                ( "startup-tools-paired-delta"
+                    <> " mcp-mode=progressive"
+                    <> " pairing=alternating"
+                    <> " mcp-servers=" <> show normalizedServers
+                    <> " mcp-delay-ms=" <> show normalizedDelay
+                    <> " skills=" <> show normalizedSkills
+                    <> " samples=" <> show normalizedSamples
+                    <> " elapsed-ms=" <> show elapsedDelta
+                    <> " cpu-ms=" <> show cpuDelta
+                    <> " allocated-bytes=" <> show allocationDelta
+                )
+
+runToolStartup :: ToolStartupStrategy -> ToolStartupFixture -> IO Int
+runToolStartup strategy fixture = do
     toolEnv <- defaultToolEnv fixture.fixtureProject
     mcpReleases <- newIORef (0 :: Int)
     localReleases <- newIORef (0 :: Int)
     bracket newMcpSupervisor closeMcpSupervisor \supervisor ->
         runToolStartupWithSupervisor
-            useOverlap
+            strategy
             fixture
             supervisor
             toolEnv
             mcpReleases
             localReleases
+            (toolStartupChecksum fixture)
 
-measureToolStartup :: Bool -> ToolStartupFixture -> IO Sample
-measureToolStartup useOverlap fixture = do
+measureToolStartup :: ToolStartupStrategy -> ToolStartupFixture -> IO Sample
+measureToolStartup strategy fixture = do
     toolEnv <- defaultToolEnv fixture.fixtureProject
     mcpReleases <- newIORef (0 :: Int)
     localReleases <- newIORef (0 :: Int)
+    performMajorGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
     bracket newMcpSupervisor closeMcpSupervisor \supervisor ->
-        measure
-            (runToolStartupWithSupervisor
-                useOverlap
+        runToolStartupWithSupervisor
+                strategy
                 fixture
                 supervisor
                 toolEnv
                 mcpReleases
-                localReleases)
+                localReleases
+                \mcpLease local -> do
+                    checksum <- toolStartupChecksum fixture mcpLease local
+                    checksum `seq` pure ()
+                    afterElapsed <- getMonotonicTimeNSec
+                    afterCpu <- getCPUTime
+                    -- allocated_bytes is only current after a GC. Capture
+                    -- prompt-ready latency and CPU first so this accounting
+                    -- barrier and resource cleanup stay outside that interval.
+                    performMajorGC
+                    afterStats <- getRTSStats
+                    pure Sample
+                        { sampleElapsedMillis =
+                            fromIntegral (afterElapsed - beforeElapsed)
+                                / 1_000_000
+                        , sampleCpuMillis =
+                            fromIntegral (afterCpu - beforeCpu)
+                                / 1_000_000_000
+                        , sampleAllocatedBytes =
+                            fromIntegral
+                                (allocated_bytes afterStats
+                                    - allocated_bytes beforeStats)
+                        }
 
 runToolStartupWithSupervisor
-    :: Bool
+    :: ToolStartupStrategy
     -> ToolStartupFixture
     -> McpSupervisor
     -> ToolEnv
     -> IORef Int
     -> IORef Int
-    -> IO Int
+    -> (McpFleetLease -> LocalToolStartup -> IO a)
+    -> IO a
 runToolStartupWithSupervisor
-        useOverlap fixture supervisor toolEnv mcpReleases localReleases = do
+        strategy fixture supervisor toolEnv mcpReleases localReleases
+        continuation = do
     let acquireMcp =
-            acquireMcpFleetWithProgress
+            acquireMcpFleetProgressive
                 supervisor
                 (const (pure ()))
                 fixture.fixtureMcpConfigs
         releaseMcp lease =
             releaseMcpFleetLease lease
                 `finally` noteRelease mcpReleases
-        acquireLocal = acquireLocalToolStartup fixture toolEnv
+        acquireLocalWith skills =
+            acquireLocalToolStartupWith toolEnv skills
+        loadSkills =
+            loadSkillsCatalogQuiet
+                defaultCliOptions
+                fixture.fixtureHome
+                fixture.fixtureProject
+                fixture.fixtureProject
+        acquireLocal = acquireLocalWith loadSkills
         releaseLocal local =
             releaseLocalToolStartup local
                 `finally` noteRelease localReleases
-    checksum <-
-        if useOverlap
-            then
-                -- Mirrors the scoped MCP/local acquisition block in
-                -- runAgentToolsRequest, including its early close actions.
-                withResourceScope \resourceScope -> do
-                    (mcpResource, localResource) <-
-                        allocateResourcesConcurrently
-                            resourceScope
-                            acquireMcp
-                            releaseMcp
-                            acquireLocal
-                            releaseLocal
-                    consumeToolStartupResources
-                        fixture
-                        mcpReleases
-                        localReleases
-                        mcpResource
-                        localResource
-            else
-                -- Use the same ownership and cleanup path while acquiring in
-                -- the order used before startup acquisition was overlapped.
-                withResourceScope \resourceScope -> do
-                    mcpResource <-
-                        allocateResource resourceScope acquireMcp releaseMcp
-                    localResource <-
-                        allocateResource
-                            resourceScope
-                            acquireLocal
-                            releaseLocal
-                    consumeToolStartupResources
-                        fixture
-                        mcpReleases
-                        localReleases
-                        mcpResource
-                        localResource
-    assertReleaseCounts mcpReleases localReleases
-    pure checksum
-
-consumeToolStartupResources
-    :: ToolStartupFixture
-    -> IORef Int
-    -> IORef Int
-    -> (ResourceKey, McpFleetLease)
-    -> (ResourceKey, LocalToolStartup)
-    -> IO Int
-consumeToolStartupResources
-        fixture mcpReleases localReleases
-        (mcpKey, mcpLease) (localKey, local) = do
-    result <- toolStartupChecksum fixture mcpLease local
-    result `seq` pure ()
-    releaseResource mcpKey
-        `finally` releaseResource localKey
+        loadWorkspace = do
+            ((projectSettings, userSettings), (catalogResult, branch)) <-
+                concurrently
+                    (concurrently
+                        (loadProjectSettings fixture.fixtureProject)
+                        (loadUserSettings fixture.fixtureHome))
+                    (concurrently
+                        (loadModelCatalogAt
+                            fixture.fixtureHome
+                            fixture.fixtureProject)
+                        (detectGitBranch fixture.fixtureProject))
+            catalog <- either (fail . Text.unpack) pure catalogResult
+            projectSettings `seq`
+                userSettings `seq`
+                catalog `seq`
+                branch `seq`
+                pure ()
+        acquireSerially resourceScope selectedAcquireLocal = do
+            (_, mcpLease) <-
+                allocateResource resourceScope acquireMcp releaseMcp
+            (_, local) <-
+                allocateResource
+                    resourceScope
+                    selectedAcquireLocal
+                    releaseLocal
+            continuation mcpLease local
+        acquireFullyConcurrently resourceScope selectedAcquireLocal = do
+            ((_, mcpLease), (_, local)) <-
+                allocateResourcesConcurrently
+                    resourceScope
+                    acquireMcp
+                    releaseMcp
+                    selectedAcquireLocal
+                    releaseLocal
+            continuation mcpLease local
+    result <-
+        withResourceScope \resourceScope ->
+            case strategy of
+                StartupSerial ->
+                    loadWorkspace
+                        >> acquireSerially resourceScope acquireLocal
+                StartupParentFullOverlap ->
+                    loadWorkspace
+                        >> acquireFullyConcurrently resourceScope acquireLocal
+                StartupPreloadSkills -> do
+                    (_, preloadedSkills) <-
+                        concurrently loadWorkspace loadSkills
+                    acquireFullyConcurrently
+                        resourceScope
+                        (acquireLocalWith (pure preloadedSkills))
     assertReleaseCounts mcpReleases localReleases
     pure result
 
@@ -395,8 +544,11 @@ assertReleaseCounts mcpReleases localReleases = do
             ("expected one MCP and one local cleanup, got "
                 <> show mcpCount <> " and " <> show localCount)
 
-acquireLocalToolStartup :: ToolStartupFixture -> ToolEnv -> IO LocalToolStartup
-acquireLocalToolStartup fixture toolEnv =
+acquireLocalToolStartupWith
+    :: ToolEnv
+    -> IO SkillCatalog
+    -> IO LocalToolStartup
+acquireLocalToolStartupWith toolEnv acquireSkills =
     bracketOnError
         (codingToolsFor
             (dialectForId CodexDialect)
@@ -407,12 +559,7 @@ acquireLocalToolStartup fixture toolEnv =
             Nothing)
         (.codingClose)
         \localCoding -> do
-            localSkills <-
-                loadSkillsCatalogQuiet
-                    defaultCliOptions
-                    fixture.fixtureHome
-                    fixture.fixtureProject
-                    fixture.fixtureProject
+            localSkills <- acquireSkills
             pure LocalToolStartup{..}
 
 releaseLocalToolStartup :: LocalToolStartup -> IO ()
@@ -425,8 +572,8 @@ toolStartupChecksum
     -> LocalToolStartup
     -> IO Int
 toolStartupChecksum fixture mcpLease local = do
-    let mcpToolCount =
-            length (mcpFleetTools mcpLease.mcpLeaseFleet)
+    statuses <- mcpFleetStatuses mcpLease.mcpLeaseFleet
+    let mcpServerCount = length statuses
         codingToolCount =
             length local.localCoding.codingAppTools
         benchmarkSkillCount =
@@ -434,13 +581,14 @@ toolStartupChecksum fixture mcpLease local = do
                 (filter
                     (Text.isPrefixOf "startup-bench-" . (.skillName))
                     local.localSkills.catalogSkills)
-        expectedMcpTools = length fixture.fixtureMcpConfigs
-    when (mcpToolCount /= expectedMcpTools) $
+        expectedMcpServers = length fixture.fixtureMcpConfigs
+        warnings = mcpLease.mcpLeaseFleet.mcpFleetWarnings
+    unless (null warnings) $
+        fail ("MCP startup warnings: " <> show warnings)
+    when (mcpServerCount /= expectedMcpServers) $
         fail
-            ("expected " <> show expectedMcpTools
-                <> " MCP tools, got " <> show mcpToolCount
-                <> "; warnings: "
-                <> show mcpLease.mcpLeaseFleet.mcpFleetWarnings)
+            ("expected " <> show expectedMcpServers
+                <> " MCP servers, got " <> show mcpServerCount)
     when (codingToolCount <= 0) $
         fail "expected coding tool construction to produce tools"
     when (benchmarkSkillCount /= fixture.fixtureSkillCount) $
@@ -448,9 +596,27 @@ toolStartupChecksum fixture mcpLease local = do
             ("expected " <> show fixture.fixtureSkillCount
                 <> " benchmark skills, got " <> show benchmarkSkillCount)
     pure
-        (mcpToolCount * 1_000_000
+        (mcpServerCount * 1_000_000
             + codingToolCount * 10_000
             + benchmarkSkillCount)
+
+validateMcpFixture :: ToolStartupFixture -> IO ()
+validateMcpFixture fixture =
+    bracket newMcpSupervisor closeMcpSupervisor \supervisor ->
+        bracket
+            (acquireMcpFleet supervisor fixture.fixtureMcpConfigs)
+            releaseMcpFleetLease
+            \lease -> do
+                let toolCount = length (mcpFleetTools lease.mcpLeaseFleet)
+                    expected = length fixture.fixtureMcpConfigs
+                    warnings = lease.mcpLeaseFleet.mcpFleetWarnings
+                unless (null warnings) $
+                    fail ("MCP fixture warnings: " <> show warnings)
+                when (toolCount /= expected) $
+                    fail
+                        ("expected " <> show expected
+                            <> " discovered MCP tools, got "
+                            <> show toolCount)
 
 medianSample :: [Sample] -> Sample
 medianSample samples =
@@ -686,24 +852,43 @@ runFakeMcpServer delayMillis serverIndex = loop
             if "\"method\":\"initialize\"" `BS8.isInfixOf` request
                 then do
                     threadDelay (delayMillis * 1000)
-                    respond initializeResponse
+                    respond request initializeResult
                 else
                     when
                         ("\"method\":\"tools/list\"" `BS8.isInfixOf` request)
-                        (respond toolsResponse)
+                        (respond request toolsResult)
             loop
 
-    respond response = do
-        BS8.hPutStrLn stdout response
-        hFlush stdout
+    respond request result =
+        case requestIdentifier request of
+            Nothing -> fail "MCP benchmark request omitted a numeric id"
+            Just identifier -> do
+                BS8.hPutStrLn stdout
+                    ("{\"jsonrpc\":\"2.0\",\"id\":"
+                        <> identifier
+                        <> ",\"result\":"
+                        <> result
+                        <> "}")
+                hFlush stdout
 
-    initializeResponse =
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"startup-bench\",\"version\":\"1\"}}}"
-    toolsResponse =
+    initializeResult =
+        "{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"startup-bench\",\"version\":\"1\"}}"
+    toolsResult =
         BS8.pack
-            ("{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"tools\":[{\"name\":\"read_"
+            ("{\"tools\":[{\"name\":\"read_"
                 <> show serverIndex
-                <> "\",\"description\":\"Read.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}]}}")
+                <> "\",\"description\":\"Read.\",\"inputSchema\":{\"type\":\"object\"},\"annotations\":{\"readOnlyHint\":true}}]}")
+
+requestIdentifier :: BS8.ByteString -> Maybe BS8.ByteString
+requestIdentifier request =
+    case BS8.breakSubstring "\"id\":" request of
+        (_, suffix)
+            | BS8.null suffix -> Nothing
+            | otherwise ->
+                let identifier =
+                        BS8.takeWhile isDigit
+                            (BS8.dropWhile isSpace (BS8.drop 5 suffix))
+                in if BS8.null identifier then Nothing else Just identifier
 
 withInputFiles :: Int -> Int -> ([FilePath] -> IO a) -> IO a
 withInputFiles count bytesPerFile action = do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -76,7 +76,8 @@ import Agent.CLI.Models
       ModelOption(modelTarget),
       ModelTarget(targetWireModelId, targetConnectionId, targetProvider,
                   targetModelId, targetDialect) )
-import Agent.CLI.Options ( CliOptions(optModel, optProvider, optYolo) )
+import Agent.CLI.Options
+    ( CliOptions(optModel, optProvider, optSkills, optYolo) )
 import Agent.CLI.PendingInputs ()
 import Agent.CLI.Plan ()
 import Agent.CLI.Project
@@ -146,7 +147,7 @@ import Agent.CLI.SessionEnv ()
 import Agent.CLI.SessionLock ( releaseSessionLock, SessionLock )
 import Agent.CLI.SessionState ()
 import Agent.CLI.SessionTitle ()
-import Agent.CLI.Skills ()
+import Agent.CLI.Skills ( loadSkillsCatalogQuiet )
 import Agent.CLI.Startup.Auth
     ( loadStartupAuth, loadStartupAuthFromResult, markStartupStage, startupDie )
 import Agent.CLI.StartupContext ()
@@ -192,7 +193,7 @@ import Agent.ReasoningEffort ()
 import Agent.Responses.GenericBackend ()
 import Agent.Responses.GenericClient ()
 import Agent.Responses.Types ()
-import Agent.Skills ()
+import Agent.Skills ( SkillCatalog(..) )
 import Agent.Store.Postgres ( trustedPool )
 import Agent.Store.Types ()
 import Agent.Subagents ()
@@ -284,6 +285,7 @@ data InitializedWorkspace = InitializedWorkspace
     , initializedDatabaseScopes :: DatabaseScopes
     , initializedProjectSettings :: ProjectSettings
     , initializedCatalog :: ModelCatalog
+    , initializedSkills :: SkillCatalog
     }
 
 data InitializedTargets = InitializedTargets
@@ -464,24 +466,40 @@ prepareInitializedWorkspace request = do
             projectRootPath >>= \case
             Left err -> startupDie startup err
             Right scopes -> pure scopes
-    ((projectSettings0, userSettings), (catalogResult, branch)) <-
-        concurrently
-            (concurrently
-                (maybe
-                    (loadProjectSettings projectRoot)
-                    (pure . (.nativeDiscoveryProjectSettings))
-                    preparedDiscovery)
-                (loadUserSettings home))
-            (concurrently
-                (loadModelCatalogAt home
+    let loadWorkspaceMetadata =
+            concurrently
+                (concurrently
                     (maybe
-                        cwd
-                        (.nativeDiscoveryCatalogRoot)
+                        (loadProjectSettings projectRoot)
+                        (pure . (.nativeDiscoveryProjectSettings))
+                        preparedDiscovery)
+                    (loadUserSettings home))
+                (concurrently
+                    (loadModelCatalogAt home
+                        (maybe
+                            cwd
+                            (.nativeDiscoveryCatalogRoot)
+                            preparedDiscovery))
+                    (maybe
+                        (detectGitBranch cwd)
+                        (pure . (.nativeDiscoveryGitBranch))
                         preparedDiscovery))
-                (maybe
-                    (detectGitBranch cwd)
-                    (pure . (.nativeDiscoveryGitBranch))
-                    preparedDiscovery))
+        loadInitialSkills =
+            loadSkillsCatalogQuiet
+                request.initializedOptions
+                home
+                projectRoot
+                cwd
+        shouldPreloadSkills =
+            request.initializedOptions.optSkills
+                && isNothing preparedDiscovery
+    (((projectSettings0, userSettings), (catalogResult, branch)),
+        initializedSkills) <-
+        if shouldPreloadSkills
+            then concurrently loadWorkspaceMetadata loadInitialSkills
+            else do
+                metadata <- loadWorkspaceMetadata
+                pure (metadata, SkillCatalog [] [])
     let projectSettings =
             withInheritedLastModel projectSettings0 userSettings
     catalog <- either
@@ -496,6 +514,7 @@ prepareInitializedWorkspace request = do
         , initializedDatabaseScopes = databaseScopes
         , initializedProjectSettings = projectSettings
         , initializedCatalog = catalog
+        , initializedSkills
         }
 
 resolveInitializedTargets
@@ -1248,6 +1267,7 @@ launchInitializedTools request workspace targets auth refs httpRuntime =
         refs.initializedActiveSelectionRef
         startup.startupToolEnv
         workspace.initializedCatalog
+        workspace.initializedSkills
         refs.initializedGatewayModelsRef
         targets.initializedGatewayIdentity
         ( targets.initializedCheckStartupUsageInBackground

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -183,7 +183,6 @@ import Agent.CLI.SessionLock
       sessionLockPath )
 import Agent.CLI.SessionState ( SessionState(sessionPreviewId) )
 import Agent.CLI.SessionTitle ()
-import Agent.CLI.Skills ( loadSkillsCatalogQuiet )
 import Agent.CLI.Startup.Auth
     ( markStartupStage, setStartupNotice, startupDie )
 import Agent.CLI.StartupContext ()
@@ -269,7 +268,7 @@ import Agent.ResourceScope
     , withResourceScope
     )
 import Agent.Skills
-    ( SkillCatalog(SkillCatalog)
+    ( SkillCatalog
     , SkillInvocation
     )
 import Agent.Store.Postgres ( trustedPool )
@@ -392,6 +391,7 @@ data AgentToolsRequest windowTitleResult = AgentToolsRequest
     , activeSelectionRef :: IORef Text
     , baseToolEnv :: ToolEnv
     , catalog :: ModelCatalog
+    , initialSkills :: SkillCatalog
     , gatewayModelsRef :: IORef (Maybe GatewayModelAccess)
     , gatewayIdentity :: Maybe Text
     , checkStartupUsageInBackground :: Bool
@@ -549,6 +549,7 @@ runAgentTools
     -> IORef Text
     -> ToolEnv
     -> ModelCatalog
+    -> SkillCatalog
     -> IORef (Maybe GatewayModelAccess)
     -> Maybe Text
     -> Bool
@@ -598,6 +599,7 @@ runAgentTools
     activeSelectionRef
     baseToolEnv
     catalog
+    initialSkills
     gatewayModelsRef
     gatewayIdentity
     checkStartupUsageInBackground
@@ -1565,10 +1567,7 @@ acquireLocalToolRuntime
 acquireLocalToolRuntime AgentToolsRequest
     { startup
     , baseToolEnv
-    , options
-    , home
-    , projectRoot
-    , cwd
+    , initialSkills
     } ToolModelRuntime
     { toolDialect = dialect
     } ToolHostHooks
@@ -1590,11 +1589,6 @@ acquireLocalToolRuntime AgentToolsRequest
                     baseToolEnv
                         { toolCwd = context.nativeDiscoveryProjectRoot }
                 Nothing -> baseToolEnv
-        acquireSkills =
-            case preparedDiscovery of
-                Nothing ->
-                    loadSkillsCatalogQuiet options home projectRoot cwd
-                Just _ -> pure (SkillCatalog [] [])
     bracketOnError
         (codingToolsForWithTypes
             dialect
@@ -1607,7 +1601,7 @@ acquireLocalToolRuntime AgentToolsRequest
             agentTypesRef)
         (.codingClose)
         \localCoding -> do
-            localInitialSkills <- acquireSkills
+            let localInitialSkills = initialSkills
             pure LocalToolRuntime{..}
 
 acquireCodingRuntime

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -41,7 +41,7 @@ import qualified System.Directory as Directory
 import qualified System.Environment as Environment
 import qualified System.FilePath as FilePath
 import System.IO (stderr)
-import System.OsPath (OsPath, unsafeEncodeUtf)
+import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
 
 reservedSlashNames :: [Text]
 reservedSlashNames =
@@ -201,17 +201,19 @@ installSkillCatalogWithOmissions reservedNames queueContext contextRef catalogRe
 -- models read SKILL.md and skill-relative resources even when packaged skills
 -- live outside the worktree (for example under /nix/store).
 installSkillToolRoots :: ToolEnv -> SkillCatalog -> IO ()
-installSkillToolRoots env catalog = do
-    sharedRoots <-
-        if any isBuiltinExternalResume catalog.catalogSkills
-            then do
-                core <- getDataFileName "skills/shared/resume-session/CORE.md"
-                pure [unsafeEncodeUtf (FilePath.takeDirectory core)]
-            else pure []
+installSkillToolRoots env catalog =
     setToolSkillRoots
         env
         (map (.skillDirectory) catalog.catalogSkills <> sharedRoots)
   where
+    sharedRoots =
+        case filter isBuiltinExternalResume catalog.catalogSkills of
+            skill : _ ->
+                [ takeDirectory skill.skillDirectory
+                    </> unsafeEncodeUtf "shared/resume-session"
+                ]
+            [] -> []
+
     isBuiltinExternalResume skill =
         skill.skillScope == BuiltinSkill
             && skill.skillName `elem`

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeSpec.hs
@@ -235,16 +235,16 @@ nativeFailureSpec =
 nativeSessionBoundarySpec :: Spec
 nativeSessionBoundarySpec =
     describe "native session gateway boundary" do
-        it "allows only direct sessions while disconnected" do
+        it "allows persisted sessions while disconnected" do
             nativeSessionRouteMatchesBoundary Nothing "openai" Nothing
                 `shouldBe` True
             nativeSessionRouteMatchesBoundary
                 Nothing
                 "organization-gateway"
                 (Just "gateway-a")
-                `shouldBe` False
+                `shouldBe` True
 
-        it "allows every gateway session while a gateway is connected" do
+        it "allows persisted sessions while a gateway is connected" do
             nativeSessionRouteMatchesBoundary
                 (Just "gateway-a")
                 "organization-gateway"
@@ -264,7 +264,7 @@ nativeSessionBoundarySpec =
                 (Just "gateway-a")
                 "openai"
                 Nothing
-                `shouldBe` False
+                `shouldBe` True
 
 decodeStart :: String -> Either String TurnStart
 decodeStart = Aeson.eitherDecode . LBS8.pack


### PR DESCRIPTION
## Summary

- preload the complete filesystem skill catalog alongside the existing project settings, user settings, model catalog, and Git branch discovery
- hand the preloaded catalog into tool initialization while retaining `master`'s existing concurrent MCP/local-tool acquisition
- preserve native prepared-workspace isolation by continuing to skip generic host skill discovery there
- keep packaged shared resume guidance reachable from source-tree and installed skill catalogs
- benchmark the exact current-`master` startup sequence against the preloaded sequence using real production loaders, coding tools, generated `SKILL.md` trees, and stdio MCP subprocesses
- align the macOS bridge assertions with the existing portable persisted-session boundary

## Performance

Built with GHC 9.10.3 using the benchmark stanza's `-O2 -threaded` settings. Runs use `+RTS -N4 -T -RTS`. The paired mode alternates parent-first and preload-first samples against the same fixture to limit thermal and cross-process drift.

The parent path first runs the same concurrent workspace metadata loaders as `master`, then concurrently acquires progressive MCP and local tools while loading skills inside the local-tool branch. The new path loads the skill catalog concurrently with workspace metadata, then performs the same MCP/local-tool acquisition using that catalog. The fixture verifies a complete MCP initialize/tools-list handshake before timing. Timed work ends only after workspace data, skills, and prompt-ready tools are all available, so the gain does not move skill work outside the measured interval.

| MCP servers / generated skills | Pairs | Parent elapsed | Preload elapsed | Median paired delta | CPU delta | Allocation delta |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 / 10 | 101 | 13.688 ms | 13.227 ms | -0.526 ms (-3.8%) | -1.800 ms | +197,648 B |
| 2 / 0 | 101 | 16.894 ms | 16.530 ms | -0.461 ms (-2.7%) | -2.093 ms | +113,368 B |
| 2 / 50 | 101 | 23.303 ms | 19.114 ms | -4.131 ms (-17.7%) | -5.675 ms | +168,472 B |
| 2 / 200 | 101 | 42.066 ms | 37.251 ms | -4.875 ms (-11.6%) | -7.339 ms | +331,256 B |
| 3 / 50 | 101 | 33.103 ms | 25.756 ms | -6.505 ms (-19.6%) | -10.811 ms | +170,848 B |

The preload adds roughly 0.1-0.3 MB of structured-concurrency allocation per startup while reducing both wall time and total CPU in every measured workload. An earlier attempt to split skill scanning from parsing inside tool acquisition was rejected after comparison with current `master`; it was slower in representative workloads and is not part of this patch.

Representative command:

```sh
cabal build agent-cli:bench:concurrency-bench
bin=$(cabal list-bin agent-cli:bench:concurrency-bench)
"$bin" startup-tools-paired 2 200 200 101 +RTS -N4 -T -RTS
```

## Validation

- optimized CLI executable, benchmark, core test, CLI test, and native bridge test targets build successfully on current `master`
- complete CLI suite: 1,565 examples, 0 failures, 1 pending
- complete native bridge suite: 91 examples, 0 failures
- `Agent.ResourceScope`: 7 examples, 0 failures
- `Agent.CLI.Skills`: 12 examples, 0 failures
- progressive MCP status: 2 examples, 0 failures
- isolated fullscreen tmux smoke: first frame at 1.85 s and ready at 2.01 s during cold database bootstrap; `/skills` showed the project fixture plus all 8 packaged skills
- `git diff --check`
