### PR TITLE
Retain validated provider defaults in an abstract model catalog

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
@@ -6,7 +6,8 @@
 module Agent.CLI.ModelConfig
     ( CatalogModel(..)
     , ConnectionKind(..)
-    , ModelCatalog(..)
+    , ModelCatalog
+    , catalogModels
     , ModelConnection(..)
     , ResponsesConnection(..)
     , builtinConnectionId
@@ -45,7 +46,6 @@ import Control.Exception.Safe (tryIO)
 import Control.Monad (unless)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isAlpha, isAlphaNum, isSpace)
-import Data.Foldable (traverse_)
 import Data.List (nub)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
@@ -95,11 +95,28 @@ data CatalogModel = CatalogModel
 
 data ModelCatalog = ModelCatalog
     { catalogConnections :: !(Map Text ModelConnection)
-    , catalogModels :: ![CatalogModel]
+    , modelEntries :: ![CatalogModel]
+    , catalogDefaults :: !ProviderDefaults
     , catalogModelsById :: !(Map Text CatalogModel)
     , catalogGatewayModelsById :: !(Map Text CatalogModel)
     }
     deriving (Eq, Show)
+
+-- Every supported provider has a default after configuration validation.
+-- Keeping a product here makes lookup exhaustive without a partial Map lookup.
+data ProviderDefaults = ProviderDefaults
+    { openAiDefault :: !CatalogModel
+    , xaiDefault :: !CatalogModel
+    , openRouterDefault :: !CatalogModel
+    , geminiDefault :: !CatalogModel
+    , claudeDefault :: !CatalogModel
+    }
+    deriving (Eq, Show)
+
+-- | Models in their configured presentation order. Catalog internals cannot
+-- be updated independently of the indexes and validated defaults.
+catalogModels :: ModelCatalog -> [CatalogModel]
+catalogModels catalog = catalog.modelEntries
 
 data ConfigFile = ConfigFile
     { configVersion :: !Int
@@ -245,7 +262,7 @@ catalogModelForConnection catalog connectionId modelId
 
 catalogModelsForConnection :: Text -> ModelCatalog -> [CatalogModel]
 catalogModelsForConnection wanted =
-    filter ((== wanted) . (.catalogModelConnectionId)) . (.catalogModels)
+    filter ((== wanted) . (.catalogModelConnectionId)) . catalogModels
 
 connectionBuiltinProvider :: ModelConnection -> Maybe Provider
 connectionBuiltinProvider connection = case connection.connectionKind of
@@ -264,15 +281,13 @@ connectionSupportsDialect connection provider dialect
                 && dialect == ClaudeCodeDialect)
     | otherwise = providerSupportsDialect provider dialect
 
-catalogDefaultForProvider :: ModelCatalog -> Provider -> Maybe CatalogModel
-catalogDefaultForProvider catalog provider =
-    case
-        [ model
-        | model <- catalogModelsForConnection (builtinConnectionId provider) catalog
-        , model.catalogModelDefault
-        ] of
-        model : _ -> Just model
-        [] -> Nothing
+catalogDefaultForProvider :: ModelCatalog -> Provider -> CatalogModel
+catalogDefaultForProvider catalog = \case
+    OpenAIProvider -> catalog.catalogDefaults.openAiDefault
+    XAIProvider -> catalog.catalogDefaults.xaiDefault
+    OpenRouterProvider -> catalog.catalogDefaults.openRouterDefault
+    GeminiProvider -> catalog.catalogDefaults.geminiDefault
+    ClaudeCodeProvider -> catalog.catalogDefaults.claudeDefault
 
 -- | Decode and validate one standalone file. This is mainly useful for tests;
 -- normal startup should use 'mergeModelConfigs' so defaults can be overlaid.
@@ -463,10 +478,16 @@ validateConfig source config = do
         Map.traverseWithKey validateModelConnection config.configConnections
     models <- validationToEither $
         traverse (validateCatalogModel connections) config.configModels
