### PR TITLE
Share PostgreSQL skill projections and row codecs

### DIFF
--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -78,6 +78,7 @@ library
                     , Agent.Store.Postgres.SessionItem.Mapping.Statements.Tagged
                     , Agent.Store.Postgres.SessionItem.Read
                     , Agent.Store.Postgres.SessionItem.Write
+                    , Agent.Store.Postgres.Skill.Mapping.Codec
                     , Agent.Store.Postgres.Skill.Mapping.Types
                     , Agent.Store.Postgres.Skill.Mapping.Statements.InsertRevision
                     , Agent.Store.Postgres.Skill.Mapping.Statements.InsertSkill

--- a/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Codec.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Codec.hs
@@ -1,0 +1,84 @@
+module Agent.Store.Postgres.Skill.Mapping.Codec
+    ( scopeSlugEncoder
+    , applicableScopesEncoder
+    , skillSelectSql
+    , skillColumns
+    , revisionColumns
+    , skillRowDecoder
+    , revisionRowDecoder
+    ) where
+
+import Agent.Store.Postgres.Skill.Mapping.Types
+import Data.Functor.Contravariant ((>$<))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
+
+scopeSlugEncoder :: Encoders.Params ScopeSlugParams
+scopeSlugEncoder =
+    ((.scopeSlugKind) >$< textParam)
+        <> ((.scopeSlugId) >$< textParam)
+        <> ((.scopeSlug) >$< textParam)
+  where
+    textParam = Encoders.param (Encoders.nonNullable Encoders.text)
+
+applicableScopesEncoder :: Encoders.Params ApplicableScopes
+applicableScopesEncoder =
+    ((.applicableUserScopeId) >$< textParam)
+        <> ((.applicableRepositoryScopeId) >$< textParam)
+        <> ((.applicableCheckoutScopeId) >$< textParam)
+  where
+    textParam = Encoders.param (Encoders.nonNullable Encoders.text)
+
+skillSelectSql :: Text
+skillSelectSql = "SELECT " <> skillColumns "" <> " FROM harness.skills"
+
+-- Keep each SQL projection beside its positional decoder. The prefix is a
+-- fixed table alias supplied by the statement, including its trailing dot.
+skillColumns :: Text -> Text
+skillColumns prefix = Text.intercalate ", " $ map (prefix <>)
+    [ "skill_id::text", "scope_kind", "scope_id::text", "slug", "title"
+    , "description", "applies_when", "instructions_text", "activation_mode"
+    , "priority", "status", "current_revision", "created_at", "updated_at"
+    ]
+
+skillRowDecoder :: Decoders.Row SkillRow
+skillRowDecoder =
+    SkillRow
+        <$> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.int4)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
+        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
+        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
+
+revisionColumns :: Text -> Text
+revisionColumns prefix = Text.intercalate ", " $ map (prefix <>)
+    [ "skill_revision_id::text", "revision_number", "title", "description"
+    , "applies_when", "instructions_text", "activation_mode", "priority"
+    , "status", "change_summary", "created_at"
+    ]
+
+revisionRowDecoder :: Decoders.Row RevisionRow
+revisionRowDecoder =
+    RevisionRow
+        <$> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.int4)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.text)
+        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)

--- a/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/ListRevisions.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/ListRevisions.hs
@@ -10,17 +10,20 @@ import qualified Hasql.Encoders as Encoders
 import Hasql.Statement (Statement)
 
 import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Postgres.Skill.Mapping.Codec
+    ( scopeSlugEncoder
+    , revisionRowDecoder
+    , revisionColumns
+    )
 import Agent.Store.Postgres.Skill.Mapping.Types
 
 listRevisionsStatement :: Statement ScopeSlugParams [RevisionRow]
 listRevisionsStatement = mkStatement
-    "SELECT r.skill_revision_id::text, r.revision_number, r.title,\
-    \ r.description, r.applies_when, r.instructions_text,\
-    \ r.activation_mode, r.priority, r.status, r.change_summary, r.created_at\
-    \ FROM harness.skill_revisions r\
-    \ JOIN harness.skills s ON s.skill_id = r.skill_id\
-    \ WHERE s.scope_kind = $1 AND s.scope_id = $2::uuid AND s.slug = $3\
-    \ ORDER BY r.revision_number DESC"
+    ("SELECT " <> revisionColumns "r."
+        <> " FROM harness.skill_revisions r\
+        \ JOIN harness.skills s ON s.skill_id = r.skill_id\
+        \ WHERE s.scope_kind = $1 AND s.scope_id = $2::uuid AND s.slug = $3\
+        \ ORDER BY r.revision_number DESC")
     scopeSlugEncoder
     (Decoders.rowList revisionRowDecoder)
     True
