### PR TITLE
Model uncommitted display attempts explicitly

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TurnState.hs
+++ b/packages/agent-cli/src/Agent/CLI/TurnState.hs
@@ -67,32 +67,65 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encoding as AesonEncoding
 import Data.List (isPrefixOf)
 import Data.Maybe (isJust)
+import Data.Sequence (Seq, (|>))
+import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
 data DisplayProjection = DisplayProjection
+    { completedAttempts :: !(Seq DisplayAttempt)
+    , currentAttempt :: !DisplayAttempt
+    }
+
+data DisplayAttempt = DisplayAttempt
     { displayItems :: ![ResponseItem]
     , displayCanAppendText :: !Bool
     }
+
+emptyDisplayAttempt :: DisplayAttempt
+emptyDisplayAttempt = DisplayAttempt [] False
 
 -- | Normalize the transient provider event journal into stable response
 -- items used only by session-history projection. These items must never enter
 -- model context.
 uncommittedDisplayItems :: LoopExecution -> [ResponseItem]
 uncommittedDisplayItems execution =
-    (.displayItems) $
+    flattenDisplayProjection $
         foldl'
             projectDisplayEvent
             DisplayProjection
-                { displayItems = []
-                , displayCanAppendText = False
+                { completedAttempts = Seq.empty
+                , currentAttempt = emptyDisplayAttempt
                 }
             execution.executionUncommittedDisplayEvents
 
+-- Keep the historical boundary encoding at the output boundary only. Empty
+-- attempts matter too: consecutive restarts must retain consecutive markers.
+flattenDisplayProjection :: DisplayProjection -> [ResponseItem]
+flattenDisplayProjection projection =
+    foldMap
+        (\attempt -> attempt.displayItems <> [displayAttemptBoundary])
+        projection.completedAttempts
+        <> projection.currentAttempt.displayItems
+
 projectDisplayEvent :: DisplayProjection -> LoopEvent -> DisplayProjection
 projectDisplayEvent projection = \case
+    ResponseRestarted _ ->
+        DisplayProjection
+            { completedAttempts =
+                projection.completedAttempts |> projection.currentAttempt
+            , currentAttempt = emptyDisplayAttempt
+            }
+    event ->
+        projection
+            { currentAttempt =
+                projectDisplayAttempt projection.currentAttempt event
+            }
+
+projectDisplayAttempt :: DisplayAttempt -> LoopEvent -> DisplayAttempt
+projectDisplayAttempt projection = \case
     TextDelta delta
         | Text.null delta -> projection
         | projection.displayCanAppendText ->
@@ -106,12 +139,6 @@ projectDisplayEvent projection = \case
                     projection.displayItems <> [displayAssistantItem delta]
                 , displayCanAppendText = True
                 }
-    ResponseRestarted _ ->
-        projection
-            { displayItems =
-                projection.displayItems <> [displayAttemptBoundary]
-            , displayCanAppendText = False
-            }
     ToolStarted call ->
         projectDisplayCall call projection
     ToolUpdated call ->
@@ -142,14 +169,13 @@ projectDisplayEvent projection = \case
     ToolRetracted callId ->
         projection
             { displayItems =
-                updateCurrentDisplayAttempt
-                    (filter (not . belongsToDisplayCall callId))
+                filter (not . belongsToDisplayCall callId)
                     projection.displayItems
             , displayCanAppendText = False
             }
     _ -> projection
 
-projectDisplayCall :: ToolCall -> DisplayProjection -> DisplayProjection
+projectDisplayCall :: ToolCall -> DisplayAttempt -> DisplayAttempt
 projectDisplayCall call projection =
     projection
         { displayItems =
@@ -159,8 +185,7 @@ projectDisplayCall call projection =
 
 replaceDisplayCall :: ToolCall -> [ResponseItem] -> [ResponseItem]
 replaceDisplayCall call =
-    updateOrAppendCurrentDisplayAttempt
-        (isDisplayCall call.callId)
+    updateOrAppendDisplayItem
         (isDisplayCall call.callId)
         (displayToolCall call)
 
@@ -170,43 +195,22 @@ replaceDisplayOutput
     -> [ResponseItem]
     -> [ResponseItem]
 replaceDisplayOutput callId replacement =
-    updateOrAppendCurrentDisplayAttempt
-        (isDisplayOutput callId)
+    updateOrAppendDisplayItem
         (isDisplayOutput callId)
         replacement
 
-updateOrAppendCurrentDisplayAttempt
+updateOrAppendDisplayItem
     :: (ResponseItem -> Bool)
-    -> (ResponseItem -> Bool)
     -> ResponseItem
     -> [ResponseItem]
     -> [ResponseItem]
-updateOrAppendCurrentDisplayAttempt exists replace replacement items =
-    let (prior, current) = splitCurrentDisplayAttempt items
-    in if any exists current
+updateOrAppendDisplayItem matches replacement items =
+    if any matches items
         then
-            prior
-                <> map
-                    (\item ->
-                        if replace item then replacement else item)
-                    current
+            map
+                (\item -> if matches item then replacement else item)
+                items
         else items <> [replacement]
-
-updateCurrentDisplayAttempt
-    :: ([ResponseItem] -> [ResponseItem])
-    -> [ResponseItem]
-    -> [ResponseItem]
-updateCurrentDisplayAttempt update items =
-    let (prior, current) = splitCurrentDisplayAttempt items
-    in prior <> update current
-
-splitCurrentDisplayAttempt
-    :: [ResponseItem]
-    -> ([ResponseItem], [ResponseItem])
-splitCurrentDisplayAttempt items =
-    let (currentReversed, priorReversed) =
-            break isDisplayAttemptBoundary (reverse items)
-    in (reverse priorReversed, reverse currentReversed)
 
 displayAttemptBoundary :: ResponseItem
 displayAttemptBoundary =

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -34,6 +34,7 @@ import Agent.Responses.Types
     , ResponseMessage(..)
     , MessageContent(..)
     , ResponseRole(..)
+    , TaggedObject(..)
     )
 import Agent.ToolDispatch
     ( ToolCallKind(..)
@@ -47,11 +48,43 @@ import Agent.Tools.PlanMode
     , newPlanModeEnv
     )
 import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.List (intersperse)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
