### PR TITLE
Scope SDK graceful shutdown worker

### DIFF
--- a/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
+++ b/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
@@ -100,6 +100,7 @@ test-suite claude-agent-sdk-haskell-test
                     , claude-agent-sdk-haskell
                     , agent-json
                     , aeson
+                    , async
                     , bytestring
                     , containers
                     , directory

--- a/packages/claude-agent-sdk-haskell/package.nix
+++ b/packages/claude-agent-sdk-haskell/package.nix
@@ -13,8 +13,8 @@ mkDerivation {
     safe-exceptions text transformers unix uuid-types
   ];
   testHaskellDepends = [
-    aeson agent-json base bytestring containers directory filepath
-    hspec safe-exceptions text unix
+    aeson agent-json async base bytestring containers directory
+    filepath hspec safe-exceptions text unix
   ];
   benchmarkHaskellDepends = [ base bytestring safe-exceptions ];
   description = "Haskell SDK for the Claude Agent SDK stream protocol";

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Client.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Client.hs
@@ -77,6 +77,7 @@ import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
     ( Async
+    , cancel
     , poll
     , withAsyncWithUnmask
     )
@@ -1082,25 +1083,24 @@ subprocessTransportFactory options request =
 
 stopRunningClient :: RunningClient -> IO ()
 stopRunningClient running =