@@ -28,38 +31,13 @@ listRevisionsStatement = mkStatement
 listRevisionsLimitedStatement
     :: Statement (ScopeSlugParams, Int64) [RevisionRow]
 listRevisionsLimitedStatement = mkStatement
-    "SELECT r.skill_revision_id::text, r.revision_number, r.title,\
-    \ r.description, r.applies_when, r.instructions_text,\
-    \ r.activation_mode, r.priority, r.status, r.change_summary, r.created_at\
-    \ FROM harness.skill_revisions r\
-    \ JOIN harness.skills s ON s.skill_id = r.skill_id\
-    \ WHERE s.scope_kind = $1 AND s.scope_id = $2::uuid AND s.slug = $3\
-    \ ORDER BY r.revision_number DESC LIMIT $4"
+    ("SELECT " <> revisionColumns "r."
+        <> " FROM harness.skill_revisions r\
+        \ JOIN harness.skills s ON s.skill_id = r.skill_id\
+        \ WHERE s.scope_kind = $1 AND s.scope_id = $2::uuid AND s.slug = $3\
+        \ ORDER BY r.revision_number DESC LIMIT $4")
     ( (fst >$< scopeSlugEncoder)
         <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.int8))
     )
     (Decoders.rowList revisionRowDecoder)
     True
-
-scopeSlugEncoder :: Encoders.Params ScopeSlugParams
-scopeSlugEncoder =
-    ((.scopeSlugKind) >$< textParam)
-        <> ((.scopeSlugId) >$< textParam)
-        <> ((.scopeSlug) >$< textParam)
-  where
-    textParam = Encoders.param (Encoders.nonNullable Encoders.text)
-
-revisionRowDecoder :: Decoders.Row RevisionRow
-revisionRowDecoder =
-    RevisionRow
-        <$> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int4)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)

--- a/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/ListSkills.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/ListSkills.hs
@@ -11,6 +11,11 @@ import qualified Hasql.Encoders as Encoders
 import Hasql.Statement (Statement)
 
 import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Postgres.Skill.Mapping.Codec
+    ( applicableScopesEncoder
+    , skillSelectSql
+    , skillRowDecoder
+    )
 import Agent.Store.Postgres.Skill.Mapping.Types
 
 listSkillsStatement :: Statement ApplicableScopes [SkillRow]
@@ -43,9 +48,7 @@ listAllSkillsLimitedStatement = mkStatement
         <> applicableWhereSql
         <> " AND ($4::text IS NULL OR scope_kind = $4)\
            \ ORDER BY scope_kind, title, slug LIMIT $5")
-    ( ((.applicableUserScopeId) . (.skillListScopes) >$< textParam)
-        <> ((.applicableRepositoryScopeId) . (.skillListScopes) >$< textParam)
-        <> ((.applicableCheckoutScopeId) . (.skillListScopes) >$< textParam)
+    ( ((.skillListScopes) >$< applicableScopesEncoder)
         <> ((.skillListKind)
             >$< Encoders.param (Encoders.nullable Encoders.text))
         <> ((.skillListLimit)
@@ -53,23 +56,6 @@ listAllSkillsLimitedStatement = mkStatement
     )
     (Decoders.rowList skillRowDecoder)
     True
-  where
-    textParam = Encoders.param (Encoders.nonNullable Encoders.text)
-
-applicableScopesEncoder :: Encoders.Params ApplicableScopes
-applicableScopesEncoder =
-    ((.applicableUserScopeId) >$< textParam)
-        <> ((.applicableRepositoryScopeId) >$< textParam)
-        <> ((.applicableCheckoutScopeId) >$< textParam)
-  where
-    textParam = Encoders.param (Encoders.nonNullable Encoders.text)
-
-skillSelectSql :: Text
-skillSelectSql =
-    "SELECT skill_id::text, scope_kind, scope_id::text, slug, title,\
-    \ description, applies_when, instructions_text, activation_mode,\
-    \ priority, status, current_revision, created_at, updated_at\
-    \ FROM harness.skills"
 
 applicableWhereSql :: Text
 applicableWhereSql =
@@ -78,21 +64,3 @@ applicableWhereSql =
     \ OR (scope_kind = 'repository' AND scope_id = $2::uuid)\
     \ OR (scope_kind = 'checkout' AND scope_id = $3::uuid)\
     \ )"
-
-skillRowDecoder :: Decoders.Row SkillRow
-skillRowDecoder =
-    SkillRow
-        <$> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int4)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
-        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
-        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)

