### PR TITLE
Fix terminal diff background colors

### DIFF
--- a/packages/agent-tui/src/Agent/TUI/Theme.hs
+++ b/packages/agent-tui/src/Agent/TUI/Theme.hs
@@ -448,11 +448,11 @@ terminalDefault =
         , (diffAddedAttr,
             V.defAttr
                 `V.withForeColor` V.brightGreen
-                `V.withBackColor` Color240 22)
+                `V.withBackColor` RGBColor 0 95 0)
         , (diffRemovedAttr,
             V.defAttr
                 `V.withForeColor` V.brightRed
-                `V.withBackColor` Color240 52)
+                `V.withBackColor` RGBColor 95 0 0)
         , (syntaxNormalAttr, palette V.cyan)
         , (syntaxKeywordAttr, palette V.magenta)
         , (syntaxTypeAttr, palette V.yellow)

--- a/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ThemeSpec.hs
@@ -188,13 +188,16 @@ spec = do
                 allSyntaxClasses
                 `shouldBe` replicate (length allSyntaxClasses) V.Default
 
-        it "uses distinct full-row backgrounds for added and removed lines" do
+        it "uses dark green and red full-row diff backgrounds" do
             let added =
                     attrMapLookup Theme.diffAddedAttr Theme.terminalDefault
                 removed =
                     attrMapLookup Theme.diffRemovedAttr Theme.terminalDefault
-            V.attrBackColor added `shouldBe` V.SetTo (Color240 22)
-            V.attrBackColor removed `shouldBe` V.SetTo (Color240 52)
+            -- Use explicit RGB values. Vty's Color240 constructor is offset
+            -- past ANSI 0-15, so Color240 22 renders as ANSI 38 (cyan), not
+            -- the intended xterm dark green at ANSI 22.
+            V.attrBackColor added `shouldBe` V.SetTo (RGBColor 0 95 0)
+            V.attrBackColor removed `shouldBe` V.SetTo (RGBColor 95 0 0)
             V.attrForeColor added `shouldBe` V.SetTo V.brightGreen
             V.attrForeColor removed `shouldBe` V.SetTo V.brightRed
 


### PR DESCRIPTION
## Summary
- replace offset Vty `Color240` indices with explicit dark RGB diff backgrounds
- prevent added lines from rendering with a bright cyan background
- add focused regression coverage for both added and removed line colors

## Validation
- focused `agent-tui` ThemeSpec in GHCi: 1 example, 0 failures
- same focused check inside a real tmux TTY
- `git diff --check`