### PR TITLE
Make REPL subsystem handlers exhaustive with dedicated action types

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -2,6 +2,10 @@
 module Agent.CLI.Command
     ( CopyRequest(..)
     , ForkRequest(..)
+    , AttachmentAction(..)
+    , SelectionAction(..)
+    , WorkflowAction(..)
+    , SessionAction(..)
     , ReplAction(..)
     , ShellMode(..)
     , SkillCommand(..)
@@ -259,7 +263,7 @@ simpleSlashCommands =
         , ("diff", ReplDiff)
         , ("history", ReplHistory)
         , ("permissions", ReplPermissions)
-        , ("fast", ReplToggleFast)
+        , ("fast", ReplSelection ReplToggleFast)
         , ("view-plan", ReplViewPlan)
         , ("queue", ReplQueue)
         , ("transcript", ReplTranscript)
@@ -267,20 +271,20 @@ simpleSlashCommands =
         , ("context", ReplContext)
         , ("recap", ReplRecap)
         , ("retry", ReplRetry)
-        , ("session", ReplShowSession)
-        , ("session-info", ReplShowSessionInfo)
+        , ("session", ReplSession ReplShowSession)
+        , ("session-info", ReplSession ReplShowSessionInfo)
         , ("desktop", ReplDesktop)
-        , ("worktree", ReplWorktree)
+        , ("worktree", ReplSession ReplWorktree)
         , ("login", ReplLogin)
-        , ("home", ReplHome)
-        , ("rewind", ReplRewind)
-        , ("clear", ReplClear)
-        , ("new", ReplNew)
-        , ("delete", ReplDelete)
+        , ("home", ReplSession ReplHome)
+        , ("rewind", ReplSession ReplRewind)
+        , ("clear", ReplSession ReplClear)
+        , ("new", ReplSession ReplNew)
+        , ("delete", ReplSession ReplDelete)
         , ("usage", ReplUsage)
         , ("reload-auth", ReplReloadAuth)
-        , ("attachments", ReplShowAttachments)
-        , ("clear-attachments", ReplClearAttachments)
+        , ("attachments", ReplAttachment ReplShowAttachments)
+        , ("clear-attachments", ReplAttachment ReplClearAttachments)
         , ("copy-diff", ReplCopyDiff)
         , ("copy-path", ReplCopyPath)
         , ("copy-session", ReplCopySession)
@@ -341,22 +345,22 @@ parseSpecializedSlashCommand catalog raw spec args commandTail =
                 spec
                 commandTail
         "afk" -> case args of
-            [] -> ReplAfk Nothing
-            [target] -> ReplAfk (Just target)
+            [] -> ReplSession (ReplAfk Nothing)
+            [target] -> ReplSession (ReplAfk (Just target))
             _ -> slashUsageError spec
         "rename" ->
             if commandTail == "--auto"
-                then ReplRenameAuto
+                then ReplSession ReplRenameAuto
                 else if Text.null commandTail
                     then slashUsageError spec
                     else if Text.length commandTail > 100
                         then ReplCommandError
                             "session titles must be at most 100 characters"
-                        else ReplRename commandTail
+                        else ReplSession (ReplRename commandTail)
         "resume" -> parseResumeCommand args
         "search" ->
             parseRequiredTextCommand
-                ReplSearch
+                (ReplSession . ReplSearch)
                 spec
                 commandTail
         "compact" -> parseOptionalTextCommand ReplCompact commandTail
@@ -427,16 +431,16 @@ parseLoopCommand original args
 parseGoalCommand :: Text -> Text -> ReplAction
 parseGoalCommand original args =
     case Text.toLower args of
-        "" -> ReplGoalStatus
-        "status" -> ReplGoalStatus
-        "pause" -> ReplGoalPause
-        "resume" -> ReplGoalResume
-        "clear" -> ReplGoalClear
+        "" -> ReplWorkflow ReplGoalStatus
+        "status" -> ReplWorkflow ReplGoalStatus
+        "pause" -> ReplWorkflow ReplGoalPause
+        "resume" -> ReplWorkflow ReplGoalResume
+        "clear" -> ReplWorkflow ReplGoalClear
         _ ->
             case parseTrailingGoalBudget args of
                 Left err -> ReplCommandError err
                 Right (objective, budget) ->
-                    ReplGoalSet
+                    ReplWorkflow (ReplGoalSet
                         original
                         objective
                         budget
@@ -447,7 +451,7 @@ parseGoalCommand original args =
                                     "\nThe host records an advisory scope budget of "
                                         <> Text.pack (show tokens)
                                         <> " tokens, but does not hard-enforce it. Keep the work proportionate and report if the objective cannot fit.")
-                                budget)
+                                budget))
 
 parseTrailingGoalBudget :: Text -> Either Text (Text, Maybe Int)
 parseTrailingGoalBudget input =
@@ -486,22 +490,22 @@ parseTrailingGoalBudget input =
 parseWorkflowCommand :: Text -> Text -> ReplAction
 parseWorkflowCommand original args =
     case Text.words args of
-        [] -> ReplWorkflowRuns
+        [] -> ReplWorkflow ReplWorkflowRuns
         [single]
             | Text.toLower single == "runs" ->
-                ReplWorkflowRuns
+                ReplWorkflow ReplWorkflowRuns
         first : rest
             | isWorkflowOperation first ->
-                ReplWorkflowManage
+                ReplWorkflow (ReplWorkflowManage
                     (Text.toLower first)
                     (nonEmptyText
                         (Text.strip
-                            (Text.drop (Text.length first) args)))
+                            (Text.drop (Text.length first) args))))
             | [operation] <- rest
             , isWorkflowOperation operation ->
-                ReplWorkflowManage
+                ReplWorkflow (ReplWorkflowManage
                     (Text.toLower operation)
-                    (Just first)
+                    (Just first))
             | otherwise ->
                 let input =
                         Text.strip
@@ -522,7 +526,7 @@ parseDeepResearchCommand original query
 
 parseForkCommand :: Text -> ReplAction
 parseForkCommand input =
-    either ReplCommandError ReplFork (go Nothing (Text.stripStart input))
+    either ReplCommandError (ReplSession . ReplFork) (go Nothing (Text.stripStart input))
   where
     go worktree rest
         | Text.null rest =
@@ -596,11 +600,11 @@ loopUsageMessage =
 
 parseResumeCommand :: [Text] -> ReplAction
 parseResumeCommand = \case
