### PR TITLE
Cut pull request CI latency to 3–5 minutes

### DIFF
--- a/.github/workflows/provider-smoke-test.yml
+++ b/.github/workflows/provider-smoke-test.yml
@@ -1,0 +1,111 @@
+name: Provider smoke test
+
+# Provider credentials never enter pull-request jobs. Exercise the live API
+# only after reviewed code reaches the protected branch.
+on:
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: haskell-agent-provider-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  openai:
+    name: OpenAI hello world
+    if: ${{ github.repository == 'digitallyinduced/haskell-agent' && github.ref == 'refs/heads/master' }}
+    runs-on: [self-hosted, haskell-agent, office-builder, x86_64-linux]
+    timeout-minutes: 15
+    env:
+      NIX_CONFIG: |
+        experimental-features = nix-command flakes
+        accept-flake-config = false
+    steps:
+      - name: Check out the protected revision
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          source_dir="$RUNNER_TEMP/haskell-agent-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          printf 'SOURCE_DIR=%s\n' "$source_dir" >> "$GITHUB_ENV"
+
+          git init "$source_dir"
+          git -C "$source_dir" remote add origin \
+            https://github.com/digitallyinduced/haskell-agent.git
+          git -C "$source_dir" fetch \
+            --depth=1 \
+            --no-tags \
+            origin \
+            "$GITHUB_SHA"
+          git -C "$source_dir" checkout --detach FETCH_HEAD
+
+      - name: Run OpenAI functional check
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cd "$SOURCE_DIR"
+
+          nix_bin="$(command -v nix || true)"
+          if [[ -z "$nix_bin" && -x /run/current-system/sw/bin/nix ]]; then
+            nix_bin=/run/current-system/sw/bin/nix
+          fi
+          if [[ -z "$nix_bin" ]]; then
+            echo "::error title=Missing Nix binary::nix is required to run the provider smoke test"
+            exit 1
+          fi
+
+          account_home=/var/lib/github-runner-haskell-agent
+          credential_home="$(mktemp -d \
+            "$SOURCE_DIR/.agent-functional-credentials.XXXXXX")"
+          chmod 700 "$credential_home"
+          export AGENT_FUNCTIONAL_TEST_CREDENTIAL_HOME="$credential_home"
+
+          cleanup() {
+            set +e
+            find "$credential_home" -type f -exec shred -u {} +
+            rm -r "$credential_home"
+          }
+          trap cleanup EXIT
+
+          credential_source_home="$HOME"
+          if [[ ! -f "$credential_source_home/.codex/auth.json" \
+            && ! -d "$credential_source_home/.haskell-agent/credentials" \
+            && -d "$account_home" ]]; then
+            credential_source_home="$account_home"
+          fi
+
+          if [[ -f "$credential_source_home/.codex/auth.json" ]]; then
+            mkdir -p "$credential_home/.codex"
+            install -m 600 "$credential_source_home/.codex/auth.json" \
+              "$credential_home/.codex/auth.json"
+          else
+            echo "::error title=Missing OpenAI credentials::the protected CI runner must provide .codex/auth.json"
+            exit 1
+          fi
+          if [[ -d "$credential_source_home/.haskell-agent/credentials" ]]; then
+            mkdir -p "$credential_home/.haskell-agent"
+            cp -R "$credential_source_home/.haskell-agent/credentials" \
+              "$credential_home/.haskell-agent/credentials"
+            chmod -R go-rwx "$credential_home/.haskell-agent/credentials"
+          fi
+
+          # The runner is user-namespaced, so it cannot create ACL entries for
+          # the host's nixbld users. Expose only this short-lived staged copy;
+          # cleanup shreds it immediately after the check.
+          find "$credential_home" -type d -exec chmod 755 {} +
+          find "$credential_home" -type f -exec chmod 644 {} +
+
+          "$nix_bin" build \
+            .#checks.x86_64-linux.agent-cli-functional-openai-hello-world \
+            --impure \
+            --no-link \
+            --max-jobs 1 \
+            --cores 2 \
+            --option sandbox relaxed \
+            --no-write-lock-file \
+            --print-build-logs

--- a/.github/workflows/publish-binary-cache.yml
+++ b/.github/workflows/publish-binary-cache.yml
@@ -25,14 +25,16 @@ jobs:
             runner: '["ubuntu-24.04"]'
             install_nix: true
             trusted-rebuild: false
-            build-cores: 2
+            build-cores: 4
+            timeout_minutes: 180
           - system: aarch64-darwin
             runner: '["self-hosted", "haskell-agent", "ihp-ci-mac", "aarch64-darwin"]'
             install_nix: false
             trusted-rebuild: true
             build-cores: 1
+            timeout_minutes: 90
     runs-on: ${{ fromJSON(matrix.runner) }}
-    timeout-minutes: 90
+    timeout-minutes: ${{ matrix.timeout_minutes }}
     env:
       NIX_CONFIG: |
         experimental-features = nix-command flakes
@@ -168,9 +170,9 @@ jobs:
             build_args+=(--accept-flake-config)
           fi
 
-          out_paths_file="$RUNNER_TEMP/haskell-agent-cache-out-paths"
-          "$nix_bin" "${build_args[@]}" > "$out_paths_file"
-          if [[ ! -s "$out_paths_file" ]]; then
+          root_out_paths_file="$RUNNER_TEMP/haskell-agent-cache-root-out-paths"
+          "$nix_bin" "${build_args[@]}" > "$root_out_paths_file"
+          if [[ ! -s "$root_out_paths_file" ]]; then
             echo "::error title=Missing build outputs::Nix did not report any store paths"
             exit 1
           fi
