### PR TITLE
Share session workspace context and optimize history eviction

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -234,6 +234,7 @@ library
                     , Agent.CLI.Session.ConversationStore
                     , Agent.CLI.Session.History
                     , Agent.CLI.SessionAdmin
+                    , Agent.CLI.Session.Workspace
                     , Agent.CLI.SessionEnv
                     , Agent.CLI.SessionState
                     , Agent.CLI.SessionTitle
@@ -417,6 +418,21 @@ benchmark history-retention-bench
     ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
     build-depends:    agent-cli
                     , base >= 4.17 && < 5
+                    , text
+
+benchmark history-eviction-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    -- Compile the production algorithm and frozen baseline with identical
+    -- optimization, independently of the agent-cli library build settings.
+    hs-source-dirs:   benchmark, src
+    main-is:          HistoryEviction.hs
+    other-modules:    Agent.CLI.TUI.History
+                    , HistoryEvictionBaseline
+    ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-tui
+                    , base >= 4.17 && < 5
+                    , containers
                     , text
 
 benchmark concurrency-bench

--- a/packages/agent-cli/benchmark/HistoryEviction.hs
+++ b/packages/agent-cli/benchmark/HistoryEviction.hs
@@ -1,0 +1,214 @@
+{-# LANGUAGE BangPatterns #-}
+
+-- | End-to-end page merge, budget enforcement, index construction and output
+-- consumption. Both implementations are compiled in this component with -O2.
+module Main (main) where
+
+import Agent.CLI.TUI.History
+import Agent.TUI.Model (BlockId(..), BlockKind(..), BlockState(..), UiBlock(..))
+import Control.Exception (evaluate)
+import Control.Monad (forM, unless)
+import Data.IORef (newIORef, readIORef)
+import Data.List (sort)
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence as Seq
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import HistoryEvictionBaseline (applyHistoryPageBaseline)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Scenario = Turns | Blocks | Bytes | Append | Page | NoEviction
+    deriving (Eq)
+
+data Input = Input !HistoryPage !HistoryWindow
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Double
+    }
+
+type Apply = HistoryPage -> HistoryWindow -> Either HistoryPageRejection HistoryWindow
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    unless enabled (die "run with +RTS -T")
+    getArgs >>= \case
+        [mode, scenarioArg, countArg, sizeArg, samplesArg] -> do
+            apply <- case mode of
+                "old" -> pure applyHistoryPageBaseline
+                "new" -> pure applyHistoryPage
+                _ -> die "mode must be old or new"
+            scenario <- case scenarioArg of
+                "turns" -> pure Turns
+                "blocks" -> pure Blocks
+                "bytes" -> pure Bytes
+                "append" -> pure Append
+                "page" -> pure Page
+                "no-eviction" -> pure NoEviction
+                _ -> die "scenario must be turns, blocks, bytes, append, page or no-eviction"
+            count <- positive countArg
+            size <- positive sizeArg
+            samples <- positive samplesArg
+            -- Separate fixtures prevent this check from precomputing a timed result.
+            let validation = makeInputs scenario count size 0
+            unless (all equivalent validation) $
+                die "baseline/production results differ"
+            results <- forM [1 .. samples] (measure apply scenario count size)
+            printf "%s,%s,%d,%d,%d,%.6f,%.6f,%.0f\n"
+                mode scenarioArg count size samples
+                (middle (map (.elapsedMillis) results))
+                (middle (map (.cpuMillis) results))
+                (middle (map (.allocatedBytes) results))
+        _ -> die "usage: history-eviction-bench old|new SCENARIO TURNS BODY_BYTES SAMPLES"
+  where
+    equivalent (Input page window) =
+        applyHistoryPageBaseline page window == applyHistoryPage page window
+    middle values = sort values !! (length values `div` 2)
+    positive raw = case reads raw of
+        [(n, "")] | n > 0 -> pure n
+        _ -> die ("expected positive integer: " <> raw)
+
+measure :: Apply -> Scenario -> Int -> Int -> Int -> IO Sample
+measure apply scenario count size sample = do
+    let inputs = makeInputs scenario count size sample
+    -- Allocate and force all input payloads and existing indexes before timing.
+    _ <- evaluate (foldl' (\n input -> n + inputChecksum input) 0 inputs)
+    ref <- newIORef inputs
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    freshInputs <- readIORef ref
+    !checksum <- evaluate (runInputs apply freshInputs)
+    afterWall <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    -- Collect after stopping the clocks so RTS allocated_bytes includes the
+    -- unfinished nursery, without timing an artificial major collection.
+    performGC
+    afterStats <- getRTSStats
+    _ <- evaluate checksum
+    let operations = fromIntegral (length inputs)
+    pure Sample
+        { elapsedMillis = fromIntegral (afterWall - beforeWall) / 1e6 / operations
+        , cpuMillis = fromIntegral (afterCpu - beforeCpu) / 1e9 / operations
+        , allocatedBytes =
+            fromIntegral (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+                / operations
+        }
+
+{-# NOINLINE runInputs #-}
+runInputs :: Apply -> [Input] -> Int
+runInputs apply = foldl' step 0
+  where
+    step !n (Input page window) = case apply page window of
+        Left rejection -> error (show rejection)
+        Right result -> n + windowChecksum result
+
+-- Twenty independent operations per sample; alternating directions cover
+-- both edges. Append models a latest turn arriving into a full window.
+makeInputs :: Scenario -> Int -> Int -> Int -> [Input]
+makeInputs scenario count size sample =
+    [ makeInput operation | operation <- [1 .. 20] ]
+  where
+    makeInput operation =
+        let older = scenario /= Append && even operation
+            existingCount =
+                if scenario == Append || scenario == Page then count else min 120 count
+            incomingCount = case scenario of
+                Append -> 1
+                Page -> 30
+                _ -> count
+            total = existingCount + incomingCount
+            -- Start within budget, including the small-input cases.
+            keep = max existingCount (total `div` 4)
+            turns = Seq.fromList
+                [ makeTurn (sample * 20 + operation) size ident
+                | ident <- [1 .. total]
+                ]
+            (incoming, existing)
+                | older = Seq.splitAt incomingCount turns
+                | otherwise =
+                    let (old, new) = Seq.splitAt existingCount turns
+                    in (new, old)
+            maxTurns = case scenario of
+                Turns -> keep
+                Append -> count
+                Page -> count
+                _ -> total
+            maxBlocks = if scenario == Blocks then keep * 4 else total * 4
+            maxBytes =
+                if scenario == Bytes then keep * 4 * (114 + 2 * size) else maxBound
+            window =
+                setHistoryWindowTurns existing $
+                    emptyHistoryWindow (HistoryGeneration 1) maxTurns maxBlocks maxBytes
+            page = HistoryPage
+                { historyPageGeneration = HistoryGeneration 1
+                , historyPageDirection = if older then HistoryOlder else HistoryNewer
+                , historyPageTurns = incoming
+                , historyPageGenerationStart = HistoryCursor 1
+                , historyPageTotalTurns = fromIntegral total
+                , historyPageHasOlder = False
+                , historyPageHasNewer = False
+                }
+        in Input page window
+
+makeTurn :: Int -> Int -> Int -> HistoryTurn
+makeTurn salt size ident =
+    HistoryTurn
+        { historyTurnCursor = HistoryCursor (fromIntegral ident)
+        , historyTurnBlocks = Seq.fromList
+            [ UiBlock
+                { blockId = BlockId (ident * 4 + offset)
+                , blockKind = BlockAssistant
+                , blockTitle = "assistant"
+                , blockBody =
+                    Text.take size $
+                        Text.pack (show salt <> ":" <> show ident <> ":" <> show offset <> ":")
+                            <> Text.replicate size "x"
+                , blockState = BlockComplete
+                , blockExpanded = True
+                , blockInspectionGroupable = False
+                , blockCallId = Nothing
+                , blockTimestamp = ""
+                , blockDetail = ""
+                }
+            | offset <- [0 .. 3]
+            ]
+        }
+
+inputChecksum :: Input -> Int
+inputChecksum (Input page window) =
+    foldl' (\n turn -> n + turnChecksum turn) 0 page.historyPageTurns
+        + windowChecksum window
+
+windowChecksum :: HistoryWindow -> Int
+windowChecksum window =
+    foldl' (\n turn -> n + turnChecksum turn) 0 window.historyWindowTurns
+        + Map.foldl' (\n turn -> n + turnChecksum turn) 0 window.historyWindowTurnsByCursor
+        + Map.foldl' (\n block -> n + blockChecksum block) 0 window.historyWindowBlocksById
+        + Set.size window.historyWindowPending
+        + fromEnum window.historyWindowHasOlder
+        + fromEnum window.historyWindowHasNewer
+
+turnChecksum :: HistoryTurn -> Int
+turnChecksum turn =
+    let HistoryCursor cursor = turn.historyTurnCursor
+    in fromIntegral cursor + foldl' (\n block -> n + blockChecksum block) 0 turn.historyTurnBlocks
+
+blockChecksum :: UiBlock -> Int
+blockChecksum block =
+    let BlockId ident = block.blockId
+    in ident
+        + Text.length block.blockBody
+        + Text.length block.blockTitle
+        + Text.length block.blockTimestamp
+        + Text.length block.blockDetail
+        + maybe 0 Text.length block.blockCallId

--- a/packages/agent-cli/benchmark/HistoryEviction.md
+++ b/packages/agent-cli/benchmark/HistoryEviction.md
@@ -1,0 +1,67 @@
+# History eviction
+
+`HistoryEvictionBaseline.hs` preserves the original page-merge implementation.
+The benchmark compiles it and production `Agent.CLI.TUI.History` together with
+`-O2`, avoiding interpreted timings or different optimization settings.
+
+```sh
+nix develop
+cabal build --offline agent-cli:bench:history-eviction-bench
+bin=$(cabal list-bin agent-cli:bench:history-eviction-bench)
+for mode in old new; do
+  "$bin" "$mode" page 120 512 7
+done
+```
+
+Arguments: implementation, scenario, turn count, ASCII body bytes per block,
+sample count. Each sample merges 20 independently constructed pages, alternating
+older/newer directions (append uses newer only). Every turn has four blocks.
+
+- `append`: one incoming turn into a full window of `count` turns.
+- `page`: 30 incoming turns into a full window of `count` turns.
+- `turns`, `blocks`, `bytes`: bulk pages of `count` turns with up to 120 existing
+  turns; the named budget retains the larger of the initial window and one
+  quarter of the merged window.
+- `no-eviction`: the bulk workload with all budgets large enough to retain it.
+
+Inputs and existing indexes are forced outside timing. Outputs are consumed
+identically, including both indexes and block text. Each invocation first
+checks full baseline/production result equality using separate fixtures.
+CSV columns are implementation, scenario, count, body bytes, samples, median
+elapsed milliseconds/operation, median CPU milliseconds/operation, and median
+allocated bytes/operation. RTS statistics are enabled by the benchmark stanza.
+Explicit collections bracket samples; the trailing collection updates allocation
+statistics but is outside the clocks. This is an in-memory merge benchmark,
+not an end-to-end terminal or storage benchmark.
+
+The optimization uses temporary budget accounting and builds indexes only after
+trimming. No persistent cached sizes are added to the public record. Anchor
+protection, duplicate precedence, paging flags, and the soft-budget exception
+for a single oversized turn remain unchanged. Sorting/deduplication, final
+index construction, and scanning retained text still cost work.
+
+## Measured results
+
+macOS/aarch64, GHC 9.10.3 from the repository Nix shell, benchmark `-O2`,
+default RTS allocation area, `-T`, seven samples of twenty operations.
+Run each row below with the command above, substituting scenario/count/body.
+Values are old → new; allocation is bytes per operation.
+
+| Scenario | Count | Body | Elapsed ms | CPU ms | Allocated bytes |
+|---|---:|---:|---:|---:|---:|
+| no-eviction | 120 | 512 | 0.20050 → 0.17245 | 0.20035 → 0.17250 | 594947 → 543035 |
+| page | 120 | 512 | 0.59810 → 0.09765 | 0.59660 → 0.09770 | 4365011 → 284019 |
+| append | 120 | 512 | 0.10685 → 0.09405 | 0.10685 → 0.09410 | 380831 → 233263 |
+| turns | 500 | 512 | 22.28490 → 0.25885 | 22.27685 → 0.25930 | 181320723 → 1294171 |
+| blocks | 500 | 512 | 26.97060 → 0.25590 | 26.41180 → 0.25565 | 205152151 → 1299987 |
+| bytes | 500 | 512 | 45.20150 → 0.44950 | 45.16595 → 0.44820 | 240530459 → 1429819 |
+| bytes | 1000 | 4096 | 474.67370 → 4.35615 | 473.93645 → 4.35265 | 782743807 → 2765023 |
+| no-eviction (repeat) | 120 | 512 | 0.18805 → 0.16605 | 0.18810 → 0.16610 | 594947 → 543035 |
+| page (repeat) | 120 | 512 | 0.55550 → 0.09395 | 0.55495 → 0.09400 | 4365011 → 284019 |
+
+Normal 30-turn paging is about 6× faster with 93.5% less allocation in this
+fixture. Bulk eviction is a stress case, not a claim about ordinary UI latency.
+An initial staged-only implementation slightly increased no-eviction allocation;
+the final version retains a no-eviction fast path and uses strict folds for
+loaded totals instead of building intermediate mapped sequences. No-eviction
+allocation now falls by 8.7%, with elapsed/CPU improvements on both runs.

--- a/packages/agent-cli/benchmark/HistoryEvictionBaseline.hs
+++ b/packages/agent-cli/benchmark/HistoryEvictionBaseline.hs
@@ -1,0 +1,151 @@
+-- | Frozen pre-batching page insertion/eviction algorithm. Keep this baseline
+-- independent of production trimming so future benchmarks remain comparable.
+module HistoryEvictionBaseline (applyHistoryPageBaseline) where
+
+import Agent.CLI.TUI.History
+import Agent.TUI.Model (UiBlock(..))
+import Data.Foldable (toList)
+import Data.List (sortOn)
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence as Seq
+import Data.Sequence (Seq)
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+
+applyHistoryPageBaseline
+    :: HistoryPage
+    -> HistoryWindow
+    -> Either HistoryPageRejection HistoryWindow
+applyHistoryPageBaseline page window
+    | page.historyPageGeneration /= window.historyWindowGeneration =
+        Left (HistoryPageStale page.historyPageGeneration)
+    | otherwise =
+        Right $
+            trimWindowPrefer
+                (case direction of
+                    HistoryOlder -> HistoryNewer
+                    HistoryNewer -> HistoryOlder)
+                window'
+                    { historyWindowPending =
+                        Set.delete direction window.historyWindowPending
+                    , historyWindowGenerationStart = page.historyPageGenerationStart
+                    , historyWindowTotalTurns = page.historyPageTotalTurns
+                    , historyWindowHasOlder = page.historyPageHasOlder
+                    , historyWindowHasNewer = page.historyPageHasNewer
+                    }
+  where
+    direction = page.historyPageDirection
+    incoming = uniqueTurns page.historyPageTurns
+    existing = window.historyWindowTurns
+    merged = case direction of
+        HistoryOlder -> incoming <> existing
+        HistoryNewer -> existing <> incoming
+    window' =
+        setTurns
+            (uniqueTurns (Seq.fromList (sortOn (.historyTurnCursor) (toList merged))))
+            window
+
+setTurns :: Seq HistoryTurn -> HistoryWindow -> HistoryWindow
+setTurns turns window =
+    window
+        { historyWindowTurns = turns
+        , historyWindowTurnsByCursor =
+            Map.fromList [(turn.historyTurnCursor, turn) | turn <- toList turns]
+        , historyWindowBlocksById =
+            Map.fromList
+                [ (block.blockId, block)
+                | turn <- toList turns
+                , block <- toList turn.historyTurnBlocks
+                ]
+        }
+
+uniqueTurns :: Seq HistoryTurn -> Seq HistoryTurn
+uniqueTurns turns = Seq.fromList (reverse uniqueReversed)
+  where
+    (uniqueReversed, _) =
+        foldl
+            (\(kept, seen) turn ->
+                if turn.historyTurnCursor `Set.member` seen
+                    then (kept, seen)
+                    else (turn : kept, Set.insert turn.historyTurnCursor seen))
+            ([], Set.empty)
+            (toList turns)
+
+trimWindowPrefer :: HistoryDirection -> HistoryWindow -> HistoryWindow
+trimWindowPrefer preferred window
+    | withinBudget window = window
+    | Seq.length window.historyWindowTurns <= 1 = window
+    | otherwise = case preferredEvictionDirection preferred window of
+        Nothing -> window
+        Just direction -> trimWindowPrefer preferred (evictOne direction window)
+
+withinBudget :: HistoryWindow -> Bool
+withinBudget window =
+    loadedTurns window <= window.historyWindowMaxTurns
+        && loadedBlocks window <= window.historyWindowMaxBlocks
+        && loadedBytes window <= window.historyWindowMaxBytes
+
+loadedTurns :: HistoryWindow -> Int
+loadedTurns = Seq.length . (.historyWindowTurns)
+
+loadedBlocks :: HistoryWindow -> Int
+loadedBlocks =
+    sum . fmap (Seq.length . (.historyTurnBlocks)) . (.historyWindowTurns)
+
+loadedBytes :: HistoryWindow -> Int
+loadedBytes = sum . fmap historyTurnBytes . (.historyWindowTurns)
+
+historyTurnBytes :: HistoryTurn -> Int
+historyTurnBytes =
+    sum . fmap historyBlockBytes . toList . (.historyTurnBlocks)
+
+historyBlockBytes :: UiBlock -> Int
+historyBlockBytes block =
+    96
+        + textBytes block.blockTitle
+        + textBytes block.blockBody
+        + textBytes block.blockTimestamp
+        + textBytes block.blockDetail
+        + maybe 0 textBytes block.blockCallId
+  where
+    textBytes = (2 *) . Text.length
+
+preferredEvictionDirection
+    :: HistoryDirection -> HistoryWindow -> Maybe HistoryDirection
+preferredEvictionDirection preferred window
+    | canEvict preferred = Just preferred
+    | canEvict fallback = Just fallback
+    | otherwise = Nothing
+  where
+    fallback = case preferred of
+        HistoryOlder -> HistoryNewer
+        HistoryNewer -> HistoryOlder
+    canEvict direction = case edgeTurn direction window of
+        Nothing -> False
+        Just turn ->
+            let cursor = turn.historyTurnCursor
+            in Just cursor /= window.historyWindowVisibleAnchor
+                && Just cursor /= window.historyWindowSelectedAnchor
+
+edgeTurn :: HistoryDirection -> HistoryWindow -> Maybe HistoryTurn
+edgeTurn direction window = case direction of
+    HistoryOlder -> window.historyWindowTurns Seq.!? 0
+    HistoryNewer ->
+        window.historyWindowTurns Seq.!? (Seq.length window.historyWindowTurns - 1)
+
+evictOne :: HistoryDirection -> HistoryWindow -> HistoryWindow
+evictOne direction window = case direction of
+    HistoryOlder ->
+        setTurns dropFirst
+            window { historyWindowHasOlder = True }
+    HistoryNewer ->
+        setTurns dropLast
+            window { historyWindowHasNewer = True }
+  where
+    turns = window.historyWindowTurns
+    dropFirst = case turns of
+        _ Seq.:<| rest -> rest
+        _ -> Seq.empty
+    dropLast = case Seq.viewr turns of
+        Seq.EmptyR -> Seq.empty
+        rest Seq.:> _ -> rest

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -49,9 +49,9 @@ mkDerivation {
   ];
   benchmarkHaskellDepends = [
     aeson agent-core agent-json agent-mcp agent-responses
-    agent-responses-types agent-store async base brick bytestring
-    containers deepseq directory filepath JuicyPixels safe-exceptions
-    text time vty
+    agent-responses-types agent-store agent-tui async base brick
+    bytestring containers deepseq directory filepath JuicyPixels
+    safe-exceptions text time vty
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -86,6 +86,7 @@ import Agent.CLI.Runtime.Types
     )
 import Agent.CLI.Session
 import Agent.CLI.SessionEnv (SessionEnv(..))
+import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.Style
     ( glyphOk
     , glyphWarn
@@ -484,7 +485,7 @@ requestAutomaticProviderFallback env apiError pending = do
                     chooseAutomaticProviderTransition
                         env.sessionProviderFallback
                         env.sessionModelCatalog
-                        env.sessionProjectRoot
+                        env.sessionWorkspace.projectRoot
                         env.sessionRender.renderStderr
                         env.sessionFullscreen
                         (tokenProviderBillingMode tokenProvider)
@@ -512,7 +513,7 @@ requestStartupProviderFallback env apiError = do
                     chooseStartupProviderTransition
                         env.sessionProviderFallback
                         env.sessionModelCatalog
-                        env.sessionProjectRoot
+                        env.sessionWorkspace.projectRoot
                         env.sessionFullscreen
                         (tokenProviderBillingMode tokenProvider)
                         env.sessionProvider

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -151,7 +151,7 @@ import Agent.CLI.Session.Runtime.Types
                      initialContextPreload, initialGrokContext, persist,
                      contextOccupancyRef, currentContextWindow,
                      startupWindowTitle, automaticCompactionRef,
-                     projectRoot, home, cwd, tokenProvider, openAiPool, startupContext,
+                     workspace, tokenProvider, openAiPool, startupContext,
                      automaticCompactionHookRef, skillsRef, skillInvocationsRef,
                      stdinControl, interrupt, multiCtx, rootTurnRef, subagentSessions,
                      pendingNotices, storeRoot, agentTypes, legacyTarget, usageRef,
@@ -161,6 +161,7 @@ import Agent.CLI.Session.Runtime.Types
                      startupNetworkRecovery, startupSessionState,
                      startupNativeHooks) )
 import Agent.CLI.Session.Selection ( reservedSessionId )
+import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.SessionState ( SessionState(sessionConversation) )
 import Agent.CLI.Startup.Auth ( markStartupStage, startupDie )
 import Agent.CLI.StartupContext
@@ -276,7 +277,7 @@ data AgentSessionRequest closeResult windowTitleResult = AgentSessionRequest
     , createSubagentWorktree
         :: OsPath -> IO (Either Text SubagentWorktree)
     , customGenericOptions :: Maybe GenericClientOptions
-    , cwd :: OsPath
+    , workspace :: !WorkspaceContext
     , databaseAppTools :: [AppTool]
     , databaseScopes :: DatabaseScopes
     , initialContext :: SessionInitialContext
@@ -292,7 +293,6 @@ data AgentSessionRequest closeResult windowTitleResult = AgentSessionRequest
     , resolveChildModel
         :: Maybe (Text -> IO (Maybe CollaborationModelTarget))
     , childModelAllowed :: Maybe (Text -> IO Bool)
-    , home :: OsPath
     , inferredTarget :: ModelTarget
     , interrupt :: InterruptState
     , learnedSkillAppTools :: [AppTool]
@@ -313,7 +313,6 @@ data AgentSessionRequest closeResult windowTitleResult = AgentSessionRequest
     , planMode :: PlanModeEnv
     , policy :: ApprovalPolicy
     , preferredOpenAiAccountRef :: IORef (Maybe Text)
-    , projectRoot :: OsPath
     , promptRequest :: Maybe ManagedTurnRequest
     , provider :: Provider
     , refreshDialectContext :: Bool
@@ -443,7 +442,7 @@ prepareSessionCodeRuntime AgentSessionRequest
     , codeModeCloseRef
     , allTools
     , effortText
-    , cwd
+    , workspace = WorkspaceContext{cwd}
     , sessionTmp
     , persist
     , mcpInstructions
@@ -576,7 +575,7 @@ prepareSessionPromptRuntime AgentSessionRequest
     { provider
     , inferredTarget
     , dialect
-    , cwd
+    , workspace = WorkspaceContext{cwd}
     , resumed
     , initialContext
     , policy
@@ -796,7 +795,7 @@ sessionWindowTitle
 sessionWindowTitle AgentSessionRequest
     { resumed
     , promptRequest
-    , cwd
+    , workspace = WorkspaceContext{cwd}
     } =
     cliWindowTitle cwd titleHint
   where
@@ -819,8 +818,7 @@ loadSessionStartupContext AgentSessionRequest
     , fullscreen
     , options
     , dialect
-    , home
-    , cwd
+    , workspace = WorkspaceContext{home, cwd}
     , initialContextPreload
     , refreshDialectContext
     } promptRuntime =
@@ -1020,9 +1018,7 @@ buildProviderSessionRequest
             , persist = request.persist
             , startupWindowTitle =
                 liveRuntime.sessionStartupWindowTitle
-            , projectRoot = request.projectRoot
-            , home = request.home
-            , cwd = request.cwd
+            , workspace = request.workspace
             , tokenProvider = sessionTokenProvider
             , openAiPool = sessionOpenAiPool
             , startupContext = liveRuntime.sessionStartupContext
@@ -1164,7 +1160,10 @@ launchProvider request promptRuntime liveRuntime shouldProbeAtStartup startupUna
             activeBackend <- prepareTransitionBackend
                 (if request.startup.startupBackground
                     then SessionLocalSwitch else TopLevelSwitch)
-                request.home request.projectRoot request.transition request.persist
+                request.workspace.home
+                request.workspace.projectRoot
+                request.transition
+                request.persist
                 noticingBackend
             runSession
                 (buildProviderSessionRequest request promptRuntime liveRuntime
@@ -1227,7 +1226,7 @@ prepareProviderConfig request promptRuntime nativeCapabilities = case request.pr
         pure $ ClaudeProviderConfig ClaudeConfig
             { withAuth = withSelectedClaudeAuth request.connectedGateway request.loaded
                 (startupDie request.startup)
-            , cwd = request.cwd
+            , cwd = request.workspace.cwd
             , initialPrevious = promptRuntime.sessionInitialPrevious
             , transportModel = request.transportModel
             , hostHandlers = defaultClaudeCodeHostHandlers
@@ -1297,7 +1296,9 @@ handleOpenAiStartupResult request nativeCapabilities shouldProbeAtStartup = \cas
               , isProviderUnavailable err ->
                 chooseStartupProviderTransition
                     nativeCapabilities.nativeProviderFallback
-                    request.catalog request.projectRoot request.fullscreen
+                    request.catalog
+                    request.workspace.projectRoot
+                    request.fullscreen
                     (tokenProviderBillingMode request.tokenProvider)
                     request.provider request.model request.unavailableProviders
                     Nothing err >>= \case

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -63,6 +63,7 @@ import Agent.CLI.Resume
         )
     , resolveSessionInitialContext
     )
+import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.Runtime.Orchestration.Session ( AgentSessionRequest(..)
     , runAgentSession
     )
@@ -796,7 +797,7 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
         , coding
         , createSubagentWorktree
         , customGenericOptions
-        , cwd
+        , workspace = WorkspaceContext{projectRoot, cwd, home}
         , databaseAppTools
         , databaseScopes
         , initialContext
@@ -811,7 +812,6 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
         , allowedChildModels
         , resolveChildModel = resolveCollaborationChildModel
         , childModelAllowed
-        , home
         , inferredTarget
         , interrupt
         , learnedSkillAppTools
@@ -832,7 +832,6 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
         , planMode
         , policy
         , preferredOpenAiAccountRef
-        , projectRoot
         , promptRequest
         , provider
         , refreshDialectContext

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -126,6 +126,7 @@ import Agent.CLI.Session.Interaction ( runBtwQuestion )
 import Agent.CLI.Session.Selection
     ( currentSessionId, pickAgentChoice )
 import Agent.CLI.SessionEnv ( SessionEnv(..) )
+import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.Skills
     ( formatSkillsListing
     , resolvePromptSkillMentions
@@ -214,7 +215,7 @@ handleReplLine
             { sessionProvider = provider
             , sessionPolicy = policyRef
             , sessionPlanMode = planMode
-            , sessionProjectRoot = projectRoot
+            , sessionWorkspace = WorkspaceContext{projectRoot}
             , sessionFullscreen = fullscreen
             }
         continueWith
@@ -574,7 +575,7 @@ manageMcpServers handlerContext next = do
             legacy $
                 runMcpManager
                     color
-                    env.sessionHome
+                    env.sessionWorkspace.home
                     env.sessionMcpRegistrations
                     env.sessionMcpWarnings
         if restart
@@ -684,7 +685,7 @@ toggleApprovalMode handlerContext next
     env = handlerContext.handlerSessionEnv
     provider = env.sessionProvider
     policyRef = env.sessionPolicy
-    projectRoot = env.sessionProjectRoot
+    projectRoot = env.sessionWorkspace.projectRoot
     displayInfo = displayReplInfo handlerContext
 
 showSavedPlan :: ReplHandlerContext -> IO RunResult -> IO RunResult
@@ -823,7 +824,7 @@ manageLogin env next = do
             else next
   where
     fullscreen = env.sessionFullscreen
-    cwd = env.sessionCwd
+    cwd = env.sessionWorkspace.cwd
 
 showUsage :: ReplHandlerContext -> IO RunResult -> IO RunResult
 showUsage handlerContext next = do
@@ -917,7 +918,7 @@ initializeProjectGuide handlerContext submitExpandedTurn next color line = do
                         (roleMuted color (glyphSession <> message))
                 next
   where
-    cwd = handlerContext.handlerSessionEnv.sessionCwd
+    cwd = handlerContext.handlerSessionEnv.sessionWorkspace.cwd
     displayInfo = displayReplInfo handlerContext
     displayError = displayReplError handlerContext
 
@@ -1089,7 +1090,7 @@ showWorkingTreeDiff :: ReplHandlerContext -> IO RunResult -> Bool -> IO RunResul
 showWorkingTreeDiff handlerContext next color = do
     result <-
         withCommandActivity env "Loading Git diff…" $
-            getGitDiff env.sessionCwd
+            getGitDiff env.sessionWorkspace.cwd
     case result of
         Left err -> do
             displayError err $
@@ -1136,7 +1137,7 @@ choosePermissions handlerContext next color
                     message <-
                         setApprovalPolicy
                             env.sessionPolicy
-                            env.sessionProjectRoot
+                            env.sessionWorkspace.projectRoot
                             (approvalPolicyAt index)
                     displayInfo message $
                         Text.hPutStrLn stderr
@@ -1233,7 +1234,7 @@ chooseReviewTarget handlerContext =
                                         (ReviewCustom
                                             <$> nonBlank instructions))
   where
-    cwd = handlerContext.handlerSessionEnv.sessionCwd
+    cwd = handlerContext.handlerSessionEnv.sessionWorkspace.cwd
     requestChoice = requestReplChoice handlerContext
     requestText = requestReplText handlerContext
     withReplActivity = withCommandActivity handlerContext.handlerSessionEnv

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
@@ -47,6 +47,7 @@ import Agent.CLI.Session
     , ensureSession
     )
 import Agent.CLI.SessionEnv ( SessionEnv(..) )
+import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.Style
     ( glyphOk, glyphSession, roleError, roleMuted, roleSuccess )
 import Agent.CLI.TUI.App
@@ -97,7 +98,7 @@ handleMetaConsoleRequest replContext slashCatalog executeCommand rawRequest
     | Text.null request =
         metaFailure runtime "Meta Console request must not be empty"
     | otherwise =
-        loadHarnessConfig env.sessionHome >>= \case
+        loadHarnessConfig env.sessionWorkspace.home >>= \case
             Left err -> metaFailure runtime err
             Right config -> do
                 plannerContext <- buildMetaContext env config
@@ -255,7 +256,7 @@ applyMetaPlan runtime initial plan =
                 if any isMetaConfigAction plan.metaActions
                     then
                         updateHarnessConfig
-                            (metaEnv runtime).sessionHome
+                            (metaEnv runtime).sessionWorkspace.home
                             (applyMetaConfigActions
                                 secrets
                                 plan.metaActions)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -66,6 +66,7 @@ import Agent.CLI.ModelPicker
     ( ModelPickerSelection(modelPickerEffort, modelPickerOption) )
 import Agent.CLI.Session.Interaction ( setSessionEffort )
 import Agent.CLI.SessionEnv ( SessionEnv(..) )
+import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.Style
     ( glyphOk, glyphSession, roleError, roleMuted )
 import Agent.CLI.TUI.App
@@ -305,8 +306,7 @@ handleSelection
             , sessionDialect = dialect
             , sessionParams = paramsRef
             , sessionPersist = persist
-            , sessionProjectRoot = projectRoot
-            , sessionHome = home
+            , sessionWorkspace = WorkspaceContext{projectRoot, home}
             , sessionDraft = draftRef
             }
         continue