-    traverse_ (validateBuiltinDefault models) allBuiltinProviders
+    defaults <- ProviderDefaults
+        <$> validateBuiltinDefault connections models OpenAIProvider
+        <*> validateBuiltinDefault connections models XAIProvider
+        <*> validateBuiltinDefault connections models OpenRouterProvider
+        <*> validateBuiltinDefault connections models GeminiProvider
+        <*> validateBuiltinDefault connections models ClaudeCodeProvider
     pure ModelCatalog
         { catalogConnections = connections
-        , catalogModels = models
+        , modelEntries = models
+        , catalogDefaults = defaults
         , catalogModelsById =
             Map.fromList
                 [ (model.catalogModelId, model)
@@ -710,14 +731,23 @@ supportedReasoningEfforts :: [Text]
 supportedReasoningEfforts =
     ["none", "low", "medium", "high", "xhigh", "max"]
 
-validateBuiltinDefault :: [CatalogModel] -> Provider -> Either Text ()
-validateBuiltinDefault models provider =
+validateBuiltinDefault
+    :: Map Text ModelConnection
+    -> [CatalogModel]
+    -> Provider
+    -> Either Text CatalogModel
+validateBuiltinDefault connections models provider = do
+    case Map.lookup (builtinConnectionId provider) connections of
+        Just ModelConnection{connectionKind = BuiltinConnection configured}
+            | configured == provider -> pure ()
+        _ -> Left ("connection " <> builtinConnectionId provider
+            <> " must be a builtin connection for its provider")
     case filter
         (\model ->
             model.catalogModelConnectionId == builtinConnectionId provider
                 && model.catalogModelDefault)
         models of
-        [_] -> Right ()
+        [model] -> Right model
         [] ->
             Left ("connection " <> builtinConnectionId provider
                 <> " must have exactly one default model")
@@ -787,7 +817,7 @@ modelMergeKey model =
 
 allBuiltinProviders :: [Provider]
 allBuiltinProviders =
-    [OpenAIProvider, XAIProvider, OpenRouterProvider, GeminiProvider]
+    [OpenAIProvider, XAIProvider, OpenRouterProvider, GeminiProvider, ClaudeCodeProvider]
 
 gatewaySupportsDialect :: DialectId -> Bool
 gatewaySupportsDialect = \case

--- a/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
@@ -33,7 +33,8 @@ module Agent.CLI.Models
 import Agent.CLI.ModelConfig
     ( CatalogModel(..)
     , ConnectionKind(..)
-    , ModelCatalog(..)
+    , ModelCatalog
+    , catalogModels
     , ModelConnection(..)
     , builtinConnectionId
     , organizationGatewayConnectionId
@@ -111,7 +112,10 @@ modelOptionFromCatalog catalog model = do
             -- Gateway-only entries provide protocol and presentation metadata
             -- for live aliases. They must never enter the direct model catalog.
             OrganizationGatewayConnection -> Nothing
-    pure ModelOption
+    pure (modelOptionForProvider provider model)
+
+modelOptionForProvider :: Provider -> CatalogModel -> ModelOption
+modelOptionForProvider provider model = ModelOption
         { modelTarget = ModelTarget
             { targetProvider = provider
             , targetConnectionId = model.catalogModelConnectionId
@@ -126,7 +130,7 @@ modelOptionFromCatalog catalog model = do
 
 modelCatalog :: ModelCatalog -> [ModelOption]
 modelCatalog catalog =
-    mapMaybe (modelOptionFromCatalog catalog) catalog.catalogModels
+    mapMaybe (modelOptionFromCatalog catalog) (catalogModels catalog)
 
 modelsForProvider :: ModelCatalog -> Provider -> [ModelOption]
 modelsForProvider catalog provider =
@@ -191,14 +195,13 @@ catalogModelIds :: ModelCatalog -> [Text]
 catalogModelIds =
     map (.modelTarget.targetModelId) . modelCatalog
 
-defaultModelOptionFor :: ModelCatalog -> Provider -> Maybe ModelOption
+defaultModelOptionFor :: ModelCatalog -> Provider -> ModelOption
 defaultModelOptionFor catalog provider =
-    catalogDefaultForProvider catalog provider
-        >>= modelOptionFromCatalog catalog
+    modelOptionForProvider provider (catalogDefaultForProvider catalog provider)
 
-defaultModelFor :: ModelCatalog -> Provider -> Maybe Text
+defaultModelFor :: ModelCatalog -> Provider -> Text
 defaultModelFor catalog provider =
-    (.modelTarget.targetModelId) <$> defaultModelOptionFor catalog provider
+    (defaultModelOptionFor catalog provider).modelTarget.targetModelId
 
 resolveConfiguredModel :: ModelCatalog -> Text -> Maybe ModelOption
 resolveConfiguredModel catalog modelId =

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
@@ -26,18 +26,16 @@ spec = describe "Agent.CLI.ModelConfig" do
         bytes <- readPackagedDefaults
         let decoded = decodeModelConfig "models.default.json" bytes
         catalog <- expectRight decoded
-        fmap (.catalogModelId)
-            (catalogDefaultForProvider catalog OpenAIProvider)
-            `shouldBe` Just "gpt-5.6-sol"
-        fmap (.catalogModelId)
-            (catalogDefaultForProvider catalog XAIProvider)
-            `shouldBe` Just "grok-4.6"
-        fmap (.catalogModelId)
-            (catalogDefaultForProvider catalog GeminiProvider)
-            `shouldBe` Just "gemini-3.7-flash"
-        fmap (.catalogModelId)
-            (catalogDefaultForProvider catalog OpenRouterProvider)
-            `shouldBe` Just "stealth/ox-alpha"
+        (catalogDefaultForProvider catalog OpenAIProvider).catalogModelId
+            `shouldBe` "gpt-5.6-sol"
+        (catalogDefaultForProvider catalog XAIProvider).catalogModelId
+            `shouldBe` "grok-4.6"
+        (catalogDefaultForProvider catalog GeminiProvider).catalogModelId
+            `shouldBe` "gemini-3.7-flash"
+        (catalogDefaultForProvider catalog OpenRouterProvider).catalogModelId
+            `shouldBe` "stealth/ox-alpha"
+        (catalogDefaultForProvider catalog ClaudeCodeProvider).catalogModelId
+            `shouldBe` "sonnet"
         catalogContextWindowFor catalog "xai" "grok-4.6"
             `shouldBe` Just 500_000
         map (catalogContextWindowFor catalog "gemini")
@@ -75,7 +73,7 @@ spec = describe "Agent.CLI.ModelConfig" do
                 , "gemini-3.1-pro-preview"
                 , "gemini-3.5-flash-lite"
                 ]
-        Map.lookup organizationGatewayConnectionId catalog.catalogConnections
+        catalogConnection catalog organizationGatewayConnectionId
             `shouldBe`
                 Just ModelConnection
                     { connectionId = organizationGatewayConnectionId
@@ -86,7 +84,7 @@ spec = describe "Agent.CLI.ModelConfig" do
                 ( model.catalogModelReasoningEfforts
                 , model.catalogModelDefaultReasoningEffort
                 ))
-            (findModel "opus" catalog.catalogModels)
+            (findModel "opus" (catalogModels catalog))
             `shouldBe`
                 Just
                     ( Just ["low", "medium", "high", "xhigh", "max"]
@@ -97,7 +95,7 @@ spec = describe "Agent.CLI.ModelConfig" do
                 ( model.catalogModelReasoningEfforts
                 , model.catalogModelDefaultReasoningEffort
                 ))
-            (Map.lookup "gpt-5.6-sol" catalog.catalogModelsById)
+            (catalogModelById catalog "gpt-5.6-sol")
             `shouldBe`
                 Just
                     ( Just ["low", "medium", "high", "xhigh", "max"]
@@ -109,7 +107,7 @@ spec = describe "Agent.CLI.ModelConfig" do
                 , model.catalogModelDefaultReasoningEffort
                 , model.catalogModelDefault
                 ))
-            (Map.lookup "gpt-6-astra" catalog.catalogModelsById)
+            (catalogModelById catalog "gpt-6-astra")
             `shouldBe`
                 Just
                     ( Just ["low", "medium", "high", "xhigh", "max"]
@@ -216,7 +214,7 @@ spec = describe "Agent.CLI.ModelConfig" do
             (mergeModelConfigs
                 ("models.default.json", defaults)
                 (Just ("models.json", overlay)))
-        Map.lookup "ollama" catalog.catalogConnections
+        catalogConnection catalog "ollama"
             `shouldBe`
                 Just ModelConnection
                     { connectionId = "ollama"
@@ -231,7 +229,7 @@ spec = describe "Agent.CLI.ModelConfig" do
                     }
         let custom =
                 filter ((== "qwen-local") . (.catalogModelId))
-                    catalog.catalogModels
+                    (catalogModels catalog)
         fmap (.catalogModelWireId) custom
             `shouldBe` ["qwen2.5-coder:32b"]
         fmap (.catalogModelDialect) custom
@@ -287,7 +285,7 @@ spec = describe "Agent.CLI.ModelConfig" do
                 (Just ("models.json", overlay)))
         let matching =
                 filter ((== "gpt-5.6-sol") . (.catalogModelId))
-                    catalog.catalogModels
+                    (catalogModels catalog)
         length matching `shouldBe` 1
         fmap (.catalogModelWireId) matching
             `shouldBe` ["gpt-5.6-sol"]
@@ -348,6 +346,22 @@ spec = describe "Agent.CLI.ModelConfig" do
             , "model local-model reasoning_efforts must not contain duplicates"
             , "model local-model default_reasoning_effort must be listed in reasoning_efforts"
             ]
+
+    it "rejects a missing Claude default during configuration validation" do
+        defaults <- readPackagedDefaults
+        let overlay = "{\"version\":1,\"models\":[{\"id\":\"sonnet\",\"connection\":\"claude-code\",\"dialect\":\"claude-code\",\"default\":false}]}"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just ("models.json", overlay))
+            `shouldSatisfy` leftContains "claude-code must have exactly one default model"
+
+    it "rejects an ambiguous Claude default during configuration validation" do
+        defaults <- readPackagedDefaults
+        let overlay = "{\"version\":1,\"models\":[{\"id\":\"opus\",\"connection\":\"claude-code\",\"dialect\":\"claude-code\",\"default\":true}]}"
+        mergeModelConfigs
+            ("models.default.json", defaults)
+            (Just ("models.json", overlay))
+            `shouldSatisfy` leftContains "claude-code has more than one default model"
 
     it "requires an API-key environment variable unless auth is optional" do
         defaults <- readPackagedDefaults
@@ -417,7 +431,7 @@ spec = describe "Agent.CLI.ModelConfig" do
             catalog <- expectRight loaded
             fmap (.catalogModelWireId)
                 (filter ((== "local-model") . (.catalogModelId))
-                    catalog.catalogModels)
+                    (catalogModels catalog))
                 `shouldBe` ["local-model"]
 
 leftContains :: Text -> Either Text value -> Bool

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -39,15 +39,15 @@ spec = do
     describe "modelsForProvider" do
         it "puts the provider default first" do
             firstId (modelsForProvider catalog XAIProvider)
