### PR TITLE
Replace hand-rolled infrastructure with maintained libraries

### DIFF
--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -105,6 +105,8 @@ library
                     , transformers
                     , unix
                     , vector
+                    , wai
+                    , warp
 
 test-suite agent-cli-runtime-test
     import:           common-options

--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -137,8 +137,12 @@ test-suite agent-cli-runtime-test
                     , directory
                     , filepath
                     , hspec >= 2.11 && < 2.12
+                    , http-client
+                    , http-types
                     , QuickCheck
                     , safe-exceptions
                     , text
                     , time
                     , unix
+                    , wai
+                    , warp

--- a/packages/agent-cli-runtime/package.nix
+++ b/packages/agent-cli-runtime/package.nix
@@ -5,7 +5,7 @@
 , entropy, filelock, filepath, hspec, http-client, http-client-tls
 , http-types, lib, memory, network, network-uri, process
 , QuickCheck, safe-exceptions, scientific, stm, text, time
-, transformers, unix, vector
+, transformers, unix, vector, wai, warp
 }:
 mkDerivation {
   pname = "agent-cli-runtime";
@@ -19,6 +19,7 @@ mkDerivation {
     crypton directory entropy filelock filepath http-client
     http-client-tls http-types memory network network-uri process
     safe-exceptions scientific stm text time transformers unix vector
+    wai warp
   ];
   testHaskellDepends = [
     aeson agent-core agent-json agent-responses-types agent-store async

--- a/packages/agent-cli-runtime/package.nix
+++ b/packages/agent-cli-runtime/package.nix
@@ -23,8 +23,8 @@ mkDerivation {
   ];
   testHaskellDepends = [
     aeson agent-core agent-json agent-responses-types agent-store async
-    base bytestring containers directory filepath hspec QuickCheck
-    safe-exceptions text time unix
+    base bytestring containers directory filepath hspec http-client
+    http-types QuickCheck safe-exceptions text time unix wai warp
   ];
   description = "Headless shared runtime for agent frontends";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -81,7 +81,16 @@ import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
 import Agent.OsPath (unsafeToFilePath)
 import Control.Concurrent (ThreadId, myThreadId, threadDelay)
 import Control.Concurrent.Async (race)
-import Control.Concurrent.MVar (MVar, newMVar, withMVar)
+import Control.Concurrent.MVar
+    ( MVar
+    , newEmptyMVar
+    , newMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    , tryPutMVar
+    , withMVar
+    )
 import Control.Concurrent.STM
     ( TVar
     , atomically
@@ -99,7 +108,7 @@ import Control.Exception.Safe
     , throwString
     , tryAny
     )
-import Control.Monad (unless, when)
+import Control.Monad (unless, void, when)
 import Crypto.Hash (Digest, SHA256, hash)
 import Data.Aeson ((.=), (.:))
 import Data.Aeson qualified as Aeson
@@ -123,23 +132,33 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TextEncoding
 import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Client.MultipartFormData qualified as Multipart
 import Network.HTTP.Client.TLS (newTlsManager)
 import Network.HTTP.Types
     ( hAccept
     , hAuthorization
+    , hCacheControl
+    , hContentLength
     , hContentType
+    , methodGet
+    , status200
     , statusCode
     , statusIsSuccessful
     )
-import Network.HTTP.Types.URI (parseQueryText, renderQueryText)
+import Network.HTTP.Types.URI
+    ( parseQueryText
+    , queryToQueryText
+    , renderQueryText
+    )
 import Network.URI qualified as URI
+import Network.Wai qualified as Wai
+import Network.Wai.Handler.Warp qualified as Warp
 import Network.Socket
     ( Family(AF_INET)
     , SockAddr(SockAddrInet)
     , Socket
     , SocketOption(ReuseAddr)
     , SocketType(Stream)
-    , accept
     , bind
     , close
     , defaultProtocol
@@ -149,7 +168,6 @@ import Network.Socket
     , socket
     , tupleToHostAddress
     )
-import Network.Socket.ByteString qualified as Socket
 import System.Directory.OsPath qualified as Directory
 import System.Entropy (getEntropy)
 import System.Exit (ExitCode (..))
@@ -683,15 +701,14 @@ postGatewayTranscription credential wav =
         Left _ -> pure (Left "Gateway credential is invalid.")
         Right () -> do
             boundary <- gatewayTranscriptionBoundary
-            let body = gatewayTranscriptionBody boundary wav
-                endpoint =
+            let endpoint =
                     Text.dropWhileEnd (== '/')
                         (Text.strip credential.gatewayBaseUrl)
                         <> "/v1/audio/transcriptions"
             outcome <- tryAny do
                 manager <- newTlsManager
                 initial <- HTTP.parseRequest (Text.unpack endpoint)
-                let request =
+                let baseRequest =
                         initial
                             { HTTP.method = "POST"
                             , HTTP.requestHeaders =
@@ -700,12 +717,8 @@ postGatewayTranscription credential wav =
                                         <> TextEncoding.encodeUtf8
                                             credential.gatewayAccessToken
                                   )
-                                , ( hContentType
-                                  , "multipart/form-data; boundary=" <> boundary
-                                  )
                                 , (hAccept, "application/json")
                                 ]
-                            , HTTP.requestBody = HTTP.RequestBodyLBS body
                             , HTTP.checkResponse = \_ _ -> pure ()
                             -- Never forward the gateway bearer to a redirect.
                             , HTTP.redirectCount = 0
@@ -713,6 +726,18 @@ postGatewayTranscription credential wav =
                                 HTTP.responseTimeoutMicro
                                     (2 * 60 * 1_000_000)
                             }
+                    audioPart =
+                        (Multipart.partFileRequestBody
+                            "file"
+                            "audio.wav"
+                            (HTTP.RequestBodyLBS wav))
+                            { Multipart.partContentType = Just "audio/wav" }
+                request <- Multipart.formDataBodyWithBoundary
+                    boundary
+                    [ Multipart.partBS "model" "dictation"
+                    , audioPart
+                    ]
+                    baseRequest
                 HTTP.withResponse request manager \response -> do
                     responseBody <-
                         readBoundedBody
@@ -762,23 +787,6 @@ gatewayTranscriptionBoundary =
     ("----haskell-agent-gateway-" <>)
         . Base64Url.encodeUnpadded
         <$> getEntropy 18
-
-gatewayTranscriptionBody
-    :: BS.ByteString
-    -> LBS.ByteString
-    -> LBS.ByteString
-gatewayTranscriptionBody boundary wav =
-    LBS.fromStrict
-        ( "--" <> boundary <> "\r\n"
-        <> "Content-Disposition: form-data; name=\"model\"\r\n\r\n"
-        <> "dictation\r\n"
-        <> "--" <> boundary <> "\r\n"
-        <> "Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n"
-        <> "Content-Type: audio/wav\r\n\r\n"
-        )
-        <> wav
-        <> LBS.fromStrict
-            ("\r\n--" <> boundary <> "--\r\n")
 
 newtype GatewayTranscript =
     GatewayTranscript { gatewayTranscriptText :: Text }
@@ -1581,17 +1589,40 @@ validateGatewayAuthorizationCallback
     -> BS.ByteString
     -> Either Text Text
 validateGatewayAuthorizationCallback expectedState request = do
-    target <- case BS8.words requestLine of
-        method : rawTarget : _
-            | method == "GET" -> Right rawTarget
-            | otherwise -> Left "Gateway OAuth callback must use GET."
+    (method, target) <- case BS8.words requestLine of
+        requestMethod : rawTarget : _ -> Right (requestMethod, rawTarget)
         _ -> Left "Gateway OAuth callback request is malformed."
     let (path, rawQuery) = BS.break (== 63) target
+    validateGatewayAuthorizationParameters
+        expectedState
+        method
+        path
+        (not (BS.null rawQuery))
+        (parseQueryText (BS.drop 1 rawQuery))
+  where
+    requestLine = BS8.takeWhile (/= '\r') request
+
+validateGatewayAuthorizationParameters
+    :: Text
+    -> BS.ByteString
+    -> BS.ByteString
+    -> Bool
+    -> [(Text, Maybe Text)]
+    -> Either Text Text
+validateGatewayAuthorizationParameters
+    expectedState
+    method
+    path
+    hasQuery
+    parameters = do
+    whenEither
+        (method /= methodGet)
+        "Gateway OAuth callback must use GET."
     whenEither
         (path /= TextEncoding.encodeUtf8 gatewayBrowserRedirectPath)
         "Gateway OAuth callback path is invalid."
     whenEither
-        (BS.null rawQuery)
+        (not hasQuery)
         "Gateway OAuth callback query is missing."
     state <- singletonParameter "state" parameters
         >>= maybe
@@ -1616,13 +1647,6 @@ validateGatewayAuthorizationCallback expectedState request = do
                 (Text.null code || Text.length code > 4096)
                 "Gateway OAuth callback authorization code is invalid."
             pure code
-  where
-    requestLine = BS8.takeWhile (/= '\r') request
-    parameters = parseQueryText (BS.drop 1 rawQueryBytes)
-    (_, rawQueryBytes) =
-        case BS8.words requestLine of
-            _ : target : _ -> BS.break (== 63) target
-            _ -> ("", "")
 
 validateGatewayAuthorizationCodeResponse
     :: Text
@@ -2085,50 +2109,42 @@ receiveGatewayAuthorizationCallback
     :: Socket
     -> Text
     -> IO (Either Text Text)
