### PR TITLE
Speed up CLI startup with structured overlap

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -116,7 +116,6 @@ library
                     , Agent.CLI.Session.Selection
                     , Agent.CLI.Session.Runtime.Types
                     , Agent.CLI.Startup.Auth
-                    , Agent.CLI.StartupContext
                     , Agent.CLI.Startup.Format
                     , Agent.CLI.TUI.Composer.Buffer
                     , Agent.CLI.TUI.Composer.Edit
@@ -225,6 +224,7 @@ library
                     , Agent.CLI.Secret
                     , Agent.CLI.Skills
                     , Agent.CLI.Status
+                    , Agent.CLI.StartupContext
                     , Agent.CLI.SteeringInputs
                     , Agent.CLI.SubagentStore
                     , Agent.CLI.Subagents.Runtime

--- a/packages/agent-cli/benchmark/Concurrency.hs
+++ b/packages/agent-cli/benchmark/Concurrency.hs
@@ -36,8 +36,19 @@ import Agent.MCP
     , newMcpSupervisor
     , releaseMcpFleetLease
     )
+import Agent.OsPath (unsafeToFilePath)
+import Agent.ProjectInstructions
+    ( DiscoverOptions(..)
+    , InstructionFile(..)
+    , LoadedAgentsMd
+    , defaultDiscoverOptions
+    , discoverProjectInstructions
+    , loadedInstructionFiles
+    , loadedInstructionWarnings
+    )
 import Agent.ResourceScope
     ( allocateResource
+    , allocateFourResourcesConcurrently
     , allocateResourcesConcurrently
     , withResourceScope
     )
@@ -107,6 +118,34 @@ data ToolStartupStrategy
     | StartupParentFullOverlap
     | StartupPreloadSkills
 
+data StartupDagStrategy
+    = StartupDagBaseline
+    | StartupDagCurrent
+
+data StartupDagContext = StartupDagContext
+    { dagAgentsContext :: !LoadedAgentsMd
+    , dagSkillsCatalog :: !SkillCatalog
+    }
+
+data StartupDagAuxResource = StartupDagAuxResource
+    { dagAuxLabel :: !Text.Text
+    , dagAuxChecksum :: !Int
+    }
+
+data StartupDagResources = StartupDagResources
+    { dagMcpLease :: !McpFleetLease
+    , dagCodingTools :: !CodingTools
+    , dagWebResource :: !StartupDagAuxResource
+    , dagLspResource :: !StartupDagAuxResource
+    }
+
+data StartupDagReleaseCounters = StartupDagReleaseCounters
+    { dagMcpReleases :: !(IORef Int)
+    , dagLocalReleases :: !(IORef Int)
+    , dagWebReleases :: !(IORef Int)
+    , dagLspReleases :: !(IORef Int)
+    }
+
 main :: IO ()
 main = do
     args <- getArgs
@@ -159,6 +198,19 @@ main = do
                 (read mcpDelayMillis)
                 (read skills)
                 (read samples)
+        [ "startup-dag-paired"
+            , servers
+            , mcpDelayMillis
+            , skills
+            , auxDelayMillis
+            , samples
+            ] ->
+                benchmarkStartupDagPaired
+                    (read servers)
+                    (read mcpDelayMillis)
+                    (read skills)
+                    (read auxDelayMillis)
+                    (read samples)
         _ -> benchmarkConcurrency args
 
 benchmarkConcurrency :: [String] -> IO ()
@@ -390,6 +442,428 @@ benchmarkStartupToolsPaired
                     <> " cpu-ms=" <> show cpuDelta
                     <> " allocated-bytes=" <> show allocationDelta
                 )
+
+-- | Retained comparison for the startup frontier changed in this branch.
+-- The baseline stages MCP/local, web/LSP, and context in three waves. The
+-- current graph overlaps all four resources with concurrent context preload.
+benchmarkStartupDagPaired :: Int -> Int -> Int -> Int -> Int -> IO ()
+benchmarkStartupDagPaired
+        serverCount mcpDelayMillis skillCount auxDelayMillis sampleCount = do
+    statsEnabled <- getRTSStatsEnabled
+    when (not statsEnabled) $
+        fail "run with +RTS -T"
+    executable <- getExecutablePath
+    let normalizedServers = max 0 serverCount
+        normalizedMcpDelay = max 0 mcpDelayMillis
+        normalizedSkills = max 0 skillCount
+        normalizedAuxDelay = max 0 auxDelayMillis
+        normalizedSamples = max 1 sampleCount
+    withStartupDagFixture
+        executable
+        normalizedServers
+        normalizedMcpDelay
+        normalizedSkills
+        \fixture -> do
+            validateMcpFixture fixture
+            baselineChecksum <-
+                runStartupDag
+                    StartupDagBaseline
+                    fixture
+                    normalizedAuxDelay
+            currentChecksum <-
+                runStartupDag
+                    StartupDagCurrent
+                    fixture
+                    normalizedAuxDelay
+            when (baselineChecksum /= currentChecksum) $
+                fail "startup DAG implementations disagree on checksum"
+            pairedSamples <-
+                forM [1 .. normalizedSamples] \index ->
+                    if odd index
+                        then do
+                            baselineSample <-
+                                measureStartupDag
+                                    StartupDagBaseline
+                                    fixture
+                                    normalizedAuxDelay
+                            currentSample <-
+                                measureStartupDag
+                                    StartupDagCurrent
+                                    fixture
+                                    normalizedAuxDelay
+                            pure (baselineSample, currentSample)
+                        else do
+                            currentSample <-
+                                measureStartupDag
+                                    StartupDagCurrent
+                                    fixture
+                                    normalizedAuxDelay
+                            baselineSample <-
+                                measureStartupDag
+                                    StartupDagBaseline
+                                    fixture
+                                    normalizedAuxDelay
+                            pure (baselineSample, currentSample)
+            let baselineSample = medianSample (map fst pairedSamples)
+                currentSample = medianSample (map snd pairedSamples)
+                elapsedDelta =
+                    median
+                        [ current.sampleElapsedMillis
+                            - baseline.sampleElapsedMillis
+                        | (baseline, current) <- pairedSamples
+                        ]
+                cpuDelta =
+                    median
+                        [ current.sampleCpuMillis - baseline.sampleCpuMillis
+                        | (baseline, current) <- pairedSamples
+                        ]
+                allocationDelta =
+                    median
+                        [ toInteger current.sampleAllocatedBytes
+                            - toInteger baseline.sampleAllocatedBytes
+                        | (baseline, current) <- pairedSamples
+                        ]
+                dimensions =
+                    " mcp-mode=progressive"
+                        <> " pairing=alternating"
+                        <> " baseline-topology=resources2+2-then-context1+1"
+                        <> " current-topology=resources4||context2"
+                        <> " shared-workspace-loaders=4"
+                        <> " resource-branches=4"
+                        <> " context-branches=2"
+                        <> " context-kind=agents+filesystem-skills"
+                        <> " mcp-servers=" <> show normalizedServers
+                        <> " mcp-delay-ms=" <> show normalizedMcpDelay
+                        <> " filesystem-skills=" <> show normalizedSkills
+                        <> " agents-files=1"
+                        <> " simulated-aux-resources=2"
+                        <> " simulated-aux-kind=web-fetch+lsp"
+                        <> " aux-delay-ms=" <> show normalizedAuxDelay
+                        <> " samples=" <> show normalizedSamples
+                printSample label sample =
+                    putStrLn
+                        ( label
+                            <> dimensions
+                            <> " elapsed-ms="
+                            <> show sample.sampleElapsedMillis
+                            <> " cpu-ms=" <> show sample.sampleCpuMillis
+                            <> " allocated-bytes="
+                            <> show sample.sampleAllocatedBytes
+                        )
+            printSample "startup-dag-paired-baseline" baselineSample
+            printSample "startup-dag-paired-current" currentSample
+            putStrLn
+                ( "startup-dag-paired-delta"
+                    <> dimensions
+                    <> " elapsed-ms=" <> show elapsedDelta
+                    <> " cpu-ms=" <> show cpuDelta
+                    <> " allocated-bytes=" <> show allocationDelta
+                )
+
+runStartupDag
+    :: StartupDagStrategy
+    -> ToolStartupFixture
+    -> Int
+    -> IO Int
+runStartupDag strategy fixture auxDelayMillis = do
+    toolEnv <- defaultToolEnv fixture.fixtureProject
+    releaseCounters <- newStartupDagReleaseCounters
+    bracket newMcpSupervisor closeMcpSupervisor \supervisor ->
+        runStartupDagWithSupervisor
+            strategy
+            fixture
+            auxDelayMillis
+            supervisor
+            toolEnv
+            releaseCounters
+            (startupDagChecksum fixture)
+
+measureStartupDag
+    :: StartupDagStrategy
+    -> ToolStartupFixture
+    -> Int
+    -> IO Sample
+measureStartupDag strategy fixture auxDelayMillis = do
+    toolEnv <- defaultToolEnv fixture.fixtureProject
+    releaseCounters <- newStartupDagReleaseCounters
+    performMajorGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    bracket newMcpSupervisor closeMcpSupervisor \supervisor ->
+        runStartupDagWithSupervisor
+            strategy
+            fixture
+            auxDelayMillis
+            supervisor
+            toolEnv
+            releaseCounters
+            \resources context -> do
+                checksum <- startupDagChecksum fixture resources context
+                checksum `seq` pure ()
+                afterElapsed <- getMonotonicTimeNSec
+                afterCpu <- getCPUTime
+                -- Capture prompt-ready latency and CPU before the accounting
+                -- GC and before the resource scope performs cleanup.
+                performMajorGC
+                afterStats <- getRTSStats
+                pure Sample
+                    { sampleElapsedMillis =
+                        fromIntegral (afterElapsed - beforeElapsed)
+                            / 1_000_000
+                    , sampleCpuMillis =
+                        fromIntegral (afterCpu - beforeCpu)
+                            / 1_000_000_000
+                    , sampleAllocatedBytes =
+                        fromIntegral
+                            (allocated_bytes afterStats
+                                - allocated_bytes beforeStats)
+                    }
+
+runStartupDagWithSupervisor
+    :: StartupDagStrategy
+    -> ToolStartupFixture
+    -> Int
+    -> McpSupervisor
+    -> ToolEnv
+    -> StartupDagReleaseCounters
+    -> (StartupDagResources -> StartupDagContext -> IO a)
+    -> IO a
+runStartupDagWithSupervisor
+        strategy
+        fixture
+        auxDelayMillis
+        supervisor
+        toolEnv
+        releaseCounters
+        continuation = do
+    let acquireMcp =
+            acquireMcpFleetProgressive
+                supervisor
+                (const (pure ()))
+                fixture.fixtureMcpConfigs
+        releaseMcp lease =
+            releaseMcpFleetLease lease
+                `finally` noteRelease releaseCounters.dagMcpReleases
+        acquireLocal =
+            codingToolsFor
+                (dialectForId CodexDialect)
+                toolEnv
+                Nothing
+                Nothing
+                Nothing
+                Nothing
+        releaseLocal coding =
+            coding.codingClose
+                `finally` noteRelease releaseCounters.dagLocalReleases
+        acquireAux label checksum = do
+            threadDelay (auxDelayMillis * 1000)
+            pure StartupDagAuxResource
+                { dagAuxLabel = label
+                , dagAuxChecksum = checksum
+                }
+        acquireWeb = acquireAux "web-fetch" 17
+        acquireLsp = acquireAux "lsp" 29
+        releaseWeb _ = noteRelease releaseCounters.dagWebReleases
+        releaseLsp _ = noteRelease releaseCounters.dagLspReleases
+        loadWorkspace = do
+            ((projectSettings, userSettings), (catalogResult, branch)) <-
+                concurrently
+                    (concurrently
+                        (loadProjectSettings fixture.fixtureProject)
+                        (loadUserSettings fixture.fixtureHome))
+                    (concurrently
+                        (loadModelCatalogAt
+                            fixture.fixtureHome
+                            fixture.fixtureProject)
+                        (detectGitBranch fixture.fixtureProject))
+            catalog <- either (fail . Text.unpack) pure catalogResult
+            projectSettings `seq`
+                userSettings `seq`
+                catalog `seq`
+                branch `seq`
+                pure ()
+        loadAgents =
+            discoverProjectInstructions
+                (defaultDiscoverOptions
+                    { discoverGlobalDir =
+                        Just
+                            (unsafeEncodeUtf
+                                (unsafeToFilePath fixture.fixtureProject
+                                    </> ".codex"))
+                    , discoverRootMarkers =
+                        [unsafeEncodeUtf ".startup-benchmark-root"]
+                    })
+                fixture.fixtureProject
+        loadSkills =
+            loadSkillsCatalogQuiet
+                defaultCliOptions
+                fixture.fixtureHome
+                fixture.fixtureProject
+                fixture.fixtureProject
+        loadContextSequentially = do
+            dagAgentsContext <- loadAgents
+            dagSkillsCatalog <- loadSkills
+            pure StartupDagContext{..}
+        loadContextConcurrently = do
+            (dagAgentsContext, dagSkillsCatalog) <-
+                concurrently loadAgents loadSkills
+            pure StartupDagContext{..}
+        continueWith
+                mcpLease
+                codingTools
+                webResource
+                lspResource
+                context =
+            continuation
+                StartupDagResources
+                    { dagMcpLease = mcpLease
+                    , dagCodingTools = codingTools
+                    , dagWebResource = webResource
+                    , dagLspResource = lspResource
+                    }
+                context
+        runBaseline resourceScope = do
+            ((_, mcpLease), (_, codingTools)) <-
+                allocateResourcesConcurrently
+                    resourceScope
+                    acquireMcp
+                    releaseMcp
+                    acquireLocal
+                    releaseLocal
+            ((_, webResource), (_, lspResource)) <-
+                allocateResourcesConcurrently
+                    resourceScope
+                    acquireWeb
+                    releaseWeb
+                    acquireLsp
+                    releaseLsp
+            context <- loadContextSequentially
+            continueWith
+                mcpLease
+                codingTools
+                webResource
+                lspResource
+                context
+        runCurrent resourceScope = do
+            (acquiredResources, context) <-
+                concurrently
+                    (allocateFourResourcesConcurrently
+                        resourceScope
+                        acquireMcp
+                        releaseMcp
+                        acquireLocal
+                        releaseLocal
+                        acquireWeb
+                        releaseWeb
+                        acquireLsp
+                        releaseLsp)
+                    loadContextConcurrently
+            let ( (_, mcpLease)
+                    , (_, codingTools)
+                    , (_, webResource)
+                    , (_, lspResource)
+                    ) = acquiredResources
+            continueWith
+                mcpLease
+                codingTools
+                webResource
+                lspResource
+                context
+    result <-
+        withResourceScope \resourceScope -> do
+            loadWorkspace
+            case strategy of
+                StartupDagBaseline -> runBaseline resourceScope
+                StartupDagCurrent -> runCurrent resourceScope
+    assertStartupDagReleaseCounts releaseCounters
+    pure result
+
+newStartupDagReleaseCounters :: IO StartupDagReleaseCounters
+newStartupDagReleaseCounters = do
+    dagMcpReleases <- newIORef 0
+    dagLocalReleases <- newIORef 0
+    dagWebReleases <- newIORef 0
+    dagLspReleases <- newIORef 0
+    pure StartupDagReleaseCounters{..}
+
+assertStartupDagReleaseCounts :: StartupDagReleaseCounters -> IO ()
+assertStartupDagReleaseCounts counters = do
+    counts <-
+        mapM readIORef
+            [ counters.dagMcpReleases
+            , counters.dagLocalReleases
+            , counters.dagWebReleases
+            , counters.dagLspReleases
+            ]
+    unless (counts == [1, 1, 1, 1]) $
+        fail
+            ("expected one MCP, local, web, and LSP cleanup, got "
+                <> show counts)
+
+startupDagChecksum
+    :: ToolStartupFixture
+    -> StartupDagResources
+    -> StartupDagContext
+    -> IO Int
+startupDagChecksum fixture resources context = do
+    statuses <- mcpFleetStatuses resources.dagMcpLease.mcpLeaseFleet
+    let mcpServerCount = length statuses
+        expectedMcpServers = length fixture.fixtureMcpConfigs
+        mcpWarnings =
+            resources.dagMcpLease.mcpLeaseFleet.mcpFleetWarnings
+        codingToolCount =
+            length resources.dagCodingTools.codingAppTools
+        benchmarkSkillCount =
+            length
+                (filter
+                    (Text.isPrefixOf "startup-bench-" . (.skillName))
+                    context.dagSkillsCatalog.catalogSkills)
+        instructionFiles =
+            loadedInstructionFiles context.dagAgentsContext
+        instructionWarnings =
+            loadedInstructionWarnings context.dagAgentsContext
+        instructionCharacters =
+            sum (map (Text.length . (.instructionContent)) instructionFiles)
+        webResource = resources.dagWebResource
+        lspResource = resources.dagLspResource
+    unless (null mcpWarnings) $
+        fail ("MCP startup warnings: " <> show mcpWarnings)
+    when (mcpServerCount /= expectedMcpServers) $
+        fail
+            ("expected " <> show expectedMcpServers
+                <> " MCP servers, got " <> show mcpServerCount)
+    when (codingToolCount <= 0) $
+        fail "expected coding tool construction to produce tools"
+    when (benchmarkSkillCount /= fixture.fixtureSkillCount) $
+        fail
+            ("expected " <> show fixture.fixtureSkillCount
+                <> " benchmark skills, got " <> show benchmarkSkillCount)
+    unless (null instructionWarnings) $
+        fail ("AGENTS.md discovery warnings: " <> show instructionWarnings)
+    when (length instructionFiles /= 1 || instructionCharacters <= 0) $
+        fail
+            ("expected one non-empty AGENTS.md file, got "
+                <> show (length instructionFiles)
+                <> " files and "
+                <> show instructionCharacters
+                <> " characters")
+    when
+        ( webResource.dagAuxLabel /= "web-fetch"
+            || webResource.dagAuxChecksum /= 17
+            || lspResource.dagAuxLabel /= "lsp"
+            || lspResource.dagAuxChecksum /= 29
+        )
+        (fail "simulated web/LSP resources disagree")
+    pure
+        ( mcpServerCount * 1_000_000
+            + codingToolCount * 10_000
+            + benchmarkSkillCount * 100
+            + length instructionFiles * 10
+            + instructionCharacters
+            + webResource.dagAuxChecksum
+            + lspResource.dagAuxChecksum
+        )
 
 runToolStartup :: ToolStartupStrategy -> ToolStartupFixture -> IO Int
 runToolStartup strategy fixture = do