-                `shouldBe` defaultModelFor catalog XAIProvider
+                `shouldBe` Just (defaultModelFor catalog XAIProvider)
             firstId (modelsForProvider catalog OpenAIProvider)
-                `shouldBe` defaultModelFor catalog OpenAIProvider
+                `shouldBe` Just (defaultModelFor catalog OpenAIProvider)
             firstId (modelsForProvider catalog OpenRouterProvider)
-                `shouldBe` defaultModelFor catalog OpenRouterProvider
+                `shouldBe` Just (defaultModelFor catalog OpenRouterProvider)
             firstId (modelsForProvider catalog GeminiProvider)
-                `shouldBe` defaultModelFor catalog GeminiProvider
+                `shouldBe` Just (defaultModelFor catalog GeminiProvider)
             firstId (modelsForProvider catalog ClaudeCodeProvider)
-                `shouldBe` defaultModelFor catalog ClaudeCodeProvider
+                `shouldBe` Just (defaultModelFor catalog ClaudeCodeProvider)
 
         it "ships the configured frontier models for each provider" do
             modelIdsFor OpenAIProvider
@@ -515,9 +515,7 @@ spec = do
 
         it "does not duplicate a known current model" do
             let base = modelsForProvider catalog XAIProvider
-                def = fromMaybe
-                    (error "shipped xAI default is missing")
-                    (defaultModelFor catalog XAIProvider)
+                def = defaultModelFor catalog XAIProvider
                 opts =
                     ensureCurrentInList
                         "xai"

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -416,9 +416,7 @@ accountSwitchTarget
                     }
                 }
         else
