### PR TITLE
Extract focused CLI motion and compaction test modules

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -455,6 +455,9 @@ test-suite agent-cli-test
                     , Agent.CLI.ComputerUseSpec
                     , Agent.CLI.ConfigSpec
                     , Agent.CLI.CompactionSpec
+                    , Agent.CLI.CompactionSpec.Fixtures
+                    , Agent.CLI.CompactionSpec.ManualOpenAI
+                    , Agent.CLI.CompactionSpec.TaskPlan
                     , Agent.CLI.ContextSpec
                     , Agent.CLI.ConversationStoreSpec
                     , Agent.CLI.ConnectivitySpec
@@ -511,6 +514,8 @@ test-suite agent-cli-test
                     , Agent.CLI.SubagentStoreSpec
                     , Agent.CLI.ToolsSpec
                     , Agent.CLI.TUIAppSpec
+                    , Agent.CLI.TUIAppSpec.AgentFixtures
+                    , Agent.CLI.TUIAppSpec.Motion
                     , Agent.CLI.TUIBridgeSpec
                     , Agent.CLI.TUIComposerSpec
                     , Agent.CLI.TUIImagePreviewSpec

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -1,7 +1,8 @@
 module Agent.CLI.CompactionSpec (spec) where
 
-import Agent.CLI.Session.Request (SessionRequestState, newSessionRequestState)
-import Agent.CLI.Session (Persistence(..))
+import Agent.CLI.CompactionSpec.Fixtures
+import qualified Agent.CLI.CompactionSpec.ManualOpenAI as ManualOpenAI
+import qualified Agent.CLI.CompactionSpec.TaskPlan as TaskPlan
 import Agent.CLI.Compaction
     ( CompactOutcome(..)
     , CompactionInstall(..)
@@ -13,11 +14,9 @@ import Agent.CLI.Compaction
     , autoCompactOpenAiBackendWithSenderHookAndDecorator
     , autoCompactOpenAiBackendWithThreshold
     , codexAutoCompactTokenLimit
-    , compactOpenAIWith
     , claudeAutoCompactTokenLimit
     , claudeCompactionInputLimit
     , decorateCompactOutcomeWithTaskPlan
-    , decorateCompactOutcomeWithTaskPlanWithin
     , estimatedOccupancy
     , installCompactOutcome
     , reportedOccupancy
@@ -32,7 +31,6 @@ import Agent.CLI.Compaction
     )
 import Agent.Connectivity (withConnectionRecoveryUsing)
 import Agent.Error (ApiError(..), ErrorType(..))
