### PR TITLE
Hand stdin between Esc watcher and prompts with explicit ownership

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
+++ b/packages/agent-cli/src/Agent/CLI/CancelWatch.hs
@@ -5,6 +5,9 @@ module Agent.CLI.CancelWatch
     ( EscapeContinuation(..)
     , readEscapeContinuation
     , escapeContinuationCancels
+    , StdinControl
+    , newStdinControl
+    , withStdinOwnership
     , withEscCancel
     , withStdinPaused
     , isBareEscape
@@ -14,8 +17,8 @@ import Agent.Cancel (CancelFlag, requestCancel)
 import Agent.CLI.Input.KeyDecoder (kittyRelease, parseKittyKey)
 import Agent.CLI.Input.Types (KittyKey(..))
 import Agent.CLI.Terminal (rawAttrs)
-import Control.Concurrent (forkIO, threadDelay)
-import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent (forkIOWithUnmask)
+import Control.Concurrent.MVar (MVar, newMVar, newEmptyMVar, putMVar, readMVar, withMVar)
 import Control.Exception.Safe (bracket, finally)
 import Control.Monad (void, when)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -39,64 +42,67 @@ import System.Posix.Terminal
     , withMode
     )
 
+-- | Shared ownership of stdin between the turn watcher and interactive prompts.
+-- A reader owns the lease for its entire input operation, including any
+-- fragmented escape sequence. Prompt entry therefore acknowledges that the
+-- watcher has finished reading instead of guessing from a polling interval.
+newtype StdinControl = StdinControl (MVar ())
+
+newStdinControl :: IO StdinControl
+newStdinControl = StdinControl <$> newMVar ()
+
+-- | Serialize stdin readers. Do not nest ownership of the same control.
+withStdinOwnership :: StdinControl -> IO a -> IO a
+withStdinOwnership (StdinControl owner) action = withMVar owner (const action)
+
 -- | Run @action@ while Esc on a TTY stdin requests soft cancel.
 -- Restores the pre-call terminal attributes afterward. Non-TTY is a no-op.
 --