-            fromMaybe
-                (error "validated default model is missing")
-                (defaultModelOptionFor catalog selectedProvider)
+            defaultModelOptionFor catalog selectedProvider
 
 persistenceTransportModel :: Text -> Persistence -> IO Text
 persistenceTransportModel fallback = \case

--- a/packages/agent-cli/src/Agent/CLI/Runtime/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/MetaConsole.hs
@@ -43,7 +43,7 @@ import Agent.CLI.MetaConsole
 import Agent.CLI.ModelConfig
     ( organizationGatewayConnectionId
     , CatalogModel(..)
-    , ModelCatalog(..)
+    , catalogModels
     )
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.SessionEnv (SessionEnv(..))
@@ -358,7 +358,7 @@ buildMetaContext env config = do
         Nothing ->
             pure
                 [ (model.catalogModelId, model.catalogModelConnectionId)
-                | model <- env.sessionModelCatalog.catalogModels
+                | model <- catalogModels env.sessionModelCatalog
                 ]
         Just access ->
             maybe

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -454,62 +454,50 @@ runAgent
                             Left err -> pure (Left err)
                             Right catalog -> do
                                 color <- resolveColor runMode.runStderr
-                                let currentTarget =
+                                let preferredTarget =
                                         ((.transitionTarget) <$> nextTransition)
                                             <|> ( (.modelTarget)
                                                     <$> (nextOptions.optModel
                                                         >>= resolveConfiguredModel
                                                             catalog)
                                                 )
