### PR TITLE
Refactor repository delivery and review module boundaries

### DIFF
--- a/packages/agent-repository/agent-repository.cabal
+++ b/packages/agent-repository/agent-repository.cabal
@@ -38,6 +38,12 @@ library
     import:           common-options
     hs-source-dirs:   src
     other-modules:    Agent.CLI.ProcessSecurity
+                    , Agent.CLI.RepositoryDelivery.Process
+                    , Agent.CLI.RepositoryDelivery.Validation
+                    , Agent.CLI.RepositoryReview.Checks
+                    , Agent.CLI.RepositoryReview.Error
+                    , Agent.CLI.RepositoryReview.GitOutput
+                    , Agent.CLI.RepositoryReview.ProcessSupport
     exposed-modules:  Agent.CLI.RepositoryDelivery
                     , Agent.CLI.RepositoryDelivery.ConfirmationStore
                     , Agent.CLI.RepositoryReview

--- a/packages/agent-repository/package.nix
+++ b/packages/agent-repository/package.nix
@@ -5,7 +5,7 @@
 mkDerivation {
   pname = "agent-repository";
   version = "0.1.0.0";
-  src = packages/agent-repository;
+  src = ./.;
   libraryHaskellDepends = [
     aeson async base bytestring containers crypton directory filelock
     filepath process safe-exceptions text time transformers unix

--- a/packages/agent-repository/package.nix
+++ b/packages/agent-repository/package.nix
@@ -5,7 +5,7 @@
 mkDerivation {
   pname = "agent-repository";
   version = "0.1.0.0";
-  src = ./.;
+  src = packages/agent-repository;
   libraryHaskellDepends = [
     aeson async base bytestring containers crypton directory filelock
     filepath process safe-exceptions text time transformers unix

--- a/packages/agent-repository/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryDelivery.hs
@@ -19,18 +19,17 @@ import Agent.CLI.RepositoryDelivery.ConfirmationStore
     , newConfirmationStore
     , takeConfirmation
     )
-import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (cancel, wait, withAsync)
-import Control.Applicative ((<|>))
+import Agent.CLI.RepositoryDelivery.Process
+    ( ProcessResult(..)
+    , ProcessFailure(..)
+    , runCommand
+    , runCommandWithEnvironment
+    , trySynchronous
+    )
+import Agent.CLI.RepositoryDelivery.Validation
 import Control.Exception.Safe
-    ( SomeException
-    , bracket
-    , finally
-    , isAsyncException
-    , mask
+    ( bracket
     , onException
-    , throwIO
-    , tryAny
     )
 import Control.Monad (unless, when)
 import Control.Monad.IO.Class (liftIO)
@@ -44,13 +43,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
-import Data.Char (isAlphaNum, isHexDigit, isSpace)
-import Data.IORef
-    ( newIORef
-    , readIORef
-    , writeIORef
-    )
-import Data.Maybe (fromMaybe)
+import Data.Char (isHexDigit, isSpace)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -66,10 +59,8 @@ import System.Directory
     , removePathForcibly
     )
 import System.Exit (ExitCode(..))
-import System.Environment (getEnvironment)
 import System.IO
-    ( Handle
-    , IOMode(ReadMode)
+    ( IOMode(ReadMode)
     , hClose
     , openBinaryFile
     )
@@ -85,24 +76,7 @@ import System.Posix.Files
     , setFileMode
     , unionFileModes
     )
-import System.Posix.Signals
-    ( Signal
-    , sigKILL
-    , sigTERM
-    , signalProcessGroup
-    )
-import System.Posix.Types (ProcessID)
 import System.Posix.Temp (mkdtemp)
-import System.Process
-    ( CreateProcess(..)
-    , ProcessHandle
-    , StdStream(CreatePipe)
-    , createProcess
-    , getPid
-    , proc
-    , terminateProcess
-    , waitForProcess
-    )
 import System.Timeout (timeout)
 
 import Agent.CLI.RepositoryReview
@@ -112,7 +86,6 @@ import Agent.CLI.RepositoryReview
 import Agent.CLI.ProcessSecurity
     ( canonicalPathOutside
     , resolveExecutableOutside
-    , sanitizeSearchPathOutside
     )
 
 data DeliveryStatus = DeliveryStatus
@@ -198,19 +171,6 @@ data StoredConfirmation = StoredConfirmation
     { storedRoot :: !FilePath
     , storedConfirmation :: !Confirmation
     }
-
-data ProcessResult = ProcessResult
-    { processExitCode :: !ExitCode
-    , processStdout :: !BS.ByteString
-    , processStderr :: !BS.ByteString
-    , processOutputTruncated :: !Bool
-    }
-
-data ProcessFailure
-    = ProcessLaunchFailed
-    | ProcessTimedOut
-    | ProcessOutputExceeded
-    deriving (Eq, Show)
 
 repositoryDeliveryStatus
     :: FilePath
@@ -1117,114 +1077,6 @@ pullRequestNumber repository url =
             | number > 0 -> Just number
         _ -> Nothing
 
-validRemoteUrl :: BS.ByteString -> Bool
-validRemoteUrl url =
-    not (BS.null url)
-        && BS.length url <= 4096
-        && BS.all (\byte -> byte >= 0x20 && byte /= 0x7f) url
-        && BS8.head url /= '-'
-        && (validHttps url
-            || validSsh url
-            || validScpLike url)
-  where
-    validHttps value =
-        "https://" `BS8.isPrefixOf` value
-            && validUrlAuthority "https://" value
-            && not (authorityContains '@' "https://" value)
-            && not (containsQueryOrFragment value)
-            && not (authorityContains '%' "https://" value)
-    validSsh value =
-        "ssh://" `BS8.isPrefixOf` value
-            && validSshAuthority value
-            && not (containsQueryOrFragment value)
-    authorityContains character prefix value =
-        BS8.elem character
-            (BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value))
-    validSshAuthority value =
-        let authority =
-                BS8.takeWhile (/= '/') (BS.drop (BS.length "ssh://") value)
-            (userinfo, separatorAndHost) = BS8.break (== '@') authority
-            host = BS.drop 1 separatorAndHost
-        in not (BS.null authority)
-            && not (BS8.elem '%' authority)
-            && if BS.null separatorAndHost
-                then validHostPort authority
-                else validUsername userinfo
-                    && validHostPort host
-                    && not (BS8.elem '@' host)
-    validUrlAuthority prefix value =
-        validHostPort
-            (BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value))
-    validHostPort authority =
-        case BS8.break (== ':') authority of
-            (host, port)
-                | BS.null port -> validHost host
-                | otherwise ->
-                    validHost host
-                        && BS.length port > 1
-                        && BS8.all
-                            (\character ->
-                                character >= '0' && character <= '9')
-                            (BS.drop 1 port)
-    validHost host =
-        not (BS.null host)
-            && BS8.all
-                (\character ->
-                    isAsciiAlphaNumeric character
-                        || character `elem` (".-" :: String))
-                host
-            && BS8.head host /= '.'
-            && BS8.last host /= '.'
-    validUsername username =
-        not (BS.null username)
-            && BS8.all
-                (\character ->
-                    isAsciiAlphaNumeric character
-                        || character `elem` ("._-" :: String))
-                username
-    isAsciiAlphaNumeric character =
-        (character >= 'a' && character <= 'z')
-            || (character >= 'A' && character <= 'Z')
-            || (character >= '0' && character <= '9')
-    containsQueryOrFragment value =
-        BS8.elem '?' value || BS8.elem '#' value
-    validScpLike value =
-        case BS8.break (== ':') value of
-            (authority, path) ->
-                let (username, separatorAndHost) = BS8.break (== '@') authority
-                    host = BS.drop 1 separatorAndHost
-                in validUsername username
-                    && not (BS.null separatorAndHost)
-                    && validHost host
-                    && not (BS8.elem '@' host)
-                    && not (BS8.elem '%' authority)
-                    && BS.length path > 1
-                    && not (BS8.elem '@' path)
-                    && not (containsQueryOrFragment value)
-
-githubRepositoryFromUrl :: BS.ByteString -> Maybe Text
-githubRepositoryFromUrl bytes
-    | not (BS.all (< 0x80) bytes) = Nothing
-    | otherwise =
-        let url = Text.pack (BS8.unpack bytes)
-        in parseHttps url
-            <|> parseSsh url
-            <|> parseScp url
-  where
-    parseHttps url =
-        Text.stripPrefix "https://github.com/" url >>= repositoryPath
-    parseSsh url =
-        (Text.stripPrefix "ssh://git@github.com/" url
-            <|> Text.stripPrefix "ssh://github.com/" url)
-            >>= repositoryPath
-    parseScp url =
-        Text.stripPrefix "git@github.com:" url >>= repositoryPath
-    repositoryPath path =
-        let withoutGit = fromMaybe path (Text.stripSuffix ".git" path)
-        in if validateRepositoryName withoutGit
-            then Just withoutGit
-            else Nothing
-
 remoteMatchesExpected :: DeliveryStatus -> Maybe Text -> Bool
 remoteMatchesExpected status =
     (== expectedRemoteHead status)
@@ -1282,75 +1134,6 @@ validatePullRequestInput base title body
     | Text.any (== '\NUL') body =
         Left (DeliveryInvalidRequest "pull-request body contains a NUL byte")
     | otherwise = Right ()
-
-validateBranchName :: Text -> Bool
-validateBranchName branch =
-    validateFullBranchRef ("refs/heads/" <> branch)
-
-validateFullBranchRef :: Text -> Bool
-validateFullBranchRef ref =
-    not (Text.null ref)
-        && Text.length ref <= 1024
-        && "refs/heads/" `Text.isPrefixOf` ref
-        && not ("/" `Text.isSuffixOf` ref)
-        && not ("." `Text.isSuffixOf` ref)
-        && not ("." `Text.isPrefixOf` ref)
-        && not ("-" `Text.isPrefixOf` Text.drop (Text.length "refs/heads/") ref)
-        && not (".." `Text.isInfixOf` ref)
-        && not ("@{" `Text.isInfixOf` ref)
-        && not ("//" `Text.isInfixOf` ref)
-        && Text.all safeRefCharacter ref
-        && all validComponent (Text.splitOn "/" ref)
-  where
-    safeRefCharacter character =
-        not (isSpace character)
-            && character >= '\x20'
-            && character /= '\x7f'
-            && character `notElem` ("~^:?*[\\" :: String)
-    validComponent component =
-        not (Text.null component)
-            && not ("." `Text.isPrefixOf` component)
-            && component /= "."
-            && component /= ".."
-            && not (".lock" `Text.isSuffixOf` component)
-
-validateRemoteName :: Text -> Bool
-validateRemoteName remote =
-    not (Text.null remote)
-        && Text.length remote <= 255
-        && Text.head remote /= '-'
-        && Text.all
-            (\character ->
-                isAlphaNum character
-                    || character `elem` ("._/-" :: String))
-            remote
-        && not (".." `Text.isInfixOf` remote)
-        && not ("//" `Text.isInfixOf` remote)
-
-validateRepositoryName :: Text -> Bool
-validateRepositoryName name =
-    case Text.splitOn "/" name of
-        [owner, repository] ->
-            validPart owner && validPart repository
-        _ -> False
-  where
-    validPart value =
-        not (Text.null value)
-            && value /= "."
-            && value /= ".."
-            && Text.length value <= 100
-            && Text.all
-                (\character ->
-                    isAlphaNum character
-                        || character `elem` ("-._" :: String))
-                value
-
-validObjectId :: Text -> Bool
-validObjectId oid =
-    Text.length oid `elem` [40, 64] && Text.all isHexDigit oid
-
-zeroObjectId :: Text -> Text
-zeroObjectId oid = Text.replicate (Text.length oid) "0"
 
 parseAheadBehind :: BS.ByteString -> Maybe (Int, Int)
 parseAheadBehind bytes =
@@ -1848,342 +1631,12 @@ runGh root arguments input timeoutMicros = do
                         (DeliveryUnavailable
                             "GitHub CLI command failed"))
 
