### PR TITLE
Add composable backend middleware type

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -54,6 +54,7 @@ import qualified Agent.Gemini.Client as Gemini
 import qualified Agent.Gemini.Options as Gemini
 import Agent.Loop
     ( Backend(..)
+    , BackendMiddleware
     , BackendResult(..)
     , BackendSnapshot(..)
     , LoopEvent(..)
@@ -1078,8 +1079,7 @@ autoCompactOpenAiBackend
     :: TokenProvider
     -> IO ResponseCreateParams
     -> IORef (Maybe OccupancySnapshot)
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 autoCompactOpenAiBackend =
     autoCompactOpenAiBackendWithThreshold Nothing
 
@@ -1090,8 +1090,7 @@ autoCompactOpenAiBackendWithThreshold
     -> TokenProvider
     -> IO ResponseCreateParams
     -> IORef (Maybe OccupancySnapshot)
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 autoCompactOpenAiBackendWithThreshold configuredThreshold tokenProvider
         getParams contextTokensRef backend =
     autoCompactOpenAiBackendWithSender
@@ -1111,8 +1110,7 @@ autoCompactOpenAiBackendWithSender
     -> (TokenUsage -> IO ())
     -> IO ResponseCreateParams
     -> IORef (Maybe OccupancySnapshot)
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 autoCompactOpenAiBackendWithSender configuredThreshold send recordUsage
         getParams contextTokensRef backend =
     autoCompactOpenAiBackendWithSenderAndHook
@@ -1135,8 +1133,7 @@ autoCompactOpenAiBackendWithSenderAndHook
     -> IO ResponseCreateParams
     -> (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
     -> IORef (Maybe OccupancySnapshot)
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 autoCompactOpenAiBackendWithSenderAndHook configuredThreshold send recordUsage
         getParams onCompacted contextTokensRef backend =
     autoCompactOpenAiBackendWithSenderHookAndDecorator
@@ -1159,8 +1156,7 @@ autoCompactOpenAiBackendWithSenderHookAndDecorator
     -> (CompactOutcome -> IO CompactOutcome)
     -> (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
     -> IORef (Maybe OccupancySnapshot)
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 autoCompactOpenAiBackendWithSenderHookAndDecorator
         configuredThreshold send recordUsage getParams decorateOutcome
         onCompacted contextTokensRef backend =
@@ -1295,8 +1291,7 @@ autoCompactOpenAiBackendWithSenderHookAndDecorator
 
 rejectOversizedInitialRequest
     :: IO ResponseCreateParams
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 rejectOversizedInitialRequest getParams (Backend submit) =
     Backend \snapshot previous inputs onEvent ->
         if null snapshot.backendItems
@@ -1319,8 +1314,7 @@ rejectOversizedInitialRequest getParams (Backend submit) =
 autoCompactOpenAiBackendWith
     :: IO (Either Text CompactOutcome)
     -> IORef (Maybe OccupancySnapshot)
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 autoCompactOpenAiBackendWith compactAction =
     autoCompactOpenAiBackendWithLimit
         (pure codexAutoCompactTokenLimit)
@@ -1339,8 +1333,7 @@ autoCompactOpenAiBackendWith compactAction =
 autoCompactOpenAiBackendWithApi
     :: IO (Either ApiError CompactOutcome)
     -> IORef (Maybe OccupancySnapshot)
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 autoCompactOpenAiBackendWithApi compactAction =
     autoCompactOpenAiBackendWithLimit
         (pure codexAutoCompactTokenLimit)
@@ -1360,8 +1353,7 @@ autoCompactBackendWith
     -> (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
     -> IO ResponseCreateParams
     -> IORef (Maybe OccupancySnapshot)
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 autoCompactBackendWith getLimit compactAction onCompacted getParams =
     autoCompactOpenAiBackendWithLimit
         getLimit
@@ -1385,8 +1377,7 @@ autoCompactOpenAiBackendWithLimit
     -> (Maybe OccupancySnapshot -> [ResponseItem] -> [TurnInput] -> IO Int)
     -> (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
     -> IORef (Maybe OccupancySnapshot)
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 autoCompactOpenAiBackendWithLimit getLimit absorbCompletedTools compactAction
         recordUsage estimateProjected
         onCompacted

--- a/packages/agent-cli/src/Agent/CLI/Compaction/Continuation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction/Continuation.hs
@@ -10,6 +10,7 @@ import Agent.CLI.Compaction.Projection
 import Agent.CLI.Compaction.Types
 import Agent.Loop
     ( Backend(..)
+    , BackendMiddleware
     , BackendSnapshot(..)
     , TurnInput(..)
     , advanceBackendSnapshot
@@ -40,8 +41,7 @@ boundCompletedToolContinuations
     :: (ResponseCreateParams -> Int)
     -> IO ResponseCreateParams
     -> IORef (Maybe OccupancySnapshot)
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 boundCompletedToolContinuations contextWindowFor getParams contextTokensRef (Backend submit) =
     Backend \snapshot previous inputs onEvent ->
         if not (any isCompletedTool inputs)

--- a/packages/agent-cli/src/Agent/CLI/PendingInputs.hs
+++ b/packages/agent-cli/src/Agent/CLI/PendingInputs.hs
@@ -15,7 +15,7 @@ import Agent.CLI.InputBudget
     ( logicalTurnInputBytes
     , saturatingAdd
     )
-import Agent.Loop (Backend(..), TurnInput(..))
+import Agent.Loop (Backend(..), BackendMiddleware, TurnInput(..))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception.Safe (mask, onException)
 import Data.Foldable (toList)
@@ -244,7 +244,7 @@ epochOf state = state.pendingEpoch
 queueOf :: PendingState -> Seq.Seq PendingEntry
 queueOf state = state.pendingQueue
 
-withPendingInputs :: PendingInputs -> Backend -> Backend
+withPendingInputs :: PendingInputs -> BackendMiddleware
 withPendingInputs (PendingInputs pending lifecycle) (Backend submit) =
     Backend \state previous inputs onEvent ->
         mask \restore ->

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -106,7 +106,7 @@ import Agent.Error
     ( ApiError(..)
     , CredentialExhaustionReason(..)
     )
-import Agent.Loop (Backend(..))
+import Agent.Loop (Backend(..), BackendMiddleware)
 import Agent.Provider
     ( AccountFailure(..)
     , BillingMode(..)
@@ -949,8 +949,7 @@ commitBackendOnSuccess
     -> IORef Bool
     -> ProviderTransition
     -> Persistence
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 commitBackendOnSuccess
         scope home projectRoot committed transition persist (Backend submit) =
     Backend \state previous inputs onEvent -> do

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -78,10 +78,11 @@ import Agent.Dialect
      dialectChildAgentProtocol, dialectForId, dialectId, dialectIdForModel)
 import Agent.InterAgentMessage (InterAgentMessage, interAgentMessagePayload)
 import Agent.Loop
-    (Backend(..), BackendSnapshot(..), BackendStateStore(..), LoopConfig(..),
-     LoopError(..), LoopEvent(..), LoopResult(..), TurnInput(..),
-     advanceBackendSnapshot, defaultLoopDispatch, emptyBackendSnapshot,
-     initialBackendSnapshot, runLoop, runLoopInputs)
+    (Backend(..), BackendMiddleware, BackendSnapshot(..),
+     BackendStateStore(..), LoopConfig(..), LoopError(..), LoopEvent(..),
+     LoopResult(..), TurnInput(..), advanceBackendSnapshot,
+     defaultLoopDispatch, emptyBackendSnapshot, initialBackendSnapshot,
+     runLoop, runLoopInputs)
 import Agent.ToolDispatch (ToolDispatchConfig(..))
 import Agent.Tools.OutputArtifact (finalizeToolOutput)
 import Agent.Tools.Background (setBackgroundTaskHooks)
@@ -508,8 +509,7 @@ compactXaiChildBackend
     -> (ResponseCreateParams -> Backend)
     -> SubagentSession
     -> ResponseCreateParams
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 compactXaiChildBackend contextWindowFor compactThresholdFor makeBackend
         session params requestBackend =
     autoCompactBackendWith
@@ -804,7 +804,7 @@ runHttpSubagentWith
     -> Provider
     -> Maybe (InterAgentMessage -> IO (Either Text Text))
     -> (ResponseCreateParams -> Backend)
-    -> (SubagentSession -> ResponseCreateParams -> Backend -> Backend)
+    -> (SubagentSession -> ResponseCreateParams -> BackendMiddleware)
     -> RunSubagent
 runHttpSubagentWith
         runtime dialect provider sendToRoot mkBackend wrapBackend =

--- a/packages/agent-connectivity/src/Agent/Connectivity.hs
+++ b/packages/agent-connectivity/src/Agent/Connectivity.hs
@@ -22,7 +22,7 @@ import Agent.Error
     , apiErrorRetryAfter
     , isInlineRetryableProviderError
     )
-import Agent.Loop (Backend(..), LoopEvent(..))
+import Agent.Loop (Backend(..), BackendMiddleware, LoopEvent(..))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
 import Control.Monad (when)
@@ -65,13 +65,13 @@ transientRetryDelayMicros apiError attempt =
 -- of times after their lower-level, replay-safe retry policy gives up.
 -- 'runLoopInputs' races every backend submission against the session cancel
 -- flag, so the sleep and all retries remain scoped to the current turn.
-withConnectionRecovery :: Backend -> Backend
+withConnectionRecovery :: BackendMiddleware
 withConnectionRecovery =
     withConnectionRecoveryUsingMaybeWatcher threadDelay Nothing
 
 -- | Retry as above, and also restart an in-flight provider submission as soon
 -- as macOS reports that an unavailable network path is satisfied again.
-withConnectionRecoveryOn :: Maybe NetworkRecovery -> Backend -> Backend
+withConnectionRecoveryOn :: Maybe NetworkRecovery -> BackendMiddleware
 withConnectionRecoveryOn recovery =
     withConnectionRecoveryUsingMaybeWatcher
         threadDelay
@@ -83,8 +83,7 @@ withConnectionRecoveryOn recovery =
 -- attempt visible rather than trying to splice or silently deduplicate it.
 withConnectionRecoveryUsing
     :: (Int -> IO ())
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 withConnectionRecoveryUsing waitMicros =
     withConnectionRecoveryUsingMaybeWatcher waitMicros Nothing
 
@@ -93,16 +92,14 @@ withConnectionRecoveryUsing waitMicros =
 withConnectionRecoveryUsingWatcher
     :: (Int -> IO ())
     -> RecoveryWatcher
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 withConnectionRecoveryUsingWatcher waitMicros watcher =
     withConnectionRecoveryUsingMaybeWatcher waitMicros (Just watcher)
 
 withConnectionRecoveryUsingMaybeWatcher
     :: (Int -> IO ())
     -> Maybe RecoveryWatcher
-    -> Backend
-    -> Backend
+    -> BackendMiddleware
 withConnectionRecoveryUsingMaybeWatcher
     waitMicros watcher (Backend submit) =
     Backend \state previous inputs onEvent ->

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -29,5 +29,35 @@ Provider-neutral infrastructure shared by the harness transports:
   unfinished exchanges poison the session so abandoned frames cannot leak
   into its successor.
 
+## Backend middleware
+
+`Backend` represents one provider/model submission. The corresponding
+middleware type is deliberately just a function:
+
+```haskell
+type BackendMiddleware = Backend -> Backend
+```
+
+Middleware therefore composes with ordinary `(.)`, uses `id` as its empty
+value, and needs no framework-specific combinator:
+
+```haskell
+middleware :: BackendMiddleware
+middleware =
+    addPendingInputs
+        . compactContext
+        . recoverConnections
+
+backend :: Backend
+backend = middleware providerBackend
+```
+
+The leftmost middleware is outermost: it sees the request first and the
+result last. A `BackendMiddleware` wraps only the provider step, including its
+streamed events and returned tool calls. Tool approval and execution happen
+later in `Agent.Loop`, outside this boundary. Consequently, retry middleware
+can replay a provider submission without replaying tools that the host has
+already completed.
+
 This package does not contain OpenAI, ChatGPT, xAI, OpenRouter, or Gemini
 transport logic.

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -3,6 +3,7 @@
 -- hits a cap.
 module Agent.Loop
     ( Backend(..)
+    , BackendMiddleware
     , BackendContinuation(..)
     , BackendRevision(..)
     , BackendResult(..)
@@ -52,6 +53,18 @@ import Agent.Loop.Internal
 import Agent.ToolDispatch (ToolDispatchConfig(..))
 import Control.Exception.Safe (SomeException)
 import qualified Data.Text as Text
+
+-- | Decorate one provider/model submission.
+--
+-- This is the model-step analogue of WAI middleware. Values compose with
+-- ordinary function composition: in @(outer . inner) backend@, @outer@
+-- observes the request first and the result last.
+--
+-- A backend submission may stream events and may produce tool calls, but host
+-- tool approval and execution happen in the surrounding loop after the
+-- submission returns. Middleware that retries its wrapped backend therefore
+-- retries only the provider step, not already-completed host tools.
+type BackendMiddleware = Backend -> Backend
 
 defaultLoopMaxTurns :: Int
 defaultLoopMaxTurns = 2000

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -43,6 +43,7 @@ import qualified Agent.Responses.LoopBackend as Responses
 import Agent.Loop
     ( Backend(..)
     , BackendContinuation(..)
+    , BackendMiddleware
     , BackendResult(..)
     , BackendSnapshot(..)
     , LoopEvent(..)
@@ -601,7 +602,7 @@ isOpenAiReplayUnsafeWebSocketTransportFailure = \case
 -- Keep this wrapper outside automatic compaction and connection recovery:
 -- compaction may mint the token needed by the immediately following request,
 -- and recovery retries must replay the same turn state rather than clearing it.
-withCodexTurnStateScope :: IO CodexTurnState -> Backend -> Backend
+withCodexTurnStateScope :: IO CodexTurnState -> BackendMiddleware
 withCodexTurnStateScope getTurnState (Backend submit) =
     Backend \state legacyPreviousResponseId inputs onEvent -> do
         when (startsNewLogicalTurn inputs) $


### PR DESCRIPTION
## Summary
- introduce `BackendMiddleware = Backend -> Backend` for one model submission
- express existing recovery, compaction, pending-input, turn-state, and transition decorators through the shared alias
- document composition order and the boundary around host tool execution

## Validation
- multi-package GHCi: 442 modules loaded
- agent-connectivity: 15 examples, 0 failures
- agent-openai `withCodexTurnStateScope`: 1 example, 0 failures
- agent-cli `withPendingInputs`: 12 examples, 0 failures
- agent-cli `autoCompactOpenAiBackendWith`: 22 examples, 0 failures
