### PR TITLE
Add native macOS computer-use bridge

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
@@ -1,8 +1,13 @@
 -- | Function-based computer use backed by macOS screen capture and input.
 module Agent.CLI.ComputerUse
-    ( computerUseTool
+    ( ComputerObservation(..)
+    , ComputerUseBackend(..)
+    , ScreenshotEncoding(..)
+    , computerUseTool
+    , computerUseToolWith
     , computerFunctionParameters
     , executeComputerCall
+    , executeComputerCallWithBackend
     , screenshotMacOS
     , summarizeComputerCall
     , summarizeComputerToolCall
@@ -40,6 +45,7 @@ import Agent.Tools.Types
     )
 import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception.Safe (finally, tryAny)
 import Control.Monad (foldM)
 import qualified Data.Aeson as Aeson
@@ -56,16 +62,27 @@ import System.Directory (getTemporaryDirectory, removeFile)
 import System.Exit (ExitCode(..))
 import System.Info (os)
 import System.IO (hClose, openBinaryTempFile)
+import System.IO.Unsafe (unsafePerformIO)
 import System.Process (readProcessWithExitCode)
 import Text.Read (readMaybe)
 
 -- | A dedicated internal schema marker, rather than a provider-native wire
 -- type, keeps this privileged handler separate from caller-defined functions.
 computerUseTool :: AppTool
-computerUseTool = AppTool
+computerUseTool
+    | os == "darwin" = computerUseToolWith localComputerUseBackend
+    | otherwise =
+        (computerUseToolWith localComputerUseBackend)
+            { appToolHandler = noArgsTool "computer"
+                (pure (Left
+                    "Local computer use is currently supported only on macOS."))
+            }
+
+computerUseToolWith :: ComputerUseBackend -> AppTool
+computerUseToolWith backend = AppTool
     { appToolName = "computer"
     , appToolDescription =
-        "Run one or more approved actions on the main macOS display and receive a fresh screenshot. Start with screenshot when the UI state is unknown."
+        "Start each computer session with a screenshot-only call. Then run up to 10 approved actions on the main macOS display and receive one fresh final screenshot. A screenshot marker is valid only at the end of a batch."
     , appToolSchema = HostedComputerSchema
     , appToolHandler = handler
     , appToolApproval = AlwaysPrompt
@@ -73,16 +90,14 @@ computerUseTool = AppTool
     , appToolResourceClaims = Nothing
     }
   where
-    handler
-        | os == "darwin" =
-            typedToolWithCall "computer" computerToolInputDecoder \call input ->
-                executeComputerCallWith
-                    (case call.callKind of
-                        ComputerFunctionCallKind -> ScreenshotJpeg
-                        _ -> ScreenshotPng)
-                    (computerCallFromInput call input)
-        | otherwise = noArgsTool "computer"
-            (pure (Left "Local computer use is currently supported only on macOS."))
+    handler =
+        typedToolWithCall "computer" computerToolInputDecoder \call input ->
+            executeComputerCallWithBackend
+                backend
+                (case call.callKind of
+                    ComputerFunctionCallKind -> ScreenshotJpeg
+                    _ -> ScreenshotPng)
+                (computerCallFromInput call input)
 
 data ComputerToolInput = ComputerToolInput
     { toolComputerActions :: ![ComputerAction]
@@ -115,7 +130,8 @@ computerFunctionParameters = Aeson.object
             , "items" Aeson..= Aeson.object
                 [ "anyOf" Aeson..= computerActionSchemas ]
             , "minItems" Aeson..= (1 :: Int)
-            , "maxItems" Aeson..= (128 :: Int)
+            -- The optional terminal screenshot marker is not executed.
+            , "maxItems" Aeson..= (11 :: Int)
             ]
         ]
     , "required" Aeson..= ["actions" :: Text]
@@ -226,55 +242,99 @@ executeComputerCall = executeComputerCallWith ScreenshotPng
 data ScreenshotEncoding
     = ScreenshotPng
     | ScreenshotJpeg
+    deriving (Eq, Show)
+
+data ComputerObservation = ComputerObservation
+    { computerObservationImage :: !ImageAttachment
+    , computerObservationAccessibility :: !(Maybe Text)
+    } deriving (Eq, Show)
+
+-- | One computer-use transaction. The backend owns display discovery,
+-- display-specific validation, action execution, settling, and observation as
+-- one serialized critical section. It must run the supplied validator before
+-- the first input side effect.
+data ComputerUseBackend = ComputerUseBackend
+    { computerRunTransaction ::
+        !( ScreenshotEncoding
+            -> [ComputerAction]
+            -> ((Int, Int) -> Either Text ())
+            -> IO (Either Text ComputerObservation)
+         )
+    }
 
 executeComputerCallWith
     :: ScreenshotEncoding
     -> ComputerCall
     -> IO (Either Text Text)
-executeComputerCallWith screenshotEncoding call
+executeComputerCallWith =
+    executeComputerCallWithBackend localComputerUseBackend
+
+executeComputerCallWithBackend
+    :: ComputerUseBackend
+    -> ScreenshotEncoding
+    -> ComputerCall
+    -> IO (Either Text Text)
+executeComputerCallWithBackend backend screenshotEncoding call
     | Left err <- validateComputerCall call = pure (Left err)
-    | otherwise = do
-        unlocked <- ensureUnlockedSession
-        case unlocked of
-            Left err -> pure (Left err)
-            Right () -> do
-                dimensions <- mainDisplayLogicalSize
-                case dimensions of
-                    Left err -> pure (Left err)
-                    Right display
-                        | Left err <-
-                            validateComputerCallForDisplay display call ->
-                            pure (Left err)
-                        | otherwise -> do
-                            actionResult <-
-                                foldM run (Right ()) call.computerActions
-                            case actionResult of
-                                Left err -> pure (Left err)
-                                Right () -> do
-                                    currentDisplay <- mainDisplayLogicalSize
-                                    case currentDisplay of
-                                        Left err -> pure (Left err)
-                                        Right value
-                                            | value /= display ->
-                                                pure (Left
-                                                    "The main display changed during computer use; take a fresh screenshot before continuing.")
-                                            | otherwise ->
-                                                screenshotMainDisplayWith
-                                                    screenshotEncoding
-                                                    display
-                                                    >>= \case
-                                                        Left err ->
-                                                            pure (Left err)
-                                                        Right image ->
-                                                            pure (Right
-                                                                (encodeComputerOutput
-                                                                    call image))
+    | otherwise =
+        backend.computerRunTransaction
+            screenshotEncoding
+            (actionsBeforeObservation call.computerActions)
+            (\display -> validateComputerCallForDisplay display call)
+            >>= \case
+                Left err -> pure (Left err)
+                Right observation ->
+                    pure (Right (encodeComputerOutput call observation))
+
+localComputerUseBackend :: ComputerUseBackend
+localComputerUseBackend = ComputerUseBackend
+    { computerRunTransaction = \encoding actions validateDisplay ->
+        withMVar localComputerUseLock \_ -> do
+            ensureUnlockedSession >>= \case
+                Left err -> pure (Left err)
+                Right () ->
+                    mainDisplayLogicalSize >>= \case
+                        Left err -> pure (Left err)
+                        Right display
+                            | Left err <- validateDisplay display ->
+                                pure (Left err)
+                            | otherwise -> do
+                                actionResult <- foldM run (Right ()) actions
+                                case actionResult of
+                                    Left err -> pure (Left err)
+                                    Right () ->
+                                        mainDisplayLogicalSize >>= \case
+                                            Left err -> pure (Left err)
+                                            Right value
+                                                | value /= display ->
+                                                    pure (Left
+                                                        "The main display changed during computer use; take a fresh screenshot before continuing.")
+                                                | otherwise -> fmap
+                                                    (fmap
+                                                        (\image ->
+                                                            ComputerObservation
+                                                                image
+                                                                Nothing))
+                                                    (screenshotMainDisplayWith
+                                                        encoding
+                                                        display)
+    }
   where
     run (Left err) _ = pure (Left err)
     run (Right ()) action = executeAction action
 
