### PR TITLE
Show gateway usage in model picker

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
@@ -7,6 +7,7 @@ module Agent.CLI.ModelPicker
     , pickModelWithEffort
     , pickModelState
     , pickModelStateWithEffort
+    , pickModelStateWithEffortAndUsage
     , formatCatalogListing
     , initialModelPickerState
     , applyModelPickerEvent
@@ -69,6 +70,7 @@ data ModelPickerState = ModelPickerState
     { modelPickerModels :: !PickerState
     , modelPickerEfforts
         :: !(Map.Map (Text, Text, DialectId) ReasoningEffort)
+    , modelPickerUsage :: !(Map.Map Text Text)
     }
     deriving (Eq, Show)
 
@@ -178,9 +180,22 @@ pickModelStateWithEffort
     -> ReasoningEffort
     -> PickerState
     -> IO (Maybe ModelPickerSelection)
-pickModelStateWithEffort color currentEffort models = do
+pickModelStateWithEffort color currentEffort =
+    pickModelStateWithEffortAndUsage color currentEffort Map.empty
+
+-- | Open the model picker with compact usage text keyed by public model alias.
+-- Usage is presentation-only and never changes the alias used for routing.
+pickModelStateWithEffortAndUsage
+    :: Bool
+    -> ReasoningEffort
+    -> Map.Map Text Text
+    -> PickerState
+    -> IO (Maybe ModelPickerSelection)
+pickModelStateWithEffortAndUsage color currentEffort usage models = do
     isTty <- hIsTerminalDevice stdin
-    let state0 = initialModelPickerState currentEffort models
+    let state0 =
+            (initialModelPickerState currentEffort models)
+                { modelPickerUsage = usage }
     if not isTty
         then do
             Text.hPutStrLn stderr
@@ -210,6 +225,7 @@ initialModelPickerState currentEffort models =
                 [ (modelIdentity option, initialModelEffort models currentEffort option)
                 | option <- models.pickerAll
                 ]
+        , modelPickerUsage = Map.empty
         }
 
 -- | Efforts supported by a model-facing dialect.
@@ -360,6 +376,10 @@ renderModelPickerFrame color state =
                         gatewayMode
                         color
                         (index == selectedIndex)
+                        (not (Map.null state.modelPickerUsage))
+                        (Map.lookup
+                            option.modelTarget.targetModelId
+                            state.modelPickerUsage)
                         models.pickerConnectionId
                         models.pickerCurrent
                         models.pickerCurrentDialect
@@ -414,6 +434,8 @@ renderRow
     :: Bool
     -> Bool
     -> Bool
+    -> Bool
+    -> Maybe Text
     -> Text
     -> Text
     -> DialectId
@@ -424,6 +446,8 @@ renderRow
         gatewayMode
         color
         selected
+        showUsage
+        usage
         currentConnection
         current
         currentDialect
@@ -431,8 +455,19 @@ renderRow
         option =
     if selected
         then roleSelected color
-            ("› " <> clippedName <> padding <> "← " <> indicator <> " →")
-        else "  " <> clippedName <> padding <> roleMuted color indicator
+            ( "› "
+                <> clippedName
+                <> padding
+                <> usageColumn
+                <> "← "
+                <> indicator
+                <> " →"
+            )
+        else
+            "  "
+                <> clippedName
+                <> padding
+                <> roleMuted color (usageColumn <> indicator)
   where
     plainName =
         displayPickerText
@@ -443,15 +478,32 @@ renderRow
                 <> if isCurrent currentConnection current currentDialect option
                     then " ✓"
                     else "")
-    clippedName = Text.take modelNameWidth plainName
+    nameWidth
+        | showUsage = modelNameWithUsageWidth
+        | otherwise = modelNameWidth
+    clippedName = Text.take nameWidth plainName
     padding =
         Text.replicate
-            (max 2 (modelNameWidth - Text.length clippedName + 2))
+            (max 2 (nameWidth - Text.length clippedName + 2))
             " "
