### PR TITLE
Require NonEmpty accounts for available OpenAI pools

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/Auth/OpenAI.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Auth/OpenAI.hs
@@ -60,6 +60,7 @@ import Data.IORef
     )
 import Data.Containers.ListUtils (nubOrdOn)
 import Data.List (find)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Maybe (catMaybes, fromMaybe, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -326,8 +327,9 @@ loadOpenAi = do
             filter ((== billing) . (.openAiBilling)) accounts
     refreshLock <- lift (newMVar ())
     accountSources <- lift (newIORef activeAccounts)
-    let initial = map (.openAiState) activeAccounts
-        refresh =
+    initial <- maybe (throwE noAuthHint) pure $
+        NonEmpty.nonEmpty (map (.openAiState) activeAccounts)
+    let refresh =
             refreshOpenAiAccount refreshLock clientId accountSources
         discover =
             discoverOpenAiAccounts billing accountSources

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -1,5 +1,6 @@
 module Agent.CLI.AuthSpec (spec) where
 
+import Data.List.NonEmpty (NonEmpty((:|)))
 import Agent.CLI.Auth
 import Agent.CLI.CredentialStore
 import Agent.CLI.Dictation
@@ -1100,9 +1101,7 @@ spec = do
     describe "preferredOpenAiTokenProvider" do
         it "keeps using the selected account until it fails" do
             pool <- OpenAI.newPool
-                [ testAuthStateFor "acc-1"
-                , testAuthStateFor "acc-2"
-                ]
+                (testAuthStateFor "acc-1" :| [testAuthStateFor "acc-2"])
                 (pure . Right)
             fallback <- OpenAICredential.poolTokenProvider pool
             preferred <- newIORef (Just "acc-2")
@@ -1144,9 +1143,7 @@ spec = do
 
         it "falls back when the preferred account is already cooling down" do
             pool <- OpenAI.newPool
-                [ testAuthStateFor "acc-1"
-                , testAuthStateFor "acc-2"
-                ]
+                (testAuthStateFor "acc-1" :| [testAuthStateFor "acc-2"])
                 (pure . Right)
             fallback <- OpenAICredential.poolTokenProvider pool
             preferred <- newIORef (Just "acc-2")
@@ -1168,9 +1165,7 @@ spec = do
 
         it "keeps the selection when another credential reports failure" do
             pool <- OpenAI.newPool
-                [ testAuthStateFor "acc-1"
-                , testAuthStateFor "acc-2"
-                ]
+                (testAuthStateFor "acc-1" :| [testAuthStateFor "acc-2"])
                 (pure . Right)
             fallback <- OpenAICredential.poolTokenProvider pool
             preferred <- newIORef (Just "acc-2")

--- a/packages/agent-openai/README.md
+++ b/packages/agent-openai/README.md
@@ -24,6 +24,8 @@ import Agent.Responses.Types
 main :: IO ()
 main = do
     -- Load tokens from wherever (env, file, DB, ...) and build a pool.
+    -- initialStates :: NonEmpty OpenAI.AuthState; validate an input list
+    -- with Data.List.NonEmpty.nonEmpty before constructing the pool.
     pool <- OpenAI.newPool initialStates
         (OpenAI.refreshAccessTokenHTTP oauthClientId)
     provider <- poolTokenProvider pool

--- a/packages/agent-openai/src/Agent/OpenAI/Auth.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Auth.hs
@@ -86,6 +86,7 @@ import Data.IORef
     )
 import Data.Containers.ListUtils (nubOrd)
 import Data.Foldable (toList)
+import Data.List.NonEmpty (NonEmpty)
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Maybe (catMaybes, fromMaybe)
@@ -201,17 +202,15 @@ authFailureRetrySeconds = 60
 
 -- | Build a pool from a non-empty list of 'AuthState' values and a refresh
 -- callback. The callback is invoked when an access token needs rotating.
---
--- Throws @error@ if @initial@ is empty.
 newPool
-    :: [AuthState]
+    :: NonEmpty AuthState
     -> (AuthState -> IO (Either ApiError AuthState))
     -> IO Pool
 newPool initial refresh =
     newPoolWithDiscovery initial refresh Nothing Nothing
 
 newDiscoveringPool
