### PR TITLE
Publish active account identity as one atomic snapshot

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -152,6 +152,7 @@ library
                     , Agent.CLI.TUI.Render.Workspace
                     , Paths_agent_cli
     exposed-modules:  Agent.CLI
+                    , Agent.CLI.ActiveAccount
                     , Agent.CLI.AccountPicker
                     , Agent.CLI.AccountSelection
                     , Agent.CLI.AgentSessions
@@ -436,7 +437,8 @@ test-suite agent-cli-test
     ghc-options:      -threaded
     hs-source-dirs:   test
     main-is:          Spec.hs
-    other-modules:    Agent.CLI.AccountSelectionSpec
+    other-modules:    Agent.CLI.ActiveAccountSpec
+                    , Agent.CLI.AccountSelectionSpec
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
                     , Agent.CLI.ArtifactSpec

--- a/packages/agent-cli/src/Agent/CLI/ActiveAccount.hs
+++ b/packages/agent-cli/src/Agent/CLI/ActiveAccount.hs
@@ -1,0 +1,71 @@
+-- | One coherent snapshot of the credential identity presented by a session.
+module Agent.CLI.ActiveAccount
+    ( ActiveAccount(..)
+    , ActiveAccountRef
+    , newActiveAccount
+    , readActiveAccount
+    , writeActiveAccount
+    , modifyActiveAccount
+    , trackCredentialAccount
+    ) where
+
+import Agent.Provider
+    ( Credential(..)
+    , TokenProvider
+    , getNextToken
+    , tokenProviderWithNextToken
+    )
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , atomicWriteIORef
+    , newIORef
+    , readIORef
+    )
+import Data.Text (Text)
+
+data ActiveAccount = ActiveAccount
+    { activeAccountId :: !Text
+    , activeSelectionId :: !Text
+    , activeAccountLabel :: !Text
+    }
+    deriving (Eq, Show)
+
+newtype ActiveAccountRef = ActiveAccountRef (IORef ActiveAccount)
+
+newActiveAccount :: ActiveAccount -> IO ActiveAccountRef
+newActiveAccount = fmap ActiveAccountRef . newIORef
+
+readActiveAccount :: ActiveAccountRef -> IO ActiveAccount
+readActiveAccount (ActiveAccountRef ref) = readIORef ref
+
+writeActiveAccount :: ActiveAccountRef -> ActiveAccount -> IO ()
+writeActiveAccount (ActiveAccountRef ref) = atomicWriteIORef ref
+
+modifyActiveAccount :: ActiveAccountRef -> (ActiveAccount -> ActiveAccount) -> IO ()
+modifyActiveAccount (ActiveAccountRef ref) update =
+    atomicModifyIORef' ref (\current -> (update current, ()))
+
+-- | Resolve the label before publishing any part of a newly acquired
+-- credential. A failed or cancelled resolver leaves the previous snapshot
+-- intact. Refreshing the same account retains its stable credential-source id.
+trackCredentialAccount
+    :: ActiveAccountRef
+    -> (Credential -> IO Text)
+    -> TokenProvider
+    -> TokenProvider
+trackCredentialAccount ref resolveLabel provider =
+    tokenProviderWithNextToken provider \failed ->
+        getNextToken provider failed >>= \case
+            Left err -> pure (Left err)
+            Right credential -> do
+                label <- resolveLabel credential
+                modifyActiveAccount ref \current -> ActiveAccount
+                    { activeAccountId = credential.accountId
+                    , activeSelectionId =
+                        if current.activeAccountId == credential.accountId
+                            then current.activeSelectionId
+                            else credential.accountId
+                    , activeAccountLabel = label
+                    }
+                pure (Right credential)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -4,6 +4,14 @@ module Agent.CLI.Runtime.Orchestration.Initialized
     , withPreparedStartupAuth
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccount(..)
+    , ActiveAccountRef
+    , newActiveAccount
+    , writeActiveAccount
+    , modifyActiveAccount
+    , trackCredentialAccount
+    )
 import Agent.CLI.AccountSelection
     ( PreparedProviderAccounts,
       SelectedAccount(..),
@@ -118,7 +126,6 @@ import Agent.Provider
       getNextToken,
       providerSlug,
       tokenProviderBillingMode,
-      tokenProviderWithNextToken,
       BillingMode(ApiBilled),
       FailedCredential(credential) )
 import Agent.Skills ( SkillCatalog(..) )
