### PR TITLE
Normalize oversized images before model submission

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -134,6 +134,7 @@ library
                     , vector
                     , websockets
                     , yaml
+                    , zlib
 
 benchmark grep-streaming-bench
     import:           common-opts
@@ -301,3 +302,4 @@ test-suite agent-core-test
                     , unix
                     , websockets
                     , yaml
+                    , zlib

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -95,7 +95,8 @@ library
                     , Agent.Tools.Types
                     , Agent.Tools.ViewImage
                     , Agent.Transport.WebSocket
-    other-modules:    Agent.Loop.EventPump
+    other-modules:    Agent.Image.Normalize
+                    , Agent.Loop.EventPump
                     , Agent.Loop.Internal
                     , Agent.Subagents.Registry.Internal.Core
                     , Agent.Subagents.Registry.Internal.Operations
@@ -286,6 +287,7 @@ test-suite agent-core-test
                     , filepath
                     , containers
                     , hspec
+                    , JuicyPixels
                     , process
                     , QuickCheck >= 2.14 && < 2.16
                     , retry >= 0.9.3.1 && < 0.10

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -3,7 +3,7 @@
 , containers, crypton-connection, directory, filepath, hspec
 , JuicyPixels, lib, process, QuickCheck, resourcet, retry
 , safe-exceptions, stm, template-haskell, text, text-builder, time