-                                            <|> ( (.modelTarget)
-                                                    <$> (nextOptions.optProvider
-                                                        >>= defaultModelOptionFor
-                                                            catalog)
-                                                )
-                                            <|> ( (.modelTarget)
-                                                    <$> defaultModelOptionFor
-                                                        catalog
-                                                        OpenAIProvider
-                                                )
-                                case currentTarget of
-                                    Nothing ->
-                                        pure
-                                            (Left
-                                                "No configured models are available.")
-                                    Just current ->
-                                        recoveryGatewayAccess
-                                            current.targetProvider
-                                            nextTransition >>= \case
-                                                Left err -> pure (Left err)
-                                                Right gatewayAccess ->
-                                                    modelChoiceWithEffort
-                                                        catalog
-                                                        gatewayAccess
-                                                        (Just runtime)
-                                                        color
-                                                        current.targetConnectionId
-                                                        current.targetProvider
-                                                        current.targetModelId
-                                                        current.targetDialect
-                                                        (fromMaybe
-                                                            (defaultEffortFor
-                                                                current.targetProvider)
-                                                            ( (nextTransition
-                                                                    >>= (.transitionEffort))
-                                                                <|> nextOptions.optEffort
-                                                            ))
-                                                        >>= \case
-                                                            Left err ->
-                                                                pure (Left err)
-                                                            Right Nothing ->
-                                                                pure (Right Nothing)
-                                                            Right (Just selection) ->
-                                                                pure $ Right $ Just $
-                                                                    recoveryModelTransition
-                                                                        nextOptions
-                                                                        nextTransition
-                                                                        selection.modelPickerOption.modelTarget
-                                                                        selection.modelPickerEffort
+                                    defaultOption = defaultModelOptionFor catalog
+                                        (fromMaybe OpenAIProvider nextOptions.optProvider)
+                                    current = fromMaybe defaultOption.modelTarget
+                                        preferredTarget
+                                recoveryGatewayAccess
+                                    current.targetProvider
+                                    nextTransition >>= \case
+                                        Left err -> pure (Left err)
+                                        Right gatewayAccess ->
+                                            modelChoiceWithEffort
+                                                catalog
+                                                gatewayAccess
+                                                (Just runtime)
+                                                color
+                                                current.targetConnectionId
+                                                current.targetProvider
+                                                current.targetModelId
+                                                current.targetDialect
+                                                (fromMaybe
+                                                    (defaultEffortFor
+                                                        current.targetProvider)
+                                                    ( (nextTransition
+                                                            >>= (.transitionEffort))
+                                                        <|> nextOptions.optEffort
+                                                    ))
+                                                >>= \case
+                                                    Left err ->
+                                                        pure (Left err)
+                                                    Right Nothing ->
+                                                        pure (Right Nothing)
+                                                    Right (Just selection) ->
+                                                        pure $ Right $ Just $
+                                                            recoveryModelTransition
+                                                                nextOptions
+                                                                nextTransition
+                                                                selection.modelPickerOption.modelTarget
+                                                                selection.modelPickerEffort
                     recoveryModelTransition
                             nextOptions nextTransition target selectedEffort =
                         case nextTransition of

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -710,9 +710,7 @@ resolveToolModel AgentToolsRequest
   where
     toolProvider = loaded.loadedProvider
     fallbackModel =