-    :: [AuthState]
+    :: NonEmpty AuthState
     -> (AuthState -> IO (Either ApiError AuthState))
     -> AccountDiscovery
     -> IO Pool
@@ -223,7 +222,7 @@ newDiscoveringPool initial refresh discover =
 -- callback is used to check current provider usage and clear only rate-limit
 -- cooldowns that have actually reset.
 newDiscoveringPoolWithRateLimitRevalidation
-    :: [AuthState]
+    :: NonEmpty AuthState
     -> (AuthState -> IO (Either ApiError AuthState))
     -> AccountDiscovery
     -> RateLimitRevalidation
@@ -237,15 +236,13 @@ newDiscoveringPoolWithRateLimitRevalidation
         (Just revalidate)
 
 newPoolWithDiscovery
-    :: [AuthState]
+    :: NonEmpty AuthState
     -> (AuthState -> IO (Either ApiError AuthState))
     -> Maybe AccountDiscovery
     -> Maybe RateLimitRevalidation
     -> IO Pool
-newPoolWithDiscovery initial refresh discovery revalidation = do
-    when (null initial) $
-        error "Agent.OpenAI.Auth.newPool: called with empty account list"
-    buildPool initial Nothing refresh discovery revalidation
+newPoolWithDiscovery initial refresh discovery revalidation =
+    buildPool (toList initial) Nothing refresh discovery revalidation
 
 -- | Build a broker-backed pool when no account is currently available but the
 -- broker supplied the earliest reset.

--- a/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/AuthSpec.hs
@@ -1,5 +1,6 @@
 module Agent.OpenAI.AuthSpec (spec) where
 
+import Data.List.NonEmpty (NonEmpty((:|)))
 import Agent.OpenAI.Auth
 import Agent.OpenAI.Auth.Refresh (RefreshResponse(RefreshResponse), decodeRefreshResponse)
 import Agent.Error
@@ -157,7 +158,7 @@ spec = do
     describe "newPool + getAccessToken" $ do
         it "dispenses fresh tokens without calling the refresh callback" $ do
             callCounter <- newIORef (0 :: Int)
-            pool <- newPool [mkFreshAuth "acc-1"] (countingRefresh callCounter)
+            pool <- newPool (mkFreshAuth "acc-1" :| []) (countingRefresh callCounter)
             result <- getAccessToken pool
             result `shouldSatisfy` isRight
             readIORef callCounter `shouldReturn` 0
@@ -180,7 +181,7 @@ spec = do
                             takeMVar releaseFirstRefresh
                         else putMVar laterRefreshStarted ()
                     pure (Right refreshed)
-            pool <- newPool [mkExpiredAuth "acc"] refresh
+            pool <- newPool (mkExpiredAuth "acc" :| []) refresh
 
             withAsync (getAccessToken pool) \firstCheckout -> do
                 takeMVar firstRefreshStarted
@@ -203,7 +204,7 @@ spec = do
 
         it "alternates between accounts on consecutive calls (round-robin)" $ do
             callCounter <- newIORef (0 :: Int)
-            let states = [ mkFreshAuth "acc-1", mkFreshAuth "acc-2" ]
+            let states = (mkFreshAuth "acc-1" :| [mkFreshAuth "acc-2"])
             pool <- newPool states (countingRefresh callCounter)
             ids <- mapM (const (accountIdOf <$> getAccessToken pool)) [1 .. 3 :: Int]
             -- Three consecutive calls with N=2 accounts must hit both, and
@@ -215,7 +216,7 @@ spec = do
                 _ -> expectationFailure "expected three round-robin samples"
 
         it "checks out a requested account without depending on round-robin" $ do
-            let states = [ mkFreshAuth "acc-1", mkFreshAuth "acc-2" ]
+            let states = (mkFreshAuth "acc-1" :| [mkFreshAuth "acc-2"])
             pool <- newPool states neverRefresh
 
             getAccessTokenForAccount pool "acc-2"
@@ -227,7 +228,7 @@ spec = do
 
         it "respects cooldown for a requested account" $ do
             pool <- newPool