-, tls, transformers, unix, vector, websockets, yaml
+, tls, transformers, unix, vector, websockets, yaml, zlib
 }:
 mkDerivation {
   pname = "agent-core";
@@ -15,13 +15,13 @@ mkDerivation {
     base64-bytestring bytestring containers crypton-connection
     directory filepath JuicyPixels process resourcet retry
     safe-exceptions stm template-haskell text time tls transformers
-    unix vector websockets yaml
+    unix vector websockets yaml zlib
   ];
   testHaskellDepends = [
     aeson agent-json agent-responses-types async base base64-bytestring
     bytestring containers crypton-connection directory filepath hspec
     JuicyPixels process QuickCheck retry safe-exceptions stm text time
-    tls unix websockets yaml
+    tls unix websockets yaml zlib
   ];
   benchmarkHaskellDepends = [
     aeson agent-json async base bytestring directory filepath process

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -20,8 +20,8 @@ mkDerivation {
   testHaskellDepends = [
     aeson agent-json agent-responses-types async base base64-bytestring
     bytestring containers crypton-connection directory filepath hspec
-    process QuickCheck retry safe-exceptions stm text time tls unix
-    websockets yaml
+    JuicyPixels process QuickCheck retry safe-exceptions stm text time
+    tls unix websockets yaml
   ];
   benchmarkHaskellDepends = [
     aeson agent-json async base bytestring directory filepath process

--- a/packages/agent-core/src/Agent/Image/Normalize.hs
+++ b/packages/agent-core/src/Agent/Image/Normalize.hs
@@ -1,0 +1,393 @@
+-- | Bounded image preparation for multimodal model requests.
+module Agent.Image.Normalize
+    ( NormalizedImage(..)
+    , normalizeImageForPrompt
+    , normalizeImageDataUrl
+    ) where
+
+import Codec.Picture
+    ( DynamicImage(..)
+    , Image
+    , PixelRGB8(..)
+    , PixelRGBA8(..)
+    , PixelYCbCr8
+    , convertRGB8
+    , convertRGBA8
+    , decodeImageWithMetadata
+    , encodeJpegAtQuality
+    , encodePng
+    , imageHeight
+    , imageWidth
+    )
+import qualified Codec.Picture.Metadata as Metadata
+import Codec.Picture.Metadata.Exif
+    ( ExifData(..)
+    , ExifTag(TagOrientation)
+    )
+import Codec.Picture.Types
+    ( Pixel
+    , convertImage
+    , dynamicMap
+    , generateImage
+    , pixelAt
+    , pixelMap
+    )
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy as LazyByteString
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word8)
+
+-- These limits match the conservative preparation used by Grok Build. They
+-- keep base64 expansion comfortably below the transport's request allowance
+-- while retaining enough pixels for model-side tiling.
+maximumImageBytes :: Int
+maximumImageBytes = 1500000
+
+maximumImageSide :: Int
+maximumImageSide = 2000
+
+maximumImagePixels :: Int
+maximumImagePixels = 2408448
+
+minimumRetrySide :: Int
+minimumRetrySide = 512
+
+jpegQualities :: [Word8]
+jpegQualities = [88, 80, 72, 64, 56, 48, 40, 32]
+
+data NormalizedImage = NormalizedImage
+    { normalizedImageMime :: !Text
+    , normalizedImageBytes :: !ByteString
+    }
+
+-- | Decode and, when necessary, resize or recompress an image before it is
+-- serialized into a provider request. Small images remain byte-for-byte
+-- unchanged. Formats JuicyPixels cannot decode (notably WebP) also remain
+-- unchanged so normalization never makes a previously usable attachment
+-- disappear.
+normalizeImageForPrompt :: Text -> ByteString -> NormalizedImage
+normalizeImageForPrompt mime bytes =
+    case decodeImageWithMetadata bytes of
+        Left _ -> original
+        Right (dynamicImage, metadata)
+            | imageAlreadyBounded dynamicImage -> original
+            | dynamicImageHasAlpha dynamicImage ->
+                firstFitting
+                    (map (encodeRgbaCandidate rgbaImage)
+                        dimensions)
+                    original
+            | otherwise ->
+                firstFitting
+                    (map (encodeRgbCandidate rgbImage)
+                        dimensions)
+                    original
+          where
+            orientation = metadataOrientation metadata
+            rgbaImage =
+                orientImage orientation (convertRGBA8 dynamicImage)
+            rgbImage =
+                orientImage orientation (convertRGB8 dynamicImage)
+            dimensions =
+                candidateDimensions
+                    (if dynamicImageHasAlpha dynamicImage
+                        then imageWidth rgbaImage
+                        else imageWidth rgbImage)
+                    (if dynamicImageHasAlpha dynamicImage
+                        then imageHeight rgbaImage
+                        else imageHeight rgbImage)
+  where
+    original = NormalizedImage mime bytes
+    imageAlreadyBounded dynamicImage =
+        ByteString.length bytes <= maximumImageBytes
+            && dynamicImageWidth dynamicImage <= maximumImageSide
+            && dynamicImageHeight dynamicImage <= maximumImageSide
+            && toInteger (dynamicImageWidth dynamicImage)
+                * toInteger (dynamicImageHeight dynamicImage)
+                <= toInteger maximumImagePixels
+
+-- | Normalize an inline base64 image while preserving malformed, remote, and
+-- already-bounded URLs exactly. Tool results use this representation instead
+-- of the raw attachment form used by user-authored turns.
+normalizeImageDataUrl :: Text -> Text
+normalizeImageDataUrl url =
+    case parseImageDataUrl url of
+        Nothing -> url
+        Just (mime, bytes) ->
+            case normalizeImageForPrompt mime bytes of
+                NormalizedImage normalizedMime normalizedBytes
+                    | normalizedMime == mime
+                        && normalizedBytes == bytes ->
+                            url
+                    | otherwise ->
+                        "data:"
+                            <> normalizedMime
+                            <> ";base64,"
+                            <> TextEncoding.decodeUtf8
+                                (Base64.encode normalizedBytes)
+
+parseImageDataUrl :: Text -> Maybe (Text, ByteString)
+parseImageDataUrl url = do
+    let (metadata, payloadWithComma) = Text.breakOn "," url
+        loweredMetadata = Text.toLower metadata
+        base64Suffix = ";base64"
+    guardMaybe (not (Text.null payloadWithComma))
+    guardMaybe ("data:image/" `Text.isPrefixOf` loweredMetadata)
+    guardMaybe (base64Suffix `Text.isSuffixOf` loweredMetadata)
+    let mime =
+            Text.drop 5
+                (Text.dropEnd (Text.length base64Suffix) metadata)
+    guardMaybe (not (Text.null mime))
+    bytes <-
+        either (const Nothing) Just
+            (Base64.decode
+                (TextEncoding.encodeUtf8 (Text.drop 1 payloadWithComma)))
+    pure (mime, bytes)
+
+guardMaybe :: Bool -> Maybe ()
+guardMaybe condition
+    | condition = Just ()
+    | otherwise = Nothing
+
+dynamicImageWidth :: DynamicImage -> Int
+dynamicImageWidth = dynamicMap imageWidth
+
+dynamicImageHeight :: DynamicImage -> Int
+dynamicImageHeight = dynamicMap imageHeight
+
+dynamicImageHasAlpha :: DynamicImage -> Bool
+dynamicImageHasAlpha = \case
+    ImageYA8 _ -> True
+    ImageYA16 _ -> True
+    ImageRGBA8 _ -> True
+    ImageRGBA16 _ -> True
+    _ -> False
+
+metadataOrientation :: Metadata.Metadatas -> Int
+metadataOrientation metadata =
+    normalizeOrientation $
+        case Metadata.lookup (Metadata.Exif TagOrientation) metadata of
+            Just (ExifShort orientation) -> fromIntegral orientation
+            Just (ExifLong orientation) -> fromIntegral orientation
+            _ -> 1
+  where
+    normalizeOrientation orientation
+        | orientation >= 1 && orientation <= 8 = orientation
+        | otherwise = 1
+
+-- EXIF orientation describes how stored pixels must be transformed for
+-- display. Re-encoding drops the metadata, so apply that transform first.
+orientImage :: Pixel pixel => Int -> Image pixel -> Image pixel
+orientImage orientation source =
+    case orientation of
+        2 -> sameSize \x y -> pixelAt source (width - 1 - x) y
+        3 -> sameSize \x y ->
+            pixelAt source (width - 1 - x) (height - 1 - y)
+        4 -> sameSize \x y -> pixelAt source x (height - 1 - y)
+        5 -> swappedSize \x y -> pixelAt source y x
+        6 -> swappedSize \x y -> pixelAt source y (height - 1 - x)
+        7 -> swappedSize \x y ->
+            pixelAt source (width - 1 - y) (height - 1 - x)
+        8 -> swappedSize \x y -> pixelAt source (width - 1 - y) x
+        _ -> source
+  where
+    width = imageWidth source
+    height = imageHeight source
+    sameSize sample = generateImage sample width height
+    swappedSize sample = generateImage sample height width
+
+candidateDimensions :: Int -> Int -> [(Int, Int)]
+candidateDimensions sourceWidth sourceHeight =
+    shrinkFrom (boundedDimensions sourceWidth sourceHeight)
+  where
+    shrinkFrom dimensions@(width, height)
+        | max width height <= minimumRetrySide = [dimensions]
+        | otherwise =
+            dimensions : shrinkFrom nextDimensions
+      where
+        longest = max width height
+        nextLongest =
+            max minimumRetrySide ((longest * 3) `div` 4)
+        scale =
+            fromIntegral nextLongest / fromIntegral longest :: Double
+        nextDimensions =
+            ( max 1 (floor (fromIntegral width * scale))
+            , max 1 (floor (fromIntegral height * scale))
+            )
+
+boundedDimensions :: Int -> Int -> (Int, Int)
+boundedDimensions width height
+    | width <= 0 || height <= 0 = (1, 1)
+    | otherwise =
+        constrainArea
+            ( max 1 (floor (fromIntegral width * scale))
+            , max 1 (floor (fromIntegral height * scale))
+            )
+  where
+    pixelCount =
+        fromIntegral width * fromIntegral height :: Double
+    sideScale =
+        fromIntegral maximumImageSide
+            / fromIntegral (max width height)
+    areaScale =
+        sqrt (fromIntegral maximumImagePixels / pixelCount)
+    scale = min 1 (min sideScale areaScale)
+
+    constrainArea dimensions@(targetWidth, targetHeight)
+        | toInteger targetWidth * toInteger targetHeight
+            <= toInteger maximumImagePixels =
+                dimensions
+        | targetWidth >= targetHeight =
+            (max 1 (maximumImagePixels `div` targetHeight), targetHeight)
+        | otherwise =
+            (targetWidth, max 1 (maximumImagePixels `div` targetWidth))
+
+encodeRgbCandidate
+    :: Image PixelRGB8
+    -> (Int, Int)
+    -> Maybe NormalizedImage
+encodeRgbCandidate source (width, height) =
+    let resized = resizeRgb8 width height source
+        png = strictEncodePng resized
+    in if ByteString.length png <= maximumImageBytes
+        then Just (NormalizedImage "image/png" png)
+        else encodeJpegCandidate resized
+
+encodeRgbaCandidate
+    :: Image PixelRGBA8
+    -> (Int, Int)
+    -> Maybe NormalizedImage
+encodeRgbaCandidate source (width, height) =
+    let resized = resizeRgba8 width height source
+        png = strictEncodePng resized
+    in if ByteString.length png <= maximumImageBytes
+        then Just (NormalizedImage "image/png" png)
+        else encodeJpegCandidate (pixelMap flattenAgainstWhite resized)
+
+encodeJpegCandidate :: Image PixelRGB8 -> Maybe NormalizedImage
+encodeJpegCandidate image =
+    go jpegQualities
+  where
+    yCbCrImage = convertImage image :: Image PixelYCbCr8
+
+    go = \case
+        [] -> Nothing
+        quality : remaining ->
+            let jpeg =
+                    LazyByteString.toStrict
+                        (encodeJpegAtQuality quality yCbCrImage)
+            in if ByteString.length jpeg <= maximumImageBytes
+                then Just (NormalizedImage "image/jpeg" jpeg)
+                else go remaining
+
+strictEncodePng image =
+    LazyByteString.toStrict (encodePng image)
+
+firstFitting
+    :: [Maybe NormalizedImage]
+    -> NormalizedImage
+    -> NormalizedImage
+firstFitting candidates fallback =
+    case candidates of
+        [] -> fallback
+        Nothing : remaining -> firstFitting remaining fallback
+        Just image : _ -> image
+
+resizeRgb8 :: Int -> Int -> Image PixelRGB8 -> Image PixelRGB8
+resizeRgb8 targetWidth targetHeight source
+    | targetWidth == imageWidth source
+        && targetHeight == imageHeight source =
+            source
+    | otherwise =
+        generateImage sample targetWidth targetHeight
+  where
+    sample x y =
+        let (x0, x1, xFraction) =
+                sourceSample (imageWidth source) targetWidth x
+            (y0, y1, yFraction) =
+                sourceSample (imageHeight source) targetHeight y
+            PixelRGB8 r00 g00 b00 = pixelAt source x0 y0
+            PixelRGB8 r10 g10 b10 = pixelAt source x1 y0
+            PixelRGB8 r01 g01 b01 = pixelAt source x0 y1
+            PixelRGB8 r11 g11 b11 = pixelAt source x1 y1
+        in PixelRGB8
+            (bilinear8 xFraction yFraction r00 r10 r01 r11)
+            (bilinear8 xFraction yFraction g00 g10 g01 g11)
+            (bilinear8 xFraction yFraction b00 b10 b01 b11)
+
+resizeRgba8 :: Int -> Int -> Image PixelRGBA8 -> Image PixelRGBA8
+resizeRgba8 targetWidth targetHeight source
+    | targetWidth == imageWidth source
+        && targetHeight == imageHeight source =
+            source
+    | otherwise =
+        generateImage sample targetWidth targetHeight
+  where
+    sample x y =
+        let (x0, x1, xFraction) =
+                sourceSample (imageWidth source) targetWidth x
+            (y0, y1, yFraction) =
+                sourceSample (imageHeight source) targetHeight y
+            PixelRGBA8 r00 g00 b00 a00 = pixelAt source x0 y0
+            PixelRGBA8 r10 g10 b10 a10 = pixelAt source x1 y0
+            PixelRGBA8 r01 g01 b01 a01 = pixelAt source x0 y1
+            PixelRGBA8 r11 g11 b11 a11 = pixelAt source x1 y1
+        in PixelRGBA8
+            (bilinear8 xFraction yFraction r00 r10 r01 r11)
+            (bilinear8 xFraction yFraction g00 g10 g01 g11)
+            (bilinear8 xFraction yFraction b00 b10 b01 b11)
+            (bilinear8 xFraction yFraction a00 a10 a01 a11)
+
+sourceSample :: Int -> Int -> Int -> (Int, Int, Double)
+sourceSample sourceLength targetLength targetIndex =
+    (lower, upper, coordinate - fromIntegral lower)
+  where
+    rawCoordinate =
+        (fromIntegral targetIndex + 0.5)
+            * fromIntegral sourceLength
+            / fromIntegral targetLength
+            - 0.5
+    coordinate =
+        max 0 (min (fromIntegral (sourceLength - 1)) rawCoordinate)
+    lower = floor coordinate
+    upper = min (sourceLength - 1) (lower + 1)
+
+bilinear8
+    :: Double
+    -> Double
+    -> Word8
+    -> Word8
+    -> Word8
+    -> Word8
+    -> Word8
+bilinear8 xFraction yFraction topLeft topRight bottomLeft bottomRight =
+    fromIntegral (max 0 (min 255 (round value :: Int)))
+  where
+    top =
+        (1 - xFraction) * fromIntegral topLeft
+            + xFraction * fromIntegral topRight
+    bottom =
+        (1 - xFraction) * fromIntegral bottomLeft
+            + xFraction * fromIntegral bottomRight
+    value =
+        (1 - yFraction) * top + yFraction * bottom
+
+flattenAgainstWhite :: PixelRGBA8 -> PixelRGB8
+flattenAgainstWhite (PixelRGBA8 red green blue alpha) =
+    PixelRGB8
+        (composite red alpha)
+        (composite green alpha)
+        (composite blue alpha)
+  where
+    composite channel opacity =
+        fromIntegral
+            ( (fromIntegral channel * fromIntegral opacity
+                + 255 * (255 - fromIntegral opacity)
+                + 127
+              )
+                `div` 255
+                :: Int
+            )

--- a/packages/agent-core/src/Agent/Image/Normalize.hs
+++ b/packages/agent-core/src/Agent/Image/Normalize.hs
@@ -13,17 +13,19 @@ import Codec.Picture
     , PixelYCbCr8
     , convertRGB8
     , convertRGBA8
-    , decodeImageWithMetadata
     , encodeJpegAtQuality
     , encodePng
     , imageHeight
     , imageWidth
     )
+import Codec.Picture.Bitmap (decodeBitmapWithMetadata)
+import Codec.Picture.Jpg (decodeJpegWithMetadata)
 import qualified Codec.Picture.Metadata as Metadata
 import Codec.Picture.Metadata.Exif
     ( ExifData(..)
     , ExifTag(TagOrientation)
     )
+import Codec.Picture.Png (decodePngWithMetadata)
 import Codec.Picture.Types
     ( Pixel
     , convertImage
@@ -32,6 +34,8 @@ import Codec.Picture.Types
     , pixelAt
     , pixelMap
     )
+import qualified Codec.Compression.Zlib.Internal as Zlib
+import Control.Monad.ST.Lazy (runST)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Base64 as Base64
@@ -53,6 +57,33 @@ maximumImageSide = 2000
 maximumImagePixels :: Int
 maximumImagePixels = 2408448
 
+-- Decoding is intentionally gated by dimensions read from the encoded image
+-- header. This bounds the largest raster JuicyPixels may allocate even when a
+-- tiny compressed input advertises decompressed dimensions of several
+-- gigapixels.
+maximumDecodedImageSide :: Integer
+maximumDecodedImageSide = 8192
+
+maximumDecodedImagePixels :: Integer
+maximumDecodedImagePixels = 25000000
+
+maximumEncodedImageBytes :: Int
+maximumEncodedImageBytes = 20 * 1024 * 1024
+
+maximumEncodedImageBase64Characters :: Int
+maximumEncodedImageBase64Characters =
+    4 * ((maximumEncodedImageBytes + 2) `div` 3)
+
+-- Account for the inflater output, JuicyPixels' decoded raster, and the
+-- normalized 8-bit RGB(A) raster. This still admits ordinary 24-megapixel
+-- RGB photos while preventing high-bit-depth PNGs from creating an
+-- unbounded multi-raster peak.
+maximumDecodedImageWorkingBytes :: Integer
+maximumDecodedImageWorkingBytes = 256 * 1024 * 1024
+
+maximumPngChunkCount :: Int
+maximumPngChunkCount = 4096
+
 minimumRetrySide :: Int
 minimumRetrySide = 512
 
@@ -64,50 +95,458 @@ data NormalizedImage = NormalizedImage
     , normalizedImageBytes :: !ByteString
     }
 
+data EncodedImageFormat
+    = EncodedPng
+    | EncodedJpeg
+    | EncodedBitmap
+
+data EncodedImageHeader = EncodedImageHeader
+    { encodedImageFormat :: !EncodedImageFormat
+    , encodedImageWidth :: !Integer
+    , encodedImageHeight :: !Integer
+    , encodedImageWorkingBytes :: !Integer
+    , encodedPngInflatedBytes :: !(Maybe Integer)
+    }
+
 -- | Decode and, when necessary, resize or recompress an image before it is
 -- serialized into a provider request. Small images remain byte-for-byte
--- unchanged. Formats JuicyPixels cannot decode (notably WebP) also remain
--- unchanged so normalization never makes a previously usable attachment
--- disappear.
+-- unchanged. Formats without a bounded header preflight also remain unchanged
+-- so normalization never makes a previously usable attachment disappear.
 normalizeImageForPrompt :: Text -> ByteString -> NormalizedImage
 normalizeImageForPrompt mime bytes =
-    case decodeImageWithMetadata bytes of
-        Left _ -> original
-        Right (dynamicImage, metadata)
-            | imageAlreadyBounded dynamicImage -> original
-            | dynamicImageHasAlpha dynamicImage ->
-                firstFitting
-                    (map (encodeRgbaCandidate rgbaImage)
-                        dimensions)
-                    original
+    case encodedImageHeader bytes of
+        Nothing -> original
+        Just header
+            | imageAlreadyBounded (headerDimensions header) -> original
+            | not (headerSafeToDecode bytes header) -> original
+            | not (encodedPayloadSafeToDecode bytes header) -> original
             | otherwise ->
-                firstFitting
-                    (map (encodeRgbCandidate rgbImage)
-                        dimensions)
-                    original
-          where
-            orientation = metadataOrientation metadata
-            rgbaImage =
-                orientImage orientation (convertRGBA8 dynamicImage)
-            rgbImage =
-                orientImage orientation (convertRGB8 dynamicImage)
-            dimensions =
-                candidateDimensions
-                    (if dynamicImageHasAlpha dynamicImage
-                        then imageWidth rgbaImage
-                        else imageWidth rgbImage)
-                    (if dynamicImageHasAlpha dynamicImage
-                        then imageHeight rgbaImage
-                        else imageHeight rgbImage)
+                case decodeSupportedImage header.encodedImageFormat bytes of
+                    Left _ -> original
+                    Right (dynamicImage, metadata)
+                        | not (dynamicImageSafeToProcess dynamicImage) ->
+                            original
+                        | dynamicImageHasAlpha dynamicImage ->
+                            firstFitting
+                                (map (encodeRgbaCandidate rgbaImage)
+                                    dimensions)
+                                original
+                        | otherwise ->
+                            firstFitting
+                                (map (encodeRgbCandidate rgbImage)
+                                    dimensions)
+                                original
+                      where
+                        orientation = metadataOrientation metadata
+                        rgbaImage =
+                            orientImage orientation (convertRGBA8 dynamicImage)
+                        rgbImage =
+                            orientImage orientation (convertRGB8 dynamicImage)
+                        dimensions =
+                            candidateDimensions
+                                (if dynamicImageHasAlpha dynamicImage
+                                    then imageWidth rgbaImage
+                                    else imageWidth rgbImage)
+                                (if dynamicImageHasAlpha dynamicImage
+                                    then imageHeight rgbaImage
+                                    else imageHeight rgbImage)
   where
     original = NormalizedImage mime bytes
-    imageAlreadyBounded dynamicImage =
+    imageAlreadyBounded (width, height) =
         ByteString.length bytes <= maximumImageBytes
-            && dynamicImageWidth dynamicImage <= maximumImageSide
-            && dynamicImageHeight dynamicImage <= maximumImageSide
-            && toInteger (dynamicImageWidth dynamicImage)
-                * toInteger (dynamicImageHeight dynamicImage)
-                <= toInteger maximumImagePixels
+            && width <= toInteger maximumImageSide
+            && height <= toInteger maximumImageSide
+            && width * height <= toInteger maximumImagePixels
+
+headerDimensions :: EncodedImageHeader -> (Integer, Integer)
+headerDimensions header =
+    (header.encodedImageWidth, header.encodedImageHeight)
+
+headerSafeToDecode :: ByteString -> EncodedImageHeader -> Bool
+headerSafeToDecode bytes header =
+    ByteString.length bytes <= maximumEncodedImageBytes
+        && dimensionsSafeToDecode (headerDimensions header)
+        && header.encodedImageWorkingBytes
+            <= maximumDecodedImageWorkingBytes
+
+encodedPayloadSafeToDecode :: ByteString -> EncodedImageHeader -> Bool
+encodedPayloadSafeToDecode bytes header =
+    case
+        ( header.encodedImageFormat
+        , header.encodedPngInflatedBytes
+        )
+    of
+        (EncodedPng, Just expectedBytes) ->
+            case pngImageDataChunks bytes of
+                Nothing -> False
+                Just chunks ->
+                    pngInflatesToExpectedSize expectedBytes chunks
+        (EncodedPng, Nothing) -> False
+        (_, _) -> True
+
+decodeSupportedImage
+    :: EncodedImageFormat
+    -> ByteString
+    -> Either String (DynamicImage, Metadata.Metadatas)
+decodeSupportedImage imageFormat =
+    case imageFormat of
+        EncodedPng -> decodePngWithMetadata
+        EncodedJpeg -> decodeJpegWithMetadata
+        EncodedBitmap -> decodeBitmapWithMetadata
+
+dimensionsSafeToDecode :: (Integer, Integer) -> Bool
+dimensionsSafeToDecode (width, height) =
+    width > 0
+        && height > 0
+        && width <= maximumDecodedImageSide
+        && height <= maximumDecodedImageSide
+        && width * height <= maximumDecodedImagePixels
+
+dynamicImageSafeToProcess :: DynamicImage -> Bool
+dynamicImageSafeToProcess dynamicImage =
+    dimensionsSafeToDecode
+        ( toInteger (dynamicImageWidth dynamicImage)
+        , toInteger (dynamicImageHeight dynamicImage)
+        )
+
+-- Only formats with a bounded dimension preflight are admitted to their
+-- format-specific decoder. Other and malformed formats stay byte-for-byte
+-- unchanged, and a malformed file cannot fall through to a different
+-- JuicyPixels decoder whose allocation was not preflighted.
+encodedImageHeader :: ByteString -> Maybe EncodedImageHeader
+encodedImageHeader bytes
+    | ByteString.take 8 bytes == pngSignature =
+        pngHeader bytes
+    | ByteString.take 2 bytes == jpegSignature =
+        fromDimensions EncodedJpeg (jpegDimensions bytes)
+    | ByteString.take 2 bytes == "BM" =
+        fromDimensions EncodedBitmap (bitmapDimensions bytes)
+    | otherwise = Nothing
+  where
+    pngSignature = "\137PNG\r\n\SUB\n"
+    jpegSignature = "\255\216"
+    fromDimensions imageFormat dimensions = do
+        (width, height) <- dimensions
+        pure EncodedImageHeader
+            { encodedImageFormat = imageFormat
+            , encodedImageWidth = width
+            , encodedImageHeight = height
+            , encodedImageWorkingBytes = width * height * 12
+            , encodedPngInflatedBytes = Nothing
+            }
+
+pngHeader :: ByteString -> Maybe EncodedImageHeader
+pngHeader bytes = do
+    guardMaybe (ByteString.length bytes >= 33)
+    chunkLength <- word32Be bytes 8
+    guardMaybe (chunkLength == 13)
+    guardMaybe (ByteString.take 4 (ByteString.drop 12 bytes) == "IHDR")
+    width <- word32Be bytes 16
+    height <- word32Be bytes 20
+    bitDepth <- byteAt bytes 24
+    colorType <- byteAt bytes 25
+    compressionMethod <- byteAt bytes 26
+    filterMethod <- byteAt bytes 27
+    interlaceMethod <- byteAt bytes 28
+    guardMaybe (compressionMethod == 0)
+    guardMaybe (filterMethod == 0)
+    guardMaybe (interlaceMethod == 0 || interlaceMethod == 1)
+    (samplesPerPixel, decodedBytesPerPixel) <-
+        pngColorLayout bitDepth colorType
+    (validWidth, validHeight) <- validDimensions width height
+    let pixelCount = validWidth * validHeight
+        inflatedBytes =
+            pngInflatedByteCount
+                validWidth
+                validHeight
+                samplesPerPixel
+                bitDepth
+                interlaceMethod
+        workingBytes =
+            inflatedBytes
+                + pixelCount * (decodedBytesPerPixel + 4)
+    pure EncodedImageHeader
+        { encodedImageFormat = EncodedPng
+        , encodedImageWidth = validWidth
+        , encodedImageHeight = validHeight
+        , encodedImageWorkingBytes = workingBytes
+        , encodedPngInflatedBytes = Just inflatedBytes
+        }
+
+pngColorLayout
+    :: Integer
+    -> Integer
+    -> Maybe (Integer, Integer)
+pngColorLayout bitDepth colorType =
+    case colorType of
+        0 -> do
+            guardMaybe (bitDepth `elem` [1, 2, 4, 8, 16])
+            pure (1, if bitDepth == 16 then 2 else 1)
+        2 -> do
+            guardMaybe (bitDepth == 8 || bitDepth == 16)
+            pure (3, if bitDepth == 16 then 6 else 3)
+        3 -> do
+            guardMaybe (bitDepth `elem` [1, 2, 4, 8])
+            pure (1, 4)
+        4 -> do
+            guardMaybe (bitDepth == 8 || bitDepth == 16)
+            pure (2, if bitDepth == 16 then 4 else 2)
+        6 -> do
+            guardMaybe (bitDepth == 8 || bitDepth == 16)
+            pure (4, if bitDepth == 16 then 8 else 4)
+        _ -> Nothing
+
+pngInflatedByteCount
+    :: Integer
+    -> Integer
+    -> Integer
+    -> Integer
+    -> Integer
+    -> Integer
+pngInflatedByteCount width height samples bitDepth interlaceMethod
+    | interlaceMethod == 0 =
+        height * (1 + scanlineBytes width)
+    | otherwise =
+        sum
+            [ passHeight * (1 + scanlineBytes passWidth)
+            | (xStart, yStart, xStep, yStep) <- adam7Passes
+            , let passWidth = passLength width xStart xStep
+            , let passHeight = passLength height yStart yStep
+            , passWidth > 0
+            , passHeight > 0
+            ]
+  where
+    scanlineBytes passWidth =
+        ceilingDivide
+            (passWidth * samples * bitDepth)
+            8
+    adam7Passes =
+        [ (0, 0, 8, 8)
+        , (4, 0, 8, 8)
+        , (0, 4, 4, 8)
+        , (2, 0, 4, 4)
+        , (0, 2, 2, 4)
+        , (1, 0, 2, 2)
+        , (0, 1, 1, 2)
+        ]
+    passLength total start step
+        | total <= start = 0
+        | otherwise = ceilingDivide (total - start) step
+
+ceilingDivide :: Integer -> Integer -> Integer
+ceilingDivide numerator denominator =
+    (numerator + denominator - 1) `div` denominator
+
+pngImageDataChunks :: ByteString -> Maybe [ByteString]
+pngImageDataChunks bytes =
+    go 33 0 False False []
+  where
+    totalBytes = toInteger (ByteString.length bytes)
+
+    go offset chunkCount sawImageData endedImageData chunks = do
+        guardMaybe (chunkCount < maximumPngChunkCount)
+        guardMaybe (offset + 12 <= totalBytes)
+        chunkLength <- word32Be bytes (fromInteger offset)
+        let dataOffset = offset + 8
+            nextOffset = dataOffset + chunkLength + 4
+        guardMaybe (nextOffset <= totalBytes)
+        let chunkType =
+                ByteString.take 4
+                    (ByteString.drop (fromInteger (offset + 4)) bytes)
+            chunkData =
+                ByteString.take (fromInteger chunkLength)
+                    (ByteString.drop (fromInteger dataOffset) bytes)
+        case chunkType of
+            "IDAT" -> do
+                guardMaybe (not endedImageData)
+                go
+                    nextOffset
+                    (chunkCount + 1)
+                    True
+                    False
+                    (chunkData : chunks)
+            "IEND" -> do
+                guardMaybe (chunkLength == 0)
+                guardMaybe sawImageData
+                guardMaybe (nextOffset == totalBytes)
+                pure (reverse chunks)
+            _ ->
+                go
+                    nextOffset
+                    (chunkCount + 1)
+                    sawImageData
+                    (endedImageData || sawImageData)
+                    chunks
+
+pngInflatesToExpectedSize :: Integer -> [ByteString] -> Bool
+pngInflatesToExpectedSize expectedBytes chunks =
+    runST $
+        drive
+            (Zlib.decompressST
+                Zlib.zlibFormat
+                Zlib.defaultDecompressParams)
+            chunks
+            False
+            0
+  where
+    drive stream remainingChunks endOfInputSupplied bytesSeen =
+        case stream of
+            Zlib.DecompressInputRequired supplyInput ->
+                case nextNonEmptyChunk remainingChunks of
+                    Just (inputChunk, rest) -> do
+                        nextStream <- supplyInput inputChunk
+                        drive
+                            nextStream
+                            rest
+                            endOfInputSupplied
+                            bytesSeen
+                    Nothing
+                        | endOfInputSupplied ->
+                            pure False
+                        | otherwise -> do
+                            nextStream <- supplyInput ByteString.empty
+                            drive nextStream [] True bytesSeen
+            Zlib.DecompressOutputAvailable outputChunk next -> do
+                let nextBytes =
+                        bytesSeen
+                            + toInteger (ByteString.length outputChunk)
+                if nextBytes > expectedBytes
+                    then pure False
+                    else do
+                        nextStream <- next
+                        drive
+                            nextStream
+                            remainingChunks
+                            endOfInputSupplied
+                            nextBytes
+            Zlib.DecompressStreamEnd unconsumed ->
+                pure
+                    ( ByteString.null unconsumed
+                        && all ByteString.null remainingChunks
+                        && bytesSeen == expectedBytes
+                    )
+            Zlib.DecompressStreamError _ ->
+                pure False
+
+    nextNonEmptyChunk = \case
+        [] -> Nothing
+        chunk : rest
+            | ByteString.null chunk ->
+                nextNonEmptyChunk rest
+            | otherwise ->
+                Just (chunk, rest)
+
+bitmapDimensions :: ByteString -> Maybe (Integer, Integer)
+bitmapDimensions bytes = do
+    headerSize <- word32Le bytes 14
+    case headerSize of
+        12 -> do
+            width <- word16Le bytes 18
+            height <- word16Le bytes 20
+            validDimensions width height
+        size
+            | size >= 40 -> do
+                width <- signedWord32Le bytes 18
+                height <- signedWord32Le bytes 22
+                validDimensions width (abs height)
+        _ -> Nothing
+
+jpegDimensions :: ByteString -> Maybe (Integer, Integer)
+jpegDimensions bytes = findMarker 2
+  where
+    scanLimit = min (ByteString.length bytes) (1024 * 1024)
+
+    findMarker offset
+        | offset + 1 >= scanLimit = Nothing
+        | ByteString.index bytes offset /= 255 =
+            findMarker (offset + 1)
+        | otherwise =
+            let markerOffset = skipFillBytes offset
+            in if markerOffset >= scanLimit
+                then Nothing
+                else inspectMarker markerOffset
+
+    skipFillBytes offset
+        | offset < scanLimit
+            && ByteString.index bytes offset == 255 =
+                skipFillBytes (offset + 1)
+        | otherwise = offset
+
+    inspectMarker markerOffset =
+        case ByteString.index bytes markerOffset of
+            0 -> findMarker (markerOffset + 1)
+            marker
+                | jpegStartOfFrame marker -> do
+                    segmentLength <- word16Be bytes (markerOffset + 1)
+                    guardMaybe (segmentLength >= 7)
+                    height <- word16Be bytes (markerOffset + 4)
+                    width <- word16Be bytes (markerOffset + 6)
+                    validDimensions width height
+                | marker == 217 || marker == 218 -> Nothing
+                | jpegStandaloneMarker marker ->
+                    findMarker (markerOffset + 1)
+                | otherwise -> do
+                    segmentLength <- word16Be bytes (markerOffset + 1)
+                    guardMaybe (segmentLength >= 2)
+                    let next =
+                            markerOffset + 1 + fromInteger segmentLength
+                    guardMaybe (next > markerOffset && next <= scanLimit)
+                    findMarker next
+
+    jpegStartOfFrame marker =
+        marker `elem`
+            [ 192, 193, 194, 195
+            , 197, 198, 199
+            , 201, 202, 203
+            , 205, 206, 207
+            ]
+
+    jpegStandaloneMarker marker =
+        marker == 1
+            || marker == 216
+            || (marker >= 208 && marker <= 215)
+
+validDimensions :: Integer -> Integer -> Maybe (Integer, Integer)
+validDimensions width height = do
+    guardMaybe (width > 0 && height > 0)
+    pure (width, height)
+
+word16Be :: ByteString -> Int -> Maybe Integer
+word16Be bytes offset = do
+    first <- byteAt bytes offset
+    second <- byteAt bytes (offset + 1)
+    pure (first * 256 + second)
+
+word16Le :: ByteString -> Int -> Maybe Integer
+word16Le bytes offset = do
+    first <- byteAt bytes offset
+    second <- byteAt bytes (offset + 1)
+    pure (first + second * 256)
+
+word32Be :: ByteString -> Int -> Maybe Integer
+word32Be bytes offset = do
+    first <- word16Be bytes offset
+    second <- word16Be bytes (offset + 2)
+    pure (first * 65536 + second)
+
+word32Le :: ByteString -> Int -> Maybe Integer
+word32Le bytes offset = do
+    first <- word16Le bytes offset
+    second <- word16Le bytes (offset + 2)
+    pure (first + second * 65536)
+
+signedWord32Le :: ByteString -> Int -> Maybe Integer
+signedWord32Le bytes offset = do
+    unsigned <- word32Le bytes offset
+    pure
+        (if unsigned >= 2147483648
+            then unsigned - 4294967296
+            else unsigned)
+
+byteAt :: ByteString -> Int -> Maybe Integer
+byteAt bytes offset
+    | offset < 0 || offset >= ByteString.length bytes = Nothing
+    | otherwise = Just (fromIntegral (ByteString.index bytes offset))
 
 -- | Normalize an inline base64 image while preserving malformed, remote, and
 -- already-bounded URLs exactly. Tool results use this representation instead
@@ -137,6 +576,10 @@ parseImageDataUrl url = do
     guardMaybe (not (Text.null payloadWithComma))
     guardMaybe ("data:image/" `Text.isPrefixOf` loweredMetadata)
     guardMaybe (base64Suffix `Text.isSuffixOf` loweredMetadata)
+    let encodedPayload = Text.drop 1 payloadWithComma
+    guardMaybe
+        (Text.length encodedPayload
+            <= maximumEncodedImageBase64Characters)
     let mime =
             Text.drop 5
                 (Text.dropEnd (Text.length base64Suffix) metadata)
@@ -144,7 +587,7 @@ parseImageDataUrl url = do
     bytes <-
         either (const Nothing) Just
             (Base64.decode
-                (TextEncoding.encodeUtf8 (Text.drop 1 payloadWithComma)))
+                (TextEncoding.encodeUtf8 encodedPayload))
     pure (mime, bytes)
 
 guardMaybe :: Bool -> Maybe ()
