### PR TITLE
Extract native MCP, database and learned-skill boundaries

### DIFF
--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -78,6 +78,7 @@ foreign-library haskell-agent-bridge
                     , Agent.CLI.MacOS.NativeRequest
                     , Agent.CLI.MacOS.NativeGatewayBoundary
                     , Agent.CLI.MacOS.NativeModelCatalog
+                    , Agent.CLI.MacOS.McpAdminBridge
                     , Agent.CLI.MacOS.RepositoryInput
                     , Agent.CLI.MacOS.ResourceAdmin
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
@@ -165,6 +166,7 @@ test-suite agent-native-bridge-test
                      , Agent.CLI.MacOS.NativeRequest
                      , Agent.CLI.MacOS.NativeGatewayBoundary
                      , Agent.CLI.MacOS.NativeModelCatalog
+                     , Agent.CLI.MacOS.McpAdminBridge
                     , Agent.CLI.MacOS.ResourceAdmin
                      , Agent.CLI.MacOS.BrowserBridgeFFISpec
                      , Agent.CLI.MacOS.ComputerBridgeSpec

--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -79,6 +79,8 @@ foreign-library haskell-agent-bridge
                     , Agent.CLI.MacOS.NativeGatewayBoundary
                     , Agent.CLI.MacOS.NativeModelCatalog
                     , Agent.CLI.MacOS.McpAdminBridge
+                    , Agent.CLI.MacOS.DatabaseBrowseBridge
+                    , Agent.CLI.MacOS.LearnedSkillsBridge
                     , Agent.CLI.MacOS.RepositoryInput
                     , Agent.CLI.MacOS.ResourceAdmin
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
@@ -167,6 +169,8 @@ test-suite agent-native-bridge-test
                      , Agent.CLI.MacOS.NativeGatewayBoundary
                      , Agent.CLI.MacOS.NativeModelCatalog
                      , Agent.CLI.MacOS.McpAdminBridge
+                     , Agent.CLI.MacOS.DatabaseBrowseBridge
+                     , Agent.CLI.MacOS.LearnedSkillsBridge
                     , Agent.CLI.MacOS.ResourceAdmin
                      , Agent.CLI.MacOS.BrowserBridgeFFISpec
                      , Agent.CLI.MacOS.ComputerBridgeSpec

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -63,17 +63,17 @@ import Agent.CLI.NativeRuntime
     , runNativeAgent
     )
 import Agent.CLI.McpAdmin