-receiveGatewayAuthorizationCallback listener expectedState =
-    bracket (fst <$> accept listener) close \connection -> do
-        request <- receiveGatewayCallbackHeaders connection
-        let result =
-                request >>= validateGatewayAuthorizationCallback expectedState
-            page = gatewayCallbackPage result
-            response =
-                "HTTP/1.1 200 OK\r\n\
-                \Content-Type: text/html; charset=utf-8\r\n\
-                \Cache-Control: no-store\r\n\
-                \Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'\r\n\
-                \X-Content-Type-Options: nosniff\r\n\
-                \Connection: close\r\n\
-                \Content-Length: "
-                    <> BS8.pack (show (BS.length page))
-                    <> "\r\n\r\n"
-                    <> page
-        Socket.sendAll connection response
-        pure result
-
-receiveGatewayCallbackHeaders
-    :: Socket
-    -> IO (Either Text BS.ByteString)
-receiveGatewayCallbackHeaders connection = go BS.empty
-  where
-    maximumHeaderBytes = 16_384
-    delimiter = "\r\n\r\n"
-
-    go accumulated
-        | delimiter `BS.isInfixOf` accumulated =
-            pure (Right accumulated)
-        | BS.length accumulated >= maximumHeaderBytes =
-            pure (Left "Gateway OAuth callback headers were too large.")
-        | otherwise = do
-            chunk <-
-                Socket.recv
-                    connection
-                    (maximumHeaderBytes - BS.length accumulated)
-            if BS.null chunk
-                then
-                    pure
-                        (Left
-                            "Gateway OAuth callback closed before sending headers.")
-                else go (accumulated <> chunk)
+receiveGatewayAuthorizationCallback listener expectedState = do
+    resultVar <- newEmptyMVar
+    shutdownVar <- newEmptyMVar
+    let settings =
+            Warp.setHost "127.0.0.1"
+                $ Warp.setMaxTotalHeaderLength 16_384
+                $ Warp.setInstallShutdownHandler
+                    (\shutdown -> putMVar shutdownVar shutdown)
+                $ Warp.defaultSettings
+        application request respond = do
+            let result =
+                    validateGatewayAuthorizationParameters
+                        expectedState
+                        (Wai.requestMethod request)
+                        (Wai.rawPathInfo request)
+                        (not (BS.null (Wai.rawQueryString request)))
+                        (queryToQueryText (Wai.queryString request))
+                page = gatewayCallbackPage result
+                finish = do
+                    void (tryPutMVar resultVar result)
+                    readMVar shutdownVar >>= id
+            respond
+                (Wai.responseLBS
+                    status200
+                    [ (hContentType, "text/html; charset=utf-8")
+                    , (hCacheControl, "no-store")
+                    , ( "Content-Security-Policy"
+                      , "default-src 'none'; style-src 'unsafe-inline'"
+                      )
+                    , ("X-Content-Type-Options", "nosniff")
+                    , (hContentLength, BS8.pack (show (BS.length page)))
+                    ]
+                    (LBS.fromStrict page))
+                `finally` finish
+    Warp.runSettingsSocket settings listener application
+    takeMVar resultVar
 
 gatewayCallbackPage :: Either Text Text -> BS.ByteString
 gatewayCallbackPage result =