@@ -335,11 +778,32 @@ resizeRgba8 targetWidth targetHeight source
             PixelRGBA8 r10 g10 b10 a10 = pixelAt source x1 y0
             PixelRGBA8 r01 g01 b01 a01 = pixelAt source x0 y1
             PixelRGBA8 r11 g11 b11 a11 = pixelAt source x1 y1
-        in PixelRGBA8
-            (bilinear8 xFraction yFraction r00 r10 r01 r11)
-            (bilinear8 xFraction yFraction g00 g10 g01 g11)
-            (bilinear8 xFraction yFraction b00 b10 b01 b11)
-            (bilinear8 xFraction yFraction a00 a10 a01 a11)
+            alpha =
+                bilinearDouble xFraction yFraction
+                    (fromIntegral a00)
+                    (fromIntegral a10)
+                    (fromIntegral a01)
+                    (fromIntegral a11)
+            premultiplied channel00 channel10 channel01 channel11 =
+                bilinearDouble xFraction yFraction
+                    (fromIntegral channel00 * fromIntegral a00)
+                    (fromIntegral channel10 * fromIntegral a10)
+                    (fromIntegral channel01 * fromIntegral a01)
+                    (fromIntegral channel11 * fromIntegral a11)
+            channel channel00 channel10 channel01 channel11
+                | alpha <= 0 = 0
+                | otherwise =
+                    word8FromDouble
+                        (premultiplied
+                            channel00 channel10 channel01 channel11
+                            / alpha)
+        in if word8FromDouble alpha == 0
+            then PixelRGBA8 0 0 0 0
+            else PixelRGBA8
+                (channel r00 r10 r01 r11)
+                (channel g00 g10 g01 g11)
+                (channel b00 b10 b01 b11)
+                (word8FromDouble alpha)
 
 sourceSample :: Int -> Int -> Int -> (Int, Int, Double)
 sourceSample sourceLength targetLength targetIndex =
