### PR TITLE
Fix stale Codex rate-limit test expectation

### DIFF
--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1383,10 +1383,6 @@ spec = do
             reverse <$> readIORef events `shouldReturn`
                 [ WarningRaised
                     "Codex usage is low: primary 8% left. Check /usage for reset details."
-                , ProviderLimitUpdated
-                    { providerLimitText = "5h limit left: 8%"
-                    , providerLimitWarning = True
-                    }
                 ]
             readIORef healthy `shouldReturn` False
             readIORef freshCalls `shouldReturn` 1


### PR DESCRIPTION
## Summary
- update the OpenAI reconnect test for the rate-limit event ownership change merged in #986
- keep asserting that informational rate-limit warnings do not block safe replay
- stop expecting `ProviderLimitUpdated` from streamed Codex events now that prompt-limit status is fetched through the organization gateway

This is the inherited failure seen in the CLI package check on #996; the provider-module split itself does not touch this path.

## Validation
- `printf ':main --match \"/openAiBackendWithConnectionRecovery/still replays after an informational Codex rate-limit warning/\"\\n:quit\\n' | nix develop -c cabal repl agent-openai:test:agent-openai-test`
- 1 example, 0 failures
- `git diff --check`