-                [mkFreshAuth "paced", mkFreshAuth "healthy"]
+                (mkFreshAuth "paced" :| [mkFreshAuth "healthy"])
                 neverRefresh
             reportRateLimit pool "paced" (Just 60)
 
@@ -239,7 +240,7 @@ spec = do
                             <> show other)
 
         it "reports an unknown requested account" $ do
-            pool <- newPool [mkFreshAuth "known"] neverRefresh
+            pool <- newPool (mkFreshAuth "known" :| []) neverRefresh
             getAccessTokenForAccount pool "missing" >>= \case
                 Left CredentialError{} -> pure ()
                 other ->
@@ -249,7 +250,7 @@ spec = do
 
         it "fails over when the selected account cannot refresh" $ do
             attempts <- newIORef ([] :: [Text])
-            let states = [ mkExpiredAuth "acc-broken", mkExpiredAuth "acc-ok" ]
+            let states = (mkExpiredAuth "acc-broken" :| [mkExpiredAuth "acc-ok"])
                 refresh state = do
                     previous <- readIORef attempts
                     modifyIORef' attempts (<> [state.accountId])
@@ -267,7 +268,7 @@ spec = do
 
         it "fails over when the selected account has a local credential error" $ do
             attempts <- newIORef ([] :: [Text])
-            let states = [ mkExpiredAuth "acc-broken", mkExpiredAuth "acc-ok" ]
+            let states = (mkExpiredAuth "acc-broken" :| [mkExpiredAuth "acc-ok"])
                 refresh state = do
                     previous <- readIORef attempts
                     modifyIORef' attempts (<> [state.accountId])
@@ -288,7 +289,7 @@ spec = do
         it "retains a token-endpoint rejection without its response body" do
             let secretBody = "TOP_SECRET_REFRESH_RESPONSE"
                 refresh _ = pure $ Left $ HttpError 403 secretBody
-            pool <- newPool [mkExpiredAuth "acc-broken"] refresh
+            pool <- newPool (mkExpiredAuth "acc-broken" :| []) refresh
 
             result <- getAccessToken pool
 
@@ -308,7 +309,7 @@ spec = do
     describe "reportRateLimit" $ do
         it "skips rate-limited accounts on subsequent picks" $ do
             callCounter <- newIORef (0 :: Int)
-            let states = [ mkFreshAuth "acc-1", mkFreshAuth "acc-2" ]
+            let states = (mkFreshAuth "acc-1" :| [mkFreshAuth "acc-2"])
             pool <- newPool states (countingRefresh callCounter)
             reportRateLimit pool "acc-1" (Just 60)
             -- Every pick for the next 60s must land on acc-2.
@@ -316,7 +317,7 @@ spec = do
             ids `shouldSatisfy` all (== "acc-2")
 
         it "does not shorten an existing longer cooldown" $ do
-            pool <- newPool [mkFreshAuth "only-acc"] neverRefresh
+            pool <- newPool (mkFreshAuth "only-acc" :| []) neverRefresh
             reportRateLimit pool "only-acc" (Just 3600)
             [before] <- snapshotAccounts pool
             reportRateLimit pool "only-acc" (Just 60)
@@ -324,7 +325,7 @@ spec = do
             after.snapshotCooldownUntil `shouldBe` before.snapshotCooldownUntil
 
         it "returns CredentialsExhausted when every account is cooling down" $ do
-            pool <- newPool [mkFreshAuth "only-acc"] neverRefresh
+            pool <- newPool (mkFreshAuth "only-acc" :| []) neverRefresh
             reportRateLimit pool "only-acc" (Just 60)
             result <- getAccessToken pool
             case result of
@@ -344,9 +345,7 @@ spec = do
                     modifyIORef' checks (auth.accountId :)
                     pure (Right (auth.accountId == "reset-account"))
             pool <- newDiscoveringPoolWithRateLimitRevalidation
-                [ mkFreshAuth "still-limited"
-                , mkFreshAuth "reset-account"
-                ]
+                (mkFreshAuth "still-limited" :| [mkFreshAuth "reset-account"])
                 neverRefresh
                 noDiscovery
                 revalidate
@@ -373,7 +372,7 @@ spec = do
                     modifyIORef' checks (+ 1)
                     pure (Right True)
             pool <- newDiscoveringPoolWithRateLimitRevalidation