+    usageColumn
+        | not showUsage = ""
+        | otherwise =
+            clippedUsage
+                <> Text.replicate
+                    (max 2 (modelUsageWidth - Text.length clippedUsage + 2))
+                    " "
+    clippedUsage = Text.take modelUsageWidth (fromMaybe "" usage)
     indicator = renderEffortIndicator option effort
 
 modelNameWidth :: Int
 modelNameWidth = 44
+
+modelNameWithUsageWidth :: Int
+modelNameWithUsageWidth = 28
+
+modelUsageWidth :: Int
+modelUsageWidth = 30
 
 -- | Render a compact absolute effort gauge plus its canonical label.
 renderEffortIndicator :: ModelOption -> ReasoningEffort -> Text

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -11,6 +11,7 @@ module Agent.CLI.Session.Choices
 import Agent.CLI.Error (formatApiErrorInlineAt)
 import Agent.CLI.GatewayClient
     ( GatewayModelAccess
+    , fetchGatewayUsage
     , refreshGatewayModels
     )
 import Agent.CLI.GatewayModels (modelOptionsForGatewayModels)
@@ -23,7 +24,7 @@ import Agent.CLI.ModelPicker
     ( ModelPickerSelection(..)
     , initialModelEffort
     , modelEffortOptions
-    , pickModelStateWithEffort
+    , pickModelStateWithEffortAndUsage
     , renderEffortIndicator
     )
 import Agent.CLI.Models
@@ -53,6 +54,7 @@ import Agent.CLI.TUI.App
 import Agent.CLI.Options (defaultEffortFor)
 import Agent.CLI.Usage
     ( AccountUsageLine(..)
+    , formatModelUsageSummary
     , formatUsageReport
     )
 import Agent.Claude
@@ -74,7 +76,8 @@ import Agent.Provider
     , getNextToken
     )
 import Data.List (elemIndex)
-import Data.Maybe (fromMaybe)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -130,8 +133,8 @@ modelChoiceWithEffort
         currentEffort = do
     scopedPicker >>= \case
         Left err -> pure (Left err)
-        Right (title, picker) ->
-            Right <$> presentPicker title picker
+        Right (title, picker, usage) ->
+            Right <$> presentPicker title picker usage
   where
     scopedPicker =
         case gatewayAccess of
@@ -155,9 +158,13 @@ modelChoiceWithEffort
                                 OpenAIProvider
                                 current
                                 currentDialect
+                        usage <- loadGatewayModelUsage access options
                         pure
                             (Right
-                                ("Models · organization gateway", picker))
+                                ( "Models · organization gateway"
+                                , picker
+                                , usage
+                                ))
             Nothing -> do
                 discovered <- discoverModelOptions connectionId provider
                 picker <-
@@ -168,12 +175,16 @@ modelChoiceWithEffort
                         provider
                         current
                         currentDialect
-                pure (Right ("Models", picker))
+                pure (Right ("Models", picker, Map.empty))
 
-    presentPicker title picker =
+    presentPicker title picker usage =
         case fullscreen of
             Nothing ->
-                pickModelStateWithEffort color currentEffort picker
+                pickModelStateWithEffortAndUsage
+                    color
+                    currentEffort
+                    usage
+                    picker
             Just runtime -> do
                 let options = picker.pickerAll
                     row option =
@@ -182,8 +193,14 @@ modelChoiceWithEffort
                                 initialModelEffort picker currentEffort option
                             initialIndex =
                                 fromMaybe 0 (elemIndex initial efforts)
-                        in ( modelRowLabel picker option
-                           , modelDetail picker option
+                            usageText =
+                                Map.lookup
+                                    option.modelTarget.targetModelId
+                                    usage
+                            withUsage separator text =
+                                text <> maybe "" (separator <>) usageText
+                        in ( withUsage "  " (modelRowLabel picker option)
+                           , withUsage "\nUsage: " (modelDetail picker option)
                            , map (renderEffortIndicator option) efforts
                            , initialIndex
                            )
@@ -202,6 +219,24 @@ modelChoiceWithEffort
                                         , modelPickerEffort = effort
                                         }
                         _ -> pure Nothing
