### PR TITLE
fix(cli): restrict gateway Grok reasoning effort

### DIFF
--- a/packages/agent-cli-runtime/config/models.default.json
+++ b/packages/agent-cli-runtime/config/models.default.json
@@ -71,6 +71,14 @@
       "fallback_priority": 10
     },
     {
+      "id": "grok-4.6",
+      "connection": "organization-gateway",
+      "dialect": "grok-build",
+      "context_window": 500000,
+      "reasoning_efforts": ["low", "medium", "high", "xhigh"],
+      "default_reasoning_effort": "high"
+    },
+    {
       "id": "gemini-3.7-flash",
       "connection": "gemini",
       "dialect": "generic-responses",

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
@@ -112,6 +112,20 @@ spec = describe "Agent.CLI.ModelConfig" do
         catalogModelsForConnection organizationGatewayConnectionId catalog
             `shouldBe`
                 [ CatalogModel
+                    { catalogModelId = "grok-4.6"
+                    , catalogModelConnectionId =
+                        organizationGatewayConnectionId
+                    , catalogModelWireId = "grok-4.6"
+                    , catalogModelDialect = GrokBuildDialect
+                    , catalogModelContextWindow = Just 500_000
+                    , catalogModelLabel = Nothing
+                    , catalogModelReasoningEfforts =
+                        Just ["low", "medium", "high", "xhigh"]
+                    , catalogModelDefaultReasoningEffort = Just "high"
+                    , catalogModelDefault = False
+                    , catalogModelFallbackPriority = Nothing
+                    }
+                , CatalogModel
                     { catalogModelId = "company-coder"
                     , catalogModelConnectionId =
                         organizationGatewayConnectionId

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -215,6 +215,23 @@ spec = do
                 options
                 `shouldBe` True
 
+        it "uses Grok capabilities for the gateway Grok model" do
+            gatewayModelOptions catalog OpenAIProvider ["grok-4.6"]
+                `shouldBe`
+                    [ ModelOption
+                        { modelTarget =
+                            ModelTarget
+                                OpenAIProvider
+                                organizationGatewayConnectionId
+                                "grok-4.6"
+                                "grok-4.6"
+                                GrokBuildDialect
+                        , modelContextWindow = Just 500_000
+                        , modelLabel = Nothing
+                        , modelFallbackPriority = Nothing
+                        }
+                    ]
+
         it "rejects a persisted gateway route after disconnection" do
             let resolve deferToGateway =
                     resolveSavedModelTarget


### PR DESCRIPTION
## Summary
- add gateway-scoped metadata for the advertised `grok-4.6` model
- preserve gateway transport while selecting the Grok dialect and capabilities
- prevent the CLI effort picker from offering unsupported `max`; it now stops at `xhigh`

## Testing
- `agent-cli-runtime-test` excluding PostgreSQL persistence: 154 examples, 0 failures
- focused gateway catalog/model tests
- existing Grok effort-capability test
- live organization-gateway picker verification: `high` → `xhigh`, with no `max` option

The PostgreSQL persistence group could not run locally because `pg_ctl` failed to start; the unrelated non-PostgreSQL suite passes.