-                [mkFreshAuth "burst-limited"]
+                (mkFreshAuth "burst-limited" :| [])
                 neverRefresh
                 noDiscovery
                 revalidate
@@ -392,9 +391,7 @@ spec = do
                     modifyIORef' checks (auth.accountId :)
                     pure (Right True)
             pool <- newDiscoveringPoolWithRateLimitRevalidation
-                [ mkFreshAuth "window-reset"
-                , mkFreshAuth "burst-limited"
-                ]
+                (mkFreshAuth "window-reset" :| [mkFreshAuth "burst-limited"])
                 neverRefresh
                 noDiscovery
                 revalidate
@@ -412,7 +409,7 @@ spec = do
 
         it "revalidates an explicitly requested cooling account" do
             pool <- newDiscoveringPoolWithRateLimitRevalidation
-                [mkFreshAuth "requested-account"]
+                (mkFreshAuth "requested-account" :| [])
                 neverRefresh
                 noDiscovery
                 (const (pure (Right True)))
@@ -437,7 +434,7 @@ spec = do
                     writeIORef checkedToken (Just auth.accessToken)
                     pure (Right True)
             pool <- newDiscoveringPoolWithRateLimitRevalidation
-                [mkExpiredAuth "reset-account"]
+                (mkExpiredAuth "reset-account" :| [])
                 refresh
                 noDiscovery
                 revalidate
@@ -457,7 +454,7 @@ spec = do
                     modifyIORef' checks (+ 1)
                     pure (Right False)
             pool <- newDiscoveringPoolWithRateLimitRevalidation
-                [mkFreshAuth "still-limited"]
+                (mkFreshAuth "still-limited" :| [])
                 neverRefresh
                 noDiscovery
                 revalidate
@@ -478,7 +475,7 @@ spec = do
                     takeMVar releaseCheck
                     pure (Right True)
             pool <- newDiscoveringPoolWithRateLimitRevalidation
-                [mkFreshAuth "reset-account"]
+                (mkFreshAuth "reset-account" :| [])
                 neverRefresh
                 noDiscovery
                 revalidate
@@ -497,7 +494,7 @@ spec = do
                     modifyIORef' discoveryCalls (<> [excluded])
                     pure (Right [mkFreshAuth "newly-healthy"])
             pool <- newDiscoveringPool
-                [mkFreshAuth "initial-account"]
+                (mkFreshAuth "initial-account" :| [])
                 neverRefresh
                 discover
             reportRateLimit pool "initial-account" (Just 60)
@@ -515,7 +512,7 @@ spec = do
                     modifyIORef' discoveryCalls (+ 1)
                     pure (Right [mkFreshAuth "new-account"])
             pool <- newDiscoveringPool
-                [mkFreshAuth "initial-account"]
+                (mkFreshAuth "initial-account" :| [])
                 neverRefresh
                 discover
 
@@ -536,7 +533,7 @@ spec = do
                     takeMVar releaseDiscovery
                     pure (Right [mkFreshAuth "discovered-account"])
             pool <- newDiscoveringPool
-                [mkFreshAuth "initial-account"]
+                (mkFreshAuth "initial-account" :| [])
                 neverRefresh
                 discover
 
@@ -568,7 +565,7 @@ spec = do
                         else pure
                             (Right [mkFreshAuth "recovered-account"])
             pool <- newDiscoveringPool
-                [mkFreshAuth "initial-account"]
+                (mkFreshAuth "initial-account" :| [])
                 neverRefresh
                 discover
 
@@ -581,7 +578,7 @@ spec = do
             let brokerUnavailable _ =
                     pure (Left (HttpError 503 "broker temporarily unavailable"))
             pool <- newDiscoveringPool
-                [mkFreshAuth "only-account"]
+                (mkFreshAuth "only-account" :| [])
                 neverRefresh
                 brokerUnavailable
             reportRateLimit pool "only-account" (Just 60)
@@ -619,7 +616,7 @@ spec = do
 
     describe "reportAuthBroken" $ do
         it "cools the account down" $ do