-encodeComputerOutput :: ComputerCall -> ImageAttachment -> Text
-encodeComputerOutput call ImageAttachment{imageMime, imageBytes} =
+{-# NOINLINE localComputerUseLock #-}
+localComputerUseLock :: MVar ()
+localComputerUseLock = unsafePerformIO (newMVar ())
+
+actionsBeforeObservation :: [ComputerAction] -> [ComputerAction]
+actionsBeforeObservation actions =
+    case reverse actions of
+        ScreenshotAction : earlier -> reverse earlier
+        _ -> actions
+
+encodeComputerOutput :: ComputerCall -> ComputerObservation -> Text
+encodeComputerOutput call observation =
     TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode $
         ComputerCallOutput
             { computerOutputItemId = Nothing
@@ -283,22 +343,41 @@ encodeComputerOutput call ImageAttachment{imageMime, imageBytes} =
             -- Reaching the handler means this exact call was approved.
             , acknowledgedChecks = call.pendingSafetyChecks
             , computerOutputStatus = Nothing
-            , computerOutputExtra = KeyMap.empty
+            , computerOutputExtra = maybe
+                KeyMap.empty
+                (KeyMap.singleton "accessibility_state" . Aeson.String)
+                observation.computerObservationAccessibility
             }
+  where
+    ImageAttachment{imageMime, imageBytes} =
+        observation.computerObservationImage
 
 validateComputerCall :: ComputerCall -> Either Text ()
 validateComputerCall call
     | null call.computerActions =
         Left "Computer call requires at least one action."
-    | exceedsList 128 call.computerActions =
-        Left "Computer call exceeds the 128-action limit."
+    | exceedsList 11 call.computerActions =
+        Left "Computer call exceeds the 10-action limit."
     | exceedsList 64 call.pendingSafetyChecks =
         Left "Computer call exceeds the 64-safety-check limit."
     | Just err <- firstJust
         (map validateSafetyCheck call.pendingSafetyChecks
             <> map validateAction call.computerActions) =
         Left err
+    | hasNonFinalScreenshot call.computerActions =
+        Left "Computer screenshot must be the final action in a batch."
+    | exceedsList 10 (actionsBeforeObservation call.computerActions) =
+        Left "Computer call exceeds the 10-action limit."
     | otherwise = Right ()
+
+hasNonFinalScreenshot :: [ComputerAction] -> Bool
+hasNonFinalScreenshot actions =
+    case reverse actions of
+        [] -> False
+        _finalAction : earlier -> any isScreenshot earlier
+  where
+    isScreenshot ScreenshotAction = True
+    isScreenshot _ = False
 
 -- | Validate all model-space coordinates before the first action in a batch.
 -- The per-action JXA checks remain as a second line of defense if the display
@@ -399,7 +478,8 @@ exceedsText limit = not . Text.null . Text.drop limit
 
 executeAction :: ComputerAction -> IO (Either Text ())
 executeAction = \case
-    ScreenshotAction -> pure (Right ())
+    ScreenshotAction ->
+        pure (Left "Computer screenshot must be the final action in a batch.")
     WaitAction -> do
         threadDelay 2000000
         pure (Right ())
@@ -479,7 +559,7 @@ pointerPrelude = Text.unlines
     , "ObjC.import('Foundation');"
     , "ObjC.import('ApplicationServices');"
     , "const tap=$.kCGHIDEventTap, left=0;"
-    , "function assertReady(){const d=ObjC.deepUnwrap($.CGSessionCopyCurrentDictionary()); if(!d) throw new Error('macOS GUI session state is unavailable'); if(Boolean(d.CGSSessionScreenIsLocked)) throw new Error('macOS session is locked'); if(!Boolean($.AXIsProcessTrusted())) throw new Error('Accessibility permission is required');}"
+    , "function assertReady(){const d=ObjC.deepUnwrap($.CGSessionCopyCurrentDictionary()); if(!d||typeof d.CGSSessionScreenIsLocked!=='boolean') throw new Error('macOS GUI session state is unavailable'); if(d.CGSSessionScreenIsLocked) throw new Error('macOS session is locked'); if(!Boolean($.AXIsProcessTrusted())) throw new Error('Accessibility permission is required');}"
     , "assertReady();"
     , "const bounds=$.CGDisplayBounds($.CGMainDisplayID());"
     , "let last=$.CGPointMake(0,0);"
@@ -502,7 +582,7 @@ keyboardPrelude = Text.unlines
     , "ObjC.import('Foundation');"
     , "ObjC.import('ApplicationServices');"
     , "const tap=$.kCGHIDEventTap;"
-    , "function assertReady(){const d=ObjC.deepUnwrap($.CGSessionCopyCurrentDictionary()); if(!d) throw new Error('macOS GUI session state is unavailable'); if(Boolean(d.CGSSessionScreenIsLocked)) throw new Error('macOS session is locked'); if(!Boolean($.AXIsProcessTrusted())) throw new Error('Accessibility permission is required');}"
+    , "function assertReady(){const d=ObjC.deepUnwrap($.CGSessionCopyCurrentDictionary()); if(!d||typeof d.CGSSessionScreenIsLocked!=='boolean') throw new Error('macOS GUI session state is unavailable'); if(d.CGSSessionScreenIsLocked) throw new Error('macOS session is locked'); if(!Boolean($.AXIsProcessTrusted())) throw new Error('Accessibility permission is required');}"
     , "assertReady();"
     , "function key(code,flags){const d=$.CGEventCreateKeyboardEvent(null,code,true),u=$.CGEventCreateKeyboardEvent(null,code,false); $.CGEventSetFlags(d,flags); $.CGEventSetFlags(u,flags); $.CGEventPost(tap,d); $.CGEventPost(tap,u);}"
     -- Keep each Unicode payload small enough for Quartz and avoid splitting a
@@ -604,6 +684,8 @@ modifierFlags rawKeys =
         "alt" -> Right "$.kCGEventFlagMaskAlternate"
         "option" -> Right "$.kCGEventFlagMaskAlternate"
         "shift" -> Right "$.kCGEventFlagMaskShift"
+        "fn" -> Right "$.kCGEventFlagMaskSecondaryFn"
+        "function" -> Right "$.kCGEventFlagMaskSecondaryFn"
         unsupported ->
             Left ("Unsupported computer modifier: " <> unsupported)
     render [] = "0"
@@ -727,8 +809,8 @@ ensureUnlockedSession = do
     let script = Text.unlines
             [ "ObjC.import('CoreGraphics');"
             , "const d=ObjC.deepUnwrap($.CGSessionCopyCurrentDictionary());"
-            , "if(!d) throw new Error('macOS GUI session state is unavailable');"
-            , "String(Boolean(d && d.CGSSessionScreenIsLocked));"
+            , "if(!d||typeof d.CGSSessionScreenIsLocked!=='boolean') throw new Error('macOS GUI session state is unavailable');"
+            , "String(d.CGSSessionScreenIsLocked);"
             ]
     attempted <- tryAny $ readProcessWithExitCode
         "/usr/bin/osascript" ["-l", "JavaScript"] (Text.unpack script)
@@ -771,7 +853,7 @@ runScript arguments script = do
 summarizeComputerCall :: ComputerCall -> Text
 summarizeComputerCall call =
     Text.intercalate "; " $
-        map summary (take 128 call.computerActions)
+        map summary (take 10 call.computerActions)
             <> map safety (take 64 call.pendingSafetyChecks)
   where
     summary = \case

--- a/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
@@ -1,7 +1,11 @@
 module Agent.CLI.ComputerUseSpec (spec) where
 
 import Agent.CLI.ComputerUse
-    ( computerApprovalPrompt
+    ( ComputerObservation(..)
+    , ComputerUseBackend(..)
+    , ScreenshotEncoding(..)
+    , computerApprovalPrompt
+    , executeComputerCallWithBackend
     , keyCombinationScript
     , parseDisplaySize
     , parseSessionLocked
@@ -12,10 +16,12 @@ import Agent.CLI.ComputerUse
     )
 import Agent.CLI.SessionAdmin (sessionToolEvent)
 import Agent.Json (rawJsonFromEncoding)
+import Agent.Loop (ImageAttachment(..))
 import Agent.Responses.Types
 import Agent.ToolDispatch (ToolCall(..), ToolCallKind(..))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -75,11 +81,15 @@ spec = do
             pointerScript (ClickAction 12 34 "left" [])
                 `shouldSatisfy` either
                     (const False)
-                    ("if(!d) throw new Error" `Text.isInfixOf`)
+                    (\script ->
+                        "if(!d||typeof d.CGSSessionScreenIsLocked!=='boolean')"
+                            `Text.isInfixOf` script)
             keyCombinationScript ["enter"]
                 `shouldSatisfy` either
                     (const False)
-                    ("if(!d) throw new Error" `Text.isInfixOf`)
+                    (\script ->
+                        "if(!d||typeof d.CGSSessionScreenIsLocked!=='boolean')"
+                            `Text.isInfixOf` script)
 
         it "validates logical main-display dimensions" do
             parseDisplaySize "2056,1329\n" `shouldBe` Just (2056, 1329)
@@ -143,9 +153,9 @@ spec = do
                     "Computer drag path exceeds 1024 points."
             validateComputerCall
                 exampleCall
-                    { computerActions = replicate 129 ScreenshotAction }
+                    { computerActions = replicate 11 WaitAction }
                 `shouldBe` Left
-                    "Computer call exceeds the 128-action limit."
+                    "Computer call exceeds the 10-action limit."
             validateComputerCall
                 exampleCall
                     { pendingSafetyChecks =
@@ -164,6 +174,122 @@ spec = do
                             (replicate 1024 (ComputerPoint 0 0))
                             []
                         ]
+                    }
+                `shouldBe` Right ()
+
+    describe "computer backend transaction" do
+        it "strips the terminal screenshot and returns one fresh observation" do
+            transactions <- newIORef
+                ([] :: [(ScreenshotEncoding, (Int, Int), [ComputerAction])])
+            let backend = ComputerUseBackend
+                    { computerRunTransaction =
+                        \encoding actions validateDisplay ->
+                            case validateDisplay (1440, 900) of
+                                Left err -> pure (Left err)
+                                Right () -> do
+                                    modifyIORef' transactions
+                                        (<> [( encoding
+                                             , (1440, 900)
+                                             , actions
+                                             )])
+                                    pure (Right
+                                        (ComputerObservation
+                                            (ImageAttachment
+                                                "image/jpeg"
+                                                "fresh-image")
+                                            Nothing))
+                    }
+                actions =
+                    [ ClickAction 20 30 "left" []
+                    , ScreenshotAction
+                    ]
+            result <- executeComputerCallWithBackend
+                backend
+                ScreenshotJpeg
+                exampleCall { computerActions = actions }
+            readIORef transactions `shouldReturn`
+                [ ( ScreenshotJpeg
+                  , (1440, 900)
+                  , [ClickAction 20 30 "left" []]
+                  )
+                ]
+            result `shouldSatisfy` either
+                (const False)
+                ("data:image/jpeg;base64,ZnJlc2gtaW1hZ2U="
+                    `Text.isInfixOf`)
+
+        it "captures a screenshot-only call without forwarding a fake action" do
+            observedActions <- newIORef Nothing
+            let backend = ComputerUseBackend
+                    { computerRunTransaction =
+                        \_ actions validateDisplay ->
+                            case validateDisplay (100, 100) of
+                                Left err -> pure (Left err)
+                                Right () -> do
+                                    modifyIORef'
+                                        observedActions
+                                        (const (Just actions))
+                                    pure (Right
+                                        (ComputerObservation
+                                            (ImageAttachment
+                                                "image/png"
+                                                "observation")
+                                            Nothing))
+                    }
+            result <- executeComputerCallWithBackend
+                backend
+                ScreenshotPng
+                exampleCall { computerActions = [ScreenshotAction] }
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef observedActions `shouldReturn` Just []
+
+        it "does not invoke a backend for an invalid batch" do
+            invocations <- newIORef (0 :: Int)
+            let backend = ComputerUseBackend
+                    { computerRunTransaction = \_ _ _ -> do
+                        modifyIORef' invocations (+ 1)
+                        pure (Right
+                            (ComputerObservation
+                                (ImageAttachment "image/png" "observation")
+                                Nothing))
+                    }
+            result <- executeComputerCallWithBackend
+                backend
+                ScreenshotPng
+                exampleCall
+                    { computerActions =
+                        [ScreenshotAction, ClickAction 1 2 "left" []]
+                    }
+            result `shouldBe` Left
+                "Computer screenshot must be the final action in a batch."
+            readIORef invocations `shouldReturn` 0
+
+        it "allows only a terminal screenshot marker" do
+            validateComputerCall
+                exampleCall
+                    { computerActions =
+                        [ScreenshotAction, ClickAction 1 2 "left" []]
+                    }
+                `shouldBe` Left
+                    "Computer screenshot must be the final action in a batch."
+            validateComputerCall
+                exampleCall
+                    { computerActions =
+                        [ClickAction 1 2 "left" [], ScreenshotAction]
+                    }
+                `shouldBe` Right ()
+            validateComputerCall
+                exampleCall { computerActions = [ScreenshotAction] }
+                `shouldBe` Right ()
+
+        it "accepts exactly ten actions" do
+            validateComputerCall
+                exampleCall { computerActions = replicate 10 WaitAction }
+                `shouldBe` Right ()
+            validateComputerCall
+                exampleCall
+                    { computerActions =
+                        replicate 10 WaitAction <> [ScreenshotAction]
                     }
                 `shouldBe` Right ()
 

--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -63,6 +63,7 @@ foreign-library haskell-agent-bridge
     options:          standalone
     hs-source-dirs:   ffi
     other-modules:    Agent.CLI.MacOS.Bridge
+                    , Agent.CLI.MacOS.ComputerBridge
                     , Agent.CLI.MacOS.EngineMailbox
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.ResourceAdmin
@@ -76,6 +77,7 @@ foreign-library haskell-agent-bridge
                     , agent-cli >= 0.1 && < 0.2
                     , agent-runtime-daemon >= 0.1 && < 0.2
                     , agent-core >= 0.1 && < 0.2
+                    , agent-responses-types >= 0.1 && < 0.2
                     , agent-store >= 0.1 && < 0.2
                     , agent-openai >= 0.1 && < 0.2
                     , agent-xai >= 0.1 && < 0.2
@@ -126,13 +128,16 @@ test-suite agent-native-bridge-test
                     , unix
     if os(darwin)
         c-sources:    test/cbits/HaskellAgentBridgeBrowserSmoke.c
+                    , test/cbits/HaskellAgentBridgeComputerSmoke.c
                     , test/cbits/HaskellAgentBridgeImageSmoke.c
                     , test/cbits/HaskellAgentBridgeTaskSmoke.c
                     , cbits/HaskellAgentBridgeRuntime.c
         include-dirs: include
         other-modules: Agent.CLI.MacOS.Bridge
+                     , Agent.CLI.MacOS.ComputerBridge
                      , Agent.CLI.MacOS.ResourceAdmin
                      , Agent.CLI.MacOS.BrowserBridgeFFISpec
+                     , Agent.CLI.MacOS.ComputerBridgeSpec
                      , Agent.CLI.MacOS.BridgeSpec
                      , Agent.CLI.MacOS.BridgeHeaderSpec
                      , Agent.CLI.MacOS.BridgeFFISpec
@@ -140,6 +145,7 @@ test-suite agent-native-bridge-test
                      , agent-cli-runtime
                      , agent-openai
                      , agent-openrouter
+                     , agent-responses-types
                      , agent-xai
                      , aeson
                      , filelock

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -8,6 +8,7 @@ module Agent.CLI.MacOS.Bridge
     , browserOutputCapacity
     , browserStatusMessage
     , browserToolsWhenEnabled
+    , composeNativeTools
     , invokeBrowserCommand
     , repositoryCancelAllAdmissionSmoke
     , repositoryCancelClassificationSmoke
@@ -32,6 +33,13 @@ module Agent.CLI.MacOS.Bridge
     ) where
 
 import Agent.CLI.MacOS.ResourceAdmin ()
