### PR TITLE
Replace partial gateway JSON instances with explicit encoding

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayBridge.hs
@@ -2,6 +2,7 @@
 module Agent.CLI.GatewayBridge
     ( ManagedBridgeRequest(..)
     , managedBridgeRequestDecoder
+    , managedBridgeRequestEncoding
     , ManagedBridgeResponse(..)
     , managedBridgeResponseDecoder
     , ManagedActivity(..)
@@ -58,6 +59,7 @@ import Data.Aeson
     , (.=)
     )
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encoding as Encoding
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isAlphaNum)
 import Data.Maybe (fromMaybe)
@@ -86,21 +88,16 @@ data ManagedBridgeRequest = ManagedBridgeRequest
     , bridgeRequestPayload :: !RawJson
     } deriving (Eq, Show)
 
-instance ToJSON ManagedBridgeRequest where
-    toJSON _ =
-        error "ManagedBridgeRequest supports Aeson encoding only"
-    toEncoding request = Aeson.pairs
-        ( "version" .= request.bridgeRequestVersion
-        <> "id" .= request.bridgeRequestId
-        <> "kind" .= request.bridgeRequestKind
-        <> "payload" .= EncodedRawJson request.bridgeRequestPayload
-        )
-
-newtype EncodedRawJson = EncodedRawJson RawJson
-
-instance ToJSON EncodedRawJson where
-    toJSON _ = error "EncodedRawJson supports Aeson encoding only"
-    toEncoding (EncodedRawJson raw) = rawJsonEncoding raw
+-- | Encode the envelope while preserving the validated, opaque payload bytes.
+-- This API deliberately returns an Encoding: constructing an Aeson Value
+-- would require decoding the payload and could change its representation.
+managedBridgeRequestEncoding :: ManagedBridgeRequest -> Encoding.Encoding
+managedBridgeRequestEncoding request = Aeson.pairs
+    ( "version" .= request.bridgeRequestVersion
+    <> "id" .= request.bridgeRequestId
+    <> "kind" .= request.bridgeRequestKind
+    <> Encoding.pair "payload" (rawJsonEncoding request.bridgeRequestPayload)
+    )
 
 managedBridgeRequestDecoder :: Hermes.Decoder ManagedBridgeRequest
 managedBridgeRequestDecoder = Hermes.object $
@@ -582,7 +579,9 @@ performBridgeRequest request callId kind payload timeoutMicros =
                     , bridgeRequestPayload =
                         rawJsonFromEncoding (Aeson.toEncoding payload)
                     }
-            writeLazyFileAtomically requestPath 0o600 (encode bridgeRequest)
+            writeLazyFileAtomically requestPath 0o600 $
+                Encoding.encodingToLazyByteString
+                    (managedBridgeRequestEncoding bridgeRequest)
             waitForBridgeResponse responsePath timeoutMicros
                 `finally` do
                     removePrivateFile requestPath

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayBridgeSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayBridgeSpec.hs
@@ -6,7 +6,7 @@ import Agent.CLI.Permission.Types (PermissionChoice(..))
 import Agent.Loop (LoopEvent(..), defaultLoopDispatch)
 import Agent.Json.Decode qualified as Hermes
 import Agent.OsPath (unsafeToFilePath)
-import Agent.Json (rawJsonBytes)
+import Agent.Json (rawJsonBytes, rawJsonDecoder)
 import Agent.ToolDispatch
     ( ToolCallResult(..)
     , dispatchToolCall
@@ -17,6 +17,8 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (withAsync, wait)
 import Control.Exception.Safe (bracket)
 import Data.Aeson (Value(..))
+import qualified Data.Aeson.Encoding as Encoding
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Maybe (listToMaybe)
 import System.Directory
@@ -32,6 +34,22 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.CLI.GatewayBridge" do
+    it "encodes an envelope without changing opaque payload bytes" do
+        let payloadBytes = "{ \"amount\" : 123456789012345678901234567890, \"items\": [null,true] }"
+        payload <- either (fail . show) pure $
+            Hermes.decodeEither rawJsonDecoder payloadBytes
+        let request = ManagedBridgeRequest
+                { bridgeRequestVersion = 1
+                , bridgeRequestId = "request-1"
+                , bridgeRequestKind = "send_document"
+                , bridgeRequestPayload = payload
+                }
+            bytes = LBS.toStrict $ Encoding.encodingToLazyByteString $
+                managedBridgeRequestEncoding request
+        bytes `shouldSatisfy` BS.isInfixOf payloadBytes
+        Hermes.decodeEither managedBridgeRequestDecoder bytes
+            `shouldBe` Right request
+
     it "round-trips a channel tool request through private files" $
         withBridgeRequest \request -> do
             let call = functionToolCall


### PR DESCRIPTION
Gateway requests advertised a ToJSON instance whose toJSON method deliberately crashed. Replace that partial instance and its EncodedRawJson wrapper with an explicit managedBridgeRequestEncoding function, and use it when writing request files.

The envelope still writes validated opaque payload bytes directly. A regression test preserves whitespace and a large integer in the raw payload and verifies the complete request round-trip.

Validation: agent-cli-runtime loaded in Nix/Cabal GHCi (33 library modules); all 6 GatewayBridgeSpec examples passed, including approval, root-access, file delivery, activity publication, and the new encoding test. `git diff --check` passed.