@@ -466,8 +466,7 @@ chooseModel env@SessionEnv
     , sessionProvider = provider
     , sessionDialect = dialect
     , sessionParams = paramsRef
-    , sessionHome = home
-    , sessionProjectRoot = projectRoot
+    , sessionWorkspace = WorkspaceContext{home, projectRoot}
     , sessionRender = render
     , sessionConversation = conversationRef
     , sessionPersist = persist
@@ -592,7 +591,7 @@ setTheme env theme next =
             next
         Just runtime -> do
             updateHarnessConfig
-                env.sessionHome
+                env.sessionWorkspace.home
                 (\config -> Right config { configTheme = theme })
                 >>= \case
                 Left err -> do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -61,6 +61,7 @@ import Agent.CLI.Session
 import Agent.CLI.Session.Selection
     ( handleConversationSearch, handleResume )
 import Agent.CLI.SessionEnv ( SessionEnv(..) )
+import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.SessionTitle
     ( invalidateSessionTitles, requestSessionTitle )
 import Agent.CLI.Status ( formatTokenUsageOrZero )
@@ -591,7 +592,7 @@ handleDeleteAction runtime = do
                                 pure
                                     (RunDeleteSession
                                         handle.sessionMeta.metaId
-                                        env.sessionCwd)
+                                        env.sessionWorkspace.cwd)
 
 handleForkAction
     :: SessionActionRuntime