-        fromMaybe
-            (error "validated default model is missing")
-            (defaultModelFor catalog toolProvider)
+        defaultModelFor catalog toolProvider
     unrestrictedModel =
         fromMaybe
             (maybe fallbackModel (.targetModelId) targetHint)

--- a/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
@@ -9,7 +9,10 @@ import Agent.CLI.ModelConfig
 import Agent.CLI.Models (ModelOption(..), ModelTarget(..))
 import Agent.Dialect (DialectId(..))
 import Agent.Provider (Provider(ClaudeCodeProvider, OpenAIProvider))
-import Data.Map.Strict qualified as Map
+import Data.Aeson qualified as Aeson
+import Data.Aeson ((.=))
+import Data.Text (Text)
+import Data.Text qualified as Text
 import Test.Hspec
 
 spec :: Spec
@@ -33,9 +36,9 @@ spec = describe "Agent.CLI.GatewayModels" do
     it "uses only direct catalog entries while disconnected" do
         let options = modelOptionsForGatewayState testCatalog Nothing
         map (.modelTarget.targetModelId) options
-            `shouldBe` ["router-default"]
+            `shouldBe` ["router-default", "grok", "gemini", "router", "sonnet"]
         map (.modelTarget.targetConnectionId) options
-            `shouldBe` ["openai"]
+            `shouldBe` ["openai", "xai", "gemini", "openrouter", "claude-code"]
 
     it "maps the unified catalog to Responses and Claude transports" do
         let options =
@@ -72,57 +75,50 @@ spec = describe "Agent.CLI.GatewayModels" do
         gatewayProviderForStartup Nothing Nothing Nothing
             `shouldBe` OpenAIProvider
 
+-- Exercise the same validated construction boundary as production. A catalog
+-- now always includes a default for each builtin provider.
 testCatalog :: ModelCatalog