+
+loadGatewayModelUsage
+    :: GatewayModelAccess
+    -> [ModelOption]
+    -> IO (Map.Map Text Text)
+loadGatewayModelUsage access options =
+    Map.fromList . concat
+        <$> mapConcurrentlyBounded 4 loadUsage options
+  where
+    loadUsage option = do
+        let modelId = option.modelTarget.targetModelId
+        fetchGatewayUsage access modelId >>= \case
+            Left _ -> pure []
+            Right snapshot ->
+                pure
+                    [ (modelId, summary)
+                    | summary <- maybeToList (formatModelUsageSummary snapshot)
+                    ]
 
 discoverModelOptions :: Text -> Provider -> IO [ModelOption]
 discoverModelOptions connectionId provider

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -83,6 +83,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Time.Clock (getCurrentTime)
 import System.IO (stdout)
+import System.Timeout (timeout)
 
 modelChoice
     :: ModelCatalog
@@ -224,9 +225,12 @@ loadGatewayModelUsage
     :: GatewayModelAccess
     -> [ModelOption]
     -> IO (Map.Map Text Text)
-loadGatewayModelUsage access options =
-    Map.fromList . concat
-        <$> mapConcurrentlyBounded 4 loadUsage options
+loadGatewayModelUsage access options = do
+    loaded <-
+        timeout 2000000 $
+            Map.fromList . concat
+                <$> mapConcurrentlyBounded 4 loadUsage options
+    pure (fromMaybe Map.empty loaded)
   where
     loadUsage option = do
         let modelId = option.modelTarget.targetModelId

--- a/packages/agent-cli/src/Agent/CLI/Usage.hs
+++ b/packages/agent-cli/src/Agent/CLI/Usage.hs
@@ -204,6 +204,7 @@ formatModelUsageSummary snapshot = do
             ]
         summaries = map summarizeWindow windows
         parts
+            | not limits.allowed = "unavailable" : summaries
             | limits.limitReached = "limit reached" : summaries
             | otherwise = summaries
     case parts of

--- a/packages/agent-cli/src/Agent/CLI/Usage.hs
+++ b/packages/agent-cli/src/Agent/CLI/Usage.hs
@@ -6,6 +6,7 @@ module Agent.CLI.Usage
     , formatGrokLimitStatus
     , formatOpenAiLimitStatus
     , formatOpenRouterLimitStatus
+    , formatModelUsageSummary
     , formatUsageReport
     , formatUsageSummary
     , formatUsageWindow
@@ -186,6 +187,29 @@ formatUsageSummary now cooldownUntil result =
         Just usageLimit
             | usageLimit.limitReached -> ["limit reached"]
         _ -> []
+    summarizeWindow window =
+        usageWindowShortLabel window
+            <> " "
+            <> Text.pack (show (max 0 (100 - window.usedPercent)))
+            <> "% left"
+
+-- | Compact gateway-model usage suitable for a model-picker row.
+formatModelUsageSummary :: UsageSnapshot -> Maybe Text
+formatModelUsageSummary snapshot = do
+    limits <- snapshot.rateLimit
+    let windows =
+            [ window
+            | Just window <-
+                [limits.primaryWindow, limits.secondaryWindow]
+            ]
+        summaries = map summarizeWindow windows
+        parts
+            | limits.limitReached = "limit reached" : summaries
+            | otherwise = summaries
+    case parts of
+        [] -> Nothing
+        _ -> Just (Text.intercalate " · " parts)
+  where
     summarizeWindow window =
         usageWindowShortLabel window
             <> " "

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -13,6 +13,7 @@ import Agent.Provider (Provider(..))
 import Agent.ReasoningEffort (ReasoningEffort(..))
 import Control.Exception.Safe (bracket)
 import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import Test.Hspec
@@ -142,6 +143,39 @@ spec = do
             frame `shouldNotSatisfy`
                 Text.isInfixOf
                     (organizationGatewayConnectionId <> "/gpt-5.6-sol")