+import Agent.CLI.MacOS.ComputerBridge
+    ( ComputerCallback
+    , ComputerHost(..)
+    , ComputerRegistration(..)
+    , computerToolWhenEnabled
+    , newComputerHost
+    )
 import qualified Agent.CLI.AgentViewport as Viewport
 import Agent.CLI.BrowserTools
     ( BrowserCommand(..)
@@ -237,7 +245,7 @@ import Agent.Tools.PlanMode
     , PlanModeHooks(..)
     )
 import Agent.Tools.Types
-    ( AppTool
+    ( AppTool(..)
     , AppToolGroup(..)
     , appToolsFromGroups
     )
@@ -1047,6 +1055,7 @@ data Engine = Engine
     , engineDone :: !(MVar ())
     , engineStagedImages :: !(TVar (Map Text [ImageAttachment]))
     , engineBrowser :: !BrowserHost
+    , engineComputer :: !ComputerHost
     , engineStagedTurnOptions :: !(TVar (Map Text NativeTurnOptions))
     , engineInteractions :: !InteractionRuntime
     }
@@ -1119,6 +1128,9 @@ foreign export ccall ha_engine_stage_turn_images
 
 foreign export ccall ha_engine_set_browser_callback
     :: Ptr () -> FunPtr BrowserCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_engine_set_computer_callback
+    :: Ptr () -> FunPtr ComputerCallback -> Ptr () -> IO CInt
 
 foreign export ccall ha_engine_cancel_task
     :: Ptr () -> Ptr Word8 -> CSize -> IO CInt
@@ -4088,6 +4100,7 @@ ha_engine_create callback context
             done <- newEmptyMVar
             stagedImages <- newTVarIO Map.empty
             browser <- BrowserHost <$> newMVar Nothing
+            computer <- newComputerHost
             stagedTurnOptions <- newTVarIO Map.empty
             interactionTarget <- newTVarIO Nothing
             interactionLock <- newMVar ()
@@ -4106,6 +4119,7 @@ ha_engine_create callback context
                     commands
                     stagedImages
                     browser
+                    computer
                     stagedTurnOptions
                     interactions)
                 (const (putMVar done ()))
@@ -4114,6 +4128,7 @@ ha_engine_create callback context
                 , engineDone = done
                 , engineStagedImages = stagedImages
                 , engineBrowser = browser
+                , engineComputer = computer
                 , engineStagedTurnOptions = stagedTurnOptions
                 , engineInteractions = interactions
                 }
@@ -4167,6 +4182,26 @@ ha_engine_set_browser_callback pointer callback context
                         else Just BrowserRegistration
                             { browserCallback = callback
                             , browserContext = context
+                            }
+        pure $ case updated of
+            Left _ -> 2
+            Right () -> 0
+
+ha_engine_set_computer_callback
+    :: Ptr () -> FunPtr ComputerCallback -> Ptr () -> IO CInt
+ha_engine_set_computer_callback pointer callback context
+    | pointer == nullPtr = pure 1
+    | otherwise = do
+        updated <- tryAny do
+            let stable = castPtrToStablePtr pointer :: StablePtr Engine
+            engine <- deRefStablePtr stable
+            modifyMVar_ engine.engineComputer.computerRegistration $ \_ ->
+                pure
+                    if callback == nullFunPtr
+                        then Nothing
+                        else Just ComputerRegistration
+                            { computerCallback = callback
+                            , computerContext = context
                             }
         pure $ case updated of
             Left _ -> 2
@@ -4546,6 +4581,9 @@ ha_engine_destroy pointer
         let stable = castPtrToStablePtr pointer :: StablePtr Engine
         (do
             engine <- deRefStablePtr stable
+            modifyMVar_
+                engine.engineComputer.computerRegistration
+                (const (pure Nothing))
             _ <- atomically
                 (closeEngineMailbox engine.engineCommands EngineStop)
             readMVar engine.engineDone)
@@ -4559,11 +4597,12 @@ workerLifecycle
     -> EngineMailbox EngineCommand
     -> TVar (Map Text [ImageAttachment])
     -> BrowserHost
+    -> ComputerHost
     -> TVar (Map Text NativeTurnOptions)
     -> InteractionRuntime
     -> IO ()
 workerLifecycle
