### PR TITLE
fix(repository): remove unowned confirmation reaper

### DIFF
--- a/packages/agent-repository/agent-repository.cabal
+++ b/packages/agent-repository/agent-repository.cabal
@@ -39,6 +39,7 @@ library
     hs-source-dirs:   src
     other-modules:    Agent.CLI.ProcessSecurity
     exposed-modules:  Agent.CLI.RepositoryDelivery
+                    , Agent.CLI.RepositoryDelivery.ConfirmationStore
                     , Agent.CLI.RepositoryReview
     build-depends:    aeson >= 2.0
                     , async

--- a/packages/agent-repository/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryDelivery.hs
@@ -13,14 +13,15 @@ module Agent.CLI.RepositoryDelivery
     , validateRemoteName
     ) where
 
+import Agent.CLI.RepositoryDelivery.ConfirmationStore
+    ( ConfirmationStore
+    , insertConfirmation
+    , newConfirmationStore
+    , takeConfirmation
+    )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (cancel, wait, withAsync)
 import Control.Applicative ((<|>))
-import Control.Concurrent.MVar
-    ( MVar
-    , modifyMVar
-    , newMVar
-    )
 import Control.Exception.Safe
     ( SomeException
     , bracket
@@ -49,8 +50,6 @@ import Data.IORef
     , readIORef
     , writeIORef
     )
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -197,7 +196,6 @@ instance Eq ValidatedRemote where
 
 data StoredConfirmation = StoredConfirmation
     { storedRoot :: !FilePath
-    , storedDeadlineNanos :: !Word64
     , storedConfirmation :: !Confirmation
     }
 
@@ -1427,25 +1425,16 @@ storeConfirmation root confirmation = do
     token <- randomToken
     let expiresAt = wallNow + confirmationLifetimeSeconds
         deadline = saturatingAdd monotonicNow confirmationLifetimeNanos
-    stored <- modifyMVar deliveryConfirmations \confirmations ->
-        let active = Map.filter
-                (\entry -> entry.storedDeadlineNanos > monotonicNow)
-                confirmations
-        in if Map.size active >= maxActiveConfirmations
-            || Map.member token active
-            then pure (active, False)
-            else
-                pure
-                    ( Map.insert
-                        token
-                        StoredConfirmation
-                            { storedRoot = root
-                            , storedDeadlineNanos = deadline
-                            , storedConfirmation = confirmation
-                            }
-                        active
-                    , True
-                    )
+    stored <-
+        insertConfirmation
+            deliveryConfirmations
+            maxActiveConfirmations
+            token
+            deadline
+            StoredConfirmation
+                { storedRoot = root
+                , storedConfirmation = confirmation
+                }
     unless stored (fail "repository delivery confirmation capacity exhausted")
     pure (token, expiresAt)
 
@@ -1475,34 +1464,27 @@ consumeConfirmation requested token
                             "repository state could not be verified"))
             Just (Right snapshot) -> do
                 monotonicNow <- getMonotonicTimeNSec
-                modifyMVar deliveryConfirmations \confirmations ->
-                    let pruned = Map.filter
-                            (\stored ->
-                                stored.storedDeadlineNanos > monotonicNow)
-                            confirmations
-                    in case Map.lookup token pruned of
+                takeConfirmation
+                    deliveryConfirmations
+                    token
+                    monotonicNow >>= \case
                         Nothing ->
                             pure
-                                ( pruned
-                                , Left
+                                (Left
                                     (DeliveryConfirmationRejected
                                         "confirmation token expired or was already used")
                                 )
                         Just stored ->
-                            let remaining = Map.delete token pruned
-                            in if stored.storedRoot /= snapshot.snapshotRoot
+                            if stored.storedRoot /= snapshot.snapshotRoot
                                 then
                                     pure
-                                        ( remaining
-                                        , Left
+                                        (Left
                                             (DeliveryConfirmationRejected
                                                 "confirmation token belongs to another repository")
                                         )
                                 else
                                     pure
-                                        ( remaining
-                                        , Right stored.storedConfirmation
-                                        )
+                                        (Right stored.storedConfirmation)
 
 randomToken :: IO Text
 randomToken =
@@ -2299,5 +2281,5 @@ maxActiveConfirmations :: Int
 maxActiveConfirmations = 1024
 
 {-# NOINLINE deliveryConfirmations #-}
-deliveryConfirmations :: MVar (Map Text StoredConfirmation)
-deliveryConfirmations = unsafePerformIO (newMVar Map.empty)
+deliveryConfirmations :: ConfirmationStore StoredConfirmation
+deliveryConfirmations = unsafePerformIO newConfirmationStore

--- a/packages/agent-repository/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryDelivery.hs
@@ -13,13 +13,12 @@ module Agent.CLI.RepositoryDelivery
     , validateRemoteName
     ) where
 
-import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (cancel, wait, withAsync)
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
-    , modifyMVar_
     , newMVar
     )
 import Control.Exception.Safe
@@ -32,7 +31,7 @@ import Control.Exception.Safe
     , throwIO
     , tryAny
     )
