### PR TITLE
Support image attachments in server turns

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -25,6 +25,11 @@ import Agent.CLI.AgentSessions
     , closeSessionThreadManager
     , newSessionThreadManager
     )
+import Agent.Loop
+    ( ImageAttachment
+    , TurnAttachment(ImageAttachmentItem)
+    , userMessageWithAttachments
+    )
 import Agent.CLI.Options
     ( Command(..)
     , CliOptions(..)
@@ -96,6 +101,7 @@ data NativeSessionTarget
 -- interactive approval and plan-mode callbacks.
 data NativeTurnRequest = NativeTurnRequest
     { nativeTurnPrompt :: !Text
+    , nativeTurnImages :: ![ImageAttachment]
     , nativeTurnSession :: !NativeSessionTarget
     , nativeTurnProvider :: !(Maybe Provider)
     , nativeTurnModel :: !(Maybe Text)
@@ -197,8 +203,19 @@ runNativeTurn runtime output hooks request =
                     { nativeInteractionMode =
                         request.nativeTurnInteractionMode
                     , nativeShellMode = request.nativeTurnShellMode
+                    , nativeInitialTurnInputs =
+                        Just
+                            [ userMessageWithAttachments
+                                initialPrompt
+                                (map ImageAttachmentItem request.nativeTurnImages)
+                            ]
                     }
                 options
+  where
+    initialPrompt
+        | Text.null (Text.strip request.nativeTurnPrompt)
+        , not (null request.nativeTurnImages) = "Image attached."
+        | otherwise = request.nativeTurnPrompt
 
 -- | Lower a typed native request into the existing orchestration options.
 --

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -22,7 +22,7 @@ import Agent.CLI.Options ( CliOptions )
 import Agent.CLI.Project ( ProjectSettings )
 import Agent.Connectivity.NetworkPath ( NetworkRecovery )
 import Agent.CLI.Permission ( PermissionChoice )
-import Agent.Loop ( LoopEvent )
+import Agent.Loop ( LoopEvent, TurnInput )
 import Agent.Provider ( Credential, TokenProvider )
 import Agent.Store.Postgres ( Store )
 import Agent.ToolDispatch ( ToolCall )
@@ -126,6 +126,7 @@ fullNativeRunCapabilities = NativeRunCapabilities
 
 data NativeRunHooks = NativeRunHooks
     { nativeOnLoopEvent :: !(LoopEvent -> IO ())
+    , nativeInitialTurnInputs :: !(Maybe [TurnInput])
     , nativeOnSessionId :: !(Text -> IO ())
     , nativeRegisterCancel :: !(IO () -> IO ())
     , nativeRegisterAgentSnapshot :: !(IO [AgentEntry] -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -1672,7 +1672,10 @@ runSessionInteraction
                 pending
         Nothing -> case promptRequest of
             Just request -> do
-                inputs <- managedTurnInputs cwd request
+                inputs <-
+                    case startup.startupNativeHooks >>= (.nativeInitialTurnInputs) of
+                        Just nativeInputs -> pure nativeInputs
+                        Nothing -> managedTurnInputs cwd request
                 skillInputs <-
                     callbacks.runnerPreparePromptSkillInputs
                         env

--- a/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
@@ -28,6 +28,7 @@ spec = describe "nativeTurnOptions" do
         let cwd = unsafeEncodeUtf "/tmp/project"
             request = NativeTurnRequest
                 { nativeTurnPrompt = "fix the tests"
+                , nativeTurnImages = []
                 , nativeTurnSession = NativeNewSession
                 , nativeTurnProvider = Just OpenAIProvider
                 , nativeTurnModel = Just "gpt-5"
@@ -113,6 +114,7 @@ spec = describe "nativeTurnOptions" do
 baseRequest :: NativeTurnRequest
 baseRequest = NativeTurnRequest
     { nativeTurnPrompt = "hello"
+    , nativeTurnImages = []
     , nativeTurnSession = NativeNewSession
     , nativeTurnProvider = Nothing
     , nativeTurnModel = Nothing

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -5247,6 +5247,7 @@ runNativeTurn
                     Nothing ->
                         forM_ (nativeLoopEvent control.turnControlId event)
                             (sendEvent callback context)
+            , nativeInitialTurnInputs = Nothing
             , nativeOnSessionId = \sessionId -> do
                 writeIORef sessionIdRef (Just sessionId)
                 atomically do

--- a/packages/agent-server-client/src/Agent/Server/Client/Protocol.hs
+++ b/packages/agent-server-client/src/Agent/Server/Client/Protocol.hs
@@ -3,6 +3,7 @@ module Agent.Server.Client.Protocol
     ( AgentServerCreateSessionRequest (..)
     , AgentServerSession (..)
     , AgentServerCreateTurnRequest (..)
+    , AgentServerTurnImage (..)
     , AgentServerTurnStatus (..)
     , AgentServerTurn (..)
     , AgentServerTurnList (..)
@@ -31,6 +32,7 @@ import Data.Aeson
 import Data.Aeson.Types (Parser)
 import Data.Bifunctor qualified as Bifunctor
 import Data.ByteString qualified as ByteString
+import Data.ByteString.Base64 qualified as Base64
 import Data.Foldable (forM_)
 import Data.Int (Int64)
 import Data.Maybe (fromMaybe)
@@ -71,14 +73,33 @@ instance FromJSON AgentServerSession where
 data AgentServerCreateTurnRequest = AgentServerCreateTurnRequest
     { createTurnClientRequestId :: !Text
     , createTurnInput :: !Text
+    , createTurnImages :: ![AgentServerTurnImage]
     }
     deriving (Eq, Show)
 
 instance ToJSON AgentServerCreateTurnRequest where
     toJSON request =
-        object
+        object $
             [ "clientRequestId" .= request.createTurnClientRequestId
             , "input" .= request.createTurnInput
+            ]
+                <> [ "images" .= request.createTurnImages
+                   | not (null request.createTurnImages)
+                   ]
+
+data AgentServerTurnImage = AgentServerTurnImage
+    { turnImageMimeType :: !Text
+    , turnImageBytes :: !ByteString.ByteString
+    }
+    deriving (Eq, Show)
+
+instance ToJSON AgentServerTurnImage where
+    toJSON image =
+        object
+            [ "mimeType" .= image.turnImageMimeType
+            , "data"
+                .= TextEncoding.decodeUtf8
+                    (Base64.encode image.turnImageBytes)
             ]
 
 data AgentServerTurnStatus

--- a/packages/agent-server-client/test/Agent/Server/Client/ProtocolSpec.hs
+++ b/packages/agent-server-client/test/Agent/Server/Client/ProtocolSpec.hs
@@ -19,6 +19,7 @@ spec = describe "agent-server client protocol" do
                     { createTurnClientRequestId =
                         "01991f6d-7200-7000-8000-000000000003"
                     , createTurnInput = "hello"
+                    , createTurnImages = []
                     }
         ( Aeson.eitherDecode (Aeson.encode request) ::
                 Either String Aeson.Value
@@ -30,6 +31,35 @@ spec = describe "agent-server client protocol" do
                                     Text
                                  )
                     , "input" Aeson..= ("hello" :: Text)
+                    ]
+                )
+
+    it "base64-encodes attached images with their media type" do
+        let request =
+                AgentServerCreateTurnRequest
+                    { createTurnClientRequestId = "request-1"
+                    , createTurnInput = ""
+                    , createTurnImages =
+                        [ AgentServerTurnImage
+                            { turnImageMimeType = "image/png"
+                            , turnImageBytes = "\x89PNG"
+                            }
+                        ]
+                    }
+        ( Aeson.eitherDecode (Aeson.encode request) ::
+                Either String Aeson.Value
+            )
+            `shouldBe` Right
+                ( Aeson.object
+                    [ "clientRequestId" Aeson..= ("request-1" :: Text)
+                    , "input" Aeson..= ("" :: Text)
+                    , "images"
+                        Aeson..=
+                            [ Aeson.object
+                                [ "mimeType" Aeson..= ("image/png" :: Text)
+                                , "data" Aeson..= ("iVBORw==" :: Text)
+                                ]
+                            ]
                     ]
                 )
 

--- a/packages/agent-server/agent-server.cabal
+++ b/packages/agent-server/agent-server.cabal
@@ -62,6 +62,7 @@ library
                     , aeson >= 2.0
                     , async
                     , base >= 4.17 && < 5
+                    , base64-bytestring
                     , bytestring
                     , containers
                     , crypton

--- a/packages/agent-server/openapi.json
+++ b/packages/agent-server/openapi.json
@@ -334,7 +334,7 @@
       "post": {
         "tags": ["turns"],
         "operationId": "createTurn",
-        "description": "Durably reserves and queues one agent turn. Reusing clientRequestId with identical input returns the original turn; reusing it with different input is rejected. Once reserved, an admission rejection is represented by the same durable failed turn. A session may have only one queued/running/waiting turn.",
+        "description": "Durably reserves and queues one agent turn with text, images, or both. Reusing clientRequestId with identical text and image content returns the original turn; reusing it with different content is rejected. Once reserved, an admission rejection is represented by the same durable failed turn. A session may have only one queued/running/waiting turn.",
         "requestBody": {
           "required": true,
           "content": {
@@ -728,9 +728,25 @@
             "format": "uuid",
             "description": "Optional for legacy callers. Supplying a stable UUID makes turn creation idempotent."
           },
-          "input": { "type": "string", "minLength": 1 }
+          "input": { "type": "string" },
+          "images": {
+            "type": "array",
+            "maxItems": 1,
+            "description": "An optional JPEG, PNG, GIF, WebP, or BMP image, limited to 20 MiB decoded.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "mimeType": {
+                  "type": "string",
+                  "enum": ["image/jpeg", "image/png", "image/gif", "image/webp", "image/bmp"]
+                },
+                "data": { "type": "string", "contentEncoding": "base64" }
+              },
+              "required": ["mimeType", "data"],
+              "additionalProperties": false
+            }
+          }
         },
-        "required": ["input"],
         "additionalProperties": false
       },
       "Turn": {

--- a/packages/agent-server/package.nix
+++ b/packages/agent-server/package.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, agent-cli, agent-cli-runtime, agent-core
-, agent-store, async, base, bytestring, containers, crypton
+, agent-store, async, base, base64-bytestring, bytestring, containers, crypton
 , directory, filepath, hspec, http-types, lib, memory
 , optparse-applicative, process, safe-exceptions, stm, temporary
 , text, time, unix, uuid-types, wai, wai-extra, warp
@@ -13,7 +13,7 @@ mkDerivation {
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [
     aeson agent-cli agent-cli-runtime agent-core agent-store async base
-    bytestring containers crypton directory filepath http-types memory
+    base64-bytestring bytestring containers crypton directory filepath http-types memory
     optparse-applicative process safe-exceptions stm text time unix
     uuid-types wai warp
   ];

--- a/packages/agent-server/src/Agent/Server/Application.hs
+++ b/packages/agent-server/src/Agent/Server/Application.hs
@@ -13,6 +13,7 @@ import Agent.Server.Auth
     , corsResponseHeaders
     , isCorsPreflight
     )
+import Agent.Loop (ImageAttachment(..))
 import Agent.Server.Backend (Backend(..), SessionMutationLease(..))
 import Agent.Server.Identifier (isUUIDText, newUUIDv7Text)
 import Agent.Server.Supervisor
@@ -50,6 +51,7 @@ import Control.Exception.Safe
     , tryAny
     )
 import Control.Monad (foldM, void)
+import Crypto.Hash (Digest, SHA256, hash)
 import Data.Aeson
     ( FromJSON
     , Value
@@ -629,6 +631,27 @@ resolveHumanRequestResponse
                                         headers
                                         (toJSONValue resolved)
 
+turnReservationInput :: CreateTurnRequest -> Text
+turnReservationInput request
+    | null request.createTurnImages = request.createTurnInput
+    | otherwise =
+        "image-turn-v1:"
+            <> Text.pack (show (hash payload :: Digest SHA256))
+  where
+    promptBytes = TextEncoding.encodeUtf8 request.createTurnInput
+    payload =
+        lengthPrefix promptBytes
+            <> promptBytes
+            <> foldMap encodeImage request.createTurnImages
+    encodeImage image =
+        let mimeBytes = TextEncoding.encodeUtf8 image.imageMime
+         in lengthPrefix mimeBytes
+                <> mimeBytes
+                <> lengthPrefix image.imageBytes
+                <> image.imageBytes
+    lengthPrefix bytes =
+        ByteString8.pack (show (ByteString.length bytes) <> ":")
+
 createTurn
     :: Backend
     -> Supervisor
@@ -637,7 +660,8 @@ createTurn
     -> CreateTurnRequest
     -> IO (Either ApiError TurnRecord)
 createTurn backend supervisor boundary sessionId request
-    | Text.null (Text.strip request.createTurnInput) =
+    | Text.null (Text.strip request.createTurnInput)
+        && null request.createTurnImages =
         pure $
             Left ApiError
                 { apiErrorStatus = 422
@@ -656,6 +680,7 @@ createTurn backend supervisor boundary sessionId request
                 { turnSpecSessionId = sessionId
                 , turnSpecClientRequestId = clientRequestId
                 , turnSpecPrompt = request.createTurnInput
+                , turnSpecImages = request.createTurnImages
                 , turnSpecBoundary = boundary
                 }
             validateSession =
@@ -671,7 +696,7 @@ createTurn backend supervisor boundary sessionId request
                                 boundary
                                 sessionId
                                 clientRequestId
-                                request.createTurnInput
+                                (turnReservationInput request)
                                 turnId
                                 now
                     case reservation of

--- a/packages/agent-server/src/Agent/Server/Config.hs
+++ b/packages/agent-server/src/Agent/Server/Config.hs
@@ -160,7 +160,9 @@ defaultServerConfig = ServerConfig
     , serverMaxEventSubscribers = 256
     , serverMaxEventSubscribersPerTenant = 8
     , serverEventReplayLimit = 1000
-    , serverMaximumRequestBytes = 1024 * 1024
+    -- Enough for one 20 MiB decoded image after base64 expansion,
+    -- while retaining a hard request-level allocation bound.
+    , serverMaximumRequestBytes = 32 * 1024 * 1024
     }
 
 parseServerConfig :: IO ServerConfig

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -1220,6 +1220,8 @@ runTurn environment control spec =
                                             NativeTurnRequest
                                                 { nativeTurnPrompt =
                                                     spec.turnSpecPrompt
+                                                , nativeTurnImages =
+                                                    spec.turnSpecImages
                                                 , nativeTurnSession =
                                                     NativeResumeSession
                                                         spec.turnSpecSessionId
@@ -1275,6 +1277,7 @@ nativeHooks environment control sessionId cwd dialect = NativeRunHooks
     { nativeOnLoopEvent = \event ->
         let (eventType, value) = projectLoopEvent event
         in control.turnControlEmit eventType value
+    , nativeInitialTurnInputs = Nothing
     , nativeOnSessionId = \_ -> pure ()
     , nativeRegisterCancel = control.turnControlRegisterCancel
     , nativeRegisterAgentSnapshot = \snapshot ->

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -39,6 +39,7 @@ module Agent.Server.Supervisor
     , deleteCancellationTaskIfOwned
     ) where
 
+import Agent.Loop (ImageAttachment(..))
 import Agent.Server.Identifier (newUUIDv7Text)
 import Agent.Server.Types
 import Control.Concurrent (ThreadId, myThreadId, threadDelay)
@@ -86,6 +87,7 @@ import Control.Exception.Safe
     )
 import Control.Monad (forM_, void, when)
 import Data.Aeson (Value, encode, object, toJSON, (.=))
+import Data.ByteString qualified as ByteString
 import Data.ByteString.Lazy qualified as LazyByteString
 import Data.Foldable (toList)
 import Data.Int (Int64)
@@ -616,12 +618,20 @@ enqueueTurnRecord supervisor reservationHeld spec record
                                 else
                                     if Seq.length state.stateQueue
                                         >= supervisor.supervisorConfig.supervisorMaxQueuedTurns
+                                        || queuedImageBytes state.stateTurns
+                                            + turnImageBytes spec
+                                            > maximumQueuedImageBytes
                                         then pure (Left SubmitQueueFull)
                                         else
                                             if queuedForTenant
                                                 spec.turnSpecBoundary.accessTenantId
                                                 state.stateTurns
                                                 >= supervisor.supervisorConfig.supervisorMaxQueuedTurnsPerTenant
+                                                || queuedImageBytesForTenant
+                                                    spec.turnSpecBoundary.accessTenantId
+                                                    state.stateTurns
+                                                    + turnImageBytes spec
+                                                    > maximumQueuedImageBytesPerTenant
                                                 then pure (Left SubmitTenantQueueFull)
                                                 else do
                                                     let turnId = record.turnRecordId
@@ -1305,6 +1315,7 @@ reserveRunnable supervisor = do
                                                         slot.turnSlotSpec
                                                             { turnSpecPrompt =
                                                                 ""
+                                                            , turnSpecImages = []
                                                             }
                                                     }
                                                 state.stateTurns
@@ -1936,6 +1947,35 @@ queuedForTenant tenantId turns =
         , slot.turnSlotRecord.turnRecordStatus == TurnQueued
         , slot.turnSlotRecord.turnRecordBoundary.accessTenantId == tenantId
         ]
+
+-- Keep decoded image payloads bounded while they wait in the in-memory queue.
+-- Running turns clear their queued copy before execution.
+maximumQueuedImageBytes, maximumQueuedImageBytesPerTenant :: Int
+maximumQueuedImageBytes = 80 * 1024 * 1024
+maximumQueuedImageBytesPerTenant = 40 * 1024 * 1024
+
+turnImageBytes :: TurnSpec -> Int
+turnImageBytes spec =
+    sum (map (ByteString.length . imageBytes) spec.turnSpecImages)
+
+queuedImageBytes :: Map TurnId TurnSlot -> Int
+queuedImageBytes =
+    sum
+        . map (turnImageBytes . turnSlotSpec)
+        . filter ((== TurnQueued) . turnRecordStatus . turnSlotRecord)
+        . Map.elems
+
+queuedImageBytesForTenant :: TenantId -> Map TurnId TurnSlot -> Int
+queuedImageBytesForTenant tenantId =
+    sum
+        . map (turnImageBytes . turnSlotSpec)
+        . filter
+            ( \slot ->
+                slot.turnSlotRecord.turnRecordStatus == TurnQueued
+                    && slot.turnSlotRecord.turnRecordBoundary.accessTenantId
+                        == tenantId
+            )
+        . Map.elems
 
 runningForTenant
     :: TenantId

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -1961,14 +1961,14 @@ turnImageBytes spec =
 queuedImageBytes :: Map TurnId TurnSlot -> Int
 queuedImageBytes =
     sum
-        . map (turnImageBytes . turnSlotSpec)
-        . filter ((== TurnQueued) . turnRecordStatus . turnSlotRecord)
+        . map (\slot -> turnImageBytes slot.turnSlotSpec)
+        . filter (\slot -> slot.turnSlotRecord.turnRecordStatus == TurnQueued)
         . Map.elems
 
 queuedImageBytesForTenant :: TenantId -> Map TurnId TurnSlot -> Int
 queuedImageBytesForTenant tenantId =
     sum
-        . map (turnImageBytes . turnSlotSpec)
+        . map (\slot -> turnImageBytes slot.turnSlotSpec)
         . filter
             ( \slot ->
                 slot.turnSlotRecord.turnRecordStatus == TurnQueued

--- a/packages/agent-server/src/Agent/Server/Types.hs
+++ b/packages/agent-server/src/Agent/Server/Types.hs
@@ -42,7 +42,9 @@ module Agent.Server.Types
     ) where
 
 import Agent.CLI.GatewayBoundary (GatewayBoundary(..))
+import Agent.Loop (ImageAttachment(..))
 import Agent.Server.Identifier (isUUIDText)
+import Control.Monad (unless, when)
 import Data.Aeson
     ( FromJSON(..)
     , Object
@@ -52,14 +54,18 @@ import Data.Aeson
     , withObject
     , (.:)
     , (.:?)
+    , (.!=)
     , (.=)
     )
 import Data.Aeson.Key (Key)
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.Aeson.Types (Parser)
+import Data.ByteString qualified as ByteString
+import Data.ByteString.Base64 qualified as Base64
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Text.Encoding qualified as TextEncoding
 import Data.Time.Clock (UTCTime)
 
 newtype TenantId = TenantId Text
@@ -150,6 +156,7 @@ data TurnSpec = TurnSpec
     { turnSpecSessionId :: !Text
     , turnSpecClientRequestId :: !ClientRequestId
     , turnSpecPrompt :: !Text
+    , turnSpecImages :: ![ImageAttachment]
     , turnSpecBoundary :: !AccessBoundary
     }
     deriving (Eq, Show)
@@ -386,6 +393,7 @@ instance FromJSON ForkSessionRequest where
 data CreateTurnRequest = CreateTurnRequest
     { createTurnClientRequestId :: !(Maybe ClientRequestId)
     , createTurnInput :: !Text
+    , createTurnImages :: ![ImageAttachment]
     }
     deriving (Eq, Show)
 
@@ -393,7 +401,7 @@ instance FromJSON CreateTurnRequest where
     parseJSON = withObject "CreateTurnRequest" \value -> do
         rejectUnknownFields
             "CreateTurnRequest"
-            ["clientRequestId", "input"]
+            ["clientRequestId", "input", "images"]
             value
         rawRequestId <- value .:? "clientRequestId"
         requestId <- case rawRequestId of
@@ -405,7 +413,53 @@ instance FromJSON CreateTurnRequest where
                             (ClientRequestId
                                 (Text.toLower candidate)))
                 | otherwise -> fail "clientRequestId must be a UUID"
