### PR TITLE
Prefer Text for internal textual APIs

### DIFF
--- a/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-cli/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -5490,7 +5490,7 @@ runNativeTurn
 nativeExceptionMessage :: SomeException -> Text
 nativeExceptionMessage exception =
     case fromException exception of
-        Just (StartupFailure message) -> Text.pack message
+        Just (StartupFailure message) -> message
         Nothing -> Text.pack (show exception)
 
 nativeTurnArguments :: TurnStart -> [String]

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -436,10 +436,7 @@ runAgentWithRuntime processRuntime runMode options = do
                                         now <- getCurrentTime
                                         throwIO $
                                             StartupFailure
-                                                (Text.unpack
-                                                    (formatApiErrorAt
-                                                        now
-                                                        apiError))
+                                                (formatApiErrorAt now apiError)
                                     | otherwise -> do
                                         reportProviderUnavailable Nothing apiError
                                         pure DevQuit
@@ -448,8 +445,7 @@ runAgentWithRuntime processRuntime runMode options = do
                             now <- getCurrentTime
                             throwIO $
                                 StartupFailure
-                                    (Text.unpack
-                                        (formatApiErrorAt now apiError))
+                                    (formatApiErrorAt now apiError)
                         | otherwise -> pure DevQuit
             RunQuit -> pure DevQuit
             RunReload sessionId -> pure (DevReload sessionId)
@@ -692,7 +688,7 @@ runAgent
                 (\failure@(StartupFailure message) ->
                     if runMode.runInBackground
                         then throwIO failure
-                        else die message)
+                        else die (Text.unpack message))
                 pure
                 startupOutcome
     case (prepared.preparedFullscreen, result) of
@@ -974,8 +970,7 @@ prepareAgentIterationTracked
                                             Nothing -> die (Text.unpack err)
                                             Just _ ->
                                                 throwIO
-                                                    (StartupFailure
-                                                        (Text.unpack err)))
+                                                    (StartupFailure err))
                                     (\path -> do
                                         color <- resolveColor stderrHandle
                                         case fullscreen of

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -463,7 +463,7 @@ prepareInitializedWorkspace request = do
             scopeNamespace
             stateDirectory
             projectRootPath >>= \case
-            Left err -> startupDie startup (Text.unpack err)
+            Left err -> startupDie startup err
             Right scopes -> pure scopes
     ((projectSettings0, userSettings), (catalogResult, branch)) <-
         concurrently
@@ -486,7 +486,7 @@ prepareInitializedWorkspace request = do
     let projectSettings =
             withInheritedLastModel projectSettings0 userSettings
     catalog <- either
-        (startupDie startup . Text.unpack)
+        (startupDie startup)
         pure
         catalogResult
     setStartupRepository fullscreen home branch cwd
@@ -584,7 +584,7 @@ resolveInitializedTargets request workspace = do
                         meta.metaId
                         sessionUiPageSize >>= \case
                             Left err ->
-                                startupDie startup (Text.unpack err)
+                                startupDie startup err
                             Right page ->
                                 setFullscreenHistorySource
                                     runtime
@@ -598,11 +598,11 @@ resolveInitializedTargets request workspace = do
                                         (HistoryGeneration 0)
                                         HistoryNewer
                                         page)
-    either (startupDie startup . Text.unpack) pure resumedHistoryResult
+    either (startupDie startup) pure resumedHistoryResult
     resumedTarget <-
-        either (startupDie startup . Text.unpack) pure resumedTargetResult
+        either (startupDie startup) pure resumedTargetResult
     projectTarget <-
-        either (startupDie startup . Text.unpack) pure projectTargetResult
+        either (startupDie startup) pure projectTargetResult
     let targetHint =
             transitionTarget
                 <|> configuredOptionTarget
@@ -671,7 +671,7 @@ loadInitializedAuth request targets =
                 request.initializedPreparedAuth
             exactLoaded <-
                 either
-                    (startupDie startup . Text.unpack)
+                    (startupDie startup)
                     pure
                     (gatewayLoadedAuthForProvider requestedProvider gateway)
             pure RoutedStartupAuth
@@ -723,7 +723,7 @@ loadCustomResponsesAuth startup connectionId responses = do
             | otherwise ->
                 startupDie startup $
                     "custom connection "
-                        <> Text.unpack connectionId
+                        <> connectionId
                         <> " requires api_key_env or api_key_optional=true"
         Just envName ->
             lookupEnv (Text.unpack envName) >>= \case
@@ -734,9 +734,9 @@ loadCustomResponsesAuth startup connectionId responses = do
                     | otherwise ->
                         startupDie startup $
                             "custom connection "
-                                <> Text.unpack connectionId
+                                <> connectionId
                                 <> " requires environment variable "