--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -138,6 +138,7 @@ import Network.HTTP.Types
     ( hAccept
     , hAuthorization
     , hCacheControl
+    , hConnection
     , hContentLength
     , hContentType
     , methodGet
@@ -2135,6 +2136,7 @@ receiveGatewayAuthorizationCallback listener expectedState = do
                     status200
                     [ (hContentType, "text/html; charset=utf-8")
                     , (hCacheControl, "no-store")
+                    , (hConnection, "close")
                     , ( "Content-Security-Policy"
                       , "default-src 'none'; style-src 'unsafe-inline'"
                       )

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
@@ -3,7 +3,13 @@ module Agent.CLI.GatewayClientSpec (spec) where
 import Agent.CLI.GatewayClient
 import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Agent.Json.Decode qualified as Hermes
-import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, threadDelay)
+import Control.Concurrent
+    ( newEmptyMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    , threadDelay
+    )
 import Control.Concurrent.Async (cancel, poll, wait, waitCatch, withAsync)
 import Control.Exception.Safe (bracket, throwString, tryAny)
 import Control.Monad (forM_, void)
@@ -15,6 +21,12 @@ import Data.Either (isLeft)
 import Data.IORef (atomicModifyIORef', newIORef)
 import Data.Maybe (isNothing)
 import Data.Text qualified as Text
+import Data.Text.Encoding qualified as TextEncoding
+import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Types (hConnection, hContentType, status200)
+import Network.HTTP.Types.URI (parseQueryText)
+import Network.Wai qualified as Wai
+import Network.Wai.Handler.Warp qualified as Warp
 import System.Directory
     ( createDirectory
     , createDirectoryIfMissing
@@ -308,6 +320,85 @@ spec = describe "gateway device authorization" do
             (pure ())
             `shouldReturn`
                 Left "Gateway browser authorization was cancelled."
+
+    it "serves and shuts down a successful loopback callback" do
+        baseUrlVar <- newEmptyMVar
+        let gatewayApplication _request respond = do
+                baseUrl <- readMVar baseUrlVar
+                let websocketUrl =
+                        Text.replace "http://" "ws://" baseUrl
+                            <> "/v1/responses"
+                respond $
+                    Wai.responseLBS
+                        status200
+                        [ (hContentType, "application/json")
+                        , (hConnection, "close")
+                        ]
+                        (Aeson.encode $
+                            Aeson.object
+                                [ "access_token"
+                                    Aeson..= ("loopback-secret" :: Text.Text)
+                                , "token_type" Aeson..= ("Bearer" :: Text.Text)
+                                , "base_url" Aeson..= baseUrl
+                                , "websocket_url" Aeson..= websocketUrl
+                                ])
+        Warp.testWithApplication (pure gatewayApplication) \port ->
+            withTempHome \home ->
+                withHomeEnvironment home do
+                    let baseUrl =
+                            "http://127.0.0.1:"
+                                <> Text.pack (show port)
+                    putMVar baseUrlVar baseUrl
+                    manager <-
+                        HTTP.newManager HTTP.defaultManagerSettings
+                    authorizationUrlVar <- newEmptyMVar
+                    withAsync
+                        (connectGatewayBrowser
+                            baseUrl
+                            "Haskell Agent CLI"
+                            (\url -> putMVar authorizationUrlVar url >> pure True))
+                        \connection -> do
+                            maybeAuthorizationUrl <-
+                                timeout 1_000_000
+                                    (takeMVar authorizationUrlVar)
+                            authorizationUrl <-
+                                case maybeAuthorizationUrl of
+                                    Nothing -> do
+                                        expectationFailure
+                                            "timed out waiting for the authorization URL"
+                                        pure ""
+                                    Just url -> pure url
+                            redirectUri <-
+                                requiredAuthorizationParameter
+                                    "redirect_uri"
+                                    authorizationUrl
+                            state <-
+                                requiredAuthorizationParameter
+                                    "state"
+                                    authorizationUrl
+                            callbackRequest <-
+                                HTTP.parseRequest $
+                                    Text.unpack
+                                        (redirectUri
+                                            <> "?code=hac_loopback_test&state="
+                                            <> state)
+                            callbackResponse <-
+                                HTTP.httpLbs callbackRequest manager
+                            HTTP.responseStatus callbackResponse
+                                `shouldBe` status200
+                            LBS.toStrict (HTTP.responseBody callbackResponse)
+                                `shouldSatisfy`
+                                    BS.isInfixOf "Authorization received"
+                            timeout 5_000_000 (wait connection)
+                                `shouldReturn` Just (Right ())
+                    let expected =
+                            GatewayCredential
+                                baseUrl
+                                (Text.replace "http://" "ws://" baseUrl
+                                    <> "/v1/responses")
+                                "loopback-secret"
+                    loadGatewayCredentialAt home
+                        `shouldReturn` Right (Just expected)
 
     it "accepts only the exact IPv4 loopback redirect contract" do
         let authorize redirect =
@@ -1087,3 +1178,18 @@ withHomeEnvironment home action =
             setEnv "HOME" $
                 either (error . show) id (decodeUtf home)
             action
+
+requiredAuthorizationParameter :: Text.Text -> Text.Text -> IO Text.Text
+requiredAuthorizationParameter name authorizationUrl =
+    case lookup name parameters >>= id of
+        Just value -> pure value
+        Nothing -> do
+            expectationFailure $
+                "authorization URL is missing " <> Text.unpack name
+            pure ""
+  where
+    parameters =
+        parseQueryText $
+            TextEncoding.encodeUtf8 $
+                Text.drop 1 $
+                    snd (Text.breakOn "?" authorizationUrl)

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -38,6 +38,7 @@ import Data.Time.Clock.POSIX (getPOSIXTime)
 import Network.HTTP.Client.TLS (newTlsManager)
 import Network.HTTP.Types
     ( hCacheControl
+    , hConnection
     , hContentType
     , methodGet
     , status200
@@ -311,6 +312,7 @@ receiveCallback listener = do
                         status200
                         [ (hContentType, "text/html; charset=utf-8")
                         , (hCacheControl, "no-store")
+                        , (hConnection, "close")
                         , ("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
                         ]
                         OAuth.oauthCallbackSuccessPage)

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -321,7 +321,12 @@ receiveCallback listener = do
     readMVar resultVar
   where
     plainResponse status body =
-        Wai.responseLBS status [(hContentType, "text/plain; charset=utf-8")] body
+        Wai.responseLBS
+            status
+            [ (hContentType, "text/plain; charset=utf-8")
+            , (hConnection, "close")
+            ]
+            body
 
 callbackFromQuery :: Query -> Callback
 callbackFromQuery query = Callback

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -18,14 +18,17 @@ module Agent.CLI.McpOAuth
 import Agent.CLI.Config (HarnessConfig(..), McpOAuthConfig(..), McpServerConfig(..), loadHarnessConfig)
 import Agent.CLI.McpOAuthStore (loadMcpOAuthRecord, mcpOAuthStorePath, saveMcpOAuthRecord)
 import qualified Agent.MCP.OAuth as OAuth
-import Control.Exception.Safe (bracket, bracketOnError, tryAny)
-import Control.Monad (forM_, when)
+import Control.Concurrent.MVar
+    ( newEmptyMVar
+    , putMVar
+    , readMVar
+    , tryPutMVar
+    )
+import Control.Exception.Safe (bracket, bracketOnError, finally, tryAny)
+import Control.Monad (forM_, void, when)
 import Crypto.Hash (Digest, SHA256, hash)
 import qualified Data.ByteArray as BA
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Base64.URL as Base64
-import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
@@ -33,13 +36,22 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Network.HTTP.Client.TLS (newTlsManager)
-import Network.HTTP.Types.URI (urlEncode)
+import Network.HTTP.Types
+    ( hCacheControl
+    , hContentType
+    , methodGet
+    , status200
+    , status404
+    , status405
+    )
+import Network.HTTP.Types.URI (Query, urlEncode)
 import Network.Socket
-    ( AddrInfo(..), Socket, SockAddr(..), SocketType(Stream), accept, bind, close
+    ( AddrInfo(..), Socket, SockAddr(..), SocketType(Stream), bind, close
     , defaultHints, defaultProtocol, getAddrInfo, getSocketName, listen
     , setSocketOption, socket, SocketOption(ReuseAddr)
     )
-import qualified Network.Socket.ByteString as Socket
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
 import qualified System.Directory.OsPath as Dir
 import qualified System.Entropy
 import System.Exit (ExitCode(..))
@@ -276,50 +288,50 @@ callbackPort sock = do
     pure (fromIntegral port)
 
 receiveCallback :: Socket -> IO Callback
-receiveCallback listener = bracket (fst <$> accept listener) close $ \sock -> do
-    bytes <- Socket.recv sock 8192
-    let requestLine = case BS8.lines bytes of line : _ -> line; _ -> ""
-        target = case BS8.words requestLine of _method : path : _ -> path; _ -> "/"
-        query = snd (BS.break (== 63) target)
-        params = parseQuery (BS.drop 1 query)
-        response = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: "
-            <> Encoding.encodeUtf8 (Text.pack (show (LBS.length OAuth.oauthCallbackSuccessPage)))
-            <> "\r\nConnection: close\r\n\r\n" <> LBS.toStrict OAuth.oauthCallbackSuccessPage
-    Socket.sendAll sock response
-    pure Callback
-        { callbackCode = lookup "code" params
-        , callbackState = lookup "state" params
-        , callbackIss = lookup "iss" params
-        , callbackError = lookup "error" params
-        , callbackErrorDescription = lookup "error_description" params
-        }
-
-parseQuery :: BS.ByteString -> [(Text, Text)]
-parseQuery raw = map parsePair (filter (not . BS.null) (BS.split 38 raw))
+receiveCallback listener = do
+    resultVar <- newEmptyMVar
+    shutdownVar <- newEmptyMVar
+    let settings =
+            Warp.setHost "127.0.0.1"
+                $ Warp.setMaxTotalHeaderLength 8_192
+                $ Warp.setInstallShutdownHandler (putMVar shutdownVar)
+                    Warp.defaultSettings
+        application request respond
+            | Wai.requestMethod request /= methodGet =
+                respond (plainResponse status405 "Method Not Allowed")
+            | Wai.rawPathInfo request /= "/callback" =
+                respond (plainResponse status404 "Not Found")
+            | otherwise = do
+                let callback = callbackFromQuery (Wai.queryString request)
+                    finish = do
+                        void (tryPutMVar resultVar callback)
+                        readMVar shutdownVar >>= id
+                respond
+                    (Wai.responseLBS
+                        status200
+                        [ (hContentType, "text/html; charset=utf-8")
+                        , (hCacheControl, "no-store")
+                        , ("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
+                        ]
+                        OAuth.oauthCallbackSuccessPage)
+                    `finally` finish
+    Warp.runSettingsSocket settings listener application
+    readMVar resultVar
   where
-    parsePair item =
-        let (key, value) = BS.break (== 61) item
-        in (decode key, decode (BS.drop 1 value))
-    decode = Encoding.decodeUtf8 . urlDecode
-    urlDecode = BS.concat . go
-    go input = case BS.uncons input of
-        Nothing -> []
-        Just (37, a) -> case BS.uncons a of
-            Just (x, b) -> case BS.uncons b of
-                Just (y, rest) -> maybe [BS.singleton 37] (\v -> [BS.singleton v]) (hex x y) <> go rest
-                _ -> [BS.singleton 37] <> go a
-            _ -> [BS.singleton 37] <> go a
-        Just (43, rest) -> BS.singleton 32 : go rest
-        Just (x, rest) -> BS.singleton x : go rest
-    hex x y = do
-        a <- digit x
-        b <- digit y
-        pure (a * 16 + b)
-    digit c
-        | c >= 48 && c <= 57 = Just (c - 48)
-        | c >= 65 && c <= 70 = Just (c - 55)
-        | c >= 97 && c <= 102 = Just (c - 87)
-        | otherwise = Nothing
+    plainResponse status body =
+        Wai.responseLBS status [(hContentType, "text/plain; charset=utf-8")] body
+
+callbackFromQuery :: Query -> Callback
+callbackFromQuery query = Callback
+    { callbackCode = parameter "code"
+    , callbackState = parameter "state"
+    , callbackIss = parameter "iss"
+    , callbackError = parameter "error"
+    , callbackErrorDescription = parameter "error_description"
+    }
+  where
+    parameter name =
+        lookup name query >>= id >>= either (const Nothing) Just . Encoding.decodeUtf8'
 
 randomUrlBytes :: Int -> IO Text
 randomUrlBytes n = do

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -111,7 +111,7 @@ library
                     , agent-process >= 0.1 && < 0.2
                     , agent-responses-types >= 0.1 && < 0.2
                     , aeson >= 2.0
-                    , async
+                    , async >= 2.2.6 && < 2.3
                     , base64-bytestring
                     , bytestring
                     , containers

--- a/packages/agent-core/src/Agent/Concurrent.hs
+++ b/packages/agent-core/src/Agent/Concurrent.hs
@@ -4,18 +4,8 @@ module Agent.Concurrent
     , forConcurrentlyBounded_
     ) where
 
-import Control.Concurrent.Async (replicateConcurrently_)
-import Control.Concurrent.STM
-    ( atomically
-    , modifyTVar'
-    , newTQueueIO
-    , newTVarIO
-    , readTQueue
-    , readTVarIO
-    , writeTQueue
-    )
-import Control.Monad (forM_, replicateM_, void)
-import qualified Data.Map.Strict as Map
+import qualified Control.Concurrent.Stream as ConcurrentStream
+import Control.Monad (void)
 
 -- | Apply an action with at most the requested number of active workers.
 --
@@ -23,29 +13,8 @@ import qualified Data.Map.Strict as Map
 -- 'replicateConcurrently_', so an exception cancels and joins the remaining
 -- workers before it escapes.
 mapConcurrentlyBounded :: Int -> (a -> IO b) -> [a] -> IO [b]
-mapConcurrentlyBounded _ _ [] = pure []
-mapConcurrentlyBounded requested action values = do
-    let workerCount = min (max 1 requested) (length values)
-    queue <- newTQueueIO
-    results <- newTVarIO Map.empty
-    atomically do
-        forM_ (zip [0 :: Int ..] values) $
-            writeTQueue queue . Just
-        replicateM_ workerCount (writeTQueue queue Nothing)
-    let worker =
-            atomically (readTQueue queue) >>= \case
-                Nothing -> pure ()
-                Just (index, value) -> do
-                    result <- action value
-                    atomically $
-                        modifyTVar' results (Map.insert index result)
-                    worker
-    replicateConcurrently_ workerCount worker
-    completed <- readTVarIO results
-    pure
-        [ completed Map.! index
-        | index <- [0 .. length values - 1]
-        ]
+mapConcurrentlyBounded requested =
+    ConcurrentStream.mapConcurrentlyBounded (max 1 requested)
 
 -- | Bounded, structured traversal when results are not needed.
 forConcurrentlyBounded_ :: Int -> (a -> IO b) -> [a] -> IO ()

--- a/packages/agent-core/src/Agent/Concurrent.hs
+++ b/packages/agent-core/src/Agent/Concurrent.hs
@@ -9,9 +9,8 @@ import Control.Monad (void)
 
 -- | Apply an action with at most the requested number of active workers.
 --
--- Results retain input order. Worker lifetimes are scoped by
--- 'replicateConcurrently_', so an exception cancels and joins the remaining
--- workers before it escapes.
+-- Results retain input order. The async traversal scopes worker lifetimes, so
+-- an exception cancels and joins the remaining workers before it escapes.
 mapConcurrentlyBounded :: Int -> (a -> IO b) -> [a] -> IO [b]
 mapConcurrentlyBounded requested =
     ConcurrentStream.mapConcurrentlyBounded (max 1 requested)

--- a/packages/agent-core/test/Agent/ConcurrentSpec.hs
+++ b/packages/agent-core/test/Agent/ConcurrentSpec.hs
@@ -31,14 +31,8 @@ spec = describe "bounded concurrency" do
             `shouldReturn` [1 .. 12]
         readIORef peak `shouldReturn` 3
 
-    it "clamps a non-positive limit to one worker" do
-        active <- newIORef (0 :: Int)
-        peak <- newIORef (0 :: Int)
-        mapConcurrentlyBounded 0
-            (\value -> bracketActive active peak (pure value))
-            [1 .. 4 :: Int]
-            `shouldReturn` [1 .. 4]
-        readIORef peak `shouldReturn` 1
+    it "clamps zero and negative limits to one worker" do
+        mapM_ assertSingleWorker [0, -3]
 
     it "cancels and joins sibling workers when one fails" do
         siblingStarted <- newEmptyMVar
@@ -76,3 +70,13 @@ bracketActive active peak action = do
 shouldReturnSatisfy :: Show a => IO a -> (a -> Bool) -> Expectation
 shouldReturnSatisfy action predicate =
     action >>= (`shouldSatisfy` predicate)
+
+assertSingleWorker :: Int -> Expectation
+assertSingleWorker limit = do
+    active <- newIORef (0 :: Int)
+    peak <- newIORef (0 :: Int)
+    mapConcurrentlyBounded limit
+        (\value -> bracketActive active peak (pure value))
+        [1 .. 4 :: Int]
+        `shouldReturn` [1 .. 4]
+    readIORef peak `shouldReturn` 1

--- a/packages/agent-gemini/agent-gemini.cabal
+++ b/packages/agent-gemini/agent-gemini.cabal
@@ -67,11 +67,14 @@ library
                     , http-types
                     , memory
                     , network
+                    , network-uri
                     , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions
                     , scientific
                     , text
                     , time
+                    , wai
+                    , warp
 
 test-suite agent-gemini-test
     import:           common-opts

--- a/packages/agent-gemini/package.nix
+++ b/packages/agent-gemini/package.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, agent-core, agent-json, agent-responses
 , agent-responses-types, async, base, base64-bytestring, bytestring
 , containers, crypton, entropy, hspec, http-client, http-client-tls
-, http-conduit, http-types, lib, memory, network, retry
-, safe-exceptions, scientific, text, time, wai, warp
+, http-conduit, http-types, lib, memory, network, network-uri
+, retry, safe-exceptions, scientific, text, time, wai, warp
 }:
 mkDerivation {
   pname = "agent-gemini";
@@ -12,7 +12,7 @@ mkDerivation {
     aeson agent-core agent-json agent-responses agent-responses-types
     base base64-bytestring bytestring containers crypton entropy
     http-client http-client-tls http-conduit http-types memory network
-    retry safe-exceptions scientific text time
+    network-uri retry safe-exceptions scientific text time wai warp
   ];
   testHaskellDepends = [
     aeson agent-core agent-json agent-responses agent-responses-types

--- a/packages/agent-gemini/src/Agent/Gemini/Auth.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Auth.hs
@@ -27,13 +27,22 @@ module Agent.Gemini.Auth
     ) where
 
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.MVar
+    ( newEmptyMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    , tryPutMVar
+    )
 import Control.Exception.Safe
     ( IOException
     , SomeException
     , bracket
+    , finally
     , fromException
     , tryAny
     )
+import Control.Monad (void)
 import Crypto.Hash (Digest, SHA256, hash)
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.:), (.:?), (.!=))
@@ -44,6 +53,7 @@ import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import Data.Bifunctor (first)
+import Data.Char (isDigit, toLower)
 import Data.List (find)
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text (Text)
@@ -51,14 +61,28 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
 import Network.HTTP.Simple
-import Network.HTTP.Types.URI (parseQueryText, renderQueryText)
+import Network.HTTP.Types
+    ( hCacheControl
+    , hContentLength
+    , hLocation
+    , methodGet
+    , status302
+    )
+import Network.HTTP.Types.URI
+    ( parseQueryText
+    , queryToQueryText
+    , renderQueryText
+    )
 import qualified Network.HTTP.Client as HttpClient
 import qualified Network.Socket as Net
-import qualified Network.Socket.ByteString as Net
+import qualified Network.URI as URI
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
 import System.Environment (lookupEnv)
 import System.Entropy (getEntropy)
 import System.IO.Error (ioeGetErrorString)
 import System.Timeout (timeout)
+import Text.Read (readMaybe)
 
 data OAuthOptions = OAuthOptions
     { authorizationEndpoint :: !String
@@ -261,8 +285,16 @@ authorizationUrl options redirectUri state challenge =
 validateOAuthCallback :: Text -> BS.ByteString -> Either Text Text
 validateOAuthCallback expectedState requestTarget = do
     let (_, queryWithQuestion) = BS8.break (== '?') requestTarget
-        parameters = parseQueryText (BS.drop 1 queryWithQuestion)
-        parameter key = lookup key parameters >>= id
+    validateOAuthParameters
+        expectedState
+        (parseQueryText (BS.drop 1 queryWithQuestion))
+
+validateOAuthParameters
+    :: Text
+    -> [(Text, Maybe Text)]
+    -> Either Text Text
+validateOAuthParameters expectedState parameters = do
+    let parameter key = lookup key parameters >>= id
     actualState <- maybe
         (Left "Google OAuth callback did not include state")
         Right
@@ -453,46 +485,43 @@ loopbackRedirectUri socket = Net.getSocketName socket >>= \case
     _ -> fail "Google OAuth loopback listener did not bind an IPv4 address"
 
 receiveOAuthCallback :: Net.Socket -> Text -> IO (Either Text Text)
-receiveOAuthCallback listener expectedState =
-    bracket (Net.accept listener) (Net.close . fst) \(connection, _) -> do
-        received <- receiveRequestHeaders connection
-        let result = case received of
-                Left err -> Left err
-                Right bytes ->
-                    case BS8.words (BS8.takeWhile (/= '\r') bytes) of
-                        _method : target : _ ->
-                            validateOAuthCallback expectedState target
-                        _ ->
-                            Left
-                                "Malformed HTTP request received by Google OAuth callback"
-            location = case result of
-                Right _ ->
-                    "https://developers.google.com/gemini-code-assist/auth_success_gemini"
-                Left _ ->
-                    "https://developers.google.com/gemini-code-assist/auth_failure_gemini"
-        Net.sendAll connection
-            ("HTTP/1.1 302 Found\r\nLocation: " <> location
-                <> "\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
-        pure result
-
-receiveRequestHeaders :: Net.Socket -> IO (Either Text BS.ByteString)
-receiveRequestHeaders connection = go BS.empty
-  where
-    maxHeaderBytes = 16_384
-    delimiter = "\r\n\r\n"
-
-    go accumulated
-        | delimiter `BS.isInfixOf` accumulated = pure (Right accumulated)
-        | BS.length accumulated >= maxHeaderBytes =
-            pure (Left "Google OAuth callback request headers were too large")
-        | otherwise = do
-            chunk <- Net.recv connection
-                (maxHeaderBytes - BS.length accumulated)
-            if BS.null chunk
-                then pure
-                    (Left
-                        "Google OAuth callback connection closed before the request headers completed")
-                else go (accumulated <> chunk)
+receiveOAuthCallback listener expectedState = do
+    resultVar <- newEmptyMVar
+    shutdownVar <- newEmptyMVar
+    let settings =
+            Warp.setHost "127.0.0.1"
+                $ Warp.setMaxTotalHeaderLength 16_384
+                $ Warp.setInstallShutdownHandler (putMVar shutdownVar)
+                $ Warp.defaultSettings
+        application request respond = do
+            let result
+                    | Wai.requestMethod request /= methodGet =
+                        Left "Google OAuth callback must use GET"
+                    | Wai.rawPathInfo request /= "/oauth2callback" =
+                        Left "Google OAuth callback used an unexpected path"
+                    | otherwise =
+                        validateOAuthParameters
+                            expectedState
+                            (queryToQueryText (Wai.queryString request))
+                location = case result of
+                    Right _ ->
+                        "https://developers.google.com/gemini-code-assist/auth_success_gemini"
+                    Left _ ->
+                        "https://developers.google.com/gemini-code-assist/auth_failure_gemini"
+                finish = do
+                    void (tryPutMVar resultVar result)
+                    readMVar shutdownVar >>= id
+            respond
+                (Wai.responseLBS
+                    status302
+                    [ (hLocation, location)
+                    , (hContentLength, "0")
+                    , (hCacheControl, "no-store")
+                    ]
+                    "")
+                `finally` finish
+    Warp.runSettingsSocket settings listener application
+    takeMVar resultVar
 
 --------------------------------------------------------------------------------
 -- HTTP and Code Assist JSON
@@ -763,12 +792,26 @@ validationRequirement response = do
         )
 
 requireHttpsValidationUrl :: Text -> IO Text
-requireHttpsValidationUrl url
-    | "https://" `Text.isPrefixOf` Text.toLower url
-    , not (Text.null (Text.drop 8 url)) =
-        pure url
-    | otherwise =
-        fail "Google account validation returned an invalid non-HTTPS URL"
+requireHttpsValidationUrl url =
+    case URI.parseURI (Text.unpack url) of
+        Just uri
+            | map toLower (URI.uriScheme uri) == "https:"
+            , Just authority <- URI.uriAuthority uri
+            , null (URI.uriUserInfo authority)
+            , not (null (URI.uriRegName authority))
+            , validUriPort (URI.uriPort authority) ->
+                pure url
+        _ ->
+            fail "Google account validation returned an invalid non-HTTPS URL"
+
+validUriPort :: String -> Bool
+validUriPort "" = True
+validUriPort (':' : digits)
+    | not (null digits)
+    , all isDigit digits
+    , Just port <- readMaybe digits =
+        port > (0 :: Int) && port < 65_536
+validUriPort _ = False
 
 validateConfiguredProject :: Maybe Text -> IO ()
 validateConfiguredProject = \case

--- a/packages/agent-gemini/src/Agent/Gemini/Auth.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Auth.hs
@@ -63,6 +63,7 @@ import Data.Time.Clock (UTCTime, addUTCTime, getCurrentTime)
 import Network.HTTP.Simple
 import Network.HTTP.Types
     ( hCacheControl
+    , hConnection
     , hContentLength
     , hLocation
     , methodGet
@@ -517,6 +518,7 @@ receiveOAuthCallback listener expectedState = do
                     [ (hLocation, location)
                     , (hContentLength, "0")
                     , (hCacheControl, "no-store")
+                    , (hConnection, "close")
                     ]
                     "")
                 `finally` finish

--- a/packages/agent-gemini/test/Agent/Gemini/AuthSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/AuthSpec.hs
@@ -5,6 +5,7 @@ import Agent.Gemini.TestSupport (withLoopbackApplication)
 import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Concurrent.Async (concurrently)
 import Control.Exception.Safe (bracket)
+import Control.Monad (forM_)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
@@ -73,6 +74,26 @@ spec = do
                     , tokenType = Just "Bearer"
                     , scope = Nothing
                     }
+
+        it "rejects callbacks with the wrong method or path" do
+            forM_
+                [ ("POST", "/oauth2callback", "Google OAuth callback must use GET")
+                , ("GET", "/unexpected", "Google OAuth callback used an unexpected path")
+                ]
+                \(method, path, expectedError) -> do
+                    recorded <- newIORef []
+                    withLoopbackApplication (pure (tokenApp recorded)) \port -> do
+                        presentedUrl <- newEmptyMVar
+                        let options = (testOAuthOptions port) { timeoutSeconds = 5 }
+                        (result, response) <- concurrently
+                            (runLoopbackOAuth options (putMVar presentedUrl))
+                            (takeMVar presentedUrl >>= \url ->
+                                sendOAuthCallback method path url)
+                        result `shouldBe` Left expectedError
+                        response `shouldSatisfy`
+                            BS8.isInfixOf
+                                "Location: https://developers.google.com/gemini-code-assist/auth_failure_gemini"
+                        readIORef recorded `shouldReturn` []
 
         it "exchanges a code and refreshes without losing the refresh token" do
             recorded <- newIORef []
@@ -227,6 +248,25 @@ spec = do
                 readIORef calls `shouldReturn` 2
                 readIORef presented `shouldReturn`
                     [("https://accounts.example.test/validate", "Verify please")]
+
+        it "rejects malformed or credential-bearing validation URLs" do
+            forM_
+                [ "http://accounts.example.test/validate"
+                , "https://?continue=yes"
+                , "https://user@accounts.example.test/validate"
+                , "https://accounts.example.test:invalid/validate"
+                , "https:///validate"
+                ]
+                \validationUrl ->
+                    withLoopbackApplication
+                        (pure (invalidValidationUrlApp validationUrl))
+                        \port -> do
+                            result <- setupCodeAssistWithValidation
+                                (testCodeAssistOptions port)
+                                "bearer"
+                                (Just (\_ _ -> pure ()))
+                            result `shouldBe` Left
+                                "Google account validation returned an invalid non-HTTPS URL"
 
         it "includes the configured project for standard-tier onboarding" do
             bodies <- newIORef []
@@ -408,6 +448,18 @@ validationRequiredApp calls _request respond = do
                 ("validated-project" :: Text)
             ]))
 
