### PR TITLE
fix(mcp): scope supervisor startup workers

### DIFF
--- a/packages/agent-mcp/src/Agent/MCP/Supervisor.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Supervisor.hs
@@ -13,9 +13,9 @@ import Agent.MCP.Fleet
     )
 import Agent.MCP.Types
 import Control.Concurrent.Async
-    ( asyncWithUnmask
-    , cancel
+    ( cancel
     , waitCatch
+    , withAsyncWithUnmask
     )
 import Control.Concurrent.MVar
     ( modifyMVar
@@ -191,19 +191,18 @@ acquireMcpFleetWith supervisor progressive start configs =
                 (\fleet -> makeLease (entryId, fleet))
                 result
         StartPending entryId completion workerSlot -> do
-            worker <-
-                asyncWithUnmask \unmask ->
-                    tryAny (unmask (start configs)) >>= \case
-                        Left exception ->
-                            pure (Left (exceptionSummary exception))
-                        Right fleet -> pure (Right fleet)
-            atomically $ void (tryPutTMVar workerSlot worker)
-            mapM_ closeMcpFleet obsolete
             outcome <-
-                restore (waitCatch worker)
-                    `onException` do
-                        cancel worker
-                        void (waitCatch worker)
+                (withAsyncWithUnmask
+                    (\unmask ->
+                        tryAny (unmask (start configs)) >>= \case
+                            Left exception ->
+                                pure (Left (exceptionSummary exception))
+                            Right fleet -> pure (Right fleet))
+                    \worker -> do
+                        atomically $ void (tryPutTMVar workerSlot worker)
+                        mapM_ closeMcpFleet obsolete
+                        restore (waitCatch worker))
+                    `onException`
                         failPending entryId completion
                             "MCP fleet startup cancelled"
             case outcome of

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -2,6 +2,8 @@ module Agent.MCPSpec (spec) where
 
 import Agent.Loop (defaultLoopDispatch)
 import Agent.MCP
+import Agent.MCP.Fleet (spawnFleetWorker)
+import Agent.MCP.Supervisor (acquireMcpFleetWith)
 import Agent.MCP.Client
     ( ProbeOutcome(..)
     , annotateHeaderParams
@@ -54,9 +56,16 @@ import Agent.Tools.Types
     , appToolHandlers
     , toolAllowsWithoutPrompt
     )
-import Control.Exception.Safe (bracket)
-import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (async, wait, waitCatch, withAsync)
+import Control.Exception.Safe (bracket, finally)
+import Control.Concurrent
+    ( newEmptyMVar
+    , putMVar
+    , takeMVar
+    , threadDelay
+    , tryPutMVar
+    )
+import Control.Concurrent.Async (async, cancel, wait, waitCatch, withAsync)
+import Control.Monad (void)
 import Data.Aeson (object, (.=))
 import qualified Data.Aeson
 import qualified Data.ByteString as BS
@@ -845,6 +854,44 @@ spec = describe "Agent.MCP" do
                     `shouldReturn` Just ()
                 _ <- waitCatch acquiring
                 pure ()
+
+        it "cancels a startup interrupted while an obsolete fleet closes" do
+            supervisor <- newMcpSupervisor
+            obsoleteStarted <- newEmptyMVar
+            obsoleteCleanupStarted <- newEmptyMVar
+            obsoleteCleanupRelease <- newEmptyMVar
+            startupStarted <- newEmptyMVar
+            startupBlock <- newEmptyMVar
+            startupStopped <- newEmptyMVar
+            bracket (pure supervisor) closeMcpSupervisor \_ ->
+                (`finally` void (tryPutMVar obsoleteCleanupRelease ())) do
+                    oldLease <- acquireMcpFleet supervisor []
+                    spawnFleetWorker oldLease.mcpLeaseFleet $
+                        (putMVar obsoleteStarted () >> takeMVar startupBlock)
+                            `finally` do
+                                putMVar obsoleteCleanupStarted ()
+                                takeMVar obsoleteCleanupRelease
+                    takeMVar obsoleteStarted
+                    releaseMcpFleetLease oldLease
+                    let startReplacement _ =
+                            (putMVar startupStarted ()
+                                >> takeMVar startupBlock
+                                >> startMcpFleet [])
+                                `finally` putMVar startupStopped ()
+                        replacement =
+                            baseConfig "replacement" "/unused"
+                    withAsync
+                        (acquireMcpFleetWith
+                            supervisor
+                            False
+                            startReplacement
+                            [replacement])
+                        \acquiring -> do
+                            takeMVar startupStarted
+                            takeMVar obsoleteCleanupStarted
+                            cancel acquiring
+                            timeout 1000000 (takeMVar startupStopped)
+                                `shouldReturn` Just ()
 
         it "reconnects once and retries a meta-tool call after transport loss" $
             withCountingReconnectServer \script counter -> do


### PR DESCRIPTION
## Summary
- scope MCP fleet startup workers with `withAsyncWithUnmask`
- cover failures while obsolete fleets are being closed
- fail pending acquisitions only after the scoped startup worker has been cancelled and joined

## Test plan
- `cabal repl agent-mcp:test:agent-mcp-test`, then `:main --match "McpSupervisor"` (10 examples, 0 failures)

This is a lifecycle-correctness change; it does not make a performance claim.