@@ -627,7 +628,7 @@ handleForkAction runtime request = do
                                                     createManagedWorktreeWithProgress
                                                         (report
                                                             . worktreeProgressMessage)
-                                                        env.sessionHome
+                                                        env.sessionWorkspace.home
                                                         source.sessionMeta.metaCwd
                                                     >>= pure . fmap
                                                         (\path ->
@@ -752,7 +753,7 @@ handleShowSessionInfoAction runtime = do
                         <> dialectSlug (dialectId env.sessionDialect)
                    , "effort: "
                         <> reasoningEffortText (currentEffort params)
-                   , "cwd: " <> toText env.sessionCwd
+                   , "cwd: " <> toText env.sessionWorkspace.cwd
                    , "shell: " <> sessionShellModeText shellMode
                    , "tokens: " <> usageText
                    , "tools: "
@@ -796,14 +797,14 @@ handleAfkAction runtime rawTarget = do
                             AfkLocal ->
                                 handoffLocal
                                     handle.sessionMeta.metaId
-                                    env.sessionCwd >>= \case
+                                    env.sessionWorkspace.cwd >>= \case
                                         Left err -> failAfk err
                                         Right message ->
                                             finishAfk message
                             AfkRemote host path ->
                                 loadSession
                                     env.sessionDatabasePool
-                                    (sessionsRoot env.sessionHome)
+                                    (sessionsRoot env.sessionWorkspace.home)
                                     handle.sessionMeta.metaId
                                     >>= \case
                                         Left err -> failAfk err
@@ -838,8 +839,8 @@ handleWorktreeAction runtime = do
     result <- runtimeWithReplActivity runtime \report ->
         createManagedWorktreeWithProgress
             (report . worktreeProgressMessage)
-            env.sessionHome
-            env.sessionCwd
+            env.sessionWorkspace.home
+            env.sessionWorkspace.cwd
     case result of
         Left err -> do
             color <- resolveColor stderr

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Transcript.hs
@@ -32,6 +32,7 @@ import Agent.CLI.Session
     )
 import Agent.CLI.Session.Selection ( currentSessionId )
 import Agent.CLI.SessionEnv ( SessionEnv(..) )