--- @paused@ suspends stdin reads (see 'withStdinPaused') so approval prompts
--- can use cooked 'getLine' without the watcher stealing keystrokes.
---
--- The watcher is never 'killThread'ed while blocked on stdin: that can leave
--- the Handle lock stuck and break the next haskeline prompt (arrow keys print
--- as raw CSI like @^[OA@). Instead we set a stop flag and wait for the
--- watcher's short poll timeout to exit.
-withEscCancel :: CancelFlag -> IORef Bool -> IO a -> IO a
-withEscCancel cancel paused action = do
+-- The watcher is never killed while blocked on stdin: that can leave the
+-- Handle lock stuck. Its owner asks it to stop and joins it before restoring
+-- terminal settings. A prompt can acquire stdin with 'withStdinPaused'.
+withEscCancel :: CancelFlag -> StdinControl -> IO a -> IO a
+withEscCancel cancel control action = do
     tty <- hIsTerminalDevice stdin
     if not tty
         then action
-        else do
-            oldTerm <- getTerminalAttributes stdInput
-            oldBuf <- hGetBuffering stdin
+        else bracket snapshot restore \(oldTerm, _) -> do
+            withStdinOwnership control do
+                setTerminalAttributes stdInput (rawAttrs oldTerm) Immediately
+                hSetBuffering stdin NoBuffering
             stopped <- newIORef False
             done <- newEmptyMVar
-            let enter = do
-                    setTerminalAttributes stdInput (rawAttrs oldTerm) Immediately
-                    hSetBuffering stdin NoBuffering
-                restore = do
-                    -- Ask the watcher to exit, then wait for its poll loop.
-                    writeIORef stopped True
-                    void (takeMVar done)
-                    setTerminalAttributes stdInput oldTerm Immediately
-                    hSetBuffering stdin oldBuf
-            bracket enter (const restore) \() -> do
-                _ <- forkIO $
-                    escLoop cancel paused stopped
+            let start = forkIOWithUnmask \unmask ->
+                    unmask (escLoop cancel control stopped)
                         `finally` putMVar done ()
-                action
+                stop _ = do
+                    writeIORef stopped True
+                    readMVar done
+            bracket start stop (const action)
+  where
+    snapshot = withStdinOwnership control $
+        (,) <$> getTerminalAttributes stdInput <*> hGetBuffering stdin
+    restore (term, buffering) = withStdinOwnership control do
+        setTerminalAttributes stdInput term Immediately
+        hSetBuffering stdin buffering
 
--- | Temporarily stop the Esc watcher and restore cooked stdin for approval.
-withStdinPaused :: IORef Bool -> IO a -> IO a
-withStdinPaused paused action = do
+-- | Own stdin and restore cooked input for the duration of a prompt. Taking
+-- the lease waits for any in-flight watcher read to finish. Brackets release
+-- ownership and restore terminal settings on errors or cancellation as well.
+withStdinPaused :: StdinControl -> IO a -> IO a
+withStdinPaused control action = withStdinOwnership control do
     tty <- hIsTerminalDevice stdin
     if not tty
         then action
-        else do
-            -- Snapshot the active (raw) attrs so we can put them back.
-            activeTerm <- getTerminalAttributes stdInput
-            activeBuf <- hGetBuffering stdin
-            let cooked = cookedAttrs activeTerm
-                enter = do
-                    writeIORef paused True
-                    -- Give the watcher one poll interval to observe @paused@
-                    -- before we start reading approval input.
-                    threadDelay 120000
-                    setTerminalAttributes stdInput cooked Immediately
-                    hSetBuffering stdin LineBuffering
-                restore = do
-                    setTerminalAttributes stdInput activeTerm Immediately
-                    hSetBuffering stdin activeBuf
-                    writeIORef paused False
-            bracket enter (const restore) (\_ -> action)
+        else bracket snapshot restore \(activeTerm, _) -> do
+            setTerminalAttributes stdInput (cookedAttrs activeTerm) Immediately
+            hSetBuffering stdin LineBuffering
+            action
+  where
+    snapshot = (,) <$> getTerminalAttributes stdInput <*> hGetBuffering stdin
+    restore (term, buffering) = do
+        setTerminalAttributes stdInput term Immediately
+        hSetBuffering stdin buffering
 
 cookedAttrs :: TerminalAttributes -> TerminalAttributes
 cookedAttrs term =
@@ -111,47 +117,36 @@ isBareEscape = \case
     "\ESC" -> True
     _ -> False
 
-escLoop :: CancelFlag -> IORef Bool -> IORef Bool -> IO ()
-escLoop cancel paused stopped = go
+escLoop :: CancelFlag -> StdinControl -> IORef Bool -> IO ()
+escLoop cancel control stopped = go
   where
     go = do
+        continue <- withStdinOwnership control do
+            done <- readIORef stopped
+            if done then pure False else readKey
+        when continue go
+
+    readKey = do
+        ready <- hWaitForInput stdin 100
         done <- readIORef stopped
         if done
-            then pure ()
-            else do
-                isPaused <- readIORef paused
-                if isPaused
-                    then hWaitForInput stdin 100 >> go
-                    else do
-                        ready <- hWaitForInput stdin 100
-                        done' <- readIORef stopped
-                        if done'
-                            then pure ()
-                            else if not ready
-                                then go
+            then pure False
+            else if not ready
+                then pure True
+                else do
+                    c <- hGetChar stdin
+                    if c /= '\ESC'
+                        then pure True
+                        else do
+                            more <- hWaitForInput stdin 50
+                            cancels <- if not more
+                                then pure True
                                 else do
-                                    -- Re-check pause: approval may have started
-                                    -- between wait and read.
-                                    isPaused' <- readIORef paused
-                                    if isPaused'
-                                        then go
-                                        else do
-                                            c <- hGetChar stdin
-                                            if c /= '\ESC'
-                                                then go
-                                                else do
-                                                    -- Peek for CSI / SS3 so arrows do not cancel,
-                                                    -- but a Kitty-encoded Esc key press must.
-                                                    more <- hWaitForInput stdin 50
-                                                    if not more
-                                                        then requestCancel cancel
-                                                        else do
-                                                            c2 <- hGetChar stdin
-                                                            continuation <-
-                                                                readEscapeContinuation stdin c2
-                                                            if escapeContinuationCancels continuation
-                                                                then requestCancel cancel
-                                                                else go
+                                    c2 <- hGetChar stdin
+                                    escapeContinuationCancels
+                                        <$> readEscapeContinuation stdin c2
+                            when cancels (requestCancel cancel)
+                            pure (not cancels)
 
 -- | The tail of an escape sequence read after a leading ESC byte.
 data EscapeContinuation

--- a/packages/agent-cli/src/Agent/CLI/McpElicitation.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpElicitation.hs
@@ -10,7 +10,7 @@ module Agent.CLI.McpElicitation
     , renderElicitationHeader
     ) where
 