-            let states = [ mkFreshAuth "acc-a", mkFreshAuth "acc-b" ]
+            let states = (mkFreshAuth "acc-a" :| [mkFreshAuth "acc-b"])
             pool <- newPool states neverRefresh
             reportAuthBroken pool "acc-a"
             ids <- mapM (const (accountIdOf <$> getAccessToken pool)) [1 .. 3 :: Int]
@@ -627,7 +624,7 @@ spec = do
 
         it "retries an auth-broken account after about one minute" $ do
             now <- getCurrentTime
-            pool <- newPool [mkFreshAuth "only-account"] neverRefresh
+            pool <- newPool (mkFreshAuth "only-account" :| []) neverRefresh
             reportAuthBroken pool "only-account"
 
             result <- getAccessToken pool
@@ -650,7 +647,7 @@ spec = do
                 refresh _ = do
                     modifyIORef' callCounter (+ 1)
                     pure (Right rotated)
-            pool <- newPool [startState] refresh
+            pool <- newPool (startState :| []) refresh
             outcome <- forceRefresh pool "acc"
             outcome `shouldSatisfy` isRight
             readIORef callCounter `shouldReturn` 1
@@ -671,7 +668,7 @@ spec = do
                     putMVar refreshStarted ()
                     takeMVar releaseRefresh
                     pure (Right rotated)
-            pool <- newPool [startState] refresh
+            pool <- newPool (startState :| []) refresh
 
             withAsync (forceRefresh pool "acc") \forcedRefresh -> do
                 takeMVar refreshStarted
@@ -692,7 +689,7 @@ spec = do
                             Right (rotated.accessToken, rotated.accountId)
 
         it "returns Left with an AuthenticationError when the accountId is unknown" $ do
-            pool <- newPool [mkFreshAuth "acc"] neverRefresh
+            pool <- newPool (mkFreshAuth "acc" :| []) neverRefresh
             outcome <- forceRefresh pool "does-not-exist"
             outcome `shouldSatisfy` isLeft
 
@@ -701,7 +698,7 @@ spec = do
                 changedIdentity =
                     (mkFreshAuth "other")
                         { accessToken = (mkFreshAuth "rotated").accessToken }
-            pool <- newPool [startState] (const (pure (Right changedIdentity)))
+            pool <- newPool (startState :| []) (const (pure (Right changedIdentity)))
 
             forceRefresh pool "acc" >>= \case
                 Left CredentialError{} -> pure ()
@@ -728,7 +725,7 @@ spec = do
                 refresh _ = do
                     modifyIORef' callCounter (+ 1)
                     pure (Right rotated)
-            pool <- newPool [startState] refresh
+            pool <- newPool (startState :| []) refresh
 
             outcome <- refreshAfterAuthFailure pool "acc"
 
@@ -749,7 +746,7 @@ spec = do
                     putMVar refreshStarted ()
                     takeMVar releaseRefresh
                     pure (Right rotated)
-            pool <- newPool [startState] refresh
+            pool <- newPool (startState :| []) refresh
             beforeCooldown <- getCurrentTime
             cooldownReportStarted <- newEmptyMVar
 
@@ -783,7 +780,7 @@ spec = do
                     maybe False (> addUTCTime 3500 beforeCooldown)
 
         it "cools a rejected account when forced refresh fails" $ do
-            let states = [mkFreshAuth "broken", mkFreshAuth "healthy"]
+            let states = (mkFreshAuth "broken" :| [mkFreshAuth "healthy"])
                 refresh state
                     | state.accountId == "broken" =
                         pure (Left (ProviderError AuthenticationError "refresh rejected" Nothing))
@@ -800,7 +797,7 @@ spec = do
             let refreshError =
                     ConnectionError "TOP_SECRET_REFRESH_EXCEPTION"
                 refresh _ = pure (Left refreshError)
-            pool <- newPool [mkFreshAuth "broken"] refresh
+            pool <- newPool (mkFreshAuth "broken" :| []) refresh
 
             refreshAfterAuthFailure pool "broken" >>= \case
                 Left err -> err `shouldBe` refreshError
@@ -820,18 +817,18 @@ spec = do
 
     describe "allAccountIds + readAccountState" $ do
         it "lists every account currently in the pool" $ do
