### PR TITLE
Refactor runtime startup to pass request records directly

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -113,7 +113,9 @@ import Agent.CLI.Runtime.Orchestration.Background ()
 import Agent.CLI.Runtime.Orchestration.Restart ()
 import Agent.CLI.Runtime.Orchestration.Startup
     ( setStartupRepository )
-import Agent.CLI.Runtime.Orchestration.Tools ( runAgentTools )
+import Agent.CLI.Runtime.Orchestration.Tools ( AgentToolsRequest(..)
+    , runAgentTools
+    )
 import Agent.CLI.Runtime.Orchestration.Types
     ( ActiveHttpAuth(activeHttpGeneration, ActiveHttpAuth,
                      activeHttpAccountId, activeHttpProvider, activeHttpResolveLabel),
@@ -1256,57 +1258,58 @@ launchInitializedTools
     -> InitializedHttpRuntime
     -> IO RunResult
 launchInitializedTools request workspace targets auth refs httpRuntime =
-    runAgentTools
-        request.initializedRunAgentChild
-        auth.initializedLoaded
-        request.initializedConnectedGateway
-        auth.initializedLearnAboutUserRequested
-        auth.initializedCustomBearerToken
-        refs.initializedActiveAccountIdRef
-        refs.initializedActiveAccountRef
-        refs.initializedActiveSelectionRef
-        startup.startupToolEnv
-        workspace.initializedCatalog
-        workspace.initializedSkills
-        refs.initializedGatewayModelsRef
-        targets.initializedGatewayIdentity
-        ( targets.initializedCheckStartupUsageInBackground
-            && isNothing auth.initializedPreparedAccountUsage
-        )
-        targets.initializedConfiguredTarget
-        targets.initializedCustomResponses
-        request.initializedCwd
-        workspace.initializedDatabaseScopes
-        startup.startupEscPaused
-        fullscreen
-        request.initializedHome
-        startup.startupInterrupt
-        startup.startupStdinTty
-        request.initializedProcessRuntime.processMcpSupervisor
-        request.initializedOptions
-        pendingTurn
-        refs.initializedPreferredOpenAiAccountRef
-        request.initializedProcessRuntime
-        workspace.initializedProjectRoot
-        workspace.initializedProjectSettings
-        targets.initializedProjectTarget
-        httpRuntime.initializedResolveActiveAccountLabel
-        request.initializedResumeLock
-        request.initializedResumed
-        targets.initializedResumedTarget
-        request.initializedRoot
-        httpRuntime.initializedSelectHttpAccount
-        refs.initializedSelectableTokenProvider
-        setWindowTitle
-        startup
-        workspace.initializedStateDirectory
-        startup.startupStderr
-        targets.initializedTargetHint
-        httpRuntime.initializedTokenProvider
-        transition
-        targets.initializedTransitionTarget
-        startup.startupUiRuntimeRef
-        unavailableProviders
+    runAgentTools AgentToolsRequest
+        { runAgentChild = request.initializedRunAgentChild
+        , loaded = auth.initializedLoaded
+        , connectedGateway = request.initializedConnectedGateway
+        , learnAboutUserRequested = auth.initializedLearnAboutUserRequested
+        , customBearerToken = auth.initializedCustomBearerToken
+        , activeAccountIdRef = refs.initializedActiveAccountIdRef
+        , activeAccountRef = refs.initializedActiveAccountRef
+        , activeSelectionRef = refs.initializedActiveSelectionRef
+        , baseToolEnv = startup.startupToolEnv
+        , catalog = workspace.initializedCatalog
+        , initialSkills = workspace.initializedSkills
+        , gatewayModelsRef = refs.initializedGatewayModelsRef
+        , gatewayIdentity = targets.initializedGatewayIdentity
+        , checkStartupUsageInBackground =
+            targets.initializedCheckStartupUsageInBackground
+                && isNothing auth.initializedPreparedAccountUsage
+        , configuredOptionTarget = targets.initializedConfiguredTarget
+        , customResponses = targets.initializedCustomResponses
+        , cwd = request.initializedCwd
+        , databaseScopes = workspace.initializedDatabaseScopes
+        , escPaused = startup.startupEscPaused
+        , fullscreen
+        , home = request.initializedHome
+        , interrupt = startup.startupInterrupt
+        , isTty = startup.startupStdinTty
+        , mcpSupervisor = request.initializedProcessRuntime.processMcpSupervisor
+        , options = request.initializedOptions
+        , pendingTurn
+        , preferredOpenAiAccountRef = refs.initializedPreferredOpenAiAccountRef
+        , processRuntime = request.initializedProcessRuntime
+        , projectRoot = workspace.initializedProjectRoot
+        , projectSettings = workspace.initializedProjectSettings
+        , projectTarget = targets.initializedProjectTarget
+        , resolveActiveAccountLabel = httpRuntime.initializedResolveActiveAccountLabel
+        , resumeLock = request.initializedResumeLock
+        , resumed = request.initializedResumed
+        , resumedTarget = targets.initializedResumedTarget
+        , root = request.initializedRoot
+        , selectHttpAccount = httpRuntime.initializedSelectHttpAccount
+        , selectableTokenProvider = refs.initializedSelectableTokenProvider
+        , setWindowTitle
+        , startup
+        , stateDirectory = workspace.initializedStateDirectory
+        , stderrHandle = startup.startupStderr
+        , targetHint = targets.initializedTargetHint
+        , tokenProvider = httpRuntime.initializedTokenProvider
+        , transition
+        , transitionTarget = targets.initializedTransitionTarget
+        , uiRuntimeRef = startup.startupUiRuntimeRef
+        , unavailableProviders
+        }
   where
     startup = request.initializedStartup
     fullscreen = startup.startupFullscreen

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -1,4 +1,7 @@
-module Agent.CLI.Runtime.Orchestration.Providers (runAgentProviders) where
+module Agent.CLI.Runtime.Orchestration.Providers
+    ( AgentProviderRequest(..)
+    , runAgentProviders
+    ) where
 
 import Agent.CLI.AccountPicker ()
 import Agent.CLI.AccountSelection ()
@@ -7,21 +10,14 @@ import Agent.CLI.AgentSessions ()
 import Agent.CLI.AgentViewport ()
 import Agent.CLI.Approval ()
 import Agent.CLI.Artifact ()
-import Agent.CLI.Auth.Types (LoadedAuth)
 import Agent.CLI.Clipboard ()
 import Agent.CLI.CodeModeRuntime ()
 import Agent.CLI.Command ()
-import Agent.CLI.Compaction
-    ( CompactOutcome
-    , CompactionInstall
-    , OccupancySnapshot
-    )
 import Agent.CLI.Config ()
 import Agent.CLI.Database ()
 import Agent.CLI.Database.Store ()
 import Agent.CLI.Dialects ()
 import Agent.CLI.GatewayBridge ()
-import Agent.CLI.GatewayClient (GatewayCredential)
 import Agent.CLI.Input ()
 import Agent.CLI.LearnedSkills ()
 import Agent.CLI.LearnedSkills.Store ()
@@ -30,16 +26,11 @@ import Agent.CLI.Lsp ()
 import Agent.CLI.ManagedTurn ()
 import Agent.CLI.McpManager ()
 import Agent.CLI.McpStatus ()
-import Agent.CLI.ModelConfig (ModelCatalog)
 import Agent.CLI.Models ()
-import Agent.CLI.Options (CliOptions)
-import Agent.CLI.PendingInputs (PendingInputs)
 import Agent.CLI.Plan ()
-import Agent.CLI.Project (ModelSwitchScope)
 import Agent.CLI.Prompt ()
 import Agent.CLI.PromptHooks ()
 import Agent.CLI.ProviderAvailability ()
-import Agent.CLI.ProviderTransition (ProviderTransition)
 import Agent.CLI.Recap ()
 import Agent.CLI.ReplMode ()
 import Agent.CLI.Request ()
@@ -75,14 +66,10 @@ import Agent.CLI.Runtime.Types (RunResult)
 import Agent.CLI.Secret ()
 import Agent.CLI.Session.Attachments ()
 import Agent.CLI.Session.Choices ()
-import Agent.CLI.Session.History (LiveConversation)
 import Agent.CLI.Session.Lifecycle ()
 import Agent.CLI.Session.Runtime.Types
-    ( SessionRequest
-    , StartupRuntime(..)
-    )
+    ( StartupRuntime(..) )
 import Agent.CLI.Session.Selection ()
-import Agent.CLI.Session.Types (Persistence)
 import Agent.CLI.SessionAdmin ()
 import Agent.CLI.SessionEnv ()
 import Agent.CLI.SessionLock ()
@@ -91,8 +78,6 @@ import Agent.CLI.SessionTitle ()
 import Agent.CLI.Skills ()
 import Agent.CLI.Startup.Auth (startupDie)
 import Agent.CLI.StartupContext ()
-import Agent.CLI.Subagents.Runtime.Types (SubagentRuntime)
-import Agent.CLI.TUI.App (FullscreenRuntime)
 import Agent.CLI.TUI.History ()
 import Agent.CLI.TUI.SessionHistory ()
 import Agent.CLI.Tools ()
@@ -101,166 +86,46 @@ import Agent.CLI.Usage ()
 import Agent.CLI.WebFetch ()
 import Agent.CLI.Worktree ()
 import Agent.Cancel ()
-import Agent.Dialect (Dialect)
-import Agent.Error (ApiError)
 import Agent.GrokBuild.Dialect.Goal ()
 import Agent.GrokBuild.Dialect.Runtime ()
 import Agent.GrokBuild.Dialect.Task ()
 import Agent.GrokBuild.Dialect.Workflow ()
-import Agent.Loop (TokenUsage, TurnInput)
-import Agent.OpenAI.Auth (Pool)
 import Agent.OpenAI.Compaction ()
 import Agent.OpenAI.Usage ()
-import Agent.OpenRouter.Options (ClientOptions)
 import Agent.Provider
-    ( Credential
-    , Provider(..)
-    , TokenProvider
-    )
+    ( Provider(..) )
 import Agent.ReasoningEffort ()
 import Agent.Responses.GenericClient ()
-import Agent.Responses.Types (ResponseCreateParams)
 import Agent.Skills ()
 import Agent.Store.Postgres ()
 import Agent.Store.Types ()
 import Agent.Subagents.TaskPath ()
 import Agent.Tools.MultiAgents ()
-import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.PlanMode ()
 import Agent.Tools.Secret ()
-import Agent.Tools.TaskPlan (TaskPlanEnv)
 import Agent.Tools.Types ()
 import Agent.TUI.Motion ()
 import Agent.XAI.Usage ()
 import Control.Applicative ()
-import Control.Concurrent.STM (STM)
 import Control.Exception ()
 import Data.ByteString ()
 import Data.Functor ()
-import Data.IORef (IORef)
 import Data.List ()
-import Data.Set (Set)
-import Data.Text (Text)
 import System.Console.ANSI ()
 import System.Console.ANSI.Codes ()
 import System.Directory.OsPath ()
 import System.Environment ()
 import System.Exit ()
-import System.IO (Handle)
-import System.OsPath (OsPath)
 import System.OsPath ()
 import qualified Agent.OpenRouter.Usage ()
 import qualified Agent.Provider ()
 import qualified Data.Map.Strict ()
 import qualified Data.Set ()
-import qualified Agent.Responses.GenericClient as GenericResponses
 
 runAgentProviders
-    :: ModelSwitchScope
-    -> LoadedAuth
-    -> Maybe GatewayCredential
-    -> (Maybe (STM ApiError)
-        -> Maybe TokenProvider
-        -> Maybe Pool
-        -> Maybe (Text -> IO (Either ApiError Text))
-        -> IO (Maybe Int)
-        -> (Maybe Text -> IO (Either Text CompactOutcome))
-        -> SessionRequest)
-    -> IORef Text
-    -> IORef Text
-    -> IORef Text
-    -> ModelCatalog
-    -> Bool
-    -> IORef (Maybe OccupancySnapshot)
-    -> ((Text -> Text) -> Int -> ResponseCreateParams -> Int)
-    -> IORef LiveConversation
-    -> ((Text -> Text) -> IO (Maybe Int))
-    -> Maybe GenericResponses.GenericClientOptions
-    -> OsPath
-    -> Dialect
-    -> Maybe FullscreenRuntime
-    -> IORef (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
-    -> Maybe TaskPlanEnv
-    -> OsPath
-    -> Maybe Text
-    -> Text
-    -> Maybe MultiAgentContext
-    -> ClientOptions
-    -> CliOptions
-    -> ResponseCreateParams
-    -> IORef ResponseCreateParams
-    -> PendingInputs
-    -> Persistence
-    -> IORef (Maybe Text)
-    -> OsPath
-    -> Provider
-    -> (TokenUsage -> IO ())
-    -> (Credential -> IO Text)
-    -> (Text -> IO (Either ApiError Text))
-    -> TokenProvider
-    -> Bool
-    -> StartupRuntime
-    -> Maybe (STM ApiError)
-    -> Handle
-    -> SubagentRuntime
-    -> TokenProvider
-    -> Maybe ProviderTransition
-    -> (Text -> Text)
-    -> Set Provider
-    -> IO RunResult
-runAgentProviders
-    modelSwitchScope
-    loaded
-    connectedGateway
-    sessionRequest
-    activeAccountIdRef
-    activeAccountRef
-    activeSelectionRef
-    catalog
-    claudeBypassEnabled
-    contextTokensRef
-    contextWindowForParams
-    conversationRef
-    currentModelContextWindow
-    customGenericOptions
-    cwd
-    dialect
-    fullscreen
-    automaticCompactionHookRef
-    taskPlan
-    home
-    initialPrevious
-    model
-    multiCtx
-    openRouterOptions
-    options
-    _params
-    paramsRef
-    pendingNotices
-    persist
-    preferredOpenAiAccountRef
-    projectRoot
-    provider
-    recordCompactionUsage
-    resolveActiveAccountLabel
-    selectHttpAccount
-    selectableTokenProvider
-    shouldProbeAtStartup
-    startup
-    startupUnavailable
-    stderrHandle
-    subagentRuntime
-    tokenProvider
-    transition
-    transportModel
-    unavailableProviders
-    =
-        runAgentProvidersRequest AgentProviderRequest{..}
-
-runAgentProvidersRequest
     :: AgentProviderRequest
     -> IO RunResult
-runAgentProvidersRequest request@AgentProviderRequest{provider, startup} =
+runAgentProviders request@AgentProviderRequest{provider, startup} =
     let nativeCapabilities =
             maybe
                 fullNativeRunCapabilities

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -1,4 +1,7 @@
-module Agent.CLI.Runtime.Orchestration.Session (runAgentSession) where
+module Agent.CLI.Runtime.Orchestration.Session
+    ( AgentSessionRequest(..)
+    , runAgentSession
+    ) where
 
 import Agent.CLI.AccountPicker ()
 import Agent.CLI.AccountSelection ()
@@ -91,7 +94,9 @@ import Agent.CLI.Resume ( resumeNeedsGeneratedContext )
 import Agent.CLI.Runtime.HistorySource ()
 import Agent.CLI.Runtime.Orchestration.Background ()
 import Agent.CLI.Runtime.Orchestration.Providers
-    ( runAgentProviders )
+    ( AgentProviderRequest(..)
+    , runAgentProviders
+    )
 import Agent.CLI.Runtime.Orchestration.Restart ()
 import Agent.CLI.Runtime.Orchestration.Startup
     ( clearNativeProgress, mcpToolCollision, reportStartupWarning )
@@ -427,183 +432,9 @@ data SessionLiveRuntime = SessionLiveRuntime
     }
 
 runAgentSession
-    :: LoadedAuth
-    -> Maybe GatewayCredential
-    -> Bool
-    -> OsPath
-    -> IORef Text
-    -> IORef Text
-    -> IORef Text
-    -> GrokSubagentSpecs
-    -> [AppTool]
-    -> ([ImageAttachment] -> IO ())
-    -> IO ()
-    -> IORef Bool
-    -> ModelCatalog
-    -> IORef (Maybe GatewayModelAccess)
-    -> Bool
-    -> (SessionHandle -> IO ())
-    -> Bool
-    -> IO closeResult
-    -> IORef (IO ())
-    -> CodingTools
-    -> (OsPath -> IO (Either Text SubagentWorktree))
-    -> Maybe GenericClientOptions
-    -> OsPath
-    -> [AppTool]
-    -> DatabaseScopes
-    -> Dialect
-    -> Text
-    -> IORef Bool
-    -> [AppTool]
-    -> Maybe FullscreenRuntime
-    -> [AppTool]
-    -> IORef Bool
-    -> Maybe [Text]
-    -> Maybe (Text -> IO (Maybe CollaborationModelTarget))
-    -> Maybe (Text -> IO Bool)
-    -> OsPath
-    -> ModelTarget
-    -> InterruptState
-    -> [AppTool]
-    -> Maybe LegacySubagentTarget
-    -> MCP.McpFleet
-    -> [(Text, Text)]
-    -> [AppTool]
-    -> Text
-    -> Maybe MultiAgentContext
-    -> (OsPath -> IO ())
-    -> ClientOptions
-    -> Maybe TokenProvider
-    -> CliOptions
-    -> PendingInputs
-    -> Maybe PendingTurn
-    -> Persistence
-    -> PlanModeHooks
-    -> PlanModeEnv
-    -> ApprovalPolicy
-    -> IORef (Maybe Text)
-    -> OsPath
-    -> Maybe ManagedTurnRequest
-    -> Provider
-    -> Bool
-    -> SubagentRegistry
-    -> (Credential -> IO Text)
-    -> Bool
-    -> Maybe (SessionMeta, [SessionTurn])
-    -> OsPath
-    -> IORef (Maybe RootTurnId)
-    -> (Text -> IO (Either ApiError Text))
-    -> TokenProvider
-    -> [AppTool]
-    -> (Text -> IO titleResult)
-    -> IORef [SkillInvocation]
-    -> IORef SkillCatalog
-    -> StartupRuntime
-    -> FilePath
-    -> Handle
-    -> IORef (Maybe (IO [ResponseItem]))
-    -> IORef (Map SubagentId SubagentSession)
-    -> SubagentStoreRoot
-    -> TokenProvider
-    -> ToolEnv
-    -> [AppTool]
-    -> Maybe ProviderTransition
-    -> (Text -> Text)
-    -> Set Provider
-    -> IO RunResult
-runAgentSession
-    loaded
-    connectedGateway
-    learnAboutUserRequested
-    sessionTmp
-    activeAccountIdRef
-    activeAccountRef
-    activeSelectionRef
-    agentTypesRef
-    allTools
-    recordImageGenerationInputs
-    clearImageGenerationHistory
-    bashEnabledRef
-    catalog
-    gatewayModelsRef
-    checkStartupUsageInBackground
-    claimCurrentSession
-    claudeBypassEnabled
-    closeAll
-    codeModeCloseRef
-    coding
-    createSubagentWorktree
-    customGenericOptions
-    cwd
-    databaseAppTools
-    databaseScopes
-    dialect
-    effortText
-    escPaused
-    extraTools
-    fullscreen
-    gatewayTools
-    ghciEnabledRef
-    allowedChildModels
-    resolveChildModel
-    childModelAllowed
-    home
-    inferredTarget
-    interrupt
-    learnedSkillAppTools
-    legacySubagentTarget
-    mcpFleet
-    mcpInstructions
-    mcpTools
-    model
-    multiCtx
-    noteSessionDir
-    openRouterOptions
-    openaiChild
-    options
-    pendingNotices
-    pendingTurn
-    persist
-    planHooks
-    planMode
-    policy
-    preferredOpenAiAccountRef
-    projectRoot
-    promptRequest
-    provider
-    refreshDialectContext
-    registry
-    resolveActiveAccountLabel
-    resumeTargetChanged
-    resumed
-    root
-    rootTurnRef
-    selectHttpAccount
-    selectableTokenProvider
-    sessionTools
-    setWindowTitle
-    skillInvocationsRef
-    skillsRef
-    startup
-    stateDirectory
-    stderrHandle
-    subagentForkSource
-    subagentSessions
-    subagentStoreRoot
-    tokenProvider
-    toolEnv
-    tools
-    transition
-    transportModel
-    unavailableProviders
-    =
-    runAgentSessionRequest AgentSessionRequest{..}
-
-runAgentSessionRequest
     :: AgentSessionRequest closeResult windowTitleResult
     -> IO RunResult
-runAgentSessionRequest request@AgentSessionRequest{closeAll} =
+runAgentSession request@AgentSessionRequest{closeAll} =
     flip finally closeAll do
         validateSessionMcpTools request
         codeRuntime <- prepareSessionCodeRuntime request
@@ -1306,59 +1137,63 @@ launchPreparedSession request promptRuntime liveRuntime = do
     runSessionWithInterruptHandling request progName $
         withSessionStartupAvailability request shouldProbeAtStartup
             \startupUnavailable ->
-                runAgentProviders
-                    (if request.startup.startupBackground
-                        then SessionLocalSwitch
-                        else TopLevelSwitch)
-                    request.loaded
-                    request.connectedGateway
-                    (buildProviderSessionRequest
-                        request
-                        promptRuntime
-                        liveRuntime)
-                    request.activeAccountIdRef
-                    request.activeAccountRef
-                    request.activeSelectionRef
-                    request.catalog
-                    request.claudeBypassEnabled
-                    liveRuntime.sessionContextTokensRef
-                    (sessionContextWindowForParams request)
-                    liveRuntime.sessionConversationRef
-                    (sessionCurrentModelContextWindow
-                        request
-                        promptRuntime)
-                    request.customGenericOptions
-                    request.cwd
-                    request.dialect
-                    request.fullscreen
-                    promptRuntime.sessionAutomaticCompactionHookRef
-                    request.coding.codingTaskPlan
-                    request.home
-                    promptRuntime.sessionInitialPrevious
-                    request.model
-                    request.multiCtx
-                    request.openRouterOptions
-                    request.options
-                    promptRuntime.sessionParams
-                    promptRuntime.sessionParamsRef
-                    request.pendingNotices
-                    request.persist
-                    request.preferredOpenAiAccountRef
-                    request.projectRoot
-                    request.provider
-                    liveRuntime.sessionRecordCompactionUsage
-                    request.resolveActiveAccountLabel
-                    request.selectHttpAccount
-                    request.selectableTokenProvider
-                    shouldProbeAtStartup
-                    request.startup
-                    startupUnavailable
-                    request.stderrHandle
-                    liveRuntime.sessionSubagentRuntime
-                    request.tokenProvider
-                    request.transition
-                    request.transportModel
-                    request.unavailableProviders
+                runAgentProviders AgentProviderRequest
+                    { modelSwitchScope =
+                          if request.startup.startupBackground
+                              then SessionLocalSwitch
+                              else TopLevelSwitch
+                    , loaded = request.loaded
+                    , connectedGateway = request.connectedGateway
+                    , sessionRequest =
+                          buildProviderSessionRequest
+                              request
+                              promptRuntime
+                              liveRuntime
+                    , activeAccountIdRef = request.activeAccountIdRef
+                    , activeAccountRef = request.activeAccountRef
+                    , activeSelectionRef = request.activeSelectionRef
+                    , catalog = request.catalog
+                    , claudeBypassEnabled = request.claudeBypassEnabled
+                    , contextTokensRef = liveRuntime.sessionContextTokensRef
+                    , contextWindowForParams = sessionContextWindowForParams request
+                    , conversationRef = liveRuntime.sessionConversationRef
+                    , currentModelContextWindow =
+                          sessionCurrentModelContextWindow
+                              request
+                              promptRuntime
+                    , customGenericOptions = request.customGenericOptions
+                    , cwd = request.cwd
+                    , dialect = request.dialect
+                    , fullscreen = request.fullscreen
+                    , automaticCompactionHookRef =
+                        promptRuntime.sessionAutomaticCompactionHookRef
+                    , taskPlan = request.coding.codingTaskPlan
+                    , home = request.home
+                    , initialPrevious = promptRuntime.sessionInitialPrevious
+                    , model = request.model
+                    , multiCtx = request.multiCtx
+                    , openRouterOptions = request.openRouterOptions
+                    , options = request.options
+                    , paramsRef = promptRuntime.sessionParamsRef
+                    , pendingNotices = request.pendingNotices
+                    , persist = request.persist
+                    , preferredOpenAiAccountRef = request.preferredOpenAiAccountRef
+                    , projectRoot = request.projectRoot
+                    , provider = request.provider
+                    , recordCompactionUsage = liveRuntime.sessionRecordCompactionUsage
+                    , resolveActiveAccountLabel = request.resolveActiveAccountLabel
+                    , selectHttpAccount = request.selectHttpAccount
+                    , selectableTokenProvider = request.selectableTokenProvider
+                    , shouldProbeAtStartup
+                    , startup = request.startup
+                    , startupUnavailable
+                    , stderrHandle = request.stderrHandle
+                    , subagentRuntime = liveRuntime.sessionSubagentRuntime
+                    , tokenProvider = request.tokenProvider
+                    , transition = request.transition
+                    , transportModel = request.transportModel
+                    , unavailableProviders = request.unavailableProviders
+                    }
 
 -- | Print a copy-pasteable --resume line whenever the CLI session quits.
 -- Ctrl-C is normalized to the same graceful 'RunQuit' result as :q/Ctrl-D so

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -1,4 +1,7 @@
-module Agent.CLI.Runtime.Orchestration.Tools (runAgentTools) where
+module Agent.CLI.Runtime.Orchestration.Tools
+    ( AgentToolsRequest(..)
+    , runAgentTools
+    ) where
 
 import Agent.CLI.AccountPicker ()
 import Agent.CLI.AccountSelection ()
@@ -136,7 +139,9 @@ import Agent.CLI.Runtime.Orchestration.Types
     , nativePreparedDiscovery
     )
 import Agent.CLI.Runtime.Orchestration.Restart ()