-import Agent.CLI.CancelWatch (withStdinPaused)
+import Agent.CLI.CancelWatch (StdinControl, withStdinPaused)
 import Agent.CLI.Input (readApprovalLine)
 import Agent.CLI.Notification
     ( AttentionRequest(InputRequested)
@@ -57,15 +57,15 @@ import System.Process (rawSystem)
 -- | Elicitation hook for the CLI. Uses the fullscreen UI when one is active
 -- and the terminal otherwise; without a terminal the request is cancelled.
 cliMcpElicitation
-    :: IORef Bool
+    :: StdinControl
     -> IORef (Maybe FullscreenRuntime)
     -> McpElicitRequest
     -> IO McpElicitResult
-cliMcpElicitation escPaused runtimeRef request = do
+cliMcpElicitation stdinControl runtimeRef request = do
     runtime <- readIORef runtimeRef
     case runtime of
         Just active -> fullscreenElicitation active request
-        Nothing -> lineElicitation escPaused request
+        Nothing -> lineElicitation stdinControl request
 
 -- | The host component of a URL, shown prominently so users can judge where
 -- a URL-mode elicitation leads.
@@ -88,9 +88,9 @@ sanitize = Text.map (\character -> if isControl character && character /= '\n' t
 
 -- * Line mode
 
-lineElicitation :: IORef Bool -> McpElicitRequest -> IO McpElicitResult
-lineElicitation escPaused request =
-    withStdinPaused escPaused do
+lineElicitation :: StdinControl -> McpElicitRequest -> IO McpElicitResult
+lineElicitation stdinControl request =
+    withStdinPaused stdinControl do
         tty <- hIsTerminalDevice stdin
         if not tty
             then pure McpElicitCancel

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -19,7 +19,7 @@ module Agent.CLI.Plan
     , planDecisionFollowUp
     ) where
 
-import Agent.CLI.CancelWatch (withStdinPaused)
+import Agent.CLI.CancelWatch (StdinControl, withStdinPaused)
 import Agent.CLI.Input
     ( ReplLine(..)
     , readChoiceSelection
@@ -53,7 +53,6 @@ import Agent.Provider (Provider)
 import Control.Exception (AsyncException(UserInterrupt))
 import Control.Exception.Safe (throwIO)
 import Data.Char (toLower)
-import Data.IORef (IORef)
 import Data.Maybe (fromMaybe, isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -65,15 +64,15 @@ import System.Console.ANSI
 import System.Console.ANSI.Codes (clearFromCursorToLineEndCode)
 import System.IO (Handle, hFlush, hIsTerminalDevice, stderr, stdin)
 
--- | Build plan-mode prompts. @escPaused@ pauses the Esc cancel watcher so
+-- | Build plan-mode prompts. @stdinControl@ pauses the Esc cancel watcher so
 -- arrow keys / single-key answers are not stolen mid-turn.
-cliPlanHooks :: Provider -> InterruptState -> IORef Bool -> IO Bool -> PlanModeHooks
-cliPlanHooks provider interrupt escPaused resolveColor = PlanModeHooks
-    { planConfirmEnter = withStdinPaused escPaused . confirmEnter resolveColor
+cliPlanHooks :: Provider -> InterruptState -> StdinControl -> IO Bool -> PlanModeHooks
+cliPlanHooks provider interrupt stdinControl resolveColor = PlanModeHooks
+    { planConfirmEnter = withStdinPaused stdinControl . confirmEnter resolveColor
     , planDecideExit =
-        withStdinPaused escPaused . decideExit provider interrupt resolveColor
+        withStdinPaused stdinControl . decideExit provider interrupt resolveColor
     , planAskQuestion = \q opts ->
-        withStdinPaused escPaused
+        withStdinPaused stdinControl
             (askQuestion provider interrupt resolveColor q opts)
     }
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/MetaConsole.hs
@@ -413,7 +413,7 @@ metaCancelScope env cancel action =
         case env.sessionFullscreen of
             Nothing
                 | not env.sessionBackground ->
-                    withEscCancel cancel env.sessionEscPaused action
+                    withEscCancel cancel env.sessionStdinControl action
             _ -> action
 
 shellModeText :: ShellMode -> Text

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Runtime.Orchestration.Flow
     , withRestoredCurrentDirectory
     ) where
 
+import Agent.CLI.CancelWatch (newStdinControl)
 import Agent.CLI.AgentSessions ( signalManagedSessionReady )
 import Agent.CLI.AgentViewport ( AgentTarget(AgentRoot) )
 import Agent.CLI.Config
@@ -105,7 +106,7 @@ import Agent.CLI.Session.Runtime.Types
       StartupRuntime(startupSessionState, StartupRuntime, startupToolEnv,
                      startupHarnessConfig,
                      startupNetworkRecovery, startupDatabaseStore,
-                     startupInterrupt, startupEscPaused,
+                     startupInterrupt, startupStdinControl,
                      startupUiRuntimeRef, startupFullscreen, startupTerminal,
                      startupStdout, startupStderr, startupBackground, startupUseColor,
                      startupStderrTty, startupStdinTty, startupStdoutTty,
@@ -912,7 +913,7 @@ prepareAgentIterationInterface request resources = do
                 color <- resolveColor stderrHandle
                 putTextLn stderrHandle (roleMuted color msg)
     -- Shared with Esc cancel and plan prompts so arrow-key pickers own stdin.
-    escPaused <- newIORef False
+    stdinControl <- newStdinControl
     stderrTty <-
         if background then pure False else hIsTerminalDevice stderrHandle
     stdinTty <- if background then pure False else hIsTerminalDevice stdin
@@ -1013,7 +1014,7 @@ prepareAgentIterationInterface request resources = do
                 request.iterationProcessRuntime.processNetworkRecovery
             , startupDatabaseStore = resources.iterationDatabaseStore
             , startupInterrupt = interrupt
-            , startupEscPaused = escPaused
+            , startupStdinControl = stdinControl
             , startupUiRuntimeRef = uiRuntimeRef
             , startupFullscreen = fullscreen
             , startupTerminal = terminal

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -97,7 +97,7 @@ import Agent.CLI.Session.History ( detectGitBranch )
 import Agent.CLI.Session.Runtime.Types
     ( StartupRuntime(startupToolEnv, startupStderr, startupStdout,
                      startupStdoutTty, startupStdinTty, startupFullscreen,
-                     startupUiRuntimeRef, startupEscPaused, startupInterrupt,
+                     startupUiRuntimeRef, startupStdinControl, startupInterrupt,
                      startupDatabaseStore, startupNativeHooks) )
 import Agent.CLI.SessionLock ( releaseSessionLock, SessionLock )
 import Agent.CLI.Skills ( loadSkillsCatalogQuiet )
@@ -1169,7 +1169,7 @@ launchInitializedTools request workspace targets auth refs httpRuntime =
         , customResponses = targets.initializedCustomResponses
         , cwd = request.initializedCwd
         , databaseScopes = workspace.initializedDatabaseScopes
-        , escPaused = startup.startupEscPaused
+        , stdinControl = startup.startupStdinControl
         , fullscreen
         , home = request.initializedHome
         , interrupt = startup.startupInterrupt

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Runtime.Orchestration.Session
     , runAgentSession
     ) where
 
+import Agent.CLI.CancelWatch (StdinControl)
 import Agent.CLI.Auth
     ( LoadedAuth(loadedTokenProvider)
     , isGatewayLoadedAuth
@@ -123,7 +124,7 @@ import Agent.CLI.Session.Runtime.Types
                      startupWindowTitle, automaticCompactionRef,
                      projectRoot, home, cwd, tokenProvider, openAiPool, startupContext,
                      automaticCompactionHookRef, skillsRef, skillInvocationsRef,
-                     escPaused, interrupt, multiCtx, rootTurnRef, subagentSessions,
+                     stdinControl, interrupt, multiCtx, rootTurnRef, subagentSessions,
                      pendingNotices, storeRoot, agentTypes, legacyTarget, usageRef,
                      accountRef, accountIdRef, selectionRef, accountLabel,
                      selectAccount, onPersisted, compactRunner, codeModeRuntime),
@@ -244,7 +245,7 @@ data AgentSessionRequest closeResult windowTitleResult = AgentSessionRequest
     , initialContextPreload :: InitialContextPreload
     , dialect :: Dialect
     , effortText :: Text
-    , escPaused :: IORef Bool
+    , stdinControl :: StdinControl
     , extraTools :: [AppTool]
     , fullscreen :: Maybe FullscreenRuntime
     , gatewayTools :: [AppTool]
@@ -971,7 +972,7 @@ buildProviderSessionRequest
                 promptRuntime.sessionAutomaticCompactionHookRef
             , skillsRef = request.skillsRef
             , skillInvocationsRef = request.skillInvocationsRef
-            , escPaused = request.escPaused
+            , stdinControl = request.stdinControl
             , interrupt = request.interrupt
             , multiCtx = request.multiCtx
             , rootTurnRef = request.rootTurnRef

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Runtime.Orchestration.Tools
     , runAgentTools
     ) where
 
+import Agent.CLI.CancelWatch (StdinControl)
 import Agent.CLI.AgentSessions
     ( agentSessionTools,
       launchSessionThread,
@@ -346,7 +347,7 @@ data AgentToolsRequest windowTitleResult = AgentToolsRequest
     , customResponses :: Maybe (Text, ResponsesConnection)
     , cwd :: OsPath
     , databaseScopes :: DatabaseScopes
-    , escPaused :: IORef Bool
+    , stdinControl :: StdinControl
     , fullscreen :: Maybe FullscreenRuntime
     , home :: OsPath
     , interrupt :: InterruptState
@@ -849,7 +850,7 @@ buildToolHostHooks
     -> ToolHostHooks
 buildToolHostHooks AgentToolsRequest
     { interrupt
-    , escPaused
+    , stdinControl
     , stderrHandle
     , uiRuntimeRef
     , options
@@ -873,11 +874,11 @@ buildToolHostHooks AgentToolsRequest
                 }
         | otherwise =
             cliPlanHooks
-                provider interrupt escPaused (resolveColor stderrHandle)
+                provider interrupt stdinControl (resolveColor stderrHandle)
     toolPlanHooks = fullscreenAwarePlanHooks uiRuntimeRef basePlanHooks
     baseSecretHooks = SecretPromptHooks \request ->
         Right <$> promptSecretLine
-            escPaused
+            stdinControl
             request.secretPromptMessage
             request.secretPromptPurpose
     toolSecretHooks
@@ -1330,7 +1331,7 @@ acquireMcpRuntime request@AgentToolsRequest
     , startup
     , options
     , isTty
-    , escPaused
+    , stdinControl
     , uiRuntimeRef
     , baseToolEnv
     , mcpSupervisor
@@ -1351,7 +1352,7 @@ acquireMcpRuntime request@AgentToolsRequest
             then Nothing
             else Just \elicitation ->
                 withToolHumanInputWait baseToolEnv $
-                    cliMcpElicitation escPaused uiRuntimeRef elicitation)
+                    cliMcpElicitation stdinControl uiRuntimeRef elicitation)
     let enqueueMcpSnapshot statuses =
             unless (null statuses) do
                 instructions <-
@@ -1986,7 +1987,7 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
         , initialContextPreload
         , dialect
         , effortText
-        , escPaused
+        , stdinControl
         , extraTools
         , fullscreen
         , gatewayTools

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Recap.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Recap.hs
@@ -80,7 +80,7 @@ runSessionRecap registerCancel env kind = do
                                             | otherwise ->
                                             withEscCancel
                                                 cancel
-                                                env.sessionEscPaused
+                                                env.sessionStdinControl
                                                 action
                                         Just _ -> action
                             else action)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
