### PR TITLE
refactor(cli): bundle pending dialogs with their replies

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -861,7 +861,9 @@ handleAskChoiceEvent presentation title body initial rows reply = do
     liftIO (state.appRuntime.runtimeNativeProgress False)
     modify' \current ->
         current
-            { appChoice = Just ChoiceOverlay
+            { appChoice = Just $ PendingDialog
+                (atomically . putTMVar reply . fmap (.choiceSelectionIndex))
+                ChoiceOverlay
                 { choicePresentation = presentation
                 , choiceTitle = title
                 , choiceBody = body
@@ -874,11 +876,6 @@ handleAskChoiceEvent presentation title body initial rows reply = do
                 , choiceAdjustmentIndices = []
                 , choiceCloseOnTurnEnd = False
                 }
-            , appChoiceReply =
-                Just
-                    (atomically
-                        . putTMVar reply
-                        . fmap (.choiceSelectionIndex))
             , appAgentHover = Nothing
             }
     vScrollToBeginning (viewportScroll OverlayViewport)
@@ -894,7 +891,9 @@ handleAskFilterChoiceEvent title initial rows reply = do
     liftIO (state.appRuntime.runtimeNativeProgress False)
     modify' \current ->
         current
-            { appChoice = Just ChoiceOverlay
+            { appChoice = Just $ PendingDialog
+                (atomically . putTMVar reply . fmap (.choiceSelectionIndex))
+                ChoiceOverlay
                 { choicePresentation = ChoiceDialog
                 , choiceTitle = title
                 , choiceBody = ""
@@ -907,11 +906,6 @@ handleAskFilterChoiceEvent title initial rows reply = do
                 , choiceAdjustmentIndices = []
                 , choiceCloseOnTurnEnd = False
                 }
-            , appChoiceReply =
-                Just
-                    (atomically
-                        . putTMVar reply
-                        . fmap (.choiceSelectionIndex))
             , appAgentHover = Nothing
             }
     vScrollToBeginning (viewportScroll OverlayViewport)
@@ -943,7 +937,9 @@ handleAskAdjustableFilterChoiceEvent title initial adjustableRows reply = do
             )
     modify' \current ->
         current
-            { appChoice = Just ChoiceOverlay
+            { appChoice = Just $ PendingDialog
+                (atomically . putTMVar reply . replySelection)
+                ChoiceOverlay
                 { choicePresentation = ChoiceDialog
                 , choiceTitle = title
                 , choiceBody = ""
@@ -956,11 +952,6 @@ handleAskAdjustableFilterChoiceEvent title initial adjustableRows reply = do
                 , choiceAdjustmentIndices = adjustmentIndices
                 , choiceCloseOnTurnEnd = False
                 }
-            , appChoiceReply =
-                Just
-                    (atomically
-                        . putTMVar reply
-                        . replySelection)
             , appAgentHover = Nothing
             }
     vScrollToBeginning (viewportScroll OverlayViewport)
@@ -982,13 +973,16 @@ handleAskResumeEvent
         liftIO (state.appRuntime.runtimeNativeProgress False)
         modify' \current ->
             current
-                { appResume = Just ResumeOverlay
+                { appResume = Just $ PendingDialog
+                    ResumeActions
+                        { resumeReply = reply
+                        , resumeLoad = loadEntry
+                        , resumeDelete = deleteEntry
+                        , resumeSearch = searchEntries
+                        }
+                    ResumeOverlay
                     { resumeOverlayBrowser = browser
                     }
-                , appResumeReply = Just reply
-                , appResumeLoad = Just loadEntry
-                , appResumeDelete = Just deleteEntry
-                , appResumeSearch = Just searchEntries
                 , appAgentHover = Nothing
                 }
         vScrollToBeginning (viewportScroll ResumeViewport)
@@ -1005,14 +999,15 @@ handleAskTextEvent mode title body initial reply = do
     liftIO (state.appRuntime.runtimeNativeProgress False)
     modify' \current ->
         current
-            { appTextPrompt = Just TextOverlay
+            { appTextPrompt = Just $ PendingDialog
+                (atomically . putTMVar reply)
+                TextOverlay
                 { textTitle = title
                 , textBody = body
                 , textDraft = initial
                 , textCursor = Text.length initial
                 , textInputMode = mode
                 }
-            , appTextReply = Just reply
             , appAgentHover = Nothing
             }
     vScrollToBeginning (viewportScroll OverlayViewport)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -189,7 +189,7 @@ import Agent.CLI.TUI.App.Navigation
 handleResumeKey :: V.Event -> EventM Name AppState ()
 handleResumeKey event = do
     state <- get
-    case state.appResume of
+    case resumeOverlay state of
         Nothing -> pure ()
         Just overlay ->
             let browser = overlay.resumeOverlayBrowser
@@ -209,11 +209,10 @@ handleDeleteConfirmation
     -> EventM Name AppState ()
 handleDeleteConfirmation state browser sessionId = \case
     V.EvKey (V.KChar 'y') [] ->
-        case state.appResumeDelete of
-            Nothing ->
-                setBrowser (setResumeNotice (Just "Session deletion is unavailable.") browser)
-            Just deleteEntry -> do
-                result <- liftIO (deleteEntry sessionId)
+        case state.appResume of
+            Nothing -> pure ()
+            Just pending -> do
+                result <- liftIO (pending.dialogReply.resumeDelete sessionId)
                 case result of
                     Left err -> setBrowser (setResumeNotice (Just err) browser)
                     Right () -> do
@@ -234,11 +233,10 @@ handleResumeSearch browser event
             setBrowser (endResumeSearch browser)
         V.EvKey V.KEnter [] -> do
             state <- get
-            case state.appResumeSearch of
-                Nothing ->
-                    setBrowser (endResumeSearch browser)
-                Just searchEntries -> do
-                    result <- liftIO (searchEntries browser.resumeBrowserQuery)
+            case state.appResume of
+                Nothing -> pure ()
+                Just pending -> do
+                    result <- liftIO (pending.dialogReply.resumeSearch browser.resumeBrowserQuery)
                     case result of
                         Left err ->
                             setBrowser (setResumeNotice (Just err) browser)
@@ -320,14 +318,10 @@ expandSelectedResume browser =
                 setBrowser (toggleResumeExpanded browser)
             | otherwise -> do
                 state <- get
-                case state.appResumeLoad of
-                    Nothing ->
-                        setBrowser
-                            (setResumeNotice
-                                (Just "Session details are unavailable.")
-                                browser)
-                    Just loadEntry -> do
-                        loaded <- liftIO (loadEntry entry.resumeId)
+                case state.appResume of
+                    Nothing -> pure ()
+                    Just pending -> do
+                        loaded <- liftIO (pending.dialogReply.resumeLoad entry.resumeId)
                         case loaded of
                             Left err ->
                                 setBrowser (setResumeNotice (Just err) browser)
@@ -344,7 +338,7 @@ moveAndReveal delta browser = do
 revealSelectedResume :: EventM Name AppState ()
 revealSelectedResume = do
     state <- get
-    case state.appResume >>= selectedResumeBrowser . (.resumeOverlayBrowser) of
+    case resumeOverlay state >>= selectedResumeBrowser . (.resumeOverlayBrowser) of
         Nothing -> pure ()
         Just entry -> makeVisible (ResumeRow entry.resumeId)
 
@@ -353,7 +347,7 @@ setBrowser browser =
     modify' \state ->
         state
             { appResume =
-                (\overlay -> overlay { resumeOverlayBrowser = browser })
+                fmap (\overlay -> overlay { resumeOverlayBrowser = browser })
                     <$> state.appResume
             }
 
@@ -365,22 +359,17 @@ setAndReveal browser = do
 resolveResume :: Bool -> EventM Name AppState ()
 resolveResume confirmed = do
     state <- get
-    case state.appResumeReply of
+    case state.appResume of
         Nothing -> pure ()
-        Just reply ->
+        Just pending ->
             liftIO $ atomically $
-                putTMVar reply $
+                putTMVar pending.dialogReply.resumeReply $
                     if confirmed
-                        then state.appResume
-                            >>= selectedResumeBrowser . (.resumeOverlayBrowser)
+                        then selectedResumeBrowser pending.dialogOverlay.resumeOverlayBrowser
                         else Nothing
     modify' \current ->
         current
             { appResume = Nothing
-            , appResumeReply = Nothing
-            , appResumeLoad = Nothing
-            , appResumeDelete = Nothing
-            , appResumeSearch = Nothing
             }
     resumeNativeProgressIfRunning
 
@@ -404,7 +393,7 @@ openCommandPalette = do
     liftIO (state.appRuntime.runtimeNativeProgress False)
     modify' \current ->
         current
-            { appChoice = Just ChoiceOverlay
+            { appChoice = Just $ PendingDialog reply ChoiceOverlay
                 { choicePresentation = ChoiceDialog
                 , choiceTitle = "Commands & shortcuts"
                 , choiceBody = ""
@@ -416,7 +405,6 @@ openCommandPalette = do
                 , choiceAdjustmentIndices = []
                 , choiceCloseOnTurnEnd = False
                 }
-            , appChoiceReply = Just reply
             , appAgentHover = Nothing
             }
     vScrollToBeginning (viewportScroll OverlayViewport)
@@ -465,7 +453,7 @@ adjustChoiceValue delta choice =
 confirmResumeId :: Text -> EventM Name AppState ()
 confirmResumeId sessionId = do
     state <- get
-    case state.appResume of
+    case resumeOverlay state of
         Nothing -> pure ()
         Just overlay ->
             case
@@ -486,14 +474,14 @@ confirmResumeId sessionId = do
 handleChoiceKey :: V.Event -> EventM Name AppState ()
 handleChoiceKey event = do
     state <- get
-    case state.appChoice of
+    case choiceOverlay state of
         Just choice
             | choice.choiceSearch -> handleFilterChoiceKey event
         _ -> handleStaticChoiceKey event
 
 handleStaticChoiceKey :: V.Event -> EventM Name AppState ()
 handleStaticChoiceKey event = do
-    choice <- gets (.appChoice)
+    choice <- gets choiceOverlay
     case (choice, event) of
         (Just current, V.EvKey V.KUp [])
             | current.choicePresentation == ChoiceDocument ->
@@ -531,12 +519,12 @@ handleStaticChoiceKey event = do
             gets
                 ( maybe False
                     ((== ChoiceTheme) . (.choicePresentation))
-                    . (.appChoice)
+                    . choiceOverlay
                 )
         modify' \state ->
             state
                 { appChoice =
-                    (\choice ->
+                    fmap (\choice ->
                         let count = length choice.choiceRows
                         in if count == 0
                             then choice
@@ -567,7 +555,7 @@ handleFilterChoiceKey event = case event of
     V.EvKey V.KEnter [] -> resolveChoice True
     V.EvKey V.KEsc [] -> do
         state <- get
-        case state.appChoice of
+        case choiceOverlay state of
             Just choice
                 | not (Text.null choice.choiceQuery) ->
                     updateChoiceQuery (const "")
@@ -590,7 +578,7 @@ handleFilterChoiceKey event = case event of
         modify' \state ->
             state
                 { appChoice =
-                    (\choice ->
+                    fmap (\choice ->
                         let count = length (choiceVisibleRows choice)
                         in choice
                             { choiceIndex =
@@ -607,14 +595,14 @@ handleFilterChoiceKey event = case event of
         modify' \state ->
             state
                 { appChoice =
-                    adjustChoiceValue delta <$> state.appChoice
+                    fmap (adjustChoiceValue delta) <$> state.appChoice
                 }
 
     updateChoiceQuery update = do
         modify' \state ->
             state
                 { appChoice =
-                    (\choice ->
+                    fmap (\choice ->
                         choice
                             { choiceQuery = update choice.choiceQuery
                             , choiceIndex = 0
@@ -626,7 +614,7 @@ handleFilterChoiceKey event = case event of
 confirmChoiceAt :: Int -> EventM Name AppState ()
 confirmChoiceAt index = do
     state <- get
-    case state.appChoice of
+    case choiceOverlay state of
         Just choice
             | choice.choiceSearch ->
                 case findIndex
@@ -636,7 +624,7 @@ confirmChoiceAt index = do
                         modify' \current ->
                             current
                                 { appChoice =
-                                    (\overlay ->
+                                    fmap (\overlay ->
                                         overlay
                                             { choiceIndex = visibleIndex })
                                         <$> current.appChoice
@@ -649,7 +637,7 @@ confirmChoiceAt index = do
                 modify' \current ->
                     current
                         { appChoice =
-                            (\overlay -> overlay { choiceIndex = index })
+                            fmap (\overlay -> overlay { choiceIndex = index })
                                 <$> current.appChoice
                         }
                 resolveChoice True
@@ -836,18 +824,17 @@ resolveChoice confirmed = do
     let previewingTheme =
             maybe False
                 ((== ChoiceTheme) . (.choicePresentation))
-                state.appChoice
-    case state.appChoiceReply of
+                (choiceOverlay state)
+    case state.appChoice of
         Nothing -> pure ()
-        Just reply ->
-            liftIO $ reply $
+        Just pending ->
+            liftIO $ pending.dialogReply $
                 if confirmed
-                    then state.appChoice >>= selectedChoice
+                    then selectedChoice pending.dialogOverlay
                     else Nothing
     modify' \current ->
         current
             { appChoice = Nothing
-            , appChoiceReply = Nothing
             }
     -- Cached transcript images already contain resolved attributes.  Closing
     -- a live preview must repaint them with the persisted theme.
@@ -875,7 +862,7 @@ handleTextPromptKey event = case event of
         modify' \state ->
             state
                 { appTextPrompt =
-                    (\prompt ->
+                    fmap (\prompt ->
                         fromMaybe prompt (applyTextPromptEdit event prompt))
                         <$> state.appTextPrompt
                 }
@@ -963,18 +950,16 @@ applyTextPromptEdit event prompt = case event of
 resolveTextPrompt :: Bool -> EventM Name AppState ()
 resolveTextPrompt confirmed = do
     state <- get
-    case state.appTextReply of
+    case state.appTextPrompt of
         Nothing -> pure ()
-        Just reply ->
-            liftIO $ atomically $
-                putTMVar reply $
-                    if confirmed
-                        then (.textDraft) <$> state.appTextPrompt
-                        else Nothing
+        Just pending ->
+            liftIO $ pending.dialogReply $
+                if confirmed
+                    then Just pending.dialogOverlay.textDraft
+                    else Nothing
     modify' \current ->
         current
             { appTextPrompt = Nothing
-            , appTextReply = Nothing
             }
     resumeNativeProgressIfRunning
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -358,7 +358,7 @@ applyUiEvent uiEvent state =
                         else state.appNativeProgressKeepaliveBucket
                 }
         nextState =
-            case state.appChoice of
+            case choiceOverlay state of
                 Just choice
                     | choiceClosesOnUiTransition
                         previousUi
@@ -366,7 +366,6 @@ applyUiEvent uiEvent state =
                         choice ->
                         nextState0
                             { appChoice = Nothing
-                            , appChoiceReply = Nothing
                             }
                 _ -> nextState0
     in Composer.applyComposerUiEvent uiEvent nextState

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -429,14 +429,8 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appTheme = runtime.runtimeTheme
         , appSlashIndex = 0
         , appChoice = Nothing
-        , appChoiceReply = Nothing
         , appResume = Nothing
-        , appResumeReply = Nothing
-        , appResumeLoad = Nothing
-        , appResumeDelete = Nothing
-        , appResumeSearch = Nothing
         , appTextPrompt = Nothing
-        , appTextReply = Nothing
         , appMetaConsole = Nothing
         , appSlashDismissed = False
         , appPasted = False

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -208,7 +208,7 @@ handleEffortControlClick applyUiEvent = do
                         _ -> pure ()
                 modify' \currentState ->
                     currentState
-                        { appChoice = Just ChoiceOverlay
+                        { appChoice = Just $ PendingDialog choose ChoiceOverlay
                             { choicePresentation = ChoiceDialog
                             , choiceTitle = "Reasoning effort"
                             , choiceBody =
@@ -221,7 +221,6 @@ handleEffortControlClick applyUiEvent = do
                             , choiceAdjustmentIndices = []
                             , choiceCloseOnTurnEnd = True
                             }
-                        , appChoiceReply = Just choose
                         }
                 vScrollToBeginning (viewportScroll OverlayViewport)
             else

--- a/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Motion.hs
@@ -24,6 +24,7 @@ import Agent.CLI.AgentViewport
     )
 import Agent.CLI.TUI.Types
     ( AppState(..)
+    , choiceOverlay
     , ChoiceOverlay(choicePresentation)
     , ChoicePresentation(ChoiceDocument)
     , FullscreenRuntime(..)
@@ -175,7 +176,7 @@ userActionPending state =
         || maybe False
             (\choice ->
                 choice.choicePresentation /= ChoiceDocument)
-            state.appChoice
+            (choiceOverlay state)
         || isJust state.appResume
         || isJust state.appMetaConsole
         || isJust state.appUi.uiPermission

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -64,8 +64,8 @@ import Agent.CLI.TUI.Motion
       motionModeForTerminalFocus )
 import Agent.CLI.TUI.Types
     ( AppState(appMetaConsole, appMotionElapsedMillis, appTerminalFocus,
-               appAgentEntries, appRuntime, appImagePreviews, appResume,
-               appTextPrompt, appChoice, appUi),
+               appAgentEntries, appRuntime, appImagePreviews, appUi),
+      choiceOverlay, resumeOverlay, textOverlay,
       activeTheme,
       FullscreenRuntime(runtimeNativeImagePreviews, runtimeWaveTrough,
                         runtimeColor, runtimeMotionMode),
@@ -214,11 +214,11 @@ import Agent.CLI.TUI.Render.Workspace
 drawApp :: AppState -> [Widget Name]
 drawApp state =
     map fullscreenBounds $
-        case state.appResume of
+        case resumeOverlay state of
             Just resume ->
                 drawResume state resume : dimmedMainLayers
             Nothing ->
-                case (state.appTextPrompt, state.appChoice, state.appUi.uiPermission) of
+                case (textOverlay state, choiceOverlay state, state.appUi.uiPermission) of
                     (Just prompt, _, _) ->
                         drawTextPrompt state prompt : dimmedMainLayers
                     (Nothing, Just choice, _) ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -68,11 +68,12 @@ import Agent.CLI.TUI.Types
                     choiceTitle, choiceBody, choiceSearch, choiceQuery,
                     choiceAdjustments, choiceAdjustmentIndices),
       choiceVisibleRows,
+      choiceOverlay,
       selectedChoiceIndex,
       ChoicePresentation(ChoiceOnboarding, ChoiceDialog, ChoiceDocument,
                          ChoiceTheme),
       AppState(appRuntime,
-               appDictation, appTextPrompt, appChoice, appMetaConsole,
+               appDictation, appTextPrompt, appMetaConsole,
                appMotionElapsedMillis, appUi, appTerminalFocus),
       activeTheme,
       FullscreenRuntime(runtimeMotionMode, runtimeColor, runtimeWaveTrough),
@@ -254,7 +255,7 @@ drawFooter state =
     footer = case
         ( state.appDictation
         , state.appTextPrompt
-        , state.appChoice
+        , choiceOverlay state
         , state.appMetaConsole
         , state.appUi.uiFocus
         , state.appUi.uiPermission

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -28,8 +28,13 @@ module Agent.CLI.TUI.Types
     , MetaConsoleOverlay(..)
     , Name(..)
     , PendingAppEvent(..)
+    , PendingDialog(..)
     , PendingUiEvent(..)
+    , ResumeActions(..)
     , ResumeOverlay(..)
+    , choiceOverlay
+    , resumeOverlay
+    , textOverlay
     , SyntaxHighlighterState(..)
     , TerminalFocus(..)
     , TextInputMode(..)
@@ -445,6 +450,30 @@ data FullscreenSessionActions = FullscreenSessionActions
     , sessionAgentSelect :: !(AgentTarget -> IO ())
     }
 
+-- | An open dialog always owns its reply and any actions it needs. Mapping a
+-- dialog edits its presentation without separating it from those capabilities.
+data PendingDialog reply overlay = PendingDialog
+    { dialogReply :: !reply
+    , dialogOverlay :: !overlay
+    }
+    deriving (Functor)
+
+data ResumeActions = ResumeActions
+    { resumeReply :: !(TMVar (Maybe ResumeEntry))
+    , resumeLoad :: !(Text -> IO (Either Text ResumeEntry))
+    , resumeDelete :: !(Text -> IO (Either Text ()))
+    , resumeSearch :: !(Text -> IO (Either Text [ResumeEntry]))
+    }
+
+choiceOverlay :: AppState -> Maybe ChoiceOverlay
+choiceOverlay state = (.dialogOverlay) <$> state.appChoice
+
+resumeOverlay :: AppState -> Maybe ResumeOverlay
+resumeOverlay state = (.dialogOverlay) <$> state.appResume
+
+textOverlay :: AppState -> Maybe TextOverlay
+textOverlay state = (.dialogOverlay) <$> state.appTextPrompt
+
 data AppState = AppState
     { appUi :: !UiState
     , appHistoryWindow :: !HistoryWindow
@@ -455,15 +484,9 @@ data AppState = AppState
     , appRuntime :: !FullscreenRuntime
     , appTheme :: !ThemeKind
     , appSlashIndex :: !Int
-    , appChoice :: !(Maybe ChoiceOverlay)
-    , appChoiceReply :: !(Maybe (Maybe ChoiceSelection -> IO ()))
-    , appResume :: !(Maybe ResumeOverlay)
-    , appResumeReply :: !(Maybe (TMVar (Maybe ResumeEntry)))
-    , appResumeLoad :: !(Maybe (Text -> IO (Either Text ResumeEntry)))
-    , appResumeDelete :: !(Maybe (Text -> IO (Either Text ())))
-    , appResumeSearch :: !(Maybe (Text -> IO (Either Text [ResumeEntry])))
-    , appTextPrompt :: !(Maybe TextOverlay)
-    , appTextReply :: !(Maybe (TMVar (Maybe Text)))
+    , appChoice :: !(Maybe (PendingDialog (Maybe ChoiceSelection -> IO ()) ChoiceOverlay))
+    , appResume :: !(Maybe (PendingDialog ResumeActions ResumeOverlay))
+    , appTextPrompt :: !(Maybe (PendingDialog (Maybe Text -> IO ()) TextOverlay))
     , appMetaConsole :: !(Maybe MetaConsoleOverlay)
     , appSlashDismissed :: !Bool
     , appPasted :: !Bool
@@ -601,7 +624,7 @@ selectedChoice choice = do
 -- | The selected picker row previews its palette before it is persisted.
 activeTheme :: AppState -> ThemeKind
 activeTheme state =
-    case state.appChoice of
+    case choiceOverlay state of
         Just choice
             | choice.choicePresentation == ChoiceTheme ->
                 themeKindAt choice.choiceIndex

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -96,6 +96,8 @@ import Agent.CLI.TUI.Types
     , HistoryCommit(..)
     , MetaConsoleOverlay(..)
     , Name(..)
+    , PendingDialog(..)
+    , ResumeActions(..)
     , ResumeOverlay(..)
     , TerminalFocus(..)
     , TextInputMode(..)
@@ -167,6 +169,7 @@ import Control.Monad (replicateM_)
 import qualified Data.ByteString as ByteString
 import Data.Foldable (find, toList)
 import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
+import Data.Maybe (isNothing)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
@@ -437,7 +440,7 @@ spec = do
                         []
                         0)
                         { appTextPrompt =
-                            Just
+                            Just $ PendingDialog (const (pure ()))
                                 (textOverlay draft (Text.length draft))
                                     { textTitle = "Request changes"
                                     , textBody =
@@ -461,6 +464,81 @@ spec = do
                     RowEnd width -> Text.replicate width " "
             rendered `shouldSatisfy` Text.isInfixOf marker
 
+    describe "pending dialogs" do
+        it "keeps each reply through edits and resolves simultaneous dialogs in priority order" do
+            runtime <- newScriptRuntime initialUiState
+            choiceReply <- newEmptyTMVarIO
+            textReply <- newEmptyTMVarIO
+            resumeReply <- newEmptyTMVarIO
+            searches <- newIORef []
+            let initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+                browser = initialResumeBrowser (posixSecondsToUTCTime 0) []
+                key value = FullscreenScriptVty (V.EvKey value [])
+                openDialogs =
+                    [ FullscreenScriptApp
+                        (AppAskChoice ChoiceDialog "Choose" "" 0
+                            [("first", ""), ("second", "")] choiceReply)
+                    , FullscreenScriptApp
+                        (AppAskText TextInputPlain "Answer" "" "draft" textReply)
+                    , FullscreenScriptApp
+                        (AppAskResume browser
+                            (const (pure (Left "not used")))
+                            (const (pure (Right ())))
+                            (\query -> do
+                                modifyIORef' searches (<> [query])
+                                pure (Right []))
+                            resumeReply)
+                    , key (V.KChar '/')
+                    , key (V.KChar 'x')
+                    , key V.KEnter
+                    , key V.KEsc
+                    , FullscreenScriptHalt
+                    ]
+            (_, afterResume) <-
+                runFullscreenScriptWithState initialState openDialogs
+            readIORef searches `shouldReturn` ["x"]
+            atomically (tryReadTMVar resumeReply)
+                `shouldReturn` Just Nothing
+            atomically (tryReadTMVar textReply) `shouldReturn` Nothing
+            atomically (tryReadTMVar choiceReply) `shouldReturn` Nothing
+            isNothing afterResume.appResume `shouldBe` True
+            (_, afterText) <-
+                runFullscreenScriptWithState afterResume
+                    [ key (V.KChar '!')
+                    , key V.KEnter
+                    , FullscreenScriptHalt
+                    ]
+            atomically (tryReadTMVar textReply)
+                `shouldReturn` Just (Just "draft!")
+            atomically (tryReadTMVar choiceReply) `shouldReturn` Nothing
+            isNothing afterText.appTextPrompt `shouldBe` True
+            (_, afterChoice) <-
+                runFullscreenScriptWithState afterText
+                    [ key V.KDown
+                    , key V.KEnter
+                    , FullscreenScriptHalt
+                    ]
+            atomically (tryReadTMVar choiceReply)
+                `shouldReturn` Just (Just 1)
+            isNothing afterChoice.appChoice `shouldBe` True
+
+        it "cancels edited text without returning the draft" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            let initialState =
+                    initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, finalState) <-
+                runFullscreenScriptWithState initialState
+                    [ FullscreenScriptApp
+                        (AppAskText TextInputPlain "Answer" "" "draft" reply)
+                    , FullscreenScriptVty (V.EvKey (V.KChar '!') [])
+                    , FullscreenScriptVty (V.EvKey V.KEsc [])
+                    , FullscreenScriptHalt
+                    ]
+            atomically (tryReadTMVar reply) `shouldReturn` Just Nothing
+            isNothing finalState.appTextPrompt `shouldBe` True
+
     describe "search overlay input viewport" do
         it "keeps the tail of a long searchable choice query visible" do
             runtime <- newScriptRuntime initialUiState
@@ -474,7 +552,7 @@ spec = do
                         []
                         0)
                         { appChoice =
-                            Just
+                            Just $ PendingDialog (const (pure ()))
                                 (choiceOverlay False)
                                     { choiceSearch = True
                                     , choiceQuery = query
@@ -485,6 +563,7 @@ spec = do
 
         it "keeps a long resume query visible while editing and afterward" do
             runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
             let marker = "RESUMETAIL"
                 query = Text.replicate 1000 "a" <> marker
                 browser =
@@ -502,19 +581,29 @@ spec = do
                         []
                         0)
                         { appResume =
-                            Just ResumeOverlay
+                            Just $ PendingDialog
+                                ResumeActions
+                                    { resumeReply = reply
+                                    , resumeLoad = const (pure (Left "not used"))
+                                    , resumeDelete = const (pure (Right ()))
+                                    , resumeSearch = const (pure (Right []))
+                                    }
+                                ResumeOverlay
                                 { resumeOverlayBrowser = browser
                                 }
                         }
                 inactiveState =
                     state
                         { appResume =
-                            Just ResumeOverlay
-                                { resumeOverlayBrowser =
-                                    browser
-                                        { resumeBrowserSearching = False
-                                        }
-                                }
+                            fmap
+                                (fmap \overlay ->
+                                    overlay
+                                        { resumeOverlayBrowser =
+                                            browser
+                                                { resumeBrowserSearching = False
+                                                }
+                                        })
+                                state.appResume
                         }
             renderedAppText (80, 24) state
                 `shouldSatisfy` Text.isInfixOf marker
@@ -770,7 +859,7 @@ spec = do
                 runFullscreenScriptWithState
                     initialState
                     (openAndSearch <> [FullscreenScriptHalt])
-            (.choiceQuery) <$> searchedState.appChoice
+            (.dialogOverlay.choiceQuery) <$> searchedState.appChoice
                 `shouldBe` Just ""
             (_, closedState) <-
                 runFullscreenScriptWithState
@@ -779,7 +868,7 @@ spec = do
                         <> [ FullscreenScriptVty (V.EvKey V.KEsc [])
                            , FullscreenScriptHalt
                            ])
-            closedState.appChoice `shouldBe` Nothing
+            isNothing closedState.appChoice `shouldBe` True
 
         it "inserts required command prefixes at the composer cursor" do
             let ui =
@@ -871,7 +960,7 @@ spec = do
             rendered
                 `shouldSatisfy`
                     ByteString.isInfixOf (encoded marker)
-            finalState.appChoice `shouldBe` Nothing
+            isNothing finalState.appChoice `shouldBe` True
             atomically (tryReadTMVar reply)
                 `shouldReturn` Just Nothing
 

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -16,6 +16,7 @@ import Agent.CLI.TUI.Types
     ( AppState(..)
     , ChoiceOverlay(..)
     , ChoicePresentation(..)
+    , PendingDialog(..)
     , TextInputMode(..)
     , TextOverlay(..)
     )
@@ -650,7 +651,7 @@ applyAction action harness =
                 { harnessApp =
                     harness.harnessApp
                         { appChoice =
-                            Just ChoiceOverlay
+                            Just $ PendingDialog (const (pure ())) ChoiceOverlay
                                 { choicePresentation = presentation
                                 , choiceTitle = title
                                 , choiceBody = body
@@ -671,7 +672,7 @@ applyAction action harness =
                     harness.harnessApp
                         { appChoice = Nothing
                         , appTextPrompt =
-                            Just TextOverlay
+                            Just $ PendingDialog (const (pure ())) TextOverlay
                                 { textTitle = title
                                 , textBody = body
                                 , textDraft = draft


### PR DESCRIPTION
## Summary
- Bundle choice/text overlays with callbacks and resume overlays with reply/load/delete/search actions in PendingDialog.
- Remove six independently optional fields and missing-handler branches while preserving simultaneous dialog priority.
- Add ownership, editing, cancellation and priority regressions.

## Validation
- Nix-provided GHCi: 212 library modules and 84 test modules loaded.
- TUIAppSpec: 125 examples; TUIPropertySpec: 11 examples; zero failures.
- Actual changed-source fullscreen agent in tmux, isolated HOME and dummy Gemini key: theme selection confirmed and persisted Daylight; later preview cancellation preserved it; resume browser opened/cancelled back to composer. No model request.
- git diff --check passed.

Direct nix develop encountered host temp permissions; used inherited Nix environment and exact flake-provisioned assets.