### PR TITLE
Send incremental accessibility updates during computer use

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayBridge.hs
@@ -514,6 +514,8 @@ updateManagedActivity event state =
             state
         NativeAgentFinished{} ->
             state
+        ModelContextReset ->
+            state
         TurnFinished _ ->
             state
                 { accumulatorKind = "finished"

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -181,6 +181,7 @@ library
                     , Agent.CLI.ComputerUse.Linux.Logind
                     , Agent.CLI.ComputerUse.Linux.Portal
                     , Agent.CLI.ComputerUse.Linux.X11
+                    , Agent.CLI.ComputerUse.Accessibility
                     , Agent.CLI.Config
                     , Agent.CLI.McpOAuthStore
                     , Agent.CLI.McpOAuth
@@ -440,6 +441,17 @@ benchmark history-eviction-bench
     build-depends:    agent-tui
                     , base >= 4.17 && < 5
                     , containers
+
+benchmark accessibility-delta-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          AccessibilityDelta.hs
+    ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-cli
+                    , aeson
+                    , base >= 4.17 && < 5
+                    , bytestring
                     , text
 
 benchmark concurrency-bench

--- a/packages/agent-cli/benchmark/AccessibilityDelta.hs
+++ b/packages/agent-cli/benchmark/AccessibilityDelta.hs
@@ -1,0 +1,212 @@
+module Main (main) where
+
+import Agent.CLI.ComputerUse
+    ( AccessibilityObservation(..)
+    , AccessibilitySnapshot(..)
+    , advanceAccessibilityObservation
+    , initialAccessibilityDeltaState
+    )
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import Data.List (sortOn)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload = Static | SmallChange | HighChurn
+    deriving (Eq, Show)
+
+data Policy = AlwaysFull | RevisionedDelta
+    deriving (Eq, Show)
+
+data Sample = Sample
+    { sampleElapsedMillis :: !Double
+    , sampleCpuMillis :: !Double
+    , sampleAllocatedBytes :: !Integer
+    , sampleOutputBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    statsEnabled <- getRTSStatsEnabled
+    if statsEnabled
+        then pure ()
+        else die "RTS statistics are disabled; run with +RTS -T"
+    getArgs >>= \case
+        [] -> runMatrix
+        [workloadArg, nodesArg, revisionsArg, samplesArg] -> do
+            workload <- parseWorkload workloadArg
+            nodes <- parsePositive "nodes" nodesArg
+            revisions <- parsePositive "revisions" revisionsArg
+            sampleCount <- parsePositive "samples" samplesArg
+            putStrLn csvHeader
+            runScenario sampleCount revisions nodes workload
+        _ -> die $
+            "usage: accessibility-delta-bench [WORKLOAD NODES REVISIONS SAMPLES]\n"
+                <> "workloads: static, small-change, high-churn\n"
+                <> "output: " <> csvHeader
+
+runMatrix :: IO ()
+runMatrix = do
+    putStrLn csvHeader
+    mapM_ (\nodes ->
+        mapM_ (runScenario 5 24 nodes) [Static, SmallChange, HighChurn])
+        [100, 500, 1000]
+
+runScenario :: Int -> Int -> Int -> Workload -> IO ()
+runScenario sampleCount revisions nodes workload = do
+    -- Build the same native snapshot stream once so measurements cover only
+    -- policy/diff work and JSON encoding, not fixture construction.
+    let snapshots =
+            [ makeSnapshot workload nodes revision
+            | revision <- [1 .. revisions]
+            ]
+    -- Warm both code paths before reading allocation and timing counters.
+    _ <- runPolicy AlwaysFull snapshots
+    _ <- runPolicy RevisionedDelta snapshots
+    mapM_ (\policy -> do
+        samples <- sequence
+            [ measure policy snapshots
+            | _ <- [1 .. sampleCount]
+            ]
+        printSample workload policy nodes revisions (median samples))
+        [AlwaysFull, RevisionedDelta]
+
+measure :: Policy -> [AccessibilitySnapshot] -> IO Sample
+measure policy snapshots = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    outputBytes <- runPolicy policy snapshots
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    afterStats <- getRTSStats
+    pure Sample
+        { sampleElapsedMillis =
+            fromIntegral (afterElapsed - beforeElapsed) / 1.0e6
+        , sampleCpuMillis =
+            fromIntegral (afterCpu - beforeCpu) / 1.0e9
+        , sampleAllocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        , sampleOutputBytes = outputBytes
+        }
+
+runPolicy :: Policy -> [AccessibilitySnapshot] -> IO Integer
+runPolicy policy snapshots = do
+    totalRef <- newIORef 0
+    case policy of
+        AlwaysFull ->
+            mapM_ (\(revision, snapshot) ->
+                addEncoded totalRef (AccessibilityFull revision snapshot))
+                (zip [1 ..] snapshots)
+        RevisionedDelta ->
+            go initialAccessibilityDeltaState snapshots totalRef
+    readIORef totalRef
+  where
+    go _ [] _ = pure ()
+    go state (snapshot : rest) totalRef = do
+        let (observation, successor) =
+                advanceAccessibilityObservation state snapshot
+        addEncoded totalRef observation
+        go successor rest totalRef
+
+addEncoded :: Aeson.ToJSON value => IORef Integer -> value -> IO ()
+addEncoded totalRef value = do
+    let bytes = fromIntegral (LBS.length (Aeson.encode value))
+    atomicModifyIORef' totalRef \total -> (total + bytes, ())
+
+makeSnapshot :: Workload -> Int -> Int -> AccessibilitySnapshot
+makeSnapshot workload nodes revision = AccessibilitySnapshot
+    { accessibilitySnapshotSchemaVersion = 1
+    , accessibilitySnapshotScope = Aeson.object
+        [ "application_bundle_identifier" Aeson..=
+            ("com.example.benchmark" :: Text)
+        , "window" Aeson..= Aeson.object
+            [ "identifier" Aeson..= ("main" :: Text) ]
+        ]
+    , accessibilitySnapshotContents = Aeson.object
+        [ "role" Aeson..= ("AXWindow" :: Text)
+        , "children" Aeson..= Aeson.Object (KeyMap.fromList
+            [ (Key.fromText (Text.pack (show index)), makeNode index)
+            | index <- [0 .. nodes - 1]
+            ])
+        ]
+    }
+  where
+    changedIndex = revision `mod` nodes
+    makeNode index = Aeson.object
+        [ "role" Aeson..= ("AXStaticText" :: Text)
+        , "identifier" Aeson..= ("row-" <> Text.pack (show index))
+        , "title" Aeson..= nodeTitle index
+        , "enabled" Aeson..= True
+        , "position" Aeson..= Aeson.object
+            [ "x" Aeson..= (index `mod` 80)
+            , "y" Aeson..= (index `div` 80)
+            ]
+        ]
+    nodeTitle index =
+        case workload of
+            Static -> "unchanged"
+            SmallChange
+                | index == changedIndex ->
+                    "changed-" <> Text.pack (show revision)
+                | otherwise -> "unchanged"
+            HighChurn ->
+                "revision-" <> Text.pack (show revision)
+                    <> "-node-" <> Text.pack (show index)
+
+median :: [Sample] -> Sample
+median samples =
+    sortOn (.sampleElapsedMillis) samples !! (length samples `div` 2)
+
+printSample :: Workload -> Policy -> Int -> Int -> Sample -> IO ()
+printSample workload policy nodes revisions sample =
+    printf
+        "%s,%s,%d,%d,%.3f,%.3f,%d,%d\n"
+        (workloadName workload)
+        (policyName policy)
+        nodes
+        revisions
+        sample.sampleElapsedMillis
+        sample.sampleCpuMillis
+        sample.sampleAllocatedBytes
+        sample.sampleOutputBytes
+
+csvHeader :: String
+csvHeader =
+    "workload,policy,nodes,revisions,elapsed_ms,cpu_ms,allocated_bytes,output_bytes"
+
+workloadName :: Workload -> String
+workloadName = \case
+    Static -> "static"
+    SmallChange -> "small-change"
+    HighChurn -> "high-churn"
+
+policyName :: Policy -> String
+policyName = \case
+    AlwaysFull -> "always-full"
+    RevisionedDelta -> "revisioned-delta"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "static" -> pure Static
+    "small-change" -> pure SmallChange
+    "high-churn" -> pure HighChurn
+    other -> die ("unknown workload: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")] | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)

--- a/packages/agent-cli/benchmark/AccessibilityDelta.hs
+++ b/packages/agent-cli/benchmark/AccessibilityDelta.hs
@@ -11,7 +11,7 @@ import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
-import Data.List (sortOn)
+import Data.List (sort)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import GHC.Clock (getMonotonicTimeNSec)
@@ -167,8 +167,17 @@ makeSnapshot workload nodes revision = AccessibilitySnapshot
                     <> "-node-" <> Text.pack (show index)
 
 median :: [Sample] -> Sample
-median samples =
-    sortOn (.sampleElapsedMillis) samples !! (length samples `div` 2)
+median samples = Sample
+    { sampleElapsedMillis = medianValue (map (.sampleElapsedMillis) samples)
+    , sampleCpuMillis = medianValue (map (.sampleCpuMillis) samples)
+    , sampleAllocatedBytes =
+        medianValue (map (.sampleAllocatedBytes) samples)
+    , sampleOutputBytes = medianValue (map (.sampleOutputBytes) samples)
+    }
+
+medianValue :: Ord value => [value] -> value
+medianValue values =
+    sort values !! (length values `div` 2)
 
 printSample :: Workload -> Policy -> Int -> Int -> Sample -> IO ()
 printSample workload policy nodes revisions sample =

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -1568,6 +1568,7 @@ autoCompactOpenAiBackendWithLimit getLimit absorbCompletedTools compactAction
         -- keep passing the inputs normally.
         installation <-
             onCompacted outcome inputs `onException` rollback
+        callbacks.onLoopEvent ModelContextReset
         let (continuationHistory, continuationInputs, rollbackIfDeferred) =
                 case installation of
                     CompactionInstalled -> (durableHistory, [], pure ())

