### PR TITLE
Auto-approve cloud sandbox execution tools by default

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -48,6 +48,20 @@ guest. Host-side project instructions, filesystem skills, Git status, and
 project settings are disabled in this mode so tenant-controlled workspace
 symlinks cannot turn startup discovery into a host read or write.
 
+Sandbox execution tools are auto-approved by default: workspace edits, shell
+commands, builds and tests do not create human approval requests. This applies
+to existing sessions on their next turn as well as new sessions. It is scoped
+to tools actually proxied into the tenant sandbox, not a global `--yolo` policy:
+host services, including mutating MCP calls, retain their existing approvals.
+Plan-mode restrictions, dangerous-command checks and the sandbox boundary are
+unchanged. Single-tenant servers without a sandbox and local CLI sessions keep
+their existing approval behavior.
+
+Sandbox networking remains available, so automatic shell approval is not a
+semantic guarantee against external side effects (for example a command using
+credentials that a user has placed in the workspace). Do not place production
+credentials in an auto-approved sandbox unless that access is intended.
+
 Use the exported NixOS module for a production multi-tenant deployment:
 
 ```nix

--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -54,6 +54,7 @@ import Agent.Tools.Types
     , lookupRegisteredTool
     , toolAcceptsCall
     , toolAllowsWithoutPrompt
+    , toolAutoApproves
     )
 import Data.IORef
     ( IORef
@@ -208,7 +209,7 @@ approveToolDecisionWithReporterAndPersistenceClassified
             planActive <- isPlanModeActive planMode
             planPath <- planFilePath planMode
             let initialFacts = ApprovalFacts
-                    { policy
+                    { policy = scopedToolPolicy policy tools call
                     , planActive
                     , planPath
                     , readOnly = Nothing
@@ -284,7 +285,7 @@ childApprove _ _ call
     | isComputerToolCallKind call.callKind =
         pure $ Left
             "Computer use must be approved in the interactive parent session."
-childApprove policy tools call = case policy of
+childApprove policy tools call = case scopedToolPolicy policy tools call of
     ApproveAll -> pure (Right True)
     DenyMutating -> do
         allowed <- isReadOnlyCall tools call
@@ -297,6 +298,15 @@ childApprove policy tools call = case policy of
                 "Subagent cannot prompt for approval on mutating tools. \
                 \Re-run the parent with auto-approve/--yolo, or have the \
                 \parent perform this edit."
+
+-- Only the ordinary mutation prompt is waived. Classification, plan mode,
+-- dangerous-command checks and computer-use consent still run as before.
+-- Do not change the live policy or persist a project-wide YOLO setting.
+scopedToolPolicy :: ApprovalPolicy -> ToolRegistry -> ToolCall -> ApprovalPolicy
+scopedToolPolicy PromptMutating tools call
+    | Just tool <- lookupRegisteredTool call.name tools
+    , toolAutoApproves tool = ApproveAll
+scopedToolPolicy policy _ _ = policy
 
 isReadOnlyCall :: ToolRegistry -> ToolCall -> IO Bool
 isReadOnlyCall tools call = case lookupRegisteredTool call.name tools of

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -22,7 +22,7 @@ import Agent.ToolDispatch
     , noArgsTool
     )
 import Agent.Tools.Types
-    ( AppTool
+    ( AppTool(..)
     , ApprovalRule(..)
     , ToolRegistry
     , jsonAppTool
@@ -277,6 +277,118 @@ spec = do
             readIORef requests `shouldReturn` 1
 
     describe "approveToolDecisionWith" do
+        it "auto-approves only the marked call without changing session policy" do
+            policy <- newIORef PromptMutating
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            permissionRequests <- newIORef (0 :: Int)
+            persistenceCalls <- newIORef (0 :: Int)
+
+            approveToolDecisionWithReporterAndPersistence
+                (\_ -> modifyIORef' permissionRequests (+ 1)
+                    >> pure (Just PermissionAllowAll))
+                (\_ -> pure ())
+                (modifyIORef' persistenceCalls (+ 1))
+                policy allowed
+                (registry [autoApproveMutatingTool])
+                plan mutatingCall
+                `shouldReturn` Right True
+
+            readIORef permissionRequests `shouldReturn` 0
+            readIORef persistenceCalls `shouldReturn` 0
+            readIORef policy `shouldReturn` PromptMutating
+            readIORef allowed `shouldReturn` Set.empty
+
+        it "still prompts for an unmarked host tool" do
+            policy <- newIORef PromptMutating
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            permissionRequests <- newIORef (0 :: Int)
+
+            approveToolDecisionWithReporter
+                (\_ -> modifyIORef' permissionRequests (+ 1)
+                    >> pure (Just PermissionDeny))
+                (\_ -> pure ())
+                policy allowed
+                (registry [mutatingTool])
+                plan mutatingCall
+                `shouldReturn` Right False
+
+            readIORef permissionRequests `shouldReturn` 1
+            readIORef policy `shouldReturn` PromptMutating
+
+        it "keeps plan mode ahead of scoped auto-approval" do
+            policy <- newIORef PromptMutating
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            activatePlanMode plan
+            permissionRequests <- newIORef (0 :: Int)
+
+            result <- approveToolDecisionWithReporter
+                (\_ -> modifyIORef' permissionRequests (+ 1)
+                    >> pure (Just PermissionAllowOnce))
+                (\_ -> pure ())
+                policy allowed
+                (registry [autoApproveMutatingTool])
+                plan mutatingCall
+
+            result `shouldSatisfy` either
+                (Text.isInfixOf "only editable file")
+                (const False)
+            readIORef permissionRequests `shouldReturn` 0
+
+        it "keeps dangerous shell denials ahead of scoped auto-approval" do
+            policy <- newIORef PromptMutating
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            permissionRequests <- newIORef (0 :: Int)
+            let call = functionToolCall
+                    "call-shell"
+                    "shell_command"
+                    "{\"command\":\"rm -rf /\"}"
+                shellTool = tool
+                    "shell_command"
+                    (AutoApprove AlwaysPrompt)
+
+            result <- approveToolDecisionWithReporter
+                (\_ -> modifyIORef' permissionRequests (+ 1)
+                    >> pure (Just PermissionAllowOnce))
+                (\_ -> pure ())
+                policy allowed (registry [shellTool]) plan call
+
+            result `shouldSatisfy` either
+                (Text.isInfixOf "Blocked dangerous shell command")
+                (const False)
+            readIORef permissionRequests `shouldReturn` 0
+
+        it "does not bypass computer-use consent when marked for auto-approval" do
+            policy <- newIORef PromptMutating
+            allowed <- newIORef Set.empty
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/tmp/approval-test") Nothing
+            permissionRequests <- newIORef (0 :: Int)
+            let call = ToolCall
+                    { callId = "computer-1"
+                    , name = computerToolName
+                    , arguments = "{}"
+                    , callKind = ComputerCallKind
+                    , argumentsEncrypted = False
+                    }
+                autoApproveComputer = computerUseTool
+                    { appToolApproval =
+                        AutoApprove computerUseTool.appToolApproval
+                    }
+
+            approveToolDecisionWithReporter
+                (\_ -> modifyIORef' permissionRequests (+ 1)
+                    >> pure (Just PermissionAllowOnce))
+                (\_ -> pure ())
+                policy allowed
+                (registry [autoApproveComputer])
+                plan call
+                `shouldReturn` Right True
+
+            readIORef permissionRequests `shouldReturn` 1
+
         it "does not classify, prompt, or persist a catastrophic shell call" do
             policy <- newIORef PromptMutating
             allowed <- newIORef Set.empty
@@ -756,6 +868,13 @@ spec = do
                 Left message -> "cannot prompt for approval" `Text.isInfixOf` message
                 Right _ -> False
 
+        it "honors scoped auto-approval without weakening read-only mode" do
+            let tools = registry [autoApproveMutatingTool]
+            childApprove PromptMutating tools mutatingCall
+                `shouldReturn` Right True
+            childApprove DenyMutating tools mutatingCall
+                `shouldReturn` Right False
+
         it "honors per-call read-only classifiers" do
             childApprove DenyMutating (registry [dynamicTool]) dynamicReadCall
                 `shouldReturn` Right True
@@ -783,6 +902,9 @@ readOnlyTool = tool "read" AlwaysReadOnly
 
 mutatingTool :: AppTool
 mutatingTool = tool "write" AlwaysPrompt
+
+autoApproveMutatingTool :: AppTool
+autoApproveMutatingTool = tool "write" (AutoApprove AlwaysPrompt)
 
 dynamicTool :: AppTool
 dynamicTool = tool "dynamic" (ClassifyReadOnly (\call -> pure (call == dynamicReadCall)))

--- a/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
@@ -429,3 +429,4 @@ approvalLabel = \case
     AlwaysAllowed -> "always-allowed"
     AlwaysPrompt -> "prompt"
     ClassifyReadOnly _ -> "classified"
+    AutoApprove original -> "auto-approve:" <> approvalLabel original

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -41,6 +41,7 @@ module Agent.Tools.Types
     , jsonToolParameters
     , appToolHandlers
     , toolAllowsWithoutPrompt
+    , toolAutoApproves
     , toolSupportsAsync
     ) where
 
@@ -113,6 +114,9 @@ data ApprovalRule
     | AlwaysAllowed
     | AlwaysPrompt
     | ClassifyReadOnly !(ToolCall -> IO Bool)
+    -- | Host-scoped auto-approval, retaining the original classification for
+    -- plan mode and explicit deny-mutating policies. Never set from tool input.
+    | AutoApprove !ApprovalRule
 
 -- | Whether a tool handler may overlap other handlers emitted in the same
 -- model turn. Approval callbacks are always evaluated serially in call order.
@@ -543,8 +547,16 @@ appToolHandlers :: [AppTool] -> [ToolHandler]
 appToolHandlers = map (.appToolHandler)
 
 toolAllowsWithoutPrompt :: AppTool -> ToolCall -> IO Bool
-toolAllowsWithoutPrompt tool call = case tool.appToolApproval of
-    AlwaysReadOnly -> pure True
-    AlwaysAllowed -> pure True
-    AlwaysPrompt -> pure False
-    ClassifyReadOnly classify -> classify call
+toolAllowsWithoutPrompt tool call = classifyRule tool.appToolApproval
+  where
+    classifyRule = \case
+        AlwaysReadOnly -> pure True
+        AlwaysAllowed -> pure True
+        AlwaysPrompt -> pure False
+        ClassifyReadOnly classify -> classify call
+        AutoApprove original -> classifyRule original
+
+toolAutoApproves :: AppTool -> Bool
+toolAutoApproves tool = case tool.appToolApproval of
+    AutoApprove _ -> True
+    _ -> False

--- a/packages/agent-mcp/src/Agent/MCP/InProcess.hs
+++ b/packages/agent-mcp/src/Agent/MCP/InProcess.hs
@@ -240,6 +240,7 @@ isStaticallyReadOnly = \case
     AlwaysAllowed -> False
     AlwaysPrompt -> False
     ClassifyReadOnly _ -> False
+    AutoApprove original -> isStaticallyReadOnly original
 
 requestedProtocolVersion :: Maybe Value -> Text
 requestedProtocolVersion = \case

--- a/packages/agent-mcp/test/Agent/MCP/InProcessSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCP/InProcessSpec.hs
@@ -13,7 +13,7 @@ import Agent.ToolDispatch
     , typedTool
     )
 import Agent.Tools.Types
-    ( AppTool
+    ( AppTool(..)
     , ApprovalRule(..)
     , ToolExecutionPolicy(..)
     , freeformApplyPatchAppToolWithExecution
@@ -63,6 +63,22 @@ spec = describe "in-process MCP server" do
                 ])
         response `shouldSatisfy` hasTextResult "echo:hello" False
         readIORef approved `shouldReturn` ["echo"]
+
+    it "does not advertise auto-approved mutations as read-only" do
+        let check original expected = do
+                server <- testServer (const (pure (Right True)))
+                    [echoTool { appToolApproval = AutoApprove original }]
+                response <- handleInProcessMcpMessage server $
+                    request 2 "tools/list" (object [])
+                case lookupPath ["result", "tools"] response of
+                    Just (Array tools)
+                        | [tool] <- toList tools ->
+                            lookupPath ["annotations", "readOnlyHint"] (Just tool)
+                                `shouldBe` Just (Bool expected)
+                    _ -> expectationFailure "expected one advertised tool"
+        check AlwaysReadOnly True
+        check AlwaysPrompt False
+        check (ClassifyReadOnly (const (pure True))) False
 
     it "does not execute a user-rejected call" do
         executions <- newIORef (0 :: Int)

--- a/packages/agent-server/src/Agent/Server/Sandbox.hs
+++ b/packages/agent-server/src/Agent/Server/Sandbox.hs
@@ -27,7 +27,8 @@ import Agent.ToolDispatch
     , passthroughTool
     )
 import Agent.Tools.Types
-    ( AppTool(..)
+    ( ApprovalRule(..)
+    , AppTool(..)
     , AppToolGroup(..)
     )
 import Control.Concurrent
@@ -224,6 +225,9 @@ composeSandboxTools sandbox sessionId cwd dialect =
             -- Host resource resolvers must not inspect paths for a guest
             -- operation. The tenant broker serializes calls itself.
             , appToolResourceClaims = Nothing
+            -- Only tools actually routed into the tenant sandbox get YOLO.
+            -- Host services (including MCP writes) retain their own approvals.
+            , appToolApproval = AutoApprove tool.appToolApproval
             }
 
 invokeTenantTool

--- a/packages/agent-server/test/Agent/Server/SandboxSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SandboxSpec.hs
@@ -19,7 +19,8 @@ import Agent.Server.Tenant
     )
 import Agent.Dialect (DialectId(CodexDialect))
 import Agent.ToolDispatch
-    ( ToolCallResult(..)
+    ( ToolCall(..)
+    , ToolCallResult(..)
     , ToolDispatchConfig(..)
     , ToolDispatchOutcome(..)
     , dispatchToolCallDetailed
@@ -31,6 +32,8 @@ import Agent.Tools.Types
     , AppTool(..)
     , AppToolGroup(..)
     , appToolSupportsAsync
+    , toolAllowsWithoutPrompt
+    , toolAutoApproves
     , jsonAppTool
     , withAsyncToolCalls
     )
@@ -111,6 +114,39 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "tenant sandbox protocol" do
+    it "auto-approves only sandbox execution tools without reclassifying mutations" do
+        let execution = testSandboxTool { appToolApproval = AlwaysPrompt }
+            host = testHostServiceTool { appToolApproval = AlwaysPrompt }
+            tools = composeSandboxTools
+                (error "approval must not start the sandbox")
+                validSessionId
+                "/workspace"
+                CodexDialect
+                [ExecutionToolGroup [execution], HostToolGroup [host]]
+        map toolAutoApproves tools `shouldBe` [True, False]
+        mapM (\tool ->
+            toolAllowsWithoutPrompt tool
+                (functionToolCall "call-approval" tool.appToolName "{}"))
+            tools `shouldReturn` [False, False]
+        toolAutoApproves execution `shouldBe` False
+
+    it "preserves per-call classification for auto-approved sandbox tools" do
+        let execution = testSandboxTool
+                { appToolApproval = ClassifyReadOnly
+                    (\call -> pure (call.arguments == "read"))
+                }
+        proxied <- composedTool (composeSandboxTools
+            (error "classification must not start the sandbox")
+            validSessionId "/workspace" CodexDialect
+            [ExecutionToolGroup [execution]])
+        toolAutoApproves proxied `shouldBe` True
+        toolAllowsWithoutPrompt proxied
+            (functionToolCall "call-read" proxied.appToolName "read")
+            `shouldReturn` True
+        toolAllowsWithoutPrompt proxied
+            (functionToolCall "call-write" proxied.appToolName "write")
+            `shouldReturn` False
+
     it "preserves async capability on proxied execution tools" do
         case composeSandboxTools
             (error "sandbox handler is not evaluated")


### PR DESCRIPTION
## Summary
- Auto-approve execution tools routed into cloud tenant sandboxes by default, including child-agent calls.
- Keep host/MCP approvals and local/non-sandbox behavior unchanged; do not mutate or persist the global YOLO policy.
- Preserve original tool classification for plan mode, explicit deny-mutating policies, and MCP read-only annotations.
- Add regression coverage for scoping, policy persistence, plan/dangerous-command guards, computer consent, child approval, and sandbox composition.

## Security boundary
This is sandbox-scoped auto-approval, not global `NativeYolo`. Existing checks remain in place. Sandbox networking is still available: shell commands with user-provided credentials can have external effects. This caveat is documented.

## Rollout
After the updated agent-server is deployed, applies to new sessions and subsequent turns of existing sandbox sessions. No deployment is included in this PR.

## Validation
- `git diff --check` passes.
- Nix/GHCi multi-repl successfully typechecked all libraries plus the CLI, MCP, and server test components (757 modules).
- Test execution was not completed: GHCi 9.10 multi-home-unit mode loaded the specs but could not import them into the interactive context. The added regression tests still need to run in CI.
- Used a temporary offline Cabal project selecting the Nix-provided dependency versions; no build configuration changes are included.