-runCommand
-    :: FilePath
-    -> FilePath
-    -> [String]
-    -> BS.ByteString
-    -> Int
-    -> IO (Either ProcessFailure ProcessResult)
-runCommand root =
-    runCommandWithEnvironment [] root root
-
-runCommandWithEnvironment
-    :: [(String, String)]
-    -> FilePath
-    -> FilePath
-    -> FilePath
-    -> [String]
-    -> BS.ByteString
-    -> Int
-    -> IO (Either ProcessFailure ProcessResult)
-runCommandWithEnvironment
-    overrides
-    trustRoot
-    workingDirectory
-    executable
-    arguments
-    input
-    timeoutMicros = do
-    launched <- trySynchronous
-        (bracket start stop \processData ->
-            timeout timeoutMicros (run processData))
-    pure case launched of
-        Left _ -> Left ProcessLaunchFailed
-        Right Nothing -> Left ProcessTimedOut
-        Right (Just result) -> result
-  where
-    start = mask \_ -> do
-        resolvedExecutable <-
-            resolveExecutableOutside trustRoot executable
-                >>= either (fail . Text.unpack) pure
-        environment <- applyEnvironmentOverrides overrides
-            <$> nonInteractiveEnvironment trustRoot executable
-        (maybeInput, maybeOutput, maybeError, process) <-
-            createProcess
-                (proc resolvedExecutable arguments)
-                    { cwd = Just workingDirectory
-                    , std_in = CreatePipe
-                    , std_out = CreatePipe
-                    , std_err = CreatePipe
-                    , close_fds = True
-                    , create_group = True
-                    , env = Just environment
-                    }
-        case (maybeInput, maybeOutput, maybeError) of
-            (Just inputHandle, Just outputHandle, Just errorHandle) -> do
-                let closePipes = do
-                        closeQuietly inputHandle
-                        closeQuietly outputHandle
-                        closeQuietly errorHandle
-                    cleanupWithoutGroup = do
-                        closePipes
-                        _ <- tryAny (terminateProcess process)
-                        _ <- tryAny (waitForProcess process)
-                        pure ()
-                processGroup <- getPid process
-                    `onException` cleanupWithoutGroup
-                completed <- newIORef False
-                    `onException` do
-                        closePipes
-                        terminateProcessGroup sigKILL processGroup process
-                        _ <- tryAny (waitForProcess process)
-                        pure ()
-                pure
-                    ( inputHandle
-                    , outputHandle
-                    , errorHandle
-                    , process
-                    , processGroup
-                    , completed
-                    )
-            _ -> do
-                terminateProcess process
-                _ <- waitForProcess process
-                fail "could not create command pipes"
-    stop
-        ( inputHandle
-        , outputHandle
-        , errorHandle
-        , process
-        , processGroup
-        , completed
-        ) = do
-        closeQuietly inputHandle
-        closeQuietly outputHandle
-        closeQuietly errorHandle
-        finished <- readIORef completed
-        unless finished do
-            terminateProcessGroup sigTERM processGroup process
-            threadDelay 100_000
-            -- A descendant can retain the group and pipes after its leader
-            -- exits, so always escalate the captured process group.
-            terminateProcessGroup sigKILL processGroup process
-        _ <- tryAny (waitForProcess process)
-        pure ()
-    run
-        ( inputHandle
-        , outputHandle
-        , errorHandle
-        , process
-        , processGroup
-        , completed
-        ) =
-        withAsync
-            (BS.hPut inputHandle input `finally` closeQuietly inputHandle)
-            \inputWriter ->
-                withAsync (readBounded outputHandle) \outputReader ->
-                    withAsync (readBounded errorHandle) \errorReader -> do
-                        exitCode <- waitForProcess process
-                        inputFinished <- timeout processPipeTeardownMicros
-                            (wait inputWriter)
-                        case inputFinished of
-                            Just () -> pure ()
-                            Nothing -> do
-                                closeQuietly inputHandle
-                                cancel inputWriter
-                        let drainReaders =
-                                (,) <$> wait outputReader <*> wait errorReader
-                        -- Give ordinary buffered output a short chance to
-                        -- drain. The captured group is then terminated even
-                        -- when EOF already arrived: a descendant may close
-                        -- its pipes while continuing to run.
-                        naturallyDrained <- timeout
-                            processPipeTeardownMicros
-                            drainReaders
-                        terminateProcessGroup sigTERM processGroup process
-                        drainedAfterTerm <- case naturallyDrained of
-                            Just values -> pure (Just values)
-                            Nothing ->
-                                timeout processGroupTermGraceMicros drainReaders
-                        -- Always escalate the captured group so a descendant
-                        -- cannot outlive a successful leader.
-                        terminateProcessGroup sigKILL processGroup process
-                        drained <- case drainedAfterTerm of
-                            Just values -> pure (Just values)
-                            Nothing ->
-                                timeout processPipeTeardownMicros drainReaders
-                        case drained of
-                            Nothing -> do
-                                closeQuietly outputHandle
-                                closeQuietly errorHandle
-                                cancel outputReader
-                                cancel errorReader
-                                pure (Left ProcessTimedOut)
-                            Just
-                                ( (output, outputTruncated)
-                                , (errors, errorsTruncated)
-                                ) -> do
-                                    writeIORef completed True
-                                    let truncated =
-                                            outputTruncated || errorsTruncated
-                                    pure
-                                        (if truncated
-                                            then Left ProcessOutputExceeded
-                                            else
-                                                Right
-                                                    ProcessResult
-                                                        { processExitCode =
-                                                            exitCode
-                                                        , processStdout = output
-                                                        , processStderr = errors
-                                                        , processOutputTruncated =
-                                                            False
-                                                        })
-
-applyEnvironmentOverrides
-    :: [(String, String)]
-    -> [(String, String)]
-    -> [(String, String)]
-applyEnvironmentOverrides overrides inherited =
-    overrides
-        <> filter
-            (\(name, _) -> name `notElem` map fst overrides)
-            inherited
-
-data BoundedReadState = BoundedReadState
-    { boundedChunks :: ![BS.ByteString]
-    , boundedRetainedBytes :: !Int
-    , boundedTruncated :: !Bool
-    }
-
-emptyBoundedReadState :: BoundedReadState
-emptyBoundedReadState = BoundedReadState
-    { boundedChunks = []
-    , boundedRetainedBytes = 0
-    , boundedTruncated = False
-    }
-
-retainBoundedChunk :: BoundedReadState -> BS.ByteString -> BoundedReadState
-retainBoundedChunk state chunk =
-    BoundedReadState
-        { boundedChunks =
-            if BS.null kept
-                then state.boundedChunks
-                else kept : state.boundedChunks
-        , boundedRetainedBytes =
-            state.boundedRetainedBytes + BS.length kept
-        , boundedTruncated =
-            state.boundedTruncated || BS.length kept < BS.length chunk
-        }
-  where
-    room = max 0 (maxProcessOutputBytes - state.boundedRetainedBytes)
-    kept = BS.take room chunk
-
-readBounded :: Handle -> IO (BS.ByteString, Bool)
-readBounded handle = do
-    finalState <-
-        drain emptyBoundedReadState `finally` closeQuietly handle
-    pure
-        ( BS.concat (reverse finalState.boundedChunks)
-        , finalState.boundedTruncated
-        )
-  where
-    drain state = do
-        chunk <- BS.hGetSome handle (64 * 1024)
-        if BS.null chunk
-            then pure state
-            else do
-                let nextState = retainBoundedChunk state chunk
-                nextState `seq` drain nextState
-
-terminateProcessGroup
-    :: Signal
-    -> Maybe ProcessID
-    -> ProcessHandle
-    -> IO ()
-terminateProcessGroup signal processGroup process = do
-    pid <- maybe (getPid process) (pure . Just) processGroup
-    case pid of
-        Nothing -> do
-            _ <- tryAny (terminateProcess process)
-            pure ()
-        Just processId -> do
-            _ <- tryAny (signalProcessGroup signal processId)
-            pure ()
-
 stripLineEnding :: BS.ByteString -> BS.ByteString
 stripLineEnding = BS8.dropWhileEnd (`elem` ['\r', '\n'])
 
 decodeTrimmed :: BS.ByteString -> Text
 decodeTrimmed =
     Text.strip . TextEncoding.decodeUtf8With lenientDecode
