### PR TITLE
Stream dictation through organization gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,10 @@ For Grok models, dictation uses the configured xAI subscription or API-key
 credential; set `XAI_STT_LANGUAGE` to override xAI's default `en`.
 When an organization gateway is connected, the recording is sent only to the
 gateway's authenticated `/v1/audio/transcriptions` endpoint. The gateway uses
-its organization-managed transcription pool and returns a final transcript
-after recording stops; it never falls back to local provider credentials.
+its organization-managed transcription pool and streams partial transcripts
+into the composer while recording. Compatible older gateways and interrupted
+streams use the final-only upload on the same endpoint with the already
+captured recording; dictation never falls back to local provider credentials.
 Dictation is currently unavailable for OpenRouter and Gemini models.
 
 ### Claude Code subscription

--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -64,8 +64,10 @@ module Agent.CLI.GatewayClient
 
 import Agent.FileRetry (retryOnFileBusy, writeLazyFileAtomically)
 import Agent.OpenAI.Transcription
-    ( encodePcm16Wav
+    ( ChatGPTDictationStreamFailure(..)
+    , encodePcm16Wav
     , openAITranscriptionSampleRate
+    , transcribePcmWithChatGPTStreamAt
     )
 import Agent.CLI.Runtime.Options (GatewayCommand (..))
 import Agent.CLI.PrivateFileLock
@@ -543,18 +545,104 @@ transcribeGatewayPcmWith admitted produceAudio onTranscript =
         loadGatewayCredential >>= \case
             Right (Just current)
                 | current == admitted ->
-                    captureGatewayWav produceAudio >>= \case
+                    case gatewayDictationWebSocketUrl current of
                         Left err -> pure (Left err)
-                        Right wav ->
-                            postGatewayTranscription current wav >>= \case
-                                Left err -> pure (Left err)
-                                Right transcript -> do
-                                    onTranscript transcript
-                                    pure (Right transcript)
+                        Right websocketUrl -> do
+                            chunks <- newIORef []
+                            capturedBytes <- newIORef 0
+                            let captureAndBuffer sendAudio =
+                                    produceAudio \chunk ->
+                                        unless (BS.null chunk) do
+                                            total <-
+                                                (+ BS.length chunk)
+                                                    <$> readIORef capturedBytes
+                                            when
+                                                (total > gatewayMaxPcmBytes)
+                                                (throwString
+                                                    "gateway dictation audio exceeded the client limit")
+                                            writeIORef capturedBytes total
+                                            modifyIORef' chunks (chunk :)
+                                            sendAudio chunk
+                            transcribePcmWithChatGPTStreamAt
+                                websocketUrl
+                                [ ( "Authorization"
+                                  , "Bearer "
+                                        <> TextEncoding.encodeUtf8
+                                            current.gatewayAccessToken
+                                  )
+                                ]
+                                captureAndBuffer
+                                onTranscript >>= \case
+                                    Left ChatGPTDictationCaptureFailed{} ->
+                                        pure $
+                                            Left
+                                                "Gateway dictation audio capture failed."
+                                    Left ChatGPTDictationStreamUnavailable{} -> do
+                                        pcm <-
+                                            BS.concat . reverse
+                                                <$> readIORef chunks
+                                        wavResult <-
+                                            if BS.null pcm
+                                                then
+                                                    captureGatewayWav
+                                                        produceAudio
+                                                else
+                                                    pure $
+                                                        case encodePcm16Wav
+                                                            openAITranscriptionSampleRate
+                                                            pcm of
+                                                                Left _ ->
+                                                                    Left
+                                                                        "Gateway dictation streaming failed."
+                                                                Right wav ->
+                                                                    Right wav
+                                        case wavResult of
+                                            Left err -> pure (Left err)
+                                            Right wav ->
+                                                loadGatewayCredential >>= \case
+                                                    Right (Just latest)
+                                                        | latest == current ->
+                                                            postGatewayTranscription
+                                                                latest
+                                                                wav >>= \case
+                                                                    Left err ->
+                                                                        pure
+                                                                            (Left
+                                                                                err)
+                                                                    Right transcript -> do
+                                                                        onTranscript
+                                                                            transcript
+                                                                        pure
+                                                                            (Right
+                                                                                transcript)
+                                                    _ ->
+                                                        pure $
+                                                            Left
+                                                                "The organization gateway changed during dictation."
+                                    Right transcript ->
+                                        pure (Right transcript)
             _ ->
                 pure $
                     Left
                         "The organization gateway changed before dictation started."
+
+gatewayDictationWebSocketUrl
+    :: GatewayCredential
+    -> Either Text Text
+gatewayDictationWebSocketUrl credential = do
+    uri <-
+        maybe
+            (Left "Gateway WebSocket URL is invalid.")
+            Right
+            (URI.parseURI (Text.unpack credential.gatewayWebSocketUrl))
+    pure $
+        Text.pack $
+            show
+                uri
+                    { URI.uriPath = "/v1/audio/transcriptions"
+                    , URI.uriQuery = ""
+                    , URI.uriFragment = ""
+                    }
 
 captureGatewayWav
     :: ((BS.ByteString -> IO ()) -> IO ())

--- a/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
@@ -1,6 +1,7 @@
 -- | Microphone transcription through OpenAI and ChatGPT.
 module Agent.OpenAI.Transcription
     ( ChatGPTDictationEvent(..)
+    , ChatGPTDictationStreamFailure(..)
     , TranscriptEvent(..)
     , chatGPTTranscriptionBaseUrl
     , decodeChatGPTDictationEvent
@@ -11,6 +12,7 @@ module Agent.OpenAI.Transcription
     , openAITranscriptionSampleRate
     , transcribePcmWithOpenAI
     , transcribePcmWithOpenAIAt
+    , transcribePcmWithChatGPTStreamAt
     ) where
 
 import Agent.Error
@@ -118,6 +120,11 @@ data TranscriptEvent
         { transcriptMessage :: !Text
         }
     | TranscriptUnknown
+    deriving (Eq, Show)
+
+data ChatGPTDictationStreamFailure
+    = ChatGPTDictationStreamUnavailable !Text
+    | ChatGPTDictationCaptureFailed !Text
     deriving (Eq, Show)
 
 transcriptEventDecoder :: Json.Decoder TranscriptEvent
@@ -271,6 +278,94 @@ transcribePcmWithOpenAIAt baseUrl provider produceAudio onTranscript =
                 provider
                 produceAudio
                 onTranscript
+
+-- | Stream PCM through a ChatGPT-compatible dictation WebSocket at an exact
+-- URL. Trusted gateways use this to terminate their own bearer and proxy the
+-- opaque dictation protocol without exposing an upstream credential.
+transcribePcmWithChatGPTStreamAt
+    :: Text
+    -> WS.Headers
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (Text -> IO ())
+    -> IO (Either ChatGPTDictationStreamFailure Text)
+transcribePcmWithChatGPTStreamAt
+    websocketUrl
+    headers
+    produceAudio
+    onTranscript =
+        case chatGPTStreamEndpointAt websocketUrl of
+            Left message ->
+                pure (Left (ChatGPTDictationStreamUnavailable message))
+            Right endpoint ->
+                tryAny
+                    (runChatGPTWebSocketWith
+                        endpoint
+                        headers
+                        (streamSession produceAudio onTranscript)) >>= \case
+                            Left err
+                                | isSyncException err ->
+                                    pure $ Left $ ChatGPTDictationStreamUnavailable
+                                        ("Gateway dictation stream failed: "
+                                            <> Text.pack
+                                                (displayException err))
+                                | otherwise ->
+                                    throwIO err
+                            Right (ChatGPTStreamSucceeded transcript) ->
+                                pure (Right transcript)
+                            Right (ChatGPTStreamUnavailable message) ->
+                                pure
+                                    (Left
+                                        (ChatGPTDictationStreamUnavailable
+                                            message))
+                            Right (ChatGPTCaptureFailed message) ->
+                                pure
+                                    (Left
+                                        (ChatGPTDictationCaptureFailed
+                                            message))
+  where
+    streamSession capture notify connection = do
+        audio <- newChan
+        withAsync
+            (capture (writeChan audio . Just)
+                `finally` writeChan audio Nothing)
+            \captureWorker ->
+                withAsync
+                    (chatGPTStreamSession audio notify connection)
+                    \streamWorker ->
+                        waitEitherCatch
+                            captureWorker
+                            streamWorker >>= \case
+                                Left (Left err)
+                                    | isSyncException err -> do
+                                        cancel streamWorker
+                                        pure $ ChatGPTCaptureFailed
+                                            (Text.pack
+                                                (displayException err))
+                                    | otherwise ->
+                                        throwIO err
+                                Left (Right ()) ->
+                                    waitCatch streamWorker
+                                        >>= resolveStreamResult
+                                Right streamResult -> do
+                                    waitCatch captureWorker >>= \case
+                                        Left err
+                                            | isSyncException err ->
+                                                pure $ ChatGPTCaptureFailed
+                                                    (Text.pack
+                                                        (displayException err))
+                                            | otherwise ->
+                                                throwIO err
+                                        Right () ->
+                                            resolveStreamResult streamResult
+    resolveStreamResult = \case
+        Left err
+            | isSyncException err ->
+                pure $ ChatGPTStreamUnavailable
+                    (Text.pack (displayException err))
+            | otherwise ->
+                throwIO err
+        Right outcome ->
+            pure outcome
 
 transcribeRealtimeWithProvider
     :: TokenProvider
@@ -821,23 +916,7 @@ runChatGPTWebSocket
     -> WS.ClientApp a
     -> IO a
 runChatGPTWebSocket endpoint credential client =
-    if endpoint.streamSecure
-        then
-            Wuss.runSecureClientWith
-                endpoint.streamHost
-                (fromIntegral endpoint.streamPort)
-                endpoint.streamPath
-                WS.defaultConnectionOptions
-                headers
-                client
-        else
-            WS.runClientWith
-                endpoint.streamHost
-                endpoint.streamPort
-                endpoint.streamPath
-                WS.defaultConnectionOptions
-                headers
-                client
+    runChatGPTWebSocketWith endpoint headers client
   where
     headers =
         [ -- Codex Desktop loads its renderer from @app://-/index.html@.
@@ -861,20 +940,55 @@ runChatGPTWebSocket endpoint credential client =
           )
         ]
 
