### PR TITLE
Add GPT-6 Astra model support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,10 +75,10 @@
                 # vendored, mirroring how other third-party dependencies enter
                 # the closure. The runtime additionally refreshes the catalog
                 # from the ChatGPT /models endpoint when credentials permit.
-                codexUpstreamRev = "4f39251a010a8bd7d692d25fb33832ff06f1635a";
+                codexUpstreamRev = "a97cf1b72eaad05aa49847bc81d09ceac9327754";
                 codexModelsJson = pkgs.fetchurl {
                     url = "https://raw.githubusercontent.com/openai/codex/${codexUpstreamRev}/codex-rs/models-manager/models.json";
-                    hash = "sha256-6w17ml3K8QOJXF+KFMFrJp30bgObN1pVupf2I4VC0u0=";
+                    hash = "sha256-1xNqQTz6wbWxaG2eDcxcgMoFvr7V6fw5ETdlYdDvbug=";
                 };
                 codexPromptMd = pkgs.fetchurl {
                     url = "https://raw.githubusercontent.com/openai/codex/${codexUpstreamRev}/codex-rs/models-manager/prompt.md";

--- a/packages/agent-cli-runtime/config/models.default.json
+++ b/packages/agent-cli-runtime/config/models.default.json
@@ -39,7 +39,7 @@
       "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "low",
       "default": true,
-      "fallback_priority": 0
+      "fallback_priority": 1
     },
     {
       "id": "gpt-6-astra",
@@ -47,7 +47,8 @@
       "dialect": "codex",
       "label": "frontier",
       "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
-      "default_reasoning_effort": "low"
+      "default_reasoning_effort": "low",
+      "fallback_priority": 0
     },
     {
       "id": "gpt-5.6-terra",
@@ -56,7 +57,7 @@
       "label": "balanced",
       "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "medium",
-      "fallback_priority": 1
+      "fallback_priority": 2
     },
     {
       "id": "gpt-5.6-luna",
@@ -65,7 +66,7 @@
       "label": "fast · low cost",
       "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "medium",
-      "fallback_priority": 2
+      "fallback_priority": 3
     },
     {
       "id": "grok-4.6",

--- a/packages/agent-cli-runtime/config/models.default.json
+++ b/packages/agent-cli-runtime/config/models.default.json
@@ -42,6 +42,14 @@
       "fallback_priority": 0
     },
     {
+      "id": "gpt-6-astra",
+      "connection": "openai",
+      "dialect": "codex",
+      "label": "frontier",
+      "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
+      "default_reasoning_effort": "low"
+    },
+    {
       "id": "gpt-5.6-terra",
       "connection": "openai",
       "dialect": "codex",

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
@@ -52,6 +52,7 @@ spec = describe "Agent.CLI.ModelConfig" do
             (catalogModelsForConnection "openai" catalog)
             `shouldBe`
                 [ "gpt-5.6-sol"
+                , "gpt-6-astra"
                 , "gpt-5.6-terra"
                 , "gpt-5.6-luna"
                 ]
@@ -89,6 +90,19 @@ spec = describe "Agent.CLI.ModelConfig" do
                 Just
                     ( Just ["low", "medium", "high", "xhigh", "max"]
                     , Just "low"
+                    )
+        fmap
+            (\model ->
+                ( model.catalogModelReasoningEfforts
+                , model.catalogModelDefaultReasoningEffort
+                , model.catalogModelDefault
+                ))
+            (Map.lookup "gpt-6-astra" catalog.catalogModelsById)
+            `shouldBe`
+                Just
+                    ( Just ["low", "medium", "high", "xhigh", "max"]
+                    , Just "low"
+                    , False
                     )
 
     it "loads protocol metadata for organization gateway aliases" do

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
@@ -56,6 +56,18 @@ spec = describe "Agent.CLI.ModelConfig" do
                 , "gpt-5.6-terra"
                 , "gpt-5.6-luna"
                 ]
+        fmap
+            (\model ->
+                ( model.catalogModelId
+                , model.catalogModelFallbackPriority
+                ))
+            (catalogModelsForConnection "openai" catalog)
+            `shouldBe`
+                [ ("gpt-5.6-sol", Just 1)
+                , ("gpt-6-astra", Just 0)
+                , ("gpt-5.6-terra", Just 2)
+                , ("gpt-5.6-luna", Just 3)
+                ]
         fmap (.catalogModelId)
             (catalogModelsForConnection "gemini" catalog)
             `shouldBe`

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -50,15 +50,17 @@ spec = do
                 `shouldBe` defaultModelFor catalog ClaudeCodeProvider
 
         it "ships the configured frontier models for each provider" do