-
-closeQuietly :: Handle -> IO ()
-closeQuietly handle = do
-    _ <- tryAny (hClose handle)
-    pure ()
-
-nonInteractiveEnvironment :: FilePath -> FilePath -> IO [(String, String)]
-nonInteractiveEnvironment root executable = do
-    inherited <- getEnvironment
-    let blocked =
-            [ "GIT_TERMINAL_PROMPT"
-            , "GCM_INTERACTIVE"
-            , "GH_PROMPT_DISABLED"
-            , "GH_REPO"
-            , "GH_HOST"
-            , "SSH_ASKPASS_REQUIRE"
-            , "GIT_DIR"
-            , "GIT_WORK_TREE"
-            , "GIT_INDEX_FILE"
-            , "GIT_OBJECT_DIRECTORY"
-            , "GIT_ALTERNATE_OBJECT_DIRECTORIES"
-            , "GIT_COMMON_DIR"
-            , "GIT_CONFIG_COUNT"
-            , "GIT_CONFIG_KEY_0"
-            , "GIT_CONFIG_VALUE_0"
-            , "GIT_CONFIG_PARAMETERS"
-            , "GIT_CONFIG_GLOBAL"
-            , "GIT_CONFIG_SYSTEM"
-            , "GIT_CONFIG_NOSYSTEM"
-            , "GIT_ATTR_NOSYSTEM"
-            , "GIT_CEILING_DIRECTORIES"
-            , "GIT_SSH_COMMAND"
-            , "GIT_ASKPASS"
-            , "GIT_PROXY_COMMAND"
-            , "GIT_EXEC_PATH"
-            ]
-        sanitized = filter
-            (\(name, _) ->
-                name `notElem` blocked
-                    && not ("GIT_CONFIG_KEY_" `prefixOf` name)
-                    && not ("GIT_CONFIG_VALUE_" `prefixOf` name))
-            inherited
-    safePath <-
-        case lookup "PATH" sanitized of
-            Nothing -> pure Nothing
-            Just value -> sanitizeSearchPathOutside root value
-    let
-        sanitizedWithSafePath =
-            case safePath of
-                Nothing -> filter ((/= "PATH") . fst) sanitized
-                Just value ->
-                    ("PATH", value) : filter ((/= "PATH") . fst) sanitized
-        retained
-            | executable == "git" =
-                filter (\(name, _) -> name `elem` gitEnvironmentAllowlist)
-                    sanitizedWithSafePath
-            | otherwise = sanitizedWithSafePath
-    pure
-        ( [ ("GIT_TERMINAL_PROMPT", "0")
-          , ("GCM_INTERACTIVE", "never")
-          , ("GH_PROMPT_DISABLED", "true")
-          , ("SSH_ASKPASS_REQUIRE", "never")
-          ]
-            <> retained
-        )
-  where
-    prefixOf prefix value = take (length prefix) value == prefix
-    gitEnvironmentAllowlist =
-        [ "PATH"
-        , "HOME"
-        , "TMPDIR"
-        , "TMP"
-        , "TEMP"
-        , "LANG"
-        , "LC_ALL"
-        , "LC_CTYPE"
-        , "USER"
-        , "LOGNAME"
-        , "SSH_AUTH_SOCK"
-        , "XDG_CONFIG_HOME"
-        , "XDG_CONFIG_DIRS"
-        , "SSL_CERT_FILE"
-        , "SSL_CERT_DIR"
-        , "NIX_SSL_CERT_FILE"
-        , "TERM"
-        ]
 
 deliveryErrorText :: DeliveryError -> Text
 deliveryErrorText = \case
@@ -2192,14 +1645,6 @@ deliveryErrorText = \case
     DeliveryUnavailable message -> message
     DeliveryCommandFailed message -> message
     DeliveryConfirmationRejected message -> message
-
-trySynchronous :: IO value -> IO (Either SomeException value)
-trySynchronous action =
-    tryAny action >>= \case
-        Left exception
-            | isAsyncException exception -> throwIO exception
-            | otherwise -> pure (Left exception)
-        Right value -> pure (Right value)
 
 confirmationLifetimeSeconds :: POSIXTime
 confirmationLifetimeSeconds = 10 * 60
@@ -2217,15 +1662,6 @@ localTimeoutMicros = 15 * 1_000_000
 
 networkTimeoutMicros :: Int
 networkTimeoutMicros = 60 * 1_000_000
-
-processPipeTeardownMicros :: Int
-processPipeTeardownMicros = 1_000_000
-
-processGroupTermGraceMicros :: Int
-processGroupTermGraceMicros = 2_000_000
-
-maxProcessOutputBytes :: Int
-maxProcessOutputBytes = 1024 * 1024
 
 maxActiveConfirmations :: Int
 maxActiveConfirmations = 1024

