### PR TITLE
Pause terminal title spinner while waiting for human input

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -313,6 +313,7 @@ import Agent.Tools.Types
     , ToolEnv(..)
     , appToolsFromGroups
     , setToolSessionTmp
+    , withToolHumanInputWait
     )
 import Agent.XAI.LoopBackend ()
 import Control.Applicative ( (<|>) )
@@ -1460,6 +1461,7 @@ acquireMcpRuntime request@AgentToolsRequest
     , isTty
     , escPaused
     , uiRuntimeRef
+    , baseToolEnv
     , mcpSupervisor
     } toolStartup ToolModelRuntime
     { toolDialectId = dialectId
@@ -1476,7 +1478,9 @@ acquireMcpRuntime request@AgentToolsRequest
     writeIORef processRuntime.processMcpElicitation
         (if isOneShot options || not isTty
             then Nothing
-            else Just (cliMcpElicitation escPaused uiRuntimeRef))
+            else Just \elicitation ->
+                withToolHumanInputWait baseToolEnv $
+                    cliMcpElicitation escPaused uiRuntimeRef elicitation)
     let enqueueMcpSnapshot statuses =
             unless (null statuses) do
                 instructions <-

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -233,6 +233,10 @@ newSessionHostRuntime SessionRequest{..} = do
         startupWindowTitle
         withIoLock
         writeWindowTitle
+    setPlanModeInputWaitHooks
+        planMode
+        windowTitle.windowTitleBeginInputWait
+        windowTitle.windowTitleEndInputWait
     setToolRootAccessRequest toolEnv (Just requestRootAccess)
     let showTitleEvent = \case
             SessionTitleGenerated SessionTitleResult{..} ->

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -35,7 +35,7 @@ import Agent.CLI.Notification
     , notifyAttention
     )
 import Agent.CLI.Approval
-import Agent.CLI.Permission (promptRootAccess)
+import Agent.CLI.Permission (promptPermission, promptRootAccess)
 import Agent.CLI.ProviderTransition (PendingTurn)
 import Agent.CLI.Recap
 import Agent.CLI.CancelWatch
