### PR TITLE
Make automatic fallback carry its billing boundary

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -366,7 +366,6 @@ requestAccountProviderSwitch
                             , transitionPendingTurn = Nothing
                             , transitionUnavailableProviders = Set.empty
                             , transitionCause = ManualTransition
-                            , transitionAutomaticBilling = Nothing
                             }
                         modelMessage
                             | currentProvider == selectedProvider =
@@ -532,10 +531,10 @@ continueAutomaticFallback
 continueAutomaticFallback
         fallbackEnabled homeHint cwdHint stderrHandle fullscreen failed apiError
     | not fallbackEnabled = pure Nothing
-    | otherwise = case ( failed.transitionAutomaticBilling
+    | otherwise = case ( failed.transitionCause
                        , failed.transitionPendingTurn
                        ) of
-        (Just billing, Just pending) -> do
+        (AutomaticFallback billing, Just pending) -> do
             home <- maybe getHomeDirectory pure homeHint
             cwd <- maybe getCurrentDirectory pure cwdHint
             loadModelCatalogAt home cwd >>= \case
@@ -644,8 +643,7 @@ chooseAutomaticProviderTransition
                         , transitionSessionId = sessionId
                         , transitionPendingTurn = Just pending
                         , transitionUnavailableProviders = unavailable'
-                        , transitionCause = AutomaticFallback
-                        , transitionAutomaticBilling = Just sourceBilling
+                        , transitionCause = AutomaticFallback sourceBilling
                         }
 
 chooseStartupProviderTransition
@@ -725,8 +723,7 @@ chooseStartupProviderTransition
                         , transitionSessionId = sessionId
                         , transitionPendingTurn = Nothing
                         , transitionUnavailableProviders = unavailable'
-                        , transitionCause = AutomaticFallback
-                        , transitionAutomaticBilling = Just sourceBilling
+                        , transitionCause = AutomaticFallback sourceBilling
                         }
 
 prepareProviderTransition
@@ -751,7 +748,6 @@ prepareProviderTransition cause unavailable pending rawChoice persist = do
                 , transitionPendingTurn = pending
                 , transitionUnavailableProviders = unavailable
                 , transitionCause = cause
-                , transitionAutomaticBilling = Nothing
                 }
 
 validateProviderTarget :: ModelOption -> IO (Either Text ())

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -36,7 +36,8 @@ data PendingTurn = PendingTurn
 
 data TransitionCause
     = ManualTransition
-    | AutomaticFallback
+    -- | Retain the initiating session's billing boundary across retries.
+    | AutomaticFallback !BillingMode
     deriving (Eq, Show)
 
 data ProviderTransition = ProviderTransition
@@ -52,10 +53,6 @@ data ProviderTransition = ProviderTransition
     , transitionPendingTurn :: !(Maybe PendingTurn)
     , transitionUnavailableProviders :: !(Set Provider)
     , transitionCause :: !TransitionCause
-    -- | Billing class of the session that initiated an automatic fallback.
-    -- Preserved across failed replacement providers so the whole chain obeys
-    -- the original billing boundary. Manual transitions use 'Nothing'.
-    , transitionAutomaticBilling :: !(Maybe BillingMode)
     }
 
 data TurnResult
@@ -102,7 +99,9 @@ resumePendingTurnIfPresent pendingTurnRef resume noPendingTurn =
 -- completes a request successfully, including fallbacks chosen at startup.
 transitionCommitsImmediately :: ProviderTransition -> Bool
 transitionCommitsImmediately transition =
-    transition.transitionCause == ManualTransition
+    case transition.transitionCause of
+        ManualTransition -> True
+        AutomaticFallback _ -> False
 
 -- | Publish a provisional prompt target before a slow validation action,
 -- restoring the prior target if that action rejects, throws, or is cancelled.

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -47,7 +47,7 @@ import Agent.CLI.ProviderTransition
       ProviderTransition(ProviderTransition, transitionCause,
                          transitionUnavailableProviders, transitionPendingTurn,
                          transitionTarget, transitionAccountSelectionId,
-                         transitionAccountId, transitionAutomaticBilling,
+                         transitionAccountId,
                          transitionSessionId, transitionEffort),
       TransitionCause(AutomaticFallback, ManualTransition) )
 import Agent.CLI.Render ( putTextLn )
@@ -322,7 +322,7 @@ runAgentWithRuntime processRuntime runMode options = do
             RunProviderStartFailed apiError ->
                 case transition of
                     Just failed
-                        | failed.transitionCause == AutomaticFallback ->
+                        | AutomaticFallback _ <- failed.transitionCause ->
                             continueAutomaticFallback
                                 (nativeProviderFallbackEnabled runMode)
                                 (nativeRunHomeHint runMode)