-    [] -> ReplResume Nothing
+    [] -> ReplSession (ReplResume Nothing)
     [sessionId]
         | Text.null (Text.strip sessionId) ->
             ReplCommandError "usage: /resume [ID]"
-        | otherwise -> ReplResume (Just sessionId)
+        | otherwise -> ReplSession (ReplResume (Just sessionId))
     _ -> ReplCommandError "usage: /resume [ID]"
 
 parseCopyCodeCommand :: [Text] -> ReplAction
@@ -623,7 +627,7 @@ parsePasteCommand rest =
             ("--send":xs) -> (True, Text.unwords xs)
             ("-s":xs) -> (True, Text.unwords xs)
             _ -> (False, rest)
-    in ReplPaste immediate (Text.strip caption)
+    in ReplAttachment (ReplPaste immediate (Text.strip caption))
 
 parseAgentsCommand :: [Text] -> ReplAction
 parseAgentsCommand = \case
@@ -636,9 +640,9 @@ parseAgentsCommand = \case
 
 parseEffortCommand :: [Text] -> ReplAction
 parseEffortCommand = \case
-    [] -> ReplShowEffort
+    [] -> ReplSelection ReplShowEffort
     [level] -> case parseEffort level of
-        Right effort -> ReplSetEffort effort
+        Right effort -> ReplSelection (ReplSetEffort effort)
         Left err -> ReplCommandError (Text.pack err)
     _ -> ReplCommandError "usage: /effort [none|low|medium|high|xhigh|max]"
 
@@ -666,18 +670,18 @@ parseComputerUseCommand = \case
 
 parseModelCommand :: [Text] -> ReplAction
 parseModelCommand = \case
-    [] -> ReplShowModel
+    [] -> ReplSelection ReplShowModel
     [name]
         | Text.null (Text.strip name) ->
             ReplCommandError "usage: /model [NAME]"
-        | otherwise -> ReplSetModel name
+        | otherwise -> ReplSelection (ReplSetModel name)
     _ -> ReplCommandError "usage: /model [NAME]"
 
 parseThemeCommand :: [Text] -> ReplAction
 parseThemeCommand = \case
-    [] -> ReplShowTheme
+    [] -> ReplSelection ReplShowTheme
     [name]
