### PR TITLE
fix(native): own long-lived workers

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -59,17 +59,15 @@ import Agent.TUI.Motion (MotionMode(..))
 import qualified Agent.MCP as MCP
 import Control.Concurrent.Async
     ( Async
-    , async
+    , asyncWithUnmask
     , cancel
-    , waitCatch
     )
 import Control.Concurrent.MVar
     ( newEmptyMVar
     , putMVar
     , takeMVar
     )
-import Control.Exception.Safe (finally, mask_, onException)
-import Control.Monad (void)
+import Control.Exception.Safe (finally, mask, mask_, onException)
 import Data.IORef
     ( IORef
     , atomicModifyIORef'
@@ -120,14 +118,13 @@ data NativeProcessRuntime = NativeProcessRuntime
     }
 
 newNativeProcessRuntime :: OsPath -> IO NativeProcessRuntime
-newNativeProcessRuntime root = do
+newNativeProcessRuntime root = mask \restore -> do
     elicitationRef <- newIORef Nothing
     cleanupStarted <- newIORef False
     cleanupRequest <- newEmptyMVar
-    cleanupWorker <- async (takeMVar cleanupRequest >>= id)
-    let closeCleanupWorker = do
-            cancel cleanupWorker
-            void (waitCatch cleanupWorker)
+    cleanupWorker <- asyncWithUnmask \unmask ->
+        unmask (takeMVar cleanupRequest >>= id)
+    let closeCleanupWorker = cancel cleanupWorker
         startCleanup action = mask_ do
             shouldStart <- atomicModifyIORef'
                 cleanupStarted
@@ -136,17 +133,18 @@ newNativeProcessRuntime root = do
                 then putMVar cleanupRequest action
                 else pure ()
     networkMonitor <-
-        newNetworkRecoveryMonitor
+        restore newNetworkRecoveryMonitor
             `onException` closeCleanupWorker
     mcpSupervisor <-
-        MCP.newMcpSupervisorWith
-            MCP.defaultMcpHostHooks
-                { MCP.mcpHostElicit = readIORef elicitationRef }
+        restore
+            (MCP.newMcpSupervisorWith
+                MCP.defaultMcpHostHooks
+                    { MCP.mcpHostElicit = readIORef elicitationRef })
             `onException`
                 (closeNetworkRecoveryMonitor networkMonitor
                     `finally` closeCleanupWorker)
     sessionThreads <-
-        newSessionThreadManager root
+        restore (newSessionThreadManager root)
             `onException`
                 (MCP.closeMcpSupervisor mcpSupervisor
                     `finally`
@@ -169,9 +167,7 @@ closeNativeProcessRuntime runtime =
                 `finally`
                     (closeNetworkRecoveryMonitor
                         runtime.nativeNetworkRecovery
-                        `finally` do
-                            cancel runtime.nativeCleanupWorker
-                            void (waitCatch runtime.nativeCleanupWorker)))
+                        `finally` cancel runtime.nativeCleanupWorker))
 
 restartNativeMcpRuntime :: NativeProcessRuntime -> IO ()
 restartNativeMcpRuntime runtime =

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -251,7 +251,6 @@ import Agent.Tools.Types
     )
 import Control.Concurrent
     ( ThreadId
-    , forkFinally
     , forkIO
     , myThreadId
     , threadDelay
@@ -1052,7 +1051,7 @@ data SessionMutation
 
 data Engine = Engine
     { engineCommands :: !(EngineMailbox EngineCommand)
-    , engineDone :: !(MVar ())
+    , engineWorker :: !(Async ())
     , engineStagedImages :: !(TVar (Map Text [ImageAttachment]))
     , engineBrowser :: !BrowserHost
     , engineComputer :: !ComputerHost
@@ -4097,7 +4096,6 @@ ha_engine_create callback context
             home <- getHomeDirectory
             config <- managedPostgresConfigForHome home
             commands <- newEngineMailboxIO
-            done <- newEmptyMVar
             stagedImages <- newTVarIO Map.empty
             browser <- BrowserHost <$> newMVar Nothing
             computer <- newComputerHost
@@ -4110,29 +4108,33 @@ ha_engine_create callback context
                     , interactionCallbackLock = interactionLock
                     , interactionPending = pendingInteractions
                     }
-            _ <- forkFinally
-                (workerLifecycle
-                    callback
-                    context
-                    config
-                    (sessionsRoot home)
-                    commands
-                    stagedImages
-                    browser
-                    computer
-                    stagedTurnOptions
-                    interactions)
-                (const (putMVar done ()))
-            stable <- newStablePtr Engine
-                { engineCommands = commands
-                , engineDone = done
-                , engineStagedImages = stagedImages
-                , engineBrowser = browser
-                , engineComputer = computer
-                , engineStagedTurnOptions = stagedTurnOptions
-                , engineInteractions = interactions
-                }
-            pure (castStablePtrToPtr stable)
+            mask \_ -> do
+                -- Keep worker creation and stable-pointer publication in one
+                -- masked region so publication failure cannot orphan it.
+                worker <- asyncWithUnmask \unmask ->
+                    unmask
+                        (workerLifecycle
+                            callback
+                            context
+                            config
+                            (sessionsRoot home)
+                            commands
+                            stagedImages
+                            browser
+                            computer
+                            stagedTurnOptions
+                            interactions)
+                let engine = Engine
+                        { engineCommands = commands
+                        , engineWorker = worker
+                        , engineStagedImages = stagedImages
+                        , engineBrowser = browser
+                        , engineComputer = computer
+                        , engineStagedTurnOptions = stagedTurnOptions
+                        , engineInteractions = interactions
+                        }
+                stable <- newStablePtr engine `onException` cancel worker
+                pure (castStablePtrToPtr stable)
         case created of
             Left exception -> do
                 sendEvent callback context $
@@ -4586,7 +4588,7 @@ ha_engine_destroy pointer
                 (const (pure Nothing))
             _ <- atomically
                 (closeEngineMailbox engine.engineCommands EngineStop)
-            readMVar engine.engineDone)
+            void (waitCatch engine.engineWorker))
             `finally` freeStablePtr stable
 
 workerLifecycle


### PR DESCRIPTION
## Summary
- retain the native engine's actual `Async` owner instead of a separate completion token
- mask engine worker creation and stable-pointer publication, cancelling on publication failure
- mask native runtime assembly while restoring blocking acquisitions and their cleanup handlers
- rely on `cancel`'s join guarantee for the runtime cleanup worker

## Tests
- `cabal test agent-cli-test --test-options='--match "native bridge FFI"' --test-show-details=direct` (14 examples, 0 failures)
- `nix build .#agent-native-bridge --no-link`
- authoritative public/private bridge headers are byte-identical

- clean private macOS integration build with this checkout supplied as the `haskell-agent` input