-import Agent.Json.Decode qualified as Hermes
 import Agent.Loop
 import Agent.OpenAI.Compaction
     ( assistantSummaryItem
@@ -52,17 +50,14 @@ import Agent.Responses.LoopBackend (turnInputsToItems)
 import Agent.Responses.Types
 import Agent.XAI.LoopBackend (xaiCompactionCheckpointOriginItem)
 import Agent.Tools.TaskPlan
-    ( CurrentTaskPlan(..)
-    , TaskPlan(..)
+    ( TaskPlan(..)
     , TaskPlanItem(..)
     , TaskPlanStatus(..)
-    , isTaskPlanContextText
     , newTaskPlanEnv
     , replaceTaskPlan
     , taskPlanContextText
     )
 import qualified Data.Aeson as Aeson
-import Data.Aeson ((.=))
 import Agent.Provider
     ( BillingMode(..)
     , Provider(..)
@@ -77,10 +72,8 @@ import Control.Exception
     , try
     )
 import Data.IORef
-import Control.Monad.Trans.Except (runExceptT)
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as LBS
-import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Test.Hspec
@@ -1223,304 +1216,9 @@ spec = do
             result `shouldSatisfy` either (const False) (const True)
             readIORef hookCalls `shouldReturn` 1
 
-    describe "compactOpenAIWith" do
-        it "uses remote compaction v2 on normal Responses" do
-            requests <- newIORef []
-            let provider = tokenProvider SubscriptionBilled \_ ->
-                    error "remote compaction unexpectedly requested credentials"
-                send _ request = do
-                    modifyIORef' requests (<> [request])
-                    pure (Right remoteCompactionResponse)
-                history = [userTextItem "old context"]
-                params = defaultResponseCreateParams
-                    { instructions = Just "keep these instructions"
-                    , tools = Just []
-                    , stream = Just False
-                    }
-            result <- runExceptT $
-                compactOpenAIWith send
-                    (Just provider)
-                    params
-                    history
-                    100
-                    Nothing
-            case result of
-                Left err -> expectationFailure (show err)
-                Right outcome -> do
-                    outcome.compactSummary
-                        `shouldBe` "Context compacted remotely."
-                    outcome.compactHistory
-                        `shouldSatisfy` hasCompactionCheckpoint
-            seen <- readIORef requests
-            length seen `shouldBe` 1
-            map (.instructions) seen `shouldBe` [Just "keep these instructions"]
-            map (.tools) seen `shouldBe` [Just []]
-            map (.parallelToolCalls) seen `shouldBe` [Just True]
-            map (.previousResponseId) seen `shouldBe` [Nothing]
-            map (.store) seen `shouldBe` [Just False]
-            map (.stream) seen `shouldBe` [Just True]
-            map (.toolChoice) seen
-                `shouldBe` [Just (ToolChoiceMode ToolChoiceAuto)]
-            map requestItems seen
-                `shouldBe` [history <> [compactionTriggerItem]]
+    ManualOpenAI.spec
 
-        it "disables parallel tool calls for Responses Lite remote compaction" do
-            requests <- newIORef []
-            let provider = tokenProvider SubscriptionBilled \_ ->
-                    error "remote compaction unexpectedly requested credentials"
-                send _ request = do
-                    modifyIORef' requests (<> [request])
-                    pure (Right remoteCompactionResponse)
-                history = [userTextItem "old context"]
-                params = defaultResponseCreateParams
-                    { model = Just "gpt-5.6-sol"
-                    , instructions = Just "keep these instructions"
-                    , store = Just True
-                    , tools = Just []
-                    }
-            result <- runExceptT $
-                compactOpenAIWith send
-                    (Just provider)
-                    params
-                    history
-                    100
-                    Nothing
-            case result of
-                Left err -> expectationFailure (show err)
-                Right outcome ->
-                    outcome.compactSummary
-                        `shouldBe` "Context compacted remotely."
-            map (.parallelToolCalls) <$> readIORef requests
-                `shouldReturn` [Just False]
-
-        it "rejects remote checkpoints that cannot fit the installed snapshot" do
-            let provider = tokenProvider SubscriptionBilled \_ ->
-                    error "remote compaction unexpectedly requested credentials"
-                contextWindow =
-                    codexEffectiveContextWindowFor
-                        defaultResponseCreateParams.model
-                oversizedResponse =
-                    responseWithOutput
-                        [ Aeson.object
-                            [ "type" .= ("compaction" :: Text)
-                            , "encrypted_content" .=
-                                Text.replicate (contextWindow * 4 + 10_000) "x"
-                            ]
-                        ]
-                send _ _ = pure (Right oversizedResponse)
-                history = [userTextItem "old context"]
-            result <- runExceptT $
-                compactOpenAIWith send
-                    (Just provider)
-                    defaultResponseCreateParams
-                    history
-                    100
-                    Nothing
-            result `shouldSatisfy` \case
-                Left message ->
-                    "remote compacted snapshot request cannot fit"
-                        `Text.isInfixOf` message
-                Right _ -> False
-
-        it "keeps focused manual compaction on local summarization" do
-            requests <- newIORef []
-            let provider = tokenProvider SubscriptionBilled \_ ->
-                    error "local summarization unexpectedly requested credentials"
-                send _ request = do
-                    modifyIORef' requests (<> [request])
-                    pure (Right (summaryResponse "local summary"))
-                history = [userTextItem "old context"]
-            result <- runExceptT $
-                compactOpenAIWith send
-                    (Just provider)
-                    defaultResponseCreateParams
-                    history
-                    100
-                    (Just "focus on auth")
-            case result of
-                Left err -> expectationFailure (show err)
-                Right outcome -> do
-                    outcome.compactSummary `shouldBe` "local summary"
-                    outcome.compactHistory
-                        `shouldBe`
-                            [ userTextItem "old context"
-                            , assistantSummaryItem "local summary"
-                            ]
-            seen <- readIORef requests
-            map (.tools) seen `shouldBe` [Nothing]
-            map (.parallelToolCalls) seen `shouldBe` [Just False]
-            map (.stream) seen `shouldBe` [Just True]
-
-        it "returns friendly provider errors from manual compaction" do
-            let provider = tokenProvider SubscriptionBilled \_ ->
-                    error "compaction unexpectedly requested credentials"
-                send _ _ =
-                    pure $ Left $
-                        ProviderError UsageLimitReached
-                            "quota exhausted"
-                            (Just 120)
-                history = [userTextItem "old context"]
-            result <- runExceptT $
-                compactOpenAIWith send
-                    (Just provider)
-                    defaultResponseCreateParams
-                    history
-                    100
-                    Nothing
-            case result of
-                Left err -> do
-                    err `shouldSatisfy`
-                        Text.isInfixOf "Usage limit reached"
-                    err `shouldSatisfy`
-                        Text.isInfixOf "Try again in 2m"
-                    err `shouldNotSatisfy`
-                        Text.isInfixOf "ProviderError"
-                Right _ ->
-                    expectationFailure "expected compaction to fail"
-
-    describe "task-plan compaction context" do
-        it "removes generated task plans before remote compaction" do
-            let stale =
-                    taskPlanContextText $
-                        CurrentTaskPlan 8 $
-                            TaskPlan Nothing
-                                [TaskPlanItem "stale" TaskPlanInProgress]
-                history =
-                    [ taskPlanMessage RoleDeveloper stale
-                    , userTextItem stale
-                    , userTextItem "retained"
-                    ]
-            params <- testRequestState defaultResponseCreateParams
-            transcript <- newIORef history
-            requests <- newIORef []
-            result <-
-                runProviderCompactWith
-                    (Just \request -> do
-                        modifyIORef' requests (<> [request])
-                        pure (Right remoteCompactionResponse))
-                    (const (pure ()))
-                    OpenAIProvider
-                    Nothing
-                    params
-                    transcript
-                    Nothing
-            result `shouldSatisfy` either (const False) (const True)
-            map requestItems <$> readIORef requests
-                `shouldReturn`
-                    [ [ userTextItem "retained"
-                      , compactionTriggerItem
-                      ]
-                    ]
-
-        it "removes generated task plans before local summarization" do
-            let stale =
-                    taskPlanContextText $
-                        CurrentTaskPlan 8 $
-                            TaskPlan Nothing
-                                [TaskPlanItem "stale" TaskPlanInProgress]
-                history =
-                    [ taskPlanMessage RoleDeveloper stale
-                    , userTextItem stale
-                    , userTextItem "retained"
-                    ]
-                focus = Just "focus on the remaining work"
-            params <- testRequestState defaultResponseCreateParams
-            transcript <- newIORef history
-            requests <- newIORef []
-            result <-
-                runProviderCompactWith
-                    (Just \request -> do
-                        modifyIORef' requests (<> [request])
-                        pure (Right (summaryResponse "local summary")))
-                    (const (pure ()))
-                    OpenAIProvider
-                    Nothing
-                    params
-                    transcript
-                    focus
-            result `shouldSatisfy` either (const False) (const True)
-            map requestItems <$> readIORef requests
-                `shouldReturn`
-                    [ [ userTextItem "retained"
-                      , userTextItem (summarizationPrompt focus)
-                      ]
-                    ]
-
-        it "replaces stale generated copies from authoritative state" do
-            let stale =
-                    taskPlanContextText $
-                        CurrentTaskPlan 8 $
-                            TaskPlan Nothing
-                                [TaskPlanItem "stale" TaskPlanPending]
-                plan = TaskPlan
-                    (Just "continue here")
-                    [TaskPlanItem "current" TaskPlanInProgress]
-                current = CurrentTaskPlan 1 plan
-                outcome = CompactOutcome
-                    { compactBeforeTokens = 20
-                    , compactAfterTokens = 10
-                    , compactHistory =
-                        [userTextItem stale, userTextItem "retained"]
-                    , compactSummary = "summary"
-                    }
-            env <- newTaskPlanEnv Nothing Nothing
-            replaceTaskPlan env plan `shouldReturn` Right current
-            decorated <-
-                decorateCompactOutcomeWithTaskPlan (Just env) outcome
-            filter responseItemHasTaskPlan decorated.compactHistory
-                `shouldSatisfy` \case
-                    [MessageItem message] ->
-                        message.role == RoleDeveloper
-                            && responseMessageHasText
-                                (taskPlanContextText current)
-                                message
-                    _ -> False
-
-        it "does not reconstruct a plan from pre-compaction history" do
-            let stale =
-                    taskPlanContextText $
-                        CurrentTaskPlan 8 $
-                            TaskPlan Nothing
-                                [TaskPlanItem "stale" TaskPlanInProgress]
-                outcome = CompactOutcome
-                    { compactBeforeTokens = 20
-                    , compactAfterTokens = 10
-                    , compactHistory =
-                        [userTextItem stale, userTextItem "retained"]
-                    , compactSummary = "summary"
-                    }
-            env <- newTaskPlanEnv Nothing Nothing
-            decorated <-
-                decorateCompactOutcomeWithTaskPlan (Just env) outcome
-            decorated.compactHistory
-                `shouldBe` [userTextItem "retained"]
-
-        it "rejects a generated plan that cannot fit the compacted request" do
-            let plan = TaskPlan Nothing
-                    [TaskPlanItem "current" TaskPlanInProgress]
-                outcome = CompactOutcome
-                    { compactBeforeTokens = 20
-                    , compactAfterTokens = 1
-                    , compactHistory = []
-                    , compactSummary = "summary"
-                    }
-                rawLimit =
-                    estimateRequestTokensWithItems
-                        defaultResponseCreateParams
-                        outcome.compactHistory
-            env <- newTaskPlanEnv Nothing Nothing
-            _ <- replaceTaskPlan env plan
-            result <-
-                decorateCompactOutcomeWithTaskPlanWithin
-                    rawLimit
-                    defaultResponseCreateParams
-                    (Just env)
-                    outcome
-            result `shouldSatisfy` \case
-                Left message ->
-                    "authoritative task plan does not fit"
-                        `Text.isInfixOf` message
-                Right _ -> False
+    TaskPlan.spec
 
     describe "autoCompactOpenAiBackendWith" do
         it "decorates before publishing and continuing automatic compaction" do
@@ -2567,137 +2265,3 @@ spec = do
                 (const (pure ()))
             result `shouldSatisfy` either (const False) (const True)
             readIORef compactCalls `shouldReturn` 1
-
-responseItemHasTaskPlan :: ResponseItem -> Bool
-responseItemHasTaskPlan = \case
-    MessageItem message ->
-        any isTaskPlanContextText (responseMessageTexts message)
-    _ -> False
-
-taskPlanMessage :: ResponseRole -> Text -> ResponseItem
-taskPlanMessage role text =
-    MessageItem ResponseMessage
-        { messageId = Nothing
-        , content = MessageContentParts [InputTextPart text Nothing]
-        , role = role
-        , status = Nothing
-        , phase = Nothing
-        , passthrough = Nothing
-        }
-
-responseMessageHasText :: Text -> ResponseMessage -> Bool
-responseMessageHasText expected =
-    elem expected . responseMessageTexts
-
-responseMessageTexts :: ResponseMessage -> [Text]
-responseMessageTexts message =
-    case message.content of
-        MessageContentText text -> [text]
-        MessageContentParts parts ->
-            [ text
-            | part <- parts
-            , text <- case part of
-                InputTextPart{text} -> [text]
-                OutputTextPart{text} -> [text]
-                PlainTextPart{text} -> [text]
-                _ -> []
-            ]
-
-successful
-    :: BackendSnapshot
-    -> TurnOutput
-    -> Either ApiError BackendResult
-successful state output =
-    Right BackendResult
-        { backendOutput = output
-        , backendState = state
-        }
-
-requestItems :: ResponseCreateParams -> [ResponseItem]
-requestItems request = case request.input of
-    Just (ResponseInputItems items) -> items
-    _ -> []
-
-remoteCompactionResponse :: Response
-remoteCompactionResponse =
-    responseWithOutput
-        [ Aeson.object
-            [ "type" .= ("compaction" :: Text)
-            , "encrypted_content" .= ("opaque" :: Text)
-            ]
-        ]
-
-responseWithoutCompaction :: Response
-responseWithoutCompaction =
-    responseWithOutput []
-
-responseWithOutput :: [Aeson.Value] -> Response
-responseWithOutput output =
-    decodeResponseFixture $ Aeson.object
-        [ "id" .= ("resp-compact" :: Text)
-        , "created_at" .= (0 :: Int)
-        , "status" .= ("completed" :: Text)
-        , "model" .= ("gpt-test" :: Text)
-        , "output" .= output
-        , "usage" .= Aeson.object
-            [ "input_tokens" .= compactionUsage.inputTokens
-            , "output_tokens" .= compactionUsage.outputTokens
-            , "total_tokens" .=
-                (compactionUsage.inputTokens + compactionUsage.outputTokens)
-            , "input_tokens_details" .= Aeson.object
-                [ "cached_tokens" .= compactionUsage.cachedTokens
-                ]
-            ]
-        ]
-
-decodeResponseFixture :: Aeson.Value -> Response
-decodeResponseFixture fixture =
-    case Hermes.decodeEither responseDecoder
-            (LBS.toStrict (Aeson.encode fixture)) of
-        Right response -> response
-        Left err -> error (Text.unpack (Hermes.jsonErrorMessage err))
-
-compactionUsage :: TokenUsage
-compactionUsage = TokenUsage
-    { inputTokens = 80
-    , outputTokens = 6
-    , cachedTokens = 40
-    }
-
-withModel :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
-withModel nextModel ResponseCreateParams { model = _, .. } =
-    ResponseCreateParams { model = nextModel, .. }
-
-summaryResponse :: Text -> Response
-summaryResponse summary =
-    summaryResponseWithStatus "completed" summary
-
-summaryResponseWithStatus :: Text -> Text -> Response
-summaryResponseWithStatus responseStatus summary =
-    decodeResponseFixture $ Aeson.object
-        [ "id" .= ("resp-summary" :: Text)
-        , "created_at" .= (0 :: Int)
-        , "status" .= responseStatus
-        , "model" .= ("gpt-test" :: Text)
-        , "output" .=
-            [ Aeson.object
-                [ "type" .= ("message" :: Text)
-                , "role" .= ("assistant" :: Text)
-                , "content" .=
-                    [ Aeson.object
-                        [ "type" .= ("output_text" :: Text)
-                        , "text" .= summary
-                        ]
-                    ]
-                ]
-            ]
-        ]
-
--- Compaction now receives the same validated request state as live sessions.
-testRequestState :: ResponseCreateParams -> IO SessionRequestState
-testRequestState params =
-    newSessionRequestState PersistenceDisabled
-        (case params.model of
-            Nothing -> params { model = Just "gpt-5.6-sol" }
-            Just _ -> params)
-        >>= either (fail . Text.unpack) pure

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec/Fixtures.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec/Fixtures.hs
@@ -1,0 +1,165 @@
+-- | Response fixtures shared by manual, automatic, and task-plan compaction.
+module Agent.CLI.CompactionSpec.Fixtures
+    ( responseItemHasTaskPlan
+    , taskPlanMessage
+    , responseMessageHasText
+    , responseMessageTexts
+    , successful
+    , requestItems
+    , remoteCompactionResponse
+    , responseWithoutCompaction
+    , responseWithOutput
+    , decodeResponseFixture
+    , compactionUsage
+    , withModel
+    , summaryResponse
+    , summaryResponseWithStatus
+    , testRequestState
+    ) where
+
+import Agent.CLI.Session.Request (SessionRequestState, newSessionRequestState)
+import Agent.CLI.Session (Persistence(..))
+import Agent.Error (ApiError)
+import Agent.Json.Decode qualified as Hermes
+import Agent.Loop
+import Agent.Responses.Types
+import Agent.Tools.TaskPlan (isTaskPlanContextText)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.=))
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+responseItemHasTaskPlan :: ResponseItem -> Bool
+responseItemHasTaskPlan = \case
+    MessageItem message ->
+        any isTaskPlanContextText (responseMessageTexts message)
+    _ -> False
+
+taskPlanMessage :: ResponseRole -> Text -> ResponseItem
+taskPlanMessage role text =
+    MessageItem ResponseMessage
+        { messageId = Nothing
+        , content = MessageContentParts [InputTextPart text Nothing]
+        , role = role
+        , status = Nothing
+        , phase = Nothing
+        , passthrough = Nothing
+        }
+
+responseMessageHasText :: Text -> ResponseMessage -> Bool
+responseMessageHasText expected =
+    elem expected . responseMessageTexts
+
+responseMessageTexts :: ResponseMessage -> [Text]
+responseMessageTexts message =
+    case message.content of
+        MessageContentText text -> [text]
+        MessageContentParts parts ->
+            [ text
+            | part <- parts
+            , text <- case part of
+                InputTextPart{text} -> [text]
+                OutputTextPart{text} -> [text]
+                PlainTextPart{text} -> [text]
+                _ -> []
+            ]
+
+successful
+    :: BackendSnapshot
+    -> TurnOutput
+    -> Either ApiError BackendResult
+successful state output =
+    Right BackendResult
+        { backendOutput = output
+        , backendState = state
+        }
+
+requestItems :: ResponseCreateParams -> [ResponseItem]
+requestItems request = case request.input of
+    Just (ResponseInputItems items) -> items
+    _ -> []
+
+remoteCompactionResponse :: Response
+remoteCompactionResponse =
+    responseWithOutput
+        [ Aeson.object
+            [ "type" .= ("compaction" :: Text)
+            , "encrypted_content" .= ("opaque" :: Text)
+            ]
+        ]
+
+responseWithoutCompaction :: Response
+responseWithoutCompaction =
+    responseWithOutput []
+
+responseWithOutput :: [Aeson.Value] -> Response
+responseWithOutput output =
+    decodeResponseFixture $ Aeson.object
+        [ "id" .= ("resp-compact" :: Text)
+        , "created_at" .= (0 :: Int)
+        , "status" .= ("completed" :: Text)
+        , "model" .= ("gpt-test" :: Text)
+        , "output" .= output
+        , "usage" .= Aeson.object
+            [ "input_tokens" .= compactionUsage.inputTokens
+            , "output_tokens" .= compactionUsage.outputTokens
+            , "total_tokens" .=
+                (compactionUsage.inputTokens + compactionUsage.outputTokens)
+            , "input_tokens_details" .= Aeson.object
+                [ "cached_tokens" .= compactionUsage.cachedTokens
+                ]
+            ]
+        ]
+
+decodeResponseFixture :: Aeson.Value -> Response
+decodeResponseFixture fixture =
+    case Hermes.decodeEither responseDecoder
+            (LBS.toStrict (Aeson.encode fixture)) of
+        Right response -> response
+        Left err -> error (Text.unpack (Hermes.jsonErrorMessage err))
+
+compactionUsage :: TokenUsage
+compactionUsage = TokenUsage
+    { inputTokens = 80
+    , outputTokens = 6
+    , cachedTokens = 40
+    }
+
+withModel :: Maybe Text -> ResponseCreateParams -> ResponseCreateParams
+withModel nextModel ResponseCreateParams { model = _, .. } =
+    ResponseCreateParams { model = nextModel, .. }
+
+summaryResponse :: Text -> Response
+summaryResponse summary =
+    summaryResponseWithStatus "completed" summary
+
+summaryResponseWithStatus :: Text -> Text -> Response
+summaryResponseWithStatus responseStatus summary =
+    decodeResponseFixture $ Aeson.object
+        [ "id" .= ("resp-summary" :: Text)
+        , "created_at" .= (0 :: Int)
+        , "status" .= responseStatus
+        , "model" .= ("gpt-test" :: Text)
+        , "output" .=
+            [ Aeson.object
+                [ "type" .= ("message" :: Text)
+                , "role" .= ("assistant" :: Text)
+                , "content" .=
+                    [ Aeson.object
+                        [ "type" .= ("output_text" :: Text)
+                        , "text" .= summary
+                        ]
+                    ]
+                ]
+            ]
+        ]
+
+-- Compaction now receives the same validated request state as live sessions.
+testRequestState :: ResponseCreateParams -> IO SessionRequestState
+testRequestState params =
+    newSessionRequestState PersistenceDisabled
+        (case params.model of
+            Nothing -> params { model = Just "gpt-5.6-sol" }
+            Just _ -> params)
+        >>= either (fail . Text.unpack) pure

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec/ManualOpenAI.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec/ManualOpenAI.hs
@@ -1,0 +1,175 @@
+module Agent.CLI.CompactionSpec.ManualOpenAI (spec) where
+
+import Agent.CLI.Compaction (CompactOutcome(..), compactOpenAIWith)
+import Agent.CLI.CompactionSpec.Fixtures
+import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.OpenAI.Compaction
+    ( assistantSummaryItem, compactionTriggerItem, hasCompactionCheckpoint
+    , userTextItem )
+import Agent.OpenAI.ModelMetadata (codexEffectiveContextWindowFor)
+import Agent.Provider (BillingMode(..), tokenProvider)
+import Agent.Responses.Types
+import Control.Monad.Trans.Except (runExceptT)
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.=))
+import Data.IORef
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "compactOpenAIWith" do
+        it "uses remote compaction v2 on normal Responses" do
+            requests <- newIORef []
+            let provider = tokenProvider SubscriptionBilled \_ ->
+                    error "remote compaction unexpectedly requested credentials"
+                send _ request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right remoteCompactionResponse)
+                history = [userTextItem "old context"]
+                params = defaultResponseCreateParams
+                    { instructions = Just "keep these instructions"
+                    , tools = Just []
+                    , stream = Just False
+                    }
+            result <- runExceptT $
+                compactOpenAIWith send
+                    (Just provider)
+                    params
+                    history
+                    100
+                    Nothing
+            case result of
+                Left err -> expectationFailure (show err)
+                Right outcome -> do
+                    outcome.compactSummary
+                        `shouldBe` "Context compacted remotely."
+                    outcome.compactHistory
+                        `shouldSatisfy` hasCompactionCheckpoint
+            seen <- readIORef requests
+            length seen `shouldBe` 1
+            map (.instructions) seen `shouldBe` [Just "keep these instructions"]
+            map (.tools) seen `shouldBe` [Just []]
+            map (.parallelToolCalls) seen `shouldBe` [Just True]
+            map (.previousResponseId) seen `shouldBe` [Nothing]
+            map (.store) seen `shouldBe` [Just False]
+            map (.stream) seen `shouldBe` [Just True]
+            map (.toolChoice) seen
+                `shouldBe` [Just (ToolChoiceMode ToolChoiceAuto)]
+            map requestItems seen
+                `shouldBe` [history <> [compactionTriggerItem]]
+
+        it "disables parallel tool calls for Responses Lite remote compaction" do
+            requests <- newIORef []
+            let provider = tokenProvider SubscriptionBilled \_ ->
+                    error "remote compaction unexpectedly requested credentials"
+                send _ request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right remoteCompactionResponse)
+                history = [userTextItem "old context"]
+                params = defaultResponseCreateParams
+                    { model = Just "gpt-5.6-sol"
+                    , instructions = Just "keep these instructions"
+                    , store = Just True
+                    , tools = Just []
+                    }
+            result <- runExceptT $
+                compactOpenAIWith send
+                    (Just provider)
+                    params
+                    history
+                    100
+                    Nothing
+            case result of
+                Left err -> expectationFailure (show err)
+                Right outcome ->
+                    outcome.compactSummary
+                        `shouldBe` "Context compacted remotely."
+            map (.parallelToolCalls) <$> readIORef requests
+                `shouldReturn` [Just False]
+
+        it "rejects remote checkpoints that cannot fit the installed snapshot" do
+            let provider = tokenProvider SubscriptionBilled \_ ->
+                    error "remote compaction unexpectedly requested credentials"
+                contextWindow =
+                    codexEffectiveContextWindowFor
+                        defaultResponseCreateParams.model
+                oversizedResponse =
+                    responseWithOutput
+                        [ Aeson.object
+                            [ "type" .= ("compaction" :: Text)
+                            , "encrypted_content" .=
+                                Text.replicate (contextWindow * 4 + 10_000) "x"
+                            ]
+                        ]
+                send _ _ = pure (Right oversizedResponse)
+                history = [userTextItem "old context"]
+            result <- runExceptT $
+                compactOpenAIWith send
+                    (Just provider)
+                    defaultResponseCreateParams
+                    history
+                    100
+                    Nothing
+            result `shouldSatisfy` \case
+                Left message ->
+                    "remote compacted snapshot request cannot fit"
+                        `Text.isInfixOf` message
+                Right _ -> False
+
+        it "keeps focused manual compaction on local summarization" do
+            requests <- newIORef []
+            let provider = tokenProvider SubscriptionBilled \_ ->
+                    error "local summarization unexpectedly requested credentials"
+                send _ request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right (summaryResponse "local summary"))
+                history = [userTextItem "old context"]
+            result <- runExceptT $
+                compactOpenAIWith send
+                    (Just provider)
+                    defaultResponseCreateParams
+                    history
+                    100
+                    (Just "focus on auth")
+            case result of
+                Left err -> expectationFailure (show err)
+                Right outcome -> do
+                    outcome.compactSummary `shouldBe` "local summary"
+                    outcome.compactHistory
+                        `shouldBe`
+                            [ userTextItem "old context"
+                            , assistantSummaryItem "local summary"
+                            ]
+            seen <- readIORef requests
+            map (.tools) seen `shouldBe` [Nothing]
+            map (.parallelToolCalls) seen `shouldBe` [Just False]
+            map (.stream) seen `shouldBe` [Just True]
+
+        it "returns friendly provider errors from manual compaction" do
+            let provider = tokenProvider SubscriptionBilled \_ ->
+                    error "compaction unexpectedly requested credentials"
+                send _ _ =
+                    pure $ Left $
+                        ProviderError UsageLimitReached
+                            "quota exhausted"
+                            (Just 120)
+                history = [userTextItem "old context"]
+            result <- runExceptT $
+                compactOpenAIWith send
+                    (Just provider)
+                    defaultResponseCreateParams
+                    history
+                    100
+                    Nothing
+            case result of
+                Left err -> do
+                    err `shouldSatisfy`
+                        Text.isInfixOf "Usage limit reached"
+                    err `shouldSatisfy`
+                        Text.isInfixOf "Try again in 2m"
+                    err `shouldNotSatisfy`
+                        Text.isInfixOf "ProviderError"
+                Right _ ->
+                    expectationFailure "expected compaction to fail"

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec/TaskPlan.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec/TaskPlan.hs
@@ -1,0 +1,164 @@
+module Agent.CLI.CompactionSpec.TaskPlan (spec) where
+
+import Agent.CLI.Compaction
+    ( CompactOutcome(..)
+    , decorateCompactOutcomeWithTaskPlan
+    , decorateCompactOutcomeWithTaskPlanWithin
+    , runProviderCompactWith
+    )
+import Agent.CLI.CompactionSpec.Fixtures
+import Agent.OpenAI.Compaction
+    ( compactionTriggerItem, estimateRequestTokensWithItems
+    , summarizationPrompt, userTextItem )
+import Agent.Provider (Provider(..))
+import Agent.Responses.Types
+import Agent.Tools.TaskPlan
+import Data.IORef
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "task-plan compaction context" do
+        it "removes generated task plans before remote compaction" do
+            let stale =
+                    taskPlanContextText $
+                        CurrentTaskPlan 8 $
+                            TaskPlan Nothing
+                                [TaskPlanItem "stale" TaskPlanInProgress]
+                history =
+                    [ taskPlanMessage RoleDeveloper stale
+                    , userTextItem stale
+                    , userTextItem "retained"
+                    ]
+            params <- testRequestState defaultResponseCreateParams
+            transcript <- newIORef history
+            requests <- newIORef []
+            result <-
+                runProviderCompactWith
+                    (Just \request -> do
+                        modifyIORef' requests (<> [request])
+                        pure (Right remoteCompactionResponse))
+                    (const (pure ()))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    Nothing
+            result `shouldSatisfy` either (const False) (const True)
+            map requestItems <$> readIORef requests
+                `shouldReturn`
+                    [ [ userTextItem "retained"
+                      , compactionTriggerItem
+                      ]
+                    ]
+
+        it "removes generated task plans before local summarization" do
+            let stale =
+                    taskPlanContextText $
+                        CurrentTaskPlan 8 $
+                            TaskPlan Nothing
+                                [TaskPlanItem "stale" TaskPlanInProgress]
+                history =
+                    [ taskPlanMessage RoleDeveloper stale
+                    , userTextItem stale
+                    , userTextItem "retained"
+                    ]
+                focus = Just "focus on the remaining work"
+            params <- testRequestState defaultResponseCreateParams
+            transcript <- newIORef history
+            requests <- newIORef []
+            result <-
+                runProviderCompactWith
+                    (Just \request -> do
+                        modifyIORef' requests (<> [request])
+                        pure (Right (summaryResponse "local summary")))
+                    (const (pure ()))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    focus
+            result `shouldSatisfy` either (const False) (const True)
+            map requestItems <$> readIORef requests
+                `shouldReturn`
+                    [ [ userTextItem "retained"
+                      , userTextItem (summarizationPrompt focus)
+                      ]
+                    ]
+
+        it "replaces stale generated copies from authoritative state" do
+            let stale =
+                    taskPlanContextText $
+                        CurrentTaskPlan 8 $
+                            TaskPlan Nothing
+                                [TaskPlanItem "stale" TaskPlanPending]
+                plan = TaskPlan
+                    (Just "continue here")
+                    [TaskPlanItem "current" TaskPlanInProgress]
+                current = CurrentTaskPlan 1 plan
+                outcome = CompactOutcome
+                    { compactBeforeTokens = 20
+                    , compactAfterTokens = 10
+                    , compactHistory =
+                        [userTextItem stale, userTextItem "retained"]
+                    , compactSummary = "summary"
+                    }
+            env <- newTaskPlanEnv Nothing Nothing
+            replaceTaskPlan env plan `shouldReturn` Right current
+            decorated <-
+                decorateCompactOutcomeWithTaskPlan (Just env) outcome
+            filter responseItemHasTaskPlan decorated.compactHistory
+                `shouldSatisfy` \case
+                    [MessageItem message] ->
+                        message.role == RoleDeveloper
+                            && responseMessageHasText
+                                (taskPlanContextText current)
+                                message
+                    _ -> False
+
+        it "does not reconstruct a plan from pre-compaction history" do
+            let stale =
+                    taskPlanContextText $
+                        CurrentTaskPlan 8 $
+                            TaskPlan Nothing
+                                [TaskPlanItem "stale" TaskPlanInProgress]
+                outcome = CompactOutcome
+                    { compactBeforeTokens = 20
+                    , compactAfterTokens = 10
+                    , compactHistory =
+                        [userTextItem stale, userTextItem "retained"]
+                    , compactSummary = "summary"
+                    }
+            env <- newTaskPlanEnv Nothing Nothing
+            decorated <-
+                decorateCompactOutcomeWithTaskPlan (Just env) outcome
+            decorated.compactHistory
+                `shouldBe` [userTextItem "retained"]
+
+        it "rejects a generated plan that cannot fit the compacted request" do
+            let plan = TaskPlan Nothing
+                    [TaskPlanItem "current" TaskPlanInProgress]
+                outcome = CompactOutcome
+                    { compactBeforeTokens = 20
+                    , compactAfterTokens = 1
+                    , compactHistory = []
+                    , compactSummary = "summary"
+                    }
+                rawLimit =
+                    estimateRequestTokensWithItems
+                        defaultResponseCreateParams
+                        outcome.compactHistory
+            env <- newTaskPlanEnv Nothing Nothing
+            _ <- replaceTaskPlan env plan
+            result <-
+                decorateCompactOutcomeWithTaskPlanWithin
+                    rawLimit
+                    defaultResponseCreateParams
+                    (Just env)
+                    outcome
+            result `shouldSatisfy` \case
+                Left message ->
+                    "authoritative task plan does not fit"
+                        `Text.isInfixOf` message
+                Right _ -> False

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1,5 +1,7 @@
 module Agent.CLI.TUIAppSpec (spec) where
 