+runChatGPTWebSocketWith
+    :: ChatGPTStreamEndpoint
+    -> WS.Headers
+    -> WS.ClientApp a
+    -> IO a
+runChatGPTWebSocketWith endpoint headers client =
+    if endpoint.streamSecure
+        then
+            Wuss.runSecureClientWith
+                endpoint.streamHost
+                (fromIntegral endpoint.streamPort)
+                endpoint.streamPath
+                WS.defaultConnectionOptions
+                headers
+                client
+        else
+            WS.runClientWith
+                endpoint.streamHost
+                endpoint.streamPort
+                endpoint.streamPath
+                WS.defaultConnectionOptions
+                headers
+                client
+
 chatGPTStreamEndpoint :: Text -> Either Text ChatGPTStreamEndpoint
 chatGPTStreamEndpoint baseUrl = do
+    endpoint <- chatGPTStreamEndpointAt baseUrl
+    pure endpoint
+        { streamPath =
+            dropTrailingSlashes endpoint.streamPath
+                <> "/dictation/stream"
+        }
+
+chatGPTStreamEndpointAt :: Text -> Either Text ChatGPTStreamEndpoint
+chatGPTStreamEndpointAt websocketUrl = do
     uri <- maybe
-        (Left "ChatGPT transcription base URL is invalid")
+        (Left "Dictation WebSocket URL is invalid")
         Right