@@ -772,6 +1246,35 @@ boundedRead paths =
 
 sumLengths :: [BS.ByteString] -> Int
 sumLengths = foldr ((+) . BS.length) 0
+
+withStartupDagFixture
+    :: FilePath
+    -> Int
+    -> Int
+    -> Int
+    -> (ToolStartupFixture -> IO a)
+    -> IO a
+withStartupDagFixture
+        executable serverCount mcpDelayMillis skillCount action =
+    withToolStartupFixture
+        executable
+        serverCount
+        mcpDelayMillis
+        skillCount
+        \fixture -> do
+            let project = unsafeToFilePath fixture.fixtureProject
+            writeFile
+                (project </> ".startup-benchmark-root")
+                ""
+            writeFile
+                (project </> "AGENTS.md")
+                (unlines
+                    [ "# Startup benchmark instructions"
+                    , ""
+                    , "Exercise the production project-instruction discovery path."
+                    , "Keep benchmark resources scoped and startup work concurrent."
+                    ])
+            action fixture
 
 withToolStartupFixture
     :: FilePath

--- a/packages/agent-cli/src/Agent/CLI/LearnedSkills/Store.hs
+++ b/packages/agent-cli/src/Agent/CLI/LearnedSkills/Store.hs
@@ -2,6 +2,8 @@
 module Agent.CLI.LearnedSkills.Store
     ( learnedSkillToolsEnvForStore
     , loadApplicableLearnedSkillsForStore
+    , loadLearnedSkillsWithPreload
+    , successfulLearnedSkillsPreload
     ) where
 
 import Agent.CLI.Database.Store
@@ -237,6 +239,21 @@ loadApplicableLearnedSkillsForStore store scopes =
         listApplicableLearnedSkills
             (trustedPool store)
             (applicableDatabaseScopes scopes)
+
+successfulLearnedSkillsPreload
+    :: Either Text [LearnedSkill]
+    -> Maybe [LearnedSkill]
+successfulLearnedSkillsPreload =
+    either (const Nothing) Just
+
+loadLearnedSkillsWithPreload
+    :: Maybe [LearnedSkill]
+    -> IO (Either Text [LearnedSkill])
+    -> IO (Either Text [LearnedSkill])
+loadLearnedSkillsWithPreload (Just learnedSkills) _ =
+    pure (Right learnedSkills)
+loadLearnedSkillsWithPreload Nothing reload =
+    reload
 
 sourceInput
     :: IO (Maybe Text)

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Resume
     , ResumeBrowser(..)
     , ResumeSourceFilter(..)
     , ResumeState(..)
+    , SessionInitialContext(..)
     , applyResumeKey
     , applyResumeSearchResults
     , beginResumeSearch
@@ -30,6 +31,7 @@ module Agent.CLI.Resume
     , resumeSearchEntries
     , filterResumeSessionsForBoundary
     , resumeRelativeAge
+    , resolveSessionInitialContext
     , resumeSourceLabel
     , selectedResumeBrowser
     , setResumeDeletePending
@@ -51,6 +53,7 @@ import Agent.CLI.Session
     , loadSessionMeta
     , loadSessionResumeStats
     )
+import Agent.CLI.Session.History (foldSessionItems)
 import Agent.CLI.Session.Types (TranscriptEffect(..))
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
 import Agent.OpenAI.Compaction (hasReloadedGeneratedContextItems)
@@ -68,7 +71,7 @@ import Control.Monad (forM)
 import Data.Char (isAlphaNum)
 import Data.Containers.ListUtils (nubOrd)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -83,6 +86,46 @@ data ResumeSourceFilter
     = ResumeAll
     | ResumeProvider !Text
     deriving (Eq, Show)
