### PR TITLE
Share Gemini and OpenRouter session orchestration

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Common.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Common.hs
@@ -1,15 +1,24 @@
 module Agent.CLI.Runtime.Orchestration.Providers.Common
-    ( decorateAutomaticCompact
+    ( HttpProviderSession(..)
+    , runHttpProvider
+    , decorateAutomaticCompact
     , decorateManualCompact
     , runSession
     , startupFailure
     ) where
 
+import Agent.CLI.Auth.Types (LoadedAuth(..), isGatewayLoadedAuth)
 import Agent.CLI.Compaction
     ( CompactOutcome
+    , OccupancySnapshot
+    , boundCompletedToolContinuations
+    , installLiveCompactOutcome
     , decorateCompactOutcomeWithTaskPlanWithin
+    , runResponsesCompactWithContextWindow
     )
 import Agent.CLI.Error (formatApiErrorAt)
+import Agent.CLI.PendingInputs (withPendingInputs)
+import Agent.CLI.Provider.Switch (prepareTransitionBackend)
 import Agent.CLI.Runtime.Orchestration.Providers.Types
     ( AgentProviderRequest(..)
     )
@@ -26,16 +35,23 @@ import Agent.CLI.Runtime.Repl
     , runPendingTurn
     )
 import Agent.CLI.Runtime.Types (RunResult)
+import Agent.CLI.Session.History (readLiveTranscript)
 import Agent.CLI.Session.Runtime.Types
