### PR TITLE
fix(render): own and join spinner worker

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -147,9 +147,10 @@ import Agent.TextBuffer
     )
 import Agent.Telemetry (telemetrySummary)
 import Control.Applicative ((<|>))
-import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (Async, asyncWithUnmask, cancel)
 import Control.Concurrent.MVar (MVar, withMVar)
-import Control.Exception.Safe (tryIO)
+import Control.Exception.Safe (mask_, tryIO)
 import Control.Monad (forM_, unless, void, when)
 import Data.IORef
 import qualified Data.Map.Strict as Map
@@ -185,7 +186,7 @@ summarizeToolCallRelative workspace call =
 
 data RenderConfig = RenderConfig
     { renderShowThinking :: !Bool
-    , renderThinkingSpinner :: !(IORef (Maybe ThreadId))
+    , renderThinkingSpinner :: !(IORef (Maybe (Async ())))
     , renderState :: !(IORef RenderState)
     , renderColor :: !Bool
     , renderLock :: !(MVar ())
@@ -699,17 +700,19 @@ startThinkingSpinnerUnlocked config
                     (state{stateThinkingVisible = True}, ())
                 paintThinkingFrame config
                 started <- getMonotonicTimeNSec
-                tid <- forkIO (spinnerLoop config started 0)
-                writeIORef config.renderThinkingSpinner (Just tid)
+                mask_ do
+                    worker <- asyncWithUnmask \unmask ->
+                        unmask (spinnerLoop config started 0)
+                    writeIORef config.renderThinkingSpinner (Just worker)
 
 -- | Stop the spinner and erase its in-place status line. Does not commit a
 -- reasoning block; callers that need that use 'commitThinkingUnlocked'.
 stopThinkingSpinnerUnlocked :: RenderConfig -> IO ()
 stopThinkingSpinnerUnlocked config = do
-    mtid <- atomicModifyIORef' config.renderThinkingSpinner \mt -> (Nothing, mt)
-    case mtid of
-        Just tid -> killThread tid
-        Nothing -> pure ()
+    mworker <-
+        atomicModifyIORef' config.renderThinkingSpinner \worker ->
+            (Nothing, worker)
+    forM_ mworker cancel
     visible <- (.stateThinkingVisible) <$> readRenderState config
     when visible do
         void $ tryIO do

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -101,8 +101,7 @@ import Agent.Tools.MultiAgents
 import Agent.Tools.PlanMode
 import Agent.Tools.Types
 import Agent.OsPath
-import Control.Concurrent (ThreadId)
-import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.Async (Async, withAsync)
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Concurrent.STM (STM)
@@ -306,7 +305,7 @@ withSessionTitleRuntime host SessionRequest{..} SessionBackend{..} =
 data SessionControlRuntime = SessionControlRuntime
     { controlToolRegistry :: !ToolRegistry
     , controlSteeringInputs :: !SteeringInputs
-    , controlSpinnerRef :: !(IORef (Maybe ThreadId))
+    , controlSpinnerRef :: !(IORef (Maybe (Async ())))
     , controlRenderStateRef :: !(IORef RenderState)
     , controlAllowedToolsRef :: !(IORef (Set.Set Text.Text))
     , controlLastAssistantRef :: !(IORef (Maybe Text.Text))

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -36,6 +36,7 @@ import Agent.TextBuffer
 import Agent.Telemetry (TurnTelemetry(..))
 import Agent.TUI.Motion (MotionMode(..), foregroundIndicator)
 import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.Async (asyncThreadId, poll)
 import Control.Concurrent.MVar (newEmptyMVar, newMVar, putMVar, takeMVar)
 import Control.Exception (finally)
 import Control.Monad (forM_)
@@ -44,7 +45,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Time.Calendar (fromGregorian)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Time.Clock (UTCTime(..), addUTCTime, diffUTCTime, getCurrentTime)
 import System.Directory (getTemporaryDirectory, removeFile)
 import System.IO (BufferMode(..), Handle, hClose, hSetBuffering, openTempFile)
@@ -660,7 +661,21 @@ spec = do
                 first <- readIORef config.renderThinkingSpinner
                 renderEvent config TurnStarted
                 second <- readIORef config.renderThinkingSpinner
-                second `shouldBe` first
+                fmap asyncThreadId second `shouldBe` fmap asyncThreadId first
+
+        it "joins the spinner worker before clearing its owner" do
+            withRenderConfig True False \config _handle _path -> do
+                renderEvent config TurnStarted
+                worker <-
+                    readIORef config.renderThinkingSpinner
+                        >>= maybe
+                            (expectationFailure "spinner worker was not started"
+                                >> fail "missing spinner worker")
+                            pure
+                clearThinking config
+                (isJust <$> readIORef config.renderThinkingSpinner)
+                    `shouldReturn` False
+                poll worker >>= (`shouldSatisfy` isJust)
 
         it "commits buffered reasoning before a continuation TurnStarted" do
             withRenderConfig True False \config handle path -> do


### PR DESCRIPTION
## Summary
- track the live thinking spinner with an `Async ()` owner instead of a raw `ThreadId`
- mask worker creation and registration so asynchronous exceptions cannot orphan it
- cancel and join the spinner before clearing or replacing its lifecycle owner
- cover worker reuse and joined shutdown

## Tests
- `cabal test agent-cli-test --test-options='--match "renderEvent"' --test-show-details=direct` (27 examples)\n- tmux/GHCi smoke: full-motion spinner advanced across frames; `clearThinking` erased it and cleared the owner