--- a/packages/agent-cli/src/Agent/CLI/Compaction/Continuation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction/Continuation.hs
@@ -11,8 +11,10 @@ import Agent.CLI.Compaction.Projection
 import Agent.CLI.Compaction.Types
 import Agent.Loop
     ( Backend(..)
+    , BackendCallbacks(..)
     , BackendMiddleware
     , BackendSnapshot(..)
+    , LoopEvent(..)
     , TurnInput(..)
     , advanceBackendSnapshot
     , backendWithCallbacks
@@ -96,8 +98,10 @@ boundCompletedToolContinuations contextWindowFor getParams contextTokensRef back
                     then backend.submitTurnWithCallbacks
                         snapshot previous inputs callbacks
                     else if requestTokens truncated <= contextWindow
-                        then backend.submitTurnWithCallbacks
-                            snapshot previous truncated callbacks
+                        then do
+                            callbacks.onLoopEvent ModelContextReset
+                            backend.submitTurnWithCallbacks
+                                snapshot previous truncated callbacks
                         else submitTrimmedHistory
                             params
                             contextWindow
@@ -127,9 +131,11 @@ boundCompletedToolContinuations contextWindowFor getParams contextTokensRef back
                     params
                     (fittedHistory <> turnInputsToItems inputs)
         if fittedTokens <= contextWindow
-            then backend.submitTurnWithCallbacks
-                (advanceBackendSnapshot snapshot fittedHistory Nothing)
-                Nothing inputs callbacks
+            then do
+                callbacks.onLoopEvent ModelContextReset
+                backend.submitTurnWithCallbacks
+                    (advanceBackendSnapshot snapshot fittedHistory Nothing)
+                    Nothing inputs callbacks
             else pure (Left toolContinuationTooLargeError)
 
 pendingToolCallIds :: [TurnInput] -> [Text]

--- a/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
@@ -1,6 +1,16 @@
 -- | Function-based computer use backed by local desktop capture and input.
 module Agent.CLI.ComputerUse
     ( ComputerObservation(..)
+    , AccessibilitySnapshot(..)
+    , AccessibilityPatchOperation(..)
+    , AccessibilityObservation(..)
+    , AccessibilityDeltaState
+    , initialAccessibilityDeltaState
+    , decodeAccessibilitySnapshot
+    , advanceAccessibilityObservation
+    , unavailableAccessibilityObservation
+    , resetAccessibilityDeltaState
+    , applyAccessibilityPatch
     , ComputerUseBackend(..)
     , ScreenshotEncoding(..)
     , ComputerUseRuntime
@@ -41,6 +51,7 @@ import qualified Agent.CLI.ComputerUse.Input as Input
 import qualified Agent.CLI.ComputerUse.Linux as Linux
 import qualified Agent.Json.Decode as Json
 import Agent.Loop (ImageAttachment(..))
+import Agent.CLI.ComputerUse.Accessibility
 import Agent.Responses.Types
     ( ComputerAction(..)
     , ComputerCall(..)
@@ -329,7 +340,7 @@ executeComputerCall =
 
 data ComputerObservation = ComputerObservation
     { computerObservationImage :: !ImageAttachment
-    , computerObservationAccessibility :: !(Maybe Text)
+    , computerObservationAccessibility :: !(Maybe AccessibilityObservation)
     } deriving (Eq, Show)
 
 -- | One computer-use transaction. The backend owns display discovery,
@@ -658,7 +669,7 @@ encodeComputerOutput call observation =
             , computerOutputStatus = Nothing
             , computerOutputExtra = maybe
                 KeyMap.empty
-                (KeyMap.singleton "accessibility_state" . Aeson.String)
+                (KeyMap.singleton "accessibility_state" . Aeson.toJSON)
                 observation.computerObservationAccessibility
             }
   where

--- a/packages/agent-cli/src/Agent/CLI/ComputerUse/Accessibility.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse/Accessibility.hs
@@ -1,0 +1,324 @@
+-- | Revisioned accessibility observations for computer use.
+module Agent.CLI.ComputerUse.Accessibility
+    ( AccessibilitySnapshot(..)
+    , AccessibilityPatchOperation(..)
+    , AccessibilityObservation(..)
+    , AccessibilityDeltaState
+    , initialAccessibilityDeltaState
+    , decodeAccessibilitySnapshot
+    , advanceAccessibilityObservation
+    , unavailableAccessibilityObservation
+    , resetAccessibilityDeltaState
+    , applyAccessibilityPatch
+    ) where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Vector as Vector
+
+-- | A versioned native snapshot. @scope@ identifies the foreground
+-- application/window and @contents@ contains the bounded AX tree.
+data AccessibilitySnapshot = AccessibilitySnapshot
+    { accessibilitySnapshotSchemaVersion :: !Int
+    , accessibilitySnapshotScope :: !Aeson.Value
+    , accessibilitySnapshotContents :: !Aeson.Value
+    } deriving (Eq, Show)
+
+instance Aeson.ToJSON AccessibilitySnapshot where
+    toJSON snapshot = Aeson.object
+        [ "schema_version" Aeson..=
+            snapshot.accessibilitySnapshotSchemaVersion
+        , "scope" Aeson..= snapshot.accessibilitySnapshotScope
+        , "contents" Aeson..= snapshot.accessibilitySnapshotContents
+        ]
+
+instance Aeson.FromJSON AccessibilitySnapshot where
+    parseJSON = Aeson.withObject "AccessibilitySnapshot" \object -> do
+        schemaVersion <- object Aeson..: "schema_version"
+        if schemaVersion /= (1 :: Int)
+            then fail "unsupported accessibility snapshot schema_version"
+            else AccessibilitySnapshot schemaVersion
+                <$> object Aeson..: "scope"
+                <*> object Aeson..: "contents"
+
+-- | The subset of RFC 6902 operations emitted by the snapshot differ.
+data AccessibilityPatchOperation
+    = AccessibilityAdd !Text !Aeson.Value
+    | AccessibilityRemove !Text
+    | AccessibilityReplace !Text !Aeson.Value
+    deriving (Eq, Show)
+
+instance Aeson.ToJSON AccessibilityPatchOperation where
+    toJSON = \case
+        AccessibilityAdd path value -> Aeson.object
+            [ "op" Aeson..= ("add" :: Text)
+            , "path" Aeson..= path
+            , "value" Aeson..= value
+            ]
+        AccessibilityRemove path -> Aeson.object
+            [ "op" Aeson..= ("remove" :: Text)
+            , "path" Aeson..= path
+            ]
+        AccessibilityReplace path value -> Aeson.object
+            [ "op" Aeson..= ("replace" :: Text)
+            , "path" Aeson..= path
+            , "value" Aeson..= value
+            ]
+
+data AccessibilityObservation
+    = AccessibilityFull !Int !AccessibilitySnapshot
+    | AccessibilityDelta
+        !Int
+        !Int
+        ![AccessibilityPatchOperation]
+    | AccessibilityUnavailable !Int !Text
+    deriving (Eq, Show)
+
+instance Aeson.ToJSON AccessibilityObservation where
+    toJSON = \case
+        AccessibilityFull revision snapshot -> Aeson.object
+            [ "kind" Aeson..= ("full" :: Text)
+            , "revision" Aeson..= revision
+            , "snapshot" Aeson..= snapshot
+            ]
+        AccessibilityDelta baseRevision revision patch -> Aeson.object
+            [ "kind" Aeson..= ("delta" :: Text)
+            , "base_revision" Aeson..= baseRevision
+            , "revision" Aeson..= revision
+            , "patch" Aeson..= patch
+            ]
+        AccessibilityUnavailable revision reason -> Aeson.object
+            [ "kind" Aeson..= ("unavailable" :: Text)
+            , "revision" Aeson..= revision
+            , "reason" Aeson..= reason
+            ]
+
+data AccessibilityDeltaState = AccessibilityDeltaState
+    { deltaRevision :: !Int
+    , deltaBaseline :: !(Maybe AccessibilitySnapshot)
+    , deltaCountSinceFull :: !Int
+    } deriving (Eq, Show)
+
+initialAccessibilityDeltaState :: AccessibilityDeltaState
+initialAccessibilityDeltaState = AccessibilityDeltaState 0 Nothing 0
+
+resetAccessibilityDeltaState
+    :: AccessibilityDeltaState
+    -> AccessibilityDeltaState
+resetAccessibilityDeltaState state =
+    state { deltaBaseline = Nothing, deltaCountSinceFull = 0 }
+
+decodeAccessibilitySnapshot
+    :: BS.ByteString
+    -> Either Text AccessibilitySnapshot
+decodeAccessibilitySnapshot bytes =
+    case Aeson.eitherDecodeStrict' bytes of
+        Left err -> Left (Text.pack err)
+        Right snapshot -> Right snapshot
+
+-- | Advance the model-visible accessibility stream. Large or periodically
+-- checkpointed changes are sent as a full snapshot.
+advanceAccessibilityObservation
+    :: AccessibilityDeltaState
+    -> AccessibilitySnapshot
+    -> (AccessibilityObservation, AccessibilityDeltaState)
+advanceAccessibilityObservation state snapshot =
+    case state.deltaBaseline of
+        Nothing -> full
+        Just baseline
+            | baseline.accessibilitySnapshotSchemaVersion
+                /= snapshot.accessibilitySnapshotSchemaVersion -> full
+            | baseline.accessibilitySnapshotScope
+                /= snapshot.accessibilitySnapshotScope -> full
+            | state.deltaCountSinceFull >= 8 -> full
+            | patchSize * 5 >= fullSize * 3 -> full
+            | otherwise ->
+                ( AccessibilityDelta state.deltaRevision revision patch
+                , AccessibilityDeltaState
+                    revision
+                    (Just snapshot)
+                    (state.deltaCountSinceFull + 1)
+                )
+          where
+            patch = diffValue "" (Aeson.toJSON baseline) (Aeson.toJSON snapshot)
+            patchSize = encodedSize patch
+            fullSize = encodedSize snapshot
+  where
+    revision = state.deltaRevision + 1
+    full =
+        ( AccessibilityFull revision snapshot
+        , AccessibilityDeltaState revision (Just snapshot) 0
+        )
+
+unavailableAccessibilityObservation
+    :: Text
+    -> AccessibilityDeltaState
+    -> (AccessibilityObservation, AccessibilityDeltaState)
+unavailableAccessibilityObservation reason state =
+    ( AccessibilityUnavailable revision reason
+    , AccessibilityDeltaState revision Nothing 0
+    )
+  where
+    revision = state.deltaRevision + 1
+
+encodedSize :: Aeson.ToJSON value => value -> Int
+encodedSize = fromIntegral . LBS.length . Aeson.encode
+
+diffValue
+    :: Text
+    -> Aeson.Value
+    -> Aeson.Value
+    -> [AccessibilityPatchOperation]
+diffValue _ old new
+    | old == new = []
+diffValue path (Aeson.Object old) (Aeson.Object new) =
+    removals <> changes
+  where
+    removals =
+        [ AccessibilityRemove (childPath path key)
+        | (key, _) <- KeyMap.toAscList old
+        , not (KeyMap.member key new)
+        ]
+    changes = concat
+        [ case KeyMap.lookup key old of
+            Nothing -> [AccessibilityAdd (childPath path key) value]
+            Just oldValue -> diffValue (childPath path key) oldValue value
+        | (key, value) <- KeyMap.toAscList new
+        ]
+-- Equal-length arrays can be compared by index, which keeps ordinary AX
+-- property changes small. Structural array changes use one exact replacement
+-- and let the checkpoint-size policy decide whether a full snapshot is better.
+diffValue path (Aeson.Array old) new@(Aeson.Array values)
+    | Vector.length old == Vector.length values =
+        concat
+            [ diffValue
+                (path <> "/" <> Text.pack (show index))
+                oldValue
+                newValue
+            | (index, (oldValue, newValue)) <-
+                zip [0 :: Int ..]
+                    (zip (Vector.toList old) (Vector.toList values))
+            ]
+    | otherwise = [AccessibilityReplace path new]
+diffValue path _ new = [AccessibilityReplace path new]
+
+childPath :: Text -> Key.Key -> Text
+childPath parent key =
+    parent <> "/" <> escapePointerToken (Key.toText key)
+
+escapePointerToken :: Text -> Text
+escapePointerToken = Text.replace "/" "~1" . Text.replace "~" "~0"
+
+-- | Apply emitted operations. Exported primarily for protocol consumers and
+-- reconstruction-property tests.
+applyAccessibilityPatch
+    :: Aeson.Value
+    -> [AccessibilityPatchOperation]
+    -> Either Text Aeson.Value
+applyAccessibilityPatch = foldl' step . Right
+  where
+    step result operation = result >>= \value -> applyOne value operation
+
+applyOne
+    :: Aeson.Value
+    -> AccessibilityPatchOperation
+    -> Either Text Aeson.Value
+applyOne value operation =
+    case operation of
+        AccessibilityAdd path replacement ->
+            updateAt True path (const (Right replacement)) value
+        AccessibilityRemove path ->
+            removeAt path value
+        AccessibilityReplace path replacement ->
+            updateAt False path (const (Right replacement)) value
+
+updateAt
+    :: Bool
+    -> Text
+    -> (Aeson.Value -> Either Text Aeson.Value)
+    -> Aeson.Value
+    -> Either Text Aeson.Value
+updateAt allowMissing path update root
+    | Text.null path = update root
+    | otherwise = descend (pointerTokens path) root
+  where
+    descend [] value = update value
+    descend (token : rest) (Aeson.Object object)
+        | null rest
+        , allowMissing =
+            Right (Aeson.Object
+                (KeyMap.insert (Key.fromText token)
+                    (either (const Aeson.Null) id (update Aeson.Null))
+                    object))
+        | otherwise = do
+            child <- maybe
+                (Left ("JSON Pointer does not exist: " <> path))
+                Right
+                (KeyMap.lookup (Key.fromText token) object)
+            replacement <- descend rest child
+            Right (Aeson.Object
+                (KeyMap.insert (Key.fromText token) replacement object))
+    descend (token : rest) (Aeson.Array values) = do
+        index <- parseIndex token
+        child <- maybe
+            (Left ("JSON Pointer does not exist: " <> path))
+            Right
+            (values Vector.!? index)
+        replacement <- descend rest child
+        Right (Aeson.Array (values Vector.// [(index, replacement)]))
+    descend _ _ = Left ("JSON Pointer does not identify a container: " <> path)
+
+removeAt :: Text -> Aeson.Value -> Either Text Aeson.Value
+removeAt path root
+    | Text.null path = Left "cannot remove the document root"
+    | otherwise = descend (pointerTokens path) root
+  where
+    descend [] _ = Left "cannot remove the document root"
+    descend [token] (Aeson.Object object)
+        | KeyMap.member key object =
+            Right (Aeson.Object (KeyMap.delete key object))
+        | otherwise = Left ("JSON Pointer does not exist: " <> path)
+      where
+        key = Key.fromText token
+    descend [token] (Aeson.Array values) = do
+        index <- parseIndex token
+        if index < Vector.length values
+            then Right (Aeson.Array
+                (Vector.take index values <> Vector.drop (index + 1) values))
+            else Left ("JSON Pointer does not exist: " <> path)
+    descend (token : rest) (Aeson.Object object) = do
+        child <- maybe
+            (Left ("JSON Pointer does not exist: " <> path))
+            Right
+            (KeyMap.lookup key object)
+        replacement <- descend rest child
+        Right (Aeson.Object (KeyMap.insert key replacement object))
+      where
+        key = Key.fromText token
+    descend (token : rest) (Aeson.Array values) = do
+        index <- parseIndex token
+        child <- maybe
+            (Left ("JSON Pointer does not exist: " <> path))
+            Right
+            (values Vector.!? index)
+        replacement <- descend rest child
+        Right (Aeson.Array (values Vector.// [(index, replacement)]))
+    descend _ _ = Left ("JSON Pointer does not identify a container: " <> path)
+
+pointerTokens :: Text -> [Text]
+pointerTokens =
+    map unescapePointerToken . Text.splitOn "/" . Text.drop 1
+
+unescapePointerToken :: Text -> Text
+unescapePointerToken = Text.replace "~1" "/" . Text.replace "~0" "~"
+
+parseIndex :: Text -> Either Text Int
+parseIndex token =
+    case reads (Text.unpack token) of
+        [(index, "")] | index >= 0 -> Right index
+        _ -> Left ("invalid JSON Pointer array index: " <> token)

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -632,6 +632,8 @@ renderEventUnlocked config = \case
         pure ()
     NativeAgentFinished{} ->
         pure ()
+    ModelContextReset ->
+        pure ()
 
 renderToolStartedUnlocked :: RenderConfig -> ToolCall -> IO ()
 renderToolStartedUnlocked config call = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -581,6 +581,7 @@ uiEventLogicalBytes = \case
                 logicalTextBytes text
             WarningRaised text -> logicalTextBytes text
             ResponseRestarted text -> logicalTextBytes text
+            ModelContextReset -> 128
             TurnStarted -> 128
             TurnFinished output -> turnOutputLogicalBytes output
             ToolStarted call -> toolCallLogicalBytes call

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -1563,7 +1563,10 @@ spec = do
                     expectationFailure
                         ("expected one compacted continuation, got "
                             <> show (length seen))
-            readIORef events `shouldReturn` [ModelContextReset]
+            readIORef events `shouldReturn`
+                [ ActivityUpdated "Compacting context…"
+                , ModelContextReset
+                ]
 
         it "rejects an oversized first turn before provider submission" do
             let params = defaultResponseCreateParams

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -1527,6 +1527,7 @@ spec = do
             contextState <- newIORef Nothing
             compactCalls <- newIORef (0 :: Int)
             seenHistory <- newIORef []
+            events <- newIORef []
             let sender _request = do
                     modifyIORef' compactCalls (+ 1)
                     pure (Right remoteCompactionResponse)
@@ -1550,7 +1551,8 @@ spec = do
                         contextState
                         base
             result <- backend.submitTurn (initialBackendSnapshot history) Nothing
-                [UserMessage pendingText] (const (pure ()))
+                [UserMessage pendingText]
+                (\event -> modifyIORef' events (<> [event]))
             result `shouldSatisfy` either (const False) (const True)
             readIORef compactCalls `shouldReturn` 1
             readIORef seenHistory >>= \case
@@ -1561,6 +1563,7 @@ spec = do
                     expectationFailure
                         ("expected one compacted continuation, got "
                             <> show (length seen))
+            readIORef events `shouldReturn` [ModelContextReset]
 
         it "rejects an oversized first turn before provider submission" do
             let params = defaultResponseCreateParams
@@ -1704,7 +1707,9 @@ spec = do
             readIORef contextState `shouldReturn`
                 Just (reportedOccupancy 25 (length compactedHistory))
             readIORef events `shouldReturn`
-                [ActivityUpdated "Compacting context…"]
+                [ ActivityUpdated "Compacting context…"
+                , ModelContextReset
+                ]
 
         it "records active-session compaction usage before a failed continuation" do
             let history = [userTextItem "old"]
@@ -1715,6 +1720,7 @@ spec = do
             requests <- newIORef []
             recordedUsage <- newIORef []
             hookCalls <- newIORef (0 :: Int)
+            events <- newIORef []
             let sender request = do
                     modifyIORef' requests (<> [request])
                     pure (Right remoteCompactionResponse)
@@ -1733,7 +1739,8 @@ spec = do
                         contextState
                         base
             backend.submitTurn (initialBackendSnapshot history) Nothing
-                [UserMessage "new"] (const (pure ()))
+                [UserMessage "new"]
+                (\event -> modifyIORef' events (<> [event]))
                 `shouldReturn` Left (ConnectionError "continuation failed")
             map requestItems <$> readIORef requests
                 `shouldReturn` [history <> [compactionTriggerItem]]
@@ -1741,6 +1748,10 @@ spec = do
             readIORef contextState >>= (`shouldSatisfy`
                 (/= oldContextState))
             readIORef hookCalls `shouldReturn` 1
+            readIORef events `shouldReturn`
+                [ ActivityUpdated "Compacting context…"
+                , ModelContextReset
+                ]
 
         it "rolls back deferred compacted state when the continuation is cancelled" do
             let history = [userTextItem "old"]
@@ -1941,6 +1952,7 @@ spec = do
             compactCalls <- newIORef (0 :: Int)
             seenPrevious <- newIORef []
             seenInputs <- newIORef []
+            events <- newIORef []
             let sender _request = do
                     modifyIORef' compactCalls (+ 1)
                     pure (Right remoteCompactionResponse)
@@ -1965,7 +1977,7 @@ spec = do
                         contextState
                         base
             result <- backend.submitTurn (initialBackendSnapshot oldHistory) (Just "resp-tool") inputs
-                (const (pure ()))
+                (\event -> modifyIORef' events (<> [event]))
             result `shouldSatisfy` either (const False) (const True)
             readIORef compactCalls `shouldReturn` 0
             readIORef seenPrevious `shouldReturn` [Just "resp-tool"]
@@ -1989,6 +2001,7 @@ spec = do
                     expectationFailure
                         ("expected one bounded tool result, got "
                             <> show submitted)
+            readIORef events `shouldReturn` [ModelContextReset]
 
         it "records provider-reported occupancy after a successful turn" do
             let history = [userTextItem "old"]
@@ -2332,6 +2345,7 @@ spec = do
             contextState <- newIORef Nothing
             compactCalls <- newIORef (0 :: Int)
             seenHistory <- newIORef []
+            events <- newIORef []
             let sender _request = do
                     modifyIORef' compactCalls (+ 1)
                     pure (Right remoteCompactionResponse)
@@ -2355,7 +2369,7 @@ spec = do
                         contextState
                         base
             result <- backend.submitTurn (initialBackendSnapshot oldHistory) Nothing inputs
-                (const (pure ()))
+                (\event -> modifyIORef' events (<> [event]))
             result `shouldSatisfy` either (const False) (const True)
             readIORef compactCalls `shouldReturn` 1
             readIORef seenHistory >>= \case
@@ -2366,6 +2380,11 @@ spec = do
                     expectationFailure
                         ("expected one compacted continuation, got "
                             <> show (length seen))
+            readIORef events `shouldReturn`
+                [ ModelContextReset
+                , ActivityUpdated "Compacting context…"
+                , ModelContextReset
+                ]
 
         it "preserves typed provider failures from automatic compaction" do
             let history = [userTextItem "old"]

--- a/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
@@ -1,14 +1,21 @@
 module Agent.CLI.ComputerUseSpec (spec) where
 
 import Agent.CLI.ComputerUse
-    ( ComputerObservation(..)
+    ( AccessibilityObservation(..)
+    , AccessibilityPatchOperation(..)
+    , AccessibilitySnapshot(..)
+    , ComputerObservation(..)
     , ComputerUseBackend(..)
     , ScreenshotEncoding(..)
+    , advanceAccessibilityObservation
+    , applyAccessibilityPatch
     , closeComputerUseRuntime
     , computerApprovalPrompt
+    , decodeAccessibilitySnapshot
     , executeComputerCallWithBackend
     , executeComputerCallWithDesktopBackend
     , executeComputerCallWithRuntime
+    , initialAccessibilityDeltaState
     , keyCombinationScript
     , newLeasedDesktopComputerUseBackend
     , newComputerUseRuntimeWithBackend
@@ -2185,7 +2192,90 @@ spec = do
             display.computerDisplayFrameHeight `shouldBe` 720
             display
                 `shouldNotBe` portalDisplayForStream sessionPath portalStream
+    describe "accessibility observations" do
+        it "decodes the versioned native snapshot schema" do
+            decodeAccessibilitySnapshot
+                "{\"schema_version\":1,\"scope\":{\"pid\":42},\"contents\":[]}"
+                `shouldBe` Right
+                    (AccessibilitySnapshot
+                        1
+                        (Aeson.object ["pid" Aeson..= (42 :: Int)])
+                        (Aeson.toJSON ([] :: [Int])))
 
+        it "rejects unsupported snapshot schema versions" do
+            decodeAccessibilitySnapshot
+                "{\"schema_version\":2,\"scope\":{},\"contents\":[]}"
+                `shouldSatisfy` either
+                    (Text.isInfixOf "unsupported")
+                    (const False)
+
+        it "emits a full snapshot followed by an empty delta" do
+            let (first, state) =
+                    advanceAccessibilityObservation
+                        initialAccessibilityDeltaState
+                        exampleAccessibilitySnapshot
+                (second, _) =
+                    advanceAccessibilityObservation
+                        state
+                        exampleAccessibilitySnapshot
+            first `shouldBe`
+                AccessibilityFull 1 exampleAccessibilitySnapshot
+            second `shouldBe` AccessibilityDelta 1 2 []
+
+        it "emits reconstructable patches with escaped JSON Pointer paths" do
+            let oldSnapshot = largeAccessibilitySnapshot
+                    (Aeson.object ["label/with~escape" Aeson..= ("old" :: Text.Text)])
+                newSnapshot = largeAccessibilitySnapshot
+                    (Aeson.object ["label/with~escape" Aeson..= ("new" :: Text.Text)])
+                (_, state) =
+                    advanceAccessibilityObservation
+                        initialAccessibilityDeltaState
+                        oldSnapshot
+                (observation, _) =
+                    advanceAccessibilityObservation state newSnapshot
+            case observation of
+                AccessibilityDelta 1 2 patch -> do
+                    patch `shouldContain`
+                        [AccessibilityReplace
+                            "/contents/change/label~1with~0escape"
+                            (Aeson.String "new")]
+                    applyAccessibilityPatch
+                        (Aeson.toJSON oldSnapshot)
+                        patch
+                        `shouldBe` Right (Aeson.toJSON newSnapshot)
+                _ -> expectationFailure "expected an accessibility delta"
+
+        it "checkpoints when the application/window scope changes" do
+            let (_, state) =
+                    advanceAccessibilityObservation
+                        initialAccessibilityDeltaState
+                        exampleAccessibilitySnapshot
+                changed = exampleAccessibilitySnapshot
+                    { accessibilitySnapshotScope =
+                        Aeson.object ["pid" Aeson..= (99 :: Int)]
+                    }
+                (observation, _) =
+                    advanceAccessibilityObservation state changed
+            observation `shouldBe` AccessibilityFull 2 changed
+
+        it "encodes accessibility state as structured JSON" do
+            let backend = ComputerUseBackend
+                    { computerRunTransaction = \_ _ _ ->
+                        pure (Right
+                            (ComputerObservation
+                                (ImageAttachment "image/png" "observation")
+                                (Just (AccessibilityFull
+                                    1
+                                    exampleAccessibilitySnapshot))))
+                    }
+            result <- executeComputerCallWithBackend
+                backend
+                ScreenshotPng
+                exampleCall { computerActions = [ScreenshotAction] }
+            result `shouldSatisfy` either
+                (const False)
+                (Text.isInfixOf
+                    "\"accessibility_state\":{\"kind\":\"full\"")
     describe "computer action validation" do
         it "preserves supported mouse buttons and modifiers" do
             pointerScript (ClickAction 12 34 "back" ["shift"])
@@ -2646,6 +2736,24 @@ spec = do
                 (not . ("top secret" `Text.isInfixOf`))
             encoded `shouldSatisfy`
                 (not . ("large-private-payload" `Text.isInfixOf`))
+
+exampleAccessibilitySnapshot :: AccessibilitySnapshot
+exampleAccessibilitySnapshot = AccessibilitySnapshot
+    1
+    (Aeson.object
+        [ "pid" Aeson..= (42 :: Int)
+        , "window" Aeson..= ("main" :: Text.Text)
+        ])
+    (Aeson.object ["role" Aeson..= ("AXWindow" :: Text.Text)])
+
+largeAccessibilitySnapshot :: Aeson.Value -> AccessibilitySnapshot
+largeAccessibilitySnapshot change = AccessibilitySnapshot
+    1
+    (Aeson.object ["pid" Aeson..= (42 :: Int)])
+    (Aeson.object
+        [ "change" Aeson..= change
+        , "unchanged" Aeson..= Text.replicate 512 "x"
+        ])
 
 toolCall :: ComputerCall -> ToolCall
 toolCall call = ToolCall

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -212,6 +212,10 @@ spec = describe "fullscreen TUI bridge" do
             ]
             `shouldBe` ["canonical"]
 
+    it "accounts model-context reset mailbox overhead" do
+        appEventLogicalBytes (AppUi (UiLoop ModelContextReset))
+            `shouldBe` 128
+
     it "backpressures a single streaming mailbox node by payload bytes" do
         runtime <- newBridgeTestRuntime
         let exactBudgetText =

--- a/packages/agent-core/benchmark/LoopEvents.hs
+++ b/packages/agent-core/benchmark/LoopEvents.hs
@@ -368,6 +368,7 @@ eventWeight = \case
     ToolRetracted callId -> Text.length callId
     ResponseAttemptDiscarded -> 1
     ResponseAttemptFailed -> 1
+    ModelContextReset -> 1
     NativeAgentStarted identifier parent label model ->
         sum
             [ Text.length identifier

--- a/packages/agent-core/src/Agent/Loop/InputItems.hs
+++ b/packages/agent-core/src/Agent/Loop/InputItems.hs
@@ -30,6 +30,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Agent.Json.Decode as Json
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Maybe (maybeToList)
 import Data.Text (Text)
@@ -202,8 +203,44 @@ computerFunctionTextOutput rawOutput =
                         "Computer action completed.\n\n"
                             <> "Current macOS accessibility state:\n"
                             <> state
+                Just state@(Aeson.Object fields) ->
+                    "Computer action completed.\n\n"
+                        <> accessibilityStateHeading fields
+                        <> "\n"
+                        <> jsonValueText state
                 _ -> "Computer action completed."
         Left _ -> rawOutput
+
+accessibilityStateHeading :: Aeson.Object -> Text
+accessibilityStateHeading fields =
+    case KeyMap.lookup "kind" fields of
+        Just (Aeson.String "full") ->
+            "Full macOS accessibility snapshot"
+                <> revisionSuffix "revision"
+                <> ":"
+        Just (Aeson.String "delta") ->
+            "macOS accessibility changes"
+                <> case (fieldText "base_revision", fieldText "revision") of
+                    (Just baseRevision, Just revision) ->
+                        ", revision " <> baseRevision <> " -> " <> revision
+                    _ -> ""
+                <> ":"
+        Just (Aeson.String "unavailable") ->
+            "macOS accessibility state unavailable"
+                <> revisionSuffix "revision"
+                <> ":"
+        _ -> "Current macOS accessibility state:"
+  where
+    revisionSuffix key =
+        maybe "" (", revision " <>) (fieldText key)
+    fieldText key =
+        jsonValueText <$> KeyMap.lookup key fields
+
+jsonValueText :: Aeson.Value -> Text
+jsonValueText =
+    Text.decodeUtf8
+        . LBS.toStrict
+        . Aeson.encode
 
 latestComputerScreenshot :: [TurnInput] -> Maybe Text
 latestComputerScreenshot inputs =

--- a/packages/agent-core/src/Agent/Loop/Output.hs
+++ b/packages/agent-core/src/Agent/Loop/Output.hs
@@ -51,6 +51,9 @@ data LoopEvent
     | ReasoningDelta Text
     -- | Ephemeral transport/tool activity for the live CLI status line.
     | ActivityUpdated Text
+    -- | The model-visible history was rewritten or truncated. Stateful tools
+    -- must discard baselines that referred to the previous context.
+    | ModelContextReset
     -- | Latest provider-reported limit status for retained prompt chrome.
     | ProviderLimitUpdated
         { providerLimitText :: !Text

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
@@ -9,6 +9,7 @@ module Agent.CLI.MacOS.ComputerBridge
     , ComputerRegistration(..)
     , ComputerSession
     , computerActionStructSize
+    , computerAccessibilityCapacity
     , computerErrorCapacity
     , computerOutputCapacity
     , computerStatusMessage
@@ -25,6 +26,14 @@ import Agent.CLI.ComputerUse
     , ComputerUseBackend(..)
     , ScreenshotEncoding(..)
     , computerUseToolWith
+    )
+import Agent.CLI.ComputerUse.Accessibility
+    ( AccessibilityDeltaState
+    , AccessibilityObservation
+    , advanceAccessibilityObservation
+    , decodeAccessibilitySnapshot
+    , initialAccessibilityDeltaState
+    , unavailableAccessibilityObservation
     )
 import Agent.Loop (ImageAttachment(..))
 import Agent.Responses.Types
@@ -142,6 +151,9 @@ type ComputerCallback =
     -> Ptr Word8
     -> CSize
     -> Ptr CSize
+    -> Ptr Word8
+    -> CSize
+    -> Ptr CSize
     -> Ptr Word64
     -> Ptr CInt
     -> Ptr CInt
@@ -161,14 +173,22 @@ newtype ComputerHost = ComputerHost
     }
 
 newtype ComputerSession = ComputerSession
-    { computerSessionObservation :: MVar (Maybe NativeComputerDisplay)
+    { computerSessionState :: MVar ComputerSessionState
+    }
+
+data ComputerSessionState = ComputerSessionState
+    { computerSessionDisplay :: !(Maybe NativeComputerDisplay)
+    , computerSessionAccessibility :: !AccessibilityDeltaState
     }
 
 newComputerHost :: IO ComputerHost
 newComputerHost = ComputerHost <$> newMVar Nothing
 
 newComputerSession :: IO ComputerSession
-newComputerSession = ComputerSession <$> newMVar Nothing
+newComputerSession = ComputerSession <$> newMVar ComputerSessionState
+    { computerSessionDisplay = Nothing
+    , computerSessionAccessibility = initialAccessibilityDeltaState
+    }
 
 computerToolWhenEnabled :: ComputerHost -> IO (Maybe AppTool)
 computerToolWhenEnabled host =
@@ -349,10 +369,11 @@ invokeComputerTransaction
     -> ((Int, Int) -> Either Text ())
     -> IO (Either Text ComputerObservation)
 invokeComputerTransaction host encoding actions validateDisplay =
-    fmap (fmap fst) $
+    fmap (fmap (\(observation, _, _) -> observation)) $
         invokeComputerTransactionWithLease
             host
             Nothing
+            initialAccessibilityDeltaState
             encoding
             actions
             validateDisplay
@@ -369,38 +390,49 @@ invokeComputerSessionTransaction
     -> ((Int, Int) -> Either Text ())
     -> IO (Either Text ComputerObservation)
 invokeComputerSessionTransaction host session encoding actions validateDisplay =
-    modifyMVar session.computerSessionObservation \previous -> do
+    modifyMVar session.computerSessionState \previous -> do
         result <-
             if null actions
                 then invokeComputerTransactionWithLease
-                    host Nothing encoding actions validateDisplay
-                else case previous of
+                    host Nothing previous.computerSessionAccessibility
+                    encoding actions validateDisplay
+                else case previous.computerSessionDisplay of
                     Nothing -> pure (Left
                         "Take a fresh computer screenshot before sending input actions.")
                     Just display ->
                         invokeComputerTransactionWithLease
                             host
                             (Just display)
+                            previous.computerSessionAccessibility
                             encoding
                             actions
                             validateDisplay
         case result of
             Left err -> pure (previous, Left err)
-            Right (observation, successor) ->
-                pure (Just successor, Right observation)
+            Right (observation, successor, accessibilityState) ->
+                pure
+                    ( ComputerSessionState
+                        (Just successor)
+                        accessibilityState
+                    , Right observation
+                    )
 
 invokeComputerTransactionWithLease
     :: ComputerHost
     -> Maybe NativeComputerDisplay
+    -> AccessibilityDeltaState
     -> ScreenshotEncoding
     -> [ComputerAction]
     -> ((Int, Int) -> Either Text ())
     -> IO
         (Either
             Text
-            (ComputerObservation, NativeComputerDisplay))
+            ( ComputerObservation
+            , NativeComputerDisplay
+            , AccessibilityDeltaState
+            ))
 invokeComputerTransactionWithLease
-        host priorDisplay encoding actions validateDisplay =
+        host priorDisplay accessibilityState encoding actions validateDisplay =
     case encodeComputerActions actions of
         Left err -> pure (Left err)
         Right batch ->
@@ -424,6 +456,7 @@ invokeComputerTransactionWithLease
                                     invokeComputerRunAndObserve
                                         registration
                                         display
+                                        accessibilityState
                                         encoding
                                         batch)
                 >>= \case
@@ -435,10 +468,11 @@ invokeComputerDisplay
     :: ComputerRegistration
     -> IO (Either Text NativeComputerDisplay)
 invokeComputerDisplay registration =
-    invokeComputer computerErrorCapacity registration query >>= \case
+    invokeComputer computerErrorCapacity 0 registration query >>= \case
         Left err -> pure (Left err)
-        Right (bytes, token, width, height, imageFormat)
+        Right (bytes, accessibility, token, width, height, imageFormat)
             | not (BS.null bytes)
+                || not (BS.null accessibility)
                 || token == 0
                 || width <= 0
                 || height <= 0
@@ -452,12 +486,13 @@ invokeComputerDisplay registration =
                     , nativeDisplayHeight = height
                     })
   where
-    query registration' output capacity outputLength outputToken
+    query registration' output capacity outputLength accessibilityOutput
+            accessibilityCapacity accessibilityLength outputToken
             width height imageFormat =
         invokeComputerCallback
             registration'.computerCallback
             registration'.computerContext
-            1
+            2
             1
             0
             0
@@ -472,6 +507,9 @@ invokeComputerDisplay registration =
             output
             capacity
             outputLength
+            accessibilityOutput
+            accessibilityCapacity
+            accessibilityLength
             outputToken
             width
             height
@@ -480,18 +518,24 @@ invokeComputerDisplay registration =
 invokeComputerRunAndObserve
     :: ComputerRegistration
     -> NativeComputerDisplay
+    -> AccessibilityDeltaState
     -> ScreenshotEncoding
     -> ComputerBatch
     -> IO
         (Either
             Text
-            (ComputerObservation, NativeComputerDisplay))
-invokeComputerRunAndObserve registration display encoding batch =
+            ( ComputerObservation
+            , NativeComputerDisplay
+            , AccessibilityDeltaState
+            ))
+invokeComputerRunAndObserve
+        registration display accessibilityState encoding batch =
     withArray batch.computerBatchActions \actionPointer ->
         withArray batch.computerBatchPoints \pointPointer ->
             BS.useAsCStringLen batch.computerBatchText
                 \(textPointer, textLength) ->
-                    invokeComputer computerOutputCapacity registration
+                    invokeComputer computerOutputCapacity
+                        computerAccessibilityCapacity registration
                         (run
                             actionPointer
                             pointPointer
@@ -499,7 +543,7 @@ invokeComputerRunAndObserve registration display encoding batch =
                             textLength)
                         >>= \case
                             Left err -> pure (Left err)
-                            Right (bytes, token, width, height, imageFormat)
+                            Right (bytes, accessibility, token, width, height, imageFormat)
                                 | token == 0
                                     || token == display.nativeDisplayToken
                                     || width /= display.nativeDisplayWidth
@@ -516,10 +560,17 @@ invokeComputerRunAndObserve registration display encoding batch =
                                     case imageMime imageFormat bytes of
                                         Left err -> pure (Left err)
                                         Right mime ->
-                                            pure (Right
+                                            let
+                                                ( accessibilityObservation
+                                                  , successorAccessibilityState
+                                                  ) =
+                                                    decodeAccessibility
+                                                        accessibility
+                                                        accessibilityState
+                                            in pure (Right
                                                 ( ComputerObservation
                                                     (ImageAttachment mime bytes)
-                                                    Nothing
+                                                    accessibilityObservation
                                                 , NativeComputerDisplay
                                                     { nativeDisplayToken =
                                                         token
@@ -528,18 +579,20 @@ invokeComputerRunAndObserve registration display encoding batch =
                                                     , nativeDisplayHeight =
                                                         height
                                                     }
+                                                , successorAccessibilityState
                                                 ))
   where
     requestedFormat = case encoding of
         ScreenshotPng -> 1
         ScreenshotJpeg -> 2
     run actionPointer pointPointer textPointer textLength
-            registration' output capacity outputLength outputToken
+            registration' output capacity outputLength accessibilityOutput
+            accessibilityCapacity accessibilityLength outputToken
             width height imageFormat =
         invokeComputerCallback
             registration'.computerCallback
             registration'.computerContext
-            1
+            2
             2
             display.nativeDisplayToken
             display.nativeDisplayWidth
@@ -554,6 +607,9 @@ invokeComputerRunAndObserve registration display encoding batch =
             output
             capacity
             outputLength
+            accessibilityOutput
+            accessibilityCapacity
+            accessibilityLength
             outputToken
             width
             height
@@ -561,6 +617,9 @@ invokeComputerRunAndObserve registration display encoding batch =
 
 type ComputerInvocation =
     ComputerRegistration
+    -> Ptr Word8
+    -> CSize
+    -> Ptr CSize
     -> Ptr Word8
     -> CSize
     -> Ptr CSize
@@ -572,46 +631,67 @@ type ComputerInvocation =
 
 invokeComputer
     :: Int
+    -> Int
     -> ComputerRegistration
     -> ComputerInvocation
-    -> IO (Either Text (BS.ByteString, Word64, CInt, CInt, CInt))
-invokeComputer capacity registration invocation =
+    -> IO (Either Text (BS.ByteString, BS.ByteString, Word64, CInt, CInt, CInt))
+invokeComputer capacity accessibilityCapacity registration invocation =
     bracket (mallocBytes capacity) free \output -> do
         fillBytes output 0 capacity
-        allocaResult \outputLength outputToken width height imageFormat -> do
-            status <- invocation
-                registration
-                output
-                (fromIntegral capacity)
-                outputLength
-                outputToken
-                width
-                height
-                imageFormat
-            CSize length <- peek outputLength
-            observedToken <- peek outputToken
-            observedWidth <- peek width
-            observedHeight <- peek height
-            observedFormat <- peek imageFormat
-            if length > fromIntegral capacity
-                then pure (Left
-                    "The native computer host reported output beyond its buffer.")
-                else do
-                    bytes <- BS.packCStringLen
-                        (castPtr output, fromIntegral length)
-                    if status == 0
-                        then pure (Right
-                            ( bytes
-                            , observedToken
-                            , observedWidth
-                            , observedHeight
-                            , observedFormat
-                            ))
-                        else pure (Left
-                            (computerFailureMessage status bytes))
+        bracket (mallocBytes (max 1 accessibilityCapacity)) free
+            \accessibilityOutputBuffer -> do
+            fillBytes accessibilityOutputBuffer 0 accessibilityCapacity
+            let accessibilityOutput
+                    | accessibilityCapacity == 0 = nullPtr
+                    | otherwise = accessibilityOutputBuffer
+            allocaResult \outputLength accessibilityLength outputToken width height imageFormat -> do
+                status <- invocation
+                    registration
+                    output
+                    (fromIntegral capacity)
+                    outputLength
+                    accessibilityOutput
+                    (fromIntegral accessibilityCapacity)
+                    accessibilityLength
+                    outputToken
+                    width
+                    height
+                    imageFormat
+                CSize length <- peek outputLength
+                CSize accessibilityLengthValue <- peek accessibilityLength
+                observedToken <- peek outputToken
+                observedWidth <- peek width
+                observedHeight <- peek height
+                observedFormat <- peek imageFormat
+                if length > fromIntegral capacity
+                    then pure (Left
+                        "The native computer host reported output beyond its buffer.")
+                    else if accessibilityLengthValue
+                            > fromIntegral accessibilityCapacity
+                        then pure (Left
+                            "The native computer host reported accessibility output beyond its buffer.")
+                    else do
+                        bytes <- BS.packCStringLen
+                            (castPtr output, fromIntegral length)
+                        accessibility <- BS.packCStringLen
+                            ( castPtr accessibilityOutputBuffer
+                            , fromIntegral accessibilityLengthValue
+                            )
+                        if status == 0
+                            then pure (Right
+                                ( bytes
+                                , accessibility
+                                , observedToken
+                                , observedWidth
+                                , observedHeight
+                                , observedFormat
+                                ))
+                            else pure (Left
+                                (computerFailureMessage status bytes))
 
 allocaResult
     :: ( Ptr CSize
+        -> Ptr CSize
         -> Ptr Word64
         -> Ptr CInt
         -> Ptr CInt
@@ -621,18 +701,21 @@ allocaResult
     -> IO value
 allocaResult action =
     allocaBytes (sizeOf (undefined :: CSize)) \outputLength ->
-        allocaBytes (sizeOf (undefined :: Word64)) \outputToken ->
+        allocaBytes (sizeOf (undefined :: CSize)) \accessibilityLength ->
+          allocaBytes (sizeOf (undefined :: Word64)) \outputToken ->
             allocaBytes (sizeOf (undefined :: CInt)) \width ->
                 allocaBytes (sizeOf (undefined :: CInt)) \height ->
                     allocaBytes (sizeOf (undefined :: CInt))
                         \imageFormat -> do
                             poke outputLength 0
+                            poke accessibilityLength 0
                             poke outputToken 0
                             poke width 0
                             poke height 0
                             poke imageFormat 0
                             action
                                 outputLength
+                                accessibilityLength
                                 outputToken
                                 width
                                 height
@@ -683,3 +766,32 @@ computerErrorCapacity = 64 * 1024
 
 computerOutputCapacity :: Int
 computerOutputCapacity = 16 * 1024 * 1024
+
+computerAccessibilityCapacity :: Int
+computerAccessibilityCapacity = 512 * 1024
+
+decodeAccessibility
+    :: BS.ByteString
+    -> AccessibilityDeltaState
+    -> (Maybe AccessibilityObservation, AccessibilityDeltaState)
+decodeAccessibility bytes state
+    | BS.null bytes =
+        let (observation, successor) =
+                unavailableAccessibilityObservation
+                    "Native accessibility snapshot unavailable."
+                    state
+        in (Just observation, successor)
+    | otherwise =
+        case decodeAccessibilitySnapshot bytes of
+            Left err ->
+                let (observation, successor) =
+                        unavailableAccessibilityObservation
+                            ( "The native computer host returned invalid accessibility JSON: "
+                                <> err
+                            )
+                            state
+                in (Just observation, successor)
+            Right snapshot ->
+                let (observation, successor) =
+                        advanceAccessibilityObservation state snapshot
+                in (Just observation, successor)

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
@@ -14,11 +14,13 @@ module Agent.CLI.MacOS.ComputerBridge
     , computerOutputCapacity
     , computerStatusMessage
     , computerToolWhenEnabled
+    , computerToolSessionWhenEnabled
     , encodeComputerActions
     , invokeComputerTransaction
     , invokeComputerSessionTransaction
     , newComputerHost
     , newComputerSession
+    , resetComputerSessionAccessibility
     ) where
 
 import Agent.CLI.ComputerUse
@@ -43,7 +45,13 @@ import Agent.Responses.Types
 import Agent.Tools.Types (AppTool)
 import Control.Exception.Safe (bracket, tryAny)
 import Control.Monad (foldM)
-import Control.Concurrent.MVar (MVar, modifyMVar, newMVar, withMVar)
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newMVar
+    , withMVar
+    )
 import qualified Data.ByteString as BS
 import Data.Bits ((.|.))
 import Data.Text (Text)
@@ -192,15 +200,29 @@ newComputerSession = ComputerSession <$> newMVar ComputerSessionState
 
 computerToolWhenEnabled :: ComputerHost -> IO (Maybe AppTool)
 computerToolWhenEnabled host =
+    fmap (fmap fst) (computerToolSessionWhenEnabled host)
+
+computerToolSessionWhenEnabled :: ComputerHost -> IO (Maybe (AppTool, IO ()))
+computerToolSessionWhenEnabled host =
     withMVar host.computerRegistration \case
         Nothing -> pure Nothing
         Just _ -> do
             session <- newComputerSession
-            pure . Just . computerUseToolWith $
-                ComputerUseBackend
-                    { computerRunTransaction =
-                        invokeComputerSessionTransaction host session
-                    }
+            pure . Just $
+                ( computerUseToolWith $
+                    ComputerUseBackend
+                        { computerRunTransaction =
+                            invokeComputerSessionTransaction host session
+                        }
+                , resetComputerSessionAccessibility session
+                )
+
+resetComputerSessionAccessibility :: ComputerSession -> IO ()
+resetComputerSessionAccessibility session =
+    modifyMVar_ session.computerSessionState \state ->
+        pure state
+            { computerSessionAccessibility = initialAccessibilityDeltaState
+            }
 
 encodeComputerActions :: [ComputerAction] -> Either Text ComputerBatch
 encodeComputerActions actions = do

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
@@ -5,7 +5,8 @@ module Agent.CLI.MacOS.NativeSupervisor
 
 import Agent.CLI.MacOS.AgentSnapshot (activeAgentSnapshot)
 import Agent.CLI.MacOS.BrowserBridge (BrowserHost, browserToolsWhenEnabled)
-import Agent.CLI.MacOS.ComputerBridge (ComputerHost, computerToolWhenEnabled)
+import Agent.CLI.MacOS.ComputerBridge
+    ( ComputerHost, computerToolSessionWhenEnabled )
 import Agent.CLI.MacOS.EngineCallbacks (invokeTaskSnapshotCallback)
 import Agent.CLI.MacOS.EngineEvents
 import Agent.CLI.MacOS.EngineMailbox
@@ -406,7 +407,7 @@ supervisorLoop
             start.turnStartSessionId
             interactions
         nativeBrowserTools <- browserToolsWhenEnabled browser
-        nativeComputerTool <- computerToolWhenEnabled computer
+        nativeComputerSession <- computerToolSessionWhenEnabled computer
         worker <- launchTrackedWorker start.turnStartId do
             withGatewayCredentialTurnLease $
                 ensureNativeGatewayIdentity
@@ -440,7 +441,7 @@ supervisorLoop
                                     processRuntime
                                     control
                                     nativeBrowserTools
-                                    nativeComputerTool
+                                    nativeComputerSession
                                     start
                                     pending.pendingTurnImages
                                     pending.pendingTurnOptions

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
@@ -63,7 +63,7 @@ runNativeTurn
     -> NativeProcessRuntime
     -> TurnControl
     -> [AppTool]
-    -> Maybe AppTool
+    -> Maybe (AppTool, IO ())
     -> TurnStart
     -> [ImageAttachment]
     -> NativeTurnOptions
@@ -71,7 +71,7 @@ runNativeTurn
     -> IO TurnOutcome
 runNativeTurn
         callback context commands processRuntime control nativeBrowserTools
-        nativeComputerTool start images turnOptions interactions = do
+        nativeComputerSession start images turnOptions interactions = do
     sessionIdRef <- newIORef start.turnStartSessionId
     completedRef <- newIORef False
     usageRef <- newIORef emptyTokenUsage
@@ -81,6 +81,8 @@ runNativeTurn
                     TurnFinished output -> do
                         writeIORef completedRef True
                         modifyIORef' usageRef (<> output.tokenUsage)
+                    ModelContextReset ->
+                        forM_ nativeComputerSession snd
                     _ -> pure ()
                 case encodeNativeLoopEvent control.turnControlId event of
                     Just bytes -> sendBinaryEvent callback context bytes
@@ -113,7 +115,7 @@ runNativeTurn
                 requestRootAccessFromClient callback context control
             , nativeToolGroups = [HostToolGroup nativeBrowserTools]
             , nativeComposeTools =
-                composeNativeTools nativeComputerTool
+                composeNativeTools (fst <$> nativeComputerSession)
             , nativePlanHooks =
                 nativePlanModeHooks control interactions
             , nativeInteractionMode =

--- a/packages/agent-native-bridge/include/HaskellAgentBridge.h
+++ b/packages/agent-native-bridge/include/HaskellAgentBridge.h
@@ -139,7 +139,7 @@ int32_t ha_engine_set_browser_callback(
 );
 
 enum {
-    HA_COMPUTER_ABI_VERSION = 1,
+    HA_COMPUTER_ABI_VERSION = 2,
     HA_COMPUTER_QUERY_DISPLAY = 1,
     HA_COMPUTER_RUN_AND_OBSERVE = 2
 };
@@ -198,7 +198,8 @@ enum {
     HA_COMPUTER_MAX_TOTAL_POINTS = 10240,
     HA_COMPUTER_MAX_TEXT_BYTES = 327680,
     HA_COMPUTER_ERROR_CAPACITY = 65536,
-    HA_COMPUTER_OUTPUT_CAPACITY = 16777216
+    HA_COMPUTER_OUTPUT_CAPACITY = 16777216,
+    HA_COMPUTER_ACCESSIBILITY_CAPACITY = 524288
 };
 
 typedef struct ha_computer_point_v1 {
@@ -245,8 +246,8 @@ typedef struct ha_computer_action_v1 {
  * dimensions and requested_image_format zero, and a writable error buffer. On
  * success it writes a nonzero opaque lease to output_display_token and positive
  * logical main-display dimensions to output_width and output_height, sets
- * output_image_format and output_length to zero, and does not write image
- * bytes.
+ * output_image_format, output_length, and accessibility_output_length to zero,
+ * and does not write image or accessibility bytes.
  *
  * RUN_AND_OBSERVE executes the complete ordered action batch, waits for the UI
  * to settle, and captures exactly one final main-display observation. It must
@@ -257,7 +258,13 @@ typedef struct ha_computer_action_v1 {
  * serialize leases across every callback context controlling the same desktop
  * and invalidate a lease when a transaction starts changing input state.
  * requested_image_format is PNG or JPEG. On success, output contains encoded
- * image bytes, output_length is their length, output_display_token is a
+ * image bytes, output_length is their length, accessibility_output contains
+ * an optional UTF-8 JSON accessibility snapshot shaped as
+ * {"schema_version":1,"scope":<JSON>,"contents":<JSON>}, and
+ * accessibility_output_length is its length. scope must identify the focused
+ * application/window closely enough that a scope change invalidates a prior
+ * tree; contents is the bounded, redacted accessibility tree.
+ * output_display_token is a
  * nonzero successor lease distinct from expected_display_token,
  * output_width/output_height are the observed logical image dimensions, and
  * output_image_format is PNG or JPEG. The encoded image is normalized to
@@ -274,13 +281,20 @@ typedef struct ha_computer_action_v1 {
  * unused fields, malformed UTF-8, and counts above the HA_COMPUTER_MAX_*
  * limits with HA_COMPUTER_STATUS_INVALID_ARGUMENT.
  *
- * output/output_length/output_display_token/output_width/output_height and
- * output_image_format are nonnull callback-scoped writable pointers. On
+ * output/output_length/accessibility_output_length/output_display_token,
+ * output_width/output_height and output_image_format are nonnull
+ * callback-scoped writable pointers. accessibility_output may be NULL only
+ * when accessibility_output_capacity is zero (as it is for QUERY_DISPLAY).
+ * A successful RUN may report an empty accessibility snapshot without
+ * failing the screenshot. On
  * failure, set the display token, dimensions, and image format to zero and
  * write a useful UTF-8 error to output when possible. Never report
- * output_length above output_capacity. The runtime supplies
+ * output_length above output_capacity. On failure also set
+ * accessibility_output_length to zero. The runtime supplies
  * HA_COMPUTER_ERROR_CAPACITY for QUERY_DISPLAY and HA_COMPUTER_OUTPUT_CAPACITY
- * for RUN_AND_OBSERVE.
+ * for RUN_AND_OBSERVE, plus HA_COMPUTER_ACCESSIBILITY_CAPACITY for its
+ * accessibility buffer. Never report accessibility_output_length above
+ * accessibility_output_capacity.
  *
  * The callback runs synchronously on an agent tool worker, never the setter's
  * caller or AppKit main thread, and must not call engine functions. No input
@@ -307,6 +321,9 @@ typedef int32_t (*ha_computer_callback)(
     uint8_t *output,
     size_t output_capacity,
     size_t *output_length,
+    uint8_t *accessibility_output,
+    size_t accessibility_output_capacity,
+    size_t *accessibility_output_length,
     uint64_t *output_display_token,
     int32_t *output_width,
     int32_t *output_height,

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
@@ -7,6 +7,9 @@ import Agent.CLI.ComputerUse
     , ScreenshotEncoding(..)
     , computerUseTool
     )
+import Agent.CLI.ComputerUse.Accessibility
+    ( AccessibilityObservation(..)
+    )
 import Agent.CLI.MacOS.Bridge (composeNativeTools)
 import Agent.CLI.MacOS.ComputerBridge
     ( CComputerAction(..)
@@ -140,12 +143,13 @@ spec = describe "native computer bridge" do
             result `shouldBe` Right
                 (ComputerObservation
                     (ImageAttachment "image/png" pngSignature)
-                    Nothing)
+                    (Just (AccessibilityUnavailable 1
+                        "Native accessibility snapshot unavailable.")))
             readIORef observed `shouldReturn`
                 [ ObservedComputerInvocation
-                    1 1 0 0 0 [] [] BS.empty 0 65536
+                    2 1 0 0 0 [] [] BS.empty 0 65536 0
                 , ObservedComputerInvocation
-                    1 2 41 100 80
+                    2 2 41 100 80
                     [ (plainObservedAction 1)
                         { cComputerX = 10
                         , cComputerY = 20
@@ -164,6 +168,7 @@ spec = describe "native computer bridge" do
                     (BS.pack [206, 187])
                     1
                     16777216
+                    524288
                 ]
 
     it "executes later actions against the lease from the model's screenshot" do
@@ -182,7 +187,8 @@ spec = describe "native computer bridge" do
                 `shouldReturn` Right
                     (ComputerObservation
                         (ImageAttachment "image/png" pngSignature)
-                        Nothing)
+                        (Just (AccessibilityUnavailable 1
+                            "Native accessibility snapshot unavailable.")))
             invokeComputerSessionTransaction
                 host session ScreenshotPng
                 [ClickAction 10 20 "left" []]
@@ -190,10 +196,51 @@ spec = describe "native computer bridge" do
                 `shouldReturn` Right
                     (ComputerObservation
                         (ImageAttachment "image/png" pngSignature)
-                        Nothing)
+                        (Just (AccessibilityUnavailable 2
+                            "Native accessibility snapshot unavailable.")))
             invocations <- readIORef observed
             map observedOperationAndToken invocations `shouldBe`
                 [(1, 0), (2, 41), (2, 42)]
+
+    it "emits a full accessibility snapshot followed by an empty delta" do
+        observed <- newIORef []
+        withComputerHost (accessibilityComputerCallback observed) \host -> do
+            session <- newComputerSession
+            first <- invokeComputerSessionTransaction
+                host session ScreenshotPng [] (const (Right ()))
+            second <- invokeComputerSessionTransaction
+                host session ScreenshotPng [] (const (Right ()))
+            case (first, second) of
+                ( Right ComputerObservation
+                    { computerObservationAccessibility =
+                        Just (AccessibilityFull 1 _)
+                    }
+                  , Right ComputerObservation
+                    { computerObservationAccessibility =
+                        Just (AccessibilityDelta 1 2 [])
+                    }
+                  ) -> pure ()
+                values -> expectationFailure
+                    ("unexpected accessibility observations: " <> show values)
+
+    it "keeps a valid screenshot when accessibility JSON is malformed" do
+        observed <- newIORef []
+        withComputerHost
+            (accessibilityComputerCallbackWith "{" observed)
+            \host -> do
+                session <- newComputerSession
+                result <- invokeComputerSessionTransaction
+                    host session ScreenshotPng [] (const (Right ()))
+                case result of
+                    Right ComputerObservation
+                        { computerObservationImage =
+                            ImageAttachment "image/png" bytes
+                        , computerObservationAccessibility =
+                            Just (AccessibilityUnavailable 1 _)
+                        } ->
+                            bytes `shouldBe` pngSignature
+                    value -> expectationFailure
+                        ("unexpected malformed accessibility result: " <> show value)
 
     it "waits for an in-flight transaction before disabling its callback" do
         runEntered <- newEmptyMVar
@@ -201,7 +248,9 @@ spec = describe "native computer bridge" do
         observed <- newIORef []
         let blockingCallback context abi operation token width height
                 actions actionCount points pointCount text textLength
-                imageFormat output outputCapacity outputLength outputToken
+                imageFormat output outputCapacity outputLength
+                accessibilityOutput accessibilityCapacity accessibilityLength
+                outputToken
                 outputWidth outputHeight outputImageFormat = do
                     if operation == 2
                         then putMVar runEntered () >> takeMVar releaseRun
@@ -210,7 +259,9 @@ spec = describe "native computer bridge" do
                         context abi operation token width height
                         actions actionCount points pointCount text textLength
                         imageFormat output outputCapacity outputLength
-                        outputToken outputWidth outputHeight outputImageFormat
+                        accessibilityOutput accessibilityCapacity
+                        accessibilityLength outputToken outputWidth outputHeight
+                        outputImageFormat
         withCallback blockingCallback \callback -> do
             registration <- newMVar
                 (Just (ComputerRegistration callback nullPtr))
@@ -235,7 +286,8 @@ spec = describe "native computer bridge" do
                             wait running `shouldReturn` Right
                                 (ComputerObservation
                                     (ImageAttachment "image/png" pngSignature)
-                                    Nothing)
+                                    (Just (AccessibilityUnavailable 1
+                                        "Native accessibility snapshot unavailable.")))
                             wait disabling
             invokeComputerTransaction host ScreenshotPng [] (const (Right ()))
                 `shouldReturn` Left "Native computer control is not active."
@@ -280,6 +332,7 @@ data ObservedComputerInvocation = ObservedComputerInvocation
     !BS.ByteString
     !CInt
     !CSize
+    !CSize
     deriving (Eq, Show)
 
 recordingComputerCallback
@@ -287,17 +340,19 @@ recordingComputerCallback
     -> ComputerCallback
 recordingComputerCallback observed _ abi operation token width height
         actions actionCount points pointCount text textLength imageFormat
-        output outputCapacity outputLength outputToken outputWidth outputHeight
-        outputImageFormat = do
+        output outputCapacity outputLength _accessibilityOutput
+        accessibilityCapacity accessibilityLength outputToken outputWidth
+        outputHeight outputImageFormat = do
     decodedActions <- peekValues actions actionCount
     decodedPoints <- peekValues points pointCount
     decodedText <- peekBytes text textLength
     modifyIORef' observed (<> [ObservedComputerInvocation
         abi operation token width height decodedActions decodedPoints
-        decodedText imageFormat outputCapacity])
+        decodedText imageFormat outputCapacity accessibilityCapacity])
     case operation of
         1 -> do
             poke outputLength 0
+            poke accessibilityLength 0
             poke outputToken 41
             poke outputWidth 100
             poke outputHeight 80
@@ -306,12 +361,39 @@ recordingComputerCallback observed _ abi operation token width height
         2 -> do
             status <- writeBytes pngSignature
                 output outputCapacity outputLength
+            poke accessibilityLength 0
             poke outputToken (token + 1)
             poke outputWidth 100
             poke outputHeight 80
             poke outputImageFormat 1
             pure status
         _ -> pure 1
+
+accessibilityComputerCallback
+    :: IORef [ObservedComputerInvocation]
+    -> ComputerCallback
+accessibilityComputerCallback =
+    accessibilityComputerCallbackWith accessibilitySnapshotBytes
+
+accessibilityComputerCallbackWith
+    :: BS.ByteString
+    -> IORef [ObservedComputerInvocation]
+    -> ComputerCallback
+accessibilityComputerCallbackWith accessibilityBytes observed
+        context abi operation token width height
+        actions actionCount points pointCount text textLength imageFormat
+        output outputCapacity outputLength accessibilityOutput
+        accessibilityCapacity accessibilityLength outputToken outputWidth
+        outputHeight outputImageFormat = do
+    status <- recordingComputerCallback observed context abi operation token
+        width height actions actionCount points pointCount text textLength
+        imageFormat output outputCapacity outputLength accessibilityOutput
+        accessibilityCapacity accessibilityLength outputToken outputWidth
+        outputHeight outputImageFormat
+    if status == 0 && operation == 2
+        then writeBytes accessibilityBytes
+            accessibilityOutput accessibilityCapacity accessibilityLength
+        else pure status
 
 peekValues :: Storable value => Ptr value -> CSize -> IO [value]
 peekValues _ (CSize 0) = pure []
@@ -368,9 +450,13 @@ plainObservedAction action = CComputerAction
 pngSignature :: BS.ByteString
 pngSignature = BS.pack [137, 80, 78, 71, 13, 10, 26, 10]
 
+accessibilitySnapshotBytes :: BS.ByteString
+accessibilitySnapshotBytes =
+    "{\"schema_version\":1,\"scope\":{\"bundle_id\":\"test\"},\"contents\":{\"role\":\"AXWindow\"}}"
+
 observedOperationAndToken
     :: ObservedComputerInvocation
     -> (CInt, Word64)
 observedOperationAndToken
-        (ObservedComputerInvocation _ operation token _ _ _ _ _ _ _) =
+        (ObservedComputerInvocation _ operation token _ _ _ _ _ _ _ _) =
     (operation, token)

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
@@ -23,6 +23,7 @@ import Agent.CLI.MacOS.ComputerBridge
     , invokeComputerSessionTransaction
     , invokeComputerTransaction
     , newComputerSession
+    , resetComputerSessionAccessibility
     )
 import Agent.Loop (ImageAttachment(..))
 import Agent.Responses.Types
@@ -222,6 +223,39 @@ spec = describe "native computer bridge" do
                   ) -> pure ()
                 values -> expectationFailure
                     ("unexpected accessibility observations: " <> show values)
+
+    it "resets accessibility to a full snapshot without discarding the display lease" do
+        observed <- newIORef []
+        withComputerHost (accessibilityComputerCallback observed) \host -> do
+            session <- newComputerSession
+            first <- invokeComputerSessionTransaction
+                host session ScreenshotPng [] (const (Right ()))
+            second <- invokeComputerSessionTransaction
+                host session ScreenshotPng [] (const (Right ()))
+            resetComputerSessionAccessibility session
+            third <- invokeComputerSessionTransaction
+                host session ScreenshotPng
+                [ClickAction 10 20 "left" []]
+                (const (Right ()))
+            case (first, second, third) of
+                ( Right ComputerObservation
+                    { computerObservationAccessibility =
+                        Just (AccessibilityFull 1 _)
+                    }
+                  , Right ComputerObservation
+                    { computerObservationAccessibility =
+                        Just (AccessibilityDelta 1 2 [])
+                    }
+                  , Right ComputerObservation
+                    { computerObservationAccessibility =
+                        Just (AccessibilityFull 1 _)
+                    }
+                  ) -> pure ()
+                values -> expectationFailure
+                    ("unexpected reset accessibility observations: " <> show values)
+            invocations <- readIORef observed
+            map observedOperationAndToken invocations `shouldBe`
+                [(1, 0), (2, 41), (1, 0), (2, 41), (2, 42)]
 
     it "keeps a valid screenshot when accessibility JSON is malformed" do
         observed <- newIORef []

--- a/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeComputerSmoke.c
+++ b/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeComputerSmoke.c
@@ -49,6 +49,9 @@ static int32_t computer_callback(
     uint8_t *output,
     size_t output_capacity,
     size_t *output_length,
+    uint8_t *accessibility_output,
+    size_t accessibility_output_capacity,
+    size_t *accessibility_output_length,
     uint64_t *output_display_token,
     int32_t *output_width,
     int32_t *output_height,
@@ -66,12 +69,17 @@ static int32_t computer_callback(
             || text != NULL || text_length != 0
             || requested_image_format != HA_COMPUTER_IMAGE_NONE
             || output == NULL || output_capacity != HA_COMPUTER_ERROR_CAPACITY
-            || output_length == NULL || output_display_token == NULL
+            || output_length == NULL
+            || accessibility_output != NULL
+            || accessibility_output_capacity != 0
+            || accessibility_output_length == NULL
+            || output_display_token == NULL
             || output_width == NULL
             || output_height == NULL || output_image_format == NULL) {
         return HA_COMPUTER_STATUS_INVALID_ARGUMENT;
     }
     *output_length = 0;
+    *accessibility_output_length = 0;
     *output_display_token = 42;
     *output_width = 1440;
     *output_height = 900;
@@ -82,18 +90,21 @@ static int32_t computer_callback(
 int ha_computer_callback_abi_smoke(void) {
     uint8_t output[HA_COMPUTER_ERROR_CAPACITY];
     size_t output_length = 17;
+    size_t accessibility_output_length = 17;
     uint64_t output_display_token = 0;
     int32_t output_width = 0;
     int32_t output_height = 0;
     int32_t output_image_format = -1;
     ha_computer_callback callback = computer_callback;
 
-    if (HA_COMPUTER_ACTION_STRUCT_SIZE_V1 != 64
+    if (HA_COMPUTER_ABI_VERSION != 2
+            || HA_COMPUTER_ACTION_STRUCT_SIZE_V1 != 64
             || HA_COMPUTER_MAX_ACTIONS != 10
             || HA_COMPUTER_MAX_POINTS_PER_ACTION != 1024
             || HA_COMPUTER_MAX_TOTAL_POINTS != 10240
             || HA_COMPUTER_MAX_TEXT_BYTES != 327680
             || HA_COMPUTER_OUTPUT_CAPACITY != 16777216
+            || HA_COMPUTER_ACCESSIBILITY_CAPACITY != 524288
             || HA_COMPUTER_STATUS_DISPLAY_CHANGED != 9) {
         return 1;
     }
@@ -115,6 +126,9 @@ int ha_computer_callback_abi_smoke(void) {
         output,
         sizeof(output),
         &output_length,
+        NULL,
+        0,
+        &accessibility_output_length,
         &output_display_token,
         &output_width,
         &output_height,
@@ -122,6 +136,7 @@ int ha_computer_callback_abi_smoke(void) {
     );
     if (status != HA_COMPUTER_STATUS_SUCCESS
             || output_length != 0
+            || accessibility_output_length != 0
             || output_display_token != 42
             || output_width != 1440
             || output_height != 900

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -362,6 +362,110 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
             other -> expectationFailure
                 ("unexpected native computer continuation: " <> show other)
 
+    it "labels a structured full accessibility snapshot with its revision" do
+        let accessibilityState = Aeson.object
+                [ "kind" Aeson..= ("full" :: Text.Text)
+                , "revision" Aeson..= (1 :: Int)
+                , "snapshot" Aeson..= Aeson.object
+                    ["application" Aeson..= ("TextEdit" :: Text.Text)]
+                ]
+            encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                ComputerCallOutput
+                    { computerOutputItemId = Nothing
+                    , computerOutputCallId = "ignored"
+                    , screenshotDataUrl = "data:image/jpeg;base64,AA=="
+                    , acknowledgedChecks = []
+                    , computerOutputStatus = Nothing
+                    , computerOutputExtra = KeyMap.singleton
+                        "accessibility_state"
+                        accessibilityState
+                    }
+            result = ToolCallResult
+                { callId = "call-native-full"
+                , output = encoded
+                , callKind = ComputerFunctionCallKind
+                }
+        case turnInputsToItems [CompletedTool result] of
+            FunctionCallOutputItem output : _ ->
+                case Aeson.toJSON output.output of
+                    Aeson.String rendered -> do
+                        rendered `shouldSatisfy` Text.isInfixOf
+                            "Full macOS accessibility snapshot, revision 1:"
+                        rendered `shouldSatisfy` Text.isInfixOf
+                            "\"kind\":\"full\""
+                    other -> expectationFailure
+                        ("expected text output, got " <> show other)
+            other -> expectationFailure
+                ("unexpected native computer continuation: " <> show other)
+
+    it "labels accessibility deltas with their base and new revisions" do
+        let accessibilityState = Aeson.object
+                [ "kind" Aeson..= ("delta" :: Text.Text)
+                , "base_revision" Aeson..= (3 :: Int)
+                , "revision" Aeson..= (4 :: Int)
+                , "patch" Aeson..= ([] :: [Aeson.Value])
+                ]
+            encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                ComputerCallOutput
+                    { computerOutputItemId = Nothing
+                    , computerOutputCallId = "ignored"
+                    , screenshotDataUrl = "data:image/jpeg;base64,AA=="
+                    , acknowledgedChecks = []
+                    , computerOutputStatus = Nothing
+                    , computerOutputExtra = KeyMap.singleton
+                        "accessibility_state"
+                        accessibilityState
+                    }
+            result = ToolCallResult
+                { callId = "call-native-delta"
+                , output = encoded
+                , callKind = ComputerFunctionCallKind
+                }
+        case turnInputsToItems [CompletedTool result] of
+            FunctionCallOutputItem output : _ ->
+                Aeson.toJSON output.output `shouldSatisfy` \case
+                    Aeson.String rendered ->
+                        "macOS accessibility changes, revision 3 -> 4:"
+                            `Text.isInfixOf` rendered
+                            && "\"patch\":[]" `Text.isInfixOf` rendered
+                    _ -> False
+            other -> expectationFailure
+                ("unexpected native computer continuation: " <> show other)
+
+    it "labels structured accessibility capture failures" do
+        let accessibilityState = Aeson.object
+                [ "kind" Aeson..= ("unavailable" :: Text.Text)
+                , "revision" Aeson..= (2 :: Int)
+                , "reason" Aeson..= ("AX timeout" :: Text.Text)
+                ]
+            encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                ComputerCallOutput
+                    { computerOutputItemId = Nothing
+                    , computerOutputCallId = "ignored"
+                    , screenshotDataUrl = "data:image/jpeg;base64,AA=="
+                    , acknowledgedChecks = []
+                    , computerOutputStatus = Nothing
+                    , computerOutputExtra = KeyMap.singleton
+                        "accessibility_state"
+                        accessibilityState
+                    }
+            result = ToolCallResult
+                { callId = "call-native-unavailable"
+                , output = encoded
+                , callKind = ComputerFunctionCallKind
+                }
+        case turnInputsToItems [CompletedTool result] of
+            FunctionCallOutputItem output : _ ->
+                Aeson.toJSON output.output `shouldSatisfy` \case
+                    Aeson.String rendered ->
+                        "macOS accessibility state unavailable, revision 2:"
+                            `Text.isInfixOf` rendered
+                            && "\"reason\":\"AX timeout\""
+                                `Text.isInfixOf` rendered
+                    _ -> False
+            other -> expectationFailure
+                ("unexpected native computer continuation: " <> show other)
+
     it "keeps computer output before its observation in standard and Lite requests" do
         let encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
                 ComputerCallOutput

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -382,6 +382,9 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
                     }
             result = ToolCallResult
                 { callId = "call-native-full"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
                 , output = encoded
                 , callKind = ComputerFunctionCallKind
                 }
@@ -418,6 +421,9 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
                     }
             result = ToolCallResult
                 { callId = "call-native-delta"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
                 , output = encoded
                 , callKind = ComputerFunctionCallKind
                 }
@@ -451,6 +457,9 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
                     }
             result = ToolCallResult
                 { callId = "call-native-unavailable"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
                 , output = encoded
                 , callKind = ComputerFunctionCallKind
                 }

--- a/packages/agent-server/src/Agent/Server/Event.hs
+++ b/packages/agent-server/src/Agent/Server/Event.hs
@@ -134,6 +134,10 @@ projectLoopEvent = \case
             , "status" .= nativeAgentStatusText status
             ]
         )
+    ModelContextReset ->
+        ( "model.context.reset"
+        , object ["displayOnly" .= True]
+        )
 
 -- | Public agent snapshots intentionally omit transcripts and retained UI
 -- state. Those may contain arbitrarily large or sensitive model/tool output.

--- a/packages/agent-server/test/Agent/Server/EventSpec.hs
+++ b/packages/agent-server/test/Agent/Server/EventSpec.hs
@@ -73,6 +73,11 @@ spec = describe "public loop-event projection" do
         LBS8.unpack (encode failed)
             `shouldContain` "\"displayOnly\":true"
 
+    it "projects model-context resets as display-only" do
+        let (eventType, value) = projectLoopEvent ModelContextReset
+        eventType `shouldBe` "model.context.reset"
+        value `shouldBe` object ["displayOnly" .= True]
+
     it "redacts encrypted durable values and applies a total budget" do
         let public = projectPublicValue $
                 object

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -402,6 +402,7 @@ reduceLoop event state = case event of
                 }
     ActivityUpdated activity ->
         state { uiActivity = activity }
+    ModelContextReset -> state
     ProviderLimitUpdated
         { providerLimitText = text
         , providerLimitWarning = warning

--- a/packages/agent-tui/test/Agent/TUI/ModelPropertySpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelPropertySpec.hs
@@ -186,6 +186,7 @@ generatedLoopEvent = frequency
     , (3, WarningRaised <$> generatedText)
     , (2, ResponseRestarted <$> generatedText)
     , (2, pure TurnStarted)
+    , (1, pure ModelContextReset)
     ]
 
 generatedNotice :: Gen (Maybe UiNotice)


### PR DESCRIPTION
## Summary

- capture a bounded, redacted accessibility snapshot alongside each native computer-use screenshot
- send a full revision initially, then RFC 6902 `add`/`remove`/`replace` deltas when they are materially smaller
- checkpoint or reset the baseline on scope changes, capture failures, large deltas, and revision limits
- extend the native computer ABI and model-facing renderer for full, delta, unchanged, and unavailable states
- add focused protocol/bridge/rendering coverage and an optimized accessibility-delta benchmark

## Safety and fallback behavior

- screenshots remain usable when accessibility capture is unavailable or malformed
- secure text values are redacted by the native client
- native capture is capped at 1,000 nodes, depth 32, 1 KiB strings, 512 KiB JSON, and a 250 ms global deadline
- full snapshots are resent when a patch is at least 60% of the encoded full snapshot or after eight deltas

## Validation

- native computer bridge: 12 examples, 0 failures
- computer-use protocol: 30 examples, 0 failures
- response rendering: 61 examples, 0 failures
- coordinated macOS accessibility/bridge tests: 12 tests, 0 failures
- coordinated Swift app target builds successfully
- `git diff --check`

## Benchmark

Optimized 1,000-node, 24-revision benchmark (`-O2`, RTS allocation stats):

- static: 2,737,239 bytes full vs 343,399 bytes delta (87.5% reduction)
- small changes: 2,737,254 bytes full vs 346,485 bytes delta (87.3% reduction)
- high churn: delta output equals full output, confirming the full-snapshot fallback

The native macOS capture/ABI consumer is implemented in the private companion repository and will be pinned to this public change after landing.