+import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.Style
     ( glyphOk, roleError, roleSuccess )
 import Agent.CLI.Terminal ( copyTerminalClipboard, resolveColor )
@@ -146,7 +147,7 @@ loadActiveTranscript
 loadActiveTranscript
         SessionEnv
             { sessionDatabasePool = databasePool
-            , sessionHome = home
+            , sessionWorkspace = WorkspaceContext{home}
             , sessionPersist = persist
             } =
     case persist of
@@ -180,7 +181,7 @@ saveTranscriptExport
     -> IO ()
 saveTranscriptExport context markdown rawPath =
     resolveExportPath
-        context.handlerSessionEnv.sessionCwd
+        context.handlerSessionEnv.sessionWorkspace.cwd
         rawPath >>= \case
             Left err ->
                 displayReplError context err $
@@ -282,7 +283,7 @@ copyAssistantResponse context request answer = do
                 (Just answer)
         Just rawPath ->
             resolveExportPath
-                context.handlerSessionEnv.sessionCwd
+                context.handlerSessionEnv.sessionWorkspace.cwd
                 rawPath >>= \case
                     Left err ->
                         displayReplError context err do
@@ -338,7 +339,7 @@ copyWorktreePath context =
         context
         "worktree path"
         "worktree path is unavailable"
-        (Just (toText context.handlerSessionEnv.sessionCwd))
+        (Just (toText context.handlerSessionEnv.sessionWorkspace.cwd))
 
 copySessionId :: ReplHandlerContext -> IO ()
 copySessionId context = do