-                                <> Text.unpack envName
+                                <> envName
     let credential = Credential
             { accessToken = token
             , accountId = connectionId
@@ -845,14 +845,14 @@ selectInitializedStartupAccount request workspace targets routed = do
                         rememberedIds
         selectStartupAccount >>= \case
             Left err ->
-                startupDie startup (Text.unpack err)
+                startupDie startup err
             Right selected ->
                 loadSelectedAccountAuth
                     provider
                     selected.selectedSelectionId
                     selected.selectedAccountId
                     >>= either
-                        (startupDie startup . Text.unpack)
+                        (startupDie startup)
                         (\selectedLoaded ->
                             pure
                                 ( selectedLoaded
@@ -882,9 +882,9 @@ validateInitializedAuth request targets loaded = do
             | not (isGatewayLoadedAuth loaded)
             , loaded.loadedProvider /= target.targetProvider ->
                 startupDie startup $ "provider transition requested "
-                    <> Text.unpack (providerSlug target.targetProvider)
+                    <> providerSlug target.targetProvider
                     <> " but auth resolved "
-                    <> Text.unpack (providerSlug loaded.loadedProvider)
+                    <> providerSlug loaded.loadedProvider
         _ -> pure ()
     case request.initializedTransition
         >>= (.transitionAutomaticBilling) of
@@ -911,7 +911,7 @@ newInitializedAccountRefs request auth = do
         loadGatewayModelAccess
             request.initializedConnectedGateway
             loaded >>= either
-                (startupDie request.initializedStartup . Text.unpack)
+                (startupDie request.initializedStartup)
                 pure
     gatewayModelsRef <- newIORef initialGatewayModels
     activeAccountRef <- newIORef ""

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Claude.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Claude.hs
@@ -73,7 +73,6 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Agent.MCP as MCP
 import qualified Data.Aeson as Aeson
-import qualified Data.Text as Text
 
 runClaudeProvider
     :: AgentProviderRequest
@@ -83,7 +82,7 @@ runClaudeProvider request@AgentProviderRequest{..} nativeCapabilities =
     withSelectedClaudeAuth
         connectedGateway
         loaded
-        (startupDie startup . Text.unpack)
+        (startupDie startup)
         \claudeAuth -> do
             let permission =
                     ClaudeCodeManual
@@ -177,7 +176,7 @@ runClaudeProvider request@AgentProviderRequest{..} nativeCapabilities =
                     (approveClaudeRegisteredTool
                         claudeRequest.claudeRuntimeSlot)
                     claudeRequest.claudeBridgeTools of
-                    Left err -> startupDie startup (Text.unpack err)
+                    Left err -> startupDie startup err
                     Right server -> pure server
             let hostHandlers =
                     defaultClaudeCodeHostHandlers

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Common.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Common.hs
@@ -40,7 +40,6 @@ import Data.Text (Text)
 import Data.Time.Clock (getCurrentTime)
 import qualified Agent.CLI.Session.Runner as SessionRunner
 import qualified Agent.CLI.Startup.Auth as Startup
-import qualified Data.Text as Text
 
 decorateManualCompact
     :: AgentProviderRequest
@@ -88,7 +87,7 @@ startupFailure
 startupFailure AgentProviderRequest{startup} err = do
     now <- getCurrentTime
     Startup.startupDie startup
-        (Text.unpack (formatApiErrorAt now err))
+        (formatApiErrorAt now err)
 
 sessionRunnerContinuation :: SessionRunner.SessionRunnerContinuation
 sessionRunnerContinuation =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Restart.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Restart.hs
@@ -55,7 +55,7 @@ runFullscreenRestartLoop callbacks runtime =
         -- chain, rather than stopping Brick after the first provider exits.
         try @_ @StartupFailure action >>= \case
             Left (StartupFailure message) ->
-                recoverStartup options transition (Text.pack message)
+                recoverStartup options transition message
             Right result -> case result of
                 RunRestart sessionId -> do
                     let nextOptions = callbacks.restartOptions options sessionId
@@ -97,7 +97,7 @@ runFullscreenRestartLoop callbacks runtime =
         try @_ @StartupFailure
             (callbacks.restartPrepare options transition) >>= \case
                 Left (StartupFailure message) ->
-                    recoverStartup options transition (Text.pack message)
+                    recoverStartup options transition message
                 Right prepared ->
                     loop options transition prepared.preparedRun
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -637,7 +637,7 @@ validateSessionMcpTools AgentSessionRequest
         of
             Just err ->
                 startupDie startup
-                    ("Failed to initialize MCP tools: " <> Text.unpack err)
+                    ("Failed to initialize MCP tools: " <> err)
             Nothing -> pure ()
 
 prepareSessionCodeRuntime

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -714,7 +714,7 @@ loadToolStartup request@AgentToolsRequest
             "gateway credential snapshot and session binding disagree"
     toolHarnessConfig <-
         loadHarnessConfig home >>= \case
-            Left err -> startupDie startup (Text.unpack err)
+            Left err -> startupDie startup err
             Right config -> pure config
     (toolGatewaySelection, toolGatewayAllowedChildModels) <-
         selectGatewayModels request
@@ -764,7 +764,7 @@ selectGatewayModels AgentToolsRequest
                                     Nothing ->
                                         startupDie startup $
                                             "Model '"
-                                                <> Text.unpack requested
+                                                <> requested
                                                 <> "' is not available through your organization gateway."
                                     Just selected -> pure selected
                             Nothing ->
@@ -1229,7 +1229,7 @@ prepareScratchRuntime AgentToolsRequest
         loadCurrentTaskPlan scratchPersistence >>= \case
             Left err ->
                 startupDie startup
-                    ("Failed to load current task plan: " <> Text.unpack err)
+                    ("Failed to load current task plan: " <> err)
             Right plan -> pure plan
     scratchTaskPlan <-
         newTaskPlanEnv
@@ -1282,7 +1282,7 @@ prepareScratchRuntime AgentToolsRequest
         acquireWorktreeLease (worktreeRoot home) cwd >>= \case
             Left err -> do
                 cleanupAllocatedScratch
-                startupDie startup (Text.unpack err)
+                startupDie startup err
             Right lease -> pure lease
     sessionTempLease <-
         (acquireSessionTempLease root scratchSessionTmp
@@ -1292,7 +1292,7 @@ prepareScratchRuntime AgentToolsRequest
                 Left err -> do
                     mapM_ releaseWorktreeLease worktreeLease
                     cleanupAllocatedScratch
-                    startupDie startup (Text.unpack err)
+                    startupDie startup err
                 Right lease -> pure lease
     let scratchCleanup =
             mapM_ releaseSessionTempLease sessionTempLease
@@ -1495,7 +1495,8 @@ acquireMcpRuntime request@AgentToolsRequest
                 Left exception -> do
                     cleanupScratch
                     startupDie startup
-                        ("Failed to initialize MCP tools: " <> show exception)
+                        ("Failed to initialize MCP tools: "
+                            <> Text.pack (show exception))
                 Right lease -> pure lease
     let runtimeMcpFleet = runtimeMcpLease.mcpLeaseFleet
     writeIORef mcpFleetRef (Just runtimeMcpFleet)
@@ -1585,7 +1586,7 @@ acquireCodingRuntime AgentToolsRequest
                             Left err ->
                                 startupDie startup
                                     ("Failed to initialize web_fetch: "
-                                        <> Text.unpack err)
+                                        <> err)
                             Right runtime -> pure runtime)
                     (mapM_ closeWebFetchRuntime)
                     (newLspRuntime harnessConfig.configLsp baseToolEnv)

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -1558,7 +1558,7 @@ runSessionInteraction
                         request.managedTurnText
                         inputs
                         >>= either
-                            (startupDie startup . Text.unpack)
+                            (startupDie startup)
                             pure
                 result <- runOneTurn env request.managedTurnText skillInputs
                 callbacks.runnerFinishTurn env True result
@@ -1589,7 +1589,7 @@ runSessionInteraction
                 text
                 [UserMessage text]
                 >>= either
-                    (startupDie startup . Text.unpack)
+                    (startupDie startup)
                     pure
         forM_ host.hostFullscreen \runtime ->
             emitUiEvent runtime (UiUserSubmitted text)

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -90,6 +90,7 @@ import Data.IORef (IORef)
 import Data.Map.Strict (Map)
 import Data.Set (Set)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time.Clock
     ( NominalDiffTime
     , UTCTime
@@ -214,11 +215,11 @@ data StartupRuntime = StartupRuntime
     , startupNativeHooks :: !(Maybe NativeRunHooks)
     }
 
-newtype StartupFailure = StartupFailure String
+newtype StartupFailure = StartupFailure Text
     deriving (Show)
 
 instance Exception StartupFailure where
-    displayException (StartupFailure message) = message
+    displayException (StartupFailure message) = Text.unpack message
 
 data StartupCancelled = StartupCancelled
     deriving (Show)

--- a/packages/agent-cli/src/Agent/CLI/Startup/Auth.hs
+++ b/packages/agent-cli/src/Agent/CLI/Startup/Auth.hs
@@ -84,13 +84,13 @@ markStartupStage startup label = do
     recordStartupTiming startup.startupStartedAt startup.startupTimings label
     setStartupNotice startup.startupFullscreen label
 
-startupDie :: StartupRuntime -> String -> IO a
+startupDie :: StartupRuntime -> Text -> IO a
 startupDie startup message =
     case startup.startupFullscreen of
         Nothing
             | startup.startupBackground ->
                 throwIO (StartupFailure message)
-            | otherwise -> die message
+            | otherwise -> die (Text.unpack message)
         Just _ -> throwIO (StartupFailure message)
 
 loadStartupAuth
@@ -129,10 +129,10 @@ loadStartupAuthFromResult startup transition requestedProvider = \case
                     >>= \(provider, learnAboutUser) ->
                         loadAuth (Just provider)
                             >>= either
-                                (startupDie startup . Text.unpack)
+                                (startupDie startup)
                                 (\loaded -> pure (loaded, learnAboutUser))
             | otherwise ->
-                startupDie startup (Text.unpack err)
+                startupDie startup err
 
 shouldReconnectGemini
     :: Maybe ProviderTransition
@@ -159,7 +159,7 @@ reconnectGeminiAtStartup startup runtime = do
             connectProviderAccount color GeminiProvider
     selectionId <- maybe (throwIO StartupCancelled) pure connected
     loadAuthForAccount GeminiProvider selectionId >>= either
-        (startupDie startup . Text.unpack)
+        (startupDie startup)
         (\loaded -> pure (loaded, False))
 
 loadTransitionAuth

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Shell.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Shell.hs
@@ -144,7 +144,7 @@ stopManagedCommands session commands =
 startCodexShellCommand
     :: CodexShellSession
     -> OsPath
-    -> String
+    -> Text
     -> Int
     -> (Text -> Text -> IO ())
     -> IO (Either Text CodexShellResult)
@@ -303,7 +303,7 @@ takeRunningOutput task =
 startManagedCommand
     :: CodexShellSession
     -> OsPath
-    -> String
+    -> Text
     -> IO (Either Text (Int, ManagedCommand))
 startManagedCommand session workdir command =
     do
@@ -350,7 +350,7 @@ startManagedCommand session workdir command =
                                             session.sessionEnv
                                             (codexCompletionNotice
                                                 commandId
-                                                (Text.pack command)
+                                                command
                                                 result
                                                     { commandStdout = out
                                                     , commandStderr = err

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -241,7 +241,7 @@ runShell env session emitOutput args
         startCodexShellCommand
             session
             dir
-            (Text.unpack args.command)
+            args.command
             yieldMs
             (\out err -> emitOutput (commandBody out err))
             >>= pure . fmap renderShellResult
@@ -251,7 +251,7 @@ runShell env session emitOutput args
         result <- runShellCommandStreaming
             env
             dir
-            (Text.unpack args.command)
+            args.command
             timeoutMs
             (\out err -> emitOutput (commandBody out err))
         if result.commandCancelled

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
@@ -578,7 +578,7 @@ monitorWorker
                 case decodeProtocolMessage line of
                     Left err ->
                         failClosed hasStarted $
-                            "invalid worker message: " <> Text.pack err
+                            "invalid worker message: " <> err
                     Right WorkerReady
                         | not hasStarted -> do
                             atomically $ void $ tryPutTMVar ready (Right ())

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Protocol.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Protocol.hs
@@ -33,7 +33,6 @@ import qualified Data.ByteString.Lazy as LBS
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
-import qualified Data.Text as Text
 
 data CodeModeToolMetadata = CodeModeToolMetadata
     { toolMetadataName :: !Text
@@ -131,9 +130,9 @@ toolInvocationDecoder = Json.object $
             <*> Json.atKey "name" Json.text
             <*> Json.atKey "arguments" rawJsonDecoder
 
-decodeProtocolMessage :: BS.ByteString -> Either String ProtocolMessage
+decodeProtocolMessage :: BS.ByteString -> Either Text ProtocolMessage
 decodeProtocolMessage =
-    either (Left . Text.unpack . (.jsonErrorMessage)) Right
+    either (Left . (.jsonErrorMessage)) Right
         . Json.decodeEither protocolMessageDecoder
 
 emptyResult :: RawJson

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -244,7 +244,7 @@ runningOutputSince running cursor = do
 runShellCommand
     :: ToolEnv
     -> OsPath
-    -> String
+    -> Text
     -> Int
     -> IO CommandResult
 runShellCommand env workdir command timeoutMs =
@@ -256,13 +256,13 @@ runShellCommand env workdir command timeoutMs =
 runShellCommandStreaming
     :: ToolEnv
     -> OsPath
-    -> String
+    -> Text
     -> Int
     -> (Text -> Text -> IO ())
     -> IO CommandResult
 runShellCommandStreaming env workdir command timeoutMs onSnapshot =
     mask \restore -> do
-    let baseSpec = (shell command)
+    let baseSpec = (shell (Text.unpack command))
             { cwd = Just (unsafeToFilePath workdir)
             , std_in = CreatePipe
             , std_out = CreatePipe
@@ -396,7 +396,7 @@ cancelledResult = CommandResult
 startShellCommand
     :: ToolEnv
     -> OsPath
-    -> String
+    -> Text
     -> IO (Either Text RunningCommand)
 startShellCommand env workdir command =
     startShellCommandWithStdin False env workdir command (\_ -> pure ())
@@ -406,7 +406,7 @@ startShellCommand env workdir command =
 startShellCommandWithCompletion
     :: ToolEnv
     -> OsPath
-    -> String
+    -> Text
     -> (CommandResult -> IO ())
     -> IO (Either Text RunningCommand)
 startShellCommandWithCompletion =
@@ -418,7 +418,7 @@ startShellCommandWithCompletion =
 startShellCommandWithInput
     :: ToolEnv
     -> OsPath
-    -> String
+    -> Text
     -> IO (Either Text RunningCommand)
 startShellCommandWithInput env workdir command =
     startShellCommandWithStdin True env workdir command (\_ -> pure ())
@@ -426,7 +426,7 @@ startShellCommandWithInput env workdir command =
 startShellCommandWithInputAndCompletion
     :: ToolEnv
     -> OsPath
-    -> String
+    -> Text
     -> (CommandResult -> IO ())
     -> IO (Either Text RunningCommand)
 startShellCommandWithInputAndCompletion =
@@ -436,11 +436,11 @@ startShellCommandWithStdin
     :: Bool
     -> ToolEnv
     -> OsPath
-    -> String
+    -> Text
     -> (CommandResult -> IO ())
     -> IO (Either Text RunningCommand)
 startShellCommandWithStdin keepStdin env workdir command onComplete = do
-    let baseSpec = (shell command)
+    let baseSpec = (shell (Text.unpack command))
             { cwd = Just (unsafeToFilePath workdir)
             , std_in = CreatePipe
             , std_out = CreatePipe

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -677,7 +677,7 @@ checkTimeoutKillsProcessGroup dir = do
                 <> show heartbeatFile
                 <> "; sleep 0.02; done) & wait"
     env <- defaultToolEnv osDir
-    result <- runShellCommand env osDir command 200
+    result <- runShellCommand env osDir (Text.pack command) 200
     result.commandTimedOut `shouldBe` True
     threadDelay 200000
     before <- readFile heartbeatFile

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
@@ -248,7 +248,7 @@ runForegroundStreaming session command timeoutMs onSnapshot =
                         result <- runShellCommandStreaming
                             session.grokEnv
                             session.grokEnv.toolCwd
-                            wrapped
+                            (Text.pack wrapped)
                             timeoutMs
                             onSnapshot
                         next <- if result.commandTimedOut
@@ -308,7 +308,7 @@ startBackgroundCommand session command =
                                         (startShellCommandWithCompletion
                                             session.grokEnv
                                             session.grokEnv.toolCwd
-                                            wrapped
+                                            (Text.pack wrapped)
                                             publish
                                             >>= either
                                                 (throwIO . userError . Text.unpack)

--- a/packages/agent-openai/src/Agent/OpenAI/Http.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Http.hs
@@ -148,7 +148,7 @@ decodeJsonResponseBodyBytes bodyBytes =
                 Right response -> rejectFailedCodexResponse response
                 Left _ -> Left
                     (JsonDecodeError
-                        (Text.pack directError)
+                        directError
                         (bodyPreview bodyBytes))
 
 wrappedResponseDecoder :: Json.Decoder OpenAI.Response

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -955,13 +955,13 @@ receiveWsResponseWithActions modelHint actions onEvent =
                     failure.failureErrorCode
                     Nothing
 
-unparsedStreamEvent :: String -> LBS.ByteString -> ResponseStreamEvent
+unparsedStreamEvent :: Text -> LBS.ByteString -> ResponseStreamEvent
 unparsedStreamEvent err bytes =
     OtherResponseStreamEvent
         { otherEventType = StreamEventUnknown unparsedStreamEventTypeText
         , sequenceNumber = Nothing
         , eventDelta = Just
-            (Text.pack err <> ": " <> framePreview bytes)
+            (err <> ": " <> framePreview bytes)
         , streamItemId = Nothing
         , streamOutputIndex = Nothing
         , summaryIndex = Nothing

--- a/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ClientSpec.hs
@@ -920,7 +920,7 @@ decodeResponse value =
     case ResponsesCodec.decodeResponse
         (LBS.toStrict (Aeson.encode value)) of
         Right response -> response
-        Left err -> error err
+        Left err -> error (Text.unpack err)
 
 extractAssistantText :: Response -> Maybe Text
 extractAssistantText response = case

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -1346,7 +1346,7 @@ spec = do
             , "output" .= output
             ] of
             Right response -> response
-            Left err -> error err
+            Left err -> error (Text.unpack err)
     agentMessage :: Text.Text -> Text.Text -> Text.Text -> ResponseItem
     agentMessage author recipient text =
         AgentMessageItem ResponseAgentMessage

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -2132,7 +2132,7 @@ testResponseWithUsage responseId output usage =
     , "output" Aeson..= output
     ] <> usageField))) of
         Right response -> response
-        Left err -> error err
+        Left err -> error (Text.unpack err)
   where
     usageField = case usage of
         Aeson.Null -> []

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -15,6 +15,7 @@ import Data.Foldable (toList)
 import Data.Either (isLeft)
 import Data.IORef
 import Data.Text (Text)
+import qualified Data.Text as Text
 
 spec :: Spec
 spec = do
@@ -783,4 +784,4 @@ responseWithOutput output =
             , "output" Aeson..= output
             ] of
         Right response -> response
-        Left err -> error err
+        Left err -> error (Text.unpack err)

--- a/packages/agent-responses/benchmark/JsonDecoding.hs
+++ b/packages/agent-responses/benchmark/JsonDecoding.hs
@@ -81,14 +81,14 @@ report mode count bytes samples =
 median :: Ord value => [value] -> value
 median values = sort values !! (length values `div` 2)
 runStream
-    :: (BS.ByteString -> IO (Either String ResponseStreamEvent))
+    :: (BS.ByteString -> IO (Either Text.Text ResponseStreamEvent))
     -> [BS.ByteString]
     -> IO Int
 runStream decode = go emptyStreamAssemblyState
   where
     go !_ [] = error "stream has no terminal event"
     go !state (payload : rest) = do
-        event <- decode payload >>= either error pure
+        event <- decode payload >>= either (error . Text.unpack) pure
         let !next = applyStreamEvent state event
         case event of
             ResponseCompletedEvent{} -> case finishStreamResponse Nothing next event of
@@ -99,11 +99,11 @@ runStream decode = go emptyStreamAssemblyState
 -- Compatibility/list baseline: decode and retain every event before assembly,
 -- matching the former shared HTTP transport's memory shape.
 runStreamList
-    :: (BS.ByteString -> IO (Either String ResponseStreamEvent))
+    :: (BS.ByteString -> IO (Either Text.Text ResponseStreamEvent))
     -> [BS.ByteString]
     -> IO Int
 runStreamList decode payloads = do
-    events <- mapM (decode >=> either error pure) payloads
+    events <- mapM (decode >=> either (error . Text.unpack) pure) payloads
     case buildStreamResponse benchmarkAssemblyConfig events of
         Left err -> error (show err)
         Right response -> evaluate (responseChecksum response)

--- a/packages/agent-responses/src/Agent/Responses/Codec.hs
+++ b/packages/agent-responses/src/Agent/Responses/Codec.hs
@@ -17,41 +17,40 @@ import qualified Data.ByteString as BS
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
-import qualified Data.Text as Text
 
 import Agent.Responses.Types
 
 encodeResponseCreateParams :: ResponseCreateParams -> LBS.ByteString
 encodeResponseCreateParams = Aeson.encode
 
-decodeResponseCreateParams :: BS.ByteString -> Either String ResponseCreateParams
+decodeResponseCreateParams :: BS.ByteString -> Either Text ResponseCreateParams
 decodeResponseCreateParams =
     decodeDirect responseCreateParamsDecoder
 
-decodeResponse :: BS.ByteString -> Either String Response
+decodeResponse :: BS.ByteString -> Either Text Response
 decodeResponse = decodeDirect responseDecoder
 
-decodeResponseStreamEvent :: BS.ByteString -> Either String ResponseStreamEvent
+decodeResponseStreamEvent :: BS.ByteString -> Either Text ResponseStreamEvent
 decodeResponseStreamEvent =
     decodeDirect responseStreamEventDecoder
 
 decodeResponseStreamEventWithType
     :: Text
     -> BS.ByteString
-    -> Either String ResponseStreamEvent
+    -> Either Text ResponseStreamEvent
 decodeResponseStreamEventWithType eventType =
     decodeDirect (responseStreamEventDecoderWithType eventType)
 
 withResponseStreamEventDecoder
-    :: ((BS.ByteString -> IO (Either String ResponseStreamEvent)) -> IO value)
+    :: ((BS.ByteString -> IO (Either Text ResponseStreamEvent)) -> IO value)
     -> IO value
 withResponseStreamEventDecoder action =
     Json.withDecoderSession \session ->
         action \bytes -> do
             result <- Json.decodeIO session responseStreamEventDecoder bytes
-            pure (either (Left . Text.unpack . (.jsonErrorMessage)) Right result)
+            pure (either (Left . (.jsonErrorMessage)) Right result)
 
-decodeDirect :: Json.Decoder value -> BS.ByteString -> Either String value
+decodeDirect :: Json.Decoder value -> BS.ByteString -> Either Text value
 decodeDirect decoder =
-    either (Left . Text.unpack . (.jsonErrorMessage)) Right
+    either (Left . (.jsonErrorMessage)) Right
         . Json.decodeEither decoder

--- a/packages/agent-responses/src/Agent/Responses/Error.hs
+++ b/packages/agent-responses/src/Agent/Responses/Error.hs
@@ -33,7 +33,7 @@ data ProviderErrorPayload = ProviderErrorPayload
     , payloadRetryAfter :: !(Maybe Int)
     }
 
-decodeOpenAIError :: Text -> Either String ApiError
+decodeOpenAIError :: Text -> Either Text ApiError
 decodeOpenAIError body = do
     payload <- decodeProviderErrorPayload body
     pure $ mkOpenAIError
@@ -120,10 +120,10 @@ nonGenericErrorType value
     | Text.toLower value == "error" = Nothing
     | otherwise = Just value
 
-decodeProviderErrorPayload :: Text -> Either String ProviderErrorPayload
+decodeProviderErrorPayload :: Text -> Either Text ProviderErrorPayload
 decodeProviderErrorPayload body =
     either
-        (Left . Text.unpack . jsonErrorMessage)
+        (Left . jsonErrorMessage)
         Right
         (decodeText providerErrorPayloadDecoder body)
 

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -1335,7 +1335,10 @@ isUserMessage = \case
 
 responseWithOutput :: [ResponseItem] -> Response
 responseWithOutput output =
-    either error id . Codec.decodeResponse . LBS.toStrict . Aeson.encode $
+    either (error . Text.unpack) id
+        . Codec.decodeResponse
+        . LBS.toStrict
+        . Aeson.encode $
         Aeson.object
             [ "id" Aeson..= ("resp-compacted" :: Text.Text)
             , "created_at" Aeson..= (0 :: Int)

--- a/packages/agent-responses/test/Agent/Responses/ResponseMergeSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/ResponseMergeSpec.hs
@@ -76,7 +76,7 @@ spec = describe "typed response merging" do
 
 baseResponse :: Response
 baseResponse =
-    either error id $ decodeResponse $ BS.pack
+    either (error . Text.unpack) id $ decodeResponse $ BS.pack
         "{\"id\":\"resp-1\",\"created_at\":0,\"model\":\"\",\
         \\"status\":\"in_progress\",\"output\":[]}"
 

--- a/packages/agent-responses/test/Agent/Responses/SSESpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/SSESpec.hs
@@ -252,7 +252,7 @@ genLifecycleEvent index = do
                 , "model" .= model
                 , "status" .= status
                 ]
-        response = either error id
+        response = either (error . Text.unpack) id
             (Codec.decodeResponse
                 (LBS.toStrict (Aeson.encode responseValue)))
     elements

--- a/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamAssemblySpec.hs
@@ -611,7 +611,7 @@ responseFragmentWithOutput responseId output =
 
 decodeResponseValue :: Aeson.Value -> Response
 decodeResponseValue value =
-    either error id
+    either (error . Text.unpack) id
         (Codec.decodeResponse (LBS.toStrict (Aeson.encode value)))
 
 completedItemTrace :: Text -> [ResponseStreamEvent] -> [ResponseStreamEvent]

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Framing.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Framing.hs
@@ -10,6 +10,8 @@ import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict', encode)
 import Data.Bits ((.|.), shiftL, shiftR)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Word (Word32, Word8)
 import Network.Socket (Socket)
 import qualified Network.Socket.ByteString as Socket
@@ -17,7 +19,7 @@ import qualified Network.Socket.ByteString as Socket
 data FrameError
     = FrameClosed
     | FrameTooLarge Int Int
-    | FrameInvalidJSON String
+    | FrameInvalidJSON Text
     deriving stock (Eq, Show)
 
 instance Exception FrameError
@@ -41,7 +43,7 @@ receiveJSONFrame maximumBytes socket = do
         then throwIO (FrameTooLarge bodyLength maximumBytes)
         else do
             body <- receiveExactly socket bodyLength
-            either (throwIO . FrameInvalidJSON) pure (eitherDecodeStrict' body)
+            either (throwIO . FrameInvalidJSON . Text.pack) pure (eitherDecodeStrict' body)
 
 receiveExactly :: Socket -> Int -> IO BS.ByteString
 receiveExactly socket expected = go [] expected

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -103,12 +103,12 @@ defaultJournalConfig directory =
         }
 
 data JournalError
-    = JournalCorrupt FilePath String
+    = JournalCorrupt FilePath Text
     | JournalEventGap Sequence Sequence
     | JournalEventTooLarge Int Int
     | JournalTaskCapacityExceeded Int
     | JournalFileTooLarge FilePath Integer Integer
-    | JournalPoisoned String
+    | JournalPoisoned Text
     | JournalInsecurePath FilePath
     | JournalSequenceExhausted Sequence
     deriving stock (Eq, Show)
@@ -139,7 +139,7 @@ data Journal = Journal
     , state :: MVar JournalState
     , subscribers :: TVar (Map Int Subscription)
     , nextSubscriber :: TVar Int
-    , poisoned :: TVar (Maybe String)
+    , poisoned :: TVar (Maybe Text)
     }
 
 data Subscription = Subscription
@@ -191,7 +191,7 @@ recoverTask config saved event
     | event.eventType /= "task_changed" = pure saved
     | otherwise =
         case fromJSON event.payload of
-            Error message -> throwIO (JournalCorrupt "events.jsonl" message)
+            Error message -> throwIO (JournalCorrupt "events.jsonl" (Text.pack message))
             Success task -> do
                 let boundedTask = boundTaskLog config task
                 boundedTasks <-
@@ -208,7 +208,7 @@ normaliseRecoveredEvent config event
         pure event {payload = redactValue event.payload}
     | otherwise =
         case fromJSON event.payload of
-            Error message -> throwIO (JournalCorrupt "events.jsonl" message)
+            Error message -> throwIO (JournalCorrupt "events.jsonl" (Text.pack message))
             Success task ->
                 pure event {payload = toJSON (boundTaskLog config task)}
 
@@ -505,7 +505,7 @@ readSnapshot config = do
     readPrivateFile (snapshotPath config) (fromIntegral config.maximumSnapshotBytes) >>= \case
         Just bytes ->
             case eitherDecodeStrict' bytes of
-                Left message -> throwIO (JournalCorrupt (snapshotPath config) message)
+                Left message -> throwIO (JournalCorrupt (snapshotPath config) (Text.pack message))
                 Right saved -> pure (True, saved)
         Nothing -> pure (False, emptySnapshot)
   where
@@ -521,7 +521,11 @@ readEvents config = do
 decodeLine :: FromJSON value => (Int, BS.ByteString) -> IO value
 decodeLine (lineNumber, bytes) =
     case eitherDecodeStrict' bytes of
-        Left message -> throwIO (JournalCorrupt "events.jsonl" ("line " <> show lineNumber <> ": " <> message))
+        Left message ->
+            throwIO $
+                JournalCorrupt
+                    "events.jsonl"
+                    ("line " <> Text.pack (show lineNumber) <> ": " <> Text.pack message)
         Right value -> pure value
 
 readPrivateFile :: FilePath -> Integer -> IO (Maybe BS.ByteString)

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Server.hs
@@ -26,6 +26,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable (for_)
+import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import Network.Socket (Socket, close)
 import System.Timeout (timeout)
@@ -58,7 +59,7 @@ defaultServerConfig =
         }
 
 data ServerError
-    = ServerTimedOut String
+    = ServerTimedOut Text
     | ServerSubscriberOverflow
     deriving stock (Eq, Show)
 
@@ -235,7 +236,7 @@ receive config peer =
     within config.ioTimeoutSeconds "socket read" $
         receiveJSONFrame config.maximumFrameBytes peer
 
-within :: Int -> String -> IO value -> IO value
+within :: Int -> Text -> IO value -> IO value
 within seconds label action =
     timeout (max 1 seconds * 1_000_000) action >>= \case
         Nothing -> throwIO (ServerTimedOut label)

--- a/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
@@ -880,7 +880,7 @@ assistantResponseItem text =
 
 responseWithTypedOutput :: [ResponseItem] -> Response
 responseWithTypedOutput output =
-    either error id
+    either (error . Text.unpack) id
         . ResponsesCodec.decodeResponse
         . LBS.toStrict
         . Aeson.encode


### PR DESCRIPTION
## Summary

- use strict `Text` for internal startup, daemon, journal, framing, and timeout diagnostics
- return `Text` errors from protocol and Responses decoders
- accept `Text` in shell command APIs and convert only at process/network/FFI boundaries
- update provider call sites, tests, and the Responses decoding benchmark

Intentional `String` uses remain where upstream APIs require them, including `FilePath`, process environments, CLI arguments, network host/path values, Aeson decoder errors, and FFI.

## Validation

- `cabal repl agent-core:test:agent-core-test --repl-options=-fno-code`
- `cabal repl agent-responses:test:agent-responses-test --repl-options=-fno-code`
- `cabal repl agent-codex-dialect:test:agent-codex-dialect-test --repl-options=-fno-code`
- `cabal repl agent-grok-build-dialect:test:agent-grok-build-dialect-test --repl-options=-fno-code`
- `cabal repl agent-runtime-daemon:test:agent-runtime-daemon-test --repl-options=-fno-code`
- `cabal repl agent-xai:test:agent-xai-test --repl-options=-fno-code`
- `cabal repl agent-responses:bench:responses-json-bench --repl-options=-fno-code`
- `git diff --check origin/master...HEAD`

The full OpenAI/CLI REPL remains blocked by the existing Template Haskell lookup of `./data/prompt.md` from the repository root; compilation reaches the changed OpenAI modules without another error.