-            modelIdsFor OpenAIProvider `shouldContain` ["gpt-5.6-sol"]
+            modelIdsFor OpenAIProvider
+                `shouldContain` ["gpt-5.6-sol", "gpt-6-astra"]
             modelIdsFor XAIProvider `shouldContain` ["grok-4.6"]
             modelIdsFor OpenRouterProvider `shouldContain` ["stealth/ox-alpha"]
             modelIdsFor GeminiProvider `shouldContain` ["gemini-3.7-flash"]
 
-        it "ships the GPT-5.6 series and each other provider frontier model" do
+        it "ships the OpenAI frontier models and each other provider frontier model" do
             modelIdsFor OpenAIProvider
                 `shouldBe`
                     [ "gpt-5.6-sol"
+                    , "gpt-6-astra"
                     , "gpt-5.6-terra"
                     , "gpt-5.6-luna"
                     ]

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -188,6 +188,7 @@ spec = do
                     "gpt-5.6-sol"
                     CodexDialect
             listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-sol"
+            listing `shouldSatisfy` Text.isInfixOf "gpt-6-astra"
             listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-terra"
             listing `shouldSatisfy` Text.isInfixOf "gpt-5.6-luna"
             listing `shouldSatisfy` Text.isInfixOf "openai"

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -55,7 +55,7 @@ spec = do
                     , model.modelTarget.targetModelId
                     ))
                 (safeHead (rankedModels catalog))
-                `shouldBe` Just (OpenAIProvider, "gpt-5.6-sol")
+                `shouldBe` Just (OpenAIProvider, "gpt-6-astra")
 
     describe "fallbackCandidates" do
         let exhausted =
@@ -71,7 +71,7 @@ spec = do
                 (fallbackCandidates catalog Set.empty XAIProvider
                     "grok-4.6" exhausted)
                 `shouldBe`