@@ -364,16 +828,38 @@ bilinear8
     -> Word8
     -> Word8
 bilinear8 xFraction yFraction topLeft topRight bottomLeft bottomRight =
-    fromIntegral (max 0 (min 255 (round value :: Int)))
+    word8FromDouble $
+        bilinearDouble xFraction yFraction
+            (fromIntegral topLeft)
+            (fromIntegral topRight)
+            (fromIntegral bottomLeft)
+            (fromIntegral bottomRight)
+
+bilinearDouble
+    :: Double
+    -> Double
+    -> Double
+    -> Double
+    -> Double
+    -> Double
+    -> Double
+bilinearDouble
+    xFraction
+    yFraction
+    topLeft
+    topRight
+    bottomLeft
+    bottomRight =
+        (1 - yFraction) * top + yFraction * bottom
   where
     top =
-        (1 - xFraction) * fromIntegral topLeft
-            + xFraction * fromIntegral topRight
+        (1 - xFraction) * topLeft + xFraction * topRight
     bottom =
-        (1 - xFraction) * fromIntegral bottomLeft
-            + xFraction * fromIntegral bottomRight
-    value =
-        (1 - yFraction) * top + yFraction * bottom
+        (1 - xFraction) * bottomLeft + xFraction * bottomRight
+
+word8FromDouble :: Double -> Word8
+word8FromDouble value =
+    fromIntegral (max 0 (min 255 (round value :: Int)))
 
 flattenAgainstWhite :: PixelRGBA8 -> PixelRGB8
 flattenAgainstWhite (PixelRGBA8 red green blue alpha) =

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -3,6 +3,11 @@ module Agent.Loop.Internal where
 import Agent.Cancel (CancelFlag, isCancelled, waitCancel)
 import qualified Agent.Json.Decode as Json
 import Agent.Error (ApiError)