-    ( SessionBackend
+    ( SessionBackend(..)
     , SessionRequest
+    , StartupRuntime(..)
     )
+import Agent.CLI.Subagents.Runtime (runHttpSubagent)
+import Agent.Connectivity (withConnectionRecoveryOn)
 import Agent.Error
     ( ApiError(ProviderError)
     , ErrorType(InvalidRequestError)
     )
-import Agent.Responses.Types (ResponseCreateParams)
-import Data.IORef (readIORef)
+import Agent.Loop (Backend)
+import Agent.Subagents (setSubagentRunner)
+import Agent.Tools.MultiAgents (MultiAgentContext(..))
+import Agent.Responses.Types (ResponseCreateParams, Response)
+import Data.IORef (IORef, newIORef, readIORef)
 import Data.Text (Text)
 import Data.Time.Clock (getCurrentTime)
 import qualified Agent.CLI.Session.Runner as SessionRunner
@@ -107,3 +123,72 @@ runSession
     -> SessionBackend
     -> IO RunResult
 runSession = SessionRunner.runSession sessionRunnerContinuation
+
+-- Transport and occupancy choices remain owned by each provider. This runner
+-- shares the HTTP session lifecycle used by Gemini and OpenRouter.
+data HttpProviderSession = HttpProviderSession
+    { httpMakeBackend :: IO ResponseCreateParams -> Backend
+    , httpSendCompact :: ResponseCreateParams -> IO (Either ApiError Response)
+    , httpTransportModel :: Text -> Text
+    , httpOccupancy :: IORef (Maybe OccupancySnapshot)
+    }
+
+runHttpProvider
+    :: AgentProviderRequest
+    -> HttpProviderSession
+    -> IO RunResult
+runHttpProvider request@AgentProviderRequest{..} HttpProviderSession{..} = do
+    let contextWindowFor = contextWindowForParams httpTransportModel 1_048_576
+        protectOverflow getParams =
+            boundCompletedToolContinuations
+                contextWindowFor getParams httpOccupancy
+    case multiCtx of
+        Just ctx ->
+            setSubagentRunner ctx.multiRegistry $
+                runHttpSubagent
+                    subagentRuntime
+                    dialect
+                    provider
+                    ctx.multiSendToRoot
+                    (\childParams ->
+                        protectOverflow
+                            (pure childParams)
+                            (httpMakeBackend (pure childParams)))
+        Nothing -> pure ()
+    let backend =
+            withPendingInputs pendingNotices $
+                withConnectionRecoveryOn startup.startupNetworkRecovery $
+                    protectOverflow
+                        (readIORef paramsRef)
+                        (httpMakeBackend (readIORef paramsRef))
+        compactRunner focus = do
+            contextWindow <- currentModelContextWindow httpTransportModel
+            historyRef <- newIORef =<< readLiveTranscript conversationRef
+            installLiveCompactOutcome conversationRef Nothing
+                (\requestedFocus ->
+                    runResponsesCompactWithContextWindow
+                        contextWindow
+                        httpSendCompact
+                        recordCompactionUsage
+                        paramsRef
+                        historyRef
+                        requestedFocus
+                        >>= decorateManualCompact request contextWindowFor)
+                focus
+    activeBackend <-
+        prepareTransitionBackend
+            modelSwitchScope home projectRoot transition persist backend
+    runSession
+        (sessionRequest
+            startupUnavailable
+            (Just tokenProvider)
+            loaded.loadedOpenAiPool
+            (if isGatewayLoadedAuth loaded then Nothing else Just selectHttpAccount)
+            (Just . contextWindowFor <$> readIORef paramsRef)
+            compactRunner)
+        SessionBackend
+            { backend = activeBackend
+            , btwBackend = httpMakeBackend . pure
+            , interruptBackend = pure ()
+            , resetBackendState = pure ()
+            }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Gemini.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Gemini.hs
@@ -2,130 +2,30 @@ module Agent.CLI.Runtime.Orchestration.Providers.Gemini
     ( runGeminiProvider
     ) where
 
-import Agent.CLI.Auth.Types
-    ( LoadedAuth(..)
-    , isGatewayLoadedAuth
-    )
-import Agent.CLI.Compaction
-    ( boundCompletedToolContinuations
-    , installLiveCompactOutcome
-    , runResponsesCompactWithContextWindow
-    )
-import Agent.Connectivity (withConnectionRecoveryOn)
-import Agent.CLI.PendingInputs (withPendingInputs)
-import Agent.CLI.Provider.Switch (prepareTransitionBackend)
 import Agent.CLI.Runtime.Orchestration.Providers.Common
-    ( decorateManualCompact
-    , runSession
+    ( HttpProviderSession(..)
+    , runHttpProvider
     )
-import Agent.CLI.Runtime.Orchestration.Providers.Types
-    ( AgentProviderRequest(..)
-    )
+import Agent.CLI.Runtime.Orchestration.Providers.Types (AgentProviderRequest(..))
 import Agent.CLI.Runtime.Types (RunResult)
-import Agent.CLI.Session.History (readLiveTranscript)
-import Agent.CLI.Session.Runtime.Types
-    ( SessionBackend(..)
-    , StartupRuntime(..)
-    )
-import Agent.CLI.Subagents.Runtime (runHttpSubagent)
 import Agent.Gemini.LoopBackend (tokenProviderStatelessGeminiBackend)
-import Agent.Provider
-    ( Provider(GeminiProvider)
-    , runWithTokenProvider
-    )
-import Agent.Subagents (setSubagentRunner)
-import Agent.Tools.MultiAgents (MultiAgentContext(..))
-import Data.IORef (newIORef, readIORef)
+import Agent.Provider (runWithTokenProvider)
+import Data.IORef (newIORef)
 import qualified Agent.Gemini.Client as GeminiClient
 import qualified Agent.Gemini.Options as Gemini
 
-runGeminiProvider
-    :: AgentProviderRequest
-    -> IO RunResult
-runGeminiProvider request@AgentProviderRequest{..} = do
+runGeminiProvider :: AgentProviderRequest -> IO RunResult
+runGeminiProvider request@AgentProviderRequest{tokenProvider} = do
     geminiOptions <- Gemini.clientOptionsFromEnv
     geminiOccupancy <- newIORef Nothing
-    let geminiContextWindow =
-            contextWindowForParams id 1_048_576
-        makeBackend getParams =
+    runHttpProvider request HttpProviderSession
+        { httpMakeBackend =
             tokenProviderStatelessGeminiBackend
                 tokenProvider
-                (GeminiClient.createResponseWithEvents
-                    geminiOptions)
-                getParams
-        protectGeminiOverflow occupancy getParams backend =
-            boundCompletedToolContinuations
-                geminiContextWindow
-                getParams
-                occupancy
-                backend
-    case multiCtx of
-        Just ctx ->
-            setSubagentRunner ctx.multiRegistry $
-                runHttpSubagent
-                    subagentRuntime
-                    dialect
-                    GeminiProvider
-                    ctx.multiSendToRoot
-                    (\childParams ->
-                        protectGeminiOverflow
-                            geminiOccupancy
-                            (pure childParams)
-                            (makeBackend
-                                (pure childParams)))
-        Nothing -> pure ()
-    let backend =
-            withPendingInputs pendingNotices $
-                withConnectionRecoveryOn
-                    startup.startupNetworkRecovery $
-                    protectGeminiOverflow
-                        geminiOccupancy
-                        (readIORef paramsRef)
-                        (makeBackend
-                            (readIORef paramsRef))
-        btwBackend privateParams =
-            makeBackend (pure privateParams)
-        compactRunner focus = do
-            contextWindow <-
-                currentModelContextWindow id
-            historyRef <-
-                newIORef =<< readLiveTranscript conversationRef
-            installLiveCompactOutcome conversationRef Nothing
-                (\requestedFocus ->
-                    runResponsesCompactWithContextWindow
-                        contextWindow
-                        (\compactRequest ->
-                            runWithTokenProvider tokenProvider
-                                \credential ->
-                                    GeminiClient.createResponseWith
-                                        geminiOptions
-                                        credential
-                                        compactRequest)
-                        recordCompactionUsage
-                        paramsRef
-                        historyRef
-                        requestedFocus
-                        >>= decorateManualCompact request
-                            geminiContextWindow)
-                focus
-    activeBackend <-
-        prepareTransitionBackend
-            modelSwitchScope home projectRoot
-            transition persist backend
-    runSession
-        (sessionRequest
-            startupUnavailable
-            (Just tokenProvider)
-            loaded.loadedOpenAiPool
-            (if isGatewayLoadedAuth loaded
-                then Nothing
-                else Just selectHttpAccount)
-            (Just . geminiContextWindow
-                <$> readIORef paramsRef)
-            compactRunner)
-        SessionBackend
-            { backend = activeBackend
-            , btwBackend
-            , interruptBackend = pure ()
-            , resetBackendState = pure ()
-            }
+                (GeminiClient.createResponseWithEvents geminiOptions)
+        , httpSendCompact = \compactRequest ->
+            runWithTokenProvider tokenProvider \credential ->
+                GeminiClient.createResponseWith geminiOptions credential compactRequest
+        , httpTransportModel = id
+        , httpOccupancy = geminiOccupancy
+        }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenRouter.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenRouter.hs
@@ -2,164 +2,56 @@ module Agent.CLI.Runtime.Orchestration.Providers.OpenRouter
     ( runOpenRouterProvider
     ) where
 
-import Agent.CLI.Auth.Types
-    ( LoadedAuth(..)
-    , isGatewayLoadedAuth
-    )
-import Agent.CLI.Compaction
-    ( boundCompletedToolContinuations
-    , installLiveCompactOutcome
-    , runResponsesCompactWithContextWindow
-    )
-import Agent.Connectivity (withConnectionRecoveryOn)
-import Agent.CLI.PendingInputs (withPendingInputs)
-import Agent.CLI.Provider.Switch (prepareTransitionBackend)
 import Agent.CLI.Runtime.Orchestration.Providers.Common
-    ( decorateManualCompact
-    , runSession
+    ( HttpProviderSession(..)
+    , runHttpProvider
     )
-import Agent.CLI.Runtime.Orchestration.Providers.Types
-    ( AgentProviderRequest(..)
-    )
+import Agent.CLI.Runtime.Orchestration.Providers.Types (AgentProviderRequest(..))
 import Agent.CLI.Runtime.Types (RunResult)
-import Agent.CLI.Session.History (readLiveTranscript)
-import Agent.CLI.Session.Runtime.Types
-    ( SessionBackend(..)
-    , StartupRuntime(..)
-    )
-import Agent.CLI.Subagents.Runtime (runHttpSubagent)
 import Agent.OpenRouter.LoopBackend (openRouterBackend)
-import Agent.Provider
-    ( Provider(OpenRouterProvider)
-    , runWithTokenProvider
-    )
+import Agent.Provider (runWithTokenProvider)
 import Agent.Responses.GenericBackend (genericResponsesBackendWith)
 import Agent.Responses.Types (ResponseCreateParams(model))
-import Agent.Subagents (setSubagentRunner)
-import Agent.Tools.MultiAgents (MultiAgentContext(..))
-import Data.IORef (newIORef, readIORef)
 import Data.Maybe (fromMaybe)
 import qualified Agent.OpenRouter as OpenRouter
 import qualified Agent.Responses.GenericClient as GenericResponses
 
-runOpenRouterProvider
-    :: AgentProviderRequest
-    -> IO RunResult
-runOpenRouterProvider request@AgentProviderRequest{..} = do
-    let openRouterContextWindow =
-            contextWindowForParams transportModel 1_048_576
-        makeBackend params =
-            case customGenericOptions of
-                Just genericOptions ->
-                    genericResponsesBackendWith
-                        (\responseRequest onEvent ->
-                            GenericResponses.createResponseWithEvents
-                                genericOptions
-                                    { GenericResponses.model =
-                                        transportModel
-                                            (fromMaybe
-                                                model
-                                                responseRequest.model)
-                                    }
-                                responseRequest
-                                onEvent)
-                        params
-                Nothing ->
-                    openRouterBackend openRouterOptions
-                        tokenProvider params
-        protectOverflow occupancy getParams backend =
-            boundCompletedToolContinuations
-                openRouterContextWindow
-                getParams
-                occupancy
-                backend
-    case multiCtx of
-        Just ctx ->
-            setSubagentRunner ctx.multiRegistry $
-                runHttpSubagent
-                    subagentRuntime
-                    dialect
-                    OpenRouterProvider
-                    ctx.multiSendToRoot
-                    (\childParams ->
-                        protectOverflow
-                            contextTokensRef
-                            (pure childParams)
-                            (makeBackend
-                                (pure childParams)))
-        Nothing -> pure ()
-    let backend =
-            withPendingInputs pendingNotices $
-                withConnectionRecoveryOn
-                    startup.startupNetworkRecovery $
-                    protectOverflow
-                        contextTokensRef
-                        (readIORef paramsRef)
-                        (makeBackend
-                            (readIORef paramsRef))
-        btwBackend privateParams =
-            makeBackend
-                (pure privateParams)
-        compactRunner focus = do
-            contextWindow <-
-                currentModelContextWindow transportModel
-            historyRef <-
-                newIORef =<< readLiveTranscript conversationRef
-            installLiveCompactOutcome conversationRef Nothing
-                (\requestedFocus ->
-                    (case customGenericOptions of
-                        Just genericOptions ->
-                            runResponsesCompactWithContextWindow
-                                contextWindow
-                                (\responseRequest ->
-                                    GenericResponses.createResponseWith
-                                        genericOptions
-                                            { GenericResponses.model =
-                                                transportModel
-                                                    (fromMaybe
-                                                        model
-                                                        responseRequest.model)
-                                            }
-                                        responseRequest)
-                                recordCompactionUsage
-                                paramsRef
-                                historyRef
-                        Nothing ->
-                            runResponsesCompactWithContextWindow
-                                contextWindow
-                                (\responseRequest ->
-                                    runWithTokenProvider
-                                        tokenProvider
-                                        \credential ->
-                                            OpenRouter.createResponseWith
-                                                openRouterOptions
-                                                credential
-                                                responseRequest)
-                                recordCompactionUsage
-                                paramsRef
-                                historyRef)
-                        requestedFocus
-                        >>= decorateManualCompact request
-                            openRouterContextWindow)
-                focus
-    activeBackend <-
-        prepareTransitionBackend
-            modelSwitchScope home projectRoot
-            transition persist backend
-    runSession
-        (sessionRequest
-            startupUnavailable
-            (Just tokenProvider)
-            loaded.loadedOpenAiPool
-            (if isGatewayLoadedAuth loaded
-                then Nothing
-                else Just selectHttpAccount)
-            (Just . openRouterContextWindow
-                <$> readIORef paramsRef)
-            compactRunner)
-        SessionBackend
-            { backend = activeBackend
-            , btwBackend
-            , interruptBackend = pure ()
-            , resetBackendState = pure ()
+runOpenRouterProvider :: AgentProviderRequest -> IO RunResult
+runOpenRouterProvider request@AgentProviderRequest{..} =
+    runHttpProvider request HttpProviderSession
+        { httpMakeBackend = makeBackend
+        , httpSendCompact = sendCompact
+        , httpTransportModel = transportModel
+        , httpOccupancy = contextTokensRef
+        }
+  where
+    optionsForRequest
+        :: GenericResponses.GenericClientOptions
+        -> ResponseCreateParams
+        -> GenericResponses.GenericClientOptions
+    optionsForRequest genericOptions responseRequest =
+        genericOptions
+            { GenericResponses.model =
+                transportModel (fromMaybe model responseRequest.model)
             }
+    makeBackend params =
+        case customGenericOptions of
+            Just genericOptions ->
+                genericResponsesBackendWith
+                    (\responseRequest onEvent ->
+                        GenericResponses.createResponseWithEvents
+                            (optionsForRequest genericOptions responseRequest)
+                            responseRequest
+                            onEvent)
+                    params
+            Nothing -> openRouterBackend openRouterOptions tokenProvider params
+    sendCompact responseRequest =
+        case customGenericOptions of
+            Just genericOptions ->
+                GenericResponses.createResponseWith
+                    (optionsForRequest genericOptions responseRequest)
+                    responseRequest
+            Nothing ->
+                runWithTokenProvider tokenProvider \credential ->
+                    OpenRouter.createResponseWith
+                        openRouterOptions credential responseRequest


### PR DESCRIPTION
Gemini and OpenRouter repeated the same subagent registration, pending-input and recovery wrappers, overflow protection, manual compaction installation, and session launch. Share that sequence in `runHttpProvider`, with a small record for the backend factory, compaction sender, model mapping, and occupancy reference.

Gemini retains its separate occupancy reference. OpenRouter retains custom Responses routing and transport-model translation, now shared between its normal and compaction senders. Middleware order and the unwrapped private backend remain unchanged.

Validation: all 202 CLI modules loaded in GHCi inside `nix develop`. Added the existing `CompactionSpec` and `ProviderTransitionSpec` modules to that GHCi load and ran them with Hspec: 74 examples, 0 failures. `git diff --check` passed.