-    ( McpAdminError(..)
-    , McpAdminServer(..)
-    , McpAdminServerInput(..)
-    , McpAdminSnapshot(..)
-    , addMcpAdminServer
-    , editMcpAdminServer
-    , listMcpAdminServers
-    , readMcpAdminServer
-    , removeMcpAdminServer
+    ( McpAdminError
+    , McpAdminSnapshot
     , restartMcpAdminServer
-    , setMcpAdminServerEnabled
+    )
+import Agent.CLI.MacOS.McpAdminBridge
+    ( McpResultCallback
+    , invokeMcpResultCallback
+    , decodeMcpInput
+    , maxMcpTextBytes
+    , emitMcpResult
+    , mcpAdminTry
     )
 import Agent.Store.Postgres.Session
     ( NativeConversationSearchResult(..)
@@ -380,20 +380,6 @@ type DataRowsCallback =
     -> CString -> CSize -> Int64 -> CInt
     -> CString -> CSize -> IO ()
 
-type McpServerCallback =
-    Ptr () -> CInt -> Word64
-    -> CString -> CSize -> CInt -> CString -> CSize -> CString -> CSize
-    -> CInt -> CInt -> CSize -> CSize -> CString -> CSize -> IO ()
-
--- kind 0 is an argument and kind 1 is an environment key. Environment values
--- never cross the bridge.
-type McpServerFieldCallback =
-    Ptr () -> CString -> CSize -> CInt -> CSize
-    -> CString -> CSize -> IO ()
-
-type McpResultCallback =
-    Ptr () -> CInt -> Word64 -> CString -> CSize -> IO ()
-
 -- Status is 0 for an active task, 1 for completion, and -1 for failure.
 -- State is 0 for queued and 1 for running. Every pointer is callback-scoped.
 type TaskSnapshotCallback =
@@ -453,18 +439,6 @@ foreign import ccall "dynamic"
 foreign import ccall "dynamic"
     invokeDataRowsCallback
         :: FunPtr DataRowsCallback -> DataRowsCallback
-
-foreign import ccall "dynamic"
-    invokeMcpServerCallback
-        :: FunPtr McpServerCallback -> McpServerCallback
-
-foreign import ccall "dynamic"
-    invokeMcpServerFieldCallback
-        :: FunPtr McpServerFieldCallback -> McpServerFieldCallback
-
-foreign import ccall "dynamic"
-    invokeMcpResultCallback
-        :: FunPtr McpResultCallback -> McpResultCallback
 
 foreign import ccall "dynamic"
     invokeTaskSnapshotCallback
@@ -723,55 +697,9 @@ foreign export ccall ha_session_import
 foreign export ccall ha_learned_skills_list
     :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
 
-foreign export ccall ha_mcp_servers_list
-    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback
-    -> Ptr () -> IO CInt
-
-foreign export ccall ha_mcp_server_read
-    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
-    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
-
-foreign export ccall ha_mcp_server_status
-    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
-    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
-
-foreign export ccall ha_mcp_server_add
-    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
-    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
-    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-
-foreign export ccall ha_mcp_server_edit
-    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
-    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
-    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-
-foreign export ccall ha_mcp_server_enable
-    :: Word64 -> Ptr Word8 -> CSize
-    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-
 foreign export ccall ha_engine_mcp_server_restart
     :: Ptr () -> Word64 -> Ptr Word8 -> CSize
     -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-
-foreign export ccall ha_mcp_server_disable
-    :: Word64 -> Ptr Word8 -> CSize
-    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-
-foreign export ccall ha_mcp_server_remove
-    :: Word64 -> Ptr Word8 -> CSize
-    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-
-ha_mcp_servers_list
-    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback
-    -> Ptr () -> IO CInt
-ha_mcp_servers_list callback fieldCallback context
-    | callback == nullFunPtr || fieldCallback == nullFunPtr = pure 1
-    | otherwise = do
-        home <- getHomeDirectory
-        _ <- forkIO $
-            mcpAdminTry (listMcpAdminServers home) >>= emitMcpServers
-                callback fieldCallback context
-        pure 0
 
 ha_engine_mcp_server_restart
     :: Ptr () -> Word64 -> Ptr Word8 -> CSize
@@ -797,264 +725,6 @@ ha_engine_mcp_server_restart pointer expected nameBytes (CSize nameLength)
                     Right False -> 3
                     Right True -> 0
 
-ha_mcp_server_status
-    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
-    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
-ha_mcp_server_status = ha_mcp_server_read
-
-ha_mcp_server_read
-    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
-    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
-ha_mcp_server_read nameBytes (CSize nameLength) callback fieldCallback context
-    | callback == nullFunPtr || fieldCallback == nullFunPtr = pure 1
-    | nameBytes == nullPtr || nameLength == 0
-        || nameLength > maxMcpTextBytes = pure 2
-    | otherwise = do
-        decodeMcpInput nameBytes nameLength >>= \case
-            Left _ -> pure 2
-            Right name -> do
-                home <- getHomeDirectory
-                _ <- forkIO $
-                    mcpAdminTry (readMcpAdminServer home name) >>= emitMcpServer
-                        callback fieldCallback context
-                pure 0
-
-ha_mcp_server_add
-    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
-    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
-    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-ha_mcp_server_add =
-    mcpServerWrite addMcpAdminServer
-
-ha_mcp_server_edit
-    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
-    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
-    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-ha_mcp_server_edit =
-    mcpServerWrite editMcpAdminServer
-
-ha_mcp_server_enable
-    :: Word64 -> Ptr Word8 -> CSize
-    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-ha_mcp_server_enable = mcpServerSetEnabled True
-
-ha_mcp_server_disable
-    :: Word64 -> Ptr Word8 -> CSize
-    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-ha_mcp_server_disable = mcpServerSetEnabled False
-
-ha_mcp_server_remove
-    :: Word64 -> Ptr Word8 -> CSize
-    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-ha_mcp_server_remove expected nameBytes (CSize nameLength) callback context
-    | callback == nullFunPtr = pure 1
-    | nameBytes == nullPtr || nameLength == 0
-        || nameLength > maxMcpTextBytes = pure 2
-    | otherwise = do
-        decodeMcpInput nameBytes nameLength >>= \case
-            Left _ -> pure 2
-            Right name -> do
-                home <- getHomeDirectory
-                _ <- forkIO $
-                    mcpAdminTry (removeMcpAdminServer home expected name)
-                        >>= emitMcpResult
-                        callback context
-                pure 0
-
-mcpServerSetEnabled
-    :: Bool -> Word64 -> Ptr Word8 -> CSize
-    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-mcpServerSetEnabled enabled expected nameBytes (CSize nameLength)
-        callback context
-    | callback == nullFunPtr = pure 1
-    | nameBytes == nullPtr || nameLength == 0
-        || nameLength > maxMcpTextBytes = pure 2
-    | otherwise = do
-        decodeMcpInput nameBytes nameLength >>= \case
-            Left _ -> pure 2
-            Right name -> do
-                home <- getHomeDirectory
-                _ <- forkIO $
-                    mcpAdminTry
-                        (setMcpAdminServerEnabled home expected name enabled)
-                        >>= emitMcpResult callback context
-                pure 0
-
-mcpServerWrite
-    :: (OsPath -> Word64 -> Text -> McpAdminServerInput
-        -> IO (Either McpAdminError (McpAdminSnapshot McpAdminServer)))
-    -> Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
-    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
-    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
-mcpServerWrite write expected nameBytes (CSize nameLength)
-        commandBytes (CSize commandLength) argsPointer argsCount
-        cwdBytes (CSize cwdLength) envPointer envCount
-        (CInt startupTimeout) (CInt requestTimeout) callback context
-    | callback == nullFunPtr = pure 1
-    | nameBytes == nullPtr || nameLength == 0
-        || nameLength > maxMcpTextBytes
-        || commandBytes == nullPtr || commandLength == 0
-        || commandLength > maxMcpTextBytes
-        || cwdLength > maxMcpTextBytes
-        || argsCount > maxMcpFields || envCount > maxMcpFields = pure 2
-    | argsPointer == nullPtr && argsCount > 0
-        || envPointer == nullPtr && envCount > 0
-        || cwdBytes == nullPtr && cwdLength > 0 = pure 2
-    | otherwise = do
-        decoded <- tryAny do
-            name <- requireMcpInput nameBytes nameLength
-            command <- requireMcpInput commandBytes commandLength
-            cwd <- requireMcpInput cwdBytes cwdLength
-            args <- mapM (peekUtf8Slice argsPointer)
-                [0 .. fromIntegral argsCount - 1]
-            env <- Map.fromList <$> mapM (peekEnvEntry envPointer)
-                [0 .. fromIntegral envCount - 1]
-            pure (name, McpAdminServerInput
-                { mcpAdminInputCommand = command
-                , mcpAdminInputArgs = args
-                , mcpAdminInputCwd = nonEmptyText cwd
-                , mcpAdminInputEnv = env
-                , mcpAdminInputStartupTimeoutSeconds =
-                    fromIntegral startupTimeout
-                , mcpAdminInputRequestTimeoutSeconds =
-                    fromIntegral requestTimeout
-                })
-        case decoded of
-            Left _ -> pure 2
-            Right (name, input) -> do
-                home <- getHomeDirectory
-                _ <- forkIO $
-                    mcpAdminTry (write home expected name input)
-                        >>= emitMcpResult callback context
-                pure 0
-
-peekUtf8Slice :: Ptr () -> Int -> IO Text
-peekUtf8Slice pointer index = do
-    let pointerSize = sizeOf (nullPtr :: Ptr ())
-        sizeSize = sizeOf (undefined :: CSize)
-        base = pointer `plusPtr` (index * (pointerSize + sizeSize))
-    bytes <- peekByteOff base 0
-    CSize length <- peekByteOff base pointerSize
-    if (bytes == (nullPtr :: Ptr Word8) && length > 0)
-            || length > maxMcpTextBytes
-        then ioError (userError "null UTF-8 slice")
-        else requireMcpInput bytes length
-
-decodeMcpInput :: Ptr Word8 -> Word64 -> IO (Either Text Text)
-decodeMcpInput pointer length
-    | pointer == nullPtr || length == 0 = pure (Right "")
-    | otherwise = do
-        bytes <- BS.packCStringLen (castPtr pointer, fromIntegral length)
-        pure (first (Text.pack . show) (TextEncoding.decodeUtf8' bytes))
-
-requireMcpInput :: Ptr Word8 -> Word64 -> IO Text
-requireMcpInput pointer length =
-    decodeMcpInput pointer length >>=
-        either (ioError . userError . Text.unpack) pure
-
-maxMcpTextBytes :: Word64
-maxMcpTextBytes = 1024 * 1024
-
-maxMcpFields :: CSize
-maxMcpFields = 4096
-
-peekEnvEntry :: Ptr () -> Int -> IO (Text, Text)
-peekEnvEntry pointer index = do
-    let sliceSize =
-            sizeOf (nullPtr :: Ptr ()) + sizeOf (undefined :: CSize)
-        base = pointer `plusPtr` (index * sliceSize * 2)
-    key <- peekUtf8Slice base 0
-    value <- peekUtf8Slice (base `plusPtr` sliceSize) 0
-    pure (key, value)
-
-emitMcpServers
-    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback -> Ptr ()
-    -> Either McpAdminError (McpAdminSnapshot [McpAdminServer]) -> IO ()
-emitMcpServers callback fieldCallback context = \case
-    Left err -> emitMcpServerError callback context err
-    Right snapshot -> do
-        forM_ snapshot.mcpAdminValue \server ->
-            emitMcpServerItem
-                callback fieldCallback context snapshot.mcpAdminRevision server
-        invokeMcpServerCallback callback context 1 snapshot.mcpAdminRevision
-            nullPtr 0 0 nullPtr 0 nullPtr 0 0 0 0 0 nullPtr 0
-
-emitMcpServer
-    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback -> Ptr ()
-    -> Either McpAdminError (McpAdminSnapshot McpAdminServer) -> IO ()
-emitMcpServer callback fieldCallback context = \case
-    Left err -> emitMcpServerError callback context err
-    Right snapshot ->
-        emitMcpServerItem
-            callback fieldCallback context snapshot.mcpAdminRevision
-            snapshot.mcpAdminValue
-
-emitMcpServerItem
-    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback -> Ptr ()
-    -> Word64 -> McpAdminServer -> IO ()
-emitMcpServerItem callback fieldCallback context revision server = do
-    withText server.mcpAdminName \name nameLength -> do
-        forM_ (zip [0..] server.mcpAdminArgs) \(index, argument) ->
-            withText argument $
-                invokeMcpServerFieldCallback fieldCallback context
-                    name nameLength 0 index
-        forM_ (zip [0..] server.mcpAdminEnvKeys) \(index, key) ->
-            withText key $
-                invokeMcpServerFieldCallback fieldCallback context
-                    name nameLength 1 index
-        withText server.mcpAdminCommand \command commandLength ->
-            withOptionalText server.mcpAdminCwd \cwd cwdLength ->
-                invokeMcpServerCallback callback context 0 revision
-                    name nameLength
-                    (if server.mcpAdminEnabled then 1 else 0)
-                    command commandLength cwd cwdLength
-                    (fromIntegral server.mcpAdminStartupTimeoutSeconds)
-                    (fromIntegral server.mcpAdminRequestTimeoutSeconds)
-                    (fromIntegral (length server.mcpAdminArgs))
-                    (fromIntegral (length server.mcpAdminEnvKeys))
-                    nullPtr 0
-
-emitMcpServerError
-    :: FunPtr McpServerCallback -> Ptr () -> McpAdminError -> IO ()
-emitMcpServerError callback context err =
-    withText (mcpAdminErrorText err) \errorPtr errorLength ->
-        invokeMcpServerCallback callback context (-1)
-            (mcpAdminErrorRevision err)
-            nullPtr 0 0 nullPtr 0 nullPtr 0 0 0 0 0
-            errorPtr errorLength
-
-emitMcpResult
-    :: FunPtr McpResultCallback -> Ptr ()
-    -> Either McpAdminError (McpAdminSnapshot a) -> IO ()
-emitMcpResult callback context = \case
-    Left err ->
-        withText (mcpAdminErrorText err) $
-            invokeMcpResultCallback callback context (-1)
-                (mcpAdminErrorRevision err)
-    Right snapshot ->
-        invokeMcpResultCallback callback context 0 snapshot.mcpAdminRevision
-            nullPtr 0
-
-mcpAdminErrorRevision :: McpAdminError -> Word64
-mcpAdminErrorRevision = \case
-    McpAdminConflict revision -> revision
-    _ -> 0
-
-mcpAdminErrorText :: McpAdminError -> Text
-mcpAdminErrorText = \case
-    McpAdminConflict _ -> "MCP catalog changed; reload before editing"
-    McpAdminNotFound name -> "MCP server not found: " <> name
-    McpAdminAlreadyExists name -> "MCP server already exists: " <> name
-    McpAdminInvalid err -> err
-
-mcpAdminTry
-    :: IO (Either McpAdminError a)
-    -> IO (Either McpAdminError a)
-mcpAdminTry action =
-    tryAny action >>= \case
-        Left exception ->
-            pure (Left (McpAdminInvalid (Text.pack (show exception))))
-        Right result -> pure result
 foreign export ccall ha_data_catalog_list
     :: Ptr Word8 -> CSize -> FunPtr DataCatalogCallback -> Ptr () -> IO CInt
 

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -64,7 +64,7 @@ import Agent.CLI.NativeRuntime
     )
 import Agent.CLI.McpAdmin
     ( McpAdminError
-    , McpAdminSnapshot
+    , McpAdminSnapshot (..)
     , restartMcpAdminServer
     )
 import Agent.CLI.MacOS.McpAdminBridge

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -84,14 +84,8 @@ import Agent.CLI.ManagedTurn
     , managedTurnRequestWithImages
     , renderManagedTurnPrompt
     )
-import Data.Bifunctor (first)
-import Agent.Store.Postgres.Scope (Scope(..), scopeKindText)
-import Agent.Store.Postgres.Skill
-    ( LearnedSkill(..)
-    , learnedSkillActivationText
-    , learnedSkillStatusText
-    , listAllLearnedSkillsLimited
-    )
+import Agent.CLI.MacOS.DatabaseBrowseBridge ()
+import Agent.CLI.MacOS.LearnedSkillsBridge ()
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
     , encodeNativeUsageEvent
@@ -116,20 +110,10 @@ import Agent.CLI.GatewayClient
 import Agent.CLI.ModelConfig
     ( organizationGatewayConnectionId
     )
-import Agent.CLI.Database (DatabaseScope(..))
-import Agent.CLI.Database.Store
-    ( DatabaseBrowsePage(..)
-    , DatabaseScopes
-    , applicableDatabaseScopes
-    , deriveDatabaseScopes
-    , listDatabaseObjects
-    , loadDatabaseRows
-    )
 import Agent.CLI.Models
     ( validateResumedGatewayBoundary
     )
 import Agent.CLI.Permission (PermissionChoice(..))
-import Agent.CLI.Project (resolveProjectRoot)
 import Agent.CLI.Session
     ( SessionMeta(..)
     , SessionTurn(..)
@@ -168,11 +152,6 @@ import Agent.Store.Postgres
     , trustedPool
     )
 import Agent.Store.Postgres.Connection (StorePool)
-import Agent.Store.Postgres.Custom
-    ( CatalogColumn(..)
-    , CatalogDefinition(..)
-    , CatalogObject(..)
-    )
 import Agent.Store.Types (renderStoreError)
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -305,7 +284,6 @@ import System.IO
 import System.OsPath
     ( OsPath
     , decodeFS
-    , takeDirectory
     , unsafeEncodeUtf
     )
 
@@ -362,24 +340,6 @@ type SearchCallback =
     -> Ptr Word8 -> CSize -- error
     -> IO ()
 
-type LearnedSkillsListCallback =
-    Ptr () -> CInt
-    -> CString -> CSize -> CString -> CSize -> CLLong
-    -> CString -> CSize -> CString -> CSize -> CString -> CSize
-    -> CString -> CSize -> CString -> CSize -> CString -> CSize
-    -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
-
-type DataCatalogCallback =
-    Ptr () -> CInt -> CInt -> CInt
-    -> CString -> CSize -> CString -> CSize
-    -> CString -> CSize -> CString -> CSize -> CInt
-    -> CString -> CSize -> CString -> CSize -> IO ()
-
-type DataRowsCallback =
-    Ptr () -> CInt -> Int64 -> Int64 -> CInt -> CInt
-    -> CString -> CSize -> Int64 -> CInt
-    -> CString -> CSize -> IO ()
-
 -- Status is 0 for an active task, 1 for completion, and -1 for failure.
 -- State is 0 for queued and 1 for running. Every pointer is callback-scoped.
 type TaskSnapshotCallback =
@@ -427,18 +387,6 @@ foreign import ccall "dynamic"
 
 foreign import ccall "dynamic"
     invokeSearchCallback :: FunPtr SearchCallback -> SearchCallback
-
-foreign import ccall "dynamic"
-    invokeLearnedSkillsListCallback
-        :: FunPtr LearnedSkillsListCallback -> LearnedSkillsListCallback
-
-foreign import ccall "dynamic"
-    invokeDataCatalogCallback
-        :: FunPtr DataCatalogCallback -> DataCatalogCallback
-
-foreign import ccall "dynamic"
-    invokeDataRowsCallback
-        :: FunPtr DataRowsCallback -> DataRowsCallback
 
 foreign import ccall "dynamic"
     invokeTaskSnapshotCallback
@@ -694,9 +642,6 @@ foreign export ccall ha_session_import
     :: Ptr Word8 -> CSize
     -> FunPtr SessionTransferResultCallback -> Ptr () -> IO CInt
 
-foreign export ccall ha_learned_skills_list
-    :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
-
 foreign export ccall ha_engine_mcp_server_restart
     :: Ptr () -> Word64 -> Ptr Word8 -> CSize
     -> FunPtr McpResultCallback -> Ptr () -> IO CInt
@@ -724,13 +669,6 @@ ha_engine_mcp_server_restart pointer expected nameBytes (CSize nameLength)
                     Left _ -> 3
                     Right False -> 3
                     Right True -> 0
-
-foreign export ccall ha_data_catalog_list
-    :: Ptr Word8 -> CSize -> FunPtr DataCatalogCallback -> Ptr () -> IO CInt
-
-foreign export ccall ha_data_rows_load
-    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize
-    -> Int64 -> CInt -> FunPtr DataRowsCallback -> Ptr () -> IO CInt
 
 ha_session_load_around
     :: Ptr Word8 -> CSize -> Int64 -> CInt
@@ -1085,323 +1023,6 @@ sessionExportFailure callback context err =
     withText err \pointer length ->
         invokeSessionExportCallback callback context (-1)
             nullPtr 0 pointer length
-
-ha_learned_skills_list
-    :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
-ha_learned_skills_list cwdBytes (CSize cwdLength) callback context
-    | callback == nullFunPtr = pure 1
-    | cwdBytes == nullPtr && cwdLength > 0 = pure 2
-    | otherwise = do
-        cwd <- decodeInput cwdBytes cwdLength
-        _ <- forkIO do
-            tryAny (listLearnedSkillsFor (Text.unpack cwd)) >>= \case
-                Left exception ->
-                    withText (Text.pack (show exception)) $ \errorPtr errorLength ->
-                        learnedSkillsTerminal callback context (-1) errorPtr errorLength
-                Right (Left err) ->
-                    withText err $ \errorPtr errorLength ->
-                        learnedSkillsTerminal callback context (-1) errorPtr errorLength
-                Right (Right skills) -> do
-                    forM_ skills \skill ->
-                        withLearnedSkillStrings skill $
-                            invokeLearnedSkillsListCallback callback context 0
-                    learnedSkillsTerminal callback context 1 nullPtr 0
-        pure 0
-  where
-    listLearnedSkillsFor cwd = do
-        home <- getHomeDirectory
-        projectRoot <- resolveProjectRoot (unsafeEncodeUtf cwd)
-        stateDirectory <- decodeFS (takeDirectory (sessionsRoot home))
-        projectRootPath <- decodeFS projectRoot
-        scopes <- deriveDatabaseScopes stateDirectory projectRootPath
-        case scopes of
-            Left err -> pure (Left err)
-            Right databaseScopes -> do
-                store <- openStore =<< managedPostgresConfigForHome home
-                case store of
-                    Left err -> pure (Left (renderStoreError err))
-                    Right opened ->
-                        bracket (pure opened) closeStore \store ->
-                            first renderStoreError
-                                <$> listAllLearnedSkillsLimited
-                                    (trustedPool store)
-                                    (applicableDatabaseScopes databaseScopes)
-                                    Nothing
-                                    1000
-
-ha_data_catalog_list
-    :: Ptr Word8 -> CSize -> FunPtr DataCatalogCallback -> Ptr () -> IO CInt
-ha_data_catalog_list cwdBytes (CSize cwdLength) callback context
-    | callback == nullFunPtr = pure 1
-    | cwdBytes == nullPtr && cwdLength > 0 = pure 2
-    | otherwise = do
-        cwd <- decodeInput cwdBytes cwdLength
-        _ <- forkIO do
-            tryAny (loadDataCatalogFor (Text.unpack cwd)) >>= \case
-                Left exception ->
-                    withText (Text.pack (show exception)) \errorPtr errorLength ->
-                        dataCatalogTerminal
-                            callback context (-1) errorPtr errorLength
-                Right (Left err) ->
-                    withText err \errorPtr errorLength ->
-                        dataCatalogTerminal
-                            callback context (-1) errorPtr errorLength
-                Right (Right scopedObjects) -> do
-                    forM_ scopedObjects \(scope, objects) ->
-                        forM_ objects (emitDataCatalogObject callback context scope)
-                    dataCatalogTerminal callback context 2 nullPtr 0
-        pure 0
-
-ha_data_rows_load
-    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize
-    -> Int64 -> CInt -> FunPtr DataRowsCallback -> Ptr () -> IO CInt
-ha_data_rows_load
-    cwdBytes
-    (CSize cwdLength)
-    rawScope
-    objectBytes
-    (CSize objectLength)
-    offset
-    rawLimit
-    callback
-    context
-    | callback == nullFunPtr = pure 1
-    | cwdBytes == nullPtr && cwdLength > 0 = pure 2
-    | objectBytes == nullPtr && objectLength > 0 = pure 2
-    | offset < 0 = pure 3
-    | rawLimit < 1 || rawLimit > 500 = pure 3
-    | Nothing <- dataScopeFromCode rawScope = pure 3
-    | otherwise = do
-        cwd <- decodeInput cwdBytes cwdLength
-        objectName <- decodeInput objectBytes objectLength
-        if Text.null objectName
-            then pure 3
-            else do
-                let Just scope = dataScopeFromCode rawScope
-                    limit = fromIntegral rawLimit
-                _ <- forkIO do
-                    tryAny
-                        (loadDataPageFor
-                            (Text.unpack cwd)
-                            scope
-                            objectName
-                            offset
-                            limit)
-                        >>= \case
-                            Left exception ->
-                                withText
-                                    (Text.pack (show exception))
-                                    \errorPtr errorLength ->
-                                        dataRowsTerminal
-                                            callback context (-1) offset 0 False
-                                            errorPtr errorLength
-                            Right (Left err) ->
-                                withText err \errorPtr errorLength ->
-                                    dataRowsTerminal
-                                        callback context (-1) offset 0 False
-                                        errorPtr errorLength
-                            Right (Right page) -> do
-                                forM_
-                                    (zip [0 :: Int64 ..] page.databaseBrowseRows)
-                                    \(rowIndex, row) ->
-                                        forM_
-                                            (zip [0 :: Int ..] row)
-                                            \(columnIndex, value) ->
-                                                withDataValue value
-                                                    \kind valuePtr valueLength ->
-                                                        invokeDataRowsCallback
-                                                            callback context 0
-                                                            offset rowIndex
-                                                            (fromIntegral columnIndex)
-                                                            kind
-                                                            valuePtr valueLength
-                                                            0 0 nullPtr 0
-                                dataRowsTerminal
-                                    callback
-                                    context
-                                    1
-                                    offset
-                                    (fromIntegral
-                                        (length page.databaseBrowseRows))
-                                    page.databaseBrowseHasMore
-                                    nullPtr
-                                    0
-                pure 0
-
-loadDataCatalogFor
-    :: FilePath
-    -> IO (Either Text [(CInt, [CatalogObject])])
-loadDataCatalogFor cwd =
-    withDatabaseStoreFor cwd \store scopes -> do
-        results <- mapM
-            (\(scopeCode, scope) ->
-                fmap (fmap ((,) scopeCode)) $
-                    listDatabaseObjects store scopes scope)
-            [ (0, DatabaseUserScope)
-            , (1, DatabaseRepositoryScope)
-            , (2, DatabaseCheckoutScope)
-            ]
-        pure (sequence results)
-
-loadDataPageFor
-    :: FilePath
-    -> DatabaseScope
-    -> Text
-    -> Int64
-    -> Int
-    -> IO (Either Text DatabaseBrowsePage)
-loadDataPageFor cwd selected objectName offset limit =
-    withDatabaseStoreFor cwd \store scopes ->
-        loadDatabaseRows store scopes selected objectName offset limit
-
-withDatabaseStoreFor
-    :: FilePath
-    -> (Store -> DatabaseScopes -> IO (Either Text value))
-    -> IO (Either Text value)
-withDatabaseStoreFor cwd action = do
-    home <- getHomeDirectory
-    projectRoot <- resolveProjectRoot (unsafeEncodeUtf cwd)
-    stateDirectory <- decodeFS (takeDirectory (sessionsRoot home))
-    projectRootPath <- decodeFS projectRoot
-    deriveDatabaseScopes stateDirectory projectRootPath >>= \case
-        Left err -> pure (Left err)
-        Right scopes -> do
-            config <- managedPostgresConfigForHome home
-            openStore config >>= \case
-                Left err -> pure (Left (renderStoreError err))
-                Right opened ->
-                    bracket (pure opened) closeStore \store ->
-                        action store scopes
-
-emitDataCatalogObject
-    :: FunPtr DataCatalogCallback
-    -> Ptr ()
-    -> CInt
-    -> CatalogObject
-    -> IO ()
-emitDataCatalogObject callback context scope object =
-    withText object.catalogObjectName \objectPtr objectLength ->
-    withOptionalText definition.definitionComment \commentPtr commentLength -> do
-        invokeDataCatalogCallback callback context
-            0 scope kind
-            objectPtr objectLength
-            commentPtr commentLength
-            nullPtr 0 nullPtr 0 0 nullPtr 0 nullPtr 0
-        forM_ definition.definitionColumns \column ->
-            withText column.columnName \columnPtr columnLength ->
-            withText column.columnType \typePtr typeLength ->
-            withOptionalText column.columnComment
-                \columnCommentPtr columnCommentLength ->
-                    invokeDataCatalogCallback callback context
-                        1 scope kind
-                        objectPtr objectLength
-                        nullPtr 0
-                        columnPtr columnLength
-                        typePtr typeLength
-                        (if column.columnNullable then 1 else 0)
-                        columnCommentPtr columnCommentLength
-                        nullPtr 0
-  where
-    definition = object.catalogObjectDefinition
-    kind = dataObjectKind object.catalogObjectKind
-
-dataObjectKind :: Text -> CInt
-dataObjectKind = \case
-    "view" -> 1
-    "materialized_view" -> 1
-    _ -> 0
-
-dataScopeFromCode :: CInt -> Maybe DatabaseScope
-dataScopeFromCode = \case
-    0 -> Just DatabaseUserScope
-    1 -> Just DatabaseRepositoryScope
-    2 -> Just DatabaseCheckoutScope
-    _ -> Nothing
-
-dataCatalogTerminal
-    :: FunPtr DataCatalogCallback
-    -> Ptr ()
-    -> CInt
-    -> CString
-    -> CSize
-    -> IO ()
-dataCatalogTerminal callback context status errorPtr errorLength =
-    invokeDataCatalogCallback callback context
-        status 0 0
-        nullPtr 0 nullPtr 0
-        nullPtr 0 nullPtr 0 0
-        nullPtr 0 errorPtr errorLength
-
-withDataValue
-    :: Aeson.Value
-    -> (CInt -> CString -> CSize -> IO value)
-    -> IO value
-withDataValue value action =
-    case value of
-        Aeson.Null -> action 0 nullPtr 0
-        Aeson.String text -> withText text (action 1)
-        Aeson.Number _ -> withEncoded 2
-        Aeson.Bool True -> withText "true" (action 3)
-        Aeson.Bool False -> withText "false" (action 3)
-        Aeson.Array _ -> withEncoded 4
-        Aeson.Object _ -> withEncoded 4
-  where
-    withEncoded kind =
-        withText
-            (TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode value)))
-            (action kind)
-
-dataRowsTerminal
-    :: FunPtr DataRowsCallback
-    -> Ptr ()
-    -> CInt
-    -> Int64
-    -> Int64
-    -> Bool
-    -> CString
-    -> CSize
-    -> IO ()
-dataRowsTerminal
-    callback context status offset rowCount hasMore errorPtr errorLength =
-        invokeDataRowsCallback callback context
-            status offset (-1) (-1) (-1)
-            nullPtr 0 rowCount (if hasMore then 1 else 0)
-            errorPtr errorLength
-
-type LearnedSkillItemCallback =
-    CString -> CSize -> CString -> CSize -> CLLong
-    -> CString -> CSize -> CString -> CSize -> CString -> CSize
-    -> CString -> CSize -> CString -> CSize -> CString -> CSize
-    -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
-
-withLearnedSkillStrings :: LearnedSkill -> LearnedSkillItemCallback -> IO ()
-withLearnedSkillStrings skill action =
-    withText (scopeKindText skill.learnedSkillScope.scopeKind) $ \scope scopeLength ->
-    withText skill.learnedSkillSlug $ \slug slugLength ->
-    withText skill.learnedSkillTitle $ \title titleLength ->
-    withText skill.learnedSkillDescription $ \description descriptionLength ->
-    withText skill.learnedSkillAppliesWhen $ \applies appliesLength ->
-    withText skill.learnedSkillInstructions $ \instructions instructionsLength ->
-    withText (learnedSkillActivationText skill.learnedSkillActivation) $ \activation activationLength ->
-    withText (learnedSkillStatusText skill.learnedSkillStatus) $ \status statusLength ->
-    withText (Text.pack (show skill.learnedSkillUpdatedAt)) $ \updated updatedLength ->
-        action scope scopeLength slug slugLength
-            (fromIntegral skill.learnedSkillRevision)
-            title titleLength description descriptionLength
-            applies appliesLength instructions instructionsLength
-            activation activationLength status statusLength
-            (fromIntegral skill.learnedSkillPriority) updated updatedLength
-            nullPtr 0
-
-learnedSkillsTerminal
-    :: FunPtr LearnedSkillsListCallback
-    -> Ptr () -> CInt -> CString -> CSize -> IO ()
-learnedSkillsTerminal callback context status errorPtr errorLength =
-    invokeLearnedSkillsListCallback callback context status
-        nullPtr 0 nullPtr 0 0
-        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
-        nullPtr 0 nullPtr 0
-        0 nullPtr 0 errorPtr errorLength
 
 foreign export ccall ha_engine_search_conversations
     :: Ptr () -> Ptr Word8 -> CSize -> CSize

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/DatabaseBrowseBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/DatabaseBrowseBridge.hs
@@ -1,0 +1,299 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Read-only scoped database browsing and callback-scoped row marshalling.
+module Agent.CLI.MacOS.DatabaseBrowseBridge () where
+
+import Agent.CLI.Database (DatabaseScope(..))
+import Agent.CLI.Database.Store
+    ( DatabaseBrowsePage(..), DatabaseScopes, deriveDatabaseScopes
+    , listDatabaseObjects, loadDatabaseRows )
+import Agent.CLI.MacOS.Marshalling (decodeInput, withOptionalText, withText)
+import Agent.CLI.Project (resolveProjectRoot)
+import Agent.CLI.Session (sessionsRoot)
+import Agent.CLI.SessionAdmin (managedPostgresConfigForHome)
+import Agent.Store.Postgres (Store, closeStore, openStore)
+import Agent.Store.Postgres.Custom
+    ( CatalogColumn(..), CatalogDefinition(..), CatalogObject(..) )
+import Agent.Store.Types (renderStoreError)
+import Control.Concurrent (forkIO)
+import Control.Exception.Safe (bracket, tryAny)
+import Control.Monad (forM_)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import Data.Int (Int64)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word8)
+import Foreign.C.String (CString)
+import Foreign.C.Types (CInt(..), CSize(..))
+import Foreign.Ptr (FunPtr, Ptr, nullFunPtr, nullPtr)
+import System.Directory.OsPath (getHomeDirectory)
+import System.OsPath (decodeFS, takeDirectory, unsafeEncodeUtf)
+
+type DataCatalogCallback =
+    Ptr () -> CInt -> CInt -> CInt
+    -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CInt
+    -> CString -> CSize -> CString -> CSize -> IO ()
+
+type DataRowsCallback =
+    Ptr () -> CInt -> Int64 -> Int64 -> CInt -> CInt
+    -> CString -> CSize -> Int64 -> CInt
+    -> CString -> CSize -> IO ()
+
+foreign import ccall "dynamic"
+    invokeDataCatalogCallback
+        :: FunPtr DataCatalogCallback -> DataCatalogCallback
+
+foreign import ccall "dynamic"
+    invokeDataRowsCallback
+        :: FunPtr DataRowsCallback -> DataRowsCallback
+
+foreign export ccall ha_data_catalog_list
+    :: Ptr Word8 -> CSize -> FunPtr DataCatalogCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_data_rows_load
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize
+    -> Int64 -> CInt -> FunPtr DataRowsCallback -> Ptr () -> IO CInt
+
+ha_data_catalog_list
+    :: Ptr Word8 -> CSize -> FunPtr DataCatalogCallback -> Ptr () -> IO CInt
+ha_data_catalog_list cwdBytes (CSize cwdLength) callback context
+    | callback == nullFunPtr = pure 1
+    | cwdBytes == nullPtr && cwdLength > 0 = pure 2
+    | otherwise = do
+        cwd <- decodeInput cwdBytes cwdLength
+        _ <- forkIO do
+            tryAny (loadDataCatalogFor (Text.unpack cwd)) >>= \case
+                Left exception ->
+                    withText (Text.pack (show exception)) \errorPtr errorLength ->
+                        dataCatalogTerminal
+                            callback context (-1) errorPtr errorLength
+                Right (Left err) ->
+                    withText err \errorPtr errorLength ->
+                        dataCatalogTerminal
+                            callback context (-1) errorPtr errorLength
+                Right (Right scopedObjects) -> do
+                    forM_ scopedObjects \(scope, objects) ->
+                        forM_ objects (emitDataCatalogObject callback context scope)
+                    dataCatalogTerminal callback context 2 nullPtr 0
+        pure 0
+
+ha_data_rows_load
+    :: Ptr Word8 -> CSize -> CInt -> Ptr Word8 -> CSize
+    -> Int64 -> CInt -> FunPtr DataRowsCallback -> Ptr () -> IO CInt
+ha_data_rows_load
+    cwdBytes
+    (CSize cwdLength)
+    rawScope
+    objectBytes
+    (CSize objectLength)
+    offset
+    rawLimit
+    callback
+    context
+    | callback == nullFunPtr = pure 1
+    | cwdBytes == nullPtr && cwdLength > 0 = pure 2
+    | objectBytes == nullPtr && objectLength > 0 = pure 2
+    | offset < 0 = pure 3
+    | rawLimit < 1 || rawLimit > 500 = pure 3
+    | Nothing <- dataScopeFromCode rawScope = pure 3
+    | otherwise = do
+        cwd <- decodeInput cwdBytes cwdLength
+        objectName <- decodeInput objectBytes objectLength
+        if Text.null objectName
+            then pure 3
+            else do
+                let Just scope = dataScopeFromCode rawScope
+                    limit = fromIntegral rawLimit
+                _ <- forkIO do
+                    tryAny
+                        (loadDataPageFor
+                            (Text.unpack cwd)
+                            scope
+                            objectName
+                            offset
+                            limit)
+                        >>= \case
+                            Left exception ->
+                                withText
+                                    (Text.pack (show exception))
+                                    \errorPtr errorLength ->
+                                        dataRowsTerminal
+                                            callback context (-1) offset 0 False
+                                            errorPtr errorLength
+                            Right (Left err) ->
+                                withText err \errorPtr errorLength ->
+                                    dataRowsTerminal
+                                        callback context (-1) offset 0 False
+                                        errorPtr errorLength
+                            Right (Right page) -> do
+                                forM_
+                                    (zip [0 :: Int64 ..] page.databaseBrowseRows)
+                                    \(rowIndex, row) ->
+                                        forM_
+                                            (zip [0 :: Int ..] row)
+                                            \(columnIndex, value) ->
+                                                withDataValue value
+                                                    \kind valuePtr valueLength ->
+                                                        invokeDataRowsCallback
+                                                            callback context 0
+                                                            offset rowIndex
+                                                            (fromIntegral columnIndex)
+                                                            kind
+                                                            valuePtr valueLength
+                                                            0 0 nullPtr 0
+                                dataRowsTerminal
+                                    callback
+                                    context
+                                    1
+                                    offset
+                                    (fromIntegral
+                                        (length page.databaseBrowseRows))
+                                    page.databaseBrowseHasMore
+                                    nullPtr
+                                    0
+                pure 0
+
+loadDataCatalogFor
+    :: FilePath
+    -> IO (Either Text [(CInt, [CatalogObject])])
+loadDataCatalogFor cwd =
+    withDatabaseStoreFor cwd \store scopes -> do
+        results <- mapM
+            (\(scopeCode, scope) ->
+                fmap (fmap ((,) scopeCode)) $
+                    listDatabaseObjects store scopes scope)
+            [ (0, DatabaseUserScope)
+            , (1, DatabaseRepositoryScope)
+            , (2, DatabaseCheckoutScope)
+            ]
+        pure (sequence results)
+
+loadDataPageFor
+    :: FilePath
+    -> DatabaseScope
+    -> Text
+    -> Int64
+    -> Int
+    -> IO (Either Text DatabaseBrowsePage)
+loadDataPageFor cwd selected objectName offset limit =
+    withDatabaseStoreFor cwd \store scopes ->
+        loadDatabaseRows store scopes selected objectName offset limit
+
+withDatabaseStoreFor
+    :: FilePath
+    -> (Store -> DatabaseScopes -> IO (Either Text value))
+    -> IO (Either Text value)
+withDatabaseStoreFor cwd action = do
+    home <- getHomeDirectory
+    projectRoot <- resolveProjectRoot (unsafeEncodeUtf cwd)
+    stateDirectory <- decodeFS (takeDirectory (sessionsRoot home))
+    projectRootPath <- decodeFS projectRoot
+    deriveDatabaseScopes stateDirectory projectRootPath >>= \case
+        Left err -> pure (Left err)
+        Right scopes -> do
+            config <- managedPostgresConfigForHome home
+            openStore config >>= \case
+                Left err -> pure (Left (renderStoreError err))
+                Right opened ->
+                    bracket (pure opened) closeStore \store ->
+                        action store scopes
+
+emitDataCatalogObject
+    :: FunPtr DataCatalogCallback
+    -> Ptr ()
+    -> CInt
+    -> CatalogObject
+    -> IO ()
+emitDataCatalogObject callback context scope object =
+    withText object.catalogObjectName \objectPtr objectLength ->
+    withOptionalText definition.definitionComment \commentPtr commentLength -> do
+        invokeDataCatalogCallback callback context
+            0 scope kind
+            objectPtr objectLength
+            commentPtr commentLength
+            nullPtr 0 nullPtr 0 0 nullPtr 0 nullPtr 0
+        forM_ definition.definitionColumns \column ->
+            withText column.columnName \columnPtr columnLength ->
+            withText column.columnType \typePtr typeLength ->
+            withOptionalText column.columnComment
+                \columnCommentPtr columnCommentLength ->
+                    invokeDataCatalogCallback callback context
+                        1 scope kind
+                        objectPtr objectLength
+                        nullPtr 0
+                        columnPtr columnLength
+                        typePtr typeLength
+                        (if column.columnNullable then 1 else 0)
+                        columnCommentPtr columnCommentLength
+                        nullPtr 0
+  where
+    definition = object.catalogObjectDefinition
+    kind = dataObjectKind object.catalogObjectKind
+
+dataObjectKind :: Text -> CInt
+dataObjectKind = \case
+    "view" -> 1
+    "materialized_view" -> 1
+    _ -> 0
+
+dataScopeFromCode :: CInt -> Maybe DatabaseScope
+dataScopeFromCode = \case
+    0 -> Just DatabaseUserScope
+    1 -> Just DatabaseRepositoryScope
+    2 -> Just DatabaseCheckoutScope
+    _ -> Nothing
+
+dataCatalogTerminal
+    :: FunPtr DataCatalogCallback
+    -> Ptr ()
+    -> CInt
+    -> CString
+    -> CSize
+    -> IO ()
+dataCatalogTerminal callback context status errorPtr errorLength =
+    invokeDataCatalogCallback callback context
+        status 0 0
+        nullPtr 0 nullPtr 0
+        nullPtr 0 nullPtr 0 0
+        nullPtr 0 errorPtr errorLength
+
+withDataValue
+    :: Aeson.Value
+    -> (CInt -> CString -> CSize -> IO value)
+    -> IO value
+withDataValue value action =
+    case value of
+        Aeson.Null -> action 0 nullPtr 0
+        Aeson.String text -> withText text (action 1)
+        Aeson.Number _ -> withEncoded 2
+        Aeson.Bool True -> withText "true" (action 3)
+        Aeson.Bool False -> withText "false" (action 3)
+        Aeson.Array _ -> withEncoded 4
+        Aeson.Object _ -> withEncoded 4
+  where
+    withEncoded kind =
+        withText
+            (TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode value)))
+            (action kind)
+
+dataRowsTerminal
+    :: FunPtr DataRowsCallback
+    -> Ptr ()
+    -> CInt
+    -> Int64
+    -> Int64
+    -> Bool
+    -> CString
+    -> CSize
+    -> IO ()
+dataRowsTerminal
+    callback context status offset rowCount hasMore errorPtr errorLength =
+        invokeDataRowsCallback callback context
+            status offset (-1) (-1) (-1)
+            nullPtr 0 rowCount (if hasMore then 1 else 0)
+            errorPtr errorLength

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/LearnedSkillsBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/LearnedSkillsBridge.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Read-only learned-skill catalog callbacks, with request-scoped stores.
+module Agent.CLI.MacOS.LearnedSkillsBridge () where
+
+import Agent.CLI.Database.Store (applicableDatabaseScopes, deriveDatabaseScopes)
+import Agent.CLI.MacOS.Marshalling (decodeInput, withText)
+import Agent.CLI.Project (resolveProjectRoot)
+import Agent.CLI.Session (sessionsRoot)
+import Agent.CLI.SessionAdmin (managedPostgresConfigForHome)
+import Agent.Store.Postgres (closeStore, openStore, trustedPool)
+import Agent.Store.Postgres.Scope (Scope(..), scopeKindText)
+import Agent.Store.Postgres.Skill
+    ( LearnedSkill(..), learnedSkillActivationText, learnedSkillStatusText
+    , listAllLearnedSkillsLimited )
+import Agent.Store.Types (renderStoreError)
+import Control.Concurrent (forkIO)
+import Control.Exception.Safe (bracket, tryAny)
+import Control.Monad (forM_)
+import Data.Bifunctor (first)
+import qualified Data.Text as Text
+import Data.Word (Word8)
+import Foreign.C.String (CString)
+import Foreign.C.Types (CInt(..), CLLong(..), CSize(..))
+import Foreign.Ptr (FunPtr, Ptr, nullFunPtr, nullPtr)
+import System.Directory.OsPath (getHomeDirectory)
+import System.OsPath (decodeFS, takeDirectory, unsafeEncodeUtf)
+
+type LearnedSkillsListCallback =
+    Ptr () -> CInt
+    -> CString -> CSize -> CString -> CSize -> CLLong
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
+
+foreign import ccall "dynamic"
+    invokeLearnedSkillsListCallback
+        :: FunPtr LearnedSkillsListCallback -> LearnedSkillsListCallback
+
+foreign export ccall ha_learned_skills_list
+    :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
+
+ha_learned_skills_list
+    :: Ptr Word8 -> CSize -> FunPtr LearnedSkillsListCallback -> Ptr () -> IO CInt
+ha_learned_skills_list cwdBytes (CSize cwdLength) callback context
+    | callback == nullFunPtr = pure 1
+    | cwdBytes == nullPtr && cwdLength > 0 = pure 2
+    | otherwise = do
+        cwd <- decodeInput cwdBytes cwdLength
+        _ <- forkIO do
+            tryAny (listLearnedSkillsFor (Text.unpack cwd)) >>= \case
+                Left exception ->
+                    withText (Text.pack (show exception)) $ \errorPtr errorLength ->
+                        learnedSkillsTerminal callback context (-1) errorPtr errorLength
+                Right (Left err) ->
+                    withText err $ \errorPtr errorLength ->
+                        learnedSkillsTerminal callback context (-1) errorPtr errorLength
+                Right (Right skills) -> do
+                    forM_ skills \skill ->
+                        withLearnedSkillStrings skill $
+                            invokeLearnedSkillsListCallback callback context 0
+                    learnedSkillsTerminal callback context 1 nullPtr 0
+        pure 0
+  where
+    listLearnedSkillsFor cwd = do
+        home <- getHomeDirectory
+        projectRoot <- resolveProjectRoot (unsafeEncodeUtf cwd)
+        stateDirectory <- decodeFS (takeDirectory (sessionsRoot home))
+        projectRootPath <- decodeFS projectRoot
+        scopes <- deriveDatabaseScopes stateDirectory projectRootPath
+        case scopes of
+            Left err -> pure (Left err)
+            Right databaseScopes -> do
+                store <- openStore =<< managedPostgresConfigForHome home
+                case store of
+                    Left err -> pure (Left (renderStoreError err))
+                    Right opened ->
+                        bracket (pure opened) closeStore \store ->
+                            first renderStoreError
+                                <$> listAllLearnedSkillsLimited
+                                    (trustedPool store)
+                                    (applicableDatabaseScopes databaseScopes)
+                                    Nothing
+                                    1000
+
+type LearnedSkillItemCallback =
+    CString -> CSize -> CString -> CSize -> CLLong
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CInt -> CString -> CSize -> CString -> CSize -> IO ()
+
+withLearnedSkillStrings :: LearnedSkill -> LearnedSkillItemCallback -> IO ()
+withLearnedSkillStrings skill action =
+    withText (scopeKindText skill.learnedSkillScope.scopeKind) $ \scope scopeLength ->
+    withText skill.learnedSkillSlug $ \slug slugLength ->
+    withText skill.learnedSkillTitle $ \title titleLength ->
+    withText skill.learnedSkillDescription $ \description descriptionLength ->
+    withText skill.learnedSkillAppliesWhen $ \applies appliesLength ->
+    withText skill.learnedSkillInstructions $ \instructions instructionsLength ->
+    withText (learnedSkillActivationText skill.learnedSkillActivation) $ \activation activationLength ->
+    withText (learnedSkillStatusText skill.learnedSkillStatus) $ \status statusLength ->
+    withText (Text.pack (show skill.learnedSkillUpdatedAt)) $ \updated updatedLength ->
+        action scope scopeLength slug slugLength
+            (fromIntegral skill.learnedSkillRevision)
+            title titleLength description descriptionLength
+            applies appliesLength instructions instructionsLength
+            activation activationLength status statusLength
+            (fromIntegral skill.learnedSkillPriority) updated updatedLength
+            nullPtr 0
+
+learnedSkillsTerminal
+    :: FunPtr LearnedSkillsListCallback
+    -> Ptr () -> CInt -> CString -> CSize -> IO ()
+learnedSkillsTerminal callback context status errorPtr errorLength =
+    invokeLearnedSkillsListCallback callback context status
+        nullPtr 0 nullPtr 0 0
+        nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+        nullPtr 0 nullPtr 0
+        0 nullPtr 0 errorPtr errorLength

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/McpAdminBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/McpAdminBridge.hs
@@ -1,0 +1,380 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Independent MCP catalog endpoints and callback marshalling. Engine restart
+-- admission and execution stay with the engine's mailbox and supervisor.
+module Agent.CLI.MacOS.McpAdminBridge
+    ( McpResultCallback
+    , invokeMcpResultCallback
+    , decodeMcpInput
+    , maxMcpTextBytes
+    , emitMcpResult
+    , mcpAdminTry
+    ) where
+
+import Agent.CLI.MacOS.Marshalling
+    ( nonEmptyText
+    , withOptionalText
+    , withText
+    )
+import Agent.CLI.McpAdmin
+    ( McpAdminError(..)
+    , McpAdminServer(..)
+    , McpAdminServerInput(..)
+    , McpAdminSnapshot(..)
+    , addMcpAdminServer
+    , editMcpAdminServer
+    , listMcpAdminServers
+    , readMcpAdminServer
+    , removeMcpAdminServer
+    , setMcpAdminServerEnabled
+    )
+import Control.Concurrent (forkIO)
+import Control.Exception.Safe (tryAny)
+import Control.Monad (forM_)
+import Data.Bifunctor (first)
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word8, Word64)
+import Foreign.C.String (CString)
+import Foreign.C.Types (CInt(..), CSize(..))
+import Foreign.Ptr
+    ( FunPtr, Ptr, castPtr, nullFunPtr, nullPtr, plusPtr )
+import Foreign.Storable (peekByteOff, sizeOf)
+import System.Directory.OsPath (getHomeDirectory)
+import System.OsPath (OsPath)
+
+type McpServerCallback =
+    Ptr () -> CInt -> Word64
+    -> CString -> CSize -> CInt -> CString -> CSize -> CString -> CSize
+    -> CInt -> CInt -> CSize -> CSize -> CString -> CSize -> IO ()
+
+-- kind 0 is an argument and kind 1 is an environment key. Environment values
+-- never cross the bridge.
+type McpServerFieldCallback =
+    Ptr () -> CString -> CSize -> CInt -> CSize
+    -> CString -> CSize -> IO ()
+
+type McpResultCallback =
+    Ptr () -> CInt -> Word64 -> CString -> CSize -> IO ()
+
+foreign import ccall "dynamic"
+    invokeMcpServerCallback
+        :: FunPtr McpServerCallback -> McpServerCallback
+
+foreign import ccall "dynamic"
+    invokeMcpServerFieldCallback
+        :: FunPtr McpServerFieldCallback -> McpServerFieldCallback
+
+foreign import ccall "dynamic"
+    invokeMcpResultCallback
+        :: FunPtr McpResultCallback -> McpResultCallback
+
+foreign export ccall ha_mcp_servers_list
+    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback
+    -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_read
+    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
+    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_status
+    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
+    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_add
+    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_edit
+    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_enable
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_disable
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_mcp_server_remove
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+
+ha_mcp_servers_list
+    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback
+    -> Ptr () -> IO CInt
+ha_mcp_servers_list callback fieldCallback context
+    | callback == nullFunPtr || fieldCallback == nullFunPtr = pure 1
+    | otherwise = do
+        home <- getHomeDirectory
+        _ <- forkIO $
+            mcpAdminTry (listMcpAdminServers home) >>= emitMcpServers
+                callback fieldCallback context
+        pure 0
+
+ha_mcp_server_status
+    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
+    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
+ha_mcp_server_status = ha_mcp_server_read
+
+ha_mcp_server_read
+    :: Ptr Word8 -> CSize -> FunPtr McpServerCallback
+    -> FunPtr McpServerFieldCallback -> Ptr () -> IO CInt
+ha_mcp_server_read nameBytes (CSize nameLength) callback fieldCallback context
+    | callback == nullFunPtr || fieldCallback == nullFunPtr = pure 1
+    | nameBytes == nullPtr || nameLength == 0
+        || nameLength > maxMcpTextBytes = pure 2
+    | otherwise = do
+        decodeMcpInput nameBytes nameLength >>= \case
+            Left _ -> pure 2
+            Right name -> do
+                home <- getHomeDirectory
+                _ <- forkIO $
+                    mcpAdminTry (readMcpAdminServer home name) >>= emitMcpServer
+                        callback fieldCallback context
+                pure 0
+
+ha_mcp_server_add
+    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+ha_mcp_server_add =
+    mcpServerWrite addMcpAdminServer
+
+ha_mcp_server_edit
+    :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+ha_mcp_server_edit =
+    mcpServerWrite editMcpAdminServer
+
+ha_mcp_server_enable
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+ha_mcp_server_enable = mcpServerSetEnabled True
+
+ha_mcp_server_disable
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+ha_mcp_server_disable = mcpServerSetEnabled False
+
+ha_mcp_server_remove
+    :: Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+ha_mcp_server_remove expected nameBytes (CSize nameLength) callback context
+    | callback == nullFunPtr = pure 1
+    | nameBytes == nullPtr || nameLength == 0
+        || nameLength > maxMcpTextBytes = pure 2
+    | otherwise = do
+        decodeMcpInput nameBytes nameLength >>= \case
+            Left _ -> pure 2
+            Right name -> do
+                home <- getHomeDirectory
+                _ <- forkIO $
+                    mcpAdminTry (removeMcpAdminServer home expected name)
+                        >>= emitMcpResult
+                        callback context
+                pure 0
+
+mcpServerSetEnabled
+    :: Bool -> Word64 -> Ptr Word8 -> CSize
+    -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+mcpServerSetEnabled enabled expected nameBytes (CSize nameLength)
+        callback context
+    | callback == nullFunPtr = pure 1
+    | nameBytes == nullPtr || nameLength == 0
+        || nameLength > maxMcpTextBytes = pure 2
+    | otherwise = do
+        decodeMcpInput nameBytes nameLength >>= \case
+            Left _ -> pure 2
+            Right name -> do
+                home <- getHomeDirectory
+                _ <- forkIO $
+                    mcpAdminTry
+                        (setMcpAdminServerEnabled home expected name enabled)
+                        >>= emitMcpResult callback context
+                pure 0
+
+mcpServerWrite
+    :: (OsPath -> Word64 -> Text -> McpAdminServerInput
+        -> IO (Either McpAdminError (McpAdminSnapshot McpAdminServer)))
+    -> Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> Ptr () -> CSize -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> CInt -> CInt -> FunPtr McpResultCallback -> Ptr () -> IO CInt
+mcpServerWrite write expected nameBytes (CSize nameLength)
+        commandBytes (CSize commandLength) argsPointer argsCount
+        cwdBytes (CSize cwdLength) envPointer envCount
+        (CInt startupTimeout) (CInt requestTimeout) callback context
+    | callback == nullFunPtr = pure 1
+    | nameBytes == nullPtr || nameLength == 0
+        || nameLength > maxMcpTextBytes
+        || commandBytes == nullPtr || commandLength == 0
+        || commandLength > maxMcpTextBytes
+        || cwdLength > maxMcpTextBytes
+        || argsCount > maxMcpFields || envCount > maxMcpFields = pure 2
+    | argsPointer == nullPtr && argsCount > 0
+        || envPointer == nullPtr && envCount > 0
+        || cwdBytes == nullPtr && cwdLength > 0 = pure 2
+    | otherwise = do
+        decoded <- tryAny do
+            name <- requireMcpInput nameBytes nameLength
+            command <- requireMcpInput commandBytes commandLength
+            cwd <- requireMcpInput cwdBytes cwdLength
+            args <- mapM (peekUtf8Slice argsPointer)
+                [0 .. fromIntegral argsCount - 1]
+            env <- Map.fromList <$> mapM (peekEnvEntry envPointer)
+                [0 .. fromIntegral envCount - 1]
+            pure (name, McpAdminServerInput
+                { mcpAdminInputCommand = command
+                , mcpAdminInputArgs = args
+                , mcpAdminInputCwd = nonEmptyText cwd
+                , mcpAdminInputEnv = env
+                , mcpAdminInputStartupTimeoutSeconds =
+                    fromIntegral startupTimeout
+                , mcpAdminInputRequestTimeoutSeconds =
+                    fromIntegral requestTimeout
+                })
+        case decoded of
+            Left _ -> pure 2
+            Right (name, input) -> do
+                home <- getHomeDirectory
+                _ <- forkIO $
+                    mcpAdminTry (write home expected name input)
+                        >>= emitMcpResult callback context
+                pure 0
+
+peekUtf8Slice :: Ptr () -> Int -> IO Text
+peekUtf8Slice pointer index = do
+    let pointerSize = sizeOf (nullPtr :: Ptr ())
+        sizeSize = sizeOf (undefined :: CSize)
+        base = pointer `plusPtr` (index * (pointerSize + sizeSize))
+    bytes <- peekByteOff base 0
+    CSize length <- peekByteOff base pointerSize
+    if (bytes == (nullPtr :: Ptr Word8) && length > 0)
+            || length > maxMcpTextBytes
+        then ioError (userError "null UTF-8 slice")
+        else requireMcpInput bytes length
+
+decodeMcpInput :: Ptr Word8 -> Word64 -> IO (Either Text Text)
+decodeMcpInput pointer length
+    | pointer == nullPtr || length == 0 = pure (Right "")
+    | otherwise = do
+        bytes <- BS.packCStringLen (castPtr pointer, fromIntegral length)
+        pure (first (Text.pack . show) (TextEncoding.decodeUtf8' bytes))
+
+requireMcpInput :: Ptr Word8 -> Word64 -> IO Text
+requireMcpInput pointer length =
+    decodeMcpInput pointer length >>=
+        either (ioError . userError . Text.unpack) pure
+
+maxMcpTextBytes :: Word64
+maxMcpTextBytes = 1024 * 1024
+
+maxMcpFields :: CSize
+maxMcpFields = 4096
+
+peekEnvEntry :: Ptr () -> Int -> IO (Text, Text)
+peekEnvEntry pointer index = do
+    let sliceSize =
+            sizeOf (nullPtr :: Ptr ()) + sizeOf (undefined :: CSize)
+        base = pointer `plusPtr` (index * sliceSize * 2)
+    key <- peekUtf8Slice base 0
+    value <- peekUtf8Slice (base `plusPtr` sliceSize) 0
+    pure (key, value)
+
+emitMcpServers
+    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback -> Ptr ()
+    -> Either McpAdminError (McpAdminSnapshot [McpAdminServer]) -> IO ()
+emitMcpServers callback fieldCallback context = \case
+    Left err -> emitMcpServerError callback context err
+    Right snapshot -> do
+        forM_ snapshot.mcpAdminValue \server ->
+            emitMcpServerItem
+                callback fieldCallback context snapshot.mcpAdminRevision server
+        invokeMcpServerCallback callback context 1 snapshot.mcpAdminRevision
+            nullPtr 0 0 nullPtr 0 nullPtr 0 0 0 0 0 nullPtr 0
+
+emitMcpServer
+    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback -> Ptr ()
+    -> Either McpAdminError (McpAdminSnapshot McpAdminServer) -> IO ()
+emitMcpServer callback fieldCallback context = \case
+    Left err -> emitMcpServerError callback context err
+    Right snapshot ->
+        emitMcpServerItem
+            callback fieldCallback context snapshot.mcpAdminRevision
+            snapshot.mcpAdminValue
+
+emitMcpServerItem
+    :: FunPtr McpServerCallback -> FunPtr McpServerFieldCallback -> Ptr ()
+    -> Word64 -> McpAdminServer -> IO ()
+emitMcpServerItem callback fieldCallback context revision server = do
+    withText server.mcpAdminName \name nameLength -> do
+        forM_ (zip [0..] server.mcpAdminArgs) \(index, argument) ->
+            withText argument $
+                invokeMcpServerFieldCallback fieldCallback context
+                    name nameLength 0 index
+        forM_ (zip [0..] server.mcpAdminEnvKeys) \(index, key) ->
+            withText key $
+                invokeMcpServerFieldCallback fieldCallback context
+                    name nameLength 1 index
+        withText server.mcpAdminCommand \command commandLength ->
+            withOptionalText server.mcpAdminCwd \cwd cwdLength ->
+                invokeMcpServerCallback callback context 0 revision
+                    name nameLength
+                    (if server.mcpAdminEnabled then 1 else 0)
+                    command commandLength cwd cwdLength
+                    (fromIntegral server.mcpAdminStartupTimeoutSeconds)
+                    (fromIntegral server.mcpAdminRequestTimeoutSeconds)
+                    (fromIntegral (length server.mcpAdminArgs))
+                    (fromIntegral (length server.mcpAdminEnvKeys))
+                    nullPtr 0
+
+emitMcpServerError
+    :: FunPtr McpServerCallback -> Ptr () -> McpAdminError -> IO ()
+emitMcpServerError callback context err =
+    withText (mcpAdminErrorText err) \errorPtr errorLength ->
+        invokeMcpServerCallback callback context (-1)
+            (mcpAdminErrorRevision err)
+            nullPtr 0 0 nullPtr 0 nullPtr 0 0 0 0 0
+            errorPtr errorLength
+
+emitMcpResult
+    :: FunPtr McpResultCallback -> Ptr ()
+    -> Either McpAdminError (McpAdminSnapshot a) -> IO ()
+emitMcpResult callback context = \case
+    Left err ->
+        withText (mcpAdminErrorText err) $
+            invokeMcpResultCallback callback context (-1)
+                (mcpAdminErrorRevision err)
+    Right snapshot ->
+        invokeMcpResultCallback callback context 0 snapshot.mcpAdminRevision
+            nullPtr 0
+
+mcpAdminErrorRevision :: McpAdminError -> Word64
+mcpAdminErrorRevision = \case
+    McpAdminConflict revision -> revision
+    _ -> 0
+
+mcpAdminErrorText :: McpAdminError -> Text
+mcpAdminErrorText = \case
+    McpAdminConflict _ -> "MCP catalog changed; reload before editing"
+    McpAdminNotFound name -> "MCP server not found: " <> name
+    McpAdminAlreadyExists name -> "MCP server already exists: " <> name
+    McpAdminInvalid err -> err
+
+mcpAdminTry
+    :: IO (Either McpAdminError a)
+    -> IO (Either McpAdminError a)
+mcpAdminTry action =
+    tryAny action >>= \case
+        Left exception ->
+            pure (Left (McpAdminInvalid (Text.pack (show exception))))
+        Right result -> pure result


### PR DESCRIPTION
## Summary
- Move independent MCP administration, database browsing and learned-skill FFI endpoints into cohesive private modules.
- Reduce Bridge.hs from 3,829 to 3,120 lines (709 lines); preserve C ABI, callback lifetimes, store brackets, gateway checks and engine-owned restart scheduling.
- Register modules in both Darwin foreign-library and native test targets. No public header or private app changes.

## Validation
- Nix development environment: object-code GHCi loaded all 36 native test modules on the merged master base.
- Linked macOS native suite: 102 examples, 0 failures (GHCRTS unset).
- Package-local cabal2nix regeneration checked; existing manual Darwin foreign-library/test dependency supplements retained, no expression change needed.
- Independent source-move review: 38 extracted function chunks and all 33 affected FFI exports/signatures preserved; git diff --check passes.

Follow-on to #1071; engine/session ownership extraction remains separate.