-        (parseURI (Text.unpack baseUrl))
+        (parseURI (Text.unpack websocketUrl))
     authority <- maybe
-        (Left "ChatGPT transcription base URL has no authority")
+        (Left "Dictation WebSocket URL has no authority")
         Right
         uri.uriAuthority
     secure <- case uri.uriScheme of
         "https:" -> Right True
+        "wss:" -> Right True
         "http:" -> Right False
-        _ -> Left "ChatGPT transcription base URL must use HTTP or HTTPS"
+        "ws:" -> Right False
+        _ -> Left "Dictation WebSocket URL must use WS, WSS, HTTP, or HTTPS"
     port <- case authority.uriPort of
         "" ->
             Right (if secure then 443 else 80)
@@ -884,18 +998,16 @@ chatGPTStreamEndpoint baseUrl = do
                     | value > 0 && value <= 65_535 ->
                         Right value
                 _ ->
-                    Left "ChatGPT transcription base URL has an invalid port"
+                    Left "Dictation WebSocket URL has an invalid port"
         _ ->
-            Left "ChatGPT transcription base URL has an invalid port"
+            Left "Dictation WebSocket URL has an invalid port"
     if null authority.uriRegName
-        then Left "ChatGPT transcription base URL has no host"
+        then Left "Dictation WebSocket URL has no host"
         else
             Right ChatGPTStreamEndpoint
                 { streamHost = authority.uriRegName
                 , streamPort = port
-                , streamPath =
-                    dropTrailingSlashes uri.uriPath
-                        <> "/dictation/stream"
+                , streamPath = uri.uriPath <> uri.uriQuery
                 , streamSecure = secure
                 }
 