-import Agent.CLI.Runtime.Orchestration.Session ( runAgentSession )
+import Agent.CLI.Runtime.Orchestration.Session ( AgentSessionRequest(..)
+    , runAgentSession
+    )
 import Agent.CLI.Runtime.Orchestration.Startup
     ( reportStartupWarning )
 import Agent.CLI.Runtime.Persistence ( preparePersistence )
@@ -541,111 +546,9 @@ data SessionToolsRuntime = SessionToolsRuntime
     }
 
 runAgentTools
-    :: (AgentRunMode -> CliOptions -> IO DevResult)
-    -> LoadedAuth
-    -> Maybe GatewayCredential
-    -> Bool
-    -> Maybe Text
-    -> IORef Text
-    -> IORef Text
-    -> IORef Text
-    -> ToolEnv
-    -> ModelCatalog
-    -> SkillCatalog
-    -> IORef (Maybe GatewayModelAccess)
-    -> Maybe Text
-    -> Bool
-    -> Maybe ModelTarget
-    -> Maybe (Text, ResponsesConnection)
-    -> OsPath
-    -> DatabaseScopes
-    -> IORef Bool
-    -> Maybe FullscreenRuntime
-    -> OsPath
-    -> InterruptState
-    -> Bool
-    -> MCP.McpSupervisor
-    -> CliOptions
-    -> Maybe PendingTurn
-    -> IORef (Maybe Text)
-    -> AgentProcessRuntime
-    -> OsPath
-    -> ProjectSettings
-    -> Maybe ModelTarget
-    -> (Credential -> IO Text)
-    -> Maybe SessionLock
-    -> Maybe (SessionMeta, [SessionTurn])
-    -> Maybe ModelTarget
-    -> OsPath
-    -> (Text -> IO (Either ApiError Text))
-    -> TokenProvider
-    -> (Text -> IO windowTitleResult)
-    -> StartupRuntime
-    -> FilePath
-    -> Handle
-    -> Maybe ModelTarget
-    -> TokenProvider
-    -> Maybe ProviderTransition
-    -> Maybe ModelTarget
-    -> IORef (Maybe FullscreenRuntime)
-    -> Set Provider
-    -> IO RunResult
-runAgentTools
-    runAgentChild
-    loaded
-    connectedGateway
-    learnAboutUserRequested
-    customBearerToken
-    activeAccountIdRef
-    activeAccountRef
-    activeSelectionRef
-    baseToolEnv
-    catalog
-    initialSkills
-    gatewayModelsRef
-    gatewayIdentity
-    checkStartupUsageInBackground
-    configuredOptionTarget
-    customResponses
-    cwd
-    databaseScopes
-    escPaused
-    fullscreen
-    home
-    interrupt
-    isTty
-    mcpSupervisor
-    options
-    pendingTurn
-    preferredOpenAiAccountRef
-    processRuntime
-    projectRoot
-    projectSettings
-    projectTarget
-    resolveActiveAccountLabel
-    resumeLock
-    resumed
-    resumedTarget
-    root
-    selectHttpAccount
-    selectableTokenProvider
-    setWindowTitle
-    startup
-    stateDirectory
-    stderrHandle
-    targetHint
-    tokenProvider
-    transition
-    transitionTarget
-    uiRuntimeRef
-    unavailableProviders
-    =
-    runAgentToolsRequest AgentToolsRequest{..}
-
-runAgentToolsRequest
     :: AgentToolsRequest windowTitleResult
     -> IO RunResult
