### PR TITLE
Cancel SDK control workers concurrently

### DIFF
--- a/packages/claude-agent-sdk-haskell/benchmark/ControlShutdown.hs
+++ b/packages/claude-agent-sdk-haskell/benchmark/ControlShutdown.hs
@@ -1,0 +1,166 @@
+-- | Compare the sequential control-handler shutdown loop against concurrent
+-- bounded cancellation.
+--
+-- Usage:
+-- control-shutdown-bench IMPLEMENTATION WORKERS TIMEOUT_US CLEANUP_US SAMPLES +RTS -T
+module Main (main) where
+
+import Control.Concurrent
+    ( newEmptyMVar
+    , putMVar
+    , takeMVar
+    , threadDelay
+    )
+import Control.Concurrent.Async
+    ( Async
+    , cancel
+    , mapConcurrently_
+    , withAsync
+    )
+import Control.Exception (evaluate)
+import Control.Exception.Safe
+    ( finally
+    , uninterruptibleMask_
+    )
+import Control.Monad (replicateM, void)
+import Data.List (sort)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import System.Timeout (timeout)
+import Text.Printf (printf)
+
+data Implementation
+    = Sequential
+    | Concurrent
+
+data Sample = Sample
+    { wallMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    if enabled
+        then pure ()
+        else die "RTS statistics are disabled; run with +RTS -T"
+    getArgs >>= \case
+        [implementationArg, workersArg, timeoutArg, cleanupArg, samplesArg] -> do
+            implementation <- parseImplementation implementationArg
+            workerCount <- parsePositive "worker count" workersArg
+            timeoutMicros <- parsePositive "timeout" timeoutArg
+            cleanupMicros <- parsePositive "cleanup delay" cleanupArg
+            sampleCount <- parsePositive "sample count" samplesArg
+            samples <-
+                mapM
+                    (const $
+                        runSample
+                            implementation
+                            workerCount
+                            timeoutMicros
+                            cleanupMicros)
+                    [1 .. sampleCount]
+            let result = median samples
+            printf
+                "%s,%d,%d,%d,%.3f,%.3f,%d\n"
+                implementationArg
+                workerCount
+                timeoutMicros
+                cleanupMicros
+                result.wallMillis
+                result.cpuMillis
+                result.allocatedBytes
+        _ ->
+            die $
+                "usage: control-shutdown-bench IMPLEMENTATION WORKERS "
+                    <> "TIMEOUT_US CLEANUP_US SAMPLES\n"
+                    <> "implementations: sequential, concurrent"
+
+parseImplementation :: String -> IO Implementation
+parseImplementation = \case
+    "sequential" -> pure Sequential
+    "concurrent" -> pure Concurrent
+    other -> die ("unknown implementation: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")]
+            | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)
+
+runSample :: Implementation -> Int -> Int -> Int -> IO Sample
+runSample implementation workerCount timeoutMicros cleanupMicros = do
+    started <- replicateM workerCount newEmptyMVar
+    let workerBody ready =
+            (putMVar ready () >> threadDelay maxBound)
+                `finally`
+                    uninterruptibleMask_ (threadDelay cleanupMicros)
+    withWorkers (map workerBody started) \workers -> do
+        mapM_ takeMVar started
+        measure do
+            case implementation of
+                Sequential ->
+                    mapM_ (cancelOnlyWithin timeoutMicros) workers
+                Concurrent ->
+                    mapConcurrently_
+                        (cancelOnlyWithin timeoutMicros)
+                        workers
+            pure (length workers)
+
+withWorkers :: [IO ()] -> ([Async ()] -> IO a) -> IO a
+withWorkers actions use = go actions []
+  where
+    go [] workers =
+        use (reverse workers)
+    go (action : remaining) workers =
+        withAsync action \worker ->
+            go remaining (worker : workers)
+
+cancelOnlyWithin :: Int -> Async a -> IO ()
+cancelOnlyWithin timeoutMicros worker =
+    void $ timeout timeoutMicros (cancel worker)
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCPU <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    result <- action
+    _ <- evaluate result
+    afterWall <- getMonotonicTimeNSec
+    afterCPU <- getCPUTime
+    performGC
+    afterStats <- getRTSStats
+    pure
+        Sample
+            { wallMillis =
+                fromIntegral (afterWall - beforeWall) / 1_000_000
+            , cpuMillis =
+                fromIntegral (afterCPU - beforeCPU) / 1_000_000_000
+            , allocatedBytes =
+                fromIntegral
+                    ( afterStats.allocated_bytes
+                        - beforeStats.allocated_bytes
+                    )
+            }
+
+median :: [Sample] -> Sample
+median samples =
+    Sample
+        { wallMillis = middle (sort (map (.wallMillis) samples))
+        , cpuMillis = middle (sort (map (.cpuMillis) samples))
+        , allocatedBytes = middle (sort (map (.allocatedBytes) samples))
+        }
+  where
+    middle values = values !! (length values `div` 2)