@@ -137,7 +144,7 @@ import Control.Concurrent.MVar
     )
 import Control.Exception.Safe ( onException )
 import Control.Monad ( forM_, void, when )
-import Data.IORef ( IORef, newIORef, readIORef, writeIORef )
+import Data.IORef ( IORef, newIORef, writeIORef )
 import Data.Maybe ( isNothing, fromMaybe, isJust )
 import Data.Text ( Text )
 import System.Environment ( lookupEnv )
@@ -209,9 +216,7 @@ data InitializedAuth = InitializedAuth
 
 data InitializedAccountRefs = InitializedAccountRefs
     { initializedGatewayModelsRef :: IORef (Maybe GatewayModelAccess)
-    , initializedActiveAccountIdRef :: IORef Text
-    , initializedActiveAccountRef :: IORef Text
-    , initializedActiveSelectionRef :: IORef Text
+    , initializedActiveAccountRef :: ActiveAccountRef
     , initializedPreferredOpenAiAccountRef :: IORef (Maybe Text)
     , initializedSelectableTokenProvider :: TokenProvider
     }
@@ -824,15 +829,12 @@ newInitializedAccountRefs request auth = do
                 (startupDie request.initializedStartup)
                 pure
     gatewayModelsRef <- newIORef initialGatewayModels
-    activeAccountRef <- newIORef ""
-    activeAccountIdRef <-
-        newIORef (maybe "" snd startupAccountIds)
-    activeSelectionRef <-
-        newIORef $
-            maybe
-                (fromMaybe "" loaded.loadedSelectionId)
-                fst
-                startupAccountIds
+    activeAccountRef <- newActiveAccount ActiveAccount
+        { activeAccountId = maybe "" snd startupAccountIds
+        , activeSelectionId =
+            maybe (fromMaybe "" loaded.loadedSelectionId) fst startupAccountIds
+        , activeAccountLabel = ""
+        }
     preferredOpenAiAccountRef <-
         newIORef $
             case (loaded.loadedProvider, startupAccountIds) of