@@ -358,7 +358,7 @@ promptMetaSecret runtime title body =
             requestFullscreenSecret fullscreen title body
         Nothing ->
             promptSecretLine
-                (metaEnv runtime).sessionEscPaused
+                (metaEnv runtime).sessionStdinControl
                 body
                 (Just
                     "Meta Console configuration; the value is written only to the local config file")

--- a/packages/agent-cli/src/Agent/CLI/Secret.hs
+++ b/packages/agent-cli/src/Agent/CLI/Secret.hs
@@ -5,14 +5,13 @@ module Agent.CLI.Secret
     , secretPromptMessage
     ) where
 
-import Agent.CLI.CancelWatch (withStdinPaused)
+import Agent.CLI.CancelWatch (StdinControl, withStdinPaused)
 import Agent.CLI.Notification
     ( AttentionRequest(SecretRequested)
     , notifyAttention
     )
 import Control.Exception.Safe (bracket_, finally, tryIO)
 import Data.Char (isControl)
-import Data.IORef (IORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -31,12 +30,12 @@ import System.IO
 -- ordinary REPL input path or its history. An unavailable terminal or empty
 -- value returns 'Nothing'.
 promptSecretLine
-    :: IORef Bool
+    :: StdinControl
     -> Text
     -> Maybe Text
     -> IO (Maybe Text)
-promptSecretLine escPaused prompt purpose =
-    withStdinPaused escPaused do
+promptSecretLine stdinControl prompt purpose =
+    withStdinPaused stdinControl do
         tty <- hIsTerminalDevice stdin
         if not tty
             then pure Nothing

--- a/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
@@ -207,7 +207,7 @@ runBtwQuestion registerCancel env question = do
                                     | otherwise ->
                                         withEscCancel
                                             cancel
-                                            env.sessionEscPaused
+                                            env.sessionStdinControl
                                             action
                                 Just _ -> action
                     else action)