-import Control.Monad (forever, unless, when)
+import Control.Monad (unless, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except
     ( ExceptT(..)
@@ -2301,12 +2300,4 @@ maxActiveConfirmations = 1024
 
 {-# NOINLINE deliveryConfirmations #-}
 deliveryConfirmations :: MVar (Map Text StoredConfirmation)
-deliveryConfirmations = unsafePerformIO do
-    confirmations <- newMVar Map.empty
-    _ <- forkIO $ forever do
-        threadDelay 60_000_000
-        monotonicNow <- getMonotonicTimeNSec
-        modifyMVar_ confirmations
-            (pure . Map.filter
-                (\stored -> stored.storedDeadlineNanos > monotonicNow))
-    pure confirmations
+deliveryConfirmations = unsafePerformIO (newMVar Map.empty)

--- a/packages/agent-repository/src/Agent/CLI/RepositoryDelivery/ConfirmationStore.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryDelivery/ConfirmationStore.hs
@@ -1,0 +1,177 @@
+module Agent.CLI.RepositoryDelivery.ConfirmationStore
+    ( ConfirmationStore
+    , closeConfirmationStore
+    , confirmationCount
+    , insertConfirmation
+    , newConfirmationStore
+    , newConfirmationStoreWithExpiryWait
+    , takeConfirmation
+    ) where
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async
+    ( Async
+    , asyncWithUnmask
+    , cancel
+    )
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newEmptyMVar
+    , newMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    )
+import Control.Exception.Safe
+    ( bracket
+    , bracketOnError
+    , finally
+    )
+import Control.Monad (when)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import Data.Unique (Unique, newUnique)
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
+
+data ConfirmationStore value = ConfirmationStore
+    { confirmationEntries :: !(MVar (Map.Map Text (ConfirmationEntry value)))
+    , confirmationWaitUntil :: !(Word64 -> IO ())
+    }
+
+data ConfirmationEntry value = ConfirmationEntry
+    { confirmationDeadline :: !Word64
+    , confirmationValue :: !value
+    , confirmationExpiryOwner :: !Unique
+    , confirmationExpiryWorker :: !(Async ())
+    }
+
+newConfirmationStore :: IO (ConfirmationStore value)
+newConfirmationStore =
+    newConfirmationStoreWithExpiryWait waitUntil
+
+-- | The injectable wait keeps expiry behavior deterministic in tests. Production
+-- callers should use 'newConfirmationStore'.
+newConfirmationStoreWithExpiryWait
+    :: (Word64 -> IO ())
+    -> IO (ConfirmationStore value)
+newConfirmationStoreWithExpiryWait confirmationWaitUntil = do
+    confirmationEntries <- newMVar Map.empty
+    pure ConfirmationStore{..}
+
+insertConfirmation
+    :: ConfirmationStore value
+    -> Int
+    -> Text
+    -> Word64
+    -> value
+    -> IO Bool
+insertConfirmation store capacity token deadline value = do
+    published <- newEmptyMVar
+    owner <- newUnique
+    bracketOnError
+        (asyncWithUnmask \restore ->
+            restore do
+                takeMVar published
+                store.confirmationWaitUntil deadline
+                removeOwned store token owner)
+        (\worker ->
+            removeOwned store token owner
+                `finally` cancel worker)
+        (\worker -> do
+            monotonicNow <- getMonotonicTimeNSec
+            (inserted, expired) <-
+                modifyMVar store.confirmationEntries \entries ->
+                    let (active, expiredEntries) =
+                            Map.partition
+                                (\entry ->
+                                    entry.confirmationDeadline > monotonicNow)
+                                entries
+                    in if Map.size active >= capacity
+                        || Map.member token active
+                        then
+                            pure
+                                ( active
+                                , (False, Map.elems expiredEntries)
+                                )
+                        else
+                            pure
+                                ( Map.insert
+                                    token
+                                    ConfirmationEntry
+                                        { confirmationDeadline = deadline
+                                        , confirmationValue = value
+                                        , confirmationExpiryOwner = owner
+                                        , confirmationExpiryWorker = worker
+                                        }
+                                    active
+                                , (True, Map.elems expiredEntries)
+                                )
+            mapM_
+                (cancel . (.confirmationExpiryWorker))
+                expired
+            if inserted
+                then putMVar published ()
+                else cancel worker
+            pure inserted)
+
+takeConfirmation
+    :: ConfirmationStore value
+    -> Text
+    -> Word64
+    -> IO (Maybe value)
+takeConfirmation store token monotonicNow =
+    bracket
+        (modifyMVar store.confirmationEntries \entries ->
+            let (entry, remaining) = Map.updateLookupWithKey
+                    (\_ _ -> Nothing)
+                    token
+                    entries
+            in pure (remaining, entry))
+        (mapM_ (\entry -> cancel entry.confirmationExpiryWorker))
+        (\case
+            Just entry
+                | entry.confirmationDeadline > monotonicNow ->
+                    pure (Just entry.confirmationValue)
+            _ -> pure Nothing)
+
+confirmationCount :: ConfirmationStore value -> IO Int
+confirmationCount store =
+    Map.size <$> readMVar store.confirmationEntries
+
+closeConfirmationStore :: ConfirmationStore value -> IO ()
+closeConfirmationStore store = do
+    entries <-
+        modifyMVar store.confirmationEntries \active ->
+            pure (Map.empty, Map.elems active)
+    mapM_ (cancel . (.confirmationExpiryWorker)) entries
+
+removeOwned
+    :: ConfirmationStore value
+    -> Text
+    -> Unique
+    -> IO ()
+removeOwned store token owner =
+    modifyMVar_ store.confirmationEntries $
+        pure . Map.update removeIfOwned token
+  where
+    removeIfOwned entry
+        | entry.confirmationExpiryOwner == owner = Nothing
+        | otherwise = Just entry
+
+waitUntil :: Word64 -> IO ()
+waitUntil deadline = do
+    monotonicNow <- getMonotonicTimeNSec
+    when (monotonicNow < deadline) do
+        threadDelay (boundedMicros (deadline - monotonicNow))
+        waitUntil deadline
+
+boundedMicros :: Word64 -> Int
+boundedMicros nanos =
+    fromIntegral (min micros (fromIntegral (maxBound :: Int)))
+  where
+    micros =
+        nanos `div` 1_000
+            + if nanos `mod` 1_000 == 0 then 0 else 1

--- a/packages/agent-repository/test/Agent/CLI/RepositoryDeliverySpec.hs
+++ b/packages/agent-repository/test/Agent/CLI/RepositoryDeliverySpec.hs
@@ -1,12 +1,24 @@
 module Agent.CLI.RepositoryDeliverySpec (spec) where
 
 import Agent.CLI.RepositoryDelivery
+import Agent.CLI.RepositoryDelivery.ConfirmationStore
+    ( ConfirmationStore
+    , closeConfirmationStore
+    , confirmationCount
+    , insertConfirmation
+    , newConfirmationStoreWithExpiryWait
+    )
 import Agent.CLI.RepositoryReview
     ( RepositorySnapshot(..)
     , repositorySnapshot
     )
 import System.Timeout (timeout)
-import Control.Concurrent (threadDelay)
+import Control.Concurrent
+    ( newEmptyMVar
+    , putMVar
+    , takeMVar
+    , threadDelay
+    )
 import Control.Exception.Safe (bracket)
 import qualified Data.Text as Text
 import System.Directory
@@ -37,6 +49,26 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "repository delivery service" do
+    it "reclaims expired confirmation payloads while idle" do
+        expiry <- newEmptyMVar
+        bracket
+            (newConfirmationStoreWithExpiryWait
+                (\_ -> takeMVar expiry))
+            closeConfirmationStore
+            \store -> do
+                insertConfirmation
+                    store
+                    1
+                    "idle-expiry"
+                    maxBound
+                    (Text.replicate (1024 * 1024) "x")
+                    `shouldReturn` True
+                confirmationCount store `shouldReturn` 1
+
+                putMVar expiry ()
+                timeout 1_000_000 (awaitEmpty store)
+                    `shouldReturn` Just ()
+
     it "validates branch and remote names without option/ref injection" do
         validateBranchName "feature/safe-name" `shouldBe` True
         validateBranchName "-force" `shouldBe` False
@@ -702,6 +734,12 @@ withTempDirectory template action = do
             pure path)
         removePathForcibly
         action
+
+awaitEmpty :: ConfirmationStore value -> IO ()
+awaitEmpty store =
+    confirmationCount store >>= \case
+        0 -> pure ()
+        _ -> threadDelay 1_000 >> awaitEmpty store
 
 withFakeGh
     :: FilePath


### PR DESCRIPTION
## Summary
- replace the unowned process-lifetime reaper with a confirmation store whose per-entry expiry workers are retained by their entries
- publish expiry workers only after atomic insertion and guard deletion with per-entry `Unique` owners
- cancel and join workers on consume, pruning, failure, capacity rejection, and explicit store close
- reclaim expired confirmation payloads at their deadline even when repository delivery is otherwise idle
- add a deterministic 1 MiB idle-expiry regression with exception-safe store cleanup

## Why
Demand-only pruning could retain up to 1,024 expired 1 MiB PR bodies while idle. Entries now release payloads at expiry without restoring the unowned periodic reaper.

## Tests
- object-code GHCi focused idle-expiry regression (1 example, 0 failures)
- `cabal test agent-cli-test --test-options='--match "repository delivery service"' --test-show-details=direct` (28 examples, 0 failures)
- post-cleanup focused Cabal regression (1 example, 0 failures)
- `git diff --check`