@@ -144,6 +144,7 @@ data SessionHostRuntime = SessionHostRuntime
     { hostInitialPrevious :: !(Maybe Text.Text)
     , hostGrokFirstTurnContextRef :: !(IORef (Maybe Text.Text))
     , hostIoLock :: !(MVar ())
+    , hostApprovalLock :: !(MVar ())
     , hostNativeCapabilities :: !NativeRunCapabilities
     , hostLoadsWorkspaceContext :: !Bool
     , hostPreparedWorkspaceEnvironment
@@ -164,6 +165,7 @@ newSessionHostRuntime SessionRequest{..} = do
     initialPrevious <- readLivePreviousResponseId conversationRef
     grokFirstTurnContextRef <- newIORef initialGrokContext
     ioLock <- newMVar ()
+    approvalLock <- newMVar ()
     let fullscreen = startup.startupFullscreen
         nativeCapabilities =
             maybe
@@ -193,33 +195,34 @@ newSessionHostRuntime SessionRequest{..} = do
         withIoLock action = withMVar ioLock (const action)
         requestRootAccess root =
             approveFilesystemRootAccess policyRef $
-                case startup.startupNativeHooks of
-                    Just hooks -> hooks.nativeRequestRootAccess root
-                    Nothing -> withMVar ioLock \_ ->
-                        case promptRequest of
-                            Just request
-                                | isJust request.managedTurnBridgeDirectory ->
-                                    requestManagedRootAccess request root
-                            _ -> case fullscreen of
-                                Just runtime -> do
-                                    notifyAttention
-                                        stderrHandle
-                                        PermissionRequested
-                                    maybe False (== 0)
-                                        <$> requestFullscreenChoiceWithBody
-                                            runtime
-                                            "Filesystem access requested"
-                                            ("Allow access to " <> toText root
-                                                <> " for this session?")
-                                            0
-                                            [ ( "Allow directory for this session"
-                                              , ""
-                                              )
-                                            , ("Deny", "")
-                                            ]
-                                Nothing ->
-                                    withStdinPaused escPaused
-                                        (promptRootAccess useColor root)
+                withToolHumanInputWait toolEnv $
+                    case startup.startupNativeHooks of
+                        Just hooks -> hooks.nativeRequestRootAccess root
+                        Nothing -> withMVar ioLock \_ ->
+                            case promptRequest of
+                                Just request
+                                    | isJust request.managedTurnBridgeDirectory ->
+                                        requestManagedRootAccess request root
+                                _ -> case fullscreen of
+                                    Just runtime -> do
+                                        notifyAttention
+                                            stderrHandle
+                                            PermissionRequested
+                                        maybe False (== 0)
+                                            <$> requestFullscreenChoiceWithBody
+                                                runtime
+                                                "Filesystem access requested"
+                                                ("Allow access to " <> toText root
+                                                    <> " for this session?")
+                                                0
+                                                [ ( "Allow directory for this session"
+                                                  , ""
+                                                  )
+                                                , ("Deny", "")
+                                                ]
+                                    Nothing ->
+                                        withStdinPaused escPaused
+                                            (promptRootAccess useColor root)
         reportSessionError message =
             case fullscreen of
                 Just runtime ->
@@ -235,6 +238,10 @@ newSessionHostRuntime SessionRequest{..} = do
         writeWindowTitle
     setPlanModeInputWaitHooks
         planMode
+        windowTitle.windowTitleBeginInputWait
+        windowTitle.windowTitleEndInputWait
+    setToolHumanInputWaitHooks
+        toolEnv
         windowTitle.windowTitleBeginInputWait
         windowTitle.windowTitleEndInputWait
     setToolRootAccessRequest toolEnv (Just requestRootAccess)
@@ -279,6 +286,7 @@ newSessionHostRuntime SessionRequest{..} = do
         { hostInitialPrevious = initialPrevious
         , hostGrokFirstTurnContextRef = grokFirstTurnContextRef
         , hostIoLock = ioLock
+        , hostApprovalLock = approvalLock
         , hostNativeCapabilities = nativeCapabilities
         , hostLoadsWorkspaceContext = loadsHostWorkspaceContext
         , hostPreparedWorkspaceEnvironment = preparedWorkspaceEnvironment
@@ -754,48 +762,38 @@ buildSessionApprovalRuntime host controls SessionRequest{..} =
         }
   where
     approveToolWithClassification classifiedReadOnly call =
-        withMVar host.hostIoLock \_ ->
-            let classify = const (pure classifiedReadOnly)
-            in case startup.startupNativeHooks of
+        withMVar host.hostApprovalLock \_ ->
+            chooseApproval
+      where
+        chooseApproval =
+            case startup.startupNativeHooks of
                 Just hooks ->
-                    approveToolDecisionWithReporterAndPersistenceClassified
-                        classify
+                    approve
                         hooks.nativeRequestApproval
                         (const (pure ()))
                         (pure ())
-                        policyRef
-                        controls.controlAllowedToolsRef
-                        controls.controlToolRegistry
-                        planMode
-                        call
                 Nothing -> case promptRequest of
                     Just request
                         | isJust request.managedTurnBridgeDirectory ->
-                            approveToolDecisionWithReporterAndPersistenceClassified
-                                classify
+                            approve
                                 (requestManagedApproval request)
                                 (const (pure ()))
                                 (pure ())
-                                policyRef
-                                controls.controlAllowedToolsRef
-                                controls.controlToolRegistry
-                                planMode
-                                call
                     _ -> case host.hostFullscreen of
                         Nothing ->
-                            withStdinPaused escPaused $
-                                approveToolDecisionClassified
-                                    classify
-                                    policyRef
-                                    controls.controlAllowedToolsRef
-                                    controls.controlToolRegistry
-                                    planMode
-                                    projectRoot
-                                    cwd
-                                    call
+                            approve
+                                (\requested ->
+                                    withStdinPaused escPaused do
+                                        color <-
+                                            resolveColor host.hostStderrHandle
+                                        promptPermission
+                                            color
+                                            (toText cwd)
+                                            requested)
+                                reportLineApproval
+                                (saveProjectAutoApprove projectRoot True)
                         Just runtime ->
-                            approveToolDecisionWithReporterAndPersistenceClassified
-                                classify
+                            approve
                                 (requestFullscreenPermission
                                     runtime
                                     (toText cwd))
@@ -808,11 +806,30 @@ buildSessionApprovalRuntime host controls SessionRequest{..} =
                                                     (successNotice
                                                         message))))
                                 (saveProjectAutoApprove projectRoot True)