--- a/packages/agent-repository/src/Agent/CLI/RepositoryDelivery/Process.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryDelivery/Process.hs
@@ -1,0 +1,394 @@
+-- | Bounded, non-interactive delivery processes. This policy intentionally
+-- remains separate from local review Git execution.
+module Agent.CLI.RepositoryDelivery.Process
+    ( ProcessResult(..)
+    , ProcessFailure(..)
+    , runCommand
+    , runCommandWithEnvironment
+    , trySynchronous
+    ) where
+
+import Agent.CLI.ProcessSecurity
+    ( resolveExecutableOutside
+    , sanitizeSearchPathOutside
+    )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (cancel, wait, withAsync)
+import Control.Exception.Safe
+    ( SomeException, bracket, finally, isAsyncException, mask
+    , onException, throwIO, tryAny
+    )
+import Control.Monad (unless)
+import qualified Data.ByteString as BS
+import Data.IORef (newIORef, readIORef, writeIORef)
+import qualified Data.Text as Text
+import System.Environment (getEnvironment)
+import System.Exit (ExitCode)
+import System.IO (Handle, hClose)
+import System.Posix.Signals (Signal, sigKILL, sigTERM, signalProcessGroup)
+import System.Posix.Types (ProcessID)
+import System.Process
+    ( CreateProcess(..), ProcessHandle, StdStream(CreatePipe)
+    , createProcess, getPid, proc, terminateProcess, waitForProcess
+    )
+import System.Timeout (timeout)
+
+data ProcessResult = ProcessResult
+    { processExitCode :: !ExitCode
+    , processStdout :: !BS.ByteString
+    , processStderr :: !BS.ByteString
+    , processOutputTruncated :: !Bool
+    }
+
+data ProcessFailure
+    = ProcessLaunchFailed
+    | ProcessTimedOut
+    | ProcessOutputExceeded
+    deriving (Eq, Show)
+
+runCommand
+    :: FilePath
+    -> FilePath
+    -> [String]
+    -> BS.ByteString
+    -> Int
+    -> IO (Either ProcessFailure ProcessResult)
+runCommand root =
+    runCommandWithEnvironment [] root root
+
+runCommandWithEnvironment
+    :: [(String, String)]
+    -> FilePath
+    -> FilePath
+    -> FilePath
+    -> [String]
+    -> BS.ByteString
+    -> Int
+    -> IO (Either ProcessFailure ProcessResult)
+runCommandWithEnvironment
+    overrides
+    trustRoot
+    workingDirectory
+    executable
+    arguments
+    input
+    timeoutMicros = do
+    launched <- trySynchronous
+        (bracket start stop \processData ->
+            timeout timeoutMicros (run processData))
+    pure case launched of
+        Left _ -> Left ProcessLaunchFailed
+        Right Nothing -> Left ProcessTimedOut
+        Right (Just result) -> result
+  where
+    start = mask \_ -> do
+        resolvedExecutable <-
+            resolveExecutableOutside trustRoot executable
+                >>= either (fail . Text.unpack) pure
+        environment <- applyEnvironmentOverrides overrides
+            <$> nonInteractiveEnvironment trustRoot executable
+        (maybeInput, maybeOutput, maybeError, process) <-
+            createProcess
+                (proc resolvedExecutable arguments)
+                    { cwd = Just workingDirectory
+                    , std_in = CreatePipe
+                    , std_out = CreatePipe
+                    , std_err = CreatePipe
+                    , close_fds = True
+                    , create_group = True
+                    , env = Just environment
+                    }
+        case (maybeInput, maybeOutput, maybeError) of
+            (Just inputHandle, Just outputHandle, Just errorHandle) -> do
+                let closePipes = do
+                        closeQuietly inputHandle
+                        closeQuietly outputHandle
+                        closeQuietly errorHandle
+                    cleanupWithoutGroup = do
+                        closePipes
+                        _ <- tryAny (terminateProcess process)
+                        _ <- tryAny (waitForProcess process)
+                        pure ()
+                processGroup <- getPid process
+                    `onException` cleanupWithoutGroup
+                completed <- newIORef False
+                    `onException` do
+                        closePipes
+                        terminateProcessGroup sigKILL processGroup process
+                        _ <- tryAny (waitForProcess process)
+                        pure ()
+                pure
+                    ( inputHandle
+                    , outputHandle
+                    , errorHandle
+                    , process
+                    , processGroup
+                    , completed
+                    )
+            _ -> do
+                terminateProcess process
+                _ <- waitForProcess process
+                fail "could not create command pipes"
+    stop
+        ( inputHandle
+        , outputHandle
+        , errorHandle
+        , process
+        , processGroup
+        , completed
+        ) = do
+        closeQuietly inputHandle
+        closeQuietly outputHandle
+        closeQuietly errorHandle
+        finished <- readIORef completed
+        unless finished do
+            terminateProcessGroup sigTERM processGroup process
+            threadDelay 100_000
+            -- A descendant can retain the group and pipes after its leader
+            -- exits, so always escalate the captured process group.
+            terminateProcessGroup sigKILL processGroup process
+        _ <- tryAny (waitForProcess process)
+        pure ()
+    run
+        ( inputHandle
+        , outputHandle
+        , errorHandle
+        , process
+        , processGroup
+        , completed
+        ) =
+        withAsync
+            (BS.hPut inputHandle input `finally` closeQuietly inputHandle)
+            \inputWriter ->
+                withAsync (readBounded outputHandle) \outputReader ->
+                    withAsync (readBounded errorHandle) \errorReader -> do
+                        exitCode <- waitForProcess process
+                        inputFinished <- timeout processPipeTeardownMicros
+                            (wait inputWriter)
+                        case inputFinished of
+                            Just () -> pure ()
+                            Nothing -> do
+                                closeQuietly inputHandle
+                                cancel inputWriter
+                        let drainReaders =
+                                (,) <$> wait outputReader <*> wait errorReader
+                        -- Give ordinary buffered output a short chance to
+                        -- drain. The captured group is then terminated even
+                        -- when EOF already arrived: a descendant may close
+                        -- its pipes while continuing to run.
+                        naturallyDrained <- timeout
+                            processPipeTeardownMicros
+                            drainReaders
+                        terminateProcessGroup sigTERM processGroup process
+                        drainedAfterTerm <- case naturallyDrained of
+                            Just values -> pure (Just values)
+                            Nothing ->
+                                timeout processGroupTermGraceMicros drainReaders
+                        -- Always escalate the captured group so a descendant
+                        -- cannot outlive a successful leader.
+                        terminateProcessGroup sigKILL processGroup process
+                        drained <- case drainedAfterTerm of
+                            Just values -> pure (Just values)
+                            Nothing ->
+                                timeout processPipeTeardownMicros drainReaders
+                        case drained of
+                            Nothing -> do
+                                closeQuietly outputHandle
+                                closeQuietly errorHandle
+                                cancel outputReader
+                                cancel errorReader
+                                pure (Left ProcessTimedOut)
+                            Just
+                                ( (output, outputTruncated)
+                                , (errors, errorsTruncated)
+                                ) -> do
+                                    writeIORef completed True
+                                    let truncated =
+                                            outputTruncated || errorsTruncated
+                                    pure
+                                        (if truncated
+                                            then Left ProcessOutputExceeded
+                                            else
+                                                Right
+                                                    ProcessResult
+                                                        { processExitCode =
+                                                            exitCode
+                                                        , processStdout = output
+                                                        , processStderr = errors
+                                                        , processOutputTruncated =
+                                                            False
+                                                        })
+
+applyEnvironmentOverrides
+    :: [(String, String)]
+    -> [(String, String)]
+    -> [(String, String)]
+applyEnvironmentOverrides overrides inherited =
+    overrides
+        <> filter
+            (\(name, _) -> name `notElem` map fst overrides)
+            inherited
+
+data BoundedReadState = BoundedReadState
+    { boundedChunks :: ![BS.ByteString]
+    , boundedRetainedBytes :: !Int
+    , boundedTruncated :: !Bool
+    }
+
+emptyBoundedReadState :: BoundedReadState
+emptyBoundedReadState = BoundedReadState
+    { boundedChunks = []
+    , boundedRetainedBytes = 0
+    , boundedTruncated = False
+    }
+
+retainBoundedChunk :: BoundedReadState -> BS.ByteString -> BoundedReadState
+retainBoundedChunk state chunk =
+    BoundedReadState
+        { boundedChunks =
+            if BS.null kept
+                then state.boundedChunks
+                else kept : state.boundedChunks
+        , boundedRetainedBytes =
+            state.boundedRetainedBytes + BS.length kept
+        , boundedTruncated =
+            state.boundedTruncated || BS.length kept < BS.length chunk
+        }
+  where
+    room = max 0 (maxProcessOutputBytes - state.boundedRetainedBytes)
+    kept = BS.take room chunk
+
+readBounded :: Handle -> IO (BS.ByteString, Bool)
+readBounded handle = do
+    finalState <-
+        drain emptyBoundedReadState `finally` closeQuietly handle
+    pure
+        ( BS.concat (reverse finalState.boundedChunks)
+        , finalState.boundedTruncated
+        )
+  where
+    drain state = do
+        chunk <- BS.hGetSome handle (64 * 1024)
+        if BS.null chunk
+            then pure state
+            else do
+                let nextState = retainBoundedChunk state chunk
+                nextState `seq` drain nextState
+
+terminateProcessGroup
+    :: Signal
+    -> Maybe ProcessID
+    -> ProcessHandle
+    -> IO ()
+terminateProcessGroup signal processGroup process = do
+    pid <- maybe (getPid process) (pure . Just) processGroup
+    case pid of
+        Nothing -> do
+            _ <- tryAny (terminateProcess process)
+            pure ()
+        Just processId -> do
+            _ <- tryAny (signalProcessGroup signal processId)
+            pure ()
+
+closeQuietly :: Handle -> IO ()
+closeQuietly handle = do
+    _ <- tryAny (hClose handle)
+    pure ()
+
+nonInteractiveEnvironment :: FilePath -> FilePath -> IO [(String, String)]
+nonInteractiveEnvironment root executable = do
+    inherited <- getEnvironment
+    let blocked =
+            [ "GIT_TERMINAL_PROMPT"
+            , "GCM_INTERACTIVE"
+            , "GH_PROMPT_DISABLED"
+            , "GH_REPO"
+            , "GH_HOST"
+            , "SSH_ASKPASS_REQUIRE"
+            , "GIT_DIR"
+            , "GIT_WORK_TREE"
+            , "GIT_INDEX_FILE"
+            , "GIT_OBJECT_DIRECTORY"
+            , "GIT_ALTERNATE_OBJECT_DIRECTORIES"
+            , "GIT_COMMON_DIR"
+            , "GIT_CONFIG_COUNT"
+            , "GIT_CONFIG_KEY_0"
+            , "GIT_CONFIG_VALUE_0"
+            , "GIT_CONFIG_PARAMETERS"
+            , "GIT_CONFIG_GLOBAL"
+            , "GIT_CONFIG_SYSTEM"
+            , "GIT_CONFIG_NOSYSTEM"
+            , "GIT_ATTR_NOSYSTEM"
+            , "GIT_CEILING_DIRECTORIES"
+            , "GIT_SSH_COMMAND"
+            , "GIT_ASKPASS"
+            , "GIT_PROXY_COMMAND"
+            , "GIT_EXEC_PATH"
+            ]
+        sanitized = filter
+            (\(name, _) ->
+                name `notElem` blocked
+                    && not ("GIT_CONFIG_KEY_" `prefixOf` name)
+                    && not ("GIT_CONFIG_VALUE_" `prefixOf` name))
+            inherited
+    safePath <-
+        case lookup "PATH" sanitized of
+            Nothing -> pure Nothing
+            Just value -> sanitizeSearchPathOutside root value
+    let
+        sanitizedWithSafePath =
+            case safePath of
+                Nothing -> filter ((/= "PATH") . fst) sanitized
+                Just value ->
+                    ("PATH", value) : filter ((/= "PATH") . fst) sanitized
+        retained
+            | executable == "git" =
+                filter (\(name, _) -> name `elem` gitEnvironmentAllowlist)
+                    sanitizedWithSafePath
+            | otherwise = sanitizedWithSafePath
+    pure
+        ( [ ("GIT_TERMINAL_PROMPT", "0")
+          , ("GCM_INTERACTIVE", "never")
+          , ("GH_PROMPT_DISABLED", "true")
+          , ("SSH_ASKPASS_REQUIRE", "never")
+          ]
+            <> retained
+        )
+  where
+    prefixOf prefix value = take (length prefix) value == prefix
+    gitEnvironmentAllowlist =
+        [ "PATH"
+        , "HOME"
+        , "TMPDIR"
+        , "TMP"
+        , "TEMP"
+        , "LANG"
+        , "LC_ALL"
+        , "LC_CTYPE"
+        , "USER"
+        , "LOGNAME"
+        , "SSH_AUTH_SOCK"
+        , "XDG_CONFIG_HOME"
+        , "XDG_CONFIG_DIRS"
+        , "SSL_CERT_FILE"
+        , "SSL_CERT_DIR"
+        , "NIX_SSL_CERT_FILE"
+        , "TERM"
+        ]
+
+trySynchronous :: IO value -> IO (Either SomeException value)
+trySynchronous action =
+    tryAny action >>= \case
+        Left exception
+            | isAsyncException exception -> throwIO exception
+            | otherwise -> pure (Left exception)
+        Right value -> pure (Right value)
+
+processPipeTeardownMicros :: Int
+processPipeTeardownMicros = 1_000_000
+
+processGroupTermGraceMicros :: Int
+processGroupTermGraceMicros = 2_000_000
+
+maxProcessOutputBytes :: Int
+maxProcessOutputBytes = 1024 * 1024

