### PR TITLE
Hide persisted image payloads in TUI history

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentViewport.hs
@@ -33,7 +33,10 @@ module Agent.CLI.AgentViewport
     , selectedAgentEntry
     ) where
 
-import Agent.CLI.Render (summarizeToolCallRelative)
+import Agent.CLI.Render
+    ( renderToolOutputValue
+    , summarizeToolCallRelative
+    )
 import Agent.CLI.AgentViewport.Status
     ( agentStatusGlyph
     , formatAgentStatus
@@ -47,8 +50,6 @@ import Agent.CLI.TextLayout
     , renderSplitPaneFrame
     )
 import Agent.Loop (LoopEvent(..))
-import Agent.Json (RawJson, rawJsonBytes)
-import Agent.Json.Decode qualified as Hermes
 import Agent.Responses.LoopBackend (responseItemToToolCall)
 import Agent.Responses.Types
 import Agent.Subagents (SubagentId(..), SubagentStatus(..))
@@ -77,7 +78,6 @@ import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as Text
 import System.Console.ANSI (getTerminalSize)
 import System.IO (hFlush, hIsTerminalDevice, stderr, stdin)
@@ -826,15 +826,6 @@ agentMessagePlainText message =
             PlainTextPart{text} -> [text]
             _ -> []
         ]
-
-renderToolOutputValue :: RawJson -> Text
-renderToolOutputValue value =
-    case Hermes.decodeEither
-            (Hermes.nullable Hermes.text)
-            (rawJsonBytes value) of
-        Right (Just text) -> text
-        Right Nothing -> ""
-        Left _ -> TextEncoding.decodeUtf8 (rawJsonBytes value)
 
 normalizeTranscriptUi :: UiState -> UiState
 normalizeTranscriptUi state =

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -42,6 +42,7 @@ module Agent.CLI.Render
     , renderAssistantTextForHandle
     , renderEvent
     , renderPrintedText
+    , renderToolOutputValue
     , resetRenderPrintedText
     , setRenderActivity
     , streamMarkdown
@@ -120,6 +121,12 @@ import Agent.Loop
     , generationTokensPerSecond
     , liveTokensPerSecond
     )