+
+        it "shows gateway usage beside each model alias" do
+            let gatewayOption modelId =
+                    let option = rawModelOption OpenAIProvider modelId
+                    in option
+                        { modelTarget =
+                            option.modelTarget
+                                { targetConnectionId =
+                                    organizationGatewayConnectionId
+                                }
+                        }
+                options =
+                    map gatewayOption ["gpt-5.6-sol", "claude-sonnet-5"]
+            models <-
+                initialPickerStateForOptions
+                    "organization gateway"
+                    options
+                    organizationGatewayConnectionId
+                    OpenAIProvider
+                    "gpt-5.6-sol"
+                    CodexDialect
+            let state =
+                    (initialModelPickerState EffortHigh models)
+                        { modelPickerUsage =
+                            Map.fromList
+                                [ ("gpt-5.6-sol", "5h 69% left · 7d 28% left")
+                                , ("claude-sonnet-5", "5h 42% left")
+                                ]
+                        }
+                frame = renderModelPickerFrame False state
+            frame `shouldSatisfy`
+                Text.isInfixOf "5h 69% left · 7d 28% left"
+            frame `shouldSatisfy` Text.isInfixOf "5h 42% left"
 
         it "makes untrusted catalog control characters inert" do
             let hostile =

--- a/packages/agent-cli/test/Agent/CLI/UsageSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UsageSpec.hs
@@ -80,6 +80,24 @@ spec = do
                 (Left (ConnectionError "offline"))
                 `shouldBe` "usage unavailable"
 
+    describe "formatModelUsageSummary" do
+        it "compacts gateway model windows without account metadata" do
+            formatModelUsageSummary sampleSnapshot
+                `shouldBe` Just "5h 69% left · 7d 28% left"
+
+        it "marks a reached gateway model limit" do
+            let snapshot = UsageSnapshot
+                    { planType = sampleSnapshot.planType
+                    , rateLimit =
+                        fmap
+                            (\limit -> limit { limitReached = True })
+                            sampleSnapshot.rateLimit
+                    , additionalRateLimits = sampleSnapshot.additionalRateLimits
+                    }
+            formatModelUsageSummary snapshot
+                `shouldBe`
+                    Just "limit reached · 5h 69% left · 7d 28% left"
+
     describe "composer limit status" do
         it "uses OpenAI's weekly window ahead of its 5-hour window" do
             formatOpenAiLimitStatus sampleSnapshot

--- a/packages/agent-cli/test/Agent/CLI/UsageSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/UsageSpec.hs
@@ -98,6 +98,19 @@ spec = do
                 `shouldBe`
                     Just "limit reached · 5h 69% left · 7d 28% left"
 
+        it "marks a disallowed gateway model as unavailable" do
+            let snapshot = UsageSnapshot
+                    { planType = sampleSnapshot.planType
+                    , rateLimit =
+                        fmap
+                            (\limit -> limit { allowed = False })
+                            sampleSnapshot.rateLimit
+                    , additionalRateLimits = sampleSnapshot.additionalRateLimits
+                    }
+            formatModelUsageSummary snapshot
+                `shouldBe`
+                    Just "unavailable · 5h 69% left · 7d 28% left"
+
     describe "composer limit status" do
         it "uses OpenAI's weekly window ahead of its 5-hour window" do
             formatOpenAiLimitStatus sampleSnapshot

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -1637,40 +1637,56 @@ drainTQueue queue =
 runAsyncToolManager :: LoopConfig -> AsyncToolManager -> IO ()
 runAsyncToolManager config manager = do
     request <- atomically (readTQueue manager.asyncToolRequests)