@@ -461,7 +462,7 @@ loadPersistedTranscript
 loadPersistedTranscript
         SessionEnv
             { sessionDatabasePool = databasePool
-            , sessionHome = home
+            , sessionWorkspace = WorkspaceContext{home}
             , sessionPersist = persist
             } =
     case persist of

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -41,6 +41,7 @@ import Agent.CLI.Session.Interaction
     )
 import Agent.CLI.Session.Retry (waitAndRetryPendingTurn)
 import Agent.CLI.SessionEnv (SessionEnv(..))
+import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.SteeringInputs (hasBackgroundCompletionWake)
 import Agent.CLI.Render
     ( RenderConfig(..)
@@ -162,7 +163,7 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
             (not (Text.null (Text.strip selectionId))
                 && not (Text.null (Text.strip accountId))) $
             saveProjectAccount
-                env.sessionProjectRoot
+                env.sessionWorkspace.projectRoot
                 env.sessionProvider
                 selectionId
                 accountId

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -70,6 +70,7 @@ import Agent.CLI.SessionState
 import Agent.CLI.Render
 import Agent.CLI.Session
 import Agent.CLI.Session.History
+import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.SessionEnv
 import Agent.CLI.SessionLock
     ( acquireSessionActivityLock
@@ -452,7 +453,7 @@ newSessionControlRuntime host SessionRequest{..} = do
         newAgentViewportRuntime AgentViewportRuntimeConfig
             { viewportConfigShowRawReasoning =
                 options.optShowRawReasoning
-            , viewportConfigWorkspace = toText cwd
+            , viewportConfigWorkspace = toText workspace.cwd
             , viewportConfigReadRootTranscript =
                 readLiveTranscript conversationRef
             , viewportConfigListChildren = listChildAgents
@@ -563,8 +564,8 @@ buildSkillContextRuntime
                         SuppressAgentsContextLoaded
                         options
                         dialect
-                        home
-                        cwd
+                        workspace.home
+                        workspace.cwd
                         []
                         Nothing
                         ((.catalogEnvironmentContext)
@@ -575,7 +576,8 @@ buildSkillContextRuntime
                             <$> codexCatalogSession)
         freshSkills <-
             if loadsHostWorkspaceContext
-                then loadSkillsCatalogQuiet options home projectRoot cwd
+                then loadSkillsCatalogQuiet
+                    options workspace.home workspace.projectRoot workspace.cwd
                 else pure (SkillCatalog [] [])
         (omitted, _) <-
             installSkills freshAgents True freshSkills
@@ -609,7 +611,8 @@ buildSkillContextRuntime
     refreshSkills queueContext = do
         refreshed <-
             if loadsHostWorkspaceContext
-                then loadSkillsCatalogQuiet options home projectRoot cwd
+                then loadSkillsCatalogQuiet
+                    options workspace.home workspace.projectRoot workspace.cwd
                 else pure (SkillCatalog [] [])
         (omitted, _) <-
             installSkills startupContext queueContext refreshed
@@ -734,7 +737,7 @@ buildSessionLoopEventRuntime
                 && terminal.terminalNativeProgress
                 && nativeProgressAnimationEnabled options.optMotionMode
         , renderMotionMode = options.optMotionMode
-        , renderWorkspace = toText cwd
+        , renderWorkspace = toText workspace.cwd
         }
     emitLoop event = do
         recordAgentViewportEvent agentViewportRuntime event
@@ -829,15 +832,15 @@ buildSessionApprovalRuntime host controls SessionRequest{..} =
                                             resolveColor host.hostStderrHandle
                                         promptPermission
                                             color
-                                            (toText cwd)
+                                            (toText workspace.cwd)
                                             requested)
                                 reportLineApproval
-                                (saveProjectAutoApprove projectRoot True)
+                                (saveProjectAutoApprove workspace.projectRoot True)
                         Just runtime ->
                             approve
                                 (requestFullscreenPermission
                                     runtime
-                                    (toText cwd))
+                                    (toText workspace.cwd))
                                 (\case
                                     ApprovalWarning _ -> pure ()
                                     ApprovalSuccess message ->
@@ -846,7 +849,7 @@ buildSessionApprovalRuntime host controls SessionRequest{..} =
                                                 (Just
                                                     (successNotice
                                                         message))))