+import Agent.Image.Normalize
+    ( NormalizedImage(..)
+    , normalizeImageDataUrl
+    , normalizeImageForPrompt
+    )
 import Agent.InterAgentMessage (InterAgentMessage)
 import Agent.Loop.EventPump
     ( EventPump
@@ -21,6 +26,7 @@ import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallResult(..)
     , ToolDispatchConfig(..)
+    , ToolResultImage(..)
     )
 import Agent.Tools.Scheduling
     ( ToolSchedulingPlan(..)
@@ -139,6 +145,40 @@ mapTurnInputUserText transform = \case
     UserMessageWithAttachments text attachments ->
         UserMessageWithAttachments (transform text) attachments
     other -> other
+
+normalizeTurnInputImages :: TurnInput -> TurnInput
+normalizeTurnInputImages = \case
+    UserMessageWithAttachments text attachments ->
+        UserMessageWithAttachments text
+            (fmap normalizeAttachment attachments)
+    CompletedTool result ->
+        CompletedTool (normalizeToolResultImages result)
+    other -> other
+  where
+    normalizeAttachment = \case
+        ImageAttachmentItem ImageAttachment{imageMime, imageBytes} ->
+            case normalizeImageForPrompt imageMime imageBytes of
+                NormalizedImage{normalizedImageMime, normalizedImageBytes} ->
+                    ImageAttachmentItem ImageAttachment
+                        { imageMime = normalizedImageMime
+                        , imageBytes = normalizedImageBytes
+                        }
+        file@FileAttachmentItem{} -> file
+
+    normalizeToolResultImages result@ToolCallResult{} = result
+    normalizeToolResultImages result@ToolCallResultWithImages{
+        toolResultImages
+    } =
+        result
+            { toolResultImages =
+                fmap normalizeToolResultImage toolResultImages
+            }
+
+    normalizeToolResultImage image@ToolResultImage{imageUrl} =
+        image { imageUrl = normalizeImageDataUrl imageUrl }
+
+normalizeTurnInputs :: [TurnInput] -> [TurnInput]
+normalizeTurnInputs = map normalizeTurnInputImages
 
 -- | Provider-reported token counts for one model response. @inputTokens@
 -- typically includes any cached prefix; @cachedTokens@ is that subset when
@@ -724,7 +764,8 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                                         config.loopBackend.submitTurn
                                             cursor.cursorState
                                             cursor.cursorPreviousResponseId
-                                            cursor.cursorInputs
+                                            (normalizeTurnInputs
+                                                cursor.cursorInputs)
                                             onBackendEvent)
                                     \submission -> do
                                     result <- restore $ race

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -9,6 +9,7 @@ import Agent.Image.Normalize
     , normalizeImageForPrompt
     )
 import Agent.InterAgentMessage (InterAgentMessage)
+import Agent.Json (RawJson, rawJsonBytes, rawJsonFromEncoding)
 import Agent.Loop.EventPump
     ( EventPump
     , EventPumpFailure(..)
@@ -20,7 +21,17 @@ import Agent.Loop.EventPump
     , runEventPump
     , waitEventPumpFailure
     )