-        | not (Text.null (Text.strip name)) -> ReplSetTheme name
+        | not (Text.null (Text.strip name)) -> ReplSelection (ReplSetTheme name)
         | otherwise -> ReplCommandError "usage: /theme [NAME]"
     _ -> ReplCommandError "usage: /theme [NAME]"
 

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -2,6 +2,10 @@
 module Agent.CLI.Command.Types
     ( CopyRequest(..)
     , ForkRequest(..)
+    , AttachmentAction(..)
+    , SelectionAction(..)
+    , WorkflowAction(..)
+    , SessionAction(..)
     , ReplAction(..)
     , ShellMode(..)
     , SkillCommand(..)
@@ -41,16 +45,8 @@ data ReplAction
     | ReplInit
     | ReplReview (Maybe Text)
     | ReplDiff
-    | ReplFork !ForkRequest
     | ReplExport (Maybe Text)
     | ReplPermissions
-    | ReplShowEffort
-    | ReplSetEffort ReasoningEffort
-    | ReplToggleFast
-    | ReplShowModel
-    | ReplSetModel Text
-    | ReplShowTheme
-    | ReplSetTheme Text
     | ReplEnableCodeMode
     | ReplToggleAlwaysApprove
     | ReplPlan (Maybe Text)
@@ -71,21 +67,10 @@ data ReplAction
     -- ^ Generate a display-only "where was I" recap of the current session.
     | ReplRetry
     -- ^ Retry the last failed turn with its original attachments.
-    | ReplShowSession
-    | ReplShowSessionInfo
     | ReplDesktop
     -- ^ Open the current persisted conversation in the native macOS app.
-    | ReplAfk (Maybe Text)
-    -- ^ Hand the active session to tmux, optionally on @host:path@.
-    | ReplWorktree
-    | ReplRename Text
-    | ReplRenameAuto
     | ReplLogin
     | ReplReloadAuth
-    | ReplPaste !Bool !Text
-    | ReplClearAttachments
-    | ReplShowAttachments
-    | ReplRemoveAttachment !Int
     | ReplCopy !CopyRequest
     | ReplCopyCode Int
     | ReplCopyDiff
@@ -98,15 +83,6 @@ data ReplAction
     | ReplSetAgentLimit Int
     | ReplMcp
     | ReplMcpPrompt Text Text [(Text, Text)]
-    | ReplGoalStatus
-    | ReplGoalPause
-    | ReplGoalResume
-    | ReplGoalClear
-    | ReplGoalSet !Text !Text !(Maybe Int) !Text
-      -- ^ Original text, objective, optional token budget, and expansion.
-    | ReplWorkflowRuns
-    | ReplWorkflowManage !Text !(Maybe Text)
-      -- ^ Operation and optional run id/display name.
     | ReplSkills !Bool
     | ReplShowShell
     | ReplSetShell !ShellMode
@@ -115,14 +91,62 @@ data ReplAction
     | ReplInvokeSkill !Text !Text
     | ReplHelp (Maybe Text)
     -- ^ @Nothing@ lists every command; @Just@ is a canonical name without @/@.
+    | ReplCompact (Maybe Text)
+    -- ^ Optional focus note for what to keep while compacting history.
+    | ReplUsage
+    | ReplCommandError Text
+    | ReplAttachment !AttachmentAction
+    | ReplSelection !SelectionAction
+    | ReplWorkflow !WorkflowAction
+    | ReplSession !SessionAction
+    deriving (Eq, Show)
+
+-- | Commands routed to the attachment handler. Each subsystem accepts only
+-- its own action type, so adding a command requires an exhaustive handler.
+data AttachmentAction
+    = ReplPaste !Bool !Text
+    | ReplClearAttachments
+    | ReplShowAttachments
+    | ReplRemoveAttachment !Int
+    deriving (Eq, Show)
+
+data SelectionAction
+    = ReplShowEffort
+    | ReplSetEffort ReasoningEffort
+    | ReplToggleFast
+    | ReplShowModel
+    | ReplSetModel Text
+    | ReplShowTheme
+    | ReplSetTheme Text
+    deriving (Eq, Show)
+
+data WorkflowAction
+    = ReplGoalStatus
+    | ReplGoalPause
+    | ReplGoalResume
+    | ReplGoalClear
+    | ReplGoalSet !Text !Text !(Maybe Int) !Text
+      -- ^ Original text, objective, optional token budget, and expansion.
+    | ReplWorkflowRuns
+    | ReplWorkflowManage !Text !(Maybe Text)
+      -- ^ Operation and optional run id/display name.
+    deriving (Eq, Show)
+
+data SessionAction
+    = ReplFork !ForkRequest
+    | ReplShowSession
+    | ReplShowSessionInfo
+    | ReplAfk (Maybe Text)
+    -- ^ Hand the active session to tmux, optionally on @host:path@.
+    | ReplWorktree
+    | ReplRename Text
+    | ReplRenameAuto
     | ReplResume (Maybe Text)
     -- ^ @Nothing@ opens the session picker; @Just@ is a session id.
     | ReplHome
     -- ^ Return to the session picker.
     | ReplSearch !Text
     -- ^ Search persisted conversation turns and open matching sessions.
-    | ReplCompact (Maybe Text)
-    -- ^ Optional focus note for what to keep while compacting history.
     | ReplRewind
       -- ^ Restore conversation state before a selected prompt.
     | ReplClear
@@ -131,8 +155,6 @@ data ReplAction
       -- ^ Start a fresh persisted session id with empty history.
     | ReplDelete
       -- ^ Confirm deletion, then remove the current session after shutdown.
-    | ReplUsage
-    | ReplCommandError Text
     deriving (Eq, Show)
 
 data ShellMode

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
@@ -1,6 +1,7 @@
 -- | Clipboard paste and pending-attachment commands.
 module Agent.CLI.Runtime.Repl.Attachments
     ( handleAttachmentAction
+    , ClipboardInput(..)
     , handleClipboardInput
     ) where
 
@@ -8,10 +9,8 @@ import Agent.CLI.Clipboard
     ( formatImageSize, loadImagesFromPastedText, nonEmptyClipboardImages,
       readClipboardImagesForPaste, readClipboardImagesImageFirst )
 import Agent.CLI.Command
-    ( ReplAction(ReplPaste, ReplShowAttachments, ReplClearAttachments,
+    ( AttachmentAction(ReplPaste, ReplShowAttachments, ReplClearAttachments,
                  ReplRemoveAttachment) )
-import Agent.CLI.Input
-    ( ReplLine(ReplClipboardPaste, ReplClipboardPasteOrText) )
 import Agent.CLI.ProviderTransition ( TurnResult )
 import Agent.CLI.Render ( resetRenderPrintedText )
 import Agent.CLI.Runtime.Types ( RunResult )
@@ -41,11 +40,16 @@ import qualified Data.ByteString as BS ( length )
 import qualified Data.Text as Text ( intercalate, null )
 import qualified Data.Text.IO as Text ( hPutStrLn, putStrLn )
 
+-- | Clipboard operations after the REPL input has been classified.
+data ClipboardInput
+    = ClipboardPaste !Text !(Maybe [ImageAttachment])
+    | ClipboardPasteOrText !Text !Text !Text
+
 handleClipboardInput
     :: SessionEnv
     -> (Text -> IO RunResult)
     -> Bool
-    -> ReplLine
+    -> ClipboardInput
     -> IO RunResult
 handleClipboardInput
         SessionEnv
@@ -55,7 +59,7 @@ handleClipboardInput
             }
         continueWith
         stdoutColor = \case
-    ReplClipboardPaste keptDraft clipboardPasteImages -> do
+    ClipboardPaste keptDraft clipboardPasteImages -> do
         case clipboardPasteImages of
             Just images@(_:_) -> do
                 message <- queueAttachedImages
@@ -88,7 +92,7 @@ handleClipboardInput
                                     (roleMuted stdoutColor
                                         (glyphOk <> message))
         continueWith keptDraft
-    ReplClipboardPasteOrText keptDraft pasted pastedDraft -> do
+    ClipboardPasteOrText keptDraft pasted pastedDraft -> do
         pastedImages <- loadImagesFromPastedText pasted
         imagesResult <- case pastedImages of
             Just images@(_:_) -> pure (Just images)
@@ -113,7 +117,6 @@ handleClipboardInput
             _ -> do
                 fullscreenEvent (UiSetNotice Nothing)
                 continueWith pastedDraft
-    _ -> error "handleClipboardInput: unsupported input"
   where
     fullscreenEvent event = case fullscreen of
         Nothing -> pure ()
@@ -133,7 +136,7 @@ handleAttachmentAction
     :: SessionEnv
     -> (Bool -> TurnResult -> IO RunResult)
     -> IO RunResult
-    -> ReplAction
+    -> AttachmentAction
     -> IO RunResult
 handleAttachmentAction
         env@SessionEnv
@@ -243,7 +246,6 @@ handleAttachmentAction
             Text.putStrLn
                 (roleMuted color (glyphOk <> message))
         continue
-    _ -> error "handleAttachmentAction: unsupported action"
   where
     fullscreenEvent event = case fullscreen of
         Nothing -> pure ()

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -12,32 +12,10 @@ import Agent.CLI.Approval ( setApprovalPolicy, toggleAlwaysApprove )
 import Agent.CLI.Changelog (loadReleaseNotes)
 import Agent.CLI.Clipboard ( loadImagesFromPastedText )
 import Agent.CLI.Command
-    ( formatSlashHelpWithCatalog,
+    ( AttachmentAction(ReplRemoveAttachment),
+      formatSlashHelpWithCatalog,
       parseReplLineWithCatalog,
-      ReplAction(ReplCommandError, ReplQuit, ReplReload,
-                 ReplUpdateAndRestart, ReplPrompt, ReplExpandedPrompt,
-                 ReplInvokeSkill, ReplSkills, ReplShowShell,
-                 ReplSetShell, ReplToggleComputerUse, ReplSetComputerUse,
-                 ReplPaste, ReplShowAttachments, ReplClearAttachments,
-                 ReplRemoveAttachment,
-                 ReplShowAgentLimit, ReplSetAgentLimit, ReplAgents, ReplMcp, ReplMcpPrompt,
-                 ReplGoalStatus, ReplGoalPause, ReplGoalResume, ReplGoalClear,
-                 ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage, ReplCopy,
-                 ReplCopyCode, ReplCopyDiff, ReplCopyPath, ReplCopySession,
-                 ReplDesktop, ReplShowTerminal, ReplChangelog,
-                 ReplShowEffort, ReplSetEffort, ReplShowModel,
-                 ReplSetModel, ReplShowTheme, ReplSetTheme,
-                 ReplToggleFast, ReplEnableCodeMode,
-                 ReplToggleAlwaysApprove, ReplCompact, ReplPlan,
-                 ReplViewPlan, ReplQueue, ReplTranscript, ReplEditPrompt,
-                 ReplContext, ReplHistory, ReplFind,
-                 ReplBtw, ReplMetaConsole, ReplRecap, ReplRetry, ReplResume, ReplSearch,
-                 ReplHome, ReplRewind, ReplClear, ReplNew, ReplDelete,
-                 ReplShowSession, ReplShowSessionInfo, ReplAfk, ReplWorktree,
-                 ReplRename, ReplRenameAuto, ReplInit, ReplReview, ReplDiff,
-                 ReplFork, ReplExport, ReplPermissions,
-                 ReplLogin, ReplUsage, ReplReloadAuth,
-                 ReplHelp),
+      ReplAction(..),
       ShellMode(ShellNone, ShellGhci, ShellBash, ShellBoth),
       SlashCatalog )
 import Agent.CLI.Command.Instructions ( initInstruction )
@@ -106,7 +84,7 @@ import Agent.CLI.Review
     )
 import Agent.CLI.Runtime.Recap ( runSessionRecap )
 import Agent.CLI.Runtime.Repl.Attachments
-    ( handleAttachmentAction, handleClipboardInput )
+    ( ClipboardInput(..), handleAttachmentAction, handleClipboardInput )
 import Agent.CLI.Runtime.Repl.Context
     ( ReplHandlerContext(..)
     , displayReplError
@@ -117,7 +95,7 @@ import Agent.CLI.Runtime.Repl.Context
     )
 import Agent.CLI.Runtime.Repl.MetaConsole ( handleMetaConsoleRequest )
 import Agent.CLI.Runtime.Repl.Selection
-    ( handleSelectionAction, handleSelectionInput )
+    ( SelectionInput(..), handleSelectionAction, handleSelectionInput )
 import Agent.CLI.Runtime.Repl.Session ( handleSessionAction )
 import Agent.CLI.Runtime.Repl.Transcript
     ( TranscriptAction(..), handleTranscriptAction )
@@ -294,28 +272,30 @@ handleReplLine
                     putStr "\ESC[2A\r\ESC[J"
                     hFlush stdout
             continueWith keptDraft
-    action@(ReplClipboardPaste _ _) ->
-        handleClipboardInput env continueWith stdoutColor action
-    action@(ReplClipboardPasteOrText _ _ _) ->
-        handleClipboardInput env continueWith stdoutColor action
-    action@(ReplChooseModel keptDraft) ->
+    ReplClipboardPaste draft images ->
+        handleClipboardInput env continueWith stdoutColor
+            (ClipboardPaste draft images)
+    ReplClipboardPasteOrText draft pasted pastedDraft ->
+        handleClipboardInput env continueWith stdoutColor
+            (ClipboardPasteOrText draft pasted pastedDraft)
+    ReplChooseModel keptDraft ->
         handleSelectionInput
             env
             (continueWith keptDraft)
             retryPendingTurn
-            action
-    action@(ReplChooseEffort keptDraft) ->
+            (ChooseModel keptDraft)
+    ReplChooseEffort keptDraft ->
         handleSelectionInput
             env
             (continueWith keptDraft)
             retryPendingTurn
-            action
-    action@(ReplChooseAccount keptDraft) ->
+            (ChooseEffort keptDraft)
+    ReplChooseAccount keptDraft ->
         handleSelectionInput
             env
             (continueWith keptDraft)
             retryPendingTurn
-            action
+            (ChooseAccount keptDraft)
     ReplMeta request ->
         runMetaConsoleRequest request
     ReplRemovePendingImage keptDraft index ->
@@ -400,10 +380,8 @@ handleReplLine
                             Text.putStrLn
                                 (roleMuted color (glyphOk <> message))
                         continue
-                    action@ReplPaste{} -> handleAttachmentAction env finishTurn continue action
-                    action@ReplShowAttachments -> handleAttachmentAction env finishTurn continue action
-                    action@ReplClearAttachments -> handleAttachmentAction env finishTurn continue action
-                    action@ReplRemoveAttachment{} -> handleAttachmentAction env finishTurn continue action
+                    ReplAttachment action ->
+                        handleAttachmentAction env finishTurn continue action
                     ReplShowAgentLimit ->
                         showAgentLimit continue
                     ReplSetAgentLimit limit ->
@@ -415,13 +393,8 @@ handleReplLine
                     ReplMcpPrompt server name arguments ->
                         submitMcpPrompt
                             continue color server name arguments
-                    action@ReplGoalStatus -> handleWorkflowAction env submitExpandedTurn color continue action
-                    action@ReplGoalPause -> handleWorkflowAction env submitExpandedTurn color continue action
-                    action@ReplGoalResume -> handleWorkflowAction env submitExpandedTurn color continue action
-                    action@ReplGoalClear -> handleWorkflowAction env submitExpandedTurn color continue action
-                    action@ReplGoalSet{} -> handleWorkflowAction env submitExpandedTurn color continue action
-                    action@ReplWorkflowRuns -> handleWorkflowAction env submitExpandedTurn color continue action
-                    action@ReplWorkflowManage{} -> handleWorkflowAction env submitExpandedTurn color continue action
+                    ReplWorkflow action ->
+                        handleWorkflowAction env submitExpandedTurn color continue action
                     ReplCopy request ->
                         handleTranscriptAction handlerContext
                             (CopyResponse request)
@@ -440,13 +413,8 @@ handleReplLine
                         showTerminalCapabilities continue color
                     ReplChangelog ->
                         showChangelog continue
-                    action@ReplShowEffort -> handleSelectionAction env continue action
-                    action@ReplSetEffort{} -> handleSelectionAction env continue action
-                    action@ReplToggleFast -> handleSelectionAction env continue action
-                    action@ReplShowModel -> handleSelectionAction env continue action
-                    action@ReplSetModel{} -> handleSelectionAction env continue action
-                    action@ReplShowTheme -> handleSelectionAction env continue action
-                    action@ReplSetTheme{} -> handleSelectionAction env continue action
+                    ReplSelection action ->
+                        handleSelectionAction env continue action
                     ReplEnableCodeMode ->
                         requestCodeModeRestart fullscreen persist
                     ReplToggleAlwaysApprove ->
@@ -484,20 +452,8 @@ handleReplLine
                                     "No failed turn is available to retry."
                                     (pure ())
                                 continue)
-                    action@ReplResume{} -> handleSessionAction env slashCatalog continue action
-                    action@ReplSearch{} -> handleSessionAction env slashCatalog continue action
-                    action@ReplHome -> handleSessionAction env slashCatalog continue action
-                    action@ReplRewind -> handleSessionAction env slashCatalog continue action
-                    action@ReplClear -> handleSessionAction env slashCatalog continue action
-                    action@ReplNew -> handleSessionAction env slashCatalog continue action
-                    action@ReplDelete -> handleSessionAction env slashCatalog continue action
-                    action@ReplFork{} -> handleSessionAction env slashCatalog continue action
-                    action@ReplShowSession -> handleSessionAction env slashCatalog continue action
-                    action@ReplShowSessionInfo -> handleSessionAction env slashCatalog continue action
-                    action@ReplAfk{} -> handleSessionAction env slashCatalog continue action
-                    action@ReplWorktree -> handleSessionAction env slashCatalog continue action
-                    action@ReplRename{} -> handleSessionAction env slashCatalog continue action
-                    action@ReplRenameAuto -> handleSessionAction env slashCatalog continue action
+                    ReplSession action ->
+                        handleSessionAction env slashCatalog continue action
                     ReplLogin ->
                         manageLogin continue
                     ReplUsage ->

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
@@ -4,10 +4,10 @@ module Agent.CLI.Runtime.Repl.MetaConsole
     ) where
 
 import Agent.CLI.Command