+import Agent.CLI.TUIAppSpec.AgentFixtures
+import qualified Agent.CLI.TUIAppSpec.Motion as Motion
 import Agent.CLI.AgentViewport
     ( AgentEntry(..)
     , AgentStep(..)
@@ -20,21 +22,17 @@ import Agent.CLI.TUI.App
     ( applyStoredFullscreenWindowTitle
     , applyMetaConsoleEdit
     , applyTextPromptEdit
-    , advanceCompletionFlashes
     , adjustChoiceValue
     , agentEntryWindow
     , agentPaneEntryLimit
     , agentPaneVisible
     , backgroundActivityText
     , cacheableBlock
-    , completionFlashTransitions
-    , completionRequiresRedraw
     , conversationScrollbarRenderer
     , choiceRowColumns
     , drawApp
     , filterChoiceRowLimit
     , choiceClosesOnUiTransition
-    , elapsedMillisSince
     , externalUrlCommand
     , launchExternalUrlCommand
     , fullscreenBounds
@@ -50,9 +48,6 @@ import Agent.CLI.TUI.App
     , withTrackedVtyBuilder
     , wrapFullscreenKeyboardVty
     , wrapMarkdownLinkCursorVty
-    , motionDemandFor
-    , motionDemandForTerminalFocus
-    , motionModeForTerminalFocus
     , lambdaArtWidget
     , quickStartCardHeight
     , quickStartRows
@@ -61,8 +56,6 @@ import Agent.CLI.TUI.App
     , quickStartCardWidth
     , drawQuickStartCard
     , startupCapabilityLines
-    , nativeProgressKeepaliveDue
-    , nextMotionSchedule
     , onboardingVisibleRowIndices
     , maskedSecretText
     , normalizeTextOverlayInsertion
@@ -73,8 +66,6 @@ import Agent.CLI.TUI.App
     , syntaxLanguagesForBlocks
     , textOverlayDisplayText
     , toolImageBlockId
-    , turnCompletionRequiresRedraw
-    , uiEventRestartsMotionSchedule
     )
 import Agent.CLI.WindowTitle (oscWindowTitleBytes)
 import Agent.CLI.TUI.Types
@@ -97,7 +88,6 @@ import Agent.CLI.TUI.Types
     , MetaConsoleOverlay(..)
     , Name(..)
     , ResumeOverlay(..)
-    , TerminalFocus(..)
     , TextInputMode(..)
     , TextOverlay(..)
     )