-                    [ (OpenAIProvider, "gpt-5.6-sol")
+                    [ (OpenAIProvider, "gpt-6-astra")
                     , (GeminiProvider, "gemini-3.7-flash")
                     , (OpenRouterProvider, "stealth/ox-alpha")
                     ]
@@ -144,6 +144,18 @@ spec = do
                 `shouldBe` [GeminiProvider, OpenRouterProvider]
 
         it "steps down through same-provider models on model access errors" do
+            map (.modelTarget.targetModelId)
+                (fallbackCandidates catalog Set.empty OpenAIProvider
+                    "gpt-6-astra"
+                    (ProviderError PermissionError "not available" Nothing))
+                `shouldBe`
+                    [ "gpt-5.6-sol"
+                    , "gpt-5.6-terra"
+                    , "gpt-5.6-luna"
+                    , "grok-4.6"
+                    , "gemini-3.7-flash"
+                    , "stealth/ox-alpha"
+                    ]
             map (.modelTarget.targetModelId)
                 (fallbackCandidates catalog Set.empty OpenAIProvider
                     "gpt-5.6-sol"

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -308,7 +308,7 @@ spec = describe "requestParams" do
                         [webSearchTool, functionTool "lookup", computerTool]
                         "high"
             lite =
-                setRequestModel OpenAIProvider "gpt-5.6-terra" generic
+                setRequestModel OpenAIProvider "gpt-6-astra" generic
             restored =
                 setRequestModel OpenAIProvider "gpt-generic-2" lite
 

--- a/packages/agent-openai/src/Agent/OpenAI/ModelMetadata.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/ModelMetadata.hs
@@ -43,7 +43,8 @@ codexModelMetadata modelName
 isCodexResponsesLiteModel :: Text -> Bool
 isCodexResponsesLiteModel modelName =
     modelName `elem`
-        [ "gpt-5.6-sol"
+        [ "gpt-6-astra"
+        , "gpt-5.6-sol"
         , "gpt-5.6-terra"
         , "gpt-5.6-luna"
         ]

--- a/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CompactionSpec.hs
@@ -1066,12 +1066,13 @@ spec = do
 
     describe "Codex model metadata" do
         it "derives the 90% auto-compaction limit for curated 272k models" do
-            codexModelMetadata "gpt-5.6-luna"
+            codexModelMetadata "gpt-6-astra"
                 `shouldBe` Just CodexModelMetadata
                     { modelContextWindow = 272_000
                     , modelEffectiveContextWindow = 258_400
                     , modelAutoCompactTokenLimit = 244_800
                     }
+            isCodexResponsesLiteModel "gpt-6-astra" `shouldBe` True
             codexAutoCompactTokenLimitFor (Just "gpt-5.6-sol")
                 `shouldBe` 244_800
 

--- a/packages/agent-openai/test/Agent/OpenAI/ModelsTypesSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ModelsTypesSpec.hs
@@ -14,11 +14,11 @@ import Test.Hspec
 spec :: Spec
 spec = do
     describe "bundled Codex model catalog" do
-        it "loads the current upstream catalog and selects Sol by priority" do
+        it "loads the current upstream catalog and selects Astra by priority" do
             catalog <- loadBundledModelsOrThrow
-            length catalog.models `shouldBe` 10
+            length catalog.models `shouldBe` 11
             defaultModelForCatalog True catalog
-                `shouldBe` Just "gpt-5.6-sol"
+                `shouldBe` Just "gpt-6-astra"
             catalog.catalogGeneration `shouldBe` Nothing
             decodeModelsOrFail (Aeson.toJSON catalog) `shouldBe` catalog
 
@@ -41,18 +41,31 @@ spec = do
                 ]
             let pickerModels = map (.model) (pickerModelPresets True catalog)
             pickerModels `shouldBe`
-                [ "gpt-5.6-sol"
+                [ "gpt-6-astra"
+                , "gpt-5.6-sol"
                 , "gpt-5.6-terra"
                 , "gpt-5.6-luna"
                 , "gpt-5.5"
                 , "gpt-5.2"
                 ]
 
-        it "exposes current 5.6 dialect selectors and reasoning defaults" do
+        it "exposes current frontier dialect selectors and reasoning defaults" do
             catalog <- loadBundledModelsOrThrow
-            let sol = modelInfoForSlug "gpt-5.6-sol" catalog
+            let astra = modelInfoForSlug "gpt-6-astra" catalog
+                sol = modelInfoForSlug "gpt-5.6-sol" catalog
                 terra = modelInfoForSlug "gpt-5.6-terra" catalog
                 luna = modelInfoForSlug "gpt-5.6-luna" catalog
+            astra.useResponsesLite `shouldBe` True
+            toolModeForInfo CoreTools.ConventionalToolMode astra
+                `shouldBe` CoreTools.CodeOnlyToolMode
+            astra.multiAgentVersion `shouldBe` Just MultiAgentV2
+            astra.contextWindow `shouldBe` Just 272_000
+            astra.maxContextWindow `shouldBe` Just 872_000
+            defaultReasoningEffortForInfo astra
+                `shouldBe` Just ReasoningEffortLow
+            defaultVerbosityForInfo astra `shouldBe` Just VerbosityLow
+            modelSupportsReasoningEffort astra ReasoningEffortUltra
+                `shouldBe` True
             sol.useResponsesLite `shouldBe` True
             toolModeForInfo CoreTools.ConventionalToolMode sol
                 `shouldBe` CoreTools.CodeOnlyToolMode


### PR DESCRIPTION
## Summary

- add `gpt-6-astra` to the direct OpenAI model catalog with its supported reasoning efforts
- update the pinned upstream Codex model catalog and mark Astra for the Codex Responses Lite path
- cover model metadata, compaction, configuration, picker, and request behavior
- keep `gpt-5.6-sol` as the packaged default

## Async tool calling

OpenAI's [GPT-6 Astra guide](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra) and [async tool calling guide](https://developers.openai.com/api/docs/guides/async-tool-calling) confirm that Astra supports `async: true` for function and custom tools.

This PR intentionally does not advertise tools as async. Correct support requires preserving async state across response types and persistence, starting tool work before the response completes, and submitting later results with the original `call_id`. The current loop waits for all tool calls before continuing, so adding only the schema flag would not implement the feature safely.

## Testing

- focused GHCi HSpec coverage for `agent-openai`
- focused GHCi HSpec coverage for `agent-cli-runtime`
- focused object-code GHCi HSpec coverage for `agent-cli`
- live tmux model-picker smoke test
- `jq empty packages/agent-cli-runtime/config/models.default.json`
- `git diff --check`