@@ -510,7 +510,6 @@ runAgent
                                     , transitionAccountId = Nothing
                                     , transitionUnavailableProviders = Set.empty
                                     , transitionCause = ManualTransition
-                                    , transitionAutomaticBilling = Nothing
                                     }
                             Nothing ->
                                 ProviderTransition
@@ -522,7 +521,6 @@ runAgent
                                     , transitionPendingTurn = Nothing
                                     , transitionUnavailableProviders = Set.empty
                                     , transitionCause = ManualTransition
-                                    , transitionAutomaticBilling = Nothing
                                     }
                     callbacks = RestartCallbacks
                         { restartPrepare =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -75,10 +75,11 @@ import Agent.CLI.Provider.Switch ( loadSelectedAccountAuth )
 import Agent.CLI.ProviderFallback
     ( allowsAutomaticBillingFallback )
 import Agent.CLI.ProviderTransition
-    ( ProviderTransition(transitionAutomaticBilling,
+    ( ProviderTransition(transitionCause,
                          transitionUnavailableProviders, transitionPendingTurn,
                          transitionTarget, transitionAccountSelectionId,
-                         transitionAccountId) )
+                         transitionAccountId)
+    , TransitionCause(AutomaticFallback) )
 import Agent.CLI.Resume ( publishResumeHistoryAfterBoundary )
 import Agent.CLI.Runtime.HistorySource
     ( loadFullscreenHistoryPage, sessionUiPageSize )
@@ -801,9 +802,8 @@ validateInitializedAuth request targets loaded = do
                     <> " but auth resolved "
                     <> providerSlug loaded.loadedProvider
         _ -> pure ()
-    case request.initializedTransition
-        >>= (.transitionAutomaticBilling) of
-        Just sourceBilling
+    case (.transitionCause) <$> request.initializedTransition of
+        Just (AutomaticFallback sourceBilling)
             | not
                 (allowsAutomaticBillingFallback
                     sourceBilling

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Restart.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Restart.hs
@@ -72,7 +72,7 @@ runFullscreenRestartLoop callbacks runtime =
                 RunProviderStartFailed apiError ->
                     case transition of
                         Just failed
-                            | failed.transitionCause == AutomaticFallback ->
+                            | AutomaticFallback _ <- failed.transitionCause ->
                                 callbacks.restartFallback failed apiError
                                     >>= \case
                                     Just next -> do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -1269,7 +1269,7 @@ handleOpenAiStartupResult request nativeCapabilities shouldProbeAtStartup = \cas
                 now <- getCurrentTime
                 startupDie request.startup (formatApiErrorAt now err)
         in case request.transition of
-            Just active | active.transitionCause == AutomaticFallback ->
+            Just active | AutomaticFallback _ <- active.transitionCause ->
                 pure (RunProviderStartFailed err)
             _ | shouldProbeAtStartup
               , not (isGatewayLoadedAuth request.loaded)

--- a/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderTransitionSpec.hs
@@ -111,8 +111,7 @@ transition sessionId pending = ProviderTransition
     , transitionSessionId = sessionId
     , transitionPendingTurn = pending
     , transitionUnavailableProviders = Set.singleton XAIProvider
-    , transitionCause = AutomaticFallback
-    , transitionAutomaticBilling = Just SubscriptionBilled
+    , transitionCause = AutomaticFallback SubscriptionBilled
     }
 
 pendingTurn :: PendingTurn


### PR DESCRIPTION
Automatic provider fallback must preserve the initiating session's billing class across replacement providers. The cause and optional billing field could previously contradict each other, and a missing field skipped the billing check.

Make `AutomaticFallback` carry `BillingMode` and remove the independent optional field. Startup validation, retry selection, and provisional-transition handling now pattern-match on that constructor; manual transitions cannot carry automatic billing metadata.

Validation: loaded the complete agent-cli library in GHCi under `nix develop` (211 modules); ProviderTransitionSpec and ProviderFallbackSpec passed (31 examples total). `git diff --check` passed.

CI note: the common base has unrelated compile blockers: `ProviderRuntimeSpec` imports hidden CLI provider modules, and `Agent.Server.Types` calls the disabled `imageBytes` / `fileBytes` record selectors. See the [CLI job](https://github.com/digitallyinduced/haskell-agent/actions/runs/33975303042/job/101330832917) and [server job](https://github.com/digitallyinduced/haskell-agent/actions/runs/33975461879/job/101331256432). The affected files and declarations were checked against the base revision.
