### PR TITLE
Serialize turn activity acquisition and cleanup

### DIFF
--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -71,6 +71,7 @@ library
                     , Agent.CLI.Session.StoreCodec
                     , Agent.CLI.Session.TitlePolicy
                     , Agent.CLI.Session.Types
+                    , Agent.CLI.Session.Activity
                     , Agent.CLI.SessionLock
                     , Agent.CLI.Transcription
     build-depends:    agent-claude >= 0.1 && < 0.2
@@ -128,6 +129,7 @@ test-suite agent-cli-runtime-test
                     , Agent.CLI.ManagedTurnSpec
                     , Agent.CLI.ModelConfigSpec
                     , Agent.CLI.ModelsSpec
+                    , Agent.CLI.SessionActivitySpec
                     , Agent.CLI.SessionSpec
     build-depends:    agent-cli-runtime
                     , agent-core

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/Activity.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/Activity.hs
@@ -1,0 +1,52 @@
+-- | Serialized ownership of a turn's optional activity marker. A turn can
+-- start before its durable session exists; persistence may install the marker
+-- later, but never after the turn has ended.
+module Agent.CLI.Session.Activity
+    ( TurnActivity
+    , newTurnActivity
+    , beginTurnActivity
+    , acquireTurnActivity
+    , endTurnActivity
+    ) where
+
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVarMasked
+    , modifyMVarMasked_
+    , newMVar
+    )
+import Data.Maybe (isJust)
+
+data ActivityState lock
+    = Inactive
+    | Active !(Maybe lock)
+
+newtype TurnActivity lock = TurnActivity (MVar (ActivityState lock))
+
+newTurnActivity :: IO (TurnActivity lock)
+newTurnActivity = TurnActivity <$> newMVar Inactive
+
+beginTurnActivity :: TurnActivity lock -> IO ()
+beginTurnActivity (TurnActivity state) =
+    modifyMVarMasked_ state \case
+        Inactive -> pure (Active Nothing)
+        active -> pure active
+
+-- | Acquire at most one marker for an active turn. The acquisition is inside
+-- the same critical section as cleanup, so ending a turn waits for any marker
+-- being acquired and releases it before publishing the inactive state.
+acquireTurnActivity :: TurnActivity lock -> IO (Maybe lock) -> IO Bool
+acquireTurnActivity (TurnActivity state) acquire =
+    modifyMVarMasked state \case
+        Active Nothing -> do
+            lock <- acquire
+            pure (Active lock, isJust lock)
+        current -> pure (current, False)
+
+endTurnActivity :: TurnActivity lock -> (lock -> IO ()) -> IO ()
+endTurnActivity (TurnActivity state) release =
+    modifyMVarMasked_ state \case
+        Inactive -> pure Inactive
+        Active lock -> do
+            mapM_ release lock
+            pure Inactive

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionActivitySpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionActivitySpec.hs
@@ -1,0 +1,64 @@
+module Agent.CLI.SessionActivitySpec (spec) where
+
+import Agent.CLI.Session.Activity
+import Control.Concurrent.Async (concurrently, wait, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Exception.Safe (finally)
+import Data.IORef (atomicModifyIORef', newIORef, readIORef)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "turn activity ownership" do
+    it "acquires once when persistence callbacks overlap" do
+        activity <- newTurnActivity
+        acquisitions <- newIORef (0 :: Int)
+        releases <- newIORef (0 :: Int)
+        let acquire = do
+                atomicModifyIORef' acquisitions (\n -> (n + 1, ()))
+                pure (Just ())
+            release () = atomicModifyIORef' releases (\n -> (n + 1, ()))
+        beginTurnActivity activity
+        (first, second) <- concurrently
+            (acquireTurnActivity activity acquire)
+            (acquireTurnActivity activity acquire)
+        (first /= second) `shouldBe` True
+        readIORef acquisitions `shouldReturn` 1
+        endTurnActivity activity release
+        endTurnActivity activity release
+        readIORef releases `shouldReturn` 1
+
+    it "joins an in-flight acquisition before ending and rejects late persistence" do
+        activity <- newTurnActivity
+        started <- newEmptyMVar
+        allowAcquire <- newEmptyMVar
+        ending <- newEmptyMVar
+        releases <- newIORef (0 :: Int)
+        let acquire = do
+                putMVar started ()
+                takeMVar allowAcquire
+                pure (Just ())
+            release () = atomicModifyIORef' releases (\n -> (n + 1, ()))
+        beginTurnActivity activity
+        withAsync (acquireTurnActivity activity acquire) \worker -> do
+            takeMVar started
+            withAsync (putMVar ending () >> endTurnActivity activity release) \cleanup -> do
+                takeMVar ending
+                blocked <- timeout 20_000 (wait cleanup)
+                    `finally` putMVar allowAcquire ()
+                blocked `shouldBe` Nothing
+                wait worker `shouldReturn` True
+                wait cleanup
+        readIORef releases `shouldReturn` 1
+        acquireTurnActivity activity
+            (expectationFailure "late persistence acquired a marker" >> pure (Just ()))
+            `shouldReturn` False
+
+    it "allows retry after an acquisition throws without losing the owner" do
+        activity <- newTurnActivity
+        beginTurnActivity activity
+        acquireTurnActivity activity (ioError (userError "failed acquisition"))
+            `shouldThrow` anyIOException
+        acquireTurnActivity activity (pure (Just ())) `shouldReturn` True
+        endTurnActivity activity (const (pure ()))
+        acquireTurnActivity activity (pure (Just ())) `shouldReturn` False

--- a/packages/agent-cli-runtime/test/Spec.hs
+++ b/packages/agent-cli-runtime/test/Spec.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import qualified Agent.CLI.SessionActivitySpec as SessionActivitySpec
 import Agent.CLI.Session.TitlePolicy (titleRefreshIndex)
 import qualified Agent.CLI.CredentialStoreSpec as CredentialStoreSpec
 import qualified Agent.CLI.EnvironmentSpec as EnvironmentSpec
@@ -15,6 +16,7 @@ import Test.Hspec
 
 main :: IO ()
 main = hspec do
+    SessionActivitySpec.spec
     describe "titleRefreshIndex" do
         it "advances only at the persisted title milestones" do
             map titleRefreshIndex [0, 1, 2, 3, 5, 6, 10]

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Session.Runner.Execution
     , SessionRunnerContinuation(..)
     , runSession
     ) where
+import qualified Agent.CLI.Session.Activity as Activity
 import Agent.CLI.CodeModeRuntime
 import Agent.CLI.Claude
     ( ClaudeSessionRuntime(..)
@@ -1264,39 +1265,28 @@ newSessionPersistenceRuntime
     -> IO SessionPersistenceRuntime
 newSessionPersistenceRuntime
         host skillsRuntime SessionRequest{..} = do
-    turnActivityRef <- newIORef Nothing
-    turnIsActiveRef <- newIORef False
+    turnActivity <- Activity.newTurnActivity
     nativeSessionIdRef <- newIORef Nothing
-    let acquireTurnActivity handle = mask_ do
-            current <- readIORef turnActivityRef
-            if isNothing current
-                then
+    let acquireTurnActivity handle =
+            Activity.acquireTurnActivity turnActivity $
+                -- The marker is best effort; the lifetime session lock
+                -- remains authoritative.
+                either (const Nothing) Just <$>
                     acquireSessionActivityLock
-                        handle.sessionDir
-                        handle.sessionMeta.metaId >>= \case
-                            -- The activity lock is an external status marker;
-                            -- the lifetime session lock remains authoritative.
-                            Left _ -> pure False
-                            Right lock -> do
-                                writeIORef turnActivityRef (Just lock)
-                                pure True
-                else pure False
-        beginTurnActivity = mask_ do
-            -- Mark first so a concurrently completed first persistence sees
-            -- the active turn and attempts the activity marker itself.
-            writeIORef turnIsActiveRef True
-            case persist of
-                PersistenceDisabled -> pure ()
-                PersistenceEnabled slotRef ->
-                    readIORef slotRef >>= \case
-                        PersistencePending{} -> pure ()
-                        PersistenceActive handle ->
-                            void (acquireTurnActivity handle)
-        endTurnActivity = do
-            writeIORef turnIsActiveRef False
-            atomicModifyIORef' turnActivityRef
-                (\current -> (Nothing, current))
-                >>= mapM_ releaseSessionLock
+                        handle.sessionDir handle.sessionMeta.metaId
+        endTurnActivity =
+            Activity.endTurnActivity turnActivity releaseSessionLock
+        beginTurnActivity = mask_ $
+            (do
+                Activity.beginTurnActivity turnActivity
+                case persist of
+                    PersistenceDisabled -> pure ()
+                    PersistenceEnabled slotRef ->
+                        readIORef slotRef >>= \case
+                            PersistencePending{} -> pure ()
+                            PersistenceActive handle ->
+                                void (acquireTurnActivity handle))
+                `onException` endTurnActivity
         notifyNativeSessionId sessionId = do
             shouldNotify <-
                 atomicModifyIORef' nativeSessionIdRef \current ->
@@ -1316,11 +1306,7 @@ newSessionPersistenceRuntime
             -- Preserve the established lock order: own the session before
             -- attempting its best-effort activity marker.
             onPersisted handle
-            active <- readIORef turnIsActiveRef
-            acquired <-
-                if active
-                    then acquireTurnActivity handle
-                    else pure False
+            acquired <- acquireTurnActivity handle
             notifyNativeSessionId handle.sessionMeta.metaId
                 `onException`
                     when acquired endTurnActivity


### PR DESCRIPTION
Turn activity used separate IORefs for the active flag and optional lock. A persistence callback could observe an active turn, overlap cleanup, and install a marker after cleanup had already released the previous state. Masking asynchronous exceptions did not serialize those transitions.

Introduce an opaque MVar-owned activity state, with acquisition and release in the same critical section. Late persistence cannot acquire after the turn ends, concurrent acquisitions share one marker, and failed acquisition leaves the owner available for retry. The runner retains its existing turn bracket and best-effort marker policy, with cleanup if beginning activity throws.

Validation: three focused GHCi tests cover overlapping persistence acquisitions, cleanup blocked behind an in-flight acquisition followed by late persistence, and acquisition failure/retry. Loaded agent-cli and agent-cli-runtime together in GHCi under `nix develop` (245 modules). Regenerated package.nix after adding the module/tests; expression unchanged. `git diff --check` passed.

CI note: the common base has unrelated compile blockers: `ProviderRuntimeSpec` imports hidden CLI provider modules, and `Agent.Server.Types` calls the disabled `imageBytes` / `fileBytes` record selectors. See the [CLI job](https://github.com/digitallyinduced/haskell-agent/actions/runs/33975303042/job/101330832917) and [server job](https://github.com/digitallyinduced/haskell-agent/actions/runs/33975461879/job/101331256432). The affected files and declarations were checked against the base revision.