+invalidValidationUrlApp :: Text -> Application
+invalidValidationUrlApp validationUrl _request respond =
+    respond (jsonResponse status200 (Aeson.object
+        [ "ineligibleTiers" Aeson..=
+            [ Aeson.object
+                [ "reasonCode" Aeson..= ("VALIDATION_REQUIRED" :: Text)
+                , "reasonMessage" Aeson..= ("Verify please" :: Text)
+                , "validationUrl" Aeson..= validationUrl
+                ]
+            ]
+        ]))
+
 standardOnboardingApp
     :: IORef [(BS.ByteString, BS.ByteString)]
     -> Application
@@ -558,6 +610,44 @@ sendSplitOAuthCallback authorization = do
                     <> " HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"
             _ <- Net.recv socket 4096
             pure ()
+
+sendOAuthCallback
+    :: BS.ByteString
+    -> BS.ByteString
+    -> Text
+    -> IO BS.ByteString
+sendOAuthCallback method path authorization = do
+    redirect <- maybe
+        (expectationFailure "authorization URL has no redirect_uri" >> pure "")
+        pure
+        (queryParameter "redirect_uri" authorization)
+    state <- maybe
+        (expectationFailure "authorization URL has no state" >> pure "")
+        pure
+        (queryParameter "state" authorization)
+    port <- maybe
+        (expectationFailure "redirect_uri has no loopback port" >> pure 0)
+        pure
+        (loopbackPort redirect)
+    bracket
+        (Net.socket Net.AF_INET Net.Stream Net.defaultProtocol)
+        Net.close
+        \socket -> do
+            Net.connect socket
+                (Net.SockAddrInet
+                    (fromIntegral port)
+                    (Net.tupleToHostAddress (127, 0, 0, 1)))
+            Net.sendAll socket
+                (method <> " " <> path <> "?code=code&state="
+                    <> TextEncoding.encodeUtf8 state
+                    <> " HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+            receiveAll socket
+  where
+    receiveAll socket = go []
+      where
+        go chunks = Net.recv socket 4096 >>= \case
+            chunk | BS.null chunk -> pure (BS.concat (reverse chunks))
+            chunk -> go (chunk : chunks)
 
 queryParameter :: Text -> Text -> Maybe Text
 queryParameter key url = do

--- a/packages/agent-mcp/agent-mcp.cabal
+++ b/packages/agent-mcp/agent-mcp.cabal
@@ -61,6 +61,7 @@ library
                     , http-client
                     , http-client-tls
                     , http-types
+                    , network-uri
                     , process
                     , safe-exceptions
                     , scientific

--- a/packages/agent-mcp/package.nix
+++ b/packages/agent-mcp/package.nix
@@ -1,8 +1,9 @@
 { mkDerivation, aeson, agent-core, agent-json, agent-process, async
 , base, base64-bytestring, bytestring, containers, directory
 , filelock, filepath, hspec, http-client, http-client-tls
-, http-types, lib, process, QuickCheck, safe-exceptions, scientific
-, stm, text, time, transformers, unix, vector
+, http-types, lib, network-uri, process, QuickCheck
+, safe-exceptions, scientific, stm, text, time, transformers, unix
+, vector
 }:
 mkDerivation {
   pname = "agent-mcp";
@@ -11,8 +12,8 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-core agent-json agent-process async base
     base64-bytestring bytestring containers directory filelock filepath
-    http-client http-client-tls http-types process safe-exceptions
-    scientific stm text time transformers unix vector
+    http-client http-client-tls http-types network-uri process
+    safe-exceptions scientific stm text time transformers unix vector
   ];
   testHaskellDepends = [
     aeson agent-core agent-json async base bytestring containers

--- a/packages/agent-mcp/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-mcp/src/Agent/MCP/OAuth.hs
@@ -72,11 +72,13 @@ import Data.Time.Clock.POSIX (getPOSIXTime)
 import Network.HTTP.Client (Manager, RequestBody(..), httpLbs, parseRequest, responseBody, responseStatus, urlEncodedBody)
 import qualified Network.HTTP.Client as HC
 import Network.HTTP.Types (statusCode)
+import Network.URI (URI(..), URIAuth(..), parseURI)
 import qualified System.FileLock as FileLock
 import System.IO.Unsafe (unsafePerformIO)
 import System.OsPath (unsafeEncodeUtf)
 import System.Posix.Files (ownerReadMode, ownerWriteMode)
 import System.Posix.IO (OpenFileFlags(..), OpenMode(ReadWrite), closeFd, defaultFileFlags, openFd)
+import Text.Read (readMaybe)
 
 -- ---------------------------------------------------------------------------
 -- Tokens
@@ -396,24 +398,38 @@ probeAuthorizationChallenge manager endpoint = do
 data UrlParts = UrlParts
     { urlScheme :: !Text
     , urlAuthority :: !Text
+    , urlHost :: !Text
+    , urlPort :: !Text
     , urlPath :: !Text
     }
 
 parseUrlParts :: Text -> Maybe UrlParts
 parseUrlParts url = do
-    let (scheme, rest) = Text.breakOn "://" url
-    guard (not (Text.null scheme) && Text.all isSchemeChar scheme && not (Text.null rest))
-    let afterScheme = Text.drop 3 rest
-        (authority, pathQuery) = Text.break (\c -> c == '/' || c == '?' || c == '#') afterScheme
-    guard (not (Text.null authority))
-    let path = Text.takeWhile (\c -> c /= '?' && c /= '#') pathQuery
+    uri <- parseURI (Text.unpack url)
+    authority <- uriAuthority uri
+    guard (not (null (uriScheme uri)))
+    guard (null (uriUserInfo authority))
+    guard (not (null (uriRegName authority)))
+    let scheme = Text.toLower (Text.dropWhileEnd (== ':') (Text.pack (uriScheme uri)))
+        host = Text.toLower (Text.pack (uriRegName authority))
+        port = Text.pack (uriPort authority)
+    guard (validPort port)
     pure UrlParts
-        { urlScheme = Text.toLower scheme
-        , urlAuthority = Text.toLower authority
-        , urlPath = Text.dropWhileEnd (== '/') path
+        { urlScheme = scheme
+        , urlAuthority = host <> port
+        , urlHost = host
+        , urlPort = port
+        , urlPath = Text.dropWhileEnd (== '/') (Text.pack (uriPath uri))
         }
   where
-    isSchemeChar c = isAlphaNum c || c == '+' || c == '-' || c == '.'
+    validPort "" = True
+    validPort rawPort = case Text.stripPrefix ":" rawPort of
+        Just digits
+            | not (Text.null digits)
+            , Text.all (`elem` ['0' .. '9']) digits
+            , Just port <- (readMaybe (Text.unpack digits) :: Maybe Integer) ->
+                port > 0 && port < 65536
+        _ -> False
 
 urlPartsOrigin :: UrlParts -> Text
 urlPartsOrigin parts = parts.urlScheme <> "://" <> parts.urlAuthority
@@ -435,11 +451,10 @@ loopbackRedirectPort :: Text -> Maybe Int
 loopbackRedirectPort url = do
     parts <- parseUrlParts url
     guard (parts.urlScheme == "http")
-    let (host, portText) = Text.breakOn ":" parts.urlAuthority
-    guard (host `elem` ["127.0.0.1", "localhost", "[::1]"])
-    digits <- Text.stripPrefix ":" portText
+    guard (parts.urlHost `elem` ["127.0.0.1", "localhost", "[::1]"])
+    digits <- Text.stripPrefix ":" parts.urlPort
     guard (not (Text.null digits) && Text.all (`elem` ['0' .. '9']) digits)
-    let port = read (Text.unpack digits)
+    port <- readMaybe (Text.unpack digits)
     guard (port > 0 && port < 65536)
     pure port
 
@@ -450,12 +465,10 @@ checkSecureUrl label url = case parseUrlParts url of
     Nothing -> Left (label <> " is not an absolute URL: " <> url)
     Just parts
         | parts.urlScheme == "https" -> Right ()
-        | parts.urlScheme == "http" && isLoopback parts.urlAuthority -> Right ()
+        | parts.urlScheme == "http" && isLoopback parts.urlHost -> Right ()
         | otherwise -> Left (label <> " must use https: " <> url)
   where
-    isLoopback authority =
-        let host = Text.takeWhile (/= ':') (Text.takeWhileEnd (/= '@') authority)
-        in host `elem` ["localhost", "127.0.0.1", "[::1]"]
+    isLoopback host = host `elem` ["localhost", "127.0.0.1", "[::1]"]
 
 -- ---------------------------------------------------------------------------
 -- Protected resource metadata (RFC 9728)

--- a/packages/agent-mcp/test/Agent/MCP/OAuthSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCP/OAuthSpec.hs
@@ -73,12 +73,20 @@ spec = describe "Agent.MCP.OAuth" do
         it "reports the origin" do
             resourceOrigin "https://mcp.example.com:8443/server/mcp" `shouldBe` Just "https://mcp.example.com:8443"
             resourceOrigin "not a url" `shouldBe` Nothing
+            resourceOrigin "1https://mcp.example.com/server" `shouldBe` Nothing
+            resourceOrigin "https://?query" `shouldBe` Nothing
+            resourceOrigin "https://user@mcp.example.com/server" `shouldBe` Nothing
+            resourceOrigin "https://mcp.example.com:/server" `shouldBe` Nothing
+            resourceOrigin "https://mcp.example.com:0/server" `shouldBe` Nothing
+            resourceOrigin "https://mcp.example.com:65536/server" `shouldBe` Nothing
 
         it "extracts loopback redirect ports" do
             loopbackRedirectPort "http://127.0.0.1:43127/callback" `shouldBe` Just 43127
             loopbackRedirectPort "http://localhost:8080/callback" `shouldBe` Just 8080
+            loopbackRedirectPort "http://[::1]:43127/callback" `shouldBe` Just 43127
             loopbackRedirectPort "https://example.com:443/callback" `shouldBe` Nothing
             loopbackRedirectPort "http://127.0.0.1/callback" `shouldBe` Nothing
+            loopbackRedirectPort "http://user@127.0.0.1:43127/callback" `shouldBe` Nothing
 
     describe "protectedResourceMetadataUrls" do
         it "tries the path-aware well-known URI before the root" do

--- a/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
@@ -466,23 +466,26 @@ fallbackToChatGPTBatch
         case encodePcm16Wav openAITranscriptionSampleRate pcm of
             Left err ->
                 pure (Left err)
-            Right wav -> do
-                seeded <- seedTokenProvider provider initial
-                runWithTokenProvider seeded \credential ->
-                    if credential.provider /= OpenAIProvider
-                        then pure $ Left $ CredentialError
-                            "ChatGPT dictation requires an OpenAI credential"
-                        else
-                            postChatGPTTranscription
-                                baseUrl
-                                credential
-                                wav >>= \case
-                                    Left err ->
-                                        pure (Left err)
-                                    Right transcript -> do
-                                        ignoreSynchronousException
-                                            (onTranscript transcript)
-                                        pure (Right transcript)
+            Right wav ->
+                prepareChatGPTTranscriptionRequest baseUrl wav >>= \case
+                    Left err ->
+                        pure (Left err)
+                    Right request -> do
+                        seeded <- seedTokenProvider provider initial
+                        runWithTokenProvider seeded \credential ->
+                            if credential.provider /= OpenAIProvider
+                                then pure $ Left $ CredentialError
+                                    "ChatGPT dictation requires an OpenAI credential"
+                                else
+                                    postChatGPTTranscription
+                                        credential
+                                        request >>= \case
+                                            Left err ->
+                                                pure (Left err)
+                                            Right transcript -> do
+                                                ignoreSynchronousException
+                                                    (onTranscript transcript)
+                                                pure (Right transcript)
 
 data ChatGPTStreamOutcome
     = ChatGPTStreamSucceeded !Text
@@ -1058,40 +1061,28 @@ encodePcm16Wav sampleRate pcm
     bytesPerSample = 2
     maxWavDataLength = fromIntegral (maxBound :: Word32) - 36
 
-postChatGPTTranscription
+prepareChatGPTTranscriptionRequest
     :: Text
-    -> Credential
     -> LBS.ByteString
-    -> IO (Either ApiError Text)
-postChatGPTTranscription baseUrl credential wav = do
+    -> IO (Either ApiError Http.Request)
+prepareChatGPTTranscriptionRequest baseUrl wav = do
     let endpoint =
             Text.unpack
                 (Text.dropWhileEnd (== '/') baseUrl <> "/transcribe")
-        accountHeader request
-            | Text.null (Text.strip credential.accountId) = request
-            | otherwise =
-                setRequestHeader
-                    "ChatGPT-Account-Id"
-                    [Text.encodeUtf8 credential.accountId]
-                    request
-    prepared <- tryAny
-        (do
-            request <- parseRequest endpoint
-            Multipart.formDataBody
-                [ (Multipart.partFileRequestBody
-                    "file"
-                    "audio.wav"
-                    (Http.RequestBodyLBS wav))
-                    { Multipart.partContentType = Just "audio/wav" }
-                ]
-                $ setRequestMethod "POST"
-                $ setRequestHeader "Accept" ["application/json"]
-                $ setRequestHeader "Originator" ["haskell-agent"]
-                $ setRequestHeader "User-Agent" ["haskell-agent"]
-                $ setRequestHeader
-                    "Authorization"
-                    ["Bearer " <> Text.encodeUtf8 credential.accessToken]
-                $ accountHeader request)
+    prepared <- tryAny do
+        request <- parseRequest endpoint
+        Multipart.formDataBody
+            [ (Multipart.partFileRequestBody
+                "file"
+                "audio.wav"
+                (Http.RequestBodyLBS wav))
+                { Multipart.partContentType = Just "audio/wav" }
+            ]
+            $ setRequestMethod "POST"
+            $ setRequestHeader "Accept" ["application/json"]
+            $ setRequestHeader "Originator" ["haskell-agent"]
+            $ setRequestHeader "User-Agent" ["haskell-agent"]
+            request
     case prepared of
         Left err
             | isSyncException err ->
@@ -1100,13 +1091,32 @@ postChatGPTTranscription baseUrl credential wav = do
                         <> Text.pack (displayException err))
             | otherwise ->
                 throwIO err
-        Right multipartRequest ->
-            retryTransientTranscription
-                [3_000_000, 6_000_000]
-                (sendRequest multipartRequest)
+        Right request ->
+            pure (Right request)
+
+postChatGPTTranscription
+    :: Credential
+    -> Http.Request
+    -> IO (Either ApiError Text)
+postChatGPTTranscription credential request =
+    retryTransientTranscription [3_000_000, 6_000_000] sendRequest
   where
-    sendRequest request =
-        tryAny (httpLBS request) >>= \case
+    addAccountHeader request'
+        | Text.null (Text.strip credential.accountId) = request'
+        | otherwise =
+            setRequestHeader
+                "ChatGPT-Account-Id"
+                [Text.encodeUtf8 credential.accountId]
+                request'
+
+    authenticatedRequest =
+        setRequestHeader
+            "Authorization"
+            ["Bearer " <> Text.encodeUtf8 credential.accessToken]
+            (addAccountHeader request)
+
+    sendRequest =
+        tryAny (httpLBS authenticatedRequest) >>= \case
             Left err
                 | isSyncException err ->
                     pure $ Left $ ConnectionError

--- a/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
@@ -64,7 +64,6 @@ import Data.Aeson ((.=))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Builder as Builder
-import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import qualified Data.Map.Strict as Map
@@ -73,14 +72,14 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text
-import Data.Unique (hashUnique, newUnique)
 import Data.Word (Word32)
+import qualified Network.HTTP.Client as Http
+import qualified Network.HTTP.Client.MultipartFormData as Multipart
 import Network.HTTP.Simple
     ( getResponseBody
     , getResponseStatusCode
     , httpLBS
     , parseRequest
-    , setRequestBodyLBS
     , setRequestHeader
     , setRequestMethod
     )
@@ -468,8 +467,6 @@ fallbackToChatGPTBatch
             Left err ->
                 pure (Left err)
             Right wav -> do
-                boundary <- transcriptionBoundary
-                let body = multipartWavBody boundary wav
                 seeded <- seedTokenProvider provider initial
                 runWithTokenProvider seeded \credential ->
                     if credential.provider /= OpenAIProvider
@@ -479,8 +476,7 @@ fallbackToChatGPTBatch
                             postChatGPTTranscription
                                 baseUrl
                                 credential
-                                boundary
-                                body >>= \case
+                                wav >>= \case
                                     Left err ->
                                         pure (Left err)
                                     Right transcript -> do
@@ -1065,53 +1061,67 @@ encodePcm16Wav sampleRate pcm
 postChatGPTTranscription
     :: Text
     -> Credential
-    -> BS.ByteString
     -> LBS.ByteString
     -> IO (Either ApiError Text)
-postChatGPTTranscription baseUrl credential boundary body =
-    retryTransientTranscription [3_000_000, 6_000_000] sendRequest
+postChatGPTTranscription baseUrl credential wav = do
+    let endpoint =
+            Text.unpack
+                (Text.dropWhileEnd (== '/') baseUrl <> "/transcribe")
+        accountHeader request
+            | Text.null (Text.strip credential.accountId) = request
+            | otherwise =
+                setRequestHeader
+                    "ChatGPT-Account-Id"
+                    [Text.encodeUtf8 credential.accountId]
+                    request
+    prepared <- tryAny
+        (do
+            request <- parseRequest endpoint
+            Multipart.formDataBody
+                [ (Multipart.partFileRequestBody
+                    "file"
+                    "audio.wav"
+                    (Http.RequestBodyLBS wav))
+                    { Multipart.partContentType = Just "audio/wav" }
+                ]
+                $ setRequestMethod "POST"
+                $ setRequestHeader "Accept" ["application/json"]
+                $ setRequestHeader "Originator" ["haskell-agent"]
+                $ setRequestHeader "User-Agent" ["haskell-agent"]
+                $ setRequestHeader
+                    "Authorization"
+                    ["Bearer " <> Text.encodeUtf8 credential.accessToken]
+                $ accountHeader request)
+    case prepared of
+        Left err
+            | isSyncException err ->
+                pure $ Left $ ConnectionError
+                    ("ChatGPT transcription request failed: "
+                        <> Text.pack (displayException err))
+            | otherwise ->
+                throwIO err
+        Right multipartRequest ->
+            retryTransientTranscription
+                [3_000_000, 6_000_000]
+                (sendRequest multipartRequest)
   where
-    sendRequest = do
-        let contentType = "multipart/form-data; boundary=" <> boundary
-            endpoint =
-                Text.unpack
-                    (Text.dropWhileEnd (== '/') baseUrl <> "/transcribe")
-            accountHeader request
-                | Text.null (Text.strip credential.accountId) = request
-                | otherwise =
-                    setRequestHeader
-                        "ChatGPT-Account-Id"
-                        [Text.encodeUtf8 credential.accountId]
-                        request
-        tryAny
-            (do
-                request <- parseRequest endpoint
-                httpLBS
-                    $ setRequestMethod "POST"
-                    $ setRequestBodyLBS body
-                    $ setRequestHeader "Content-Type" [contentType]
-                    $ setRequestHeader "Accept" ["application/json"]
-                    $ setRequestHeader "Originator" ["haskell-agent"]
-                    $ setRequestHeader "User-Agent" ["haskell-agent"]
-                    $ setRequestHeader
-                        "Authorization"
-                        ["Bearer " <> Text.encodeUtf8 credential.accessToken]
-                    $ accountHeader request) >>= \case
-                        Left err
-                            | isSyncException err ->
-                                pure $ Left $ ConnectionError
-                                    ("ChatGPT transcription request failed: "
-                                        <> Text.pack (displayException err))
-                            | otherwise ->
-                                throwIO err
-                        Right response -> do
-                            let status = getResponseStatusCode response
-                                responseBody = getResponseBody response
-                            pure $
-                                if status >= 200 && status < 300
-                                    then decodeTranscriptionResponse responseBody
-                                    else Left $ HttpError status
-                                        (responseBodyPreview responseBody)
+    sendRequest request =
+        tryAny (httpLBS request) >>= \case
+            Left err
+                | isSyncException err ->
+                    pure $ Left $ ConnectionError
+                        ("ChatGPT transcription request failed: "
+                            <> Text.pack (displayException err))
+                | otherwise ->
+                    throwIO err
+            Right response -> do
+                let status = getResponseStatusCode response
+                    responseBody = getResponseBody response
+                pure $
+                    if status >= 200 && status < 300
+                        then decodeTranscriptionResponse responseBody
+                        else Left $ HttpError status
+                            (responseBodyPreview responseBody)
 
 retryTransientTranscription
     :: [Int]
@@ -1126,24 +1136,6 @@ retryTransientTranscription retryDelays action =
                     retryTransientTranscription remaining action
             _ ->
                 pure result
-
-transcriptionBoundary :: IO BS.ByteString
-transcriptionBoundary = do
-    unique <- hashUnique <$> newUnique
-    pure $ BS8.pack
-        ("----haskell-agent-transcribe-"
-            <> show (abs (toInteger unique)))
-
-multipartWavBody :: BS.ByteString -> LBS.ByteString -> LBS.ByteString
-multipartWavBody boundary wav =
-    LBS.fromStrict
-        ( "--" <> boundary <> "\r\n"
-        <> "Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n"
-        <> "Content-Type: audio/wav\r\n\r\n"
-        )
-        <> wav
-        <> LBS.fromStrict
-            ("\r\n--" <> boundary <> "--\r\n")
 
 transcriptionResponseDecoder :: Json.Decoder Text
 transcriptionResponseDecoder =

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -89,7 +89,7 @@ library
                     , Agent.Store.Postgres.Skill.Mapping.Statements.UpdateSkill
     hs-source-dirs:   src
     build-depends:    base >= 4.14 && < 5
-                    , async
+                    , async >= 2.2.6 && < 2.3
                     , bytestring
                     , containers
                     , contravariant

--- a/packages/agent-store/src/Agent/Store/PoolCache.hs
+++ b/packages/agent-store/src/Agent/Store/PoolCache.hs
@@ -9,11 +9,11 @@ module Agent.Store.PoolCache
     , closePoolCache
     ) where
 
-import Control.Concurrent.Async (replicateConcurrently_)
+import qualified Control.Concurrent.Stream as ConcurrentStream
 import Control.Concurrent.MVar
 import Control.Concurrent.STM
 import qualified Control.Exception as Exception
-import Control.Monad (forM_, replicateM_, void)
+import Control.Monad (void)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 
@@ -207,7 +207,7 @@ closeOwned
     -> [TMVar (Either err resource)]
     -> IO ()
 closeOwned cache ready opening = do
-    outcomes <- mapConcurrentlyBounded
+    outcomes <- ConcurrentStream.mapConcurrentlyBounded
         cache.cacheCloseConcurrency
         run
         (map CloseResource ready <> map WaitOpening opening)
@@ -233,32 +233,3 @@ tryAnyException
     :: IO a
     -> IO (Either Exception.SomeException a)
 tryAnyException = Exception.try
-
-mapConcurrentlyBounded
-    :: Int
-    -> (a -> IO b)
-    -> [a]
-    -> IO [b]
-mapConcurrentlyBounded _ _ [] = pure []
-mapConcurrentlyBounded limit action values = do
-    let workerCount = min (max 1 limit) (length values)
-    queue <- newTQueueIO
-    results <- newTVarIO Map.empty
-    atomically do
-        forM_ (zip [0 :: Int ..] values) $
-            writeTQueue queue . Just
-        replicateM_ workerCount (writeTQueue queue Nothing)
-    let worker =
-            atomically (readTQueue queue) >>= \case
-                Nothing -> pure ()
-                Just (index, value) -> do
-                    result <- action value
-                    atomically $
-                        modifyTVar' results (Map.insert index result)
-                    worker
-    replicateConcurrently_ workerCount worker
-    completed <- readTVarIO results
-    pure
-        [ completed Map.! index
-        | index <- [0 .. length values - 1]
-        ]

--- a/packages/agent-telegram/agent-telegram.cabal
+++ b/packages/agent-telegram/agent-telegram.cabal
@@ -73,6 +73,7 @@ library
                     , http-client
                     , http-client-tls
                     , http-types
+                    , optparse-applicative
                     , process >= 1.6.26
                     , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions

--- a/packages/agent-telegram/package.nix
+++ b/packages/agent-telegram/package.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, agent-cli-runtime, agent-core, agent-json
 , agent-store, async, base, bytestring, containers, directory
 , filelock, filepath, hspec, http-client, http-client-tls
-, http-types, lib, process, retry, safe-exceptions, temporary, text
-, time, unix, vector
+, http-types, lib, optparse-applicative, process, retry
+, safe-exceptions, temporary, text, time, unix, vector
 }:
 mkDerivation {
   pname = "agent-telegram";
@@ -13,8 +13,8 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-cli-runtime agent-core agent-json agent-store async
     base bytestring containers directory filelock filepath http-client
-    http-client-tls http-types process retry safe-exceptions text time
-    unix vector
+    http-client-tls http-types optparse-applicative process retry
+    safe-exceptions text time unix vector
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [

--- a/packages/agent-telegram/src/Agent/Telegram/Client.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Client.hs
@@ -44,14 +44,13 @@ import Data.Aeson
     , (.=)
     )
 import qualified Data.Aeson.Key as Key
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import qualified Network.HTTP.Client as Http
+import qualified Network.HTTP.Client.MultipartFormData as Multipart
 import Network.HTTP.Types.Status (statusCode)
 import System.Directory (doesFileExist)
 import System.FilePath (takeFileName)
@@ -537,9 +536,7 @@ sendMultipartFile client key method fieldName path caption requestedName = do
     if not exists
         then pure (Left ("file does not exist: " <> Text.pack path))
         else do
-            bytes <- BS.readFile path
-            let boundary = "haskell-agent-telegram-boundary"
-                filename = fromMaybe (Text.pack (takeFileName path)) requestedName
+            let filename = fromMaybe (Text.pack (takeFileName path)) requestedName
                 fields =
                     [("chat_id", Text.pack (show key.chatId))]
                         <> maybe []
@@ -547,63 +544,32 @@ sendMultipartFile client key method fieldName path caption requestedName = do
                                 [("message_thread_id", Text.pack (show threadId))])
                             key.messageThreadId
                         <> maybe [] (\text -> [("caption", text)]) caption