-        CreateTurnRequest requestId <$> value .: "input"
+        input <- value .:? "input" .!= ""
+        imageValues <- value .:? "images" .!= []
+        when (length imageValues > maxTurnImageCount) $
+            fail "images must contain at most one item"
+        images <- traverse parseTurnImage imageValues
+        pure (CreateTurnRequest requestId input images)
+
+maxTurnImageCount, maxTurnImageBytesEach :: Int
+maxTurnImageCount = 1
+maxTurnImageBytesEach = 20 * 1024 * 1024
+
+parseTurnImage :: Value -> Parser ImageAttachment
+parseTurnImage = withObject "TurnImage" \value -> do
+    rejectUnknownFields "TurnImage" ["mimeType", "data"] value
+    mime <- value .: "mimeType"
+    unless (mime `elem` supportedTurnImageTypes) $
+        fail "image mimeType must be image/jpeg, image/png, image/gif, image/webp, or image/bmp"
+    encoded <- value .: "data"
+    bytes <-
+        either
+            (const (fail "image data must be valid base64"))
+            pure
+            (Base64.decode (TextEncoding.encodeUtf8 encoded))
+    when (ByteString.null bytes) $
+        fail "image data must not be empty"
+    when (ByteString.length bytes > maxTurnImageBytesEach) $
+        fail "each image is limited to 20 MiB decoded"
+    unless (matchesTurnImageSignature mime bytes) $
+        fail "image data does not match its mimeType"
+    pure ImageAttachment{imageMime = mime, imageBytes = bytes}
+
+supportedTurnImageTypes :: [Text]
+supportedTurnImageTypes =
+    ["image/jpeg", "image/png", "image/gif", "image/webp", "image/bmp"]
+
+matchesTurnImageSignature :: Text -> ByteString.ByteString -> Bool
+matchesTurnImageSignature "image/jpeg" = ByteString.isPrefixOf "\xff\xd8\xff"
+matchesTurnImageSignature "image/png" =
+    ByteString.isPrefixOf "\x89PNG\r\n\x1a\n"
+matchesTurnImageSignature "image/gif" = \bytes ->
+    "GIF87a" `ByteString.isPrefixOf` bytes
+        || "GIF89a" `ByteString.isPrefixOf` bytes
+matchesTurnImageSignature "image/webp" = \bytes ->
+    "RIFF" `ByteString.isPrefixOf` bytes
+        && ByteString.take 4 (ByteString.drop 8 bytes) == "WEBP"
+matchesTurnImageSignature "image/bmp" = ByteString.isPrefixOf "BM"
+matchesTurnImageSignature _ = const False
 
 data ResolveRequest = ResolveRequest
     { resolveRequestDecision :: !Text

--- a/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
@@ -8,6 +8,7 @@ import Agent.Server.Auth
 import Agent.Server.Backend (Backend (..), SessionMutationLease (..))
 import Agent.Server.Supervisor
 import Agent.Server.Types
+import Agent.Loop (ImageAttachment(..))
 import Control.Concurrent.Async (cancel, wait, waitCatch, withAsync)
 import Control.Concurrent.MVar (
     MVar,
@@ -25,6 +26,7 @@ import Control.Monad (void)
 import Data.Aeson (Value (..), eitherDecode, object, (.=))
 import Data.Aeson.KeyMap qualified as KeyMap
 import Data.ByteString.Lazy.Char8 qualified as LBS8
+import Data.Either (isLeft)
 import Data.IORef (atomicModifyIORef', newIORef, readIORef)
 import Data.List (find)
 import Data.Set qualified as Set
@@ -67,6 +69,33 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "agent-server WAI application" do
+    it "decodes image-only turn requests" do
+        request <-
+            case eitherDecode
+                "{\"images\":[{\"mimeType\":\"image/png\",\"data\":\"iVBORw0KGgo=\"}]}"
+            of
+                Left err -> expectationFailure err >> fail "unreachable"
+                Right decoded -> pure decoded
+        request.createTurnInput `shouldBe` ""
+        request.createTurnImages
+            `shouldBe` [ImageAttachment "image/png" "\x89PNG\r\n\x1a\n"]
+
+    it "rejects invalid image base64 and media types" do
+        let decode body = eitherDecode body :: Either String CreateTurnRequest
+        decode "{\"input\":\"x\",\"images\":[{\"mimeType\":\"image/png\",\"data\":\"\"}]}"
+            `shouldSatisfy` isLeft
+        decode "{\"input\":\"x\",\"images\":[{\"mimeType\":\"image/png\",\"data\":\"!\"}]}"
+            `shouldSatisfy` isLeft
+        decode "{\"input\":\"x\",\"images\":[{\"mimeType\":\"image/svg+xml\",\"data\":\"PHN2Zz4=\"}]}"
+            `shouldSatisfy` isLeft
+        decode "{\"input\":\"x\",\"images\":[{\"mimeType\":\"image/png\",\"data\":\"R0lGODlh\"}]}"
+            `shouldSatisfy` isLeft
+
+    it "rejects more than one image per turn" do
+        let image = "{\"mimeType\":\"image/png\",\"data\":\"iVBORw0KGgo=\"}"
+        (eitherDecode ("{\"images\":[" <> image <> "," <> image <> "]}") :: Either String CreateTurnRequest)
+            `shouldSatisfy` isLeft
+
     it "rejects requests without the strict loopback Host" do
         withApplication immediateRunner \application -> do
             response <-

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -1030,6 +1030,7 @@ turnSpecFor boundary sessionId =
         , turnSpecClientRequestId =
             ClientRequestId "01999999-1111-7111-8111-111111111111"
         , turnSpecPrompt = "hello"
+        , turnSpecImages = []
         , turnSpecBoundary = boundary
         }
 


### PR DESCRIPTION
## Summary
- accept bounded base64 image attachments in agent-server turn requests
- propagate images into native multimodal turn inputs
- validate signatures, preserve idempotency, and bound queued image memory
- update client protocol and OpenAPI coverage

## Validation
- `git diff --check`
- OpenAPI JSON parses successfully
- full Nix/GHCi validation was attempted but the configured private binary cache returned repeated HTTP 500 responses
- host Cabal validation is blocked by missing zlib/OpenSSL/PostgreSQL development libraries

Companion gateway PR will be linked after creation.