-import Agent.Responses.Types (ResponseItem)
+import Agent.Responses.Types
+    ( ComputerCallOutput(..)
+    , CustomToolCallOutput(..)
+    , FunctionCallOutput(..)
+    , MessageContent(..)
+    , ResponseContentPart(..)
+    , ResponseAgentMessage(..)
+    , ResponseItem(..)
+    , ResponseMessage(..)
+    , ReasoningItem(..)
+    )
 import Agent.Telemetry (TurnTelemetry)
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -52,6 +63,8 @@ import Control.Exception.Safe
     )
 import Control.Monad (when)
 import Data.Aeson (ToJSON(..), object, (.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
 import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
@@ -174,11 +187,109 @@ normalizeTurnInputImages = \case
                 fmap normalizeToolResultImage toolResultImages
             }
 
+    normalizeToolResultImage :: ToolResultImage -> ToolResultImage
     normalizeToolResultImage image@ToolResultImage{imageUrl} =
         image { imageUrl = normalizeImageDataUrl imageUrl }
 
 normalizeTurnInputs :: [TurnInput] -> [TurnInput]
 normalizeTurnInputs = map normalizeTurnInputImages
+
+normalizeBackendSnapshotImages :: BackendSnapshot -> BackendSnapshot
+normalizeBackendSnapshotImages snapshot =
+    snapshot
+        { backendItems =
+            map normalizeResponseItemImages snapshot.backendItems
+        }
+
+normalizeResponseItemImages :: ResponseItem -> ResponseItem
+normalizeResponseItemImages = \case
+    MessageItem message ->
+        MessageItem
+            message
+                { content =
+                    normalizeMessageContentImages message.content
+                }
+    AgentMessageItem message ->
+        AgentMessageItem
+            message
+                { content =
+                    map normalizeResponseContentPartImage message.content
+                }
+    ReasoningItemValue reasoning ->
+        ReasoningItemValue
+            reasoning
+                { content =
+                    fmap
+                        (map normalizeResponseContentPartImage)
+                        reasoning.content
+                }
+    FunctionCallOutputItem callOutput ->
+        FunctionCallOutputItem
+            callOutput
+                { output = normalizeRawJsonImages callOutput.output
+                }
+    CustomToolCallOutputItem callOutput ->
+        CustomToolCallOutputItem
+            callOutput
+                { output = normalizeRawJsonImages callOutput.output
+                }
+    ComputerCallOutputItem callOutput ->
+        ComputerCallOutputItem
+            callOutput
+                { screenshotDataUrl =
+                    normalizeImageDataUrl callOutput.screenshotDataUrl
+                }
+    item -> item
+
+normalizeMessageContentImages :: MessageContent -> MessageContent
+normalizeMessageContentImages = \case
+    MessageContentText text -> MessageContentText text
+    MessageContentParts parts ->
+        MessageContentParts (map normalizeResponseContentPartImage parts)
+
+normalizeResponseContentPartImage
+    :: ResponseContentPart
+    -> ResponseContentPart
+normalizeResponseContentPartImage part@InputImagePart{imageUrl} =
+    part
+        { imageUrl = fmap normalizeImageDataUrl imageUrl
+        }
+normalizeResponseContentPartImage part = part
+
+normalizeRawJsonImages :: RawJson -> RawJson
+normalizeRawJsonImages raw =
+    case Aeson.decodeStrict' (rawJsonBytes raw) of
+        Nothing -> raw
+        Just value ->
+            let normalized = normalizeJsonImageValues value
+            in if normalized == value
+                then raw
+                else rawJsonFromEncoding (Aeson.toEncoding normalized)
+
+normalizeJsonImageValues :: Aeson.Value -> Aeson.Value
+normalizeJsonImageValues = \case
+    Aeson.Object object ->
+        Aeson.Object (normalizeObjectImageUrl recursivelyNormalized)
+      where
+        recursivelyNormalized = KeyMap.map normalizeJsonImageValues object
+    Aeson.Array values ->
+        Aeson.Array (fmap normalizeJsonImageValues values)
+    value -> value
+  where
+    normalizeObjectImageUrl object =
+        case
+            ( KeyMap.lookup "type" object
+            , KeyMap.lookup "image_url" object
+            )
+        of
+            (Just (Aeson.String kind), Just (Aeson.String imageUrl))
+                | kind == "input_image"
+                    || kind == "computer_screenshot" ->
+                        KeyMap.insert
+                            "image_url"
+                            (Aeson.String (normalizeImageDataUrl imageUrl))
+                            object
+            _ -> object
 
 -- | Provider-reported token counts for one model response. @inputTokens@
 -- typically includes any cached prefix; @cachedTokens@ is that subset when
@@ -762,7 +873,8 @@ runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
                                   withAsync
                                     (restore $
                                         config.loopBackend.submitTurn
-                                            cursor.cursorState
+                                            (normalizeBackendSnapshotImages
+                                                cursor.cursorState)
                                             cursor.cursorPreviousResponseId
                                             (normalizeTurnInputs
                                                 cursor.cursorInputs)

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -25,6 +25,17 @@ import Agent.Tools.Types
     , toolExecutionPolicyFor
     , withToolResourceClaims
     )
+import Codec.Picture
+    ( PixelRGB8(..)
+    , convertRGB8
+    , decodeImage
+    , encodeBitmap
+    , encodeJpegAtQuality
+    , generateImage
+    , imageHeight
+    , imageWidth
+    )
+import Codec.Picture.Types (convertImage)
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Async (cancel, wait, withAsync)
 import Control.Concurrent.MVar
@@ -35,9 +46,13 @@ import Control.Concurrent.MVar
     , tryReadMVar
     )
 import qualified Control.Exception as Exception
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy as LazyByteString
 import Data.IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
 import System.Timeout (timeout)
 import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
@@ -143,6 +158,151 @@ spec = describe "runLoop" do
             }
         seen <- readIORef submissions
         seen `shouldBe` [(Nothing, inputs)]
+
+    it "normalizes oversized images before backend submission" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-image" [] (Just "saw it")
+            ]
+        let sourceBytes = oversizedFixtureBytes
+            input =
+                userMessageWithAttachments
+                    "see this"
+                    [ ImageAttachmentItem
+                        (ImageAttachment "image/bmp" sourceBytes)
+                    ]
+        ByteString.length sourceBytes `shouldSatisfy` (> 1500000)
+        config <- testConfig backend
+        result <- runLoopInputs config Nothing [input]
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-image"
+            , finalText = Just "saw it"
+            , turnsUsed = 1
+            , tokenUsage = emptyTokenUsage
+            }
+        seen <- readIORef submissions
+        case seen of
+            [(Nothing, [submitted])] ->
+                case turnInputImages submitted of
+                    [normalized] ->
+                        assertNormalizedImage
+                            sourceBytes
+                            normalized.imageMime
+                            normalized.imageBytes
+                    images ->
+                        expectationFailure $
+                            "expected one submitted image, got "
+                                <> show (length images)
+            submissionsSeen ->
+                expectationFailure $
+                    "unexpected submissions: " <> show submissionsSeen
+
+    it "normalizes oversized tool images before follow-up submission" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-tool-image"
+                [functionToolCall "c1" "image" "{}"]
+                Nothing
+            , Right $ emptyTurnOutput "resp-tool-done" [] (Just "saw it")
+            ]
+        let sourceUrl =
+                "data:image/bmp;base64,"
+                    <> TextEncoding.decodeUtf8
+                        (Base64.encode oversizedFixtureBytes)
+            imageTool =
+                passthroughTool "image" \_emit _call ->
+                    pure . Right $ ToolHandlerResult
+                        { resultText = "viewed image"
+                        , resultImages =
+                            [ToolResultImage sourceUrl (Just "auto")]
+                        }
+        config0 <- testConfig backend
+        result <- runLoop
+            config0 { loopTools = registryFromHandlers [imageTool] }
+            Nothing
+            "show it"
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-tool-done"
+            , finalText = Just "saw it"
+            , turnsUsed = 2
+            , tokenUsage = emptyTokenUsage
+            }
+        seen <- readIORef submissions
+        case seen of
+            [ _
+              , ( Just "resp-tool-image"
+                , [ CompletedTool ToolCallResultWithImages{
+                        toolResultImages = [normalized]
+                    }
+                  ]
+                )
+              ] -> do
+                normalized.imageUrl `shouldNotBe` sourceUrl
+                let (metadata, payloadWithComma) =
+                        Text.breakOn "," normalized.imageUrl
+                metadata
+                    `shouldSatisfy`
+                        (`elem`
+                            [ "data:image/png;base64"
+                            , "data:image/jpeg;base64"
+                            ])
+                case Base64.decode
+                        (TextEncoding.encodeUtf8
+                            (Text.drop 1 payloadWithComma)) of
+                    Left decodeError ->
+                        expectationFailure decodeError
+                    Right normalizedBytes ->
+                        assertNormalizedImage
+                            oversizedFixtureBytes
+                            (Text.drop 5 (Text.dropEnd 7 metadata))
+                            normalizedBytes
+            submissionsSeen ->
+                expectationFailure $
+                    "unexpected submissions: " <> show submissionsSeen
+
+    it "applies EXIF orientation while normalizing oversized camera JPEGs" do
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-oriented-image" [] (Just "saw it")
+            ]
+        let sourceBytes = orientedFixtureBytes
+            input =
+                userMessageWithAttachments
+                    "see this"
+                    [ ImageAttachmentItem
+                        (ImageAttachment "image/jpeg" sourceBytes)
+                    ]
+        config <- testConfig backend
+        result <- runLoopInputs config Nothing [input]
+        result `shouldBe` Right LoopResult
+            { finalResponseId = "resp-oriented-image"
+            , finalText = Just "saw it"
+            , turnsUsed = 1
+            , tokenUsage = emptyTokenUsage
+            }
+        seen <- readIORef submissions
+        case seen of
+            [(Nothing, [submitted])] ->
+                case turnInputImages submitted of
+                    [normalized] -> do
+                        assertNormalizedImage
+                            sourceBytes
+                            normalized.imageMime
+                            normalized.imageBytes
+                        case decodeImage normalized.imageBytes of
+                            Left decodeError ->
+                                expectationFailure decodeError
+                            Right dynamicImage -> do
+                                let image = convertRGB8 dynamicImage
+                                imageHeight image
+                                    `shouldSatisfy` (> imageWidth image)
+                    images ->
+                        expectationFailure $
+                            "expected one submitted image, got "
+                                <> show (length images)
+            submissionsSeen ->
+                expectationFailure $
+                    "unexpected submissions: " <> show submissionsSeen
 
     it "accepts file attachments in multimodal turns" do
         submissions <- newIORef []
@@ -2114,6 +2274,74 @@ functionResult callId output = ToolCallResult
     , output
     , callKind = FunctionCallKind
     }
