### PR TITLE
Fix fresh-store flake evaluation in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,10 +133,16 @@ jobs:
             --print-build-logs
 
           if [[ "$EVALUATE_FLAKE" == true ]]; then
-            # Building the CLI root first materialises the callCabal2nix
-            # import needed to evaluate every exported flake output on a
-            # fresh store. `--no-build` then checks their shape without
-            # duplicating the targeted builds above.
+            # The native CLI build materialises its GNU callCabal2nix
+            # imports, but packages.default uses a separate musl package set.
+            # Instantiate that derivation with builds enabled so its generated
+            # package expressions exist before `--no-build` checks every
+            # exported flake output.
+            "$nix_bin" eval \
+              --raw \
+              .#packages.x86_64-linux.default.drvPath \
+              --no-write-lock-file \
+              > /dev/null
             "$nix_bin" flake check \
               --no-build \
               --no-write-lock-file


### PR DESCRIPTION
## Summary

- materialize the static/musl `callCabal2nix` inputs before the CLI job runs a full `nix flake check --no-build`
- keep complete flake-output evaluation in PR CI without rebuilding or duplicating the static CLI target
- fix the false failure seen after all 1,664 CLI tests had passed in run 33868470003

## Root cause

The CLI check realizes the GHC 9.10 GNU package set's generated Nix expressions. `packages.x86_64-linux.default` uses a separate GHC 9.12 musl package set, so full flake evaluation needs different IFD outputs. On a fresh hosted store, `--no-build` could not realize the missing `cabal2nix-hasql-pool.drv` and failed while checking `packages.default`.

Evaluating only `packages.x86_64-linux.default.drvPath` with builds enabled realizes those small generated expressions; it does not build the static CLI. The following `flake check --no-build` can then validate every exported output as intended.

## Validation

- reproduced the original failure in an isolated chroot Nix store after materializing only the native CLI evaluation inputs
- ran the new static drvPath preflight in that same store, then completed `nix flake check --no-build --no-write-lock-file` successfully (32 seconds total, 915 MiB scratch store)
- `actionlint .github/workflows/*.yml`
- `nix flake check --no-build --no-write-lock-file`
- `git diff --check origin/master...HEAD`
