### PR TITLE
Split large CLI handlers into focused helpers

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -211,28 +211,11 @@ handleReplLine
     -> IO RunResult
 handleReplLine
         env@SessionEnv
-            { sessionCompact = compactRunner
-            , sessionRender = render
-            , sessionConversation = conversationRef
-            , sessionContextOccupancy = contextOccupancyRef
-            , sessionContextWindow = currentContextWindow
-            , sessionProvider = provider
+            { sessionProvider = provider
             , sessionPolicy = policyRef
-            , sessionPersist = persist
             , sessionPlanMode = planMode
             , sessionProjectRoot = projectRoot
-            , sessionCwd = cwd
-            , sessionTokenProvider = tokenProvider
-            , sessionOpenAiPool = openAiPool
-            , sessionGatewayModels = gatewayModelsRef
-            , sessionSkills = skillsRef
-            , sessionSkillInvocations = skillInvocationsRef
-            , sessionRefreshSkills = refreshSkills
-            , sessionDraft = draftRef
-            , sessionPreviewId = previewIdRef
-            , sessionTerminal = terminal
             , sessionFullscreen = fullscreen
-            , sessionAgentViewport = agentViewport
             }
         continueWith
         finishTurn
@@ -300,7 +283,11 @@ handleReplLine
             retryPendingTurn
             (ChooseAccount keptDraft)
     ReplMeta request ->
-        runMetaConsoleRequest request
+        handleMetaConsoleRequest
+            handlerContext
+            slashCatalog
+            (submit (pure RunQuit) False)
+            request
     ReplRemovePendingImage keptDraft index ->
         handleAttachmentAction
             env
@@ -308,11 +295,9 @@ handleReplLine
             (continueWith keptDraft)
             (ReplRemoveAttachment index)
     ReplPasted pasted ->
-        submitLine slashCatalog skillInvocations
-            continue stdoutColor True pasted
+        submit (continueWith "") True pasted
     ReplText line ->
-        submitLine slashCatalog skillInvocations
-            continue stdoutColor False line
+        submit (continueWith "") False line
   where
     handlerContext =
         ReplHandlerContext
@@ -320,6 +305,35 @@ handleReplLine
             , handlerContinueWith = continueWith
             , handlerStdoutColor = stdoutColor
             }
+    displayInfo = displayReplInfo handlerContext
+    submit =
+        submitReplLine
+            handlerContext finishTurn retryPendingTurn slashCatalog skillInvocations
+
+-- | Submit editor text, keeping the caller's continuation distinct from the
+-- continuation used by one-shot meta-console requests.
+submitReplLine
+    :: ReplHandlerContext
+    -> (Bool -> TurnResult -> IO RunResult)
+    -> (PendingTurn -> IO RunResult)
+    -> SlashCatalog
+    -> [SkillInvocation]
+    -> IO RunResult
+    -> Bool
+    -> Text
+    -> IO RunResult
+submitReplLine handlerContext finishTurn retryPendingTurn slashCatalog skillInvocations next pasted line =
+    submitLine slashCatalog skillInvocations next stdoutColor pasted line
+  where
+    ReplHandlerContext
+        { handlerSessionEnv = env
+        , handlerStdoutColor = stdoutColor
+        } = handlerContext
+    SessionEnv
+        { sessionConversation = conversationRef
+        , sessionPersist = persist
+        , sessionFullscreen = fullscreen
+        } = env
     submitLine
             slashCatalog skillInvocations
             continue color pasted line = do
@@ -340,23 +354,25 @@ handleReplLine
                     ReplMetaConsole request ->
                         runMetaConsoleRequest request
                     ReplPrompt text ->
-                        submitPrompt pasted continue color text
+                        submitPrompt handlerContext finishTurn pasted continue color text
                     ReplExpandedPrompt original expanded ->
                         submitExpandedTurnWithPaste
                             pasted continue color original expanded
                     ReplInit ->
-                        initializeProjectGuide continue color line
+                        initializeProjectGuide handlerContext submitExpandedTurn continue color line
                     ReplReview review ->
-                        submitReview continue color line review
+                        submitReview handlerContext submitExpandedTurn continue color line review
                     ReplDiff ->
-                        showWorkingTreeDiff continue color
+                        showWorkingTreeDiff handlerContext continue color
                     ReplExport maybePath ->
                         handleTranscriptAction handlerContext
                             (ExportTranscript maybePath)
                     ReplPermissions ->
-                        choosePermissions continue color
+                        choosePermissions handlerContext continue color
                     ReplInvokeSkill invocationName arguments ->
                         submitSkillInvocation
+                            handlerContext
+                            finishTurn
                             skillInvocations
                             continue
                             color
@@ -364,11 +380,11 @@ handleReplLine
                             invocationName
                             arguments
                     ReplSkills reloadFirst ->
-                        showSkills continue color reloadFirst
+                        showSkills handlerContext continue color reloadFirst
                     ReplShowShell ->
-                        showShellMode continue color
+                        showShellMode handlerContext continue color
                     ReplSetShell mode ->
-                        setShellMode continue color mode
+                        setShellMode handlerContext continue color mode
                     ReplToggleComputerUse -> do
                         enabled <- env.sessionComputerUseEnabled
                         message <-
@@ -386,15 +402,16 @@ handleReplLine
                     ReplAttachment action ->
                         handleAttachmentAction env finishTurn continue action
                     ReplShowAgentLimit ->
-                        showAgentLimit continue
+                        showAgentLimit handlerContext continue
                     ReplSetAgentLimit limit ->
-                        setAgentLimit continue limit
+                        setAgentLimit handlerContext continue limit
                     ReplAgents ->
-                        chooseAgent continue
+                        chooseAgent env continue
                     ReplMcp ->
-                        manageMcpServers continue
+                        manageMcpServers handlerContext continue
                     ReplMcpPrompt server name arguments ->
                         submitMcpPrompt
+                            handlerContext submitExpandedTurn
                             continue color server name arguments
                     ReplWorkflow action ->
                         handleWorkflowAction env submitExpandedTurn color continue action
@@ -411,41 +428,41 @@ handleReplLine
                     ReplCopySession ->
                         handleTranscriptAction handlerContext CopySessionId
                     ReplDesktop ->
-                        openDesktopSession continue
+                        openDesktopSession handlerContext continue
                     ReplShowTerminal ->
-                        showTerminalCapabilities continue color
+                        showTerminalCapabilities handlerContext continue color
                     ReplChangelog ->
-                        showChangelog continue
+                        showChangelog handlerContext continue
                     ReplSelection action ->
                         handleSelectionAction env continue action
                     ReplEnableCodeMode ->
                         requestCodeModeRestart fullscreen persist
                     ReplToggleAlwaysApprove ->
-                        toggleApprovalMode continue
+                        toggleApprovalMode handlerContext continue
                     ReplCompact focus ->
-                        compactContext continue focus
+                        compactContext handlerContext continue focus
                     ReplViewPlan ->
-                        showSavedPlan continue
+                        showSavedPlan handlerContext continue
                     ReplPlan maybeDescription ->
-                        enterPlanCommand continue maybeDescription
+                        enterPlanCommand handlerContext continue maybeDescription
                     ReplQueue ->
-                        showQueuedPrompts continue
+                        showQueuedPrompts handlerContext continue
                     ReplContext ->
-                        showContextReport continue
+                        showContextReport handlerContext continue
                     ReplHistory ->
-                        showPromptHistory continue color
+                        showPromptHistory handlerContext continue color
                     ReplTranscript ->
                         handleTranscriptAction handlerContext ShowTranscript
                     ReplFind maybeQuery ->
                         handleTranscriptAction handlerContext
                             (FindTranscript maybeQuery)
                     ReplEditPrompt ->
-                        editCurrentPrompt continue color
+                        editCurrentPrompt handlerContext continue color
                     ReplBtw question -> do
                         runBtwQuestion True env question
                         continue
                     ReplRecap ->
-                        requestSessionRecap continue
+                        requestSessionRecap env continue
                     ReplRetry ->
                         resumePendingTurnIfPresent
                             env.sessionLastFailedTurn
@@ -458,16 +475,32 @@ handleReplLine
                     ReplSession action ->
                         handleSessionAction env slashCatalog continue action
                     ReplLogin ->
-                        manageLogin continue
+                        manageLogin env continue
                     ReplUsage ->
-                        showUsage continue
+                        showUsage handlerContext continue
                     ReplReloadAuth ->
-                        reloadProviderAuth continue
+                        reloadProviderAuth handlerContext continue
                     ReplHelp maybeName ->
-                        showCommandHelp slashCatalog continue maybeName
+                        showCommandHelp handlerContext slashCatalog continue maybeName
                     ReplCommandError err ->
-                        showCommandError continue err
-    showShellMode next color = do
+                        showCommandError handlerContext continue err
+    submitExpandedTurn = submitExpandedTurnWithPaste False
+    submitExpandedTurnWithPaste =
+        submitExpandedPrompt handlerContext finishTurn
+    runMetaConsoleRequest =
+        handleMetaConsoleRequest
+            handlerContext
+            slashCatalog
+            (submitLine
+                slashCatalog
+                skillInvocations
+                (pure RunQuit)
+                stdoutColor
+                False)
+    displayInfo = displayReplInfo handlerContext
+
+showShellMode :: ReplHandlerContext -> IO RunResult -> Bool -> IO RunResult
+showShellMode handlerContext next color = do
         mode <- env.sessionShellMode
         let message = "shell tools: " <> case mode of
                 ShellGhci -> "ghci"
@@ -478,12 +511,22 @@ handleReplLine
             Text.putStrLn
                 (roleMuted color (glyphSession <> message))
         next
-    setShellMode next color mode = do
+  where
+    env = handlerContext.handlerSessionEnv
+    displayInfo = displayReplInfo handlerContext
+
+setShellMode :: ReplHandlerContext -> IO RunResult -> Bool -> ShellMode -> IO RunResult
+setShellMode handlerContext next color mode = do
         message <- env.sessionSetShellMode mode
         displayInfo message $
             Text.putStrLn (roleMuted color (glyphOk <> message))
         next
-    showAgentLimit next = do
+  where
+    env = handlerContext.handlerSessionEnv
+    displayInfo = displayReplInfo handlerContext
+
+showAgentLimit :: ReplHandlerContext -> IO RunResult -> IO RunResult
+showAgentLimit handlerContext next = do
         limit <- env.sessionConcurrentLimit
         let message =
                 "concurrent agent limit: " <> Text.pack (show limit)
@@ -492,13 +535,23 @@ handleReplLine
             Text.putStrLn
                 (roleMuted color (glyphSession <> message))
         next
-    setAgentLimit next limit = do
+  where
+    env = handlerContext.handlerSessionEnv
+    displayInfo = displayReplInfo handlerContext
+
+setAgentLimit :: ReplHandlerContext -> IO RunResult -> Int -> IO RunResult
+setAgentLimit handlerContext next limit = do
         message <- env.sessionSetConcurrentLimit limit
         color <- resolveColor stdout
         displayInfo message $
             Text.putStrLn (roleMuted color (glyphOk <> message))
         next
-    chooseAgent next =
+  where
+    env = handlerContext.handlerSessionEnv
+    displayInfo = displayReplInfo handlerContext
+
+chooseAgent :: SessionEnv -> IO RunResult -> IO RunResult
+chooseAgent env next =
         case agentViewport of
             Nothing -> next
             Just viewport -> do
@@ -510,7 +563,12 @@ handleReplLine
                         Nothing -> pure ()
                         Just target -> viewport.viewportSelect target
                 next
-    manageMcpServers next = do
+  where
+    agentViewport = env.sessionAgentViewport
+    fullscreen = env.sessionFullscreen
+
+manageMcpServers :: ReplHandlerContext -> IO RunResult -> IO RunResult
+manageMcpServers handlerContext next = do
         color <- resolveColor stderr
         restart <-
             legacy $
@@ -522,7 +580,19 @@ handleReplLine
         if restart
             then requestMcpRestart fullscreen persist
             else next
-    submitMcpPrompt next color server name arguments = do
+  where
+    env = handlerContext.handlerSessionEnv
+    fullscreen = env.sessionFullscreen
+    persist = env.sessionPersist
+    legacy = withReplSuspended handlerContext
+
+-- | Submit an expanded prompt with the original command retained for display.
+type ExpandedTurn = IO RunResult -> Bool -> Text -> Text -> IO RunResult
+
+submitMcpPrompt
+    :: ReplHandlerContext -> ExpandedTurn -> IO RunResult -> Bool
+    -> Text -> Text -> [(Text, Text)] -> IO RunResult
+submitMcpPrompt handlerContext submitExpandedTurn next color server name arguments = do
         outcome <- case env.sessionMcpFleet of
             Nothing -> pure (Left "no MCP servers are configured")
             Just fleet ->
@@ -538,7 +608,12 @@ handleReplLine
                     color
                     ("/mcp prompt " <> server <> " " <> name)
                     (MCP.renderMcpPromptResult result)
-    openDesktopSession next = do
+  where
+    env = handlerContext.handlerSessionEnv
+    displayError = displayReplError handlerContext
+
+openDesktopSession :: ReplHandlerContext -> IO RunResult -> IO RunResult
+openDesktopSession handlerContext next = do
         currentSessionId persist >>= \case
             Nothing -> do
                 let err = "/desktop requires a persisted conversation"
@@ -559,12 +634,23 @@ handleReplLine
                             Text.hPutStrLn stderr
                                 (roleSuccess color (glyphOk <> message))
         next
-    showTerminalCapabilities next color = do
+  where
+    persist = handlerContext.handlerSessionEnv.sessionPersist
+    displayInfo = displayReplInfo handlerContext
+    displayError = displayReplError handlerContext
+
+showTerminalCapabilities :: ReplHandlerContext -> IO RunResult -> Bool -> IO RunResult
+showTerminalCapabilities handlerContext next color = do
         let message = formatTerminalCapabilities terminal
         displayInfo message $
             Text.putStrLn (roleMuted color message)
         next
-    showChangelog next = do
+  where
+    terminal = handlerContext.handlerSessionEnv.sessionTerminal
+    displayInfo = displayReplInfo handlerContext
+
+showChangelog :: ReplHandlerContext -> IO RunResult -> IO RunResult
+showChangelog handlerContext next = do
         releaseNotes <- loadReleaseNotes
         case fullscreen of
             Just runtime ->
@@ -575,7 +661,12 @@ handleReplLine
             Nothing ->
                 displayInfo releaseNotes (Text.putStrLn releaseNotes)
         next
-    toggleApprovalMode next
+  where
+    fullscreen = handlerContext.handlerSessionEnv.sessionFullscreen
+    displayInfo = displayReplInfo handlerContext
+
+toggleApprovalMode :: ReplHandlerContext -> IO RunResult -> IO RunResult
+toggleApprovalMode handlerContext next
         | provider == ClaudeCodeProvider = do
             let message =
                     "Claude Code permissions are fixed for this provider session; restart with --yolo or --no-yolo."
