### PR TITLE
Scope Claude auth pipe drainers

### DIFF
--- a/packages/agent-claude/agent-claude.cabal
+++ b/packages/agent-claude/agent-claude.cabal
@@ -54,6 +54,7 @@ library
                     , agent-responses-types >= 0.1 && < 0.2
                     , claude-agent-sdk-haskell >= 0.1 && < 0.2
                     , aeson                 >= 2.0
+                    , async
                     , bytestring
                     , containers
                     , directory

--- a/packages/agent-claude/package.nix
+++ b/packages/agent-claude/package.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, agent-core, agent-json, agent-process
-, agent-responses, agent-responses-types, base, bytestring
+, agent-responses, agent-responses-types, async, base, bytestring
 , claude-agent-sdk-haskell, containers, directory, filepath
 , hermes-json, hspec, lib, process, safe-exceptions, text, unix
 , uuid-types
@@ -10,9 +10,9 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson agent-core agent-json agent-process agent-responses
-    agent-responses-types base bytestring claude-agent-sdk-haskell
-    containers directory filepath hermes-json process safe-exceptions
-    text uuid-types
+    agent-responses-types async base bytestring
+    claude-agent-sdk-haskell containers directory filepath hermes-json
+    process safe-exceptions text uuid-types
   ];
   testHaskellDepends = [
     aeson agent-core agent-json agent-responses agent-responses-types

--- a/packages/agent-claude/src/Agent/Claude/Auth.hs
+++ b/packages/agent-claude/src/Agent/Claude/Auth.hs
@@ -15,9 +15,14 @@ import Agent.Claude.Transport
     )
 import Agent.Process (terminateProcessGroup)
 import qualified Agent.Json.Decode as Json
-import Control.Concurrent (forkIO, killThread)
-import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
-import Control.Exception.Safe (displayException, mask, onException, tryAny)
+import Control.Concurrent.Async (waitBoth, withAsync)
+import Control.Exception.Safe
+    ( displayException
+    , finally
+    , mask
+    , onException
+    , tryAny
+    )
 import Control.Monad (void)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -124,30 +129,32 @@ runAuthStatusProbe executablePath cleanEnvironment =
         case (mOut, mErr) of
             (Just out, Just err) -> do
                 mapM_ setupHandle [out, err]
-                outDone <- newEmptyMVar
-                errDone <- newEmptyMVar
-                outThread <- forkIO (safeDrain out outDone)
-                errThread <- forkIO (safeDrain err errDone)
-                let cleanup = do
-                        killThread outThread
-                        killThread errThread
-                        mapM_ hCloseQuiet [out, err]
-                    stop = do
+                let stop = do
                         group <- getPid processHandle
                         terminateProcessGroup group processHandle
-                        cleanup
-                result <- restore
-                    (timeout authProbeTimeoutMicros (waitForProcess processHandle))
-                    `onException` stop
-                case result of
-                    Nothing -> do
-                        stop
-                        pure (ExitFailure 124, "", "authentication probe timed out")
-                    Just code -> do
-                        stdoutText <- maybe "" id <$> timeout readerDrainTimeoutMicros (takeMVar outDone)
-                        stderrText <- maybe "" id <$> timeout readerDrainTimeoutMicros (takeMVar errDone)
-                        cleanup
-                        pure (code, stdoutText, stderrText)
+                    awaitProbe =
+                        withAsync (safeDrain out) \outReader ->
+                            withAsync (safeDrain err) \errReader -> do
+                                result <- restore
+                                    (timeout authProbeTimeoutMicros
+                                        (waitForProcess processHandle))
+                                    `onException` stop
+                                case result of
+                                    Nothing -> do
+                                        stop
+                                        pure
+                                            ( ExitFailure 124
+                                            , ""
+                                            , "authentication probe timed out"
+                                            )
+                                    Just code -> do
+                                        streams <- restore $
+                                            timeout readerDrainTimeoutMicros
+                                                (waitBoth outReader errReader)
+                                        let (stdoutText, stderrText) =
+                                                maybe ("", "") id streams
+                                        pure (code, stdoutText, stderrText)
+                awaitProbe `finally` mapM_ hCloseQuiet [out, err]
             _ -> do
                 mapM_ (maybe (pure ()) hCloseQuiet) [mOut, mErr]
                 group <- getPid processHandle
@@ -155,9 +162,8 @@ runAuthStatusProbe executablePath cleanEnvironment =
                 pure (ExitFailure 1, "", "Claude Code did not provide output pipes")
   where
     hCloseQuiet = void . tryAny . hClose
-    safeDrain handle slot = do
-        value <- tryAny (drainCapped handle)
-        putMVar slot (either (const "") id value)
+    safeDrain handle =
+        either (const "") id <$> tryAny (drainCapped handle)
     setupHandle handle = do
         hSetBinaryMode handle True
         hSetBuffering handle NoBuffering