-                body = multipartBody boundary fields fieldName filename bytes
+                textPart (name, value) =
+                    Multipart.partBS name (TextEncoding.encodeUtf8 value)
+                filePart =
+                    (Multipart.partFileSource fieldName path)
+                        { Multipart.partFilename =
+                            Just (Text.unpack (sanitizeFilename filename))
+                        , Multipart.partContentType =
+                            Just "application/octet-stream"
+                        }
             result <- runRetrying client do
                 base <- Http.parseRequest $
                     "https://api.telegram.org/bot"
                         <> Text.unpack client.clientToken
                         <> "/"
                         <> method
-                Http.httpLbs
+                request <- Multipart.formDataBody
+                    (map textPart fields <> [filePart])
                     base
                         { Http.method = "POST"
-                        , Http.requestHeaders =
-                            [ ( "Content-Type"
-                              , "multipart/form-data; boundary=" <> boundary
-                              )
-                            ]
-                        , Http.requestBody = Http.RequestBodyLBS body
                         , Http.responseTimeout =
                             Http.responseTimeoutMicro 60_000_000
                         }
-                    client.clientManager
+                Http.httpLbs request client.clientManager
             case result of
                 Left err -> pure (Left err)
                 Right response -> pure (decodeSentMessageId response)
-
-multipartBody
-    :: BS.ByteString
-    -> [(Text, Text)]
-    -> Text
-    -> Text
-    -> BS.ByteString
-    -> LBS.ByteString
-multipartBody boundary fields fileField filename fileBytes =
-    mconcat
-        (map textPart fields)
-        <> filePart
-        <> LBS8.pack ("--" <> BS8.unpack boundary <> "--\r\n")
-  where
-    delimiter = "--" <> BS8.unpack boundary <> "\r\n"
-    textPart (name, value) = LBS8.pack $
-        delimiter
-            <> "Content-Disposition: form-data; name=\""
-            <> Text.unpack name
-            <> "\"\r\n\r\n"
-            <> Text.unpack value
-            <> "\r\n"
-    filePart =
-        LBS8.pack
-            ( delimiter
-                <> "Content-Disposition: form-data; name=\""
-                <> Text.unpack fileField
-                <> "\"; filename=\""
-                <> Text.unpack (sanitizeFilename filename)
-                <> "\"\r\n"
-                <> "Content-Type: application/octet-stream\r\n\r\n"
-            )
-            <> LBS.fromStrict fileBytes
-            <> "\r\n"
 
 sanitizeFilename :: Text -> Text
 sanitizeFilename =