--- a/packages/agent-repository/src/Agent/CLI/RepositoryDelivery/Validation.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryDelivery/Validation.hs
@@ -1,0 +1,196 @@
+-- | Pure validation of delivery destinations and Git references.
+module Agent.CLI.RepositoryDelivery.Validation
+    ( validRemoteUrl
+    , githubRepositoryFromUrl
+    , validateBranchName
+    , validateFullBranchRef
+    , validateRemoteName
+    , validateRepositoryName
+    , validObjectId
+    , zeroObjectId
+    ) where
+
+import Control.Applicative ((<|>))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import Data.Char (isAlphaNum, isHexDigit, isSpace)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+validRemoteUrl :: BS.ByteString -> Bool
+validRemoteUrl url =
+    not (BS.null url)
+        && BS.length url <= 4096
+        && BS.all (\byte -> byte >= 0x20 && byte /= 0x7f) url
+        && BS8.head url /= '-'
+        && (validHttps url
+            || validSsh url
+            || validScpLike url)
+  where
+    validHttps value =
+        "https://" `BS8.isPrefixOf` value
+            && validUrlAuthority "https://" value
+            && not (authorityContains '@' "https://" value)
+            && not (containsQueryOrFragment value)
+            && not (authorityContains '%' "https://" value)
+    validSsh value =
+        "ssh://" `BS8.isPrefixOf` value
+            && validSshAuthority value
+            && not (containsQueryOrFragment value)
+    authorityContains character prefix value =
+        BS8.elem character
+            (BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value))
+    validSshAuthority value =
+        let authority =
+                BS8.takeWhile (/= '/') (BS.drop (BS.length "ssh://") value)
+            (userinfo, separatorAndHost) = BS8.break (== '@') authority
+            host = BS.drop 1 separatorAndHost
+        in not (BS.null authority)
+            && not (BS8.elem '%' authority)
+            && if BS.null separatorAndHost
+                then validHostPort authority
+                else validUsername userinfo
+                    && validHostPort host
+                    && not (BS8.elem '@' host)
+    validUrlAuthority prefix value =
+        validHostPort
+            (BS8.takeWhile (/= '/') (BS.drop (BS.length prefix) value))
+    validHostPort authority =
+        case BS8.break (== ':') authority of
+            (host, port)
+                | BS.null port -> validHost host
+                | otherwise ->
+                    validHost host
+                        && BS.length port > 1
+                        && BS8.all
+                            (\character ->
+                                character >= '0' && character <= '9')
+                            (BS.drop 1 port)
+    validHost host =
+        not (BS.null host)
+            && BS8.all
+                (\character ->
+                    isAsciiAlphaNumeric character
+                        || character `elem` (".-" :: String))
+                host
+            && BS8.head host /= '.'
+            && BS8.last host /= '.'
+    validUsername username =
+        not (BS.null username)
+            && BS8.all
+                (\character ->
+                    isAsciiAlphaNumeric character
+                        || character `elem` ("._-" :: String))
+                username
+    isAsciiAlphaNumeric character =
+        (character >= 'a' && character <= 'z')
+            || (character >= 'A' && character <= 'Z')
+            || (character >= '0' && character <= '9')
+    containsQueryOrFragment value =
+        BS8.elem '?' value || BS8.elem '#' value
+    validScpLike value =
+        case BS8.break (== ':') value of
+            (authority, path) ->
+                let (username, separatorAndHost) = BS8.break (== '@') authority
+                    host = BS.drop 1 separatorAndHost
+                in validUsername username
+                    && not (BS.null separatorAndHost)
+                    && validHost host
+                    && not (BS8.elem '@' host)
+                    && not (BS8.elem '%' authority)
+                    && BS.length path > 1
+                    && not (BS8.elem '@' path)
+                    && not (containsQueryOrFragment value)
+
+githubRepositoryFromUrl :: BS.ByteString -> Maybe Text
+githubRepositoryFromUrl bytes
+    | not (BS.all (< 0x80) bytes) = Nothing
+    | otherwise =
+        let url = Text.pack (BS8.unpack bytes)
+        in parseHttps url
+            <|> parseSsh url
+            <|> parseScp url
+  where
+    parseHttps url =
+        Text.stripPrefix "https://github.com/" url >>= repositoryPath
+    parseSsh url =
+        (Text.stripPrefix "ssh://git@github.com/" url
+            <|> Text.stripPrefix "ssh://github.com/" url)
+            >>= repositoryPath
+    parseScp url =
+        Text.stripPrefix "git@github.com:" url >>= repositoryPath
+    repositoryPath path =
+        let withoutGit = fromMaybe path (Text.stripSuffix ".git" path)
+        in if validateRepositoryName withoutGit
+            then Just withoutGit
+            else Nothing
+
+validateBranchName :: Text -> Bool
+validateBranchName branch =
+    validateFullBranchRef ("refs/heads/" <> branch)
+
+validateFullBranchRef :: Text -> Bool
+validateFullBranchRef ref =
+    not (Text.null ref)
+        && Text.length ref <= 1024
+        && "refs/heads/" `Text.isPrefixOf` ref
+        && not ("/" `Text.isSuffixOf` ref)
+        && not ("." `Text.isSuffixOf` ref)
+        && not ("." `Text.isPrefixOf` ref)
+        && not ("-" `Text.isPrefixOf` Text.drop (Text.length "refs/heads/") ref)
+        && not (".." `Text.isInfixOf` ref)
+        && not ("@{" `Text.isInfixOf` ref)
+        && not ("//" `Text.isInfixOf` ref)
+        && Text.all safeRefCharacter ref
+        && all validComponent (Text.splitOn "/" ref)
+  where
+    safeRefCharacter character =
+        not (isSpace character)
+            && character >= '\x20'
+            && character /= '\x7f'
+            && character `notElem` ("~^:?*[\\" :: String)
+    validComponent component =
+        not (Text.null component)
+            && not ("." `Text.isPrefixOf` component)
+            && component /= "."
+            && component /= ".."
+            && not (".lock" `Text.isSuffixOf` component)
+
+validateRemoteName :: Text -> Bool
+validateRemoteName remote =
+    not (Text.null remote)
+        && Text.length remote <= 255
+        && Text.head remote /= '-'
+        && Text.all
+            (\character ->
+                isAlphaNum character
+                    || character `elem` ("._/-" :: String))
+            remote
+        && not (".." `Text.isInfixOf` remote)
+        && not ("//" `Text.isInfixOf` remote)
+
+validateRepositoryName :: Text -> Bool
+validateRepositoryName name =
+    case Text.splitOn "/" name of
+        [owner, repository] ->
+            validPart owner && validPart repository
+        _ -> False
+  where
+    validPart value =
+        not (Text.null value)
+            && value /= "."
+            && value /= ".."
+            && Text.length value <= 100
+            && Text.all
+                (\character ->
+                    isAlphaNum character
+                        || character `elem` ("-._" :: String))
+                value
+
+validObjectId :: Text -> Bool
+validObjectId oid =
+    Text.length oid `elem` [40, 64] && Text.all isHexDigit oid
+
+zeroObjectId :: Text -> Text
+zeroObjectId oid = Text.replicate (Text.length oid) "0"

--- a/packages/agent-repository/src/Agent/CLI/RepositoryReview.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryReview.hs
@@ -18,15 +18,14 @@ module Agent.CLI.RepositoryReview
     , repositoryErrorText
     ) where
 
+import Agent.CLI.RepositoryReview.Checks
+import Agent.CLI.RepositoryReview.Error
+import Agent.CLI.RepositoryReview.GitOutput
+import Agent.CLI.RepositoryReview.ProcessSupport
 import Control.Concurrent (threadDelay)
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async
-    ( Async
-    , asyncWithUnmask
-    , cancel
-    , poll
-    , wait
-    , waitCatch
+    ( wait
     , withAsync
     )
 import Control.Concurrent.MVar
@@ -36,10 +35,8 @@ import Control.Concurrent.MVar
     , withMVar
     )
 import Control.Exception.Safe