-testCatalog =
-    ModelCatalog
-        { catalogConnections =
-            Map.fromList
-                [ ( "openai"
-                  , ModelConnection
-                        { connectionId = "openai"
-                        , connectionKind = BuiltinConnection OpenAIProvider
-                        }
-                  )
-                , ( organizationGatewayConnectionId
-                  , ModelConnection
-                        { connectionId = organizationGatewayConnectionId
-                        , connectionKind = OrganizationGatewayConnection
-                        }
-                  )
-                ]
-        , catalogModels = [directModel, gatewayMetadata]
-        , catalogModelsById =
-            Map.singleton directModel.catalogModelId directModel
-        , catalogGatewayModelsById =
-            Map.singleton gatewayMetadata.catalogModelId gatewayMetadata
-        }
-
-directModel :: CatalogModel
-directModel =
-    CatalogModel
-        { catalogModelId = "router-default"
-        , catalogModelConnectionId = "openai"
-        , catalogModelWireId = "router-default"
-        , catalogModelDialect = CodexDialect
-        , catalogModelContextWindow = Nothing
-        , catalogModelLabel = Nothing
-        , catalogModelReasoningEfforts = Nothing
-        , catalogModelDefaultReasoningEffort = Nothing
-        , catalogModelDefault = True
-        , catalogModelFallbackPriority = Nothing
-        }
-
-gatewayMetadata :: CatalogModel
-gatewayMetadata =
-    CatalogModel
-        { catalogModelId = "company-a"
-        , catalogModelConnectionId = organizationGatewayConnectionId
-        , catalogModelWireId = "company-a"
-        , catalogModelDialect = GenericResponsesDialect
-        , catalogModelContextWindow = Just 131_072
-        , catalogModelLabel = Just "Company A"
-        , catalogModelReasoningEfforts = Just ["high"]
-        , catalogModelDefaultReasoningEffort = Just "high"
-        , catalogModelDefault = False
-        , catalogModelFallbackPriority = Nothing
-        }
+testCatalog = either (error . Text.unpack) id $
+    decodeModelConfig "gateway-test.json" $ Aeson.encode $ Aeson.object
+        [ "version" .= (1 :: Int)
+        , "connections" .= Aeson.object
+            [ "openai" .= builtin "openai"
+            , "xai" .= builtin "xai"
+            , "gemini" .= builtin "gemini"
+            , "openrouter" .= builtin "openrouter"
+            , "claude-code" .= builtin "claude-code"
+            , "organization-gateway" .= Aeson.object ["api" .= ("gateway" :: Text)]
+            ]
+        , "models" .=
+            ( [ Aeson.object
+                    [ "id" .= model
+                    , "connection" .= provider
+                    , "dialect" .= dialect
+                    , "default" .= True
+                    ]
+              | (provider, model, dialect) <- builtinModels
+              ]
+                <> [ Aeson.object
+                        [ "id" .= ("company-a" :: Text)
+                        , "connection" .= organizationGatewayConnectionId
+                        , "dialect" .= ("generic-responses" :: Text)
+                        , "context_window" .= (131_072 :: Int)
+                        , "label" .= ("Company A" :: Text)
+                        , "reasoning_efforts" .= ["high" :: Text]
+                        , "default_reasoning_effort" .= ("high" :: Text)
+                        ]
+                   ]
+            )
+        ]
+  where
+    builtin :: Text -> Aeson.Value
+    builtin provider = Aeson.object
+        [ "api" .= ("builtin" :: Text), "provider" .= provider ]
+    builtinModels :: [(Text, Text, Text)]
+    builtinModels =
+        [ ("openai", "router-default", "codex")
+        , ("xai", "grok", "grok-build")
+        , ("gemini", "gemini", "generic-responses")
+        , ("openrouter", "router", "generic-responses")
+        , ("claude-code", "sonnet", "claude-code")
+        ]

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -55,7 +55,7 @@ spec = do
             frame `shouldSatisfy` Text.isInfixOf "openrouter"
             frame `shouldSatisfy` Text.isInfixOf "claude-code"
             defaultModelFor catalog XAIProvider
