### PR TITLE
Cancel CodeMode callbacks concurrently

### DIFF
--- a/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
@@ -60,6 +60,7 @@ import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
     , cancel
+    , mapConcurrently_
     , race
     , waitCatch
     )
@@ -901,8 +902,7 @@ cancelCellCallbacks :: Cell -> IO ()
 cancelCellCallbacks cell = do
     callbacks <- modifyMVar cell.cellCallbacks \current ->
         pure ([], current)
-    mapM_ cancel callbacks
-    mapM_ (void . waitCatch) callbacks
+    mapConcurrently_ cancel callbacks
 
 stopIncomplete
     :: Handle

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -30,9 +30,11 @@ import Control.Concurrent
     , readMVar
     , takeMVar
     , threadDelay
+    , tryPutMVar
     )
 import Control.Concurrent.Async (async, cancel, wait, withAsync)
-import Control.Exception.Safe (bracket, finally)
+import Control.Exception.Safe (bracket, finally, uninterruptibleMask_)
+import Control.Monad (void)
 import Data.Aeson (Value(..))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -155,6 +157,61 @@ spec = describe "code-mode Bun host" do
                 terminateCodeCell host "1" `shouldReturn`
                     Left (CodeModeUnknownCell "1")
         closeCodeModeHost host
+
+    it "cancels concurrent nested tools before waiting for either cleanup" do
+        firstStarted <- newEmptyMVar
+        secondStarted <- newEmptyMVar
+        firstCancelling <- newEmptyMVar
+        secondCancelling <- newEmptyMVar
+        releaseCleanup <- newEmptyMVar
+        let blockedHandler started cancelling =
+                finally
+                    ( putMVar started ()
+                        >> threadDelay maxBound
+                        >> pure (Right Null)
+                    )
+                    ( uninterruptibleMask_ do
+                        putMVar cancelling ()
+                        readMVar releaseCleanup
+                    )
+            handler name _
+                | name == "first" =
+                    blockedHandler firstStarted firstCancelling
+                | name == "second" =
+                    blockedHandler secondStarted secondCancelling
+                | otherwise = pure (Left "unexpected tool call")
+            config = defaultCodeModeConfig
+                "data/code-mode/worker.mjs"
+                handler
+        bracket (newCodeModeHost config) closeCodeModeHost \host ->
+            (do
+                started <- execCodeCell
+                    host
+                    "await Promise.all([tools.first({}), tools.second({})]);"
+                    ["first", "second"]
+                    1
+                started `shouldBe`
+                    Right CodeModeRunning
+                        { cellId = "1"
+                        , cellOutput = emptyContent
+                        }
+                timeout
+                    5000000
+                    (readMVar firstStarted >> readMVar secondStarted)
+                    `shouldReturn` Just ()
+                withAsync (terminateCodeCell host "1") \terminating -> do
+                    cancelled <- timeout
+                        500000
+                        (readMVar firstCancelling >> readMVar secondCancelling)
+                    _ <- tryPutMVar releaseCleanup ()
+                    result <- wait terminating
+                    result `shouldBe`
+                        Right CodeModeTerminated
+                            { cellId = "1"
+                            , cellValue = emptyContent
+                            }
+                    cancelled `shouldBe` Just ())
+                `finally` void (tryPutMVar releaseCleanup ())
 
     it "keeps JavaScript globals isolated when reusing a pooled worker" do
         let config = defaultCodeModeConfig


### PR DESCRIPTION
## Summary
- cancel outstanding nested tool callbacks concurrently when a cell is released or stopped
- rely on the join semantics of `cancel` instead of a redundant serial wait pass
- add a regression proving both callback cleanups begin before either is allowed to finish

## Tests
- focused concurrent-cancellation regression (fails before the source change, passes after)
- CodeMode Bun host tests: 31 examples, 0 failures
- full `agent-core-test`: 533 examples, 4 failures, 8 pending; all CodeMode tests pass

The four full-suite failures are unrelated fixture/environment issues: one ProjectInstructions fixture sees repository-level instructions, and three ListDir fixtures observe empty directory listings.