--- a/packages/agent-telegram/src/Agent/Telegram/Internal/App.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/App.hs
@@ -29,6 +29,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async ()
 import Control.Concurrent.Chan ()
 import Control.Concurrent.MVar ()
+import Control.Applicative (many, (<|>))
 import Control.Exception.Safe
     ( SomeException
     , bracket
@@ -44,7 +45,6 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Int ()
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Map.Strict as Map
-import Data.List ()
 import Data.Maybe ()
 import Data.Set ()
 import qualified Data.Set as Set
@@ -53,6 +53,32 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Time.Clock ()
 import qualified Network.HTTP.Client.TLS as HttpTls
+import Options.Applicative
+    ( Parser
+    , ParserInfo
+    , ParserResult(..)
+    , ReadM
+    , argument
+    , command
+    , defaultPrefs
+    , eitherReader
+    , execParserPure
+    , flag'
+    , fullDesc
+    , header
+    , help
+    , helper
+    , hsubparser
+    , info
+    , long
+    , metavar
+    , option
+    , progDesc
+    , renderFailure
+    , short
+    , strOption
+    , (<**>)
+    )
 import qualified System.Directory as Directory ()
 import System.Directory.OsPath
     ( createDirectoryIfMissing
@@ -97,69 +123,127 @@ telegramMain =
     getArgs >>= either die executeTelegramCommand . parseTelegramArgs
 
 parseTelegramArgs :: [String] -> Either String TelegramCommand
-parseTelegramArgs = \case
-    [] -> Right TelegramRun
-    ["run"] -> Right TelegramRun
-    ["start"] -> Right TelegramStart
-    ["stop"] -> Right TelegramStop
-    ["status"] -> Right TelegramStatus
-    ["users", "list"] -> Right (TelegramUsers TelegramUsersList)
-    ["users", "add", value] ->
-        TelegramUsers . TelegramUsersAdd <$> parseUserId value
-    ["users", "remove", value] ->
-        TelegramUsers . TelegramUsersRemove <$> parseUserId value
-    ["--help"] -> Right TelegramHelp
-    ["-h"] -> Right TelegramHelp
-    ["--version"] -> Right TelegramVersion
-    "setup" : rest -> TelegramSetup <$> parseSetupOptions rest
-    _ -> Left telegramUsage
-  where
-    parseUserId value =
-        case readMaybe value of
-            Just userId | userId > 0 -> Right userId
-            _ -> Left ("invalid Telegram user ID: " <> value)
+parseTelegramArgs args =
+    case execParserPure defaultPrefs telegramParserInfo args of
+        Success commandValue -> Right commandValue
+        Failure failure -> Left (fst (renderFailure failure "agent-telegram"))
+        CompletionInvoked _ -> Left telegramUsage
 
-parseSetupOptions :: [String] -> Either String TelegramSetupOptions
-parseSetupOptions = go defaultTelegramSetupOptions
+telegramParserInfo :: ParserInfo TelegramCommand
+telegramParserInfo = info telegramCommandParser
+    (fullDesc
+        <> progDesc "Run and configure the Haskell Agent Telegram gateway"
+        <> header "agent-telegram")
+
+telegramCommandParser :: Parser TelegramCommand
+telegramCommandParser =
+    flag' TelegramHelp
+        (long "help" <> short 'h' <> help "Show this help text")
+        <|> telegramOperationalParser
+
+telegramOperationalParser :: Parser TelegramCommand
+telegramOperationalParser =
+    flag' TelegramVersion (long "version" <> help "Show the version")
+        <|> telegramSubcommandParser
+        <|> pure TelegramRun
+
+telegramSubcommandParser :: Parser TelegramCommand
+telegramSubcommandParser = hsubparser
+    ( command "setup"
+        (info (TelegramSetup <$> telegramSetupOptionsParser)
+            (progDesc "Configure the Telegram gateway"))
+        <> command "run"
+            (info (pure TelegramRun) (progDesc "Run the configured gateway"))
+        <> command "start"
+            (info (pure TelegramStart) (progDesc "Start the background gateway"))
+        <> command "stop"
+            (info (pure TelegramStop) (progDesc "Stop the background gateway"))
+        <> command
+            "status"
+            (info (pure TelegramStatus) (progDesc "Show gateway status"))
+        <> command "users"
+            (info telegramUsersParser (progDesc "Manage allowed Telegram users"))
+    )
+
+telegramUsersParser :: Parser TelegramCommand
+telegramUsersParser = TelegramUsers <$> hsubparser
+    ( command "list"
+        (info (pure TelegramUsersList) (progDesc "List allowed users"))
+        <> command "add"
+            (info
+                (TelegramUsersAdd <$> argument telegramUserIdReader (metavar "ID"))
+                (progDesc "Allow a Telegram user"))
+        <> command "remove"
+            (info
+                (TelegramUsersRemove <$> argument telegramUserIdReader (metavar "ID"))
+                (progDesc "Remove a Telegram user"))
+    )
+
+telegramSetupOptionsParser :: Parser TelegramSetupOptions
+telegramSetupOptionsParser =
+    foldl' (\options update -> update options) defaultTelegramSetupOptions
+        <$> many setupOption
   where
-    go options = \case
-        [] -> Right options
-        "--provider" : value : rest ->
-            case parseProvider (Text.pack value) of
-                Nothing -> Left ("unknown provider: " <> value)
-                Just provider -> go options { setupProvider = Just provider } rest
-        "--model" : value : rest ->
-            go options { setupModel = Just (Text.pack value) } rest
-        "--cwd" : value : rest ->
-            go options { setupCwd = Just value } rest
-        "--effort" : value : rest ->
-            go options { setupEffort = Just (Text.pack value) } rest
-        "--allowed-user" : value : rest ->
-            case readMaybe value of
-                Just userId | userId > 0 ->
-                    go options
-                        { setupAllowedUsers =
-                            options.setupAllowedUsers <> [userId]
-                        }
-                        rest
-                _ -> Left ("invalid Telegram user ID: " <> value)
-        "--yolo" : rest ->
-            go options { setupApprovalMode = TelegramApprovalYolo } rest
-        "--deny-mutations" : rest ->
-            go options { setupApprovalMode = TelegramApprovalDeny } rest
-        "--all-group-messages" : rest ->
-            go options { setupRespondToAllGroupMessages = True } rest
-        "--workers" : value : rest ->
-            case readMaybe value of
-                Just workers
-                    | workers >= 1
-                    , workers <= maximumTelegramWorkerCount ->
-                        go options { setupWorkerCount = workers } rest
-                _ -> Left
-                    ("workers must be between 1 and "
-                        <> show maximumTelegramWorkerCount)
-        "--start" : rest -> go options { setupStart = True } rest
-        flag : _ -> Left ("unknown setup option: " <> flag <> "\n\n" <> telegramUsage)
+    setupOption =
+        (\provider options -> options { setupProvider = Just provider })
+            <$> option providerReader
+                (long "provider" <> metavar "NAME" <> help "Provider name")
+        <|> (\model options -> options { setupModel = Just (Text.pack model) })
+            <$> strOption
+                (long "model" <> metavar "NAME"
+                    <> help "Optional model override")
+        <|> (\cwd options -> options { setupCwd = Just cwd })
+            <$> strOption
+                (long "cwd" <> metavar "PATH" <> help "Agent working directory")
+        <|> (\effort options -> options { setupEffort = Just (Text.pack effort) })
+            <$> strOption
+                (long "effort" <> metavar "LEVEL"
+                    <> help "Optional reasoning effort")
+        <|> (\userId options ->
+                options
+                    { setupAllowedUsers = options.setupAllowedUsers <> [userId] })
+            <$> option telegramUserIdReader
+                (long "allowed-user" <> metavar "ID"
+                    <> help "Allowed Telegram user ID; may be repeated")
+        <|> flag' (\options ->
+                options { setupApprovalMode = TelegramApprovalYolo })
+            (long "yolo" <> help "Auto-approve mutating agent tools")
+        <|> flag' (\options ->
+                options { setupApprovalMode = TelegramApprovalDeny })
+            (long "deny-mutations" <> help "Deny mutating agent tools")
+        <|> flag' (\options ->
+                options { setupRespondToAllGroupMessages = True })
+            (long "all-group-messages"
+                <> help "Consider every allowed-user group message")
+        <|> (\workers options -> options { setupWorkerCount = workers })
+            <$> option workerCountReader
+                (long "workers" <> metavar "N"
+                    <> help ("Concurrent chat workers (1-"
+                        <> show maximumTelegramWorkerCount <> ")"))
+        <|> flag' (\options -> options { setupStart = True })
+            (long "start" <> help "Start the gateway after setup")
+
+providerReader :: ReadM Provider
+providerReader = eitherReader \value ->
+    maybe (Left ("unknown provider: " <> value)) Right
+        (parseProvider (Text.pack value))
+
+telegramUserIdReader :: ReadM Integer
+telegramUserIdReader = eitherReader \value ->
+    case readMaybe value of
+        Just userId | userId > 0 -> Right userId
+        _ -> Left ("invalid Telegram user ID: " <> value)
+
+workerCountReader :: ReadM Int
+workerCountReader = eitherReader \value ->
+    case readMaybe value of
+        Just workers
+            | workers >= 1
+            , workers <= maximumTelegramWorkerCount ->
+                Right workers
+        _ -> Left
+            ("workers must be between 1 and "
+                <> show maximumTelegramWorkerCount)
 
 executeTelegramCommand :: TelegramCommand -> IO ()
 executeTelegramCommand = \case
