### PR TITLE
Add model details to agent commit attribution

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.Prompt
     ( appendMcpInstructions
     , codexEnvironmentContext
+    , commitAttributionGuidanceForTools
     , mcpInstructionsForRequest
     , mcpInstructionsGuidance
     , secretInputGuidance
@@ -38,6 +39,7 @@ import Agent.GrokBuild.Dialect.Prompt
     )
 import Agent.OsPath (toText)
 import Agent.Provider (BillingMode(..), Provider(..))
+import Data.Char (isControl)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -77,12 +79,21 @@ subscriptionSubagentModelGuidance provider billing
     | otherwise = Nothing
 
 -- | @isNonInteractive@ is True for one-shot @-p@ (no human in the loop).
-systemPrompt :: Dialect -> OsPath -> Maybe OsPath -> Day -> Bool -> Text
-systemPrompt dialect cwd sessionTmp today isNonInteractive =
+systemPrompt
+    :: Dialect
+    -> Text
+    -> Text
+    -> OsPath
+    -> Maybe OsPath
+    -> Day
+    -> Bool
+    -> Text
+systemPrompt dialect model effort cwd sessionTmp today isNonInteractive =
     Text.intercalate "\n\n" $
         filter (not . Text.null)
             [ base
             , sessionTempGuidance sessionTmp
+            , commitAttributionGuidance model effort
             , ghciGuidanceForDialect dialect
             , timeContextGuidance
             ]
@@ -100,6 +111,8 @@ systemPrompt dialect cwd sessionTmp today isNonInteractive =
 -- including provider-hosted search by default.
 systemPromptForTools
     :: Dialect
+    -> Text
+    -> Text
     -> [Text]
     -> OsPath
     -> Maybe OsPath
@@ -115,6 +128,8 @@ systemPromptForTools =
 systemPromptForToolsWithHostedSearch
     :: Bool
     -> Dialect
+    -> Text
+    -> Text
     -> [Text]
     -> OsPath
     -> Maybe OsPath
@@ -122,11 +137,16 @@ systemPromptForToolsWithHostedSearch
     -> Bool
     -> Text
 systemPromptForToolsWithHostedSearch includeHostedSearch
