### PR TITLE
Update Codex rate-limit event expectation

### DIFF
--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec.hs
@@ -1383,10 +1383,6 @@ spec = do
             reverse <$> readIORef events `shouldReturn`
                 [ WarningRaised
                     "Codex usage is low: primary 8% left. Check /usage for reset details."
-                , ProviderLimitUpdated
-                    { providerLimitText = "5h limit left: 8%"
-                    , providerLimitWarning = True
-                    }
                 ]
             readIORef healthy `shouldReturn` False
             readIORef freshCalls `shouldReturn` 1


### PR DESCRIPTION
## Summary
- align the OpenAI connection-recovery test with #986's intentional removal of streamed `ProviderLimitUpdated` events
- continue asserting that the informational low-usage warning is delivered before a replay

This stale downstream assertion was exposed by the post-merge CI run for #996.

## Validation
- `printf ':main --match "/openAiBackendWithConnectionRecovery/still replays after an informational Codex rate-limit warning/"\\n:quit\\n' | nix develop -c cabal repl agent-openai:test:agent-openai-test` — 1 example, 0 failures
- `git diff --check`