@@ -1830,352 +1820,7 @@ spec = do
             timeout 2_000_000 unfocusedStreamingRefreshesOnMotionTick
                 `shouldReturn` Just True
 
-    describe "motion demand" do
-        it "distinguishes foreground, waiting, background, and static modes" do
-            let idle =
-                    reduceUi
-                        (UiUserSubmitted "done")
-                        initialUiState
-                running =
-                    reduceUi (UiLoop TurnStarted) idle
-            motionDemandFor MotionFull False False False running
-                `shouldBe` MotionFast
-            motionDemandFor MotionFull True False False running
-                `shouldBe` MotionSlow
-            motionDemandFor MotionFull False True False idle
-                `shouldBe` MotionSlow
-            motionDemandFor MotionFull False False False idle
-                `shouldBe` MotionNone
-            motionDemandFor MotionFull False False False initialUiState
-                `shouldBe` MotionSlow
-            motionDemandFor MotionReduced False False False initialUiState
-                `shouldBe` MotionNone
-            motionDemandFor MotionReduced False False False running
-                `shouldBe` MotionSlow
-            motionDemandFor MotionOff False False False running
-                `shouldBe` MotionSlow
-
-        it "keeps semantic countdown updates active in every motion mode" do
-            let countdown =
-                    reduceUi
-                        (UiRetryCountdown
-                            "Provider unavailable.\n"
-                            60000
-                            ", or choose another provider.")
-                        initialUiState
-            motionDemandFor MotionFull False False False countdown
-                `shouldBe` MotionSlow
-            motionDemandFor MotionReduced False False False countdown
-                `shouldBe` MotionSlow
-            motionDemandFor MotionOff False False False countdown
-                `shouldBe` MotionSlow
-
-        it "suppresses cosmetic motion and slows cadence while unfocused" do
-            let idle =
-                    reduceUi
-                        (UiUserSubmitted "done")
-                        initialUiState
-                running =
-                    reduceUi (UiLoop TurnStarted) idle
-            motionDemandForTerminalFocus
-                TerminalFocused
-                MotionFull
-                False
-                False
-                False
-                running
-                `shouldBe` MotionFast
-            motionDemandForTerminalFocus
-                TerminalUnfocused
-                MotionFull
-                False
-                True
-                True
-                idle
-                `shouldBe` MotionNone
-            motionDemandForTerminalFocus
-                TerminalUnfocused
-                MotionFull
-                False
-                False
-                False
-                running
-                `shouldBe` MotionSlow
-            motionModeForTerminalFocus TerminalFocused MotionFull
-                `shouldBe` MotionFull
-            motionModeForTerminalFocus TerminalFocusUnknown MotionReduced
-                `shouldBe` MotionReduced
-            motionModeForTerminalFocus TerminalUnfocused MotionFull
-                `shouldBe` MotionOff
-
-        it "bumps the scheduler generation on demand or timer boundaries" do
-            nextMotionSchedule
-                False
-                MotionSlow
-                160000
-                (MotionSlow, 160000, 4)
-                `shouldBe` (MotionSlow, 160000, 4)
-            nextMotionSchedule
-                True
-                MotionSlow
-                160000
-                (MotionSlow, 160000, 4)
-                `shouldBe` (MotionSlow, 160000, 5)
-            nextMotionSchedule
-                False
-                MotionFast
-                80000
-                (MotionSlow, 160000, 4)
-                `shouldBe` (MotionFast, 80000, 5)
-            nextMotionSchedule
-                False
-                MotionSlow
-                400000
-                (MotionSlow, 500000, 4)
-                `shouldBe` (MotionSlow, 400000, 5)
-
-        it "requests one unfocused redraw when a running turn becomes idle" do
-            let running = reduceUi (UiLoop TurnStarted) initialUiState
-                finished =
-                    reduceUi
-                        (UiLoop
-                            (TurnFinished
-                                (emptyTurnOutput "response-1" [] Nothing)))
-                        running
-                continuing =
-                    reduceUi
-                        (UiLoop
-                            (TurnFinished
-                                (emptyTurnOutput
-                                    "response-1"
-                                    [functionToolCall "call-1" "read_file" "{}"]
-                                    Nothing)))
-                        running
-            turnCompletionRequiresRedraw running finished `shouldBe` True
-            turnCompletionRequiresRedraw running continuing `shouldBe` False
-            turnCompletionRequiresRedraw finished finished `shouldBe` False
-
-        it "requests an unfocused redraw when any child agent finishes" do
-            let runningChild = childEntry 1
-                sibling = childEntry 2
-                finishedChild =
-                    runningChild { agentStatus = "completed" }
-                stillStreaming =
-                    runningChild
-                        { agentTranscript = ["assistant: still working"] }
-            completionRequiresRedraw
-                initialUiState
-                [rootEntry, runningChild, sibling]
-                initialUiState
-                [rootEntry, finishedChild, sibling]
-                `shouldBe` True
-            completionRequiresRedraw
-                initialUiState
-                [rootEntry, runningChild, sibling]
-                initialUiState
-                [rootEntry, stillStreaming, sibling]
-                `shouldBe` False
-            completionRequiresRedraw
-                initialUiState
-                [rootEntry, runningChild, sibling]
-                initialUiState
-                [rootEntry, sibling]
-                `shouldBe` True
-
-        it "retains sub-millisecond time across clock samples" do
-            elapsedMillisSince 1000000 1499999
-                `shouldBe` (0, 1000000)
-            elapsedMillisSince 1234567 3234999
-                `shouldBe` (2, 3234567)
-            elapsedMillisSince 4000000 3000000
-                `shouldBe` (0, 4000000)
-
-        it "restarts cadence when turn, notice, and promoted-input timers start" do
-            let idle =
-                    reduceUi
-                        (UiUserSubmitted "done")
-                        initialUiState
-                turnStarted =
-                    reduceUi (UiLoop TurnStarted) idle
-                turnFinished =
-                    reduceUi
-                        (UiLoop
-                            (TurnFinished
-                                (emptyTurnOutput
-                                    "response-1"
-                                    []
-                                    Nothing)))
-                        turnStarted
-                notice =
-                    reduceUi
-                        (UiSetNotice
-                            (Just (successNotice "saved")))
-                        idle
-                warning =
-                    reduceUi
-                        (UiLoop (WarningRaised "Codex usage is low"))
-                        turnStarted
-                promoted =
-                    reduceUi (UiInputPromoted "urgent") turnStarted
-            uiEventRestartsMotionSchedule
-                (UiLoop TurnStarted)
-                idle
-                turnStarted
-                Map.empty
-                `shouldBe` True
-            uiEventRestartsMotionSchedule
-                (UiLoop
-                    (TurnFinished
-                        (emptyTurnOutput "response-1" [] Nothing)))
-                turnStarted
-                turnFinished
-                Map.empty
-                `shouldBe` True
-            uiEventRestartsMotionSchedule
-                (UiSetNotice (Just (successNotice "saved")))
-                idle
-                notice
-                Map.empty
-                `shouldBe` True
-            uiEventRestartsMotionSchedule
-                (UiLoop (WarningRaised "Codex usage is low"))
-                turnStarted
-                warning
-                Map.empty
-                `shouldBe` True
-            uiEventRestartsMotionSchedule
-                (UiInputPromoted "urgent")
-                turnStarted
-                promoted
-                Map.empty
-                `shouldBe` True
-            uiEventRestartsMotionSchedule
-                (UiLoop (ActivityUpdated "still working"))
-                turnStarted
-                (reduceUi
-                    (UiLoop (ActivityUpdated "still working"))
-                    turnStarted)
-                Map.empty
-                `shouldBe` False
-
-        it "refreshes native progress only after each five-second bucket" do
-            let running =
-                    advanceUiTime 5000 $
-                        reduceUi (UiLoop TurnStarted) initialUiState
-            nativeProgressKeepaliveDue False 0 running
-                `shouldBe` True
-            nativeProgressKeepaliveDue False 1 running
-                `shouldBe` False
-            nativeProgressKeepaliveDue True 0 running
-                `shouldBe` False
-
-        it "self-schedules completion flashes but disables them in off mode" do
-            let idle =
-                    reduceUi
-                        (UiUserSubmitted "done")
-                        initialUiState
-            motionDemandFor MotionFull False False True idle
-                `shouldBe` MotionFast
-            motionDemandFor MotionReduced False False True idle
-                `shouldBe` MotionSlow
-            motionDemandFor MotionOff False False True idle
-                `shouldBe` MotionNone
-
-    describe "completion flashes" do
-        it "detects only live-to-terminal block transitions" do
-            let call =
-                    functionToolCall
-                        "tool-1"
-                        "run_terminal_cmd"
-                        "{\"command\":\"true\"}"
-                running =
-                    reduceUi
-                        (UiLoop (ToolStarted call))
-                        (reduceUi (UiLoop TurnStarted) initialUiState)
-                completed =
-                    reduceUi
-                        (UiLoop
-                            (ToolFinished
-                                ToolCallResult
-                                    { callId = "tool-1"
-                                    , output = "exit: 0"
-                                    , callKind = FunctionCallKind
-                                    }))
-                        running
-            completionFlashTransitions running completed
-                `shouldBe` [BlockId 1]
-            completionFlashTransitions completed completed
-                `shouldBe` []
-
-        it "does not schedule completion flashes for inspection blocks" do
-            let call =
-                    functionToolCall
-                        "inspect-1"
-                        "read_file"
-                        "{\"target_file\":\"README.md\"}"
-                running =
-                    reduceUi
-                        (UiLoop (ToolStarted call))
-                        (reduceUi (UiLoop TurnStarted) initialUiState)
-                completed =
-                    reduceUi
-                        (UiLoop
-                            (ToolFinished
-                                ToolCallResult
-                                    { callId = "inspect-1"
-                                    , output = "contents"
-                                    , callKind = FunctionCallKind
-                                    }))
-                        running
-            completionFlashTransitions running completed
-                `shouldBe` []
-
-        it "ignores assistant streams and unsuccessful terminal states" do
-            let assistantRunning =
-                    reduceUi
-                        (UiLoop (TextDelta "answer"))
-                        (reduceUi (UiLoop TurnStarted) initialUiState)
-                assistantComplete =
-                    reduceUi
-                        (UiLoop
-                            (TurnFinished
-                                (emptyTurnOutput
-                                    "response-1"
-                                    []
-                                    (Just "answer"))))
-                        assistantRunning
-                call =
-                    functionToolCall
-                        "tool-2"
-                        "run_terminal_cmd"
-                        "{\"command\":\"false\"}"
-                toolRunning =
-                    reduceUi
-                        (UiLoop (ToolStarted call))
-                        (reduceUi (UiLoop TurnStarted) initialUiState)
-                toolFailed =
-                    reduceUi
-                        (UiLoop
-                            (ToolFinished
-                                ToolCallResult
-                                    { callId = "tool-2"
-                                    , output = "Error: failed"
-                                    , callKind = FunctionCallKind
-                                    }))
-                        toolRunning
-            completionFlashTransitions
-                assistantRunning
-                assistantComplete
-                `shouldBe` []
-            completionFlashTransitions toolRunning toolFailed
-                `shouldBe` []
-
-        it "expires completion flashes from elapsed milliseconds" do
-            let active = Map.singleton (BlockId 7) 400
-            advanceCompletionFlashes 399 active
-                `shouldBe` Map.singleton (BlockId 7) 1
-            advanceCompletionFlashes 400 active
-                `shouldBe` Map.empty
+    Motion.spec
 
 data FullscreenScriptEvent
     = FullscreenScriptApp !AppEvent