-runAgentToolsRequest request = withResourceScope \resourceScope -> do
+runAgentTools request = withResourceScope \resourceScope -> do
     toolStartup <- loadToolStartup request
     let toolModelRuntime = resolveToolModel request toolStartup
         toolHostHooks =
@@ -2044,88 +1947,91 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
     forM_ startup.startupNativeHooks \hooks ->
         when (hooks.nativeInteractionMode == NativePlan) $
             writeIORef planMode.planStateRef PlanPending
-    runAgentSession
-        loaded
-        connectedGateway
-        learnAboutUserRequested
-        sessionTmp
-        activeAccountIdRef
-        activeAccountRef
-        activeSelectionRef
-        agentTypesRef
-        allTools
-        (recordImageGenerationImages imageGenerationHistory)
-        (clearImageGenerationHistory imageGenerationHistory)
-        bashEnabledRef
-        catalog
-        gatewayModelsRef
-        checkStartupUsageInBackground
-        claimCurrentSession
-        claudeBypassEnabled
-        closeAll
-        codeModeCloseRef
-        coding
-        createSubagentWorktree
-        customGenericOptions
-        cwd
-        databaseAppTools
-        databaseScopes
-        dialect
-        effortText
-        escPaused
-        extraTools
-        fullscreen
-        gatewayTools
-        ghciEnabledRef
-        allowedChildModels
-        resolveCollaborationChildModel
-        childModelAllowed
-        home
-        inferredTarget
-        interrupt
-        learnedSkillAppTools
-        legacySubagentTarget
-        mcpFleet
-        mcpInstructions
-        mcpTools
-        model
-        multiCtx
-        noteSessionDir
-        openRouterOptions
-        openaiChild
-        options
-        pendingNotices
-        pendingTurn
-        persist
-        planHooks
-        planMode
-        policy
-        preferredOpenAiAccountRef
-        projectRoot
-        promptRequest
-        provider
-        refreshDialectContext
-        registry
-        resolveActiveAccountLabel
-        resumeTargetChanged
-        resumed
-        root
-        rootTurnRef
-        selectHttpAccount
-        selectableTokenProvider
-        agentSessionAppTools
-        setWindowTitle
-        skillInvocationsRef
-        skillsRef
-        startup
-        stateDirectory
-        stderrHandle
-        subagentForkSource
-        subagentSessions
-        subagentStoreRoot
-        tokenProvider
-        baseToolEnv
-        tools
-        transition
-        transportModel
-        unavailableProviders
+    runAgentSession AgentSessionRequest
+        { loaded
+        , connectedGateway
+        , learnAboutUserRequested
+        , sessionTmp
+        , activeAccountIdRef
+        , activeAccountRef
+        , activeSelectionRef
+        , agentTypesRef
+        , allTools
+        , recordImageGenerationInputs =
+            recordImageGenerationImages imageGenerationHistory
+        , clearImageGenerationHistory =
+            clearImageGenerationHistory imageGenerationHistory
+        , bashEnabledRef
+        , catalog
+        , gatewayModelsRef
+        , checkStartupUsageInBackground
+        , claimCurrentSession
+        , claudeBypassEnabled
+        , closeAll
+        , codeModeCloseRef
+        , coding
+        , createSubagentWorktree
+        , customGenericOptions
+        , cwd
+        , databaseAppTools
+        , databaseScopes
+        , dialect
+        , effortText
+        , escPaused
+        , extraTools
+        , fullscreen
+        , gatewayTools
+        , ghciEnabledRef
+        , allowedChildModels
+        , resolveChildModel = resolveCollaborationChildModel
+        , childModelAllowed
+        , home
+        , inferredTarget
+        , interrupt
+        , learnedSkillAppTools
+        , legacySubagentTarget
+        , mcpFleet
+        , mcpInstructions
+        , mcpTools
+        , model
+        , multiCtx
+        , noteSessionDir
+        , openRouterOptions
+        , openaiChild
+        , options
+        , pendingNotices
+        , pendingTurn
+        , persist
+        , planHooks
+        , planMode
+        , policy
+        , preferredOpenAiAccountRef
+        , projectRoot
+        , promptRequest
+        , provider
+        , refreshDialectContext
+        , registry
+        , resolveActiveAccountLabel
+        , resumeTargetChanged
+        , resumed
+        , root
+        , rootTurnRef
+        , selectHttpAccount
+        , selectableTokenProvider
+        , sessionTools = agentSessionAppTools
+        , setWindowTitle
+        , skillInvocationsRef
+        , skillsRef
+        , startup
+        , stateDirectory
+        , stderrHandle
+        , subagentForkSource
+        , subagentSessions
+        , subagentStoreRoot
+        , tokenProvider
+        , toolEnv = baseToolEnv
+        , tools
+        , transition
+        , transportModel
+        , unavailableProviders
+        }


### PR DESCRIPTION
The runtime startup path passed 48 arguments into tool setup, 86 into session setup, and 45 into provider dispatch, only to immediately wrap them in existing request records. Callers now construct those records directly with named fields, and the redundant adapters and unused provider parameter are removed.

Validation: `nix develop -c cabal repl agent-cli:lib:agent-cli --repl-options=-ignore-dot-ghci` loaded all 202 modules successfully; `git diff --check` passed. This changes internal argument wiring without changing CLI interactions or provider behavior.
