### PR TITLE
Cancel daemon task workers concurrently

### DIFF
--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -13,6 +13,7 @@ import Control.Concurrent.Async
     , asyncWithUnmask
     , cancel
     , concurrently_
+    , mapConcurrently_
     , race
     , wait
     , waitCatch
@@ -595,8 +596,7 @@ shutdownRegistry registry = do
         current <- readTVar registry
         writeTVar registry Map.empty
         pure (Map.elems current)
-    mapM_ (cancel . (.runningWorker)) running
-    mapM_ (waitCatch . (.runningWorker)) running
+    mapConcurrently_ (cancel . (.runningWorker)) running
 
 taskResult :: Text -> DurableTask -> Value
 taskResult state task =

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -732,6 +732,66 @@ main = hspec $ do
                         indices `shouldBe` [1 .. chunkCount - 1]
 
     describe "task adapter IPC" $ do
+        it "cancels all running tasks before waiting for their cleanup" $
+            withSystemTempDirectory "daemon-task-shutdown" $ \directory -> do
+                journal <- openJournal (defaultJournalConfig directory)
+                runForever <- newEmptyTMVarIO
+                callbackReady <- newEmptyTMVarIO
+                stopCallback <- newEmptyTMVarIO
+                started <- newTQueueIO
+                cancelling <- newTQueueIO
+                releaseCleanup <- newTQueueIO
+                let runner =
+                        TaskRunner
+                            { runTask = \task _ -> do
+                                atomically (writeTQueue started task.taskId)
+                                _ <-
+                                    atomically (takeTMVar runForever)
+                                        `finally`
+                                            uninterruptibleMask_
+                                                ( do
+                                                    atomically (writeTQueue cancelling task.taskId)
+                                                    atomically (readTQueue releaseCleanup)
+                                                )
+                                pure (Right ())
+                            }
+                    runAdapter =
+                        withTaskAdapter journal runner $ \supervisor -> do
+                            supervisor.handleCommand
+                                (CommandId "submit-shutdown-first")
+                                (submitCommand "shutdown-first" "shutdown-session")
+                                >>= shouldSucceed
+                            supervisor.handleCommand
+                                (CommandId "submit-shutdown-second")
+                                (submitCommand "shutdown-second" "other-shutdown-session")
+                                >>= shouldSucceed
+                            _ <- atomically (readTQueue started)
+                            _ <- atomically (readTQueue started)
+                            atomically (putTMVar callbackReady ())
+                            atomically (takeTMVar stopCallback)
+                withAsync runAdapter $ \adapter -> do
+                    cancelled <-
+                        ( do
+                            timeout 1_000_000 (atomically (takeTMVar callbackReady))
+                                `shouldReturn` Just ()
+                            atomically (putTMVar stopCallback ())
+                            timeout
+                                500_000
+                                ( sequence
+                                    [ atomically (readTQueue cancelling)
+                                    , atomically (readTQueue cancelling)
+                                    ]
+                                )
+                        ) `finally`
+                            atomically
+                                ( writeTQueue releaseCleanup ()
+                                    >> writeTQueue releaseCleanup ()
+                                )
+                    wait adapter
+                    cancelled `shouldSatisfy` \case
+                        Just taskIds -> length taskIds == 2
+                        Nothing -> False
+
         it "submits, queues, cancels, lists, and replays durable task changes" $
             withSystemTempDirectory "daemon-task-adapter" $ \directory -> do
                 journal <- openJournal (defaultJournalConfig directory)


### PR DESCRIPTION
## Summary
- cancel registered daemon task workers concurrently during adapter shutdown
- rely on `cancel`'s join semantics instead of performing a redundant serial `waitCatch` pass
- add a regression proving all task cleanups begin before shutdown waits for any one cleanup

## Tests
- `cabal test agent-runtime-daemon-test --test-options='--match "cancels all running tasks before waiting for their cleanup"'` (regression failed before the source change and passes after it)
- `cabal test agent-runtime-daemon-test --test-options='--match "/task adapter IPC/"'` (9 examples, 0 failures)
- `cabal test agent-runtime-daemon-test` (36 examples pass; 5 existing sandbox-sensitive Unix socket tests fail because this environment denies directory creation in the system temp location)