@@ -2911,28 +2556,3 @@ textOverlay draft cursor = TextOverlay
     , textCursor = cursor
     , textInputMode = TextInputPlain
     }
-
-rootEntry :: AgentEntry
-rootEntry = AgentEntry
-    { agentTarget = AgentRoot
-    , agentPath = "/root"
-    , agentStatus = "active"
-    , agentModel = Nothing
-    , agentSteps = []
-    , agentTranscript = []
-    , agentConversation = initialUiState
-    }
-
-childEntry :: Int -> AgentEntry
-childEntry index = AgentEntry
-    { agentTarget = AgentChild (SubagentId name)
-    , agentPath = "/root/" <> name
-    , agentStatus = "running"
-    , agentModel = Just "gpt-5.6-luna"
-    , agentSteps = []
-    , agentTranscript = []
-    , agentConversation = initialUiState
-    }
-  where
-    name :: Text
-    name = "agent-" <> Text.pack (show index)

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec/AgentFixtures.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec/AgentFixtures.hs
@@ -1,0 +1,32 @@
+module Agent.CLI.TUIAppSpec.AgentFixtures (rootEntry, childEntry) where
+
+import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.Subagents (SubagentId(..))
+import Agent.TUI.Model (initialUiState)
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+rootEntry :: AgentEntry
+rootEntry = AgentEntry
+    { agentTarget = AgentRoot
+    , agentPath = "/root"
+    , agentStatus = "active"
+    , agentModel = Nothing
+    , agentSteps = []
+    , agentTranscript = []
+    , agentConversation = initialUiState
+    }
+
+childEntry :: Int -> AgentEntry
+childEntry index = AgentEntry
+    { agentTarget = AgentChild (SubagentId name)
+    , agentPath = "/root/" <> name
+    , agentStatus = "running"
+    , agentModel = Just "gpt-5.6-luna"
+    , agentSteps = []
+    , agentTranscript = []
+    , agentConversation = initialUiState
+    }
+  where
+    name :: Text
+    name = "agent-" <> Text.pack (show index)

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec/Motion.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec/Motion.hs
@@ -1,0 +1,373 @@
+module Agent.CLI.TUIAppSpec.Motion (spec) where
+
+import Agent.CLI.AgentViewport (AgentEntry(..))
+import Agent.CLI.TUIAppSpec.AgentFixtures
+import Agent.CLI.TUI.App
+    ( advanceCompletionFlashes
+    , completionFlashTransitions
+    , completionRequiresRedraw
+    , elapsedMillisSince
+    , motionDemandFor
+    , motionDemandForTerminalFocus
+    , motionModeForTerminalFocus
+    , nativeProgressKeepaliveDue
+    , nextMotionSchedule
+    , turnCompletionRequiresRedraw
+    , uiEventRestartsMotionSchedule
+    )
+import Agent.CLI.TUI.Types (TerminalFocus(..))
+import Agent.Loop (LoopEvent(..), emptyTurnOutput)
+import Agent.ToolDispatch (ToolCallKind(..), ToolCallResult(..), functionToolCall)
+import Agent.TUI.Model
+import Agent.TUI.Motion
+import qualified Data.Map.Strict as Map
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "motion demand" do
+        it "distinguishes foreground, waiting, background, and static modes" do
+            let idle =
+                    reduceUi
+                        (UiUserSubmitted "done")
+                        initialUiState
+                running =
+                    reduceUi (UiLoop TurnStarted) idle
+            motionDemandFor MotionFull False False False running
+                `shouldBe` MotionFast
+            motionDemandFor MotionFull True False False running
+                `shouldBe` MotionSlow
+            motionDemandFor MotionFull False True False idle
+                `shouldBe` MotionSlow
+            motionDemandFor MotionFull False False False idle
+                `shouldBe` MotionNone
+            motionDemandFor MotionFull False False False initialUiState
+                `shouldBe` MotionSlow
+            motionDemandFor MotionReduced False False False initialUiState
+                `shouldBe` MotionNone
+            motionDemandFor MotionReduced False False False running
+                `shouldBe` MotionSlow
+            motionDemandFor MotionOff False False False running
+                `shouldBe` MotionSlow
+
+        it "keeps semantic countdown updates active in every motion mode" do
+            let countdown =
+                    reduceUi
+                        (UiRetryCountdown
+                            "Provider unavailable.\n"
+                            60000
+                            ", or choose another provider.")
+                        initialUiState
+            motionDemandFor MotionFull False False False countdown
+                `shouldBe` MotionSlow
+            motionDemandFor MotionReduced False False False countdown
+                `shouldBe` MotionSlow
+            motionDemandFor MotionOff False False False countdown
+                `shouldBe` MotionSlow
+
+        it "suppresses cosmetic motion and slows cadence while unfocused" do
+            let idle =
+                    reduceUi
+                        (UiUserSubmitted "done")
+                        initialUiState
+                running =
+                    reduceUi (UiLoop TurnStarted) idle
+            motionDemandForTerminalFocus
+                TerminalFocused
+                MotionFull
+                False
+                False
+                False
+                running
+                `shouldBe` MotionFast
+            motionDemandForTerminalFocus
+                TerminalUnfocused
+                MotionFull
+                False
+                True
+                True
+                idle
+                `shouldBe` MotionNone
+            motionDemandForTerminalFocus
+                TerminalUnfocused
+                MotionFull
+                False
+                False
+                False
+                running
+                `shouldBe` MotionSlow
+            motionModeForTerminalFocus TerminalFocused MotionFull
+                `shouldBe` MotionFull
+            motionModeForTerminalFocus TerminalFocusUnknown MotionReduced
+                `shouldBe` MotionReduced
+            motionModeForTerminalFocus TerminalUnfocused MotionFull
+                `shouldBe` MotionOff
+
+        it "bumps the scheduler generation on demand or timer boundaries" do
+            nextMotionSchedule
+                False
+                MotionSlow
+                160000
+                (MotionSlow, 160000, 4)
+                `shouldBe` (MotionSlow, 160000, 4)
+            nextMotionSchedule
+                True
+                MotionSlow
+                160000
+                (MotionSlow, 160000, 4)
+                `shouldBe` (MotionSlow, 160000, 5)
+            nextMotionSchedule
+                False
+                MotionFast
+                80000
+                (MotionSlow, 160000, 4)
+                `shouldBe` (MotionFast, 80000, 5)
+            nextMotionSchedule
+                False
+                MotionSlow
+                400000
+                (MotionSlow, 500000, 4)
+                `shouldBe` (MotionSlow, 400000, 5)
+
+        it "requests one unfocused redraw when a running turn becomes idle" do
+            let running = reduceUi (UiLoop TurnStarted) initialUiState
+                finished =
+                    reduceUi
+                        (UiLoop
+                            (TurnFinished
+                                (emptyTurnOutput "response-1" [] Nothing)))
+                        running
+                continuing =
+                    reduceUi
+                        (UiLoop
+                            (TurnFinished
+                                (emptyTurnOutput
+                                    "response-1"
+                                    [functionToolCall "call-1" "read_file" "{}"]
+                                    Nothing)))
+                        running
+            turnCompletionRequiresRedraw running finished `shouldBe` True
+            turnCompletionRequiresRedraw running continuing `shouldBe` False
+            turnCompletionRequiresRedraw finished finished `shouldBe` False
+
+        it "requests an unfocused redraw when any child agent finishes" do
+            let runningChild = childEntry 1
+                sibling = childEntry 2
+                finishedChild =
+                    runningChild { agentStatus = "completed" }
+                stillStreaming =
+                    runningChild
+                        { agentTranscript = ["assistant: still working"] }
+            completionRequiresRedraw
+                initialUiState
+                [rootEntry, runningChild, sibling]
+                initialUiState
+                [rootEntry, finishedChild, sibling]
+                `shouldBe` True
+            completionRequiresRedraw
+                initialUiState
+                [rootEntry, runningChild, sibling]
+                initialUiState
+                [rootEntry, stillStreaming, sibling]
+                `shouldBe` False
+            completionRequiresRedraw
+                initialUiState
+                [rootEntry, runningChild, sibling]
+                initialUiState
+                [rootEntry, sibling]
+                `shouldBe` True
+
+        it "retains sub-millisecond time across clock samples" do
+            elapsedMillisSince 1000000 1499999
+                `shouldBe` (0, 1000000)
+            elapsedMillisSince 1234567 3234999
+                `shouldBe` (2, 3234567)
+            elapsedMillisSince 4000000 3000000
+                `shouldBe` (0, 4000000)
+
+        it "restarts cadence when turn, notice, and promoted-input timers start" do
+            let idle =
+                    reduceUi
+                        (UiUserSubmitted "done")
+                        initialUiState
+                turnStarted =
+                    reduceUi (UiLoop TurnStarted) idle
+                turnFinished =
+                    reduceUi
+                        (UiLoop
+                            (TurnFinished
+                                (emptyTurnOutput
+                                    "response-1"
+                                    []
+                                    Nothing)))
+                        turnStarted
+                notice =
+                    reduceUi
+                        (UiSetNotice
+                            (Just (successNotice "saved")))
+                        idle
+                warning =
+                    reduceUi
+                        (UiLoop (WarningRaised "Codex usage is low"))
+                        turnStarted
+                promoted =
+                    reduceUi (UiInputPromoted "urgent") turnStarted
+            uiEventRestartsMotionSchedule
+                (UiLoop TurnStarted)
+                idle
+                turnStarted
+                Map.empty
+                `shouldBe` True
+            uiEventRestartsMotionSchedule
+                (UiLoop
+                    (TurnFinished
+                        (emptyTurnOutput "response-1" [] Nothing)))
+                turnStarted
+                turnFinished
+                Map.empty
+                `shouldBe` True
+            uiEventRestartsMotionSchedule
+                (UiSetNotice (Just (successNotice "saved")))
+                idle
+                notice
+                Map.empty
+                `shouldBe` True
+            uiEventRestartsMotionSchedule
+                (UiLoop (WarningRaised "Codex usage is low"))
+                turnStarted
+                warning
+                Map.empty
+                `shouldBe` True
+            uiEventRestartsMotionSchedule
+                (UiInputPromoted "urgent")
+                turnStarted
+                promoted
+                Map.empty
+                `shouldBe` True
+            uiEventRestartsMotionSchedule
+                (UiLoop (ActivityUpdated "still working"))
+                turnStarted
+                (reduceUi
+                    (UiLoop (ActivityUpdated "still working"))
+                    turnStarted)
+                Map.empty
+                `shouldBe` False
+
+        it "refreshes native progress only after each five-second bucket" do
+            let running =
+                    advanceUiTime 5000 $
+                        reduceUi (UiLoop TurnStarted) initialUiState
+            nativeProgressKeepaliveDue False 0 running
+                `shouldBe` True
+            nativeProgressKeepaliveDue False 1 running
+                `shouldBe` False
+            nativeProgressKeepaliveDue True 0 running
+                `shouldBe` False
+
+        it "self-schedules completion flashes but disables them in off mode" do
+            let idle =
+                    reduceUi
+                        (UiUserSubmitted "done")
+                        initialUiState
+            motionDemandFor MotionFull False False True idle
+                `shouldBe` MotionFast
+            motionDemandFor MotionReduced False False True idle
+                `shouldBe` MotionSlow
+            motionDemandFor MotionOff False False True idle
+                `shouldBe` MotionNone
+
+    describe "completion flashes" do
+        it "detects only live-to-terminal block transitions" do
+            let call =
+                    functionToolCall
+                        "tool-1"
+                        "run_terminal_cmd"
+                        "{\"command\":\"true\"}"
+                running =
+                    reduceUi
+                        (UiLoop (ToolStarted call))
+                        (reduceUi (UiLoop TurnStarted) initialUiState)
+                completed =
+                    reduceUi
+                        (UiLoop
+                            (ToolFinished
+                                ToolCallResult
+                                    { callId = "tool-1"
+                                    , output = "exit: 0"
+                                    , callKind = FunctionCallKind
+                                    }))
+                        running
+            completionFlashTransitions running completed
+                `shouldBe` [BlockId 1]
+            completionFlashTransitions completed completed
+                `shouldBe` []
+
+        it "does not schedule completion flashes for inspection blocks" do
+            let call =
+                    functionToolCall
+                        "inspect-1"
+                        "read_file"
+                        "{\"target_file\":\"README.md\"}"
+                running =
+                    reduceUi
+                        (UiLoop (ToolStarted call))
+                        (reduceUi (UiLoop TurnStarted) initialUiState)
+                completed =
+                    reduceUi
+                        (UiLoop
+                            (ToolFinished
+                                ToolCallResult
+                                    { callId = "inspect-1"
+                                    , output = "contents"
+                                    , callKind = FunctionCallKind
+                                    }))
+                        running
+            completionFlashTransitions running completed
+                `shouldBe` []
+
+        it "ignores assistant streams and unsuccessful terminal states" do
+            let assistantRunning =
+                    reduceUi
+                        (UiLoop (TextDelta "answer"))
+                        (reduceUi (UiLoop TurnStarted) initialUiState)
+                assistantComplete =
+                    reduceUi
+                        (UiLoop
+                            (TurnFinished
+                                (emptyTurnOutput
+                                    "response-1"
+                                    []
+                                    (Just "answer"))))
+                        assistantRunning
+                call =
+                    functionToolCall
+                        "tool-2"
+                        "run_terminal_cmd"
+                        "{\"command\":\"false\"}"
+                toolRunning =
+                    reduceUi
+                        (UiLoop (ToolStarted call))
+                        (reduceUi (UiLoop TurnStarted) initialUiState)
+                toolFailed =
+                    reduceUi
+                        (UiLoop
+                            (ToolFinished
+                                ToolCallResult
+                                    { callId = "tool-2"
+                                    , output = "Error: failed"
+                                    , callKind = FunctionCallKind
+                                    }))
+                        toolRunning
+            completionFlashTransitions
+                assistantRunning
+                assistantComplete
+                `shouldBe` []
+            completionFlashTransitions toolRunning toolFailed
+                `shouldBe` []
+
+        it "expires completion flashes from elapsed milliseconds" do
+            let active = Map.singleton (BlockId 7) 400
+            advanceCompletionFlashes 399 active
+                `shouldBe` Map.singleton (BlockId 7) 1
+            advanceCompletionFlashes 400 active
+                `shouldBe` Map.empty


### PR DESCRIPTION
## Summary
- Separate motion scheduling/completion-flash examples and small shared agent fixtures from TUIAppSpec (2,938 → 2,558 lines).
- Separate manual OpenAI compaction, task-plan compaction, and shared response/request fixtures from CompactionSpec (2,703 → 2,267 lines).
- Keep all existing example bodies, group labels, registration order, and runtime-script ownership unchanged. New test modules are 32–373 lines; no production behavior changes.

## Validation
- Object-code GHCi in the inherited Nix development shell: `GHCRTS=-M3G cabal repl --offline agent-cli:test:agent-cli-test -j2 --repl-options=-fobject-code`; `hspec Agent.CLI.TUIAppSpec.spec` and `hspec Agent.CLI.CompactionSpec.spec`: **123 + 66 examples, 0 failures** (repeated after final import cleanup).
- Reconstructed both spec bodies from the extracted modules and compared with the baseline: exact equality ignoring blank lines, preserving every example and its order.
- Regenerated package.nix with cabal2nix: unchanged.
- `git diff --check` passes.

This is a bounded first-pass test refactor alongside the production-module splits; remaining integration groups stay together rather than moving into a large catch-all module.