@@ -173,29 +257,16 @@ executeTelegramCommand = \case
     TelegramVersion -> putStrLn "agent-telegram 0.1.0.0"
 
 telegramUsage :: String
-telegramUsage = unlines
-    [ "Usage: agent-telegram setup [OPTIONS]"
-    , "       agent-telegram run"
-    , "       agent-telegram start"
-    , "       agent-telegram stop"
-    , "       agent-telegram status"
-    , "       agent-telegram users list|add ID|remove ID"
-    , ""
-    , "Setup options:"
-    , "  --provider NAME       openai, xai, openrouter, gemini, or claude-code"
-    , "  --model NAME          optional model override"
-    , "  --cwd PATH            agent working directory"
-    , "  --effort LEVEL        optional reasoning effort"
-    , "  --allowed-user ID     numeric Telegram user ID"
-    , "                          may be repeated"
-    , "  --yolo                auto-approve mutating agent tools"
-    , "  --deny-mutations       deny mutating agent tools"
-    , "                          default: ask with Telegram buttons"
-    , "  --all-group-messages  consider every allowed-user group message"
-    , "                          and reply only when useful"
-    , "  --workers N           concurrent chat workers (1-64, default: 8)"
-    , "  --start               start the gateway after setup"
-    ]
+telegramUsage =
+    case execParserPure defaultPrefs
+        (info (telegramOperationalParser <**> helper)
+            (fullDesc
+                <> progDesc
+                    "Run and configure the Haskell Agent Telegram gateway"
+                <> header "agent-telegram"))
+        ["--help"] of
+        Failure failure -> fst (renderFailure failure "agent-telegram")
+        _ -> "Usage: agent-telegram COMMAND"
 
 manageTelegramUsers :: TelegramUsersCommand -> IO ()
 manageTelegramUsers command = do

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -100,6 +100,16 @@ spec = describe "Agent.Telegram" do
         it "runs the configured gateway by default" do
             parseTelegramArgs [] `shouldBe` Right TelegramRun
             parseTelegramArgs ["run"] `shouldBe` Right TelegramRun
