### PR TITLE
Cancel server workers concurrently

### DIFF
--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -35,6 +35,7 @@ import Control.Concurrent.Async
     ( Async
     , async
     , cancel
+    , mapConcurrently_
     , waitCatch
     )
 import Control.Concurrent.MVar
@@ -304,9 +305,8 @@ closeSupervisor supervisor = mask \restore -> do
                 void $
                     timeout cancelHookTimeoutMicros
                         (void (tryAny (restore action)))
-        stopWorkers = do
-            forM_ workers cancel
-            forM_ workers (void . waitCatch)
+        stopWorkers =
+            mapConcurrently_ cancel workers
         stopDispatcher = do
             dispatcher <- readMVar supervisor.supervisorDispatcher
             cancel dispatcher

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -17,6 +17,7 @@ import Control.Concurrent.STM
 import Control.Concurrent.Async
     ( async
     , wait
+    , withAsync
     )
 import Control.Exception.Safe (bracket, finally)
 import Control.Monad (void)
@@ -172,16 +173,23 @@ spec = describe "turn supervisor" do
                 takeWithin firstStarted
                 takeWithin secondStarted
 
-                shutdown <- async (closeSupervisor supervisor)
-                cancelledTogether <-
-                    timeout 500_000 do
-                        takeMVar firstCancelled
-                        takeMVar secondCancelled
-                putMVar releaseFirst ()
-                putMVar releaseSecond ()
-                wait shutdown
+                withAsync (closeSupervisor supervisor) \shutdown ->
+                    finally
+                        (do
+                            cancelledTogether <-
+                                timeout 500_000 do
+                                    takeMVar firstCancelled
+                                    takeMVar secondCancelled
+                            putMVar releaseFirst ()
+                            putMVar releaseSecond ()
+                            wait shutdown
 
-                cancelledTogether `shouldBe` Just ()
+                            cancelledTogether `shouldBe` Just ()
+                        )
+                        (do
+                            void (tryPutMVar releaseFirst ())
+                            void (tryPutMVar releaseSecond ())
+                        )
 
     it "keeps queued turns from blocking work in another session" do
         firstStarted <- newEmptyMVar

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -18,7 +18,7 @@ import Control.Concurrent.Async
     ( async
     , wait
     )
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, finally)
 import Control.Monad (void)
 import Data.Aeson (object)
 import Data.Text (Text)
@@ -143,6 +143,45 @@ spec = describe "turn supervisor" do
                 localAccessBoundary
                 "session-a"
                 `shouldReturn` False
+
+    it "cancels active workers concurrently during shutdown" do
+        firstStarted <- newEmptyMVar
+        secondStarted <- newEmptyMVar
+        firstCancelled <- newEmptyMVar
+        secondCancelled <- newEmptyMVar
+        releaseFirst <- newEmptyMVar
+        releaseSecond <- newEmptyMVar
+        never <- newEmptyMVar
+        let runner _ turn = do
+                let (started, cancelled, release)
+                        | turn.turnSpecSessionId == "session-a" =
+                            (firstStarted, firstCancelled, releaseFirst)
+                        | otherwise =
+                            (secondStarted, secondCancelled, releaseSecond)
+                (putMVar started () >> takeMVar never)
+                    `finally`
+                        (putMVar cancelled () >> takeMVar release)
+        withSupervisorConfig
+            defaultConfig
+                { supervisorMaxConcurrentTurns = 2
+                , supervisorMaxConcurrentTurnsPerTenant = 2
+                }
+            runner \supervisor -> do
+                void (submitTurn supervisor (turnSpec "session-a"))
+                void (submitTurn supervisor (turnSpec "session-b"))
+                takeWithin firstStarted
+                takeWithin secondStarted
+
+                shutdown <- async (closeSupervisor supervisor)
+                cancelledTogether <-
+                    timeout 500_000 do
+                        takeMVar firstCancelled
+                        takeMVar secondCancelled
+                putMVar releaseFirst ()
+                putMVar releaseSecond ()
+                wait shutdown
+
+                cancelledTogether `shouldBe` Just ()
 
     it "keeps queued turns from blocking work in another session" do
         firstStarted <- newEmptyMVar


### PR DESCRIPTION
## Summary
- fan out active turn-worker cancellation with `mapConcurrently_` during supervisor shutdown
- rely on `cancel`'s built-in join instead of a second serial wait pass
- add a regression that holds cancellation finalizers open and verifies every active worker is interrupted before any one finishes
- scope the test's `closeSupervisor` task with `withAsync`, releasing blocked cleanup gates in `finally` so exceptional exits cannot leak or hang the worker

## Tests
- regression against the old serial implementation: 1 example, 1 expected failure
- `cabal repl agent-server:test:agent-server-test` → `:main --match "cancels active workers concurrently"` (1 example, 0 failures)
- `cabal test agent-server-test --test-options='--match "turn supervisor"' --test-show-details=direct` (11 examples, 0 failures)

## Test environment note
A full package run reached 43 examples; 5 `tenant sandbox protocol` integration examples fail in this development shell. All 11 supervisor examples pass.