-    race
-        (waitCancel config.loopCancel)
-        (do
-            prepared <-
-                prepareManagedToolCall
-                    config
-                    request.managedRecord.managedCall
-            plan <- schedulingPlanForPrepared config prepared
-            pure (prepared, plan))
-        >>= \case
-            Left () -> do
-                -- Approval and scheduling are allowed to perform IO. Keep
-                -- cancellation structured around that whole preparation step
-                -- so a blocking approval cannot strand result waiters.
-                completeManagedToolRequest manager request (Right Nothing)
-                runAsyncToolManager config manager
-            Right (prepared, plan) -> do
-                atomically $
-                    modifyTVar'
-                        manager.asyncToolScheduled
-                        (IntMap.insert request.managedSequence plan)
-                withAsync
-                    (runManagedToolWorker
-                        config
-                        manager
-                        request
-                        prepared
-                        plan)
-                    \worker ->
-                        withAsync
-                            (waitCatch worker
-                                >>= completeManagedToolRequest manager request)
-                            \_monitor ->
-                                runAsyncToolManager config manager
+    cancelledBefore <- isCancelled config.loopCancel
+    if cancelledBefore
+        then completeCancelledRequest request
+        else
+            race
+                (waitCancel config.loopCancel)
+                (do
+                    prepared <-
+                        prepareManagedToolCall
+                            config
+                            request.managedRecord.managedCall
+                    plan <- schedulingPlanForPrepared config prepared
+                    pure (prepared, plan))
+                >>= \case
+                    Left () ->
+                        completeCancelledRequest request
+                    Right (prepared, plan) -> do
+                        cancelledAfter <- isCancelled config.loopCancel
+                        if cancelledAfter
+                            then completeCancelledRequest request
+                            else do
+                                atomically $
+                                    modifyTVar'
+                                        manager.asyncToolScheduled
+                                        (IntMap.insert
+                                            request.managedSequence
+                                            plan)
+                                withAsync
+                                    (runManagedToolWorker
+                                        config
+                                        manager
+                                        request
+                                        prepared
+                                        plan)
+                                    \worker ->
+                                        withAsync
+                                            (waitCatch worker
+                                                >>= completeManagedToolRequest
+                                                    manager
+                                                    request)
+                                            \_monitor ->
+                                                runAsyncToolManager
+                                                    config
+                                                    manager
+  where
+    -- Approval and scheduling are allowed to perform IO. Complete cancelled
+    -- requests so blocking result waiters cannot be stranded.
+    completeCancelledRequest request = do
+        completeManagedToolRequest manager request (Right Nothing)
+        runAsyncToolManager config manager
 
 prepareManagedToolCall :: LoopConfig -> ToolCall -> IO PreparedToolCall
 prepareManagedToolCall config call

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -63,6 +63,7 @@ import Control.Concurrent.MVar
     , tryReadMVar
     )
 import qualified Control.Exception as Exception
+import Control.Monad (when)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Bits (complement, shiftR, xor, (.&.))
@@ -1317,6 +1318,7 @@ spec = describe "runLoop" do
 
     it "evaluates dynamic-call approvals serially in model order" do
         approvalOrder <- newIORef []
+        approvalsFinished <- newEmptyMVar
         releaseFirst <- newEmptyMVar
         firstStarted <- newEmptyMVar
         let first = do
@@ -1343,10 +1345,14 @@ spec = describe "runLoop" do
                 { loopTools = registryFromTools tools
                 , loopApprove = \call -> do
                     modifyIORef' approvalOrder (<> [call.name])
+                    when (call.name == "independent") $
+                        putMVar approvalsFinished ()
                     pure (Right True)
                 }
         withAsync (runLoop config Nothing "go") \running -> do
             timeout concurrencyProbeMicros (takeMVar firstStarted)
+                `shouldReturn` Just ()
+            timeout concurrencyProbeMicros (takeMVar approvalsFinished)
                 `shouldReturn` Just ()
             readIORef approvalOrder
                 `shouldReturn` ["first", "conflicting", "independent"]


### PR DESCRIPTION
## Summary
- fetch per-model usage from the organization gateway with bounded concurrency
- show compact usage windows in minimal and fullscreen model pickers
- keep model selection available when individual usage requests fail

## Testing
- `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code` (focused model picker and usage specs)
- live minimal picker smoke test in tmux, including selection navigation
- `git diff --check`