-                `shouldSatisfy` maybe False (\model -> Text.isInfixOf model frame)
+                `shouldSatisfy` (\model -> Text.isInfixOf model frame)
             frame `shouldSatisfy` Text.isInfixOf "grok-4.6"
             frame `shouldSatisfy` Text.isInfixOf "confirm"
             frame `shouldSatisfy` Text.isInfixOf "reasoning effort"

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -6033,26 +6033,17 @@ loadNativeModelCatalog
                                 == target.targetConnectionId
                                 then Just option
                                 else Nothing
-                    selectedTarget <-
-                        traverse
-                            (fmap (.modelTarget)
-                                . resolveModelOptionDialect)
-                            ( configuredTarget
-                                <|> defaultModelOptionFor
-                                    catalog
-                                    OpenAIProvider
-                                <|> listToMaybe (modelCatalog catalog)
-                            )
-                    case selectedTarget of
-                        Nothing -> pure (Left "model catalog is empty")
-                        Just target -> do
-                            picker <- initialPickerStateResolved
-                                catalog
-                                target.targetConnectionId
-                                target.targetProvider
-                                target.targetModelId
-                                target.targetDialect
-                            pure (Right (modelPickerJSON catalog picker))
+                    selected <- resolveModelOptionDialect $
+                        fromMaybe (defaultModelOptionFor catalog OpenAIProvider)
+                            configuredTarget
+                    let target = selected.modelTarget
+                    picker <- initialPickerStateResolved
+                        catalog
+                        target.targetConnectionId
+                        target.targetProvider
+                        target.targetModelId
+                        target.targetDialect
+                    pure (Right (modelPickerJSON catalog picker))
 
 modelPickerJSON :: ModelCatalog -> PickerState -> Aeson.Value
 modelPickerJSON catalog picker =

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -1592,11 +1592,8 @@ selectModel boundary catalog options requested =
         case boundary.accessGatewayBoundary.gatewayBoundaryIdentity of
         Just _ -> listToMaybe options
         Nothing ->
-            (defaultModelOptionFor catalog OpenAIProvider
-                >>= \preferred ->
-                    find
-                        ((== preferred.modelTarget) . (.modelTarget))
-                        options)
+            let preferred = defaultModelOptionFor catalog OpenAIProvider
+            in find ((== preferred.modelTarget) . (.modelTarget)) options
                 <|> listToMaybe options
 
 resolveEffort

--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Launch.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Launch.hs
@@ -128,12 +128,8 @@ runTelegramWithStore store home config token = do
                     | option.modelTarget.targetProvider == provider ->
                         Just option
                 _ -> Just (rawModelOption provider model)
-    selectedOption <- case configuredOption of
-        Just option -> pure option
-        Nothing -> maybe
-            (die "configured provider has no default model")
-            pure
-            (defaultModelOptionFor catalog provider)
+    let selectedOption =
+            fromMaybe (defaultModelOptionFor catalog provider) configuredOption
     resolvedOption <- resolveModelOptionDialect selectedOption
     let target = resolvedOption.modelTarget
     createDirectoryIfMissing True gatewayDir


### PR DESCRIPTION
Validated model catalogs previously discarded their default-model checks, forcing callers to handle `Maybe` and sometimes call `error` for a supposedly impossible missing default. Keep a private default for each built-in provider in the abstract `ModelCatalog`, and make default lookup total. CLI, server, Telegram, and native callers now use that guarantee directly.

Validation now also includes Claude (previously omitted from the provider list) and checks that each default points to the matching built-in connection. Missing or duplicate Claude defaults produce configuration errors.

Validation:
- Nix/Cabal GHCi: 54 model configuration/model tests and 17 gateway/model-picker tests pass.
- CLI, server, and Telegram libraries typechecked (247 modules).
- Native bridge and its test modules typechecked in GHCi with `-fno-code` (232 modules; no native FFI execution claimed).
- Live CLI in an isolated tmux session: startup, model picker/current-model selection, and return to the prompt passed.
