### PR TITLE
Allow cold CI checks to finish

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,16 @@ jobs:
               .#checks.x86_64-linux.agent-repository
               .#checks.x86_64-linux.agent-native-bridge
               .#checks.x86_64-linux.package-boundaries
+            # Repository integration tests deliberately exercise Git and gh
+            # process timeouts; after their extraction they run in one suite.
+            timeout_minutes: 60
           - name: Native CLI
             targets: .#checks.x86_64-linux.agent-cli-executable
           - name: Static CLI runtime
             targets: .#checks.x86_64-linux.agent-cli-static-runtime
-            timeout_minutes: 90
+            # A cold static package graph can exceed 90 minutes before the
+            # protected-ref publisher has populated the binary cache.
+            timeout_minutes: 120
           - name: Linux integrations
             targets: >-
               .#checks.x86_64-linux.agent-sandbox-runner


### PR DESCRIPTION
## Summary

- give the extracted-package matrix leg 60 minutes instead of the default 30
- give the cold static CLI graph 120 minutes instead of 90
- document why both targeted jobs need larger wall-clock budgets

## Hosted evidence

Run 33883340857 canceled `Extracted package tests` at exactly 30 minutes while `agent-repository` was still progressing: 45/53 tests had passed with no failure, and `agent-native-bridge` had passed all 41 tests.

Run 33890800619 then proved the 60-minute budget: the extracted-package leg passed in 14m10s. In that same cold-cache run, Static CLI was canceled at 90 minutes while still compiling normally (187/225 announced derivations had started), so its existing cold-build allowance is raised to 120 minutes.

## Validation

- hosted extracted-package leg: success under the new 60-minute budget
- `actionlint .github/workflows/*.yml`
- `nix eval --raw .#packages.x86_64-linux.default.drvPath --no-write-lock-file`
- `nix flake check --no-build --no-write-lock-file`
- `git diff --check origin/master...HEAD`