-    ( SomeException
-    , bracket
+    ( bracket
     , finally
-    , isAsyncException
     , mask
     , onException
     , throwIO
@@ -50,14 +47,13 @@ import Control.Exception.Safe
 import Control.Monad (foldM, unless, when)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
-import Data.Char (isDigit, toLower)
+import Data.Char (toLower)
 import Data.List (find, nub, sort)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.IORef
-    ( IORef
-    , newIORef
+    ( newIORef
     , readIORef
     , writeIORef
     )
@@ -86,10 +82,8 @@ import System.FilePath
     , (</>)
     )
 import System.Posix.Signals
-    ( Signal
-    , sigKILL
+    ( sigKILL
     , sigTERM
-    , signalProcessGroup
     )
 import System.Posix.Files
     ( fileMode
@@ -112,10 +106,9 @@ import System.Posix.IO
     , openFd
     )
 import System.Posix.Temp (mkdtemp)
-import System.Posix.Types (FileMode, ProcessID)
+import System.Posix.Types (FileMode)
 import System.Process
     ( CreateProcess(..)
-    , ProcessHandle
     , StdStream(CreatePipe)
     , createProcess
     , getPid
@@ -145,25 +138,10 @@ data RepositoryDiffKind
     | RepositoryStagedDiff
     deriving (Eq, Show)
 
-data RepositoryFile = RepositoryFile
-    { repositoryFilePath :: !FilePath
-    , repositoryFileOriginalPath :: !(Maybe FilePath)
-    , repositoryFileIndexStatus :: !Char
-    , repositoryFileWorktreeStatus :: !Char
-    } deriving (Eq, Show)
-
 data RepositoryDiff = RepositoryDiff
     { repositoryDiffPatch :: !BS.ByteString
     , repositoryDiffBinary :: !Bool
     , repositoryDiffHunks :: ![DiffHunk]
-    } deriving (Eq, Show)
-
-data DiffHunk = DiffHunk
-    { hunkOldStart :: !Int
-    , hunkOldCount :: !Int
-    , hunkNewStart :: !Int
-    , hunkNewCount :: !Int
-    , hunkHeader :: !Text
     } deriving (Eq, Show)
 
 data RepositoryMutation
@@ -173,25 +151,6 @@ data RepositoryMutation
     | StageHunks !FilePath ![Int]
     | UnstageHunks !FilePath ![Int]
     | RestoreHunks !FilePath ![Int]
-    deriving (Eq, Show)
-
-data RepositoryCheckStream
-    = RepositoryCheckStdout
-    | RepositoryCheckStderr
-    deriving (Eq, Show)
-
-data RepositoryCheck = RepositoryCheck
-    { repositoryCheckProcess :: !ProcessHandle
-    , repositoryCheckProcessGroup :: !(Maybe ProcessID)
-    , repositoryCheckWorker :: !(Async ())
-    , repositoryCheckCancelled :: !(IORef Bool)
-    }
-
-data RepositoryError
-    = NotARepository !Text
-    | StaleRepositorySnapshot !Text !Text
-    | InvalidRepositoryRequest !Text
-    | RepositoryCommandFailed !Text !Int !Text
     deriving (Eq, Show)
 
 repositorySnapshot :: FilePath -> IO (Either RepositoryError RepositorySnapshot)
@@ -371,230 +330,9 @@ startRepositoryCheck requested expected executable arguments onOutput onExit =
         checked <- requireSnapshot root expected
         case checked of
             Left err -> pure (Left err)
-            Right _
-                | null executable || '\NUL' `elem` executable ->
-                    pure
-                        (Left
-                            (InvalidRepositoryRequest
-                                "check executable is invalid"))
-                | length executable > maxRepositoryArgumentCharacters ->
-                    pure
-                        (Left
-                            (InvalidRepositoryRequest
-                                "check executable exceeds the 1 MiB character limit"))
-                | length arguments > maxRepositoryCheckArguments ->
-                    pure
-                        (Left
-                            (InvalidRepositoryRequest
-                                "check has too many arguments"))
-                | any (elem '\NUL') arguments ->
-                    pure
-                        (Left
-                            (InvalidRepositoryRequest
-                                "check argument contains a NUL byte"))
-                | any null arguments ->
-                    pure
-                        (Left
-                            (InvalidRepositoryRequest
-                                "check argument is empty"))
-                | any
-                    ((> maxRepositoryArgumentCharacters) . length)
-                    arguments ->
-                        pure
-                            (Left
-                                (InvalidRepositoryRequest
-                                    "check argument exceeds the 1 MiB character limit"))
-                | sum (map (toInteger . length) arguments)
-                    > toInteger maxRepositoryCheckTotalCharacters ->
-                        pure
-                            (Left
-                                (InvalidRepositoryRequest
-                                    "check arguments exceed the 8 MiB total limit"))
-                | otherwise -> do
-                    -- Keep asynchronous cancellation masked across process
-                    -- acquisition and construction of its owning worker.
-                    -- Once this returns, every resource is reachable through
-                    -- RepositoryCheck and cancellation is owned by that
-                    -- worker's finalizer.
-                    created <- trySynchronous (mask \_ -> do
-                        (maybeOutput, maybeError, process, processGroup) <-
-                            createCheckProcess root executable arguments
-                        cancelled <- newIORef False
-                        let cleanup = do
-                                closeQuietly maybeOutput
-                                closeQuietly maybeError
-                                signalCheckProcessGroup
-                                    sigKILL processGroup process
-                                _ <- tryAny (waitForProcess process)
-                                pure ()
-                        worker <- asyncWithUnmask
-                            (\unmask ->
-                                unmask
-                                    (withAsync
-                                        (drainCheckOutput
-                                            RepositoryCheckStdout
-                                            maybeOutput)
-                                        \outputReader ->
-                                            withAsync
-                                                (drainCheckOutput
-                                                    RepositoryCheckStderr
-                                                    maybeError)
-                                                \errorReader -> do
-                                                    exitCode <-
-                                                        waitForProcess process
-                                                    -- The requested leader is
-                                                    -- complete. Any process
-                                                    -- still in its dedicated
-                                                    -- group is a residual
-                                                    -- descendant and must not
-                                                    -- outlive the check.
-                                                    signalCheckProcessGroup
-                                                        sigKILL
-                                                        processGroup
-                                                        process
-                                                    -- Reader failures
-                                                    -- (including callback
-                                                    -- failures) must not
-                                                    -- suppress the one terminal
-                                                    -- callback. An escaped
-                                                    -- process outside the
-                                                    -- group still cannot hold
-                                                    -- this worker indefinitely.
-                                                    drained <- timeout
-                                                        processPipeTeardownMicros
-                                                        ((,)
-                                                            <$> waitCatch outputReader
-                                                            <*> waitCatch errorReader)
-                                                    case drained of
-                                                        Just _ -> pure ()
-                                                        Nothing -> do
-                                                            closeQuietly
-                                                                maybeOutput
-                                                            closeQuietly
-                                                                maybeError
-                                                            cancel outputReader
-                                                            cancel errorReader
-                                                    wasCancelled <-
-                                                        readIORef cancelled
-                                                    onExit
-                                                        wasCancelled
-                                                        exitCode)
-                                    `finally` cleanup)
-                                `onException` cleanup
-                        pure RepositoryCheck
-                            { repositoryCheckProcess = process
-                            , repositoryCheckProcessGroup = processGroup
-                            , repositoryCheckWorker = worker
-                            , repositoryCheckCancelled = cancelled
-                            })
-                    pure case created of
-                        Left exception ->
-                            Left
-                                (RepositoryCommandFailed
-                                    (renderCommand executable arguments)
-                                    (-1)
-                                    (Text.pack (show exception)))
-                        Right check -> Right check
-  where
-    drainCheckOutput stream handle =
-        let drain callbackEnabled = do
-                bytes <- BS.hGetSome handle (64 * 1024)
-                if BS.null bytes
-                    then pure ()
-                    else do
-                        nextEnabled <-
-                            if callbackEnabled
-                                then
-                                    trySynchronous (onOutput stream bytes) >>= \case
-                                        Left _ -> pure False
-                                        Right () -> pure True
-                                else pure False
-                        -- A failed foreign callback is disabled for this
-                        -- stream, but the pipe remains actively drained.
-                        drain nextEnabled
-        in drain True `finally` closeQuietly handle
-
-cancelRepositoryCheck :: RepositoryCheck -> IO ()
-cancelRepositoryCheck check = do
-    writeIORef check.repositoryCheckCancelled True
-    signalCheckProcessGroup
-        sigTERM
-        check.repositoryCheckProcessGroup
-        check.repositoryCheckProcess
-    threadDelay 250_000
-    poll check.repositoryCheckWorker >>= \case
-        Nothing ->
-            signalCheckProcessGroup
-                sigKILL
-                check.repositoryCheckProcessGroup
-                check.repositoryCheckProcess
-        Just _ -> pure ()
-    -- Cancellation owns process teardown: do not return while descendants,
-    -- pipe readers, or the terminal callback are still active.
-    waitRepositoryCheck check
-
-waitRepositoryCheck :: RepositoryCheck -> IO ()
-waitRepositoryCheck check = do
-    _ <- waitCatch check.repositoryCheckWorker
-    pure ()
-
-signalCheckProcessGroup
-    :: Signal
-    -> Maybe ProcessID
-    -> ProcessHandle
-    -> IO ()
-signalCheckProcessGroup signal processGroup process = do
-    processId <- maybe (getPid process) (pure . Just) processGroup
-    case processId of
-        Nothing -> do
-            _ <- tryAny (terminateProcess process)
-            pure ()
-        Just pid -> do
-            _ <- tryAny (signalProcessGroup signal pid)
-            pure ()
-
-createCheckProcess
-    :: FilePath
-    -> FilePath
-    -> [String]
-    -> IO (Handle, Handle, ProcessHandle, Maybe ProcessID)
-createCheckProcess root executable arguments = mask \_ -> do
-    (maybeInput, maybeOutput, maybeError, process) <-
-        createProcess
-            (proc executable arguments)
-                { cwd = Just root
-                , std_in = CreatePipe
-                , std_out = CreatePipe
-                , std_err = CreatePipe
-                , close_fds = True
-                , create_group = True
-                }
-    case (maybeInput, maybeOutput, maybeError) of
-        (Just input, Just output, Just errors) -> do
-            let cleanupWithoutGroup = do
-                    closeQuietly input
-                    closeQuietly output
-                    closeQuietly errors
-                    _ <- tryAny (terminateProcess process)
-                    _ <- tryAny (waitForProcess process)
-                    pure ()
-            processGroup <- getPid process
-                `onException` cleanupWithoutGroup
-            let cleanup = do
-                    closeQuietly input
-                    closeQuietly output
-                    closeQuietly errors
-                    signalCheckProcessGroup sigKILL processGroup process
-                    _ <- tryAny (waitForProcess process)
-                    pure ()
-            -- Checks have no stdin API. Closing immediately prevents an
-            -- inherited terminal or pipe from leaving a check blocked.
-            (hClose input >> pure (output, errors, process, processGroup))
-                `onException` cleanup
-        _ -> do
-            _ <- tryAny (terminateProcess process)
-            _ <- tryAny (waitForProcess process)
-            fail "could not create check output pipes"
+            Right _ ->
+                startRepositoryCheckAtRoot
+                    root executable arguments onOutput onExit
 
 snapshotAtRoot :: FilePath -> IO (Either RepositoryError RepositorySnapshot)
 snapshotAtRoot root =
@@ -1037,87 +775,6 @@ hashMaterialWith
 hashMaterialWith run root bytes =
     fmap decodeTrimmed
         <$> run root ["hash-object", "--no-filters", "--stdin"] bytes
-
-parsePorcelain :: BS.ByteString -> Either RepositoryError [RepositoryFile]
-parsePorcelain bytes = go (filter (not . BS.null) (BS.split 0 bytes)) []
-  where
-    go [] acc = Right (reverse acc)
-    go (entry:rest) acc
-        | BS.length entry < 3 =
-            Left (InvalidRepositoryRequest "git returned malformed status")
-        | otherwise =
-            let indexStatus = toStatus (BS.index entry 0)
-                worktreeStatus = toStatus (BS.index entry 1)
-                path = decodePath (BS.drop 3 entry)
-                renamed = indexStatus `elem` ['R', 'C']
-                    || worktreeStatus `elem` ['R', 'C']
-            in if renamed
-                then case rest of
-                    [] ->
-                        Left
-                            (InvalidRepositoryRequest
-                                "git returned an incomplete rename status")
-                    original:remaining ->
-                        go remaining
-                            (RepositoryFile
-                                { repositoryFilePath = path
-                                , repositoryFileOriginalPath =
-                                    Just (decodePath original)
-                                , repositoryFileIndexStatus = indexStatus
-                                , repositoryFileWorktreeStatus = worktreeStatus
-                                }
-                                : acc)
-                else
-                    go rest
-                        (RepositoryFile
-                            { repositoryFilePath = path
-                            , repositoryFileOriginalPath = Nothing
-                            , repositoryFileIndexStatus = indexStatus
-                            , repositoryFileWorktreeStatus = worktreeStatus
-                            }
-                            : acc)
-    toStatus byte
-        | byte == 32 = ' '
-        | otherwise = toEnum (fromIntegral byte)
-
-parseDiffHunks :: BS.ByteString -> [DiffHunk]
-parseDiffHunks =
-    reverse
-        . foldl' collect []
-        . Text.lines
-        . TextEncoding.decodeUtf8With lenientDecode
-  where
-    collect acc line =
-        maybe acc (: acc) (parseHunkHeader line)
-
-parseHunkHeader :: Text -> Maybe DiffHunk
-parseHunkHeader line = do
-    body <- Text.stripPrefix "@@ -" line
-    let (oldRange, afterOld) = Text.breakOn " +" body
-    newAndHeader <- Text.stripPrefix " +" afterOld
-    let (newRange, afterNew) = Text.breakOn " @@" newAndHeader
-    header <- Text.stripPrefix " @@" afterNew
-    (oldStart, oldCount) <- parseRange oldRange
-    (newStart, newCount) <- parseRange newRange
-    pure DiffHunk
-        { hunkOldStart = oldStart
-        , hunkOldCount = oldCount
-        , hunkNewStart = newStart
-        , hunkNewCount = newCount
-        , hunkHeader = Text.strip header
-        }
-
-parseRange :: Text -> Maybe (Int, Int)
-parseRange text = case Text.splitOn "," text of
-    [start] -> (, 1) <$> decimal start
-    [start, count] -> (,) <$> decimal start <*> decimal count
-    _ -> Nothing
-  where
-    decimal value
-        | Text.null value || Text.any (not . isDigit) value = Nothing
-        | otherwise = case reads (Text.unpack value) of
-            [(number, "")] -> Just number
-            _ -> Nothing
 
 runRepositoryRead
     :: FilePath
@@ -2078,37 +1735,9 @@ hGetBounded limit handle = go 0 False []
                     then go total True chunks
                     else go next False (chunk : chunks)
 
-closeQuietly :: Handle -> IO ()
-closeQuietly handle = do
-    _ <- tryAny (hClose handle)
-    pure ()
-
 decodeTrimmed :: BS.ByteString -> Text
 decodeTrimmed =
     Text.strip . TextEncoding.decodeUtf8With lenientDecode
-
-decodePath :: BS.ByteString -> FilePath
-decodePath = Text.unpack . TextEncoding.decodeUtf8With lenientDecode
-
-renderCommand :: FilePath -> [String] -> Text
-renderCommand executable arguments =
-    Text.unwords (Text.pack executable : map (Text.pack . show) arguments)
-
-repositoryErrorText :: RepositoryError -> Text
-repositoryErrorText = \case
-    NotARepository message -> message
-    StaleRepositorySnapshot expected actual ->
-        "repository changed (expected "
-            <> expected
-            <> ", actual "
-            <> actual
-            <> ")"
-    InvalidRepositoryRequest message -> message
-    RepositoryCommandFailed command code message ->
-        command
-            <> " exited "
-            <> Text.pack (show code)
-            <> if Text.null message then "" else ": " <> message
 
 voidResult :: Either error value -> Either error ()
 voidResult = fmap (const ())
@@ -2124,15 +1753,6 @@ maxRepositorySelectedHunks = 4096
 
 maxRepositoryCommitCharacters :: Int
 maxRepositoryCommitCharacters = 8 * 1024 * 1024
-
-maxRepositoryCheckArguments :: Int
-maxRepositoryCheckArguments = 4096
-
-maxRepositoryArgumentCharacters :: Int
-maxRepositoryArgumentCharacters = 1024 * 1024
-
-maxRepositoryCheckTotalCharacters :: Int
-maxRepositoryCheckTotalCharacters = 8 * 1024 * 1024
 
 maxRepositoryProcessOutputBytes :: Int
 maxRepositoryProcessOutputBytes = 64 * 1024 * 1024
@@ -2157,14 +1777,3 @@ repositoryConfigTimeoutMicros = 2_000_000
 
 maxRepositoryDiffCommandMicros :: Int
 maxRepositoryDiffCommandMicros = 15_000_000
-
-processPipeTeardownMicros :: Int
-processPipeTeardownMicros = 1_000_000
-
-trySynchronous :: IO value -> IO (Either SomeException value)
-trySynchronous action =
-    tryAny action >>= \case
-        Left exception
-            | isAsyncException exception -> throwIO exception
-            | otherwise -> pure (Left exception)
-        Right value -> pure (Right value)

--- a/packages/agent-repository/src/Agent/CLI/RepositoryReview/Checks.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryReview/Checks.hs
@@ -1,0 +1,266 @@
+-- | Check-process validation and ownership. Repository locking and snapshot
+-- validation remain with the caller, which must hold the lock during startup.
+module Agent.CLI.RepositoryReview.Checks
+    ( RepositoryCheck
+    , RepositoryCheckStream(..)
+    , startRepositoryCheckAtRoot
+    , cancelRepositoryCheck
+    , waitRepositoryCheck
+    ) where
+
+import Agent.CLI.RepositoryReview.Error
+import Agent.CLI.RepositoryReview.ProcessSupport
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async
+    ( Async, asyncWithUnmask, cancel, poll, waitCatch, withAsync )
+import Control.Exception.Safe (finally, mask, onException, tryAny)
+import qualified Data.ByteString as BS
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import qualified Data.Text as Text
+import System.Exit (ExitCode)
+import System.IO (Handle, hClose)
+import System.Posix.Signals (sigKILL, sigTERM)
+import System.Posix.Types (ProcessID)
+import System.Process
+    ( CreateProcess(..), ProcessHandle, StdStream(CreatePipe)
+    , createProcess, getPid, proc, terminateProcess, waitForProcess
+    )
+import System.Timeout (timeout)
+
+data RepositoryCheckStream
+    = RepositoryCheckStdout
+    | RepositoryCheckStderr
+    deriving (Eq, Show)
+
+data RepositoryCheck = RepositoryCheck
+    { repositoryCheckProcess :: !ProcessHandle
+    , repositoryCheckProcessGroup :: !(Maybe ProcessID)
+    , repositoryCheckWorker :: !(Async ())
+    , repositoryCheckCancelled :: !(IORef Bool)
+    }
+
+startRepositoryCheckAtRoot
+    :: FilePath
+    -> FilePath
+    -> [String]
+    -> (RepositoryCheckStream -> BS.ByteString -> IO ())
+    -> (Bool -> ExitCode -> IO ())
+    -> IO (Either RepositoryError RepositoryCheck)
+startRepositoryCheckAtRoot root executable arguments onOutput onExit
+    | null executable || '\NUL' `elem` executable =
+        pure
+            (Left
+                (InvalidRepositoryRequest
+                    "check executable is invalid"))
+    | length executable > maxRepositoryArgumentCharacters =
+        pure
+            (Left
+                (InvalidRepositoryRequest
+                    "check executable exceeds the 1 MiB character limit"))
+    | length arguments > maxRepositoryCheckArguments =
+        pure
+            (Left
+                (InvalidRepositoryRequest
+                    "check has too many arguments"))
+    | any (elem '\NUL') arguments =
+        pure
+            (Left
+                (InvalidRepositoryRequest
+                    "check argument contains a NUL byte"))
+    | any null arguments =
+        pure
+            (Left
+                (InvalidRepositoryRequest
+                    "check argument is empty"))
+    | any
+        ((> maxRepositoryArgumentCharacters) . length)
+        arguments =
+            pure
+                (Left
+                    (InvalidRepositoryRequest
+                        "check argument exceeds the 1 MiB character limit"))
+    | sum (map (toInteger . length) arguments)
+        > toInteger maxRepositoryCheckTotalCharacters =
+            pure
+                (Left
+                    (InvalidRepositoryRequest
+                        "check arguments exceed the 8 MiB total limit"))
+    | otherwise = do
+        -- Keep asynchronous cancellation masked across process
+        -- acquisition and construction of its owning worker.
+        -- Once this returns, every resource is reachable through
+        -- RepositoryCheck and cancellation is owned by that
+        -- worker's finalizer.
+        created <- trySynchronous (mask \_ -> do
+            (maybeOutput, maybeError, process, processGroup) <-
+                createCheckProcess root executable arguments
+            cancelled <- newIORef False
+            let cleanup = do
+                    closeQuietly maybeOutput
+                    closeQuietly maybeError
+                    signalCheckProcessGroup
+                        sigKILL processGroup process
+                    _ <- tryAny (waitForProcess process)
+                    pure ()
+            worker <- asyncWithUnmask
+                (\unmask ->
+                    unmask
+                        (withAsync
+                            (drainCheckOutput
+                                RepositoryCheckStdout
+                                maybeOutput)
+                            \outputReader ->
+                                withAsync
+                                    (drainCheckOutput
+                                        RepositoryCheckStderr
+                                        maybeError)
+                                    \errorReader -> do
+                                        exitCode <-
+                                            waitForProcess process
+                                        -- The requested leader is
+                                        -- complete. Any process
+                                        -- still in its dedicated
+                                        -- group is a residual
+                                        -- descendant and must not
+                                        -- outlive the check.
+                                        signalCheckProcessGroup
+                                            sigKILL
+                                            processGroup
+                                            process
+                                        -- Reader failures
+                                        -- (including callback
+                                        -- failures) must not
+                                        -- suppress the one terminal
+                                        -- callback. An escaped
+                                        -- process outside the
+                                        -- group still cannot hold
+                                        -- this worker indefinitely.
+                                        drained <- timeout
+                                            processPipeTeardownMicros
+                                            ((,)
+                                                <$> waitCatch outputReader
+                                                <*> waitCatch errorReader)
+                                        case drained of
+                                            Just _ -> pure ()
+                                            Nothing -> do
+                                                closeQuietly
+                                                    maybeOutput
+                                                closeQuietly
+                                                    maybeError
+                                                cancel outputReader
+                                                cancel errorReader
+                                        wasCancelled <-
+                                            readIORef cancelled
+                                        onExit
+                                            wasCancelled
+                                            exitCode)
+                        `finally` cleanup)
+                    `onException` cleanup
+            pure RepositoryCheck
+                { repositoryCheckProcess = process
+                , repositoryCheckProcessGroup = processGroup
+                , repositoryCheckWorker = worker
+                , repositoryCheckCancelled = cancelled
+                })
+        pure case created of
+            Left exception ->
+                Left
+                    (RepositoryCommandFailed
+                        (renderCommand executable arguments)
+                        (-1)
+                        (Text.pack (show exception)))
+            Right check -> Right check
+  where
+    drainCheckOutput stream handle =
+        let drain callbackEnabled = do
+                bytes <- BS.hGetSome handle (64 * 1024)
+                if BS.null bytes
+                    then pure ()
+                    else do
+                        nextEnabled <-
+                            if callbackEnabled
+                                then
+                                    trySynchronous (onOutput stream bytes) >>= \case
+                                        Left _ -> pure False
+                                        Right () -> pure True
+                                else pure False
+                        -- A failed foreign callback is disabled for this
+                        -- stream, but the pipe remains actively drained.
+                        drain nextEnabled
+        in drain True `finally` closeQuietly handle
+
+cancelRepositoryCheck :: RepositoryCheck -> IO ()
+cancelRepositoryCheck check = do
+    writeIORef check.repositoryCheckCancelled True
+    signalCheckProcessGroup
+        sigTERM
+        check.repositoryCheckProcessGroup
+        check.repositoryCheckProcess
+    threadDelay 250_000
+    poll check.repositoryCheckWorker >>= \case
+        Nothing ->
+            signalCheckProcessGroup
+                sigKILL
+                check.repositoryCheckProcessGroup
+                check.repositoryCheckProcess
+        Just _ -> pure ()
+    -- Cancellation owns process teardown: do not return while descendants,
+    -- pipe readers, or the terminal callback are still active.
+    waitRepositoryCheck check
+
+waitRepositoryCheck :: RepositoryCheck -> IO ()
+waitRepositoryCheck check = do
+    _ <- waitCatch check.repositoryCheckWorker
+    pure ()
+
+createCheckProcess
+    :: FilePath
+    -> FilePath
+    -> [String]
+    -> IO (Handle, Handle, ProcessHandle, Maybe ProcessID)
+createCheckProcess root executable arguments = mask \_ -> do
+    (maybeInput, maybeOutput, maybeError, process) <-
+        createProcess
+            (proc executable arguments)
+                { cwd = Just root
+                , std_in = CreatePipe
+                , std_out = CreatePipe
+                , std_err = CreatePipe
+                , close_fds = True
+                , create_group = True
+                }
+    case (maybeInput, maybeOutput, maybeError) of
+        (Just input, Just output, Just errors) -> do
+            let cleanupWithoutGroup = do
+                    closeQuietly input
+                    closeQuietly output
+                    closeQuietly errors
+                    _ <- tryAny (terminateProcess process)
+                    _ <- tryAny (waitForProcess process)
+                    pure ()
+            processGroup <- getPid process
+                `onException` cleanupWithoutGroup
+            let cleanup = do
+                    closeQuietly input
+                    closeQuietly output
+                    closeQuietly errors
+                    signalCheckProcessGroup sigKILL processGroup process
+                    _ <- tryAny (waitForProcess process)
+                    pure ()
+            -- Checks have no stdin API. Closing immediately prevents an
+            -- inherited terminal or pipe from leaving a check blocked.
+            (hClose input >> pure (output, errors, process, processGroup))
+                `onException` cleanup
+        _ -> do
+            _ <- tryAny (terminateProcess process)
+            _ <- tryAny (waitForProcess process)
+            fail "could not create check output pipes"
+
+maxRepositoryCheckArguments :: Int
+maxRepositoryCheckArguments = 4096
+
+maxRepositoryArgumentCharacters :: Int
+maxRepositoryArgumentCharacters = 1024 * 1024
+
+maxRepositoryCheckTotalCharacters :: Int
+maxRepositoryCheckTotalCharacters = 8 * 1024 * 1024

--- a/packages/agent-repository/src/Agent/CLI/RepositoryReview/Error.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryReview/Error.hs
@@ -1,0 +1,30 @@
+module Agent.CLI.RepositoryReview.Error
+    ( RepositoryError(..)
+    , repositoryErrorText
+    ) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+data RepositoryError
+    = NotARepository !Text
+    | StaleRepositorySnapshot !Text !Text
+    | InvalidRepositoryRequest !Text
+    | RepositoryCommandFailed !Text !Int !Text
+    deriving (Eq, Show)
+
+repositoryErrorText :: RepositoryError -> Text
+repositoryErrorText = \case
+    NotARepository message -> message
+    StaleRepositorySnapshot expected actual ->
+        "repository changed (expected "
+            <> expected
+            <> ", actual "
+            <> actual
+            <> ")"
+    InvalidRepositoryRequest message -> message
+    RepositoryCommandFailed command code message ->
+        command
+            <> " exited "
+            <> Text.pack (show code)
+            <> if Text.null message then "" else ": " <> message

--- a/packages/agent-repository/src/Agent/CLI/RepositoryReview/GitOutput.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryReview/GitOutput.hs
@@ -1,0 +1,115 @@
+-- | Pure decoding of Git status and diff output.
+module Agent.CLI.RepositoryReview.GitOutput
+    ( RepositoryFile(..)
+    , DiffHunk(..)
+    , parsePorcelain
+    , parseDiffHunks
+    , decodePath
+    ) where
+
+import Agent.CLI.RepositoryReview.Error
+import qualified Data.ByteString as BS
+import Data.Char (isDigit)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Text.Encoding.Error (lenientDecode)
+
+data RepositoryFile = RepositoryFile
+    { repositoryFilePath :: !FilePath
+    , repositoryFileOriginalPath :: !(Maybe FilePath)
+    , repositoryFileIndexStatus :: !Char
+    , repositoryFileWorktreeStatus :: !Char
+    } deriving (Eq, Show)
+
+data DiffHunk = DiffHunk
+    { hunkOldStart :: !Int
+    , hunkOldCount :: !Int
+    , hunkNewStart :: !Int
+    , hunkNewCount :: !Int
+    , hunkHeader :: !Text
+    } deriving (Eq, Show)
+
+parsePorcelain :: BS.ByteString -> Either RepositoryError [RepositoryFile]
+parsePorcelain bytes = go (filter (not . BS.null) (BS.split 0 bytes)) []
+  where
+    go [] acc = Right (reverse acc)
+    go (entry:rest) acc
+        | BS.length entry < 3 =
+            Left (InvalidRepositoryRequest "git returned malformed status")
+        | otherwise =
+            let indexStatus = toStatus (BS.index entry 0)
+                worktreeStatus = toStatus (BS.index entry 1)
+                path = decodePath (BS.drop 3 entry)
+                renamed = indexStatus `elem` ['R', 'C']
+                    || worktreeStatus `elem` ['R', 'C']
+            in if renamed
+                then case rest of
+                    [] ->
+                        Left
+                            (InvalidRepositoryRequest
+                                "git returned an incomplete rename status")
+                    original:remaining ->
+                        go remaining
+                            (RepositoryFile
+                                { repositoryFilePath = path
+                                , repositoryFileOriginalPath =
+                                    Just (decodePath original)
+                                , repositoryFileIndexStatus = indexStatus
+                                , repositoryFileWorktreeStatus = worktreeStatus
+                                }
+                                : acc)
+                else
+                    go rest
+                        (RepositoryFile
+                            { repositoryFilePath = path
+                            , repositoryFileOriginalPath = Nothing
+                            , repositoryFileIndexStatus = indexStatus
+                            , repositoryFileWorktreeStatus = worktreeStatus
+                            }
+                            : acc)
+    toStatus byte
+        | byte == 32 = ' '
+        | otherwise = toEnum (fromIntegral byte)
+
+parseDiffHunks :: BS.ByteString -> [DiffHunk]
+parseDiffHunks =
+    reverse
+        . foldl' collect []
+        . Text.lines
+        . TextEncoding.decodeUtf8With lenientDecode
+  where
+    collect acc line =
+        maybe acc (: acc) (parseHunkHeader line)
+
+parseHunkHeader :: Text -> Maybe DiffHunk
+parseHunkHeader line = do
+    body <- Text.stripPrefix "@@ -" line
+    let (oldRange, afterOld) = Text.breakOn " +" body
+    newAndHeader <- Text.stripPrefix " +" afterOld
+    let (newRange, afterNew) = Text.breakOn " @@" newAndHeader
+    header <- Text.stripPrefix " @@" afterNew
+    (oldStart, oldCount) <- parseRange oldRange
+    (newStart, newCount) <- parseRange newRange
+    pure DiffHunk
+        { hunkOldStart = oldStart
+        , hunkOldCount = oldCount
+        , hunkNewStart = newStart
+        , hunkNewCount = newCount
+        , hunkHeader = Text.strip header
+        }
+
+parseRange :: Text -> Maybe (Int, Int)
+parseRange text = case Text.splitOn "," text of
+    [start] -> (, 1) <$> decimal start
+    [start, count] -> (,) <$> decimal start <*> decimal count
+    _ -> Nothing
+  where
+    decimal value
+        | Text.null value || Text.any (not . isDigit) value = Nothing
+        | otherwise = case reads (Text.unpack value) of
+            [(number, "")] -> Just number
+            _ -> Nothing
+
+decodePath :: BS.ByteString -> FilePath
+decodePath = Text.unpack . TextEncoding.decodeUtf8With lenientDecode

--- a/packages/agent-repository/src/Agent/CLI/RepositoryReview/ProcessSupport.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryReview/ProcessSupport.hs
@@ -1,0 +1,51 @@
+-- | Shared teardown and error reporting for review Git processes and checks.
+module Agent.CLI.RepositoryReview.ProcessSupport
+    ( closeQuietly
+    , signalCheckProcessGroup
+    , trySynchronous
+    , renderCommand
+    , processPipeTeardownMicros
+    ) where
+
+import Control.Exception.Safe (SomeException, isAsyncException, throwIO, tryAny)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.IO (Handle, hClose)
+import System.Posix.Signals (Signal, signalProcessGroup)
+import System.Posix.Types (ProcessID)
+import System.Process (ProcessHandle, getPid, terminateProcess)
+
+signalCheckProcessGroup
+    :: Signal
+    -> Maybe ProcessID
+    -> ProcessHandle
+    -> IO ()
+signalCheckProcessGroup signal processGroup process = do
+    processId <- maybe (getPid process) (pure . Just) processGroup
+    case processId of
+        Nothing -> do
+            _ <- tryAny (terminateProcess process)
+            pure ()
+        Just pid -> do
+            _ <- tryAny (signalProcessGroup signal pid)
+            pure ()
+
+closeQuietly :: Handle -> IO ()
+closeQuietly handle = do
+    _ <- tryAny (hClose handle)
+    pure ()
+
+renderCommand :: FilePath -> [String] -> Text
+renderCommand executable arguments =
+    Text.unwords (Text.pack executable : map (Text.pack . show) arguments)
+
+processPipeTeardownMicros :: Int
+processPipeTeardownMicros = 1_000_000
+
+trySynchronous :: IO value -> IO (Either SomeException value)
+trySynchronous action =
+    tryAny action >>= \case
+        Left exception
+            | isAsyncException exception -> throwIO exception
+            | otherwise -> pure (Left exception)
+        Right value -> pure (Right value)


### PR DESCRIPTION
## Summary

Extract six cohesive private modules without changing public API or runtime policies:
- Delivery: bounded/non-interactive process execution and pure destination/reference validation.
- Review: opaque check-process ownership/validation, pure Git-output decoding, process teardown helpers, and error rendering.
- Keep locking and snapshot validation together. Check startup remains inside the original lock and snapshot guard.
- Keep local review and network delivery execution policies separate; confirmation consumption and remote revalidation are unchanged.

| Module | Before | After |
| --- | ---: | ---: |
| RepositoryDelivery | 2,235 | 1,671 |
| RepositoryReview | 2,170 | 1,779 |

New implementation modules are 30–394 lines, registered as private Cabal `other-modules`. This is an incremental extraction; coupled delivery and snapshot/mutation workflows remain together.

## Validation

- `git diff --check` passes.
- Original top-level declaration blocks remain byte-for-byte identical except `startRepositoryCheck`, which delegates its unchanged guarded startup to `startRepositoryCheckAtRoot`.
- Nix GHCi typechecking succeeds for all library and test modules (`--offline -j2`, `GHCRTS=-M3G`).
- Regenerated `package.nix` with `cabal2nix .` from the package-local directory using inherited Nix tooling; verified a second regeneration is byte-identical. Corrected the source path to `./.` following review.
- Local full suite attempted, but sandbox prevents a clean result: normal session TMPDIR causes Git `Invalid path .../tmp/sessions: Operation not permitted` (52 fixture failures); worktree-local TMPDIR causes nested-repository discovery/executable-trust interference (21 failures, 33 pass including process cancellation tests). No runtime policy or fixture changes made to bypass this restriction.
- Full CI required before merge.