-        callback context config root commands stagedImages browser
+        callback context config root commands stagedImages browser computer
         stagedTurnOptions interactions =
     (do
         store <- newMVar Nothing
@@ -4583,6 +4622,7 @@ workerLifecycle
             commands
             stagedImages
             browser
+            computer
             stagedTurnOptions
             interactions
             workerRegistry
@@ -4620,13 +4660,15 @@ supervisorLoop
     -> EngineMailbox EngineCommand
     -> TVar (Map Text [ImageAttachment])
     -> BrowserHost
+    -> ComputerHost
     -> TVar (Map Text NativeTurnOptions)
     -> InteractionRuntime
     -> TVar (Map Text RunningTurn)
     -> TaskSupervisor
     -> IO ()
 supervisorLoop
-        callback context config store root processRuntime commands stagedImages browser
+        callback context config store root processRuntime commands stagedImages
+        browser computer
         stagedTurnOptions interactions workerRegistry =
     go
   where
@@ -4955,6 +4997,7 @@ supervisorLoop
             start.turnStartSessionId
             interactions
         nativeBrowserTools <- browserToolsWhenEnabled browser
+        nativeComputerTool <- computerToolWhenEnabled computer
         worker <- launchTrackedWorker start.turnStartId do
             withGatewayCredentialTurnLease $
                 ensureNativeGatewayIdentity
@@ -4988,6 +5031,7 @@ supervisorLoop
                                     processRuntime
                                     control
                                     nativeBrowserTools
+                                    nativeComputerTool
                                     start
                                     pending.pendingTurnImages
                                     pending.pendingTurnOptions
@@ -5298,6 +5342,23 @@ browserToolsWhenEnabled host =
         Nothing -> pure []
         Just _ -> pure (browserTools (invokeBrowserCommand host))
 
+-- | Replace, rather than append, the generic desktop backend. This keeps the
+-- command-line computer-use flag authoritative and guarantees a single
+-- model-visible @computer@ tool.
+composeNativeTools :: Maybe AppTool -> [AppToolGroup] -> [AppTool]
+composeNativeTools Nothing = appToolsFromGroups
+composeNativeTools (Just nativeComputer) =
+    replaceFirst False . appToolsFromGroups
+  where
+    replaceFirst _ [] = []
+    replaceFirst found (tool : tools)
+        | tool.appToolName /= "computer" =
+            tool : replaceFirst found tools
+        | found =
+            replaceFirst True tools
+        | otherwise =
+            nativeComputer : replaceFirst True tools
+
 invokeBrowserCommand
     :: BrowserHost
     -> BrowserCommand
@@ -5397,6 +5458,7 @@ runNativeTurn
     -> NativeProcessRuntime
     -> TurnControl
     -> [AppTool]
+    -> Maybe AppTool
     -> TurnStart
     -> [ImageAttachment]
     -> NativeTurnOptions
@@ -5404,7 +5466,7 @@ runNativeTurn
     -> IO TurnOutcome
 runNativeTurn
         callback context commands processRuntime control nativeBrowserTools
-        start images turnOptions interactions = do
+        nativeComputerTool start images turnOptions interactions = do
     sessionIdRef <- newIORef start.turnStartSessionId
     completedRef <- newIORef False
     usageRef <- newIORef emptyTokenUsage
@@ -5444,7 +5506,8 @@ runNativeTurn
             , nativeRequestRootAccess =
                 requestRootAccessFromClient callback context control
             , nativeToolGroups = [HostToolGroup nativeBrowserTools]
-            , nativeComposeTools = appToolsFromGroups
+            , nativeComposeTools =
+                composeNativeTools nativeComputerTool
             , nativePlanHooks =
                 nativePlanModeHooks control interactions
             , nativeInteractionMode =

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
@@ -1,0 +1,685 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Agent.CLI.MacOS.ComputerBridge
+    ( CComputerAction(..)
+    , CComputerPoint(..)
+    , ComputerBatch(..)
+    , ComputerCallback
+    , ComputerHost(..)
+    , ComputerRegistration(..)
+    , ComputerSession
+    , computerActionStructSize
+    , computerErrorCapacity
+    , computerOutputCapacity
+    , computerStatusMessage
+    , computerToolWhenEnabled
+    , encodeComputerActions
+    , invokeComputerTransaction
+    , invokeComputerSessionTransaction
+    , newComputerHost
+    , newComputerSession
+    ) where
+
+import Agent.CLI.ComputerUse
+    ( ComputerObservation(..)
+    , ComputerUseBackend(..)
+    , ScreenshotEncoding(..)
+    , computerUseToolWith
+    )
+import Agent.Loop (ImageAttachment(..))
+import Agent.Responses.Types
+    ( ComputerAction(..)
+    , ComputerPoint(..)
+    )
+import Agent.Tools.Types (AppTool)
+import Control.Exception.Safe (bracket, tryAny)
+import Control.Monad (foldM)
+import Control.Concurrent.MVar (MVar, modifyMVar, newMVar, withMVar)
+import qualified Data.ByteString as BS
+import Data.Bits ((.|.))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word8, Word32, Word64)
+import Foreign
+    ( FunPtr
+    , Ptr
+    , Storable(..)
+    , castPtr
+    , nullPtr
+    , peek
+    , peekByteOff
+    , poke
+    , pokeByteOff
+    )
+import Foreign.C.Types (CInt(..), CSize(..))
+import Foreign.Marshal.Alloc (allocaBytes, free, mallocBytes)
+import Foreign.Marshal.Array (withArray)
+import Foreign.Marshal.Utils (fillBytes)
+
+data CComputerPoint = CComputerPoint
+    { cComputerPointX :: !CInt
+    , cComputerPointY :: !CInt
+    } deriving (Eq, Show)
+
+instance Storable CComputerPoint where
+    sizeOf _ = 8
+    alignment _ = alignment (undefined :: CInt)
+    peek pointer =
+        CComputerPoint
+            <$> peekByteOff pointer 0
+            <*> peekByteOff pointer 4
+    poke pointer point = do
+        pokeByteOff pointer 0 point.cComputerPointX
+        pokeByteOff pointer 4 point.cComputerPointY
+
+data CComputerAction = CComputerAction
+    { cComputerStructSize :: !Word32
+    , cComputerAction :: !CInt
+    , cComputerX :: !CInt
+    , cComputerY :: !CInt
+    , cComputerDeltaX :: !CInt
+    , cComputerDeltaY :: !CInt
+    , cComputerButton :: !CInt
+    , cComputerModifiers :: !Word32
+    , cComputerTextOffset :: !Word64
+    , cComputerTextLength :: !Word64
+    , cComputerPointOffset :: !Word64
+    , cComputerPointCount :: !Word64
+    } deriving (Eq, Show)
+
+instance Storable CComputerAction where
+    sizeOf _ = computerActionStructSize
+    alignment _ = alignment (undefined :: Word64)
+    peek pointer =
+        CComputerAction
+            <$> peekByteOff pointer 0
+            <*> peekByteOff pointer 4
+            <*> peekByteOff pointer 8
+            <*> peekByteOff pointer 12
+            <*> peekByteOff pointer 16
+            <*> peekByteOff pointer 20
+            <*> peekByteOff pointer 24
+            <*> peekByteOff pointer 28
+            <*> peekByteOff pointer 32
+            <*> peekByteOff pointer 40
+            <*> peekByteOff pointer 48
+            <*> peekByteOff pointer 56
+    poke pointer action = do
+        pokeByteOff pointer 0 action.cComputerStructSize
+        pokeByteOff pointer 4 action.cComputerAction
+        pokeByteOff pointer 8 action.cComputerX
+        pokeByteOff pointer 12 action.cComputerY
+        pokeByteOff pointer 16 action.cComputerDeltaX
+        pokeByteOff pointer 20 action.cComputerDeltaY
+        pokeByteOff pointer 24 action.cComputerButton
+        pokeByteOff pointer 28 action.cComputerModifiers
+        pokeByteOff pointer 32 action.cComputerTextOffset
+        pokeByteOff pointer 40 action.cComputerTextLength
+        pokeByteOff pointer 48 action.cComputerPointOffset
+        pokeByteOff pointer 56 action.cComputerPointCount
+
+data ComputerBatch = ComputerBatch
+    { computerBatchActions :: ![CComputerAction]
+    , computerBatchPoints :: ![CComputerPoint]
+    , computerBatchText :: !BS.ByteString
+    } deriving (Eq, Show)
+
+type ComputerCallback =
+    Ptr ()
+    -> Word32
+    -> CInt
+    -> Word64
+    -> CInt
+    -> CInt
+    -> Ptr CComputerAction
+    -> CSize
+    -> Ptr CComputerPoint
+    -> CSize
+    -> Ptr Word8
+    -> CSize
+    -> CInt
+    -> Ptr Word8
+    -> CSize
+    -> Ptr CSize
+    -> Ptr Word64
+    -> Ptr CInt
+    -> Ptr CInt
+    -> Ptr CInt
+    -> IO CInt
+
+foreign import ccall safe "dynamic"
+    invokeComputerCallback :: FunPtr ComputerCallback -> ComputerCallback
+
+data ComputerRegistration = ComputerRegistration
+    { computerCallback :: !(FunPtr ComputerCallback)
+    , computerContext :: !(Ptr ())
+    }
+
+newtype ComputerHost = ComputerHost
+    { computerRegistration :: MVar (Maybe ComputerRegistration)
+    }
+
+newtype ComputerSession = ComputerSession
+    { computerSessionObservation :: MVar (Maybe NativeComputerDisplay)
+    }
+
+newComputerHost :: IO ComputerHost
+newComputerHost = ComputerHost <$> newMVar Nothing
+
+newComputerSession :: IO ComputerSession
+newComputerSession = ComputerSession <$> newMVar Nothing
+
+computerToolWhenEnabled :: ComputerHost -> IO (Maybe AppTool)
+computerToolWhenEnabled host =
+    withMVar host.computerRegistration \case
+        Nothing -> pure Nothing
+        Just _ -> do
+            session <- newComputerSession
+            pure . Just . computerUseToolWith $
+                ComputerUseBackend
+                    { computerRunTransaction =
+                        invokeComputerSessionTransaction host session
+                    }
+
+encodeComputerActions :: [ComputerAction] -> Either Text ComputerBatch
+encodeComputerActions actions = do
+    batch <- foldM appendAction emptyBatch actions
+    if length batch.computerBatchActions > 10
+        then Left "Computer callback action count exceeds 10."
+        else if length batch.computerBatchPoints > 10240
+            then Left "Computer callback point count exceeds 10240."
+            else if BS.length batch.computerBatchText > 327680
+                then Left "Computer callback text exceeds 327680 UTF-8 bytes."
+                else Right batch
+  where
+    emptyBatch = ComputerBatch [] [] BS.empty
+
+appendAction :: ComputerBatch -> ComputerAction -> Either Text ComputerBatch
+appendAction batch action = case action of
+    ClickAction{clickX, clickY, clickButton, clickKeys} -> do
+        button <- computerButtonCode clickButton
+        modifiers <- computerModifierMask clickKeys
+        pure (addAction batch ((plainAction 1)
+            { cComputerX = int32 clickX
+            , cComputerY = int32 clickY
+            , cComputerButton = button
+            , cComputerModifiers = modifiers
+            }))
+    DoubleClickAction{doubleClickX, doubleClickY, doubleClickKeys} -> do
+        modifiers <- computerModifierMask doubleClickKeys
+        pure (addAction batch ((plainAction 2)
+            { cComputerX = int32 doubleClickX
+            , cComputerY = int32 doubleClickY
+            , cComputerModifiers = modifiers
+            }))
+    ScrollAction{scrollX, scrollY, scrollDx, scrollDy, scrollKeys} -> do
+        modifiers <- computerModifierMask scrollKeys
+        pure (addAction batch ((plainAction 3)
+            { cComputerX = int32 scrollX
+            , cComputerY = int32 scrollY
+            , cComputerDeltaX = int32 scrollDx
+            , cComputerDeltaY = int32 scrollDy
+            , cComputerModifiers = modifiers
+            }))
+    MoveAction{moveX, moveY, moveKeys} -> do
+        modifiers <- computerModifierMask moveKeys
+        pure (addAction batch ((plainAction 4)
+            { cComputerX = int32 moveX
+            , cComputerY = int32 moveY
+            , cComputerModifiers = modifiers
+            }))
+    DragAction{dragPath, dragKeys} -> do
+        modifiers <- computerModifierMask dragKeys
+        let offset = length batch.computerBatchPoints
+            encodedPoints =
+                [ CComputerPoint (int32 pointX) (int32 pointY)
+                | ComputerPoint{pointX, pointY} <- dragPath
+                ]
+            encoded = (plainAction 5)
+                { cComputerModifiers = modifiers
+                , cComputerPointOffset = fromIntegral offset
+                , cComputerPointCount = fromIntegral (length encodedPoints)
+                }
+        pure (addAction
+            (batch
+                { computerBatchPoints =
+                    batch.computerBatchPoints <> encodedPoints
+                })
+            encoded)
+    TypeAction value ->
+        pure (addTextAction batch 6 value 0)
+    KeypressAction keys -> case reverse keys of
+        [] -> Left "Computer key combination is empty."
+        key : reversedModifiers -> do
+            modifiers <- computerModifierMask (reverse reversedModifiers)
+            pure (addTextAction batch 7 (Text.strip key) modifiers)
+    WaitAction ->
+        pure (addAction batch (plainAction 8))
+    ScreenshotAction ->
+        Left "Computer screenshot must not cross the native action ABI."
+    UnknownComputerAction _ ->
+        Left "Unsupported computer action crossed the native action ABI."
+
+addAction :: ComputerBatch -> CComputerAction -> ComputerBatch
+addAction batch action =
+    batch { computerBatchActions = batch.computerBatchActions <> [action] }
+
+addTextAction
+    :: ComputerBatch
+    -> CInt
+    -> Text
+    -> Word32
+    -> ComputerBatch
+addTextAction batch actionCode value modifiers =
+    let bytes = TextEncoding.encodeUtf8 value
+        offset = BS.length batch.computerBatchText
+        action = (plainAction actionCode)
+            { cComputerModifiers = modifiers
+            , cComputerTextOffset = fromIntegral offset
+            , cComputerTextLength = fromIntegral (BS.length bytes)
+            }
+    in addAction
+        (batch { computerBatchText = batch.computerBatchText <> bytes })
+        action
+
+plainAction :: CInt -> CComputerAction
+plainAction action = CComputerAction
+    { cComputerStructSize = fromIntegral computerActionStructSize
+    , cComputerAction = action
+    , cComputerX = 0
+    , cComputerY = 0
+    , cComputerDeltaX = 0
+    , cComputerDeltaY = 0
+    , cComputerButton = 0
+    , cComputerModifiers = 0
+    , cComputerTextOffset = 0
+    , cComputerTextLength = 0
+    , cComputerPointOffset = 0
+    , cComputerPointCount = 0
+    }
+
+computerButtonCode :: Text -> Either Text CInt
+computerButtonCode raw = case normalize raw of
+    "left" -> Right 1
+    "right" -> Right 2
+    "wheel" -> Right 3
+    "middle" -> Right 3
+    "back" -> Right 4
+    "forward" -> Right 5
+    value -> Left ("Unsupported computer mouse button: " <> value)
+
+computerModifierMask :: [Text] -> Either Text Word32
+computerModifierMask =
+    fmap (foldr (.|.) 0) . traverse modifier . map normalize
+  where
+    modifier = \case
+        "shift" -> Right 1
+        "ctrl" -> Right 2
+        "control" -> Right 2
+        "alt" -> Right 4
+        "option" -> Right 4
+        "cmd" -> Right 8
+        "command" -> Right 8
+        "meta" -> Right 8
+        "fn" -> Right 16
+        "function" -> Right 16
+        value -> Left ("Unsupported computer modifier: " <> value)
+
+normalize :: Text -> Text
+normalize = Text.toLower . Text.strip
+
+int32 :: Int -> CInt
+int32 = fromIntegral
+
+data NativeComputerDisplay = NativeComputerDisplay
+    { nativeDisplayToken :: !Word64
+    , nativeDisplayWidth :: !CInt
+    , nativeDisplayHeight :: !CInt
+    }
+
+-- | Hold the callback registration for the complete query, display-specific
+-- validation, and run sequence. This both serializes desktop transactions in
+-- one engine and makes callback replacement quiescent across the whole
+-- sequence rather than between its two native calls.
+invokeComputerTransaction
+    :: ComputerHost
+    -> ScreenshotEncoding
+    -> [ComputerAction]
+    -> ((Int, Int) -> Either Text ())
+    -> IO (Either Text ComputerObservation)
+invokeComputerTransaction host encoding actions validateDisplay =
+    fmap (fmap fst) $
+        invokeComputerTransactionWithLease
+            host
+            Nothing
+            encoding
+            actions
+            validateDisplay
+
+-- | A tool instance retains the lease returned with its last screenshot.
+-- Mutation batches therefore execute against the exact observation that the
+-- model saw instead of minting a new lease after the model chose coordinates.
+-- An explicit screenshot has no native actions and safely refreshes the lease.
+invokeComputerSessionTransaction
+    :: ComputerHost
+    -> ComputerSession
+    -> ScreenshotEncoding
+    -> [ComputerAction]
+    -> ((Int, Int) -> Either Text ())
+    -> IO (Either Text ComputerObservation)
+invokeComputerSessionTransaction host session encoding actions validateDisplay =
+    modifyMVar session.computerSessionObservation \previous -> do
+        result <-
+            if null actions
+                then invokeComputerTransactionWithLease
+                    host Nothing encoding actions validateDisplay
+                else case previous of
+                    Nothing -> pure (Left
+                        "Take a fresh computer screenshot before sending input actions.")
+                    Just display ->
+                        invokeComputerTransactionWithLease
+                            host
+                            (Just display)
+                            encoding
+                            actions
+                            validateDisplay
+        case result of
+            Left err -> pure (previous, Left err)
+            Right (observation, successor) ->
+                pure (Just successor, Right observation)
+
+invokeComputerTransactionWithLease
+    :: ComputerHost
+    -> Maybe NativeComputerDisplay
+    -> ScreenshotEncoding
+    -> [ComputerAction]
+    -> ((Int, Int) -> Either Text ())
+    -> IO
+        (Either
+            Text
+            (ComputerObservation, NativeComputerDisplay))
+invokeComputerTransactionWithLease
+        host priorDisplay encoding actions validateDisplay =
+    case encodeComputerActions actions of
+        Left err -> pure (Left err)
+        Right batch ->
+            tryAny
+                (withMVar host.computerRegistration \case
+                    Nothing ->
+                        pure (Left "Native computer control is not active.")
+                    Just registration ->
+                        maybe
+                            (invokeComputerDisplay registration)
+                            (pure . Right)
+                            priorDisplay >>= \case
+                            Left err -> pure (Left err)
+                            Right display
+                                | Left err <- validateDisplay
+                                    ( fromIntegral display.nativeDisplayWidth
+                                    , fromIntegral display.nativeDisplayHeight
+                                    ) ->
+                                    pure (Left err)
+                                | otherwise ->
+                                    invokeComputerRunAndObserve
+                                        registration
+                                        display
+                                        encoding
+                                        batch)
+                >>= \case
+                    Left exception ->
+                        pure (Left (Text.pack (show exception)))
+                    Right result -> pure result
+
+invokeComputerDisplay
+    :: ComputerRegistration
+    -> IO (Either Text NativeComputerDisplay)
+invokeComputerDisplay registration =
+    invokeComputer computerErrorCapacity registration query >>= \case
+        Left err -> pure (Left err)
+        Right (bytes, token, width, height, imageFormat)
+            | not (BS.null bytes)
+                || token == 0
+                || width <= 0
+                || height <= 0
+                || imageFormat /= 0 ->
+                pure (Left
+                    "The native computer host returned an invalid display lease.")
+            | otherwise ->
+                pure (Right NativeComputerDisplay
+                    { nativeDisplayToken = token
+                    , nativeDisplayWidth = width
+                    , nativeDisplayHeight = height
+                    })
+  where
+    query registration' output capacity outputLength outputToken
+            width height imageFormat =
+        invokeComputerCallback
+            registration'.computerCallback
+            registration'.computerContext
+            1
+            1
+            0
+            0
+            0
+            nullPtr
+            0
+            nullPtr
+            0
+            nullPtr
+            0
+            0
+            output
+            capacity
+            outputLength
+            outputToken
+            width
+            height
+            imageFormat
+
+invokeComputerRunAndObserve
+    :: ComputerRegistration
+    -> NativeComputerDisplay
+    -> ScreenshotEncoding
+    -> ComputerBatch
+    -> IO
+        (Either
+            Text
+            (ComputerObservation, NativeComputerDisplay))
+invokeComputerRunAndObserve registration display encoding batch =
+    withArray batch.computerBatchActions \actionPointer ->
+        withArray batch.computerBatchPoints \pointPointer ->
+            BS.useAsCStringLen batch.computerBatchText
+                \(textPointer, textLength) ->
+                    invokeComputer computerOutputCapacity registration
+                        (run
+                            actionPointer
+                            pointPointer
+                            (castPtr textPointer)
+                            textLength)
+                        >>= \case
+                            Left err -> pure (Left err)
+                            Right (bytes, token, width, height, imageFormat)
+                                | token == 0
+                                    || token == display.nativeDisplayToken
+                                    || width /= display.nativeDisplayWidth
+                                    || height /= display.nativeDisplayHeight ->
+                                    pure (Left
+                                        "The native computer host returned an invalid successor display lease.")
+                                | imageFormat /= requestedFormat ->
+                                    pure (Left
+                                        "The native computer host returned a screenshot in the wrong format.")
+                                | BS.null bytes ->
+                                    pure (Left
+                                        "The native computer host returned an empty screenshot.")
+                                | otherwise ->
+                                    case imageMime imageFormat bytes of
+                                        Left err -> pure (Left err)
+                                        Right mime ->
+                                            pure (Right
+                                                ( ComputerObservation
+                                                    (ImageAttachment mime bytes)
+                                                    Nothing
+                                                , NativeComputerDisplay
+                                                    { nativeDisplayToken =
+                                                        token
+                                                    , nativeDisplayWidth =
+                                                        width
+                                                    , nativeDisplayHeight =
+                                                        height
+                                                    }
+                                                ))
+  where
+    requestedFormat = case encoding of
+        ScreenshotPng -> 1
+        ScreenshotJpeg -> 2
+    run actionPointer pointPointer textPointer textLength
+            registration' output capacity outputLength outputToken
+            width height imageFormat =
+        invokeComputerCallback
+            registration'.computerCallback
+            registration'.computerContext
+            1
+            2
+            display.nativeDisplayToken
+            display.nativeDisplayWidth
+            display.nativeDisplayHeight
+            actionPointer
+            (fromIntegral (length batch.computerBatchActions))
+            pointPointer
+            (fromIntegral (length batch.computerBatchPoints))
+            textPointer
+            (fromIntegral textLength)
+            requestedFormat
+            output
+            capacity
+            outputLength
+            outputToken
+            width
+            height
+            imageFormat
+
+type ComputerInvocation =
+    ComputerRegistration
+    -> Ptr Word8
+    -> CSize
+    -> Ptr CSize
+    -> Ptr Word64
+    -> Ptr CInt
+    -> Ptr CInt
+    -> Ptr CInt
+    -> IO CInt
+
+invokeComputer
+    :: Int
+    -> ComputerRegistration
+    -> ComputerInvocation
+    -> IO (Either Text (BS.ByteString, Word64, CInt, CInt, CInt))
+invokeComputer capacity registration invocation =
+    bracket (mallocBytes capacity) free \output -> do
+        fillBytes output 0 capacity
+        allocaResult \outputLength outputToken width height imageFormat -> do
+            status <- invocation
+                registration
+                output
+                (fromIntegral capacity)
+                outputLength
+                outputToken
+                width
+                height
+                imageFormat
+            CSize length <- peek outputLength
+            observedToken <- peek outputToken
+            observedWidth <- peek width
+            observedHeight <- peek height
+            observedFormat <- peek imageFormat
+            if length > fromIntegral capacity
+                then pure (Left
+                    "The native computer host reported output beyond its buffer.")
+                else do
+                    bytes <- BS.packCStringLen
+                        (castPtr output, fromIntegral length)
+                    if status == 0
+                        then pure (Right
+                            ( bytes
+                            , observedToken
+                            , observedWidth
+                            , observedHeight
+                            , observedFormat
+                            ))
+                        else pure (Left
+                            (computerFailureMessage status bytes))
+
+allocaResult
+    :: ( Ptr CSize
+        -> Ptr Word64
+        -> Ptr CInt
+        -> Ptr CInt
+        -> Ptr CInt
+        -> IO value
+       )
+    -> IO value
+allocaResult action =
+    allocaBytes (sizeOf (undefined :: CSize)) \outputLength ->
+        allocaBytes (sizeOf (undefined :: Word64)) \outputToken ->
+            allocaBytes (sizeOf (undefined :: CInt)) \width ->
+                allocaBytes (sizeOf (undefined :: CInt)) \height ->
+                    allocaBytes (sizeOf (undefined :: CInt))
+                        \imageFormat -> do
+                            poke outputLength 0
+                            poke outputToken 0
+                            poke width 0
+                            poke height 0
+                            poke imageFormat 0
+                            action
+                                outputLength
+                                outputToken
+                                width
+                                height
+                                imageFormat
+
+imageMime :: CInt -> BS.ByteString -> Either Text Text
+imageMime imageFormat bytes = case imageFormat of
+    1
+        | BS.take 8 bytes == BS.pack [137, 80, 78, 71, 13, 10, 26, 10] ->
+            Right "image/png"
+        | otherwise ->
+            Left "The native computer host returned malformed PNG data."
+    2
+        | BS.take 2 bytes == BS.pack [255, 216] ->
+            Right "image/jpeg"
+        | otherwise ->
+            Left "The native computer host returned malformed JPEG data."
+    _ -> Left "The native computer host returned an unsupported image format."
+
+computerFailureMessage :: CInt -> BS.ByteString -> Text
+computerFailureMessage status bytes =
+    case TextEncoding.decodeUtf8' bytes of
+        Right message | not (Text.null message) -> message
+        _ -> computerStatusMessage status
+
+computerStatusMessage :: CInt -> Text
+computerStatusMessage = \case
+    1 -> "The native computer host rejected an invalid argument."
+    2 -> "Native computer control is unavailable."
+    3 -> "The native computer operation timed out."
+    4 -> "Accessibility or Screen Recording permission is required."
+    5 -> "The native computer host does not support this operation."
+    6 -> "The native computer host failed internally."
+    7 -> "The native computer screenshot exceeded the 16 MiB output limit."
+    8 -> "Computer use is unavailable while the macOS session is locked."
+    9 ->
+        "The main display changed during computer use; take a fresh screenshot before continuing."
+    status ->
+        "The native computer operation failed (status "
+            <> Text.pack (show status)
+            <> ")."
+
+computerActionStructSize :: Int
+computerActionStructSize = 64
+
+computerErrorCapacity :: Int
+computerErrorCapacity = 64 * 1024
+
+computerOutputCapacity :: Int
+computerOutputCapacity = 16 * 1024 * 1024