--- a/packages/agent-cli/src/Agent/CLI/Session/Retry.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Retry.hs
@@ -94,7 +94,7 @@ waitAndRetryPendingTurn resumeDraft retryPending env delay pending = do
             Nothing
                 | env.sessionBackground -> waitForCancel
                 | otherwise ->
-                    withEscCancel cancel env.sessionEscPaused waitForCancel
+                    withEscCancel cancel env.sessionStdinControl waitForCancel
     setPersistenceActivity
         env.sessionPersist
         "provider_cooldown"

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -238,7 +238,7 @@ newSessionHostRuntime SessionRequest{..} = do
                                                 , ("Deny", "")
                                                 ]
                                     Nothing ->
-                                        withStdinPaused escPaused
+                                        withStdinPaused stdinControl
                                             (promptRootAccess useColor root)
         reportSessionError message =
             case fullscreen of
@@ -818,7 +818,7 @@ buildSessionApprovalRuntime host controls SessionRequest{..} =
                         Nothing ->
                             approve
                                 (\requested ->
-                                    withStdinPaused escPaused do
+                                    withStdinPaused stdinControl do
                                         color <-
                                             resolveColor host.hostStderrHandle
                                         promptPermission
@@ -1479,7 +1479,7 @@ buildSessionEnv
         , sessionSetComputerUseEnabled =
             loopRuntime.loopRuntimeShell.shellSetComputerUseEnabled
         , sessionBackground = startup.startupBackground
-        , sessionEscPaused = escPaused
+        , sessionStdinControl = stdinControl
         , sessionDraft = startup.startupSessionState.sessionDraft
         , sessionPreviewId =
             startup.startupSessionState.sessionPreviewId

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -8,6 +8,7 @@ module Agent.CLI.Session.Runtime.Types
     , StartupRuntime(..)
     ) where
 