@@ -856,9 +858,7 @@ newInitializedAccountRefs request auth = do
                 unguardedSelectableTokenProvider
     pure InitializedAccountRefs
         { initializedGatewayModelsRef = gatewayModelsRef
-        , initializedActiveAccountIdRef = activeAccountIdRef
         , initializedActiveAccountRef = activeAccountRef
-        , initializedActiveSelectionRef = activeSelectionRef
         , initializedPreferredOpenAiAccountRef =
             preferredOpenAiAccountRef
         , initializedSelectableTokenProvider =
@@ -873,7 +873,8 @@ initializeActiveHttpAuth
 initializeActiveHttpAuth targets auth refs = do
     initialHttp <- case targets.initializedCustomResponses of
         Just (connectionId, _) -> do
-            writeIORef activeAccountRef connectionId
+            modifyActiveAccount activeAccountRef \current ->
+                current { activeAccountLabel = connectionId }
             pure
                 ( selectableTokenProvider
                 , const (pure connectionId)
@@ -890,13 +891,12 @@ initializeActiveHttpAuth targets auth refs = do
                 probeLoadedAuthCredential loaded >>= \case
                     Right (credential, usable) -> do
                         label <- usable.loadedAccountLabel credential
-                        writeIORef activeAccountRef label
-                        writeIORef activeAccountIdRef credential.accountId
-                        let selectionId =
-                                fromMaybe
-                                    credential.accountId
-                                    usable.loadedSelectionId
-                        writeIORef activeSelectionRef selectionId
+                        writeActiveAccount activeAccountRef ActiveAccount
+                            { activeAccountId = credential.accountId
+                            , activeSelectionId =
+                                fromMaybe credential.accountId usable.loadedSelectionId
+                            , activeAccountLabel = label
+                            }
                         pure
                             ( usable.loadedTokenProvider
                             , usable.loadedAccountLabel
@@ -910,8 +910,11 @@ initializeActiveHttpAuth targets auth refs = do
                                 ClaudeCodeProvider -> "Claude Code"
                             selectionId =
                                 fromMaybe "" loaded.loadedSelectionId
-                        writeIORef activeAccountRef fallback
-                        writeIORef activeSelectionRef selectionId
+                        modifyActiveAccount activeAccountRef \current ->
+                            current
+                                { activeAccountLabel = fallback
+                                , activeSelectionId = selectionId
+                                }
                         pure
                             ( selectableTokenProvider
                             , loaded.loadedAccountLabel
@@ -931,8 +934,6 @@ initializeActiveHttpAuth targets auth refs = do
   where
     loaded = auth.initializedLoaded
     activeAccountRef = refs.initializedActiveAccountRef
-    activeAccountIdRef = refs.initializedActiveAccountIdRef
-    activeSelectionRef = refs.initializedActiveSelectionRef
     selectableTokenProvider =
         refs.initializedSelectableTokenProvider
 
@@ -963,12 +964,12 @@ makeSwitchableTokenProvider refs activeHttpAuth =
                             if current.activeHttpGeneration
                                 == snapshot.activeHttpGeneration
                                 then do
-                                    writeIORef
-                                        refs.initializedActiveAccountIdRef
-                                        credential.accountId
-                                    writeIORef
-                                        refs.initializedActiveAccountRef
-                                        label
+                                    modifyActiveAccount
+                                        refs.initializedActiveAccountRef \account ->
+                                            account
+                                                { activeAccountId = credential.accountId
+                                                , activeAccountLabel = label
+                                                }
                                     pure current
                                         { activeHttpAccountId =
                                             credential.accountId
@@ -1046,15 +1047,13 @@ selectInitializedHttpAccount
                                             writeIORef
                                                 refs.initializedGatewayModelsRef
                                                 selectedGatewayModels
-                                            writeIORef
-                                                refs.initializedActiveAccountIdRef
-                                                credential.accountId
-                                            writeIORef
-                                                refs.initializedActiveSelectionRef
-                                                selectionId
-                                            writeIORef
+                                            writeActiveAccount
                                                 refs.initializedActiveAccountRef
-                                                label
+                                                ActiveAccount
+                                                    { activeAccountId = credential.accountId
+                                                    , activeSelectionId = selectionId
+                                                    , activeAccountLabel = label
+                                                    }
                                             pure ActiveHttpAuth
                                                 { activeHttpGeneration =
                                                     current.activeHttpGeneration
@@ -1099,8 +1098,6 @@ newInitializedHttpRuntime auth refs activeHttpAuth =
             OpenAIProvider ->
                 trackCredentialAccount
                     refs.initializedActiveAccountRef
-                    refs.initializedActiveAccountIdRef
-                    refs.initializedActiveSelectionRef
                     resolveActiveAccountLabel
                     selectableTokenProvider
             _ -> switchableTokenProvider
@@ -1154,9 +1151,7 @@ launchInitializedTools request workspace targets auth refs httpRuntime =
         , connectedGateway = request.initializedConnectedGateway
         , learnAboutUserRequested = auth.initializedLearnAboutUserRequested
         , customBearerToken = auth.initializedCustomBearerToken
-        , activeAccountIdRef = refs.initializedActiveAccountIdRef
         , activeAccountRef = refs.initializedActiveAccountRef
-        , activeSelectionRef = refs.initializedActiveSelectionRef
         , baseToolEnv = startup.startupToolEnv
         , catalog = workspace.initializedCatalog
         , initialSkills = workspace.initializedSkills
@@ -1261,25 +1256,6 @@ loadPreparedOrStartupAuth
   where
     loadFallback =
         (, Nothing) <$> loadStartupAuth startup transition requestedProvider
-
-trackCredentialAccount
-    :: IORef Text
-    -> IORef Text
-    -> IORef Text
-    -> (Credential -> IO Text)
-    -> TokenProvider
-    -> TokenProvider
-trackCredentialAccount accountRef accountIdRef selectionRef resolveLabel provider =
-    tokenProviderWithNextToken provider \failed ->
-        getNextToken provider failed >>= \case
-            Left err -> pure (Left err)
-            Right credential -> do
-                previousAccountId <- readIORef accountIdRef
-                writeIORef accountIdRef credential.accountId
-                when (previousAccountId /= credential.accountId) $
-                    writeIORef selectionRef credential.accountId
-                resolveLabel credential >>= writeIORef accountRef
-                pure (Right credential)
 
 loadGatewayModelAccess
     :: Maybe GatewayCredential

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Claude.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Claude.hs
@@ -2,6 +2,10 @@ module Agent.CLI.Runtime.Orchestration.Providers.Claude
     ( runClaudeProvider
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccount(..)
+    , modifyActiveAccount
+    )
 import Agent.CLI.Auth.Types
     ( LoadedAuth
     , isGatewayLoadedAuth
@@ -214,7 +218,8 @@ runClaudeProvider request@AgentProviderRequest{..} nativeCapabilities =
                             roleWarn color $
                                 glyphWarn
                                     <> "Claude Code --yolo is active; host catastrophic-command and Plan Mode denies remain enforced."
-            writeIORef activeAccountRef claudeAuth.accountLabel
+            modifyActiveAccount activeAccountRef \current ->
+                current { activeAccountLabel = claudeAuth.accountLabel }
             claudeTranscriptRef <-
                 newIORef =<< readLiveTranscript conversationRef
             withClaudeCodeBackendWithHost

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenAI.hs
@@ -2,6 +2,11 @@ module Agent.CLI.Runtime.Orchestration.Providers.OpenAI
     ( runOpenAiProvider
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccount(..)
+    , readActiveAccount
+    , writeActiveAccount
+    )
 import Agent.CLI.Auth.Types
     ( LoadedAuth(..)
     , isGatewayLoadedAuth
@@ -209,15 +214,11 @@ newOpenAiProviderRuntime AgentProviderRequest{..} conn credential = do
                                         newCredential
                                         newHealthy
                                         newConn
-                                writeIORef
-                                    activeAccountIdRef
-                                    newCredential.accountId
-                                writeIORef
-                                    activeSelectionRef
-                                    newCredential.accountId
-                                writeIORef
-                                    activeAccountRef
-                                    label
+                                writeActiveAccount activeAccountRef ActiveAccount
+                                    { activeAccountId = newCredential.accountId
+                                    , activeSelectionId = newCredential.accountId
+                                    , activeAccountLabel = label
+                                    }
                                 writeIORef
                                     httpFallbackActive
                                     usesHttp
@@ -231,7 +232,7 @@ newOpenAiProviderRuntime AgentProviderRequest{..} conn credential = do
                     oldConnection <-
                         readIORef activeConnectionRef
                     previousAccountId <-
-                        readIORef activeAccountIdRef
+                        (.activeAccountId) <$> readActiveAccount activeAccountRef
                     let OpenAiPersistentConnection
                             _
                             oldHealthy

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Types.hs
@@ -2,6 +2,9 @@ module Agent.CLI.Runtime.Orchestration.Providers.Types
     ( AgentProviderRequest(..)
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccountRef
+    )
 import Agent.CLI.Auth.Types (LoadedAuth)
 import Agent.CLI.Compaction
     ( CompactOutcome
@@ -48,9 +51,7 @@ data AgentProviderRequest = AgentProviderRequest
         -> IO (Maybe Int)
         -> (Maybe Text -> IO (Either Text CompactOutcome))
         -> SessionRequest
-    , activeAccountIdRef :: IORef Text
-    , activeAccountRef :: IORef Text
-    , activeSelectionRef :: IORef Text
+    , activeAccountRef :: ActiveAccountRef
     , catalog :: ModelCatalog
     , claudeBypassEnabled :: Bool
     , contextTokensRef :: IORef (Maybe OccupancySnapshot)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -3,6 +3,9 @@ module Agent.CLI.Runtime.Orchestration.Session
     , runAgentSession
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccountRef
+    )
 import Agent.CLI.Auth
     ( LoadedAuth(loadedTokenProvider)
     , isGatewayLoadedAuth
@@ -125,7 +128,7 @@ import Agent.CLI.Session.Runtime.Types
                      automaticCompactionHookRef, skillsRef, skillInvocationsRef,
                      escPaused, interrupt, multiCtx, rootTurnRef, subagentSessions,
                      pendingNotices, storeRoot, agentTypes, legacyTarget, usageRef,
-                     accountRef, accountIdRef, selectionRef, accountLabel,
+                     accountRef, accountLabel,
                      selectAccount, onPersisted, compactRunner, codeModeRuntime),
       StartupRuntime(startupBackground, startupDatabaseStore,
                      startupNetworkRecovery, startupSessionState,
@@ -218,9 +221,7 @@ data AgentSessionRequest closeResult windowTitleResult = AgentSessionRequest
     , connectedGateway :: Maybe GatewayCredential
     , learnAboutUserRequested :: Bool
     , sessionTmp :: OsPath
-    , activeAccountIdRef :: IORef Text
-    , activeAccountRef :: IORef Text
-    , activeSelectionRef :: IORef Text
+    , activeAccountRef :: ActiveAccountRef
     , agentTypesRef :: GrokSubagentSpecs
     , allTools :: [AppTool]
     , recordImageGenerationInputs :: [ImageAttachment] -> IO ()
@@ -982,8 +983,6 @@ buildProviderSessionRequest
             , legacyTarget = request.legacySubagentTarget
             , usageRef = liveRuntime.sessionUsageRef
             , accountRef = request.activeAccountRef
-            , accountIdRef = request.activeAccountIdRef
-            , selectionRef = request.activeSelectionRef
             , accountLabel = request.resolveActiveAccountLabel
             , selectAccount = sessionSelectAccount
             , onPersisted = request.claimCurrentSession
@@ -1060,9 +1059,7 @@ launchPreparedSession request promptRuntime liveRuntime = do
                               request
                               promptRuntime
                               liveRuntime
-                    , activeAccountIdRef = request.activeAccountIdRef
                     , activeAccountRef = request.activeAccountRef
-                    , activeSelectionRef = request.activeSelectionRef
                     , catalog = request.catalog
                     , claudeBypassEnabled = request.claudeBypassEnabled
                     , contextTokensRef = liveRuntime.sessionContextTokensRef

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -3,6 +3,9 @@ module Agent.CLI.Runtime.Orchestration.Tools
     , runAgentTools
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccountRef
+    )
 import Agent.CLI.AgentSessions
     ( agentSessionTools,
       launchSessionThread,
@@ -333,9 +336,7 @@ data AgentToolsRequest windowTitleResult = AgentToolsRequest
     , connectedGateway :: Maybe GatewayCredential
     , learnAboutUserRequested :: Bool
     , customBearerToken :: Maybe Text
-    , activeAccountIdRef :: IORef Text
-    , activeAccountRef :: IORef Text
-    , activeSelectionRef :: IORef Text
+    , activeAccountRef :: ActiveAccountRef
     , baseToolEnv :: ToolEnv
     , catalog :: ModelCatalog
     , initialSkills :: SkillCatalog
@@ -1959,9 +1960,7 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
         , connectedGateway
         , learnAboutUserRequested
         , sessionTmp
-        , activeAccountIdRef
         , activeAccountRef
-        , activeSelectionRef
         , agentTypesRef
         , allTools
         , recordImageGenerationInputs =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -8,6 +8,10 @@ module Agent.CLI.Runtime.Repl
     , preparePromptSkillInputsWithPaste
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccount(..)
+    , readActiveAccount
+    )
 import Agent.CLI.AgentViewport
     ( renderAgentViewportPanelFor,
       AgentViewportEnv(viewportSelected, viewportEntries) )
@@ -203,7 +207,7 @@ replWithDraft env@SessionEnv
     pendingAttachments <- readLiveAttachments conversationRef
     let idleMode = replModeFromState planState policy
     usage <- readIORef usageRef
-    account <- readIORef accountRef
+    account <- (.activeAccountLabel) <$> readActiveAccount accountRef
     mlineResult <- case fullscreen of
         Just runtime -> do
             syncFullscreenContext env

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -5,6 +5,10 @@ module Agent.CLI.Runtime.Repl.Selection
     , selectRequestedAccount
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccount(..)
+    , readActiveAccount
+    )
 import Agent.CLI.AccountPicker
     ( AccountPickerOption(..),
       accountPickerMatches,
@@ -147,8 +151,9 @@ selectRequestedAccountWithoutGateway env requestedProvider selector =
                 (Left
                     "Account selection needs the fullscreen account picker; use /login in minimal mode")
         Just runtime -> do
-            currentSelectionId <- readIORef env.sessionAccountSelectionId
-            currentAccountId <- readIORef env.sessionAccountId
+            account <- readActiveAccount env.sessionAccount
+            let currentSelectionId = account.activeSelectionId
+                currentAccountId = account.activeAccountId
             loaded <- withActivity runtime $
                 loadAllAccountPickerOptions env.sessionProvider
             let options =
@@ -249,7 +254,7 @@ selectRequestedAccountWithoutGateway env requestedProvider selector =
                     pure (Right Nothing)
         | otherwise = do
             params <- readIORef env.sessionParams
-            currentAccount <- readIORef env.sessionAccount
+            currentAccount <- (.activeAccountLabel) <$> readActiveAccount env.sessionAccount
             requestAccountProviderSwitch
                 env.sessionModelCatalog
                 (Just runtime)
@@ -296,8 +301,6 @@ handleSelection
             , sessionProjectRoot = projectRoot
             , sessionHome = home
             , sessionDraft = draftRef
-            , sessionAccountId = accountIdRef
-            , sessionAccountSelectionId = selectionRef
             , sessionSelectAccount = selectAccount
             , sessionTokenProvider = tokenProvider
             , sessionFullscreen = fullscreen
@@ -628,8 +631,9 @@ handleSelection
     chooseAccountFromOptions next =
         case fullscreen of
             Just runtime -> do
-                currentSelectionId <- readIORef selectionRef
-                currentAccountId <- readIORef accountIdRef
+                account <- readActiveAccount env.sessionAccount
+                let currentSelectionId = account.activeSelectionId
+                    currentAccountId = account.activeAccountId
                 options <- withReplActivity
                     "Loading account usage…"
                     (loadAllAccountPickerOptionsCached databasePool provider)
@@ -756,7 +760,7 @@ handleSelection
                                         next
                         | otherwise = do
                             params <- readIORef paramsRef
-                            currentAccount <- readIORef env.sessionAccount
+                            currentAccount <- (.activeAccountLabel) <$> readActiveAccount env.sessionAccount
                             requestAccountProviderSwitch
                                 catalog fullscreen provider connectionId
                                 (currentModel params) currentAccount

--- a/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
@@ -8,6 +8,10 @@ module Agent.CLI.Session.Interaction
     , syncFullscreenPrompt
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccount(..)
+    , readActiveAccount
+    )
 import Agent.CLI.Btw
     ( formatBtwError
     , runBtwWithCancel
@@ -90,7 +94,7 @@ syncFullscreenPrompt env = do
         planState <- readIORef env.sessionPlanMode.planStateRef
         params <- readIORef env.sessionParams
         policy <- readIORef env.sessionPolicy
-        account <- readIORef env.sessionAccount
+        account <- (.activeAccountLabel) <$> readActiveAccount env.sessionAccount
         usage <- readIORef env.sessionUsage
         attachments <- readLiveAttachments env.sessionConversation
         emitUiEvent runtime $ UiSetPrompt $

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -6,6 +6,10 @@ module Agent.CLI.Session.Lifecycle
     , runPendingTurn
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccount(..)
+    , readActiveAccount
+    )
 import Agent.CLI.Notification
     ( AttentionRequest(InputRequested)
     , notifyAttention
@@ -151,8 +155,9 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
     TurnSucceeded -> do
         env.sessionQueueRecap RecapTurnSummary
         writeIORef env.sessionUnavailableProviders Set.empty
-        selectionId <- readIORef env.sessionAccountSelectionId
-        accountId <- readIORef env.sessionAccountId
+        account <- readActiveAccount env.sessionAccount
+        let selectionId = account.activeSelectionId
+            accountId = account.activeAccountId
         when
             (not (Text.null (Text.strip selectionId))
                 && not (Text.null (Text.strip accountId))) $

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -1489,8 +1489,6 @@ buildSessionEnv
         , sessionStoreRoot = storeRoot
         , sessionUsage = usageRef
         , sessionAccount = accountRef
-        , sessionAccountId = accountIdRef
-        , sessionAccountSelectionId = selectionRef
         , sessionAccountLabel = accountLabel
         , sessionSelectAccount = selectAccount
         , sessionLastAssistant = controls.controlLastAssistantRef

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -8,6 +8,9 @@ module Agent.CLI.Session.Runtime.Types
     , StartupRuntime(..)
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccountRef
+    )
 import Agent.CLI.AgentViewport
     ( AgentEntry
     , AgentTarget
@@ -190,9 +193,7 @@ data SessionRequest = SessionRequest
     , agentTypes :: !GrokSubagentSpecs
     , legacyTarget :: !(Maybe LegacySubagentTarget)
     , usageRef :: !(IORef TokenUsage)
-    , accountRef :: !(IORef Text)
-    , accountIdRef :: !(IORef Text)
-    , selectionRef :: !(IORef Text)
+    , accountRef :: !ActiveAccountRef
     , accountLabel :: !(Credential -> IO Text)
     , selectAccount :: !(Maybe (Text -> IO (Either ApiError Text)))
     , onPersisted :: !(SessionHandle -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -4,6 +4,9 @@ module Agent.CLI.SessionEnv
     , SessionEnv(..)
     ) where
 
+import Agent.CLI.ActiveAccount
+    ( ActiveAccountRef
+    )
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.AgentViewport (AgentViewportEnv)
 import Agent.CLI.GatewayClient (GatewayModelAccess)
@@ -114,9 +117,7 @@ data SessionEnv = SessionEnv
     , sessionLastFailedTurn :: !(IORef (Maybe PendingTurn))
     , sessionStoreRoot :: !(IORef (Maybe OsPath))
     , sessionUsage :: !(IORef TokenUsage)
-    , sessionAccount :: !(IORef Text)
-    , sessionAccountId :: !(IORef Text)
-    , sessionAccountSelectionId :: !(IORef Text)
+    , sessionAccount :: !ActiveAccountRef
     , sessionAccountLabel :: !(Credential -> IO Text)
     , sessionSelectAccount
         :: !(Maybe (Text -> IO (Either ApiError Text)))

--- a/packages/agent-cli/test/Agent/CLI/ActiveAccountSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ActiveAccountSpec.hs
@@ -1,0 +1,71 @@
+module Agent.CLI.ActiveAccountSpec (spec) where
+
+import Agent.CLI.ActiveAccount
+import Agent.Provider
+    ( BillingMode(..)
+    , Credential(..)
+    , Provider(..)
+    , getNextToken
+    , tokenProvider
+    )
+import Control.Concurrent.Async (cancel, wait, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Exception.Safe (throwIO)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "active account snapshots" do
+    it "publishes the identity and label together after resolving the label" do
+        ref <- newActiveAccount original
+        started <- newEmptyMVar
+        finish <- newEmptyMVar
+        let tracked = trackCredentialAccount ref
+                (\_ -> putMVar started () >> takeMVar finish)
+                (tokenProvider SubscriptionBilled (\_ -> pure (Right replacement)))
+        withAsync (getNextToken tracked Nothing) \worker -> do
+            takeMVar started
+            readActiveAccount ref `shouldReturn` original
+            putMVar finish "New account"
+            wait worker `shouldReturn` Right replacement
+        readActiveAccount ref `shouldReturn`
+            ActiveAccount "new-id" "new-id" "New account"
+
+    it "retains the entire previous account when label resolution throws" do
+        ref <- newActiveAccount original
+        let tracked = trackCredentialAccount ref
+                (\_ -> throwIO (userError "label unavailable"))
+                (tokenProvider SubscriptionBilled (\_ -> pure (Right replacement)))
+        getNextToken tracked Nothing `shouldThrow` anyIOException
+        readActiveAccount ref `shouldReturn` original
+
+    it "retains the entire previous account when label resolution is cancelled" do
+        ref <- newActiveAccount original
+        started <- newEmptyMVar
+        finish <- newEmptyMVar
+        let tracked = trackCredentialAccount ref
+                (\_ -> putMVar started () >> takeMVar finish)
+                (tokenProvider SubscriptionBilled (\_ -> pure (Right replacement)))
+        withAsync (getNextToken tracked Nothing) \worker -> do
+            takeMVar started
+            cancel worker
+        readActiveAccount ref `shouldReturn` original
+
+    it "preserves a stable selection id when refreshing the same account" do
+        ref <- newActiveAccount original
+        let credential = replacement { accountId = original.activeAccountId }
+            tracked = trackCredentialAccount ref (\_ -> pure "Updated label")
+                (tokenProvider SubscriptionBilled (\_ -> pure (Right credential)))
+        getNextToken tracked Nothing `shouldReturn` Right credential
+        readActiveAccount ref `shouldReturn`
+            original { activeAccountLabel = "Updated label" }
+
+original :: ActiveAccount
+original = ActiveAccount "old-id" "managed:source" "Old account"
+
+replacement :: Credential
+replacement = Credential
+    { accessToken = "token"
+    , accountId = "new-id"
+    , leaseId = Nothing
+    , provider = OpenAIProvider
+    }

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -27,6 +27,7 @@ import Test.Hspec.Runner
     )
 import Text.Read (readMaybe)
 
+import qualified Agent.CLI.ActiveAccountSpec as ActiveAccountSpec
 import qualified Agent.CLI.AccountSelectionSpec as AccountSelectionSpec
 import qualified Agent.CLI.AgentSessionsSpec as AgentSessionsSpec
 import qualified Agent.CLI.AgentViewportSpec as AgentViewportSpec
@@ -152,6 +153,7 @@ main = do
 
 specs :: Spec
 specs = do
+    ActiveAccountSpec.spec
     AccountSelectionSpec.spec
     AgentViewportSpec.spec
     AgentViewportRuntimeSpec.spec


### PR DESCRIPTION
Account identity was spread across three independently writable `IORef`s. During credential rotation, the account and selection IDs could change before label resolution completed; an exception or cancellation then left a mixed identity visible to the session.

Publish one strict `ActiveAccount` record through an opaque reference. Resolve credential labels before the atomic update, retain stable source-selection IDs when refreshing the same credential, and read one snapshot wherever an ID/selection pair is needed. Provider rotation, startup, session persistence, and account-picker callers now share this representation.

Validation:
- Nix/Cabal GHCi loaded all 211 CLI library modules.
- All 18 account snapshot and account selection tests pass, covering blocked, failing, and cancelled label resolution and stable source-selection IDs.
- Regenerated `package.nix` with `cabal2nix`; output unchanged because dependencies are unchanged.
- Live CLI in tmux: startup, `/session-info`, and return to the prompt passed. The first startup encountered a transient gateway connection error; retry succeeded.