-            let states = [ mkFreshAuth "a", mkFreshAuth "b", mkFreshAuth "c" ]
+            let states = (mkFreshAuth "a" :| [mkFreshAuth "b", mkFreshAuth "c"])
             pool <- newPool states neverRefresh
             ids <- allAccountIds pool
             uniq ids `shouldMatchList` ["a", "b", "c"]
 
         it "returns Nothing for unknown accountIds" $ do
-            pool <- newPool [mkFreshAuth "known"] neverRefresh
+            pool <- newPool (mkFreshAuth "known" :| []) neverRefresh
             mState <- readAccountState pool "unknown"
             mState `shouldSatisfy` isNothing
 
         it "snapshots cooldown alongside auth state" $ do
-            pool <- newPool [mkFreshAuth "paced"] neverRefresh
+            pool <- newPool (mkFreshAuth "paced" :| []) neverRefresh
             reportRateLimit pool "paced" (Just 120)
             snaps <- snapshotAccounts pool
             case snaps of

--- a/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/CredentialSpec.hs
@@ -1,5 +1,6 @@
 module Agent.OpenAI.CredentialSpec (spec) where
 
+import Data.List.NonEmpty (NonEmpty(..))
 import Agent.OpenAI.Auth (AuthState(..), newPool)
 import qualified Agent.OpenAI.Auth as Auth
 import Agent.OpenAI.Credential
@@ -175,7 +176,7 @@ spec = do
 
     describe "poolTokenProvider" do
         it "acquires a credential without exposing local pool details" do
-            provider <- localProvider ["acc-a"] (pure . Right)
+            provider <- localProvider ("acc-a" :| []) (pure . Right)
 
             tokenProviderBillingMode provider `shouldBe` SubscriptionBilled
             result <- getNextToken provider Nothing
@@ -183,7 +184,7 @@ spec = do
             fmap (.accountId) result `shouldBe` Right "acc-a"
 
         it "marks a limited account and immediately returns another" do
-            provider <- localProvider ["acc-a", "acc-b"] (pure . Right)
+            provider <- localProvider ("acc-a" :| ["acc-b"]) (pure . Right)
             first <- expectCredential =<< getNextToken provider Nothing
 
             second <- expectCredential =<< getNextToken provider
@@ -200,7 +201,7 @@ spec = do
             second.accountId `shouldNotBe` first.accountId
 
         it "returns CredentialsExhausted after every local account failed" do
-            provider <- localProvider ["acc-a", "acc-b"] (pure . Right)
+            provider <- localProvider ("acc-a" :| ["acc-b"]) (pure . Right)
             first <- expectCredential =<< getNextToken provider Nothing
             second <- expectCredential =<< getNextToken provider
                 (failed first (AccountRateLimited (Just 60)))
@@ -218,7 +219,7 @@ spec = do
                 refresh state = do
                     modifyIORef' refreshCalls (+ 1)
                     pure $ Right state { Auth.accessToken = freshToken "rotated" }
-            provider <- localProvider ["acc-a"] refresh
+            provider <- localProvider ("acc-a" :| []) refresh
             initial <- expectCredential =<< getNextToken provider Nothing
 
             rotated <- expectCredential =<< getNextToken provider
@@ -234,7 +235,7 @@ spec = do
                     { exhaustionErrorType = Nothing
                     , exhaustionStatusCode = Just 401
                     }