-                                policyRef
-                                controls.controlAllowedToolsRef
-                                controls.controlToolRegistry
-                                planMode
-                                call
+        classify = const (pure classifiedReadOnly)
+        approve request report persist =
+            approveToolDecisionWithReporterAndPersistenceClassified
+                classify
+                (\requested ->
+                    withToolHumanInputWait toolEnv $
+                        withMVar host.hostIoLock \_ ->
+                            request requested)
+                (\notice ->
+                    withMVar host.hostIoLock \_ ->
+                        report notice)
+                persist
+                policyRef
+                controls.controlAllowedToolsRef
+                controls.controlToolRegistry
+                planMode
+                call
+        reportLineApproval = \case
+            ApprovalWarning message -> do
+                color <- resolveColor host.hostStderrHandle
+                putTextLn host.hostStderrHandle (roleWarn color message)
+            ApprovalSuccess message -> do
+                color <- resolveColor host.hostStderrHandle
+                putTextLn host.hostStderrHandle (roleSuccess color message)
     approveRegisteredTool =
         approveToolWithClassification Nothing
 

--- a/packages/agent-cli/src/Agent/CLI/Style.hs
+++ b/packages/agent-cli/src/Agent/CLI/Style.hs
@@ -76,7 +76,7 @@ import System.Console.ANSI
 import System.Console.ANSI.Codes (setSGRCode)
 import System.Environment (lookupEnv)
 import System.OsPath (OsPath)
-import System.IO (Handle)
+import System.IO (Handle, hFlush)
 import System.IO.Unsafe (unsafePerformIO)
 
 terminalCyan, terminalMagenta, terminalYellow, terminalRed :: SGR
@@ -332,4 +332,8 @@ cliWindowTitle _cwd sessionTitle =
 setCliWindowTitle :: Bool -> Handle -> Text -> IO ()
 setCliWindowTitle tty handle title
     | not tty = pure ()
-    | otherwise = hSetTitle handle (Text.unpack title)
+    | otherwise = do
+        hSetTitle handle (Text.unpack title)
+        -- OSC titles contain no newline, so publish a final static title even
+        -- when the animation worker pauses before another stdout write.
+        hFlush handle

