### PR TITLE
Optimize display journal projection and allocation

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -219,6 +219,36 @@ benchmark loop-events-bench
                     , base >= 4.14 && < 5
                     , text
 
+benchmark display-journal-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    -- Both algorithms and their shared types are compiled with the same -O2.
+    hs-source-dirs:   benchmark, src
+    main-is:          DisplayJournal.hs
+    other-modules:    DisplayJournalBaseline
+                    , Agent.Dialect
+                    , Agent.Error
+                    , Agent.Loop.DisplayJournal
+                    , Agent.Loop.EventPump
+                    , Agent.Loop.Output
+                    , Agent.Loop.TokenUsage
+                    , Agent.Provider
+                    , Agent.Telemetry
+                    , Agent.TextBuffer
+                    , Agent.ToolDispatch
+    ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-json
+                    , agent-responses-types
+                    , aeson
+                    , async
+                    , base >= 4.14 && < 5
+                    , bytestring
+                    , containers
+                    , safe-exceptions
+                    , stm
+                    , text
+                    , time
+
 benchmark concurrent-discovery-bench
     import:           common-opts
     type:             exitcode-stdio-1.0

--- a/packages/agent-core/benchmark/DisplayJournal.hs
+++ b/packages/agent-core/benchmark/DisplayJournal.hs
@@ -1,0 +1,335 @@
+module Main (main) where
+
+import qualified Agent.Loop.DisplayJournal as New
+import Agent.Loop.Output (LoopEvent(..))
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , ToolCallKind(..)
+    , ToolCallMode(..)
+    , ToolCallResult(..)
+    , functionToolCall
+    , setToolCallArguments
+    )
+-- safe-exceptions does not export evaluate.
+import Control.Exception (evaluate)
+import Control.Monad (forM, forM_, unless)
+import Data.Char (ord)
+import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
+import Data.List (inits, sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Word (Word64)
+import qualified DisplayJournalBaseline as Old
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (GCDetails(..), RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Mode = Old | New
+data Workload
+    = TextFailure
+    | TextSuccess
+    | TextAfterToolFailure
+    | TextAfterToolSuccess
+    | ToolsFailure
+    | ToolsSuccess
+    | RetryRetract
+
+data Sample = Sample
+    { wallMs :: !Double
+    , cpuMs :: !Double
+    , allocated :: !Integer
+    }
+
+main :: IO ()
+main = getArgs >>= \case
+    ["--verify"] -> validatePrefixes
+    ["--retain", mode, tools, snapshots, size] -> do
+        parsedTools <- positive tools
+        parsedSnapshots <- positive snapshots
+        parsedSize <- positive size
+        retention mode parsedTools parsedSnapshots parsedSize
+    args -> runBenchmark args
+
+-- Independent process diagnostic, not a timed sample. The construction frame
+-- must be gone before collection so the input list cannot keep dead snapshots
+-- alive independently of the journal.
+retention :: String -> Int -> Int -> Int -> IO ()
+retention mode tools snapshots size = do
+    enabled <- getRTSStatsEnabled
+    unless enabled $ die "RTS stats disabled; use +RTS -T"
+    (project, clear) <- retainedJournal mode tools snapshots size
+    performGC
+    admitted <- getRTSStats
+    output <- project
+    checksum <- evaluate (eventsChecksum output)
+    performGC
+    projected <- getRTSStats
+    -- Keep both the journal and output alive across the second collection.
+    again <- project >>= evaluate . eventsChecksum
+    unless (again == checksum) $ die "retained projection changed"
+    _ <- evaluate (eventsChecksum output)
+    clear
+    performGC
+    cleared <- getRTSStats
+    -- Keep output and the now-empty reference alive over the final collection.
+    emptyOutput <- project
+    unless (null emptyOutput) $ die "journal clear failed"
+    _ <- evaluate (eventsChecksum output)
+    printf "%s,retained,%d,%d,%d,%d,%d,%d,%d\n" mode tools snapshots size
+        (gcdetails_live_bytes (gc admitted))
+        (gcdetails_live_bytes (gc projected))
+        (gcdetails_live_bytes (gc cleared))
+        checksum
+
+{-# NOINLINE retainedJournal #-}
+retainedJournal :: String -> Int -> Int -> Int -> IO (IO [LoopEvent], IO ())
+retainedJournal mode tools snapshots size = case mode of
+    "old" -> build [] Old.recordDisplayEvent Old.displayEventsFromJournal
+    "new" -> build New.emptyDisplayJournal New.recordDisplayEvent New.displayEventsFromJournal
+    _ -> die "mode must be old or new"
+  where
+    build empty record project = do
+        ref <- newIORef empty
+        forM_ [1 .. tools] \identifier -> do
+            let event = ToolStarted
+                    (functionToolCall (Text.pack (show identifier)) "read_file" "{}")
+            _ <- evaluate (eventsChecksum [event])
+            modifyIORef' ref (record event)
+        -- Generate and force each independent payload just before admission.
+        -- No input list can root superseded snapshots at the collection point.
+        forM_ [1 .. snapshots] \index -> do
+            let identifier = Text.pack (show (1 + (index - 1) `mod` tools))
+                payload = Text.take size
+                    (Text.pack (show index) <> Text.replicate size "x")
+                event = ToolOutputUpdated identifier payload
+            _ <- evaluate (eventsChecksum [event])
+            modifyIORef' ref (record event)
+        pure (project <$> readIORef ref, writeIORef ref empty)
+
+runBenchmark :: [String] -> IO ()
+runBenchmark args = do
+    enabled <- getRTSStatsEnabled
+    unless enabled $ die "RTS stats disabled; use +RTS -T"
+    case args of
+        [modeArg, workloadArg, countArg, sizeArg, samplesArg] -> do
+            mode <- case modeArg of
+                "old" -> pure Old
+                "new" -> pure New
+                _ -> die "mode must be old or new"
+            workload <- case workloadArg of
+                "text-failure" -> pure TextFailure
+                "text-success" -> pure TextSuccess
+                "text-after-tool-failure" -> pure TextAfterToolFailure
+                "text-after-tool-success" -> pure TextAfterToolSuccess
+                "tools-failure" -> pure ToolsFailure
+                "tools-success" -> pure ToolsSuccess
+                "retry-retract" -> pure RetryRetract
+                _ -> die "unknown workload"
+            count <- positive countArg
+            size <- positive sizeArg
+            sampleCount <- positive samplesArg
+            validatePrefixes
+            -- Separate fixtures prevent validation from evaluating timed work.
+            old <- runJournal Old workload (fixture workload count size 0)
+            new <- runJournal New workload (fixture workload count size 0)
+            unless (old == new) $ die "baseline/production output mismatch"
+            samples <- forM [1 .. sampleCount] \sample -> do
+                let inputs =
+                        [ fixture workload count size (sample * repetitions + n)
+                        | n <- [1 .. repetitions]
+                        ]
+                _ <- evaluate $ sum (map eventsChecksum inputs)
+                measure $ runInputs mode workload inputs
+            printf "%s,%s,%d,%d,%d,%.6f,%.6f,%d\n"
+                modeArg workloadArg count size sampleCount
+                (median (map (.wallMs) samples) / fromIntegral repetitions)
+                (median (map (.cpuMs) samples) / fromIntegral repetitions)
+                (median (map (.allocated) samples) `div` fromIntegral repetitions)
+        _ -> die "usage: display-journal-bench old|new WORKLOAD COUNT BODY_BYTES SAMPLES"
+
+-- Exercise removals at every position, shared update slots, discarded attempts,
+-- reused call ids and text chunk boundaries, including observations before a
+-- subsequent event could conceal an ordering bug. Kept outside timing.
+validatePrefixes :: IO ()
+validatePrefixes =
+    forM_ [1 .. 64 :: Word64] \seed ->
+        forM_ (inits (mixed seed)) \events -> do
+            old <- runJournal Old TextFailure events
+            new <- runJournal New TextFailure events
+            unless (old == new) $
+                die ("mixed-prefix mismatch: seed " <> show seed
+                    <> ", prefix " <> show (length events))
+  where
+    mixed seed =
+        map
+            (\n -> choices !! fromIntegral ((n `div` 65536) `mod` fromIntegral (length choices)))
+            (take 100 (drop 1 (iterate (\n -> n * 6364136223846793005 + 1442695040888963407) seed)))
+    first = functionToolCall "same" "read_file" "{}"
+    second = functionToolCall "other" "grep" "{\"x\":1}"
+    choices =
+        [ TextDelta "a"
+        , ToolStarted first
+        , ToolUpdated first
+        , TextDelta ""
+        , ToolArgumentsUpdated second
+        , ToolOutputUpdated "same" "old"
+        , ToolStarted second
+        , ToolOutputUpdated "same" "new"
+        , ToolRetracted "other"
+        , TextDelta "b"
+        , ResponseRestarted "retry"
+        , ToolArgumentsUpdated first
+        , ResponseAttemptDiscarded
+        , ToolRetracted "same"
+        , ToolFinished (finished "same" "first finish")
+        , ToolStarted first
+        , ToolFinished (finished "same" "second finish")
+        , ResponseAttemptDiscarded
+        , ToolFinished (finished "other" "other finish")
+        ]
+
+finished :: Text -> Text -> ToolCallResult
+finished identifier output = ToolCallResult
+    { callId = identifier
+    , output
+    , callKind = FunctionCallKind
+    , toolResultMode = BlockingToolCall
+    , toolResultImages = []
+    , toolResultOutcome = Nothing
+    }
+
+positive :: String -> IO Int
+positive raw = case reads raw of
+    [(n, "")] | n > 0 -> pure n
+    _ -> die ("expected positive integer: " <> raw)
+
+repetitions :: Int
+repetitions = 20
+
+-- Exercise the same strict IORef admission/clear/discard operations as
+-- recordVisibleLoopEvent. A failed turn forces retained projection; success
+-- drops it, matching the loop's TurnFinished branch. This deliberately
+-- excludes provider/event-pump timing, which LoopEvents.hs measures separately.
+runJournal :: Mode -> Workload -> [LoopEvent] -> IO [LoopEvent]
+runJournal mode workload events = case mode of
+    Old -> run [] Old.recordDisplayEvent
+        Old.discardCurrentDisplayAttempt Old.displayEventsFromJournal
+    New -> run New.emptyDisplayJournal New.recordDisplayEvent
+        New.discardCurrentDisplayAttempt New.displayEventsFromJournal
+  where
+    run empty record discard project = do
+        ref <- newIORef empty
+        mapM_
+            (\event ->
+                modifyIORef' ref $
+                    case event of
+                        ResponseAttemptDiscarded -> discard
+                        _ -> record event)
+            events
+        case workload of
+            TextSuccess -> writeIORef ref empty
+            TextAfterToolSuccess -> writeIORef ref empty
+            ToolsSuccess -> writeIORef ref empty
+            _ -> pure ()
+        project <$> readIORef ref
+
+{-# NOINLINE runInputs #-}
+runInputs :: Mode -> Workload -> [[LoopEvent]] -> IO Int
+runInputs mode workload = go 0
+  where
+    go total [] = pure total
+    go total (events : rest) = do
+        output <- runJournal mode workload events
+        checksum <- evaluate (eventsChecksum output)
+        let total' = total + checksum
+        total' `seq` go total' rest
+
+fixture :: Workload -> Int -> Int -> Int -> [LoopEvent]
+fixture workload count size salt = case workload of
+    TextFailure -> texts
+    TextSuccess -> texts
+    TextAfterToolFailure -> ToolStarted (makeCall 1) : texts
+    TextAfterToolSuccess -> ToolStarted (makeCall 1) : texts
+    ToolsFailure -> tools
+    ToolsSuccess -> tools
+    RetryRetract ->
+        tools
+            <> [ResponseRestarted "retry"]
+            <> tools
+            <> map (ToolRetracted . (.callId)) calls
+            <> [TextDelta body, ResponseAttemptDiscarded, TextDelta body]
+  where
+    body = Text.replicate size (Text.singleton (toEnum (97 + salt `mod` 26)))
+    snapshot round =
+        Text.replicate size (Text.singleton (toEnum (97 + (salt + round) `mod` 26)))
+    texts = replicate count (TextDelta body)
+    makeCall :: Int -> ToolCall
+    makeCall n =
+        functionToolCall
+            (Text.pack ("call-" <> show salt <> "-" <> show n))
+            "read_file"
+            body
+    calls = map makeCall [1 .. count]
+    tools =
+        map ToolStarted calls
+            <> concat
+                [ concat
+                    [ [ if even round then ToolUpdated updated else ToolArgumentsUpdated updated
+                      , ToolOutputUpdated call.callId (snapshot round)
+                      ]
+                    | call <- calls
+                    , let updated = setToolCallArguments (snapshot round) call
+                    ]
+                | round <- [1 .. (16 :: Int)]
+                ]
+            <> map
+                (\call -> ToolFinished (finished call.callId body))
+                calls
+
+eventsChecksum :: [LoopEvent] -> Int
+eventsChecksum = foldl' (\n event -> n * 33 + eventChecksum event) 5381
+
+eventChecksum :: LoopEvent -> Int
+eventChecksum = \case
+    TextDelta text -> 1 + textChecksum text
+    ToolStarted call -> 2 + callChecksum call
+    ToolUpdated call -> 3 + callChecksum call
+    ToolArgumentsUpdated call -> 4 + callChecksum call
+    ToolOutputUpdated identifier output -> 5 + textChecksum identifier + textChecksum output
+    ToolFinished result -> 6 + textChecksum result.callId + textChecksum result.output
+    ToolRetracted identifier -> 7 + textChecksum identifier
+    ResponseRestarted reason -> 8 + textChecksum reason
+    ResponseAttemptDiscarded -> 9
+    _ -> error "unexpected benchmark event"
+
+callChecksum :: ToolCall -> Int
+callChecksum call =
+    textChecksum call.callId + textChecksum call.name + textChecksum call.arguments
+
+textChecksum :: Text -> Int
+textChecksum = Text.foldl' (\n c -> n * 33 + ord c) 5381
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performGC
+    before <- getRTSStats
+    wallStart <- getMonotonicTimeNSec
+    cpuStart <- getCPUTime
+    result <- action
+    _ <- evaluate result
+    cpuEnd <- getCPUTime
+    wallEnd <- getMonotonicTimeNSec
+    performGC
+    after <- getRTSStats
+    pure Sample
+        { wallMs = fromIntegral (wallEnd - wallStart) / 1e6
+        , cpuMs = fromIntegral (cpuEnd - cpuStart) / 1e9
+        , allocated = fromIntegral (after.allocated_bytes - before.allocated_bytes)
+        }
+
+median :: Ord a => [a] -> a
+median values = sort values !! (length values `div` 2)

--- a/packages/agent-core/benchmark/DisplayJournal.md
+++ b/packages/agent-core/benchmark/DisplayJournal.md
@@ -1,0 +1,264 @@
+# Display-journal updates
+
+Build and run inside the repository Nix development shell:
+
+```sh
+nix develop
+cabal build --offline agent-core:bench:display-journal-bench
+bin=$(cabal list-bin agent-core:bench:display-journal-bench)
+for mode in old new; do
+  "$bin" "$mode" tools-failure 100 64 7
+done
+```
+
+The benchmark compiles production `Agent.Loop.DisplayJournal`, a frozen copy of
+the original list algorithm, and their shared types with the same `-O2` flags.
+The baseline comes from commit `1d17af7e9`.
+
+Arguments are implementation, workload, count, ASCII payload bytes, and sample
+count. Each sample runs twenty independently salted fixtures. Fixtures and their
+payloads are forced before measurement. Full output equality and 6,464
+mixed-sequence prefix comparisons run outside measurement.
+Run `"$bin" --verify` to run only those semantic comparisons. The mixed inputs
+use 64 fixed seeds of a Word64 linear congruential generator, each producing
+100 events, including duplicate starts/finishes and repeated discards.
+
+The timed path uses the same strict `IORef` journal updates, attempt discard,
+success clearing, and failed-output projection as the loop admission path.
+Failure results are fully consumed, including their retained text/tool payloads;
+success clears the journal without projecting it. This distinction matters:
+the old list's lazy filtering can defer work until failed output is observed.
+The benchmark does not include provider, event-pump, terminal, or storage time.
+`LoopEvents.hs` provides a separate integrated loop streaming/failure workload.
+
+CSV columns: implementation, workload, count, payload bytes, samples, median
+elapsed milliseconds/operation, median CPU milliseconds/operation, median
+allocated bytes/operation. RTS statistics are enabled by default (`-T`).
+Collections bracket each sample; the final collection updates nursery allocation
+statistics but is excluded from both clocks.
+
+## Workloads
+
+- `text-failure`, `text-success`: `count` adjacent text deltas.
+- `text-after-tool-failure`, `text-after-tool-success`: one tool start followed
+  by `count` adjacent deltas, guarding the text fast path in a tool-bearing turn.
+- `tools-failure`, `tools-success`: `count` retained tool starts, sixteen rounds
+  of alternating argument/metadata snapshots and output snapshots for every
+  tool, then one finish per tool. Snapshot arguments and output differ in each
+  round. Each tool has 34 total events.
+- `retry-retract`: two copies of the tool workload separated by a restart, with
+  the same call IDs reused; retract every second-attempt tool, append text,
+  discard the current attempt, then append text again.
+
+Use small tool counts (1, 4, 16), larger counts (100, 1,000), and text counts
+(1,000, 10,000). Repeat representative cases to check stability, and include
+larger payloads to separate indexing costs from text-copy costs.
+
+## Final newest-first projection
+
+The final implementation keeps cheap raw event/chunk admission and performs
+one newest-first projection, using seen-call sets for update/output slots.
+It avoids both per-event admission indexes and chronological reconstruction.
+On macOS/aarch64, GHC 9.10.3, `-O2`, default RTS allocation area, seven samples
+of twenty independently salted operations produced:
+
+| Workload | Count | Bytes | Wall ms, old → new | CPU ms, old → new | Allocated bytes, old → new |
+|---|---:|---:|---:|---:|---:|
+| tools-failure | 1 | 64 | 0.00140 → 0.00070 | 0.00135 → 0.00070 | 8637 → 2365 |
+| tools-success | 1 | 64 | 0.00025 → 0.00030 | 0.00025 → 0.00025 | 3365 → 1765 |
+| tools-failure | 16 | 64 | 0.24545 → 0.01805 | 0.24590 → 0.01805 | 1439757 → 41005 |
+| tools-success | 16 | 64 | 0.00325 → 0.00305 | 0.00320 → 0.00305 | 51725 → 26125 |
+| tools-failure | 100 | 64 | 16.44030 → 0.22290 | 16.42930 → 0.22290 | 81168621 → 283981 |
+| tools-success | 100 | 64 | 0.03810 → 0.04185 | 0.03800 → 0.04185 | 322541 → 162541 |
+| text-failure | 1000 | 16 | 0.03450 → 0.03375 | 0.03445 → 0.03365 | 104405 → 88317 |
+| text-success | 1000 | 16 | 0.00830 → 0.00780 | 0.00820 → 0.00775 | 64141 → 48141 |
+| text-failure | 10000 | 16 | 0.46710 → 0.46525 | 0.46705 → 0.46490 | 1040405 → 880317 |
+| text-success | 10000 | 16 | 0.16255 → 0.14655 | 0.16215 → 0.14630 | 640141 → 480141 |
+| text-after-tool-failure | 1000 | 16 | 0.03660 → 0.03480 | 0.03655 → 0.03480 | 104621 → 88429 |
+| text-after-tool-success | 1000 | 16 | 0.00820 → 0.00705 | 0.00820 → 0.00705 | 64181 → 48165 |
+| retry-retract | 16 | 64 | 0.48800 → 0.05775 | 0.48795 → 0.05770 | 2891925 → 299269 |
+| tools-failure (repeat) | 16 | 64 | 0.24835 → 0.01690 | 0.24800 → 0.01690 | 1439757 → 41005 |
+
+The 100-tool failure workload is about 74× faster with 99.65% less allocation.
+The one-tool failure allocation regression of the earlier prototype is gone.
+Successful 100-tool timing is noisy: three additional new-then-old invocations
+with eleven samples gave wall ms old → new of 0.05220 → 0.06865,
+0.09015 → 0.09295, and 0.07600 → 0.06530 (CPU: 0.05215 → 0.06860,
+0.09015 → 0.09115, 0.07595 → 0.06505). Allocation consistently fell from
+322541 to 162541 bytes; these timing samples do not establish a success-path
+speedup. Sub-microsecond differences in the smallest cases are not meaningful.
+
+Reproduce the final matrix:
+
+```sh
+"$bin" --verify
+for case in \
+  "tools-failure 1 64" "tools-success 1 64" \
+  "tools-failure 16 64" "tools-success 16 64" \
+  "tools-failure 100 64" "tools-success 100 64" \
+  "text-failure 1000 16" "text-success 1000 16" \
+  "text-failure 10000 16" "text-success 10000 16" \
+  "text-after-tool-failure 1000 16" "text-after-tool-success 1000 16" \
+  "retry-retract 16 64" "tools-failure 16 64"; do
+  for mode in old new; do "$bin" "$mode" $case 7; done
+done
+```
+
+### Retained heap and lifetime boundary
+
+`--retain old|new TOOLS SNAPSHOTS BYTES` streams individually forced, distinct
+output snapshots round-robin directly into the journal. No input list remains
+rooted. GC live bytes are measured after admission, after fully forcing output
+while retaining the journal, and after clearing the journal while keeping output
+and the empty reference alive. The last phase models releasing the journal root;
+it does not require clearing the production journal during error finalization.
+
+```sh
+for tools in 1 16; do
+  for snapshots in 100 1000; do
+    for mode in old new; do
+      "$bin" --retain "$mode" "$tools" "$snapshots" 65536
+    done
+  done
+done
+```
+
+CSV columns: mode, `retained`, tools, total snapshots, bytes/snapshot, live bytes
+after admission, live bytes after projection, live bytes after clear, checksum.
+Checksums match for each old/new pair.
+
+| Tools | Snapshots | Admission live bytes, old → new | Projected with journal rooted, old → new | After clear, old → new |
+|---:|---:|---:|---:|---:|
+| 1 | 100 | 6574440 → 6569624 | 101912 → 6570736 | 102896 → 71016 |
+| 1 | 1000 | 65715256 → 65667240 | 101928 → 65668352 | 102912 → 71032 |
+| 16 | 100 | 6582168 → 6577112 | 1090712 → 6578464 | 1090496 → 1058616 |
+| 16 | 1000 | 65770248 → 65721992 | 1090728 → 65723344 | 1090512 → 1058632 |
+
+There is **no claim of reduced snapshot retention before projection**: both
+versions retain roughly the raw payload history here. The new journal retains
+superseded snapshots while its raw root stays alive even after projection;
+releasing that root leaves only the projected output. Production must preserve
+the journal until late manager/event-pump failure handling finishes, because
+those paths may reconstruct the execution result. These numbers are journal
+diagnostics, not end-to-end loop memory or latency measurements.
+
+## Rejected chronological-map projection prototype
+
+The second prototype admitted raw events/chunks and normalized tool snapshots
+into chronological maps only when projecting failed output. It passed the same
+6,464 differential
+prefixes. Seven samples of twenty operations, on the same machine/toolchain:
+
+| Workload | Count | Bytes | Wall ms, old → deferred | Allocated bytes, old → deferred |
+|---|---:|---:|---:|---:|
+| tools-failure | 1 | 64 | 0.00140 → 0.00145 | 8637 → 13669 |
+| tools-success | 1 | 64 | 0.00030 → 0.00030 | 3365 → 1765 |
+| tools-failure | 16 | 64 | 0.26240 → 0.06345 | 1439757 → 381181 |
+| tools-success | 16 | 64 | 0.00480 → 0.00385 | 51725 → 26125 |
+| text-after-tool-failure | 1000 | 16 | 0.04245 → 0.03900 | 104621 → 88477 |
+| text-after-tool-success | 1000 | 16 | 0.00945 → 0.00890 | 64181 → 48165 |
+
+The success/text admission regressions were removed, but the one-tool failure
+allocation increase remained; the final newest-first projection replaced it.
+The following retained-heap results belong to that rejected prototype:
+
+```sh
+for tools in 1 16; do
+  for snapshots in 100 1000; do
+    for mode in old new; do
+      "$bin" --retain "$mode" "$tools" "$snapshots" 65536
+    done
+  done
+done
+```
+
+This separate-process diagnostic streams distinct, fully forced 64-KiB output
+snapshots round-robin across the requested tools. No input list remains rooted.
+The historical diagnostic collected after admission, then after forced projection while deliberately
+keeping both the journal and its output alive. Its CSV columns were implementation,
+`retained`, tool count, total snapshot count, bytes/snapshot, live bytes after
+admission, live bytes after projection, and output checksum.
+
+| Tools | Snapshots | Admission live bytes, old → deferred | Projected live bytes, old → deferred |
+|---:|---:|---:|---:|
+| 1 | 100 | 6574440 → 6569624 | 101912 → 6602616 |
+| 1 | 1000 | 65715256 → 65667240 | 101928 → 65700232 |
+| 16 | 100 | 6582168 → 6577112 | 1090712 → 6610344 |
+| 16 | 1000 | 65770248 → 65721992 | 1090728 → 65755224 |
+
+Both implementations retain roughly the entire raw snapshot history before
+projection in this workload. Projection evaluates and releases the old lazy
+filter chain, but the deferred prototype retains raw history if the journal
+itself remains rooted. This is a diagnostic of that lifetime, not a claim that
+the real loop retains its journal after returning failed output.
+
+## Rejected eager-index prototype
+
+The initial prototype promoted every tool-bearing attempt into strict `IntMap`
+and call-ID indexes immediately. On macOS/aarch64, GHC 9.10.3, `-O2`, default RTS
+allocation area, seven samples of twenty operations, it showed the following
+old → prototype results:
+
+| Workload | Count | Bytes | Wall ms | CPU ms | Allocated bytes |
+|---|---:|---:|---:|---:|---:|
+| tools-failure | 1 | 64 | 0.00155 → 0.00155 | 0.00155 → 0.00150 | 8445 → 14533 |
+| tools-success | 1 | 64 | 0.00030 → 0.00120 | 0.00025 → 0.00115 | 3365 → 14125 |
+| tools-failure | 16 | 64 | 0.26170 → 0.06655 | 0.26150 → 0.06655 | 1436685 → 435381 |
+| tools-success | 16 | 64 | 0.00350 → 0.05930 | 0.00345 → 0.05935 | 51725 → 428853 |
+| tools-failure | 100 | 64 | 16.49830 → 0.68720 | 16.48230 → 0.68350 | 81149421 → 3507221 |
+| tools-success | 100 | 64 | 0.08620 → 0.65020 | 0.07780 → 0.64930 | 322541 → 3466421 |
+| text-after-tool-failure | 1000 | 16 | 0.03715 → 0.04465 | 0.03730 → 0.04460 | 104493 → 240629 |
+| text-after-tool-success | 1000 | 16 | 0.00950 → 0.01280 | 0.00955 → 0.01315 | 64181 → 200381 |
+
+The failure-path improvement does not justify these success-path and
+text-after-tool regressions. Eagerly building indexes shifts work from failed
+projection into every successful turn; updating the text entry inside the map
+also adds per-delta allocation. These prototype numbers are diagnostic, not a
+claim about the final implementation.
+
+## Integrated loop validation
+
+The unchanged `LoopEvents.hs` driver was also built against baseline
+`1d17af7e93e4760a4e4c25b584d080f0808b700f` and the final journal, using separate
+Cabal projects with `optimization: 2`, GHC 9.10.3, and identical local dependency
+sources. Unlike the direct journal driver, these runs include the event pump,
+backend callback, and loop lifecycle. `streaming-failure` forces the retained
+`executionUncommittedDisplayEvents`; `streaming` follows the successful path.
+There is no provider/network request or UI rendering.
+
+Each cell is old → new. Times are independently selected medians of seven runs,
+in milliseconds; allocation is bytes. Sink delay is zero. The repeat reverses
+the old/new execution order.
+
+| Workload | Deltas | Run | CPU ms | Wall ms | Allocated bytes |
+|---|---:|---|---:|---:|---:|
+| streaming | 10000 | first | 2.190 → 2.477 | 2.192 → 2.477 | 6778704 → 6620008 |
+| streaming | 10000 | repeat | 2.118 → 2.077 | 2.118 → 2.078 | 6777112 → 6617400 |
+| streaming-failure | 10000 | first | 2.697 → 2.500 | 2.704 → 2.508 | 7272384 → 7112584 |
+| streaming-failure | 10000 | repeat | 2.295 → 2.257 | 2.295 → 2.259 | 7272384 → 7113768 |
+| streaming | 100000 | first | 33.830 → 33.490 | 34.261 → 33.510 | 67363272 → 65758064 |
+| streaming | 100000 | repeat | 34.220 → 32.413 | 34.254 → 32.472 | 67361976 → 65755872 |
+| streaming-failure | 100000 | first | 37.563 → 39.317 | 37.605 → 39.370 | 72358328 → 70751056 |
+| streaming-failure | 100000 | repeat | 36.639 → 35.476 | 36.696 → 35.484 | 72358048 → 70752096 |
+
+Integrated allocation consistently falls about 16 bytes per delta (2.2–2.4%).
+Timing varies between runs: the first 10000-delta success and 100000-delta
+failure runs regress, but neither regression reproduces in reverse-order
+repeats. Treat integrated CPU as approximately neutral, not a claimed speedup.
+
+To reproduce, build `agent-core:bench:loop-events-bench` in separate baseline
+and candidate checkouts, with the same Nix development environment and
+`--enable-optimization=2`, then run each resulting binary:
+
+```sh
+cabal build --offline --enable-optimization=2 agent-core:bench:loop-events-bench
+BIN=$(cabal list-bin --enable-optimization=2 agent-core:bench:loop-events-bench)
+for count in 10000 100000; do
+    "$BIN" streaming "$count" 0 7 +RTS -T
+    "$BIN" streaming-failure "$count" 0 7 +RTS -T
+done
+```
+
+Final focused GHCi validation of `Agent.Loop.FailedDisplaySpec` and
+`Agent.LoopSpec`: 107 examples, zero failures. Package-boundary checks,
+`git diff --check`, and regenerated `package.nix` consistency also passed.

--- a/packages/agent-core/benchmark/DisplayJournalBaseline.hs
+++ b/packages/agent-core/benchmark/DisplayJournalBaseline.hs
@@ -1,0 +1,105 @@
+-- Frozen list journal from 1d17af7e9. Do not replace its scans with production
+-- helpers: it is the retained before-change performance/semantics baseline.
+module DisplayJournalBaseline
+    ( DisplayJournalEntry
+    , recordDisplayEvent
+    , displayEventsFromJournal
+    , discardCurrentDisplayAttempt
+    ) where
+
+import Agent.Loop.Output (LoopEvent(..))
+import Agent.ToolDispatch (ToolCallResult(..))
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+data DisplayJournalEntry
+    = DisplayTextChunks ![Text]
+    | DisplayEvent !LoopEvent
+
+recordDisplayEvent :: LoopEvent -> [DisplayJournalEntry] -> [DisplayJournalEntry]
+recordDisplayEvent event events = case event of
+    TextDelta delta ->
+        case events of
+            DisplayTextChunks chunks : rest ->
+                DisplayTextChunks (delta : chunks) : rest
+            _ -> DisplayTextChunks [delta] : events
+    ToolUpdated call ->
+        DisplayEvent event : removeCurrentToolUpdates call.callId events
+    ToolArgumentsUpdated call ->
+        DisplayEvent event : removeCurrentToolUpdates call.callId events
+    ToolOutputUpdated callId output ->
+        DisplayEvent (ToolOutputUpdated callId (boundLoopToolOutput output))
+            : removeCurrentToolOutput callId events
+    ToolFinished result ->
+        DisplayEvent
+            (ToolFinished result { output = boundLoopToolOutput result.output })
+            : removeCurrentToolOutput result.callId events
+    ToolRetracted callId ->
+        removeCurrentToolEvents callId events
+    _ -> DisplayEvent event : events
+
+displayEventsFromJournal :: [DisplayJournalEntry] -> [LoopEvent]
+displayEventsFromJournal = map entryToEvent . reverse
+  where
+    entryToEvent = \case
+        DisplayTextChunks chunks -> TextDelta (Text.concat (reverse chunks))
+        DisplayEvent event -> event
+
+discardCurrentDisplayAttempt :: [DisplayJournalEntry] -> [DisplayJournalEntry]
+discardCurrentDisplayAttempt =
+    dropWhile \case
+        DisplayEvent (ResponseRestarted _) -> False
+        _ -> True
+
+removeCurrentToolUpdates :: Text -> [DisplayJournalEntry] -> [DisplayJournalEntry]
+removeCurrentToolUpdates callId =
+    filterCurrentAttempt \case
+        DisplayEvent (ToolUpdated call) -> call.callId /= callId
+        DisplayEvent (ToolArgumentsUpdated call) -> call.callId /= callId
+        _ -> True
+
+removeCurrentToolOutput :: Text -> [DisplayJournalEntry] -> [DisplayJournalEntry]
+removeCurrentToolOutput callId =
+    filterCurrentAttempt \case
+        DisplayEvent (ToolOutputUpdated identifier _) -> identifier /= callId
+        _ -> True
+
+removeCurrentToolEvents :: Text -> [DisplayJournalEntry] -> [DisplayJournalEntry]
+removeCurrentToolEvents callId =
+    filterCurrentAttempt \case
+        DisplayEvent (ToolStarted call) -> call.callId /= callId
+        DisplayEvent (ToolUpdated call) -> call.callId /= callId
+        DisplayEvent (ToolArgumentsUpdated call) -> call.callId /= callId
+        DisplayEvent (ToolOutputUpdated identifier _) -> identifier /= callId
+        DisplayEvent (ToolFinished result) -> result.callId /= callId
+        _ -> True
+
+filterCurrentAttempt
+    :: (DisplayJournalEntry -> Bool)
+    -> [DisplayJournalEntry]
+    -> [DisplayJournalEntry]
+filterCurrentAttempt keep = go
+  where
+    go [] = []
+    go allEvents@(DisplayEvent (ResponseRestarted _) : _) = allEvents
+    go (event : rest)
+        | keep event = event : go rest
+        | otherwise = go rest
+
+boundLoopToolOutput :: Text -> Text
+boundLoopToolOutput output
+    | Text.length output <= loopEventTailPayloadBudgetCodeUnits = Text.copy output
+    | otherwise =
+        toolOutputOmissionMarker
+            <> Text.copy (Text.takeEnd loopEventTailPayloadCodeUnits output)
+
+loopEventTailPayloadCodeUnits :: Int
+loopEventTailPayloadCodeUnits =
+    max 0
+        (loopEventTailPayloadBudgetCodeUnits - Text.length toolOutputOmissionMarker)
+
+toolOutputOmissionMarker :: Text
+toolOutputOmissionMarker = "[earlier tool output truncated]\n"
+
+loopEventTailPayloadBudgetCodeUnits :: Int
+loopEventTailPayloadBudgetCodeUnits = (8 * 1024 * 1024 - 64) `div` 4

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -24,8 +24,9 @@ mkDerivation {
     tls unix websockets yaml zlib
   ];
   benchmarkHaskellDepends = [
-    aeson agent-json async base bytestring directory filepath process
-    safe-exceptions text text-builder time unix
+    aeson agent-json agent-responses-types async base bytestring
+    containers directory filepath process safe-exceptions stm text
+    text-builder time unix
   ];
   description = "Provider-neutral infrastructure for the agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-core/src/Agent/Loop/DisplayJournal.hs
+++ b/packages/agent-core/src/Agent/Loop/DisplayJournal.hs
@@ -1,7 +1,8 @@
 -- | Display-only history for uncommitted response attempts, and bounded
 -- delivery of live events. This history must never enter backend/model state.
 module Agent.Loop.DisplayJournal
-    ( DisplayJournalEntry
+    ( DisplayJournal
+    , emptyDisplayJournal
     , replayableDisplayEvent
     , recordDisplayEvent
     , displayEventsFromJournal
@@ -18,6 +19,7 @@ import Agent.Loop.EventPump
     )
 import Agent.Loop.Output (LoopEvent(..))
 import Agent.ToolDispatch (ToolCallResult(..), setToolCallArguments)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -35,104 +37,97 @@ replayableDisplayEvent = \case
     ToolRetracted _ -> True
     _ -> False
 
--- The journal and each text chunk list are stored newest-first. Keeping
--- adjacent deltas as chunks avoids repeatedly copying the accumulated prefix.
--- A restart is the boundary between the current provider attempt and older
--- attempts that remain visible.
-data DisplayJournalEntry
-    = DisplayTextChunks ![Text]
-    | DisplayEvent !LoopEvent
+-- Admission remains a cheap chunk/event cons operation: successful responses
+-- clear the journal without projecting it. Normalize only when failed output
+-- is retained. Entries and text chunks are newest-first. Tails deliberately
+-- remain lazy, preserving prefix release and sharing during retractions.
+data DisplayJournal
+    = EmptyDisplayJournal
+    | DisplayJournalText ![Text] DisplayJournal
+    | DisplayJournalEvent !LoopEvent DisplayJournal
+
+emptyDisplayJournal :: DisplayJournal
+emptyDisplayJournal = EmptyDisplayJournal
 
 recordDisplayEvent
     :: LoopEvent
-    -> [DisplayJournalEntry]
-    -> [DisplayJournalEntry]
-recordDisplayEvent event events = case event of
-    TextDelta delta ->
-        case events of
-            DisplayTextChunks chunks : rest ->
-                DisplayTextChunks (delta : chunks) : rest
-            _ -> DisplayTextChunks [delta] : events
-    ToolUpdated call ->
-        DisplayEvent event : removeCurrentToolUpdates call.callId events
-    ToolArgumentsUpdated call ->
-        DisplayEvent event : removeCurrentToolUpdates call.callId events
+    -> DisplayJournal
+    -> DisplayJournal
+recordDisplayEvent event journal = case event of
+    TextDelta delta -> case journal of
+        DisplayJournalText chunks rest ->
+            DisplayJournalText (delta : chunks) rest
+        _ -> DisplayJournalText [delta] journal
     ToolOutputUpdated callId output ->
-        DisplayEvent (ToolOutputUpdated callId (boundLoopToolOutput output))
-            : removeCurrentToolOutput callId events
+        DisplayJournalEvent
+            (ToolOutputUpdated callId (boundLoopToolOutput output)) journal
     ToolFinished result ->
-        DisplayEvent
-            (ToolFinished
-                result
-                    { output = boundLoopToolOutput result.output
-                    })
-            : removeCurrentToolOutput result.callId events
-    ToolRetracted callId ->
-        removeCurrentToolEvents callId events
-    _ -> DisplayEvent event : events
+        DisplayJournalEvent
+            (ToolFinished result { output = boundLoopToolOutput result.output }) journal
+    ToolRetracted callId -> retractRawTool callId journal
+    _ -> DisplayJournalEvent event journal
 
-displayEventsFromJournal :: [DisplayJournalEntry] -> [LoopEvent]
-displayEventsFromJournal =
-    map entryToEvent . reverse
+-- Retractions keep the former lazy-filter behavior: forcing the new journal
+-- immediately releases a removed leading prefix, and the remaining tail is
+-- filtered as demanded. Do not retain retracted payloads in a raw operation log.
+-- Distinct text nodes stay distinct, even if filtering makes them adjacent.
+retractRawTool :: Text -> DisplayJournal -> DisplayJournal
+retractRawTool callId = go
   where
-    entryToEvent = \case
-        DisplayTextChunks chunks ->
-            TextDelta (Text.concat (reverse chunks))
-        DisplayEvent event -> event
+    go EmptyDisplayJournal = EmptyDisplayJournal
+    go boundary@(DisplayJournalEvent (ResponseRestarted _) _) = boundary
+    go (DisplayJournalText chunks rest) =
+        DisplayJournalText chunks (go rest)
+    go (DisplayJournalEvent event rest)
+        | belongsToTool event = go rest
+        | otherwise = DisplayJournalEvent event (go rest)
+    belongsToTool = \case
+        ToolStarted call -> call.callId == callId
+        ToolUpdated call -> call.callId == callId
+        ToolArgumentsUpdated call -> call.callId == callId
+        ToolOutputUpdated identifier _ -> identifier == callId
+        ToolFinished result -> result.callId == callId
+        _ -> False
+
+-- One newest-first pass keeps the latest snapshot of each kind per call ID.
+-- A finish suppresses earlier output snapshots, but is itself always retained.
+-- Sets reset at restart boundaries: providers may reuse IDs on later attempts.
+-- Consing retained entries yields chronological output without an ordered map.
+-- Raw text nodes remain distinct even when retraction removed their separator.
+displayEventsFromJournal :: DisplayJournal -> [LoopEvent]
+displayEventsFromJournal journal = go journal Set.empty Set.empty []
+  where
+    go EmptyDisplayJournal _ _ result = result
+    go (DisplayJournalText chunks rest) updates outputs result =
+        go rest updates outputs
+            (TextDelta (Text.concat (reverse chunks)) : result)
+    go (DisplayJournalEvent event rest) updates outputs result =
+        case event of
+            ToolUpdated call -> keepUpdate call.callId
+            ToolArgumentsUpdated call -> keepUpdate call.callId
+            ToolOutputUpdated callId _
+                | Set.member callId outputs -> go rest updates outputs result
+                | otherwise ->
+                    go rest updates (Set.insert callId outputs) (event : result)
+            ToolFinished callResult ->
+                go rest updates (Set.insert callResult.callId outputs) (event : result)
+            ResponseRestarted _ ->
+                go rest Set.empty Set.empty (event : result)
+            _ -> go rest updates outputs (event : result)
+      where
+        keepUpdate callId
+            | Set.member callId updates = go rest updates outputs result
+            | otherwise =
+                go rest (Set.insert callId updates) outputs (event : result)
 
 discardCurrentDisplayAttempt
-    :: [DisplayJournalEntry]
-    -> [DisplayJournalEntry]
-discardCurrentDisplayAttempt =
-    dropWhile \case
-        DisplayEvent (ResponseRestarted _) -> False
-        _ -> True
-
-removeCurrentToolUpdates
-    :: Text
-    -> [DisplayJournalEntry]
-    -> [DisplayJournalEntry]
-removeCurrentToolUpdates callId =
-    filterCurrentAttempt \case
-        DisplayEvent (ToolUpdated call) -> call.callId /= callId
-        DisplayEvent (ToolArgumentsUpdated call) -> call.callId /= callId
-        _ -> True
-
-removeCurrentToolOutput
-    :: Text
-    -> [DisplayJournalEntry]
-    -> [DisplayJournalEntry]
-removeCurrentToolOutput callId =
-    filterCurrentAttempt \case
-        DisplayEvent (ToolOutputUpdated identifier _) ->
-            identifier /= callId
-        _ -> True
-
-removeCurrentToolEvents
-    :: Text
-    -> [DisplayJournalEntry]
-    -> [DisplayJournalEntry]
-removeCurrentToolEvents callId =
-    filterCurrentAttempt \case
-        DisplayEvent (ToolStarted call) -> call.callId /= callId
-        DisplayEvent (ToolUpdated call) -> call.callId /= callId
-        DisplayEvent (ToolArgumentsUpdated call) -> call.callId /= callId
-        DisplayEvent (ToolOutputUpdated identifier _) ->
-            identifier /= callId
-        DisplayEvent (ToolFinished result) -> result.callId /= callId
-        _ -> True
-
-filterCurrentAttempt
-    :: (DisplayJournalEntry -> Bool)
-    -> [DisplayJournalEntry]
-    -> [DisplayJournalEntry]
-filterCurrentAttempt keep = go
-  where
-    go [] = []
-    go allEvents@(DisplayEvent (ResponseRestarted _) : _) = allEvents
-    go (event : rest)
-        | keep event = event : go rest
-        | otherwise = go rest
+    :: DisplayJournal
+    -> DisplayJournal
+discardCurrentDisplayAttempt = \case
+    EmptyDisplayJournal -> EmptyDisplayJournal
+    boundary@(DisplayJournalEvent (ResponseRestarted _) _) -> boundary
+    DisplayJournalText _ rest -> discardCurrentDisplayAttempt rest
+    DisplayJournalEvent _ rest -> discardCurrentDisplayAttempt rest
 
 data LoopEventCoalescingKey
     = AssistantTextDelta

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -302,7 +302,7 @@ data LoopRuntime = LoopRuntime
     , loopRuntimePendingRef :: IORef [TurnInput]
     , loopRuntimeUncommittedTextRef :: IORef ([[Text]], [Text])
     , loopRuntimeUncommittedDisplayEventsRef
-        :: IORef [DisplayJournalEntry]
+        :: IORef DisplayJournal
     , loopRuntimeProviderAttemptActiveRef :: IORef Bool
     , loopRuntimeProviderTelemetryRef :: IORef [TurnTelemetry]
     , loopRuntimeInitialSteering :: [TurnInput]
@@ -331,7 +331,7 @@ initializeLoopRuntime config0 initialState firstInputs = do
     eventAdmissionLock <- newMVar ()
     progressRef <- newIORef (initialState, NoResponseCommitted)
     uncommittedTextRef <- newIORef ([], [])
-    uncommittedDisplayEventsRef <- newIORef []
+    uncommittedDisplayEventsRef <- newIORef emptyDisplayJournal
     providerAttemptActiveRef <- newIORef False
     providerTelemetryRef <- newIORef []
     initialSteering <- config0.loopReadSteering
@@ -365,7 +365,7 @@ initializeLoopRuntime config0 initialState firstInputs = do
 
 recordVisibleLoopEvent
     :: IORef ([[Text]], [Text])
-    -> IORef [DisplayJournalEntry]
+    -> IORef DisplayJournal
     -> IORef Bool
     -> LoopEvent
     -> IO ()
@@ -386,10 +386,10 @@ recordVisibleLoopEvent
         case event of
             TurnStarted -> do
                 writeIORef providerAttemptActiveRef True
-                writeIORef uncommittedDisplayEventsRef []
+                writeIORef uncommittedDisplayEventsRef emptyDisplayJournal
             TurnFinished _ -> do
                 writeIORef providerAttemptActiveRef False
-                writeIORef uncommittedDisplayEventsRef []
+                writeIORef uncommittedDisplayEventsRef emptyDisplayJournal
             ResponseRestarted _ ->
                 modifyIORef'
                     uncommittedDisplayEventsRef
@@ -631,7 +631,7 @@ continueCommittedLoop runtime cursor turn = do
     -- assistant text now lives in the committed state.
     writeIORef runtime.loopRuntimePendingRef []
     writeIORef runtime.loopRuntimeUncommittedTextRef ([], [])
-    writeIORef runtime.loopRuntimeUncommittedDisplayEventsRef []
+    writeIORef runtime.loopRuntimeUncommittedDisplayEventsRef emptyDisplayJournal
     writeIORef runtime.loopRuntimeProviderAttemptActiveRef False
     -- Result metadata belongs to the response commit even when a cancellation
     -- lands before the completion event is painted.

--- a/packages/agent-core/test/Agent/Loop/FailedDisplaySpec.hs
+++ b/packages/agent-core/test/Agent/Loop/FailedDisplaySpec.hs
@@ -135,6 +135,78 @@ spec = do
         result <- runLoop config Nothing "hello"
         result `shouldBe` Left (LoopTransport (ConnectionError "down"))
 
+    it "replaces snapshots at their latest positions without losing intervening text" do
+        let call = functionToolCall "c1" "shell_command" "{}"
+            updated = setToolCallArguments "{\"command\":\"pwd\"}" call
+            finished = ToolCallResult
+                "c1" "done" FunctionCallKind BlockingToolCall [] Nothing
+            events =
+                [ ToolStarted call
+                , ToolUpdated call
+                , TextDelta "first"
+                , ToolArgumentsUpdated updated
+                , ToolOutputUpdated "c1" "old"
+                , TextDelta "second"
+                , ToolOutputUpdated "c1" "new"
+                , ToolFinished finished
+                ]
+            backend = Backend \_state _prev _inputs onEvent -> do
+                mapM_ onEvent events
+                pure (Left (ConnectionError "down"))
+        config <- testConfig backend
+        execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+        execution.executionUncommittedDisplayEvents `shouldBe`
+            [ ToolStarted call
+            , TextDelta "first"
+            , ToolArgumentsUpdated updated
+            , TextDelta "second"
+            , ToolFinished finished
+            ]
+
+    it "scopes retraction and discard to the latest attempt when tool IDs repeat" do
+        let call = functionToolCall "same" "shell_command" "{}"
+            events =
+                [ ToolStarted call
+                , ToolOutputUpdated "same" "retained"
+                , ResponseRestarted "retry"
+                , ToolStarted call
+                , ToolOutputUpdated "same" "removed"
+                , ToolRetracted "same"
+                , TextDelta "discarded"
+                , ResponseAttemptDiscarded
+                , ResponseAttemptDiscarded
+                , ToolStarted call
+                , ToolOutputUpdated "same" "latest"
+                ]
+            backend = Backend \_state _prev _inputs onEvent -> do
+                mapM_ onEvent events
+                pure (Left (ConnectionError "down"))
+        config <- testConfig backend
+        execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+        execution.executionUncommittedDisplayEvents `shouldBe`
+            [ ToolStarted call
+            , ToolOutputUpdated "same" "retained"
+            , ResponseRestarted "retry"
+            , ToolStarted call
+            , ToolOutputUpdated "same" "latest"
+            ]
+
+    it "resumes the latest text chunk after retracting a trailing tool" do
+        let call = functionToolCall "c1" "shell_command" "{}"
+            backend = Backend \_state _prev _inputs onEvent -> do
+                mapM_ onEvent
+                    [ TextDelta "before"
+                    , ToolStarted call
+                    , ToolOutputUpdated "c1" "removed"
+                    , ToolRetracted "c1"
+                    , TextDelta " after"
+                    ]
+                pure (Left (ConnectionError "down"))
+        config <- testConfig backend
+        execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+        execution.executionUncommittedDisplayEvents
+            `shouldBe` [TextDelta "before after"]
+
     it "bounds completed tool output retained after failure" do
         let oversized =
                 Text.replicate (3 * 1024 * 1024) "x" <> "newest-tail"


### PR DESCRIPTION
## Summary
- Replace the display journal list wrapper with an opaque journal and a newest-first projection using per-attempt seen sets.
- Preserve display ordering, retry boundaries, tool retractions, text grouping, and late-failure recovery.
- Keep a frozen baseline, differential verifier, and optimized benchmarks in the repository.

## Validation
- 107 focused Hspec examples passed through GHCi.
- 6,464 differential prefix comparisons passed.
- Package boundaries, regenerated package.nix consistency, and diff checks passed.
- Final code review found no actionable issues.

## Performance boundaries
- 100-tool failure workload: about 74x faster and 99.65% less allocation.
- Integrated streaming allocation falls 2.2–2.4%; timing is approximately neutral across repeats.
- No claim of reduced active raw-journal retained payload memory. Eager/indexed prototypes that regressed successful turns were rejected.

## Reproduction and complete evidence
# Display-journal updates

Build and run inside the repository Nix development shell:

```sh
nix develop
cabal build --offline agent-core:bench:display-journal-bench
bin=$(cabal list-bin agent-core:bench:display-journal-bench)
for mode in old new; do
  "$bin" "$mode" tools-failure 100 64 7
done
```

The benchmark compiles production `Agent.Loop.DisplayJournal`, a frozen copy of
the original list algorithm, and their shared types with the same `-O2` flags.
The baseline comes from commit `1d17af7e9`.

Arguments are implementation, workload, count, ASCII payload bytes, and sample
count. Each sample runs twenty independently salted fixtures. Fixtures and their
payloads are forced before measurement. Full output equality and 6,464
mixed-sequence prefix comparisons run outside measurement.
Run `"$bin" --verify` to run only those semantic comparisons. The mixed inputs
use 64 fixed seeds of a Word64 linear congruential generator, each producing
100 events, including duplicate starts/finishes and repeated discards.

The timed path uses the same strict `IORef` journal updates, attempt discard,
success clearing, and failed-output projection as the loop admission path.
Failure results are fully consumed, including their retained text/tool payloads;
success clears the journal without projecting it. This distinction matters:
the old list's lazy filtering can defer work until failed output is observed.
The benchmark does not include provider, event-pump, terminal, or storage time.
`LoopEvents.hs` provides a separate integrated loop streaming/failure workload.

CSV columns: implementation, workload, count, payload bytes, samples, median
elapsed milliseconds/operation, median CPU milliseconds/operation, median
allocated bytes/operation. RTS statistics are enabled by default (`-T`).
Collections bracket each sample; the final collection updates nursery allocation
statistics but is excluded from both clocks.

## Workloads

- `text-failure`, `text-success`: `count` adjacent text deltas.
- `text-after-tool-failure`, `text-after-tool-success`: one tool start followed
  by `count` adjacent deltas, guarding the text fast path in a tool-bearing turn.
- `tools-failure`, `tools-success`: `count` retained tool starts, sixteen rounds
  of alternating argument/metadata snapshots and output snapshots for every
  tool, then one finish per tool. Snapshot arguments and output differ in each
  round. Each tool has 34 total events.
- `retry-retract`: two copies of the tool workload separated by a restart, with
  the same call IDs reused; retract every second-attempt tool, append text,
  discard the current attempt, then append text again.

Use small tool counts (1, 4, 16), larger counts (100, 1,000), and text counts
(1,000, 10,000). Repeat representative cases to check stability, and include
larger payloads to separate indexing costs from text-copy costs.

## Final newest-first projection

The final implementation keeps cheap raw event/chunk admission and performs
one newest-first projection, using seen-call sets for update/output slots.
It avoids both per-event admission indexes and chronological reconstruction.
On macOS/aarch64, GHC 9.10.3, `-O2`, default RTS allocation area, seven samples
of twenty independently salted operations produced:

| Workload | Count | Bytes | Wall ms, old → new | CPU ms, old → new | Allocated bytes, old → new |
|---|---:|---:|---:|---:|---:|
| tools-failure | 1 | 64 | 0.00140 → 0.00070 | 0.00135 → 0.00070 | 8637 → 2365 |
| tools-success | 1 | 64 | 0.00025 → 0.00030 | 0.00025 → 0.00025 | 3365 → 1765 |
| tools-failure | 16 | 64 | 0.24545 → 0.01805 | 0.24590 → 0.01805 | 1439757 → 41005 |
| tools-success | 16 | 64 | 0.00325 → 0.00305 | 0.00320 → 0.00305 | 51725 → 26125 |
| tools-failure | 100 | 64 | 16.44030 → 0.22290 | 16.42930 → 0.22290 | 81168621 → 283981 |
| tools-success | 100 | 64 | 0.03810 → 0.04185 | 0.03800 → 0.04185 | 322541 → 162541 |
| text-failure | 1000 | 16 | 0.03450 → 0.03375 | 0.03445 → 0.03365 | 104405 → 88317 |
| text-success | 1000 | 16 | 0.00830 → 0.00780 | 0.00820 → 0.00775 | 64141 → 48141 |
| text-failure | 10000 | 16 | 0.46710 → 0.46525 | 0.46705 → 0.46490 | 1040405 → 880317 |
| text-success | 10000 | 16 | 0.16255 → 0.14655 | 0.16215 → 0.14630 | 640141 → 480141 |
| text-after-tool-failure | 1000 | 16 | 0.03660 → 0.03480 | 0.03655 → 0.03480 | 104621 → 88429 |
| text-after-tool-success | 1000 | 16 | 0.00820 → 0.00705 | 0.00820 → 0.00705 | 64181 → 48165 |
| retry-retract | 16 | 64 | 0.48800 → 0.05775 | 0.48795 → 0.05770 | 2891925 → 299269 |
| tools-failure (repeat) | 16 | 64 | 0.24835 → 0.01690 | 0.24800 → 0.01690 | 1439757 → 41005 |

The 100-tool failure workload is about 74× faster with 99.65% less allocation.
The one-tool failure allocation regression of the earlier prototype is gone.
Successful 100-tool timing is noisy: three additional new-then-old invocations
with eleven samples gave wall ms old → new of 0.05220 → 0.06865,
0.09015 → 0.09295, and 0.07600 → 0.06530 (CPU: 0.05215 → 0.06860,
0.09015 → 0.09115, 0.07595 → 0.06505). Allocation consistently fell from
322541 to 162541 bytes; these timing samples do not establish a success-path
speedup. Sub-microsecond differences in the smallest cases are not meaningful.

Reproduce the final matrix:

```sh
"$bin" --verify
for case in \
  "tools-failure 1 64" "tools-success 1 64" \
  "tools-failure 16 64" "tools-success 16 64" \
  "tools-failure 100 64" "tools-success 100 64" \
  "text-failure 1000 16" "text-success 1000 16" \
  "text-failure 10000 16" "text-success 10000 16" \
  "text-after-tool-failure 1000 16" "text-after-tool-success 1000 16" \
  "retry-retract 16 64" "tools-failure 16 64"; do
  for mode in old new; do "$bin" "$mode" $case 7; done
done
```

### Retained heap and lifetime boundary

`--retain old|new TOOLS SNAPSHOTS BYTES` streams individually forced, distinct
output snapshots round-robin directly into the journal. No input list remains
rooted. GC live bytes are measured after admission, after fully forcing output
while retaining the journal, and after clearing the journal while keeping output
and the empty reference alive. The last phase models releasing the journal root;
it does not require clearing the production journal during error finalization.

```sh
for tools in 1 16; do
  for snapshots in 100 1000; do
    for mode in old new; do
      "$bin" --retain "$mode" "$tools" "$snapshots" 65536
    done
  done
done
```

CSV columns: mode, `retained`, tools, total snapshots, bytes/snapshot, live bytes
after admission, live bytes after projection, live bytes after clear, checksum.
Checksums match for each old/new pair.

| Tools | Snapshots | Admission live bytes, old → new | Projected with journal rooted, old → new | After clear, old → new |
|---:|---:|---:|---:|---:|
| 1 | 100 | 6574440 → 6569624 | 101912 → 6570736 | 102896 → 71016 |
| 1 | 1000 | 65715256 → 65667240 | 101928 → 65668352 | 102912 → 71032 |
| 16 | 100 | 6582168 → 6577112 | 1090712 → 6578464 | 1090496 → 1058616 |
| 16 | 1000 | 65770248 → 65721992 | 1090728 → 65723344 | 1090512 → 1058632 |

There is **no claim of reduced snapshot retention before projection**: both
versions retain roughly the raw payload history here. The new journal retains
superseded snapshots while its raw root stays alive even after projection;
releasing that root leaves only the projected output. Production must preserve
the journal until late manager/event-pump failure handling finishes, because
those paths may reconstruct the execution result. These numbers are journal
diagnostics, not end-to-end loop memory or latency measurements.

## Rejected chronological-map projection prototype

The second prototype admitted raw events/chunks and normalized tool snapshots
into chronological maps only when projecting failed output. It passed the same
6,464 differential
prefixes. Seven samples of twenty operations, on the same machine/toolchain:

| Workload | Count | Bytes | Wall ms, old → deferred | Allocated bytes, old → deferred |
|---|---:|---:|---:|---:|
| tools-failure | 1 | 64 | 0.00140 → 0.00145 | 8637 → 13669 |
| tools-success | 1 | 64 | 0.00030 → 0.00030 | 3365 → 1765 |
| tools-failure | 16 | 64 | 0.26240 → 0.06345 | 1439757 → 381181 |
| tools-success | 16 | 64 | 0.00480 → 0.00385 | 51725 → 26125 |
| text-after-tool-failure | 1000 | 16 | 0.04245 → 0.03900 | 104621 → 88477 |
| text-after-tool-success | 1000 | 16 | 0.00945 → 0.00890 | 64181 → 48165 |

The success/text admission regressions were removed, but the one-tool failure
allocation increase remained; the final newest-first projection replaced it.
The following retained-heap results belong to that rejected prototype:

```sh
for tools in 1 16; do
  for snapshots in 100 1000; do
    for mode in old new; do
      "$bin" --retain "$mode" "$tools" "$snapshots" 65536
    done
  done
done
```

This separate-process diagnostic streams distinct, fully forced 64-KiB output
snapshots round-robin across the requested tools. No input list remains rooted.
The historical diagnostic collected after admission, then after forced projection while deliberately
keeping both the journal and its output alive. Its CSV columns were implementation,
`retained`, tool count, total snapshot count, bytes/snapshot, live bytes after
admission, live bytes after projection, and output checksum.

| Tools | Snapshots | Admission live bytes, old → deferred | Projected live bytes, old → deferred |
|---:|---:|---:|---:|
| 1 | 100 | 6574440 → 6569624 | 101912 → 6602616 |
| 1 | 1000 | 65715256 → 65667240 | 101928 → 65700232 |
| 16 | 100 | 6582168 → 6577112 | 1090712 → 6610344 |
| 16 | 1000 | 65770248 → 65721992 | 1090728 → 65755224 |

Both implementations retain roughly the entire raw snapshot history before
projection in this workload. Projection evaluates and releases the old lazy
filter chain, but the deferred prototype retains raw history if the journal
itself remains rooted. This is a diagnostic of that lifetime, not a claim that
the real loop retains its journal after returning failed output.

## Rejected eager-index prototype

The initial prototype promoted every tool-bearing attempt into strict `IntMap`
and call-ID indexes immediately. On macOS/aarch64, GHC 9.10.3, `-O2`, default RTS
allocation area, seven samples of twenty operations, it showed the following
old → prototype results:

| Workload | Count | Bytes | Wall ms | CPU ms | Allocated bytes |
|---|---:|---:|---:|---:|---:|
| tools-failure | 1 | 64 | 0.00155 → 0.00155 | 0.00155 → 0.00150 | 8445 → 14533 |
| tools-success | 1 | 64 | 0.00030 → 0.00120 | 0.00025 → 0.00115 | 3365 → 14125 |
| tools-failure | 16 | 64 | 0.26170 → 0.06655 | 0.26150 → 0.06655 | 1436685 → 435381 |
| tools-success | 16 | 64 | 0.00350 → 0.05930 | 0.00345 → 0.05935 | 51725 → 428853 |
| tools-failure | 100 | 64 | 16.49830 → 0.68720 | 16.48230 → 0.68350 | 81149421 → 3507221 |
| tools-success | 100 | 64 | 0.08620 → 0.65020 | 0.07780 → 0.64930 | 322541 → 3466421 |
| text-after-tool-failure | 1000 | 16 | 0.03715 → 0.04465 | 0.03730 → 0.04460 | 104493 → 240629 |
| text-after-tool-success | 1000 | 16 | 0.00950 → 0.01280 | 0.00955 → 0.01315 | 64181 → 200381 |

The failure-path improvement does not justify these success-path and
text-after-tool regressions. Eagerly building indexes shifts work from failed
projection into every successful turn; updating the text entry inside the map
also adds per-delta allocation. These prototype numbers are diagnostic, not a
claim about the final implementation.

## Integrated loop validation

The unchanged `LoopEvents.hs` driver was also built against baseline
`1d17af7e93e4760a4e4c25b584d080f0808b700f` and the final journal, using separate
Cabal projects with `optimization: 2`, GHC 9.10.3, and identical local dependency
sources. Unlike the direct journal driver, these runs include the event pump,
backend callback, and loop lifecycle. `streaming-failure` forces the retained
`executionUncommittedDisplayEvents`; `streaming` follows the successful path.
There is no provider/network request or UI rendering.

Each cell is old → new. Times are independently selected medians of seven runs,
in milliseconds; allocation is bytes. Sink delay is zero. The repeat reverses
the old/new execution order.

| Workload | Deltas | Run | CPU ms | Wall ms | Allocated bytes |
|---|---:|---|---:|---:|---:|
| streaming | 10000 | first | 2.190 → 2.477 | 2.192 → 2.477 | 6778704 → 6620008 |
| streaming | 10000 | repeat | 2.118 → 2.077 | 2.118 → 2.078 | 6777112 → 6617400 |
| streaming-failure | 10000 | first | 2.697 → 2.500 | 2.704 → 2.508 | 7272384 → 7112584 |
| streaming-failure | 10000 | repeat | 2.295 → 2.257 | 2.295 → 2.259 | 7272384 → 7113768 |
| streaming | 100000 | first | 33.830 → 33.490 | 34.261 → 33.510 | 67363272 → 65758064 |
| streaming | 100000 | repeat | 34.220 → 32.413 | 34.254 → 32.472 | 67361976 → 65755872 |
| streaming-failure | 100000 | first | 37.563 → 39.317 | 37.605 → 39.370 | 72358328 → 70751056 |
| streaming-failure | 100000 | repeat | 36.639 → 35.476 | 36.696 → 35.484 | 72358048 → 70752096 |

Integrated allocation consistently falls about 16 bytes per delta (2.2–2.4%).
Timing varies between runs: the first 10000-delta success and 100000-delta
failure runs regress, but neither regression reproduces in reverse-order
repeats. Treat integrated CPU as approximately neutral, not a claimed speedup.

To reproduce, build `agent-core:bench:loop-events-bench` in separate baseline
and candidate checkouts, with the same Nix development environment and
`--enable-optimization=2`, then run each resulting binary:

```sh
cabal build --offline --enable-optimization=2 agent-core:bench:loop-events-bench
BIN=$(cabal list-bin --enable-optimization=2 agent-core:bench:loop-events-bench)
for count in 10000 100000; do
    "$BIN" streaming "$count" 0 7 +RTS -T
    "$BIN" streaming-failure "$count" 0 7 +RTS -T
done
```

Final focused GHCi validation of `Agent.Loop.FailedDisplaySpec` and
`Agent.LoopSpec`: 107 examples, zero failures. Package-boundary checks,
`git diff --check`, and regenerated `package.nix` consistency also passed.