-            provider <- localProvider ["acc-a", "acc-b"] refresh
+            provider <- localProvider ("acc-a" :| ["acc-b"]) refresh
             first <- expectCredential =<< getNextToken provider Nothing
             second <- expectCredential =<< getNextToken provider
                 (failedWithReason
@@ -269,7 +270,7 @@ spec = do
                     takeMVar releaseRefresh
                     pure $ Right current
                         { Auth.accessToken = rotatedToken }
-            pool <- newPool [state] refresh
+            pool <- newPool (state :| []) refresh
             firstProvider <- poolTokenProvider pool
             secondProvider <- poolTokenProvider pool
             initial <- expectCredential
@@ -301,7 +302,7 @@ spec = do
                     call <- atomicModifyIORef' refreshCalls (\n -> (n + 1, n + 1))
                     pure $ Right state
                         { Auth.accessToken = freshToken ("rotated-" <> showText call) }
-            provider <- localProvider ["acc-a"] refresh
+            provider <- localProvider ("acc-a" :| []) refresh
             initial <- expectCredential =<< getNextToken provider Nothing
             let rejectionReason = ExhaustedByAuthentication
                     { exhaustionErrorType = Nothing
@@ -368,11 +369,10 @@ staticPoolAuthenticationTest :: IO ()
 staticPoolAuthenticationTest = do
     state <- freshAuth "acc-static"
     pool <- newPool
-        [ state
+        (state
             { accessToken = "static-token"
             , refreshToken = ""
-            }
-        ]
+            } :| [])
         unexpectedRefresh
     provider <- poolTokenProvider pool
     initial <- expectCredential =<< getNextToken provider Nothing
@@ -392,9 +392,7 @@ staticPoolCooldownTest = do
     staticState <- freshAuth "acc-static"
     oauthState <- freshAuth "acc-oauth"
     pool <- newPool
-        [ staticState { accessToken = "static-token", refreshToken = "" }
-        , oauthState
-        ]
+        (staticState { accessToken = "static-token", refreshToken = "" } :| [oauthState])
         (pure . Right)
     Auth.reportRateLimit pool "acc-oauth" (Just 90)
     provider <- poolTokenProvider pool
@@ -408,7 +406,7 @@ staticPoolCooldownTest = do
             ("expected CredentialsExhausted, got " <> show other)
 
 localProvider
-    :: [Text]
+    :: NonEmpty Text
     -> (AuthState -> IO (Either ApiError AuthState))
     -> IO TokenProvider
 localProvider accountIds refresh = do

--- a/packages/agent-openai/test/Agent/OpenAI/FunctionalSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/FunctionalSpec.hs
@@ -1,5 +1,6 @@
 module Agent.OpenAI.FunctionalSpec where
 
+import Data.List.NonEmpty (NonEmpty((:|)))
 import Test.Hspec
 
 import qualified Agent.OpenAI.Auth as Auth
@@ -28,7 +29,7 @@ spec = describe "Codex functional streaming" do
                 pendingWith "set CODEX_AUTH_JSON or CODEX_ACCESS_TOKEN (+ CODEX_ACCOUNT_ID or CODEX_ID_TOKEN) with a fresh access token to run the live Codex functional test"
             Just authState -> do
                 model <- fmap (Text.pack . fromMaybe "gpt-5.5") (lookupEnv "CODEX_TEST_MODEL")
-                pool <- Auth.newPool [authState] \state -> pure (Right state)
+                pool <- Auth.newPool (authState :| []) \state -> pure (Right state)
                 withCodexWs pool \conn _accountId -> do
                     first <- runHelloTurn conn model Nothing "Reply with exactly: hello world" "hello world"
                     _second <- runHelloTurn conn model (Just first.responseId) "Reply with exactly: hello again" "hello again"


### PR DESCRIPTION
Pool constructors accepted an empty account list and crashed with `error`, although available pools require at least one account. Require `NonEmpty AuthState` in the public available/discovering constructors and validate the loaded list at the CLI credential boundary. The explicit unavailable pool constructor still supports starting empty and discovering capacity later.

Update all callers, test fixtures, and the README example. Internal pool state can still become empty during discovery; this change concerns the available-pool construction contract.

Validation: GHCi under `nix develop`, `agent-openai:test:agent-openai-test`: AuthSpec and CredentialSpec passed (76 examples). Loaded `agent-cli-runtime:lib:agent-cli-runtime` in GHCi successfully (33 modules), including the updated credential loader. `git diff --check` passed.

CI note: the common base has unrelated compile blockers: `ProviderRuntimeSpec` imports hidden CLI provider modules, and `Agent.Server.Types` calls the disabled `imageBytes` / `fileBytes` record selectors. See the [CLI job](https://github.com/digitallyinduced/haskell-agent/actions/runs/33975303042/job/101330832917) and [server job](https://github.com/digitallyinduced/haskell-agent/actions/runs/33975461879/job/101331256432). The affected files and declarations were checked against the base revision.
