### PR TITLE
ci: finish remaining cold-store builds

### DIFF
--- a/.github/workflows/publish-binary-cache.yml
+++ b/.github/workflows/publish-binary-cache.yml
@@ -26,7 +26,7 @@ jobs:
             install_nix: true
             trusted-rebuild: false
             build-cores: 4
-            timeout_minutes: 180
+            timeout_minutes: 240
           - system: aarch64-darwin
             runner: '["self-hosted", "haskell-agent", "ihp-ci-mac", "aarch64-darwin"]'
             install_nix: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
           - name: CLI package tests
             targets: .#checks.x86_64-linux.agent-cli
             evaluate_flake: true
+            timeout_minutes: 60
           - name: Telegram package tests
             targets: .#checks.x86_64-linux.agent-telegram
           - name: Server package tests


### PR DESCRIPTION
## Summary
- give CLI package tests 60 minutes instead of the inherited 30
- give the Linux cache publisher 240 minutes instead of 180

A cold CLI package/evaluation run exhausted 30 minutes. The Linux publisher exhausted 180 minutes while still making forward progress and had already reached top-level static packages. Master now separately grants the extracted-package and static checks enough time; this PR retains only the remaining measured limits.

## Validation
- `git diff --check`
- `nix flake check --no-build --no-write-lock-file`
- prior exact-head run completed every matrix leg successfully with the extended limits before the branch was rebased over the overlapping master timeout repair