--- a/packages/agent-native-bridge/include/HaskellAgentBridge.h
+++ b/packages/agent-native-bridge/include/HaskellAgentBridge.h
@@ -136,6 +136,197 @@ int32_t ha_engine_set_browser_callback(
     void *context
 );
 
+enum {
+    HA_COMPUTER_ABI_VERSION = 1,
+    HA_COMPUTER_QUERY_DISPLAY = 1,
+    HA_COMPUTER_RUN_AND_OBSERVE = 2
+};
+
+enum {
+    HA_COMPUTER_ACTION_CLICK = 1,
+    HA_COMPUTER_ACTION_DOUBLE_CLICK = 2,
+    HA_COMPUTER_ACTION_SCROLL = 3,
+    HA_COMPUTER_ACTION_MOVE = 4,
+    HA_COMPUTER_ACTION_DRAG = 5,
+    HA_COMPUTER_ACTION_TYPE = 6,
+    HA_COMPUTER_ACTION_KEYPRESS = 7,
+    HA_COMPUTER_ACTION_WAIT = 8
+};
+
+enum {
+    HA_COMPUTER_BUTTON_NONE = 0,
+    HA_COMPUTER_BUTTON_LEFT = 1,
+    HA_COMPUTER_BUTTON_RIGHT = 2,
+    HA_COMPUTER_BUTTON_MIDDLE = 3,
+    HA_COMPUTER_BUTTON_BACK = 4,
+    HA_COMPUTER_BUTTON_FORWARD = 5
+};
+
+enum {
+    HA_COMPUTER_MODIFIER_SHIFT = 1 << 0,
+    HA_COMPUTER_MODIFIER_CONTROL = 1 << 1,
+    HA_COMPUTER_MODIFIER_OPTION = 1 << 2,
+    HA_COMPUTER_MODIFIER_COMMAND = 1 << 3,
+    HA_COMPUTER_MODIFIER_FUNCTION = 1 << 4
+};
+
+enum {
+    HA_COMPUTER_IMAGE_NONE = 0,
+    HA_COMPUTER_IMAGE_PNG = 1,
+    HA_COMPUTER_IMAGE_JPEG = 2
+};
+
+enum {
+    HA_COMPUTER_STATUS_SUCCESS = 0,
+    HA_COMPUTER_STATUS_INVALID_ARGUMENT = 1,
+    HA_COMPUTER_STATUS_UNAVAILABLE = 2,
+    HA_COMPUTER_STATUS_TIMEOUT = 3,
+    HA_COMPUTER_STATUS_PERMISSION_DENIED = 4,
+    HA_COMPUTER_STATUS_UNSUPPORTED = 5,
+    HA_COMPUTER_STATUS_FAILED = 6,
+    HA_COMPUTER_STATUS_OUTPUT_TOO_LARGE = 7,
+    HA_COMPUTER_STATUS_SESSION_LOCKED = 8,
+    HA_COMPUTER_STATUS_DISPLAY_CHANGED = 9
+};
+
+enum {
+    HA_COMPUTER_ACTION_STRUCT_SIZE_V1 = 64,
+    HA_COMPUTER_MAX_ACTIONS = 10,
+    HA_COMPUTER_MAX_POINTS_PER_ACTION = 1024,
+    HA_COMPUTER_MAX_TOTAL_POINTS = 10240,
+    HA_COMPUTER_MAX_TEXT_BYTES = 327680,
+    HA_COMPUTER_ERROR_CAPACITY = 65536,
+    HA_COMPUTER_OUTPUT_CAPACITY = 16777216
+};
+
+typedef struct ha_computer_point_v1 {
+    int32_t x;
+    int32_t y;
+} ha_computer_point_v1;
+
+/*
+ * Fixed-width action record for HA_COMPUTER_ABI_VERSION. struct_size must be
+ * HA_COMPUTER_ACTION_STRUCT_SIZE_V1. text_offset/text_length select UTF-8 in
+ * the callback's text buffer. point_offset/point_count select records in its
+ * point buffer. Offsets and lengths are element counts, not byte pointers.
+ *
+ * Pointer coordinates are integer logical pixels in the final screenshot's
+ * top-left coordinate space: 0 <= x < output_width and
+ * 0 <= y < output_height. CLICK uses x/y, button, and modifiers.
+ * DOUBLE_CLICK and MOVE use x/y and modifiers. SCROLL uses x/y,
+ * delta_x/delta_y, and modifiers; positive deltas follow browser-wheel
+ * convention and move the viewport right/down. DRAG uses at least two ordered
+ * points, including its start and end, and the left button. TYPE uses a text
+ * range. KEYPRESS uses a nonempty text range for the final key and modifiers
+ * for the chord. WAIT has no fields and waits two seconds. Every field not
+ * named for an action must be zero.
+ */
+typedef struct ha_computer_action_v1 {
+    uint32_t struct_size;
+    int32_t action;
+    int32_t x;
+    int32_t y;
+    int32_t delta_x;
+    int32_t delta_y;
+    int32_t button;
+    uint32_t modifiers;
+    uint64_t text_offset;
+    uint64_t text_length;
+    uint64_t point_offset;
+    uint64_t point_count;
+} ha_computer_action_v1;
+
+/*
+ * Host computer-control callback for native agent turns.
+ *
+ * QUERY_DISPLAY requires zero actions/points/text, expected display token and
+ * dimensions and requested_image_format zero, and a writable error buffer. On
+ * success it writes a nonzero opaque lease to output_display_token and positive
+ * logical main-display dimensions to output_width and output_height, sets
+ * output_image_format and output_length to zero, and does not write image
+ * bytes.
+ *
+ * RUN_AND_OBSERVE executes the complete ordered action batch, waits for the UI
+ * to settle, and captures exactly one final main-display observation. It must
+ * verify expected_display_token is the host's current unconsumed lease for the
+ * same main display and that the logical display remains expected_width by
+ * expected_height before changing input state. A stale lease must fail with
+ * HA_COMPUTER_STATUS_DISPLAY_CHANGED before any side effect. The host must
+ * serialize leases across every callback context controlling the same desktop
+ * and invalidate a lease when a transaction starts changing input state.
+ * requested_image_format is PNG or JPEG. On success, output contains encoded
+ * image bytes, output_length is their length, output_display_token is a
+ * nonzero successor lease distinct from expected_display_token,
+ * output_width/output_height are the observed logical image dimensions, and
+ * output_image_format is PNG or JPEG. The encoded image is normalized to
+ * exactly output_width by output_height pixels, including on Retina displays,
+ * so action coordinates map one-to-one to image pixels. Every successful RUN
+ * consumes its input lease, including an observation-only run with zero
+ * actions.
+ *
+ * Actions contain no screenshot record: the Haskell runtime removes a final
+ * screenshot marker and rejects an earlier one. actions may be NULL only when
+ * action_count is zero. points and text follow the same rule. All ranges must
+ * be contained in their corresponding buffers. The host must reject unknown
+ * versions, operations, action values, modifiers, image formats, nonzero
+ * unused fields, malformed UTF-8, and counts above the HA_COMPUTER_MAX_*
+ * limits with HA_COMPUTER_STATUS_INVALID_ARGUMENT.
+ *
+ * output/output_length/output_display_token/output_width/output_height and
+ * output_image_format are nonnull callback-scoped writable pointers. On
+ * failure, set the display token, dimensions, and image format to zero and
+ * write a useful UTF-8 error to output when possible. Never report
+ * output_length above output_capacity. The runtime supplies
+ * HA_COMPUTER_ERROR_CAPACITY for QUERY_DISPLAY and HA_COMPUTER_OUTPUT_CAPACITY
+ * for RUN_AND_OBSERVE.
+ *
+ * The callback runs synchronously on an agent tool worker, never the setter's
+ * caller or AppKit main thread, and must not call engine functions. No input
+ * or output buffer remains valid after it returns. The host owns callback and
+ * context. ha_engine_set_computer_callback may wait for an in-flight callback;
+ * after it returns, a replaced callback/context will not be used again. Keep
+ * the installed callback/context valid until replacement, disable, or engine
+ * destruction returns.
+ */
+typedef int32_t (*ha_computer_callback)(
+    void *context,
+    uint32_t abi_version,
+    int32_t operation,
+    uint64_t expected_display_token,
+    int32_t expected_width,
+    int32_t expected_height,
+    const ha_computer_action_v1 *actions,
+    size_t action_count,
+    const ha_computer_point_v1 *points,
+    size_t point_count,
+    const uint8_t *text,
+    size_t text_length,
+    int32_t requested_image_format,
+    uint8_t *output,
+    size_t output_capacity,
+    size_t *output_length,
+    uint64_t *output_display_token,
+    int32_t *output_width,
+    int32_t *output_height,
+    int32_t *output_image_format
+);
+
+/*
+ * Installs native computer control for future turns. A turn replaces the
+ * local macOS backend only when its turn.start enables computer use and this
+ * callback is nonnull. Passing NULL disables native computer control; context
+ * is ignored. Tools retained by an already-started turn fail as inactive.
+ *
+ * Returns 0 on success, 1 for a null engine, or 2 for an internal failure.
+ * Calls must be serialized with ha_engine_destroy. This function may block
+ * until a running computer callback returns.
+ */
+int32_t ha_engine_set_computer_callback(
+    void *engine,
+    ha_computer_callback callback,
+    void *context
+);
+
 typedef void (*ha_repository_check_output_callback)(
     void *context,
     int32_t stream,

--- a/packages/agent-native-bridge/package.nix
+++ b/packages/agent-native-bridge/package.nix
@@ -1,9 +1,9 @@
 { mkDerivation, aeson, agent-cli, agent-cli-runtime, agent-core
-, agent-json, agent-mcp, agent-openai, agent-openrouter, agent-repository
-, agent-runtime-daemon, agent-store, agent-xai, async, base
-, bytestring, containers, directory, filelock, filepath, hspec, lib
-, network-uri, safe-exceptions, stdenv, stm, text, time, transformers
-, unix
+, agent-json, agent-mcp, agent-openai, agent-openrouter
+, agent-repository, agent-responses-types, agent-runtime-daemon
+, agent-store, agent-xai, async, base, bytestring, containers
+, directory, filelock, filepath, hspec, lib, network-uri
+, safe-exceptions, stdenv, stm, text, time, transformers, unix
 }:
 mkDerivation {
   pname = "agent-native-bridge";
@@ -16,8 +16,8 @@ mkDerivation {
     bytestring containers filepath network-uri text time transformers
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     aeson agent-openai agent-openrouter agent-repository
-    agent-runtime-daemon agent-xai async directory filelock
-    safe-exceptions stm
+    agent-responses-types agent-runtime-daemon agent-xai async directory
+    filelock safe-exceptions stm
   ];
   testHaskellDepends = [
     agent-cli agent-core agent-mcp agent-runtime-daemon agent-store
@@ -25,7 +25,7 @@ mkDerivation {
     safe-exceptions stm text unix
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     aeson agent-cli-runtime agent-openai agent-openrouter
-    agent-repository agent-xai filelock time
+    agent-repository agent-responses-types agent-xai filelock time
   ];
   description = "Native host integration for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
@@ -1,0 +1,376 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Agent.CLI.MacOS.ComputerBridgeSpec (spec) where
+
+import Agent.CLI.ComputerUse
+    ( ComputerObservation(..)
+    , ScreenshotEncoding(..)
+    , computerUseTool
+    )
+import Agent.CLI.MacOS.Bridge (composeNativeTools)
+import Agent.CLI.MacOS.ComputerBridge
+    ( CComputerAction(..)
+    , CComputerPoint(..)
+    , ComputerBatch(..)
+    , ComputerCallback
+    , ComputerHost(..)
+    , ComputerRegistration(..)
+    , computerActionStructSize
+    , encodeComputerActions
+    , invokeComputerSessionTransaction
+    , invokeComputerTransaction
+    , newComputerSession
+    )
+import Agent.Loop (ImageAttachment(..))
+import Agent.Responses.Types
+    ( ComputerAction(..)
+    , ComputerPoint(..)
+    )
+import Agent.Tools.Types (AppTool(..), AppToolGroup(..))
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (poll, wait, withAsync)
+import Control.Concurrent.MVar
+    ( modifyMVar_
+    , newEmptyMVar
+    , newMVar
+    , putMVar
+    , takeMVar
+    )
+import Control.Exception.Safe (bracket)
+import qualified Data.ByteString as BS
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Data.Word (Word8, Word32, Word64)
+import Foreign
+    ( FunPtr
+    , Ptr
+    , castPtr
+    , copyBytes
+    , freeHaskellFunPtr
+    , nullPtr
+    , peekArray
+    , poke
+    )
+import Foreign.C.Types (CInt(..), CSize(..))
+import Foreign.Storable (Storable, sizeOf)
+import Test.Hspec
+    ( Spec
+    , describe
+    , expectationFailure
+    , it
+    , shouldBe
+    , shouldReturn
+    )
+
+foreign import ccall "ha_computer_callback_abi_smoke"
+    computerCallbackABISmoke :: IO CInt
+
+foreign import ccall "wrapper"
+    wrapComputerCallback :: ComputerCallback -> IO (FunPtr ComputerCallback)
+
+spec :: Spec
+spec = describe "native computer bridge" do
+    it "keeps the Haskell records aligned with the versioned C ABI" do
+        sizeOf (undefined :: CComputerPoint) `shouldBe` 8
+        sizeOf (undefined :: CComputerAction) `shouldBe` 64
+        computerActionStructSize `shouldBe` 64
+        computerCallbackABISmoke `shouldReturn` 0
+
+    it "encodes UTF-8, drag ranges, buttons, and modifier masks" do
+        let result = encodeComputerActions
+                [ ClickAction 10 20 "back" ["shift", "fn"]
+                , TypeAction "hé"
+                , DragAction
+                    [ComputerPoint 1 2, ComputerPoint 3 4]
+                    ["cmd"]
+                , KeypressAction ["ctrl", "A"]
+                , WaitAction
+                ]
+        case result of
+            Left err -> fail (show err)
+            Right batch -> do
+                batch.computerBatchText `shouldBe`
+                    BS.pack [104, 195, 169, 65]
+                batch.computerBatchPoints `shouldBe`
+                    [CComputerPoint 1 2, CComputerPoint 3 4]
+                case batch.computerBatchActions of
+                    [click, typed, drag, keypress, waited] -> do
+                        ( click.cComputerAction
+                            , click.cComputerX
+                            , click.cComputerY
+                            , click.cComputerButton
+                            , click.cComputerModifiers
+                            ) `shouldBe` (1, 10, 20, 4, 17)
+                        ( typed.cComputerAction
+                            , typed.cComputerTextOffset
+                            , typed.cComputerTextLength
+                            ) `shouldBe` (6, 0, 3)
+                        ( drag.cComputerAction
+                            , drag.cComputerPointOffset
+                            , drag.cComputerPointCount
+                            , drag.cComputerModifiers
+                            ) `shouldBe` (5, 0, 2, 8)
+                        ( keypress.cComputerAction
+                            , keypress.cComputerTextOffset
+                            , keypress.cComputerTextLength
+                            , keypress.cComputerModifiers
+                            ) `shouldBe` (7, 3, 1, 2)
+                        waited.cComputerAction `shouldBe` 8
+                    actions -> fail ("unexpected actions: " <> show actions)
+
+    it "never sends screenshot markers through the native action ABI" do
+        encodeComputerActions [ScreenshotAction] `shouldBe`
+            Left "Computer screenshot must not cross the native action ABI."
+
+    it "round-trips the display lease and typed batch through the callback" do
+        observed <- newIORef []
+        withComputerHost (recordingComputerCallback observed) \host -> do
+            result <- invokeComputerTransaction
+                host
+                ScreenshotPng
+                [ ClickAction 10 20 "left" ["shift"]
+                , TypeAction "λ"
+                , DragAction
+                    [ComputerPoint 1 2, ComputerPoint 3 4]
+                    ["cmd"]
+                ]
+                (\dimensions ->
+                    if dimensions == (100, 80)
+                        then Right ()
+                        else Left "unexpected dimensions")
+            result `shouldBe` Right
+                (ComputerObservation
+                    (ImageAttachment "image/png" pngSignature)
+                    Nothing)
+            readIORef observed `shouldReturn`
+                [ ObservedComputerInvocation
+                    1 1 0 0 0 [] [] BS.empty 0 65536
+                , ObservedComputerInvocation
+                    1 2 41 100 80
+                    [ (plainObservedAction 1)
+                        { cComputerX = 10
+                        , cComputerY = 20
+                        , cComputerButton = 1
+                        , cComputerModifiers = 1
+                        }
+                    , (plainObservedAction 6)
+                        { cComputerTextLength = 2
+                        }
+                    , (plainObservedAction 5)
+                        { cComputerModifiers = 8
+                        , cComputerPointCount = 2
+                        }
+                    ]
+                    [CComputerPoint 1 2, CComputerPoint 3 4]
+                    (BS.pack [206, 187])
+                    1
+                    16777216
+                ]
+
+    it "executes later actions against the lease from the model's screenshot" do
+        observed <- newIORef []
+        withComputerHost (recordingComputerCallback observed) \host -> do
+            session <- newComputerSession
+            invokeComputerSessionTransaction
+                host session ScreenshotPng
+                [ClickAction 10 20 "left" []]
+                (const (Right ()))
+                `shouldReturn` Left
+                    "Take a fresh computer screenshot before sending input actions."
+            readIORef observed `shouldReturn` []
+            invokeComputerSessionTransaction
+                host session ScreenshotPng [] (const (Right ()))
+                `shouldReturn` Right
+                    (ComputerObservation
+                        (ImageAttachment "image/png" pngSignature)
+                        Nothing)
+            invokeComputerSessionTransaction
+                host session ScreenshotPng
+                [ClickAction 10 20 "left" []]
+                (const (Right ()))
+                `shouldReturn` Right
+                    (ComputerObservation
+                        (ImageAttachment "image/png" pngSignature)
+                        Nothing)
+            invocations <- readIORef observed
+            map observedOperationAndToken invocations `shouldBe`
+                [(1, 0), (2, 41), (2, 42)]
+
+    it "waits for an in-flight transaction before disabling its callback" do
+        runEntered <- newEmptyMVar
+        releaseRun <- newEmptyMVar
+        observed <- newIORef []
+        let blockingCallback context abi operation token width height
+                actions actionCount points pointCount text textLength
+                imageFormat output outputCapacity outputLength outputToken
+                outputWidth outputHeight outputImageFormat = do
+                    if operation == 2
+                        then putMVar runEntered () >> takeMVar releaseRun
+                        else pure ()
+                    recordingComputerCallback observed
+                        context abi operation token width height
+                        actions actionCount points pointCount text textLength
+                        imageFormat output outputCapacity outputLength
+                        outputToken outputWidth outputHeight outputImageFormat
+        withCallback blockingCallback \callback -> do
+            registration <- newMVar
+                (Just (ComputerRegistration callback nullPtr))
+            let host = ComputerHost registration
+            withAsync
+                (invokeComputerTransaction
+                    host
+                    ScreenshotPng
+                    []
+                    (const (Right ())))
+                \running -> do
+                    takeMVar runEntered
+                    withAsync
+                        (modifyMVar_ registration (const (pure Nothing)))
+                        \disabling -> do
+                            threadDelay 20000
+                            poll disabling >>= \case
+                                Nothing -> pure ()
+                                Just _ -> expectationFailure
+                                    "callback disabled during a transaction"
+                            putMVar releaseRun ()
+                            wait running `shouldReturn` Right
+                                (ComputerObservation
+                                    (ImageAttachment "image/png" pngSignature)
+                                    Nothing)
+                            wait disabling
+            invokeComputerTransaction host ScreenshotPng [] (const (Right ()))
+                `shouldReturn` Left "Native computer control is not active."
+
+    it "replaces the generic computer tool once without enabling it" do
+        let genericComputer = computerUseTool
+            nativeComputer = genericComputer
+                { appToolDescription = "native computer"
+                }
+            otherTool = genericComputer
+                { appToolName = "other"
+                }
+            names tools = map (\tool -> tool.appToolName) tools
+            descriptions tools =
+                map (\tool -> tool.appToolDescription) tools
+        names (composeNativeTools
+            (Just nativeComputer)
+            [ ExecutionToolGroup [genericComputer, otherTool]
+            , HostToolGroup [genericComputer]
+            ]) `shouldBe` ["computer", "other"]
+        descriptions (composeNativeTools
+            (Just nativeComputer)
+            [ExecutionToolGroup [genericComputer]]) `shouldBe`
+                ["native computer"]
+        names (composeNativeTools
+            (Just nativeComputer)
+            [ExecutionToolGroup [otherTool]]) `shouldBe` ["other"]
+        names (composeNativeTools
+            Nothing
+            [ ExecutionToolGroup [genericComputer, otherTool]
+            , HostToolGroup [genericComputer]
+            ]) `shouldBe` ["computer", "other", "computer"]
+
+data ObservedComputerInvocation = ObservedComputerInvocation
+    !Word32
+    !CInt
+    !Word64
+    !CInt
+    !CInt
+    ![CComputerAction]
+    ![CComputerPoint]
+    !BS.ByteString
+    !CInt
+    !CSize
+    deriving (Eq, Show)
+
+recordingComputerCallback
+    :: IORef [ObservedComputerInvocation]
+    -> ComputerCallback
+recordingComputerCallback observed _ abi operation token width height
+        actions actionCount points pointCount text textLength imageFormat
+        output outputCapacity outputLength outputToken outputWidth outputHeight
+        outputImageFormat = do
+    decodedActions <- peekValues actions actionCount
+    decodedPoints <- peekValues points pointCount
+    decodedText <- peekBytes text textLength
+    modifyIORef' observed (<> [ObservedComputerInvocation
+        abi operation token width height decodedActions decodedPoints
+        decodedText imageFormat outputCapacity])
+    case operation of
+        1 -> do
+            poke outputLength 0
+            poke outputToken 41
+            poke outputWidth 100
+            poke outputHeight 80
+            poke outputImageFormat 0
+            pure 0
+        2 -> do
+            status <- writeBytes pngSignature
+                output outputCapacity outputLength
+            poke outputToken (token + 1)
+            poke outputWidth 100
+            poke outputHeight 80
+            poke outputImageFormat 1
+            pure status
+        _ -> pure 1
+
+peekValues :: Storable value => Ptr value -> CSize -> IO [value]
+peekValues _ (CSize 0) = pure []
+peekValues pointer (CSize count) =
+    peekArray (fromIntegral count) pointer
+
+peekBytes :: Ptr value -> CSize -> IO BS.ByteString
+peekBytes _ (CSize 0) = pure BS.empty
+peekBytes pointer (CSize length) =
+    BS.packCStringLen (castPtr pointer, fromIntegral length)
+
+writeBytes :: BS.ByteString -> Ptr Word8 -> CSize -> Ptr CSize -> IO CInt
+writeBytes bytes output (CSize capacity) outputLength
+    | BS.length bytes > fromIntegral capacity = pure 7
+    | otherwise = do
+        BS.useAsCStringLen bytes \(source, length) ->
+            copyBytes output (castPtr source) length
+        poke outputLength (fromIntegral (BS.length bytes))
+        pure 0
+
+withComputerHost
+    :: ComputerCallback
+    -> (ComputerHost -> IO value)
+    -> IO value
+withComputerHost callback action =
+    withCallback callback \funPtr -> do
+        registration <- newMVar
+            (Just (ComputerRegistration funPtr nullPtr))
+        action (ComputerHost registration)
+
+withCallback
+    :: ComputerCallback
+    -> (FunPtr ComputerCallback -> IO value)
+    -> IO value
+withCallback callback =
+    bracket (wrapComputerCallback callback) freeHaskellFunPtr
+
+plainObservedAction :: CInt -> CComputerAction
+plainObservedAction action = CComputerAction
+    { cComputerStructSize = 64
+    , cComputerAction = action
+    , cComputerX = 0
+    , cComputerY = 0
+    , cComputerDeltaX = 0
+    , cComputerDeltaY = 0
+    , cComputerButton = 0
+    , cComputerModifiers = 0
+    , cComputerTextOffset = 0
+    , cComputerTextLength = 0
+    , cComputerPointOffset = 0
+    , cComputerPointCount = 0
+    }
+
+pngSignature :: BS.ByteString
+pngSignature = BS.pack [137, 80, 78, 71, 13, 10, 26, 10]
+
+observedOperationAndToken
+    :: ObservedComputerInvocation
+    -> (CInt, Word64)
+observedOperationAndToken
+        (ObservedComputerInvocation _ operation token _ _ _ _ _ _ _) =
+    (operation, token)

--- a/packages/agent-native-bridge/test/Spec.hs
+++ b/packages/agent-native-bridge/test/Spec.hs
@@ -15,6 +15,7 @@ import qualified Agent.CLI.MacOS.BridgeFFISpec as BridgeFFISpec
 import qualified Agent.CLI.MacOS.BridgeHeaderSpec as BridgeHeaderSpec
 import qualified Agent.CLI.MacOS.BridgeSpec as BridgeSpec
 import qualified Agent.CLI.MacOS.BrowserBridgeFFISpec as BrowserBridgeFFISpec
+import qualified Agent.CLI.MacOS.ComputerBridgeSpec as ComputerBridgeSpec
 #endif
 
 main :: IO ()
@@ -30,4 +31,5 @@ main = hspec do
     BridgeFFISpec.spec
     BridgeHeaderSpec.spec
     BridgeSpec.spec
+    ComputerBridgeSpec.spec
 #endif

--- a/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeComputerSmoke.c
+++ b/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeComputerSmoke.c
@@ -1,0 +1,132 @@
+#include "HaskellAgentBridge.h"
+
+#include <stddef.h>
+#include <string.h>
+
+_Static_assert(sizeof(ha_computer_point_v1) == 8,
+    "ha_computer_point_v1 must remain 8 bytes");
+_Static_assert(sizeof(ha_computer_action_v1) == 64,
+    "ha_computer_action_v1 must remain 64 bytes");
+_Static_assert(offsetof(ha_computer_action_v1, struct_size) == 0,
+    "unexpected struct_size offset");
+_Static_assert(offsetof(ha_computer_action_v1, action) == 4,
+    "unexpected action offset");
+_Static_assert(offsetof(ha_computer_action_v1, x) == 8,
+    "unexpected x offset");
+_Static_assert(offsetof(ha_computer_action_v1, y) == 12,
+    "unexpected y offset");
+_Static_assert(offsetof(ha_computer_action_v1, delta_x) == 16,
+    "unexpected delta_x offset");
+_Static_assert(offsetof(ha_computer_action_v1, delta_y) == 20,
+    "unexpected delta_y offset");
+_Static_assert(offsetof(ha_computer_action_v1, button) == 24,
+    "unexpected button offset");
+_Static_assert(offsetof(ha_computer_action_v1, modifiers) == 28,
+    "unexpected modifiers offset");
+_Static_assert(offsetof(ha_computer_action_v1, text_offset) == 32,
+    "unexpected text_offset offset");
+_Static_assert(offsetof(ha_computer_action_v1, text_length) == 40,
+    "unexpected text_length offset");
+_Static_assert(offsetof(ha_computer_action_v1, point_offset) == 48,
+    "unexpected point_offset offset");
+_Static_assert(offsetof(ha_computer_action_v1, point_count) == 56,
+    "unexpected point_count offset");
+
+static int32_t computer_callback(
+    void *context,
+    uint32_t abi_version,
+    int32_t operation,
+    uint64_t expected_display_token,
+    int32_t expected_width,
+    int32_t expected_height,
+    const ha_computer_action_v1 *actions,
+    size_t action_count,
+    const ha_computer_point_v1 *points,
+    size_t point_count,
+    const uint8_t *text,
+    size_t text_length,
+    int32_t requested_image_format,
+    uint8_t *output,
+    size_t output_capacity,
+    size_t *output_length,
+    uint64_t *output_display_token,
+    int32_t *output_width,
+    int32_t *output_height,
+    int32_t *output_image_format
+) {
+    const char *expected_context = "computer-context";
+    if (context == NULL
+            || strcmp((const char *)context, expected_context) != 0
+            || abi_version != HA_COMPUTER_ABI_VERSION
+            || operation != HA_COMPUTER_QUERY_DISPLAY
+            || expected_display_token != 0
+            || expected_width != 0 || expected_height != 0
+            || actions != NULL || action_count != 0
+            || points != NULL || point_count != 0
+            || text != NULL || text_length != 0
+            || requested_image_format != HA_COMPUTER_IMAGE_NONE
+            || output == NULL || output_capacity != HA_COMPUTER_ERROR_CAPACITY
+            || output_length == NULL || output_display_token == NULL
+            || output_width == NULL
+            || output_height == NULL || output_image_format == NULL) {
+        return HA_COMPUTER_STATUS_INVALID_ARGUMENT;
+    }
+    *output_length = 0;
+    *output_display_token = 42;
+    *output_width = 1440;
+    *output_height = 900;
+    *output_image_format = HA_COMPUTER_IMAGE_NONE;
+    return HA_COMPUTER_STATUS_SUCCESS;
+}
+
+int ha_computer_callback_abi_smoke(void) {
+    uint8_t output[HA_COMPUTER_ERROR_CAPACITY];
+    size_t output_length = 17;
+    uint64_t output_display_token = 0;
+    int32_t output_width = 0;
+    int32_t output_height = 0;
+    int32_t output_image_format = -1;
+    ha_computer_callback callback = computer_callback;
+
+    if (HA_COMPUTER_ACTION_STRUCT_SIZE_V1 != 64
+            || HA_COMPUTER_MAX_ACTIONS != 10
+            || HA_COMPUTER_MAX_POINTS_PER_ACTION != 1024
+            || HA_COMPUTER_MAX_TOTAL_POINTS != 10240
+            || HA_COMPUTER_MAX_TEXT_BYTES != 327680
+            || HA_COMPUTER_OUTPUT_CAPACITY != 16777216
+            || HA_COMPUTER_STATUS_DISPLAY_CHANGED != 9) {
+        return 1;
+    }
+
+    int32_t status = callback(
+        (void *)"computer-context",
+        HA_COMPUTER_ABI_VERSION,
+        HA_COMPUTER_QUERY_DISPLAY,
+        0,
+        0,
+        0,
+        NULL,
+        0,
+        NULL,
+        0,
+        NULL,
+        0,
+        HA_COMPUTER_IMAGE_NONE,
+        output,
+        sizeof(output),
+        &output_length,
+        &output_display_token,
+        &output_width,
+        &output_height,
+        &output_image_format
+    );
+    if (status != HA_COMPUTER_STATUS_SUCCESS
+            || output_length != 0
+            || output_display_token != 42
+            || output_width != 1440
+            || output_height != 900
+            || output_image_format != HA_COMPUTER_IMAGE_NONE) {
+        return 2;
+    }
+    return 0;
+}

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -749,8 +749,16 @@ computerFunctionTextOutput :: Text -> Text
 computerFunctionTextOutput rawOutput =
     case Hermes.decodeEither computerCallOutputDecoder
             (Text.encodeUtf8 rawOutput) of
-        Right ComputerCallOutput{} ->
-            "Computer action completed."
+        Right output ->
+            case KeyMap.lookup
+                    "accessibility_state"
+                    output.computerOutputExtra of
+                Just (Aeson.String state)
+                    | not (Text.null (Text.strip state)) ->
+                        "Computer action completed.\n\n"
+                            <> "Current macOS accessibility state:\n"
+                            <> state
+                _ -> "Computer action completed."
         Left _ -> rawOutput
 
 latestComputerScreenshot :: [TurnInput] -> Maybe Text

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -195,6 +195,31 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
             other -> expectationFailure
                 ("unexpected computer continuation: " <> show other)
 
+    it "returns native accessibility state beside the screenshot" do
+        let encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                ComputerCallOutput
+                    { computerOutputItemId = Nothing
+                    , computerOutputCallId = "ignored"
+                    , screenshotDataUrl = "data:image/jpeg;base64,AA=="
+                    , acknowledgedChecks = []
+                    , computerOutputStatus = Nothing
+                    , computerOutputExtra = KeyMap.singleton
+                        "accessibility_state"
+                        (Aeson.String
+                            "app=\"TextEdit\"\n[1] AXButton \"Save\"")
+                    }
+            result = ToolCallResult
+                { callId = "call-native"
+                , output = encoded
+                , callKind = ComputerFunctionCallKind
+                }
+        case turnInputsToItems [CompletedTool result] of
+            FunctionCallOutputItem output : _ ->
+                Aeson.toJSON output.output `shouldBe` Aeson.String
+                    "Computer action completed.\n\nCurrent macOS accessibility state:\napp=\"TextEdit\"\n[1] AXButton \"Save\""
+            other -> expectationFailure
+                ("unexpected native computer continuation: " <> show other)
+
     it "keeps computer output before its observation in standard and Lite requests" do
         let encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
                 ComputerCallOutput


### PR DESCRIPTION
## Summary
- execute computer actions transactionally against the display lease associated with the model's screenshot, cap batches at 10 actions, and return one fresh observation
- add a versioned typed macOS callback ABI in `agent-native-bridge`, including race-safe registration, quiescent disable, and native-tool replacement
- propagate native accessibility state alongside screenshots and validate coordinates, modifiers, keys, drag paths, and screenshot placement before desktop mutation

## Testing
- focused `Agent.CLI.ComputerUseSpec`: 24 examples, 0 failures
- focused `Agent.CLI.MacOS.ComputerBridgeSpec`: 7 examples, 0 failures
- focused `Agent.Responses.LoopBackendSpec`: 42 examples, 0 failures
- `cabal --builddir=.task-tmp/pr-dist build --jobs=1 agent-native-bridge:flib:haskell-agent-bridge -v0`

The focused suites were run through `nix develop` with GHCi object code in an isolated serial Cabal build directory. No live click or typing smoke test was performed.

Companion macOS app PR: https://github.com/digitallyinduced/haskell-agent-macos/pull/151
