### PR TITLE
Extract native repository worker lifecycle and move smoke tests

### DIFF
--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -66,6 +66,7 @@ foreign-library haskell-agent-bridge
                     , Agent.CLI.MacOS.ComputerBridge
                     , Agent.CLI.MacOS.EngineMailbox
                     , Agent.CLI.MacOS.NativeLoopEvent
+                    , Agent.CLI.MacOS.RepositoryWorkers
                     , Agent.CLI.MacOS.ResourceAdmin
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
     include-dirs:     include
@@ -106,6 +107,8 @@ test-suite agent-native-bridge-test
                     , Agent.CLI.MacOS.EngineMailboxSpec
                     , Agent.CLI.MacOS.NativeLoopEvent
                     , Agent.CLI.MacOS.NativeLoopEventSpec
+                    , Agent.CLI.MacOS.RepositoryWorkers
+                    , Agent.CLI.MacOS.RepositoryWorkersSpec
                     , Agent.CLI.MacOS.TaskSchedulerSpec
                     , Agent.CLI.McpAdminSpec
                     , Agent.CLI.ResourceAdminSpec
@@ -135,7 +138,8 @@ test-suite agent-native-bridge-test
         include-dirs: include
         other-modules: Agent.CLI.MacOS.Bridge
                      , Agent.CLI.MacOS.ComputerBridge
-                     , Agent.CLI.MacOS.ResourceAdmin
+                     , Agent.CLI.MacOS.RepositoryWorkers
+                    , Agent.CLI.MacOS.ResourceAdmin
                      , Agent.CLI.MacOS.BrowserBridgeFFISpec
                      , Agent.CLI.MacOS.ComputerBridgeSpec
                      , Agent.CLI.MacOS.BridgeSpec

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -10,11 +10,8 @@ module Agent.CLI.MacOS.Bridge
     , browserToolsWhenEnabled
     , composeNativeTools
     , invokeBrowserCommand
-    , repositoryCancelAllAdmissionSmoke
-    , repositoryCancelClassificationSmoke
-    , repositoryCancelAllReentrancySmoke
-    , repositoryCheckDestroyReentrancySmoke
-    , repositoryTerminalThrowSmoke
+    , RepositoryCheckHandle(..)
+    , ha_repository_check_destroy
     , TurnStart(..)
     , nativeExceptionMessage
     , nativeRequestRequiresGatewayLock
@@ -33,6 +30,13 @@ module Agent.CLI.MacOS.Bridge
     ) where
 
 import Agent.CLI.MacOS.ResourceAdmin ()
+import Agent.CLI.MacOS.RepositoryWorkers
+    ( cancelRepositoryWorkers
+    , isRepositoryCallbackThread
+    , startRepositoryWorker
+    , tryRepositorySynchronous
+    , withRepositoryCallbackThread
+    )
 import Agent.CLI.MacOS.ComputerBridge
     ( ComputerCallback
     , ComputerHost(..)
@@ -249,19 +253,13 @@ import Agent.Tools.Types
     , AppToolGroup(..)
     , appToolsFromGroups
     )
-import Control.Concurrent
-    ( ThreadId
-    , forkIO
-    , myThreadId
-    , threadDelay
-    )
+import Control.Concurrent (forkIO)
 import Control.Concurrent.Async
     ( Async
     , asyncWithUnmask
     , cancel
     , mapConcurrently
     , waitCatch
-    , withAsync
     )
 import Control.Concurrent.MVar
     ( MVar
@@ -272,7 +270,6 @@ import Control.Concurrent.MVar
     , putMVar
     , readMVar
     , withMVar
-    , tryReadMVar
     , takeMVar
     )
 import Control.Concurrent.STM
@@ -291,19 +288,14 @@ import Control.Concurrent.STM
     )
 import Control.Applicative ((<|>))
 import Control.Exception.Safe