--- a/packages/agent-cli/src/Agent/CLI/WindowTitle.hs
+++ b/packages/agent-cli/src/Agent/CLI/WindowTitle.hs
@@ -16,7 +16,6 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
     ( atomically
     , check
-    , modifyTVar'
     , newTVarIO
     , readTVar
     , writeTVar
@@ -31,12 +30,15 @@ data WindowTitleController = WindowTitleController
     { windowTitleSet :: !(Text -> IO ())
     , windowTitleBeginBusy :: !(IO ())
     , windowTitleEndBusy :: !(IO ())
+    , windowTitleBeginInputWait :: !(IO ())
+    , windowTitleEndInputWait :: !(IO ())
     , windowTitleWorker :: !(IO ())
     }
 
 data WindowTitleState = WindowTitleState
     { titleBase :: !Text
     , titleBusyDepth :: !Int
+    , titleInputWaitDepth :: !Int
     }
 
 -- | Build a title controller. The caller supplies a shared output lock and the
@@ -53,6 +55,7 @@ newWindowTitleController motionMode initialTitle withOutputLock writeTitle = do
         WindowTitleState
             { titleBase = initialTitle
             , titleBusyDepth = 0
+            , titleInputWaitDepth = 0
             }
     let frames = case spinnerFrames of
             [] -> ["*"]
@@ -68,38 +71,43 @@ newWindowTitleController motionMode initialTitle withOutputLock writeTitle = do
                     writeTVar stateVar updated
                     pure updated
                 writeTitle
-                    (if state.titleBusyDepth > 0
+                    (if titleIsBusy state
                         then busyWindowTitle firstFrame title
                         else title)
-        beginBusy =
+        changeActivity update =
             withOutputLock do
-                state <- atomically do
-                    modifyTVar' stateVar \current ->
-                        current
-                            { titleBusyDepth = current.titleBusyDepth + 1 }
-                    readTVar stateVar
-                when (state.titleBusyDepth == 1) $
-                    writeTitle (busyWindowTitle firstFrame state.titleBase)
-        endBusy =
-            withOutputLock do
-                state <- atomically do
-                    modifyTVar' stateVar \current ->
-                        current
-                            { titleBusyDepth =
-                                max 0 (current.titleBusyDepth - 1)
-                            }
-                    readTVar stateVar
-                when (state.titleBusyDepth == 0) $
-                    writeTitle state.titleBase
+                (wasBusy, state) <- atomically do
+                    current <- readTVar stateVar
+                    let updated = update current
+                    writeTVar stateVar updated
+                    pure (titleIsBusy current, updated)
+                when (wasBusy /= titleIsBusy state) $
+                    writeTitle $
+                        if titleIsBusy state
+                            then busyWindowTitle firstFrame state.titleBase
+                            else state.titleBase
+        beginBusy = changeActivity \current ->
+            current { titleBusyDepth = current.titleBusyDepth + 1 }
+        endBusy = changeActivity \current ->
+            current
+                { titleBusyDepth = max 0 (current.titleBusyDepth - 1) }
+        beginInputWait = changeActivity \current ->
+            current
+                { titleInputWaitDepth = current.titleInputWaitDepth + 1 }
+        endInputWait = changeActivity \current ->
+            current
+                { titleInputWaitDepth =
+                    max 0 (current.titleInputWaitDepth - 1)
+                }
         worker =
             when (motionMode == MotionFull) $
                 forM_ (cycle frames) \frame -> do
                     atomically do
                         state <- readTVar stateVar
-                        check (state.titleBusyDepth > 0)
+                        check (titleIsBusy state)
                     withOutputLock do
                         state <- atomically (readTVar stateVar)
-                        when (state.titleBusyDepth > 0) $
+                        when (titleIsBusy state) $
                             writeTitle
                                 (busyWindowTitle frame state.titleBase)
                     threadDelay (motionIntervalMicros motionMode MotionSlow)
@@ -107,8 +115,14 @@ newWindowTitleController motionMode initialTitle withOutputLock writeTitle = do
         { windowTitleSet = setTitle
         , windowTitleBeginBusy = beginBusy
         , windowTitleEndBusy = endBusy
+        , windowTitleBeginInputWait = beginInputWait
+        , windowTitleEndInputWait = endInputWait
         , windowTitleWorker = worker
         }
+
+titleIsBusy :: WindowTitleState -> Bool
+titleIsBusy state =
+    state.titleBusyDepth > 0 && state.titleInputWaitDepth == 0
 
 busyWindowTitle :: Text -> Text -> Text
 busyWindowTitle frame title = frame <> " " <> title

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -131,6 +131,31 @@ spec = do
                 , "renamed"
                 ]
 
+        it "shows a static title while waiting for human input" do
+            written <- newIORef []
+            let firstFrame = case spinnerFrames of
+                    frame : _ -> frame
+                    [] -> "*"
+            controller <- newWindowTitleController
+                MotionOff
+                "initial"
+                id
+                (\title -> modifyIORef' written (<> [title]))
+            controller.windowTitleBeginBusy
+            controller.windowTitleBeginInputWait
+            controller.windowTitleSet "renamed"
+            controller.windowTitleEndInputWait
+            controller.windowTitleEndBusy
+            actual <- readIORef written
+            actual
+                `shouldBe`
+                [ firstFrame <> " initial"
+                , "initial"
+                , "renamed"
+                , firstFrame <> " renamed"
+                , "renamed"
+                ]
+
         it "keeps reduced-motion busy titles static" do
             written <- newIORef []
             let firstFrame = case spinnerFrames of

--- a/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/StyleSpec.hs
@@ -156,6 +156,31 @@ spec = do
                 , "renamed"
                 ]
 
+        it "keeps the title static until nested input waits end" do
+            written <- newIORef []
+            let firstFrame = case spinnerFrames of
+                    frame : _ -> frame
+                    [] -> "*"
+            controller <- newWindowTitleController
+                MotionOff
+                "initial"
+                id
+                (\title -> modifyIORef' written (<> [title]))
+            controller.windowTitleBeginBusy
+            controller.windowTitleBeginInputWait
+            controller.windowTitleBeginInputWait
+            controller.windowTitleEndInputWait
+            controller.windowTitleEndInputWait
+            controller.windowTitleEndBusy
+            actual <- readIORef written
+            actual
+                `shouldBe`
+                [ firstFrame <> " initial"
+                , "initial"
+                , firstFrame <> " initial"
+                , "initial"
+                ]
+
         it "keeps reduced-motion busy titles static" do
             written <- newIORef []
             let firstFrame = case spinnerFrames of

--- a/packages/agent-core/src/Agent/Tools/PlanMode.hs
+++ b/packages/agent-core/src/Agent/Tools/PlanMode.hs
@@ -12,6 +12,7 @@ module Agent.Tools.PlanMode
     , PlanModeEnv(..)
     , PlanModeHooks(..)
     , newPlanModeEnv
+    , setPlanModeInputWaitHooks
     , planFileName
     , planFilePath
     , isPlanModeActive
@@ -47,7 +48,7 @@ import Agent.Tools.Types
     , jsonTool
     )
 import Control.Applicative ((<|>))
-import Control.Exception.Safe (tryAny)
+import Control.Exception.Safe (bracket_, tryAny)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LazyByteString
@@ -85,6 +86,7 @@ data PlanModeEnv = PlanModeEnv
     , planSessionDir :: !(IORef (Maybe OsPath))
     , planFallbackDir :: !OsPath
     , planHooks :: !PlanModeHooks
+    , planInputWaitHooks :: !(IORef (IO (), IO ()))
     }
 
 data PlanModeHooks = PlanModeHooks
