### PR TITLE
Split provider orchestration by backend

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -89,6 +89,13 @@ library
                     , Agent.CLI.Runtime.Orchestration.Flow
                     , Agent.CLI.Runtime.Orchestration.Initialized
                     , Agent.CLI.Runtime.Orchestration.Providers
+                    , Agent.CLI.Runtime.Orchestration.Providers.Claude
+                    , Agent.CLI.Runtime.Orchestration.Providers.Common
+                    , Agent.CLI.Runtime.Orchestration.Providers.Gemini
+                    , Agent.CLI.Runtime.Orchestration.Providers.OpenAI
+                    , Agent.CLI.Runtime.Orchestration.Providers.OpenRouter
+                    , Agent.CLI.Runtime.Orchestration.Providers.Types
+                    , Agent.CLI.Runtime.Orchestration.Providers.XAI
                     , Agent.CLI.Runtime.Orchestration.Restart
                     , Agent.CLI.Runtime.Orchestration.Session
                     , Agent.CLI.Runtime.Orchestration.Startup

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -1,46 +1,27 @@
 module Agent.CLI.Runtime.Orchestration.Providers (runAgentProviders) where
 
 import Agent.CLI.AccountPicker ()
-import Agent.CLI.Claude
-    ( approveClaudeRegisteredTool
-    , handleClaudePermissionRequest
-    )
 import Agent.CLI.AccountSelection ()
 import Agent.CLI.Afk ()
 import Agent.CLI.AgentSessions ()
 import Agent.CLI.AgentViewport ()
 import Agent.CLI.Approval ()
 import Agent.CLI.Artifact ()
-import Agent.CLI.Auth.Types (LoadedAuth(..), isGatewayLoadedAuth)
-import Agent.CLI.ClaudeGatewayProxy (withClaudeGatewayProxy)
+import Agent.CLI.Auth.Types (LoadedAuth)
 import Agent.CLI.Clipboard ()
 import Agent.CLI.CodeModeRuntime ()
 import Agent.CLI.Command ()
 import Agent.CLI.Compaction
-    ( CompactionInstall,
-      CompactOutcome,
-      OccupancySnapshot,
-      autoCompactBackendWith,
-      boundCompletedToolContinuations,
-      claudeAutoCompactTokenLimit,
-      claudeCompactionInputLimit,
-      decorateCompactOutcomeWithTaskPlan,
-      decorateCompactOutcomeWithTaskPlanWithin,
-      installLiveCompactOutcome,
-      runProviderCompactWith,
-      runBackendCompactHistoryWithLimits,
-      runBackendCompactWithLimits,
-      runResponsesCompactWithContextWindow,
-      runXaiBackendCompactHistoryWithContextWindow,
-      runXaiResponsesCompactWithContextWindow )
+    ( CompactOutcome
+    , CompactionInstall
+    , OccupancySnapshot
+    )
 import Agent.CLI.Config ()
-import Agent.Connectivity ( withConnectionRecoveryOn )
 import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
-import Agent.CLI.Error ( formatApiErrorAt )
-import Agent.CLI.GatewayClient (GatewayCredential)
 import Agent.CLI.GatewayBridge ()
+import Agent.CLI.GatewayClient (GatewayCredential)
 import Agent.CLI.Input ()
 import Agent.CLI.LearnedSkills ()
 import Agent.CLI.LearnedSkills.Store ()
@@ -51,182 +32,116 @@ import Agent.CLI.McpManager ()
 import Agent.CLI.McpStatus ()
 import Agent.CLI.ModelConfig (ModelCatalog)
 import Agent.CLI.Models ()
-import Agent.CLI.Options (CliOptions(..))
-import Agent.CLI.PendingInputs (PendingInputs, withPendingInputs)
+import Agent.CLI.Options (CliOptions)
+import Agent.CLI.PendingInputs (PendingInputs)
 import Agent.CLI.Plan ()
 import Agent.CLI.Project (ModelSwitchScope)
 import Agent.CLI.Prompt ()
 import Agent.CLI.PromptHooks ()
-import Agent.CLI.Provider.OpenAI
-    ( OpenAiPersistentConnection(..), lockedOpenAiSession )
-import Agent.CLI.Provider.Switch
-    ( chooseStartupProviderTransition, prepareTransitionBackend )
 import Agent.CLI.ProviderAvailability ()
-import Agent.CLI.ProviderFallback ( isProviderUnavailable )
-import Agent.CLI.ProviderTransition
-    ( ProviderTransition(transitionCause),
-      TransitionCause(AutomaticFallback) )
-import Agent.Tools.TaskPlan (TaskPlanEnv)
+import Agent.CLI.ProviderTransition (ProviderTransition)
 import Agent.CLI.Recap ()
-import Agent.CLI.Render ( putTextLn )
 import Agent.CLI.ReplMode ()
 import Agent.CLI.Request ()
 import Agent.CLI.Resume ()
 import Agent.CLI.Runtime.HistorySource ()
 import Agent.CLI.Runtime.Orchestration.Background ()
 import Agent.CLI.Runtime.Orchestration.Concurrent ()
+import Agent.CLI.Runtime.Orchestration.Providers.Claude
+    ( runClaudeProvider
+    )
+import Agent.CLI.Runtime.Orchestration.Providers.Gemini
+    ( runGeminiProvider
+    )
+import Agent.CLI.Runtime.Orchestration.Providers.OpenAI
+    ( runOpenAiProvider
+    )
+import Agent.CLI.Runtime.Orchestration.Providers.OpenRouter
+    ( runOpenRouterProvider
+    )
+import Agent.CLI.Runtime.Orchestration.Providers.Types
+    ( AgentProviderRequest(..)
+    )
+import Agent.CLI.Runtime.Orchestration.Providers.XAI
+    ( runXaiProvider
+    )
 import Agent.CLI.Runtime.Orchestration.Restart ()
-import Agent.CLI.Runtime.Orchestration.Startup
-    ( finishStartup )
 import Agent.CLI.Runtime.Orchestration.Types