+
+-- | Transcript-derived context requirements that can be resolved before
+-- provider prompt construction. Keeping this decision pure allows startup
+-- context reads to overlap independent tool acquisition without changing
+-- resume semantics.
+data SessionInitialContext = SessionInitialContext
+    { initialContextItems :: [ResponseItem]
+    , initialContextResumeNeedsFresh :: Bool
+    , initialContextPrevious :: Maybe Text
+    , initialContextNeeded :: Bool
+    , initialContextMayRestoreSnapshot :: Bool
+    }
+    deriving (Eq, Show)
+
+resolveSessionInitialContext
+    :: Bool
+    -> Bool
+    -> Maybe (SessionMeta, [SessionTurn])
+    -> SessionInitialContext
+resolveSessionInitialContext hasTransition resumeTargetChanged resumed =
+    SessionInitialContext{..}
+  where
+    initialTurns = maybe [] snd resumed
+    initialContextItems = maybe [] (foldSessionItems . snd) resumed
+    initialContextResumeNeedsFresh =
+        resumeNeedsGeneratedContext initialTurns
+    initialContextPrevious
+        | hasTransition || resumeTargetChanged = Nothing
+        | otherwise =
+            resumed >>= \(meta, _) -> meta.metaLastResponseId
+    initialContextNeeded =
+        initialContextResumeNeedsFresh
+            || (null initialTurns && initialContextPrevious == Nothing)
+    initialContextMayRestoreSnapshot =
+        case resumed of
+            Just (meta, turns) ->
+                null turns
+                    && initialContextPrevious == Nothing
+                    && isJust meta.metaPromptSnapshot
+            Nothing -> False
 
 data ResumeEntry = ResumeEntry
     { resumeId :: !Text

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -145,6 +145,7 @@ import Agent.CLI.Session.Runtime.Types
     ( StartupCancelled(..),
       StartupFailure(..),
       StartupRuntime(startupSessionState, StartupRuntime, startupToolEnv,
+                     startupHarnessConfig,
                      startupNetworkRecovery, startupDatabaseStore,
                      startupInterrupt, startupEscPaused,
                      startupUiRuntimeRef, startupFullscreen, startupTerminal,
@@ -191,7 +192,7 @@ import Agent.CLI.Turn ()
 import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch ()
 import Agent.CLI.Worktree
-    ( createManagedWorktreeWithProgress, worktreeProgressMessage )
+    ( createManagedWorktreeFromConfigWithProgress, worktreeProgressMessage )
 import Agent.Cancel ( requestCancel )
 import Agent.Claude ()
 import Agent.Dialect ()
@@ -749,6 +750,7 @@ data AgentIterationResources = AgentIterationResources
     , iterationStartupTimings :: IORef [(Text, NominalDiffTime)]
     , iterationSyntaxLoadDuration :: IORef (Maybe NominalDiffTime)
     , iterationStartupFinished :: IORef Bool
+    , iterationHarnessConfig :: HarnessConfig
     , iterationConfiguredTheme :: ThemeKind
     , iterationHome :: OsPath
     , iterationRoot :: OsPath
@@ -829,11 +831,12 @@ prepareAgentIterationResources request = do
     home <- case nativeRunHomeHint request.iterationRunMode of
         Nothing -> getHomeDirectory
         Just path -> pure path
-    configuredTheme <-
+    harnessConfig <-
         loadHarnessConfig home >>= \case
             Left err ->
                 failAgentIterationPreparation request err
-            Right config -> pure config.configTheme
+            Right config -> pure config
+    let configuredTheme = harnessConfig.configTheme
     let root = sessionsRoot home
     databaseStore <-
         case
@@ -878,6 +881,7 @@ prepareAgentIterationResources request = do
         , iterationStartupTimings = startupTimingsRef
         , iterationSyntaxLoadDuration = syntaxLoadDurationRef
         , iterationStartupFinished = startupFinishedRef
+        , iterationHarnessConfig = harnessConfig
         , iterationConfiguredTheme = configuredTheme
         , iterationHome = home
         , iterationRoot = root
@@ -1104,6 +1108,7 @@ prepareAgentIterationInterface request resources = do
                     (\target -> readIORef agentSelectRef >>= ($ target))
         buildStartupRuntime toolEnv = StartupRuntime
             { startupToolEnv = toolEnv
+            , startupHarnessConfig = resources.iterationHarnessConfig
             , startupNetworkRecovery =
                 request.iterationProcessRuntime.processNetworkRecovery
             , startupDatabaseStore = resources.iterationDatabaseStore
@@ -1222,8 +1227,9 @@ resolveAgentIterationCwd request resources interface resumeLock =
         Nothing
             | request.iterationOptions.optWorktree -> do
                 readMVar interface.iterationFirstFrameReady
-                createManagedWorktreeWithProgress
+                createManagedWorktreeFromConfigWithProgress
                     reportWorktreeProgress
+                    resources.iterationHarnessConfig
                     resources.iterationHome
                     resources.iterationSource
                     >>= either worktreeFailed worktreeCreated

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -1,4 +1,6 @@
-module Agent.CLI.Runtime.Orchestration.Session (runAgentSession) where
+module Agent.CLI.Runtime.Orchestration.Session
+    ( runAgentSession
+    ) where
 
 import Agent.CLI.AccountPicker ()
 import Agent.CLI.AccountSelection ()
@@ -87,7 +89,9 @@ import Agent.CLI.Request
     , setRequestInstructionsAndTools
     , setRequestPromptCacheKey
     )
-import Agent.CLI.Resume ( resumeNeedsGeneratedContext )
+import Agent.CLI.Resume
+    ( SessionInitialContext(..)
+    )
 import Agent.CLI.Runtime.HistorySource ()
 import Agent.CLI.Runtime.Orchestration.Background ()
 import Agent.CLI.Runtime.Orchestration.Providers
@@ -118,7 +122,7 @@ import Agent.CLI.Session
       PersistenceState(PersistenceActive, PersistencePending),
       LegacySubagentTarget,
       SessionHandle(sessionDir),
-      SessionMeta(metaId, metaLastResponseId, metaPromptSnapshot, metaTitle),
+      SessionMeta(metaId, metaPromptSnapshot, metaTitle),
       SessionTurn,
       SessionPromptSnapshot(..) )
 import Agent.CLI.Session.Attachments ()
@@ -128,12 +132,12 @@ import Agent.CLI.Session.History
     , currentLiveTranscriptGeneration,
       durableTranscriptCheckpoint,
       evictLiveTranscript,
-      foldSessionItems,
       readLiveTranscript,
       replaceLiveConversation )
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
-    ( SessionRequest(codexCatalogSession, SessionRequest, catalog,
+    ( InitialContextPreload(..)
+    , SessionRequest(codexCatalogSession, SessionRequest, catalog,
                      gatewayModelsRef, modelInfo,
                      connectionId, gatewayIdentity,
                      options, provider, dialect, commitAttributionModel,
@@ -148,7 +152,7 @@ import Agent.CLI.Session.Runtime.Types
                      learnAboutUserRequested, databaseScopes, promptRequest,
                      pendingTurn, unavailableProviders, startupUnavailable, paramsRef,
                      conversationRef, needsInitialContext, queueInitialContext,
-                     initialGrokContext, persist,
+                     initialContextPreload, initialGrokContext, persist,
                      contextOccupancyRef, currentContextWindow,
                      startupWindowTitle, automaticCompactionRef,
                      projectRoot, home, cwd, tokenProvider, openAiPool, startupContext,
@@ -169,7 +173,7 @@ import Agent.CLI.SessionTitle ()
 import Agent.CLI.Skills ()
 import Agent.CLI.Startup.Auth ( markStartupStage, startupDie )
 import Agent.CLI.StartupContext
-    ( AgentsContextNotice(..), loadAgentsContext )
+    ( AgentsContextNotice(..), loadAgentsContextWithPreload )
 import Agent.CLI.Style ( cliWindowTitle, roleMuted )
 import Agent.CLI.Subagents.Runtime
     ( SubagentRuntime(subagentOpenAiChild, SubagentRuntime,
@@ -288,7 +292,6 @@ import qualified Agent.Provider as Provider ()
 import qualified Agent.CLI.Session.Lifecycle as SessionLifecycle ()
 import qualified Agent.CLI.Session.Runner as SessionRunner ()
 import qualified Data.Set as Set ()
-import qualified Data.Text as Text ( unpack )
 import qualified Data.Text.IO as Text ( hPutStr )
 import qualified Agent.XAI.Options as XAI ()
 import qualified Agent.XAI.Client as XAIClient ()
@@ -322,6 +325,8 @@ data AgentSessionRequest closeResult windowTitleResult = AgentSessionRequest
     , cwd :: OsPath
     , databaseAppTools :: [AppTool]
     , databaseScopes :: DatabaseScopes
+    , initialContext :: SessionInitialContext
+    , initialContextPreload :: InitialContextPreload
     , dialect :: Dialect
     , effortText :: Text
     , escPaused :: IORef Bool
@@ -452,6 +457,8 @@ runAgentSession
     -> OsPath
     -> [AppTool]
     -> DatabaseScopes
+    -> SessionInitialContext
+    -> InitialContextPreload
     -> Dialect
     -> Text
     -> IORef Bool
@@ -538,6 +545,8 @@ runAgentSession
     cwd
     databaseAppTools
     databaseScopes
+    initialContext
+    initialContextPreload
     dialect
     effortText
     escPaused
@@ -784,8 +793,7 @@ prepareSessionPromptRuntime AgentSessionRequest
     , dialect
     , cwd
     , resumed
-    , transition
-    , resumeTargetChanged
+    , initialContext
     , policy
     , allTools
     } sessionCodeRuntime = do
@@ -811,19 +819,13 @@ prepareSessionPromptRuntime AgentSessionRequest
                     (`setRequestPromptCacheKey`
                         sessionCodeRuntime.sessionBaseParams)
                     sessionCodeRuntime.sessionReservedId
-        sessionInitialItems = maybe [] (foldSessionItems . snd) resumed
+        sessionInitialItems = initialContext.initialContextItems
         initialTurns = maybe [] snd resumed
         sessionResumeNeedsFreshContext =
-            resumeNeedsGeneratedContext initialTurns
-        sessionInitialPrevious = case transition of
-            Just _ -> Nothing
-            Nothing
-                | resumeTargetChanged -> Nothing
-                | otherwise ->
-                    resumed >>= \(meta, _) -> meta.metaLastResponseId
+            initialContext.initialContextResumeNeedsFresh
+        sessionInitialPrevious = initialContext.initialContextPrevious
         sessionNeedsInitialContext =
-            sessionResumeNeedsFreshContext
-                || (null initialTurns && isNothing sessionInitialPrevious)
+            initialContext.initialContextNeeded
         sessionRestoredPromptSnapshot
             | null initialTurns && isNothing sessionInitialPrevious =
                 compatiblePromptSnapshot
@@ -1030,6 +1032,7 @@ loadSessionStartupContext AgentSessionRequest
     , dialect
     , home
     , cwd
+    , initialContextPreload
     , refreshDialectContext
     } promptRuntime =
     case promptRuntime.sessionRestoredPromptSnapshot of
@@ -1041,7 +1044,7 @@ loadSessionStartupContext AgentSessionRequest
                 newIORef
                     promptRuntime.sessionCodeRuntime.sessionEnvironmentContext
             | otherwise ->
-                loadAgentsContext
+                loadAgentsContextWithPreload
                     stderrHandle
                     fullscreen
                     agentsContextNotice
@@ -1052,6 +1055,7 @@ loadSessionStartupContext AgentSessionRequest
                     initialItems
                     initialPrevious
                     promptRuntime.sessionCodeRuntime.sessionEnvironmentContext
+                    initialContextPreload.preloadedAgentsContext
   where
     agentsContextNotice
         | isNothing resumed && isNothing transition =
@@ -1213,6 +1217,7 @@ buildProviderSessionRequest
                 promptRuntime.sessionNeedsInitialContext
             , queueInitialContext =
                 promptRuntime.sessionQueueInitialContext
+            , initialContextPreload = request.initialContextPreload
             , initialGrokContext =
                 promptRuntime.sessionRestoredPromptSnapshot
                     >>= (.promptSnapshotGrokContext)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -58,6 +58,7 @@ import Agent.CLI.LearnedSkills ( learnedSkillTools )
 import Agent.CLI.LearnedSkills.Store
     ( learnedSkillToolsEnvForStore
     , loadApplicableLearnedSkillsForStore
+    , successfulLearnedSkillsPreload
     )
 import Agent.CLI.Login ()
 import Agent.CLI.Lsp
@@ -1737,11 +1738,10 @@ prepareInitialContextPreload AgentToolsRequest
         | otherwise = pure Nothing
     preloadLearnedSkills
         | contextRequirements.initialContextNeeded =
-            loadApplicableLearnedSkillsForStore
-                startup.startupDatabaseStore
-                databaseScopes >>= \case
-                    Left _ -> pure Nothing
-                    Right learnedSkills -> pure (Just learnedSkills)
+            successfulLearnedSkillsPreload
+                <$> loadApplicableLearnedSkillsForStore
+                    startup.startupDatabaseStore
+                    databaseScopes
         | otherwise = pure Nothing
 
 installCollaborationCallbacks

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -783,7 +783,9 @@ loadToolStartup request@AgentToolsRequest
                 (.nativeCapabilities)
                 startup.startupNativeHooks
     toolOpenRouterOptions <- OpenRouter.clientOptionsFromEnv
-    markStartupStage startup "Loading tools…"
+    -- Tool resources and initial-context discovery now share one startup
+    -- frontier, so attribute the elapsed interval to both.
+    markStartupStage startup "Loading tools and context…"
     when (isGatewayLoadedAuth loaded /= isJust gatewayIdentity) $
         startupDie startup
             "gateway session binding and loaded credentials disagree"

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -56,7 +56,9 @@ import Agent.CLI.Input ()
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.LearnedSkills ( learnedSkillTools )
 import Agent.CLI.LearnedSkills.Store
-    ( learnedSkillToolsEnvForStore )
+    ( learnedSkillToolsEnvForStore
+    , loadApplicableLearnedSkillsForStore
+    )
 import Agent.CLI.Login ()
 import Agent.CLI.Lsp
     ( LspStartup(..), closeLspRuntime, lspRuntimeTool, newLspRuntime )
@@ -132,10 +134,18 @@ import Agent.CLI.Runtime.Orchestration.Types
     , NativeRunCapabilities(..)
     , NativeRunHooks(..)
     , fullNativeRunCapabilities
+    , nativeLoadsHostWorkspaceContext
     , nativePreparedDiscovery
     )
 import Agent.CLI.Runtime.Orchestration.Restart ()
-import Agent.CLI.Runtime.Orchestration.Session ( runAgentSession )
+import Agent.CLI.Resume
+    ( SessionInitialContext
+        ( initialContextMayRestoreSnapshot
+        , initialContextNeeded
+        )
+    , resolveSessionInitialContext
+    )
+import Agent.CLI.Runtime.Orchestration.Session (runAgentSession)
 import Agent.CLI.Runtime.Orchestration.Startup
     ( reportStartupWarning )
 import Agent.CLI.Runtime.Persistence ( preparePersistence )
@@ -168,7 +178,8 @@ import Agent.CLI.Session.Choices ()
 import Agent.CLI.Session.History (foldSessionItems)
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
-    ( StartupRuntime(startupFullscreen, startupBackground,
+    ( InitialContextPreload(..)
+    , StartupRuntime(startupFullscreen, startupBackground,
                      startupFinished, startupDatabaseStore,
                      startupHarnessConfig,
                      startupSessionState, startupNativeHooks,
@@ -187,7 +198,7 @@ import Agent.CLI.SessionState ( SessionState(sessionPreviewId) )
 import Agent.CLI.SessionTitle ()
 import Agent.CLI.Startup.Auth
     ( markStartupStage, setStartupNotice, startupDie )
-import Agent.CLI.StartupContext ()
+import Agent.CLI.StartupContext ( preloadAgentsContext )
 import Agent.CLI.Style ()
 import Agent.CLI.Subagents.Runtime
     ( flushAllSubagentSnapshots,
@@ -211,7 +222,11 @@ import Agent.CLI.Tools ()
 import Agent.CLI.Turn ()
 import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch
-    ( closeWebFetchRuntime, newWebFetchRuntime, webFetchRuntimeTool )
+    ( WebFetchRuntime
+    , closeWebFetchRuntime
+    , newWebFetchRuntime
+    , webFetchRuntimeTool
+    )
 import Agent.CLI.Worktree
     ( acquireWorktreeLease,
       cleanupStaleWorktrees,
@@ -263,9 +278,8 @@ import Agent.Responses.GenericBackend ()
 import Agent.Responses.GenericClient ( GenericClientOptions(..) )
 import Agent.Responses.Types ( ResponseItem )
 import Agent.ResourceScope
-    ( ResourceScope
-    , allocateResource
-    , allocateResourcesConcurrently
+    ( allocateResource
+    , allocateFourResourcesConcurrently
     , releaseResource
     , withResourceScope
     )
@@ -664,24 +678,42 @@ runAgentToolsRequest request = withResourceScope \resourceScope -> do
     let scratchRuntime =
             acquiredScratchRuntime
                 { scratchCleanup = releaseResource scratchKey }
-    ((mcpKey, acquiredMcpRuntime), (localToolKey, acquiredLocalToolRuntime)) <-
-        allocateResourcesConcurrently
-            resourceScope
-            (acquireMcpRuntime
-                request
-                toolStartup
-                toolModelRuntime
-                collaborationRuntime
-                scratchRuntime)
-            (.runtimeCloseMcp)
-            (acquireLocalToolRuntime
-                request
-                toolModelRuntime
-                toolHostHooks
-                collaborationRuntime
-                scratchRuntime)
-            (.localCoding.codingClose)
-    let mcpRuntime =
+    (acquiredResources, (initialContext, initialContextPreload)) <-
+        concurrently
+            ( allocateFourResourcesConcurrently
+                resourceScope
+                (acquireMcpRuntime
+                    request
+                    toolStartup
+                    toolModelRuntime
+                    collaborationRuntime
+                    scratchRuntime)
+                (.runtimeCloseMcp)
+                (acquireLocalToolRuntime
+                    request
+                    toolModelRuntime
+                    toolHostHooks
+                    collaborationRuntime
+                    scratchRuntime)
+                (.localCoding.codingClose)
+                (acquireWebFetchRuntime
+                    request
+                    toolStartup
+                    toolModelRuntime)
+                (mapM_ closeWebFetchRuntime)
+                (acquireLspStartup
+                    request
+                    toolStartup
+                    toolModelRuntime)
+                (mapM_ closeLspRuntime . (.lspStartupRuntime))
+            )
+            (prepareInitialContextPreload request toolModelRuntime)
+    let ( (mcpKey, acquiredMcpRuntime)
+          , (localToolKey, acquiredLocalToolRuntime)
+          , (webFetchKey, webFetchRuntime)
+          , (lspKey, lspStartup)
+          ) = acquiredResources
+        mcpRuntime =
             acquiredMcpRuntime
                 { runtimeCloseMcp = releaseResource mcpKey }
         localToolRuntime =
@@ -690,13 +722,19 @@ runAgentToolsRequest request = withResourceScope \resourceScope -> do
                     acquiredLocalToolRuntime.localCoding
                         { codingClose = releaseResource localToolKey }
                 }
-    codingRuntime <-
-        acquireCodingRuntime
-            resourceScope
-            request
-            toolStartup
-            toolModelRuntime
-            localToolRuntime
+        lspRuntime = lspStartup.lspStartupRuntime
+        runtimeCoding = localToolRuntime.localCoding
+        runtimeExtraTools =
+            maybe [] (pure . webFetchRuntimeTool) webFetchRuntime
+                <> maybe [] (pure . lspRuntimeTool) lspRuntime
+        runtimeCloseExtraTools =
+            concurrently_
+                (releaseResource lspKey)
+                (releaseResource webFetchKey)
+        codingRuntime = CodingRuntime{..}
+    mapM_
+        (reportStartupWarning request.startup)
+        lspStartup.lspStartupWarnings
     installCollaborationCallbacks request collaborationRuntime
     sessionControlRuntime <-
         newSessionControlRuntime
@@ -725,6 +763,8 @@ runAgentToolsRequest request = withResourceScope \resourceScope -> do
         scratchRuntime
         mcpRuntime
         codingRuntime
+        initialContext
+        initialContextPreload
         sessionControlRuntime
         sessionToolsRuntime
 
@@ -1602,14 +1642,12 @@ acquireLocalToolRuntime AgentToolsRequest
             let localInitialSkills = initialSkills
             pure LocalToolRuntime{..}
 
-acquireCodingRuntime
-    :: ResourceScope
-    -> AgentToolsRequest windowTitleResult
+acquireWebFetchRuntime
+    :: AgentToolsRequest windowTitleResult
     -> ToolStartup
     -> ToolModelRuntime
-    -> LocalToolRuntime
-    -> IO CodingRuntime
-acquireCodingRuntime resourceScope AgentToolsRequest
+    -> IO (Maybe WebFetchRuntime)
+acquireWebFetchRuntime AgentToolsRequest
     { startup
     , baseToolEnv
     } ToolStartup
@@ -1617,48 +1655,90 @@ acquireCodingRuntime resourceScope AgentToolsRequest
     , toolHarnessConfig = harnessConfig
     } ToolModelRuntime
     { toolDialectId = dialectId
-    } LocalToolRuntime
-    { localCoding = runtimeCoding
+    }
+    | not nativeCapabilities.nativeHostExtensions
+        || dialectId /= GrokBuildDialect =
+        pure Nothing
+    | otherwise =
+        newWebFetchRuntime
+            harnessConfig.configWebFetch
+            baseToolEnv >>= \case
+                Left err ->
+                    startupDie startup
+                        ("Failed to initialize web_fetch: " <> err)
+                Right runtime -> pure runtime
+
+acquireLspStartup
+    :: AgentToolsRequest windowTitleResult
+    -> ToolStartup
+    -> ToolModelRuntime
+    -> IO LspStartup
+acquireLspStartup AgentToolsRequest
+    { baseToolEnv
+    } ToolStartup
+    { toolNativeCapabilities = nativeCapabilities
+    , toolHarnessConfig = harnessConfig
+    } ToolModelRuntime
+    { toolDialectId = dialectId
+    }
+    | not nativeCapabilities.nativeHostExtensions
+        || dialectId /= GrokBuildDialect =
+        pure LspStartup
+            { lspStartupRuntime = Nothing
+            , lspStartupWarnings = []
+            }
+    | otherwise =
+        newLspRuntime harnessConfig.configLsp baseToolEnv
+
+prepareInitialContextPreload
+    :: AgentToolsRequest windowTitleResult
+    -> ToolModelRuntime
+    -> IO (SessionInitialContext, InitialContextPreload)
+prepareInitialContextPreload AgentToolsRequest
+    { options
+    , startup
+    , databaseScopes
+    , home
+    , cwd
+    , resumed
+    , transition
+    } ToolModelRuntime
+    { toolDialect = dialect
+    , toolResumeTargetChanged = resumeTargetChanged
+    , toolRefreshDialectContext = refreshDialectContext
     } = do
-    let acquireWebFetch
-            | not nativeCapabilities.nativeHostExtensions
-                || dialectId /= GrokBuildDialect =
-                pure Nothing
-            | otherwise =
-                newWebFetchRuntime
-                    harnessConfig.configWebFetch
-                    baseToolEnv >>= \case
-                        Left err ->
-                            startupDie startup
-                                ("Failed to initialize web_fetch: "
-                                    <> err)
-                        Right runtime -> pure runtime
-        acquireLsp
-            | not nativeCapabilities.nativeHostExtensions
-                || dialectId /= GrokBuildDialect =
-                pure LspStartup
-                    { lspStartupRuntime = Nothing
-                    , lspStartupWarnings = []
-                    }
-            | otherwise =
-                newLspRuntime harnessConfig.configLsp baseToolEnv
-    ((webFetchKey, webFetchRuntime), (lspKey, lspStartup)) <-
-        allocateResourcesConcurrently
-            resourceScope
-            acquireWebFetch
-            (mapM_ closeWebFetchRuntime)
-            acquireLsp
-            (mapM_ closeLspRuntime . (.lspStartupRuntime))
-    mapM_ (reportStartupWarning startup) lspStartup.lspStartupWarnings
-    let lspRuntime = lspStartup.lspStartupRuntime
-        runtimeExtraTools =
-            maybe [] (pure . webFetchRuntimeTool) webFetchRuntime
-                <> maybe [] (pure . lspRuntimeTool) lspRuntime
-        runtimeCloseExtraTools =
-            concurrently_
-                (releaseResource lspKey)
-                (releaseResource webFetchKey)
-    pure CodingRuntime{..}
+    (preloadedAgentsContext, preloadedLearnedSkills) <-
+        concurrently preloadAgents preloadLearnedSkills
+    pure (contextRequirements, InitialContextPreload{..})
+  where
+    contextRequirements =
+        resolveSessionInitialContext
+            (isJust transition)
+            resumeTargetChanged
+            resumed
+    loadsHostWorkspaceContext =
+        maybe
+            True
+            ( nativeLoadsHostWorkspaceContext
+                . (.nativeWorkspaceDiscovery)
+            )
+            startup.startupNativeHooks
+    preloadAgents
+        | loadsHostWorkspaceContext
+            && ( contextRequirements.initialContextNeeded
+                || refreshDialectContext
+               ) =
+            if refreshDialectContext
+                || not contextRequirements.initialContextMayRestoreSnapshot
+                then preloadAgentsContext options dialect home cwd
+                else pure Nothing
+        | otherwise = pure Nothing
+    preloadLearnedSkills
+        | contextRequirements.initialContextNeeded =
+            Just <$> loadApplicableLearnedSkillsForStore
+                startup.startupDatabaseStore
+                databaseScopes
+        | otherwise = pure Nothing
 
 installCollaborationCallbacks
     :: AgentToolsRequest windowTitleResult
@@ -1971,6 +2051,8 @@ launchAgentToolsSession
     -> ScratchRuntime
     -> McpRuntime
     -> CodingRuntime
+    -> SessionInitialContext
+    -> InitialContextPreload
     -> SessionControlRuntime
     -> SessionToolsRuntime
     -> IO RunResult
@@ -2016,7 +2098,7 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
     } CodingRuntime
     { runtimeCoding = coding
     , runtimeExtraTools = extraTools
-    } SessionControlRuntime
+    } initialContext initialContextPreload SessionControlRuntime
     { controlGhciEnabledRef = ghciEnabledRef
     , controlBashEnabledRef = bashEnabledRef
     , controlSkillsRef = skillsRef
@@ -2066,6 +2148,8 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
         cwd
         databaseAppTools
         databaseScopes
+        initialContext
+        initialContextPreload
         dialect
         effortText
         escPaused

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -1735,9 +1735,11 @@ prepareInitialContextPreload AgentToolsRequest
         | otherwise = pure Nothing
     preloadLearnedSkills
         | contextRequirements.initialContextNeeded =
-            Just <$> loadApplicableLearnedSkillsForStore
+            loadApplicableLearnedSkillsForStore
                 startup.startupDatabaseStore
-                databaseScopes
+                databaseScopes >>= \case
+                    Left _ -> pure Nothing
+                    Right learnedSkills -> pure (Just learnedSkills)
         | otherwise = pure Nothing
 
 installCollaborationCallbacks

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -29,7 +29,6 @@ import Agent.CLI.Compaction ()
 import Agent.CLI.Config
     ( HarnessConfig(..),
       McpServerConfig(..),
-      loadHarnessConfig,
       useProgressiveMcp )
 import Agent.Connectivity ()
 import Agent.CLI.Database ( databaseTools )
@@ -171,6 +170,7 @@ import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
     ( StartupRuntime(startupFullscreen, startupBackground,
                      startupFinished, startupDatabaseStore,
+                     startupHarnessConfig,
                      startupSessionState, startupNativeHooks,
                      startupStdinTty) )
 import Agent.CLI.Session.Selection
@@ -735,7 +735,6 @@ loadToolStartup request@AgentToolsRequest
     { loaded
     , connectedGateway
     , gatewayIdentity
-    , home
     , startup
     } = do
     let toolNativeCapabilities =
@@ -751,10 +750,7 @@ loadToolStartup request@AgentToolsRequest
     when ((gatewayCredentialIdentity <$> connectedGateway) /= gatewayIdentity) $
         startupDie startup
             "gateway credential snapshot and session binding disagree"
-    toolHarnessConfig <-
-        loadHarnessConfig home >>= \case
-            Left err -> startupDie startup err
-            Right config -> pure config
+    let toolHarnessConfig = startup.startupHarnessConfig
     (toolGatewaySelection, toolGatewayAllowedChildModels) <-
         selectGatewayModels request
     pure ToolStartup{..}

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -521,10 +521,12 @@ buildSkillContextRuntime
             ( omitted
             , max 0 (contextLength after - contextLength before)
             )
-    installLearnedSkills context maximum queueContext =
+    loadLearnedSkills =
         loadApplicableLearnedSkillsForStore
             startup.startupDatabaseStore
             databaseScopes
+    installLearnedSkills context maximum queueContext =
+        loadLearnedSkills
             >>= installLearnedSkillResult context maximum queueContext
     installLearnedSkillResult context maximum queueContext = \case
         Left err -> do
@@ -676,19 +678,16 @@ buildSkillContextRuntime
         reportSkillCatalog (isNothing fullscreen) skills omitted
         learnedSkills <-
             if needsInitialContext
-                then
-                    case initialContextPreload.preloadedLearnedSkills of
-                        Just preloaded ->
-                            installLearnedSkillResult
-                                startupContext
-                                defaultLearnedSkillContextMaxChars
-                                queueInitialContext
-                                (Right preloaded)
-                        Nothing ->
-                            installLearnedSkills
-                                startupContext
-                                defaultLearnedSkillContextMaxChars
-                                queueInitialContext
+                then do
+                    loaded <-
+                        loadLearnedSkillsWithPreload
+                            initialContextPreload.preloadedLearnedSkills
+                            loadLearnedSkills
+                    installLearnedSkillResult
+                        startupContext
+                        defaultLearnedSkillContextMaxChars
+                        queueInitialContext
+                        loaded
                 else pure []
         callbacks.runnerFinishStartup startup
         pure learnedSkills

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -683,7 +683,7 @@ buildSkillContextRuntime
                                 startupContext
                                 defaultLearnedSkillContextMaxChars
                                 queueInitialContext
-                                preloaded
+                                (Right preloaded)
                         Nothing ->
                             installLearnedSkills
                                 startupContext

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -524,25 +524,27 @@ buildSkillContextRuntime
     installLearnedSkills context maximum queueContext =
         loadApplicableLearnedSkillsForStore
             startup.startupDatabaseStore
-            databaseScopes >>= \case
-                Left err -> do
-                    reportLearnedSkillWarning
-                        ("learned skills unavailable: " <> err)
-                    pure []
-                Right learnedSkills -> do
-                    omitted <-
-                        if queueContext
-                            then queueLearnedSkillContextWithOmissions
-                                maximum
-                                context
-                                learnedSkills
-                            else pure 0
-                    when (omitted > 0) $
-                        reportLearnedSkillWarning
-                            ("learned skills: "
-                                <> Text.pack (show omitted)
-                                <> " omitted from model context due to the context budget")
-                    pure learnedSkills
+            databaseScopes
+            >>= installLearnedSkillResult context maximum queueContext
+    installLearnedSkillResult context maximum queueContext = \case
+        Left err -> do
+            reportLearnedSkillWarning
+                ("learned skills unavailable: " <> err)
+            pure []
+        Right learnedSkills -> do
+            omitted <-
+                if queueContext
+                    then queueLearnedSkillContextWithOmissions
+                        maximum
+                        context
+                        learnedSkills
+                    else pure 0
+            when (omitted > 0) $
+                reportLearnedSkillWarning
+                    ("learned skills: "
+                        <> Text.pack (show omitted)
+                        <> " omitted from model context due to the context budget")
+            pure learnedSkills
     reloadGeneratedContext = do
         freshAgents <-
             if loadsHostWorkspaceContext
@@ -674,10 +676,19 @@ buildSkillContextRuntime
         reportSkillCatalog (isNothing fullscreen) skills omitted
         learnedSkills <-
             if needsInitialContext
-                then installLearnedSkills
-                    startupContext
-                    defaultLearnedSkillContextMaxChars
-                    queueInitialContext
+                then
+                    case initialContextPreload.preloadedLearnedSkills of
+                        Just preloaded ->
+                            installLearnedSkillResult
+                                startupContext
+                                defaultLearnedSkillContextMaxChars
+                                queueInitialContext
+                                preloaded
+                        Nothing ->
+                            installLearnedSkills
+                                startupContext
+                                defaultLearnedSkillContextMaxChars
+                                queueInitialContext
                 else pure []
         callbacks.runnerFinishStartup startup
         pure learnedSkills

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -1,6 +1,7 @@
 -- | Typed inputs shared by provider startup and the session loop.
 module Agent.CLI.Session.Runtime.Types
-    ( SessionBackend(..)
+    ( InitialContextPreload(..)
+    , SessionBackend(..)
     , SessionRequest(..)
     , StartupCancelled(..)
     , StartupFailure(..)
@@ -69,11 +70,13 @@ import Agent.Provider
     , TokenProvider
     )
 import Agent.Responses.Types (ResponseCreateParams)
+import Agent.ProjectInstructions (LoadedAgentsMd)
 import Agent.Skills
     ( SkillCatalog
     , SkillInvocation
     )
 import Agent.Store.Postgres (Store)
+import Agent.Store.Postgres.Skill (LearnedSkill)
 import Agent.Subagents
     ( RootTurnId
     , SubagentId
@@ -105,6 +108,15 @@ data SessionBackend = SessionBackend
     , interruptBackend :: !(IO ())
     , resetBackendState :: !(IO ())
     }
+
+-- | Side-effect-free startup reads that can be prepared while independent
+-- tool resources initialize. Their warnings and model-facing formatting are
+-- intentionally deferred until the normal session installation boundary.
+data InitialContextPreload = InitialContextPreload
+    { preloadedAgentsContext :: !(Maybe LoadedAgentsMd)
+    , preloadedLearnedSkills :: !(Maybe (Either Text [LearnedSkill]))
+    }
+    deriving (Eq, Show)
 
 data SessionRequest = SessionRequest
     { catalog :: !ModelCatalog
@@ -153,6 +165,7 @@ data SessionRequest = SessionRequest
         :: !(IORef (Maybe AutomaticCompactionBoundary))
     , needsInitialContext :: !Bool
     , queueInitialContext :: !Bool
+    , initialContextPreload :: !InitialContextPreload
     , initialGrokContext :: !(Maybe Text)
     , persist :: !Persistence
     , startupWindowTitle :: !Text

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -12,6 +12,7 @@ import Agent.CLI.AgentViewport
     , AgentTarget
     )
 import Agent.CLI.Claude (ClaudeSessionRuntimeSlot)
+import Agent.CLI.Config (HarnessConfig)
 import Agent.CLI.Session.History (LiveConversation)
 import Agent.CLI.Btw (BtwBackendFactory)
 import Agent.CLI.CodeModeRuntime
@@ -192,6 +193,7 @@ data SessionRequest = SessionRequest
 
 data StartupRuntime = StartupRuntime
     { startupToolEnv :: !ToolEnv
+    , startupHarnessConfig :: !HarnessConfig
     , startupNetworkRecovery :: !(Maybe NetworkRecovery)
     , startupDatabaseStore :: !Store
     , startupInterrupt :: !InterruptState

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -114,7 +114,7 @@ data SessionBackend = SessionBackend
 -- intentionally deferred until the normal session installation boundary.
 data InitialContextPreload = InitialContextPreload
     { preloadedAgentsContext :: !(Maybe LoadedAgentsMd)
-    , preloadedLearnedSkills :: !(Maybe (Either Text [LearnedSkill]))
+    , preloadedLearnedSkills :: !(Maybe [LearnedSkill])
     }
     deriving (Eq, Show)
 

--- a/packages/agent-cli/src/Agent/CLI/StartupContext.hs
+++ b/packages/agent-cli/src/Agent/CLI/StartupContext.hs
@@ -1,7 +1,9 @@
 -- | Discover repository instructions for fresh or regenerated context.
 module Agent.CLI.StartupContext
     ( AgentsContextNotice(..)
+    , preloadAgentsContext
     , loadAgentsContext
+    , loadAgentsContextWithPreload
     ) where
 
 import Agent.CLI.Dialects
@@ -26,6 +28,7 @@ import Agent.OsPath (toText)
 import Agent.ProjectInstructions
     ( DiscoverOptions(..)
     , InstructionWarning(..)
+    , LoadedAgentsMd
     , defaultDiscoverOptions
     , discoverProjectInstructions
     , loadedInstructionFiles
@@ -70,16 +73,64 @@ loadAgentsContext
     -> IO (IORef (Maybe Text))
 loadAgentsContext
         stderrHandle fullscreen notice options dialect home cwd
-        initialItems initialPrevious extraContext
+        initialItems initialPrevious extraContext =
+    loadAgentsContextWithPreload
+        stderrHandle
+        fullscreen
+        notice
+        options
+        dialect
+        home
+        cwd
+        initialItems
+        initialPrevious
+        extraContext
+        Nothing
+
+-- | Read project instructions without reporting or formatting them. Startup
+-- can overlap this filesystem work with independent tool acquisition while
+-- leaving all user-visible effects at the original context-install boundary.
+preloadAgentsContext
+    :: CliOptions
+    -> Dialect
+    -> OsPath
+    -> OsPath
+    -> IO (Maybe LoadedAgentsMd)
+preloadAgentsContext options dialect home cwd
+    | not options.optAgentsMd = pure Nothing
+    | otherwise =
+        Just <$> discoverProjectInstructions
+            (agentsDiscoverOptions dialect home)
+            cwd
+
+-- | Finalize generated context from an optional startup preload. A preload
+-- that becomes unnecessary because persisted history is reusable is discarded
+-- before warnings or success notices are emitted.
+loadAgentsContextWithPreload
+    :: Handle
+    -> Maybe FullscreenRuntime
+    -> AgentsContextNotice
+    -> CliOptions
+    -> Dialect
+    -> OsPath
+    -> OsPath
+    -> [ResponseItem]
+    -> Maybe Text
+    -> Maybe Text
+    -> Maybe LoadedAgentsMd
+    -> IO (IORef (Maybe Text))
+loadAgentsContextWithPreload
+        stderrHandle fullscreen notice options dialect home cwd
+        initialItems initialPrevious extraContext preloaded
     | not (null initialItems) || isJust initialPrevious = newIORef Nothing
     | not options.optAgentsMd = newIORef extraContext
     | otherwise = do
-        let discoverOptions = DiscoverOptions
-                { discoverMaxBytes = defaultDiscoverOptions.discoverMaxBytes
-                , discoverGlobalDir = Just (globalAgentsHomeDir dialect home)
-                , discoverRootMarkers = defaultDiscoverOptions.discoverRootMarkers
-                }
-        loaded <- discoverProjectInstructions discoverOptions cwd
+        loaded <- case preloaded of
+            Just value -> pure value
+            Nothing ->
+                discoverProjectInstructions
+                    (agentsDiscoverOptions dialect home)
+                    cwd
         mapM_ (reportInstructionWarning stderrHandle fullscreen)
             (loadedInstructionWarnings loaded)
         let files = loadedInstructionFiles loaded
@@ -102,6 +153,14 @@ loadAgentsContext
                                 emitUiEvent runtime (UiSystemMessage message)
                 newIORef
                     (Just (text <> maybe "" ("\n\n" <>) extraContext))
+
+agentsDiscoverOptions :: Dialect -> OsPath -> DiscoverOptions
+agentsDiscoverOptions dialect home =
+    DiscoverOptions
+        { discoverMaxBytes = defaultDiscoverOptions.discoverMaxBytes
+        , discoverGlobalDir = Just (globalAgentsHomeDir dialect home)
+        , discoverRootMarkers = defaultDiscoverOptions.discoverRootMarkers
+        }
 
 reportInstructionWarning
     :: Handle

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Worktree
     , createWorktreeWithFetch
     , createManagedWorktree
     , createManagedWorktreeWithProgress
+    , createManagedWorktreeFromConfigWithProgress
     , removeWorktree
     , cleanupStaleWorktrees
     , defaultWorktreeKeepCount
@@ -170,9 +171,9 @@ createWorktreeWithFetchProgress report fetchLatest source root = runExceptT do
     withGitWorktreeLock repo $
         addUnique repo root repoName day start base 0
 
--- | Create a worktree using the machine-wide policy under the supplied home.
--- Configuration is read for every creation so startup, slash-command, and
--- subagent worktrees all follow the same current setting.
+-- | Create a worktree using the current machine-wide policy under the
+-- supplied home. Interactive and subagent creation use this fresh-read entry
+-- point; initial CLI startup uses its already validated snapshot below.
 createManagedWorktree :: OsPath -> OsPath -> IO (Either Text OsPath)
 createManagedWorktree =
     createManagedWorktreeWithProgress (const (pure ()))
@@ -186,11 +187,28 @@ createManagedWorktreeWithProgress report home source =
     loadHarnessConfig home >>= \case
         Left err -> pure (Left err)
         Right config ->
-            createWorktreeWithFetchProgress
+            createManagedWorktreeFromConfigWithProgress
                 report
-                config.configWorktree.worktreeFetchLatestUpstream
+                config
+                home
                 source
-                (worktreeRoot home)
+
+-- | Create an initial managed worktree from an already validated startup
+-- configuration snapshot. Later interactive worktree creation deliberately
+-- continues through 'createManagedWorktreeWithProgress' so it observes
+-- configuration changes made after startup.
+createManagedWorktreeFromConfigWithProgress
+    :: (WorktreeProgress -> IO ())
+    -> HarnessConfig
+    -> OsPath
+    -> OsPath
+    -> IO (Either Text OsPath)
+createManagedWorktreeFromConfigWithProgress report config home source =
+    createWorktreeWithFetchProgress
+        report
+        config.configWorktree.worktreeFetchLatestUpstream
+        source
+        (worktreeRoot home)
 
 -- | Remove a managed worktree and the branch created for it.
 removeWorktree :: OsPath -> OsPath -> IO (Either Text ())

--- a/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
@@ -8,6 +8,13 @@ import Agent.CLI.Dialects
     , formatAgentsMdForDialect
     , globalAgentsHomeDir
     )
+import Agent.CLI.Options (defaultCliOptions)
+import Agent.CLI.StartupContext
+    ( AgentsContextNotice(SuppressAgentsContextLoaded)
+    , loadAgentsContext
+    , loadAgentsContextWithPreload
+    , preloadAgentsContext
+    )
 import Agent.Dialect
     ( claudeCodeDialect
     , codexDialect
@@ -30,9 +37,17 @@ import Agent.Tools.Types
     )
 import Control.Exception.Safe (bracket, finally)
 import Control.Monad (forM_)
+import qualified Data.ByteString as BS
+import Data.IORef (IORef, readIORef)
 import qualified Data.Text as Text
-import System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
+import qualified Data.Text.IO as TextIO
+import System.Directory
+    ( createDirectoryIfMissing
+    , getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
 import System.FilePath ((</>))
+import System.IO (Handle, IOMode(WriteMode), hClose, openFile)
 import System.OsPath (unsafeEncodeUtf)
 import System.Posix.Temp (mkdtemp)
 import Test.Hspec
@@ -70,6 +85,102 @@ spec = describe "Agent.CLI.Dialects" do
             `shouldBe` unsafeEncodeUtf "/home/u/.haskell-agent"
         globalAgentsHomeDir claudeCodeDialect home
             `shouldBe` unsafeEncodeUtf "/home/u/.claude"
+
+    it "keeps synchronous and preloaded AGENTS context equivalent" do
+        withTempDirectory \directory -> do
+            let home = directory </> "home"
+                project = directory </> "project"
+                nested = project </> "nested"
+                homePath = unsafeEncodeUtf home
+                nestedPath = unsafeEncodeUtf nested
+                extraContext = Just "<environment_context>fixture</environment_context>"
+            createDirectoryIfMissing True home
+            createDirectoryIfMissing True (project </> ".git")
+            createDirectoryIfMissing True nested
+            writeFile (project </> "AGENTS.md") "root instructions\n"
+            -- Invalid UTF-8 exercises deferred warning reporting as well as
+            -- successful parent-directory instruction formatting.
+            BS.writeFile (nested </> "AGENTS.md") (BS.pack [0xff, 0xfe])
+
+            preloaded <-
+                preloadAgentsContext
+                    defaultCliOptions
+                    codexDialect
+                    homePath
+                    nestedPath
+            synchronous <-
+                captureAgentsContext
+                    (directory </> "synchronous.stderr")
+                    \stderrHandle ->
+                        loadAgentsContext
+                            stderrHandle
+                            Nothing
+                            SuppressAgentsContextLoaded
+                            defaultCliOptions
+                            codexDialect
+                            homePath
+                            nestedPath
+                            []
+                            Nothing
+                            extraContext
+            fromPreload <-
+                captureAgentsContext
+                    (directory </> "preloaded.stderr")
+                    \stderrHandle ->
+                        loadAgentsContextWithPreload
+                            stderrHandle
+                            Nothing
+                            SuppressAgentsContextLoaded
+                            defaultCliOptions
+                            codexDialect
+                            homePath
+                            nestedPath
+                            []
+                            Nothing
+                            extraContext
+                            preloaded
+
+            fromPreload `shouldBe` synchronous
+            fst fromPreload
+                `shouldSatisfy`
+                    maybe False (Text.isInfixOf "root instructions")
+            snd fromPreload
+                `shouldSatisfy`
+                    Text.isInfixOf "agents.md ignored:"
+
+    it "discards an unused AGENTS preload without reporting its warnings" do
+        withTempDirectory \directory -> do
+            let home = directory </> "home"
+                project = directory </> "project"
+                homePath = unsafeEncodeUtf home
+                projectPath = unsafeEncodeUtf project
+            createDirectoryIfMissing True home
+            createDirectoryIfMissing True (project </> ".git")
+            BS.writeFile (project </> "AGENTS.md") (BS.pack [0xff])
+            preloaded <-
+                preloadAgentsContext
+                    defaultCliOptions
+                    codexDialect
+                    homePath
+                    projectPath
+            (context, warnings) <-
+                captureAgentsContext
+                    (directory </> "discarded.stderr")
+                    \stderrHandle ->
+                        loadAgentsContextWithPreload
+                            stderrHandle
+                            Nothing
+                            SuppressAgentsContextLoaded
+                            defaultCliOptions
+                            codexDialect
+                            homePath
+                            projectPath
+                            []
+                            (Just "response-1")
+                            Nothing
+                            preloaded
+            context `shouldBe` Nothing
+            warnings `shouldBe` ""
 
     it "allocates only the AskUserQuestion MCP fallback for Claude Code" do
         env <- defaultToolEnv (unsafeEncodeUtf "/tmp")
@@ -183,12 +294,30 @@ spec = describe "Agent.CLI.Dialects" do
 
 withTempToolEnv :: (ToolEnv -> IO a) -> IO a
 withTempToolEnv action = do
+    withTempDirectory \directory ->
+        defaultToolEnv (unsafeEncodeUtf directory) >>= action
+
+withTempDirectory :: (FilePath -> IO a) -> IO a
+withTempDirectory action = do
     root <- getTemporaryDirectory
     bracket
         (mkdtemp (root </> "agent-cli-dialects-"))
         removeDirectoryRecursive
-        (\directory ->
-            defaultToolEnv (unsafeEncodeUtf directory) >>= action)
+        action
+
+captureAgentsContext
+    :: FilePath
+    -> (Handle -> IO (IORef (Maybe Text.Text)))
+    -> IO (Maybe Text.Text, Text.Text)
+captureAgentsContext outputPath action = do
+    contextRef <-
+        bracket
+            (openFile outputPath WriteMode)
+            hClose
+            action
+    context <- readIORef contextRef
+    output <- TextIO.readFile outputPath
+    pure (context, output)
 
 fakeTool :: Text.Text -> AppTool
 fakeTool name =

--- a/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
@@ -3,6 +3,10 @@ module Agent.CLI.LearnedSkillsSpec (spec) where
 import Agent.CLI (learnAboutUserOnboardingPrompt)
 import Agent.CLI.Database (DatabaseScope(..))
 import Agent.CLI.LearnedSkills
+import Agent.CLI.LearnedSkills.Store
+    ( loadLearnedSkillsWithPreload
+    , successfulLearnedSkillsPreload
+    )
 import Agent.Skills
     ( Skill(..)
     , SkillContextMode(..)
@@ -186,6 +190,33 @@ spec = do
                     \\"evidence\":\"Evidence\"}")
             readIORef called `shouldReturn` False
             noOp.output `shouldContainText` "must change at least one field"
+
+    describe "learned skill startup preload" do
+        it "retries a failed preload at the normal initialization boundary" do
+            attempts <- newIORef (0 :: Int)
+            let expected = skill "retry" SkillRelevant
+                load = do
+                    attempt <- readIORef attempts
+                    writeIORef attempts (attempt + 1)
+                    pure $
+                        if attempt == 0
+                            then Left "transient preload failure"
+                            else Right [expected]
+            preload <- successfulLearnedSkillsPreload <$> load
+            result <- loadLearnedSkillsWithPreload preload load
+            result `shouldBe` Right [expected]
+            readIORef attempts `shouldReturn` 2
+
+        it "reuses a successful empty preload without querying again" do
+            attempts <- newIORef (0 :: Int)
+            let load = do
+                    attempt <- readIORef attempts
+                    writeIORef attempts (attempt + 1)
+                    pure (Right [])
+            preload <- successfulLearnedSkillsPreload <$> load
+            result <- loadLearnedSkillsWithPreload preload load
+            result `shouldBe` Right []
+            readIORef attempts `shouldReturn` 1
 
     describe "formatLearnedSkillContext" do
         it "includes always instructions but only indexes relevant/manual skills" do

--- a/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ResumeSpec.hs
@@ -225,6 +225,72 @@ spec = do
             resumeNeedsGeneratedContext [ordinarySummaryHeading]
                 `shouldBe` False
 
+    describe "resolveSessionInitialContext" do
+        it "requests generated context for a fresh session" do
+            let initial = resolveSessionInitialContext False False Nothing
+            initial.initialContextItems `shouldBe` []
+            initial.initialContextResumeNeedsFresh `shouldBe` False
+            initial.initialContextPrevious `shouldBe` Nothing
+            initial.initialContextNeeded `shouldBe` True
+            initial.initialContextMayRestoreSnapshot `shouldBe` False
+
+        it "reuses a compatible response chain without regenerating context" do
+            let meta =
+                    (sampleMeta "abc" "first")
+                        { metaLastResponseId = Just "response-1"
+                        }
+                initial =
+                    resolveSessionInitialContext
+                        False
+                        False
+                        (Just (meta, [sampleTurn]))
+            initial.initialContextPrevious `shouldBe` Just "response-1"
+            initial.initialContextNeeded `shouldBe` False
+            initial.initialContextMayRestoreSnapshot `shouldBe` False
+
+        it "drops the response chain when the provider target changes" do
+            let meta =
+                    (sampleMeta "abc" "first")
+                        { metaLastResponseId = Just "response-1"
+                        }
+                initial =
+                    resolveSessionInitialContext
+                        False
+                        True
+                        (Just (meta, [sampleTurn]))
+            initial.initialContextPrevious `shouldBe` Nothing
+            initial.initialContextNeeded `shouldBe` False
+            initial.initialContextMayRestoreSnapshot `shouldBe` False
+
+        it "requests generated context after a transcript reset" do
+            let boundary =
+                    sampleTurn
+                        { turnEffect = TranscriptReset
+                        }
+                initial =
+                    resolveSessionInitialContext
+                        False
+                        False
+                        (Just (sampleMeta "abc" "first", [boundary]))
+            initial.initialContextResumeNeedsFresh `shouldBe` True
+            initial.initialContextNeeded `shouldBe` True
+            initial.initialContextMayRestoreSnapshot `shouldBe` False
+
+        it "marks a saved prompt snapshot as a possible fast resume" do
+            let meta =
+                    (sampleMeta "abc" "first")
+                        { metaLastResponseId = Nothing
+                        , metaPromptSnapshot =
+                            Just (error "snapshot value should remain lazy")
+                        }
+                initial =
+                    resolveSessionInitialContext
+                        False
+                        False
+                        (Just (meta, []))
+            initial.initialContextNeeded `shouldBe` True
+            initial.initialContextMayRestoreSnapshot `shouldBe` True
+
     describe "applyResumeKey" do
         let entries =
                 resumeEntriesFrom

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -392,8 +392,10 @@ spec = do
                 `shouldBe` Nothing
 
         it "does not block on a long-running URL opener" do
-            result <- timeout 1_000_000
-                (launchExternalUrlCommand ("sleep", ["2"]))
+            -- Keep CI scheduling headroom while remaining well below the
+            -- child lifetime, so waiting for the opener would still fail.
+            result <- timeout 5_000_000
+                (launchExternalUrlCommand ("sleep", ["10"]))
             result `shouldBe` Just True
 
         it "reports an opener that exits unsuccessfully" do

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -176,6 +176,40 @@ spec = describe "Agent.CLI.Worktree" do
                 doesFileExist (path </> fromFilePath "LOCAL")
                     `shouldReturn` True
 
+        it "keeps startup worktree policy on its snapshot while later creation reloads config" $
+            withTempRemoteRepo \repo updater ->
+            withTempDir "agent-home-" \home -> do
+                local <- git repo ["rev-parse", "HEAD"]
+                latest <- git updater ["rev-parse", "HEAD"]
+                local `shouldNotBe` latest
+                let initialConfig = defaultHarnessConfig
+                        { configWorktree = WorktreeConfig
+                            { worktreeFetchLatestUpstream = False
+                            }
+                        }
+
+                -- Model a config edit after startup captured its snapshot.
+                saveHarnessConfig home initialConfig `shouldReturn` Right ()
+                startupConfig <- loadHarnessConfig home >>= \case
+                    Left err -> do
+                        expectationFailure
+                            ("failed to load startup config: "
+                                <> Text.unpack err)
+                        pure defaultHarnessConfig
+                    Right config -> pure config
+                saveHarnessConfig home defaultHarnessConfig
+                    `shouldReturn` Right ()
+                startupPath <- expectRight
+                    =<< createManagedWorktreeFromConfigWithProgress
+                        (const (pure ()))
+                        startupConfig
+                        home
+                        repo
+                git startupPath ["rev-parse", "HEAD"] `shouldReturn` local
+
+                laterPath <- expectRight =<< createManagedWorktree home repo
+                git laterPath ["rev-parse", "HEAD"] `shouldReturn` latest
+
         it "uses isolated fetch refs for concurrent worktree creation" $
             withTempRemoteRepo \repo updater ->
             withTempDir "agent-home-" \home -> do

--- a/packages/agent-core/src/Agent/ResourceScope.hs
+++ b/packages/agent-core/src/Agent/ResourceScope.hs
@@ -10,6 +10,7 @@ module Agent.ResourceScope
     , closeResourceScope
     , allocateResource
     , allocateResourcesConcurrently
+    , allocateFourResourcesConcurrently
     , registerResource
     , releaseResource
     ) where
@@ -62,9 +63,8 @@ allocateResource
     -> (a -> IO ())
     -> IO (ResourceKey, a)
 allocateResource scope acquire cleanup =
-    withOpenScope scope \state -> do
-        (key, value) <- runInScope state (allocate acquire cleanup)
-        pure (ResourceKey key, value)
+    withOpenScope scope \state ->
+        allocateInScope state acquire cleanup
 
 -- | Acquire two independently-owned resources concurrently.
 --
@@ -82,10 +82,53 @@ allocateResourcesConcurrently
 allocateResourcesConcurrently scope acquireLeft releaseLeft acquireRight releaseRight =
     withOpenScope scope \state ->
         concurrently
-            (wrap <$> runInScope state (allocate acquireLeft releaseLeft))
-            (wrap <$> runInScope state (allocate acquireRight releaseRight))
-  where
-    wrap (key, value) = (ResourceKey key, value)
+            (allocateInScope state acquireLeft releaseLeft)
+            (allocateInScope state acquireRight releaseRight)
+
+-- | Acquire four independently-owned, potentially heterogeneous resources
+-- concurrently.
+--
+-- All four resources are registered in the same scope before this function
+-- returns.  If any acquisition fails, or the caller is interrupted, the
+-- lexical scope remains responsible for every acquisition which completed.
+allocateFourResourcesConcurrently
+    :: ResourceScope
+    -> IO a
+    -> (a -> IO ())
+    -> IO b
+    -> (b -> IO ())
+    -> IO c
+    -> (c -> IO ())
+    -> IO d
+    -> (d -> IO ())
+    -> IO
+        ( (ResourceKey, a)
+        , (ResourceKey, b)
+        , (ResourceKey, c)
+        , (ResourceKey, d)
+        )
+allocateFourResourcesConcurrently
+    scope
+    acquireFirst
+    releaseFirst
+    acquireSecond
+    releaseSecond
+    acquireThird
+    releaseThird
+    acquireFourth
+    releaseFourth =
+        withOpenScope scope \state -> do
+            ((first, second), (third, fourth)) <-
+                concurrently
+                    ( concurrently
+                        (allocateInScope state acquireFirst releaseFirst)
+                        (allocateInScope state acquireSecond releaseSecond)
+                    )
+                    ( concurrently
+                        (allocateInScope state acquireThird releaseThird)
+                        (allocateInScope state acquireFourth releaseFourth)
+                    )
+            pure (first, second, third, fourth)
 
 registerResource :: ResourceScope -> IO () -> IO ResourceKey
 registerResource scope cleanup =
@@ -97,6 +140,15 @@ releaseResource (ResourceKey key) = release key
 
 runInScope :: InternalState -> ResourceT IO a -> IO a
 runInScope = flip runInternalState
+
+allocateInScope
+    :: InternalState
+    -> IO a
+    -> (a -> IO ())
+    -> IO (ResourceKey, a)
+allocateInScope state acquireResource cleanupResource = do
+    (key, value) <- runInScope state (allocate acquireResource cleanupResource)
+    pure (ResourceKey key, value)
 
 withOpenScope :: ResourceScope -> (InternalState -> IO a) -> IO a
 withOpenScope (ResourceScope stateVar) action =

--- a/packages/agent-core/test/Agent/ResourceScopeSpec.hs
+++ b/packages/agent-core/test/Agent/ResourceScopeSpec.hs
@@ -1,15 +1,19 @@
 module Agent.ResourceScopeSpec (spec) where
 
 import Agent.ResourceScope
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
 import Control.Concurrent.MVar
     ( newEmptyMVar
     , putMVar
+    , readMVar
     , takeMVar
     )
 import Control.Exception.Safe (throwIO, tryAny)
+import Control.Monad (replicateM_, when)
 import Data.IORef
 import Data.List (sort)
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
@@ -94,6 +98,104 @@ spec = describe "Agent.ResourceScope" do
                     expectationFailure "blocked acquisition unexpectedly completed"
                 Right () -> pure ()
         readIORef releases `shouldReturn` 1
+
+    it "acquires four heterogeneous resources at the same time" do
+        started <- newIORef (0 :: Int)
+        allStarted <- newEmptyMVar
+        let acquire value = do
+                count <- atomicModifyIORef' started \n ->
+                    let next = n + 1
+                    in (next, next)
+                when (count == 4) (putMVar allStarted ())
+                readMVar allStarted
+                pure value
+        outcome <- timeout 1000000 $ withResourceScope \scope -> do
+            ((_, first), (_, second), (_, third), (_, fourth)) <-
+                allocateFourResourcesConcurrently
+                    scope
+                    (acquire (1 :: Int))
+                    (const (pure ()))
+                    (acquire ("two" :: String))
+                    (const (pure ()))
+                    (acquire True)
+                    (const (pure ()))
+                    (acquire '4')
+                    (const (pure ()))
+            pure (first, second, third, fourth)
+        outcome `shouldBe` Just (1, "two", True, '4')
+
+    it "keeps four-resource cleanup reverse ordered and idempotent" do
+        released <- newIORef ([] :: [Int])
+        firstAcquired <- newEmptyMVar
+        secondAcquired <- newEmptyMVar
+        thirdAcquired <- newEmptyMVar
+        withResourceScope \scope -> do
+            (_, _, _, (fourthKey, _)) <-
+                allocateFourResourcesConcurrently
+                    scope
+                    (putMVar firstAcquired () >> pure (1 :: Int))
+                    (const (record released 1))
+                    ( takeMVar firstAcquired
+                        >> threadDelay 20000
+                        >> putMVar secondAcquired ()
+                        >> pure ("two" :: String)
+                    )
+                    (const (record released 2))
+                    (takeMVar secondAcquired >> threadDelay 20000 >> putMVar thirdAcquired () >> pure True)
+                    (const (record released 3))
+                    (takeMVar thirdAcquired >> threadDelay 20000 >> pure '4')
+                    (const (record released 4))
+            releaseResource fourthKey
+            releaseResource fourthKey
+        readIORef released `shouldReturn` [4, 3, 2, 1]
+
+    it "cleans every completed four-way acquisition when one fails" do
+        releases <- newIORef ([] :: [Int])
+        completed <- newEmptyMVar
+        result <- tryAny $ withResourceScope \scope -> do
+            _ <-
+                allocateFourResourcesConcurrently
+                    scope
+                    (putMVar completed () >> pure (1 :: Int))
+                    (const (record releases 1))
+                    (putMVar completed () >> pure ("two" :: String))
+                    (const (record releases 2))
+                    (putMVar completed () >> pure True)
+                    (const (record releases 3))
+                    (replicateM_ 3 (takeMVar completed) >> threadDelay 20000 >> throwIO (userError "boom"))
+                    (const (record releases 4))
+            pure ()
+        result `shouldSatisfy` isLeft
+        (sort <$> readIORef releases) `shouldReturn` [1, 2, 3]
+
+    it "cancels four-way acquisition and cleans completed resources without hanging" do
+        releases <- newIORef ([] :: [Int])
+        firstCompleted <- newEmptyMVar
+        secondCompleted <- newEmptyMVar
+        thirdCompleted <- newEmptyMVar
+        blocked <- newEmptyMVar
+        let waitForCompleted =
+                mapM_ readMVar
+                    [firstCompleted, secondCompleted, thirdCompleted]
+        outcome <-
+            race
+                (withResourceScope \scope ->
+                    allocateFourResourcesConcurrently
+                        scope
+                        (putMVar firstCompleted () >> pure (1 :: Int))
+                        (const (record releases 1))
+                        (putMVar secondCompleted () >> pure ("two" :: String))
+                        (const (record releases 2))
+                        (putMVar thirdCompleted () >> pure True)
+                        (const (record releases 3))
+                        (waitForCompleted >> (takeMVar blocked :: IO ()))
+                        (const (record releases 4)))
+                (waitForCompleted >> threadDelay 20000)
+        case outcome of
+            Left _ ->
+                expectationFailure "blocked acquisition unexpectedly completed"
+            Right () -> pure ()
+        (sort <$> readIORef releases) `shouldReturn` [1, 2, 3]
 
 record :: IORef [Int] -> Int -> IO ()
 record ref value =

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -162,6 +162,19 @@ benchmark real-session-load-bench
                     , time
                     , vector
 
+benchmark managed-startup-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          ManagedStartup.hs
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-store
+                    , base >= 4.14 && < 5
+                    , hasql
+                    , safe-exceptions
+                    , temporary
+                    , text
+
 test-suite agent-store-test
     import:           common-opts
     type:             exitcode-stdio-1.0

--- a/packages/agent-store/benchmark/ManagedStartup.hs
+++ b/packages/agent-store/benchmark/ManagedStartup.hs
@@ -5,17 +5,22 @@ module Main (main) where
 import Agent.Store.Postgres
     ( ManagedPostgresConfig
     , defaultManagedPostgresConfig
-    , trustedPool
-    , withStore
+    , openStartupOwnerPool
     )
-import Agent.Store.Postgres.Connection (withSession)
+import Agent.Store.Postgres.Connection
+    ( StorePool
+    , closeStorePool
+    , defaultPoolConfig
+    , openStorePool
+    , withSession
+    )
 import Agent.Store.Postgres.Managed
     ( ensureManagedPostgres
     , stopManagedPostgres
     )
 import Agent.Store.Types (StoreError, renderStoreError)
 import Control.Exception (evaluate)
-import Control.Exception.Safe (finally)
+import Control.Exception.Safe (bracket, finally)
 import Control.Monad (forM, unless, void)
 import Data.List (sort)
 import qualified Data.Text as Text
@@ -58,18 +63,18 @@ main = do
     withSystemTempDirectory "ham" \stateDirectory -> do
         let config = defaultManagedPostgresConfig stateDirectory ""
         (do
-            -- Provision and migrate outside the measured warm-start region.
-            _ <- requireStore =<< openAndQuery config
-            _ <- measure (openAndQuery config)
+            -- Provision outside the measured warm-start region.
+            _ <- requireStore =<< warmOpenAndQuery config
+            _ <- measure (warmOpenAndQuery config)
             _ <- measure (legacyOpenAndQuery config)
             pairs <- forM [0 .. sampleCount - 1] \index ->
                 if even index
                     then do
                         legacy <- measure (legacyOpenAndQuery config)
-                        warm <- measure (openAndQuery config)
+                        warm <- measure (warmOpenAndQuery config)
                         pure (legacy, warm)
                     else do
-                        warm <- measure (openAndQuery config)
+                        warm <- measure (warmOpenAndQuery config)
                         legacy <- measure (legacyOpenAndQuery config)
                         pure (legacy, warm)
             let (legacySamples, warmSamples) = unzip pairs
@@ -94,15 +99,30 @@ legacyOpenAndQuery :: ManagedPostgresConfig -> IO (Either StoreError Int)
 legacyOpenAndQuery config =
     ensureManagedPostgres config >>= \case
         Left err -> pure (Left err)
-        Right _ -> openAndQuery config
+        Right _ ->
+            openAndQueryWith
+                (openStorePool config defaultPoolConfig)
 
-openAndQuery :: ManagedPostgresConfig -> IO (Either StoreError Int)
-openAndQuery config =
-    withStore config \store ->
+warmOpenAndQuery :: ManagedPostgresConfig -> IO (Either StoreError Int)
+warmOpenAndQuery config =
+    openAndQueryWith (openStartupOwnerPool config)
+
+openAndQueryWith
+    :: IO (Either StoreError StorePool)
+    -> IO (Either StoreError Int)
+openAndQueryWith acquirePool =
+    acquirePool >>= \case
+        Left err -> pure (Left err)
+        Right pool ->
+            bracket
+                (pure pool)
+                closeStorePool
+                query
+  where
+    query pool =
         withSession
-            (trustedPool store)
+            pool
             (Session.statement () oneStatement)
-            >>= requireStore
 
 oneStatement :: Statement () Int
 oneStatement = Statement.preparable

--- a/packages/agent-store/benchmark/ManagedStartup.hs
+++ b/packages/agent-store/benchmark/ManagedStartup.hs
@@ -17,7 +17,7 @@ import Agent.Store.Types (StoreError, renderStoreError)
 import Control.Exception (evaluate)
 import Control.Exception.Safe (finally)
 import Control.Monad (forM, unless, void)
-import Data.List (sortOn)
+import Data.List (sort)
 import qualified Data.Text as Text
 import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Stats
@@ -143,7 +143,20 @@ measure action = do
 
 median :: [Sample] -> Sample
 median samples =
-    sortOn (.sampleElapsedMillis) samples !! (length samples `div` 2)
+    Sample
+        { sampleElapsedMillis =
+            medianValue (map (.sampleElapsedMillis) samples)
+        , sampleCpuMillis =
+            medianValue (map (.sampleCpuMillis) samples)
+        , sampleAllocatedBytes =
+            medianValue (map (.sampleAllocatedBytes) samples)
+        , sampleChecksum =
+            medianValue (map (.sampleChecksum) samples)
+        }
+
+medianValue :: Ord a => [a] -> a
+medianValue values =
+    sort values !! (length values `div` 2)
 
 printSample :: Int -> Strategy -> Sample -> IO ()
 printSample sampleCount strategy sample =

--- a/packages/agent-store/benchmark/ManagedStartup.hs
+++ b/packages/agent-store/benchmark/ManagedStartup.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Main (main) where
+
+import Agent.Store.Postgres
+    ( ManagedPostgresConfig
+    , defaultManagedPostgresConfig
+    , trustedPool
+    , withStore
+    )
+import Agent.Store.Postgres.Connection (withSession)
+import Agent.Store.Postgres.Managed
+    ( ensureManagedPostgres
+    , stopManagedPostgres
+    )
+import Agent.Store.Types (StoreError, renderStoreError)
+import Control.Exception (evaluate)
+import Control.Exception.Safe (finally)
+import Control.Monad (forM, unless, void)
+import Data.List (sortOn)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+    ( RTSStats(..)
+    , getRTSStats
+    , getRTSStatsEnabled
+    )
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Session as Session
+import Hasql.Statement (Statement)
+import qualified Hasql.Statement as Statement
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.IO.Temp (withSystemTempDirectory)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Strategy
+    = LegacyLifecycleCheck
+    | WarmConnection
+    deriving (Eq, Show)
+
+data Sample = Sample
+    { sampleElapsedMillis :: !Double
+    , sampleCpuMillis :: !Double
+    , sampleAllocatedBytes :: !Integer
+    , sampleChecksum :: !Int
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    unless enabled $
+        die "RTS statistics are disabled; run with +RTS -T"
+    sampleCount <- parseArguments =<< getArgs
+    withSystemTempDirectory "ham" \stateDirectory -> do
+        let config = defaultManagedPostgresConfig stateDirectory ""
+        (do
+            -- Provision and migrate outside the measured warm-start region.
+            _ <- requireStore =<< openAndQuery config
+            _ <- measure (openAndQuery config)
+            _ <- measure (legacyOpenAndQuery config)
+            pairs <- forM [0 .. sampleCount - 1] \index ->
+                if even index
+                    then do
+                        legacy <- measure (legacyOpenAndQuery config)
+                        warm <- measure (openAndQuery config)
+                        pure (legacy, warm)
+                    else do
+                        warm <- measure (openAndQuery config)
+                        legacy <- measure (legacyOpenAndQuery config)
+                        pure (legacy, warm)
+            let (legacySamples, warmSamples) = unzip pairs
+            printSample sampleCount LegacyLifecycleCheck
+                (median legacySamples)
+            printSample sampleCount WarmConnection
+                (median warmSamples)
+            )
+            `finally` void (stopManagedPostgres config)
+
+parseArguments :: [String] -> IO Int
+parseArguments = \case
+    [] -> pure 21
+    [raw] ->
+        case reads raw of
+            [(value, "")]
+                | value > 0 -> pure value
+            _ -> die ("invalid sample count: " <> raw)
+    _ -> die "usage: managed-startup-bench [SAMPLES]"
+
+legacyOpenAndQuery :: ManagedPostgresConfig -> IO (Either StoreError Int)
+legacyOpenAndQuery config =
+    ensureManagedPostgres config >>= \case
+        Left err -> pure (Left err)
+        Right _ -> openAndQuery config
+
+openAndQuery :: ManagedPostgresConfig -> IO (Either StoreError Int)
+openAndQuery config =
+    withStore config \store ->
+        withSession
+            (trustedPool store)
+            (Session.statement () oneStatement)
+            >>= requireStore
+
+oneStatement :: Statement () Int
+oneStatement = Statement.preparable
+    "SELECT 1::int4"
+    Encoders.noParams
+    (Decoders.singleRow $
+        fromIntegral
+            <$> Decoders.column (Decoders.nonNullable Decoders.int4))
+
+requireStore :: Either StoreError a -> IO a
+requireStore =
+    either (die . Text.unpack . renderStoreError) pure
+
+measure :: IO (Either StoreError Int) -> IO Sample
+measure action = do
+    performGC
+    statsBefore <- getRTSStats
+    cpuBefore <- getCPUTime
+    elapsedBefore <- getMonotonicTimeNSec
+    checksum <- requireStore =<< action
+    forced <- evaluate checksum
+    elapsedAfter <- getMonotonicTimeNSec
+    cpuAfter <- getCPUTime
+    -- Flush allocation counters after stopping the elapsed/CPU clocks. Small
+    -- warm starts usually do not trigger a GC on their own.
+    performGC
+    statsAfter <- getRTSStats
+    pure Sample
+        { sampleElapsedMillis =
+            fromIntegral (elapsedAfter - elapsedBefore) / 1_000_000
+        , sampleCpuMillis =
+            fromIntegral (cpuAfter - cpuBefore) / 1_000_000_000
+        , sampleAllocatedBytes =
+            fromIntegral
+                (allocated_bytes statsAfter - allocated_bytes statsBefore)
+        , sampleChecksum = forced
+        }
+
+median :: [Sample] -> Sample
+median samples =
+    sortOn (.sampleElapsedMillis) samples !! (length samples `div` 2)
+
+printSample :: Int -> Strategy -> Sample -> IO ()
+printSample sampleCount strategy sample =
+    printf
+        "managed-startup strategy=%s samples=%d elapsed-ms=%.3f \
+        \cpu-ms=%.3f allocated-bytes=%d checksum=%d\n"
+        (strategyLabel strategy)
+        sampleCount
+        sample.sampleElapsedMillis
+        sample.sampleCpuMillis
+        sample.sampleAllocatedBytes
+        sample.sampleChecksum
+
+strategyLabel :: Strategy -> String
+strategyLabel = \case
+    LegacyLifecycleCheck -> "legacy-lifecycle-check"
+    WarmConnection -> "warm-connection"

--- a/packages/agent-store/package.nix
+++ b/packages/agent-store/package.nix
@@ -1,16 +1,17 @@
-{ mkDerivation, aeson, async, base, bytestring, containers, contravariant
-, directory, filelock, filepath, hasql, hasql-pool
-, hasql-transaction, hspec, lib, pqi, pqi-ffi, process, safe-exceptions
-, stm, temporary, text, time, unix, uuid-types, vector
+{ mkDerivation, aeson, async, base, bytestring, containers
+, contravariant, directory, filelock, filepath, hasql, hasql-pool
+, hasql-transaction, hspec, lib, pqi, pqi-ffi, process
+, safe-exceptions, stm, temporary, text, time, unix, uuid-types
+, vector
 }:
 mkDerivation {
   pname = "agent-store";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson async base bytestring containers contravariant directory filelock
-    filepath hasql hasql-pool hasql-transaction pqi pqi-ffi process
-    safe-exceptions stm text time unix uuid-types vector
+    aeson async base bytestring containers contravariant directory
+    filelock filepath hasql hasql-pool hasql-transaction pqi pqi-ffi
+    process safe-exceptions stm text time unix uuid-types vector
   ];
   testHaskellDepends = [
     async base bytestring hasql hspec safe-exceptions temporary text

--- a/packages/agent-store/src/Agent/Store/Postgres.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres.hs
@@ -60,54 +60,74 @@ openStoreWithRuntimeRole
     -> Text
     -> IO (Either StoreError Store)
 openStoreWithRuntimeRole config runtimeRole = mask \restore ->
-    restore (ensureManagedPostgres config) >>= \case
+    restore (openStartupOwnerPool config) >>= \case
         Left err -> pure (Left err)
-        Right _ -> do
-            restore (openStorePool config defaultPoolConfig) >>= \case
-                Left err -> pure (Left err)
-                Right ownerPool -> do
-                    migrationResult <-
+        Right ownerPool -> do
+            migrationResult <-
+                restore
+                    (runCoreMigrationsForRuntimeRole ownerPool runtimeRole)
+                    `onException` closeStorePool ownerPool
+            case migrationResult of
+                Left err ->
+                    closeStorePool ownerPool >> pure (Left err)
+                Right () -> do
+                    runtimeResult <-
                         restore
-                            (runCoreMigrationsForRuntimeRole
-                                ownerPool runtimeRole)
+                            (openRoleStorePool
+                                config
+                                runtimeRole
+                                defaultPoolConfig)
                             `onException` closeStorePool ownerPool
-                    case migrationResult of
-                        Left err ->
-                            closeStorePool ownerPool >> pure (Left err)
-                        Right () -> do
-                            runtimeResult <-
-                                restore
-                                    (openRoleStorePool
+                    case runtimeResult of
+                        Left err -> do
+                            closeStorePool ownerPool
+                            pure (Left err)
+                        Right runtimePool -> do
+                            pools <- newPoolCache
+                                8
+                                storeClosedError
+                                storeExceptionError
+                                (\role ->
+                                    openRoleStorePool
                                         config
-                                        runtimeRole
-                                        defaultPoolConfig)
-                                    `onException` closeStorePool ownerPool
-                            case runtimeResult of
-                                    Left err -> do
-                                        closeStorePool ownerPool
-                                        pure (Left err)
-                                    Right runtimePool -> do
-                                        pools <- newPoolCache
-                                            8
-                                            storeClosedError
-                                            storeExceptionError
-                                            (\role ->
-                                                openRoleStorePool
-                                                    config
-                                                    role
-                                                    (defaultPoolConfig
-                                                        { poolSize = 2
-                                                        }))
-                                            closeStorePool
-                                        closeState <- newMVar StoreOpen
-                                        pure $ Right Store
-                                            { storeConfigInternal = config
-                                            , provisioningPoolInternal =
-                                                ownerPool
-                                            , trustedPoolInternal = runtimePool
-                                            , scopePoolsInternal = pools
-                                            , storeCloseInternal = closeState
-                                            }
+                                        role
+                                        (defaultPoolConfig
+                                            { poolSize = 2
+                                            }))
+                                closeStorePool
+                            closeState <- newMVar StoreOpen
+                            pure $ Right Store
+                                { storeConfigInternal = config
+                                , provisioningPoolInternal = ownerPool
+                                , trustedPoolInternal = runtimePool
+                                , scopePoolsInternal = pools
+                                , storeCloseInternal = closeState
+                                }
+
+-- | Reuse a direct owner connection when the managed cluster is already
+-- running. The socket check avoids paying even the short connection timeout
+-- on cold startup; any failed optimistic connection falls back to the existing
+-- lifecycle lock and provisioning commands.
+openStartupOwnerPool
+    :: ManagedPostgresConfig
+    -> IO (Either StoreError StorePool)
+openStartupOwnerPool config =
+    prepareManagedPostgres config >>= \case
+        Left err -> pure (Left err)
+        Right socketExists
+            | socketExists ->
+                openStorePoolWithConnectionTimeout
+                    config
+                    1
+                    defaultPoolConfig >>= \case
+                    Right pool -> pure (Right pool)
+                    Left _ -> ensureAndOpen
+            | otherwise -> ensureAndOpen
+  where
+    ensureAndOpen =
+        ensureManagedPostgres config >>= \case
+            Left err -> pure (Left err)
+            Right _ -> openStorePool config defaultPoolConfig
 
 closeStore :: Store -> IO ()
 closeStore store =

--- a/packages/agent-store/src/Agent/Store/Postgres.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres.hs
@@ -8,6 +8,7 @@ module Agent.Store.Postgres
     , managedPostgresConfigFromEnv
     , openStore
     , openStoreWithRuntimeRole
+    , openStartupOwnerPool
     , closeStore
     , withStore
     , storeConfig

--- a/packages/agent-store/src/Agent/Store/Postgres.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres.hs
@@ -21,7 +21,7 @@ import Control.Concurrent.MVar
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.STM
 import qualified Control.Exception as Exception
-import Control.Exception.Safe (bracket, mask, onException)
+import Control.Exception.Safe (bracket, mask, onException, tryAny)
 import Control.Monad (void)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -30,6 +30,11 @@ import Data.Time.Clock
     , diffTimeToPicoseconds
     , picosecondsToDiffTime
     )
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Session as Session
+import qualified Hasql.Statement as Statement
+import System.Directory (canonicalizePath)
 
 import Agent.Store.Postgres.Config
 import Agent.Store.Postgres.Connection
@@ -116,18 +121,55 @@ openStartupOwnerPool config =
         Left err -> pure (Left err)
         Right socketExists
             | socketExists ->
-                openStorePoolWithConnectionTimeout
-                    config
-                    1
-                    defaultPoolConfig >>= \case
-                    Right pool -> pure (Right pool)
-                    Left _ -> ensureAndOpen
+                mask \restore -> do
+                    connectionResult <- restore $
+                        openStorePoolWithConnectionTimeout
+                            config
+                            1
+                            defaultPoolConfig
+                    case connectionResult of
+                        Right pool -> do
+                            matches <-
+                                restore (warmPoolMatchesConfig config pool)
+                                    `onException` closeStorePool pool
+                            if matches
+                                then pure (Right pool)
+                                else
+                                    closeStorePool pool
+                                        >> restore ensureAndOpen
+                        Left _ -> restore ensureAndOpen
             | otherwise -> ensureAndOpen
   where
     ensureAndOpen =
         ensureManagedPostgres config >>= \case
             Left err -> pure (Left err)
             Right _ -> openStorePool config defaultPoolConfig
+
+-- | A socket path can outlive its intended configuration or be shared by a
+-- different PostgreSQL instance. Before bypassing lifecycle management, prove
+-- that the connected server is backed by this configuration's data directory.
+warmPoolMatchesConfig :: ManagedPostgresConfig -> StorePool -> IO Bool
+warmPoolMatchesConfig config pool =
+    withSession
+        pool
+        (Session.statement () managedDataDirectoryStatement) >>= \case
+        Left _ -> pure False
+        Right actualDirectory -> do
+            expectedResult <- tryAny $
+                canonicalizePath
+                    config.postgresPaths.postgresDataDirectory
+            actualResult <- tryAny $
+                canonicalizePath (Text.unpack actualDirectory)
+            pure case (expectedResult, actualResult) of
+                (Right expected, Right actual) -> expected == actual
+                _ -> False
+
+managedDataDirectoryStatement :: Statement.Statement () Text
+managedDataDirectoryStatement = Statement.preparable
+    "SELECT current_setting('data_directory')"
+    Encoders.noParams
+    (Decoders.singleRow
+        (Decoders.column (Decoders.nonNullable Decoders.text)))
 
 closeStore :: Store -> IO ()
 closeStore store =

--- a/packages/agent-store/src/Agent/Store/Postgres/Config.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Config.hs
@@ -9,6 +9,7 @@ module Agent.Store.Postgres.Config
     , defaultManagedPostgresConfig
     , managedPostgresConfigFromEnv
     , postgresExecutable
+    , postgresSocketPath
     , socketHost
     , postgresqlConf
     , pgHbaConf
@@ -85,6 +86,12 @@ postgresExecutable :: ManagedPostgresConfig -> FilePath -> FilePath
 postgresExecutable config executable
     | null config.postgresBinDirectory = executable
     | otherwise = config.postgresBinDirectory </> executable
+
+-- | Filesystem path used by PostgreSQL for this cluster's Unix socket.
+postgresSocketPath :: ManagedPostgresConfig -> FilePath
+postgresSocketPath config =
+    config.postgresPaths.postgresSocketDirectory
+        </> (".s.PGSQL." <> show config.postgresPort)
 
 socketHost :: ManagedPostgresConfig -> ByteString
 socketHost config =

--- a/packages/agent-store/src/Agent/Store/Postgres/Connection.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Connection.hs
@@ -11,6 +11,7 @@ module Agent.Store.Postgres.Connection
     , defaultPoolConfig
     , connectionSettingsForRole
     , openStorePool
+    , openStorePoolWithConnectionTimeout
     , openRoleStorePool
     , closeStorePool
     , withStorePool
@@ -60,12 +61,22 @@ connectionSettingsForRole
     -> Text
     -> ConnectionSettings.Settings
 connectionSettingsForRole config role =
+    connectionSettingsForRoleWithTimeout config role 10
+
+connectionSettingsForRoleWithTimeout
+    :: ManagedPostgresConfig
+    -> Text
+    -> Int
+    -> ConnectionSettings.Settings
+connectionSettingsForRoleWithTimeout config role timeoutSeconds =
     ConnectionSettings.hostAndPort
         (Text.pack config.postgresPaths.postgresSocketDirectory)
         config.postgresPort
         <> ConnectionSettings.user role
         <> ConnectionSettings.dbname config.postgresDatabase
-        <> ConnectionSettings.other "connect_timeout" "10"
+        <> ConnectionSettings.other
+            "connect_timeout"
+            (Text.pack (show timeoutSeconds))
         <> ConnectionSettings.applicationName "haskell-agent"
 
 openStorePool
@@ -75,19 +86,48 @@ openStorePool
 openStorePool config =
     openRoleStorePool config config.postgresOwnerRole
 
+-- | Open the owner pool with a bounded libpq connection attempt. This is used
+-- for an optimistic warm-start probe before lifecycle management takes over.
+openStorePoolWithConnectionTimeout
+    :: ManagedPostgresConfig
+    -> Int
+    -> PoolConfig
+    -> IO (Either StoreError StorePool)
+openStorePoolWithConnectionTimeout config timeoutSeconds =
+    openRoleStorePoolWithConnectionTimeout
+        config
+        config.postgresOwnerRole
+        timeoutSeconds
+
 openRoleStorePool
     :: ManagedPostgresConfig
     -> Text
     -> PoolConfig
     -> IO (Either StoreError StorePool)
-openRoleStorePool config role options = mask \restore -> do
+openRoleStorePool config role =
+    openRoleStorePoolWithConnectionTimeout config role 10
+
+openRoleStorePoolWithConnectionTimeout
+    :: ManagedPostgresConfig
+    -> Text
+    -> Int
+    -> PoolConfig
+    -> IO (Either StoreError StorePool)
+openRoleStorePoolWithConnectionTimeout
+    config
+    role
+    timeoutSeconds
+    options = mask \restore -> do
     pool <- Pool.acquire Pqi.adapter $ PoolConfig.settings
         [ PoolConfig.size options.poolSize
         , PoolConfig.acquisitionTimeout options.poolAcquisitionTimeout
         , PoolConfig.agingTimeout options.poolAgingTimeout
         , PoolConfig.idlenessTimeout options.poolIdlenessTimeout
         , PoolConfig.staticConnectionSettings
-            (connectionSettingsForRole config role)
+            (connectionSettingsForRoleWithTimeout
+                config
+                role
+                timeoutSeconds)
         ]
     validationResult <-
         restore (Pool.use pool (pure ()))

--- a/packages/agent-store/src/Agent/Store/Postgres/Managed.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Managed.hs
@@ -12,6 +12,7 @@
 -- start and recovery.
 module Agent.Store.Postgres.Managed
     ( ManagedPostgresStatus(..)
+    , prepareManagedPostgres
     , managedPostgresStatus
     , ensureManagedPostgres
     , stopManagedPostgres
@@ -27,6 +28,7 @@ import qualified Data.Text.Encoding as Text
 import System.Directory
     ( createDirectoryIfMissing
     , doesFileExist
+    , doesPathExist
     )
 import System.Exit (ExitCode(..))
 import qualified System.FileLock as FileLock
@@ -42,6 +44,25 @@ data ManagedPostgresStatus
     | PostgresStopped
     | PostgresRunning
     deriving (Eq, Show)
+
+-- | Perform the cheap, process-free checks required before either connecting
+-- to an already-running cluster or entering the lifecycle-managed fallback.
+--
+-- The result says whether the configured PostgreSQL Unix socket currently
+-- exists. Its presence is only a hint: callers must still validate a direct
+-- connection and fall back to 'ensureManagedPostgres' when that fails.
+prepareManagedPostgres
+    :: ManagedPostgresConfig
+    -> IO (Either StoreError Bool)
+prepareManagedPostgres config =
+    case validateConfig config of
+        Left err -> pure (Left err)
+        Right () -> do
+            prepareDirectories config
+            validateClusterVersion config >>= \case
+                Left err -> pure (Left err)
+                Right () ->
+                    Right <$> doesPathExist (postgresSocketPath config)
 
 managedPostgresStatus
     :: ManagedPostgresConfig

--- a/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
@@ -9,6 +9,7 @@ import Control.Exception.Safe (finally)
 import Data.ByteString (ByteString)
 import Data.Either (isLeft, isRight)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time.Clock (addUTCTime, getCurrentTime)
 import qualified Hasql.Decoders as Decoders
 import qualified Hasql.Encoders as Encoders
@@ -25,6 +26,7 @@ import Agent.Store.Postgres.Connection
     , openStorePool
     , withSession
     )
+import Agent.Store.Postgres.Config (postgresSocketPath)
 import Agent.Store.Postgres.Managed
     ( ensureManagedPostgres
     , stopManagedPostgres
@@ -92,6 +94,65 @@ spec =
                                 ("could not open managed store: " <> show err)
                         Right () -> pure ())
                     `finally` cleanup
+
+        it "reuses a warm socket without lifecycle executables and falls back when stopped" $
+            withSystemTempDirectory "ha" \stateDirectory -> do
+                let
+                    config = defaultManagedPostgresConfig stateDirectory ""
+                    unavailableBinConfig =
+                        config
+                            { postgresBinDirectory =
+                                stateDirectory <> "/missing-postgres-bin"
+                            }
+                    cleanup = do
+                        _ <- stopManagedPostgres config
+                        pure ()
+                (do
+                    ensureManagedPostgres config
+                        >>= (`shouldSatisfy` isRight)
+
+                    -- The running server remains reachable through its socket.
+                    -- An attempted pg_ctl/psql command would fail because this
+                    -- configuration points at a deliberately absent bin dir.
+                    -- The cluster has not been migrated yet, so this also
+                    -- proves that the fast path runs migrations before it
+                    -- validates and returns the runtime-role pool.
+                    (withStore unavailableBinConfig \store -> do
+                        withSession
+                            (trustedPool store)
+                            (Session.statement () serverStatement)
+                            `shouldReturn`
+                                Right
+                                    ( "haskell_agent"
+                                    , "ha_runtime"
+                                    , True
+                                    , True
+                                    , True
+                                    )
+                        withSession
+                            (trustedPool store)
+                            (Session.script
+                                "CREATE SCHEMA warm_runtime_must_not_create")
+                            >>= (`shouldSatisfy` isLeft)
+                        ) >>= (`shouldSatisfy` isRight)
+
+                    stopManagedPostgres config `shouldReturn` Right ()
+                    -- A stale path exercises failed-probe fallback, rather
+                    -- than only the simpler missing-socket branch.
+                    writeFile (postgresSocketPath config) ""
+                    withStore unavailableBinConfig (const (pure ()))
+                        >>= \case
+                            Left (StoreProcessError message) ->
+                                message `shouldSatisfy`
+                                    Text.isInfixOf "Could not run pg_ctl"
+                            Left err ->
+                                expectationFailure $
+                                    "expected lifecycle fallback failure, got: "
+                                        <> show err
+                            Right () ->
+                                expectationFailure
+                                    "stopped cluster unexpectedly opened"
+                    ) `finally` cleanup
 
         it "ignores an unrelated migration 11 from another worktree" $
             withSystemTempDirectory "ha" \stateDirectory -> do

--- a/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
@@ -99,10 +99,17 @@ spec =
             withSystemTempDirectory "ha" \stateDirectory -> do
                 let
                     config = defaultManagedPostgresConfig stateDirectory ""
+                    dataDirectoryAlias =
+                        config.postgresPaths.postgresDataDirectory <> "/."
                     unavailableBinConfig =
                         config
                             { postgresBinDirectory =
                                 stateDirectory <> "/missing-postgres-bin"
+                            , postgresPaths =
+                                config.postgresPaths
+                                    { postgresDataDirectory =
+                                        dataDirectoryAlias
+                                    }
                             }
                     cleanup = do
                         _ <- stopManagedPostgres config
@@ -114,6 +121,8 @@ spec =
                     -- The running server remains reachable through its socket.
                     -- An attempted pg_ctl/psql command would fail because this
                     -- configuration points at a deliberately absent bin dir.
+                    -- Reaching it through a non-normalized data-directory alias
+                    -- also proves the identity check compares canonical paths.
                     -- The cluster has not been migrated yet, so this also
                     -- proves that the fast path runs migrations before it
                     -- validates and returns the runtime-role pool.
@@ -152,6 +161,47 @@ spec =
                             Right () ->
                                 expectationFailure
                                     "stopped cluster unexpectedly opened"
+                    ) `finally` cleanup
+
+        it "rejects a warm socket backed by a different data directory" $
+            withSystemTempDirectory "ha" \stateDirectory -> do
+                let
+                    config = defaultManagedPostgresConfig stateDirectory ""
+                    otherDataDirectory = stateDirectory <> "/other-data"
+                    mismatchedConfig =
+                        config
+                            { postgresBinDirectory =
+                                stateDirectory <> "/missing-postgres-bin"
+                            , postgresPaths =
+                                config.postgresPaths
+                                    { postgresDataDirectory =
+                                        otherDataDirectory
+                                    }
+                            }
+                    cleanup = do
+                        _ <- stopManagedPostgres config
+                        pure ()
+                (do
+                    ensureManagedPostgres config
+                        >>= (`shouldSatisfy` isRight)
+
+                    -- The socket, database, and owner role all resolve, but
+                    -- the connected server belongs to the original data
+                    -- directory. A correct warm probe must reject it and enter
+                    -- lifecycle fallback, whose deliberately missing binary
+                    -- makes the distinction observable.
+                    withStore mismatchedConfig (const (pure ()))
+                        >>= \case
+                            Left (StoreProcessError message) ->
+                                message `shouldSatisfy`
+                                    Text.isInfixOf "Could not run initdb"
+                            Left err ->
+                                expectationFailure $
+                                    "expected lifecycle fallback failure, got: "
+                                        <> show err
+                            Right () ->
+                                expectationFailure
+                                    "mismatched cluster unexpectedly opened"
                     ) `finally` cleanup
 
         it "ignores an unrelated migration 11 from another worktree" $


### PR DESCRIPTION
## Summary

- reuse one immutable harness-config snapshot throughout startup, including startup worktree policy
- acquire MCP, local coding tools, web fetch, and LSP in one structured four-way frontier while raw AGENTS instructions, filesystem skills, and learned skills preload concurrently
- preserve deferred warning delivery, learned-skill retry behavior, resume semantics, and structured cleanup/cancellation ownership
- reuse a warm managed-PostgreSQL socket only after verifying its canonical `data_directory`, with lifecycle fallback on mismatch or failure
- retain paired startup benchmarks for both the CLI DAG and managed PostgreSQL path

## Performance

All figures are independent medians over 51 alternating samples with RTS allocation statistics enabled.

### Managed PostgreSQL warm startup

Real managed cluster, comparing the former lifecycle-owner-pool path with the direct verified warm owner-pool path at an equivalent acquisition/query/cleanup boundary:

| Metric | Baseline | Current | Delta |
|---|---:|---:|---:|
| Wall | 16.078 ms | 2.045 ms | **-87.3%** |
| CPU | 1.397 ms | 0.544 ms | **-61.1%** |
| Allocated | 577,080 B | 325,168 B | **-43.7%** |

An independent confirmation run measured wall time at 16.131 ms → 2.161 ms.

### Combined CLI startup frontier

The benchmark compares `resources2+2-then-context1+1` with `resources4||context2`. It uses actual progressive MCP/local/raw-AGENTS/filesystem-skill loaders and deterministic web-fetch/LSP delay stand-ins.

| Workload | Wall baseline → current | Wall delta | CPU baseline → current | Allocated baseline → current |
|---|---:|---:|---:|---:|
| Small (1 MCP, 10 skills, 20 ms aux) | 35.439 → 28.448 ms | **-19.7%** | 12.011 → 12.775 ms | 9,505,344 → 9,387,928 B |
| Representative (2 MCP, 50 skills, 50 ms aux) | 72.595 → 58.592 ms | **-19.3%** | 27.010 → 30.546 ms | 19,982,232 → 19,941,288 B |
| Large (3 MCP, 200 skills, 100 ms aux) | 137.043 → 109.354 ms | **-20.2%** | 64.836 → 75.794 ms | 53,609,152 → 53,567,320 B |

The combined frontier intentionally trades modest extra CPU overlap (+6–17%) for roughly 20% lower prompt-ready wall time; allocations remain flat to slightly lower.

## Validation

- current-head `agent-core-test`: 542 examples, 0 failures (8 environment-dependent pending)
- current-head `agent-cli-test`: 1,591 examples, 0 failures (1 Linux-only pending)
- affected PostgreSQL tests pass locally: 34 PostgreSQL examples, 0 failures, including the three server-turn tests
- the one order-dependent local full-store `pg_ctl` startup failure reproduces unchanged on exact current `master`, so it is not branch-introduced
- corrected managed-startup benchmark builds and completed two independent 51-sample runs
- `agent-cli/package.nix` and `agent-store/package.nix` both match fresh `cabal2nix` output
- current-head cold/warm tmux smoke passed: cold first frame 990 ms / ready 1.22 s; warm first frame 9 ms / ready 41 ms
- `git diff --check` and exact commit-trailer audit passed at the final candidate head
- independent final review found no branch-introduced P1/P2 issues