--- a/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
+++ b/packages/claude-agent-sdk-haskell/claude-agent-sdk-haskell.cabal
@@ -83,6 +83,16 @@ benchmark output-buffer-bench
                     , bytestring
                     , safe-exceptions
 
+benchmark control-shutdown-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          ControlShutdown.hs
+    ghc-options:      -O2 -threaded -rtsopts
+    build-depends:    base >= 4.17 && < 5
+                    , async
+                    , safe-exceptions
+
 test-suite claude-agent-sdk-haskell-test
     import:           common-opts
     type:             exitcode-stdio-1.0

--- a/packages/claude-agent-sdk-haskell/package.nix
+++ b/packages/claude-agent-sdk-haskell/package.nix
@@ -16,7 +16,9 @@ mkDerivation {
     aeson agent-json async base bytestring containers directory
     filepath hspec safe-exceptions text unix
   ];
-  benchmarkHaskellDepends = [ base bytestring safe-exceptions ];
+  benchmarkHaskellDepends = [
+    async base bytestring safe-exceptions
+  ];
   description = "Haskell SDK for the Claude Agent SDK stream protocol";
   license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/ControlRuntime.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/ControlRuntime.hs
@@ -17,7 +17,7 @@ import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
     , cancel
-    , waitCatch
+    , mapConcurrently_
     )
 import Control.Concurrent.Chan
     ( Chan
@@ -535,19 +535,16 @@ stopCore core reader = do
             (True, stopped)
     unless alreadyStopped do
         workers <- readMVar core.coreWorkers
-        forM_ (Map.elems workers) \worker ->
-            void $
-                timeout
-                    core.coreHandlers.shutdownTimeoutMicros
-                    (cancel worker)
+        let cancelWithinTimeout worker =
+                void $
+                    timeout
+                        core.coreHandlers.shutdownTimeoutMicros
+                        (cancel worker)
+        mapConcurrently_ cancelWithinTimeout (Map.elems workers)
         void $
             timeout
                 core.coreHandlers.shutdownTimeoutMicros
                 (cancel reader)
-        void $
-            timeout
-                core.coreHandlers.shutdownTimeoutMicros
-                (waitCatch reader)
 
 controlException :: SomeException -> ClaudeSDKError
 controlException exception =

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/ControlRuntime.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/ControlRuntime.hs
@@ -18,6 +18,7 @@ import Control.Concurrent.Async
     , asyncWithUnmask
     , cancel
     , mapConcurrently_
+    , waitCatch
     )
 import Control.Concurrent.Chan
     ( Chan
@@ -545,6 +546,10 @@ stopCore core reader = do
             timeout
                 core.coreHandlers.shutdownTimeoutMicros
                 (cancel reader)
+        void $
+            timeout
+                core.coreHandlers.shutdownTimeoutMicros
+                (waitCatch reader)
 
 controlException :: SomeException -> ClaudeSDKError
 controlException exception =

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ControlSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ControlSpec.hs
@@ -25,6 +25,7 @@ import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as LazyByteString
 import Data.IORef
     ( IORef
+    , atomicModifyIORef'
     , modifyIORef'
     , newIORef
     , readIORef
@@ -485,6 +486,57 @@ spec = describe "Claude SDK control protocol" do
                         pure ()
                 result `shouldBe` Just (Right ())
         takeMVar endInputObservedClosed `shouldReturn` False
+
+    it "joins reader cleanup past the shutdown timeout before transport close" do
+        factory <-
+            fakeTransportFactory \emit value ->
+                case request value of
+                    Just (requestId, "initialize", _) ->
+                        emit (successResponse requestId (Aeson.object []))
+                    _ -> pure ()
+        secondReadStarted <- newEmptyMVar
+        never <- newEmptyMVar
+        readerCleanupFinished <- newIORef False
+        closeSawFinishedCleanup <- newIORef False
+        let slowReaderFactory requestInfo = do
+                transport <- factory.transportFactory requestInfo
+                readCount <- newIORef (0 :: Int)
+                pure transport
+                    { transportRead = do
+                        current <-
+                            atomicModifyIORef' readCount \count ->
+                                (count + 1, count)
+                        if current == 0
+                            then transport.transportRead
+                            else
+                                finally
+                                    ( putMVar secondReadStarted ()
+                                        >> takeMVar never
+                                    )
+                                    ( uninterruptibleMask_ do
+                                        threadDelay 30_000
+                                        writeIORef readerCleanupFinished True
+                                    )
+                    , transportClose = do
+                        readIORef readerCleanupFinished
+                            >>= writeIORef closeSawFinishedCleanup
+                        transport.transportClose
+                    }
+            handlers =
+                defaultClaudeAgentHandlers
+                    { shutdownTimeoutMicros = 20_000
+                    }
+        result <-
+            withClaudeSDKClientWithTransportAndHandlers
+                testOptions
+                slowReaderFactory
+                handlers
+                \client ->
+                    withTurn client \_ -> do
+                        readMVar secondReadStarted
+                        pure (Right ((), pure ()))
+        result `shouldBe` Right ()
+        readIORef closeSawFinishedCleanup `shouldReturn` True
 
 permissionRequest :: Text -> Text -> Aeson.Value
 permissionRequest requestId toolName =

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ControlSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/ControlSpec.hs
@@ -2,19 +2,22 @@ module Claude.Agent.SDK.ControlSpec (spec) where
 
 import Claude.Agent.SDK
 import Control.Concurrent
-    ( forkIO
+    ( forkFinally
+    , forkIO
     , newChan
     , newEmptyMVar
     , newMVar
     , putMVar
     , readChan
+    , readMVar
     , takeMVar
     , threadDelay
+    , tryPutMVar
     , withMVar
     , writeChan
     )
 import Control.Concurrent.Async (wait, withAsync)
-import Control.Exception.Safe (finally)
+import Control.Exception.Safe (finally, uninterruptibleMask_)
 import Control.Monad (void)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -235,6 +238,82 @@ spec = describe "Claude SDK control protocol" do
         mapMaybeResponseId writes
             `shouldNotContain` ["cancel-me"]
 
+    it "cancels in-flight control handlers concurrently during shutdown" do
+        firstStarted <- newEmptyMVar
+        secondStarted <- newEmptyMVar
+        firstCancelling <- newEmptyMVar
+        secondCancelling <- newEmptyMVar
+        releaseCleanup <- newEmptyMVar
+        factory <-
+            fakeTransportFactory \emit value ->
+                case request value of
+                    Just (requestId, "initialize", _) -> do
+                        emit (successResponse requestId (Aeson.object []))
+                        emit (permissionRequest "first" "First")
+                        emit (permissionRequest "second" "Second")
+                    _ -> pure ()
+        let blockedHandler started cancelling =
+                finally
+                    ( putMVar started ()
+                        >> threadDelay maxBound
+                        >> pure (ToolPermissionAllow Nothing [])
+                    )
+                    ( uninterruptibleMask_ do
+                        putMVar cancelling ()
+                        readMVar releaseCleanup
+                    )
+            handlers =
+                defaultClaudeAgentHandlers
+                    { canUseTool =
+                        Just \permission ->
+                            case permission.toolName of
+                                "First" ->
+                                    blockedHandler
+                                        firstStarted
+                                        firstCancelling
+                                "Second" ->
+                                    blockedHandler
+                                        secondStarted
+                                        secondCancelling
+                                other ->
+                                    expectationFailure
+                                        ("unexpected tool: " <> show other)
+                                        >> pure
+                                            (ToolPermissionAllow Nothing [])
+                    , shutdownTimeoutMicros = 1_000_000
+                    }
+            runClient =
+                withClaudeSDKClientWithTransportAndHandlers
+                    testOptions
+                    factory.transportFactory
+                    handlers
+                    \client ->
+                        withTurn client \_ -> do
+                            readMVar firstStarted
+                            readMVar secondStarted
+                            pure (Right ((), pure ()))
+        (do
+            finished <- newEmptyMVar
+            void $ forkFinally runClient (putMVar finished)
+            cancelled <-
+                timeout
+                    500_000
+                    ( readMVar firstCancelling
+                        >> readMVar secondCancelling
+                    )
+            _ <- tryPutMVar releaseCleanup ()
+            outcome <- timeout 5_000_000 (takeMVar finished)
+            case outcome of
+                Just (Right result) ->
+                    result `shouldBe` Right ()
+                Just (Left exception) ->
+                    expectationFailure
+                        ("client failed: " <> show exception)
+                Nothing ->
+                    expectationFailure "client did not shut down"
+            cancelled `shouldBe` Just ())
+            `finally` void (tryPutMVar releaseCleanup ())
+
     it "fails closed for unknown inbound control requests" do
         responseSeen <- newEmptyMVar
         factory <-
@@ -406,6 +485,18 @@ spec = describe "Claude SDK control protocol" do
                         pure ()
                 result `shouldBe` Just (Right ())
         takeMVar endInputObservedClosed `shouldReturn` False
+
+permissionRequest :: Text -> Text -> Aeson.Value
+permissionRequest requestId toolName =
+    Aeson.object
+        [ "type" Aeson..= ("control_request" :: Text)
+        , "request_id" Aeson..= requestId
+        , "request" Aeson..= Aeson.object
+            [ "subtype" Aeson..= ("can_use_tool" :: Text)
+            , "tool_name" Aeson..= toolName
+            , "input" Aeson..= Aeson.object []
+            ]
+        ]
 
 data FakeTransport = FakeTransport
     { transportFactory :: !TransportFactory


### PR DESCRIPTION
## Summary
- cancel in-flight SDK control-handler workers concurrently during runtime shutdown
- keep the existing per-handler timeout while avoiding one timeout window per worker
- retain the reader's separate bounded cancellation and bounded `waitCatch` phases, so cleanup that outlasts cancellation's first timeout gets another bounded join opportunity before transport close
- add regressions for concurrent handler cleanup and reader cleanup that completes between the two reader shutdown intervals
- retain an optimized old/new shutdown benchmark in the package

## Tests
- focused reader-cleanup regression: 1 example, 0 failures
- full `claude-agent-sdk-haskell-test`: 102 examples, 0 failures
- `nix build .#claude-agent-sdk-haskell --no-link`: success
- `git diff --check`: success

## Benchmark
`control-shutdown-bench` is committed with `-O2 -threaded -rtsopts`. It runs the old sequential loop and new concurrent loop against the identical per-handler operation, `timeout timeoutMicros (cancel worker)`.

Environment: aarch64 macOS, GHC 9.10.3, Nix dev shell. Each row is the median of 9 samples with `+RTS -T`, a 20,000 µs cancellation timeout, and 60,000 µs masked worker cleanup.

| implementation | workers | wall (ms) | CPU (ms) | allocated bytes |
|---|---:|---:|---:|---:|
| sequential | 1 | 21.060 | 0.089 | 11,416 |
| concurrent | 1 | 21.065 | 0.114 | 18,600 |
| sequential | 4 | 83.284 | 0.412 | 31,656 |
| concurrent | 4 | 21.115 | 0.141 | 37,040 |
| sequential | 16 | 334.695 | 1.707 | 94,448 |
| concurrent | 16 | 21.092 | 0.162 | 130,728 |

A repeated 16-worker run measured 334.106 ms / 1.591 ms CPU / 94,360 B sequentially and 20.586 ms / 0.163 ms CPU / 130,728 B concurrently. The benefit is specifically multi-handler shutdown latency; one-worker latency is unchanged, and concurrency uses more allocation.