+import Agent.CLI.CancelWatch (StdinControl)
 import Agent.CLI.AgentViewport
     ( AgentEntry
     , AgentTarget
@@ -180,7 +181,7 @@ data SessionRequest = SessionRequest
             (CompactOutcome -> [TurnInput] -> IO CompactionInstall))
     , skillsRef :: !(IORef SkillCatalog)
     , skillInvocationsRef :: !(IORef [SkillInvocation])
-    , escPaused :: !(IORef Bool)
+    , stdinControl :: !StdinControl
     , interrupt :: !InterruptState
     , multiCtx :: !(Maybe MultiAgentContext)
     , rootTurnRef :: !(IORef (Maybe RootTurnId))
@@ -210,7 +211,7 @@ data StartupRuntime = StartupRuntime
     , startupNetworkRecovery :: !(Maybe NetworkRecovery)
     , startupDatabaseStore :: !Store
     , startupInterrupt :: !InterruptState
-    , startupEscPaused :: !(IORef Bool)
+    , startupStdinControl :: !StdinControl
     , startupUiRuntimeRef :: !(IORef (Maybe FullscreenRuntime))
     , startupFullscreen :: !(Maybe FullscreenRuntime)
     , startupTerminal :: !TerminalCapabilities

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -4,6 +4,7 @@ module Agent.CLI.SessionEnv
     , SessionEnv(..)
     ) where
 