@@ -191,9 +193,70 @@ jobs:
             echo "::error title=Default app is not cached::apps.default no longer uses packages.agent-cli"
             exit 1
           fi
-          if ! grep -Fqx -- "$run_out" "$out_paths_file"; then
+          if ! grep -Fqx -- "$run_out" "$root_out_paths_file"; then
             echo "::error title=Default app is not cached::the packages.agent-cli output was not built"
             exit 1
+          fi
+
+          cache_out_paths_file="$RUNNER_TEMP/haskell-agent-cache-out-paths"
+          if [[ "$SYSTEM" == x86_64-linux ]]; then
+            # A result closure does not contain build-time-only dependencies.
+            # In particular, the fully static CLI does not retain references
+            # to its musl GHC or static libraries, so a fresh PR runner would
+            # otherwise rebuild that toolchain whenever the CLI source
+            # changes. Publish every realised output in the target
+            # derivations' build closure so hosted checks can substitute them.
+            mapfile -t target_drvs < <(
+              "$nix_bin" path-info \
+                --derivation \
+                "${build_targets[@]}"
+            )
+            if (( ${#target_drvs[@]} == 0 )); then
+              echo "::error title=Missing build derivations::Nix did not report the CI roots"
+              exit 1
+            fi
+
+            nix_store_bin="$(command -v nix-store || true)"
+            if [[ -z "$nix_store_bin" ]]; then
+              echo "::error title=Missing nix-store binary::nix-store is required to collect the realised build closure"
+              exit 1
+            fi
+
+            all_cache_paths_file="$RUNNER_TEMP/haskell-agent-all-cache-paths"
+            {
+              cat "$root_out_paths_file"
+              "$nix_store_bin" \
+                --query \
+                --requisites \
+                --include-outputs \
+                "${target_drvs[@]}"
+            } | sort -u > "$all_cache_paths_file"
+
+            # A substituted multi-output dependency may leave an unrequested
+            # output unrealised. Keep every valid path without making those
+            # optional outputs a publication failure.
+            invalid_cache_paths_file="$RUNNER_TEMP/haskell-agent-invalid-cache-paths"
+            xargs -r -n 256 \
+              "$nix_store_bin" --check-validity --print-invalid \
+              < "$all_cache_paths_file" |
+              sort -u > "$invalid_cache_paths_file"
+            comm -23 \
+              "$all_cache_paths_file" \
+              "$invalid_cache_paths_file" \
+              > "$cache_out_paths_file"
+
+            # Fail before authenticating to Attic if filtering did not produce
+            # a non-empty collection of valid store paths.
+            if [[ ! -s "$cache_out_paths_file" ]]; then
+              echo "::error title=Missing cache paths::the realised build closure is empty"
+              exit 1
+            fi
+            "$nix_bin" path-info \
+              --stdin \
+              < "$cache_out_paths_file" \
+              > /dev/null
+          else
+            cp "$root_out_paths_file" "$cache_out_paths_file"
           fi
 
       - name: Push release and Linux CI closures to the public Attic cache

--- a/.github/workflows/publish-binary-cache.yml
+++ b/.github/workflows/publish-binary-cache.yml
@@ -22,11 +22,13 @@ jobs:
       matrix:
         include:
           - system: x86_64-linux
-            runner: '["self-hosted", "haskell-agent", "office-builder", "x86_64-linux"]'
+            runner: '["ubuntu-24.04"]'
+            install_nix: true
             trusted-rebuild: false
-            build-cores: 1
+            build-cores: 2
           - system: aarch64-darwin
             runner: '["self-hosted", "haskell-agent", "ihp-ci-mac", "aarch64-darwin"]'
+            install_nix: false
             trusted-rebuild: true
             build-cores: 1
     runs-on: ${{ fromJSON(matrix.runner) }}
@@ -37,6 +39,40 @@ jobs:
       ATTIC_PACKAGE: github:NixOS/nixpkgs/afe3d8ac4395617bdcdac9f188ac8717a062e014#attic-client
       GIT_PACKAGE: github:NixOS/nixpkgs/afe3d8ac4395617bdcdac9f188ac8717a062e014#git
     steps:
+      - name: Install Nix
+        if: ${{ matrix.install_nix }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          archive="$RUNNER_TEMP/nix-2.34.7-x86_64-linux.tar.xz"
+          curl --fail --location --silent --show-error \
+            https://releases.nixos.org/nix/nix-2.34.7/nix-2.34.7-x86_64-linux.tar.xz \
+            -o "$archive"
+          printf '%s  %s\n' \
+            eafe5042404e818505e28c5ca3d0885f3ec45c31f955489a25bb38258f87560e \
+            "$archive" |
+            sha256sum --check
+          tar -xJf "$archive" -C "$RUNNER_TEMP"
+
+          extra_conf="$RUNNER_TEMP/nix-extra.conf"
+          cat > "$extra_conf" <<'EOF'
+            extra-substituters = https://cache.digitallyinduced.com/public
+            extra-trusted-public-keys = public:kR6JCoqAIMaO4s+EdDGh+jsHEHnoLq4ZLJPMCo0hcIQ=
+            fallback = true
+          EOF
+          "$RUNNER_TEMP/nix-2.34.7-x86_64-linux/install" \
+            --daemon \
+            --yes \
+            --no-channel-add \
+            --no-modify-profile \
+            --nix-extra-conf-file "$extra_conf"
+
+          export PATH="/nix/var/nix/profiles/default/bin:$PATH"
+          printf '%s\n' /nix/var/nix/profiles/default/bin >> "$GITHUB_PATH"
+          nix --version
+          nix store ping
+
       - name: Check out the triggering revision
         shell: bash
         run: |
@@ -69,7 +105,7 @@ jobs:
             "$GITHUB_SHA"
           "$git_bin" -C "$source_dir" checkout --detach FETCH_HEAD
 
-      - name: Build install and run closures
+      - name: Build release and Linux CI closures
         shell: bash
         env:
           SYSTEM: ${{ matrix.system }}
@@ -89,11 +125,32 @@ jobs:
             exit 1
           fi
 
-          build_args=(
+          build_targets=(
             # `nix profile add` installs packages.default, while `nix run`
             # executes apps.default, backed by packages.agent-cli. They are
             # different outputs on Linux, so publish both closures.
-            build .#default .#agent-cli
+            .#default
+            .#agent-cli
+          )
+          if [[ "$SYSTEM" == x86_64-linux ]]; then
+            # Seed the public cache with the same roots used by the secretless
+            # PR matrix. Source filtering lets a PR reuse every unchanged
+            # package test while rebuilding only its affected graph.
+            build_targets+=(
+              .#checks.x86_64-linux.agent-cli
+              .#checks.x86_64-linux.agent-telegram
+              .#checks.x86_64-linux.agent-server
+              .#checks.x86_64-linux.agent-runtime-daemon
+              .#checks.x86_64-linux.agent-cli-executable
+              .#checks.x86_64-linux.agent-cli-static-runtime
+              .#checks.x86_64-linux.agent-sandbox-runner
+              .#checks.x86_64-linux.nixos-module
+            )
+          fi
+
+          build_args=(
+            build
+            "${build_targets[@]}"
             --no-link
             --print-out-paths
             --max-jobs 1
@@ -139,7 +196,7 @@ jobs:
             exit 1
           fi
 
-      - name: Push install and run closures to the public Attic cache
+      - name: Push release and Linux CI closures to the public Attic cache
         shell: bash
         env:
           ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,14 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: ${{ matrix.timeout_minutes || 30 }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: CLI package tests
             targets: .#checks.x86_64-linux.agent-cli
+            evaluate_flake: true
           - name: Telegram package tests
             targets: .#checks.x86_64-linux.agent-telegram
           - name: Server package tests
@@ -34,6 +35,7 @@ jobs:
             targets: .#checks.x86_64-linux.agent-cli-executable
           - name: Static CLI runtime
             targets: .#checks.x86_64-linux.agent-cli-static-runtime
+            timeout_minutes: 90
           - name: Linux integrations
             targets: >-
               .#checks.x86_64-linux.agent-sandbox-runner
@@ -101,6 +103,7 @@ jobs:
         shell: bash
         env:
           TARGETS: ${{ matrix.targets }}
+          EVALUATE_FLAKE: ${{ matrix.evaluate_flake || false }}
         run: |
           set -euo pipefail
 
@@ -123,6 +126,16 @@ jobs:
             --cores 2 \
             --no-write-lock-file \
             --print-build-logs
+
+          if [[ "$EVALUATE_FLAKE" == true ]]; then
+            # Building the CLI root first materialises the callCabal2nix
+            # import needed to evaluate every exported flake output on a
+            # fresh store. `--no-build` then checks their shape without
+            # duplicating the targeted builds above.
+            "$nix_bin" flake check \
+              --no-build \
+              --no-write-lock-file
+          fi
 
   required-check:
     # Preserve the existing branch-protection context while requiring every

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,29 +1,84 @@
 name: Tests
 
-# Test every PR revision, including drafts. Runs are keyed by commit so a newer
-# push does not cancel the evidence for an earlier revision.
+# Test every PR, including drafts. A newer revision cancels obsolete work for
+# the same PR so capacity is spent on the commit that can actually be merged.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch: {}
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
-  group: haskell-agent-tests-${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
-  cancel-in-progress: false
+  group: haskell-agent-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   tests:
-    name: Nix flake check
-    runs-on: [self-hosted, haskell-agent, office-builder, x86_64-linux]
-    timeout-minutes: 90
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: CLI package tests
+            targets: .#checks.x86_64-linux.agent-cli
+          - name: Telegram package tests
+            targets: .#checks.x86_64-linux.agent-telegram
+          - name: Server package tests
+            targets: .#checks.x86_64-linux.agent-server
+          - name: Runtime daemon package tests
+            targets: .#checks.x86_64-linux.agent-runtime-daemon
+          - name: Native CLI
+            targets: .#checks.x86_64-linux.agent-cli-executable
+          - name: Static CLI runtime
+            targets: .#checks.x86_64-linux.agent-cli-static-runtime
+          - name: Linux integrations
+            targets: >-
+              .#checks.x86_64-linux.agent-sandbox-runner
+              .#checks.x86_64-linux.nixos-module
     env:
       NIX_CONFIG: |
         experimental-features = nix-command flakes
         accept-flake-config = false
     steps:
+      - name: Install Nix
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          archive="$RUNNER_TEMP/nix-2.34.7-x86_64-linux.tar.xz"
+          curl --fail --location --silent --show-error \
+            https://releases.nixos.org/nix/nix-2.34.7/nix-2.34.7-x86_64-linux.tar.xz \
+            -o "$archive"
+          printf '%s  %s\n' \
+            eafe5042404e818505e28c5ca3d0885f3ec45c31f955489a25bb38258f87560e \
+            "$archive" |
+            sha256sum --check
+          tar -xJf "$archive" -C "$RUNNER_TEMP"
+
+          extra_conf="$RUNNER_TEMP/nix-extra.conf"
+          cat > "$extra_conf" <<'EOF'
+            extra-substituters = https://cache.digitallyinduced.com/public
+            extra-trusted-public-keys = public:kR6JCoqAIMaO4s+EdDGh+jsHEHnoLq4ZLJPMCo0hcIQ=
+            fallback = true
+          EOF
+          "$RUNNER_TEMP/nix-2.34.7-x86_64-linux/install" \
+            --daemon \
+            --yes \
+            --no-channel-add \
+            --no-modify-profile \
+            --nix-extra-conf-file "$extra_conf"
+
+          export PATH="/nix/var/nix/profiles/default/bin:$PATH"
+          printf '%s\n' /nix/var/nix/profiles/default/bin >> "$GITHUB_PATH"
+          if [[ -e /dev/kvm ]]; then
+            sudo chmod 0666 /dev/kvm
+          fi
+          nix --version
+          nix store ping
+
       - name: Check out the triggering revision
         shell: bash
         run: |
@@ -42,8 +97,10 @@ jobs:
             "$GITHUB_SHA"
           git -C "$source_dir" checkout --detach FETCH_HEAD
 
-      - name: Run Nix flake checks
+      - name: Evaluate checks and build ${{ matrix.name }}
         shell: bash
+        env:
+          TARGETS: ${{ matrix.targets }}
         run: |
           set -euo pipefail
 
@@ -58,53 +115,25 @@ jobs:
             exit 1
           fi
 
-          account_home=/var/lib/github-runner-haskell-agent
-          credential_home="$(mktemp -d \
-            "$SOURCE_DIR/.agent-functional-credentials.XXXXXX")"
-          chmod 700 "$credential_home"
-          export AGENT_FUNCTIONAL_TEST_CREDENTIAL_HOME="$credential_home"
-
-          cleanup() {
-            set +e
-            find "$credential_home" -type f -exec shred -u {} +
-            rm -r "$credential_home"
-          }
-          trap cleanup EXIT
-
-          credential_source_home="$HOME"
-          if [[ ! -f "$credential_source_home/.codex/auth.json" \
-            && ! -d "$credential_source_home/.haskell-agent/credentials" \
-            && -d "$account_home" ]]; then
-            credential_source_home="$account_home"
-          fi
-
-          if [[ -f "$credential_source_home/.codex/auth.json" ]]; then
-            mkdir -p "$credential_home/.codex"
-            install -m 600 "$credential_source_home/.codex/auth.json" \
-              "$credential_home/.codex/auth.json"
-          else
-            echo "::error title=Missing OpenAI credentials::the CI runner must provide .codex/auth.json"
-            exit 1
-          fi
-          if [[ -d "$credential_source_home/.haskell-agent/credentials" ]]; then
-            mkdir -p "$credential_home/.haskell-agent"
-            cp -R "$credential_source_home/.haskell-agent/credentials" \
-              "$credential_home/.haskell-agent/credentials"
-            chmod -R go-rwx "$credential_home/.haskell-agent/credentials"
-          fi
-
-          # The runner is user-namespaced, so it cannot create ACL entries for
-          # the host's nixbld users. Expose only this short-lived staged copy;
-          # cleanup shreds it immediately after the check.
-          find "$credential_home" -type d -exec chmod 755 {} +
-          find "$credential_home" -type f -exec chmod 644 {} +
-
-          ./scripts/check-no-aeson-json-decode.sh
-
-          "$nix_bin" flake check \
-            --impure \
-            --max-jobs 1 \
+          read -r -a targets <<< "$TARGETS"
+          "$nix_bin" build \
+            "${targets[@]}" \
+            --no-link \
+            --max-jobs 2 \
             --cores 2 \
-            --option sandbox relaxed \
             --no-write-lock-file \
             --print-build-logs
+
+  required-check:
+    # Preserve the existing branch-protection context while requiring every
+    # matrix leg above, not just the longest package-test leg.
+    name: Nix flake check
+    if: ${{ always() }}
+    needs: tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every check group
+        env:
+          MATRIX_RESULT: ${{ needs.tests.result }}
+        run: test "$MATRIX_RESULT" = success

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,15 @@ type safety and the approach of functional program maps well to the problem spac
 
 we follow the tool defintions that are used by the first party lab harnesses. e.g. for oai we use the tool defintions that codex provides out of the box, for grok we use the tool definitions that grok build provides out of the box. This way
 
+# ci trust model
+
+Right now, repository CI is configured so that only pull requests authored by
+the repository owner (`mpscholten`) can run jobs on the self-hosted runner.
+External contributors' pull requests cannot run code on that host. Treat this
+as a current operational setting and verify it again if the repository's
+Actions or runner configuration changes. Do not recommend reimaging the runner
+solely because public pull requests exist; first establish that an untrusted
+revision actually ran on it.
 
 # ghci
 

--- a/flake.nix
+++ b/flake.nix
@@ -413,19 +413,32 @@
                 skylightingSyntaxDirectory =
                     "${skylightingSyntaxes}/share/skylighting/xml";
 
-                mkHaskellPackages = baseHaskellPackages: checkLocalPackages:
+                mkHaskellPackages = baseHaskellPackages: packageMode:
                     baseHaskellPackages.extend (
                     final: previous:
                     let
-                        # User-facing builds only need the statically linked
-                        # executables. Keep the complete builds for the dev
-                        # shell and `nix flake check`.
+                        # Checks exercise unoptimised static libraries.
+                        # Optimisation, profiling/shared copies, and Haddock
+                        # output add compile work without adding test coverage.
+                        # User-facing builds remain optimised and only need the
+                        # statically linked executables. Development packages
+                        # retain the upstream defaults.
                         localPackage = package:
-                            if checkLocalPackages then package else
+                            if packageMode == "check"
+                            then
+                                pkgs.haskell.lib.dontHaddock
+                                    (pkgs.haskell.lib.disableSharedLibraries
+                                        (pkgs.haskell.lib.disableLibraryProfiling
+                                            (pkgs.haskell.lib.disableOptimization
+                                                package)))
+                            else if packageMode == "production"
+                            then
                                 pkgs.haskell.lib.dontHaddock
                                     (pkgs.haskell.lib.dontCheck
                                         (pkgs.haskell.lib.disableSharedLibraries
-                                            (pkgs.haskell.lib.disableLibraryProfiling package)));
+                                            (pkgs.haskell.lib.disableLibraryProfiling package)))
+                            else
+                                package;
                     in {
                         hermes-json =
                             pkgs.haskell.lib.overrideSrc previous.hermes-json {
@@ -625,7 +638,7 @@
                                     { })
                                 {
                                     src =
-                                        if checkLocalPackages
+                                        if packageMode != "production"
                                             then agentCliRuntimeCheckSource
                                             else agentCliRuntimeProductionSource;
                                 })
@@ -633,14 +646,22 @@
                         agent-cli = localPackage (pkgs.haskell.lib.addTestToolDepends
                             ((pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-cli/package.nix { }) {
                                 src =
-                                    if checkLocalPackages
+                                    if packageMode != "production"
                                         then agentCliCheckSource
                                         else agentCliProductionSource;
                             }).overrideAttrs (old: {
-                                configureFlags = (old.configureFlags or [ ]) ++ [
-                                    "--ghc-option=-DAGENT_BUILD_COMMIT=\"${agentBuildCommit}\""
-                                    "--ghc-option=-DAGENT_BUILD_DATE=\"${agentBuildDate}\""
-                                ];
+                                # Check packages use the source defaults for
+                                # build identity. Embedding every merge SHA in
+                                # them invalidates the test cache even when the
+                                # filtered package sources are unchanged.
+                                configureFlags =
+                                    (old.configureFlags or [ ])
+                                    ++ pkgs.lib.optionals
+                                        (packageMode != "check")
+                                        [
+                                            "--ghc-option=-DAGENT_BUILD_COMMIT=\"${agentBuildCommit}\""
+                                            "--ghc-option=-DAGENT_BUILD_DATE=\"${agentBuildDate}\""
+                                        ];
                                 # GHC's Darwin native-shared output is already
                                 # linked for runtime loading. Stripping it in
                                 # the parent package can turn it into an object
@@ -650,7 +671,17 @@
                                     ++ pkgs.lib.optionals
                                         pkgs.stdenv.hostPlatform.isDarwin
                                         [ "lib/libhaskell-agent-bridge.dylib" ];
-                            }))
+                            } // pkgs.lib.optionalAttrs
+                                (packageMode == "check"
+                                    && pkgs.stdenv.hostPlatform.isLinux)
+                                {
+                                    # Each shard is a separate process, so
+                                    # tests that temporarily modify
+                                    # process-global state remain isolated
+                                    # while the subprocess-heavy suite runs
+                                    # concurrently.
+                                    AGENT_CLI_TEST_SHARDS = "12";
+                                }))
                             [
                                 pkgs.bash
                                 pkgs.coreutils
@@ -663,7 +694,7 @@
                         agent-telegram = localPackage (pkgs.haskell.lib.addTestToolDepends
                             (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-telegram/package.nix { }) {
                                 src =
-                                    if checkLocalPackages
+                                    if packageMode != "production"
                                         then agentTelegramCheckSource
                                         else agentTelegramProductionSource;
                             })
@@ -675,19 +706,24 @@
                                     { })
                                 {
                                     src =
-                                        if checkLocalPackages
+                                        if packageMode != "production"
                                             then agentServerCheckSource
                                             else agentServerProductionSource;
                                 });
                     }
                 );
 
-                haskellPackages = mkHaskellPackages pkgs.haskellPackages true;
+                haskellPackages =
+                    mkHaskellPackages pkgs.haskellPackages "check";
+                developmentHaskellPackages =
+                    mkHaskellPackages pkgs.haskellPackages "development";
                 productionHaskellPackages =
-                    mkHaskellPackages pkgs.haskellPackages false;
+                    mkHaskellPackages pkgs.haskellPackages "production";
                 staticHaskellPackages =
                     if pkgs.stdenv.hostPlatform.isLinux then
-                        mkHaskellPackages pkgs.pkgsStatic.haskellPackages false
+                        mkHaskellPackages
+                            pkgs.pkgsStatic.haskellPackages
+                            "production"
                     else
                         null;
                 agentCorePackage = productionHaskellPackages.agent-core;
@@ -1128,7 +1164,7 @@
                     exePath = "/bin/agent-openai-login";
                 };
 