-    withAsyncWithUnmask
+    ( withAsyncWithUnmask
         (\unmask -> unmask running.runningTransport.transportEndInput)
-        \endInputWorker ->
-            (do
-                endInputResult <-
-                    pollAsyncUntil
-                        running.runningShutdownTimeoutMicros
-                        endInputWorker
-                case endInputResult of
-                    Nothing ->
-                        pure ()
-                    Just (Left exception) ->
-                        throwIO exception
-                    Just (Right ()) ->
-                        pure ()
-                waitForTransportExit
+        \endInputWorker -> do
+            endInputResult <-
+                pollAsyncUntil
                     running.runningShutdownTimeoutMicros
-                    running.runningTransport
-            ) `finally` forceCloseRunningClient running
+                    endInputWorker
+            case endInputResult of
+                Nothing ->
+                    cancel endInputWorker
+                Just (Left exception) ->
+                    throwIO exception
+                Just (Right ()) ->
+                    pure ()
+            waitForTransportExit
+                running.runningShutdownTimeoutMicros
+                running.runningTransport
+    ) `finally` forceCloseRunningClient running
 
 pollAsyncUntil
     :: Int

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Client.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Client.hs
@@ -77,9 +77,8 @@ import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
     ( Async
-    , asyncWithUnmask
-    , cancel
     , poll
+    , withAsyncWithUnmask
     )
 import Control.Concurrent.MVar
     ( MVar
@@ -1083,26 +1082,25 @@ subprocessTransportFactory options request =
 
 stopRunningClient :: RunningClient -> IO ()
 stopRunningClient running =
-    (do
-        endInputWorker <-
-            asyncWithUnmask \unmask ->
-                unmask running.runningTransport.transportEndInput
-        endInputResult <-
-            pollAsyncUntil
-                running.runningShutdownTimeoutMicros
-                endInputWorker
-        case endInputResult of
-            Nothing ->
-                cancel endInputWorker
-            Just (Left exception) ->
-                throwIO exception
-            Just (Right ()) ->
-                pure ()
-        waitForTransportExit
-            running.runningShutdownTimeoutMicros
-            running.runningTransport)
-        `finally`
-            forceCloseRunningClient running
+    withAsyncWithUnmask
+        (\unmask -> unmask running.runningTransport.transportEndInput)
+        \endInputWorker ->
+            (do
+                endInputResult <-
+                    pollAsyncUntil
+                        running.runningShutdownTimeoutMicros
+                        endInputWorker
+                case endInputResult of
+                    Nothing ->
+                        pure ()
+                    Just (Left exception) ->
+                        throwIO exception
+                    Just (Right ()) ->
+                        pure ()
+                waitForTransportExit
+                    running.runningShutdownTimeoutMicros
+                    running.runningTransport
+            ) `finally` forceCloseRunningClient running
 
 pollAsyncUntil
     :: Int

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ControlSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ControlSpec.hs
@@ -5,12 +5,15 @@ import Control.Concurrent
     ( forkIO
     , newChan
     , newEmptyMVar
+    , newMVar
     , putMVar
     , readChan
     , takeMVar
     , threadDelay
+    , withMVar
     , writeChan
     )
+import Control.Concurrent.Async (wait, withAsync)
 import Control.Exception.Safe (finally)
 import Control.Monad (void)
 import qualified Data.Aeson as Aeson
@@ -359,25 +362,30 @@ spec = describe "Claude SDK control protocol" do
                         emit (successResponse requestId (Aeson.object []))
                     _ -> pure ()
         block <- newEmptyMVar
+        endInputStarted <- newEmptyMVar
+        lifecycleLock <- newMVar ()
         closed <- newIORef False
         endInputObservedClosed <- newEmptyMVar
         let blockedFactory requestInfo = do
                 transport <- factory.transportFactory requestInfo
                 pure transport
                     { transportClose =
-                        writeIORef closed True
-                            >> transport.transportClose
+                        withMVar lifecycleLock \_ ->
+                            writeIORef closed True
+                                >> transport.transportClose
                     , transportEndInput =
-                        takeMVar block
-                            `finally`
-                                (readIORef closed
-                                    >>= putMVar endInputObservedClosed)
+                        withMVar lifecycleLock \_ -> do
+                            putMVar endInputStarted ()
+                            takeMVar block
+                                `finally`
+                                    (readIORef closed
+                                        >>= putMVar endInputObservedClosed)
                     }
             handlers =
                 defaultClaudeAgentHandlers
                     { shutdownTimeoutMicros = 20_000
                     }
-        timeout 500_000
+        withAsync
             (withClaudeSDKClientWithTransportAndHandlers
                 testOptions
                 blockedFactory
@@ -385,8 +393,19 @@ spec = describe "Claude SDK control protocol" do
                 \client ->
                     withTurn client \_ ->
                         pure (Right ((), pure ())))
-            `shouldReturn` Just (Right ())
-        takeMVar endInputObservedClosed `shouldReturn` True
+            \shutdown -> do
+                takeMVar endInputStarted
+                result <- timeout 500_000 (wait shutdown)
+                case result of
+                    Nothing -> do
+                        -- Keep a regression failure from leaking the blocked
+                        -- shutdown worker into the rest of the suite.
+                        putMVar block ()
+                        void (wait shutdown)
+                    Just _ ->
+                        pure ()
+                result `shouldBe` Just (Right ())
+        takeMVar endInputObservedClosed `shouldReturn` False
 
 data FakeTransport = FakeTransport
     { transportFactory :: !TransportFactory

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ControlSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ControlSpec.hs
@@ -11,6 +11,7 @@ import Control.Concurrent
     , threadDelay
     , writeChan
     )
+import Control.Exception.Safe (finally)
 import Control.Monad (void)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -350,7 +351,7 @@ spec = describe "Claude SDK control protocol" do
                 readIORef closes `shouldReturn` 1
         readIORef closes `shouldReturn` 2
 
-    it "bounds a blocked endInput during shutdown" do
+    it "bounds and joins a blocked endInput during shutdown" do
         factory <-
             fakeTransportFactory \emit value ->
                 case request value of
@@ -358,10 +359,19 @@ spec = describe "Claude SDK control protocol" do
                         emit (successResponse requestId (Aeson.object []))
                     _ -> pure ()
         block <- newEmptyMVar
+        closed <- newIORef False
+        endInputObservedClosed <- newEmptyMVar
         let blockedFactory requestInfo = do
                 transport <- factory.transportFactory requestInfo
                 pure transport
-                    { transportEndInput = takeMVar block
+                    { transportClose =
+                        writeIORef closed True
+                            >> transport.transportClose
+                    , transportEndInput =
+                        takeMVar block
+                            `finally`
+                                (readIORef closed
+                                    >>= putMVar endInputObservedClosed)
                     }
             handlers =
                 defaultClaudeAgentHandlers
@@ -376,6 +386,7 @@ spec = describe "Claude SDK control protocol" do
                     withTurn client \_ ->
                         pure (Right ((), pure ())))
             `shouldReturn` Just (Right ())
+        takeMVar endInputObservedClosed `shouldReturn` True
 
 data FakeTransport = FakeTransport
     { transportFactory :: !TransportFactory


### PR DESCRIPTION
## Summary
- own the SDK `transportEndInput` worker with `withAsyncWithUnmask`
- cancel and join a timed-out `transportEndInput` worker before any force-close path can acquire the same lifecycle lock
- complete the structured worker scope before force-closing the transport, while preserving bounded process-exit polling
- add a shared-lock regression for the blocked-input shutdown path

## Tests
- regression against the pre-fix `Client.hs`: expected timeout failure after 0.503s
- `cabal test claude-agent-sdk-haskell-test --test-options='--match "Claude SDK control protocol"' --test-show-details=direct` (8 examples, 0 failures)
- `cabal test claude-agent-sdk-haskell-test --test-show-details=direct` (100 examples, 0 failures)
