### PR TITLE
Enable computer use in terminal sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,18 @@ Start an interactive session:
 agent-cli
 ```
 
+On macOS, supported OpenAI sessions can use the local desktop from the
+terminal by default. The first computer-use workflow after enabling requires
+explicit approval, including under `--yolo`; later actions in that workflow do
+not prompt again unless the provider raises a new safety check.
+`/computer-use` toggles the capability, while
+`/computer-use on` and `/computer-use off` set it explicitly. Disabling or
+re-enabling clears the workflow approval. Grant Screen Recording and
+Accessibility access to the terminal application in **System Settings →
+Privacy & Security** before using it. Start with
+`agent-cli --no-computer-use` to hide the tool from the model, then enable it
+later with `/computer-use`.
+
 To embed the runtime through a local REST and Server-Sent Events API, run
 `nix run .#agent-server`. It provides durable session management, concurrent
 turn supervision, approvals, cancellation, and an OpenAPI 3.1 document. See

--- a/README.md
+++ b/README.md
@@ -185,10 +185,12 @@ Start an interactive session:
 agent-cli
 ```
 
-On macOS, supported OpenAI sessions can use the local desktop from the
-terminal by default. The first computer-use workflow after enabling requires
-explicit approval, including under `--yolo`; later actions in that workflow do
-not prompt again unless the provider raises a new safety check.
+On macOS, supported OpenAI sessions can use the local desktop by default in an
+interactive terminal. Non-interactive runs keep the tool hidden unless
+`--computer-use` is supplied explicitly. Computer-use requests require
+separate approval, including under `--yolo`; choose **Always allow this tool
+this session** to let the workflow continue without prompting for every
+action. A provider safety check still requires fresh approval.
 `/computer-use` toggles the capability, while
 `/computer-use on` and `/computer-use off` set it explicitly. Disabling or
 re-enabling clears the workflow approval. Grant Screen Recording and

--- a/packages/agent-cli-runtime/src/Agent/CLI/AgentSessions/Process.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/AgentSessions/Process.hs
@@ -288,6 +288,7 @@ launchSessionTurnInput
                 ]
                     <> inputArgs
                     <> [ "--save-session"
+                       , "--no-computer-use"
                        ]
                     <> approvalArgs
                     <> ["--no-ghci" | not ghciEnabled]

--- a/packages/agent-cli/eval/GhciVsBash.hs
+++ b/packages/agent-cli/eval/GhciVsBash.hs
@@ -426,6 +426,7 @@ runOne config trial task mode = do
                   , "--save-session"
                   , "--no-agents-md"
                   , "--no-skills"
+                  , "--no-computer-use"
                   , "--max-turns", "30"
                   ]
                     <> modeFlags mode
@@ -633,6 +634,7 @@ validateForwardedArgs = go
 
     reservedFlags =
         [ "--ghci", "--no-ghci", "--bash", "--no-bash"
+        , "--computer-use", "--no-computer-use"
         , "--cwd", "--prompt", "-p", "--prompt-file"
         , "--save-session", "--agents-md", "--no-agents-md", "--skills"
         , "--no-skills", "--max-turns", "--worktree", "--resume"

--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -283,7 +283,7 @@ childApprove _ tools call
 childApprove _ _ call
     | isComputerToolCallKind call.callKind =
         pure $ Left
-            "Computer use requires an explicit parent approval for every call."
+            "Computer use must be approved in the interactive parent session."
 childApprove policy tools call = case policy of
     ApproveAll -> pure (Right True)
     DenyMutating -> do

--- a/packages/agent-cli/src/Agent/CLI/Approval/Decision.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval/Decision.hs
@@ -15,6 +15,8 @@ module Agent.CLI.Approval.Decision
 
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Permission (PermissionChoice(..))
+import Agent.CLI.ComputerUse
+    ( computerToolCallHasPendingSafetyChecks )
 import Agent.CLI.Style (glyphOk, glyphWarn)
 import Agent.JsonText (jsonTextFieldDefault)
 import Agent.OsPath (fromText)
@@ -102,7 +104,12 @@ planApproval facts =
                     facts.planActive facts.planPath facts.call ->
                         approved
                 | isComputerToolCallKind facts.call.callKind ->
-                    NeedPermissionPrompt
+                    if computerToolCallHasPendingSafetyChecks facts.call
+                        then NeedPermissionPrompt
+                        else case facts.allowedForSession of
+                            Nothing -> NeedSessionAllowance
+                            Just True -> approved
+                            Just False -> NeedPermissionPrompt
                 | otherwise -> case facts.allowedForSession of
                     Nothing -> NeedSessionAllowance
                     Just True -> approved
@@ -117,7 +124,25 @@ resolveApprovalPrompt call choice
         case choice of
             Nothing -> denied
             Just PermissionDeny -> denied
-            Just _ -> approved
+            Just PermissionAllowAll ->
+                CompleteApproval
+                    (Right True)
+                    [ SetApprovalPolicy ApproveAll
+                    , PersistProjectAutoApprove
+                    , RememberToolForSession
+                        (canonicalToolName call.name)
+                    , ReportApprovalNotice
+                        (ApprovalSuccess
+                            (glyphOk <> "auto-approve on (saved for project)"))
+                    , computerWorkflowNotice
+                    ]
+            Just _ ->
+                CompleteApproval
+                    (Right True)
+                    [ RememberToolForSession
+                        (canonicalToolName call.name)
+                    , computerWorkflowNotice
+                    ]
     | otherwise = resolveOrdinary choice
   where
     resolveOrdinary = \case
@@ -146,6 +171,10 @@ resolveApprovalPrompt call choice
                 ]
     approved = CompleteApproval (Right True) []
     denied = CompleteApproval (Right False) []
+    computerWorkflowNotice =
+        ReportApprovalNotice
+            (ApprovalSuccess
+                (glyphOk <> "computer use approved until disabled"))
 
 policyPlan :: ApprovalPolicy -> Bool -> ApprovalPlan
 policyPlan policy readOnly = case policy of

--- a/packages/agent-cli/src/Agent/CLI/Approval/Decision.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval/Decision.hs
@@ -136,7 +136,8 @@ resolveApprovalPrompt call choice
                             (glyphOk <> "auto-approve on (saved for project)"))
                     , computerWorkflowNotice
                     ]
-            Just _ ->
+            Just PermissionAllowOnce -> approved
+            Just PermissionAllowTool ->
                 CompleteApproval
                     (Right True)
                     [ RememberToolForSession

--- a/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
@@ -21,6 +21,7 @@ module Agent.CLI.CodeModeRuntime
     , codeModeSessionRuntimeFor
     , imageGenerationCodeModeRuntimeFor
     , imageGenerationCodeModeProjection
+    , filterStartupUnavailableTools
     ) where
 
 import Agent.CLI.Models (modelsCacheFilePath)
@@ -316,6 +317,12 @@ imageGenerationCodeModeProjection mode tools
   where
     isImageGenerationTool tool =
         tool.appToolName == imageGenerationToolName
+
+filterStartupUnavailableTools :: Bool -> [AppTool] -> [AppTool]
+filterStartupUnavailableTools suppressDirectImageGeneration
+    | suppressDirectImageGeneration =
+        filter ((/= imageGenerationToolName) . (.appToolName))
+    | otherwise = id
 
 buildRuntime
     :: ModelInfo

--- a/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
@@ -8,6 +8,7 @@
 -- closed.
 module Agent.CLI.CodeModeRuntime
     ( CodeModeSessionRuntime(..)
+    , CodeModeProjectionStrategy(..)
     , CodeModeToolProjection(..)
     , CodeModeNestedSlot
     , CodexCatalogSession(..)
@@ -16,6 +17,7 @@ module Agent.CLI.CodeModeRuntime
     , loadCodexCatalogModelInfo
     , codexCatalogDefaultEffort
     , projectCodeModeTools
+    , projectCodeModeToolsFor
     , codeModeSessionRuntimeFor
     , imageGenerationCodeModeRuntimeFor
     , imageGenerationCodeModeProjection
@@ -119,11 +121,19 @@ data CodexCatalogSession = CodexCatalogSession
     , catalogEnvironmentContext :: !Text
     }
 
+data CodeModeProjectionStrategy
+    = FullCodeModeProjection
+    | ImageGenerationOnlyCodeModeProjection
+    deriving (Eq, Show)
+
 data CodeModeSessionRuntime = CodeModeSessionRuntime
     { codeModeWireTools :: ![AppTool]
       -- ^ The @exec@ and @wait@ code-mode entry points.
     , codeModeDirectTools :: ![AppTool]
       -- ^ Conventional tools that remain provider-visible alongside code mode.
+    , codeModeProjectionStrategy :: !CodeModeProjectionStrategy
+      -- ^ How to rebuild the provider-visible direct surface when tools are
+      -- enabled or disabled during the session.
     , codeModeNestedSlot :: !CodeModeNestedSlot
     , codeModeNestedToolNames :: ![Text]
     , codeModeClose :: !(IO ())
@@ -158,6 +168,19 @@ projectCodeModeTools mode tools = case mode of
         case tool.appToolSchema of
             HostedComputerSchema -> True
             _ -> False
+
+projectCodeModeToolsFor
+    :: CodeModeProjectionStrategy
+    -> [AppTool]
+    -> CodeModeToolProjection
+projectCodeModeToolsFor strategy tools =
+    case strategy of
+        FullCodeModeProjection ->
+            projectCodeModeTools CodeOnlyToolMode tools
+        ImageGenerationOnlyCodeModeProjection ->
+            case imageGenerationCodeModeProjection CodeOnlyToolMode tools of
+                Just projection -> projection
+                Nothing -> CodeModeToolProjection tools []
 
 -- | Resolve catalog metadata for the active model. With ChatGPT credentials
 -- the live @/models@ catalog is fetched at session start (Codex parity:
@@ -251,6 +274,7 @@ codeModeSessionRuntimeFor maybeInfo tools =
                     buildRuntime
                         info
                         CodeOnlyToolMode
+                        FullCodeModeProjection
                         (projectCodeModeTools CodeOnlyToolMode tools)
 
 -- | Catalog @code_mode_only@ models reserve @image_gen.imagegen@ but expect it
@@ -271,6 +295,7 @@ imageGenerationCodeModeRuntimeFor maybeInfo tools =
                 buildRuntime
                     info
                     CodeOnlyToolMode
+                    ImageGenerationOnlyCodeModeProjection
                     projection
         _ -> pure (Right Nothing)
 
@@ -295,9 +320,10 @@ imageGenerationCodeModeProjection mode tools
 buildRuntime
     :: ModelInfo
     -> ToolMode
+    -> CodeModeProjectionStrategy
     -> CodeModeToolProjection
     -> IO (Either Text (Maybe CodeModeSessionRuntime))
-buildRuntime info mode projection = do
+buildRuntime info mode strategy projection = do
     slot <- newCodeModeNestedSlot
     workerPath <- codeModeWorkerPath
     built <- newCodeModeToolSet
@@ -311,6 +337,7 @@ buildRuntime info mode projection = do
         Right toolSet -> Right $ Just CodeModeSessionRuntime
             { codeModeWireTools = toolSet.codeModeTools
             , codeModeDirectTools = projection.directCodeModeTools
+            , codeModeProjectionStrategy = strategy
             , codeModeNestedSlot = slot
             , codeModeNestedToolNames = toolSet.codeModeNestedToolNames
             , codeModeClose = toolSet.closeCodeModeToolSet

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -384,6 +384,7 @@ parseSpecializedSlashCommand catalog raw spec args commandTail =
             ["reload"] -> ReplSkills True
             _ -> slashUsageError spec
         "shell" -> parseShellCommand args
+        "computer-use" -> parseComputerUseCommand args
         other -> unknownCommand ("/" <> other)
 
 parseOptionalTextCommand :: (Maybe Text -> ReplAction) -> Text -> ReplAction
@@ -652,6 +653,17 @@ parseShellCommand = \case
         _ -> ReplCommandError "usage: /shell [ghci|bash|both|none]"
     _ -> ReplCommandError "usage: /shell [ghci|bash|both|none]"
 
+parseComputerUseCommand :: [Text] -> ReplAction
+parseComputerUseCommand = \case
+    [] -> ReplToggleComputerUse
+    [raw] -> case Text.toLower raw of
+        "on" -> ReplSetComputerUse True
+        "off" -> ReplSetComputerUse False
+        _ -> usageError
+    _ -> usageError
+  where
+    usageError = ReplCommandError "usage: /computer-use [on|off]"
+
 parseModelCommand :: [Text] -> ReplAction
 parseModelCommand = \case
     [] -> ReplShowModel
@@ -856,6 +868,7 @@ argCompletions catalog spec = case spec.slashName of
             (reasoningEffortsForDialect catalog.slashCatalogDialect)
     "model" -> catalog.slashCatalogModelIds
     "shell" -> ["ghci", "bash", "both", "none"]
+    "computer-use" -> ["on", "off"]
     "help" ->
         map (.slashName) catalog.slashCatalogCommands
             <> map (.skillCommandName) catalog.slashCatalogSkills

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -65,6 +65,7 @@ slashCommands =
     , grokToolCmd "workflow" "deep-research" [] "/deep-research <query>" "Run bounded background research, cross-check evidence, and write a cited report" True
     , cmd "skills" [] "/skills [reload]" "List discovered skills or reload them from disk" True
     , cmd "shell" [] "/shell [ghci|bash|both|none]" "Show or select the allowed shell tools" True
+    , cmd "computer-use" [] "/computer-use [on|off]" "Toggle local macOS desktop control" True
     , cmd "codemod" ["code-mode"] "/codemod" "Enable JavaScript code mode for this session" False
     , cmd "always-approve" ["yolo"] "/always-approve" "Toggle project auto-approve (or Shift+Tab)" False
     , cmd "update-and-restart" [] "/update-and-restart" "Install the latest Haskell Agent and resume this session" False

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -110,6 +110,8 @@ data ReplAction
     | ReplSkills !Bool
     | ReplShowShell
     | ReplSetShell !ShellMode
+    | ReplToggleComputerUse
+    | ReplSetComputerUse !Bool
     | ReplInvokeSkill !Text !Text
     | ReplHelp (Maybe Text)
     -- ^ @Nothing@ lists every command; @Just@ is a canonical name without @/@.

--- a/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
@@ -3,6 +3,7 @@ module Agent.CLI.ComputerUse
     ( ComputerObservation(..)
     , ComputerUseBackend(..)
     , ScreenshotEncoding(..)
+    , computerToolName
     , computerUseTool
     , computerUseToolWith
     , computerFunctionParameters
@@ -11,6 +12,7 @@ module Agent.CLI.ComputerUse
     , screenshotMacOS
     , summarizeComputerCall
     , summarizeComputerToolCall
+    , computerToolCallHasPendingSafetyChecks
     , computerApprovalPrompt
     , pointerScript
     , keyCombinationScript
@@ -66,6 +68,11 @@ import System.IO.Unsafe (unsafePerformIO)
 import System.Process (readProcessWithExitCode)
 import Text.Read (readMaybe)
 
+-- | Stable internal handler identity. The Codex wire schema is projected as
+-- @computer_use@, but incoming calls are normalized back to this name.
+computerToolName :: Text
+computerToolName = "computer"
+
 -- | A dedicated internal schema marker, rather than a provider-native wire
 -- type, keeps this privileged handler separate from caller-defined functions.
 computerUseTool :: AppTool
@@ -73,14 +80,14 @@ computerUseTool
     | os == "darwin" = computerUseToolWith localComputerUseBackend
     | otherwise =
         (computerUseToolWith localComputerUseBackend)
-            { appToolHandler = noArgsTool "computer"
+            { appToolHandler = noArgsTool computerToolName
                 (pure (Left
                     "Local computer use is currently supported only on macOS."))
             }
 
 computerUseToolWith :: ComputerUseBackend -> AppTool
 computerUseToolWith backend = AppTool
-    { appToolName = "computer"
+    { appToolName = computerToolName
     , appToolDescription =
         "Start each computer session with a screenshot-only call. Then run up to 10 approved actions on the main macOS display and receive one fresh final screenshot. A screenshot marker is valid only at the end of a batch."
     , appToolSchema = HostedComputerSchema
@@ -91,7 +98,7 @@ computerUseToolWith backend = AppTool
     }
   where
     handler =
-        typedToolWithCall "computer" computerToolInputDecoder \call input ->
+        typedToolWithCall computerToolName computerToolInputDecoder \call input ->
             executeComputerCallWithBackend
                 backend
                 (case call.callKind of
@@ -908,7 +915,7 @@ safeQuoted limit value =
 
 summarizeComputerToolCall :: ToolCall -> Maybe Text
 summarizeComputerToolCall call
-    | call.name /= "computer"
+    | call.name /= computerToolName
         || not (isComputerToolCallKind call.callKind) = Nothing
     | otherwise =
         case Json.decodeText computerToolInputDecoder call.arguments of
@@ -921,9 +928,17 @@ summarizeComputerToolCall call
                         then "Computer action"
                         else "Computer: " <> detail
 
+computerToolCallHasPendingSafetyChecks :: ToolCall -> Bool
+computerToolCallHasPendingSafetyChecks call
+    | not (isComputerToolCallKind call.callKind) = False
+    | otherwise =
+        case Json.decodeText computerToolInputDecoder call.arguments of
+            Left _ -> False
+            Right input -> not (null input.toolPendingSafetyChecks)
+
 computerApprovalPrompt :: ToolCall -> Maybe Text
 computerApprovalPrompt call =
-    fmap ("Allow this computer action?\n\n" <>) $
+    fmap ("Allow this computer-use workflow until disabled?\n\n" <>) $
         summarizeComputerToolCall call
 
 dataUrl :: Text -> BS.ByteString -> Text

--- a/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
@@ -938,7 +938,7 @@ computerToolCallHasPendingSafetyChecks call
 
 computerApprovalPrompt :: ToolCall -> Maybe Text
 computerApprovalPrompt call =
-    fmap ("Allow this computer-use workflow until disabled?\n\n" <>) $
+    fmap ("Allow this computer-use request?\n\n" <>) $
         summarizeComputerToolCall call
 
 dataUrl :: Text -> BS.ByteString -> Text

--- a/packages/agent-cli/src/Agent/CLI/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/MetaConsole.hs
@@ -426,6 +426,10 @@ validateSessionCommand raw =
         ["/shell", mode]
             | Text.toLower mode `elem` ["ghci", "bash", "both", "none"] ->
                 pure ()
+        ["/computer-use"] -> pure ()
+        ["/computer-use", mode]
+            | Text.toLower mode `elem` ["on", "off"] ->
+                pure ()
         ["/codemod"] -> pure ()
         ["/always-approve"] -> pure ()
         ["/agents", "limit", limit]
@@ -910,7 +914,7 @@ metaConsolePrompt context request =
         , "Secret environment actions carry only name and key; the host securely prompts for the value. Never add a value field."
         , "select_account must be the plan's only action. Omit account to show every connected account for that provider."
         , "A supplied account is matched exactly (case-insensitively) against its label or id. If it could refer to multiple accounts, use clarify rather than guessing."
-        , "Allowed session_command forms: /model MODEL, /effort LEVEL, /fast, /shell MODE, /codemod, /always-approve, /agents limit N, /skills reload."
+        , "Allowed session_command forms: /model MODEL, /effort LEVEL, /fast, /shell MODE, /computer-use [on|off], /codemod, /always-approve, /agents limit N, /skills reload."
         ]
 
 renderJson :: Aeson.Value -> Text

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -219,12 +219,15 @@ isOneShot options =
         || isJust options.optManagedTurnFile
 
 -- | Resolve the provider-visible computer-use capability. It is enabled by
--- default only for an interactive terminal, while explicit flags remain
--- authoritative for native clients and deliberate non-interactive runs.
+-- default only for an interactive terminal session that keeps reading input,
+-- while explicit flags remain authoritative for native clients and deliberate
+-- one-shot or non-interactive runs.
 resolveComputerUseEnabled :: CliOptions -> Bool -> Bool
 resolveComputerUseEnabled options stdinTty =
     options.optComputerUse
-        && (stdinTty || options.optComputerUseExplicit)
+        && ( options.optComputerUseExplicit
+                || (stdinTty && not (isOneShot options))
+           )
 
 -- | One-shot without a TTY auto-approves so scripts do not hang, unless
 -- @--no-yolo@ is set. Interactive sessions prompt on mutating tools, unless

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -22,6 +22,7 @@ module Agent.CLI.Options
     , reasoningEfforts
     , reasoningEffortsForDialect
     , resolveApprovalPolicy
+    , resolveComputerUseEnabled
     , usage
     ) where
 
@@ -150,8 +151,10 @@ data CliOptions = CliOptions
       -- ^ Expose the provider's explicit shell execution tool (default: True).
     , optComputerUse :: !Bool
       -- ^ Allow the model to request control of the local macOS desktop.
-      -- Terminal sessions default to 'True'; the first workflow after enabling
-      -- still requires explicit approval.
+      -- Interactive terminal sessions default to 'True'.
+    , optComputerUseExplicit :: !Bool
+      -- ^ Whether a computer-use flag was supplied explicitly. This lets
+      -- native clients opt in while non-interactive defaults stay safe.
     , optCodeMode :: !Bool
       -- ^ Honor catalog-selected JavaScript code mode (default: False).
     , optScreenMode :: !ScreenMode
@@ -182,6 +185,7 @@ defaultCliOptions = CliOptions
     , optGhci = False
     , optBash = True
     , optComputerUse = True
+    , optComputerUseExplicit = False
     , optCodeMode = False
     , optScreenMode = ScreenAuto
     , optMotionMode = MotionFull
@@ -213,6 +217,14 @@ isOneShot options =
     isJust options.optPrompt
         || isJust options.optPromptFile
         || isJust options.optManagedTurnFile
+
+-- | Resolve the provider-visible computer-use capability. It is enabled by
+-- default only for an interactive terminal, while explicit flags remain
+-- authoritative for native clients and deliberate non-interactive runs.
+resolveComputerUseEnabled :: CliOptions -> Bool -> Bool
+resolveComputerUseEnabled options stdinTty =
+    options.optComputerUse
+        && (stdinTty || options.optComputerUseExplicit)
 
 -- | One-shot without a TTY auto-approves so scripts do not hang, unless
 -- @--no-yolo@ is set. Interactive sessions prompt on mutating tools, unless
@@ -425,7 +437,7 @@ optionUpdateParser = asum
         pathReader (\value options -> options { optCwd = Just value })
     , flagUpdate "worktree" "Create a new git worktree"
         (\options -> options { optWorktree = True })
-    , flagUpdate "yolo" "Auto-approve tools (computer use still asks once)"
+    , flagUpdate "yolo" "Auto-approve tools (computer use asks separately)"
         (\options -> options { optYolo = True, optNoYolo = False })
     , flagUpdate "no-yolo" "Deny mutating tools without a TTY"
         (\options -> options { optNoYolo = True, optYolo = False })
@@ -485,10 +497,16 @@ optionUpdateParser = asum
     , boolFlagUpdate "no-bash" False "Disable shell execution tools"
         (\value options -> options { optBash = value })
     , boolFlagUpdate "computer-use" True
-        "Enable local macOS computer use (default)"
-        (\value options -> options { optComputerUse = value })
+        "Enable local macOS computer use (default with a TTY)"
+        (\value options -> options
+            { optComputerUse = value
+            , optComputerUseExplicit = True
+            })
     , boolFlagUpdate "no-computer-use" False "Disable local computer use"
-        (\value options -> options { optComputerUse = value })
+        (\value options -> options
+            { optComputerUse = value
+            , optComputerUseExplicit = True
+            })
     , boolFlagUpdate "code-mode" True "Enable catalog-selected code mode"
         (\value options -> options { optCodeMode = value })
     , boolFlagUpdate "no-code-mode" False "Use conventional tool calling"
@@ -679,12 +697,13 @@ usage = unlines
     , "      --no-ghci           Disable the persistent GHCi tool (default)"
     , "      --bash              Enable explicit shell execution tools (default)"
     , "      --no-bash           Disable explicit shell execution tools"
-    , "      --computer-use      Enable local macOS desktop control (default)"
+    , "      --computer-use      Enable local macOS desktop control"
+    , "                          (default only with an interactive TTY)"
     , "      --no-computer-use   Disable local macOS desktop control"
     , "      --fullscreen        Use the retained full-screen TUI"
     , "      --minimal           Use terminal-native append-only rendering"
     , "      --motion MODE       Animation policy: full, reduced, or off"
-    , "      --yolo              Auto-approve tools; computer use still asks once"
+    , "      --yolo              Auto-approve tools; computer use asks separately"
     , "      --no-yolo           Never auto-approve; deny mutating tools without a TTY"
     , "      --max-turns N       Stop after N model turns (default: "
         <> show defaultLoopMaxTurns <> ")"
@@ -725,7 +744,7 @@ usage = unlines
     , "/shell shows the active shell tools; /shell ghci or /shell bash switches"
     , "the current session. /shell both and /shell none are also available."
     , "/computer-use toggles local macOS desktop control; on/off are explicit."
-    , "The first computer-use workflow after enabling asks for approval once."
+    , "Choose Always this tool to approve the current computer-use workflow."
     , "/always-approve (or :yolo) toggles auto-approve and saves it under"
     , "<project>/.haskell-agent/settings.json. Permission prompts offer Allow once"
     , "or Always this tool this session; /always-approve still enables project yolo."

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -149,7 +149,9 @@ data CliOptions = CliOptions
     , optBash :: !Bool
       -- ^ Expose the provider's explicit shell execution tool (default: True).
     , optComputerUse :: !Bool
-      -- ^ Allow the model to control the local macOS desktop (default: False).
+      -- ^ Allow the model to request control of the local macOS desktop.
+      -- Terminal sessions default to 'True'; the first workflow after enabling
+      -- still requires explicit approval.
     , optCodeMode :: !Bool
       -- ^ Honor catalog-selected JavaScript code mode (default: False).
     , optScreenMode :: !ScreenMode
@@ -179,7 +181,7 @@ defaultCliOptions = CliOptions
     , optSkills = True
     , optGhci = False
     , optBash = True
-    , optComputerUse = False
+    , optComputerUse = True
     , optCodeMode = False
     , optScreenMode = ScreenAuto
     , optMotionMode = MotionFull
@@ -423,7 +425,7 @@ optionUpdateParser = asum
         pathReader (\value options -> options { optCwd = Just value })
     , flagUpdate "worktree" "Create a new git worktree"
         (\options -> options { optWorktree = True })
-    , flagUpdate "yolo" "Auto-approve every tool"
+    , flagUpdate "yolo" "Auto-approve tools (computer use still asks once)"
         (\options -> options { optYolo = True, optNoYolo = False })
     , flagUpdate "no-yolo" "Deny mutating tools without a TTY"
         (\options -> options { optNoYolo = True, optYolo = False })
@@ -482,7 +484,8 @@ optionUpdateParser = asum
         (\value options -> options { optBash = value })
     , boolFlagUpdate "no-bash" False "Disable shell execution tools"
         (\value options -> options { optBash = value })
-    , boolFlagUpdate "computer-use" True "Enable local macOS computer use"
+    , boolFlagUpdate "computer-use" True
+        "Enable local macOS computer use (default)"
         (\value options -> options { optComputerUse = value })
     , boolFlagUpdate "no-computer-use" False "Disable local computer use"
         (\value options -> options { optComputerUse = value })
@@ -676,12 +679,12 @@ usage = unlines
     , "      --no-ghci           Disable the persistent GHCi tool (default)"
     , "      --bash              Enable explicit shell execution tools (default)"
     , "      --no-bash           Disable explicit shell execution tools"
-    , "      --computer-use      Enable local macOS desktop control (opt-in)"
-    , "      --no-computer-use   Disable local desktop control (default)"
+    , "      --computer-use      Enable local macOS desktop control (default)"
+    , "      --no-computer-use   Disable local macOS desktop control"
     , "      --fullscreen        Use the retained full-screen TUI"
     , "      --minimal           Use terminal-native append-only rendering"
     , "      --motion MODE       Animation policy: full, reduced, or off"
-    , "      --yolo              Auto-approve every tool"
+    , "      --yolo              Auto-approve tools; computer use still asks once"
     , "      --no-yolo           Never auto-approve; deny mutating tools without a TTY"
     , "      --max-turns N       Stop after N model turns (default: "
         <> show defaultLoopMaxTurns <> ")"
@@ -721,6 +724,8 @@ usage = unlines
     , "the live concurrent subagent cap and saves it to project settings."
     , "/shell shows the active shell tools; /shell ghci or /shell bash switches"
     , "the current session. /shell both and /shell none are also available."
+    , "/computer-use toggles local macOS desktop control; on/off are explicit."
+    , "The first computer-use workflow after enabling asks for approval once."
     , "/always-approve (or :yolo) toggles auto-approve and saves it under"
     , "<project>/.haskell-agent/settings.json. Permission prompts offer Allow once"
     , "or Always this tool this session; /always-approve still enables project yolo."

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Background.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Background.hs
@@ -52,6 +52,8 @@ runInProcessSessionTurn runAgent parentOptions policy ghciEnabled bashEnabled
                 , optSaveSession = True
                 , optGhci = ghciEnabled
                 , optBash = bashEnabled
+                , optComputerUse = False
+                , optComputerUseExplicit = True
                 , optScreenMode = ScreenMinimal
                 }
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -20,6 +20,7 @@ import Agent.CLI.CodeModeRuntime
     ( CodeModeSessionRuntime(..),
       CodexCatalogSession(..),
       codeModeSessionRuntimeFor,
+      filterStartupUnavailableTools,
       imageGenerationCodeModeRuntimeFor,
       loadCodexCatalogModelInfo )
 import Agent.CLI.Command ()
@@ -136,7 +137,7 @@ import Agent.CLI.Session.Runtime.Types
                      gatewayModelsRef, modelInfo,
                      connectionId, gatewayIdentity,
                      options, provider, dialect, commitAttributionModel,
-                     commitAttributionEffort, policyRef, allTools,
+                     commitAttributionEffort, policyRef, allTools, refreshTools,
                      claudeRuntimeSlot, claudeBridgeTools,
                      recordImageGenerationInputs, clearImageGenerationHistory,
                      suspendGhci, resetToolSessionTemp, grokRuntime,
@@ -213,7 +214,6 @@ import Agent.Loop
     , emptyTokenUsage
     )
 import Agent.OpenAI.Compaction ()
-import Agent.OpenAI.ImageGeneration ( imageGenerationToolName )
 import Agent.OpenAI.Usage ()
 import Agent.OpenAI.WebSocketClient ()
 import Agent.OpenAI.Models.Types ( ModelInfo, resolvedContextWindow )
@@ -390,6 +390,7 @@ data SessionCodeRuntime = SessionCodeRuntime
     , sessionCodeModeRuntime :: Maybe CodeModeSessionRuntime
     , sessionCatalogSession :: Maybe CodexCatalogSession
     , sessionRegistryTools :: [AppTool]
+    , sessionRefreshTools :: [AppTool]
     , sessionBaseParams :: ResponseCreateParams
     , sessionReservedId :: Maybe Text
     , sessionEnvironmentContext :: Maybe Text
@@ -710,12 +711,16 @@ prepareSessionCodeRuntime AgentSessionRequest
     writeIORef codeModeCloseRef
         (maybe (pure ()) (.codeModeClose) sessionCodeModeRuntime)
     sessionReservedId <- reservedSessionId persist
-    let providerTools
-            | suppressDirectImageGeneration =
-                filter
-                    ((/= imageGenerationToolName) . (.appToolName))
-                    tools
-            | otherwise = tools
+    let providerTools =
+            filterStartupUnavailableTools
+                suppressDirectImageGeneration
+                tools
+        -- Keep toggle-disabled tools available for later refreshes, but never
+        -- re-advertise a tool whose startup runtime failed to initialize.
+        sessionRefreshTools =
+            filterStartupUnavailableTools
+                suppressDirectImageGeneration
+                allTools
         sessionCatalogSession = sessionModelInfo <&> \info ->
             CodexCatalogSession
                 { catalogInstructionsFor = \toolNames sessionTmpDir ->
@@ -1164,6 +1169,8 @@ buildProviderSessionRequest
             , policyRef = promptRuntime.sessionPolicyRef
             , allTools =
                 promptRuntime.sessionCodeRuntime.sessionRegistryTools
+            , refreshTools =
+                promptRuntime.sessionCodeRuntime.sessionRefreshTools
             , recordImageGenerationInputs =
                 request.recordImageGenerationInputs
             , clearImageGenerationHistory =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -155,7 +155,7 @@ import Agent.CLI.Session.Runtime.Types
                      escPaused, interrupt, multiCtx, rootTurnRef, subagentSessions,
                      pendingNotices, storeRoot, agentTypes, legacyTarget, usageRef,
                      accountRef, accountIdRef, selectionRef, accountLabel,
-                     selectAccount, onPersisted, compactRunner, codeModeNestedSlot),
+                     selectAccount, onPersisted, compactRunner, codeModeRuntime),
       StartupRuntime(startupBackground, startupDatabaseStore,
                      startupNetworkRecovery, startupSessionState,
                      startupNativeHooks) )
@@ -1239,9 +1239,8 @@ buildProviderSessionRequest
             , selectAccount = sessionSelectAccount
             , onPersisted = request.claimCurrentSession
             , compactRunner = sessionCompactRunner
-            , codeModeNestedSlot =
-                (.codeModeNestedSlot)
-                    <$> promptRuntime.sessionCodeRuntime.sessionCodeModeRuntime
+            , codeModeRuntime =
+                promptRuntime.sessionCodeRuntime.sessionCodeModeRuntime
             , codexCatalogSession =
                 promptRuntime.sessionCodeRuntime.sessionCatalogSession
             }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -1886,9 +1886,13 @@ assembleSessionToolsRuntime AgentToolsRequest
             maybe [] (.nativeToolGroups) startup.startupNativeHooks
         computerTools =
             [ ComputerUse.computerUseTool
-            | options.optComputerUse
-            , provider == OpenAIProvider
+            | provider == OpenAIProvider
             , os == "darwin"
+            ]
+        activeComputerTools =
+            [ tool
+            | options.optComputerUse
+            , tool <- computerTools
             ]
         imageGenerationTools =
             [ imageGenerationTool
@@ -1903,7 +1907,7 @@ assembleSessionToolsRuntime AgentToolsRequest
             , inferredTarget.targetConnectionId
                 == builtinConnectionId OpenAIProvider
             ]
-        surroundingToolGroups =
+        surroundingToolGroupsFor selectedComputerTools =
             [ ExecutionToolGroup extraTools
             , ExecutionToolGroup sessionMcpTools
             , HostToolGroup persistedSessionTools
@@ -1914,13 +1918,16 @@ assembleSessionToolsRuntime AgentToolsRequest
             ]
                 <> nativeToolGroups
                 <> [ HostToolGroup imageGenerationTools
-                   , ExecutionToolGroup computerTools
+                   , ExecutionToolGroup selectedComputerTools
                    ]
         allToolGroups =
-            coding.codingAppToolGroups <> surroundingToolGroups
+            coding.codingAppToolGroups
+                <> surroundingToolGroupsFor computerTools
         activeCodingGroups =
             map filterCodingExecution coding.codingAppToolGroups
-        activeToolGroups = activeCodingGroups <> surroundingToolGroups
+        activeToolGroups =
+            activeCodingGroups
+                <> surroundingToolGroupsFor activeComputerTools
         filterCodingExecution = \case
             ExecutionToolGroup appTools ->
                 ExecutionToolGroup $

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -90,8 +90,9 @@ import Agent.CLI.Options
       isOneShot,
       normalizeReasoningEffortForDialect,
       resolveApprovalPolicy,
+      resolveComputerUseEnabled,
       CliOptions(optYolo, optModel, optEffort, optMaxConcurrentAgents,
-                 optGhci, optBash, optComputerUse, optNoYolo, optSkills) )
+                 optGhci, optBash, optNoYolo, optSkills) )
 import Agent.CLI.PendingInputs
     ( PendingInputs
     , PendingNoticeKind(..)
@@ -170,7 +171,8 @@ import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
     ( StartupRuntime(startupFullscreen, startupBackground,
                      startupFinished, startupDatabaseStore,
-                     startupSessionState, startupNativeHooks) )
+                     startupSessionState, startupNativeHooks,
+                     startupStdinTty) )
 import Agent.CLI.Session.Selection
     ( currentSessionId, loadPrompt, reservedSessionId )
 import Agent.CLI.SessionAdmin ()
@@ -1891,7 +1893,7 @@ assembleSessionToolsRuntime AgentToolsRequest
             ]
         activeComputerTools =
             [ tool
-            | options.optComputerUse
+            | resolveComputerUseEnabled options startup.startupStdinTty
             , tool <- computerTools
             ]
         imageGenerationTools =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -22,7 +22,8 @@ import Agent.CLI.Command
       ReplAction(ReplCommandError, ReplQuit, ReplReload,
                  ReplUpdateAndRestart, ReplPrompt, ReplExpandedPrompt,
                  ReplInvokeSkill, ReplSkills, ReplShowShell,
-                 ReplSetShell, ReplPaste, ReplShowAttachments, ReplClearAttachments,
+                 ReplSetShell, ReplToggleComputerUse, ReplSetComputerUse,
+                 ReplPaste, ReplShowAttachments, ReplClearAttachments,
                  ReplRemoveAttachment,
                  ReplShowAgentLimit, ReplSetAgentLimit, ReplAgents, ReplMcp, ReplMcpPrompt,
                  ReplGoalStatus, ReplGoalPause, ReplGoalResume, ReplGoalClear,
@@ -469,6 +470,20 @@ handleReplLine
                         showShellMode continue color
                     ReplSetShell mode ->
                         setShellMode continue color mode
+                    ReplToggleComputerUse -> do
+                        enabled <- env.sessionComputerUseEnabled
+                        message <-
+                            env.sessionSetComputerUseEnabled (not enabled)
+                        displayInfo message $
+                            Text.putStrLn
+                                (roleMuted color (glyphOk <> message))
+                        continue
+                    ReplSetComputerUse enabled -> do
+                        message <- env.sessionSetComputerUseEnabled enabled
+                        displayInfo message $
+                            Text.putStrLn
+                                (roleMuted color (glyphOk <> message))
+                        continue
                     action@ReplPaste{} -> handleAttachmentAction env finishTurn continue action
                     action@ReplShowAttachments -> handleAttachmentAction env finishTurn continue action
                     action@ReplClearAttachments -> handleAttachmentAction env finishTurn continue action

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
@@ -5,7 +5,8 @@ module Agent.CLI.Runtime.Repl.MetaConsole
 
 import Agent.CLI.Command
     ( ReplAction(ReplSetEffort, ReplToggleFast, ReplSetModel,
-                 ReplSetShell, ReplToggleAlwaysApprove, ReplSetAgentLimit,
+                 ReplSetShell, ReplToggleComputerUse, ReplSetComputerUse,
+                 ReplToggleAlwaysApprove, ReplSetAgentLimit,
                  ReplEnableCodeMode, ReplSkills)
     , SlashCatalog
     , parseReplLineWithCatalog
@@ -456,6 +457,8 @@ safeMetaSessionAction = \case
     ReplToggleFast -> True
     ReplSetModel{} -> True
     ReplSetShell{} -> True
+    ReplToggleComputerUse -> True
+    ReplSetComputerUse{} -> True
     ReplToggleAlwaysApprove -> True
     ReplSetAgentLimit{} -> True
     ReplEnableCodeMode -> True

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -376,7 +376,7 @@ newSessionControlRuntime host SessionRequest{..} = do
     renderStateRef <- newIORef emptyRenderState
     allowedToolsRef <- newIORef Set.empty
     computerUseEnabledRef <- newIORef $
-        options.optComputerUse
+        resolveComputerUseEnabled options startup.startupStdinTty
             && isJust
                 (lookupAppTool
                     computerToolName
@@ -1043,7 +1043,7 @@ buildSessionShellRuntime host controls SessionRequest{..} =
                 if enabled
                     then
                         "computer use: on \
-                        \(approval required for the next workflow)"
+                        \(approval required before control)"
                     else "computer use: off"
     setSessionTempDir tempDir = do
         -- Persistent tool runtimes capture temp-backed state at startup.

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -380,7 +380,7 @@ newSessionControlRuntime host SessionRequest{..} = do
             && isJust
                 (lookupAppTool
                     computerToolName
-                    (sessionDirectTools allTools codeModeRuntime))
+                    (sessionDirectTools refreshTools codeModeRuntime))
     lastAssistantRef <- newIORef Nothing
     modelRef <- newIORef =<< (currentModel <$> readIORef paramsRef)
     unavailableProvidersRef <- newIORef unavailableProviders
@@ -887,7 +887,7 @@ buildSessionShellRuntime host controls SessionRequest{..} =
   where
     nativeCapabilities = host.hostNativeCapabilities
     computerUseEnabledRef = controls.controlComputerUseEnabledRef
-    sessionTools = sessionDirectTools allTools codeModeRuntime
+    sessionTools = sessionDirectTools refreshTools codeModeRuntime
     computerUseAvailable =
         isJust (lookupAppTool computerToolName sessionTools)
     toolDisabledReason call = do

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -20,6 +20,7 @@ import Agent.CLI.Artifact (fencedCodeBlock, lastDiffBlock)
 import Agent.CLI.Context (contextUsageTokens, formatContextReport)
 import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Responses.Types (ResponseCreateParams(model))
+import Agent.CLI.ComputerUse (computerToolName)
 import Agent.CLI.Session.Runner.Types
     ( SessionRunnerContinuation(..) )
 import Agent.CLI.AgentViewport (AgentViewportEnv)
@@ -135,6 +136,23 @@ formatQueuedPrompts prompts =
         Text.pack (show index)
             <> ". "
             <> Text.replace "\n" "\n   " prompt
+
+sessionDirectTools
+    :: [AppTool]
+    -> Maybe CodeModeSessionRuntime
+    -> [AppTool]
+sessionDirectTools allTools codeModeRuntime =
+    filter
+        (\tool ->
+            canonicalToolName tool.appToolName
+                `Set.notMember` codeModeWireNames)
+        allTools
+  where
+    codeModeWireNames =
+        Set.fromList $
+            map
+                (canonicalToolName . (.appToolName))
+                (maybe [] (.codeModeWireTools) codeModeRuntime)
 
 -- | Host-facing session resources that are established before the title and
 -- turn runtimes. Keeping these together makes the outer session runner a
@@ -321,6 +339,7 @@ data SessionControlRuntime = SessionControlRuntime
     , controlSpinnerRef :: !(IORef (Maybe ThreadId))
     , controlRenderStateRef :: !(IORef RenderState)
     , controlAllowedToolsRef :: !(IORef (Set.Set Text.Text))
+    , controlComputerUseEnabledRef :: !(IORef Bool)
     , controlLastAssistantRef :: !(IORef (Maybe Text.Text))
     , controlModelRef :: !(IORef Text.Text)
     , controlUnavailableProvidersRef :: !(IORef (Set.Set Provider))
@@ -356,6 +375,12 @@ newSessionControlRuntime host SessionRequest{..} = do
     spinnerRef <- newIORef Nothing
     renderStateRef <- newIORef emptyRenderState
     allowedToolsRef <- newIORef Set.empty
+    computerUseEnabledRef <- newIORef $
+        options.optComputerUse
+            && isJust
+                (lookupAppTool
+                    computerToolName
+                    (sessionDirectTools allTools codeModeRuntime))
     lastAssistantRef <- newIORef Nothing
     modelRef <- newIORef =<< (currentModel <$> readIORef paramsRef)
     unavailableProvidersRef <- newIORef unavailableProviders
@@ -444,6 +469,7 @@ newSessionControlRuntime host SessionRequest{..} = do
         , controlSpinnerRef = spinnerRef
         , controlRenderStateRef = renderStateRef
         , controlAllowedToolsRef = allowedToolsRef
+        , controlComputerUseEnabledRef = computerUseEnabledRef
         , controlLastAssistantRef = lastAssistantRef
         , controlModelRef = modelRef
         , controlUnavailableProvidersRef = unavailableProvidersRef
@@ -834,37 +860,69 @@ buildSessionApprovalRuntime host controls SessionRequest{..} =
         approveToolWithClassification Nothing
 
 data SessionShellRuntime = SessionShellRuntime
-    { shellToolAllowed :: !(ToolCall -> IO Bool)
+    { shellToolDisabledReason :: !(ToolCall -> IO (Maybe Text.Text))
     , shellActiveToolNames :: !(IO [Text.Text])
     , shellCurrentMode :: !(IO ShellMode)
     , shellSetMode :: !(ShellMode -> IO Text.Text)
+    , shellComputerUseEnabled :: !(IO Bool)
+    , shellSetComputerUseEnabled :: !(Bool -> IO Text.Text)
     , shellSetTempDir :: !(OsPath -> IO ())
     }
 
 buildSessionShellRuntime
     :: SessionHostRuntime
+    -> SessionControlRuntime
     -> SessionRequest
     -> SessionShellRuntime
-buildSessionShellRuntime host SessionRequest{..} =
+buildSessionShellRuntime host controls SessionRequest{..} =
     SessionShellRuntime
-        { shellToolAllowed = shellToolAllowed
+        { shellToolDisabledReason = toolDisabledReason
         , shellActiveToolNames = currentActiveToolNames
         , shellCurrentMode = currentShellMode
         , shellSetMode = setShellMode
+        , shellComputerUseEnabled = readIORef computerUseEnabledRef
+        , shellSetComputerUseEnabled = setComputerUse
         , shellSetTempDir = setSessionTempDir
         }
   where
     nativeCapabilities = host.hostNativeCapabilities
-    shellToolAllowed call = do
+    computerUseEnabledRef = controls.controlComputerUseEnabledRef
+    sessionTools = sessionDirectTools allTools codeModeRuntime
+    computerUseAvailable =
+        isJust (lookupAppTool computerToolName sessionTools)
+    toolDisabledReason call = do
         ghciEnabled <- readIORef ghciEnabledRef
         bashEnabled <- readIORef bashEnabledRef
+        computerUseEnabled <- readIORef computerUseEnabledRef
         let toolName = canonicalToolName call.name
         pure $
-            (not (isGhciToolName toolName) || ghciEnabled)
-                && (not (isBashToolName toolName) || bashEnabled)
-    activeShellTools ghciEnabled bashEnabled =
-        filterGhciTools ghciEnabled
-            (filterBashTools bashEnabled allTools)
+            if isComputerToolCallKind call.callKind
+                && not computerUseEnabled
+                then Just
+                    "Computer use is disabled. Run /computer-use to enable it."
+            else if (isGhciToolName toolName && not ghciEnabled)
+                || (isBashToolName toolName && not bashEnabled)
+                then Just
+                    ("Tool " <> call.name
+                        <> " is disabled by the current /shell setting.")
+            else Nothing
+    activeSessionTools ghciEnabled bashEnabled computerUseEnabled =
+        filterComputerUseTools computerUseEnabled $
+            filterGhciTools ghciEnabled
+                (filterBashTools bashEnabled sessionTools)
+    providerVisibleTools enabledTools =
+        case codeModeRuntime of
+            Nothing -> enabledTools
+            Just runtime ->
+                runtime.codeModeWireTools
+                    <> (projectCodeModeToolsFor
+                            runtime.codeModeProjectionStrategy
+                            enabledTools
+                        ).directCodeModeTools
+    filterComputerUseTools True = id
+    filterComputerUseTools False =
+        filter \tool ->
+            canonicalToolName tool.appToolName /= computerToolName
     currentShellMode = do
         ghciEnabled <- readIORef ghciEnabledRef
         bashEnabled <- readIORef bashEnabledRef
@@ -876,9 +934,16 @@ buildSessionShellRuntime host SessionRequest{..} =
     currentActiveToolNames = do
         ghciEnabled <- readIORef ghciEnabledRef
         bashEnabled <- readIORef bashEnabledRef
+        computerUseEnabled <- readIORef computerUseEnabledRef
         let active =
-                activeShellTools ghciEnabled bashEnabled
-            internalNames = map (.appToolName) active
+                activeSessionTools
+                    ghciEnabled
+                    bashEnabled
+                    computerUseEnabled
+            reportTools =
+                active
+                    <> maybe [] (.codeModeWireTools) codeModeRuntime
+            internalNames = map (.appToolName) reportTools
             projectedNames =
                 case dialectToolLayout dialect of
                     NoHostToolLayout -> []
@@ -911,45 +976,75 @@ buildSessionShellRuntime host SessionRequest{..} =
         ShellBash -> "bash"
         ShellBoth -> "ghci + bash"
         ShellNone -> "none"
-    refreshShellParams ghciEnabled bashEnabled
-        | isJust codeModeNestedSlot = pure ()
-        | otherwise = do
-            sessionTmp <- readIORef toolEnv.toolSessionTmp
-            today <- utctDay <$> getCurrentTime
-            let enabledTools = activeShellTools ghciEnabled bashEnabled
-                enabledNames = map (.appToolName) enabledTools
-                instructionText =
-                    appendMcpInstructions mcpInstructions case codexCatalogSession of
-                        Just catalog ->
-                            catalog.catalogInstructionsFor
-                                enabledNames sessionTmp
-                        Nothing ->
-                            systemPromptForToolsWithHostedSearch
-                                nativeCapabilities.nativeProviderHostedTools
-                                dialect
-                                commitAttributionModel
-                                commitAttributionEffort
-                                enabledNames
-                                cwd
-                                sessionTmp
-                                today
-                                (isOneShot options)
-                toolSchemas =
-                    schemasFromAppToolsWithHostedSearch
-                        nativeCapabilities.nativeProviderHostedTools
-                        dialect
-                        enabledTools
-            modifyIORef' paramsRef
-                (setRequestInstructionsAndTools
-                    instructionText
-                    (Just toolSchemas))
+    refreshSessionParams ghciEnabled bashEnabled computerUseEnabled = do
+        sessionTmp <- readIORef toolEnv.toolSessionTmp
+        today <- utctDay <$> getCurrentTime
+        let enabledTools =
+                activeSessionTools
+                    ghciEnabled
+                    bashEnabled
+                    computerUseEnabled
+            enabledNames = map (.appToolName) enabledTools
+            instructionText =
+                appendMcpInstructions mcpInstructions case codexCatalogSession of
+                    Just catalog ->
+                        catalog.catalogInstructionsFor
+                            enabledNames sessionTmp
+                    Nothing ->
+                        systemPromptForToolsWithHostedSearch
+                            nativeCapabilities.nativeProviderHostedTools
+                            dialect
+                            commitAttributionModel
+                            commitAttributionEffort
+                            enabledNames
+                            cwd
+                            sessionTmp
+                            today
+                            (isOneShot options)
+            toolSchemas =
+                case codeModeRuntime of
+                    Just _ ->
+                        schemasFromAppToolsCodeModeWithHostedSearch
+                            nativeCapabilities.nativeProviderHostedTools
+                            dialect
+                            (providerVisibleTools enabledTools)
+                    Nothing ->
+                        schemasFromAppToolsWithHostedSearch
+                            nativeCapabilities.nativeProviderHostedTools
+                            dialect
+                            enabledTools
+        modifyIORef' paramsRef
+            (setRequestInstructionsAndTools
+                instructionText
+                (Just toolSchemas))
     setShellMode mode = do
         let (ghciEnabled, bashEnabled) = shellModeFlags mode
         writeIORef ghciEnabledRef ghciEnabled
         writeIORef bashEnabledRef bashEnabled
         unless ghciEnabled suspendGhci
-        refreshShellParams ghciEnabled bashEnabled
+        computerUseEnabled <- readIORef computerUseEnabledRef
+        refreshSessionParams
+            ghciEnabled
+            bashEnabled
+            computerUseEnabled
         pure ("shell tools: " <> shellModeLabel mode)
+    setComputerUse enabled
+        | enabled && not computerUseAvailable =
+            pure
+                "computer use is unavailable for this provider or platform"
+        | otherwise = do
+            writeIORef computerUseEnabledRef enabled
+            modifyIORef' controls.controlAllowedToolsRef
+                (Set.delete computerToolName)
+            ghciEnabled <- readIORef ghciEnabledRef
+            bashEnabled <- readIORef bashEnabledRef
+            refreshSessionParams ghciEnabled bashEnabled enabled
+            pure $
+                if enabled
+                    then
+                        "computer use: on \
+                        \(approval required for the next workflow)"
+                    else "computer use: off"
     setSessionTempDir tempDir = do
         -- Persistent tool runtimes capture temp-backed state at startup.
         -- Reset them before publishing the new root so no process or state
@@ -958,7 +1053,11 @@ buildSessionShellRuntime host SessionRequest{..} =
         setToolSessionTmp toolEnv (Just tempDir)
         ghciEnabled <- readIORef ghciEnabledRef
         bashEnabled <- readIORef bashEnabledRef
-        refreshShellParams ghciEnabled bashEnabled
+        computerUseEnabled <- readIORef computerUseEnabledRef
+        refreshSessionParams
+            ghciEnabled
+            bashEnabled
+            computerUseEnabled
 
 data SessionSubagentRuntime = SessionSubagentRuntime
     { subagentBeginTurn :: !(IO (Maybe RootTurnId))
@@ -1038,12 +1137,9 @@ buildSessionLoopConfig
         , loopMaxTurns = options.optMaxTurns
         , loopOnEvent = eventRuntime.loopEventEmit
         , loopApprove = \call ->
-            shellRuntime.shellToolAllowed call >>= \case
-                False ->
-                    pure (Left
-                        ("Tool " <> call.name
-                            <> " is disabled by the current /shell setting."))
-                True -> approvalRuntime.approvalApproveRegistered call
+            shellRuntime.shellToolDisabledReason call >>= \case
+                Just reason -> pure (Left reason)
+                Nothing -> approvalRuntime.approvalApproveRegistered call
         , loopReadSteering =
             readSteeringInputs controls.controlSteeringInputs
         , loopCommitSteering = \count ->
@@ -1073,14 +1169,11 @@ installSessionToolRuntimes
         , providerNativeToolsEnabled =
             host.hostNativeCapabilities.nativeProviderNativeTools
         }
-    forM_ codeModeNestedSlot \slot ->
+    forM_ ((.codeModeNestedSlot) <$> codeModeRuntime) \slot ->
         setCodeModeNestedInvoke slot \call -> do
-            allowed <- shellRuntime.shellToolAllowed call
-            if not allowed
-                then pure $ Left $
-                    "Tool " <> call.name
-                        <> " is disabled by the current /shell setting."
-                else
+            shellRuntime.shellToolDisabledReason call >>= \case
+                Just reason -> pure (Left reason)
+                Nothing ->
                     approvalRuntime.approvalApproveRegistered call >>= \case
                         Left denial -> pure (Left denial)
                         Right False ->
@@ -1118,7 +1211,7 @@ newSessionLoopRuntime host controls request@SessionRequest{..} sessionBackend = 
     let eventRuntime =
             buildSessionLoopEventRuntime
                 host controls request managedLoopPublisher
-        shellRuntime = buildSessionShellRuntime host request
+        shellRuntime = buildSessionShellRuntime host controls request
         approvalRuntime =
             buildSessionApprovalRuntime host controls request
         subagentRuntime = buildSessionSubagentRuntime request
@@ -1372,6 +1465,10 @@ buildSessionEnv
             loopRuntime.loopRuntimeShell.shellCurrentMode
         , sessionSetShellMode =
             loopRuntime.loopRuntimeShell.shellSetMode
+        , sessionComputerUseEnabled =
+            loopRuntime.loopRuntimeShell.shellComputerUseEnabled
+        , sessionSetComputerUseEnabled =
+            loopRuntime.loopRuntimeShell.shellSetComputerUseEnabled
         , sessionBackground = startup.startupBackground
         , sessionEscPaused = escPaused
         , sessionDraft = startup.startupSessionState.sessionDraft

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -15,7 +15,7 @@ import Agent.CLI.Claude (ClaudeSessionRuntimeSlot)
 import Agent.CLI.Session.History (LiveConversation)
 import Agent.CLI.Btw (BtwBackendFactory)
 import Agent.CLI.CodeModeRuntime
-    ( CodeModeNestedSlot
+    ( CodeModeSessionRuntime
     , CodexCatalogSession
     )
 import Agent.CLI.Compaction
@@ -180,9 +180,9 @@ data SessionRequest = SessionRequest
     , selectAccount :: !(Maybe (Text -> IO (Either ApiError Text)))
     , onPersisted :: !(SessionHandle -> IO ())
     , compactRunner :: !(Maybe Text -> IO (Either Text CompactOutcome))
-      -- | Late-bound nested dispatcher for code-mode sessions. The runner
-      -- installs the approval-aware invoke once its approval pipeline exists.
-    , codeModeNestedSlot :: !(Maybe CodeModeNestedSlot)
+      -- | Code-mode projection and late-bound nested dispatcher. The runner
+      -- uses the projection to rebuild direct schemas when tools are toggled.
+    , codeModeRuntime :: !(Maybe CodeModeSessionRuntime)
       -- | Catalog-instruction context for OpenAI models with a catalog entry.
     , codexCatalogSession :: !(Maybe CodexCatalogSession)
     }

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -120,6 +120,9 @@ data SessionRequest = SessionRequest
     , commitAttributionEffort :: !Text
     , policyRef :: !(IORef ApprovalPolicy)
     , allTools :: ![AppTool]
+      -- | Full toggleable tool surface, minus tools unavailable at startup.
+      -- Unlike allTools, this list governs provider availability and refreshes.
+    , refreshTools :: ![AppTool]
     , recordImageGenerationInputs :: !([ImageAttachment] -> IO ())
     , clearImageGenerationHistory :: !(IO ())
     , suspendGhci :: !(IO ())

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -103,6 +103,8 @@ data SessionEnv = SessionEnv
     , sessionGrokRuntime :: !(Maybe GrokRuntimeControl)
     , sessionShellMode :: !(IO ShellMode)
     , sessionSetShellMode :: !(ShellMode -> IO Text)
+    , sessionComputerUseEnabled :: !(IO Bool)
+    , sessionSetComputerUseEnabled :: !(Bool -> IO Text)
     , sessionBackground :: !Bool
     , sessionEscPaused :: !(IORef Bool)
     , sessionDraft :: !(IORef Text)

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -474,7 +474,7 @@ spec = describe "Agent.CLI.AgentSessions" do
                 args `shouldContain` ["--bash"]
                 closeSessionProcessManager manager
 
-    it "forwards ghci disablement to managed session turns" $
+    it "keeps terminal-only capabilities out of managed session turns" $
         withTempStoreDir "agent-session-runtime-" \pool root -> do
             let argsPath = toFilePath root FilePath.</> "agent-args"
             script <- writeFakeAgentBody root
@@ -490,6 +490,7 @@ spec = describe "Agent.CLI.AgentSessions" do
                     handle.sessionMeta.metaId
                     "completed"
                 args <- lines <$> readFile argsPath
+                args `shouldContain` ["--no-computer-use"]
                 args `shouldContain` ["--no-ghci", "--bash"]
                 closeSessionProcessManager manager
 

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -242,6 +242,25 @@ spec = do
                             "✓ computer use approved until disabled")
                     ]
 
+        it "keeps Allow once distinct from a computer workflow grant" do
+            let call = ToolCall
+                    { callId = "computer-1"
+                    , name = computerToolName
+                    , arguments = "{}"
+                    , callKind = ComputerCallKind
+                    , argumentsEncrypted = False
+                    }
+            resolveApprovalPrompt call (Just PermissionAllowOnce)
+                `shouldBe` CompleteApproval (Right True) []
+            resolveApprovalPrompt call (Just PermissionAllowTool)
+                `shouldBe` CompleteApproval
+                    (Right True)
+                    [ RememberToolForSession computerToolName
+                    , ReportApprovalNotice
+                        (ApprovalSuccess
+                            "✓ computer use approved until disabled")
+                    ]
+
     describe "approveFilesystemRootAccess" do
         it "bypasses the prompt whenever the live policy is yolo" do
             policy <- newIORef PromptMutating
@@ -559,7 +578,7 @@ spec = do
             notices <- newIORef []
             let request _ = do
                     modifyIORef' permissionRequests (+ 1)
-                    pure (Just PermissionAllowOnce)
+                    pure (Just PermissionAllowTool)
                 computerCall kind = ToolCall
                     { callId = "computer-1"
                     , name = computerToolName
@@ -582,6 +601,34 @@ spec = do
             readIORef notices `shouldReturn`
                 [ApprovalSuccess
                     "✓ computer use approved until disabled"]
+
+        it "prompts for each computer call after an Allow once choice" do
+            policy <- newIORef ApproveAll
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv
+                (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            permissionRequests <- newIORef (0 :: Int)
+            notices <- newIORef []
+            let request _ = do
+                    modifyIORef' permissionRequests (+ 1)
+                    pure (Just PermissionAllowOnce)
+                call = ToolCall
+                    { callId = "computer-1"
+                    , name = computerToolName
+                    , arguments = "{}"
+                    , callKind = ComputerCallKind
+                    , argumentsEncrypted = False
+                    }
+                approve = approveToolDecisionWithReporter
+                    request
+                    (\notice -> modifyIORef' notices (<> [notice]))
+                    policy allowed
+                    (registry [computerUseTool]) plan call
+            approve `shouldReturn` Right True
+            approve `shouldReturn` Right True
+            readIORef permissionRequests `shouldReturn` 2
+            readIORef allowed `shouldReturn` Set.empty
+            readIORef notices `shouldReturn` []
 
         it "prompts again when a computer call introduces safety checks" do
             policy <- newIORef ApproveAll

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -13,7 +13,7 @@ import Agent.CLI.Approval
     , resolveApprovalPrompt
     )
 import Agent.CLI.Options (ApprovalPolicy(..))
-import Agent.CLI.ComputerUse (computerUseTool)
+import Agent.CLI.ComputerUse (computerToolName, computerUseTool)
 import Agent.CLI.Permission (PermissionChoice(..))
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -218,6 +218,28 @@ spec = do
                     , ReportApprovalNotice
                         (ApprovalSuccess
                             "✓ always allow run_terminal_command this session")
+                    ]
+
+        it "preserves project-wide approval semantics for a computer workflow" do
+            let call = ToolCall
+                    { callId = "computer-1"
+                    , name = computerToolName
+                    , arguments = "{}"
+                    , callKind = ComputerCallKind
+                    , argumentsEncrypted = False
+                    }
+            resolveApprovalPrompt call (Just PermissionAllowAll)
+                `shouldBe` CompleteApproval
+                    (Right True)
+                    [ SetApprovalPolicy ApproveAll
+                    , PersistProjectAutoApprove
+                    , RememberToolForSession computerToolName
+                    , ReportApprovalNotice
+                        (ApprovalSuccess
+                            "✓ auto-approve on (saved for project)")
+                    , ReportApprovalNotice
+                        (ApprovalSuccess
+                            "✓ computer use approved until disabled")
                     ]
 
     describe "approveFilesystemRootAccess" do
@@ -528,34 +550,70 @@ spec = do
             readIORef permissionRequests `shouldReturn` 1
             readIORef allowed `shouldReturn` Set.singleton "run_terminal_cmd"
 
-        it "prompts for every computer call even under ApproveAll" do
+        it "prompts once for a computer-use workflow even under ApproveAll" do
             policy <- newIORef ApproveAll
             allowed <- newIORef Set.empty
             plan <- newPlanModeEnv
                 (unsafeEncodeUtf "/tmp/approval-test") Nothing
             permissionRequests <- newIORef (0 :: Int)
+            notices <- newIORef []
             let request _ = do
                     modifyIORef' permissionRequests (+ 1)
-                    pure (Just PermissionAllowTool)
+                    pure (Just PermissionAllowOnce)
                 computerCall kind = ToolCall
                     { callId = "computer-1"
-                    , name = "computer"
+                    , name = computerToolName
                     , arguments = "{}"
                     , callKind = kind
                     , argumentsEncrypted = False
                     }
                 approve kind = approveToolDecisionWithReporter
-                    request (\_ -> pure ()) policy allowed
-                    (registry [mutatingTool]) plan (computerCall kind)
+                    request
+                    (\notice -> modifyIORef' notices (<> [notice]))
+                    policy allowed
+                    (registry [computerUseTool]) plan (computerCall kind)
             mapM_ (\kind -> do
                 approve kind `shouldReturn` Right True
                 approve kind `shouldReturn` Right True)
                 [ComputerCallKind, ComputerFunctionCallKind]
-            readIORef permissionRequests `shouldReturn` 4
+            readIORef permissionRequests `shouldReturn` 1
             readIORef policy `shouldReturn` ApproveAll
-            readIORef allowed `shouldReturn` Set.empty
+            readIORef allowed `shouldReturn` Set.singleton computerToolName
+            readIORef notices `shouldReturn`
+                [ApprovalSuccess
+                    "✓ computer use approved until disabled"]
 
-        it "does not cache allow-tool for computer calls" do
+        it "prompts again when a computer call introduces safety checks" do
+            policy <- newIORef ApproveAll
+            allowed <- newIORef (Set.singleton computerToolName)
+            plan <- newPlanModeEnv
+                (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            permissionRequests <- newIORef (0 :: Int)
+            let call arguments = ToolCall
+                    { callId = "computer-1"
+                    , name = computerToolName
+                    , arguments
+                    , callKind = ComputerCallKind
+                    , argumentsEncrypted = False
+                    }
+                approve computerCall = approveToolDecisionWithReporter
+                    (\_ -> modifyIORef' permissionRequests (+ 1)
+                        >> pure (Just PermissionAllowOnce))
+                    (\_ -> pure ())
+                    policy allowed
+                    (registry [computerUseTool])
+                    plan computerCall
+            approve (call "{\"actions\":[{\"type\":\"screenshot\"}]}")
+                `shouldReturn` Right True
+            readIORef permissionRequests `shouldReturn` 0
+            approve
+                (call
+                    "{\"actions\":[{\"type\":\"screenshot\"}],\
+                    \\"pending_safety_checks\":[{\"id\":\"check-1\"}]}")
+                `shouldReturn` Right True
+            readIORef permissionRequests `shouldReturn` 1
+
+        it "prompts again after the computer-use workflow grant is cleared" do
             policy <- newIORef PromptMutating
             allowed <- newIORef Set.empty
             plan <- newPlanModeEnv
@@ -566,30 +624,32 @@ spec = do
                     pure (Just PermissionAllowTool)
                 computerCall kind = ToolCall
                     { callId = "computer-1"
-                    , name = "computer"
+                    , name = computerToolName
                     , arguments = "{}"
                     , callKind = kind
                     , argumentsEncrypted = False
                     }
                 approve kind = approveToolDecisionWithReporter
                     request (\_ -> pure ()) policy allowed
-                    (registry [mutatingTool]) plan (computerCall kind)
-            mapM_ (\kind -> do
-                approve kind `shouldReturn` Right True
-                approve kind `shouldReturn` Right True)
-                [ComputerCallKind, ComputerFunctionCallKind]
-            readIORef permissionRequests `shouldReturn` 4
-            readIORef allowed `shouldReturn` Set.empty
+                    (registry [computerUseTool]) plan (computerCall kind)
+            approve ComputerCallKind `shouldReturn` Right True
+            approve ComputerCallKind `shouldReturn` Right True
+            readIORef permissionRequests `shouldReturn` 1
+            modifyIORef' allowed (Set.delete computerToolName)
+            approve ComputerFunctionCallKind `shouldReturn` Right True
+            approve ComputerFunctionCallKind `shouldReturn` Right True
+            readIORef permissionRequests `shouldReturn` 2
+            readIORef allowed `shouldReturn` Set.singleton computerToolName
 
         it "rejects spoofed function/custom computer calls under ApproveAll" do
             policy <- newIORef ApproveAll
-            allowed <- newIORef (Set.singleton "computer")
+            allowed <- newIORef (Set.singleton computerToolName)
             plan <- newPlanModeEnv
                 (unsafeEncodeUtf "/tmp/approval-test") Nothing
             permissionRequests <- newIORef (0 :: Int)
             let spoof kind = ToolCall
                     { callId = "spoof-1"
-                    , name = "computer"
+                    , name = computerToolName
                     , arguments = "{}"
                     , callKind = kind
                     , argumentsEncrypted = False
@@ -630,7 +690,7 @@ spec = do
                     (computerCall kind)
                     `shouldReturn`
                         Left
-                            "Computer use requires an explicit parent approval for every call.")
+                            "Computer use must be approved in the interactive parent session.")
                 [ComputerCallKind, ComputerFunctionCallKind]
 
         it "allows only read-only tools under DenyMutating" do

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -164,6 +164,17 @@ spec = do
                 `shouldBe` ReplCommandError
                     "usage: /shell [ghci|bash|both|none]"
 
+        it "toggles or explicitly sets computer use" do
+            parseReplLine "/computer-use"
+                `shouldBe` ReplToggleComputerUse
+            parseReplLine "/computer-use on"
+                `shouldBe` ReplSetComputerUse True
+            parseReplLine "/computer-use OFF"
+                `shouldBe` ReplSetComputerUse False
+            parseReplLine "/computer-use status"
+                `shouldBe` ReplCommandError
+                    "usage: /computer-use [on|off]"
+
         it "parses runtime code-mode enablement" do
             parseReplLine "/codemod" `shouldBe` ReplEnableCodeMode
             parseReplLine "/code-mode" `shouldBe` ReplEnableCodeMode
@@ -513,6 +524,7 @@ spec = do
                     , "deep-research"
                     , "skills"
                     , "shell"
+                    , "computer-use"
                     , "codemod"
                     , "always-approve"
                     , "update-and-restart"
@@ -596,6 +608,8 @@ spec = do
                 `shouldBe` ["--worktree", "--no-worktree"]
             slashCompletionCandidates "llehs/" "b"
                 `shouldBe` ["bash", "both"]
+            slashCompletionCandidates "esu-retupmoc/" "o"
+                `shouldBe` ["on", "off"]
 
         it "does not complete ordinary prompts" do
             slashCompletionCandidates "" "help" `shouldBe` []

--- a/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
@@ -389,7 +389,7 @@ spec = do
             summary `shouldSatisfy`
                 (not . ("top secret" `Text.isInfixOf`))
             prompt `shouldSatisfy`
-                maybe False ("Allow this computer-use workflow until disabled?"
+                maybe False ("Allow this computer-use request?"
                     `Text.isPrefixOf`)
 
         it "escapes control characters in untrusted summary fields" do

--- a/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
@@ -389,7 +389,7 @@ spec = do
             summary `shouldSatisfy`
                 (not . ("top secret" `Text.isInfixOf`))
             prompt `shouldSatisfy`
-                maybe False ("Allow this computer action?"
+                maybe False ("Allow this computer-use workflow until disabled?"
                     `Text.isPrefixOf`)
 
         it "escapes control characters in untrusted summary fields" do

--- a/packages/agent-cli/test/Agent/CLI/MetaConsoleSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MetaConsoleSpec.hs
@@ -142,6 +142,33 @@ spec = do
                     Left err -> "unsafe or unsupported" `Text.isInfixOf` err
                     Right _ -> False
 
+        it "allows only the supported computer-use workflow controls" do
+            let decode command =
+                    decodeMetaPlan
+                        ( "{\"summary\":\"desktop\",\"actions\":[{\"type\":\"session_command\",\"command\":\""
+                            <> command
+                            <> "\"}]}"
+                        )
+                commands =
+                    [ "/computer-use"
+                    , "/computer-use on"
+                    , "/computer-use OFF"
+                    ]
+            map decode commands
+                `shouldBe`
+                    map
+                        (\command ->
+                            Right MetaPlan
+                                { metaSummary = "desktop"
+                                , metaActions = [MetaSessionCommand command]
+                                }
+                        )
+                        commands
+            decode "/computer-use status"
+                `shouldSatisfy` \case
+                    Left err -> "unsafe or unsupported" `Text.isInfixOf` err
+                    Right _ -> False
+
         it "rejects plans that remove and modify the same server" do
             decodeMetaPlan
                 (Text.concat

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -366,9 +366,12 @@ spec = do
             parseArgs ["--no-bash", "--bash"]
                 `shouldBe` Right (RunAgent defaultCliOptions { optBash = True })
 
-        it "keeps computer use opt-in" do
-            defaultCliOptions.optComputerUse `shouldBe` False
-            parseArgs ["--computer-use"]
+        it "enables computer use by default and allows an explicit override" do
+            defaultCliOptions.optComputerUse `shouldBe` True
+            parseArgs ["--no-computer-use"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optComputerUse = False })
+            parseArgs ["--no-computer-use", "--computer-use"]
                 `shouldBe` Right (RunAgent defaultCliOptions
                     { optComputerUse = True })
             parseArgs ["--computer-use", "--no-computer-use"]

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -366,17 +366,42 @@ spec = do
             parseArgs ["--no-bash", "--bash"]
                 `shouldBe` Right (RunAgent defaultCliOptions { optBash = True })
 
-        it "enables computer use by default and allows an explicit override" do
+        it "tracks explicit computer-use overrides with last-flag-wins semantics" do
             defaultCliOptions.optComputerUse `shouldBe` True
+            defaultCliOptions.optComputerUseExplicit `shouldBe` False
             parseArgs ["--no-computer-use"]
                 `shouldBe` Right (RunAgent defaultCliOptions
-                    { optComputerUse = False })
+                    { optComputerUse = False
+                    , optComputerUseExplicit = True
+                    })
             parseArgs ["--no-computer-use", "--computer-use"]
                 `shouldBe` Right (RunAgent defaultCliOptions
-                    { optComputerUse = True })
+                    { optComputerUse = True
+                    , optComputerUseExplicit = True
+                    })
             parseArgs ["--computer-use", "--no-computer-use"]
                 `shouldBe` Right (RunAgent defaultCliOptions
-                    { optComputerUse = False })
+                    { optComputerUse = False
+                    , optComputerUseExplicit = True
+                    })
+
+        it "defaults computer use to TTY sessions while honoring explicit flags" do
+            resolveComputerUseEnabled defaultCliOptions True `shouldBe` True
+            resolveComputerUseEnabled defaultCliOptions False `shouldBe` False
+            resolveComputerUseEnabled
+                defaultCliOptions
+                    { optComputerUse = True
+                    , optComputerUseExplicit = True
+                    }
+                False
+                `shouldBe` True
+            resolveComputerUseEnabled
+                defaultCliOptions
+                    { optComputerUse = False
+                    , optComputerUseExplicit = True
+                    }
+                True
+                `shouldBe` False
 
         it "uses conventional tool calling by default" do
             defaultCliOptions.optCodeMode `shouldBe` False

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -403,6 +403,30 @@ spec = do
                 True
                 `shouldBe` False
 
+        it "requires an explicit opt-in for one-shot TTY invocations" do
+            resolveComputerUseEnabled
+                defaultCliOptions { optPrompt = Just "hi" }
+                True
+                `shouldBe` False
+            resolveComputerUseEnabled
+                defaultCliOptions
+                    { optPromptFile = Just (fromFilePath "prompt.md") }
+                True
+                `shouldBe` False
+            resolveComputerUseEnabled
+                defaultCliOptions
+                    { optManagedTurnFile = Just (fromFilePath "turn.json") }
+                True
+                `shouldBe` False
+            resolveComputerUseEnabled
+                defaultCliOptions
+                    { optPrompt = Just "hi"
+                    , optComputerUse = True
+                    , optComputerUseExplicit = True
+                    }
+                True
+                `shouldBe` True
+
         it "uses conventional tool calling by default" do
             defaultCliOptions.optCodeMode `shouldBe` False
             parseArgs ["--code-mode"]

--- a/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
@@ -77,7 +77,7 @@ spec = do
                 prompt = approvalToolCallPromptRelative "/repo" call
             prompt `shouldSatisfy`
                 Text.isPrefixOf
-                    "Allow this computer-use workflow until disabled?"
+                    "Allow this computer-use request?"
             prompt `shouldNotSatisfy` Text.isInfixOf "\"actions\""
 
     describe "approval policy picker" do

--- a/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PermissionSpec.hs
@@ -76,7 +76,8 @@ spec = do
                     }
                 prompt = approvalToolCallPromptRelative "/repo" call
             prompt `shouldSatisfy`
-                Text.isPrefixOf "Allow this computer action?"
+                Text.isPrefixOf
+                    "Allow this computer-use workflow until disabled?"
             prompt `shouldNotSatisfy` Text.isInfixOf "\"actions\""
 
     describe "approval policy picker" do

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -3,9 +3,11 @@ module Agent.CLI.ToolsSpec (spec) where
 import Agent.CLI.Tools
 import Agent.CLI.ComputerUse (computerUseTool)
 import Agent.CLI.CodeModeRuntime
-    ( CodeModeToolProjection(..)
+    ( CodeModeProjectionStrategy(..)
+    , CodeModeToolProjection(..)
     , imageGenerationCodeModeProjection
     , projectCodeModeTools
+    , projectCodeModeToolsFor
     )
 import Agent.Dialect
     ( claudeCodeDialect
@@ -115,6 +117,24 @@ spec = describe "schemasFromAppTools" do
             `shouldBe` ["shell_command", "computer"]
         map (.appToolName) projection.nestedCodeModeTools
             `shouldBe` ["read_file", "shell_command"]
+
+    it "reprojects direct computer use when a code-mode tool set changes" do
+        let withoutComputer =
+                map testTool ["read_file", "imagegen", "shell_command"]
+            withComputer = withoutComputer <> [computerUseTool]
+            directNames strategy =
+                map (.appToolName)
+                    . (.directCodeModeTools)
+                    . projectCodeModeToolsFor strategy
+        directNames FullCodeModeProjection withoutComputer
+            `shouldBe` ["shell_command"]
+        directNames FullCodeModeProjection withComputer
+            `shouldBe` ["shell_command", "computer"]
+        directNames ImageGenerationOnlyCodeModeProjection withoutComputer
+            `shouldBe` ["read_file", "shell_command"]
+        directNames ImageGenerationOnlyCodeModeProjection withComputer
+            `shouldBe` ["read_file", "shell_command", "computer"]
+
     it "nests only imagegen for code-only models when full code mode is off" do
         let tools = map testTool ["read_file", "imagegen", "shell_command"]
         case imageGenerationCodeModeProjection CodeOnlyToolMode tools of

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -5,6 +5,7 @@ import Agent.CLI.ComputerUse (computerUseTool)
 import Agent.CLI.CodeModeRuntime
     ( CodeModeProjectionStrategy(..)
     , CodeModeToolProjection(..)
+    , filterStartupUnavailableTools
     , imageGenerationCodeModeProjection
     , projectCodeModeTools
     , projectCodeModeToolsFor
@@ -134,6 +135,17 @@ spec = describe "schemasFromAppTools" do
             `shouldBe` ["read_file", "shell_command"]
         directNames ImageGenerationOnlyCodeModeProjection withComputer
             `shouldBe` ["read_file", "shell_command", "computer"]
+
+    it "retains toggleable computer use when imagegen fails at startup" do
+        let refreshTools =
+                filterStartupUnavailableTools
+                    True
+                    [ testTool "read_file"
+                    , testTool "imagegen"
+                    , computerUseTool
+                    ]
+        map (.appToolName) refreshTools
+            `shouldBe` ["read_file", "computer"]
 
     it "nests only imagegen for code-only models when full code mode is off" do
         let tools = map testTool ["read_file", "imagegen", "shell_command"]

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/TaskAdapter.hs
@@ -748,7 +748,11 @@ runProcessTask runtimeSeconds executable task logLine = do
 
 processTaskArguments :: DurableTask -> [String]
 processTaskArguments task =
-    ["--prompt", Text.unpack task.description, "--save-session", "--no-yolo"]
+    [ "--prompt", Text.unpack task.description
+    , "--save-session"
+    , "--no-yolo"
+    , "--no-computer-use"
+    ]
         <> maybe [] (\value -> ["--resume", Text.unpack value]) task.sessionId
         <> ["--cwd", task.workingDirectory]
         <> maybe [] (\value -> ["--provider", Text.unpack value]) task.provider

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -1051,6 +1051,7 @@ main = hspec $ do
                         , "hello agent"
                         , "--save-session"
                         , "--no-yolo"
+                        , "--no-computer-use"
                         , "--resume"
                         , "session-id"
                         , "--cwd"

--- a/tests/functional/agent-cli-hello-world.sh
+++ b/tests/functional/agent-cli-hello-world.sh
@@ -104,6 +104,7 @@ args=(
   --motion off
   --no-agents-md
   --no-skills
+  --no-computer-use
   --max-turns 12
 )
 if [[ -n $(printf '%q' "$provider") ]]; then


### PR DESCRIPTION
## Summary
- enable local macOS computer use for terminal CLI sessions, with `--computer-use` / `--no-computer-use` startup controls
- add `/computer-use`, `/computer-use on`, and `/computer-use off`, including dynamic tool visibility and safe rejection of stale disabled calls
- prompt once when a computer-use workflow begins, reuse that grant for subsequent actions, and require a fresh decision for safety checks or after re-enabling
- keep daemon/headless launchers opted out and document the required macOS permissions
- repair the `StartupFailure Text` conversion left inconsistent by the current `master`, so the rebased CLI builds

## Testing
- object-code GHCi: computer-use-focused suite (44 examples, 0 failures)
- object-code GHCi: daemon argv/process-output test (1 example, 0 failures)
- object-code GHCi: slash-command completion test (1 example, 0 failures)
- `nix develop -c cabal build agent-cli:exe:agent-cli`
- live tmux smoke: toggle, disable, re-enable, explicit on, and explicit off
- macOS host Swift test: `CLIAgentClientArgumentsTests` (2 tests, 0 failures)
- `git diff --check`

Companion macOS PR: digitallyinduced/haskell-agent-macos#150.