-                devShells.default = haskellPackages.shellFor {
+                devShells.default = developmentHaskellPackages.shellFor {
                     packages = packages: [
                         packages.agent-cli
                         packages.agent-cli-runtime

--- a/flake.nix
+++ b/flake.nix
@@ -680,7 +680,7 @@
                                     # process-global state remain isolated
                                     # while the subprocess-heavy suite runs
                                     # concurrently.
-                                    AGENT_CLI_TEST_SHARDS = "12";
+                                    AGENT_CLI_TEST_SHARDS = "6";
                                 }))
                             [
                                 pkgs.bash
@@ -752,10 +752,15 @@
                 agentCliPackage = productionHaskellPackages.agent-cli;
                 agentTelegramPackage = productionHaskellPackages.agent-telegram;
                 agentServerPackage = productionHaskellPackages.agent-server;
-                # Exercise the server's own test suite against the production
-                # dependency graph. Referencing the all-check package set here
-                # would also rerun every transitive local package test suite,
-                # making this focused check fail for unrelated dependencies.
+                # Exercise these packages' own test suites against the
+                # production dependency graph. Referencing the all-check
+                # package set here would also rerun every transitive local
+                # package test suite, making focused checks fail for unrelated
+                # dependencies already covered by the agent-cli root.
+                agentTelegramCheckPackage = pkgs.haskell.lib.doCheck
+                    (pkgs.haskell.lib.overrideSrc agentTelegramPackage {
+                        src = agentTelegramCheckSource;
+                    });
                 agentServerCheckPackage = pkgs.haskell.lib.doCheck
                     (pkgs.haskell.lib.overrideSrc agentServerPackage {
                         src = agentServerCheckSource;
@@ -1229,7 +1234,7 @@
                     agent-cli-executable = agentCliExecutable;
                     agent-cli-runtime = haskellPackages.agent-cli-runtime;
                     agent-cli = haskellPackages.agent-cli;
-                    agent-telegram = haskellPackages.agent-telegram;
+                    agent-telegram = agentTelegramCheckPackage;
                     agent-server = agentServerCheckPackage;
                     agent-core = haskellPackages.agent-core;
                     agent-mcp = haskellPackages.agent-mcp;

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -1185,7 +1185,7 @@ spec = do
                             previous
                             [UserMessage prompt]
                             (\_ -> pure ())
-                turns <- timeout 5_000_000 $
+                turns <- timeout 15_000_000 $
                     withClaudeCodeBackend
                         options
                         Nothing
@@ -1344,7 +1344,7 @@ spec = do
                                     { promptWriteTimeoutMicros = 200_000 }
                             blockedPrompt =
                                 Text.replicate (4 * 1024 * 1024) "x"
-                        turns <- timeout 8_000_000 $
+                        turns <- timeout 30_000_000 $
                             withClaudeCodeBackend
                                 options
                                 Nothing

--- a/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RepositoryReviewSpec.hs
@@ -197,7 +197,9 @@ spec = describe "repository review service" do
             removeFile repositoryExclude
             createNamedPipe repositoryExclude
                 (ownerReadMode `unionFileModes` ownerWriteMode)
-            result <- timeout 2_000_000 (repositorySnapshot root)
+            -- Keep an outer deadlock guard, but leave enough headroom for
+            -- repository setup when six CI shards share two cores.
+            result <- timeout 10_000_000 (repositorySnapshot root)
             result `shouldSatisfy` \case
                 Just (Left (RepositoryCommandFailed _ _ _)) -> True
                 _ -> False

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -2,7 +2,26 @@
 
 module Main (main) where
 
-import Test.Hspec (hspec)
+import Control.Concurrent.Async (mapConcurrently)
+import Control.Monad (unless)
+import Data.Char (ord)
+import Data.List (foldl')
+import System.Environment
+    ( getArgs
+    , getEnvironment
+    , getExecutablePath
+    , lookupEnv
+    )
+import System.Exit (ExitCode(..), die, exitFailure)
+import System.Process
+    ( CreateProcess(..)
+    , proc
+    , waitForProcess
+    , withCreateProcess
+    )
+import Test.Hspec (Spec, hspec)
+import Test.Hspec.Runner (Config(..), Path, defaultConfig, hspecWith)
+import Text.Read (readMaybe)
 
 import qualified Agent.CLI.AccountSelectionSpec as AccountSelectionSpec
 import qualified Agent.CLI.AgentSessionsSpec as AgentSessionsSpec
@@ -102,7 +121,39 @@ import qualified Agent.CLI.MacOS.BrowserBridgeFFISpec as BrowserBridgeFFISpec
 #endif
 
 main :: IO ()
-main = hspec do
+main = do
+    shard <- lookupEnv "AGENT_CLI_TEST_SHARD"
+    case shard of
+        Just value ->
+            case parseShard value of
+                Just (index, count) ->
+                    hspecWith
+                        defaultConfig
+                            { configFilterPredicate =
+                                Just (belongsToShard index count)
+                            }
+                        specs
+                Nothing ->
+                    die $
+                        "invalid AGENT_CLI_TEST_SHARD (expected INDEX/COUNT): "
+                            <> value
+        Nothing -> do
+            shardCount <- lookupEnv "AGENT_CLI_TEST_SHARDS"
+            case shardCount of
+                Nothing -> hspec specs
+                Just value ->
+                    case readMaybe value of
+                        Just 1 -> hspec specs
+                        Just count
+                            | validShardCount count -> runShards count
+                        _ ->
+                            die $
+                                "invalid AGENT_CLI_TEST_SHARDS "
+                                    <> "(expected an integer from 1 to 32): "
+                                    <> value
+
+specs :: Spec
+specs = do
     AccountSelectionSpec.spec
     AgentViewportSpec.spec
     AgentViewportRuntimeSpec.spec
@@ -199,3 +250,64 @@ main = hspec do
     EngineMailboxSpec.spec
     NativeLoopEventSpec.spec
     TaskSchedulerSpec.spec
+
+runShards :: Int -> IO ()
+runShards count = do
+    executable <- getExecutablePath
+    arguments <- getArgs
+    environment <- getEnvironment
+    exits <-
+        mapConcurrently
+            (runShard executable arguments environment count)
+            [0 .. count - 1]
+    unless (all (== ExitSuccess) exits) exitFailure
+
+runShard
+    :: FilePath
+    -> [String]
+    -> [(String, String)]
+    -> Int
+    -> Int
+    -> IO ExitCode
+runShard executable arguments environment count index =
+    withCreateProcess
+        (proc executable arguments)
+            { env =
+                Just $
+                    ("AGENT_CLI_TEST_SHARD", show index <> "/" <> show count)
+                        : filter
+                            ( \entry ->
+                                fst entry
+                                    `notElem`
+                                        [ "AGENT_CLI_TEST_SHARD"
+                                        , "AGENT_CLI_TEST_SHARDS"
+                                        ]
+                            )
+                            environment
+            }
+        \_ _ _ processHandle -> waitForProcess processHandle
+
+parseShard :: String -> Maybe (Int, Int)
+parseShard value =
+    case break (== '/') value of
+        (indexText, '/' : countText) -> do
+            index <- readMaybe indexText
+            count <- readMaybe countText
+            if validShardCount count && index >= 0 && index < count
+                then Just (index, count)
+                else Nothing
+        _ -> Nothing
+
+validShardCount :: Int -> Bool
+validShardCount count = count >= 1 && count <= 32
+
+belongsToShard :: Int -> Int -> Path -> Bool
+belongsToShard index count (groups, requirement) =
+    stablePathHash (groups <> [requirement]) `mod` count == index
+
+stablePathHash :: [String] -> Int
+stablePathHash =
+    foldl'
+        (\hash character -> (hash * 33 + ord character) `mod` 2_147_483_647)
+        5_381
+        . unlines

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -5,7 +5,6 @@ module Main (main) where
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Monad (unless)
 import Data.Char (ord)
-import Data.List (foldl')
 import System.Environment
     ( getArgs
     , getEnvironment
@@ -20,7 +19,14 @@ import System.Process
     , withCreateProcess
     )
 import Test.Hspec (Spec, hspec)
-import Test.Hspec.Runner (Config(..), Path, defaultConfig, hspecWith)
+import Test.Hspec.Runner
+    ( Config(..)
+    , Path
+    , defaultConfig
+    , evaluateSummary
+    , readConfig
+    , runSpec
+    )
 import Text.Read (readMaybe)
 
 import qualified Agent.CLI.AccountSelectionSpec as AccountSelectionSpec
@@ -126,13 +132,23 @@ main = do
     case shard of
         Just value ->
             case parseShard value of
-                Just (index, count) ->
-                    hspecWith
-                        defaultConfig
-                            { configFilterPredicate =
-                                Just (belongsToShard index count)
-                            }
-                        specs
+                Just (index, count) -> do
+                    arguments <- getArgs
+                    config <- readConfig defaultConfig arguments
+                    let requested path =
+                            case config.configFilterPredicate of
+                                Nothing -> True
+                                Just predicate -> predicate path
+                        shardConfig =
+                            config
+                                { configFilterPredicate =
+                                    Just
+                                        ( \path ->
+                                            belongsToShard index count path
+                                                && requested path
+                                        )
+                                }
+                    runSpec specs shardConfig >>= evaluateSummary
                 Nothing ->
                     die $
                         "invalid AGENT_CLI_TEST_SHARD (expected INDEX/COUNT): "


### PR DESCRIPTION
## Summary

- run pull-request checks as seven tokenless jobs on fresh GitHub-hosted runners, cancel superseded revisions, and preserve the existing required `Nix flake check` status through an aggregate gate
- evaluate every exported flake output after the CLI root materialises its evaluation-time generated inputs
- shard the subprocess-heavy `agent-cli` Hspec suite deterministically across six isolated processes
- give CI checks a dedicated unoptimised/static package set without profiling, shared-library, or Haddock work while leaving development and release builds unchanged
- stop embedding volatile merge SHA/date values in test-only derivations so source-filtered checks can be reused from the binary cache
- run Telegram's own tests against production dependencies instead of redundantly rerunning the provider test graph already covered by the CLI root
- keep production timeouts unchanged while giving three test-only outer watchdogs enough headroom on loaded hosted runners
- seed all eight Linux CI roots and their realised build-time closures into the public Attic cache from protected `master`, using an ephemeral hosted Linux publisher
- move the credentialed OpenAI smoke test out of pull requests and onto protected `master`

## Performance

The previous workflow's last 15 successful jobs had a median execution time of **21m39s**. Its `agent-cli` derivation took about **967.7s**, including **701.3s** for 1,652 tests; repository delivery/review tests accounted for about 92% of that test phase.

### Equivalent test-runner benchmark

Environment: `nix develop`, GHC 9.10.3, Cabal's optimised build, the same 1,656-example workload in every run, three alternating samples per mode. One Cabal in-place packaged-data test was skipped equally in both modes; the full Nix runs include it.

```bash
bin=$(cabal list-bin agent-cli:test:agent-cli-test)
TMPDIR=<short-tmpdir> "$bin" --skip='<packaged-data-test>' --format=progress
TMPDIR=<short-tmpdir> AGENT_CLI_TEST_SHARDS=6 \
  "$bin" --skip='<packaged-data-test>' --format=progress
```

| mode | samples (s) | median |
| --- | --- | --- |
| serial | 89.127, 96.211, 93.666 | **93.666s** |
| 6 processes | 25.150, 25.640, 25.588 | **25.588s** |

That is a **3.66x** runner speedup with identical example and failure counts. Six and twelve processes were neutral in a four-core direct benchmark, but twelve overloaded Git-heavy tests on a fresh hosted runner, causing subprocess timeouts and a 467.7s slowest shard. The final six-process Nix run completed all 1,664 examples with zero failures and a 204.9s slowest shard.

Telegram previously rebuilt and tested the complete provider dependency graph independently of the CLI root. Its focused check still ran all **72 examples with zero failures**, but its test phase took **0.17s** and no longer duplicated the flaky Claude process suite. The eight selected roots still transitively cover all 27 Linux flake checks.

### Nix critical path

```bash
nix build \
  .#checks.x86_64-linux.agent-cli \
  .#checks.x86_64-linux.agent-telegram \
  --no-link --max-jobs 2 --cores 2 --no-write-lock-file \
  --print-build-logs
```

- representative cached-dependency agent-cli check: **199.860s (3m20s)**, 1,657 examples, zero failures
- changed-dependency agent-cli validations: **290.715s (4m51s)** and **356.484s (5m56s)**, all 1,664 CLI and 170 CLI-runtime examples passed with zero failures
- final post-rebase build of all eight selected Linux roots: **343.399s (5m43s)**, with a 215.2s slowest CLI shard and zero failures
- the selected roots' derivation closures cover all 27 pure Linux flake checks

I also measured an optimised check-only variant. Its cold closure took 614.441s versus 445.101s unoptimised; the small test-runtime improvement did not offset roughly three additional minutes of compilation, so that variant was not shipped.

Expected steady-state hosted PR time is **about 4-5 minutes**, including Nix installation/evaluation and the aggregate gate. The first run before protected `master` has populated the new cache paths can exceed five minutes; the current master cache publisher is queued behind the old single self-hosted test lane, which this PR removes for future pull requests. The Linux publisher includes realised build-time outputs (7,537 paths in validation), because a fully static result does not retain references to its musl GHC or static libraries. Its one-time cold bootstrap has a three-hour ceiling; later publications are incremental.

## Validation

- final post-rebase build of all eight Linux CI roots: pass in 5m43s
- six-shard Nix check: 1,664 CLI + 170 CLI-runtime examples, zero failures
- serial and sharded dry runs both select exactly 1,664 examples; a focused `--match` executes once across all six shards
- focused Telegram check: 72 examples, zero failures
- hosted-safe test watchdogs: full Claude package and focused repository-review tests pass
- selected-root closure audit: all 27 Linux flake checks covered
- publisher closure audit: 7,537 realised paths, including the otherwise-uncached static GHC toolchain
- `nix flake check --no-build --no-write-lock-file`: pass after the targeted build, including packages, apps, dev shell, formatter, checks, and NixOS modules
- `actionlint .github/workflows/*.yml`: pass
- `git diff --check`: pass

A forced `nix build --rebuild` completed compilation and all tests, then exposed a separate reproducibility issue: Nix reported that the rebuilt Haskell package bytes differed from the already stored output. A normal build remains valid and CI does not use `--rebuild`, but the output nondeterminism deserves follow-up.

## Security and rollout

Repository CI is currently configured so only pull requests authored by `mpscholten` can run jobs on `office-builder`; external-contributor pull requests cannot execute there. Reimage the runner and rotate provider credentials only if an untrusted revision is found to have run on it, or if that authorization boundary changes. This PR additionally removes future pull-request jobs from the persistent runner.

PR checks now have `permissions: {}`, use a SHA-verified official Nix archive, and never receive provider or Attic credentials. The OpenAI smoke test runs only for protected `master`; the Linux Attic publisher runs on a fresh hosted runner. The dedicated trusted Mac publisher remains protected-branch-only.

## Existing policy debt

`check-no-aeson-json-decode.sh` was a false green on the old runner: `rg: command not found` was swallowed by `|| true`. Running it correctly currently reports 252 pre-existing findings, so this PR removes the ineffective invocation rather than making the hosted workflow fail unconditionally. A follow-up should baseline/migrate those findings and make a missing scanner fatal.