@@ -110,12 +112,32 @@ newPlanModeEnv :: OsPath -> Maybe PlanModeHooks -> IO PlanModeEnv
 newPlanModeEnv fallbackDir hooks = do
     stateRef <- newIORef PlanInactive
     sessionRef <- newIORef Nothing
+    inputWaitHooksRef <- newIORef (pure (), pure ())
+    let baseHooks = fromMaybe defaultHooks hooks
+        withInputWait action = do
+            (beginWait, endWait) <- readIORef inputWaitHooksRef
+            bracket_ beginWait endWait action
+        wrappedHooks = PlanModeHooks
+            { planConfirmEnter = \reason ->
+                withInputWait (baseHooks.planConfirmEnter reason)
+            , planDecideExit = \markdown ->
+                withInputWait (baseHooks.planDecideExit markdown)
+            , planAskQuestion = \question options ->
+                withInputWait (baseHooks.planAskQuestion question options)
+            }
     pure PlanModeEnv
         { planStateRef = stateRef
         , planSessionDir = sessionRef
         , planFallbackDir = fallbackDir
-        , planHooks = fromMaybe defaultHooks hooks
+        , planHooks = wrappedHooks
+        , planInputWaitHooks = inputWaitHooksRef
         }
+
+-- | Configure callbacks which bracket every plan-mode prompt that can wait
+-- for the user. The default callbacks are no-ops for non-interactive hosts.
+setPlanModeInputWaitHooks :: PlanModeEnv -> IO () -> IO () -> IO ()
+setPlanModeInputWaitHooks env beginWait endWait =
+    writeIORef env.planInputWaitHooks (beginWait, endWait)
 
 planFilePath :: PlanModeEnv -> IO OsPath
 planFilePath env = do

--- a/packages/agent-core/src/Agent/Tools/Secret.hs
+++ b/packages/agent-core/src/Agent/Tools/Secret.hs
@@ -25,6 +25,7 @@ import Agent.Tools.Types
     , ToolEnv(..)
     , ToolExecutionPolicy(..)
     , jsonTool
+    , withToolHumanInputWait
     )
 import Control.Concurrent.MVar
     ( MVar
@@ -152,10 +153,11 @@ runAskSecret store args
         pure (Left "Secret prompt must not be empty.")
     | otherwise = do
         prompted <- tryAny $
-            store.secretHooks.promptSecret SecretPrompt
-            { secretPromptMessage = args.prompt
-            , secretPromptPurpose = args.purpose
-            }
+            withToolHumanInputWait store.secretToolEnv $
+                store.secretHooks.promptSecret SecretPrompt
+                    { secretPromptMessage = args.prompt
+                    , secretPromptPurpose = args.purpose
+                    }
         case prompted of
             Left _ -> pure (Left "Secure secret entry failed.")
             Right (Left err) -> pure (Left err)

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -13,6 +13,7 @@ module Agent.Tools.Types
     , ToolEnv(..)
     , addToolAllowedRoot
     , defaultToolEnv
+    , setToolHumanInputWaitHooks
     , setToolRootAccessRequest
     , setToolSkillRoots
     , setToolSessionTmp
@@ -24,6 +25,7 @@ module Agent.Tools.Types
     , freeformApplyPatchAppTool
     , freeformApplyPatchAppToolWithExecution
     , freeformGrammarAppToolWithExecution
+    , withToolHumanInputWait
     , withToolResourceClaims
     , mkToolRegistry
     , toolRegistryTools
@@ -58,10 +60,16 @@ import Agent.Tools.Scheduling
     , ToolResourceClaim(..)
     , ToolSchedulingPlan(..)
     )