--- a/packages/agent-claude/src/Agent/Claude/Auth.hs
+++ b/packages/agent-claude/src/Agent/Claude/Auth.hs
@@ -15,7 +15,7 @@ import Agent.Claude.Transport
     )
 import Agent.Process (terminateProcessGroup)
 import qualified Agent.Json.Decode as Json
-import Control.Concurrent.Async (waitBoth, withAsync)
+import Control.Concurrent.Async (poll, waitBoth, withAsync)
 import Control.Exception.Safe
     ( displayException
     , finally
@@ -151,8 +151,14 @@ runAuthStatusProbe executablePath cleanEnvironment =
                                         streams <- restore $
                                             timeout readerDrainTimeoutMicros
                                                 (waitBoth outReader errReader)
-                                        let (stdoutText, stderrText) =
-                                                maybe ("", "") id streams
+                                        (stdoutText, stderrText) <-
+                                            case streams of
+                                                Just completed ->
+                                                    pure completed
+                                                Nothing ->
+                                                    (,)
+                                                        <$> completedOutput outReader
+                                                        <*> completedOutput errReader
                                         pure (code, stdoutText, stderrText)
                 awaitProbe `finally` mapM_ hCloseQuiet [out, err]
             _ -> do
@@ -164,6 +170,10 @@ runAuthStatusProbe executablePath cleanEnvironment =
     hCloseQuiet = void . tryAny . hClose
     safeDrain handle =
         either (const "") id <$> tryAny (drainCapped handle)
+    completedOutput reader =
+        poll reader >>= \case
+            Just (Right output) -> pure output
+            _ -> pure ""
     setupHandle handle = do
         hSetBinaryMode handle True
         hSetBuffering handle NoBuffering

--- a/packages/agent-claude/test/Agent/Claude/AuthSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/AuthSpec.hs
@@ -196,6 +196,44 @@ spec = do
                                 (Left
                                     "Claude Code returned an unreadable authentication status.")
 
+        it "preserves completed stdout when stderr remains open" $
+            withScratchDirectory "agent-claude-auth-open-stderr" \root -> do
+                let executable = root </> "fake-claude"
+                writeFile executable fakeAuthScriptWithOpenStderr
+                setFileMode executable $
+                    ownerReadMode
+                        `unionFileModes` ownerWriteMode
+                        `unionFileModes` ownerExecuteMode
+                withEnvironmentVariables
+                    [("CLAUDE_CODE_EXECUTABLE", Just executable)]
+                    do
+                        result <- timeout 1_750_000 loadClaudeCodeAuth
+                        result `shouldBe`
+                            Just
+                                (Right ClaudeCodeAuth
+                                    { executable
+                                    , accountLabel = "open-stderr@example.com"
+                                    , subscriptionType = Just "max"
+                                    , transport = ClaudeCodeLocalSubscription
+                                    })
+
+        it "preserves completed stderr when stdout remains open" $
+            withScratchDirectory "agent-claude-auth-open-stdout" \root -> do
+                let executable = root </> "fake-claude"
+                writeFile executable fakeAuthScriptWithOpenStdout
+                setFileMode executable $
+                    ownerReadMode
+                        `unionFileModes` ownerWriteMode
+                        `unionFileModes` ownerExecuteMode
+                withEnvironmentVariables
+                    [("CLAUDE_CODE_EXECUTABLE", Just executable)]
+                    do
+                        result <- timeout 1_750_000 loadClaudeCodeAuth
+                        result `shouldBe`
+                            Just
+                                (Left
+                                    "Claude Code authentication status failed (exit 17): retained diagnostic")
+
         it "uses explicit gateway credentials without requiring a local Claude login" $
             withScratchDirectory "agent-claude-gateway-auth" \root -> do
                 let executable = root </> "fake-claude"
@@ -302,6 +340,23 @@ fakeAuthScriptWithOpenPipes =
         , "(while :; do printf ' '; sleep 1; done) &"
         , "(while :; do printf x >&2; sleep 1; done) &"
         , "printf '%s\\n' '{\"loggedIn\":true,\"authMethod\":\"claude.ai\",\"apiProvider\":\"firstParty\",\"email\":\"open-pipes@example.com\",\"subscriptionType\":\"max\"}'"
+        ]
+
+fakeAuthScriptWithOpenStderr :: String
+fakeAuthScriptWithOpenStderr =
+    unlines
+        [ "#!/bin/sh"
+        , "(exec 1>&-; while :; do printf x >&2; sleep 1; done) &"
+        , "printf '%s\\n' '{\"loggedIn\":true,\"authMethod\":\"claude.ai\",\"apiProvider\":\"firstParty\",\"email\":\"open-stderr@example.com\",\"subscriptionType\":\"max\"}'"
+        ]
+
+fakeAuthScriptWithOpenStdout :: String
+fakeAuthScriptWithOpenStdout =
+    unlines
+        [ "#!/bin/sh"
+        , "(exec 2>&-; while :; do printf ' '; sleep 1; done) &"
+        , "printf '%s\\n' 'retained diagnostic' >&2"
+        , "exit 17"
         ]
 
 withScratchDirectory :: String -> (FilePath -> IO a) -> IO a