+import Agent.CLI.CancelWatch (StdinControl)
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.AgentViewport (AgentViewportEnv)
 import Agent.CLI.GatewayClient (GatewayModelAccess)
@@ -106,7 +107,7 @@ data SessionEnv = SessionEnv
     , sessionComputerUseEnabled :: !(IO Bool)
     , sessionSetComputerUseEnabled :: !(Bool -> IO Text)
     , sessionBackground :: !Bool
-    , sessionEscPaused :: !(IORef Bool)
+    , sessionStdinControl :: !StdinControl
     , sessionDraft :: !(IORef Text)
     , sessionPreviewId :: !(IORef Int)
     , sessionInterrupt :: !InterruptState

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -266,7 +266,7 @@ runOneTurnBusy includeTurnContext env@SessionEnv{}
   withTurnCancel env.sessionInterrupt config.loopCancel $
     (if isJust fullscreen || env.sessionBackground
         then id
-        else withEscCancel config.loopCancel env.sessionEscPaused) do
+        else withEscCancel config.loopCancel env.sessionStdinControl) do
     prepared <- prepareBusyTurn request
     executed <- executeBusyTurn request prepared
     finishBusyTurn executed

--- a/packages/agent-cli/test/Agent/CLI/CancelWatchSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CancelWatchSpec.hs
@@ -4,8 +4,14 @@ import Agent.CLI.CancelWatch
     ( EscapeContinuation(..)
     , escapeContinuationCancels
     , isBareEscape
+    , newStdinControl
+    , withStdinOwnership
+    , withStdinPaused
     , readEscapeContinuation
     )