+
+oversizedFixtureBytes :: ByteString.ByteString
+oversizedFixtureBytes =
+    LazyByteString.toStrict (encodeBitmap sourceImage)
+  where
+    sourceImage =
+        generateImage fixturePixel 2200 1200
+    fixturePixel x y =
+        PixelRGB8
+            (channel 73 151 x y)
+            (channel 193 41 x y)
+            (channel 17 239 x y)
+    channel xFactor yFactor x y =
+        fromIntegral
+            ((x * xFactor + y * yFactor + x * y) `mod` 256)
+
+orientedFixtureBytes :: ByteString.ByteString
+orientedFixtureBytes =
+    addExifOrientation 6 $
+        LazyByteString.toStrict
+            (encodeJpegAtQuality 90 (convertImage sourceImage))
+  where
+    sourceImage =
+        generateImage fixturePixel 2200 800
+    fixturePixel x y =
+        PixelRGB8
+            (fromIntegral (x `mod` 256))
+            (fromIntegral (y `mod` 256))
+            (fromIntegral ((x + y) `mod` 256))
+
+addExifOrientation :: Int -> ByteString.ByteString -> ByteString.ByteString
+addExifOrientation orientation jpeg
+    | ByteString.take 2 jpeg == ByteString.pack [0xff, 0xd8] =
+        ByteString.take 2 jpeg
+            <> ByteString.pack
+                [ 0xff, 0xe1, 0x00, 0x22
+                , 0x45, 0x78, 0x69, 0x66, 0x00, 0x00
+                , 0x4d, 0x4d, 0x00, 0x2a
+                , 0x00, 0x00, 0x00, 0x08
+                , 0x00, 0x01
+                , 0x01, 0x12
+                , 0x00, 0x03
+                , 0x00, 0x00, 0x00, 0x01
+                , 0x00, fromIntegral orientation, 0x00, 0x00
+                , 0x00, 0x00, 0x00, 0x00
+                ]
+            <> ByteString.drop 2 jpeg
+    | otherwise = jpeg
+
+assertNormalizedImage
+    :: ByteString.ByteString
+    -> Text
+    -> ByteString.ByteString
+    -> Expectation
+assertNormalizedImage sourceBytes mime bytes = do
+    ByteString.length bytes `shouldSatisfy` (<= 1500000)
+    bytes `shouldNotBe` sourceBytes
+    mime `shouldSatisfy` (`elem` ["image/png", "image/jpeg"])
+    case decodeImage bytes of
+        Left decodeError ->
+            expectationFailure decodeError
+        Right dynamicImage -> do
+            let image = convertRGB8 dynamicImage
+                width = imageWidth image
+                height = imageHeight image
+            width `shouldSatisfy` (<= 2000)
+            height `shouldSatisfy` (<= 2000)
+            width * height `shouldSatisfy` (<= 2408448)
 
 scriptedBackend
     :: IORef [(Maybe Text, [TurnInput])]

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -1,10 +1,20 @@
 module Agent.LoopSpec (spec) where
 
+import Agent.Json (RawJson, rawJsonBytes, rawJsonDecoder)
 import qualified Agent.Json.Decode as Json
 import Agent.Cancel (newCancelFlag, requestCancel)
 import Agent.Error (ApiError(..))
 import Agent.Loop
-import Agent.Responses.Types (ResponseItem(..), TaggedObject(..))
+import Agent.Responses.Types
+    ( FunctionCallOutput(..)
+    , MessageContent(..)
+    , ReasoningItem(..)
+    , ResponseContentPart(..)
+    , ResponseItem(..)
+    , ResponseMessage(..)
+    , ResponseRole(..)
+    , TaggedObject(..)
+    )
 import Agent.Telemetry (TurnTelemetry(..))
 import Agent.ToolArgs (objectArgs, reqText)
 import Agent.ToolDispatch
@@ -26,16 +36,22 @@ import Agent.Tools.Types
     , withToolResourceClaims
     )
 import Codec.Picture
-    ( PixelRGB8(..)
+    ( Image
+    , PixelRGB8(..)
+    , PixelRGBA8(..)
     , convertRGB8
+    , convertRGBA8
     , decodeImage
     , encodeBitmap
     , encodeJpegAtQuality
+    , encodePng
     , generateImage
     , imageHeight
     , imageWidth
+    , pixelAt
     )
 import Codec.Picture.Types (convertImage)
+import qualified Codec.Compression.Zlib as Zlib
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Concurrent.Async (cancel, wait, withAsync)
 import Control.Concurrent.MVar
@@ -46,13 +62,24 @@ import Control.Concurrent.MVar
     , tryReadMVar
     )
 import qualified Control.Exception as Exception
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Bits (complement, shiftR, xor, (.&.))
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Base64 as Base64
+import Data.ByteString.Builder
+    ( Builder
+    , byteString
+    , toLazyByteString
+    , word8
+    , word32BE
+    )
 import qualified Data.ByteString.Lazy as LazyByteString
 import Data.IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word32)
 import System.Timeout (timeout)
 import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
@@ -196,6 +223,216 @@ spec = describe "runLoop" do
             submissionsSeen ->
                 expectationFailure $
                     "unexpected submissions: " <> show submissionsSeen
+
+    it "rejects unsafe encoded dimensions before decoding a raster" do
+        finished <-
+            timeout 2000000 $
+                runSingleImageSubmission "image/png" unsafeDimensionPng
+        case finished of
+            Nothing ->
+                expectationFailure
+                    "image dimension preflight did not return promptly"
+            Just (Left failure) ->
+                expectationFailure failure
+            Just (Right (result, submittedImage)) -> do
+                result `shouldBe` completedImageLoopResult
+                submittedImage.imageMime `shouldBe` "image/png"
+                submittedImage.imageBytes `shouldBe` unsafeDimensionPng
+
+    it "bounds PNG inflation before allocating the decoded raster" do
+        _ <- Exception.evaluate (ByteString.length pngInflationBomb)
+        finished <-
+            timeout 500000 $
+                runSingleImageSubmission "image/png" pngInflationBomb
+        case finished of
+            Nothing ->
+                expectationFailure
+                    "PNG inflation preflight did not return promptly"
+            Just (Left failure) ->
+                expectationFailure failure
+            Just (Right (result, submittedImage)) -> do
+                result `shouldBe` completedImageLoopResult
+                submittedImage.imageMime `shouldBe` "image/png"
+                submittedImage.imageBytes `shouldBe` pngInflationBomb
+
+    it "bounds PNG chunk metadata before collecting image data" do
+        _ <-
+            Exception.evaluate
+                (ByteString.length pngWithExcessiveImageDataChunks)
+        finished <-
+            timeout 500000 $
+                runSingleImageSubmission
+                    "image/png"
+                    pngWithExcessiveImageDataChunks
+        case finished of
+            Nothing ->
+                expectationFailure
+                    "PNG chunk preflight did not return promptly"
+            Just (Left failure) ->
+                expectationFailure failure
+            Just (Right (result, submittedImage)) -> do
+                result `shouldBe` completedImageLoopResult
+                submittedImage.imageMime `shouldBe` "image/png"
+                submittedImage.imageBytes
+                    `shouldBe` pngWithExcessiveImageDataChunks
+
+    it "does not decode GIF frames without a bounded frame preflight" do
+        finished <-
+            timeout 2000000 $
+                runSingleImageSubmission "image/gif" oversizedGifFrame
+        case finished of
+            Nothing ->
+                expectationFailure
+                    "unsupported GIF normalization did not return promptly"
+            Just (Left failure) ->
+                expectationFailure failure
+            Just (Right (result, submittedImage)) -> do
+                result `shouldBe` completedImageLoopResult
+                submittedImage.imageMime `shouldBe` "image/gif"
+                submittedImage.imageBytes `shouldBe` oversizedGifFrame
+
+    it "resizes transparent pixels in premultiplied-alpha space" do
+        let sourceBytes =
+                LazyByteString.toStrict
+                    (encodePng transparentEdgeFixture)
+        submission <- runSingleImageSubmission "image/png" sourceBytes
+        case submission of
+            Left failure ->
+                expectationFailure failure
+            Right (result, submittedImage) -> do
+                result `shouldBe` completedImageLoopResult
+                submittedImage.imageMime `shouldBe` "image/png"
+                submittedImage.imageBytes `shouldNotBe` sourceBytes
+                case decodeImage submittedImage.imageBytes of
+                    Left decodeError ->
+                        expectationFailure decodeError
+                    Right dynamicImage ->
+                        pixelAt (convertRGBA8 dynamicImage) 0 0
+                            `shouldBe` PixelRGBA8 255 255 255 128
+
+    it "normalizes retained backend history only for provider submission" do
+        submittedState <- newIORef Nothing
+        let sourceUrl = imageDataUrl "image/bmp" oversizedFixtureBytes
+            rawSourceUrl =
+                "DATA:IMAGE/BMP;BASE64,"
+                    <> TextEncoding.decodeUtf8
+                        (Base64.encode oversizedFixtureBytes)
+            rawHistoryOutput =
+                rawJsonFixture $
+                    "{\"type\":\"input_image\",\"image_url\":\""
+                        <> "DATA:IMAGE\\/BMP;BASE64,"
+                        <> Base64.encode oversizedFixtureBytes
+                        <> "\"}"
+            messageHistoryItem =
+                MessageItem ResponseMessage
+                    { messageId = Just "history-message"
+                    , content =
+                        MessageContentParts
+                            [ InputImagePart
+                                { detail = Just "high"
+                                , fileId = Nothing
+                                , imageUrl = Just sourceUrl
+                                , promptCacheBreakpoint = Nothing
+                                }
+                            ]
+                    , role = RoleUser
+                    , status = Nothing
+                    , phase = Nothing
+                    , passthrough = Nothing
+                    }
+            reasoningHistoryItem =
+                ReasoningItemValue ReasoningItem
+                    { itemId = Just "history-reasoning"
+                    , summary = []
+                    , content =
+                        Just
+                            [ InputImagePart
+                                { detail = Just "high"
+                                , fileId = Nothing
+                                , imageUrl = Just sourceUrl
+                                , promptCacheBreakpoint = Nothing
+                                }
+                            ]
+                    , encryptedContent = Nothing
+                    , status = Nothing
+                    }
+            functionHistoryItem =
+                FunctionCallOutputItem FunctionCallOutput
+                    { itemId = Just "history-function-output"
+                    , callId = "history-call"
+                    , name = Just "image"
+                    , namespace = Nothing
+                    , provider = Nothing
+                    , output = rawHistoryOutput
+                    , status = Nothing
+                    }
+            initialState =
+                initialBackendSnapshot
+                    [ messageHistoryItem
+                    , reasoningHistoryItem
+                    , functionHistoryItem
+                    ]
+            backend = Backend \state _previous _inputs _onEvent -> do
+                writeIORef submittedState (Just state)
+                pure (Left (ConnectionError "down"))
+        storedState <- newIORef initialState
+        config0 <- testConfig backend
+        let config = config0
+                { loopBackendState = BackendStateStore
+                    { readBackendState = readIORef storedState
+                    , commitBackendState = \state -> do
+                        writeIORef storedState state
+                        pure state
+                    }
+                }
+        execution <-
+            runLoopInputsDetailed config Nothing [UserMessage "continue"]
+        execution.executionResult
+            `shouldBe` Left (LoopTransport (ConnectionError "down"))
+        readIORef storedState `shouldReturn` initialState
+        readIORef submittedState >>= \case
+            Just BackendSnapshot{
+                backendItems =
+                    [ MessageItem ResponseMessage{
+                        content =
+                            MessageContentParts
+                                [ InputImagePart{
+                                    imageUrl = Just normalizedMessageUrl
+                                }
+                                ]
+                    }
+                    , ReasoningItemValue ReasoningItem{
+                        content =
+                            Just
+                                [ InputImagePart{
+                                    imageUrl = Just normalizedReasoningUrl
+                                }
+                                ]
+                    }
+                    , FunctionCallOutputItem FunctionCallOutput{
+                        output = normalizedRawOutput
+                    }
+                    ]
+            } -> do
+                assertNormalizedDataUrl
+                    oversizedFixtureBytes
+                    sourceUrl
+                    normalizedMessageUrl
+                assertNormalizedDataUrl
+                    oversizedFixtureBytes
+                    sourceUrl
+                    normalizedReasoningUrl
+                case rawJsonImageUrl normalizedRawOutput of
+                    Left failure ->
+                        expectationFailure failure
+                    Right normalizedRawUrl ->
+                        assertNormalizedDataUrl
+                            oversizedFixtureBytes
+                            rawSourceUrl
+                            normalizedRawUrl
+            state ->
+                expectationFailure $
+                    "unexpected submitted backend state: " <> show state
 
     it "normalizes oversized tool images before follow-up submission" do
         submissions <- newIORef []