-import Control.Exception.Safe (tryAny)
+import Control.Exception.Safe (bracket_, tryAny)
 import Control.Monad (foldM)
 import Data.Aeson (Value)
-import Data.IORef (IORef, atomicModifyIORef', newIORef, writeIORef)
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -175,6 +183,10 @@ data ToolEnv = ToolEnv
       -- | Optional session-local callback used when a path falls outside
       -- the configured roots. An approved path is added to
       -- 'toolAllowedRoots' by the filesystem resolver.
+    , toolHumanInputWaitHooks :: !(IORef (IO (), IO ()))
+      -- | Session-local callbacks that bracket tool-driven waits for human
+      -- input. Stored behind an IORef because the CLI title controller is
+      -- installed after the tool runtime is constructed.
     , toolSkillRoots :: !(IORef [OsPath])
       -- | Directories belonging to the currently discovered skill catalog.
       -- Kept separate so catalog refreshes can replace them without
@@ -197,6 +209,7 @@ defaultToolEnv cwd = do
     cancel <- newCancelFlag
     allowedRoots <- newIORef []
     rootAccessRequest <- newIORef Nothing
+    humanInputWaitHooks <- newIORef (pure (), pure ())
     skillRoots <- newIORef []
     sessionTmp <- newIORef Nothing
     backgroundTaskHooks <- newIORef noBackgroundTaskHooks
@@ -204,6 +217,7 @@ defaultToolEnv cwd = do
         { toolCwd = dropTrailingPathSeparator cwd
         , toolAllowedRoots = allowedRoots
         , toolRootAccessRequest = rootAccessRequest
+        , toolHumanInputWaitHooks = humanInputWaitHooks
         , toolSkillRoots = skillRoots
         , toolSessionTmp = sessionTmp
         , toolOutputInlineCap = 50 * 1024
@@ -219,6 +233,19 @@ defaultToolEnv cwd = do
 -- approval and return whether the requested root may be added.
 setToolRootAccessRequest :: ToolEnv -> Maybe (OsPath -> IO Bool) -> IO ()
 setToolRootAccessRequest env = writeIORef env.toolRootAccessRequest
+
+-- | Configure callbacks which bracket tool-driven waits for human input.
+-- The default callbacks are no-ops for non-interactive hosts.
+setToolHumanInputWaitHooks :: ToolEnv -> IO () -> IO () -> IO ()
+setToolHumanInputWaitHooks env beginWait endWait =
+    writeIORef env.toolHumanInputWaitHooks (beginWait, endWait)
+
+-- | Run a tool-driven human interaction within the current session hooks.
+-- Cleanup runs even when the interaction throws or is interrupted.
+withToolHumanInputWait :: ToolEnv -> IO a -> IO a
+withToolHumanInputWait env action = do
+    (beginWait, endWait) <- readIORef env.toolHumanInputWaitHooks
+    bracket_ beginWait endWait action
 
 -- | Add a canonical directory to the roots available for this session.
 -- Duplicate roots are ignored so repeated approvals remain idempotent.

--- a/packages/agent-core/test/Agent/Tools/PlanModeSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/PlanModeSpec.hs
@@ -44,6 +44,22 @@ spec = describe "Agent.Tools.PlanMode" do
             deactivatePlanMode env
             isPlanModeActive env `shouldReturn` False
 
+    it "brackets questions with the configured input-wait hooks" do
+        events <- newIORef ([] :: [Text])
+        let record event = modifyIORef' events (<> [event])
+            hooks = testHooks \_ _ -> do
+                record "question"
+                pure (Just "answer")
+        withTempPlanHooks hooks \env -> do
+            setPlanModeInputWaitHooks
+                env
+                (record "begin wait")
+                (record "end wait")
+            env.planHooks.planAskQuestion "Question?" []
+                `shouldReturn` Just "answer"
+            readIORef events `shouldReturn`
+                ["begin wait", "question", "end wait"]
+
     it "writes and reads plan.md under the fallback directory" do
         withTempPlan \env -> do
             writePlanMarkdown env "# Hello\n" `shouldReturn` Right ()

--- a/packages/agent-core/test/Agent/Tools/SecretSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/SecretSpec.hs
@@ -12,8 +12,10 @@ import Agent.Tools.Secret
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
+    , ToolEnv
     , defaultToolEnv
     , jsonToolParameters
+    , setToolHumanInputWaitHooks
     , setToolSessionTmp
     )
 import Control.Exception.Safe (bracket, throwString)
@@ -103,13 +105,21 @@ spec = describe "Agent.Tools.Secret" do
                 listDirectory temp `shouldReturn` []
 
     it "does not expose host prompt exceptions" do
-        withStore
-            (const (throwString "host detail that must stay private"))
-            \_ tool temp -> do
-                output <- runTool tool "{\"prompt\":\"Token\"}"
-                output `shouldBe` "ERR Secure secret entry failed."
-                output `shouldNotSatisfy` Text.isInfixOf "host detail"
-                listDirectory temp `shouldReturn` []
+        events <- newIORef ([] :: [Text])
+        let record event = modifyIORef' events (<> [event])
+            hook _ = do
+                record "prompt"
+                throwString "host detail that must stay private"
+        withStoreEnv hook \env _ tool temp -> do
+            setToolHumanInputWaitHooks
+                env
+                (record "begin")
+                (record "end")
+            output <- runTool tool "{\"prompt\":\"Token\"}"
+            output `shouldBe` "ERR Secure secret entry failed."
+            output `shouldNotSatisfy` Text.isInfixOf "host detail"
+            readIORef events `shouldReturn` ["begin", "prompt", "end"]
+            listDirectory temp `shouldReturn` []
 
     it "requires a configured session temporary directory" do
         root <- getTemporaryDirectory
@@ -138,7 +148,15 @@ withStoreManual
     :: (SecretPrompt -> IO (Either Text (Maybe Text)))
     -> (SecretStore -> AppTool -> FilePath -> IO a)
     -> IO a
-withStoreManual hook action = do
+withStoreManual hook action =
+    withStoreEnv hook \_ store tool temp ->
+        action store tool temp
+
+withStoreEnv
+    :: (SecretPrompt -> IO (Either Text (Maybe Text)))
+    -> (ToolEnv -> SecretStore -> AppTool -> FilePath -> IO a)
+    -> IO a
+withStoreEnv hook action = do
     root <- getTemporaryDirectory
     bracket
         (mkdtemp (root </> "agent-secret-test-"))
@@ -150,7 +168,7 @@ withStoreManual hook action = do
             bracket
                 (newSecretStore env (SecretPromptHooks hook))
                 closeSecretStore
-                (\store -> action store (askSecretTool store) temp)
+                (\store -> action env store (askSecretTool store) temp)
 
 runTool :: AppTool -> Text -> IO Text
 runTool tool arguments = do


### PR DESCRIPTION
## Summary
- pause terminal-title busy animation while plan confirmations and `ask_user_question` prompts await human input
- apply the same wait state to tool approvals, dynamic filesystem-root approval, trusted secret entry, and MCP elicitation
- keep nested wait scopes exception-safe and resume animation only when active work continues
- preserve animation for real backend/tool execution; ordinary REPL and slash-command pickers already run outside the busy turn scope

## Testing
- `cabal repl agent-core:lib:agent-core agent-cli:lib:agent-cli --repl-options=-fobject-code`
- `cabal test agent-core:agent-core-test --test-options=--match=Agent.Tools.Secret --test-show-details=direct`
- `cabal test agent-core:agent-core-test --test-options=--match=input-wait --test-show-details=direct`
- `cabal test agent-cli:agent-cli-test --test-options=--match=WindowTitleController --test-show-details=direct`
- `cabal test agent-cli:agent-cli-test --test-options=--match=approveToolDecisionWith --test-show-details=direct`
- live tmux smoke: sampled the terminal title 20 times during a real tool-permission prompt; every sample was the same spinner-free title