--- a/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/LoadRevision.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/LoadRevision.hs
@@ -10,6 +10,10 @@ import qualified Hasql.Encoders as Encoders
 import Hasql.Statement (Statement)
 
 import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Postgres.Skill.Mapping.Codec
+    ( revisionRowDecoder
+    , revisionColumns
+    )
 import Agent.Store.Postgres.Skill.Mapping.Types
 
 loadRevisionStatement :: Statement (Text, Int64) (Maybe RevisionRow)
@@ -24,21 +28,4 @@ loadRevisionStatement = mkStatement
 
 revisionSelectSql :: Text
 revisionSelectSql =
-    "SELECT skill_revision_id::text, revision_number, title, description,\
-    \ applies_when, instructions_text, activation_mode, priority, status,\
-    \ change_summary, created_at FROM harness.skill_revisions"
-
-revisionRowDecoder :: Decoders.Row RevisionRow
-revisionRowDecoder =
-    RevisionRow
-        <$> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int4)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
+    "SELECT " <> revisionColumns "" <> " FROM harness.skill_revisions"

--- a/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/LockSkill.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/LockSkill.hs
@@ -2,13 +2,15 @@ module Agent.Store.Postgres.Skill.Mapping.Statements.LockSkill
     ( lockSkillStatement
     ) where
 
-import Data.Functor.Contravariant ((>$<))
-import Data.Text (Text)
 import qualified Hasql.Decoders as Decoders
-import qualified Hasql.Encoders as Encoders
 import Hasql.Statement (Statement)
 
 import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Postgres.Skill.Mapping.Codec
+    ( scopeSlugEncoder
+    , skillSelectSql
+    , skillRowDecoder
+    )
 import Agent.Store.Postgres.Skill.Mapping.Types
 
 lockSkillStatement :: Statement ScopeSlugParams (Maybe SkillRow)
@@ -19,36 +21,3 @@ lockSkillStatement = mkStatement
     scopeSlugEncoder
     (Decoders.rowMaybe skillRowDecoder)
     True
-
-scopeSlugEncoder :: Encoders.Params ScopeSlugParams
-scopeSlugEncoder =
-    ((.scopeSlugKind) >$< textParam)
-        <> ((.scopeSlugId) >$< textParam)
-        <> ((.scopeSlug) >$< textParam)
-  where
-    textParam = Encoders.param (Encoders.nonNullable Encoders.text)
-
-skillSelectSql :: Text
-skillSelectSql =
-    "SELECT skill_id::text, scope_kind, scope_id::text, slug, title,\
-    \ description, applies_when, instructions_text, activation_mode,\
-    \ priority, status, current_revision, created_at, updated_at\
-    \ FROM harness.skills"
-
-skillRowDecoder :: Decoders.Row SkillRow
-skillRowDecoder =
-    SkillRow
-        <$> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int4)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
-        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
-        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)

--- a/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/ReadSkill.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/ReadSkill.hs
@@ -5,12 +5,18 @@ module Agent.Store.Postgres.Skill.Mapping.Statements.ReadSkill
 
 import Data.Functor.Contravariant ((>$<))
 import Data.Int (Int64)
-import Data.Text (Text)
 import qualified Hasql.Decoders as Decoders
 import qualified Hasql.Encoders as Encoders
 import Hasql.Statement (Statement)
 
 import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Postgres.Skill.Mapping.Codec
+    ( scopeSlugEncoder
+    , skillSelectSql
+    , skillRowDecoder
+    , revisionRowDecoder
+    , revisionColumns
+    )
 import Agent.Store.Postgres.Skill.Mapping.Types
 
 readSkillStatement :: Statement ScopeSlugParams (Maybe SkillRow)
@@ -24,63 +30,13 @@ readSkillStatement = mkStatement
 readRevisionStatement
     :: Statement (ScopeSlugParams, Int64) (Maybe RevisionRow)
 readRevisionStatement = mkStatement
-    "SELECT r.skill_revision_id::text, r.revision_number, r.title,\
-    \ r.description, r.applies_when, r.instructions_text,\
-    \ r.activation_mode, r.priority, r.status, r.change_summary, r.created_at\
-    \ FROM harness.skill_revisions r\
-    \ JOIN harness.skills s ON s.skill_id = r.skill_id\
-    \ WHERE s.scope_kind = $1 AND s.scope_id = $2::uuid AND s.slug = $3\
-    \ AND r.revision_number = $4"
+    ("SELECT " <> revisionColumns "r."
+        <> " FROM harness.skill_revisions r\
+        \ JOIN harness.skills s ON s.skill_id = r.skill_id\
+        \ WHERE s.scope_kind = $1 AND s.scope_id = $2::uuid AND s.slug = $3\
+        \ AND r.revision_number = $4")
     ( (fst >$< scopeSlugEncoder)
         <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.int8))
     )
     (Decoders.rowMaybe revisionRowDecoder)
     True
