### PR TITLE
Separate provider runtimes from session orchestration

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -487,6 +487,7 @@ test-suite agent-cli-test
                     , Agent.CLI.ProviderFallbackSpec
                     , Agent.CLI.ProviderAvailabilitySpec
                     , Agent.CLI.ProviderTransitionSpec
+                    , Agent.CLI.ProviderRuntimeSpec
                     , Agent.CLI.RequestSpec
                     , Agent.CLI.RenderSpec
                     , Agent.CLI.ReplStatusSpec

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -1,59 +1,24 @@
 module Agent.CLI.Runtime.Orchestration.Providers
-    ( AgentProviderRequest(..)
-    , runAgentProviders
+    ( withProviderRuntime
     ) where
 
-import Agent.CLI.Runtime.Orchestration.Providers.Claude
-    ( runClaudeProvider
-    )
-import Agent.CLI.Runtime.Orchestration.Providers.Gemini
-    ( runGeminiProvider
-    )
-import Agent.CLI.Runtime.Orchestration.Providers.OpenAI
-    ( runOpenAiProvider
-    )
-import Agent.CLI.Runtime.Orchestration.Providers.OpenRouter
-    ( runOpenRouterProvider
-    )
+import Agent.CLI.Runtime.Orchestration.Providers.Claude (withClaudeProvider)
+import Agent.CLI.Runtime.Orchestration.Providers.Gemini (withGeminiProvider)
+import Agent.CLI.Runtime.Orchestration.Providers.OpenAI (withOpenAiProvider)
+import Agent.CLI.Runtime.Orchestration.Providers.OpenRouter (withOpenRouterProvider)
 import Agent.CLI.Runtime.Orchestration.Providers.Types
-    ( AgentProviderRequest(..)
-    )
-import Agent.CLI.Runtime.Orchestration.Providers.XAI
-    ( runXaiProvider
-    )
-import Agent.CLI.Runtime.Orchestration.Types
-    ( NativeRunCapabilities(..)
-    , NativeRunHooks(..)
-    , fullNativeRunCapabilities
-    )
-import Agent.CLI.Runtime.Types (RunResult)
-import Agent.CLI.Session.Runtime.Types
-    ( StartupRuntime(..) )
-import Agent.CLI.Startup.Auth (startupDie)
-import Agent.Provider
-    ( Provider(..) )
+import Agent.CLI.Runtime.Orchestration.Providers.XAI (withXaiProvider)
 
-runAgentProviders
-    :: AgentProviderRequest
-    -> IO RunResult
-runAgentProviders request@AgentProviderRequest{provider, startup} =
-    let nativeCapabilities =
-            maybe
-                fullNativeRunCapabilities
-                (.nativeCapabilities)
-                startup.startupNativeHooks
-    in case provider of
-        OpenAIProvider ->
-            runOpenAiProvider request nativeCapabilities
-        XAIProvider ->
-            runXaiProvider request nativeCapabilities
-        GeminiProvider ->
-            runGeminiProvider request
-        ClaudeCodeProvider
-            | not nativeCapabilities.nativeProviderNativeTools ->
-                startupDie startup
-                    "Claude Code is unavailable in this runtime"
-            | otherwise ->
-                runClaudeProvider request nativeCapabilities
-        OpenRouterProvider ->
-            runOpenRouterProvider request
+-- | Scope provider resources around a consumer. The consumer decides how to
+-- compose the backend with session persistence, notices, and child agents.
+withProviderRuntime
+    :: ProviderConfig
+    -> ProviderHost
+    -> (ProviderRuntime -> IO a)
+    -> IO a
+withProviderRuntime config host use = case config of
+    OpenAiProviderConfig openAi -> withOpenAiProvider openAi host use
+    XaiProviderConfig tokens hostedTools -> withXaiProvider tokens hostedTools host use
+    GeminiProviderConfig tokens -> withGeminiProvider tokens host use
+    OpenRouterProviderConfig openRouter -> withOpenRouterProvider openRouter host use
+    ClaudeProviderConfig claude -> withClaudeProvider claude host use

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Claude.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Claude.hs
@@ -1,16 +1,7 @@
 module Agent.CLI.Runtime.Orchestration.Providers.Claude
-    ( runClaudeProvider
+    ( withClaudeProvider
     ) where
 
-import Agent.CLI.Auth.Types
-    ( LoadedAuth
-    , isGatewayLoadedAuth
-    )
-import Agent.CLI.Claude
-    ( approveClaudeRegisteredTool
-    , handleClaudePermissionRequest
-    )
-import Agent.CLI.ClaudeGatewayProxy (withClaudeGatewayProxy)
 import Agent.CLI.Compaction
     ( autoCompactBackendWith
     , claudeAutoCompactTokenLimit
@@ -19,29 +10,18 @@ import Agent.CLI.Compaction
     , runBackendCompactHistoryWithLimits
     , runBackendCompactWithLimits
     )
-import Agent.CLI.GatewayClient (GatewayCredential)
-import Agent.CLI.Options (CliOptions(..))
-import Agent.CLI.Provider.Switch (prepareTransitionBackend)
-import Agent.CLI.Render (putTextLn)
 import Agent.CLI.Runtime.Orchestration.Providers.Common
     ( decorateAutomaticCompact
     , decorateManualCompact
-    , runSession
     )
 import Agent.CLI.Runtime.Orchestration.Providers.Types
-    ( AgentProviderRequest(..)
+    ( ClaudeConfig(..), ProviderHost(..), ProviderCompaction(..)
+    , ProviderRuntime(..), ProviderAccountSelection(..), ProviderSubagents(..)
     )
-import Agent.CLI.Runtime.Orchestration.Types (NativeRunCapabilities(..))
-import Agent.CLI.Runtime.Types (RunResult)
 import Agent.CLI.Session.History (readLiveTranscript)
 import Agent.CLI.Session.Runtime.Types
     ( SessionBackend(..)
-    , SessionRequest(..)
     )
-import Agent.CLI.Startup.Auth (startupDie)
-import Agent.CLI.Style (glyphWarn, roleWarn)
-import Agent.CLI.TUI.App (emitUiEvent)
-import Agent.CLI.Terminal (resolveColor)
 import Agent.Claude
     ( ClaudeCodeAuth(..)
     , ClaudeCodeBackendHandle(..)
@@ -49,238 +29,134 @@ import Agent.Claude
     , ClaudeCodePermission(..)
     , claudeCodeOneShotBackend
     , defaultClaudeCodeOptions
-    , loadClaudeCodeAuth
-    , loadClaudeCodeGatewayAuth
     , withClaudeCodeBackendWithHost
-    )
-import Agent.Claude.Control
-    ( ClaudeCodeHostHandlers(..)
-    , ClaudeCodeMcpRequest(..)
-    , defaultClaudeCodeHostHandlers
     )
 import Agent.Loop
     ( Backend(Backend, submitTurn)
     , BackendSnapshot(..)
-    , defaultLoopDispatch
     )
 import Agent.OsPath (unsafeToFilePath)
-import Agent.ToolDispatch (ToolDispatchConfig(..))
-import Agent.Tools.OutputArtifact (finalizeToolOutput)
-import Agent.TUI.Model (UiEvent(UiSystemMessage))
-import Control.Monad (when)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
-import Data.Text (Text)
-import qualified Agent.MCP as MCP
-import qualified Data.Aeson as Aeson
 
-runClaudeProvider
-    :: AgentProviderRequest
-    -> NativeRunCapabilities
-    -> IO RunResult
-runClaudeProvider request@AgentProviderRequest{..} nativeCapabilities =
-    withSelectedClaudeAuth
-        connectedGateway
-        loaded
-        (startupDie startup)
-        \claudeAuth -> do
-            let permission =
-                    ClaudeCodeManual
-                claudeOptions =
-                    (defaultClaudeCodeOptions
-                        claudeAuth.executable
-                        (unsafeToFilePath cwd))
-                        { permission
-                        , safeMode = True
-                        , transport = claudeAuth.transport
-                        }
-                claudeContextWindow = do
-                    currentParams <- readIORef paramsRef
-                    pure $
-                        contextWindowForParams
-                            transportModel
-                            200_000
-                            currentParams
-                claudeCompactThreshold = do
-                    contextWindow <- claudeContextWindow
-                    let hardLimit =
-                            claudeCompactionInputLimit contextWindow
-                    pure $
-                        max 1 $
-                            min hardLimit $
-                                fromMaybe
-                                    (claudeAutoCompactTokenLimit
-                                        contextWindow)
-                                    options.optCompactThreshold
-                claudeSummaryInputLimit =
-                    claudeCompactionInputLimit
-                        <$> claudeContextWindow
-                btwBackend privateParams =
-                    Backend \state previous inputs onEvent -> do
-                        privateTranscript <-
-                            newIORef state.backendItems
-                        let privateBackend =
-                                claudeCodeOneShotBackend
-                                    claudeOptions
-                                        { permission =
-                                            ClaudeCodeDontAsk
-                                        }
-                                    (pure privateParams)
-                                    privateTranscript
-                        privateBackend.submitTurn
-                            state
-                            previous
-                            inputs
-                            onEvent
-                compactRunner focus = do
-                    contextWindow <- claudeContextWindow
-                    inputLimit <- claudeSummaryInputLimit
-                    historyRef <-
-                        newIORef =<< readLiveTranscript
-                            conversationRef
-                    installLiveCompactOutcome
+withClaudeProvider
+    :: ClaudeConfig
+    -> ProviderHost
+    -> (ProviderRuntime -> IO a)
+    -> IO a
+withClaudeProvider ClaudeConfig{..}
+        ProviderHost{compaction = ProviderCompaction{..}} use =
+    withAuth \claudeAuth -> do
+        let permission =
+                ClaudeCodeManual
+            claudeOptions =
+                (defaultClaudeCodeOptions
+                    claudeAuth.executable
+                    (unsafeToFilePath cwd))
+                    { permission
+                    , safeMode = True
+                    , transport = claudeAuth.transport
+                    }
+            claudeContextWindow = do
+                currentParams <- readIORef paramsRef
+                pure $
+                    contextWindowForParams
+                        transportModel
+                        200_000
+                        currentParams
+            claudeCompactThreshold = do
+                contextWindow <- claudeContextWindow
+                let hardLimit =
+                        claudeCompactionInputLimit contextWindow
+                pure $
+                    max 1 $
+                        min hardLimit $
+                            fromMaybe
+                                (claudeAutoCompactTokenLimit
+                                    contextWindow)
+                                compactThreshold
+            claudeSummaryInputLimit =
+                claudeCompactionInputLimit
+                    <$> claudeContextWindow
+            btwBackend privateParams =
+                Backend \state previous inputs onEvent -> do
+                    privateTranscript <-
+                        newIORef state.backendItems
+                    let privateBackend =
+                            claudeCodeOneShotBackend
+                                claudeOptions
+                                    { permission =
+                                        ClaudeCodeDontAsk
+                                    }
+                                (pure privateParams)
+                                privateTranscript
+                    privateBackend.submitTurn
+                        state
+                        previous
+                        inputs
+                        onEvent
+            compactRunner focus = do
+                contextWindow <- claudeContextWindow
+                inputLimit <- claudeSummaryInputLimit
+                historyRef <-
+                    newIORef =<< readLiveTranscript
                         conversationRef
-                        (Just contextTokensRef)
-                        (\requestedFocus ->
-                            runBackendCompactWithLimits
-                                contextWindow
-                                inputLimit
-                                btwBackend
-                                recordCompactionUsage
-                                paramsRef
-                                historyRef
-                                requestedFocus
-                                >>= decorateManualCompact request
-                                    (const contextWindow))
-                        focus
-                claudeRequest =
-                    sessionRequest
-                        startupUnavailable
-                        Nothing
-                        Nothing
-                        Nothing
-                        (Just <$> claudeContextWindow)
-                        compactRunner
-            claudeMcpServer <-
-                case MCP.createInProcessMcpServer
-                    "haskell-agent"
-                    "0.1.0"
-                    (defaultLoopDispatch
-                        { toolDispatchFinalizeOutput =
-                            \call output ->
-                                finalizeToolOutput
-                                    claudeRequest.toolEnv
-                                    call
-                                    output
-                        })
-                    (approveClaudeRegisteredTool
-                        claudeRequest.claudeRuntimeSlot)
-                    claudeRequest.claudeBridgeTools of
-                    Left err -> startupDie startup err
-                    Right server -> pure server
-            let hostHandlers =
-                    defaultClaudeCodeHostHandlers
-                        { canUseTool =
-                            Just
-                                (handleClaudePermissionRequest
-                                    claudeRequest.claudeRuntimeSlot)
-                        , handleMcpMessage =
-                            Just \mcpRequest ->
-                                if mcpRequest.serverName
-                                        /= "haskell-agent"
-                                    then
-                                        pure Aeson.Null
-                                    else
-                                        MCP.handleInProcessMcpMessage
-                                            claudeMcpServer
-                                            mcpRequest.message
-                                            >>= pure . fromMaybe
-                                                (Aeson.object [])
-                        , mcpToolNames =
-                            MCP.inProcessMcpToolNames
-                                claudeMcpServer
-                        , nativeToolsEnabled =
-                            nativeCapabilities.nativeProviderNativeTools
+                installLiveCompactOutcome
+                    conversationRef
+                    (Just contextTokensRef)
+                    (\requestedFocus ->
+                        runBackendCompactWithLimits
+                            contextWindow
+                            inputLimit
+                            btwBackend
+                            recordCompactionUsage
+                            paramsRef
+                            historyRef
+                            requestedFocus
+                            >>= decorateManualCompact (readIORef paramsRef) taskPlan
+                                (const contextWindow))
+                    focus
+        onConnected claudeAuth.accountLabel
+        claudeTranscriptRef <-
+            newIORef =<< readLiveTranscript conversationRef
+        withClaudeCodeBackendWithHost
+            claudeOptions
+            hostHandlers
+            initialPrevious
+            (readIORef paramsRef)
+            claudeTranscriptRef
+            \handle -> do
+                let compactHistory history _inputs = do
+                        contextWindow <- claudeContextWindow
+                        inputLimit <- claudeSummaryInputLimit
+                        currentParams <- readIORef paramsRef
+                        runBackendCompactHistoryWithLimits
+                            contextWindow
+                            inputLimit
+                            btwBackend
+                            recordCompactionUsage
+                            currentParams
+                            history
+                            Nothing
+                            >>= decorateAutomaticCompact (readIORef paramsRef) taskPlan
+                                (const contextWindow)
+                    compactingBackend =
+                        autoCompactBackendWith
+                            claudeCompactThreshold
+                            compactHistory
+                            installAutomaticCompact
+                            (readIORef paramsRef)
+                            contextTokensRef
+                            handle.loopBackend
+                use ProviderRuntime
+                    { sessionBackend = SessionBackend
+                        { backend = compactingBackend
+                        , btwBackend
+                        , interruptBackend = handle.interruptActiveTurn
+                        , resetBackendState = writeIORef claudeTranscriptRef []
                         }
-            when claudeBypassEnabled $
-                case fullscreen of
-                    Just runtime ->
-                        emitUiEvent runtime
-                            (UiSystemMessage
-                                "Claude Code --yolo is active; host catastrophic-command and Plan Mode denies remain enforced.")
-                    Nothing -> do
-                        color <- resolveColor stderrHandle
-                        putTextLn stderrHandle $
-                            roleWarn color $
-                                glyphWarn
-                                    <> "Claude Code --yolo is active; host catastrophic-command and Plan Mode denies remain enforced."
-            writeIORef activeAccountRef claudeAuth.accountLabel
-            claudeTranscriptRef <-
-                newIORef =<< readLiveTranscript conversationRef
-            withClaudeCodeBackendWithHost
-                claudeOptions
-                hostHandlers
-                initialPrevious
-                (readIORef paramsRef)
-                claudeTranscriptRef
-                \handle -> do
-                    let compactHistory history _inputs = do
-                            contextWindow <- claudeContextWindow
-                            inputLimit <- claudeSummaryInputLimit
-                            currentParams <- readIORef paramsRef
-                            runBackendCompactHistoryWithLimits
-                                contextWindow
-                                inputLimit
-                                btwBackend
-                                recordCompactionUsage
-                                currentParams
-                                history
-                                Nothing
-                                >>= decorateAutomaticCompact request
-                                    (const contextWindow)
-                        compactingBackend =
-                            autoCompactBackendWith
-                                claudeCompactThreshold
-                                compactHistory
-                                (\outcome inputs ->
-                                    readIORef
-                                        automaticCompactionHookRef
-                                        >>= \hook ->
-                                            hook outcome inputs)
-                                (readIORef paramsRef)
-                                contextTokensRef
-                                handle.loopBackend
-                    activeBackend <-
-                        prepareTransitionBackend
-                            modelSwitchScope home projectRoot
-                            transition persist compactingBackend
-                    runSession
-                        claudeRequest
-                        SessionBackend
-                            { backend = activeBackend
-                            , btwBackend
-                            , interruptBackend =
-                                handle.interruptActiveTurn
-                            , resetBackendState =
-                                writeIORef claudeTranscriptRef []
-                            }
-
-withSelectedClaudeAuth
-    :: Maybe GatewayCredential
-    -> LoadedAuth
-    -> (Text -> IO value)
-    -> (ClaudeCodeAuth -> IO value)
-    -> IO value
-withSelectedClaudeAuth connectedGateway loaded onError action
-    -- Use the same immutable credential snapshot that selected the catalog,
-    -- auth, and session boundary. Reloading here could cross organizations.
-    | not (isGatewayLoadedAuth loaded) =
-        loadClaudeCodeAuth >>= either onError action
-    | otherwise = case connectedGateway of
-        Nothing ->
-            onError "No organization gateway credential is connected."
-        Just credential -> do
-            result <- withClaudeGatewayProxy credential \transport ->
-                loadClaudeCodeGatewayAuth transport
-                    >>= either onError action
-            either onError pure result
+                    , currentContextWindow = Just <$> claudeContextWindow
+                    , compactRunner
+                    , accountSelection = NoAccountSelection
+                    , subagents = NoProviderSubagents
+                    }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Common.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Common.hs
@@ -1,91 +1,69 @@
 module Agent.CLI.Runtime.Orchestration.Providers.Common
-    ( HttpProviderSession(..)
-    , runHttpProvider
+    ( HttpProviderTransport(..)
+    , withHttpProvider
     , decorateAutomaticCompact
     , decorateManualCompact
-    , runSession
-    , startupFailure
     ) where
 
-import Agent.CLI.Auth.Types (LoadedAuth(..), isGatewayLoadedAuth)
 import Agent.CLI.Compaction
     ( CompactOutcome
     , OccupancySnapshot
     , boundCompletedToolContinuations
     , installLiveCompactOutcome
-    , decorateCompactOutcomeWithTaskPlanWithin
     , runResponsesCompactWithContextWindow
+    , decorateCompactOutcomeWithTaskPlanWithin
     )
-import Agent.CLI.Error (formatApiErrorAt)
-import Agent.CLI.PendingInputs (withPendingInputs)
-import Agent.CLI.Provider.Switch (prepareTransitionBackend)
 import Agent.CLI.Runtime.Orchestration.Providers.Types
-    ( AgentProviderRequest(..)
+    ( ProviderHost(..), ProviderCompaction(..), ProviderRuntime(..)
+    , ProviderAccountSelection(..), ProviderSubagents(..)
     )
-import Agent.CLI.Runtime.Orchestration.Startup (finishStartup)
-import Agent.CLI.Runtime.Recap
-    ( runSessionRecap
-    , runSessionTurnSummary
-    )
-import Agent.CLI.Runtime.Repl
-    ( finishTurn
-    , preparePromptSkillInputsWithPaste
-    , repl
-    , replWithDraft
-    , runPendingTurn
-    )
-import Agent.CLI.Runtime.Types (RunResult)
 import Agent.CLI.Session.History (readLiveTranscript)
-import Agent.CLI.Session.Runtime.Types
-    ( SessionBackend(..)
-    , SessionRequest
-    , StartupRuntime(..)
-    )
-import Agent.CLI.Subagents.Runtime (runHttpSubagent)
+import Agent.CLI.Session.Runtime.Types (SessionBackend(..))
 import Agent.Connectivity (withConnectionRecoveryOn)
+import Agent.Loop (Backend)
+import Data.IORef (IORef, newIORef, readIORef)
 import Agent.Error
     ( ApiError(ProviderError)
     , ErrorType(InvalidRequestError)
     )
-import Agent.Loop (Backend)
-import Agent.Subagents (setSubagentRunner)
-import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.Responses.Types (ResponseCreateParams, Response)
-import Data.IORef (IORef, newIORef, readIORef)
+import Agent.Tools.TaskPlan (TaskPlanEnv)
 import Data.Text (Text)
-import Data.Time.Clock (getCurrentTime)
-import qualified Agent.CLI.Session.Runner as SessionRunner
-import qualified Agent.CLI.Startup.Auth as Startup
 
 decorateManualCompact
-    :: AgentProviderRequest
+    :: IO ResponseCreateParams
+    -> Maybe TaskPlanEnv
     -> (ResponseCreateParams -> Int)
     -> Either Text CompactOutcome
     -> IO (Either Text CompactOutcome)
 decorateManualCompact
-    request
+    getParams
+    taskPlan
     contextWindowForResult = \case
         Left err -> pure (Left err)
         Right outcome -> do
-            currentParams <- readIORef request.paramsRef
+            currentParams <- getParams
             decorateCompactOutcomeWithTaskPlanWithin
                 (contextWindowForResult currentParams)
                 currentParams
-                request.taskPlan
+                taskPlan
                 outcome
 
 decorateAutomaticCompact
-    :: AgentProviderRequest
+    :: IO ResponseCreateParams
+    -> Maybe TaskPlanEnv
     -> (ResponseCreateParams -> Int)
     -> Either ApiError CompactOutcome
     -> IO (Either ApiError CompactOutcome)
 decorateAutomaticCompact
-    request
+    getParams
+    taskPlan
     contextWindowForResult = \case
         Left err -> pure (Left err)
         Right outcome ->
             decorateManualCompact
-                request
+                getParams
+                taskPlan
                 contextWindowForResult
                 (Right outcome) >>= pure . \case
                     Left message ->
@@ -96,71 +74,33 @@ decorateAutomaticCompact
                                 Nothing)
                     Right decorated -> Right decorated
 
-startupFailure
-    :: AgentProviderRequest
-    -> ApiError
-    -> IO RunResult
-startupFailure AgentProviderRequest{startup} err = do
-    now <- getCurrentTime
-    Startup.startupDie startup
-        (formatApiErrorAt now err)
-
-sessionRunnerContinuation :: SessionRunner.SessionRunnerContinuation
-sessionRunnerContinuation =
-    SessionRunner.SessionRunnerContinuation
-        { runnerRepl = repl
-        , runnerReplWithDraft = replWithDraft
-        , runnerRunPendingTurn = runPendingTurn
-        , runnerFinishTurn = finishTurn
-        , runnerFinishStartup = finishStartup
-        , runnerPreparePromptSkillInputs = preparePromptSkillInputsWithPaste
-        , runnerRunSessionRecap = runSessionRecap
-        , runnerRunSessionTurnSummary = runSessionTurnSummary
-        }
-
-runSession
-    :: SessionRequest
-    -> SessionBackend
-    -> IO RunResult
-runSession = SessionRunner.runSession sessionRunnerContinuation
-
--- Transport and occupancy choices remain owned by each provider. This runner
--- shares the HTTP session lifecycle used by Gemini and OpenRouter.
-data HttpProviderSession = HttpProviderSession
+-- | Gemini and OpenRouter share HTTP backend and manual-compaction assembly.
+-- The transport chooses its sender, model mapping, and occupancy state; the
+-- consumer owns session startup, persistence, notices, and subagent registration.
+data HttpProviderTransport = HttpProviderTransport
     { httpMakeBackend :: IO ResponseCreateParams -> Backend
     , httpSendCompact :: ResponseCreateParams -> IO (Either ApiError Response)
     , httpTransportModel :: Text -> Text
     , httpOccupancy :: IORef (Maybe OccupancySnapshot)
     }
 
-runHttpProvider
-    :: AgentProviderRequest
-    -> HttpProviderSession
-    -> IO RunResult
-runHttpProvider request@AgentProviderRequest{..} HttpProviderSession{..} = do
+withHttpProvider
+    :: ProviderHost
+    -> HttpProviderTransport
+    -> (ProviderRuntime -> IO a)
+    -> IO a
+withHttpProvider
+        ProviderHost{compaction = ProviderCompaction{..}, networkRecovery}
+        HttpProviderTransport{..} use = do
     let contextWindowFor = contextWindowForParams httpTransportModel 1_048_576
         protectOverflow getParams =
             boundCompletedToolContinuations
                 contextWindowFor getParams httpOccupancy
-    case multiCtx of
-        Just ctx ->
-            setSubagentRunner ctx.multiRegistry $
-                runHttpSubagent
-                    subagentRuntime
-                    dialect
-                    provider
-                    ctx.multiSendToRoot
-                    (\childParams ->
-                        protectOverflow
-                            (pure childParams)
-                            (httpMakeBackend (pure childParams)))
-        Nothing -> pure ()
-    let backend =
-            withPendingInputs pendingNotices $
-                withConnectionRecoveryOn startup.startupNetworkRecovery $
-                    protectOverflow
-                        (readIORef paramsRef)
-                        (httpMakeBackend (readIORef paramsRef))
+        backend =
+            withConnectionRecoveryOn networkRecovery $
+                protectOverflow
+                    (readIORef paramsRef)
+                    (httpMakeBackend (readIORef paramsRef))
         compactRunner focus = do
             contextWindow <- currentModelContextWindow httpTransportModel
             historyRef <- newIORef =<< readLiveTranscript conversationRef
@@ -173,22 +113,21 @@ runHttpProvider request@AgentProviderRequest{..} HttpProviderSession{..} = do
                         paramsRef
                         historyRef
                         requestedFocus
-                        >>= decorateManualCompact request contextWindowFor)
+                        >>= decorateManualCompact
+                            (readIORef paramsRef) taskPlan contextWindowFor)
                 focus
-    activeBackend <-
-        prepareTransitionBackend
-            modelSwitchScope home projectRoot transition persist backend
-    runSession
-        (sessionRequest
-            startupUnavailable
-            (Just tokenProvider)
-            loaded.loadedOpenAiPool
-            (if isGatewayLoadedAuth loaded then Nothing else Just selectHttpAccount)
-            (Just . contextWindowFor <$> readIORef paramsRef)
-            compactRunner)
-        SessionBackend
-            { backend = activeBackend
+    use ProviderRuntime
+        { sessionBackend = SessionBackend
+            { backend
             , btwBackend = httpMakeBackend . pure
             , interruptBackend = pure ()
             , resetBackendState = pure ()
             }
+        , currentContextWindow = Just . contextWindowFor <$> readIORef paramsRef
+        , compactRunner
+        , accountSelection = HttpAccountSelection
+        , subagents = HttpSubagents \childParams ->
+            protectOverflow
+                (pure childParams)
+                (httpMakeBackend (pure childParams))
+        }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Gemini.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Gemini.hs
@@ -1,24 +1,28 @@
 module Agent.CLI.Runtime.Orchestration.Providers.Gemini
-    ( runGeminiProvider
+    ( withGeminiProvider
     ) where
 
 import Agent.CLI.Runtime.Orchestration.Providers.Common
-    ( HttpProviderSession(..)
-    , runHttpProvider
+    ( HttpProviderTransport(..)
+    , withHttpProvider
     )
-import Agent.CLI.Runtime.Orchestration.Providers.Types (AgentProviderRequest(..))
-import Agent.CLI.Runtime.Types (RunResult)
+import Agent.CLI.Runtime.Orchestration.Providers.Types
+    ( ProviderHost(..), ProviderRuntime )
 import Agent.Gemini.LoopBackend (tokenProviderStatelessGeminiBackend)
-import Agent.Provider (runWithTokenProvider)
+import Agent.Provider (TokenProvider, runWithTokenProvider)
 import Data.IORef (newIORef)
 import qualified Agent.Gemini.Client as GeminiClient
 import qualified Agent.Gemini.Options as Gemini
 
-runGeminiProvider :: AgentProviderRequest -> IO RunResult
-runGeminiProvider request@AgentProviderRequest{tokenProvider} = do
+withGeminiProvider
+    :: TokenProvider
+    -> ProviderHost
+    -> (ProviderRuntime -> IO a)
+    -> IO a
+withGeminiProvider tokenProvider host use = do
     geminiOptions <- Gemini.clientOptionsFromEnv
     geminiOccupancy <- newIORef Nothing
-    runHttpProvider request HttpProviderSession
+    withHttpProvider host HttpProviderTransport
         { httpMakeBackend =
             tokenProviderStatelessGeminiBackend
                 tokenProvider
@@ -28,4 +32,4 @@ runGeminiProvider request@AgentProviderRequest{tokenProvider} = do
                 GeminiClient.createResponseWith geminiOptions credential compactRequest
         , httpTransportModel = id
         , httpOccupancy = geminiOccupancy
-        }
+        } use

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenAI.hs
@@ -1,61 +1,36 @@
 module Agent.CLI.Runtime.Orchestration.Providers.OpenAI
-    ( runOpenAiProvider
+    ( withOpenAiProvider
     ) where
 
-import Agent.CLI.Auth.Types
-    ( LoadedAuth(..)
-    , isGatewayLoadedAuth
-    )
 import Agent.CLI.Compaction
     ( decorateCompactOutcomeWithTaskPlan
     , installLiveCompactOutcome
     , runProviderCompactWith
     )
-import Agent.CLI.PendingInputs (withPendingInputs)
-import Agent.CLI.Options (CliOptions(..))
 import Agent.CLI.Provider.OpenAI
     ( OpenAiPersistentConnection(..)
     , lockedOpenAiSession
     )
-import Agent.CLI.Provider.Switch
-    ( chooseStartupProviderTransition
-    , prepareTransitionBackend
-    )
-import Agent.CLI.ProviderFallback (isProviderUnavailable)
-import Agent.CLI.ProviderTransition
-    ( ProviderTransition(transitionCause)
-    , TransitionCause(AutomaticFallback)
-    )
 import Agent.CLI.Runtime.Orchestration.Providers.Common
     ( decorateManualCompact
-    , runSession
-    , startupFailure
     )
 import Agent.CLI.Runtime.Orchestration.Providers.Types
-    ( AgentProviderRequest(..)
-    )
-import Agent.CLI.Runtime.Orchestration.Types
-    ( AccountSwitchRequest(..)
-    , NativeRunCapabilities(..)
-    )
-import Agent.CLI.Runtime.Types
-    ( RunResult(RunProviderStartFailed, RunSwitchProvider)
+    ( OpenAiConfig(..), OpenAiAccounts(..), ProviderHost(..)
+    , ProviderCompaction(..), ProviderRuntime(..)
+    , ProviderAccountSelection(..), ProviderSubagents(..)
     )
 import Agent.CLI.Session.History (readLiveTranscript)
 import Agent.CLI.Session.Runtime.Types
     ( SessionBackend(..)
-    , StartupRuntime(..)
     )
-import Agent.CLI.Subagents.Runtime
+import Agent.CLI.Subagents.Runtime.OpenAI
     ( freshOpenAiBackend
-    , runCodexSubagent
     )
 import Agent.Error (ApiError(..))
 import Agent.OpenAI.Auth (Pool)
 import Agent.OpenAI.ModelMetadata (codexEffectiveContextWindowFor)
 import Agent.OpenAI.WebSocketClient
-    ( CodexAuthFailed(..)
-    , CodexConn
+    ( CodexConn
     , closeCodexConn
     , codexConnTurnState
     , codexConnUsesHttpFallback
@@ -67,11 +42,8 @@ import Agent.OpenAI.WebSocketClient
 import Agent.Provider
     ( Credential(..)
     , Provider(OpenAIProvider)
-    , tokenProviderBillingMode
     )
 import Agent.Responses.Types (ResponseCreateParams(model))
-import Agent.Subagents (setSubagentRunner)
-import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Control.Concurrent.Async (link, withAsync)
 import Control.Concurrent.Chan
     ( Chan
@@ -88,7 +60,7 @@ import Control.Concurrent.MVar
     , tryPutMVar
     , withMVar
     )
-import Control.Exception.Safe (catchAny, finally, try)
+import Control.Exception.Safe (catchAny, finally)
 import Control.Monad (when)
 import Data.IORef
     ( IORef
@@ -101,15 +73,17 @@ import Data.Text (Text)
 import qualified Agent.OpenAI.Auth as OpenAI
 import qualified Data.Text as Text
 
-runOpenAiProvider
-    :: AgentProviderRequest
-    -> NativeRunCapabilities
-    -> IO RunResult
-runOpenAiProvider request@AgentProviderRequest{tokenProvider} nativeCapabilities =
-    try @_ @CodexAuthFailed
-        (withCodexWsWithProviderOrHttpFallback tokenProvider \conn credential ->
-            runConnectedOpenAiProvider request conn credential)
-        >>= handleOpenAiProviderResult request nativeCapabilities
+withOpenAiProvider
+    :: OpenAiConfig
+    -> ProviderHost
+    -> (ProviderRuntime -> IO a)
+    -> IO a
+withOpenAiProvider config@OpenAiConfig{tokenProvider} host use =
+    withCodexWsWithProviderOrHttpFallback tokenProvider \conn credential ->
+        withConnectedOpenAiProvider config host conn credential use
+
+data AccountSwitchRequest
+    = AccountSwitchRequest !Credential !(MVar (Either ApiError Text))
 
 data OpenAiProviderRuntime = OpenAiProviderRuntime
     { openAiWsLock :: MVar ()
@@ -141,11 +115,11 @@ newOpenAiConnectionState conn credential = do
     pure OpenAiConnectionState{..}
 
 newOpenAiProviderRuntime
-    :: AgentProviderRequest
+    :: OpenAiAccounts
     -> CodexConn
     -> Credential
     -> IO OpenAiProviderRuntime
-newOpenAiProviderRuntime AgentProviderRequest{..} conn credential = do
+newOpenAiProviderRuntime OpenAiAccounts{..} conn credential = do
     OpenAiConnectionState
         { openAiConnectionLock = wsLock
         , openAiConnectionRef =
@@ -155,9 +129,7 @@ newOpenAiProviderRuntime AgentProviderRequest{..} conn credential = do
         } <- newOpenAiConnectionState conn credential
     switchRequests <-
         newChan :: IO (Chan AccountSwitchRequest)
-    let selectableOpenAiPool
-            | isGatewayLoadedAuth loaded = Nothing
-            | otherwise = loaded.loadedOpenAiPool
+    let selectableOpenAiPool = selectablePool
         selectAccount =
             selectOpenAiAccount switchRequests
                 <$> selectableOpenAiPool
@@ -201,7 +173,7 @@ newOpenAiProviderRuntime AgentProviderRequest{..} conn credential = do
                                     newIORef
                                         (not usesHttp)
                                 label <-
-                                    resolveActiveAccountLabel
+                                    resolveAccountLabel
                                         newCredential
                                 writeIORef
                                     activeConnectionRef $
@@ -209,15 +181,7 @@ newOpenAiProviderRuntime AgentProviderRequest{..} conn credential = do
                                         newCredential
                                         newHealthy
                                         newConn
-                                writeIORef
-                                    activeAccountIdRef
-                                    newCredential.accountId
-                                writeIORef
-                                    activeSelectionRef
-                                    newCredential.accountId
-                                writeIORef
-                                    activeAccountRef
-                                    label
+                                installAccount newCredential label
                                 writeIORef
                                     httpFallbackActive
                                     usesHttp
@@ -231,7 +195,7 @@ newOpenAiProviderRuntime AgentProviderRequest{..} conn credential = do
                     oldConnection <-
                         readIORef activeConnectionRef
                     previousAccountId <-
-                        readIORef activeAccountIdRef
+                        readActiveAccountId
                     let OpenAiPersistentConnection
                             _
                             oldHealthy
@@ -239,9 +203,7 @@ newOpenAiProviderRuntime AgentProviderRequest{..} conn credential = do
                                 oldConnection
                     writeIORef oldHealthy False
                     closeCodexConn oldConn
-                    writeIORef
-                        preferredOpenAiAccountRef
-                        (Just selectedCredential.accountId)
+                    preferAccount selectedCredential.accountId
                     let connectSelected =
                             withCodexWsCredentialOrHttpFallback
                                 selectedCredential
@@ -260,9 +222,7 @@ newOpenAiProviderRuntime AgentProviderRequest{..} conn credential = do
                             | Text.null previousAccountId =
                                 failSwitch selectedError
                             | otherwise = do
-                                writeIORef
-                                    preferredOpenAiAccountRef
-                                    (Just previousAccountId)
+                                preferAccount previousAccountId
                                 OpenAI.getAccessTokenForAccount
                                     pool
                                     previousAccountId
@@ -351,12 +311,16 @@ selectOpenAiAccount switchRequests pool selectedAccountId = do
                     reply
             takeMVar reply
 
-runConnectedOpenAiProvider
-    :: AgentProviderRequest
+withConnectedOpenAiProvider
+    :: OpenAiConfig
+    -> ProviderHost
     -> CodexConn
     -> Credential
-    -> IO RunResult
-runConnectedOpenAiProvider request@AgentProviderRequest{..} conn credential = do
+    -> (ProviderRuntime -> IO a)
+    -> IO a
+withConnectedOpenAiProvider OpenAiConfig{..}
+        ProviderHost{compaction = ProviderCompaction{..}, networkRecovery}
+        conn credential use = do
     OpenAiProviderRuntime
         { openAiWsLock = wsLock
         , openAiActiveConnectionRef =
@@ -368,26 +332,16 @@ runConnectedOpenAiProvider request@AgentProviderRequest{..} conn credential = do
         , openAiSelectAccount = selectAccount
         , openAiSwitchLoop = switchLoop
         } <- newOpenAiProviderRuntime
-            request
+            accounts
             conn
             credential
-    case multiCtx of
-        Just ctx ->
-            setSubagentRunner ctx.multiRegistry $
-                runCodexSubagent
-                    (isGatewayWebSocketCredential
-                        credential)
-                    subagentRuntime
-                    selectableTokenProvider
-                    ctx.multiSendToRoot
-        Nothing -> pure ()
     let (compactSender, lockedBackend) =
             lockedOpenAiSession
-                startup.startupNetworkRecovery
+                networkRecovery
                 (isGatewayWebSocketCredential
                     credential)
-                options.optCompactThreshold
-                options.optShowRawReasoning
+                compactThreshold
+                showRawReasoning
                 wsLock
                 httpFallbackActive
                 tokenProvider
@@ -397,17 +351,10 @@ runConnectedOpenAiProvider request@AgentProviderRequest{..} conn credential = do
                 recordCompactionUsage
                 (decorateCompactOutcomeWithTaskPlan
                     taskPlan)
-                (\outcome inputs ->
-                    readIORef
-                        automaticCompactionHookRef
-                        >>= \hook ->
-                            hook outcome inputs)
-        noticingBackend =
-            withPendingInputs pendingNotices
-                lockedBackend
+                installAutomaticCompact
         btwBackend privateParams =
             freshOpenAiBackend
-                options.optShowRawReasoning
+                showRawReasoning
                 tokenProvider
                 (pure privateParams)
         compactRunner focus =
@@ -430,34 +377,23 @@ runConnectedOpenAiProvider request@AgentProviderRequest{..} conn credential = do
                                 runProviderCompactWith
                                     (Just compactSender)
                                     recordCompactionUsage
-                                    provider
+                                    OpenAIProvider
                                     (Just tokenProvider)
                                     paramsRef
                                     historyRef
                                     requestedFocus
-                                    >>= decorateManualCompact request
+                                    >>= decorateManualCompact (readIORef paramsRef) taskPlan
                                         (codexEffectiveContextWindowFor
                                             . (.model)))
                             focus
                 resetCodexTurnState turnState
                 runCompact `finally`
                     resetCodexTurnState turnState
-    activeBackend <-
-        prepareTransitionBackend
-            modelSwitchScope home projectRoot
-            transition persist noticingBackend
     withAsync switchLoop \switchWorker -> do
         link switchWorker
-        runSession
-            (sessionRequest
-                startupUnavailable
-                (Just tokenProvider)
-                selectableOpenAiPool
-                selectAccount
-                (currentModelContextWindow transportModel)
-                compactRunner)
-            SessionBackend
-                { backend = activeBackend
+        use ProviderRuntime
+            { sessionBackend = SessionBackend
+                { backend = lockedBackend
                 , btwBackend
                 , interruptBackend = pure ()
                 , resetBackendState = do
@@ -466,43 +402,10 @@ runConnectedOpenAiProvider request@AgentProviderRequest{..} conn credential = do
                         _connectionHealthy
                         activeConn <-
                             readIORef activeConnectionRef
-                    resetCodexTurnState
-                        (codexConnTurnState activeConn)
+                    resetCodexTurnState (codexConnTurnState activeConn)
                 }
-
-handleOpenAiProviderResult
-    :: AgentProviderRequest
-    -> NativeRunCapabilities
-    -> Either CodexAuthFailed RunResult
-    -> IO RunResult
-handleOpenAiProviderResult request@AgentProviderRequest{..} nativeCapabilities = \case
-    Left (CodexAuthFailed err) ->
-        case transition of
-            Just active
-                | active.transitionCause == AutomaticFallback ->
-                    pure (RunProviderStartFailed err)
-            _
-                | shouldProbeAtStartup
-                , not (isGatewayLoadedAuth loaded)
-                , isProviderUnavailable err ->
-                    chooseStartupProviderTransition
-                        nativeCapabilities.nativeProviderFallback
-                        catalog
-                        projectRoot
-                        fullscreen
-                        (tokenProviderBillingMode
-                            tokenProvider)
-                        provider
-                        model
-                        unavailableProviders
-                        Nothing
-                        err >>= \case
-                            Just next ->
-                                pure
-                                    (RunSwitchProvider
-                                        next)
-                            Nothing ->
-                                startupFailure request err
-            _ ->
-                startupFailure request err
-    Right result -> pure result
+            , currentContextWindow = currentModelContextWindow transportModel
+            , compactRunner
+            , accountSelection = OpenAiAccountSelection selectableOpenAiPool selectAccount
+            , subagents = CodexSubagents (isGatewayWebSocketCredential credential)
+            }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenRouter.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenRouter.hs
@@ -1,13 +1,13 @@
 module Agent.CLI.Runtime.Orchestration.Providers.OpenRouter
-    ( runOpenRouterProvider
+    ( withOpenRouterProvider
     ) where
 
 import Agent.CLI.Runtime.Orchestration.Providers.Common
-    ( HttpProviderSession(..)
-    , runHttpProvider
+    ( HttpProviderTransport(..)
+    , withHttpProvider
     )
-import Agent.CLI.Runtime.Orchestration.Providers.Types (AgentProviderRequest(..))
-import Agent.CLI.Runtime.Types (RunResult)
+import Agent.CLI.Runtime.Orchestration.Providers.Types
+    ( ProviderHost(..), ProviderRuntime, OpenRouterConfig(..), ProviderCompaction(..) )
 import Agent.OpenRouter.LoopBackend (openRouterBackend)
 import Agent.Provider (runWithTokenProvider)
 import Agent.Responses.GenericBackend (genericResponsesBackendWith)
@@ -16,14 +16,19 @@ import Data.Maybe (fromMaybe)
 import qualified Agent.OpenRouter as OpenRouter
 import qualified Agent.Responses.GenericClient as GenericResponses
 
-runOpenRouterProvider :: AgentProviderRequest -> IO RunResult
-runOpenRouterProvider request@AgentProviderRequest{..} =
-    runHttpProvider request HttpProviderSession
+withOpenRouterProvider
+    :: OpenRouterConfig
+    -> ProviderHost
+    -> (ProviderRuntime -> IO a)
+    -> IO a
+withOpenRouterProvider OpenRouterConfig{genericOptions = customGenericOptions, ..}
+        host use =
+    withHttpProvider host HttpProviderTransport
         { httpMakeBackend = makeBackend
         , httpSendCompact = sendCompact
         , httpTransportModel = transportModel
-        , httpOccupancy = contextTokensRef
-        }
+        , httpOccupancy = host.compaction.contextTokensRef
+        } use
   where
     optionsForRequest
         :: GenericResponses.GenericClientOptions
@@ -44,7 +49,7 @@ runOpenRouterProvider request@AgentProviderRequest{..} =
                             responseRequest
                             onEvent)
                     params
-            Nothing -> openRouterBackend openRouterOptions tokenProvider params
+            Nothing -> openRouterBackend clientOptions tokenProvider params
     sendCompact responseRequest =
         case customGenericOptions of
             Just genericOptions ->
@@ -54,4 +59,4 @@ runOpenRouterProvider request@AgentProviderRequest{..} =
             Nothing ->
                 runWithTokenProvider tokenProvider \credential ->
                     OpenRouter.createResponseWith
-                        openRouterOptions credential responseRequest
+                        clientOptions credential responseRequest

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Types.hs
@@ -1,99 +1,119 @@
 module Agent.CLI.Runtime.Orchestration.Providers.Types
-    ( AgentProviderRequest(..)
+    ( ProviderConfig(..)
+    , OpenAiConfig(..)
+    , OpenAiAccounts(..)
+    , OpenRouterConfig(..)
+    , ClaudeConfig(..)
+    , ProviderHost(..)
+    , ProviderCompaction(..)
+    , ProviderRuntime(..)
+    , ProviderAccountSelection(..)
+    , ProviderSubagents(..)
     ) where
 
-import Agent.CLI.Auth.Types (LoadedAuth)
-import Agent.CLI.Compaction
-    ( CompactOutcome
-    , CompactionInstall
-    , OccupancySnapshot
-    )
-import Agent.CLI.GatewayClient (GatewayCredential)
-import Agent.CLI.ModelConfig (ModelCatalog)
-import Agent.CLI.Options (CliOptions)
-import Agent.CLI.PendingInputs (PendingInputs)
-import Agent.CLI.Project (ModelSwitchScope)
-import Agent.CLI.ProviderTransition (ProviderTransition)
+import Agent.CLI.Compaction (CompactOutcome, CompactionInstall, OccupancySnapshot)
 import Agent.CLI.Session.History (LiveConversation)
-import Agent.CLI.Session.Runtime.Types (SessionRequest, StartupRuntime)
-import Agent.CLI.Session.Types (Persistence)
-import Agent.CLI.Subagents.Runtime.Types (SubagentRuntime)
-import Agent.CLI.TUI.App (FullscreenRuntime)
-import Agent.Dialect (Dialect)
+import Agent.CLI.Session.Runtime.Types (SessionBackend)
+import Agent.Claude (ClaudeCodeAuth)
+import Agent.Claude.Control (ClaudeCodeHostHandlers)
+import Agent.Connectivity.NetworkPath (NetworkRecovery)
 import Agent.Error (ApiError)
-import Agent.Loop (TokenUsage, TurnInput)
+import Agent.Loop (Backend, TokenUsage, TurnInput)
 import Agent.OpenAI.Auth (Pool)
 import Agent.OpenRouter.Options (ClientOptions)
-import Agent.Provider (Credential, Provider, TokenProvider)
+import Agent.Provider (Credential, TokenProvider)
 import Agent.Responses.Types (ResponseCreateParams)
-import Agent.Tools.MultiAgents (MultiAgentContext)
 import Agent.Tools.TaskPlan (TaskPlanEnv)
-import Control.Concurrent.STM (STM)
 import Data.IORef (IORef)
-import Data.Set (Set)
 import Data.Text (Text)
-import System.IO (Handle)
 import System.OsPath (OsPath)
 import qualified Agent.Responses.GenericClient as GenericResponses
 
-data AgentProviderRequest = AgentProviderRequest
-    { modelSwitchScope :: ModelSwitchScope
-    , loaded :: LoadedAuth
-    , connectedGateway :: Maybe GatewayCredential
-    , sessionRequest
-        :: Maybe (STM ApiError)
-        -> Maybe TokenProvider
-        -> Maybe Pool
-        -> Maybe (Text -> IO (Either ApiError Text))
-        -> IO (Maybe Int)
-        -> (Maybe Text -> IO (Either Text CompactOutcome))
-        -> SessionRequest
-    , activeAccountIdRef :: IORef Text
-    , activeAccountRef :: IORef Text
-    , activeSelectionRef :: IORef Text
-    , catalog :: ModelCatalog
-    , claudeBypassEnabled :: Bool
-    , contextTokensRef :: IORef (Maybe OccupancySnapshot)
-    , contextWindowForParams
-        :: (Text -> Text)
-        -> Int
-        -> ResponseCreateParams
-        -> Int
-    , conversationRef :: IORef LiveConversation
-    , currentModelContextWindow
-        :: (Text -> Text)
-        -> IO (Maybe Int)
-    , customGenericOptions :: Maybe GenericResponses.GenericClientOptions
-    , cwd :: OsPath
-    , dialect :: Dialect
-    , fullscreen :: Maybe FullscreenRuntime
-    , automaticCompactionHookRef
-        :: IORef
-            (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
-    , taskPlan :: Maybe TaskPlanEnv
-    , home :: OsPath
-    , initialPrevious :: Maybe Text
-    , model :: Text
-    , multiCtx :: Maybe MultiAgentContext
-    , openRouterOptions :: ClientOptions
-    , options :: CliOptions
-    , paramsRef :: IORef ResponseCreateParams
-    , pendingNotices :: PendingInputs
-    , persist :: Persistence
-    , preferredOpenAiAccountRef :: IORef (Maybe Text)
-    , projectRoot :: OsPath
-    , provider :: Provider
-    , recordCompactionUsage :: TokenUsage -> IO ()
-    , resolveActiveAccountLabel :: Credential -> IO Text
-    , selectHttpAccount :: Text -> IO (Either ApiError Text)
-    , selectableTokenProvider :: TokenProvider
-    , shouldProbeAtStartup :: Bool
-    , startup :: StartupRuntime
-    , startupUnavailable :: Maybe (STM ApiError)
-    , stderrHandle :: Handle
-    , subagentRuntime :: SubagentRuntime
-    , tokenProvider :: TokenProvider
-    , transition :: Maybe ProviderTransition
+-- | Only the selected provider's configuration crosses the provider boundary.
+data ProviderConfig
+    = OpenAiProviderConfig OpenAiConfig
+    | XaiProviderConfig TokenProvider Bool
+    | GeminiProviderConfig TokenProvider
+    | OpenRouterProviderConfig OpenRouterConfig
+    | ClaudeProviderConfig ClaudeConfig
+
+data OpenAiConfig = OpenAiConfig
+    { tokenProvider :: TokenProvider
+    , showRawReasoning :: Bool
     , transportModel :: Text -> Text
-    , unavailableProviders :: Set Provider
+    , accounts :: OpenAiAccounts
     }
+
+-- | Account switching owns connections; the host owns account presentation
+-- and preferences. Keep those mutations behind operations.
+data OpenAiAccounts = OpenAiAccounts
+    { selectablePool :: Maybe Pool
+    , readActiveAccountId :: IO Text
+    , resolveAccountLabel :: Credential -> IO Text
+    , installAccount :: Credential -> Text -> IO ()
+    , preferAccount :: Text -> IO ()
+    }
+
+data OpenRouterConfig = OpenRouterConfig
+    { tokenProvider :: TokenProvider
+    , clientOptions :: ClientOptions
+    , genericOptions :: Maybe GenericResponses.GenericClientOptions
+    , model :: Text
+    , transportModel :: Text -> Text
+    }
+
+data ClaudeConfig = ClaudeConfig
+    { withAuth :: forall a. (ClaudeCodeAuth -> IO a) -> IO a
+    , cwd :: OsPath
+    , initialPrevious :: Maybe Text
+    , transportModel :: Text -> Text
+    , hostHandlers :: ClaudeCodeHostHandlers
+    , onConnected :: Text -> IO ()
+    }
+
+-- | Shared services used to construct a provider backend. Session startup,
+-- persistence, UI, and subagent registration belong to the caller.
+data ProviderHost = ProviderHost
+    { compaction :: ProviderCompaction
+    , networkRecovery :: Maybe NetworkRecovery
+    }
+
+-- | The live compaction state is shared with the session. Providers supply
+-- transport-specific summarization and context limits; installation stays
+-- behind the shared compaction helpers and the session's automatic hook.
+data ProviderCompaction = ProviderCompaction
+    { paramsRef :: IORef ResponseCreateParams
+    , contextTokensRef :: IORef (Maybe OccupancySnapshot)
+    , contextWindowForParams :: (Text -> Text) -> Int -> ResponseCreateParams -> Int
+    , currentModelContextWindow :: (Text -> Text) -> IO (Maybe Int)
+    , conversationRef :: IORef LiveConversation
+    , installAutomaticCompact :: CompactOutcome -> [TurnInput] -> IO CompactionInstall
+    , taskPlan :: Maybe TaskPlanEnv
+    , recordCompactionUsage :: TokenUsage -> IO ()
+    , compactThreshold :: Maybe Int
+    }
+
+-- | Valid only inside the continuation passed to 'withProviderRuntime'.
+-- Its backend and account operations must not be used after that scope closes.
+data ProviderRuntime = ProviderRuntime
+    { sessionBackend :: SessionBackend
+    , currentContextWindow :: IO (Maybe Int)
+    , compactRunner :: Maybe Text -> IO (Either Text CompactOutcome)
+    , accountSelection :: ProviderAccountSelection
+    , subagents :: ProviderSubagents
+    }
+
+data ProviderAccountSelection
+    = HttpAccountSelection
+    | OpenAiAccountSelection (Maybe Pool) (Maybe (Text -> IO (Either ApiError Text)))
+    | NoAccountSelection
+
+-- | Describe child transport support without accessing the session registry.
+data ProviderSubagents
+    = HttpSubagents (ResponseCreateParams -> Backend)
+    | XaiSubagents
+        (ResponseCreateParams -> Int)
+        (ResponseCreateParams -> Int)
+        (ResponseCreateParams -> Backend)
+    | CodexSubagents Bool
+    | NoProviderSubagents

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/XAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/XAI.hs
@@ -1,11 +1,7 @@
 module Agent.CLI.Runtime.Orchestration.Providers.XAI
-    ( runXaiProvider
+    ( withXaiProvider
     ) where
 
-import Agent.CLI.Auth.Types
-    ( LoadedAuth(..)
-    , isGatewayLoadedAuth
-    )
 import Agent.CLI.Compaction
     ( autoCompactBackendWith
     , boundCompletedToolContinuations
@@ -14,48 +10,40 @@ import Agent.CLI.Compaction
     , runXaiResponsesCompactWithContextWindow
     )
 import Agent.Connectivity (withConnectionRecoveryOn)
-import Agent.CLI.Options (CliOptions(..))
-import Agent.CLI.PendingInputs (withPendingInputs)
-import Agent.CLI.Provider.Switch (prepareTransitionBackend)
 import Agent.CLI.Runtime.Orchestration.Providers.Common
     ( decorateAutomaticCompact
     , decorateManualCompact
-    , runSession
     )
 import Agent.CLI.Runtime.Orchestration.Providers.Types
-    ( AgentProviderRequest(..)
+    ( ProviderHost(..), ProviderCompaction(..), ProviderRuntime(..)
+    , ProviderAccountSelection(..), ProviderSubagents(..)
     )
-import Agent.CLI.Runtime.Orchestration.Types
-    ( NativeRunCapabilities(..)
-    )
-import Agent.CLI.Runtime.Types (RunResult)
 import Agent.CLI.Session.History (readLiveTranscript)
 import Agent.CLI.Session.Runtime.Types
     ( SessionBackend(..)
-    , StartupRuntime(..)
     )
-import Agent.CLI.Subagents.Runtime (runXaiParentSubagent)
-import Agent.Provider (runWithTokenProvider)
+import Agent.Provider (TokenProvider, runWithTokenProvider)
 import Agent.Responses.Types (ResponseCreateParams(model))
-import Agent.Subagents (setSubagentRunner)
-import Agent.Tools.MultiAgents (MultiAgentContext(..))
 import Agent.XAI.LoopBackend (xaiBackendWithClientOptions)
 import Data.IORef (newIORef, readIORef)
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe)
 import qualified Agent.XAI.Client as XAIClient
 import qualified Agent.XAI.Options as XAI
 import qualified Agent.XAI.Request as XAIRequest
 
-runXaiProvider
-    :: AgentProviderRequest
-    -> NativeRunCapabilities
-    -> IO RunResult
-runXaiProvider request@AgentProviderRequest{..} nativeCapabilities = do
+withXaiProvider
+    :: TokenProvider
+    -> Bool
+    -> ProviderHost
+    -> (ProviderRuntime -> IO a)
+    -> IO a
+withXaiProvider tokenProvider hostedTools
+        ProviderHost{compaction = ProviderCompaction{..}, networkRecovery} use = do
     xaiOptions0 <- XAI.clientOptionsFromEnv
     let xaiOptions =
             xaiOptions0
                 { XAI.hostedXSearchEnabled =
-                    nativeCapabilities.nativeProviderHostedTools
+                    hostedTools
                 }
     let xaiContextWindow =
             contextWindowForParams
@@ -74,7 +62,7 @@ runXaiProvider request@AgentProviderRequest{..} nativeCapabilities = do
                         (XAI.grokAutoCompactTokenLimit
                             (xaiWireModel currentParams)
                             contextWindow)
-                        options.optCompactThreshold
+                        compactThreshold
         xaiOptionsFor currentParams =
             xaiOptions
                 { XAI.autoCompactTokenLimit =
@@ -91,21 +79,6 @@ runXaiProvider request@AgentProviderRequest{..} nativeCapabilities = do
                 getParams
                 occupancy
                 backend
-    case multiCtx of
-        Just ctx ->
-            setSubagentRunner ctx.multiRegistry $
-                runXaiParentSubagent
-                    subagentRuntime
-                    dialect
-                    ctx.multiSendToRoot
-                    xaiContextWindow
-                    xaiCompactThresholdFor
-                    (\childParams ->
-                        xaiBackendWithClientOptions
-                            xaiOptionsFor
-                            tokenProvider
-                            (pure childParams))
-        Nothing -> pure ()
     let btwBackend privateParams =
             xaiBackendWithClientOptions
                 xaiOptionsFor
@@ -120,14 +93,14 @@ runXaiProvider request@AgentProviderRequest{..} nativeCapabilities = do
                 currentParams
                 history
                 Nothing
-                >>= decorateAutomaticCompact request
+                >>= decorateAutomaticCompact (readIORef paramsRef) taskPlan
                     xaiContextWindow
         -- Reconnection wraps only the continuation. Keeping automatic
         -- compaction outside it prevents a failed continuation from
         -- rerunning the summary.
         requestBackend =
             withConnectionRecoveryOn
-                startup.startupNetworkRecovery $
+                networkRecovery $
                 protectXaiOverflow
                     contextTokensRef
                     (readIORef paramsRef)
@@ -139,16 +112,10 @@ runXaiProvider request@AgentProviderRequest{..} nativeCapabilities = do
             autoCompactBackendWith
                 xaiCompactThreshold
                 compactHistory
-                (\outcome inputs ->
-                    readIORef automaticCompactionHookRef
-                        >>= \hook ->
-                            hook outcome inputs)
+                installAutomaticCompact
                 (readIORef paramsRef)
                 contextTokensRef
                 requestBackend
-        backend =
-            withPendingInputs pendingNotices
-                compactingBackend
         compactRunner focus = do
             contextWindow <-
                 currentModelContextWindow
@@ -172,28 +139,20 @@ runXaiProvider request@AgentProviderRequest{..} nativeCapabilities = do
                         paramsRef
                         historyRef
                         requestedFocus
-                        >>= decorateManualCompact request
+                        >>= decorateManualCompact (readIORef paramsRef) taskPlan
                             xaiContextWindow)
                 focus
-    activeBackend <-
-        prepareTransitionBackend
-            modelSwitchScope home projectRoot
-            transition persist backend
-    runSession
-        (sessionRequest
-            startupUnavailable
-            (Just tokenProvider)
-            loaded.loadedOpenAiPool
-            (if isGatewayLoadedAuth loaded
-                || isJust customGenericOptions
-                then Nothing
-                else Just selectHttpAccount)
-            (Just . xaiContextWindow
-                <$> readIORef paramsRef)
-            compactRunner)
-        SessionBackend
-            { backend = activeBackend
+    use ProviderRuntime
+        { sessionBackend = SessionBackend
+            { backend = compactingBackend
             , btwBackend
             , interruptBackend = pure ()
             , resetBackendState = pure ()
             }
+        , currentContextWindow = Just . xaiContextWindow <$> readIORef paramsRef
+        , compactRunner
+        , accountSelection = HttpAccountSelection
+        , subagents = XaiSubagents xaiContextWindow xaiCompactThresholdFor
+            (\childParams ->
+                xaiBackendWithClientOptions xaiOptionsFor tokenProvider (pure childParams))
+        }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -4,11 +4,13 @@ module Agent.CLI.Runtime.Orchestration.Session
     ) where
 
 import Agent.CLI.Auth
-    ( LoadedAuth(loadedTokenProvider)
+    ( LoadedAuth(loadedTokenProvider, loadedOpenAiPool)
     , isGatewayLoadedAuth
     )
 import Agent.CLI.Claude
-    ( ClaudeSessionRuntimeSlot
+    ( approveClaudeRegisteredTool
+    , handleClaudePermissionRequest
+    , ClaudeSessionRuntimeSlot
     , newClaudeSessionRuntimeSlot
     )
 import Agent.CLI.CodeModeRuntime
@@ -26,6 +28,7 @@ import Agent.CLI.Compaction
     )
 import Agent.CLI.Database.Store (DatabaseScopes)
 import Agent.CLI.Dialects (CodingTools(..))
+import Agent.CLI.Error (formatApiErrorAt)
 import Agent.CLI.GatewayClient
     ( GatewayCredential
     , GatewayModelAccess
@@ -44,9 +47,9 @@ import Agent.CLI.Models (ModelTarget(targetConnectionId))
 import Agent.CLI.Options
     ( ApprovalPolicy
     , isOneShot
-    , CliOptions(optCodeMode)
+    , CliOptions(optCodeMode, optCompactThreshold, optShowRawReasoning)
     )
-import Agent.CLI.PendingInputs (PendingInputs)
+import Agent.CLI.PendingInputs (PendingInputs, withPendingInputs)
 import Agent.CLI.Project ( ModelSwitchScope(..) )
 import Agent.CLI.Prompt
     ( codexEnvironmentContext,
@@ -54,9 +57,11 @@ import Agent.CLI.Prompt
       appendMcpInstructions,
       systemPromptForCatalogModelWithHostedSearch,
       systemPromptForToolsWithHostedSearch )
+import Agent.CLI.Provider.Switch (chooseStartupProviderTransition, prepareTransitionBackend)
 import Agent.CLI.ProviderAvailability ( probeLoadedAvailability )
 import Agent.CLI.ProviderFallback ( isProviderUnavailable )
-import Agent.CLI.ProviderTransition (PendingTurn, ProviderTransition)
+import Agent.CLI.ProviderTransition
+    ( PendingTurn, ProviderTransition(transitionCause), TransitionCause(AutomaticFallback) )
 import Agent.CLI.Render ( putTextLn )
 import Agent.CLI.Request
     ( requestParams
@@ -67,18 +72,26 @@ import Agent.CLI.Resume
     ( SessionInitialContext(..)
     )
 import Agent.CLI.Runtime.Orchestration.Providers
-    ( AgentProviderRequest(..)
-    , runAgentProviders
+    ( withProviderRuntime )
+import Agent.CLI.Runtime.Orchestration.Providers.Types
+    ( ProviderConfig(..), OpenAiConfig(..), OpenAiAccounts(..)
+    , OpenRouterConfig(..), ClaudeConfig(..), ProviderHost(..)
+    , ProviderCompaction(..), ProviderRuntime(..)
+    , ProviderAccountSelection(..), ProviderSubagents(..)
     )
 import Agent.CLI.Runtime.Orchestration.Startup
-    ( clearNativeProgress, mcpToolCollision, reportStartupWarning )
+    ( clearNativeProgress, mcpToolCollision, reportStartupWarning, finishStartup )
 import Agent.CLI.Runtime.Orchestration.Types
     ( NativeRunCapabilities(..)
     , NativeRunHooks(nativeCapabilities, nativeWorkspaceDiscovery)
     , fullNativeRunCapabilities
     , nativeLoadsHostWorkspaceContext
     )
-import Agent.CLI.Runtime.Types ( RunResult(RunQuit) )
+import Agent.CLI.Runtime.Recap (runSessionRecap, runSessionTurnSummary)
+import Agent.CLI.Runtime.Repl
+    ( finishTurn, preparePromptSkillInputsWithPaste, repl, replWithDraft, runPendingTurn )
+import qualified Agent.CLI.Session.Runner as SessionRunner
+import Agent.CLI.Runtime.Types ( RunResult(RunQuit, RunProviderStartFailed, RunSwitchProvider) )
 import Agent.CLI.Session
     ( addSessionUsage,
       ensureSession,
@@ -102,7 +115,8 @@ import Agent.CLI.Session.History
       readLiveTranscript,
       replaceLiveConversation )
 import Agent.CLI.Session.Runtime.Types
-    ( InitialContextPreload(..)
+    ( SessionBackend(..)
+    , InitialContextPreload(..)
     , SessionRequest(codexCatalogSession, SessionRequest, catalog,
                      gatewayModelsRef, modelInfo,
                      connectionId, gatewayIdentity,
@@ -135,9 +149,10 @@ import Agent.CLI.SessionState ( SessionState(sessionConversation) )
 import Agent.CLI.Startup.Auth ( markStartupStage, startupDie )
 import Agent.CLI.StartupContext
     ( AgentsContextNotice(..), loadAgentsContextWithPreload )
-import Agent.CLI.Style ( cliWindowTitle, roleMuted )
+import Agent.CLI.Style ( cliWindowTitle, roleMuted, glyphWarn, roleWarn )
 import Agent.CLI.Subagents.Runtime
-    ( SubagentRuntime(subagentOpenAiChild, SubagentRuntime,
+    ( runCodexSubagent, runHttpSubagent, runXaiParentSubagent
+    , SubagentRuntime(subagentOpenAiChild, SubagentRuntime,
                       subagentOptions, subagentNetworkRecovery,
                       subagentGhciEnabled, subagentBashEnabled,
                       subagentPolicy, subagentPlanHooks, subagentSkillRoots,
@@ -151,12 +166,20 @@ import Agent.CLI.Subagents.Runtime
 import Agent.CLI.Subagents.Runtime.Types
     (SubagentSession, SubagentStoreRoot)
 import Agent.CLI.TUI.App
-    ( FullscreenRuntime, withFullscreenSuspended )
+    ( FullscreenRuntime, withFullscreenSuspended, emitUiEvent )
 import Agent.CLI.Terminal ( resolveColor )
 import Agent.CLI.Tools
     ( schemasFromAppToolsCodeModeWithHostedSearch
     , schemasFromAppToolsWithHostedSearch
     )
+import Agent.Tools.OutputArtifact (finalizeToolOutput)
+import qualified Control.Exception.Safe as Safe
+import qualified Data.Aeson as Aeson
+import Agent.Claude
+    ( ClaudeCodeAuth, loadClaudeCodeAuth, loadClaudeCodeGatewayAuth )
+import Agent.Claude.Control
+    ( ClaudeCodeHostHandlers(..), ClaudeCodeMcpRequest(..), defaultClaudeCodeHostHandlers )
+import Agent.CLI.ClaudeGatewayProxy (withClaudeGatewayProxy)
 import Agent.Dialect (Dialect, dialectId)
 import Agent.Error (ApiError)
 import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs)
@@ -166,23 +189,26 @@ import Agent.Loop
     , TurnInput
     , addTokenUsage
     , emptyTokenUsage
+    , defaultLoopDispatch
     )
+import Agent.OpenAI.WebSocketClient (CodexAuthFailed(..))
 import Agent.OpenAI.Models.Types ( ModelInfo, resolvedContextWindow )
 import Agent.OpenRouter.Options (ClientOptions)
 import Agent.Provider
-    (Credential, Provider(OpenAIProvider), TokenProvider,
+    (Credential(..), Provider(..), TokenProvider,
      tokenProviderBillingMode)
 import Agent.Responses.GenericClient (GenericClientOptions)
 import Agent.Responses.Types
     (ResponseItem, ResponseCreateParams(model))
 import Agent.Skills (SkillCatalog, SkillInvocation)
 import Agent.Store.Postgres ( trustedPool )
-import Agent.Subagents (SubagentRegistry)
+import Agent.Subagents (SubagentRegistry, setSubagentRunner)
 import Agent.Subagents.Types (RootTurnId, SubagentId)
+import Agent.TUI.Model (UiEvent(UiSystemMessage))
 import Agent.Tools.MultiAgents
-    (CollaborationModelTarget, MultiAgentContext, SubagentWorktree)
+    (CollaborationModelTarget, MultiAgentContext(..), SubagentWorktree)
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks)
-import Agent.ToolDispatch (canonicalToolName)
+import Agent.ToolDispatch (canonicalToolName, ToolDispatchConfig(..))
 import Agent.Tools.Types
     ( AppTool(..)
     , ToolSchema(..)
@@ -210,7 +236,6 @@ import System.IO (Handle, stderr)
 import System.Mem ( performMajorGC )
 import System.OsPath (OsPath)
 import qualified Agent.MCP as MCP
-import qualified Agent.OpenAI.Auth as OpenAI (Pool)
 import qualified Data.Text.IO as Text ( hPutStr )
 
 data AgentSessionRequest closeResult windowTitleResult = AgentSessionRequest
@@ -873,22 +898,29 @@ buildProviderSessionRequest
     -> SessionPromptRuntime
     -> SessionLiveRuntime
     -> Maybe (STM ApiError)
-    -> Maybe TokenProvider
-    -> Maybe OpenAI.Pool
-    -> Maybe (Text -> IO (Either ApiError Text))
-    -> IO (Maybe Int)
-    -> (Maybe Text -> IO (Either Text CompactOutcome))
+    -> ProviderRuntime
     -> SessionRequest
 buildProviderSessionRequest
     request
     promptRuntime
     liveRuntime
     startupUnavailable
-    sessionTokenProvider
-    sessionOpenAiPool
-    sessionSelectAccount
-    sessionContextWindow
-    sessionCompactRunner =
+    runtime =
+        let (sessionTokenProvider, sessionOpenAiPool, sessionSelectAccount) =
+                case runtime.accountSelection of
+                    NoAccountSelection -> (Nothing, Nothing, Nothing)
+                    OpenAiAccountSelection pool select ->
+                        (Just request.tokenProvider, pool, select)
+                    HttpAccountSelection ->
+                        ( Just request.tokenProvider
+                        , request.loaded.loadedOpenAiPool
+                        , if isGatewayLoadedAuth request.loaded
+                                || (request.provider == XAIProvider
+                                    && isJust request.customGenericOptions)
+                            then Nothing
+                            else Just request.selectHttpAccount
+                        )
+        in
         SessionRequest
             { catalog = request.catalog
             , gatewayModelsRef = request.gatewayModelsRef
@@ -943,7 +975,7 @@ buildProviderSessionRequest
             , contextOccupancyRef =
                 liveRuntime.sessionContextTokensRef
             , currentContextWindow = do
-                configured <- sessionContextWindow
+                configured <- runtime.currentContextWindow
                 pure $
                     configured
                         <|> (resolvedContextWindow
@@ -987,7 +1019,7 @@ buildProviderSessionRequest
             , accountLabel = request.resolveActiveAccountLabel
             , selectAccount = sessionSelectAccount
             , onPersisted = request.claimCurrentSession
-            , compactRunner = sessionCompactRunner
+            , compactRunner = runtime.compactRunner
             , codeModeRuntime =
                 promptRuntime.sessionCodeRuntime.sessionCodeModeRuntime
             , codexCatalogSession =
@@ -1048,63 +1080,218 @@ launchPreparedSession request promptRuntime liveRuntime = do
     runSessionWithInterruptHandling request progName $
         withSessionStartupAvailability request shouldProbeAtStartup
             \startupUnavailable ->
-                runAgentProviders AgentProviderRequest
-                    { modelSwitchScope =
-                          if request.startup.startupBackground
-                              then SessionLocalSwitch
-                              else TopLevelSwitch
-                    , loaded = request.loaded
-                    , connectedGateway = request.connectedGateway
-                    , sessionRequest =
-                          buildProviderSessionRequest
-                              request
-                              promptRuntime
-                              liveRuntime
-                    , activeAccountIdRef = request.activeAccountIdRef
-                    , activeAccountRef = request.activeAccountRef
-                    , activeSelectionRef = request.activeSelectionRef
-                    , catalog = request.catalog
-                    , claudeBypassEnabled = request.claudeBypassEnabled
-                    , contextTokensRef = liveRuntime.sessionContextTokensRef
-                    , contextWindowForParams = sessionContextWindowForParams request
-                    , conversationRef = liveRuntime.sessionConversationRef
-                    , currentModelContextWindow =
-                          sessionCurrentModelContextWindow
-                              request
-                              promptRuntime
-                    , customGenericOptions = request.customGenericOptions
-                    , cwd = request.cwd
-                    , dialect = request.dialect
-                    , fullscreen = request.fullscreen
-                    , automaticCompactionHookRef =
-                        promptRuntime.sessionAutomaticCompactionHookRef
-                    , taskPlan = request.coding.codingTaskPlan
-                    , home = request.home
-                    , initialPrevious = promptRuntime.sessionInitialPrevious
-                    , model = request.model
-                    , multiCtx = request.multiCtx
-                    , openRouterOptions = request.openRouterOptions
-                    , options = request.options
-                    , paramsRef = promptRuntime.sessionParamsRef
-                    , pendingNotices = request.pendingNotices
-                    , persist = request.persist
-                    , preferredOpenAiAccountRef = request.preferredOpenAiAccountRef
-                    , projectRoot = request.projectRoot
-                    , provider = request.provider
-                    , recordCompactionUsage = liveRuntime.sessionRecordCompactionUsage
-                    , resolveActiveAccountLabel = request.resolveActiveAccountLabel
-                    , selectHttpAccount = request.selectHttpAccount
-                    , selectableTokenProvider = request.selectableTokenProvider
-                    , shouldProbeAtStartup
-                    , startup = request.startup
-                    , startupUnavailable
-                    , stderrHandle = request.stderrHandle
-                    , subagentRuntime = liveRuntime.sessionSubagentRuntime
-                    , tokenProvider = request.tokenProvider
-                    , transition = request.transition
-                    , transportModel = request.transportModel
-                    , unavailableProviders = request.unavailableProviders
-                    }
+                launchProvider request promptRuntime liveRuntime
+                    shouldProbeAtStartup startupUnavailable
+
+sessionRunnerContinuation :: SessionRunner.SessionRunnerContinuation
+sessionRunnerContinuation =
+    SessionRunner.SessionRunnerContinuation
+        { runnerRepl = repl
+        , runnerReplWithDraft = replWithDraft
+        , runnerRunPendingTurn = runPendingTurn
+        , runnerFinishTurn = finishTurn
+        , runnerFinishStartup = finishStartup
+        , runnerPreparePromptSkillInputs = preparePromptSkillInputsWithPaste
+        , runnerRunSessionRecap = runSessionRecap
+        , runnerRunSessionTurnSummary = runSessionTurnSummary
+        }
+
+runSession
+    :: SessionRequest
+    -> SessionBackend
+    -> IO RunResult
+runSession = SessionRunner.runSession sessionRunnerContinuation
+
+-- | The session owns composition and presentation. Provider runtimes only
+-- supply transport capabilities, scoped around this continuation.
+launchProvider
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> SessionPromptRuntime
+    -> SessionLiveRuntime
+    -> Bool
+    -> Maybe (STM ApiError)
+    -> IO RunResult
+launchProvider request promptRuntime liveRuntime shouldProbeAtStartup startupUnavailable = do
+    let nativeCapabilities = maybe fullNativeRunCapabilities (.nativeCapabilities)
+            request.startup.startupNativeHooks
+        host = ProviderHost
+            { networkRecovery = request.startup.startupNetworkRecovery
+            , compaction = ProviderCompaction
+                { paramsRef = promptRuntime.sessionParamsRef
+                , contextTokensRef = liveRuntime.sessionContextTokensRef
+                , contextWindowForParams = sessionContextWindowForParams request
+                , currentModelContextWindow = sessionCurrentModelContextWindow request promptRuntime
+                , conversationRef = liveRuntime.sessionConversationRef
+                , installAutomaticCompact = \outcome inputs ->
+                    readIORef promptRuntime.sessionAutomaticCompactionHookRef
+                        >>= \hook -> hook outcome inputs
+                , taskPlan = request.coding.codingTaskPlan
+                , recordCompactionUsage = liveRuntime.sessionRecordCompactionUsage
+                , compactThreshold = request.options.optCompactThreshold
+                }
+            }
+        use runtime = do
+            installProviderSubagents request liveRuntime runtime.subagents
+            let sessionBackend = runtime.sessionBackend
+                noticingBackend = case request.provider of
+                    ClaudeCodeProvider -> sessionBackend.backend
+                    _ -> withPendingInputs request.pendingNotices sessionBackend.backend
+            activeBackend <- prepareTransitionBackend
+                (if request.startup.startupBackground
+                    then SessionLocalSwitch else TopLevelSwitch)
+                request.home request.projectRoot request.transition request.persist
+                noticingBackend
+            runSession
+                (buildProviderSessionRequest request promptRuntime liveRuntime
+                    startupUnavailable runtime)
+                sessionBackend{backend = activeBackend}
+    config <- prepareProviderConfig request promptRuntime nativeCapabilities
+    case request.provider of
+        OpenAIProvider ->
+            Safe.try @_ @CodexAuthFailed (withProviderRuntime config host use)
+                >>= handleOpenAiStartupResult request nativeCapabilities shouldProbeAtStartup
+        _ -> withProviderRuntime config host use
+
+prepareProviderConfig
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> SessionPromptRuntime
+    -> NativeRunCapabilities
+    -> IO ProviderConfig
+prepareProviderConfig request promptRuntime nativeCapabilities = case request.provider of
+    OpenAIProvider -> pure $ OpenAiProviderConfig OpenAiConfig
+        { tokenProvider = request.tokenProvider
+        , showRawReasoning = request.options.optShowRawReasoning
+        , transportModel = request.transportModel
+        , accounts = OpenAiAccounts
+            { selectablePool = if isGatewayLoadedAuth request.loaded
+                then Nothing else request.loaded.loadedOpenAiPool
+            , readActiveAccountId = readIORef request.activeAccountIdRef
+            , resolveAccountLabel = request.resolveActiveAccountLabel
+            , installAccount = \credential label -> do
+                writeIORef request.activeAccountIdRef credential.accountId
+                writeIORef request.activeSelectionRef credential.accountId
+                writeIORef request.activeAccountRef label
+            , preferAccount = writeIORef request.preferredOpenAiAccountRef . Just
+            }
+        }
+    XAIProvider -> pure $ XaiProviderConfig request.tokenProvider
+        nativeCapabilities.nativeProviderHostedTools
+    GeminiProvider -> pure $ GeminiProviderConfig request.tokenProvider
+    OpenRouterProvider -> pure $ OpenRouterProviderConfig OpenRouterConfig
+        { tokenProvider = request.tokenProvider
+        , clientOptions = request.openRouterOptions
+        , genericOptions = request.customGenericOptions
+        , model = request.model
+        , transportModel = request.transportModel
+        }
+    ClaudeCodeProvider -> do
+        when (not nativeCapabilities.nativeProviderNativeTools) $
+            startupDie request.startup "Claude Code is unavailable in this runtime"
+        mcpServer <- case MCP.createInProcessMcpServer "haskell-agent" "0.1.0"
+                (defaultLoopDispatch
+                    { toolDispatchFinalizeOutput = \call output ->
+                        finalizeToolOutput request.toolEnv call output
+                    })
+                (approveClaudeRegisteredTool promptRuntime.sessionClaudeRuntimeSlot)
+                promptRuntime.sessionClaudeBridgeTools of
+            Left err -> startupDie request.startup err
+            Right server -> pure server
+        pure $ ClaudeProviderConfig ClaudeConfig
+            { withAuth = withSelectedClaudeAuth request.connectedGateway request.loaded
+                (startupDie request.startup)
+            , cwd = request.cwd
+            , initialPrevious = promptRuntime.sessionInitialPrevious
+            , transportModel = request.transportModel
+            , hostHandlers = defaultClaudeCodeHostHandlers
+                { canUseTool = Just $ handleClaudePermissionRequest
+                    promptRuntime.sessionClaudeRuntimeSlot
+                , handleMcpMessage = Just \mcpRequest ->
+                    if mcpRequest.serverName /= "haskell-agent"
+                        then pure Aeson.Null
+                        else MCP.handleInProcessMcpMessage mcpServer mcpRequest.message
+                            >>= pure . fromMaybe (Aeson.object [])
+                , mcpToolNames = MCP.inProcessMcpToolNames mcpServer
+                , nativeToolsEnabled = nativeCapabilities.nativeProviderNativeTools
+                }
+            , onConnected = \label -> do
+                when request.claudeBypassEnabled $ do
+                    let notice = "Claude Code --yolo is active; host catastrophic-command and Plan Mode denies remain enforced."
+                    case request.fullscreen of
+                        Just runtime -> emitUiEvent runtime (UiSystemMessage notice)
+                        Nothing -> do
+                            color <- resolveColor request.stderrHandle
+                            putTextLn request.stderrHandle $
+                                roleWarn color $ glyphWarn <> notice
+                writeIORef request.activeAccountRef label
+            }
+
+installProviderSubagents
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> SessionLiveRuntime
+    -> ProviderSubagents
+    -> IO ()
+installProviderSubagents request liveRuntime capabilities =
+    case request.multiCtx of
+        Nothing -> pure ()
+        Just ctx -> do
+            let runtime = liveRuntime.sessionSubagentRuntime
+                install = setSubagentRunner ctx.multiRegistry
+            case capabilities of
+                NoProviderSubagents -> pure ()
+                CodexSubagents gatewayOnly -> install $
+                    runCodexSubagent gatewayOnly runtime request.selectableTokenProvider
+                        ctx.multiSendToRoot
+                HttpSubagents makeBackend -> install $
+                    runHttpSubagent runtime request.dialect request.provider
+                        ctx.multiSendToRoot makeBackend
+                XaiSubagents contextWindow threshold makeBackend -> install $
+                    runXaiParentSubagent runtime request.dialect ctx.multiSendToRoot
+                        contextWindow threshold makeBackend
+
+handleOpenAiStartupResult
+    :: AgentSessionRequest closeResult windowTitleResult
+    -> NativeRunCapabilities
+    -> Bool
+    -> Either CodexAuthFailed RunResult
+    -> IO RunResult
+handleOpenAiStartupResult request nativeCapabilities shouldProbeAtStartup = \case
+    Right result -> pure result
+    Left (CodexAuthFailed err) ->
+        let startupFailure = do
+                now <- getCurrentTime
+                startupDie request.startup (formatApiErrorAt now err)
+        in case request.transition of
+            Just active | active.transitionCause == AutomaticFallback ->
+                pure (RunProviderStartFailed err)
+            _ | shouldProbeAtStartup
+              , not (isGatewayLoadedAuth request.loaded)
+              , isProviderUnavailable err ->
+                chooseStartupProviderTransition
+                    nativeCapabilities.nativeProviderFallback
+                    request.catalog request.projectRoot request.fullscreen
+                    (tokenProviderBillingMode request.tokenProvider)
+                    request.provider request.model request.unavailableProviders
+                    Nothing err >>= \case
+                        Just next -> pure (RunSwitchProvider next)
+                        Nothing -> startupFailure
+            _ -> startupFailure
+
+withSelectedClaudeAuth
+    :: Maybe GatewayCredential
+    -> LoadedAuth
+    -> (Text -> IO value)
+    -> (ClaudeCodeAuth -> IO value)
+    -> IO value
+withSelectedClaudeAuth connectedGateway loaded onError action
+    -- Preserve the credential snapshot that selected the session's catalog.
+    | not (isGatewayLoadedAuth loaded) =
+        loadClaudeCodeAuth >>= either onError action
+    | otherwise = case connectedGateway of
+        Nothing -> onError "No organization gateway credential is connected."
+        Just credential -> do
+            result <- withClaudeGatewayProxy credential \transport ->
+                loadClaudeCodeGatewayAuth transport >>= either onError action
+            either onError pure result
 
 -- | Print a copy-pasteable --resume line whenever the CLI session quits.
 -- Ctrl-C is normalized to the same graceful 'RunQuit' result as :q/Ctrl-D so

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -1,6 +1,5 @@
 module Agent.CLI.Runtime.Orchestration.Types
     ( ActiveHttpAuth(..)
-    , AccountSwitchRequest(..)
     , AgentProcessRuntime(..)
     , AgentRunMode(..)
     , NativeInteractionMode(..)
@@ -23,14 +22,12 @@ import Agent.CLI.Options ( CliOptions )
 import Agent.CLI.Project ( ProjectSettings )
 import Agent.Connectivity.NetworkPath ( NetworkRecovery )
 import Agent.CLI.Permission ( PermissionChoice )
-import Agent.Error ( ApiError )
 import Agent.Loop ( LoopEvent )
 import Agent.Provider ( Credential, TokenProvider )
 import Agent.Store.Postgres ( Store )
 import Agent.ToolDispatch ( ToolCall )
 import Agent.Tools.PlanMode ( PlanModeHooks )
 import Agent.Tools.Types ( AppTool, AppToolGroup )
-import Control.Concurrent.MVar ( MVar )
 import Data.IORef ( IORef )
 import Data.Text ( Text )
 import System.IO ( Handle, stderr, stdout )
@@ -44,9 +41,6 @@ data ActiveHttpAuth = ActiveHttpAuth
     , activeHttpResolveLabel :: !(Credential -> IO Text)
     , activeHttpAccountId :: !Text
     }
-
-data AccountSwitchRequest
-    = AccountSwitchRequest !Credential !(MVar (Either ApiError Text))
 
 data AgentProcessRuntime = AgentProcessRuntime
     { processMcpSupervisor :: !MCP.McpSupervisor

--- a/packages/agent-cli/test/Agent/CLI/ProviderRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderRuntimeSpec.hs
@@ -1,0 +1,79 @@
+module Agent.CLI.ProviderRuntimeSpec (spec) where
+
+import Agent.CLI.Compaction (CompactionInstall(..), reportedOccupancy)
+import Agent.CLI.Runtime.Orchestration.Providers (withProviderRuntime)
+import Agent.CLI.Runtime.Orchestration.Providers.Types
+import Agent.CLI.Session.ConversationStore (newConversationStore)
+import Agent.CLI.Session.History (readLivePreviousResponseId, readLiveTranscript)
+import Agent.Provider (BillingMode(..), TokenProvider, tokenProvider)
+import Agent.Responses.Types (defaultResponseCreateParams)
+import qualified Agent.Responses.Types as Responses (ResponseCreateParams(model))
+import Control.Exception.Safe (throwString)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Test.Hspec
+import qualified Agent.OpenRouter.Options as OpenRouter
+
+spec :: Spec
+spec = describe "provider runtime composition" do
+    mapM_ checkProvider
+        [ ("Gemini", GeminiProviderConfig noNetworkTokens)
+        , ("xAI", XaiProviderConfig noNetworkTokens False)
+        , ("OpenRouter", OpenRouterProviderConfig OpenRouterConfig
+            { tokenProvider = noNetworkTokens
+            , clientOptions = OpenRouter.defaultClientOptions
+            , genericOptions = Nothing
+            , model = "small"
+            , transportModel = id
+            })
+        ]
+  where
+    checkProvider (name, config) = describe name do
+        it "observes model changes after the runtime is constructed" do
+            host <- newHost
+            result <- withProviderRuntime config host \runtime -> do
+                runtime.currentContextWindow `shouldReturn` Just 32_768
+                writeIORef host.compaction.paramsRef
+                    defaultResponseCreateParams{Responses.model = Just "large"}
+                runtime.currentContextWindow `shouldReturn` Just 65_536
+                pure "consumer result"
+            result `shouldBe` ("consumer result" :: String)
+
+        it "leaves live session state intact when manual compaction fails" do
+            host <- newHost
+            let beforeOccupancy = Just (reportedOccupancy 1234 0)
+            writeIORef host.compaction.contextTokensRef beforeOccupancy
+            withProviderRuntime config host \runtime ->
+                runtime.compactRunner Nothing `shouldReturn` Left "nothing to compact"
+            readLivePreviousResponseId host.compaction.conversationRef
+                `shouldReturn` Just "previous-response"
+            readLiveTranscript host.compaction.conversationRef `shouldReturn` []
+            readIORef host.compaction.contextTokensRef `shouldReturn` beforeOccupancy
+
+-- Construct a real runtime without CLI startup, persistence, or a subagent
+-- registry. Any accidental credential acquisition fails before network IO.
+noNetworkTokens :: TokenProvider
+noNetworkTokens = tokenProvider ApiBilled \_ ->
+    throwString "runtime composition unexpectedly requested credentials"
+
+newHost :: IO ProviderHost
+newHost = do
+    paramsRef <- newIORef defaultResponseCreateParams{Responses.model = Just "small"}
+    contextTokensRef <- newIORef Nothing
+    conversationRef <- newIORef =<< newConversationStore (Just "previous-response") [] []
+    let contextWindow params = case params.model of
+            Just "large" -> 65_536
+            _ -> 32_768
+    pure ProviderHost
+        { networkRecovery = Nothing
+        , compaction = ProviderCompaction
+            { paramsRef
+            , contextTokensRef
+            , conversationRef
+            , contextWindowForParams = \_ _ -> contextWindow
+            , currentModelContextWindow = \_ -> Just . contextWindow <$> readIORef paramsRef
+            , installAutomaticCompact = \_ _ -> pure CompactionNotInstalled
+            , taskPlan = Nothing
+            , recordCompactionUsage = \_ -> pure ()
+            , compactThreshold = Nothing
+            }
+        }

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -78,6 +78,7 @@ import qualified Agent.CLI.RecapSpec as RecapSpec
 import qualified Agent.CLI.ProviderFallbackSpec as ProviderFallbackSpec
 import qualified Agent.CLI.ProviderAvailabilitySpec as ProviderAvailabilitySpec
 import qualified Agent.CLI.ProviderTransitionSpec as ProviderTransitionSpec
+import qualified Agent.CLI.ProviderRuntimeSpec as ProviderRuntimeSpec
 import qualified Agent.CLI.RequestSpec as RequestSpec
 import qualified Agent.CLI.RenderSpec as RenderSpec
 import qualified Agent.CLI.ReplStatusSpec as ReplStatusSpec
@@ -203,6 +204,7 @@ specs = do
     ProviderFallbackSpec.spec
     ProviderAvailabilitySpec.spec
     ProviderTransitionSpec.spec
+    ProviderRuntimeSpec.spec
     RequestSpec.spec
     RenderSpec.spec
     ReplStatusSpec.spec


### PR DESCRIPTION
Provider adapters currently receive a broad `AgentProviderRequest` that mixes transport setup with session startup, persistence, UI, account presentation, and subagent registration. This makes each adapter depend on most of the CLI runtime.

Replace that request with configuration for the selected provider, shared compaction services, and `withProviderRuntime`, which scopes a provider's backend and capabilities around a consumer. Session orchestration now constructs the session request, applies persistence transitions and pending inputs, registers subagents, and handles startup failures. OpenAI connection/account-worker lifetimes, atomic account snapshots, and Claude interrupt, reset, and host permission callbacks retain their existing behavior.

The shared Gemini/OpenRouter HTTP transport helper remains in place and now supplies a runtime instead of launching a session.

Validation:
- Loaded the complete agent-cli library in GHCi inside `nix develop`.
- Ran 231 Hspec examples after merging current master covering runtime composition, compaction, provider transitions/fallback, pending inputs, Claude permissions and gateway proxying, native runtime options, atomic account state, stdin ownership, and command parsing; all passed. Six new examples check live model changes and preservation of session state after failed compaction.
- `bash scripts/check-package-boundaries.sh` and `git diff --check` passed.
- Regenerated `packages/agent-cli/package.nix`; no dependency-expression change was needed.

No live model requests were exercised.