+import Test.QuickCheck (elements, forAll, listOf, property, (===))
+
+projectEvents :: [LoopEvent] -> [ResponseItem]
+projectEvents events =
+    uncommittedDisplayItems
+        ((uncommittedExecution prepared)
+            { executionUncommittedDisplayEvents = events })
+
+expectedDisplayBoundary :: ResponseItem
+expectedDisplayBoundary =
+    UnknownResponseItem (TaggedObject "haskell_agent_display_attempt_boundary")
+
+displayAttemptEvents :: [LoopEvent]
+displayAttemptEvents =
+    [ TextDelta ""
+    , TextDelta "hello"
+    , TextDelta " world"
+    , ToolStarted first
+    , ToolUpdated updated
+    , ToolArgumentsUpdated updated
+    , ToolStarted other
+    , ToolOutputUpdated "same" "running"
+    , ToolOutputUpdated "other" "other output"
+    , ToolFinished (ToolCallResult "same" "done" FunctionCallKind)
+    , ToolRetracted "same"
+    , ToolRetracted "other"
+    ]
+  where
+    first = functionToolCall "same" "shell_command" "{}"
+    updated = functionToolCall "same" "shell_command" "{\"command\":\"pwd\"}"
+    other = functionToolCall "other" "read_file" "{}"
 
 spec :: Spec
 spec = do
@@ -70,6 +103,53 @@ spec = do
                     ]
 
     describe "uncommittedDisplayItems" do
+        it "preserves empty attempts and the historical restart marker" do
+            projectEvents
+                [ ResponseRestarted "first"
+                , TextDelta ""
+                , ResponseRestarted "second"
+                , ResponseRestarted "third"
+                ]
+                `shouldBe` replicate 3 expectedDisplayBoundary
+
+        it "projects retry attempts independently, including reused and retracted ids" $
+            property $
+                forAll (listOf (listOf (elements displayAttemptEvents))) \attempts ->
+                    let events =
+                            concat
+                                (intersperse [ResponseRestarted "retry"] attempts)
+                        expected =
+                            concat
+                                (intersperse [expectedDisplayBoundary]
+                                    (map projectEvents attempts))
+                    in projectEvents events === expected
+
+        it "retracts only the current attempt's call and output" do
+            let call = functionToolCall "same" "shell_command" "{}"
+                first = [ToolStarted call, ToolOutputUpdated "same" "first"]
+            projectEvents
+                (first
+                    <> [ ResponseRestarted "retry"
+                       , ToolStarted call
+                       , ToolOutputUpdated "same" "second"
+                       , ToolRetracted "same"
+                       ])
+                `shouldBe` projectEvents first <> [expectedDisplayBoundary]
+
+        it "does not coalesce text across a tool event even if that tool is retracted" do
+            let call = functionToolCall "c1" "shell_command" "{}"
+            projectEvents
+                [ TextDelta "before"
+                , ToolStarted call
+                , ToolRetracted "c1"
+                , TextDelta "after"
+                , TextDelta ""
+                , TextDelta "!"
+                ]
+                `shouldBe`
+                    projectEvents [TextDelta "before"]
+                        <> projectEvents [TextDelta "after!"]
+
         it "normalizes failed text, tools, and retry attempts for history only" do
             let call =
                     functionToolCall


### PR DESCRIPTION
## Summary
- Replace sentinel-delimited internal projection with completed attempts and one current DisplayAttempt.
- Scope updates and retractions structurally to the current attempt; encode historical boundary markers only when flattening for display.
- Preserve output ordering, empty retries, reused IDs, and the display-only/model-context boundary.
- Add retry-isolation property coverage and regression examples. This is a semantic simplification, not a performance claim.

## Validation
- `TMPDIR="$HOME/.hatmp" GHCRTS=-M4G nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`, then `hspec Agent.CLI.TurnSpec.spec`: 35 examples, 0 failures; QuickCheck passed 100 tests.
- Live isolated tmux smoke via GHCi: minimal Gemini CLI startup rendered model/status; Ctrl-D exited cleanly with resume hint (dummy API key, no provider request).
- `git diff --check` clean.