-
-scopeSlugEncoder :: Encoders.Params ScopeSlugParams
-scopeSlugEncoder =
-    ((.scopeSlugKind) >$< textParam)
-        <> ((.scopeSlugId) >$< textParam)
-        <> ((.scopeSlug) >$< textParam)
-  where
-    textParam = Encoders.param (Encoders.nonNullable Encoders.text)
-
-skillSelectSql :: Text
-skillSelectSql =
-    "SELECT skill_id::text, scope_kind, scope_id::text, slug, title,\
-    \ description, applies_when, instructions_text, activation_mode,\
-    \ priority, status, current_revision, created_at, updated_at\
-    \ FROM harness.skills"
-
-skillRowDecoder :: Decoders.Row SkillRow
-skillRowDecoder =
-    SkillRow
-        <$> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int4)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
-        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
-        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
-
-revisionRowDecoder :: Decoders.Row RevisionRow
-revisionRowDecoder =
-    RevisionRow
-        <$> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int4)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)

--- a/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/SearchSkills.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Skill/Mapping/Statements/SearchSkills.hs
@@ -9,6 +9,11 @@ import qualified Hasql.Encoders as Encoders
 import Hasql.Statement (Statement)
 
 import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Postgres.Skill.Mapping.Codec
+    ( skillRowDecoder
+    , skillColumns
+    , applicableScopesEncoder
+    )
 import Agent.Store.Postgres.Skill.Mapping.Types
 
 searchSkillsStatement
@@ -30,9 +35,7 @@ searchSkillsStatement = mkStatement
            \ ORDER BY ts_rank_cd(s.search_vector, query.value) DESC,\
            \ s.priority DESC, s.updated_at DESC\
            \ LIMIT $5")
-    ( ((.applicableUserScopeId) . (.skillSearchScopes) >$< Encoders.param (Encoders.nonNullable Encoders.text))
-        <> ((.applicableRepositoryScopeId) . (.skillSearchScopes) >$< Encoders.param (Encoders.nonNullable Encoders.text))
-        <> ((.applicableCheckoutScopeId) . (.skillSearchScopes) >$< Encoders.param (Encoders.nonNullable Encoders.text))
+    ( ((.skillSearchScopes) >$< applicableScopesEncoder)
         <> ((.skillSearchQuery) >$< Encoders.param (Encoders.nonNullable Encoders.text))
         <> ((.skillSearchLimit) >$< Encoders.param (Encoders.nonNullable Encoders.int8))
     )
@@ -40,10 +43,7 @@ searchSkillsStatement = mkStatement
     True
 
 skillSelectSqlWithPrefix :: Text
-skillSelectSqlWithPrefix =
-    "SELECT s.skill_id::text, s.scope_kind, s.scope_id::text, s.slug, s.title,\
-    \ s.description, s.applies_when, s.instructions_text, s.activation_mode,\
-    \ s.priority, s.status, s.current_revision, s.created_at, s.updated_at"
+skillSelectSqlWithPrefix = "SELECT " <> skillColumns "s."
 
 applicableWhereSqlWithPrefix :: Text
 applicableWhereSqlWithPrefix =
@@ -52,21 +52,3 @@ applicableWhereSqlWithPrefix =
     \ OR (s.scope_kind = 'repository' AND s.scope_id = $2::uuid)\
     \ OR (s.scope_kind = 'checkout' AND s.scope_id = $3::uuid)\
     \ )"
-
-skillRowDecoder :: Decoders.Row SkillRow
-skillRowDecoder =
-    SkillRow
-        <$> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int4)
-        <*> Decoders.column (Decoders.nonNullable Decoders.text)
-        <*> Decoders.column (Decoders.nonNullable Decoders.int8)
-        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)
-        <*> Decoders.column (Decoders.nonNullable Decoders.timestamptz)


### PR DESCRIPTION
Skill reads, lists, searches, and updates maintained separate copies of the same SQL column order, row decoders, and scope encoders. Move those definitions into an internal mapping codec, including the revision mapping, and reuse them from the existing statements. Query filtering, ordering, locking, and parameter positions are preserved.

Validation: `nix develop -c cabal repl --offline agent-store:test:agent-store-test --repl-options=-ignore-dot-ghci`, then `:main --match "PostgreSQL learned skill storage"`: 3 examples, 0 failures, exercising create/search/update/archive/rollback and persistence across reopening the store. The library and test modules also loaded in multi-package GHCi. Regenerated `package.nix` with `cabal2nix` (no dependency-expression change); `git diff --check` passed.