--- a/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
@@ -15,7 +15,7 @@ import Agent.Provider
     )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (wait, withAsync)
-import Control.Exception.Safe (bracket, finally)
+import Control.Exception.Safe (bracket, finally, throwString)
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
@@ -431,7 +431,57 @@ spec = describe "OpenAI transcription" do
                 first == second
                     && "RIFF" `BS.isInfixOf` LBS.toStrict first
             _ -> False
+    it "distinguishes local capture failures from unavailable gateway streams" do
+        let server pending = do
+                connection <- WS.acceptRequest pending
+                start <- WS.receiveData connection
+                decodeValue start `shouldBe` Aeson.object
+                    [ "type" .= ("session.start" :: Text)
+                    , "config" .= Aeson.object
+                        [ "input_audio_format" .= ("pcm16" :: Text)
+                        , "sample_rate_hz" .= (24_000 :: Int)
+                        , "num_channels" .= (1 :: Int)
+                        , "max_buffer_size_bytes" .= (4 * 1024 * 1024 :: Int)
+                        , "max_utterance_duration_ms" .= (30_000 :: Int)
+                        , "session_ttl_ms" .= (300_000 :: Int)
+                        , "provider_mode" .= ("streaming_sse" :: Text)
+                        , "transcript_delivery_mode" .= ("delta" :: Text)
+                        , "vad" .= Aeson.object
+                            [ "type" .= ("server_vad" :: Text)
+                            , "threshold" .= (0.5 :: Double)
+                            , "prefix_padding_ms" .= (300 :: Int)
+                            , "silence_duration_ms" .= (500 :: Int)
+                            ]
+                        ]
+                    ]
+                sendEvent connection $
+                    Aeson.object ["type" .= ("session.started" :: Text)]
+                threadDelay (2 * 1_000_000)
+        withWebSocketServer server \port -> do
+            let websocketUrl =
+                    "ws://127.0.0.1:"
+                        <> Text.pack (show port)
+                        <> "/v1/audio/transcriptions"
+            result <-
+                transcribePcmWithChatGPTStreamAt
+                    websocketUrl
+                    []
+                    (\_ -> throwString "microphone failed")
+                    (const (pure ()))
+            result `shouldSatisfy` \case
+                Left (ChatGPTDictationCaptureFailed message) ->
+                    "microphone failed" `Text.isInfixOf` message
+                _ -> False
 
+        transcribePcmWithChatGPTStreamAt
+            "ftp://gateway.example/v1/audio/transcriptions"
+            []
+            (\_ -> expectationFailure "capture should not start")
+            (const (pure ()))
+            `shouldReturn`
+                Left
+                    (ChatGPTDictationStreamUnavailable
+                        "Dictation WebSocket URL must use WS, WSS, HTTP, or HTTPS")
 withWebSocketServer
     :: WS.ServerApp
     -> (Int -> IO value)


### PR DESCRIPTION
## Summary
- stream PCM dictation through the organization gateway WebSocket so partial transcripts appear while speaking
- use the gateway URL and bearer already admitted for the turn, with exact credential revalidation
- retain the existing gateway POST transcription as a batch fallback when streaming is unavailable
- distinguish capture failures from transport failures so partial audio is never submitted after microphone errors

## Validation
- focused `Agent.OpenAI.TranscriptionSpec`: 10 examples passed
- affected OpenAI and gateway-client modules loaded in GHCi
- `git diff --check`
- fresh cross-boundary security review found no actionable issues

## Paired gateway change
- https://github.com/digitallyinduced/haskell-agent-gateway/pull/63

The client remains compatible with older gateways by using the existing POST fallback.