+import Control.Concurrent.Async (cancel, wait, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Exception.Safe (throwIO)
 import System.IO (BufferMode(..), hClose, hPutStr, hFlush, hSetBuffering)
 import System.Posix.IO (createPipe, fdToHandle)
 import System.Timeout (timeout)
@@ -13,6 +19,48 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "stdin ownership" do
+        it "waits for the complete reader operation before entering a prompt" do
+            control <- newStdinControl
+            reading <- newEmptyMVar
+            finishRead <- newEmptyMVar
+            promptStarted <- newEmptyMVar
+            promptEntered <- newEmptyMVar
+            withAsync (withStdinOwnership control do
+                putMVar reading ()
+                takeMVar finishRead) \reader -> do
+                takeMVar reading
+                withAsync (do
+                    putMVar promptStarted ()
+                    withStdinPaused control (putMVar promptEntered ())) \prompt -> do
+                    takeMVar promptStarted
+                    -- Longer than the former 120 ms handoff delay: ownership
+                    -- must still belong to the unfinished read.
+                    timeout 200000 (takeMVar promptEntered) `shouldReturn` Nothing
+                    putMVar finishRead ()
+                    wait reader
+                    timeout 1000000 (wait prompt) `shouldReturn` Just ()
+                    takeMVar promptEntered
+
+        it "releases ownership after a prompt throws" do
+            control <- newStdinControl
+            withStdinPaused control (throwIO (userError "prompt failed"))
+                `shouldThrow` anyIOException
+            timeout 1000000 (withStdinPaused control (pure ()))
+                `shouldReturn` Just ()
+
+        it "releases ownership after a prompt is cancelled" do
+            control <- newStdinControl
+            entered <- newEmptyMVar
+            finish <- newEmptyMVar
+            withAsync (withStdinPaused control do
+                putMVar entered ()
+                takeMVar finish) \prompt -> do
+                takeMVar entered
+                cancel prompt
+            timeout 1000000 (withStdinPaused control (pure ()))
+                `shouldReturn` Just ()
+
     describe "isBareEscape" do
         it "accepts a lone ESC" do
             isBareEscape "\ESC" `shouldBe` True


### PR DESCRIPTION
Approval prompts previously set a pause flag and slept 120 ms before reading stdin. The Esc watcher could still be consuming a fragmented escape sequence when that delay expired, allowing two readers to compete for prompt input.

Replace the pause flag with an opaque `StdinControl` backed by an `MVar`. The watcher owns stdin for a complete read, including the escape tail; prompts acquire the same ownership before changing terminal modes or reading. Brackets restore modes and release ownership on failure or cancellation. Watcher shutdown remains cooperative and joins the reader before restoring the terminal.

Validation:
- Nix/Cabal GHCi loaded all 210 CLI modules; 31 cancel-watcher, plan, and secret-prompt tests pass.
- Regression tests cover waiting beyond the former handoff delay, throwing prompts, and cancelled prompts.
- Real tmux TTY: a 25-byte fragmented CSI tail sent at 30 ms intervals spanned prompt entry; the prompt subsequently read exactly `approved`. Arrow keys did not cancel; bare Esc and Kitty `CSI 27 u` did.
- Live agent: navigated an approval prompt with arrow keys, accepted one-time approval, denied a subsequent prompt, and returned to normal REPL input. The shell action itself encountered the existing hardcoded-temp-path guard because the smoke workspace was under `/private/tmp`; this check validates stdin ownership and terminal recovery, not shell execution.
