### PR TITLE
Retry transient dictation submission failures

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
@@ -13,7 +13,10 @@ module Agent.OpenAI.Transcription
     , transcribePcmWithOpenAIAt
     ) where
 
-import Agent.Error (ApiError(..))
+import Agent.Error
+    ( ApiError(..)
+    , isInlineRetryableProviderError
+    )
 import qualified Agent.Json.Decode as Json
 import Agent.Provider
     ( BillingMode(..)
@@ -26,6 +29,7 @@ import Agent.Provider
     , tokenProviderBillingMode
     )
 import Control.Applicative ((<|>))
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async
     ( cancel
     , waitCatch
@@ -952,47 +956,64 @@ postChatGPTTranscription
     -> BS.ByteString
     -> LBS.ByteString
     -> IO (Either ApiError Text)
-postChatGPTTranscription baseUrl credential boundary body = do
-    let contentType = "multipart/form-data; boundary=" <> boundary
-        endpoint =
-            Text.unpack
-                (Text.dropWhileEnd (== '/') baseUrl <> "/transcribe")
-        accountHeader request
-            | Text.null (Text.strip credential.accountId) = request
-            | otherwise =
-                setRequestHeader
-                    "ChatGPT-Account-Id"
-                    [Text.encodeUtf8 credential.accountId]
-                    request
-    tryAny
-        (do
-            request <- parseRequest endpoint
-            httpLBS
-                $ setRequestMethod "POST"
-                $ setRequestBodyLBS body
-                $ setRequestHeader "Content-Type" [contentType]
-                $ setRequestHeader "Accept" ["application/json"]
-                $ setRequestHeader "Originator" ["haskell-agent"]
-                $ setRequestHeader "User-Agent" ["haskell-agent"]
-                $ setRequestHeader
-                    "Authorization"
-                    ["Bearer " <> Text.encodeUtf8 credential.accessToken]
-                $ accountHeader request) >>= \case
-                    Left err
-                        | isSyncException err ->
-                            pure $ Left $ ConnectionError
-                                ("ChatGPT transcription request failed: "
-                                    <> Text.pack (displayException err))
-                        | otherwise ->
-                            throwIO err
-                    Right response -> do
-                        let status = getResponseStatusCode response
-                            responseBody = getResponseBody response
-                        pure $
-                            if status >= 200 && status < 300
-                                then decodeTranscriptionResponse responseBody
-                                else Left $ HttpError status
-                                    (responseBodyPreview responseBody)
+postChatGPTTranscription baseUrl credential boundary body =
+    retryTransientTranscription [3_000_000, 6_000_000] sendRequest
+  where
+    sendRequest = do
+        let contentType = "multipart/form-data; boundary=" <> boundary
+            endpoint =
+                Text.unpack
+                    (Text.dropWhileEnd (== '/') baseUrl <> "/transcribe")
+            accountHeader request
+                | Text.null (Text.strip credential.accountId) = request
+                | otherwise =
+                    setRequestHeader
+                        "ChatGPT-Account-Id"
+                        [Text.encodeUtf8 credential.accountId]
+                        request
+        tryAny
+            (do
+                request <- parseRequest endpoint
+                httpLBS
+                    $ setRequestMethod "POST"
+                    $ setRequestBodyLBS body
+                    $ setRequestHeader "Content-Type" [contentType]
+                    $ setRequestHeader "Accept" ["application/json"]
+                    $ setRequestHeader "Originator" ["haskell-agent"]
+                    $ setRequestHeader "User-Agent" ["haskell-agent"]
+                    $ setRequestHeader
+                        "Authorization"
+                        ["Bearer " <> Text.encodeUtf8 credential.accessToken]
+                    $ accountHeader request) >>= \case
+                        Left err
+                            | isSyncException err ->
+                                pure $ Left $ ConnectionError
+                                    ("ChatGPT transcription request failed: "
+                                        <> Text.pack (displayException err))
+                            | otherwise ->
+                                throwIO err
+                        Right response -> do
+                            let status = getResponseStatusCode response
+                                responseBody = getResponseBody response
+                            pure $
+                                if status >= 200 && status < 300
+                                    then decodeTranscriptionResponse responseBody
+                                    else Left $ HttpError status
+                                        (responseBodyPreview responseBody)
+
+retryTransientTranscription
+    :: [Int]
+    -> IO (Either ApiError Text)
+    -> IO (Either ApiError Text)
+retryTransientTranscription retryDelays action =
+    action >>= \result ->
+        case (retryDelays, result) of
+            (delay : remaining, Left err)
+                | isInlineRetryableProviderError err -> do
+                    threadDelay delay
+                    retryTransientTranscription remaining action
+            _ ->
+                pure result
 
 transcriptionBoundary :: IO BS.ByteString
 transcriptionBoundary = do

--- a/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
@@ -376,6 +376,62 @@ spec = describe "OpenAI transcription" do
                         ]
             _ -> False
 
+    it "retries a transient ChatGPT server error with the buffered audio" do
+        recorded <- newIORef []
+        attempts <- newIORef (0 :: Int)
+        captures <- newIORef (0 :: Int)
+        callbacks <- newIORef []
+        let credential = openAiCredential "subscription-token"
+            provider = tokenProvider SubscriptionBilled \_ ->
+                pure (Right credential)
+            app request respond =
+                if Wai.rawPathInfo request
+                    == "/backend-api/dictation/stream"
+                    then
+                        respond $ Wai.responseLBS HTTP.status404 [] ""
+                    else do
+                        body <- Wai.strictRequestBody request
+                        modifyIORef' recorded (<> [body])
+                        attempt <- atomicModifyIORef' attempts \count ->
+                            (count + 1, count)
+                        respond $
+                            if attempt == 0
+                                then Wai.responseLBS
+                                    HTTP.status503
+                                    [("Content-Type", "application/json")]
+                                    "{\"error\":\"temporarily unavailable\"}"
+                                else Wai.responseLBS
+                                    HTTP.status200
+                                    [("Content-Type", "application/json")]
+                                    (Aeson.encode (Aeson.object
+                                        [ "text" .=
+                                            ("recovered speech" :: Text)
+                                        ]))
+        withLoopbackApplication (pure app) \port -> do
+            let baseUrl =
+                    "http://127.0.0.1:"
+                        <> Text.pack (show port)
+                        <> "/backend-api"
+                produce send = do
+                    modifyIORef' captures (+ 1)
+                    send "\x01\x00\x02\x00"
+            result <- Timeout.timeout (8 * 1_000_000) $
+                transcribePcmWithOpenAIAt
+                    baseUrl
+                    provider
+                    produce
+                    (\text -> modifyIORef' callbacks (<> [text]))
+            result `shouldBe` Just (Right "recovered speech")
+
+        readIORef captures `shouldReturn` 1
+        readIORef callbacks `shouldReturn` ["recovered speech"]
+        requests <- readIORef recorded
+        requests `shouldSatisfy` \case
+            [first, second] ->
+                first == second
+                    && "RIFF" `BS.isInfixOf` LBS.toStrict first
+            _ -> False
+
 withWebSocketServer
     :: WS.ServerApp
     -> (Int -> IO value)


### PR DESCRIPTION
## Summary
- retry transient ChatGPT dictation submission failures after 3 and 6 seconds
- replay the already-buffered multipart WAV body so microphone capture runs only once
- cover server-error recovery and exact audio-body reuse with a loopback integration test

## Testing
- `cabal repl agent-openai:test:agent-openai-test`
- `:main --match "OpenAI transcription"` (10 examples, 0 failures)
- `git diff --check`