+import Agent.Json (RawJson, rawJsonBytes)
+import Agent.Json.Decode qualified as Hermes
+import Agent.Responses.Types
+    ( ResponseContentPart(..)
+    )
+import Agent.Responses.Types.Content (responseContentPartDecoder)
 import Agent.TUI.Presentation
     ( SearchReplaceAction(..)
     , SearchReplaceDiff(..)
@@ -152,11 +159,15 @@ import Control.Concurrent.Async (Async, asyncWithUnmask, cancel)
 import Control.Concurrent.MVar (MVar, withMVar)
 import Control.Exception.Safe (mask_, tryIO)
 import Control.Monad (forM_, unless, void, when)
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Key (Key)
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.IO as Text
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
 import Data.Word (Word64)
@@ -183,6 +194,143 @@ summarizeToolCallRelative workspace call =
     fromMaybe
         (Presentation.summarizeToolCallRelative workspace call)
         (summarizeComputerToolCall call)
+
+-- | Render a persisted tool result without exposing encoded media payloads.
+--
+-- Rich tool results are stored as Responses content-part arrays so the model
+-- can consume their media. The live UI only sees the short textual result; a
+-- restored transcript must preserve that behavior instead of dumping the
+-- array's data URLs. Other structured JSON output remains unchanged.
+renderToolOutputValue :: RawJson -> Text
+renderToolOutputValue value =
+    case Hermes.decodeEither
+            (Hermes.nullable Hermes.text)
+            bytes of
+        Right (Just text) -> text
+        Right Nothing -> ""
+        Left _ ->
+            case Hermes.decodeEither
+                    (Hermes.list responseContentPartDecoder)
+                    bytes of
+                Right parts
+                    | any isOpaqueContentPart parts ->
+                        renderRichToolOutput parts
+                _ ->
+                    fromMaybe
+                        (TextEncoding.decodeUtf8 bytes)
+                        (renderOpaqueJsonArray value)
+  where
+    bytes = rawJsonBytes value
+
+isOpaqueContentPart :: ResponseContentPart -> Bool
+isOpaqueContentPart = \case
+    InputImagePart{} -> True
+    InputFilePart{} -> True
+    InputAudioPart{} -> True
+    EncryptedContentPart{} -> True
+    _ -> False
+
+-- Keep media payloads hidden even if a future or malformed content part no
+-- longer decodes through 'responseContentPartDecoder'. This deliberately only
+-- handles top-level arrays, which is how rich tool results are persisted, so
+-- structured JSON outside that envelope still renders verbatim.
+renderOpaqueJsonArray :: RawJson -> Maybe Text
+renderOpaqueJsonArray value =
+    case Aeson.decodeStrict' (rawJsonBytes value) of
+        Just (Aeson.Array parts)
+            | any jsonContainsOpaqueContent parts ->
+                Just $
+                    Text.intercalate "\n" $
+                        case filter (not . Text.null . Text.strip)
+                                (foldMap jsonContentText parts) of
+                            [] -> ["[media]"]
+                            textParts -> textParts
+        _ -> Nothing
+
+jsonContainsOpaqueContent :: Aeson.Value -> Bool
+jsonContainsOpaqueContent = \case
+    Aeson.Object object ->
+        hasOpaqueContentType object
+            || any (`KeyMap.member` object) opaqueContentKeys
+            || any jsonContainsOpaqueContent object
+    Aeson.Array values -> any jsonContainsOpaqueContent values
+    Aeson.String text -> looksLikeEncodedDataUrl text
+    _ -> False
+
+hasOpaqueContentType :: Aeson.Object -> Bool
+hasOpaqueContentType object =
+    case KeyMap.lookup "type" object of
+        Just (Aeson.String contentType) ->
+            contentType `elem`
+                [ "input_image"
+                , "input_file"
+                , "input_audio"
+                , "encrypted_content"
+                ]
+        _ -> False
+
+opaqueContentKeys :: [Key]
+opaqueContentKeys =
+    [ "image_url"
+    , "file_data"
+    , "file_url"
+    , "input_audio"
+    , "encrypted_content"
+    ]
+
+jsonContentText :: Aeson.Value -> [Text]
+jsonContentText = \case
+    Aeson.Object object ->
+        [ text
+        | key <- ["text", "refusal"]
+        , Just (Aeson.String text) <- [KeyMap.lookup key object]
+        , not (looksLikeEncodedDataUrl text)
+        ]
+    _ -> []
+
+looksLikeEncodedDataUrl :: Text -> Bool
+looksLikeEncodedDataUrl text =
+    let header = Text.toLower (Text.take 512 (Text.stripStart text))
+    in "data:" `Text.isPrefixOf` header
+        && ";base64," `Text.isInfixOf` header
+
+renderRichToolOutput :: [ResponseContentPart] -> Text
+renderRichToolOutput parts =
+    Text.intercalate "\n" $
+        case filter (not . Text.null . Text.strip)
+                (concatMap contentPartText parts) of
+            [] -> concatMap contentPartPlaceholder parts
+            textParts -> textParts
+
+contentPartText :: ResponseContentPart -> [Text]
+contentPartText part =
+    filter (not . looksLikeEncodedDataUrl) $
+        case part of
+            InputTextPart text _ -> [text]
+            OutputTextPart text _ _ -> [text]
+            RefusalPart refusal -> [refusal]
+            ReasoningTextPart text -> [text]
+            SummaryTextPart text -> [text]
+            PlainTextPart text -> [text]
+            _ -> []
+
+contentPartPlaceholder :: ResponseContentPart -> [Text]
+contentPartPlaceholder = \case
+    InputImagePart{} -> ["[image]"]
+    InputFilePart _ _ _ _ filename _ ->
+        [ "[file"
+            <> maybe
+                ""
+                (\name ->
+                    if looksLikeEncodedDataUrl name
+                        then ""
+                        else " " <> name)
+                filename
+            <> "]"
+        ]
+    InputAudioPart{} -> ["[audio]"]
+    EncryptedContentPart{} -> ["[encrypted content]"]
+    _ -> []
 
 data RenderConfig = RenderConfig
     { renderShowThinking :: !Bool

--- a/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
@@ -13,12 +13,11 @@ import Agent.CLI.Session
     , SessionTurnPage(..)
     )
 import Agent.CLI.Session.Types (TranscriptEffect(..))
+import Agent.CLI.Render (renderToolOutputValue)
 import Agent.CLI.TurnState
     ( isDisplayAttemptBoundary
     , isTurnAbortedNote
     )
-import Agent.Json (RawJson, rawJsonBytes)
-import qualified Agent.Json.Decode as Hermes
 import Agent.CLI.TUI.History
     ( HistoryCursor(..)
     , HistoryDirection
@@ -62,7 +61,6 @@ import Agent.TUI.Model
 import Data.Foldable (toList)
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as TextEncoding
 
 sessionHistoryPage
     :: HistoryGeneration
@@ -235,7 +233,7 @@ projectItem state = \case
                 (ToolFinished
                     (ToolCallResult
                         output.callId
-                        (renderJsonValue output.output)
+                        (renderToolOutputValue output.output)
                         FunctionCallKind)))
             state
     CustomToolCallOutputItem output ->
@@ -244,7 +242,7 @@ projectItem state = \case
                 (ToolFinished
                     (ToolCallResult
                         output.callId
-                        (renderJsonValue output.output)
+                        (renderToolOutputValue output.output)
                         CustomCallKind)))
             state
     _ -> state