--- a/packages/agent-claude/test/Agent/Claude/AuthSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/AuthSpec.hs
@@ -160,6 +160,42 @@ spec = do
                                 , transport = ClaudeCodeLocalSubscription
                                 }
 
+        it "drains noisy stderr concurrently with the auth response" $
+            withScratchDirectory "agent-claude-auth-noisy" \root -> do
+                let executable = root </> "fake-claude"
+                writeFile executable fakeNoisyAuthScript
+                setFileMode executable $
+                    ownerReadMode
+                        `unionFileModes` ownerWriteMode
+                        `unionFileModes` ownerExecuteMode
+                withEnvironmentVariables
+                    [("CLAUDE_CODE_EXECUTABLE", Just executable)]
+                    do
+                        loadClaudeCodeAuth `shouldReturn`
+                            Right ClaudeCodeAuth
+                                { executable
+                                , accountLabel = "noisy@example.com"
+                                , subscriptionType = Just "max"
+                                , transport = ClaudeCodeLocalSubscription
+                                }
+
+        it "uses one deadline while joining both pipe drainers" $
+            withScratchDirectory "agent-claude-auth-open-pipes" \root -> do
+                let executable = root </> "fake-claude"
+                writeFile executable fakeAuthScriptWithOpenPipes
+                setFileMode executable $
+                    ownerReadMode
+                        `unionFileModes` ownerWriteMode
+                        `unionFileModes` ownerExecuteMode
+                withEnvironmentVariables
+                    [("CLAUDE_CODE_EXECUTABLE", Just executable)]
+                    do
+                        result <- timeout 1_750_000 loadClaudeCodeAuth
+                        result `shouldBe`
+                            Just
+                                (Left
+                                    "Claude Code returned an unreadable authentication status.")
+
         it "uses explicit gateway credentials without requiring a local Claude login" $
             withScratchDirectory "agent-claude-gateway-auth" \root -> do
                 let executable = root </> "fake-claude"
@@ -245,6 +281,27 @@ fakeAuthScriptReadsStdin =
         [ "#!/bin/sh"
         , "cat >/dev/null"
         , "printf '%s\\n' '{\"loggedIn\":true,\"authMethod\":\"claude.ai\",\"apiProvider\":\"firstParty\",\"email\":\"stdin@example.com\",\"subscriptionType\":\"max\"}'"
+        ]
+
+fakeNoisyAuthScript :: String
+fakeNoisyAuthScript =
+    unlines
+        [ "#!/bin/sh"
+        , "i=0"
+        , "while [ \"$i\" -lt 2048 ]; do"
+        , "  printf '%s' '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' >&2"
+        , "  i=$((i + 1))"
+        , "done"
+        , "printf '%s\\n' '{\"loggedIn\":true,\"authMethod\":\"claude.ai\",\"apiProvider\":\"firstParty\",\"email\":\"noisy@example.com\",\"subscriptionType\":\"max\"}'"
+        ]
+
+fakeAuthScriptWithOpenPipes :: String
+fakeAuthScriptWithOpenPipes =
+    unlines
+        [ "#!/bin/sh"
+        , "(while :; do printf ' '; sleep 1; done) &"
+        , "(while :; do printf x >&2; sleep 1; done) &"
+        , "printf '%s\\n' '{\"loggedIn\":true,\"authMethod\":\"claude.ai\",\"apiProvider\":\"firstParty\",\"email\":\"open-pipes@example.com\",\"subscriptionType\":\"max\"}'"
         ]
 
 withScratchDirectory :: String -> (FilePath -> IO a) -> IO a


### PR DESCRIPTION
## Summary
- replace manually forked stdout/stderr reader threads with nested `withAsync` scopes
- join both readers under one bounded deadline and let scope exit cancel and join unfinished readers before closing their handles
- after that shared deadline, preserve each reader's independently completed output instead of discarding both streams
- cover noisy stderr, inherited open-pipe cases, and both one-sided completion directions

## Testing
- `cabal repl agent-claude:test:agent-claude-test --repl-options=-fobject-code`
- `:main --match loadClaudeCodeAuth` (8 examples, 0 failures)
- `:main` (53 examples, 0 failures)