-    ( SomeAsyncException
-    , SomeException
+    ( SomeException
     , bracket
-    , catchAsync
     , finally
     , fromException
-    , isAsyncException
     , mask
     , onException
-    , throwIO
     , throwString
     , tryAny
-    , uninterruptibleMask_
     )
 import Control.Monad
     ( foldM
@@ -329,7 +321,6 @@ import Data.IORef
     , readIORef
     , writeIORef
     )
-import System.IO.Unsafe (unsafePerformIO)
 import Data.Int (Int64)
 import Data.Foldable (toList)
 import Data.List (partition)
@@ -338,7 +329,7 @@ import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
-import Data.Maybe (fromMaybe, isJust, isNothing, listToMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -2086,217 +2077,8 @@ prepareRepositoryResult callback context action =
                 (emitRepositorySuccess
                     callback context snapshot.snapshotId)
 
-startRepositoryWorker :: IO () -> IO (IO ()) -> IO Bool
-startRepositoryWorker onCancelled prepare =
-    tryRepositorySynchronous
-        (mask \_ -> do
-            gate <- newEmptyMVar
-            admitted <- modifyMVar repositoryWorkers \state ->
-                case state.repositoryWorkerBarrier of
-                    Just _ -> pure (state, False)
-                    Nothing -> do
-                        let workerId = state.repositoryWorkerNextId
-                        worker <- asyncWithUnmask \unmask -> do
-                            withRepositoryCallbackThread
-                                (((Just <$> (readMVar gate >> unmask prepare))
-                                    `catchAsync`
-                                        \(_ :: SomeAsyncException) ->
-                                            onCancelled >> pure Nothing)
-                                    >>= mapM_ id)
-                                `finally`
-                                unregisterRepositoryWorker workerId
-                        pure
-                            ( state
-                                { repositoryWorkerNextId = workerId + 1
-                                , repositoryWorkerActive =
-                                    Map.insert
-                                        workerId
-                                        worker
-                                        state.repositoryWorkerActive
-                                }
-                            , True
-                            )
-            when admitted (putMVar gate ())
-            pure admitted)
-        >>= \case
-            Left _ -> pure False
-            Right admitted -> pure admitted
-
-unregisterRepositoryWorker :: Int -> IO ()
-unregisterRepositoryWorker workerId =
-    modifyMVar repositoryWorkers \state ->
-        pure
-            ( state
-                { repositoryWorkerActive =
-                    Map.delete workerId state.repositoryWorkerActive
-                }
-            , ()
-            )
-
 ha_repository_cancel_all :: IO ()
-ha_repository_cancel_all =
-    isRepositoryCallbackThread >>= \case
-        True -> pure ()
-        False -> mask \restore -> do
-            admission <- modifyMVar repositoryWorkers \state ->
-                case state.repositoryWorkerBarrier of
-                    Just barrier ->
-                        pure (state, Left barrier)
-                    Nothing -> do
-                        barrier <- newEmptyMVar
-                        pure
-                            ( state
-                                { repositoryWorkerActive = Map.empty
-                                , repositoryWorkerBarrier = Just barrier
-                                }
-                            , Right
-                                ( barrier
-                                , Map.elems state.repositoryWorkerActive
-                                )
-                            )
-            case admission of
-                Left activeBarrier -> restore (readMVar activeBarrier)
-                Right (barrier, workers) ->
-                    restore
-                        (mapM_ cancel workers >> mapM_ waitCatch workers)
-                        `finally` do
-                            modifyMVar repositoryWorkers \state ->
-                                pure
-                                    ( state
-                                        { repositoryWorkerBarrier = Nothing }
-                                    , ()
-                                    )
-                            putMVar barrier ()
-
--- Deterministic regression hook for the admission-barrier lifecycle. This is
--- a Haskell test hook, not part of the C ABI.
-repositoryCancelAllAdmissionSmoke :: IO Bool
-repositoryCancelAllAdmissionSmoke = do
-    entered <- newEmptyMVar
-    cancelled <- newEmptyMVar
-    firstAccepted <- startRepositoryWorker (putMVar cancelled ()) do
-        putMVar entered ()
-        uninterruptibleMask_ (threadDelay 250_000)
-        pure (pure ())
-    if not firstAccepted
-        then pure False
-        else do
-            readMVar entered
-            withAsync ha_repository_cancel_all \canceller -> do
-                rejectedDuringBarrier <- awaitRejection 1000
-                _ <- waitCatch canceller
-                cancellationDelivered <- readMVar cancelled >> pure True
-                completed <- newEmptyMVar
-                acceptedAfter <- startRepositoryWorker
-                    (pure ())
-                    (pure (putMVar completed ()))
-                finishedAfter <- if acceptedAfter
-                    then readMVar completed >> pure True
-                    else pure False
-                pure
-                    ( rejectedDuringBarrier
-                        && cancellationDelivered
-                        && finishedAfter
-                    )
-  where
-    awaitRejection attempts
-        | attempts <= (0 :: Int) = pure False
-        | otherwise =
-            startRepositoryWorker (pure ()) (pure (pure ())) >>= \case
-                False -> pure True
-                True -> threadDelay 1000 >> awaitRejection (attempts - 1)
-
-repositoryCancelAllReentrancySmoke :: IO Bool
-repositoryCancelAllReentrancySmoke = do
-    completed <- newEmptyMVar
-    accepted <- startRepositoryWorker (pure ()) do
-        pure do
-            ha_repository_cancel_all
-            putMVar completed ()
-    if accepted
-        then readMVar completed >> pure True
-        else pure False
-
-repositoryCancelClassificationSmoke :: IO Bool
-repositoryCancelClassificationSmoke = do
-    entered <- newEmptyMVar
-    cancelled <- newEmptyMVar
-    synthesizedFailure <- newEmptyMVar
-    accepted <- startRepositoryWorker (putMVar cancelled ()) do
-        putMVar entered ()
-        tryRepositorySynchronous (threadDelay 30_000_000) >>= \case
-            Left _ -> putMVar synthesizedFailure ()
-            Right () -> pure ()
-        pure (pure ())
-    if not accepted
-        then pure False
-        else do
-            readMVar entered
-            ha_repository_cancel_all
-            cancellation <- tryReadMVar cancelled
-            failure <- tryReadMVar synthesizedFailure
-            pure (isJust cancellation && isNothing failure)
-
-repositoryTerminalThrowSmoke :: IO Bool
-repositoryTerminalThrowSmoke = do
-    cancelled <- newEmptyMVar
-    terminal <- newEmptyMVar
-    finished <- newEmptyMVar
-    accepted <- startRepositoryWorker (putMVar cancelled ()) do
-        pure
-            ((putMVar terminal () >> throwString "terminal callback failed")
-                `finally` putMVar finished ())
-    if not accepted
-        then pure False
-        else do
-            readMVar terminal
-            readMVar finished
-            ha_repository_cancel_all
-            cancellation <- tryReadMVar cancelled
-            pure (isNothing cancellation)
-
-{-# NOINLINE repositoryWorkers #-}
-repositoryWorkers :: MVar RepositoryWorkerState
-repositoryWorkers = unsafePerformIO
-    (newMVar RepositoryWorkerState
-        { repositoryWorkerNextId = 0
-        , repositoryWorkerActive = Map.empty
-        , repositoryWorkerBarrier = Nothing
-        })
-
-data RepositoryWorkerState = RepositoryWorkerState
-    { repositoryWorkerNextId :: !Int
-    , repositoryWorkerActive :: !(Map Int (Async ()))
-    , repositoryWorkerBarrier :: !(Maybe (MVar ()))
-    }
-
-{-# NOINLINE repositoryCallbackThreads #-}
-repositoryCallbackThreads :: MVar (Set.Set ThreadId)
-repositoryCallbackThreads = unsafePerformIO (newMVar Set.empty)
-
-withRepositoryCallbackThread :: IO value -> IO value
-withRepositoryCallbackThread action = do
-    thread <- myThreadId
-    modifyMVar repositoryCallbackThreads \threads ->
-        pure (Set.insert thread threads, ())
-    action `finally`
-        modifyMVar repositoryCallbackThreads \threads ->
-            pure (Set.delete thread threads, ())
-
-isRepositoryCallbackThread :: IO Bool
-isRepositoryCallbackThread = do
-    thread <- myThreadId
-    Set.member thread <$> readMVar repositoryCallbackThreads
-
-tryRepositorySynchronous
-    :: IO value
-    -> IO (Either SomeException value)
-tryRepositorySynchronous action =
-    tryAny action >>= \case
-        Left exception
-            | isAsyncException exception -> throwIO exception
-            | otherwise -> pure (Left exception)
-        Right value -> pure (Right value)
+ha_repository_cancel_all = cancelRepositoryWorkers
 
 data RepositoryCheckHandle = RepositoryCheckHandle
     { repositoryCheckValue :: !(IORef (Maybe RepositoryReview.RepositoryCheck))
@@ -2453,25 +2235,6 @@ ha_repository_check_destroy pointer
                 handle <- deRefStablePtr stable
                 _ <- waitCatch handle.repositoryCheckOwner
                 freeStablePtr stable
-
-repositoryCheckDestroyReentrancySmoke :: IO Bool
-repositoryCheckDestroyReentrancySmoke = do
-    gate <- newEmptyMVar
-    owner <- asyncWithUnmask \unmask -> unmask (readMVar gate)
-    value <- newIORef Nothing
-    cancelled <- newIORef False
-    stable <- newStablePtr RepositoryCheckHandle
-        { repositoryCheckValue = value
-        , repositoryCheckCancelRequested = cancelled
-        , repositoryCheckOwner = owner
-        }
-    let pointer = castStablePtrToPtr stable
-    result <- tryAny
-        (withRepositoryCallbackThread
-            (ha_repository_check_destroy pointer))
-    putMVar gate ()
-    ha_repository_check_destroy pointer
-    pure (isRight result)
 
 copyRepositoryCheckArguments
     :: Ptr () -> CSize -> IO (Either () [Text])

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/RepositoryWorkers.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/RepositoryWorkers.hs
@@ -1,0 +1,150 @@
+module Agent.CLI.MacOS.RepositoryWorkers
+    ( startRepositoryWorker
+    , cancelRepositoryWorkers
+    , withRepositoryCallbackThread
+    , isRepositoryCallbackThread
+    , tryRepositorySynchronous
+    ) where
+
+import Control.Concurrent (ThreadId, myThreadId)
+import Control.Concurrent.Async (Async, asyncWithUnmask, cancel, waitCatch)
+import Control.Concurrent.MVar
+    ( MVar, modifyMVar, newEmptyMVar, newMVar, putMVar, readMVar )
+import Control.Exception.Safe
+    ( SomeAsyncException, SomeException, catchAsync, finally, isAsyncException
+    , mask, throwIO, tryAny
+    )
+import Control.Monad (when)
+import Data.Map.Strict (Map)
+import System.IO.Unsafe (unsafePerformIO)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+
+-- The C API owns one process-wide repository worker group. Workers are
+-- registered before their admission gate opens; cancel-all closes admission,
+-- cancels and joins the group, then permits new work again.
+startRepositoryWorker :: IO () -> IO (IO ()) -> IO Bool
+startRepositoryWorker onCancelled prepare =
+    tryRepositorySynchronous
+        (mask \_ -> do
+            gate <- newEmptyMVar
+            admitted <- modifyMVar repositoryWorkers \state ->
+                case state.repositoryWorkerBarrier of
+                    Just _ -> pure (state, False)
+                    Nothing -> do
+                        let workerId = state.repositoryWorkerNextId
+                        worker <- asyncWithUnmask \unmask -> do
+                            withRepositoryCallbackThread
+                                (((Just <$> (readMVar gate >> unmask prepare))
+                                    `catchAsync`
+                                        \(_ :: SomeAsyncException) ->
+                                            onCancelled >> pure Nothing)
+                                    >>= mapM_ id)
+                                `finally`
+                                unregisterRepositoryWorker workerId
+                        pure
+                            ( state
+                                { repositoryWorkerNextId = workerId + 1
+                                , repositoryWorkerActive =
+                                    Map.insert
+                                        workerId
+                                        worker
+                                        state.repositoryWorkerActive
+                                }
+                            , True
+                            )
+            when admitted (putMVar gate ())
+            pure admitted)
+        >>= \case
+            Left _ -> pure False
+            Right admitted -> pure admitted
+
+unregisterRepositoryWorker :: Int -> IO ()
+unregisterRepositoryWorker workerId =
+    modifyMVar repositoryWorkers \state ->
+        pure
+            ( state
+                { repositoryWorkerActive =
+                    Map.delete workerId state.repositoryWorkerActive
+                }
+            , ()
+            )
+
+cancelRepositoryWorkers :: IO ()
+cancelRepositoryWorkers =
+    isRepositoryCallbackThread >>= \case
+        True -> pure ()
+        False -> mask \restore -> do
+            admission <- modifyMVar repositoryWorkers \state ->
+                case state.repositoryWorkerBarrier of
+                    Just barrier ->
+                        pure (state, Left barrier)
+                    Nothing -> do
+                        barrier <- newEmptyMVar
+                        pure
+                            ( state
+                                { repositoryWorkerActive = Map.empty
+                                , repositoryWorkerBarrier = Just barrier
+                                }
+                            , Right
+                                ( barrier
+                                , Map.elems state.repositoryWorkerActive
+                                )
+                            )
+            case admission of
+                Left activeBarrier -> restore (readMVar activeBarrier)
+                Right (barrier, workers) ->
+                    restore
+                        (mapM_ cancel workers >> mapM_ waitCatch workers)
+                        `finally` do
+                            modifyMVar repositoryWorkers \state ->
+                                pure
+                                    ( state
+                                        { repositoryWorkerBarrier = Nothing }
+                                    , ()
+                                    )
+                            putMVar barrier ()
+
+{-# NOINLINE repositoryWorkers #-}
+repositoryWorkers :: MVar RepositoryWorkerState
+repositoryWorkers = unsafePerformIO
+    (newMVar RepositoryWorkerState
+        { repositoryWorkerNextId = 0
+        , repositoryWorkerActive = Map.empty
+        , repositoryWorkerBarrier = Nothing
+        })
+
+data RepositoryWorkerState = RepositoryWorkerState
+    { repositoryWorkerNextId :: !Int
+    , repositoryWorkerActive :: !(Map Int (Async ()))
+    , repositoryWorkerBarrier :: !(Maybe (MVar ()))
+    }
+
+{-# NOINLINE repositoryCallbackThreads #-}
+repositoryCallbackThreads :: MVar (Set.Set ThreadId)
+repositoryCallbackThreads = unsafePerformIO (newMVar Set.empty)
+
+withRepositoryCallbackThread :: IO value -> IO value
+withRepositoryCallbackThread action = do
+    thread <- myThreadId
+    modifyMVar repositoryCallbackThreads \threads ->
+        pure (Set.insert thread threads, ())
+    action `finally`
+        modifyMVar repositoryCallbackThreads \threads ->
+            pure (Set.delete thread threads, ())
+
+isRepositoryCallbackThread :: IO Bool
+isRepositoryCallbackThread = do
+    thread <- myThreadId
+    Set.member thread <$> readMVar repositoryCallbackThreads
+
+tryRepositorySynchronous
+    :: IO value
+    -> IO (Either SomeException value)
+tryRepositorySynchronous action =
+    tryAny action >>= \case
+        Left exception
+            | isAsyncException exception -> throwIO exception
+            | otherwise -> pure (Left exception)
+        Right value -> pure (Right value)
+

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -3,10 +3,11 @@
 
 module Agent.CLI.MacOS.BridgeFFISpec (spec) where
 
-import qualified Agent.CLI.MacOS.Bridge as Bridge
 #ifdef darwin_HOST_OS
 import Agent.CLI.MacOS.Bridge
-    ( NativeInteractionResolution(..)
+    ( RepositoryCheckHandle(..)
+    , ha_repository_check_destroy
+    , NativeInteractionResolution(..)
     , PendingInteraction(..)
     , cancelPendingInteractions
     , discardStagedTurn
@@ -14,7 +15,9 @@ import Agent.CLI.MacOS.Bridge
     , resolvePendingInteraction
     , turnStartCleanupId
     )
-import Control.Concurrent.Async (concurrently)
+import Agent.CLI.MacOS.RepositoryWorkers (withRepositoryCallbackThread)
+import Control.Concurrent.Async (concurrently, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, readMVar)
 import Control.Concurrent.STM
     ( atomically
     , newEmptyTMVarIO
@@ -22,9 +25,13 @@ import Control.Concurrent.STM
     , readTMVar
     , readTVarIO
     )
+import Control.Exception.Safe (finally, tryAny)
+import Data.Either (isRight)
+import Data.IORef (newIORef)
 import qualified Data.Aeson as Aeson
 import qualified Data.Map.Strict as Map
 import Foreign.C.Types (CInt(..))
+import Foreign.StablePtr (castStablePtrToPtr, newStablePtr)
 import Test.Hspec
     ( Spec
     , describe
@@ -63,18 +70,12 @@ spec = describe "native bridge FFI" do
 #else
         pendingWith "the native bridge smoke test only links on macOS"
 #endif
-    it "blocks new repository workers until cancel-all returns" do
-        Bridge.repositoryCancelAllAdmissionSmoke `shouldReturn` True
-
-    it "does not self-deadlock on callback lifecycle calls" do
-        Bridge.repositoryCancelAllReentrancySmoke `shouldReturn` True
-        Bridge.repositoryCheckDestroyReentrancySmoke `shouldReturn` True
-
-    it "classifies async cancellation as cancelled, not failure" do
-        Bridge.repositoryCancelClassificationSmoke `shouldReturn` True
-
-    it "does not retry a terminal callback that throws" do
-        Bridge.repositoryTerminalThrowSmoke `shouldReturn` True
+    it "does not self-deadlock when a callback destroys its check" do
+#ifdef darwin_HOST_OS
+        repositoryCheckDestroyReentrancySmoke `shouldReturn` True
+#else
+        pendingWith "the native bridge smoke test only links on macOS"
+#endif
 
     it "validates the typed repository-review ABI from native code" do
 #ifdef darwin_HOST_OS
@@ -202,4 +203,25 @@ spec = describe "native bridge FFI" do
         nativeTurnOptionsStageSmoke `shouldReturn` 0
 #else
         pendingWith "the native bridge smoke test only links on macOS"
+#endif
+
+#ifdef darwin_HOST_OS
+repositoryCheckDestroyReentrancySmoke :: IO Bool
+repositoryCheckDestroyReentrancySmoke = do
+    gate <- newEmptyMVar
+    withAsync (readMVar gate) \owner -> do
+        value <- newIORef Nothing
+        cancelled <- newIORef False
+        stable <- newStablePtr RepositoryCheckHandle
+            { repositoryCheckValue = value
+            , repositoryCheckCancelRequested = cancelled
+            , repositoryCheckOwner = owner
+            }
+        let pointer = castStablePtrToPtr stable
+        result <- tryAny
+            (withRepositoryCallbackThread
+                (ha_repository_check_destroy pointer))
+            `finally` putMVar gate ()
+        ha_repository_check_destroy pointer
+        pure (isRight result)
 #endif

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/RepositoryWorkersSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/RepositoryWorkersSpec.hs
@@ -1,0 +1,109 @@
+module Agent.CLI.MacOS.RepositoryWorkersSpec (spec) where
+
+import Agent.CLI.MacOS.RepositoryWorkers
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (waitCatch, withAsync)
+import Control.Concurrent.MVar
+    ( newEmptyMVar, putMVar, readMVar, tryReadMVar )
+import Control.Exception.Safe (finally, throwString, uninterruptibleMask_)
+import Data.Maybe (isJust, isNothing)
+import Test.Hspec (Spec, describe, it, shouldReturn)
+
+spec :: Spec
+spec = describe "repository worker lifecycle" do
+    it "blocks new repository workers until cancel-all returns" do
+        repositoryCancelAllAdmissionSmoke `shouldReturn` True
+    it "does not self-deadlock on callback lifecycle calls" do
+        repositoryCancelAllReentrancySmoke `shouldReturn` True
+    it "classifies async cancellation as cancelled, not failure" do
+        repositoryCancelClassificationSmoke `shouldReturn` True
+    it "does not retry a terminal callback that throws" do
+        repositoryTerminalThrowSmoke `shouldReturn` True
+
+-- Deterministic regression hook for the admission-barrier lifecycle. This is
+-- a Haskell test hook, not part of the C ABI.
+repositoryCancelAllAdmissionSmoke :: IO Bool
+repositoryCancelAllAdmissionSmoke = do
+    entered <- newEmptyMVar
+    cancelled <- newEmptyMVar
+    firstAccepted <- startRepositoryWorker (putMVar cancelled ()) do
+        putMVar entered ()
+        uninterruptibleMask_ (threadDelay 250_000)
+        pure (pure ())
+    if not firstAccepted
+        then pure False
+        else do
+            readMVar entered
+            withAsync cancelRepositoryWorkers \canceller -> do
+                rejectedDuringBarrier <- awaitRejection 1000
+                _ <- waitCatch canceller
+                cancellationDelivered <- readMVar cancelled >> pure True
+                completed <- newEmptyMVar
+                acceptedAfter <- startRepositoryWorker
+                    (pure ())
+                    (pure (putMVar completed ()))
+                finishedAfter <- if acceptedAfter
+                    then readMVar completed >> pure True
+                    else pure False
+                pure
+                    ( rejectedDuringBarrier
+                        && cancellationDelivered
+                        && finishedAfter
+                    )
+  where
+    awaitRejection attempts
+        | attempts <= (0 :: Int) = pure False
+        | otherwise =
+            startRepositoryWorker (pure ()) (pure (pure ())) >>= \case
+                False -> pure True
+                True -> threadDelay 1000 >> awaitRejection (attempts - 1)
+
+repositoryCancelAllReentrancySmoke :: IO Bool
+repositoryCancelAllReentrancySmoke = do
+    completed <- newEmptyMVar
+    accepted <- startRepositoryWorker (pure ()) do
+        pure do
+            cancelRepositoryWorkers
+            putMVar completed ()
+    if accepted
+        then readMVar completed >> pure True
+        else pure False
+
+repositoryCancelClassificationSmoke :: IO Bool
+repositoryCancelClassificationSmoke = do
+    entered <- newEmptyMVar
+    cancelled <- newEmptyMVar
+    synthesizedFailure <- newEmptyMVar
+    accepted <- startRepositoryWorker (putMVar cancelled ()) do
+        putMVar entered ()
+        tryRepositorySynchronous (threadDelay 30_000_000) >>= \case
+            Left _ -> putMVar synthesizedFailure ()
+            Right () -> pure ()
+        pure (pure ())
+    if not accepted
+        then pure False
+        else do
+            readMVar entered
+            cancelRepositoryWorkers
+            cancellation <- tryReadMVar cancelled
+            failure <- tryReadMVar synthesizedFailure
+            pure (isJust cancellation && isNothing failure)
+
+repositoryTerminalThrowSmoke :: IO Bool
+repositoryTerminalThrowSmoke = do
+    cancelled <- newEmptyMVar
+    terminal <- newEmptyMVar
+    finished <- newEmptyMVar
+    accepted <- startRepositoryWorker (putMVar cancelled ()) do
+        pure
+            ((putMVar terminal () >> throwString "terminal callback failed")
+                `finally` putMVar finished ())
+    if not accepted
+        then pure False
+        else do
+            readMVar terminal
+            readMVar finished
+            cancelRepositoryWorkers
+            cancellation <- tryReadMVar cancelled
+            pure (isNothing cancellation)
+

--- a/packages/agent-native-bridge/test/Spec.hs
+++ b/packages/agent-native-bridge/test/Spec.hs
@@ -7,6 +7,7 @@ import Test.Hspec (hspec)
 import qualified Agent.CLI.BrowserToolsSpec as BrowserToolsSpec
 import qualified Agent.CLI.MacOS.EngineMailboxSpec as EngineMailboxSpec
 import qualified Agent.CLI.MacOS.NativeLoopEventSpec as NativeLoopEventSpec
+import qualified Agent.CLI.MacOS.RepositoryWorkersSpec as RepositoryWorkersSpec
 import qualified Agent.CLI.MacOS.TaskSchedulerSpec as TaskSchedulerSpec
 import qualified Agent.CLI.McpAdminSpec as McpAdminSpec
 import qualified Agent.CLI.ResourceAdminSpec as ResourceAdminSpec
@@ -26,6 +27,7 @@ main = hspec do
     NativeLoopEventSpec.spec
     ResourceAdminSpec.spec
     TaskSchedulerSpec.spec
+    RepositoryWorkersSpec.spec
 #ifdef darwin_HOST_OS
     BrowserBridgeFFISpec.spec
     BridgeFFISpec.spec


### PR DESCRIPTION
Extract repository worker registration, cancellation/joining, and callback reentrancy tracking from the native FFI bridge into `RepositoryWorkers`. Keep the process-wide worker group and lifecycle behavior unchanged; `ha_repository_cancel_all` now forwards to the extracted implementation.

Move the four worker regression scenarios into a portable Hspec module, and move the check-destroy reentrancy scenario into the native FFI test module. Production code no longer contains the smoke-test scenarios.

Validation:
- Native test executable: `cabal test --offline agent-native-bridge:test:agent-native-bridge-test --test-show-details=direct` inside `nix develop`: 92 examples, 0 failures, including C ABI smoke tests.
- GHCi with object code passed the worker tests but crashed at the existing browser callback ABI test; the native executable above passed the full suite.
- Verified all 58 foreign export declarations are unchanged and the extracted worker implementation is identical apart from the cancel-all function name.
- Package boundary check and `git diff --check` passed. Regenerated the Nix expression with `cabal2nix` and retained its existing required Darwin foreign-library adjustments; dependencies are unchanged.