-                                (saveProjectAutoApprove projectRoot True)
+                                (saveProjectAutoApprove workspace.projectRoot True)
         classify = const (pure classifiedReadOnly)
         approve request report persist =
             approveToolDecisionWithReporterAndPersistenceClassified
@@ -1015,7 +1018,7 @@ buildSessionShellRuntime host controls SessionRequest{..} =
                             commitAttributionModel
                             commitAttributionEffort
                             enabledNames
-                            cwd
+                            workspace.cwd
                             sessionTmp
                             today
                             (isOneShot options)
@@ -1132,7 +1135,7 @@ buildSessionSubagentRuntime SessionRequest{..} =
         case multiCtx of
             Just ctx -> setMaxConcurrent ctx.multiRegistry next
             Nothing -> pure ()
-        saveProjectMaxConcurrentAgents projectRoot next
+        saveProjectMaxConcurrentAgents workspace.projectRoot next
         pure ("concurrent agent limit: " <> Text.pack (show next))
 
 buildSessionLoopConfig
@@ -1451,13 +1454,11 @@ buildSessionEnv
         , sessionTitleTurnCount = controls.controlTitleTurnCount
         , sessionPlanMode = planMode
         , sessionTaskPlan = taskPlan
-        , sessionProjectRoot = projectRoot
-        , sessionCwd = cwd
+        , sessionWorkspace = workspace
         , sessionProviderFallback =
             host.hostNativeCapabilities.nativeProviderFallback
         , sessionPreparedWorkspaceEnvironment =
             host.hostPreparedWorkspaceEnvironment
-        , sessionHome = home
         , sessionMcpRegistrations = mcpRegistrations
         , sessionMcpWarnings = mcpWarnings
         , sessionMcpFleet = mcpFleet
@@ -1624,7 +1625,7 @@ installSessionActions
                         copyImmediate
                             "worktree path"
                             "worktree path is unavailable"
-                            (Just (toText cwd))
+                            (Just (toText workspace.cwd))
                     ReplCopySession ->
                         currentSessionId persist >>= copyImmediate
                             "session id"
@@ -1681,7 +1682,7 @@ runSessionInteraction
                 inputs <-
                     case startup.startupNativeHooks >>= (.nativeInitialTurnInputs) of
                         Just nativeInputs -> pure nativeInputs
-                        Nothing -> managedTurnInputs cwd request
+                        Nothing -> managedTurnInputs workspace.cwd request
                 skillInputs <-
                     callbacks.runnerPreparePromptSkillInputs
                         env

--- a/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runtime/Types.hs
@@ -20,6 +20,7 @@ import Agent.CLI.AgentViewport
 import Agent.CLI.Claude (ClaudeSessionRuntimeSlot)
 import Agent.CLI.Config (HarnessConfig)
 import Agent.CLI.Session.History (LiveConversation)
+import Agent.CLI.Session.Workspace (WorkspaceContext)
 import Agent.CLI.Btw (BtwBackendFactory)
 import Agent.CLI.CodeModeRuntime
     ( CodeModeSessionRuntime
@@ -173,9 +174,7 @@ data SessionRequest = SessionRequest
     , initialGrokContext :: !(Maybe Text)
     , persist :: !Persistence
     , startupWindowTitle :: !Text
-    , projectRoot :: !OsPath
-    , home :: !OsPath
-    , cwd :: !OsPath
+    , workspace :: !WorkspaceContext
     , tokenProvider :: !(Maybe TokenProvider)
     , openAiPool :: !(Maybe OpenAI.Pool)
     , startupContext :: !(IORef (Maybe Text))

--- a/packages/agent-cli/src/Agent/CLI/Session/Workspace.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Workspace.hs
@@ -1,0 +1,19 @@
+-- | Immutable path identity carried from startup into the session.
+--
+-- These paths have different roles: the working directory can be a nested
+-- directory or worktree, the project root scopes project configuration, and
+-- the user's home locates user configuration and session storage. Keep them
+-- together when handing a session to another runtime rather than resolving
+-- them again from the process's mutable working directory.
+module Agent.CLI.Session.Workspace
+    ( WorkspaceContext(..)
+    ) where
+
+import System.OsPath (OsPath)
+
+data WorkspaceContext = WorkspaceContext
+    { projectRoot :: !OsPath
+    , cwd :: !OsPath
+    , home :: !OsPath
+    }
+    deriving (Eq, Show)

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -25,6 +25,7 @@ import Agent.CLI.Options (ApprovalPolicy)
 import Agent.CLI.Render (RenderConfig)
 import Agent.CLI.Session (Persistence, SessionHandle)
 import Agent.CLI.Session.History (LiveConversation)
+import Agent.CLI.Session.Workspace (WorkspaceContext)
 import Agent.CLI.SessionTitle (SessionTitleManager)
 import Agent.CLI.Terminal (TerminalCapabilities)
 import Agent.CLI.SteeringInputs (SteeringInputs)
@@ -84,14 +85,12 @@ data SessionEnv = SessionEnv
     , sessionTitleTurnCount :: !(IORef Int)
     , sessionPlanMode :: !PlanModeEnv
     , sessionTaskPlan :: !(Maybe TaskPlanEnv)
-    , sessionProjectRoot :: !OsPath
-    , sessionCwd :: !OsPath
+    , sessionWorkspace :: !WorkspaceContext
     , sessionProviderFallback :: !Bool
     -- | Prepared environment facts avoid inspecting the host workspace.
     -- 'Nothing' requests ordinary local discovery.
     , sessionPreparedWorkspaceEnvironment
         :: !(Maybe PreparedWorkspaceEnvironment)
-    , sessionHome :: !OsPath
     , sessionMcpRegistrations :: ![McpToolRegistration]
     , sessionMcpWarnings :: ![Text]
     , sessionMcpFleet :: !(Maybe McpFleet)

--- a/packages/agent-cli/src/Agent/CLI/TUI/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/History.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE NoFieldSelectors #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 
@@ -158,11 +159,13 @@ historyWindowLoadedTurns = Seq.length . (.historyWindowTurns)
 
 historyWindowLoadedBlocks :: HistoryWindow -> Int
 historyWindowLoadedBlocks =
-    sum . fmap (Seq.length . (.historyTurnBlocks)) . (.historyWindowTurns)
+    foldl' (\total turn -> total + Seq.length turn.historyTurnBlocks) 0
+        . (.historyWindowTurns)
 
 historyWindowLoadedBytes :: HistoryWindow -> Int
 historyWindowLoadedBytes =
-    sum . fmap historyTurnBytes . (.historyWindowTurns)
+    foldl' (\total turn -> total + historyTurnBytes turn) 0
+        . (.historyWindowTurns)
 
 historyWindowHasBlocks :: HistoryWindow -> Bool
 historyWindowHasBlocks = not . Seq.null . (.historyWindowTurns)
@@ -353,7 +356,9 @@ applyHistoryPage page window
 
 mergePage :: HistoryPage -> HistoryWindow -> HistoryWindow
 mergePage page window =
-    trimWindowPrefer
+    setHistoryWindowTurns trimmed.historyWindowTurns trimmed
+  where
+    trimmed = trimWindowPrefer
         (case direction of
             HistoryOlder -> HistoryNewer
             HistoryNewer -> HistoryOlder)
@@ -369,7 +374,6 @@ mergePage page window =
             , historyWindowHasNewer =
                 page.historyPageHasNewer
             }