-        dialect toolNames cwd sessionTmp today isNonInteractive =
+        dialect model effort toolNames cwd sessionTmp today isNonInteractive =
     Text.intercalate "\n\n" $
         filter (not . Text.null)
             [ base
             , sessionTempGuidance sessionTmp
+            , commitAttributionGuidanceForTools
+                dialect
+                model
+                effort
+                (Set.toList available)
             , secretInputGuidance available
             , imageDisplayGuidance available
             , learnedSkillGuidance available
@@ -165,6 +185,8 @@ systemPromptForToolsWithHostedSearch includeHostedSearch
 -- them through 'codexEnvironmentContext', matching upstream placement.
 systemPromptForCatalogModel
     :: Dialect
+    -> Text
+    -> Text
     -> ModelInfo
     -> [Text]
     -> Maybe OsPath
@@ -175,17 +197,24 @@ systemPromptForCatalogModel =
 systemPromptForCatalogModelWithHostedSearch
     :: Bool
     -> Dialect
+    -> Text
+    -> Text
     -> ModelInfo
     -> [Text]
     -> Maybe OsPath
     -> Text
 systemPromptForCatalogModelWithHostedSearch
-        includeHostedSearch dialect info toolNames sessionTmp =
+        includeHostedSearch dialect model effort info toolNames sessionTmp =
     Text.intercalate "\n\n" $
         filter (not . Text.null)
             [ Text.strip
                 (renderModelInstructions ModelPersonalityDefault info)
             , sessionTempGuidance sessionTmp
+            , commitAttributionGuidanceForTools
+                dialect
+                model
+                effort
+                (Set.toList available)
             , secretInputGuidance available
             , imageDisplayGuidance available
             , learnedSkillGuidance available
@@ -241,6 +270,49 @@ sessionTempGuidance = \case
             , "Filesystem-tool paths under /tmp or /private/tmp are redirected into this directory."
             , "HASKELL_AGENT_TMPDIR and TMPDIR point to this directory for shell commands; use $TMPDIR instead of a literal /tmp or /private/tmp path."
             ]
+
+-- | Keep the user's configured Git identity as the commit author while making
+-- the harness's contribution visible in GitHub and other trailer-aware tools.
+commitAttributionGuidance :: Text -> Text -> Text
+commitAttributionGuidance model effort =
+    Text.unlines
+        [ "Git commit attribution:"
+        , "- When you create or amend a Git commit for work performed in this session, append exactly one `"
+            <> trailer
+            <> "` trailer to the commit message."
+        , "- Preserve the user's configured author identity and any existing co-author trailers."
+        , "- Do not add a duplicate Haskell Agent trailer, and omit it if the user explicitly asks you not to add it."
+        ]
+  where
+    trailer =
+        "Co-authored-by: Haskell Agent ("
+            <> sanitizeCommitIdentityComponent model
+            <> ", "
+            <> sanitizeCommitIdentityComponent effort
+            <> ") <agent@digitallyinduced.com>"
+
+commitAttributionGuidanceForTools
+    :: Dialect -> Text -> Text -> [Text] -> Text
+commitAttributionGuidanceForTools dialect model effort available
+    | dialectPromptStyle dialect == ClaudeCodePromptStyle =
+        commitAttributionGuidance model effort
+    | not (any (`Set.member` commandTools) available) = ""
+    | otherwise = commitAttributionGuidance model effort
+  where
+    commandTools =
+        Set.fromList
+            [ "shell_command"
+            , "run_terminal_cmd"
+            , "run_terminal_command"
+            , "run_ghci"
+            ]
+
+sanitizeCommitIdentityComponent :: Text -> Text
+sanitizeCommitIdentityComponent =
+    Text.map \character ->
+        if isControl character || character `elem` ['<', '>']
+            then '-'
+            else character
 
 -- | Keep sensitive values outside model-visible text and tool arguments when
 -- the host exposes the dedicated secret-entry capability.

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -136,7 +136,8 @@ import Agent.CLI.Session.Runtime.Types
     ( SessionRequest(codexCatalogSession, SessionRequest, catalog,
                      gatewayModelsRef, modelInfo,
                      connectionId, gatewayIdentity,
-                     options, provider, dialect, policyRef, allTools,
+                     options, provider, dialect, commitAttributionModel,
+                     commitAttributionEffort, policyRef, allTools,
                      claudeRuntimeSlot, claudeBridgeTools,
                      recordImageGenerationInputs, clearImageGenerationHistory,
                      suspendGhci, resetToolSessionTemp, grokRuntime,
@@ -722,6 +723,8 @@ prepareSessionCodeRuntime AgentSessionRequest
                     systemPromptForCatalogModelWithHostedSearch
                         includeHostedSearch
                         dialect
+                        model
+                        effortText
                         info
                         toolNames
                         sessionTmpDir
@@ -738,6 +741,8 @@ prepareSessionCodeRuntime AgentSessionRequest
                     systemPromptForToolsWithHostedSearch
                         includeHostedSearch
                         dialect
+                        model
+                        effortText
                         (map (.appToolName) providerTools)
                         cwd
                         (Just sessionTmp)
@@ -1155,6 +1160,8 @@ buildProviderSessionRequest
             , options = request.options
             , provider = request.provider
             , dialect = request.dialect
+            , commitAttributionModel = request.model
+            , commitAttributionEffort = request.effortText
             , policyRef = promptRuntime.sessionPolicyRef
             , allTools =
                 promptRuntime.sessionCodeRuntime.sessionRegistryTools

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -909,6 +909,8 @@ buildSessionShellRuntime host SessionRequest{..} =
                             systemPromptForToolsWithHostedSearch
                                 nativeCapabilities.nativeProviderHostedTools
                                 dialect
+                                commitAttributionModel
+                                commitAttributionEffort
                                 enabledNames
                                 cwd
                                 sessionTmp

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -115,6 +115,8 @@ data SessionRequest = SessionRequest
     , options :: !CliOptions
     , provider :: !Provider
     , dialect :: !Dialect
+    , commitAttributionModel :: !Text
+    , commitAttributionEffort :: !Text
     , policyRef :: !(IORef ApprovalPolicy)
     , allTools :: ![AppTool]
     , recordImageGenerationInputs :: !([ImageAttachment] -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -22,7 +22,12 @@ import Agent.CLI.Compaction
     )
 import Agent.Connectivity (withConnectionRecoveryOn)
 import Agent.CLI.Options (CliOptions(..), defaultEffortFor)
-import Agent.CLI.Prompt (sessionTempGuidance, systemPrompt, systemPromptForTools)
+import Agent.CLI.Prompt
+    ( commitAttributionGuidanceForTools
+    , sessionTempGuidance
+    , systemPrompt
+    , systemPromptForTools
+    )
 import Agent.CLI.Request (requestParams)
 import Agent.CLI.Session (LegacySubagentTarget(..))
 import Agent.CLI.SubagentStore
@@ -620,6 +625,8 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                                 CodexCollaborationProtocol ->
                                     systemPromptForTools
                                         childDialect
+                                        model
+                                        effort
                                         (map (.appToolName) tools)
                                         env.subCwd
                                         sessionTmp
@@ -639,10 +646,17 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                                                 agentType
                                                 env.subId.unSubagentId
                                             , sessionTempGuidance sessionTmp
+                                            , commitAttributionGuidanceForTools
+                                                childDialect
+                                                model
+                                                effort
+                                                (map (.appToolName) tools)
                                             ]
                                 GenericTaskProtocol ->
                                     systemPromptForTools
                                         childDialect
+                                        model
+                                        effort
                                         (map (.appToolName) tools)
                                         env.subCwd
                                         sessionTmp
@@ -651,6 +665,8 @@ runCodexSubagent gatewayOnly runtime tokenProvider sendToRoot =
                                 NoHostChildAgentProtocol ->
                                     systemPrompt
                                         childDialect
+                                        model
+                                        effort
                                         env.subCwd
                                         sessionTmp
                                         today
@@ -880,6 +896,8 @@ runHttpSubagentWith
                                 CodexCollaborationProtocol ->
                                     systemPromptForTools
                                         childDialect
+                                        model
+                                        effort
                                         (map (.appToolName) tools)
                                         env.subCwd
                                         sessionTmp
@@ -899,10 +917,17 @@ runHttpSubagentWith
                                                 agentType
                                                 env.subId.unSubagentId
                                             , sessionTempGuidance sessionTmp
+                                            , commitAttributionGuidanceForTools
+                                                childDialect
+                                                model
+                                                effort
+                                                (map (.appToolName) tools)
                                             ]
                                 GenericTaskProtocol ->
                                     systemPromptForTools
                                         childDialect
+                                        model
+                                        effort
                                         (map (.appToolName) tools)
                                         env.subCwd
                                         sessionTmp
@@ -911,6 +936,8 @@ runHttpSubagentWith
                                 NoHostChildAgentProtocol ->
                                     systemPrompt
                                         childDialect
+                                        model
+                                        effort
                                         env.subCwd
                                         sessionTmp
                                         today

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -1,19 +1,53 @@
 module Agent.CLI.PromptSpec (spec) where
 
-import Agent.CLI.Prompt
+import Agent.CLI.Prompt hiding
+    ( systemPrompt
+    , systemPromptForTools
+    , systemPromptForToolsWithHostedSearch
+    )
+import qualified Agent.CLI.Prompt as Prompt
 import Agent.Dialect
-    ( claudeCodeDialect
+    ( Dialect
+    , claudeCodeDialect
     , codexDialect
     , genericResponsesDialect
     , grokBuildDialect
     )
-import System.OsPath (unsafeEncodeUtf)
 import Agent.Provider (BillingMode(..), Provider(..))
-import Data.Time.Calendar (fromGregorian)
+import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Time.Calendar (Day, fromGregorian)
+import System.OsPath (OsPath, unsafeEncodeUtf)
 import Test.Hspec
 
+fromFilePath :: String -> OsPath
 fromFilePath = unsafeEncodeUtf
+
+systemPrompt
+    :: Dialect -> OsPath -> Maybe OsPath -> Day -> Bool -> Text
+systemPrompt dialect =
+    Prompt.systemPrompt dialect "gpt-5.6-sol" "high"
+
+systemPromptForTools
+    :: Dialect -> [Text] -> OsPath -> Maybe OsPath -> Day -> Bool -> Text
+systemPromptForTools dialect =
+    Prompt.systemPromptForTools dialect "gpt-5.6-sol" "high"
+
+systemPromptForToolsWithHostedSearch
+    :: Bool
+    -> Dialect
+    -> [Text]
+    -> OsPath
+    -> Maybe OsPath
+    -> Day
+    -> Bool
+    -> Text
+systemPromptForToolsWithHostedSearch includeHostedSearch dialect =
+    Prompt.systemPromptForToolsWithHostedSearch
+        includeHostedSearch
+        dialect
+        "gpt-5.6-sol"
+        "high"
 
 spec :: Spec
 spec = describe "systemPrompt" do
@@ -88,6 +122,8 @@ spec = describe "systemPrompt" do
         claude `shouldSatisfy` Text.isInfixOf "at most five minutes"
         claude `shouldSatisfy` Text.isInfixOf
             "report its current status and URL"
+        claude `shouldSatisfy` Text.isInfixOf
+            "Co-authored-by: Haskell Agent (gpt-5.6-sol, high) <agent@digitallyinduced.com>"
 
     it "uses a neutral identity for generic Responses models" do
         let generic =
@@ -327,6 +363,36 @@ spec = describe "systemPrompt" do
         bashOnly `shouldSatisfy` Text.isInfixOf "shell_command"
         bashOnly `shouldNotSatisfy` Text.isInfixOf "run_ghci"
         bashOnly `shouldNotSatisfy` Text.isInfixOf "Prefer ghci for scripting"
+        ghciOnly `shouldSatisfy` Text.isInfixOf
+            "Co-authored-by: Haskell Agent (gpt-5.6-sol, high) <agent@digitallyinduced.com>"
+        bashOnly `shouldSatisfy` Text.isInfixOf
+            "Co-authored-by: Haskell Agent (gpt-5.6-sol, high) <agent@digitallyinduced.com>"
+
+    it "uses the actual runtime model and reasoning effort in attribution" do
+        let prompt =
+                Prompt.systemPromptForTools
+                    codexDialect
+                    "gpt-5.6-terra"
+                    "xhigh"
+                    ["shell_command"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    (fromGregorian 2026 8 19)
+                    False
+        prompt `shouldSatisfy` Text.isInfixOf
+            "Co-authored-by: Haskell Agent (gpt-5.6-terra, xhigh) <agent@digitallyinduced.com>"
+
+    it "omits commit attribution when no command tool can create commits" do
+        let prompt =
+                systemPromptForTools
+                    genericResponsesDialect
+                    ["read_file", "grep", "apply_patch"]
+                    (fromFilePath "/tmp/repo")
+                    Nothing
+                    (fromGregorian 2026 8 19)
+                    False
+        prompt `shouldNotSatisfy` Text.isInfixOf
+            "Co-authored-by: Haskell Agent"
 
     it "omits hidden Grok terminal names from ghci-only prompts" do
         let prompt =


### PR DESCRIPTION
## Summary
- add Haskell Agent co-author guidance for commit-capable sessions
- include the resolved coding model and reasoning effort in the trailer
- propagate attribution identity through root, refreshed shell, and child prompts

## Testing
- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`
- `:main --match "systemPrompt"` (20 examples, 0 failures)