-    ( ReplAction(ReplSetEffort, ReplToggleFast, ReplSetModel,
-                 ReplSetShell, ReplToggleComputerUse, ReplSetComputerUse,
+    ( ReplAction(ReplSelection, ReplSetShell, ReplToggleComputerUse, ReplSetComputerUse,
                  ReplToggleAlwaysApprove, ReplSetAgentLimit,
                  ReplEnableCodeMode, ReplSkills)
+    , SelectionAction(ReplSetEffort, ReplToggleFast, ReplSetModel)
     , SlashCatalog
     , parseReplLineWithCatalog
     )
@@ -453,9 +453,9 @@ runMetaSessionCommand runtime command =
 
 safeMetaSessionAction :: ReplAction -> Bool
 safeMetaSessionAction = \case
-    ReplSetEffort{} -> True
-    ReplToggleFast -> True
-    ReplSetModel{} -> True
+    ReplSelection ReplSetEffort{} -> True
+    ReplSelection ReplToggleFast -> True
+    ReplSelection ReplSetModel{} -> True
     ReplSetShell{} -> True
     ReplToggleComputerUse -> True
     ReplSetComputerUse{} -> True

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -1,6 +1,7 @@
 -- | Model, effort, and account selection commands.
 module Agent.CLI.Runtime.Repl.Selection
     ( handleSelectionAction
+    , SelectionInput(..)
     , handleSelectionInput
     , selectRequestedAccount
     ) where
@@ -16,7 +17,7 @@ import Agent.CLI.Auth ( geminiAuthErrorNeedsReconnect )
 import Agent.CLI.Command
     ( currentEffort,
       currentModel,
-      ReplAction(ReplSetModel, ReplShowEffort, ReplSetEffort, ReplToggleFast,
+      SelectionAction(ReplSetModel, ReplShowEffort, ReplSetEffort, ReplToggleFast,
                  ReplShowModel, ReplShowTheme, ReplSetTheme) )
 import Agent.CLI.Config
     ( HarnessConfig(configTheme)
@@ -25,8 +26,6 @@ import Agent.CLI.Config
 import Agent.CLI.Error ( formatApiErrorInlineAt )
 import Agent.CLI.GatewayClient ( refreshGatewayModels )
 import Agent.CLI.GatewayModels (modelOptionsForGatewayModels)
-import Agent.CLI.Input
-    ( ReplLine(ReplChooseAccount, ReplChooseModel, ReplChooseEffort) )
 import Agent.CLI.Login ( connectProviderAccount )
 import Agent.CLI.Models
     ( gatewayModelOptions,
@@ -100,16 +99,22 @@ import System.IO ( stdout, stderr )
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text ( putStrLn, hPutStrLn )
 
+-- | Selection shortcuts emitted by the interactive editor.
+data SelectionInput
+    = ChooseModel !Text
+    | ChooseEffort !Text
+    | ChooseAccount !Text
+
 handleSelectionInput
     :: SessionEnv
     -> IO RunResult
     -> (PendingTurn -> IO RunResult)
-    -> ReplLine
+    -> SelectionInput
     -> IO RunResult
 handleSelectionInput env continue retryPendingTurn input =
     handleSelection env continue retryPendingTurn (Left input)
 
-handleSelectionAction :: SessionEnv -> IO RunResult -> ReplAction -> IO RunResult
+handleSelectionAction :: SessionEnv -> IO RunResult -> SelectionAction -> IO RunResult
 handleSelectionAction env continue action =
     handleSelection env continue (\_ -> continue) (Right action)
 
@@ -279,7 +284,7 @@ handleSelection
     :: SessionEnv
     -> IO RunResult
     -> (PendingTurn -> IO RunResult)
-    -> Either ReplLine ReplAction
+    -> Either SelectionInput SelectionAction
     -> IO RunResult
 handleSelection
         env@SessionEnv
@@ -304,11 +309,11 @@ handleSelection
             }
         continue
         retryPendingTurn = \case
-    Left (ReplChooseModel keptDraft) -> do
+    Left (ChooseModel keptDraft) -> do
         writeIORef draftRef keptDraft
         chooseModel continue
-    Left (ReplChooseEffort _) -> chooseEffort continue
-    Left (ReplChooseAccount keptDraft) -> do
+    Left (ChooseEffort _) -> chooseEffort continue
+    Left (ChooseAccount keptDraft) -> do
         writeIORef draftRef keptDraft
         chooseAccount continue
     Right ReplShowEffort -> do
@@ -393,7 +398,6 @@ handleSelection
                 continue
             Just theme ->
                 setTheme theme continue
-    _ -> error "handleSelection: unsupported input"
   where
     displayInfo message minimalAction = case fullscreen of
         Nothing -> minimalAction

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -9,7 +9,7 @@ import Agent.CLI.Command
     ( currentEffort,
       currentModel,
       ForkRequest(..),
-      ReplAction(ReplRenameAuto, ReplResume, ReplSearch, ReplHome, ReplRewind, ReplClear,
+      SessionAction(ReplRenameAuto, ReplResume, ReplSearch, ReplHome, ReplRewind, ReplClear,
                  ReplNew, ReplDelete, ReplShowSession, ReplShowSessionInfo, ReplAfk,
                  ReplWorktree, ReplRename, ReplFork),
       ShellMode(ShellNone, ShellGhci, ShellBash, ShellBoth),
@@ -110,7 +110,7 @@ handleSessionAction
     :: SessionEnv
     -> SlashCatalog
     -> IO RunResult
-    -> ReplAction
+    -> SessionAction
     -> IO RunResult
 handleSessionAction
         env
@@ -130,7 +130,7 @@ data SessionActionRuntime = SessionActionRuntime
 
 dispatchSessionAction
     :: SessionActionRuntime
-    -> ReplAction
+    -> SessionAction
     -> IO RunResult
 dispatchSessionAction runtime = \case
     ReplResume maybeId -> handleResumeAction runtime maybeId
@@ -147,7 +147,6 @@ dispatchSessionAction runtime = \case
     ReplWorktree -> handleWorktreeAction runtime
     ReplRename title -> handleRenameAction runtime title
     ReplRenameAuto -> handleRenameAutoAction runtime
-    _ -> error "handleSessionAction: unsupported action"
 
 runtimeFullscreenEvent :: SessionActionRuntime -> UiEvent -> IO ()
 runtimeFullscreenEvent runtime event =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Workflow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Workflow.hs
@@ -4,7 +4,7 @@ module Agent.CLI.Runtime.Repl.Workflow
     ) where
 
 import Agent.CLI.Command
-    ( ReplAction(ReplGoalStatus, ReplGoalPause, ReplGoalResume, ReplGoalClear,
+    ( WorkflowAction(ReplGoalStatus, ReplGoalPause, ReplGoalResume, ReplGoalClear,
                  ReplGoalSet, ReplWorkflowRuns, ReplWorkflowManage) )
 import Agent.CLI.Runtime.Types ( RunResult )
 import Agent.CLI.SessionEnv ( SessionEnv(..) )
@@ -26,7 +26,7 @@ handleWorkflowAction
     -> (IO RunResult -> Bool -> Text -> Text -> IO RunResult)
     -> Bool
     -> IO RunResult
-    -> ReplAction
+    -> WorkflowAction
     -> IO RunResult
 handleWorkflowAction
         SessionEnv
@@ -180,7 +180,6 @@ handleWorkflowAction
                 (roleError color err)
         continue
 
-    _ -> error "handleWorkflowAction: unsupported action"
   where
     displayInfo message minimalAction = case fullscreen of
         Nothing -> minimalAction

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -70,24 +70,24 @@ spec = do
                     "  /Users/marc/Downloads/template.png use this template  "
 
         it "shows the current effort with a bare /effort" do
-            parseReplLine "/effort" `shouldBe` ReplShowEffort
-            parseReplLine "  /Effort  " `shouldBe` ReplShowEffort
+            parseReplLine "/effort" `shouldBe` ReplSelection ReplShowEffort
+            parseReplLine "  /Effort  " `shouldBe` ReplSelection ReplShowEffort
 
         it "toggles Fast mode with /fast" do
             let catalog = mkSlashCatalog True CodexDialect [] [] []
             parseReplLineWithCatalog catalog "/fast"
-                `shouldBe` ReplToggleFast
+                `shouldBe` ReplSelection ReplToggleFast
             parseReplLineWithCatalog catalog "/FAST"
-                `shouldBe` ReplToggleFast
+                `shouldBe` ReplSelection ReplToggleFast
             parseReplLineWithCatalog catalog "/fast on"
                 `shouldBe` ReplCommandError "usage: /fast"
 
         it "sets a valid effort level" do
-            parseReplLine "/effort none" `shouldBe` ReplSetEffort EffortNone
-            parseReplLine "/effort high" `shouldBe` ReplSetEffort EffortHigh
-            parseReplLine "/effort XHIGH" `shouldBe` ReplSetEffort EffortXHigh
-            parseReplLine "/effort MAX" `shouldBe` ReplSetEffort EffortMax
-            parseReplLine "/effort medium" `shouldBe` ReplSetEffort EffortMedium
+            parseReplLine "/effort none" `shouldBe` ReplSelection (ReplSetEffort EffortNone)
+            parseReplLine "/effort high" `shouldBe` ReplSelection (ReplSetEffort EffortHigh)
+            parseReplLine "/effort XHIGH" `shouldBe` ReplSelection (ReplSetEffort EffortXHigh)
+            parseReplLine "/effort MAX" `shouldBe` ReplSelection (ReplSetEffort EffortMax)
+            parseReplLine "/effort medium" `shouldBe` ReplSelection (ReplSetEffort EffortMedium)
 
         it "parses the Codex workflow commands" do
             parseReplLine "/init" `shouldBe` ReplInit
@@ -100,23 +100,23 @@ spec = do
             parseReplLine "/diff now"
                 `shouldBe` ReplCommandError "usage: /diff"
             parseReplLine "/fork"
-                `shouldBe` ReplFork (ForkRequest Nothing Nothing)
+                `shouldBe` ReplSession (ReplFork (ForkRequest Nothing Nothing))
             parseReplLine "/fork   experiment branch  "
                 `shouldBe`
-                    ReplFork
-                        (ForkRequest Nothing (Just "experiment branch"))
+                    ReplSession (ReplFork
+                        (ForkRequest Nothing (Just "experiment branch")))
             parseReplLine "/fork --worktree fix the tests"
                 `shouldBe`
-                    ReplFork
-                        (ForkRequest (Just True) (Just "fix the tests"))
+                    ReplSession (ReplFork
+                        (ForkRequest (Just True) (Just "fix the tests")))
             parseReplLine "/fork --no-worktree"
-                `shouldBe` ReplFork (ForkRequest (Just False) Nothing)
+                `shouldBe` ReplSession (ReplFork (ForkRequest (Just False) Nothing))
             parseReplLine "/fork --unknown stays a directive"
                 `shouldBe`
-                    ReplFork
+                    ReplSession (ReplFork
                         (ForkRequest
                             Nothing
-                            (Just "--unknown stays a directive"))
+                            (Just "--unknown stays a directive")))
             parseReplLine "/fork --worktree --no-worktree"
                 `shouldBe`
                     ReplCommandError
@@ -188,14 +188,14 @@ spec = do
                 `shouldBe` ReplCommandError "usage: /always-approve"
 
         it "prints the current session id" do
-            parseReplLine "/session" `shouldBe` ReplShowSession
+            parseReplLine "/session" `shouldBe` ReplSession ReplShowSession
             parseReplLine "/session now"
                 `shouldBe` ReplCommandError "usage: /session"
 
         it "shows expanded session information through compatibility aliases" do
-            parseReplLine "/session-info" `shouldBe` ReplShowSessionInfo
-            parseReplLine "/status" `shouldBe` ReplShowSessionInfo
-            parseReplLine "/info" `shouldBe` ReplShowSessionInfo
+            parseReplLine "/session-info" `shouldBe` ReplSession ReplShowSessionInfo
+            parseReplLine "/status" `shouldBe` ReplSession ReplShowSessionInfo
+            parseReplLine "/info" `shouldBe` ReplSession ReplShowSessionInfo
             parseReplLine "/status now"
                 `shouldBe` ReplCommandError "usage: /session-info"
 
@@ -206,24 +206,24 @@ spec = do
                 `shouldBe` ReplCommandError "usage: /desktop"
 
         it "hands the session to local or remote tmux" do
-            parseReplLine "/afk" `shouldBe` ReplAfk Nothing
+            parseReplLine "/afk" `shouldBe` ReplSession (ReplAfk Nothing)
             parseReplLine "/afk office-builder:~/haskell-agent"
-                `shouldBe` ReplAfk (Just "office-builder:~/haskell-agent")
+                `shouldBe` ReplSession (ReplAfk (Just "office-builder:~/haskell-agent"))
             parseReplLine "/afk one two"
                 `shouldBe` ReplCommandError "usage: /afk [HOST:PATH]"
 
         it "starts a fresh session in a new worktree" do
-            parseReplLine "/worktree" `shouldBe` ReplWorktree
-            parseReplLine "  /Worktree  " `shouldBe` ReplWorktree
+            parseReplLine "/worktree" `shouldBe` ReplSession ReplWorktree
+            parseReplLine "  /Worktree  " `shouldBe` ReplSession ReplWorktree
             parseReplLine "/worktree now"
                 `shouldBe` ReplCommandError "usage: /worktree"
 
         it "renames sessions or restores automatic titles" do
             parseReplLine "/rename Fix auth races"
-                `shouldBe` ReplRename "Fix auth races"
+                `shouldBe` ReplSession (ReplRename "Fix auth races")
             parseReplLine "/title   keep  spaces"
-                `shouldBe` ReplRename "keep  spaces"
-            parseReplLine "/rename --auto" `shouldBe` ReplRenameAuto
+                `shouldBe` ReplSession (ReplRename "keep  spaces")
+            parseReplLine "/rename --auto" `shouldBe` ReplSession ReplRenameAuto
             parseReplLine "/rename"
                 `shouldBe` ReplCommandError "usage: /rename <TITLE>|--auto"
 
@@ -240,9 +240,9 @@ spec = do
                 `shouldBe` ReplCommandError "usage: /login"
 
         it "clears, starts, or deletes a session" do
-            parseReplLine "/clear" `shouldBe` ReplClear
-            parseReplLine "/new" `shouldBe` ReplNew
-            parseReplLine "/delete" `shouldBe` ReplDelete
+            parseReplLine "/clear" `shouldBe` ReplSession ReplClear
+            parseReplLine "/new" `shouldBe` ReplSession ReplNew
+            parseReplLine "/delete" `shouldBe` ReplSession ReplDelete
             parseReplLine "/clear now"
                 `shouldBe` ReplCommandError "usage: /clear"
             parseReplLine "/new now"
@@ -251,10 +251,10 @@ spec = do
                 `shouldBe` ReplCommandError "usage: /delete"
 
         it "returns home or rewinds through Grok-compatible aliases" do
-            parseReplLine "/home" `shouldBe` ReplHome
-            parseReplLine "/welcome" `shouldBe` ReplHome
-            parseReplLine "/rewind" `shouldBe` ReplRewind
-            parseReplLine "/undo" `shouldBe` ReplRewind
+            parseReplLine "/home" `shouldBe` ReplSession ReplHome
+            parseReplLine "/welcome" `shouldBe` ReplSession ReplHome
+            parseReplLine "/rewind" `shouldBe` ReplSession ReplRewind
+            parseReplLine "/undo" `shouldBe` ReplSession ReplRewind
             parseReplLine "/home now"
                 `shouldBe` ReplCommandError "usage: /home"
             parseReplLine "/undo now"
@@ -277,19 +277,19 @@ spec = do
 
         it "pastes clipboard images with an optional caption" do
             parseReplLine "/paste"
-                `shouldBe` ReplPaste False ""
+                `shouldBe` ReplAttachment (ReplPaste False "")
             parseReplLine "  /Paste  "
-                `shouldBe` ReplPaste False ""
+                `shouldBe` ReplAttachment (ReplPaste False "")
             parseReplLine "/paste what is this?"
-                `shouldBe` ReplPaste False "what is this?"
+                `shouldBe` ReplAttachment (ReplPaste False "what is this?")
             parseReplLine "/paste   keep  spaces"
-                `shouldBe` ReplPaste False "keep  spaces"
+                `shouldBe` ReplAttachment (ReplPaste False "keep  spaces")
             parseReplLine "/paste --send"
-                `shouldBe` ReplPaste True ""
+                `shouldBe` ReplAttachment (ReplPaste True "")
             parseReplLine "/paste --send look"
-                `shouldBe` ReplPaste True "look"
-            parseReplLine "/attachments" `shouldBe` ReplShowAttachments
-            parseReplLine "/clear-attachments" `shouldBe` ReplClearAttachments
+                `shouldBe` ReplAttachment (ReplPaste True "look")
+            parseReplLine "/attachments" `shouldBe` ReplAttachment ReplShowAttachments
+            parseReplLine "/clear-attachments" `shouldBe` ReplAttachment ReplClearAttachments
 
         it "parses terminal clipboard commands" do
             parseReplLine "/copy"
@@ -319,40 +319,40 @@ spec = do
                 `shouldBe` ReplCommandError "usage: /copy-code [N]"
 
         it "opens the model picker with a bare /model" do
-            parseReplLine "/model" `shouldBe` ReplShowModel
-            parseReplLine "  /Model  " `shouldBe` ReplShowModel
-            parseReplLine "/m" `shouldBe` ReplShowModel
+            parseReplLine "/model" `shouldBe` ReplSelection ReplShowModel
+            parseReplLine "  /Model  " `shouldBe` ReplSelection ReplShowModel
+            parseReplLine "/m" `shouldBe` ReplSelection ReplShowModel
 
         it "sets a model name" do
-            parseReplLine "/model grok-4.6" `shouldBe` ReplSetModel "grok-4.6"
+            parseReplLine "/model grok-4.6" `shouldBe` ReplSelection (ReplSetModel "grok-4.6")
             parseReplLine "/m openai/gpt-5.1"
-                `shouldBe` ReplSetModel "openai/gpt-5.1"
+                `shouldBe` ReplSelection (ReplSetModel "openai/gpt-5.1")
             parseReplLine "/model openai/gpt-5.1"
-                `shouldBe` ReplSetModel "openai/gpt-5.1"
+                `shouldBe` ReplSelection (ReplSetModel "openai/gpt-5.1")
 
         it "opens and selects a theme" do
-            parseReplLine "/theme" `shouldBe` ReplShowTheme
-            parseReplLine "/t" `shouldBe` ReplShowTheme
+            parseReplLine "/theme" `shouldBe` ReplSelection ReplShowTheme
+            parseReplLine "/t" `shouldBe` ReplSelection ReplShowTheme
             parseReplLine "/theme TokyoNight"
-                `shouldBe` ReplSetTheme "TokyoNight"
+                `shouldBe` ReplSelection (ReplSetTheme "TokyoNight")
             parseReplLine "/t daylight"
-                `shouldBe` ReplSetTheme "daylight"
+                `shouldBe` ReplSelection (ReplSetTheme "daylight")
 
         it "rejects extra theme arguments" do
             parseReplLine "/theme tokyo night"
                 `shouldBe` ReplCommandError "usage: /theme [NAME]"
 
         it "opens the resume picker" do
-            parseReplLine "/resume" `shouldBe` ReplResume Nothing
-            parseReplLine "/resume abc-123" `shouldBe` ReplResume (Just "abc-123")
+            parseReplLine "/resume" `shouldBe` ReplSession (ReplResume Nothing)
+            parseReplLine "/resume abc-123" `shouldBe` ReplSession (ReplResume (Just "abc-123"))
             parseReplLine "/resume a b"
                 `shouldBe` ReplCommandError "usage: /resume [ID]"
 
         it "searches past conversations with the full query suffix" do
             parseReplLine "/search postgres migration"
-                `shouldBe` ReplSearch "postgres migration"
+                `shouldBe` ReplSession (ReplSearch "postgres migration")
             parseReplLine "/SEARCH   keep  spaces"
-                `shouldBe` ReplSearch "keep  spaces"
+                `shouldBe` ReplSession (ReplSearch "keep  spaces")
             parseReplLine "/search"
                 `shouldBe` ReplCommandError "usage: /search <QUERY>"
 
@@ -795,18 +795,18 @@ spec = do
 
         it "parses goal lifecycle and a strict trailing budget" do
             parseReplLineWithCatalog enabled "/goal"
-                `shouldBe` ReplGoalStatus
+                `shouldBe` ReplWorkflow ReplGoalStatus
             parseReplLineWithCatalog enabled "/goal status"
-                `shouldBe` ReplGoalStatus
+                `shouldBe` ReplWorkflow ReplGoalStatus
             parseReplLineWithCatalog enabled "/goal pause"
-                `shouldBe` ReplGoalPause
+                `shouldBe` ReplWorkflow ReplGoalPause
             parseReplLineWithCatalog enabled "/goal resume"
-                `shouldBe` ReplGoalResume
+                `shouldBe` ReplWorkflow ReplGoalResume
             parseReplLineWithCatalog enabled "/goal clear"
-                `shouldBe` ReplGoalClear
+                `shouldBe` ReplWorkflow ReplGoalClear
             case parseReplLineWithCatalog enabled
                     "/goal ship the widget --budget 1200" of
-                ReplGoalSet original objective budget expanded -> do
+                ReplWorkflow (ReplGoalSet original objective budget expanded) -> do
                     original
                         `shouldBe`
                             "/goal ship the widget --budget 1200"
@@ -835,13 +835,13 @@ spec = do
                 ""
                 `shouldBe` ["runs"]
             parseReplLineWithCatalog enabled "/workflow"
-                `shouldBe` ReplWorkflowRuns
+                `shouldBe` ReplWorkflow ReplWorkflowRuns
             parseReplLineWithCatalog enabled "/workflow runs"
-                `shouldBe` ReplWorkflowRuns
+                `shouldBe` ReplWorkflow ReplWorkflowRuns
             parseReplLineWithCatalog enabled "/workflow pause wf_12"
-                `shouldBe` ReplWorkflowManage "pause" (Just "wf_12")
+                `shouldBe` ReplWorkflow (ReplWorkflowManage "pause" (Just "wf_12"))
             parseReplLineWithCatalog enabled "/workflow wf_12 stop"
-                `shouldBe` ReplWorkflowManage "stop" (Just "wf_12")
+                `shouldBe` ReplWorkflow (ReplWorkflowManage "stop" (Just "wf_12"))
             case parseReplLineWithCatalog enabled
                     "/workflow deep-research rust pitfalls" of
                 ReplExpandedPrompt original expanded -> do


### PR DESCRIPTION
REPL dispatch previously passed the entire `ReplAction` sum to handlers that accepted only a few constructors and called `error` for everything else. Introduce attachment, selection, workflow, and session action types inside the outer sum. Each dispatcher branch unwraps its subsystem once, and the corresponding handler is exhaustive.

Narrow clipboard and selection shortcut inputs as well, removing all five unsupported-input/action crashes. Update slash-command parsing, parser expectations, and the Meta Console's explicit command allowlist while preserving command behavior.

Validation:
- Nix/Cabal GHCi loaded all 210 CLI modules with incomplete-pattern checks enabled.
- 149 command, TUI composer, and Meta Console examples pass, including QuickCheck properties with 500 and 300 cases.
- Live CLI in tmux: `/effort`, `/attachments`, and `/session-info` dispatch successfully and return to the prompt.