-  where
     direction = page.historyPageDirection
     incoming = uniqueTurns page.historyPageTurns
     existing = window.historyWindowTurns
@@ -378,7 +382,7 @@ mergePage page window =
             HistoryOlder -> incoming <> existing
             HistoryNewer -> existing <> incoming
     window' =
-        setHistoryWindowTurns (uniqueTurns (sortTurns merged)) window
+        window { historyWindowTurns = uniqueTurns (sortTurns merged) }
 
 sortTurns :: Seq HistoryTurn -> Seq HistoryTurn
 sortTurns = Seq.fromList . sortOn (.historyTurnCursor) . toList
@@ -404,17 +408,41 @@ trimWindowPrefer
     -> HistoryWindow
     -> HistoryWindow
 trimWindowPrefer preferred window
+    -- Keep the common no-eviction path out of the staged accounting worker.
     | withinBudget window = window
-    -- Turns are the paging unit, so an oversized turn cannot be trimmed
-    -- without losing its whole prompt and response. Keep one turn even when
-    -- it exceeds a soft block or byte budget; otherwise committing a long
-    -- live turn would clear it from the transcript immediately.
-    | Seq.length window.historyWindowTurns <= 1 = window
-    | otherwise =
-        case preferredEvictionDirection preferred window of
-            Nothing -> window
-            Just direction ->
-                trimWindowPrefer preferred (evictOne direction window)
+    | turnCount > window.historyWindowMaxTurns = turnTrimmed
+    | blockCount > window.historyWindowMaxBlocks = blockTrimmed
+    | otherwise = snd $
+        trimBudget historyTurnBytes window.historyWindowMaxBytes
+            (historyWindowLoadedBytes blockTrimmed) blockTrimmed
+  where
+    -- Evictions follow the same edge preference for every budget, so satisfy
+    -- the cheap limits first. In particular, do not measure text belonging
+    -- to turns that the turn/block limits will discard anyway.
+    (turnCount, turnTrimmed) = trimBudget (const 1) window.historyWindowMaxTurns
+        (historyWindowLoadedTurns window) window
+    (blockCount, blockTrimmed) = trimBudget (Seq.length . (.historyTurnBlocks))
+        window.historyWindowMaxBlocks
+        (historyWindowLoadedBlocks turnTrimmed) turnTrimmed
+
+    -- Accounting is local to this merge: public record updates cannot leave
+    -- a cached total stale. Indexes are rebuilt once, after all evictions.
+    trimBudget measure limit = go
+      where
+        go !total current
+            | total <= limit = (total, current)
+            -- Turns remain the paging unit. Keep one oversized turn rather
+            -- than making a long completed response disappear altogether.
+            | historyWindowLoadedTurns current <= 1 = (total, current)
+            | otherwise =
+                case preferredEvictionDirection preferred current of
+                    Nothing -> (total, current)
+                    Just direction ->
+                        case edgeTurn direction current of
+                            Nothing -> (total, current)
+                            Just removed ->
+                                go (total - measure removed)
+                                    (evictOne direction current)
 
 withinBudget :: HistoryWindow -> Bool
 withinBudget window =
@@ -475,11 +503,15 @@ evictOne :: HistoryDirection -> HistoryWindow -> HistoryWindow
 evictOne direction window =
     case direction of
         HistoryOlder ->
-            setHistoryWindowTurns dropFirst $
-                window { historyWindowHasOlder = True }
+            window
+                { historyWindowTurns = dropFirst
+                , historyWindowHasOlder = True
+                }
         HistoryNewer ->
-            setHistoryWindowTurns dropLast $
-                window { historyWindowHasNewer = True }
+            window
+                { historyWindowTurns = dropLast
+                , historyWindowHasNewer = True
+                }
   where
     turns = window.historyWindowTurns
     dropFirst =

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -69,6 +69,7 @@ import Agent.CLI.Session
     , sessionTitleFromPrompt
     , setGeneratedSessionTitle
     )
+import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.SessionEnv
     ( PreparedWorkspaceEnvironment(..)
     , SessionEnv(..)
@@ -376,7 +377,7 @@ prepareBusyTurn request = do
                                 grokFirstTurnContext
                                 (loadGrokFirstTurnPrefix
                                     env.sessionPreparedWorkspaceEnvironment
-                                    env.sessionCwd)
+                                    env.sessionWorkspace.cwd)
                         pure (UserMessage prefix : framed, Just prefix)
                     else pure (framed, Nothing)
             else pure (stampedInputs, Nothing)
@@ -440,7 +441,7 @@ persistTurnPromptSnapshot request sentStartupContext pendingGrokContext =
                 , promptSnapshotConnection = env.sessionConnection
                 , promptSnapshotModel = modelName
                 , promptSnapshotDialect = dialectId env.sessionDialect
-                , promptSnapshotCwd = env.sessionCwd
+                , promptSnapshotCwd = env.sessionWorkspace.cwd
                 , promptSnapshotInstructions = instructionText
                 , promptSnapshotTools = toolSchemas
                 , promptSnapshotGeneratedContext = sentStartupContext
@@ -1028,7 +1029,7 @@ evictDurableConversation env handle = do
         checkpoint =
             durableTranscriptCheckpoint
                 env.sessionDatabasePool
-                (sessionsRoot env.sessionHome)
+                (sessionsRoot env.sessionWorkspace.home)
                 sessionId
     evicted <-
         evictLiveTranscript

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -387,6 +387,49 @@ spec = describe "bounded fullscreen history window" do
         historyWindowLoadedBytes completed `shouldSatisfy` (> 180)
         historyWindowOlderAvailable completed `shouldBe` True
 