@@ -589,68 +680,15 @@ handleReplLine
             displayInfo message $
                 putTextLn stderr (roleMuted color message)
             next
-    compactContext next focus = do
-        color <- resolveColor stderr
-        result <-
-            withReplActivity "Compacting context…" $
-                compactRunner focus
-        case result of
-            Left err -> do
-                displayError err $
-                    Text.hPutStrLn stderr (roleError color err)
-                next
-            Right outcome -> do
-                persistCompactOutcome focus outcome
-                let statsMessage =
-                        "compacted "
-                            <> Text.pack
-                                (show outcome.compactBeforeTokens)
-                            <> " → "
-                            <> Text.pack
-                                (show outcome.compactAfterTokens)
-                            <> " tokens ("
-                            <> Text.pack
-                                (show (length outcome.compactHistory))
-                            <> " items)"
-                displayInfo statsMessage $
-                    Text.hPutStrLn stderr
-                        (roleMuted color (glyphSession <> statsMessage))
-                next
-    persistCompactOutcome focus outcome =
-        case persist of
-            PersistenceDisabled ->
-                fullscreenEvent
-                    (UiSystemMessage outcome.compactSummary)
-            PersistenceEnabled slotRef -> do
-                forM_ fullscreen beginFullscreenLiveHistory
-                fullscreenEvent
-                    (UiSystemMessage outcome.compactSummary)
-                now <- getCurrentTime
-                handle <- ensureSession slotRef
-                let turn = SessionTurn
-                        { turnAt = now
-                        , turnUserText = compactSessionUserText focus
-                        , turnAssistantText = Just outcome.compactSummary
-                        , turnError = Nothing
-                        , turnResponseId = Nothing
-                        , turnEffect = TranscriptReplace
-                        , turnItems = outcome.compactHistory
-                        , turnDisplayItems = []
-                        -- Compaction response usage is recorded immediately
-                        -- by compactRunner, including response-level failures.
-                        , turnUsage = Nothing
-                        , turnProviderTelemetry = []
-                        }
-                (handle', turnIndex) <-
-                    appendTurnWithMetaUpdateIndexed handle turn
-                        \meta -> meta { metaLastResponseId = Nothing }
-                writeIORef slotRef (PersistenceActive handle')
-                forM_ fullscreen \runtime ->
-                    commitFullscreenHistoryTurn
-                        runtime
-                        (sessionHistoryTurn turnIndex turn)
-                        HistoryCommitAppend
-    showSavedPlan next = do
+  where
+    env = handlerContext.handlerSessionEnv
+    provider = env.sessionProvider
+    policyRef = env.sessionPolicy
+    projectRoot = env.sessionProjectRoot
+    displayInfo = displayReplInfo handlerContext
+
+showSavedPlan :: ReplHandlerContext -> IO RunResult -> IO RunResult
+showSavedPlan handlerContext next = do
         markdown <- readPlanMarkdown planMode
         if Text.null (Text.strip markdown)
             then do
@@ -660,7 +698,12 @@ handleReplLine
             else
                 displayInfo markdown (Text.putStrLn markdown)
         next
-    enterPlanCommand next maybeDescription
+  where
+    planMode = handlerContext.handlerSessionEnv.sessionPlanMode
+    displayInfo = displayReplInfo handlerContext
+
+enterPlanCommand :: ReplHandlerContext -> IO RunResult -> Maybe Text -> IO RunResult
+enterPlanCommand handlerContext next maybeDescription
         | provider == ClaudeCodeProvider = do
             let message =
                     "Outer plan mode is unavailable for Claude Code because its tools run inside the Claude CLI."
@@ -673,7 +716,13 @@ handleReplLine
                 Just providerSwitch ->
                     pure (RunSwitchProvider providerSwitch)
                 Nothing -> next
-    showQueuedPrompts next = do
+  where
+    env = handlerContext.handlerSessionEnv
+    provider = env.sessionProvider
+    displayInfo = displayReplInfo handlerContext
+
+showQueuedPrompts :: ReplHandlerContext -> IO RunResult -> IO RunResult
+showQueuedPrompts handlerContext next = do
         prompts <- case fullscreen of
             Nothing -> pure []
             Just runtime ->
@@ -682,7 +731,12 @@ handleReplLine
         let message = formatQueuedPrompts prompts
         displayInfo message (Text.putStrLn message)
         next
-    showContextReport next = do
+  where
+    fullscreen = handlerContext.handlerSessionEnv.sessionFullscreen
+    displayInfo = displayReplInfo handlerContext
+
+showContextReport :: ReplHandlerContext -> IO RunResult -> IO RunResult
+showContextReport handlerContext next = do
         currentParams <- readSessionRequestParams env.sessionParams
         history <- readLiveTranscript conversationRef
         occupancy <- readIORef contextOccupancyRef
@@ -699,7 +753,15 @@ handleReplLine
                     activeTools
         displayInfo message (Text.putStrLn message)
         next
-    showPromptHistory next color = do
+  where
+    env = handlerContext.handlerSessionEnv
+    conversationRef = env.sessionConversation
+    contextOccupancyRef = env.sessionContextOccupancy
+    currentContextWindow = env.sessionContextWindow
+    displayInfo = displayReplInfo handlerContext
+
+showPromptHistory :: ReplHandlerContext -> IO RunResult -> Bool -> IO RunResult
+showPromptHistory handlerContext next color = do
         prompts <-
             filter
                 ((/= "/history") . Text.toCaseFold . Text.strip)
@@ -729,14 +791,13 @@ handleReplLine
                                     (historyLabel prompt))
                             prompts
                 maybe next continueWith selected
-    editCurrentPrompt next color =
-        legacy editPrompt >>= \case
-            Left err -> do
-                displayError err $
-                    Text.hPutStrLn stderr (roleError color err)
-                next
-            Right edited -> continueWith edited
-    requestSessionRecap next =
+  where
+    fullscreen = handlerContext.handlerSessionEnv.sessionFullscreen
+    continueWith = handlerContext.handlerContinueWith
+    displayInfo = displayReplInfo handlerContext
+
+requestSessionRecap :: SessionEnv -> IO RunResult -> IO RunResult
+requestSessionRecap env next =
         case fullscreen of
             Just runtime -> do
                 emitUiEvent runtime UiRecapStarted
@@ -745,7 +806,11 @@ handleReplLine
             Nothing -> do
                 runSessionRecap True env RecapManual
                 next
-    manageLogin next = do
+  where
+    fullscreen = env.sessionFullscreen
+
+manageLogin :: SessionEnv -> IO RunResult -> IO RunResult
+manageLogin env next = do
         gatewayBefore <- loadGatewayCredential
         case fullscreen of
             Just runtime -> runFullscreenLoginManager runtime
@@ -756,7 +821,12 @@ handleReplLine
         if gatewayRoutingChanged gatewayBefore gatewayAfter
             then requestGatewayRestart fullscreen cwd
             else next
-    showUsage next = do
+  where
+    fullscreen = env.sessionFullscreen
+    cwd = env.sessionCwd
+
+showUsage :: ReplHandlerContext -> IO RunResult -> IO RunResult
+showUsage handlerContext next = do
         readIORef gatewayModelsRef >>= \case
             Just _ ->
                 displayInfo
@@ -773,7 +843,18 @@ handleReplLine
                             False provider tokenProvider openAiPool
                             >>= emitUiEvent runtime . UiSystemMessage
         next
-    reloadProviderAuth next = do
+  where
+    env = handlerContext.handlerSessionEnv
+    gatewayModelsRef = env.sessionGatewayModels
+    fullscreen = env.sessionFullscreen
+    provider = env.sessionProvider
+    tokenProvider = env.sessionTokenProvider
+    openAiPool = env.sessionOpenAiPool
+    stdoutColor = handlerContext.handlerStdoutColor
+    displayInfo = displayReplInfo handlerContext
+
+reloadProviderAuth :: ReplHandlerContext -> IO RunResult -> IO RunResult
+reloadProviderAuth handlerContext next = do
         reloadResult <- reloadAuth provider tokenProvider
         color <- resolveColor stderr
         case reloadResult of
@@ -784,58 +865,36 @@ handleReplLine
                 displayInfo message $
                     putTextLn stderr (roleMuted color message)
         next
-    showCommandHelp catalog next maybeName = do
+  where
+    env = handlerContext.handlerSessionEnv
+    provider = env.sessionProvider
+    tokenProvider = env.sessionTokenProvider
+    displayInfo = displayReplInfo handlerContext
+    displayError = displayReplError handlerContext
+
+showCommandHelp :: ReplHandlerContext -> SlashCatalog -> IO RunResult -> Maybe Text -> IO RunResult
+showCommandHelp handlerContext catalog next maybeName = do
         color <- resolveColor stdout
         displayInfo
             (formatSlashHelpWithCatalog False catalog maybeName) $
             Text.putStrLn
                 (formatSlashHelpWithCatalog color catalog maybeName)
         next
-    showCommandError next err = do
+  where
+    displayInfo = displayReplInfo handlerContext
+
+showCommandError :: ReplHandlerContext -> IO RunResult -> Text -> IO RunResult
+showCommandError handlerContext next err = do
         color <- resolveColor stderr
         displayError err $
             Text.hPutStrLn stderr (roleError color err)
         next
-    submitPrompt pasted next color text = do
-        -- Native Cmd+V of a Finder image often pastes a path rather than
-        -- bitmap bytes. Treat a prompt that is only image path(s) as an attach
-        -- plus in-terminal preview, matching Grok Build's paste chip.
-        pastedImages <- loadImagesFromPastedText text
-        case pastedImages of
-            Just images@(_:_) -> do
-                message <- queueAttachedImages
-                    conversationRef
-                    previewIdRef
-                    color
-                    (isNothing fullscreen)
-                    images
-                syncFullscreenImagePreviews
-                displayInfo message $
-                    Text.putStrLn
-                        (roleMuted color (glyphOk <> message))
-                next
-            _ -> do
-                pendingImages <-
-                    modifyLiveAttachments conversationRef \imgs -> ([], imgs)
-                forM_ fullscreen \runtime ->
-                    commitFullscreenImagePreviews runtime pendingImages
-                resetRenderPrintedText render
-                let turnInputs =
-                        [ userMessageWithAttachments
-                            text
-                            (map ImageAttachmentItem pendingImages)
-                        ]
-                preparePromptSkillInputsWithPaste
-                    env pasted text turnInputs >>= \case
-                        Left err -> do
-                            displayError err $
-                                Text.hPutStrLn stderr (roleError color err)
-                            next
-                        Right skillInputs -> do
-                            fullscreenEvent (UiUserSubmitted text)
-                            result <- runOneTurn env text skillInputs
-                            finishTurn False result
-    initializeProjectGuide next color line = do
+  where
+    displayError = displayReplError handlerContext
+
+initializeProjectGuide
+    :: ReplHandlerContext -> ExpandedTurn -> IO RunResult -> Bool -> Text -> IO RunResult
+initializeProjectGuide handlerContext submitExpandedTurn next color line = do
         let guidePath = cwd </> unsafeEncodeUtf "AGENTS.md"
         tryIO
             (getSymbolicLinkStatus
@@ -857,7 +916,15 @@ handleReplLine
                     Text.putStrLn
                         (roleMuted color (glyphSession <> message))
                 next
-    submitReview next color line = \case
+  where
+    cwd = handlerContext.handlerSessionEnv.sessionCwd
+    displayInfo = displayReplInfo handlerContext
+    displayError = displayReplError handlerContext
+
+submitReview
+    :: ReplHandlerContext -> ExpandedTurn -> IO RunResult -> Bool
+    -> Text -> Maybe Text -> IO RunResult
+submitReview handlerContext submitExpandedTurn next color line = \case
         Just instructions ->
             submitExpandedTurn
                 next
@@ -865,7 +932,7 @@ handleReplLine
                 line
                 (reviewPrompt (ReviewCustom instructions))
         Nothing ->
-            chooseReviewTarget >>= \case
+            chooseReviewTarget handlerContext >>= \case
                 Left err -> do
                     displayError err $
                         Text.hPutStrLn stderr (roleError color err)
@@ -877,58 +944,13 @@ handleReplLine
                         color
                         line
                         (reviewPrompt target)
-    showWorkingTreeDiff next color = do
-        result <-
-            withReplActivity "Loading Git diff…" $
-                getGitDiff cwd
-        case result of
-            Left err -> do
-                displayError err $
-                    Text.hPutStrLn stderr (roleError color err)
-                next
-            Right GitDiffNotRepository -> do
-                let message = "not a Git repository"
-                displayError message $
-                    Text.hPutStrLn stderr (roleError color message)
-                next
-            Right (GitDiffOutput diff)
-                | Text.null (Text.strip diff) -> do
-                    let message = "No working-tree changes."
-                    displayInfo message $
-                        Text.putStrLn
-                            (roleMuted color (glyphSession <> message))
-                    next
-                | otherwise -> do
-                    displayInfo diff $
-                        Text.putStrLn (colorizeGitDiff color diff)
-                    next
-    choosePermissions next color
-        | provider == ClaudeCodeProvider = do
-            let message =
-                    "Claude Code permissions are fixed for this provider session; restart with --yolo or --no-yolo."
-            displayInfo message $
-                Text.hPutStrLn stderr (roleMuted color message)
-            next
-        | otherwise = do
-            current <- readIORef policyRef
-            requestChoice
-                "Permissions"
-                "Choose how mutating tools are handled."
-                (approvalPolicyIndex current)
-                approvalPolicyRows >>= \case
-                    Nothing -> next
-                    Just index -> do
-                        message <-
-                            setApprovalPolicy
-                                policyRef
-                                projectRoot
-                                (approvalPolicyAt index)
-                        displayInfo message $
-                            Text.hPutStrLn stderr
-                                (roleMuted color (glyphOk <> message))
-                        next
-    submitSkillInvocation
-            invocations next color line invocationName arguments =
+  where
+    displayError = displayReplError handlerContext
+
+submitSkillInvocation
+    :: ReplHandlerContext -> (Bool -> TurnResult -> IO RunResult)
+    -> [SkillInvocation] -> IO RunResult -> Bool -> Text -> Text -> Text -> IO RunResult
+submitSkillInvocation handlerContext finishTurn invocations next color line invocationName arguments =
         case resolveSkillInvocation invocations invocationName of
             Left err -> do
                 displayError err $
@@ -958,7 +980,16 @@ handleReplLine
                 fullscreenEvent (UiUserSubmitted line)
                 result <- runOneTurn env line skillInputs
                 finishTurn False result
-    showSkills next color reloadFirst = do
+  where
+    env = handlerContext.handlerSessionEnv
+    conversationRef = env.sessionConversation
+    fullscreen = env.sessionFullscreen
+    render = env.sessionRender
+    fullscreenEvent = emitReplEvent env
+    displayError = displayReplError handlerContext
+
+showSkills :: ReplHandlerContext -> IO RunResult -> Bool -> Bool -> IO RunResult
+showSkills handlerContext next color reloadFirst = do
         when reloadFirst (refreshSkills True)
         current <- readIORef skillsRef
         invocations <- readIORef skillInvocationsRef
@@ -966,8 +997,17 @@ handleReplLine
         displayInfo (formatSkillsListing False current invocations) $
             Text.putStrLn listing
         next
-    submitExpandedTurn = submitExpandedTurnWithPaste False
-    submitExpandedTurnWithPaste pasted next color original expanded = do
+  where
+    env = handlerContext.handlerSessionEnv
+    refreshSkills = env.sessionRefreshSkills
+    skillsRef = env.sessionSkills
+    skillInvocationsRef = env.sessionSkillInvocations
+    displayInfo = displayReplInfo handlerContext
+
+submitExpandedPrompt
+    :: ReplHandlerContext -> (Bool -> TurnResult -> IO RunResult)
+    -> Bool -> ExpandedTurn
+submitExpandedPrompt handlerContext finishTurn pasted next color original expanded = do
         pendingImages <-
             modifyLiveAttachments conversationRef \imgs -> ([], imgs)
         forM_ fullscreen \runtime ->
@@ -987,19 +1027,127 @@ handleReplLine
                 fullscreenEvent (UiUserSubmitted original)
                 result <- runOneTurn env original skillInputs
                 finishTurn False result
-    runMetaConsoleRequest =
-        handleMetaConsoleRequest
-            handlerContext
-            slashCatalog
-            (submitLine
-                slashCatalog
-                skillInvocations
-                (pure RunQuit)
-                stdoutColor
-                False)
+  where
+    env = handlerContext.handlerSessionEnv
+    conversationRef = env.sessionConversation
+    fullscreen = env.sessionFullscreen
+    render = env.sessionRender
+    fullscreenEvent = emitReplEvent env
+    displayError = displayReplError handlerContext
 
-    continue = continueWith ""
-    chooseReviewTarget =
+submitPrompt
+    :: ReplHandlerContext
+    -> (Bool -> TurnResult -> IO RunResult)
+    -> Bool -> IO RunResult -> Bool -> Text -> IO RunResult
+submitPrompt handlerContext finishTurn pasted next color text = do
+    -- Native Cmd+V of a Finder image often pastes a path rather than
+    -- bitmap bytes. Treat a prompt that is only image path(s) as an attach
+    -- plus in-terminal preview, matching Grok Build's paste chip.
+    pastedImages <- loadImagesFromPastedText text
+    case pastedImages of
+        Just images@(_:_) -> do
+            message <- queueAttachedImages
+                conversationRef
+                env.sessionPreviewId
+                color
+                (isNothing fullscreen)
+                images
+            forM_ fullscreen \runtime ->
+                readLiveAttachments conversationRef
+                    >>= setFullscreenImagePreviews runtime
+            displayReplInfo handlerContext message $
+                Text.putStrLn
+                    (roleMuted color (glyphOk <> message))
+            next
+        _ -> do
+            pendingImages <-
+                modifyLiveAttachments conversationRef \imgs -> ([], imgs)
+            forM_ fullscreen \runtime ->
+                commitFullscreenImagePreviews runtime pendingImages
+            resetRenderPrintedText env.sessionRender
+            let turnInputs =
+                    [ userMessageWithAttachments
+                        text
+                        (map ImageAttachmentItem pendingImages)
+                    ]
+            preparePromptSkillInputsWithPaste
+                env pasted text turnInputs >>= \case
+                    Left err -> do
+                        displayReplError handlerContext err $
+                            Text.hPutStrLn stderr (roleError color err)
+                        next
+                    Right skillInputs -> do
+                        emitReplEvent env (UiUserSubmitted text)
+                        result <- runOneTurn env text skillInputs
+                        finishTurn False result
+  where
+    env = handlerContext.handlerSessionEnv
+    conversationRef = env.sessionConversation
+    fullscreen = env.sessionFullscreen
+
+showWorkingTreeDiff :: ReplHandlerContext -> IO RunResult -> Bool -> IO RunResult
+showWorkingTreeDiff handlerContext next color = do
+    result <-
+        withCommandActivity env "Loading Git diff…" $
+            getGitDiff env.sessionCwd
+    case result of
+        Left err -> do
+            displayError err $
+                Text.hPutStrLn stderr (roleError color err)
+            next
+        Right GitDiffNotRepository -> do
+            let message = "not a Git repository"
+            displayError message $
+                Text.hPutStrLn stderr (roleError color message)
+            next
+        Right (GitDiffOutput diff)
+            | Text.null (Text.strip diff) -> do
+                let message = "No working-tree changes."
+                displayInfo message $
+                    Text.putStrLn
+                        (roleMuted color (glyphSession <> message))
+                next
+            | otherwise -> do
+                displayInfo diff $
+                    Text.putStrLn (colorizeGitDiff color diff)
+                next
+  where
+    env = handlerContext.handlerSessionEnv
+    displayInfo = displayReplInfo handlerContext
+    displayError = displayReplError handlerContext
+
+choosePermissions :: ReplHandlerContext -> IO RunResult -> Bool -> IO RunResult
+choosePermissions handlerContext next color
+    | env.sessionProvider == ClaudeCodeProvider = do
+        let message =
+                "Claude Code permissions are fixed for this provider session; restart with --yolo or --no-yolo."
+        displayInfo message $
+            Text.hPutStrLn stderr (roleMuted color message)
+        next
+    | otherwise = do
+        current <- readIORef env.sessionPolicy
+        requestReplChoice handlerContext
+            "Permissions"
+            "Choose how mutating tools are handled."
+            (approvalPolicyIndex current)
+            approvalPolicyRows >>= \case
+                Nothing -> next
+                Just index -> do
+                    message <-
+                        setApprovalPolicy
+                            env.sessionPolicy
+                            env.sessionProjectRoot
+                            (approvalPolicyAt index)
+                    displayInfo message $
+                        Text.hPutStrLn stderr
+                            (roleMuted color (glyphOk <> message))
+                    next
+  where
+    env = handlerContext.handlerSessionEnv
+    displayInfo = displayReplInfo handlerContext
+
+chooseReviewTarget :: ReplHandlerContext -> IO (Either Text (Maybe ReviewTarget))
+chooseReviewTarget handlerContext =
         requestChoice
             "Review"
             "Select what the agent should review."
@@ -1084,86 +1232,172 @@ handleReplLine
                                     (Right
                                         (ReviewCustom
                                             <$> nonBlank instructions))
+  where
+    cwd = handlerContext.handlerSessionEnv.sessionCwd
     requestChoice = requestReplChoice handlerContext
     requestText = requestReplText handlerContext
-    approvalPolicyRows =
-        [ (label, detail)
-        | (_, label, detail) <- approvalPolicyOptions
-        ]
-    approvalPolicyIndex policy =
-        fromMaybe 0 $
-            findIndex
-                (\(candidate, _, _) -> candidate == policy)
-                approvalPolicyOptions
-    approvalPolicyAt index =
-        case indexMaybe index approvalPolicyOptions of
-            Just (policy, _, _) -> policy
-            Nothing -> PromptMutating
-    indexMaybe index values
-        | index < 0 = Nothing
-        | otherwise =
-            case drop index values of
-                value : _ -> Just value
-                [] -> Nothing
-    nonBlank value
-        | Text.null stripped = Nothing
-        | otherwise = Just stripped
-      where
-        stripped = Text.strip value
-    legacy = withReplSuspended handlerContext
-    fullscreenEvent event = case fullscreen of
-        Nothing -> pure ()
-        Just runtime -> emitUiEvent runtime event
-    syncFullscreenImagePreviews =
-        forM_ fullscreen \runtime ->
-            readLiveAttachments conversationRef
-                >>= setFullscreenImagePreviews runtime
-    displayInfo = displayReplInfo handlerContext
-    displayError = displayReplError handlerContext
-    withReplActivity message action = do
-        case fullscreen of
-            Nothing ->
-                renderEvent render (ActivityUpdated message)
-            Just runtime ->
-                emitUiEvent runtime
-                    (UiSetNotice (Just (progressNotice message)))
-        action `finally`
-            case fullscreen of
-                Nothing -> clearThinking render
-                Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
-    editPrompt = do
-        initialDraft <- readIORef draftRef
-        outcome <- tryAny do
-            resolveExternalProgram
-                [("VISUAL", "$VISUAL"), ("EDITOR", "$EDITOR")]
-                "vi" >>= \case
-                    Left err -> pure (Left err)
-                    Right program ->
-                        withTemporaryTextFile
-                            "agent-prompt-"
-                            initialDraft
-                            \path ->
-                                runExternalProgramOnFile program path >>= \case
-                                    Left err -> pure (Left err)
-                                    Right () ->
-                                        Right . normalizeEditedText
-                                            <$> Text.readFile path
-        pure $ case outcome of
-            Left exception ->
-                Left
-                    ( "could not edit prompt: "
-                        <> Text.pack (show exception)
-                    )
-            Right result -> result
+    withReplActivity = withCommandActivity handlerContext.handlerSessionEnv
 
-    historyLabel =
-        truncateDisplayText 120 . Text.replace "\n" " ↵ "
+approvalPolicyRows :: [(Text, Text)]
+approvalPolicyRows =
+    [ (label, detail)
+    | (_, label, detail) <- approvalPolicyOptions
+    ]
 
-    listAt index values
-        | index < 0 = Nothing
-        | otherwise = case drop index values of
+approvalPolicyIndex :: ApprovalPolicy -> Int
+approvalPolicyIndex policy =
+    fromMaybe 0 $
+        findIndex
+            (\(candidate, _, _) -> candidate == policy)
+            approvalPolicyOptions
+
+approvalPolicyAt :: Int -> ApprovalPolicy
+approvalPolicyAt index =
+    case indexMaybe index approvalPolicyOptions of
+        Just (policy, _, _) -> policy
+        Nothing -> PromptMutating
+
+indexMaybe :: Int -> [a] -> Maybe a
+indexMaybe index values
+    | index < 0 = Nothing
+    | otherwise =
+        case drop index values of
             value : _ -> Just value
             [] -> Nothing
+
+nonBlank :: Text -> Maybe Text
+nonBlank value
+    | Text.null stripped = Nothing
+    | otherwise = Just stripped
+  where
+    stripped = Text.strip value
+
+emitReplEvent :: SessionEnv -> UiEvent -> IO ()
+emitReplEvent env event = case env.sessionFullscreen of
+    Nothing -> pure ()
+    Just runtime -> emitUiEvent runtime event
+
+withCommandActivity :: SessionEnv -> Text -> IO a -> IO a
+withCommandActivity env message action = do
+    case fullscreen of
+        Nothing ->
+            renderEvent render (ActivityUpdated message)
+        Just runtime ->
+            emitUiEvent runtime
+                (UiSetNotice (Just (progressNotice message)))
+    action `finally`
+        case fullscreen of
+            Nothing -> clearThinking render
+            Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
+  where
+    fullscreen = env.sessionFullscreen
+    render = env.sessionRender
+
+editCurrentPrompt :: ReplHandlerContext -> IO RunResult -> Bool -> IO RunResult
+editCurrentPrompt handlerContext next color =
+    withReplSuspended handlerContext (editPrompt handlerContext.handlerSessionEnv) >>= \case
+        Left err -> do
+            displayReplError handlerContext err $
+                Text.hPutStrLn stderr (roleError color err)
+            next
+        Right edited -> handlerContext.handlerContinueWith edited
+
+editPrompt :: SessionEnv -> IO (Either Text Text)
+editPrompt env = do
+    initialDraft <- readIORef env.sessionDraft
+    outcome <- tryAny do
+        resolveExternalProgram
+            [("VISUAL", "$VISUAL"), ("EDITOR", "$EDITOR")]
+            "vi" >>= \case
+                Left err -> pure (Left err)
+                Right program ->
+                    withTemporaryTextFile
+                        "agent-prompt-"
+                        initialDraft
+                        \path ->
+                            runExternalProgramOnFile program path >>= \case
+                                Left err -> pure (Left err)
+                                Right () ->
+                                    Right . normalizeEditedText
+                                        <$> Text.readFile path
+    pure $ case outcome of
+        Left exception ->
+            Left
+                ( "could not edit prompt: "
+                    <> Text.pack (show exception)
+                )
+        Right result -> result
+
+historyLabel :: Text -> Text
+historyLabel =
+    truncateDisplayText 120 . Text.replace "\n" " ↵ "
+
+listAt :: Int -> [a] -> Maybe a
+listAt = indexMaybe
+
+compactContext :: ReplHandlerContext -> IO RunResult -> Maybe Text -> IO RunResult
+compactContext handlerContext next focus = do
+    color <- resolveColor stderr
+    result <-
+        withCommandActivity env "Compacting context…" $
+            env.sessionCompact focus
+    case result of
+        Left err -> do
+            displayReplError handlerContext err $
+                Text.hPutStrLn stderr (roleError color err)
+            next
+        Right outcome -> do
+            persistCompactOutcome env focus outcome
+            let statsMessage =
+                    "compacted "
+                        <> Text.pack (show outcome.compactBeforeTokens)
+                        <> " → "
+                        <> Text.pack (show outcome.compactAfterTokens)
+                        <> " tokens ("
+                        <> Text.pack (show (length outcome.compactHistory))
+                        <> " items)"
+            displayReplInfo handlerContext statsMessage $
+                Text.hPutStrLn stderr
+                    (roleMuted color (glyphSession <> statsMessage))
+            next
+  where
+    env = handlerContext.handlerSessionEnv
+
+persistCompactOutcome :: SessionEnv -> Maybe Text -> CompactOutcome -> IO ()
+persistCompactOutcome env focus outcome =
+    case env.sessionPersist of
+        PersistenceDisabled ->
+            emitReplEvent env (UiSystemMessage outcome.compactSummary)
+        PersistenceEnabled slotRef -> do
+            forM_ fullscreen beginFullscreenLiveHistory
+            emitReplEvent env (UiSystemMessage outcome.compactSummary)
+            now <- getCurrentTime
+            handle <- ensureSession slotRef
+            let turn = SessionTurn
+                    { turnAt = now
+                    , turnUserText = compactSessionUserText focus
+                    , turnAssistantText = Just outcome.compactSummary
+                    , turnError = Nothing
+                    , turnResponseId = Nothing
+                    , turnEffect = TranscriptReplace
+                    , turnItems = outcome.compactHistory
+                    , turnDisplayItems = []
+                    -- Compaction response usage is recorded immediately
+                    -- by sessionCompact, including response-level failures.
+                    , turnUsage = Nothing
+                    , turnProviderTelemetry = []
+                    }
+            (handle', turnIndex) <-
+                appendTurnWithMetaUpdateIndexed handle turn
+                    \meta -> meta { metaLastResponseId = Nothing }
+            writeIORef slotRef (PersistenceActive handle')
+            forM_ fullscreen \runtime ->
+                commitFullscreenHistoryTurn
+                    runtime
+                    (sessionHistoryTurn turnIndex turn)
+                    HistoryCommitAppend
+  where
+    fullscreen = env.sessionFullscreen
 
 formatQueuedPrompts :: [Text] -> Text
 formatQueuedPrompts [] = "No prompts are queued."

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -86,13 +86,14 @@ import Agent.Provider
     ( Provider(GeminiProvider, OpenAIProvider),
       providerSlug,
       tokenProviderBillingMode )
-import Agent.ReasoningEffort (reasoningEffortText)
+import Agent.ReasoningEffort (ReasoningEffort, reasoningEffortText)
 import Agent.Responses.Types (ResponseCreateParams(..))
 import Agent.TUI.Model
     ( progressNotice,
       UiEvent(UiSetNotice, UiSystemMessage, UiErrorMessage) )
 import Agent.TUI.Theme
-    ( parseThemeKind
+    ( ThemeKind
+    , parseThemeKind
     , themeKindAt
     , themeKindRows
     , themeKindText
@@ -301,28 +302,22 @@ handleSelection
             , sessionConversation = conversationRef
             , sessionProvider = provider
             , sessionConnection = connectionId
-            , sessionModelCatalog = catalog
-            , sessionGatewayModels = gatewayModelsRef
             , sessionDialect = dialect
             , sessionParams = paramsRef
             , sessionPersist = persist
-            , sessionDatabasePool = databasePool
             , sessionProjectRoot = projectRoot
             , sessionHome = home
             , sessionDraft = draftRef
-            , sessionSelectAccount = selectAccount
-            , sessionTokenProvider = tokenProvider
-            , sessionFullscreen = fullscreen
             }
         continue
         retryPendingTurn = \case
     Left (ChooseModel keptDraft) -> do
         writeIORef draftRef keptDraft
-        chooseModel continue
-    Left (ChooseEffort _) -> chooseEffort continue
+        chooseModel env continue
+    Left (ChooseEffort _) -> chooseEffort env continue
     Left (ChooseAccount keptDraft) -> do
         writeIORef draftRef keptDraft
-        chooseAccount continue
+        chooseAccount env retryPendingTurn continue
     Right ReplShowEffort -> do
         color <- resolveColor stdout
         params <- readSessionRequestParams paramsRef
@@ -337,7 +332,7 @@ handleSelection
                 (roleMuted color (glyphSession <> message))
         continue
     Right (ReplSetEffort level) -> do
-        setEffort level
+        setEffort env level
         continue
     Right ReplToggleFast -> do
         color <- resolveColor stdout
@@ -366,19 +361,19 @@ handleSelection
                     Text.putStrLn (roleMuted color (glyphOk <> message))
         continue
     Right ReplShowModel -> do
-        chooseModel continue
+        chooseModel env continue
     Right (ReplSetModel name) -> do
         color <- resolveColor stdout
-        resolveRequestedModel name >>= \case
+        resolveRequestedModel env name >>= \case
             Left err -> do
-                displayError err $
+                selectionError env err $
                     Text.hPutStrLn stderr (roleError color err)
                 continue
             Right choice ->
                 if modelTargetRequiresRebuild
                         connectionId provider (dialectId dialect) choice
                     then
-                        switchModelTarget color choice Nothing continue
+                        switchModelTarget env color choice Nothing continue
                     else do
                         message <- applyModelChange
                             home projectRoot provider connectionId
@@ -392,7 +387,7 @@ handleSelection
                                 (roleMuted color (glyphOk <> message))
                         continue
     Right ReplShowTheme ->
-        chooseTheme continue
+        chooseTheme env continue
     Right (ReplSetTheme name) ->
         case parseThemeKind name of
             Nothing -> do
@@ -405,397 +400,467 @@ handleSelection
                     Text.hPutStrLn stderr (roleError color message)
                 continue
             Just theme ->
-                setTheme theme continue
+                setTheme env theme continue
   where
-    displayInfo message minimalAction = case fullscreen of
-        Nothing -> minimalAction
-        Just runtime -> emitUiEvent runtime (UiSystemMessage message)
-    displayError message minimalAction = case fullscreen of
-        Nothing -> minimalAction
-        Just runtime -> emitUiEvent runtime (UiErrorMessage message)
-    withReplActivity message action = do
-        case fullscreen of
-            Nothing -> renderEvent render (ActivityUpdated message)
-            Just runtime ->
-                emitUiEvent runtime
-                    (UiSetNotice (Just (progressNotice message)))
-        action `finally`
-            case fullscreen of
-                Nothing -> clearThinking render
-                Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
-    setEffort level = do
-        color <- resolveColor stdout
-        let supported = reasoningEffortsForDialect (dialectId dialect)
-            levelText = reasoningEffortText level
-        if level `elem` supported
-            then do
-                setSessionEffort env level
-                displayInfo ("effort set to " <> levelText) $
+    displayInfo = selectionInfo env
+    displayError = selectionError env
+
+selectionInfo :: SessionEnv -> Text -> IO () -> IO ()
+selectionInfo env message minimalAction = case env.sessionFullscreen of
+    Nothing -> minimalAction
+    Just runtime -> emitUiEvent runtime (UiSystemMessage message)
+
+selectionError :: SessionEnv -> Text -> IO () -> IO ()
+selectionError env message minimalAction = case env.sessionFullscreen of
+    Nothing -> minimalAction
+    Just runtime -> emitUiEvent runtime (UiErrorMessage message)
+
+withReplActivity :: SessionEnv -> Text -> IO a -> IO a
+withReplActivity env message action = do
+    case env.sessionFullscreen of
+        Nothing -> renderEvent env.sessionRender (ActivityUpdated message)
+        Just runtime ->
+            emitUiEvent runtime
+                (UiSetNotice (Just (progressNotice message)))
+    action `finally`
+        case env.sessionFullscreen of
+            Nothing -> clearThinking env.sessionRender
+            Just runtime -> emitUiEvent runtime (UiSetNotice Nothing)
+
+setEffort :: SessionEnv -> ReasoningEffort -> IO ()
+setEffort env level = do
+    color <- resolveColor stdout
+    let supported = reasoningEffortsForDialect (dialectId env.sessionDialect)
+        levelText = reasoningEffortText level
+    if level `elem` supported
+        then do
+            setSessionEffort env level
+            selectionInfo env ("effort set to " <> levelText) $
+                Text.putStrLn
+                    (roleMuted color
+                        (glyphOk <> "effort set to " <> levelText))
+        else do
+            let message =
+                    "effort "
+                        <> levelText
+                        <> " is not supported by the active model"
+            selectionError env message $
+                Text.hPutStrLn stderr (roleError color message)
+
+chooseEffort :: SessionEnv -> IO RunResult -> IO RunResult
+chooseEffort env next = do
+    params <- readSessionRequestParams env.sessionParams
+    effortChoice
+        env.sessionFullscreen
+        (reasoningEffortsForDialect (dialectId env.sessionDialect))
+        (currentEffort params) >>= \case
+        Nothing -> next
+        Just level -> setEffort env level >> next
+
+chooseModel :: SessionEnv -> IO RunResult -> IO RunResult
+chooseModel env@SessionEnv
+    { sessionModelCatalog = catalog
+    , sessionGatewayModels = gatewayModelsRef
+    , sessionFullscreen = fullscreen
+    , sessionConnection = connectionId
+    , sessionProvider = provider
+    , sessionDialect = dialect
+    , sessionParams = paramsRef
+    , sessionHome = home
+    , sessionProjectRoot = projectRoot
+    , sessionRender = render
+    , sessionConversation = conversationRef
+    , sessionPersist = persist
+    } next = do
+    color <- resolveColor stderr
+    params <- readSessionRequestParams paramsRef
+    gatewayAccess <- readIORef gatewayModelsRef
+    let current = currentModel params
+    modelChoiceWithEffort
+        catalog gatewayAccess fullscreen color connectionId provider current
+            (dialectId dialect) (currentEffort params) >>= \case
+        Left err -> do
+            selectionError env err $
+                Text.hPutStrLn stderr (roleError color err)
+            next
+        Right Nothing -> next
+        Right (Just selection) -> do
+            let rawChoice = selection.modelPickerOption
+                selectedEffort = selection.modelPickerEffort
+            choice <- resolveModelOptionDialect rawChoice
+            if choice.modelTarget.targetProvider == provider
+                && choice.modelTarget.targetConnectionId == connectionId
+                && choice.modelTarget.targetModelId == current
+                && choice.modelTarget.targetDialect == dialectId dialect
+              then do
+                setSessionEffort env selectedEffort
+                let message =
+                        "model: "
+                            <> connectionId
+                            <> "/"
+                            <> choice.modelTarget.targetModelId
+                            <> " · effort "
+                            <> reasoningEffortText selectedEffort
+                selectionInfo env message $
                     Text.putStrLn
                         (roleMuted color
-                            (glyphOk <> "effort set to " <> levelText))
-            else do
-                let message =
-                        "effort "
-                            <> levelText
-                            <> " is not supported by the active model"
-                displayError message $
-                    Text.hPutStrLn stderr (roleError color message)
-    chooseEffort next = do
-        params <- readSessionRequestParams paramsRef
-        effortChoice
-            fullscreen
-            (reasoningEffortsForDialect (dialectId dialect))
-            (currentEffort params) >>= \case
-            Nothing -> next
-            Just level -> setEffort level >> next
-    chooseModel next = do
-        color <- resolveColor stderr
-        params <- readSessionRequestParams paramsRef
-        gatewayAccess <- readIORef gatewayModelsRef
-        let current = currentModel params
-        modelChoiceWithEffort
-            catalog gatewayAccess fullscreen color connectionId provider current
-                (dialectId dialect) (currentEffort params) >>= \case
-            Left err -> do
-                displayError err $
-                    Text.hPutStrLn stderr (roleError color err)
+                            (glyphSession <> message))
                 next
-            Right Nothing -> next
-            Right (Just selection) -> do
-                let rawChoice = selection.modelPickerOption
-                    selectedEffort = selection.modelPickerEffort
-                choice <- resolveModelOptionDialect rawChoice
-                if choice.modelTarget.targetProvider == provider
-                    && choice.modelTarget.targetConnectionId == connectionId
-                    && choice.modelTarget.targetModelId == current
-                    && choice.modelTarget.targetDialect == dialectId dialect
-                  then do
-                    setSessionEffort env selectedEffort
-                    let message =
-                            "model: "
-                                <> connectionId
-                                <> "/"
-                                <> choice.modelTarget.targetModelId
-                                <> " · effort "
-                                <> reasoningEffortText selectedEffort
-                    displayInfo message $
-                        Text.putStrLn
-                            (roleMuted color
-                                (glyphSession <> message))
-                    next
-                  else if not
-                        (modelTargetRequiresRebuild
-                            connectionId provider (dialectId dialect) choice)
-                  then do
-                    message <- applyModelChange
-                        home projectRoot provider connectionId
-                        choice.modelTarget.targetModelId
-                        choice.modelTarget.targetWireModelId
-                        choice.modelTarget.targetDialect
-                        paramsRef render conversationRef persist
-                    env.sessionRefreshRequestParams
-                    setSessionEffort env selectedEffort
-                    displayInfo message $
-                        Text.putStrLn
-                            (roleMuted color
-                                (glyphOk <> message))
-                    next
-                  else
-                    switchModelTarget color choice (Just selectedEffort) next
-    resolveRequestedModel name =
-        readIORef gatewayModelsRef >>= \case
-            Just access ->
-                refreshGatewayModels access >>= \case
-                    Left err -> pure (Left err)
-                    Right models ->
-                        case
-                            resolveModelOptionById
-                                (modelOptionsForGatewayModels catalog models)
-                                name
-                        of
-                            Nothing ->
-                                pure
-                                    (Left
-                                        ("Model '"
-                                            <> name
-                                            <> "' is not available through your organization gateway."))
-                            Just choice ->
-                                Right <$> resolveModelOptionDialect choice
-            Nothing -> do
-                let rawChoice = rawModelOption provider name
-                    choice =
-                        fromMaybe
-                            (rawChoice
-                                { modelTarget =
-                                    rawChoice.modelTarget
-                                        { targetConnectionId = connectionId
-                                        , targetDialect = dialectId dialect
-                                        }
-                                })
-                            (resolveConfiguredModel catalog name)
-                Right <$> resolveModelOptionDialect choice
-    chooseTheme next =
-        case fullscreen of
-            Nothing -> do
-                color <- resolveColor stderr
-                let message = "theme selection requires fullscreen mode"
-                Text.hPutStrLn stderr (roleError color message)
+              else if not
+                    (modelTargetRequiresRebuild
+                        connectionId provider (dialectId dialect) choice)
+              then do
+                message <- applyModelChange
+                    home projectRoot provider connectionId
+                    choice.modelTarget.targetModelId
+                    choice.modelTarget.targetWireModelId
+                    choice.modelTarget.targetDialect
+                    paramsRef render conversationRef persist
+                env.sessionRefreshRequestParams
+                setSessionEffort env selectedEffort
+                selectionInfo env message $
+                    Text.putStrLn
+                        (roleMuted color
+                            (glyphOk <> message))
                 next
-            Just runtime -> do
-                current <- readIORef runtime.runtimeThemeRef
-                let initial =
-                        fromMaybe 0 $
-                            findIndex
-                                (== current)
-                                (map themeKindAt [0 .. length themeKindRows - 1])
-                requestFullscreenThemeChoice
-                    runtime
-                    initial
-                    themeKindRows >>= \case
-                    Nothing -> next
-                    Just index -> setTheme (themeKindAt index) next
-    setTheme theme next =
-        case fullscreen of
-            Nothing -> do
-                color <- resolveColor stderr
-                let message = "theme selection requires fullscreen mode"
-                Text.hPutStrLn stderr (roleError color message)
-                next
-            Just runtime -> do
-                updateHarnessConfig
-                    env.sessionHome
-                    (\config -> Right config { configTheme = theme })
-                    >>= \case
-                    Left err -> do
-                        color <- resolveColor stderr
-                        Text.hPutStrLn stderr (roleError color err)
-                        next
-                    Right _ -> do
-                        enqueueAppEvent runtime (AppSetTheme theme)
-                        emitUiEvent runtime
-                            (UiSystemMessage
-                                ("theme set to " <> themeKindText theme))
-                        next
-    switchModelTarget color choice selectedEffort next =
-        requestModelTargetSwitch fullscreen choice persist >>= \case
-            Left err
-                | choice.modelTarget.targetProvider == GeminiProvider
-                , modelAuthErrorNeedsConnect GeminiProvider err -> do
-                    connected <- case fullscreen of
+              else
+                switchModelTarget env color choice (Just selectedEffort) next
+
+resolveRequestedModel :: SessionEnv -> Text -> IO (Either Text ModelOption)
+resolveRequestedModel env name =
+    readIORef env.sessionGatewayModels >>= \case
+        Just access ->
+            refreshGatewayModels access >>= \case
+                Left err -> pure (Left err)
+                Right models ->
+                    case
+                        resolveModelOptionById
+                            (modelOptionsForGatewayModels env.sessionModelCatalog models)
+                            name
+                    of
                         Nothing ->
-                            connectProviderAccount color GeminiProvider
-                        Just runtime ->
-                            withFullscreenSuspended runtime $
-                                connectProviderAccount color GeminiProvider
-                    case connected of
-                        Nothing -> next
-                        Just _ ->
-                            requestModelTargetSwitch
-                                fullscreen choice persist >>= \case
-                                Left retryErr -> do
-                                    displayError retryErr $
-                                        Text.hPutStrLn stderr
-                                            (roleError color retryErr)
-                                    next
-                                Right result ->
-                                    pure
-                                        (applyTransitionEffort
-                                            selectedEffort
-                                            result)
-            Left err -> do
-                displayError err $
+                            pure
+                                (Left
+                                    ("Model '"
+                                        <> name
+                                        <> "' is not available through your organization gateway."))
+                        Just choice ->
+                            Right <$> resolveModelOptionDialect choice
+        Nothing -> do
+            let rawChoice = rawModelOption env.sessionProvider name
+                choice =
+                    fromMaybe
+                        (rawChoice
+                            { modelTarget =
+                                rawChoice.modelTarget
+                                    { targetConnectionId = env.sessionConnection
+                                    , targetDialect = dialectId env.sessionDialect
+                                    }
+                            })
+                        (resolveConfiguredModel env.sessionModelCatalog name)
+            Right <$> resolveModelOptionDialect choice
+
+chooseTheme :: SessionEnv -> IO RunResult -> IO RunResult
+chooseTheme env next =
+    case env.sessionFullscreen of
+        Nothing -> do
+            color <- resolveColor stderr
+            let message = "theme selection requires fullscreen mode"
+            Text.hPutStrLn stderr (roleError color message)
+            next
+        Just runtime -> do
+            current <- readIORef runtime.runtimeThemeRef
+            let initial =
+                    fromMaybe 0 $
+                        findIndex
+                            (== current)
+                            (map themeKindAt [0 .. length themeKindRows - 1])
+            requestFullscreenThemeChoice
+                runtime
+                initial
+                themeKindRows >>= \case
+                Nothing -> next
+                Just index -> setTheme env (themeKindAt index) next
+
+setTheme :: SessionEnv -> ThemeKind -> IO RunResult -> IO RunResult
+setTheme env theme next =
+    case env.sessionFullscreen of
+        Nothing -> do
+            color <- resolveColor stderr
+            let message = "theme selection requires fullscreen mode"
+            Text.hPutStrLn stderr (roleError color message)
+            next
+        Just runtime -> do
+            updateHarnessConfig
+                env.sessionHome
+                (\config -> Right config { configTheme = theme })
+                >>= \case
+                Left err -> do
+                    color <- resolveColor stderr
                     Text.hPutStrLn stderr (roleError color err)
-                next
-            Right result ->
-                pure (applyTransitionEffort selectedEffort result)
-    applyTransitionEffort selectedEffort = \case
+                    next
+                Right _ -> do
+                    enqueueAppEvent runtime (AppSetTheme theme)
+                    emitUiEvent runtime
+                        (UiSystemMessage
+                            ("theme set to " <> themeKindText theme))
+                    next
+
+switchModelTarget
+    :: SessionEnv
+    -> Bool
+    -> ModelOption
+    -> Maybe ReasoningEffort
+    -> IO RunResult
+    -> IO RunResult
+switchModelTarget env color choice selectedEffort next =
+    requestModelTargetSwitch env.sessionFullscreen choice env.sessionPersist >>= \case
+        Left err
+            | choice.modelTarget.targetProvider == GeminiProvider
+            , modelAuthErrorNeedsConnect GeminiProvider err -> do
+                connected <- case env.sessionFullscreen of
+                    Nothing ->
+                        connectProviderAccount color GeminiProvider
+                    Just runtime ->
+                        withFullscreenSuspended runtime $
+                            connectProviderAccount color GeminiProvider
+                case connected of
+                    Nothing -> next
+                    Just _ ->
+                        requestModelTargetSwitch
+                            env.sessionFullscreen choice env.sessionPersist >>= \case
+                            Left retryErr -> do
+                                selectionError env retryErr $
+                                    Text.hPutStrLn stderr
+                                        (roleError color retryErr)
+                                next
+                            Right result ->
+                                pure
+                                    (applyTransitionEffort
+                                        selectedEffort
+                                        result)
+        Left err -> do
+            selectionError env err $
+                Text.hPutStrLn stderr (roleError color err)
+            next
+        Right result ->
+            pure (applyTransitionEffort selectedEffort result)
+
+applyTransitionEffort :: Maybe ReasoningEffort -> RunResult -> RunResult
+applyTransitionEffort selectedEffort = \case
+    RunSwitchProvider transition ->
+        RunSwitchProvider
+            transition { transitionEffort = selectedEffort }
+    result -> result
+
+attachPendingTurn :: RunResult -> PendingTurn -> RunResult
+attachPendingTurn result pending =
+    case result of
         RunSwitchProvider transition ->
-            RunSwitchProvider
-                transition { transitionEffort = selectedEffort }
-        result -> result
-    attachPendingTurn result pending =
-        case result of
-            RunSwitchProvider transition ->
-                RunSwitchProvider transition
-                    { transitionPendingTurn = Just pending }
-            other -> other
-    modelAuthErrorNeedsConnect targetProvider message =
-        geminiAuthErrorNeedsReconnect message
-            || maybe False geminiAuthErrorNeedsReconnect
-                (Text.stripPrefix
-                    ( "cannot switch to "
-                        <> providerSlug targetProvider
-                        <> ": "
-                    )
-                    message)
-    chooseAccount next = do
-        gatewayAccess <- readIORef gatewayModelsRef
-        case gatewayAccess of
-            Just _ -> do
-                displayError
-                    "Account switching is unavailable while connected to the organization gateway. Disconnect the gateway first."
-                    (pure ())
-                next
-            Nothing -> chooseAccountFromOptions next
-    chooseAccountFromOptions next =
-        case fullscreen of
-            Just runtime -> do
-                account <- readActiveAccount env.sessionAccount
-                let currentSelectionId = account.activeSelectionId
-                    currentAccountId = account.activeAccountId
-                options <- withReplActivity
-                    "Loading account usage…"
-                    (loadAllAccountPickerOptionsCached databasePool provider)
-                let initial =
-                        fromMaybe 0 $
-                            findIndex
-                                (accountPickerMatches
-                                    provider
-                                    currentSelectionId
-                                    currentAccountId)
-                                options
-                requestFullscreenChoiceWithBody
-                    runtime
-                    "Accounts"
-                    "Choose any account. Switching provider also switches to its default model."
-                    initial
-                    (map
-                        (accountPickerRow
-                            provider
-                            currentSelectionId
-                            currentAccountId)
-                        options)
-                    >>= \case
-                        Just index
-                            | Just option <- atMay index options ->
-                                case option of
-                                    AccountPickerAccount
-                                        selectedProvider
-                                        selectedBilling
-                                        selectedSelectionId
-                                        selectedAccountId
-                                        selectedLabel
-                                        _ ->
-                                            chooseSelectedAccount
+            RunSwitchProvider transition
+                { transitionPendingTurn = Just pending }
+        other -> other
+
+modelAuthErrorNeedsConnect :: Provider -> Text -> Bool
+modelAuthErrorNeedsConnect targetProvider message =
+    geminiAuthErrorNeedsReconnect message
+        || maybe False geminiAuthErrorNeedsReconnect
+            (Text.stripPrefix
+                ( "cannot switch to "
+                    <> providerSlug targetProvider
+                    <> ": "
+                )
+                message)
+
+chooseAccount
+    :: SessionEnv
+    -> (PendingTurn -> IO RunResult)
+    -> IO RunResult
+    -> IO RunResult
+chooseAccount env retryPendingTurn next = do
+    gatewayAccess <- readIORef env.sessionGatewayModels
+    case gatewayAccess of
+        Just _ -> do
+            selectionError env
+                "Account switching is unavailable while connected to the organization gateway. Disconnect the gateway first."
+                (pure ())
+            next
+        Nothing -> chooseAccountFromOptions env retryPendingTurn next
+
+chooseAccountFromOptions
+    :: SessionEnv
+    -> (PendingTurn -> IO RunResult)
+    -> IO RunResult
+    -> IO RunResult
+chooseAccountFromOptions env@SessionEnv
+    { sessionFullscreen = fullscreen
+    , sessionDatabasePool = databasePool
+    , sessionProvider = provider
+    , sessionTokenProvider = tokenProvider
+    , sessionSelectAccount = selectAccount
+    , sessionParams = paramsRef
+    , sessionModelCatalog = catalog
+    , sessionConnection = connectionId
+    , sessionDialect = dialect
+    , sessionPersist = persist
+    } retryPendingTurn next =
+    case fullscreen of
+        Just runtime -> do
+            account <- readActiveAccount env.sessionAccount
+            let currentSelectionId = account.activeSelectionId
+                currentAccountId = account.activeAccountId
+            options <- withReplActivity env
+                "Loading account usage…"
+                (loadAllAccountPickerOptionsCached databasePool provider)
+            let initial =
+                    fromMaybe 0 $
+                        findIndex
+                            (accountPickerMatches
+                                provider
+                                currentSelectionId
+                                currentAccountId)
+                            options
+            requestFullscreenChoiceWithBody
+                runtime
+                "Accounts"
+                "Choose any account. Switching provider also switches to its default model."
+                initial
+                (map
+                    (accountPickerRow
+                        provider
+                        currentSelectionId
+                        currentAccountId)
+                    options)
+                >>= \case
+                    Just index
+                        | Just option <- atMay index options ->
+                            case option of
+                                AccountPickerAccount
+                                    selectedProvider
+                                    selectedBilling
+                                    selectedSelectionId
+                                    selectedAccountId
+                                    selectedLabel
+                                    _ ->
+                                        chooseSelectedAccount
+                                            selectedProvider
+                                            selectedBilling
+                                            selectedSelectionId
+                                            selectedAccountId
+                                            selectedLabel
+                                AccountPickerConnect selectedProvider -> do
+                                    color <- resolveColor stderr
+                                    connected <-
+                                        withFullscreenSuspended runtime $
+                                            connectProviderAccount
+                                                color
                                                 selectedProvider
-                                                selectedBilling
-                                                selectedSelectionId
-                                                selectedAccountId
-                                                selectedLabel
-                                    AccountPickerConnect selectedProvider -> do
-                                        color <- resolveColor stderr
-                                        connected <-
-                                            withFullscreenSuspended runtime $
-                                                connectProviderAccount
-                                                    color
-                                                    selectedProvider
-                                        case connected of
-                                            Nothing -> next
-                                            Just connectedId -> do
-                                                refreshed <-
-                                                    loadAllAccountPickerOptionsCached
-                                                        databasePool
-                                                        provider
-                                                case listToMaybe
-                                                        [ account
-                                                        | account@(AccountPickerAccount
-                                                            accountProvider
-                                                            _
-                                                            selectionId
-                                                            accountId
-                                                            _
-                                                            _) <- refreshed
-                                                        , accountProvider
-                                                            == selectedProvider
-                                                        , selectionId
+                                    case connected of
+                                        Nothing -> next
+                                        Just connectedId -> do
+                                            refreshed <-
+                                                loadAllAccountPickerOptionsCached
+                                                    databasePool
+                                                    provider
+                                            case listToMaybe
+                                                    [ account
+                                                    | account@(AccountPickerAccount
+                                                        accountProvider
+                                                        _
+                                                        selectionId
+                                                        accountId
+                                                        _
+                                                        _) <- refreshed
+                                                    , accountProvider
+                                                        == selectedProvider
+                                                    , selectionId
+                                                        == connectedId
+                                                        || accountId
                                                             == connectedId
-                                                            || accountId
-                                                                == connectedId
-                                                        ] of
-                                                    Just
-                                                        (AccountPickerAccount
-                                                            accountProvider
-                                                            billing
-                                                            selectionId
-                                                            accountId
-                                                            label
-                                                            _) ->
-                                                        chooseSelectedAccount
-                                                            accountProvider
-                                                            billing
-                                                            selectionId
-                                                            accountId
-                                                            label
-                                                    _ -> do
-                                                        displayError
-                                                            "Connected account could not be loaded."
-                                                            (pure ())
-                                                        next
-                        _ -> next
-              where
-                currentBilling =
-                    tokenProviderBillingMode
-                        <$> tokenProvider
-                chooseSelectedAccount
-                    selectedProvider
-                    selectedBilling
-                    selectedSelectionId
-                    selectedAccountId
-                    selectedLabel
-                        | selectedProvider == provider
-                        , Just selectedBilling == currentBilling
-                        , Just select <- selectAccount =
-                            let liveSelectionId =
-                                    case selectedProvider of
-                                        OpenAIProvider -> selectedAccountId
-                                        _ -> selectedSelectionId
-                            in select liveSelectionId >>= \case
-                                Left err -> do
-                                    now <- getCurrentTime
-                                    let message =
-                                            "could not select account: "
-                                                <> formatApiErrorInlineAt
-                                                    now
-                                                    err
-                                    displayError message (pure ())
+                                                    ] of
+                                                Just
+                                                    (AccountPickerAccount
+                                                        accountProvider
+                                                        billing
+                                                        selectionId
+                                                        accountId
+                                                        label
+                                                        _) ->
+                                                    chooseSelectedAccount
+                                                        accountProvider
+                                                        billing
+                                                        selectionId
+                                                        accountId
+                                                        label
+                                                _ -> do
+                                                    selectionError env
+                                                        "Connected account could not be loaded."
+                                                        (pure ())
+                                                    next
+                    _ -> next
+          where
+            currentBilling =
+                tokenProviderBillingMode
+                    <$> tokenProvider
+            chooseSelectedAccount
+                selectedProvider
+                selectedBilling
+                selectedSelectionId
+                selectedAccountId
+                selectedLabel
+                    | selectedProvider == provider
+                    , Just selectedBilling == currentBilling
+                    , Just select <- selectAccount =
+                        let liveSelectionId =
+                                case selectedProvider of
+                                    OpenAIProvider -> selectedAccountId
+                                    _ -> selectedSelectionId
+                        in select liveSelectionId >>= \case
+                            Left err -> do
+                                now <- getCurrentTime
+                                let message =
+                                        "could not select account: "
+                                            <> formatApiErrorInlineAt
+                                                now
+                                                err
+                                selectionError env message (pure ())
+                                next
+                            Right label -> do
+                                selectionInfo env
+                                    ("account switched to " <> label)
+                                    (pure ())
+                                resumePendingTurnIfPresent
+                                    env.sessionLastFailedTurn
+                                    retryPendingTurn
                                     next
-                                Right label -> do
-                                    displayInfo
-                                        ("account switched to " <> label)
+                    | otherwise = do
+                        params <- readSessionRequestParams paramsRef
+                        currentAccount <- (.activeAccountLabel) <$> readActiveAccount env.sessionAccount
+                        requestAccountProviderSwitch
+                            catalog fullscreen provider connectionId
+                            (currentModel params) currentAccount
+                            (dialectId dialect)
+                            selectedProvider selectedSelectionId
+                            selectedAccountId selectedLabel
+                            persist >>= \case
+                                Left err -> do
+                                    selectionError env err (pure ())
+                                    next
+                                Right result -> do
+                                    selectionInfo env
+                                        ("switching to "
+                                            <> selectedLabel
+                                            <> " ("
+                                            <> providerSlug
+                                                selectedProvider
+                                            <> ")")
                                         (pure ())
                                     resumePendingTurnIfPresent
                                         env.sessionLastFailedTurn
-                                        retryPendingTurn
-                                        next
-                        | otherwise = do
-                            params <- readSessionRequestParams paramsRef
-                            currentAccount <- (.activeAccountLabel) <$> readActiveAccount env.sessionAccount
-                            requestAccountProviderSwitch
-                                catalog fullscreen provider connectionId
-                                (currentModel params) currentAccount
-                                (dialectId dialect)
-                                selectedProvider selectedSelectionId
-                                selectedAccountId selectedLabel
-                                persist >>= \case
-                                    Left err -> do
-                                        displayError err (pure ())
-                                        next
-                                    Right result -> do
-                                        displayInfo
-                                            ("switching to "
-                                                <> selectedLabel
-                                                <> " ("
-                                                <> providerSlug
-                                                    selectedProvider
-                                                <> ")")
-                                            (pure ())
-                                        resumePendingTurnIfPresent
-                                            env.sessionLastFailedTurn
-                                            (pure . attachPendingTurn result)
-                                            (pure result)
-            Nothing -> do
-                displayError
-                    "Account switching is unavailable for this session."
-                    (pure ())
-                next
+                                        (pure . attachPendingTurn result)
+                                        (pure result)
+        Nothing -> do
+            selectionError env
+                "Account switching is unavailable for this session."
+                (pure ())
+            next

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -341,21 +341,21 @@ handleComposerKey
         slashMenu = currentSlashMenu state
     case event of
         _ | Bridge.isSendNowKey event ->
-            sendNow
+            sendNow applyUiEvent
         V.EvKey (V.KChar 'q') modifiers
             | V.MCtrl `elem` modifiers ->
-                submitRaw ReplEof
+                submitRaw applyUiEvent ReplEof
         V.EvKey (V.KChar 'd') modifiers
             | V.MCtrl `elem` modifiers
             , Text.null ui.uiDraft ->
-                submitRaw ReplEof
+                submitRaw applyUiEvent ReplEof
         V.EvKey (V.KChar 'd') modifiers
             | V.MCtrl `elem` modifiers ->
-                deleteAfter
+                deleteAfter applyUiEvent
         V.EvKey (V.KChar 'd') modifiers
             | V.MMeta `elem` modifiers
                 || V.MAlt `elem` modifiers ->
-                killWordAfter
+                killWordAfter applyUiEvent
         V.EvKey (V.KChar 'c') modifiers
             | V.MCtrl `elem` modifiers ->
                 void handleCtrlC
@@ -364,7 +364,7 @@ handleComposerKey
                 ui.uiAwaitingInput
                 (maybe False (const True) slashMenu) of
                 EscapeCancelTurn ->
-                    cancelOrClear
+                    cancelOrClear applyUiEvent
                 EscapeDismissSlashMenu ->
                     modify' \current ->
                         current { appSlashDismissed = True }
@@ -372,121 +372,121 @@ handleComposerKey
                     pure ()
         V.EvKey V.KBackTab []
             | ui.uiAwaitingInput ->
-                submitRaw (ReplCycleMode ui.uiDraft)
+                submitRaw applyUiEvent (ReplCycleMode ui.uiDraft)
         V.EvKey V.KUp []
             | Just menu <- slashMenu
             , not (null menu.slashMenuSuggestions) ->
                 moveSlash (-1) (length menu.slashMenuSuggestions)
         V.EvKey V.KUp [] ->
             case verticalCursorMove (-1) ui.uiDraft ui.uiCursor of
-                Just cursor -> setCursor cursor
-                Nothing -> moveHistory 1
+                Just cursor -> setCursor applyUiEvent cursor
+                Nothing -> moveHistory applyUiEvent 1
         V.EvKey V.KDown []
             | Just menu <- slashMenu
             , not (null menu.slashMenuSuggestions) ->
                 moveSlash 1 (length menu.slashMenuSuggestions)
         V.EvKey V.KDown [] ->
             case verticalCursorMove 1 ui.uiDraft ui.uiCursor of
-                Just cursor -> setCursor cursor
-                Nothing -> moveHistory (-1)
+                Just cursor -> setCursor applyUiEvent cursor
+                Nothing -> moveHistory applyUiEvent (-1)
         V.EvKey (V.KChar '\t') [] ->
             case slashMenu of
-                Just menu -> acceptSlash menu
+                Just menu -> acceptSlash applyUiEvent menu
                 Nothing ->
                     when
                         (composerScrollbackAvailable
                             ui
                             state.appHistoryWindow) $
-                        modifyUi (UiFocusChanged FocusScrollback)
+                        modifyUi applyUiEvent (UiFocusChanged FocusScrollback)
         V.EvKey V.KEnter modifiers
             | V.MShift `elem` modifiers ->
-                insertText "\n"
+                insertText applyUiEvent "\n"
         V.EvKey V.KEnter [] ->
             case slashMenu of
-                Just menu -> handleSlashEnter menu
-                Nothing -> submitDraft
+                Just menu -> handleSlashEnter applyUiEvent menu
+                Nothing -> submitDraft applyUiEvent
         V.EvKey V.KBS [] ->
-            deleteBefore
+            deleteBefore applyUiEvent
         V.EvKey V.KBS modifiers
             | any (`elem` modifiers) [V.MMeta, V.MAlt, V.MCtrl] ->
-                killPreviousWord
+                killPreviousWord applyUiEvent
         V.EvKey (V.KChar 'w') modifiers
             | V.MCtrl `elem` modifiers ->
-                killPreviousWord
+                killPreviousWord applyUiEvent
         V.EvKey (V.KChar 'u') modifiers
             | V.MCtrl `elem` modifiers ->
-                killLineStart
+                killLineStart applyUiEvent
         V.EvKey (V.KChar 'k') modifiers
             | V.MCtrl `elem` modifiers ->
-                killLineEnd
+                killLineEnd applyUiEvent
         V.EvKey (V.KChar 'y') modifiers
             | V.MCtrl `elem` modifiers ->
-                insertKillBuffer
+                insertKillBuffer applyUiEvent
         V.EvKey (V.KChar 'l') modifiers
             | V.MCtrl `elem` modifiers ->
                 invalidateCache
         V.EvKey (V.KChar 'r') modifiers
             | V.MCtrl `elem` modifiers ->
-                startDictation
+                startDictation applyUiEvent
         V.EvKey (V.KChar '\DC2') _ ->
-            startDictation
+            startDictation applyUiEvent
         V.EvKey (V.KChar 'a') modifiers
             | V.MCtrl `elem` modifiers ->
-                setCursor (lineStartCursor ui.uiDraft ui.uiCursor)
+                setCursor applyUiEvent (lineStartCursor ui.uiDraft ui.uiCursor)
         V.EvKey (V.KChar 'e') modifiers
             | V.MCtrl `elem` modifiers ->
-                setCursor (lineEndCursor ui.uiDraft ui.uiCursor)
+                setCursor applyUiEvent (lineEndCursor ui.uiDraft ui.uiCursor)
         V.EvKey (V.KChar 'b') modifiers
             | V.MCtrl `elem` modifiers ->
-                moveCursor (-1)
+                moveCursor applyUiEvent (-1)
         V.EvKey (V.KChar 'b') modifiers
             | V.MMeta `elem` modifiers
                 || V.MAlt `elem` modifiers ->
-                setCursor (moveWordLeft ui.uiDraft ui.uiCursor)
+                setCursor applyUiEvent (moveWordLeft ui.uiDraft ui.uiCursor)
         V.EvKey (V.KChar 'f') modifiers
             | V.MCtrl `elem` modifiers ->
-                moveCursor 1
+                moveCursor applyUiEvent 1
         V.EvKey (V.KChar 'f') modifiers
             | V.MMeta `elem` modifiers
                 || V.MAlt `elem` modifiers ->
-                setCursor (moveWordRight ui.uiDraft ui.uiCursor)
+                setCursor applyUiEvent (moveWordRight ui.uiDraft ui.uiCursor)
         V.EvKey (V.KChar '_') modifiers
             | V.MCtrl `elem` modifiers ->
-                undoEdit
+                undoEdit applyUiEvent
         V.EvKey (V.KChar '\US') _ ->
-            undoEdit
+            undoEdit applyUiEvent
         V.EvKey (V.KChar 'v') modifiers
             | V.MCtrl `elem` modifiers
                 || V.MMeta `elem` modifiers -> do
                 clipboardText <- liftIO readClipboardText
                 case nonEmptyClipboardText clipboardText of
-                    Just text -> insertPastedText text
+                    Just text -> insertPastedText applyUiEvent text
                     Nothing ->
-                        submitRaw (ReplClipboardPaste ui.uiDraft Nothing)
+                        submitRaw applyUiEvent (ReplClipboardPaste ui.uiDraft Nothing)
         V.EvKey V.KDel [] ->
-            deleteAfter
+            deleteAfter applyUiEvent
         V.EvKey V.KLeft modifiers
             | V.MMeta `elem` modifiers
                 || V.MAlt `elem` modifiers ->
-                setCursor (moveWordLeft ui.uiDraft ui.uiCursor)
+                setCursor applyUiEvent (moveWordLeft ui.uiDraft ui.uiCursor)
         V.EvKey V.KRight modifiers
             | V.MMeta `elem` modifiers
                 || V.MAlt `elem` modifiers ->
-                setCursor (moveWordRight ui.uiDraft ui.uiCursor)
+                setCursor applyUiEvent (moveWordRight ui.uiDraft ui.uiCursor)
         V.EvKey V.KLeft [] ->
-            moveCursor (-1)
+            moveCursor applyUiEvent (-1)
         V.EvKey V.KRight [] ->
-            moveCursor 1
+            moveCursor applyUiEvent 1
         V.EvKey V.KHome [] ->
-            setCursor (lineStartCursor ui.uiDraft ui.uiCursor)
+            setCursor applyUiEvent (lineStartCursor ui.uiDraft ui.uiCursor)
         V.EvKey V.KEnd [] ->
-            setCursor (lineEndCursor ui.uiDraft ui.uiCursor)
+            setCursor applyUiEvent (lineEndCursor ui.uiDraft ui.uiCursor)
         V.EvKey V.KPageUp [] ->
             scrollConversationPage Up
         V.EvKey V.KPageDown [] ->
             scrollConversationPage Down
         V.EvKey (V.KChar character) [] ->
-            insertText (Text.singleton character)
+            insertText applyUiEvent (Text.singleton character)
         V.EvPaste bytes -> do
             let pasted = decodePaste bytes
                 (pastedDraft, pastedCursor, clipboardInput) =
@@ -497,450 +497,497 @@ handleComposerKey
                         pasted
             case clipboardInput of
                 Nothing -> do
-                    modifyUiResetSlash
+                    modifyUiResetSlash applyUiEvent
                         (UiSetDraft pastedDraft pastedCursor)
                     modify' \current -> current { appPasted = True }
                 Just replLine -> do
                     when (not (Text.null pasted)) $
-                        modifyUi
+                        modifyUi applyUiEvent
                             (UiSetNotice
                                 (Just (progressNotice "Reading clipboard…")))
-                    submitRaw replLine
+                    submitRaw applyUiEvent replLine
         _ -> pure ()
     -- Only a kill directly followed by another kill accumulates into the
     -- kill buffer; any other key breaks the chain.
     modify' \current -> current { appKillChain = isKillKey event }
-  where
-    startDictation = do
-        current <- get
-        case current.appDictation of
-            Just session ->
-                liftIO (requestDictationStop session False)
-            Nothing -> do
-                stop <- liftIO newEmptyMVar
-                abort <- liftIO (newIORef False)
-                let session =
-                        DictationSession
-                            { dictationStop = stop
-                            , dictationAbort = abort
-                            }
-                applyUiEvent
-                    (UiSetNotice (Just (dictationProgressNotice "")))
-                    \state -> state { appDictation = Just session }
-                liftIO $ atomically $
-                    writeTQueue
-                        current.appRuntime.runtimeDictationJobs
-                        DictationJob
-                            { dictationJobWaitForStop = takeMVar stop
-                            }
 
-    submitRaw replLine = do
-        state <- get
-        void (enqueueInput state replLine Nothing False)
-
-    submitDraft = do
-        state <- get
-        let draft = state.appUi.uiDraft
-            attachmentCount =
-                state.appUi.uiPrompt.promptAttachments
-        case submissionPromptText attachmentCount draft of
-            Nothing -> pure ()
-            Just text -> submitText state text state.appPasted
-
-    submitText state text pasted = do
-        let replLine = if pasted then ReplPasted text else ReplText text
-        accepted <- case immediateReplCommand state.appUi replLine of
-            Just command -> do
-                applyUiEvent UiDraftSubmitted \current ->
-                    current
-                        { appSlashIndex = 0
-                        , appSlashDismissed = False
-                        , appUndo = []
+startDictation :: ApplyLocalUiEvent -> EventM Name AppState ()
+startDictation applyUiEvent = do
+    current <- get
+    case current.appDictation of
+        Just session ->
+            liftIO (requestDictationStop session False)
+        Nothing -> do
+            stop <- liftIO newEmptyMVar
+            abort <- liftIO (newIORef False)
+            let session =
+                    DictationSession
+                        { dictationStop = stop
+                        , dictationAbort = abort
                         }
-                _ <- liftIO
-                    (state.appRuntime.runtimeImmediateCommand command)
-                pure True
-            Nothing ->
-                case immediateBtwQuestion state.appUi replLine of
-                    Just question -> do
-                        applyUiEvent UiDraftSubmitted \current ->
-                            current
-                                { appSlashIndex = 0
-                                , appSlashDismissed = False
-                                , appUndo = []
-                                }
-                        _ <- liftIO (state.appRuntime.runtimeBtw question)
-                        pure True
-                    Nothing ->
-                        case steeringPrompt state.appUi pasted text of
-                            Just (steeringPasted, prompt) -> do
-                                result <- liftIO
-                                    (state.appRuntime.runtimeSteer
-                                        steeringPasted
-                                        prompt)
-                                case result of
-                                    Left message -> do
-                                        applyUiEvent
-                                            (UiSetNotice
-                                                (Just (warningNotice message)))
-                                            id
-                                        pure False
-                                    Right () -> do
-                                        applyUiEvent UiDraftSubmitted \current ->
-                                            current
-                                                { appSlashIndex = 0
-                                                , appSlashDismissed = False
-                                                , appUndo = []
-                                                }
-                                        pure True
-                            Nothing ->
-                                enqueueInput state replLine (Just text) True
-        when accepted do
-            liftIO (appendReplHistory text)
-            modify' \current ->
-                current
-                    { appPasted = False
-                    , appHistory = Bridge.pushHistory text current.appHistory
-                    , appHistoryIndex = Nothing
-                    , appHistoryDraft = ""
-                    }
-            vScrollToEnd (viewportScroll ConversationViewport)
+            applyUiEvent
+                (UiSetNotice (Just (dictationProgressNotice "")))
+                \state -> state { appDictation = Just session }
+            liftIO $ atomically $
+                writeTQueue
+                    current.appRuntime.runtimeDictationJobs
+                    DictationJob
+                        { dictationJobWaitForStop = takeMVar stop
+                        }
 
-    sendNow = do
-        state <- get
-        let ui = state.appUi
-            draft = ui.uiDraft
-        when ui.uiRunning $
-            if Text.null (Text.strip draft)
-                then
-                    if Seq.null ui.uiQueuedInputs
-                        then modifyUi
-                            (UiSetNotice
-                                (Just
-                                    (warningNotice
-                                        "There is no queued prompt to send now.")))
-                        else do
-                            modifyUi
-                                (UiSetNotice
-                                    (Just
-                                        (warningNotice
-                                            "Cancelling the current turn; sending the queued prompt next…")))
-                            liftIO state.appRuntime.runtimeCancel
-                else do
-                    promoted <- liftIO $ atomically $
-                        promoteFullscreenInput
-                            state.appRuntime.runtimeInput
-                            FullscreenInput
-                                { fullscreenInputLine =
-                                    if state.appPasted
-                                        then ReplPasted draft
-                                        else ReplText draft
-                                , fullscreenInputQueued = True
-                                , fullscreenInputDisplay = Just draft
-                                }
-                    case promoted of
-                        Left message ->
-                            modifyUi
-                                (UiSetNotice
-                                    (Just (warningNotice message)))
-                        Right () -> do
-                            liftIO (appendReplHistory draft)
-                            applyUiEvent
-                                (UiInputPromoted draft)
-                                \current ->
-                                    current
-                                        { appPasted = False
-                                        , appHistory =
-                                            Bridge.pushHistory draft current.appHistory
-                                        , appHistoryIndex = Nothing
-                                        , appHistoryDraft = ""
-                                        , appSlashIndex = 0
-                                        , appSlashDismissed = False
-                                        , appUndo = []
-                                        }
-                            liftIO state.appRuntime.runtimeCancel
-                            vScrollToEnd
-                                (viewportScroll ConversationViewport)
+submitRaw :: ApplyLocalUiEvent -> ReplLine -> EventM Name AppState ()
+submitRaw applyUiEvent replLine = do
+    state <- get
+    void (enqueueInput applyUiEvent state replLine Nothing False)
 
-    enqueueInput state replLine display clearDraft = do
-        let queued = not state.appUi.uiAwaitingInput
-            event =
-                if queued
-                    then UiInputQueued <$> display
-                    else Just
-                        (if clearDraft
-                            then UiDraftSubmitted
-                            else UiSetAwaitingInput False)
-            update current =
+submitDraft :: ApplyLocalUiEvent -> EventM Name AppState ()
+submitDraft applyUiEvent = do
+    state <- get
+    let draft = state.appUi.uiDraft
+        attachmentCount =
+            state.appUi.uiPrompt.promptAttachments
+    case submissionPromptText attachmentCount draft of
+        Nothing -> pure ()
+        Just text -> submitText applyUiEvent state text state.appPasted
+
+submitText
+    :: ApplyLocalUiEvent
+    -> AppState
+    -> Text
+    -> Bool
+    -> EventM Name AppState ()
+submitText applyUiEvent state text pasted = do
+    let replLine = if pasted then ReplPasted text else ReplText text
+    accepted <- case immediateReplCommand state.appUi replLine of
+        Just command -> do
+            applyUiEvent UiDraftSubmitted \current ->
                 current
                     { appSlashIndex = 0
                     , appSlashDismissed = False
-                    , appUndo =
-                        -- A submitted prompt leaves an empty composer; its
-                        -- edit steps are no longer undoable.
-                        if clearDraft || maybe False (const True) display
-                            then []
-                            else current.appUndo
+                    , appUndo = []
                     }
-        result <- liftIO $ atomically $
-            appendFullscreenInput state.appRuntime.runtimeInput FullscreenInput
-                { fullscreenInputLine = replLine
-                , fullscreenInputQueued = queued
-                , fullscreenInputDisplay = display
-                }
-        case result of
-            Left message -> do
-                applyUiEvent
-                    (UiSetNotice (Just (warningNotice message)))
-                    id
-                pure False
-            Right () -> do
-                case event of
-                    Nothing -> modify' update
-                    Just uiEvent -> applyUiEvent uiEvent update
-                pure True
-
-    cancelOrClear = do
-        state <- get
-        if not state.appUi.uiAwaitingInput
-            then do
-                liftIO state.appRuntime.runtimeCancel
-                modifyUi
-                    (UiSetNotice (Just (progressNotice "Cancelling…")))
-            else do
-                -- Esc must not destroy a typed draft irrecoverably: stash it
-                -- in the kill buffer so Ctrl-Y (or Ctrl-_) restores it.
-                let draft = state.appUi.uiDraft
-                if Text.null draft
-                    then modifyUi (UiSetDraft "" 0)
-                    else modifyUiWithKill
-                        KillBackward
-                        draft
-                        (UiSetDraft "" 0)
-
-    insertText inserted = do
-        state <- get
-        let ui = state.appUi
-            before = Text.take ui.uiCursor ui.uiDraft
-            after = Text.drop ui.uiCursor ui.uiDraft
-        modifyUiResetSlash $
-            UiSetDraft
-                (before <> inserted <> after)
-                (ui.uiCursor + Text.length inserted)
-
-    insertPastedText inserted = do
-        insertText inserted
-        modify' \current -> current { appPasted = True }
-
-    deleteBefore = do
-        state <- get
-        let ui = state.appUi
-        when (ui.uiCursor > 0) do
-            let start =
-                    previousGraphemeBoundary
-                        ui.uiDraft
-                        ui.uiCursor
-                before = Text.take start ui.uiDraft
-                after = Text.drop ui.uiCursor ui.uiDraft
-            modifyUiResetSlash
-                (UiSetDraft (before <> after) start)
-
-    deleteAfter = do
-        state <- get
-        let ui = state.appUi
-        when (ui.uiCursor < Text.length ui.uiDraft) do
-            let before = Text.take ui.uiCursor ui.uiDraft
-                after =
-                    Text.drop
-                        (nextGraphemeBoundary ui.uiDraft ui.uiCursor)
-                        ui.uiDraft
-            modifyUiResetSlash
-                (UiSetDraft (before <> after) ui.uiCursor)
-
-    killPreviousWord = do
-        state <- get
-        let old = state.appUi.uiDraft
-            oldCursor = state.appUi.uiCursor
-            (next, cursor) =
-                deleteWordBefore state.appUi.uiDraft state.appUi.uiCursor
-            killed =
-                Text.take (oldCursor - cursor) (Text.drop cursor old)
-        modifyUiWithKill KillBackward killed (UiSetDraft next cursor)
-
-    killWordAfter = do
-        state <- get
-        let old = state.appUi.uiDraft
-            oldCursor = state.appUi.uiCursor
-            (next, cursor) =
-                deleteWordAfter state.appUi.uiDraft state.appUi.uiCursor
-            killedLength = Text.length old - Text.length next
-            killed = Text.take killedLength (Text.drop oldCursor old)
-        modifyUiWithKill KillForward killed (UiSetDraft next cursor)
-
-    killLineEnd = do
-        state <- get
-        let old = state.appUi.uiDraft
-            oldCursor = state.appUi.uiCursor
-            (next, cursor) =
-                deleteToLineEnd state.appUi.uiDraft state.appUi.uiCursor
-            killedLength = Text.length old - Text.length next
-            killed = Text.take killedLength (Text.drop oldCursor old)
-        modifyUiWithKill KillForward killed (UiSetDraft next cursor)
-
-    killLineStart = do
-        state <- get
-        let old = state.appUi.uiDraft
-            oldCursor = state.appUi.uiCursor
-            (next, cursor) =
-                deleteToLineStart state.appUi.uiDraft state.appUi.uiCursor
-            killed =
-                Text.take (oldCursor - cursor) (Text.drop cursor old)
-        modifyUiWithKill KillBackward killed (UiSetDraft next cursor)
-
-    undoEdit = do
-        state <- get
-        case state.appUndo of
-            [] -> pure ()
-            (text, cursor) : rest ->
-                applyUiEvent (UiSetDraft text cursor) \current ->
-                    current
-                        { appUndo = rest
-                        , appSlashIndex = 0
-                        , appSlashDismissed = False
-                        , appHistoryIndex = Nothing
-                        , appHistoryDraft = text
-                        }
-
-    insertKillBuffer = do
-        state <- get
-        when (not (Text.null state.appKillBuffer)) $
-            insertText state.appKillBuffer
-
-    moveCursor :: Int -> EventM Name AppState ()
-    moveCursor delta = do
-        state <- get
-        let ui = state.appUi
-            cursor
-                | delta < 0 =
-                    previousGraphemeBoundary ui.uiDraft ui.uiCursor
-                | delta > 0 =
-                    nextGraphemeBoundary ui.uiDraft ui.uiCursor
-                | otherwise = ui.uiCursor
-        setCursor cursor
-
-    setCursor cursor =
-        get >>= \current ->
-            applyUiEvent
-                (UiSetDraft current.appUi.uiDraft cursor)
-                \state -> state { appSlashIndex = 0 }
-
-    modifyUi uiEvent =
-        applyUiEvent uiEvent id
-
-    modifyUiResetSlash uiEvent = do
-        old <- get
-        applyUiEvent uiEvent \state ->
-            (pushUndo old uiEvent state)
-                { appSlashIndex = 0
-                , appSlashDismissed = False
-                , appHistoryIndex = Nothing
-                , appHistoryDraft =
-                    case uiEvent of
-                        UiSetDraft text _ -> text
-                        _ -> state.appHistoryDraft
-                }
-
-    modifyUiWithKill direction killed uiEvent = do
-        old <- get
-        applyUiEvent uiEvent \state ->
-            (pushUndo old uiEvent state)
-                { appSlashIndex = 0
-                , appSlashDismissed = False
-                , appKillBuffer =
-                    if Text.null killed
-                        then state.appKillBuffer
-                        else if old.appKillChain
-                            then combineKill
-                                direction
-                                killed
-                                state.appKillBuffer
-                            else killed
-                , appHistoryIndex = Nothing
-                , appHistoryDraft =
-                    case uiEvent of
-                        UiSetDraft text _ -> text
-                        _ -> state.appHistoryDraft
-                }
-
-    -- Record the pre-edit draft for Ctrl-_ when the edit changes the text.
-    pushUndo old uiEvent state =
-        case uiEvent of
-            UiSetDraft text _
-                | text /= old.appUi.uiDraft ->
-                    state
-                        { appUndo =
-                            take undoLimit
-                                ((old.appUi.uiDraft, old.appUi.uiCursor)
-                                    : state.appUndo)
-                        }
-            _ -> state
-
-    moveHistory delta = do
-        state <- get
-        let (text, index, draft) =
-                Bridge.historyMove
-                    delta
-                    state.appHistory
-                    state.appHistoryIndex
-                    state.appUi.uiDraft
-                    state.appHistoryDraft
-        applyUiEvent
-            (UiSetDraft text (Text.length text))
-            \currentState ->
-                currentState
-                    { appHistoryIndex = index
-                    , appHistoryDraft = draft
-                    , appSlashIndex = 0
-                    , appSlashDismissed = False
-                    }
-
-    moveSlash delta count =
+            _ <- liftIO
+                (state.appRuntime.runtimeImmediateCommand command)
+            pure True
+        Nothing ->
+            case immediateBtwQuestion state.appUi replLine of
+                Just question -> do
+                    applyUiEvent UiDraftSubmitted \current ->
+                        current
+                            { appSlashIndex = 0
+                            , appSlashDismissed = False
+                            , appUndo = []
+                            }
+                    _ <- liftIO (state.appRuntime.runtimeBtw question)
+                    pure True
+                Nothing ->
+                    case steeringPrompt state.appUi pasted text of
+                        Just (steeringPasted, prompt) -> do
+                            result <- liftIO
+                                (state.appRuntime.runtimeSteer
+                                    steeringPasted
+                                    prompt)
+                            case result of
+                                Left message -> do
+                                    applyUiEvent
+                                        (UiSetNotice
+                                            (Just (warningNotice message)))
+                                        id
+                                    pure False
+                                Right () -> do
+                                    applyUiEvent UiDraftSubmitted \current ->
+                                        current
+                                            { appSlashIndex = 0
+                                            , appSlashDismissed = False
+                                            , appUndo = []
+                                            }
+                                    pure True
+                        Nothing ->
+                            enqueueInput applyUiEvent state replLine (Just text) True
+    when accepted do
+        liftIO (appendReplHistory text)
         modify' \current ->
             current
-                { appSlashIndex =
-                    (current.appSlashIndex + delta) `mod` count
+                { appPasted = False
+                , appHistory = Bridge.pushHistory text current.appHistory
+                , appHistoryIndex = Nothing
+                , appHistoryDraft = ""
+                }
+        vScrollToEnd (viewportScroll ConversationViewport)
+
+sendNow :: ApplyLocalUiEvent -> EventM Name AppState ()
+sendNow applyUiEvent = do
+    state <- get
+    let ui = state.appUi
+        draft = ui.uiDraft
+    when ui.uiRunning $
+        if Text.null (Text.strip draft)
+            then
+                if Seq.null ui.uiQueuedInputs
+                    then modifyUi applyUiEvent
+                        (UiSetNotice
+                            (Just
+                                (warningNotice
+                                    "There is no queued prompt to send now.")))
+                    else do
+                        modifyUi applyUiEvent
+                            (UiSetNotice
+                                (Just
+                                    (warningNotice
+                                        "Cancelling the current turn; sending the queued prompt next…")))
+                        liftIO state.appRuntime.runtimeCancel
+            else do
+                promoted <- liftIO $ atomically $
+                    promoteFullscreenInput
+                        state.appRuntime.runtimeInput
+                        FullscreenInput
+                            { fullscreenInputLine =
+                                if state.appPasted
+                                    then ReplPasted draft
+                                    else ReplText draft
+                            , fullscreenInputQueued = True
+                            , fullscreenInputDisplay = Just draft
+                            }
+                case promoted of
+                    Left message ->
+                        modifyUi applyUiEvent
+                            (UiSetNotice
+                                (Just (warningNotice message)))
+                    Right () -> do
+                        liftIO (appendReplHistory draft)
+                        applyUiEvent
+                            (UiInputPromoted draft)
+                            \current ->
+                                current
+                                    { appPasted = False
+                                    , appHistory =
+                                        Bridge.pushHistory draft current.appHistory
+                                    , appHistoryIndex = Nothing
+                                    , appHistoryDraft = ""
+                                    , appSlashIndex = 0
+                                    , appSlashDismissed = False
+                                    , appUndo = []
+                                    }
+                        liftIO state.appRuntime.runtimeCancel
+                        vScrollToEnd
+                            (viewportScroll ConversationViewport)
+
+enqueueInput
+    :: ApplyLocalUiEvent
+    -> AppState
+    -> ReplLine
+    -> Maybe Text
+    -> Bool
+    -> EventM Name AppState Bool
+enqueueInput applyUiEvent state replLine display clearDraft = do
+    let queued = not state.appUi.uiAwaitingInput
+        event =
+            if queued
+                then UiInputQueued <$> display
+                else Just
+                    (if clearDraft
+                        then UiDraftSubmitted
+                        else UiSetAwaitingInput False)
+        update current =
+            current
+                { appSlashIndex = 0
+                , appSlashDismissed = False
+                , appUndo =
+                    -- A submitted prompt leaves an empty composer; its
+                    -- edit steps are no longer undoable.
+                    if clearDraft || maybe False (const True) display
+                        then []
+                        else current.appUndo
+                }
+    result <- liftIO $ atomically $
+        appendFullscreenInput state.appRuntime.runtimeInput FullscreenInput
+            { fullscreenInputLine = replLine
+            , fullscreenInputQueued = queued
+            , fullscreenInputDisplay = display
+            }
+    case result of
+        Left message -> do
+            applyUiEvent
+                (UiSetNotice (Just (warningNotice message)))
+                id
+            pure False
+        Right () -> do
+            case event of
+                Nothing -> modify' update
+                Just uiEvent -> applyUiEvent uiEvent update
+            pure True
+
+cancelOrClear :: ApplyLocalUiEvent -> EventM Name AppState ()
+cancelOrClear applyUiEvent = do
+    state <- get
+    if not state.appUi.uiAwaitingInput
+        then do
+            liftIO state.appRuntime.runtimeCancel
+            modifyUi applyUiEvent
+                (UiSetNotice (Just (progressNotice "Cancelling…")))
+        else do
+            -- Esc must not destroy a typed draft irrecoverably: stash it
+            -- in the kill buffer so Ctrl-Y (or Ctrl-_) restores it.
+            let draft = state.appUi.uiDraft
+            if Text.null draft
+                then modifyUi applyUiEvent (UiSetDraft "" 0)
+                else modifyUiWithKill applyUiEvent
+                    KillBackward
+                    draft
+                    (UiSetDraft "" 0)
+
+insertText :: ApplyLocalUiEvent -> Text -> EventM Name AppState ()
+insertText applyUiEvent inserted = do
+    state <- get
+    let ui = state.appUi
+        before = Text.take ui.uiCursor ui.uiDraft
+        after = Text.drop ui.uiCursor ui.uiDraft
+    modifyUiResetSlash applyUiEvent $
+        UiSetDraft
+            (before <> inserted <> after)
+            (ui.uiCursor + Text.length inserted)
+
+insertPastedText :: ApplyLocalUiEvent -> Text -> EventM Name AppState ()
+insertPastedText applyUiEvent inserted = do
+    insertText applyUiEvent inserted
+    modify' \current -> current { appPasted = True }
+
+deleteBefore :: ApplyLocalUiEvent -> EventM Name AppState ()
+deleteBefore applyUiEvent = do
+    state <- get
+    let ui = state.appUi
+    when (ui.uiCursor > 0) do
+        let start =
+                previousGraphemeBoundary
+                    ui.uiDraft
+                    ui.uiCursor
+            before = Text.take start ui.uiDraft
+            after = Text.drop ui.uiCursor ui.uiDraft
+        modifyUiResetSlash applyUiEvent
+            (UiSetDraft (before <> after) start)
+
+deleteAfter :: ApplyLocalUiEvent -> EventM Name AppState ()
+deleteAfter applyUiEvent = do
+    state <- get
+    let ui = state.appUi
+    when (ui.uiCursor < Text.length ui.uiDraft) do
+        let before = Text.take ui.uiCursor ui.uiDraft
+            after =
+                Text.drop
+                    (nextGraphemeBoundary ui.uiDraft ui.uiCursor)
+                    ui.uiDraft
+        modifyUiResetSlash applyUiEvent
+            (UiSetDraft (before <> after) ui.uiCursor)
+
+killPreviousWord :: ApplyLocalUiEvent -> EventM Name AppState ()
+killPreviousWord applyUiEvent = do
+    state <- get
+    let old = state.appUi.uiDraft
+        oldCursor = state.appUi.uiCursor
+        (next, cursor) =
+            deleteWordBefore state.appUi.uiDraft state.appUi.uiCursor
+        killed =
+            Text.take (oldCursor - cursor) (Text.drop cursor old)
+    modifyUiWithKill applyUiEvent KillBackward killed (UiSetDraft next cursor)
+
+killWordAfter :: ApplyLocalUiEvent -> EventM Name AppState ()
+killWordAfter applyUiEvent = do
+    state <- get
+    let old = state.appUi.uiDraft
+        oldCursor = state.appUi.uiCursor
+        (next, cursor) =
+            deleteWordAfter state.appUi.uiDraft state.appUi.uiCursor
+        killedLength = Text.length old - Text.length next
+        killed = Text.take killedLength (Text.drop oldCursor old)
+    modifyUiWithKill applyUiEvent KillForward killed (UiSetDraft next cursor)
+
+killLineEnd :: ApplyLocalUiEvent -> EventM Name AppState ()
+killLineEnd applyUiEvent = do
+    state <- get
+    let old = state.appUi.uiDraft
+        oldCursor = state.appUi.uiCursor
+        (next, cursor) =
+            deleteToLineEnd state.appUi.uiDraft state.appUi.uiCursor
+        killedLength = Text.length old - Text.length next
+        killed = Text.take killedLength (Text.drop oldCursor old)
+    modifyUiWithKill applyUiEvent KillForward killed (UiSetDraft next cursor)
+
+killLineStart :: ApplyLocalUiEvent -> EventM Name AppState ()
+killLineStart applyUiEvent = do
+    state <- get
+    let old = state.appUi.uiDraft
+        oldCursor = state.appUi.uiCursor
+        (next, cursor) =
+            deleteToLineStart state.appUi.uiDraft state.appUi.uiCursor
+        killed =
+            Text.take (oldCursor - cursor) (Text.drop cursor old)
+    modifyUiWithKill applyUiEvent KillBackward killed (UiSetDraft next cursor)
+
+undoEdit :: ApplyLocalUiEvent -> EventM Name AppState ()
+undoEdit applyUiEvent = do
+    state <- get
+    case state.appUndo of
+        [] -> pure ()
+        (text, cursor) : rest ->
+            applyUiEvent (UiSetDraft text cursor) \current ->
+                current
+                    { appUndo = rest
+                    , appSlashIndex = 0
+                    , appSlashDismissed = False
+                    , appHistoryIndex = Nothing
+                    , appHistoryDraft = text
+                    }
+
+insertKillBuffer :: ApplyLocalUiEvent -> EventM Name AppState ()
+insertKillBuffer applyUiEvent = do
+    state <- get
+    when (not (Text.null state.appKillBuffer)) $
+        insertText applyUiEvent state.appKillBuffer
+
+moveCursor :: ApplyLocalUiEvent -> Int -> EventM Name AppState ()
+moveCursor applyUiEvent delta = do
+    state <- get
+    let ui = state.appUi
+        cursor
+            | delta < 0 =
+                previousGraphemeBoundary ui.uiDraft ui.uiCursor
+            | delta > 0 =
+                nextGraphemeBoundary ui.uiDraft ui.uiCursor
+            | otherwise = ui.uiCursor
+    setCursor applyUiEvent cursor
+
+setCursor :: ApplyLocalUiEvent -> Int -> EventM Name AppState ()
+setCursor applyUiEvent cursor =
+    get >>= \current ->
+        applyUiEvent
+            (UiSetDraft current.appUi.uiDraft cursor)
+            \state -> state { appSlashIndex = 0 }
+
+modifyUi :: ApplyLocalUiEvent -> UiEvent -> EventM Name AppState ()
+modifyUi applyUiEvent uiEvent =
+    applyUiEvent uiEvent id
+
+modifyUiResetSlash :: ApplyLocalUiEvent -> UiEvent -> EventM Name AppState ()
+modifyUiResetSlash applyUiEvent uiEvent = do
+    old <- get
+    applyUiEvent uiEvent \state ->
+        (pushUndo old uiEvent state)
+            { appSlashIndex = 0
+            , appSlashDismissed = False
+            , appHistoryIndex = Nothing
+            , appHistoryDraft =
+                case uiEvent of
+                    UiSetDraft text _ -> text
+                    _ -> state.appHistoryDraft
+            }
+
+modifyUiWithKill
+    :: ApplyLocalUiEvent
+    -> KillDirection
+    -> Text
+    -> UiEvent
+    -> EventM Name AppState ()
+modifyUiWithKill applyUiEvent direction killed uiEvent = do
+    old <- get
+    applyUiEvent uiEvent \state ->
+        (pushUndo old uiEvent state)
+            { appSlashIndex = 0
+            , appSlashDismissed = False
+            , appKillBuffer =
+                if Text.null killed
+                    then state.appKillBuffer
+                    else if old.appKillChain
+                        then combineKill
+                            direction
+                            killed
+                            state.appKillBuffer
+                        else killed
+            , appHistoryIndex = Nothing
+            , appHistoryDraft =
+                case uiEvent of
+                    UiSetDraft text _ -> text
+                    _ -> state.appHistoryDraft
+            }
+
+-- Record the pre-edit draft for Ctrl-_ when the edit changes the text.
+pushUndo :: AppState -> UiEvent -> AppState -> AppState
+pushUndo old uiEvent state =
+    case uiEvent of
+        UiSetDraft text _
+            | text /= old.appUi.uiDraft ->
+                state
+                    { appUndo =
+                        take undoLimit
+                            ((old.appUi.uiDraft, old.appUi.uiCursor)
+                                : state.appUndo)
+                    }
+        _ -> state
+
+moveHistory :: ApplyLocalUiEvent -> Int -> EventM Name AppState ()
+moveHistory applyUiEvent delta = do
+    state <- get
+    let (text, index, draft) =
+            Bridge.historyMove
+                delta
+                state.appHistory
+                state.appHistoryIndex
+                state.appUi.uiDraft
+                state.appHistoryDraft
+    applyUiEvent
+        (UiSetDraft text (Text.length text))
+        \currentState ->
+            currentState
+                { appHistoryIndex = index
+                , appHistoryDraft = draft
+                , appSlashIndex = 0
+                , appSlashDismissed = False
                 }
 
-    acceptSlash menu = do
-        current <- get
-        case selectedSlashSuggestion current menu of
-            Nothing -> pure ()
-            Just suggestion -> acceptSlashSuggestion menu suggestion
+moveSlash :: Int -> Int -> EventM Name AppState ()
+moveSlash delta count =
+    modify' \current ->
+        current
+            { appSlashIndex =
+                (current.appSlashIndex + delta) `mod` count
+            }
 
-    handleSlashEnter menu = do
-        current <- get
-        case selectedSlashSuggestion current menu of
-            Nothing -> submitDraft
-            Just suggestion
-                | Text.strip current.appUi.uiDraft
-                    == suggestion.slashSuggestionDisplay ->
-                        submitDraft
-                | suggestion.slashSuggestionTakesArguments ->
-                    acceptSlashSuggestion menu suggestion
-                | otherwise -> do
-                    let next = slashReplacement
-                            current.appUi.uiDraft
-                            menu
-                            suggestion
-                    submitText current next False
+acceptSlash :: ApplyLocalUiEvent -> SlashMenu -> EventM Name AppState ()
+acceptSlash applyUiEvent menu = do
+    current <- get
+    case selectedSlashSuggestion current menu of
+        Nothing -> pure ()
+        Just suggestion -> acceptSlashSuggestion applyUiEvent menu suggestion
 
-    acceptSlashSuggestion menu suggestion = do
-        current <- get
-        let next = slashReplacement
-                current.appUi.uiDraft
-                menu
-                suggestion
-            cursor =
-                menu.slashMenuReplaceStart
-                    + Text.length suggestion.slashSuggestionReplacement
-        modifyUiResetSlash (UiSetDraft next cursor)
+handleSlashEnter :: ApplyLocalUiEvent -> SlashMenu -> EventM Name AppState ()
+handleSlashEnter applyUiEvent menu = do
+    current <- get
+    case selectedSlashSuggestion current menu of
+        Nothing -> submitDraft applyUiEvent
+        Just suggestion
+            | Text.strip current.appUi.uiDraft
+                == suggestion.slashSuggestionDisplay ->
+                    submitDraft applyUiEvent
+            | suggestion.slashSuggestionTakesArguments ->
+                acceptSlashSuggestion applyUiEvent menu suggestion
+            | otherwise -> do
+                let next = slashReplacement
+                        current.appUi.uiDraft
+                        menu
+                        suggestion
+                submitText applyUiEvent current next False
+
+acceptSlashSuggestion
+    :: ApplyLocalUiEvent
+    -> SlashMenu
+    -> SlashSuggestion
+    -> EventM Name AppState ()
+acceptSlashSuggestion applyUiEvent menu suggestion = do
+    current <- get
+    let next = slashReplacement
+            current.appUi.uiDraft
+            menu
+            suggestion
+        cursor =
+            menu.slashMenuReplaceStart
+                + Text.length suggestion.slashSuggestionReplacement
+    modifyUiResetSlash applyUiEvent (UiSetDraft next cursor)


### PR DESCRIPTION
## Summary
- Extract private, explicitly typed helpers from three large Haskell handlers, preserving existing behavior and effect ordering.
- Reduce `handleReplLine` from 968 to 115 lines, `handleComposerKey` from 619 to 186 lines, and `handleSelection` from 510 to 115 lines (signature blocks including local helpers).
- Keep every extracted helper under 200 lines; no public API or dependency changes.

## Validation
- Loaded current source through GHCi inside `nix develop`: 212 modules loaded successfully.
- Ran focused Hspec tests through `cabal repl agent-cli:test:agent-cli-test --offline --repl-options=-fobject-code`: **116 examples, 0 failures** (fullscreen composer, account selection, parseReplLine, accountSwitchTarget).
- Live current-source fullscreen tmux smoke passed: typing, Ctrl-W word kill, Ctrl-Y yank, Ctrl-U clear, `/help`, `/model` navigation and Esc cancellation, and clean Ctrl-Q exit. Used isolated HOME and dummy credentials; no model calls.
- `git diff --check` passed.