@@ -263,7 +261,7 @@ projectDisplayItem state item
                         (UiLoop
                             (ToolOutputUpdated
                                 output.callId
-                                (renderJsonValue output.output)))
+                                (renderToolOutputValue output.output)))
                         state
             CustomToolCallOutputItem output
                 | output.status == Just ItemIncomplete ->
@@ -271,7 +269,7 @@ projectDisplayItem state item
                         (UiLoop
                             (ToolOutputUpdated
                                 output.callId
-                                (renderJsonValue output.output)))
+                                (renderToolOutputValue output.output)))
                         state
             _ -> projectItem state item
 
@@ -342,12 +340,3 @@ responseContentText = \case
     SummaryTextPart{text} -> [text]
     RefusalPart{refusal} -> [refusal]
     _ -> []
-
-renderJsonValue :: RawJson -> Text.Text
-renderJsonValue value =
-    case Hermes.decodeEither
-            (Hermes.nullable Hermes.text)
-            (rawJsonBytes value) of
-        Right (Just text) -> text
-        Right Nothing -> ""
-        Left _ -> TextEncoding.decodeUtf8 (rawJsonBytes value)

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -12,7 +12,13 @@ import Agent.CLI.TUI.History
 import Agent.Json (rawJsonFromEncoding)
 import Agent.CLI.TUI.Composer (composerScrollbackAvailable)
 import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn)
+import Agent.Responses.LoopBackend (toolResultToItem)
 import Agent.Responses.Types
+import Agent.ToolDispatch
+    ( ToolCallKind(..)
+    , ToolCallResult(..)
+    , ToolResultImage(..)
+    )
 import qualified Data.Aeson as Aeson
 import Data.Foldable (toList)
 import Agent.TUI.Model
@@ -377,6 +383,86 @@ spec = describe "bounded fullscreen history window" do
         map (.blockBody) blocks
             `shouldSatisfy`
                 all (not . Text.isInfixOf "Don't mention skills")