+    it "matches single-eviction semantics and indexes across budgets and anchors" do
+        let generation = HistoryGeneration 6
+            existing = Seq.fromList [turn 2 1, turn 3 3, turn 4 2]
+            cases =
+                [ (direction, visible, selected, maxTurns, maxBlocks, maxBytes)
+                | direction <- [HistoryOlder, HistoryNewer]
+                , visible <- [Nothing, Just (HistoryCursor 2), Just (HistoryCursor 4)]
+                , selected <- [Nothing, Just (HistoryCursor 3), Just (HistoryCursor 4)]
+                , maxTurns <- [1, 3, 10]
+                , maxBlocks <- [1, 4, 100]
+                , maxBytes <- [1, 400, 1_000_000]
+                ]
+        mapM_ (\(direction, visible, selected, maxTurns, maxBlocks, maxBytes) -> do
+            let initial = historyWindowSetAnchors visible selected $
+                    setHistoryWindowTurns existing $
+                        emptyHistoryWindow generation maxTurns maxBlocks maxBytes
+                page = HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = direction
+                    -- Unsorted, overlapping, duplicate, and empty turns.
+                    , historyPageTurns =
+                        Seq.fromList [turn 5 2, turn 2 4, turn 1 0, turn 5 1]
+                    , historyPageGenerationStart = HistoryCursor 1
+                    , historyPageTotalTurns = 5
+                    , historyPageHasOlder = False
+                    , historyPageHasNewer = False
+                    }
+                unlimited = initial
+                    { historyWindowMaxTurns = maxBound
+                    , historyWindowMaxBlocks = maxBound
+                    , historyWindowMaxBytes = maxBound
+                    }
+            merged <- expectRight (applyHistoryPage page unlimited)
+            actual <- expectRight (applyHistoryPage page initial)
+            let expected = referenceTrim direction merged
+                    { historyWindowMaxTurns = maxTurns
+                    , historyWindowMaxBlocks = maxBlocks
+                    , historyWindowMaxBytes = maxBytes
+                    }
+            -- Equality checks both indexes, flags, metadata, and anchors,
+            -- not just the surviving cursor range.
+            actual `shouldBe` expected) cases
+
     it "omits persisted reasoning while projecting tool and assistant history" do
         let projected =
                 sessionHistoryTurn
@@ -825,6 +868,40 @@ spec = describe "bounded fullscreen history window" do
             blocks = toList projected.historyTurnBlocks
         map (.blockKind) blocks `shouldBe` [BlockSystem]
         map (.blockBody) blocks `shouldBe` ["Earlier conversation summary"]
+
+-- Deliberately retain the old repeated-eviction algorithm as a simple oracle.
+referenceTrim :: HistoryDirection -> HistoryWindow -> HistoryWindow
+referenceTrim incoming window
+    | historyWindowLoadedTurns window <= window.historyWindowMaxTurns
+        && historyWindowLoadedBlocks window <= window.historyWindowMaxBlocks
+        && historyWindowLoadedBytes window <= window.historyWindowMaxBytes =
+        window
+    | historyWindowLoadedTurns window <= 1 = window
+    | otherwise =
+        case filter canEvict [preferred, incoming] of
+            [] -> window
+            direction : _ ->
+                referenceTrim incoming $
+                    case direction of
+                        HistoryOlder ->
+                            setHistoryWindowTurns (Seq.drop 1 turns)
+                                window { historyWindowHasOlder = True }
+                        HistoryNewer ->
+                            setHistoryWindowTurns (Seq.take (Seq.length turns - 1) turns)
+                                window { historyWindowHasNewer = True }
+  where
+    turns = window.historyWindowTurns
+    preferred = case incoming of
+        HistoryOlder -> HistoryNewer
+        HistoryNewer -> HistoryOlder
+    canEvict direction =
+        case turns Seq.!? (case direction of
+                HistoryOlder -> 0
+                HistoryNewer -> Seq.length turns - 1) of
+            Nothing -> False
+            Just edge ->
+                Just edge.historyTurnCursor /= window.historyWindowVisibleAnchor
+                    && Just edge.historyTurnCursor /= window.historyWindowSelectedAnchor
 
 turn :: Int64 -> Int -> HistoryTurn
 turn cursor blocks =


### PR DESCRIPTION
## Summary
- Share immutable WorkspaceContext across the three largest session records.
- Trim history with local budget accounting, strict total folds, and one final index rebuild.
- Preserve anchor protection, duplicate precedence, paging flags, and the single-oversized-turn exception.

## Validation
- 49 focused Hspec examples passed, including a 486-case baseline comparison.
- CLI library and test modules typechecked using object-code GHCi on macOS.
- Live tmux prompt, /session-info nested cwd, and clean /quit verified; zero model tokens.
- Package boundaries and regenerated package.nix consistency passed.
- Rebased cleanly onto current master; CI will validate the resulting head.

## Reproducible performance evidence
# History eviction

`HistoryEvictionBaseline.hs` preserves the original page-merge implementation.
The benchmark compiles it and production `Agent.CLI.TUI.History` together with
`-O2`, avoiding interpreted timings or different optimization settings.

```sh
nix develop
cabal build --offline agent-cli:bench:history-eviction-bench
bin=$(cabal list-bin agent-cli:bench:history-eviction-bench)
for mode in old new; do
  "$bin" "$mode" page 120 512 7
done
```

Arguments: implementation, scenario, turn count, ASCII body bytes per block,
sample count. Each sample merges 20 independently constructed pages, alternating
older/newer directions (append uses newer only). Every turn has four blocks.

- `append`: one incoming turn into a full window of `count` turns.
- `page`: 30 incoming turns into a full window of `count` turns.
- `turns`, `blocks`, `bytes`: bulk pages of `count` turns with up to 120 existing
  turns; the named budget retains the larger of the initial window and one
  quarter of the merged window.
- `no-eviction`: the bulk workload with all budgets large enough to retain it.

Inputs and existing indexes are forced outside timing. Outputs are consumed
identically, including both indexes and block text. Each invocation first
checks full baseline/production result equality using separate fixtures.
CSV columns are implementation, scenario, count, body bytes, samples, median
elapsed milliseconds/operation, median CPU milliseconds/operation, and median
allocated bytes/operation. RTS statistics are enabled by the benchmark stanza.
Explicit collections bracket samples; the trailing collection updates allocation
statistics but is outside the clocks. This is an in-memory merge benchmark,
not an end-to-end terminal or storage benchmark.

The optimization uses temporary budget accounting and builds indexes only after
trimming. No persistent cached sizes are added to the public record. Anchor
protection, duplicate precedence, paging flags, and the soft-budget exception
for a single oversized turn remain unchanged. Sorting/deduplication, final
index construction, and scanning retained text still cost work.

## Measured results

macOS/aarch64, GHC 9.10.3 from the repository Nix shell, benchmark `-O2`,
default RTS allocation area, `-T`, seven samples of twenty operations.
Run each row below with the command above, substituting scenario/count/body.
Values are old → new; allocation is bytes per operation.

| Scenario | Count | Body | Elapsed ms | CPU ms | Allocated bytes |
|---|---:|---:|---:|---:|---:|
| no-eviction | 120 | 512 | 0.20050 → 0.17245 | 0.20035 → 0.17250 | 594947 → 543035 |
| page | 120 | 512 | 0.59810 → 0.09765 | 0.59660 → 0.09770 | 4365011 → 284019 |
| append | 120 | 512 | 0.10685 → 0.09405 | 0.10685 → 0.09410 | 380831 → 233263 |
| turns | 500 | 512 | 22.28490 → 0.25885 | 22.27685 → 0.25930 | 181320723 → 1294171 |
| blocks | 500 | 512 | 26.97060 → 0.25590 | 26.41180 → 0.25565 | 205152151 → 1299987 |
| bytes | 500 | 512 | 45.20150 → 0.44950 | 45.16595 → 0.44820 | 240530459 → 1429819 |
| bytes | 1000 | 4096 | 474.67370 → 4.35615 | 473.93645 → 4.35265 | 782743807 → 2765023 |
| no-eviction (repeat) | 120 | 512 | 0.18805 → 0.16605 | 0.18810 → 0.16610 | 594947 → 543035 |
| page (repeat) | 120 | 512 | 0.55550 → 0.09395 | 0.55495 → 0.09400 | 4365011 → 284019 |

Normal 30-turn paging is about 6× faster with 93.5% less allocation in this
fixture. Bulk eviction is a stress case, not a claim about ordinary UI latency.
An initial staged-only implementation slightly increased no-eviction allocation;
the final version retains a no-eviction fast path and uses strict folds for
loaded totals instead of building intermediate mapped sequences. No-eviction
allocation now falls by 8.7%, with elapsed/CPU improvements on both runs.
