### PR TITLE
Preserve oversized TUI history turns

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/History.hs
@@ -405,6 +405,11 @@ trimWindowPrefer
     -> HistoryWindow
 trimWindowPrefer preferred window
     | withinBudget window = window
+    -- Turns are the paging unit, so an oversized turn cannot be trimmed
+    -- without losing its whole prompt and response. Keep one turn even when
+    -- it exceeds a soft block or byte budget; otherwise committing a long
+    -- live turn would clear it from the transcript immediately.
+    | Seq.length window.historyWindowTurns <= 1 = window
     | otherwise =
         case preferredEvictionDirection preferred window of
             Nothing -> window

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -300,6 +300,26 @@ spec = describe "bounded fullscreen history window" do
             `shouldBe` Seq.singleton (HistoryCursor 2)
         historyWindowLoadedBytes window `shouldSatisfy` (<= 180)
 
+    it "keeps an oversized completed turn visible after archiving its live blocks" do
+        let generation = HistoryGeneration 6
+            initial = emptyHistoryWindow generation 100 100 180
+            page =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns = Seq.singleton (turn 1 1)
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 2
+                    , historyPageHasOlder = True
+                    , historyPageHasNewer = False
+                    }
+        loaded <- expectRight (applyHistoryPage page initial)
+        let completed = appendHistoryTurn (turn 2 2) loaded
+        historyWindowCursors completed
+            `shouldBe` Seq.singleton (HistoryCursor 2)
+        historyWindowLoadedBytes completed `shouldSatisfy` (> 180)
+        historyWindowOlderAvailable completed `shouldBe` True
+
     it "omits persisted reasoning while projecting tool and assistant history" do
         let projected =
                 sessionHistoryTurn


### PR DESCRIPTION
## Summary
- keep one complete TUI history turn when that indivisible turn exceeds the soft block or byte budget
- continue evicting older completed turns first, so committing a large response cannot leave the transcript blank after live blocks are archived
- add a regression covering an oversized latest turn with older persisted history still available

## Testing
- focused regression on rebased `master`: 1 example, 0 failures
- bounded fullscreen history window group: 23 examples, 0 failures
- focused durable-tail viewport test: 1 example, 0 failures
- live tmux TTY smoke with an isolated fake provider: oversized completed response remained visible and composer returned to idle
- `git diff --check`

The focused suites were run through `nix develop` with the macOS GHCi object-code test REPL.