+
+    it "does not render persisted image payloads as tool output" do
+        let summary = "Viewed image file: example.png"
+            payloadMarker = "VERY_SECRET_IMAGE_BYTES"
+            imageOutput =
+                toolResultToItem
+                    (ToolCallResultWithImages
+                        "image-call"
+                        summary
+                        FunctionCallKind
+                        [ ToolResultImage
+                            ("data:image/png;base64," <> payloadMarker)
+                            (Just "high")
+                        ])
+            rendered = projectedToolResult imageOutput
+        rendered `shouldSatisfy` Text.isInfixOf summary
+        rendered `shouldSatisfy` (not . Text.isInfixOf payloadMarker)
+        rendered `shouldSatisfy` (not . Text.isInfixOf "base64")
+        rendered `shouldSatisfy` (not . Text.isInfixOf "\"input_image\"")
+
+    it "fails closed for schema-drifted persisted media output" do
+        let summary = "Viewed schema-drifted image"
+            payloadMarker = "SCHEMA_DRIFT_IMAGE_BYTES"
+            rendered =
+                projectedToolResult $
+                    toolOutputItem
+                        [ Aeson.object
+                            [ "type" Aeson..= ("input_image" :: Text.Text)
+                            , "image_url" Aeson..= (7 :: Int)
+                            , "payload" Aeson..=
+                                ("data:image/png;base64," <> payloadMarker)
+                            ]
+                        , Aeson.object
+                            [ "type" Aeson..= ("input_text" :: Text.Text)
+                            , "text" Aeson..= summary
+                            ]
+                        ]
+        rendered `shouldSatisfy` Text.isInfixOf summary
+        rendered `shouldSatisfy` (not . Text.isInfixOf payloadMarker)
+        rendered `shouldSatisfy` (not . Text.isInfixOf "base64")
+
+    it "fails closed for future persisted media content parts" do
+        let summary = "Viewed future image"
+            payloadMarker = "FUTURE_IMAGE_BYTES"
+            rendered =
+                projectedToolResult $
+                    toolOutputItem
+                        [ Aeson.object
+                            [ "type" Aeson..= ("future_media" :: Text.Text)
+                            , "payload" Aeson..=
+                                (" DATA:image/png;BASE64," <> payloadMarker)
+                            ]
+                        , Aeson.object
+                            [ "type" Aeson..= ("input_text" :: Text.Text)
+                            , "text" Aeson..= summary
+                            ]
+                        ]
+        rendered `shouldSatisfy` Text.isInfixOf summary
+        rendered `shouldSatisfy` (not . Text.isInfixOf payloadMarker)
+        rendered `shouldSatisfy` (not . Text.isInfixOf "BASE64")
+
+    it "does not trust text fields inside persisted media arrays" do
+        let payloadMarker = "TEXT_FIELD_IMAGE_BYTES"
+            rendered =
+                projectedToolResult $
+                    toolOutputItem
+                        [ Aeson.object
+                            [ "type" Aeson..= ("input_image" :: Text.Text)
+                            , "image_url" Aeson..=
+                                ("https://example.test/image.png" :: Text.Text)
+                            ]
+                        , Aeson.object
+                            [ "type" Aeson..= ("input_text" :: Text.Text)
+                            , "text" Aeson..=
+                                ("data:image/png;base64," <> payloadMarker)
+                            ]
+                        ]
+        rendered `shouldSatisfy` Text.isInfixOf "[image]"
+        rendered `shouldSatisfy` (not . Text.isInfixOf payloadMarker)
+        rendered `shouldSatisfy` (not . Text.isInfixOf "base64")
 
     it "preserves partial assistant output in a cancelled durable turn" do
         let turnValue =
@@ -744,6 +830,43 @@ assistantMessage text =
         , phase = Nothing
         , passthrough = Nothing
         }
+
+toolOutputItem :: [Aeson.Value] -> ResponseItem
+toolOutputItem parts =
+    FunctionCallOutputItem FunctionCallOutput
+        { itemId = Nothing
+        , callId = "image-call"
+        , name = Nothing
+        , namespace = Nothing
+        , provider = Nothing
+        , output = rawJsonFromEncoding (Aeson.toEncoding parts)
+        , status = Nothing
+        }
+
+projectedToolResult :: ResponseItem -> Text.Text
+projectedToolResult outputItem =
+    Text.intercalate "\n" $
+        map (.blockBody) (toList projected.historyTurnBlocks)
+  where
+    projected =
+        sessionHistoryTurn
+            (13 :: Int)
+            (sessionTurn
+                TranscriptAppend
+                "inspect the image"
+                [ userMessage "inspect the image"
+                , FunctionCallItem FunctionCall
+                    { itemId = Nothing
+                    , callId = "image-call"
+                    , name = "view_image"
+                    , namespace = Nothing
+                    , provider = Nothing
+                    , arguments = "{\"path\":\"example.png\"}"
+                    , encryptedFunctionArgs = Nothing
+                    , status = Nothing
+                    }
+                , outputItem
+                ])
 
 fixedTime :: UTCTime
 fixedTime =


### PR DESCRIPTION
## Summary
- render persisted rich tool results through a shared media-aware formatter
- keep image/file/audio/encrypted payloads out of restored TUI history while retaining safe summaries
- fail closed for malformed or future media content-part arrays and reuse the behavior in both history projection paths

## Root cause
Image-bearing tool results are persisted as Responses content-part JSON arrays. Live rendering receives only the short textual summary, but restored history decoded only scalar JSON strings and otherwise rendered the raw array, including `data:` base64 payloads.

## Validation
- `bounded fullscreen history window`: 27 examples, 0 failures
- affected viewport/preview groups: 12 examples, 0 failures
- real Brick fullscreen tmux smoke: summary visible; payload marker and `base64` absent
- `git diff --check`