@@ -2275,6 +2512,144 @@ functionResult callId output = ToolCallResult
     , callKind = FunctionCallKind
     }
 
+completedImageLoopResult :: Either LoopError LoopResult
+completedImageLoopResult =
+    Right LoopResult
+        { finalResponseId = "resp-image-check"
+        , finalText = Just "saw it"
+        , turnsUsed = 1
+        , tokenUsage = emptyTokenUsage
+        }
+
+runSingleImageSubmission
+    :: Text
+    -> ByteString.ByteString
+    -> IO
+        ( Either
+            String
+            (Either LoopError LoopResult, ImageAttachment)
+        )
+runSingleImageSubmission mime bytes = do
+    submissions <- newIORef []
+    backend <- scriptedBackend submissions
+        [ Right $ emptyTurnOutput "resp-image-check" [] (Just "saw it")
+        ]
+    config <- testConfig backend
+    result <-
+        runLoopInputs config Nothing
+            [ userMessageWithAttachments
+                "see this"
+                [ImageAttachmentItem (ImageAttachment mime bytes)]
+            ]
+    readIORef submissions >>= \case
+        [(Nothing, [submitted])] ->
+            case turnInputImages submitted of
+                [image] -> do
+                    _ <- Exception.evaluate (ByteString.length image.imageBytes)
+                    pure (Right (result, image))
+                images ->
+                    pure . Left $
+                        "expected one submitted image, got "
+                            <> show (length images)
+        submissionsSeen ->
+            pure . Left $
+                "unexpected submissions: " <> show submissionsSeen
+
+unsafeDimensionPng :: ByteString.ByteString
+unsafeDimensionPng =
+    LazyByteString.toStrict $
+        encodePng (generateImage (\_ _ -> PixelRGB8 0 0 0) 8193 1)
+
+pngInflationBomb :: ByteString.ByteString
+pngInflationBomb =
+    LazyByteString.toStrict . toLazyByteString $
+        byteString "\137PNG\r\n\SUB\n"
+            <> pngChunk "IHDR" header
+            <> pngChunk "IDAT" compressedPayload
+            <> pngChunk "IEND" ""
+  where
+    header =
+        LazyByteString.toStrict . toLazyByteString $
+            word32BE 2001
+                <> word32BE 1
+                <> word8 8
+                <> word8 2
+                <> word8 0
+                <> word8 0
+                <> word8 0
+    compressedPayload =
+        LazyByteString.toStrict . Zlib.compress $
+            LazyByteString.replicate (256 * 1024 * 1024) 0
+
+pngWithExcessiveImageDataChunks :: ByteString.ByteString
+pngWithExcessiveImageDataChunks =
+    LazyByteString.toStrict . toLazyByteString $
+        byteString "\137PNG\r\n\SUB\n"
+            <> pngChunk "IHDR" header
+            <> mconcat (replicate 4097 (pngChunk "IDAT" ""))
+            <> pngChunk "IDAT" compressedPayload
+            <> pngChunk "IEND" ""
+  where
+    header =
+        LazyByteString.toStrict . toLazyByteString $
+            word32BE 2001
+                <> word32BE 1
+                <> word8 8
+                <> word8 2
+                <> word8 0
+                <> word8 0
+                <> word8 0
+    compressedPayload =
+        LazyByteString.toStrict . Zlib.compress $
+            LazyByteString.replicate 6004 0
+
+pngChunk :: ByteString.ByteString -> ByteString.ByteString -> Builder
+pngChunk chunkType payload =
+    word32BE (fromIntegral (ByteString.length payload))
+        <> byteString chunkType
+        <> byteString payload
+        <> word32BE (pngCrc32 (chunkType <> payload))
+
+pngCrc32 :: ByteString.ByteString -> Word32
+pngCrc32 =
+    complement
+        . ByteString.foldl' updateCrc maxBound
+  where
+    updateCrc crc byte =
+        updateBits 8 (crc `xor` fromIntegral byte)
+
+    updateBits :: Int -> Word32 -> Word32
+    updateBits remaining value
+        | remaining <= 0 = value
+        | value .&. 1 == 1 =
+            updateBits
+                (remaining - 1)
+                ((value `shiftR` 1) `xor` 0xedb88320)
+        | otherwise =
+            updateBits (remaining - 1) (value `shiftR` 1)
+
+oversizedGifFrame :: ByteString.ByteString
+oversizedGifFrame =
+    ByteString.pack
+        [ 0x47, 0x49, 0x46, 0x38, 0x39, 0x61
+        , 0xd1, 0x07, 0x01, 0x00
+        , 0x00, 0x00, 0x00
+        , 0x2c
+        , 0x00, 0x00, 0x00, 0x00
+        , 0xff, 0xff, 0xff, 0xff
+        , 0x00
+        , 0x02, 0x01, 0x00, 0x00
+        , 0x3b
+        ]
+
+transparentEdgeFixture :: Image PixelRGBA8
+transparentEdgeFixture =
+    generateImage pixel 4000 1
+  where
+    pixel x _
+        | even x = PixelRGBA8 255 255 255 255
+        | otherwise = PixelRGBA8 0 0 0 0
+
 oversizedFixtureBytes :: ByteString.ByteString
 oversizedFixtureBytes =
     LazyByteString.toStrict (encodeBitmap sourceImage)
@@ -2342,6 +2717,52 @@ assertNormalizedImage sourceBytes mime bytes = do
             width `shouldSatisfy` (<= 2000)
             height `shouldSatisfy` (<= 2000)
             width * height `shouldSatisfy` (<= 2408448)
+
+imageDataUrl :: Text -> ByteString.ByteString -> Text
+imageDataUrl mime bytes =
+    "data:"
+        <> mime
+        <> ";base64,"
+        <> TextEncoding.decodeUtf8 (Base64.encode bytes)
+
+rawJsonFixture :: ByteString.ByteString -> RawJson
+rawJsonFixture bytes =
+    either (error . show) id
+        (Json.decodeEither rawJsonDecoder bytes)
+
+rawJsonImageUrl :: RawJson -> Either String Text
+rawJsonImageUrl raw =
+    case Aeson.decodeStrict' (rawJsonBytes raw) of
+        Just (Aeson.Object object) ->
+            case KeyMap.lookup "image_url" object of
+                Just (Aeson.String imageUrl) -> Right imageUrl
+                _ -> Left "normalized raw JSON has no image_url string"
+        _ -> Left "normalized tool output is not a JSON object"
+
+assertNormalizedDataUrl
+    :: ByteString.ByteString
+    -> Text
+    -> Text
+    -> Expectation
+assertNormalizedDataUrl sourceBytes sourceUrl normalizedUrl = do
+    normalizedUrl `shouldNotBe` sourceUrl
+    let (metadata, payloadWithComma) =
+            Text.breakOn "," normalizedUrl
+    metadata
+        `shouldSatisfy`
+            (`elem`
+                [ "data:image/png;base64"
+                , "data:image/jpeg;base64"
+                ])
+    case Base64.decode
+        (TextEncoding.encodeUtf8 (Text.drop 1 payloadWithComma)) of
+        Left decodeError ->
+            expectationFailure decodeError
+        Right normalizedBytes ->
+            assertNormalizedImage
+                sourceBytes
+                (Text.drop 5 (Text.dropEnd 7 metadata))
+                normalizedBytes
 
 scriptedBackend
     :: IORef [(Maybe Text, [TurnInput])]


### PR DESCRIPTION
## Summary
- normalize direct attachments and inline tool-result images at the provider-neutral submission boundary
- bound images to 1.5 MB, a 2,000 px maximum side, and 2,408,448 pixels using resize plus PNG/JPEG recompression
- apply EXIF orientation before re-encoding while preserving already-bounded or undecodable images unchanged

## Validation
- `nix develop -c cabal test agent-core:test:agent-core-test --test-show-details=direct` — 541 examples, 0 failures, 8 environment-dependent pending tests
- regenerated `packages/agent-core/package.nix`; it exactly matches `cabal2nix`
- `git diff --check`
- independent blocker-only review: no blockers

A local Darwin `nix flake check` reaches `agent-core` but fails six sandbox-dependent GHCi/IO tests. The untouched `origin/master` revision reproduces the exact same six failures, so they are unrelated baseline environment failures; Linux PR CI remains authoritative.