-    ( AccountSwitchRequest(..)
-    , NativeRunCapabilities(..)
+    ( NativeRunCapabilities(..)
     , NativeRunHooks(..)
     , fullNativeRunCapabilities
     )
 import Agent.CLI.Runtime.Persistence ()
-import Agent.CLI.Runtime.Recap
-    ( runSessionRecap, runSessionTurnSummary )
-import Agent.CLI.Runtime.Repl
-    ( finishTurn,
-      preparePromptSkillInputsWithPaste,
-      repl,
-      replWithDraft,
-      runPendingTurn )
-import Agent.CLI.Runtime.Types
-    ( RunResult(RunSwitchProvider, RunProviderStartFailed) )
+import Agent.CLI.Runtime.Types (RunResult)
 import Agent.CLI.Secret ()
 import Agent.CLI.Session.Attachments ()
 import Agent.CLI.Session.Choices ()
-import Agent.CLI.Session.History
-    ( LiveConversation, readLiveTranscript )
+import Agent.CLI.Session.History (LiveConversation)
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
-    ( StartupRuntime(..),
-      SessionBackend(..)
-    , SessionRequest(..)
+    ( SessionRequest
+    , StartupRuntime(..)
     )
-import Agent.CLI.Session.Types (Persistence)
 import Agent.CLI.Session.Selection ()
+import Agent.CLI.Session.Types (Persistence)
 import Agent.CLI.SessionAdmin ()
 import Agent.CLI.SessionEnv ()
 import Agent.CLI.SessionLock ()
 import Agent.CLI.SessionState ()
 import Agent.CLI.SessionTitle ()
 import Agent.CLI.Skills ()
-import Agent.CLI.Startup.Auth ( startupDie )
+import Agent.CLI.Startup.Auth (startupDie)
 import Agent.CLI.StartupContext ()
-import Agent.CLI.Style ( glyphWarn, roleWarn )
-import Agent.CLI.Subagents.Runtime
-    ( freshOpenAiBackend,
-      runCodexSubagent,
-      runHttpSubagent,
-      runXaiParentSubagent )
 import Agent.CLI.Subagents.Runtime.Types (SubagentRuntime)
-import Agent.CLI.TUI.App
-    ( FullscreenRuntime, emitUiEvent )
+import Agent.CLI.TUI.App (FullscreenRuntime)
 import Agent.CLI.TUI.History ()
 import Agent.CLI.TUI.SessionHistory ()
-import Agent.CLI.Terminal ( resolveColor )
 import Agent.CLI.Tools ()
 import Agent.CLI.Turn ()
 import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch ()
 import Agent.CLI.Worktree ()
 import Agent.Cancel ()
-import Agent.Claude
-    ( ClaudeCodeAuth(..),
-      ClaudeCodeBackendHandle(..),
-      ClaudeCodeOptions(..),
-      ClaudeCodePermission(..),
-      claudeCodeOneShotBackend,
-      defaultClaudeCodeOptions,
-      loadClaudeCodeAuth,
-      loadClaudeCodeGatewayAuth,
-      withClaudeCodeBackendWithHost )
-import Agent.Claude.Control
-    ( ClaudeCodeHostHandlers(..)
-    , ClaudeCodeMcpRequest(..)
-    , defaultClaudeCodeHostHandlers
-    )
 import Agent.Dialect (Dialect)
-import Agent.Error ( ApiError(..), ErrorType(InvalidRequestError) )
+import Agent.Error (ApiError)
 import Agent.GrokBuild.Dialect.Goal ()
 import Agent.GrokBuild.Dialect.Runtime ()
 import Agent.GrokBuild.Dialect.Task ()
 import Agent.GrokBuild.Dialect.Workflow ()
-import Agent.Gemini.LoopBackend
-    ( tokenProviderStatelessGeminiBackend )
-import Agent.Loop
-    ( Backend(submitTurn, Backend)
-    , BackendSnapshot(..)
-    , TokenUsage
-    , TurnInput
-    , defaultLoopDispatch
-    )
+import Agent.Loop (TokenUsage, TurnInput)
 import Agent.OpenAI.Auth (Pool)
 import Agent.OpenAI.Compaction ()
-import Agent.OpenAI.ModelMetadata (codexEffectiveContextWindowFor)
 import Agent.OpenAI.Usage ()
-import Agent.OpenAI.WebSocketClient
-    ( CodexAuthFailed(..),
-      CodexConn,
-      closeCodexConn,
-      codexConnTurnState,
-      codexConnUsesHttpFallback,
-      isGatewayWebSocketCredential,
-      resetCodexTurnState,
-      withCodexWsCredentialOrHttpFallback,
-      withCodexWsWithProviderOrHttpFallback )
-import Agent.OpenRouter.LoopBackend ( openRouterBackend )
 import Agent.OpenRouter.Options (ClientOptions)
-import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider
-    ( Provider(OpenRouterProvider, OpenAIProvider, XAIProvider,
-               GeminiProvider, ClaudeCodeProvider),
-      Credential(accountId, Credential, accessToken, leaseId, provider),
-      TokenProvider,
-      runWithTokenProvider,
-      tokenProviderBillingMode )
+    ( Credential
+    , Provider(..)
+    , TokenProvider
+    )
 import Agent.ReasoningEffort ()
-import Agent.Responses.GenericBackend
-    ( genericResponsesBackendWith )
 import Agent.Responses.GenericClient ()
-import Agent.Responses.Types ( ResponseCreateParams(model) )
+import Agent.Responses.Types (ResponseCreateParams)
 import Agent.Skills ()
 import Agent.Store.Postgres ()
 import Agent.Store.Types ()
-import Agent.Subagents ( setSubagentRunner )
 import Agent.Subagents.TaskPath ()
-import Agent.TUI.Model ( UiEvent(UiSystemMessage) )
-import Agent.TUI.Motion ()
 import Agent.Tools.MultiAgents ()
-import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode ()
 import Agent.Tools.Secret ()
+import Agent.Tools.TaskPlan (TaskPlanEnv)
 import Agent.Tools.Types ()
-import Agent.Tools.OutputArtifact (finalizeToolOutput)
-import Agent.ToolDispatch (ToolDispatchConfig(..))
-import Agent.XAI.LoopBackend ( xaiBackendWithClientOptions )
+import Agent.TUI.Motion ()
+import Agent.XAI.Usage ()
 import Control.Applicative ()
-import Control.Concurrent.Async ( link, withAsync )
-import Control.Concurrent.Chan
-    ( Chan, newChan, readChan, writeChan )
-import Control.Concurrent.MVar
-    ( MVar, withMVar, newEmptyMVar, newMVar, putMVar, takeMVar, tryPutMVar )
 import Control.Concurrent.STM (STM)
 import Control.Exception ()
-import Control.Exception.Safe ( catchAny, finally, try )
-import Control.Monad ( when )
+import Data.ByteString ()
 import Data.Functor ()
-import Data.IORef
-    ( IORef, atomicModifyIORef', newIORef, readIORef, writeIORef )
+import Data.IORef (IORef)
 import Data.List ()
-import Data.Maybe ( fromMaybe, isJust )
 import Data.Set (Set)
-import Data.Text ()
 import Data.Text (Text)
-import Data.Time.Clock ( getCurrentTime )
 import System.Console.ANSI ()
 import System.Console.ANSI.Codes ()
 import System.Directory.OsPath ()
@@ -235,101 +150,11 @@ import System.Exit ()
 import System.IO (Handle)
 import System.OsPath (OsPath)
 import System.OsPath ()
-import qualified Data.ByteString as BS ()
-import qualified Data.Aeson as Aeson
+import qualified Agent.OpenRouter.Usage ()
+import qualified Agent.Provider ()
+import qualified Data.Map.Strict ()
+import qualified Data.Set ()
 import qualified Agent.Responses.GenericClient as GenericResponses
-    ( GenericClientOptions(model),
-      createResponseWith,
-      createResponseWithEvents )
-import qualified Agent.MCP as MCP
-import qualified Data.Map.Strict as Map ()
-import qualified Agent.OpenAI.Auth as OpenAI
-    ( discoverAccounts, getAccessTokenForAccount )
-import qualified Agent.OpenRouter as OpenRouter
-    ( createResponseWith )
-import qualified Agent.OpenRouter.Usage as OpenRouterUsage ()
-import qualified Agent.Provider as Provider ()
-import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
-import qualified Agent.CLI.Session.Runner as SessionRunner
-    ( runSession, SessionRunnerContinuation(..) )
-import qualified Data.Set as Set ()
-import qualified Data.Text as Text ( null, unpack )
-import qualified Agent.XAI.Options as XAI
-    ( ClientOptions(..)
-    , clientOptionsFromEnv
-    , grokAutoCompactTokenLimit
-    , grokDefaultContextWindow
-    )
-import qualified Agent.XAI.Client as XAIClient
-    ( createResponseWith )
-import qualified Agent.XAI.Request as XAIRequest ( mapModel )
-import qualified Agent.XAI.Usage as XAIUsage ()
-import qualified Agent.Gemini.Client as GeminiClient
-    ( createResponseWith, createResponseWithEvents )
-import qualified Agent.Gemini.Options as Gemini
-    ( clientOptionsFromEnv )
-
-data AgentProviderRequest = AgentProviderRequest
-    { modelSwitchScope :: ModelSwitchScope
-    , loaded :: LoadedAuth
-    , connectedGateway :: Maybe GatewayCredential
-    , sessionRequest
-        :: Maybe (STM ApiError)
-        -> Maybe TokenProvider
-        -> Maybe Pool
-        -> Maybe (Text -> IO (Either ApiError Text))
-        -> IO (Maybe Int)
-        -> (Maybe Text -> IO (Either Text CompactOutcome))
-        -> SessionRequest
-    , activeAccountIdRef :: IORef Text
-    , activeAccountRef :: IORef Text
-    , activeSelectionRef :: IORef Text
-    , catalog :: ModelCatalog
-    , claudeBypassEnabled :: Bool
-    , contextTokensRef :: IORef (Maybe OccupancySnapshot)
-    , contextWindowForParams
-        :: (Text -> Text)
-        -> Int
-        -> ResponseCreateParams
-        -> Int
-    , conversationRef :: IORef LiveConversation
-    , currentModelContextWindow
-        :: (Text -> Text)
-        -> IO (Maybe Int)
-    , customGenericOptions :: Maybe GenericResponses.GenericClientOptions
-    , cwd :: OsPath
-    , dialect :: Dialect
-    , fullscreen :: Maybe FullscreenRuntime
-    , automaticCompactionHookRef
-        :: IORef
-            (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
-    , taskPlan :: Maybe TaskPlanEnv
-    , home :: OsPath
-    , initialPrevious :: Maybe Text
-    , model :: Text
-    , multiCtx :: Maybe MultiAgentContext
-    , openRouterOptions :: ClientOptions
-    , options :: CliOptions
-    , paramsRef :: IORef ResponseCreateParams
-    , pendingNotices :: PendingInputs
-    , persist :: Persistence
-    , preferredOpenAiAccountRef :: IORef (Maybe Text)
-    , projectRoot :: OsPath
-    , provider :: Provider
-    , recordCompactionUsage :: TokenUsage -> IO ()
-    , resolveActiveAccountLabel :: Credential -> IO Text
-    , selectHttpAccount :: Text -> IO (Either ApiError Text)
-    , selectableTokenProvider :: TokenProvider
-    , shouldProbeAtStartup :: Bool
-    , startup :: StartupRuntime
-    , startupUnavailable :: Maybe (STM ApiError)
-    , stderrHandle :: Handle
-    , subagentRuntime :: SubagentRuntime
-    , tokenProvider :: TokenProvider
-    , transition :: Maybe ProviderTransition
-    , transportModel :: Text -> Text
-    , unavailableProviders :: Set Provider
-    }
 
 runAgentProviders
     :: ModelSwitchScope
@@ -437,1078 +262,23 @@ runAgentProvidersRequest
     :: AgentProviderRequest
     -> IO RunResult
 runAgentProvidersRequest request@AgentProviderRequest{provider, startup} =
-        let nativeCapabilities =
-                maybe
-                    fullNativeRunCapabilities
-                    (.nativeCapabilities)
-                    startup.startupNativeHooks
-        in case provider of
-                    OpenAIProvider ->
-                        runOpenAiProvider request nativeCapabilities
-                    XAIProvider ->
-                        runXaiProvider request nativeCapabilities
-                    GeminiProvider ->
-                        runGeminiProvider request
-                    ClaudeCodeProvider
-                        | not
-                            nativeCapabilities.nativeProviderNativeTools ->
-                            startupDie startup
-                                "Claude Code is unavailable in this runtime"
-                        | otherwise ->
-                            runClaudeProvider request nativeCapabilities
-                    OpenRouterProvider ->
-                        runOpenRouterProvider request
-
-runOpenAiProvider
-    :: AgentProviderRequest
-    -> NativeRunCapabilities
-    -> IO RunResult
-runOpenAiProvider request@AgentProviderRequest{tokenProvider} nativeCapabilities =
-    try @_ @CodexAuthFailed
-        (withCodexWsWithProviderOrHttpFallback tokenProvider \conn credential ->
-            runConnectedOpenAiProvider request conn credential)
-        >>= handleOpenAiProviderResult request nativeCapabilities
-
-data OpenAiProviderRuntime = OpenAiProviderRuntime
-    { openAiWsLock :: MVar ()
-    , openAiActiveConnectionRef :: IORef OpenAiPersistentConnection
-    , openAiHttpFallbackActive :: IORef Bool
-    , openAiSelectablePool :: Maybe Pool
-    , openAiSelectAccount :: Maybe (Text -> IO (Either ApiError Text))
-    , openAiSwitchLoop :: IO ()
-    }
-
-data OpenAiConnectionState = OpenAiConnectionState
-    { openAiConnectionLock :: MVar ()
-    , openAiConnectionRef :: IORef OpenAiPersistentConnection
-    , openAiFallbackRef :: IORef Bool
-    }
-
-newOpenAiConnectionState
-    :: CodexConn
-    -> Credential
-    -> IO OpenAiConnectionState
-newOpenAiConnectionState conn credential = do
-    openAiConnectionLock <- newMVar ()
-    let startsOnHttp = codexConnUsesHttpFallback conn
-    initialWsHealthy <- newIORef (not startsOnHttp)
-    openAiConnectionRef <-
-        newIORef $
-            OpenAiPersistentConnection credential initialWsHealthy conn
-    openAiFallbackRef <- newIORef startsOnHttp
-    pure OpenAiConnectionState{..}
-
-newOpenAiProviderRuntime
-    :: AgentProviderRequest
-    -> CodexConn
-    -> Credential
-    -> IO OpenAiProviderRuntime
-newOpenAiProviderRuntime AgentProviderRequest{..} conn credential = do
-                                OpenAiConnectionState
-                                    { openAiConnectionLock = wsLock
-                                    , openAiConnectionRef =
-                                        activeConnectionRef
-                                    , openAiFallbackRef =
-                                        httpFallbackActive
-                                    } <- newOpenAiConnectionState conn credential
-                                switchRequests <-
-                                    newChan :: IO (Chan AccountSwitchRequest)
-                                let selectableOpenAiPool
-                                        | isGatewayLoadedAuth loaded = Nothing
-                                        | otherwise = loaded.loadedOpenAiPool
-                                    selectAccount =
-                                        selectOpenAiAccount switchRequests
-                                            <$> selectableOpenAiPool
-                                    switchLoop = case selectableOpenAiPool of
-                                        Nothing -> pure ()
-                                        Just pool ->
-                                            readChan switchRequests
-                                                >>= switchTo pool
-                                    switchTo pool request =
-                                        runSwitch pool request >>= \case
-                                            Nothing -> switchLoop
-                                            Just next -> switchTo pool next
-                                    runSwitch
-                                        pool
-                                        (AccountSwitchRequest
-                                            selectedCredential
-                                            reply) = do
-                                                takeMVar wsLock
-                                                lockHeld <- newIORef True
-                                                let releaseLock = do
-                                                        held <-
-                                                            atomicModifyIORef'
-                                                                lockHeld
-                                                                (\held ->
-                                                                    (False, held))
-                                                        when held $
-                                                            putMVar wsLock ()
-                                                    failSwitch err = do
-                                                        releaseLock
-                                                        _ <- tryPutMVar
-                                                            reply
-                                                            (Left err)
-                                                        pure Nothing
-                                                    installConnection
-                                                        newCredential
-                                                        newConn = do
-                                                            let usesHttp =
-                                                                    codexConnUsesHttpFallback
-                                                                        newConn
-                                                            newHealthy <-
-                                                                newIORef
-                                                                    (not usesHttp)
-                                                            label <-
-                                                                resolveActiveAccountLabel
-                                                                    newCredential
-                                                            writeIORef
-                                                                activeConnectionRef $
-                                                                OpenAiPersistentConnection
-                                                                    newCredential
-                                                                    newHealthy
-                                                                    newConn
-                                                            writeIORef
-                                                                activeAccountIdRef
-                                                                newCredential.accountId
-                                                            writeIORef
-                                                                activeSelectionRef
-                                                                newCredential.accountId
-                                                            writeIORef
-                                                                activeAccountRef
-                                                                label
-                                                            writeIORef
-                                                                httpFallbackActive
-                                                                usesHttp
-                                                            pure (newHealthy, label)
-                                                    awaitNext newHealthy =
-                                                        readChan switchRequests
-                                                            `finally`
-                                                                writeIORef
-                                                                    newHealthy
-                                                                    False
-                                                oldConnection <-
-                                                    readIORef activeConnectionRef
-                                                previousAccountId <-
-                                                    readIORef activeAccountIdRef
-                                                let OpenAiPersistentConnection
-                                                        _
-                                                        oldHealthy
-                                                        oldConn =
-                                                            oldConnection
-                                                writeIORef oldHealthy False
-                                                closeCodexConn oldConn
-                                                writeIORef
-                                                    preferredOpenAiAccountRef
-                                                    (Just
-                                                        selectedCredential.accountId)
-                                                let connectSelected =
-                                                        withCodexWsCredentialOrHttpFallback
-                                                            selectedCredential
-                                                            \newConn
-                                                                newCredential -> do
-                                                                    (newHealthy, label) <-
-                                                                        installConnection
-                                                                            newCredential
-                                                                            newConn
-                                                                    releaseLock
-                                                                    _ <- tryPutMVar
-                                                                        reply
-                                                                        (Right label)
-                                                                    awaitNext
-                                                                        newHealthy
-                                                    restorePrevious
-                                                        selectedError
-                                                        | Text.null
-                                                            previousAccountId =
-                                                            failSwitch
-                                                                selectedError
-                                                        | otherwise = do
-                                                            writeIORef
-                                                                preferredOpenAiAccountRef
-                                                                (Just
-                                                                    previousAccountId)
-                                                            OpenAI.getAccessTokenForAccount
-                                                                pool
-                                                                previousAccountId
-                                                                >>= \case
-                                                                    Left _ ->
-                                                                        failSwitch
-                                                                            selectedError
-                                                                    Right
-                                                                        ( previousToken
-                                                                        , restoredId
-                                                                        ) -> do
-                                                                            let restoredCredential =
-                                                                                    Credential
-                                                                                        { accessToken =
-                                                                                            previousToken
-                                                                                        , accountId =
-                                                                                            restoredId
-                                                                                        , leaseId =
-                                                                                            Nothing
-                                                                                        , provider =
-                                                                                            OpenAIProvider
-                                                                                        }
-                                                                            (withCodexWsCredentialOrHttpFallback
-                                                                                restoredCredential
-                                                                                \newConn
-                                                                                    newCredential -> do
-                                                                                        (newHealthy, _) <-
-                                                                                            installConnection
-                                                                                                newCredential
-                                                                                                newConn
-                                                                                        releaseLock
-                                                                                        _ <- tryPutMVar
-                                                                                            reply
-                                                                                            (Left
-                                                                                                selectedError)
-                                                                                        awaitNext
-                                                                                            newHealthy)
-                                                                                >>= \case
-                                                                                    Left _ ->
-                                                                                        failSwitch
-                                                                                            selectedError
-                                                                                    Right next ->
-                                                                                        pure
-                                                                                            (Just
-                                                                                                next)
-                                                (connectSelected >>= \case
-                                                    Left selectedError ->
-                                                        restorePrevious
-                                                            selectedError
-                                                    Right next ->
-                                                        pure (Just next))
-                                                    `catchAny` \_ ->
-                                                        failSwitch $
-                                                            ConnectionError
-                                                                "account switch failed"
-                                pure
-                                    OpenAiProviderRuntime
-                                        { openAiWsLock = wsLock
-                                        , openAiActiveConnectionRef =
-                                            activeConnectionRef
-                                        , openAiHttpFallbackActive =
-                                            httpFallbackActive
-                                        , openAiSelectablePool =
-                                            selectableOpenAiPool
-                                        , openAiSelectAccount = selectAccount
-                                        , openAiSwitchLoop = switchLoop
-                                        }
-
-selectOpenAiAccount
-    :: Chan AccountSwitchRequest
-    -> Pool
-    -> Text
-    -> IO (Either ApiError Text)
-selectOpenAiAccount switchRequests pool selectedAccountId = do
-    _ <- OpenAI.discoverAccounts pool
-    OpenAI.getAccessTokenForAccount pool selectedAccountId >>= \case
-        Left err ->
-            pure (Left err)
-        Right (accessToken, accountId) -> do
-            reply <- newEmptyMVar
-            writeChan switchRequests $
-                AccountSwitchRequest
-                    Credential
-                        { accessToken
-                        , accountId
-                        , leaseId = Nothing
-                        , provider = OpenAIProvider
-                        }
-                    reply
-            takeMVar reply
-
-runConnectedOpenAiProvider
-    :: AgentProviderRequest
-    -> CodexConn
-    -> Credential
-    -> IO RunResult
-runConnectedOpenAiProvider request@AgentProviderRequest{..} conn credential = do
-                                OpenAiProviderRuntime
-                                    { openAiWsLock = wsLock
-                                    , openAiActiveConnectionRef =
-                                        activeConnectionRef
-                                    , openAiHttpFallbackActive =
-                                        httpFallbackActive
-                                    , openAiSelectablePool =
-                                        selectableOpenAiPool
-                                    , openAiSelectAccount = selectAccount
-                                    , openAiSwitchLoop = switchLoop
-                                    } <- newOpenAiProviderRuntime
-                                        request
-                                        conn
-                                        credential
-                                case multiCtx of
-                                    Just ctx ->
-                                        setSubagentRunner ctx.multiRegistry $
-                                            runCodexSubagent
-                                                (isGatewayWebSocketCredential
-                                                    credential)
-                                                subagentRuntime
-                                                selectableTokenProvider
-                                                ctx.multiSendToRoot
-                                    Nothing -> pure ()
-                                let (compactSender, lockedBackend) =
-                                        lockedOpenAiSession
-                                            startup.startupNetworkRecovery
-                                            (isGatewayWebSocketCredential
-                                                credential)
-                                            options.optCompactThreshold
-                                            options.optShowRawReasoning
-                                            wsLock
-                                            httpFallbackActive
-                                            tokenProvider
-                                            activeConnectionRef
-                                            (readIORef paramsRef)
-                                            contextTokensRef
-                                            recordCompactionUsage
-                                            (decorateCompactOutcomeWithTaskPlan
-                                                taskPlan)
-                                            (\outcome inputs ->
-                                                readIORef
-                                                    automaticCompactionHookRef
-                                                    >>= \hook ->
-                                                        hook outcome inputs)
-                                    noticingBackend =
-                                        withPendingInputs pendingNotices
-                                            lockedBackend
-                                    btwBackend privateParams =
-                                        freshOpenAiBackend
-                                            options.optShowRawReasoning
-                                            tokenProvider
-                                            (pure privateParams)
-                                    compactRunner focus =
-                                        withMVar wsLock \_ -> do
-                                            OpenAiPersistentConnection
-                                                _credential
-                                                _connectionHealthy
-                                                activeConn <-
-                                                    readIORef activeConnectionRef
-                                            historyRef <-
-                                                newIORef =<< readLiveTranscript
-                                                    conversationRef
-                                            let turnState =
-                                                    codexConnTurnState activeConn
-                                                runCompact =
-                                                    installLiveCompactOutcome
-                                                        conversationRef
-                                                        (Just contextTokensRef)
-                                                        (\requestedFocus ->
-                                                            runProviderCompactWith
-                                                                (Just compactSender)
-                                                                recordCompactionUsage
-                                                                provider
-                                                                (Just tokenProvider)
-                                                                paramsRef
-                                                                historyRef
-                                                                requestedFocus
-                                                                >>= decorateManualCompact request
-                                                                    (codexEffectiveContextWindowFor
-                                                                        . (.model)))
-                                                        focus
-                                            resetCodexTurnState turnState
-                                            runCompact `finally`
-                                                resetCodexTurnState turnState
-                                activeBackend <-
-                                    prepareTransitionBackend
-                                        modelSwitchScope home projectRoot
-                                        transition persist noticingBackend
-                                withAsync switchLoop \switchWorker -> do
-                                    link switchWorker
-                                    runSession
-                                        (sessionRequest
-                                            startupUnavailable
-                                            (Just tokenProvider)
-                                            selectableOpenAiPool
-                                            selectAccount
-                                            (currentModelContextWindow transportModel)
-                                            compactRunner)
-                                        SessionBackend
-                                            { backend = activeBackend
-                                            , btwBackend
-                                            , interruptBackend = pure ()
-                                            , resetBackendState = do
-                                                OpenAiPersistentConnection
-                                                    _credential
-                                                    _connectionHealthy
-                                                    activeConn <-
-                                                        readIORef activeConnectionRef
-                                                resetCodexTurnState
-                                                    (codexConnTurnState activeConn)
-                                            }
-
-handleOpenAiProviderResult
-    :: AgentProviderRequest
-    -> NativeRunCapabilities
-    -> Either CodexAuthFailed RunResult
-    -> IO RunResult
-handleOpenAiProviderResult request@AgentProviderRequest{..} nativeCapabilities = \case
-                                Left (CodexAuthFailed err) ->
-                                    case transition of
-                                        Just active
-                                            | active.transitionCause == AutomaticFallback ->
-                                                pure (RunProviderStartFailed err)
-                                        _
-                                            | shouldProbeAtStartup
-                                            , not (isGatewayLoadedAuth loaded)
-                                            , isProviderUnavailable err ->
-                                                chooseStartupProviderTransition
-                                                    nativeCapabilities.nativeProviderFallback
-                                                    catalog
-                                                    projectRoot
-                                                    fullscreen
-                                                    (tokenProviderBillingMode
-                                                        tokenProvider)
-                                                    provider
-                                                    model
-                                                    unavailableProviders
-                                                    Nothing
-                                                    err >>= \case
-                                                        Just next ->
-                                                            pure
-                                                                (RunSwitchProvider
-                                                                    next)
-                                                        Nothing ->
-                                                            startupFailure request err
-                                        _ -> do
-                                            startupFailure request err
-                                Right result -> pure result
-runXaiProvider
-    :: AgentProviderRequest
-    -> NativeRunCapabilities
-    -> IO RunResult
-runXaiProvider request@AgentProviderRequest{..} nativeCapabilities = do
-                        xaiOptions0 <- XAI.clientOptionsFromEnv
-                        let xaiOptions =
-                                xaiOptions0
-                                    { XAI.hostedXSearchEnabled =
-                                        nativeCapabilities.nativeProviderHostedTools
-                                    }
-                        let xaiContextWindow =
-                                contextWindowForParams
-                                    (XAIRequest.mapModel xaiOptions)
-                                    XAI.grokDefaultContextWindow
-                            xaiWireModel params =
-                                maybe xaiOptions.defaultModel
-                                    (XAIRequest.mapModel xaiOptions)
-                                    params.model
-                            xaiCompactThresholdFor currentParams =
-                                let contextWindow =
-                                        xaiContextWindow currentParams
-                                in max 1 $
-                                    min contextWindow $
-                                        fromMaybe
-                                            (XAI.grokAutoCompactTokenLimit
-                                                (xaiWireModel currentParams)
-                                                contextWindow)
-                                            options.optCompactThreshold
-                            xaiOptionsFor currentParams =
-                                xaiOptions
-                                    { XAI.autoCompactTokenLimit =
-                                        Just
-                                            (xaiCompactThresholdFor
-                                                currentParams)
-                                    }
-                            xaiCompactThreshold =
-                                xaiCompactThresholdFor
-                                    <$> readIORef paramsRef
-                            protectXaiOverflow occupancy getParams backend =
-                                boundCompletedToolContinuations
-                                    xaiContextWindow
-                                    getParams
-                                    occupancy
-                                    backend
-                        case multiCtx of
-                            Just ctx ->
-                                setSubagentRunner ctx.multiRegistry $
-                                    runXaiParentSubagent
-                                        subagentRuntime
-                                        dialect
-                                        ctx.multiSendToRoot
-                                        xaiContextWindow
-                                        xaiCompactThresholdFor
-                                        (\childParams ->
-                                            xaiBackendWithClientOptions
-                                                xaiOptionsFor
-                                                tokenProvider
-                                                (pure childParams))
-                            Nothing -> pure ()
-                        let btwBackend privateParams =
-                                xaiBackendWithClientOptions
-                                    xaiOptionsFor
-                                    tokenProvider
-                                    (pure privateParams)
-                            compactHistory history _inputs = do
-                                currentParams <- readIORef paramsRef
-                                runXaiBackendCompactHistoryWithContextWindow
-                                    (xaiContextWindow currentParams)
-                                    btwBackend
-                                    recordCompactionUsage
-                                    currentParams
-                                    history
-                                    Nothing
-                                    >>= decorateAutomaticCompact request
-                                        xaiContextWindow
-                            -- Reconnection wraps only the continuation. Keeping
-                            -- automatic compaction outside it prevents a
-                            -- failed continuation from rerunning the summary.
-                            requestBackend =
-                                withConnectionRecoveryOn
-                                    startup.startupNetworkRecovery $
-                                    protectXaiOverflow
-                                        contextTokensRef
-                                        (readIORef paramsRef)
-                                        (xaiBackendWithClientOptions
-                                            xaiOptionsFor
-                                            tokenProvider
-                                            (readIORef paramsRef))
-                            compactingBackend =
-                                autoCompactBackendWith
-                                    xaiCompactThreshold
-                                    compactHistory
-                                    (\outcome inputs ->
-                                        readIORef automaticCompactionHookRef
-                                            >>= \hook ->
-                                                hook outcome inputs)
-                                    (readIORef paramsRef)
-                                    contextTokensRef
-                                    requestBackend
-                            backend =
-                                withPendingInputs pendingNotices
-                                    compactingBackend
-                            compactRunner focus = do
-                                contextWindow <-
-                                    currentModelContextWindow
-                                        (XAIRequest.mapModel xaiOptions)
-                                historyRef <-
-                                    newIORef =<< readLiveTranscript conversationRef
-                                installLiveCompactOutcome
-                                    conversationRef
-                                    (Just contextTokensRef)
-                                    (\requestedFocus ->
-                                        runXaiResponsesCompactWithContextWindow
-                                            contextWindow
-                                            (\request ->
-                                                runWithTokenProvider tokenProvider
-                                                    \credential ->
-                                                        XAIClient.createResponseWith
-                                                            (xaiOptionsFor request)
-                                                            credential
-                                                            request)
-                                            recordCompactionUsage
-                                            paramsRef
-                                            historyRef
-                                            requestedFocus
-                                            >>= decorateManualCompact request
-                                                xaiContextWindow)
-                                    focus
-                        activeBackend <-
-                            prepareTransitionBackend
-                                modelSwitchScope home projectRoot
-                                transition persist backend
-                        runSession
-                            (sessionRequest
-                                startupUnavailable
-                                (Just tokenProvider)
-                                loaded.loadedOpenAiPool
-                                (if isGatewayLoadedAuth loaded
-                                    || isJust customGenericOptions
-                                    then Nothing
-                                    else Just selectHttpAccount)
-                                (Just . xaiContextWindow
-                                    <$> readIORef paramsRef)
-                                compactRunner)
-                            SessionBackend
-                                { backend = activeBackend
-                                , btwBackend
-                                , interruptBackend = pure ()
-                                , resetBackendState = pure ()
-                                }
-runGeminiProvider
-    :: AgentProviderRequest
-    -> IO RunResult
-runGeminiProvider request@AgentProviderRequest{..} = do
-                        geminiOptions <- Gemini.clientOptionsFromEnv
-                        geminiOccupancy <- newIORef Nothing
-                        let geminiContextWindow =
-                                contextWindowForParams id 1_048_576
-                            makeBackend getParams =
-                                tokenProviderStatelessGeminiBackend
-                                    tokenProvider
-                                    (GeminiClient.createResponseWithEvents
-                                        geminiOptions)
-                                    getParams
-                            protectGeminiOverflow occupancy getParams backend =
-                                boundCompletedToolContinuations
-                                    geminiContextWindow
-                                    getParams
-                                    occupancy
-                                    backend
-                        case multiCtx of
-                            Just ctx ->
-                                setSubagentRunner ctx.multiRegistry $
-                                    runHttpSubagent
-                                        subagentRuntime
-                                        dialect
-                                        GeminiProvider
-                                        ctx.multiSendToRoot
-                                        (\childParams ->
-                                            protectGeminiOverflow
-                                                geminiOccupancy
-                                                (pure childParams)
-                                                (makeBackend
-                                                    (pure childParams)))
-                            Nothing -> pure ()
-                        let backend =
-                                withPendingInputs pendingNotices $
-                                    withConnectionRecoveryOn
-                                        startup.startupNetworkRecovery $
-                                        protectGeminiOverflow
-                                            geminiOccupancy
-                                            (readIORef paramsRef)
-                                            (makeBackend
-                                                (readIORef paramsRef))
-                            btwBackend privateParams =
-                                makeBackend (pure privateParams)
-                            compactRunner focus = do
-                                contextWindow <-
-                                    currentModelContextWindow id
-                                historyRef <-
-                                    newIORef =<< readLiveTranscript conversationRef
-                                installLiveCompactOutcome conversationRef Nothing
-                                    (\requestedFocus ->
-                                        runResponsesCompactWithContextWindow
-                                            contextWindow
-                                            (\request ->
-                                                runWithTokenProvider tokenProvider
-                                                    \credential ->
-                                                        GeminiClient.createResponseWith
-                                                            geminiOptions
-                                                            credential
-                                                            request)
-                                            recordCompactionUsage
-                                            paramsRef
-                                            historyRef
-                                            requestedFocus
-                                            >>= decorateManualCompact request
-                                                geminiContextWindow)
-                                    focus
-                        activeBackend <-
-                            prepareTransitionBackend
-                                modelSwitchScope home projectRoot
-                                transition persist backend
-                        runSession
-                            (sessionRequest
-                                startupUnavailable
-                                (Just tokenProvider)
-                                loaded.loadedOpenAiPool
-                                (if isGatewayLoadedAuth loaded
-                                    then Nothing
-                                    else Just selectHttpAccount)
-                                (Just . geminiContextWindow
-                                    <$> readIORef paramsRef)
-                                compactRunner)
-                            SessionBackend
-                                { backend = activeBackend
-                                , btwBackend
-                                , interruptBackend = pure ()
-                                , resetBackendState = pure ()
-                                }
-runClaudeProvider
-    :: AgentProviderRequest
-    -> NativeRunCapabilities
-    -> IO RunResult
-runClaudeProvider request@AgentProviderRequest{..} nativeCapabilities =
-                        withSelectedClaudeAuth
-                            connectedGateway
-                            loaded
-                            (startupDie startup . Text.unpack)
-                            \claudeAuth -> do
-                        let permission =
-                                ClaudeCodeManual
-                            claudeOptions =
-                                (defaultClaudeCodeOptions
-                                    claudeAuth.executable
-                                    (unsafeToFilePath cwd))
-                                    { permission
-                                    , safeMode = True
-                                    , transport = claudeAuth.transport
-                                    }
-                            claudeContextWindow = do
-                                currentParams <- readIORef paramsRef
-                                pure $
-                                    contextWindowForParams
-                                        transportModel
-                                        200_000
-                                        currentParams
-                            claudeCompactThreshold = do
-                                contextWindow <- claudeContextWindow
-                                let hardLimit =
-                                        claudeCompactionInputLimit contextWindow
-                                pure $
-                                    max 1 $
-                                        min hardLimit $
-                                            fromMaybe
-                                                (claudeAutoCompactTokenLimit
-                                                    contextWindow)
-                                                options.optCompactThreshold
-                            claudeSummaryInputLimit =
-                                claudeCompactionInputLimit
-                                    <$> claudeContextWindow
-                            btwBackend privateParams =
-                                Backend \state previous inputs onEvent -> do
-                                    privateTranscript <-
-                                        newIORef state.backendItems
-                                    let privateBackend =
-                                            claudeCodeOneShotBackend
-                                                claudeOptions
-                                                    { permission =
-                                                        ClaudeCodeDontAsk
-                                                    }
-                                                (pure privateParams)
-                                                privateTranscript
-                                    privateBackend.submitTurn
-                                        state
-                                        previous
-                                        inputs
-                                        onEvent
-                            compactRunner focus = do
-                                contextWindow <- claudeContextWindow
-                                inputLimit <- claudeSummaryInputLimit
-                                historyRef <-
-                                    newIORef =<< readLiveTranscript
-                                        conversationRef
-                                installLiveCompactOutcome
-                                    conversationRef
-                                    (Just contextTokensRef)
-                                    (\requestedFocus ->
-                                        runBackendCompactWithLimits
-                                            contextWindow
-                                            inputLimit
-                                            btwBackend
-                                            recordCompactionUsage
-                                            paramsRef
-                                            historyRef
-                                            requestedFocus
-                                            >>= decorateManualCompact request
-                                                (const contextWindow))
-                                    focus
-                            claudeRequest =
-                                sessionRequest
-                                    startupUnavailable
-                                    Nothing
-                                    Nothing
-                                    Nothing
-                                    (Just <$> claudeContextWindow)
-                                    compactRunner
-                        claudeMcpServer <-
-                            case MCP.createInProcessMcpServer
-                                "haskell-agent"
-                                "0.1.0"
-                                (defaultLoopDispatch
-                                    { toolDispatchFinalizeOutput =
-                                        \call output ->
-                                            finalizeToolOutput
-                                                claudeRequest.toolEnv
-                                                call
-                                                output
-                                    })
-                                (approveClaudeRegisteredTool
-                                    claudeRequest.claudeRuntimeSlot)
-                                claudeRequest.claudeBridgeTools of
-                                Left err -> startupDie startup (Text.unpack err)
-                                Right server -> pure server
-                        let hostHandlers =
-                                defaultClaudeCodeHostHandlers
-                                    { canUseTool =
-                                        Just
-                                            (handleClaudePermissionRequest
-                                                claudeRequest.claudeRuntimeSlot)
-                                    , handleMcpMessage =
-                                        Just \request ->
-                                            if request.serverName
-                                                    /= "haskell-agent"
-                                                then
-                                                    pure Aeson.Null
-                                                else
-                                                    MCP.handleInProcessMcpMessage
-                                                        claudeMcpServer
-                                                        request.message
-                                                        >>= pure . fromMaybe
-                                                            (Aeson.object [])
-                                    , mcpToolNames =
-                                        MCP.inProcessMcpToolNames
-                                            claudeMcpServer
-                                    , nativeToolsEnabled =
-                                        nativeCapabilities.nativeProviderNativeTools
-                                    }
-                        when claudeBypassEnabled $
-                            case fullscreen of
-                                Just runtime ->
-                                    emitUiEvent runtime
-                                        (UiSystemMessage
-                                            "Claude Code --yolo is active; host catastrophic-command and Plan Mode denies remain enforced.")
-                                Nothing -> do
-                                    color <- resolveColor stderrHandle
-                                    putTextLn stderrHandle $
-                                        roleWarn color $
-                                            glyphWarn
-                                                <> "Claude Code --yolo is active; host catastrophic-command and Plan Mode denies remain enforced."
-                        writeIORef activeAccountRef claudeAuth.accountLabel
-                        claudeTranscriptRef <-
-                            newIORef =<< readLiveTranscript conversationRef
-                        withClaudeCodeBackendWithHost
-                            claudeOptions
-                            hostHandlers
-                            initialPrevious
-                            (readIORef paramsRef)
-                            claudeTranscriptRef
-                            \handle -> do
-                                let compactHistory history _inputs = do
-                                        contextWindow <- claudeContextWindow
-                                        inputLimit <- claudeSummaryInputLimit
-                                        currentParams <- readIORef paramsRef
-                                        runBackendCompactHistoryWithLimits
-                                            contextWindow
-                                            inputLimit
-                                            btwBackend
-                                            recordCompactionUsage
-                                            currentParams
-                                            history
-                                            Nothing
-                                            >>= decorateAutomaticCompact request
-                                                (const contextWindow)
-                                    compactingBackend =
-                                        autoCompactBackendWith
-                                            claudeCompactThreshold
-                                            compactHistory
-                                            (\outcome inputs ->
-                                                readIORef
-                                                    automaticCompactionHookRef
-                                                    >>= \hook ->
-                                                        hook outcome inputs)
-                                            (readIORef paramsRef)
-                                            contextTokensRef
-                                            handle.loopBackend
-                                activeBackend <-
-                                    prepareTransitionBackend
-                                        modelSwitchScope home projectRoot
-                                        transition persist compactingBackend
-                                result <- runSession
-                                    claudeRequest
-                                    SessionBackend
-                                        { backend = activeBackend
-                                        , btwBackend
-                                        , interruptBackend =
-                                            handle.interruptActiveTurn
-                                        , resetBackendState =
-                                            writeIORef claudeTranscriptRef []
-                                        }
-                                pure result
-runOpenRouterProvider
-    :: AgentProviderRequest
-    -> IO RunResult
-runOpenRouterProvider request@AgentProviderRequest{..} = do
-                        let openRouterContextWindow =
-                                contextWindowForParams transportModel 1_048_576
-                            makeBackend params =
-                                case customGenericOptions of
-                                    Just genericOptions ->
-                                        genericResponsesBackendWith
-                                            (\request onEvent ->
-                                                GenericResponses.createResponseWithEvents
-                                                    genericOptions
-                                                        { GenericResponses.model =
-                                                            transportModel
-                                                                (fromMaybe
-                                                                    model
-                                                                    request.model)
-                                                        }
-                                                    request
-                                                    onEvent)
-                                            params
-                                    Nothing ->
-                                        openRouterBackend openRouterOptions
-                                            tokenProvider params
-                            protectOverflow occupancy getParams backend =
-                                boundCompletedToolContinuations
-                                    openRouterContextWindow
-                                    getParams
-                                    occupancy
-                                    backend
-                        case multiCtx of
-                            Just ctx ->
-                                setSubagentRunner ctx.multiRegistry $
-                                    runHttpSubagent
-                                        subagentRuntime
-                                        dialect
-                                        OpenRouterProvider
-                                        ctx.multiSendToRoot
-                                        (\childParams ->
-                                            protectOverflow
-                                                contextTokensRef
-                                                (pure childParams)
-                                                (makeBackend
-                                                    (pure childParams)))
-                            Nothing -> pure ()
-                        let backend =
-                                withPendingInputs pendingNotices $
-                                    withConnectionRecoveryOn
-                                        startup.startupNetworkRecovery $
-                                        protectOverflow
-                                            contextTokensRef
-                                            (readIORef paramsRef)
-                                            (makeBackend
-                                                (readIORef paramsRef))
-                            btwBackend privateParams =
-                                makeBackend
-                                    (pure privateParams)
-                            compactRunner focus = do
-                                contextWindow <-
-                                    currentModelContextWindow transportModel
-                                historyRef <-
-                                    newIORef =<< readLiveTranscript conversationRef
-                                installLiveCompactOutcome conversationRef Nothing
-                                    (\requestedFocus ->
-                                        (case customGenericOptions of
-                                            Just genericOptions ->
-                                                runResponsesCompactWithContextWindow
-                                                    contextWindow
-                                                    (\request ->
-                                                        GenericResponses.createResponseWith
-                                                            genericOptions
-                                                                { GenericResponses.model =
-                                                                    transportModel
-                                                                        (fromMaybe
-                                                                            model
-                                                                            request.model)
-                                                                }
-                                                            request)
-                                                    recordCompactionUsage
-                                                    paramsRef
-                                                    historyRef
-                                            Nothing ->
-                                                runResponsesCompactWithContextWindow
-                                                    contextWindow
-                                                    (\request ->
-                                                        runWithTokenProvider
-                                                            tokenProvider
-                                                            \credential ->
-                                                                OpenRouter.createResponseWith
-                                                                    openRouterOptions
-                                                                    credential
-                                                                    request)
-                                                    recordCompactionUsage
-                                                    paramsRef
-                                                    historyRef)
-                                            requestedFocus
-                                            >>= decorateManualCompact request
-                                                openRouterContextWindow)
-                                    focus
-                        activeBackend <-
-                            prepareTransitionBackend
-                                modelSwitchScope home projectRoot
-                                transition persist backend
-                        runSession
-                            (sessionRequest
-                                startupUnavailable
-                                (Just tokenProvider)
-                                loaded.loadedOpenAiPool
-                                (if isGatewayLoadedAuth loaded
-                                    then Nothing
-                                    else Just selectHttpAccount)
-                                (Just . openRouterContextWindow
-                                    <$> readIORef paramsRef)
-                                compactRunner)
-                            SessionBackend
-                                { backend = activeBackend
-                                , btwBackend
-                                , interruptBackend = pure ()
-                                , resetBackendState = pure ()
-                                }
-decorateManualCompact
-    :: AgentProviderRequest
-    -> (ResponseCreateParams -> Int)
-    -> Either Text CompactOutcome
-    -> IO (Either Text CompactOutcome)
-decorateManualCompact
-    request
-    contextWindowForResult = \case
-        Left err -> pure (Left err)
-        Right outcome -> do
-            currentParams <- readIORef request.paramsRef
-            decorateCompactOutcomeWithTaskPlanWithin
-                (contextWindowForResult currentParams)
-                currentParams
-                request.taskPlan
-                outcome
-
-decorateAutomaticCompact
-    :: AgentProviderRequest
-    -> (ResponseCreateParams -> Int)
-    -> Either ApiError CompactOutcome
-    -> IO (Either ApiError CompactOutcome)
-decorateAutomaticCompact
-    request
-    contextWindowForResult = \case
-        Left err -> pure (Left err)
-        Right outcome ->
-            decorateManualCompact
-                request
-                contextWindowForResult
-                (Right outcome) >>= pure . \case
-                    Left message ->
-                        Left
-                            (ProviderError
-                                InvalidRequestError
-                                message
-                                Nothing)
-                    Right decorated -> Right decorated
-
-startupFailure
-    :: AgentProviderRequest
-    -> ApiError
-    -> IO RunResult
-startupFailure AgentProviderRequest{startup} err = do
-    now <- getCurrentTime
-    startupDie startup
-        (Text.unpack (formatApiErrorAt now err))
-
-
-withSelectedClaudeAuth
-    :: Maybe GatewayCredential
-    -> LoadedAuth
-    -> (Text -> IO value)
-    -> (ClaudeCodeAuth -> IO value)
-    -> IO value
-withSelectedClaudeAuth connectedGateway loaded onError action
-    -- Use the same immutable credential snapshot that selected the catalog,
-    -- auth, and session boundary. Reloading here could cross organizations.
-    | not (isGatewayLoadedAuth loaded) =
-        loadClaudeCodeAuth >>= either onError action
-    | otherwise = case connectedGateway of
-        Nothing ->
-            onError "No organization gateway credential is connected."
-        Just credential -> do
-            result <- withClaudeGatewayProxy credential \transport ->
-                loadClaudeCodeGatewayAuth transport
-                    >>= either onError action
-            either onError pure result
-
-sessionRunnerContinuation :: SessionRunner.SessionRunnerContinuation
-sessionRunnerContinuation =
-    SessionRunner.SessionRunnerContinuation
-        { runnerRepl = repl
-        , runnerReplWithDraft = replWithDraft
-        , runnerRunPendingTurn = runPendingTurn
-        , runnerFinishTurn = finishTurn
-        , runnerFinishStartup = finishStartup
-        , runnerPreparePromptSkillInputs = preparePromptSkillInputsWithPaste
-        , runnerRunSessionRecap = runSessionRecap
-        , runnerRunSessionTurnSummary = runSessionTurnSummary
-        }
-runSession
-    :: SessionRequest
-    -> SessionBackend
-    -> IO RunResult
-runSession = SessionRunner.runSession sessionRunnerContinuation
+    let nativeCapabilities =
+            maybe
+                fullNativeRunCapabilities
+                (.nativeCapabilities)
+                startup.startupNativeHooks
+    in case provider of
+        OpenAIProvider ->
+            runOpenAiProvider request nativeCapabilities
+        XAIProvider ->
+            runXaiProvider request nativeCapabilities
+        GeminiProvider ->
+            runGeminiProvider request
+        ClaudeCodeProvider
+            | not nativeCapabilities.nativeProviderNativeTools ->
+                startupDie startup
+                    "Claude Code is unavailable in this runtime"
+            | otherwise ->
+                runClaudeProvider request nativeCapabilities
+        OpenRouterProvider ->
+            runOpenRouterProvider request

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Claude.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Claude.hs
@@ -1,0 +1,287 @@
+module Agent.CLI.Runtime.Orchestration.Providers.Claude
+    ( runClaudeProvider
+    ) where
+
+import Agent.CLI.Auth.Types
+    ( LoadedAuth
+    , isGatewayLoadedAuth
+    )
+import Agent.CLI.Claude
+    ( approveClaudeRegisteredTool
+    , handleClaudePermissionRequest
+    )
+import Agent.CLI.ClaudeGatewayProxy (withClaudeGatewayProxy)
+import Agent.CLI.Compaction
+    ( autoCompactBackendWith
+    , claudeAutoCompactTokenLimit
+    , claudeCompactionInputLimit
+    , installLiveCompactOutcome
+    , runBackendCompactHistoryWithLimits
+    , runBackendCompactWithLimits
+    )
+import Agent.CLI.GatewayClient (GatewayCredential)
+import Agent.CLI.Options (CliOptions(..))
+import Agent.CLI.Provider.Switch (prepareTransitionBackend)
+import Agent.CLI.Render (putTextLn)
+import Agent.CLI.Runtime.Orchestration.Providers.Common
+    ( decorateAutomaticCompact
+    , decorateManualCompact
+    , runSession
+    )
+import Agent.CLI.Runtime.Orchestration.Providers.Types
+    ( AgentProviderRequest(..)
+    )
+import Agent.CLI.Runtime.Orchestration.Types (NativeRunCapabilities(..))
+import Agent.CLI.Runtime.Types (RunResult)
+import Agent.CLI.Session.History (readLiveTranscript)
+import Agent.CLI.Session.Runtime.Types
+    ( SessionBackend(..)
+    , SessionRequest(..)
+    )
+import Agent.CLI.Startup.Auth (startupDie)
+import Agent.CLI.Style (glyphWarn, roleWarn)
+import Agent.CLI.TUI.App (emitUiEvent)
+import Agent.CLI.Terminal (resolveColor)
+import Agent.Claude
+    ( ClaudeCodeAuth(..)
+    , ClaudeCodeBackendHandle(..)
+    , ClaudeCodeOptions(..)
+    , ClaudeCodePermission(..)
+    , claudeCodeOneShotBackend
+    , defaultClaudeCodeOptions
+    , loadClaudeCodeAuth
+    , loadClaudeCodeGatewayAuth
+    , withClaudeCodeBackendWithHost
+    )
+import Agent.Claude.Control
+    ( ClaudeCodeHostHandlers(..)
+    , ClaudeCodeMcpRequest(..)
+    , defaultClaudeCodeHostHandlers
+    )
+import Agent.Loop
+    ( Backend(Backend, submitTurn)
+    , BackendSnapshot(..)
+    , defaultLoopDispatch
+    )
+import Agent.OsPath (unsafeToFilePath)
+import Agent.ToolDispatch (ToolDispatchConfig(..))
+import Agent.Tools.OutputArtifact (finalizeToolOutput)
+import Agent.TUI.Model (UiEvent(UiSystemMessage))
+import Control.Monad (when)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Agent.MCP as MCP
+import qualified Data.Aeson as Aeson
+import qualified Data.Text as Text
+
+runClaudeProvider
+    :: AgentProviderRequest
+    -> NativeRunCapabilities
+    -> IO RunResult
+runClaudeProvider request@AgentProviderRequest{..} nativeCapabilities =
+    withSelectedClaudeAuth
+        connectedGateway
+        loaded
+        (startupDie startup . Text.unpack)
+        \claudeAuth -> do
+            let permission =
+                    ClaudeCodeManual
+                claudeOptions =
+                    (defaultClaudeCodeOptions
+                        claudeAuth.executable
+                        (unsafeToFilePath cwd))
+                        { permission
+                        , safeMode = True
+                        , transport = claudeAuth.transport
+                        }
+                claudeContextWindow = do
+                    currentParams <- readIORef paramsRef
+                    pure $
+                        contextWindowForParams
+                            transportModel
+                            200_000
+                            currentParams
+                claudeCompactThreshold = do
+                    contextWindow <- claudeContextWindow
+                    let hardLimit =
+                            claudeCompactionInputLimit contextWindow
+                    pure $
+                        max 1 $
+                            min hardLimit $
+                                fromMaybe
+                                    (claudeAutoCompactTokenLimit
+                                        contextWindow)
+                                    options.optCompactThreshold
+                claudeSummaryInputLimit =
+                    claudeCompactionInputLimit
+                        <$> claudeContextWindow
+                btwBackend privateParams =
+                    Backend \state previous inputs onEvent -> do
+                        privateTranscript <-
+                            newIORef state.backendItems
+                        let privateBackend =
+                                claudeCodeOneShotBackend
+                                    claudeOptions
+                                        { permission =
+                                            ClaudeCodeDontAsk
+                                        }
+                                    (pure privateParams)
+                                    privateTranscript
+                        privateBackend.submitTurn
+                            state
+                            previous
+                            inputs
+                            onEvent
+                compactRunner focus = do
+                    contextWindow <- claudeContextWindow
+                    inputLimit <- claudeSummaryInputLimit
+                    historyRef <-
+                        newIORef =<< readLiveTranscript
+                            conversationRef
+                    installLiveCompactOutcome
+                        conversationRef
+                        (Just contextTokensRef)
+                        (\requestedFocus ->
+                            runBackendCompactWithLimits
+                                contextWindow
+                                inputLimit
+                                btwBackend
+                                recordCompactionUsage
+                                paramsRef
+                                historyRef
+                                requestedFocus
+                                >>= decorateManualCompact request
+                                    (const contextWindow))
+                        focus
+                claudeRequest =
+                    sessionRequest
+                        startupUnavailable
+                        Nothing
+                        Nothing
+                        Nothing
+                        (Just <$> claudeContextWindow)
+                        compactRunner
+            claudeMcpServer <-
+                case MCP.createInProcessMcpServer
+                    "haskell-agent"
+                    "0.1.0"
+                    (defaultLoopDispatch
+                        { toolDispatchFinalizeOutput =
+                            \call output ->
+                                finalizeToolOutput
+                                    claudeRequest.toolEnv
+                                    call
+                                    output
+                        })
+                    (approveClaudeRegisteredTool
+                        claudeRequest.claudeRuntimeSlot)
+                    claudeRequest.claudeBridgeTools of
+                    Left err -> startupDie startup (Text.unpack err)
+                    Right server -> pure server
+            let hostHandlers =
+                    defaultClaudeCodeHostHandlers
+                        { canUseTool =
+                            Just
+                                (handleClaudePermissionRequest
+                                    claudeRequest.claudeRuntimeSlot)
+                        , handleMcpMessage =
+                            Just \mcpRequest ->
+                                if mcpRequest.serverName
+                                        /= "haskell-agent"
+                                    then
+                                        pure Aeson.Null
+                                    else
+                                        MCP.handleInProcessMcpMessage
+                                            claudeMcpServer
+                                            mcpRequest.message
+                                            >>= pure . fromMaybe
+                                                (Aeson.object [])
+                        , mcpToolNames =
+                            MCP.inProcessMcpToolNames
+                                claudeMcpServer
+                        , nativeToolsEnabled =
+                            nativeCapabilities.nativeProviderNativeTools
+                        }
+            when claudeBypassEnabled $
+                case fullscreen of
+                    Just runtime ->
+                        emitUiEvent runtime
+                            (UiSystemMessage
+                                "Claude Code --yolo is active; host catastrophic-command and Plan Mode denies remain enforced.")
+                    Nothing -> do
+                        color <- resolveColor stderrHandle
+                        putTextLn stderrHandle $
+                            roleWarn color $
+                                glyphWarn
+                                    <> "Claude Code --yolo is active; host catastrophic-command and Plan Mode denies remain enforced."
+            writeIORef activeAccountRef claudeAuth.accountLabel
+            claudeTranscriptRef <-
+                newIORef =<< readLiveTranscript conversationRef
+            withClaudeCodeBackendWithHost
+                claudeOptions
+                hostHandlers
+                initialPrevious
+                (readIORef paramsRef)
+                claudeTranscriptRef
+                \handle -> do
+                    let compactHistory history _inputs = do
+                            contextWindow <- claudeContextWindow
+                            inputLimit <- claudeSummaryInputLimit
+                            currentParams <- readIORef paramsRef
+                            runBackendCompactHistoryWithLimits
+                                contextWindow
+                                inputLimit
+                                btwBackend
+                                recordCompactionUsage
+                                currentParams
+                                history
+                                Nothing
+                                >>= decorateAutomaticCompact request
+                                    (const contextWindow)
+                        compactingBackend =
+                            autoCompactBackendWith
+                                claudeCompactThreshold
+                                compactHistory
+                                (\outcome inputs ->
+                                    readIORef
+                                        automaticCompactionHookRef
+                                        >>= \hook ->
+                                            hook outcome inputs)
+                                (readIORef paramsRef)
+                                contextTokensRef
+                                handle.loopBackend
+                    activeBackend <-
+                        prepareTransitionBackend
+                            modelSwitchScope home projectRoot
+                            transition persist compactingBackend
+                    runSession
+                        claudeRequest
+                        SessionBackend
+                            { backend = activeBackend
+                            , btwBackend
+                            , interruptBackend =
+                                handle.interruptActiveTurn
+                            , resetBackendState =
+                                writeIORef claudeTranscriptRef []
+                            }
+
+withSelectedClaudeAuth
+    :: Maybe GatewayCredential
+    -> LoadedAuth
+    -> (Text -> IO value)
+    -> (ClaudeCodeAuth -> IO value)
+    -> IO value
+withSelectedClaudeAuth connectedGateway loaded onError action
+    -- Use the same immutable credential snapshot that selected the catalog,
+    -- auth, and session boundary. Reloading here could cross organizations.
+    | not (isGatewayLoadedAuth loaded) =
+        loadClaudeCodeAuth >>= either onError action
+    | otherwise = case connectedGateway of
+        Nothing ->
+            onError "No organization gateway credential is connected."
+        Just credential -> do
+            result <- withClaudeGatewayProxy credential \transport ->
+                loadClaudeCodeGatewayAuth transport
+                    >>= either onError action
+            either onError pure result

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Common.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Common.hs
@@ -1,0 +1,110 @@
+module Agent.CLI.Runtime.Orchestration.Providers.Common
+    ( decorateAutomaticCompact
+    , decorateManualCompact
+    , runSession
+    , startupFailure
+    ) where
+
+import Agent.CLI.Compaction
+    ( CompactOutcome
+    , decorateCompactOutcomeWithTaskPlanWithin
+    )
+import Agent.CLI.Error (formatApiErrorAt)
+import Agent.CLI.Runtime.Orchestration.Providers.Types
+    ( AgentProviderRequest(..)
+    )
+import Agent.CLI.Runtime.Orchestration.Startup (finishStartup)
+import Agent.CLI.Runtime.Recap
+    ( runSessionRecap
+    , runSessionTurnSummary
+    )
+import Agent.CLI.Runtime.Repl
+    ( finishTurn
+    , preparePromptSkillInputsWithPaste
+    , repl
+    , replWithDraft
+    , runPendingTurn
+    )
+import Agent.CLI.Runtime.Types (RunResult)
+import Agent.CLI.Session.Runtime.Types
+    ( SessionBackend
+    , SessionRequest
+    )
+import Agent.Error
+    ( ApiError(ProviderError)
+    , ErrorType(InvalidRequestError)
+    )
+import Agent.Responses.Types (ResponseCreateParams)
+import Data.IORef (readIORef)
+import Data.Text (Text)
+import Data.Time.Clock (getCurrentTime)
+import qualified Agent.CLI.Session.Runner as SessionRunner
+import qualified Agent.CLI.Startup.Auth as Startup
+import qualified Data.Text as Text
+
+decorateManualCompact
+    :: AgentProviderRequest
+    -> (ResponseCreateParams -> Int)
+    -> Either Text CompactOutcome
+    -> IO (Either Text CompactOutcome)
+decorateManualCompact
+    request
+    contextWindowForResult = \case
+        Left err -> pure (Left err)
+        Right outcome -> do
+            currentParams <- readIORef request.paramsRef
+            decorateCompactOutcomeWithTaskPlanWithin
+                (contextWindowForResult currentParams)
+                currentParams
+                request.taskPlan
+                outcome
+
+decorateAutomaticCompact
+    :: AgentProviderRequest
+    -> (ResponseCreateParams -> Int)
+    -> Either ApiError CompactOutcome
+    -> IO (Either ApiError CompactOutcome)
+decorateAutomaticCompact
+    request
+    contextWindowForResult = \case
+        Left err -> pure (Left err)
+        Right outcome ->
+            decorateManualCompact
+                request
+                contextWindowForResult
+                (Right outcome) >>= pure . \case
+                    Left message ->
+                        Left
+                            (ProviderError
+                                InvalidRequestError
+                                message
+                                Nothing)
+                    Right decorated -> Right decorated
+
+startupFailure
+    :: AgentProviderRequest
+    -> ApiError
+    -> IO RunResult
+startupFailure AgentProviderRequest{startup} err = do
+    now <- getCurrentTime
+    Startup.startupDie startup
+        (Text.unpack (formatApiErrorAt now err))
+
+sessionRunnerContinuation :: SessionRunner.SessionRunnerContinuation
+sessionRunnerContinuation =
+    SessionRunner.SessionRunnerContinuation
+        { runnerRepl = repl
+        , runnerReplWithDraft = replWithDraft
+        , runnerRunPendingTurn = runPendingTurn
+        , runnerFinishTurn = finishTurn
+        , runnerFinishStartup = finishStartup
+        , runnerPreparePromptSkillInputs = preparePromptSkillInputsWithPaste
+        , runnerRunSessionRecap = runSessionRecap
+        , runnerRunSessionTurnSummary = runSessionTurnSummary
+        }
+
+runSession
+    :: SessionRequest
+    -> SessionBackend
+    -> IO RunResult
+runSession = SessionRunner.runSession sessionRunnerContinuation

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Gemini.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Gemini.hs
@@ -1,0 +1,131 @@
+module Agent.CLI.Runtime.Orchestration.Providers.Gemini
+    ( runGeminiProvider
+    ) where
+
+import Agent.CLI.Auth.Types
+    ( LoadedAuth(..)
+    , isGatewayLoadedAuth
+    )
+import Agent.CLI.Compaction
+    ( boundCompletedToolContinuations
+    , installLiveCompactOutcome
+    , runResponsesCompactWithContextWindow
+    )
+import Agent.Connectivity (withConnectionRecoveryOn)
+import Agent.CLI.PendingInputs (withPendingInputs)
+import Agent.CLI.Provider.Switch (prepareTransitionBackend)
+import Agent.CLI.Runtime.Orchestration.Providers.Common
+    ( decorateManualCompact
+    , runSession
+    )
+import Agent.CLI.Runtime.Orchestration.Providers.Types
+    ( AgentProviderRequest(..)
+    )
+import Agent.CLI.Runtime.Types (RunResult)
+import Agent.CLI.Session.History (readLiveTranscript)
+import Agent.CLI.Session.Runtime.Types
+    ( SessionBackend(..)
+    , StartupRuntime(..)
+    )
+import Agent.CLI.Subagents.Runtime (runHttpSubagent)
+import Agent.Gemini.LoopBackend (tokenProviderStatelessGeminiBackend)
+import Agent.Provider
+    ( Provider(GeminiProvider)
+    , runWithTokenProvider
+    )
+import Agent.Subagents (setSubagentRunner)
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Data.IORef (newIORef, readIORef)
+import qualified Agent.Gemini.Client as GeminiClient
+import qualified Agent.Gemini.Options as Gemini
+
+runGeminiProvider
+    :: AgentProviderRequest
+    -> IO RunResult
+runGeminiProvider request@AgentProviderRequest{..} = do
+    geminiOptions <- Gemini.clientOptionsFromEnv
+    geminiOccupancy <- newIORef Nothing
+    let geminiContextWindow =
+            contextWindowForParams id 1_048_576
+        makeBackend getParams =
+            tokenProviderStatelessGeminiBackend
+                tokenProvider
+                (GeminiClient.createResponseWithEvents
+                    geminiOptions)
+                getParams
+        protectGeminiOverflow occupancy getParams backend =
+            boundCompletedToolContinuations
+                geminiContextWindow
+                getParams
+                occupancy
+                backend
+    case multiCtx of
+        Just ctx ->
+            setSubagentRunner ctx.multiRegistry $
+                runHttpSubagent
+                    subagentRuntime
+                    dialect
+                    GeminiProvider
+                    ctx.multiSendToRoot
+                    (\childParams ->
+                        protectGeminiOverflow
+                            geminiOccupancy
+                            (pure childParams)
+                            (makeBackend
+                                (pure childParams)))
+        Nothing -> pure ()
+    let backend =
+            withPendingInputs pendingNotices $
+                withConnectionRecoveryOn
+                    startup.startupNetworkRecovery $
+                    protectGeminiOverflow
+                        geminiOccupancy
+                        (readIORef paramsRef)
+                        (makeBackend
+                            (readIORef paramsRef))
+        btwBackend privateParams =
+            makeBackend (pure privateParams)
+        compactRunner focus = do
+            contextWindow <-
+                currentModelContextWindow id
+            historyRef <-
+                newIORef =<< readLiveTranscript conversationRef
+            installLiveCompactOutcome conversationRef Nothing
+                (\requestedFocus ->
+                    runResponsesCompactWithContextWindow
+                        contextWindow
+                        (\compactRequest ->
+                            runWithTokenProvider tokenProvider
+                                \credential ->
+                                    GeminiClient.createResponseWith
+                                        geminiOptions
+                                        credential
+                                        compactRequest)
+                        recordCompactionUsage
+                        paramsRef
+                        historyRef
+                        requestedFocus
+                        >>= decorateManualCompact request
+                            geminiContextWindow)
+                focus
+    activeBackend <-
+        prepareTransitionBackend
+            modelSwitchScope home projectRoot
+            transition persist backend
+    runSession
+        (sessionRequest
+            startupUnavailable
+            (Just tokenProvider)
+            loaded.loadedOpenAiPool
+            (if isGatewayLoadedAuth loaded
+                then Nothing
+                else Just selectHttpAccount)
+            (Just . geminiContextWindow
+                <$> readIORef paramsRef)
+            compactRunner)
+        SessionBackend
+            { backend = activeBackend
+            , btwBackend
+            , interruptBackend = pure ()
+            , resetBackendState = pure ()
+            }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenAI.hs
@@ -1,0 +1,508 @@
+module Agent.CLI.Runtime.Orchestration.Providers.OpenAI
+    ( runOpenAiProvider
+    ) where
+
+import Agent.CLI.Auth.Types
+    ( LoadedAuth(..)
+    , isGatewayLoadedAuth
+    )
+import Agent.CLI.Compaction
+    ( decorateCompactOutcomeWithTaskPlan
+    , installLiveCompactOutcome
+    , runProviderCompactWith
+    )
+import Agent.CLI.PendingInputs (withPendingInputs)
+import Agent.CLI.Options (CliOptions(..))
+import Agent.CLI.Provider.OpenAI
+    ( OpenAiPersistentConnection(..)
+    , lockedOpenAiSession
+    )
+import Agent.CLI.Provider.Switch
+    ( chooseStartupProviderTransition
+    , prepareTransitionBackend
+    )
+import Agent.CLI.ProviderFallback (isProviderUnavailable)
+import Agent.CLI.ProviderTransition
+    ( ProviderTransition(transitionCause)
+    , TransitionCause(AutomaticFallback)
+    )
+import Agent.CLI.Runtime.Orchestration.Providers.Common
+    ( decorateManualCompact
+    , runSession
+    , startupFailure
+    )
+import Agent.CLI.Runtime.Orchestration.Providers.Types
+    ( AgentProviderRequest(..)
+    )
+import Agent.CLI.Runtime.Orchestration.Types
+    ( AccountSwitchRequest(..)
+    , NativeRunCapabilities(..)
+    )
+import Agent.CLI.Runtime.Types
+    ( RunResult(RunProviderStartFailed, RunSwitchProvider)
+    )
+import Agent.CLI.Session.History (readLiveTranscript)
+import Agent.CLI.Session.Runtime.Types
+    ( SessionBackend(..)
+    , StartupRuntime(..)
+    )
+import Agent.CLI.Subagents.Runtime
+    ( freshOpenAiBackend
+    , runCodexSubagent
+    )
+import Agent.Error (ApiError(..))
+import Agent.OpenAI.Auth (Pool)
+import Agent.OpenAI.ModelMetadata (codexEffectiveContextWindowFor)
+import Agent.OpenAI.WebSocketClient
+    ( CodexAuthFailed(..)
+    , CodexConn
+    , closeCodexConn
+    , codexConnTurnState
+    , codexConnUsesHttpFallback
+    , isGatewayWebSocketCredential
+    , resetCodexTurnState
+    , withCodexWsCredentialOrHttpFallback
+    , withCodexWsWithProviderOrHttpFallback
+    )
+import Agent.Provider
+    ( Credential(..)
+    , Provider(OpenAIProvider)
+    , tokenProviderBillingMode
+    )
+import Agent.Responses.Types (ResponseCreateParams(model))
+import Agent.Subagents (setSubagentRunner)
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Control.Concurrent.Async (link, withAsync)
+import Control.Concurrent.Chan
+    ( Chan
+    , newChan
+    , readChan
+    , writeChan
+    )
+import Control.Concurrent.MVar
+    ( MVar
+    , newEmptyMVar
+    , newMVar
+    , putMVar
+    , takeMVar
+    , tryPutMVar
+    , withMVar
+    )
+import Control.Exception.Safe (catchAny, finally, try)
+import Control.Monad (when)
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Text (Text)
+import qualified Agent.OpenAI.Auth as OpenAI
+import qualified Data.Text as Text
+
+runOpenAiProvider
+    :: AgentProviderRequest
+    -> NativeRunCapabilities
+    -> IO RunResult
+runOpenAiProvider request@AgentProviderRequest{tokenProvider} nativeCapabilities =
+    try @_ @CodexAuthFailed
+        (withCodexWsWithProviderOrHttpFallback tokenProvider \conn credential ->
+            runConnectedOpenAiProvider request conn credential)
+        >>= handleOpenAiProviderResult request nativeCapabilities
+
+data OpenAiProviderRuntime = OpenAiProviderRuntime
+    { openAiWsLock :: MVar ()
+    , openAiActiveConnectionRef :: IORef OpenAiPersistentConnection
+    , openAiHttpFallbackActive :: IORef Bool
+    , openAiSelectablePool :: Maybe Pool
+    , openAiSelectAccount :: Maybe (Text -> IO (Either ApiError Text))
+    , openAiSwitchLoop :: IO ()
+    }
+
+data OpenAiConnectionState = OpenAiConnectionState
+    { openAiConnectionLock :: MVar ()
+    , openAiConnectionRef :: IORef OpenAiPersistentConnection
+    , openAiFallbackRef :: IORef Bool
+    }
+
+newOpenAiConnectionState
+    :: CodexConn
+    -> Credential
+    -> IO OpenAiConnectionState
+newOpenAiConnectionState conn credential = do
+    openAiConnectionLock <- newMVar ()
+    let startsOnHttp = codexConnUsesHttpFallback conn
+    initialWsHealthy <- newIORef (not startsOnHttp)
+    openAiConnectionRef <-
+        newIORef $
+            OpenAiPersistentConnection credential initialWsHealthy conn
+    openAiFallbackRef <- newIORef startsOnHttp
+    pure OpenAiConnectionState{..}
+
+newOpenAiProviderRuntime
+    :: AgentProviderRequest
+    -> CodexConn
+    -> Credential
+    -> IO OpenAiProviderRuntime
+newOpenAiProviderRuntime AgentProviderRequest{..} conn credential = do
+    OpenAiConnectionState
+        { openAiConnectionLock = wsLock
+        , openAiConnectionRef =
+            activeConnectionRef
+        , openAiFallbackRef =
+            httpFallbackActive
+        } <- newOpenAiConnectionState conn credential
+    switchRequests <-
+        newChan :: IO (Chan AccountSwitchRequest)
+    let selectableOpenAiPool
+            | isGatewayLoadedAuth loaded = Nothing
+            | otherwise = loaded.loadedOpenAiPool
+        selectAccount =
+            selectOpenAiAccount switchRequests
+                <$> selectableOpenAiPool
+        switchLoop = case selectableOpenAiPool of
+            Nothing -> pure ()
+            Just pool ->
+                readChan switchRequests
+                    >>= switchTo pool
+        switchTo pool switchRequest =
+            runSwitch pool switchRequest >>= \case
+                Nothing -> switchLoop
+                Just next -> switchTo pool next
+        runSwitch
+            pool
+            (AccountSwitchRequest
+                selectedCredential
+                reply) = do
+                    takeMVar wsLock
+                    lockHeld <- newIORef True
+                    let releaseLock = do
+                            held <-
+                                atomicModifyIORef'
+                                    lockHeld
+                                    (\held ->
+                                        (False, held))
+                            when held $
+                                putMVar wsLock ()
+                        failSwitch err = do
+                            releaseLock
+                            _ <- tryPutMVar
+                                reply
+                                (Left err)
+                            pure Nothing
+                        installConnection
+                            newCredential
+                            newConn = do
+                                let usesHttp =
+                                        codexConnUsesHttpFallback
+                                            newConn
+                                newHealthy <-
+                                    newIORef
+                                        (not usesHttp)
+                                label <-
+                                    resolveActiveAccountLabel
+                                        newCredential
+                                writeIORef
+                                    activeConnectionRef $
+                                    OpenAiPersistentConnection
+                                        newCredential
+                                        newHealthy
+                                        newConn
+                                writeIORef
+                                    activeAccountIdRef
+                                    newCredential.accountId
+                                writeIORef
+                                    activeSelectionRef
+                                    newCredential.accountId
+                                writeIORef
+                                    activeAccountRef
+                                    label
+                                writeIORef
+                                    httpFallbackActive
+                                    usesHttp
+                                pure (newHealthy, label)
+                        awaitNext newHealthy =
+                            readChan switchRequests
+                                `finally`
+                                    writeIORef
+                                        newHealthy
+                                        False
+                    oldConnection <-
+                        readIORef activeConnectionRef
+                    previousAccountId <-
+                        readIORef activeAccountIdRef
+                    let OpenAiPersistentConnection
+                            _
+                            oldHealthy
+                            oldConn =
+                                oldConnection
+                    writeIORef oldHealthy False
+                    closeCodexConn oldConn
+                    writeIORef
+                        preferredOpenAiAccountRef
+                        (Just selectedCredential.accountId)
+                    let connectSelected =
+                            withCodexWsCredentialOrHttpFallback
+                                selectedCredential
+                                \newConn newCredential -> do
+                                    (newHealthy, label) <-
+                                        installConnection
+                                            newCredential
+                                            newConn
+                                    releaseLock
+                                    _ <- tryPutMVar
+                                        reply
+                                        (Right label)
+                                    awaitNext newHealthy
+                        restorePrevious
+                            selectedError
+                            | Text.null previousAccountId =
+                                failSwitch selectedError
+                            | otherwise = do
+                                writeIORef
+                                    preferredOpenAiAccountRef
+                                    (Just previousAccountId)
+                                OpenAI.getAccessTokenForAccount
+                                    pool
+                                    previousAccountId
+                                    >>= \case
+                                        Left _ ->
+                                            failSwitch
+                                                selectedError
+                                        Right
+                                            ( previousToken
+                                            , restoredId
+                                            ) -> do
+                                                let restoredCredential =
+                                                        Credential
+                                                            { accessToken =
+                                                                previousToken
+                                                            , accountId =
+                                                                restoredId
+                                                            , leaseId =
+                                                                Nothing
+                                                            , provider =
+                                                                OpenAIProvider
+                                                            }
+                                                (withCodexWsCredentialOrHttpFallback
+                                                    restoredCredential
+                                                    \newConn newCredential -> do
+                                                        (newHealthy, _) <-
+                                                            installConnection
+                                                                newCredential
+                                                                newConn
+                                                        releaseLock
+                                                        _ <- tryPutMVar
+                                                            reply
+                                                            (Left selectedError)
+                                                        awaitNext
+                                                            newHealthy)
+                                                    >>= \case
+                                                        Left _ ->
+                                                            failSwitch
+                                                                selectedError
+                                                        Right next ->
+                                                            pure
+                                                                (Just next)
+                    (connectSelected >>= \case
+                        Left selectedError ->
+                            restorePrevious
+                                selectedError
+                        Right next ->
+                            pure (Just next))
+                        `catchAny` \_ ->
+                            failSwitch $
+                                ConnectionError
+                                    "account switch failed"
+    pure
+        OpenAiProviderRuntime
+            { openAiWsLock = wsLock
+            , openAiActiveConnectionRef =
+                activeConnectionRef
+            , openAiHttpFallbackActive =
+                httpFallbackActive
+            , openAiSelectablePool =
+                selectableOpenAiPool
+            , openAiSelectAccount = selectAccount
+            , openAiSwitchLoop = switchLoop
+            }
+
+selectOpenAiAccount
+    :: Chan AccountSwitchRequest
+    -> Pool
+    -> Text
+    -> IO (Either ApiError Text)
+selectOpenAiAccount switchRequests pool selectedAccountId = do
+    _ <- OpenAI.discoverAccounts pool
+    OpenAI.getAccessTokenForAccount pool selectedAccountId >>= \case
+        Left err ->
+            pure (Left err)
+        Right (accessToken, accountId) -> do
+            reply <- newEmptyMVar
+            writeChan switchRequests $
+                AccountSwitchRequest
+                    Credential
+                        { accessToken
+                        , accountId
+                        , leaseId = Nothing
+                        , provider = OpenAIProvider
+                        }
+                    reply
+            takeMVar reply
+
+runConnectedOpenAiProvider
+    :: AgentProviderRequest
+    -> CodexConn
+    -> Credential
+    -> IO RunResult
+runConnectedOpenAiProvider request@AgentProviderRequest{..} conn credential = do
+    OpenAiProviderRuntime
+        { openAiWsLock = wsLock
+        , openAiActiveConnectionRef =
+            activeConnectionRef
+        , openAiHttpFallbackActive =
+            httpFallbackActive
+        , openAiSelectablePool =
+            selectableOpenAiPool
+        , openAiSelectAccount = selectAccount
+        , openAiSwitchLoop = switchLoop
+        } <- newOpenAiProviderRuntime
+            request
+            conn
+            credential
+    case multiCtx of
+        Just ctx ->
+            setSubagentRunner ctx.multiRegistry $
+                runCodexSubagent
+                    (isGatewayWebSocketCredential
+                        credential)
+                    subagentRuntime
+                    selectableTokenProvider
+                    ctx.multiSendToRoot
+        Nothing -> pure ()
+    let (compactSender, lockedBackend) =
+            lockedOpenAiSession
+                startup.startupNetworkRecovery
+                (isGatewayWebSocketCredential
+                    credential)
+                options.optCompactThreshold
+                options.optShowRawReasoning
+                wsLock
+                httpFallbackActive
+                tokenProvider
+                activeConnectionRef
+                (readIORef paramsRef)
+                contextTokensRef
+                recordCompactionUsage
+                (decorateCompactOutcomeWithTaskPlan
+                    taskPlan)
+                (\outcome inputs ->
+                    readIORef
+                        automaticCompactionHookRef
+                        >>= \hook ->
+                            hook outcome inputs)
+        noticingBackend =
+            withPendingInputs pendingNotices
+                lockedBackend
+        btwBackend privateParams =
+            freshOpenAiBackend
+                options.optShowRawReasoning
+                tokenProvider
+                (pure privateParams)
+        compactRunner focus =
+            withMVar wsLock \_ -> do
+                OpenAiPersistentConnection
+                    _credential
+                    _connectionHealthy
+                    activeConn <-
+                        readIORef activeConnectionRef
+                historyRef <-
+                    newIORef =<< readLiveTranscript
+                        conversationRef
+                let turnState =
+                        codexConnTurnState activeConn
+                    runCompact =
+                        installLiveCompactOutcome
+                            conversationRef
+                            (Just contextTokensRef)
+                            (\requestedFocus ->
+                                runProviderCompactWith
+                                    (Just compactSender)
+                                    recordCompactionUsage
+                                    provider
+                                    (Just tokenProvider)
+                                    paramsRef
+                                    historyRef
+                                    requestedFocus
+                                    >>= decorateManualCompact request
+                                        (codexEffectiveContextWindowFor
+                                            . (.model)))
+                            focus
+                resetCodexTurnState turnState
+                runCompact `finally`
+                    resetCodexTurnState turnState
+    activeBackend <-
+        prepareTransitionBackend
+            modelSwitchScope home projectRoot
+            transition persist noticingBackend
+    withAsync switchLoop \switchWorker -> do
+        link switchWorker
+        runSession
+            (sessionRequest
+                startupUnavailable
+                (Just tokenProvider)
+                selectableOpenAiPool
+                selectAccount
+                (currentModelContextWindow transportModel)
+                compactRunner)
+            SessionBackend
+                { backend = activeBackend
+                , btwBackend
+                , interruptBackend = pure ()
+                , resetBackendState = do
+                    OpenAiPersistentConnection
+                        _credential
+                        _connectionHealthy
+                        activeConn <-
+                            readIORef activeConnectionRef
+                    resetCodexTurnState
+                        (codexConnTurnState activeConn)
+                }
+
+handleOpenAiProviderResult
+    :: AgentProviderRequest
+    -> NativeRunCapabilities
+    -> Either CodexAuthFailed RunResult
+    -> IO RunResult
+handleOpenAiProviderResult request@AgentProviderRequest{..} nativeCapabilities = \case
+    Left (CodexAuthFailed err) ->
+        case transition of
+            Just active
+                | active.transitionCause == AutomaticFallback ->
+                    pure (RunProviderStartFailed err)
+            _
+                | shouldProbeAtStartup
+                , not (isGatewayLoadedAuth loaded)
+                , isProviderUnavailable err ->
+                    chooseStartupProviderTransition
+                        nativeCapabilities.nativeProviderFallback
+                        catalog
+                        projectRoot
+                        fullscreen
+                        (tokenProviderBillingMode
+                            tokenProvider)
+                        provider
+                        model
+                        unavailableProviders
+                        Nothing
+                        err >>= \case
+                            Just next ->
+                                pure
+                                    (RunSwitchProvider
+                                        next)
+                            Nothing ->
+                                startupFailure request err
+            _ ->
+                startupFailure request err
+    Right result -> pure result

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenRouter.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenRouter.hs
@@ -1,0 +1,165 @@
+module Agent.CLI.Runtime.Orchestration.Providers.OpenRouter
+    ( runOpenRouterProvider
+    ) where
+
+import Agent.CLI.Auth.Types
+    ( LoadedAuth(..)
+    , isGatewayLoadedAuth
+    )
+import Agent.CLI.Compaction
+    ( boundCompletedToolContinuations
+    , installLiveCompactOutcome
+    , runResponsesCompactWithContextWindow
+    )
+import Agent.Connectivity (withConnectionRecoveryOn)
+import Agent.CLI.PendingInputs (withPendingInputs)
+import Agent.CLI.Provider.Switch (prepareTransitionBackend)
+import Agent.CLI.Runtime.Orchestration.Providers.Common
+    ( decorateManualCompact
+    , runSession
+    )
+import Agent.CLI.Runtime.Orchestration.Providers.Types
+    ( AgentProviderRequest(..)
+    )
+import Agent.CLI.Runtime.Types (RunResult)
+import Agent.CLI.Session.History (readLiveTranscript)
+import Agent.CLI.Session.Runtime.Types
+    ( SessionBackend(..)
+    , StartupRuntime(..)
+    )
+import Agent.CLI.Subagents.Runtime (runHttpSubagent)
+import Agent.OpenRouter.LoopBackend (openRouterBackend)
+import Agent.Provider
+    ( Provider(OpenRouterProvider)
+    , runWithTokenProvider
+    )
+import Agent.Responses.GenericBackend (genericResponsesBackendWith)
+import Agent.Responses.Types (ResponseCreateParams(model))
+import Agent.Subagents (setSubagentRunner)
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Data.IORef (newIORef, readIORef)
+import Data.Maybe (fromMaybe)
+import qualified Agent.OpenRouter as OpenRouter
+import qualified Agent.Responses.GenericClient as GenericResponses
+
+runOpenRouterProvider
+    :: AgentProviderRequest
+    -> IO RunResult
+runOpenRouterProvider request@AgentProviderRequest{..} = do
+    let openRouterContextWindow =
+            contextWindowForParams transportModel 1_048_576
+        makeBackend params =
+            case customGenericOptions of
+                Just genericOptions ->
+                    genericResponsesBackendWith
+                        (\responseRequest onEvent ->
+                            GenericResponses.createResponseWithEvents
+                                genericOptions
+                                    { GenericResponses.model =
+                                        transportModel
+                                            (fromMaybe
+                                                model
+                                                responseRequest.model)
+                                    }
+                                responseRequest
+                                onEvent)
+                        params
+                Nothing ->
+                    openRouterBackend openRouterOptions
+                        tokenProvider params
+        protectOverflow occupancy getParams backend =
+            boundCompletedToolContinuations
+                openRouterContextWindow
+                getParams
+                occupancy
+                backend
+    case multiCtx of
+        Just ctx ->
+            setSubagentRunner ctx.multiRegistry $
+                runHttpSubagent
+                    subagentRuntime
+                    dialect
+                    OpenRouterProvider
+                    ctx.multiSendToRoot
+                    (\childParams ->
+                        protectOverflow
+                            contextTokensRef
+                            (pure childParams)
+                            (makeBackend
+                                (pure childParams)))
+        Nothing -> pure ()
+    let backend =
+            withPendingInputs pendingNotices $
+                withConnectionRecoveryOn
+                    startup.startupNetworkRecovery $
+                    protectOverflow
+                        contextTokensRef
+                        (readIORef paramsRef)
+                        (makeBackend
+                            (readIORef paramsRef))
+        btwBackend privateParams =
+            makeBackend
+                (pure privateParams)
+        compactRunner focus = do
+            contextWindow <-
+                currentModelContextWindow transportModel
+            historyRef <-
+                newIORef =<< readLiveTranscript conversationRef
+            installLiveCompactOutcome conversationRef Nothing
+                (\requestedFocus ->
+                    (case customGenericOptions of
+                        Just genericOptions ->
+                            runResponsesCompactWithContextWindow
+                                contextWindow
+                                (\responseRequest ->
+                                    GenericResponses.createResponseWith
+                                        genericOptions
+                                            { GenericResponses.model =
+                                                transportModel
+                                                    (fromMaybe
+                                                        model
+                                                        responseRequest.model)
+                                            }
+                                        responseRequest)
+                                recordCompactionUsage
+                                paramsRef
+                                historyRef
+                        Nothing ->
+                            runResponsesCompactWithContextWindow
+                                contextWindow
+                                (\responseRequest ->
+                                    runWithTokenProvider
+                                        tokenProvider
+                                        \credential ->
+                                            OpenRouter.createResponseWith
+                                                openRouterOptions
+                                                credential
+                                                responseRequest)
+                                recordCompactionUsage
+                                paramsRef
+                                historyRef)
+                        requestedFocus
+                        >>= decorateManualCompact request
+                            openRouterContextWindow)
+                focus
+    activeBackend <-
+        prepareTransitionBackend
+            modelSwitchScope home projectRoot
+            transition persist backend
+    runSession
+        (sessionRequest
+            startupUnavailable
+            (Just tokenProvider)
+            loaded.loadedOpenAiPool
+            (if isGatewayLoadedAuth loaded
+                then Nothing
+                else Just selectHttpAccount)
+            (Just . openRouterContextWindow
+                <$> readIORef paramsRef)
+            compactRunner)
+        SessionBackend
+            { backend = activeBackend
+            , btwBackend
+            , interruptBackend = pure ()
+            , resetBackendState = pure ()
+            }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Types.hs
@@ -1,0 +1,99 @@
+module Agent.CLI.Runtime.Orchestration.Providers.Types
+    ( AgentProviderRequest(..)
+    ) where
+
+import Agent.CLI.Auth.Types (LoadedAuth)
+import Agent.CLI.Compaction
+    ( CompactOutcome
+    , CompactionInstall
+    , OccupancySnapshot
+    )
+import Agent.CLI.GatewayClient (GatewayCredential)
+import Agent.CLI.ModelConfig (ModelCatalog)
+import Agent.CLI.Options (CliOptions)
+import Agent.CLI.PendingInputs (PendingInputs)
+import Agent.CLI.Project (ModelSwitchScope)
+import Agent.CLI.ProviderTransition (ProviderTransition)
+import Agent.CLI.Session.History (LiveConversation)
+import Agent.CLI.Session.Runtime.Types (SessionRequest, StartupRuntime)
+import Agent.CLI.Session.Types (Persistence)
+import Agent.CLI.Subagents.Runtime.Types (SubagentRuntime)
+import Agent.CLI.TUI.App (FullscreenRuntime)
+import Agent.Dialect (Dialect)
+import Agent.Error (ApiError)
+import Agent.Loop (TokenUsage, TurnInput)
+import Agent.OpenAI.Auth (Pool)
+import Agent.OpenRouter.Options (ClientOptions)
+import Agent.Provider (Credential, Provider, TokenProvider)
+import Agent.Responses.Types (ResponseCreateParams)
+import Agent.Tools.MultiAgents (MultiAgentContext)
+import Agent.Tools.TaskPlan (TaskPlanEnv)
+import Control.Concurrent.STM (STM)
+import Data.IORef (IORef)
+import Data.Set (Set)
+import Data.Text (Text)
+import System.IO (Handle)
+import System.OsPath (OsPath)
+import qualified Agent.Responses.GenericClient as GenericResponses
+
+data AgentProviderRequest = AgentProviderRequest
+    { modelSwitchScope :: ModelSwitchScope
+    , loaded :: LoadedAuth
+    , connectedGateway :: Maybe GatewayCredential
+    , sessionRequest
+        :: Maybe (STM ApiError)
+        -> Maybe TokenProvider
+        -> Maybe Pool
+        -> Maybe (Text -> IO (Either ApiError Text))
+        -> IO (Maybe Int)
+        -> (Maybe Text -> IO (Either Text CompactOutcome))
+        -> SessionRequest
+    , activeAccountIdRef :: IORef Text
+    , activeAccountRef :: IORef Text
+    , activeSelectionRef :: IORef Text
+    , catalog :: ModelCatalog
+    , claudeBypassEnabled :: Bool
+    , contextTokensRef :: IORef (Maybe OccupancySnapshot)
+    , contextWindowForParams
+        :: (Text -> Text)
+        -> Int
+        -> ResponseCreateParams
+        -> Int
+    , conversationRef :: IORef LiveConversation
+    , currentModelContextWindow
+        :: (Text -> Text)
+        -> IO (Maybe Int)
+    , customGenericOptions :: Maybe GenericResponses.GenericClientOptions
+    , cwd :: OsPath
+    , dialect :: Dialect
+    , fullscreen :: Maybe FullscreenRuntime
+    , automaticCompactionHookRef
+        :: IORef
+            (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
+    , taskPlan :: Maybe TaskPlanEnv
+    , home :: OsPath
+    , initialPrevious :: Maybe Text
+    , model :: Text
+    , multiCtx :: Maybe MultiAgentContext
+    , openRouterOptions :: ClientOptions
+    , options :: CliOptions
+    , paramsRef :: IORef ResponseCreateParams
+    , pendingNotices :: PendingInputs
+    , persist :: Persistence
+    , preferredOpenAiAccountRef :: IORef (Maybe Text)
+    , projectRoot :: OsPath
+    , provider :: Provider
+    , recordCompactionUsage :: TokenUsage -> IO ()
+    , resolveActiveAccountLabel :: Credential -> IO Text
+    , selectHttpAccount :: Text -> IO (Either ApiError Text)
+    , selectableTokenProvider :: TokenProvider
+    , shouldProbeAtStartup :: Bool
+    , startup :: StartupRuntime
+    , startupUnavailable :: Maybe (STM ApiError)
+    , stderrHandle :: Handle
+    , subagentRuntime :: SubagentRuntime
+    , tokenProvider :: TokenProvider
+    , transition :: Maybe ProviderTransition
+    , transportModel :: Text -> Text
+    , unavailableProviders :: Set Provider
+    }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/XAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/XAI.hs
@@ -1,0 +1,199 @@
+module Agent.CLI.Runtime.Orchestration.Providers.XAI
+    ( runXaiProvider
+    ) where
+
+import Agent.CLI.Auth.Types
+    ( LoadedAuth(..)
+    , isGatewayLoadedAuth
+    )
+import Agent.CLI.Compaction
+    ( autoCompactBackendWith
+    , boundCompletedToolContinuations
+    , installLiveCompactOutcome
+    , runXaiBackendCompactHistoryWithContextWindow
+    , runXaiResponsesCompactWithContextWindow
+    )
+import Agent.Connectivity (withConnectionRecoveryOn)
+import Agent.CLI.Options (CliOptions(..))
+import Agent.CLI.PendingInputs (withPendingInputs)
+import Agent.CLI.Provider.Switch (prepareTransitionBackend)
+import Agent.CLI.Runtime.Orchestration.Providers.Common
+    ( decorateAutomaticCompact
+    , decorateManualCompact
+    , runSession
+    )
+import Agent.CLI.Runtime.Orchestration.Providers.Types
+    ( AgentProviderRequest(..)
+    )
+import Agent.CLI.Runtime.Orchestration.Types
+    ( NativeRunCapabilities(..)
+    )
+import Agent.CLI.Runtime.Types (RunResult)
+import Agent.CLI.Session.History (readLiveTranscript)
+import Agent.CLI.Session.Runtime.Types
+    ( SessionBackend(..)
+    , StartupRuntime(..)
+    )
+import Agent.CLI.Subagents.Runtime (runXaiParentSubagent)
+import Agent.Provider (runWithTokenProvider)
+import Agent.Responses.Types (ResponseCreateParams(model))
+import Agent.Subagents (setSubagentRunner)
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Agent.XAI.LoopBackend (xaiBackendWithClientOptions)
+import Data.IORef (newIORef, readIORef)
+import Data.Maybe (fromMaybe, isJust)
+import qualified Agent.XAI.Client as XAIClient
+import qualified Agent.XAI.Options as XAI
+import qualified Agent.XAI.Request as XAIRequest
+
+runXaiProvider
+    :: AgentProviderRequest
+    -> NativeRunCapabilities
+    -> IO RunResult
+runXaiProvider request@AgentProviderRequest{..} nativeCapabilities = do
+    xaiOptions0 <- XAI.clientOptionsFromEnv
+    let xaiOptions =
+            xaiOptions0
+                { XAI.hostedXSearchEnabled =
+                    nativeCapabilities.nativeProviderHostedTools
+                }
+    let xaiContextWindow =
+            contextWindowForParams
+                (XAIRequest.mapModel xaiOptions)
+                XAI.grokDefaultContextWindow
+        xaiWireModel params =
+            maybe xaiOptions.defaultModel
+                (XAIRequest.mapModel xaiOptions)
+                params.model
+        xaiCompactThresholdFor currentParams =
+            let contextWindow =
+                    xaiContextWindow currentParams
+            in max 1 $
+                min contextWindow $
+                    fromMaybe
+                        (XAI.grokAutoCompactTokenLimit
+                            (xaiWireModel currentParams)
+                            contextWindow)
+                        options.optCompactThreshold
+        xaiOptionsFor currentParams =
+            xaiOptions
+                { XAI.autoCompactTokenLimit =
+                    Just
+                        (xaiCompactThresholdFor
+                            currentParams)
+                }
+        xaiCompactThreshold =
+            xaiCompactThresholdFor
+                <$> readIORef paramsRef
+        protectXaiOverflow occupancy getParams backend =
+            boundCompletedToolContinuations
+                xaiContextWindow
+                getParams
+                occupancy
+                backend
+    case multiCtx of
+        Just ctx ->
+            setSubagentRunner ctx.multiRegistry $
+                runXaiParentSubagent
+                    subagentRuntime
+                    dialect
+                    ctx.multiSendToRoot
+                    xaiContextWindow
+                    xaiCompactThresholdFor
+                    (\childParams ->
+                        xaiBackendWithClientOptions
+                            xaiOptionsFor
+                            tokenProvider
+                            (pure childParams))
+        Nothing -> pure ()
+    let btwBackend privateParams =
+            xaiBackendWithClientOptions
+                xaiOptionsFor
+                tokenProvider
+                (pure privateParams)
+        compactHistory history _inputs = do
+            currentParams <- readIORef paramsRef
+            runXaiBackendCompactHistoryWithContextWindow
+                (xaiContextWindow currentParams)
+                btwBackend
+                recordCompactionUsage
+                currentParams
+                history
+                Nothing
+                >>= decorateAutomaticCompact request
+                    xaiContextWindow
+        -- Reconnection wraps only the continuation. Keeping automatic
+        -- compaction outside it prevents a failed continuation from
+        -- rerunning the summary.
+        requestBackend =
+            withConnectionRecoveryOn
+                startup.startupNetworkRecovery $
+                protectXaiOverflow
+                    contextTokensRef
+                    (readIORef paramsRef)
+                    (xaiBackendWithClientOptions
+                        xaiOptionsFor
+                        tokenProvider
+                        (readIORef paramsRef))
+        compactingBackend =
+            autoCompactBackendWith
+                xaiCompactThreshold
+                compactHistory
+                (\outcome inputs ->
+                    readIORef automaticCompactionHookRef
+                        >>= \hook ->
+                            hook outcome inputs)
+                (readIORef paramsRef)
+                contextTokensRef
+                requestBackend
+        backend =
+            withPendingInputs pendingNotices
+                compactingBackend
+        compactRunner focus = do
+            contextWindow <-
+                currentModelContextWindow
+                    (XAIRequest.mapModel xaiOptions)
+            historyRef <-
+                newIORef =<< readLiveTranscript conversationRef
+            installLiveCompactOutcome
+                conversationRef
+                (Just contextTokensRef)
+                (\requestedFocus ->
+                    runXaiResponsesCompactWithContextWindow
+                        contextWindow
+                        (\compactRequest ->
+                            runWithTokenProvider tokenProvider
+                                \credential ->
+                                    XAIClient.createResponseWith
+                                        (xaiOptionsFor compactRequest)
+                                        credential
+                                        compactRequest)
+                        recordCompactionUsage
+                        paramsRef
+                        historyRef
+                        requestedFocus
+                        >>= decorateManualCompact request
+                            xaiContextWindow)
+                focus
+    activeBackend <-
+        prepareTransitionBackend
+            modelSwitchScope home projectRoot
+            transition persist backend
+    runSession
+        (sessionRequest
+            startupUnavailable
+            (Just tokenProvider)
+            loaded.loadedOpenAiPool
+            (if isGatewayLoadedAuth loaded
+                || isJust customGenericOptions
+                then Nothing
+                else Just selectHttpAccount)
+            (Just . xaiContextWindow
+                <$> readIORef paramsRef)
+            compactRunner)
+        SessionBackend
+            { backend = activeBackend
+            , btwBackend
+            , interruptBackend = pure ()
+            , resetBackendState = pure ()
+            }


### PR DESCRIPTION
## Summary
- keep `runAgentProviders` as a compatibility façade with its existing call shape and dispatch behavior
- move OpenAI, xAI, Gemini, Claude Code, and OpenRouter orchestration into provider-specific modules
- extract the shared request record and common compaction/session helpers into internal modules
- register the new internal modules in `agent-cli.cabal`

The original provider module drops from 1,514 lines to 284 lines; the largest extracted module is the 508-line OpenAI runner.

## Validation
- `printf ':quit\\n' | nix develop -c cabal repl agent-cli:lib:agent-cli` — all 219 modules loaded
- `git diff --check`
- regenerated `agent-cli`'s Cabal expression for comparison; retained the checked-in `package.nix` because the only generated difference removed its documented manual Darwin runtime dependency