+            parseTelegramArgs ["--help"] `shouldBe` Right TelegramHelp
+            parseTelegramArgs ["--version"] `shouldBe` Right TelegramVersion
+
+        it "parses user management commands" do
+            parseTelegramArgs ["users", "list"]
+                `shouldBe` Right (TelegramUsers TelegramUsersList)
+            parseTelegramArgs ["users", "add", "42"]
+                `shouldBe` Right (TelegramUsers (TelegramUsersAdd 42))
+            parseTelegramArgs ["users", "remove", "42"]
+                `shouldBe` Right (TelegramUsers (TelegramUsersRemove 42))
 
         it "parses non-secret setup options" do
             parseTelegramArgs
@@ -134,6 +144,10 @@ spec = describe "Agent.Telegram" do
                 `shouldSatisfy` isLeft
             parseTelegramArgs ["setup", "--workers", "65"]
                 `shouldSatisfy` isLeft
+            parseTelegramArgs ["setup", "--yolo", "--deny-mutations"]
+                `shouldBe` Right
+                    (TelegramSetup defaultTelegramSetupOptions
+                        { setupApprovalMode = TelegramApprovalDeny })
 
     describe "parseAllowedUsers" do
         it "parses and deduplicates numeric IDs" do


### PR DESCRIPTION
## Summary

- replace custom multipart encoders in Telegram uploads, ChatGPT transcription, and gateway dictation with `http-client` multipart helpers, including replay-safe request reuse across credential retries
- replace duplicate bounded worker-pool implementations with `async` ordered, cancellation-safe bounded traversal
- replace raw loopback OAuth HTTP parsing with WAI/Warp servers that bound headers, validate request targets, and shut down without keep-alive delays
- replace ad-hoc OAuth URL splitting with `network-uri` authority, userinfo, host, and port validation
- replace Telegram's manual CLI argument walker with `optparse-applicative` while retaining default-run and ordered override behavior
- regenerate the affected Cabal-derived Nix package expressions

## Validation

- bounded concurrency: 5 examples, 0 failures
- store pool cache: 6 examples, 0 failures
- `agent-mcp`: 99 examples, 0 failures
- `agent-gemini`: 53 examples, 0 failures
- `agent-telegram`: 73 examples, 0 failures
- `agent-openai`: 350 examples, 0 failures, 1 credential-gated pending test
- gateway device authorization: 37 examples, 0 failures
- complete `agent-cli` library: 212 modules loaded in GHCi
- checked-in `package.nix` files match `cabal2nix`
- `git diff --check origin/master..HEAD`
- patch-identical rebase onto current `origin/master`
- independent final review found no actionable correctness, security, lifecycle, compatibility, or metadata issues

## Local environment note

Broad PostgreSQL persistence filters cannot start their temporary server from this deep macOS worktree because the Unix socket path exceeds PostgreSQL's limit; CI runs the flake checks from a short checkout path.
