### PR TITLE
Preserve Claude tool-result images across session replay

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
+++ b/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
@@ -49,6 +49,7 @@ import Claude.Agent.SDK.Types
     , SystemMessage(..)
     , Usage(..)
     , ToolResultContent(..)
+    , ToolResultPart(..)
     , UserMessage(..)
     , QueryMessageScope(..)
     , QueryProgress(..)
@@ -58,7 +59,9 @@ import Claude.Agent.SDK.Types
     , messageUuid
     , modelUsageToUsage
     )
+import qualified Data.Aeson as AesonValue
 import qualified Data.Aeson.Encoding as Aeson
+import qualified Data.ByteString.Base64 as Base64
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
@@ -612,10 +615,27 @@ functionCallItem callId name input =
         , async = Nothing
         }
 
--- | Persist the text projection rather than the wire JSON: structured
--- results (tool references, image reads carrying base64 payloads) are
--- replayed into the transcript view and imported into later prompts as
--- plain text.
+encodeResultContent :: ToolResultContent -> RawJson
+encodeResultContent content
+    | any isImage content.blocks =
+        rawJsonFromEncoding (AesonValue.toEncoding (map toPart content.blocks))
+    | otherwise = rawJsonFromEncoding (Aeson.text (renderResultContent content))
+  where
+    isImage ToolResultImage{} = True
+    isImage _ = False
+    toPart (ToolResultText text) = InputTextPart text Nothing
+    toPart ToolResultImage{mediaType, imageBytes} =
+        InputImagePart
+            { detail = Nothing
+            , fileId = Nothing
+            , imageUrl = Just $
+                "data:" <> mediaType <> ";base64,"
+                    <> TextEncoding.decodeUtf8 (Base64.encode imageBytes)
+            , promptCacheBreakpoint = Nothing
+            }
+
+-- | Persist validated images as canonical content parts, never as wire JSON
+-- embedded in prompt text. Text-only results retain their historical encoding.
 functionOutputItem
     :: Text
     -> Maybe ToolResultContent
@@ -632,7 +652,7 @@ functionOutputItem callId content isError =
         , output =
             maybe
                 (rawJsonFromEncoding Aeson.null_)
-                (rawJsonFromEncoding . Aeson.text . renderResultContent)
+                encodeResultContent
                 content
         , status =
             Just $

--- a/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
+++ b/packages/agent-claude/src/Agent/Claude/LoopBackend.hs
@@ -85,6 +85,7 @@ import Agent.Responses.Types
     )
 import qualified Agent.ToolDispatch as ToolDispatch
 import Agent.Json (RawJson, rawJsonBytes)
+import Agent.Responses.Types.Content (responseContentPartDecoder)
 import qualified Agent.Json.Decode as Json
 import Claude.Agent.SDK.Client
     ( ClaudeSDKClient
@@ -693,13 +694,11 @@ renderResponseItem = \case
             "Assistant tool call"
             (call.name <> " " <> call.input)
     FunctionCallOutputItem output ->
-        labelled
-            ("Tool result " <> output.callId)
-            (renderRawJson output.output)
+        Just (UserTextBlock ("Tool result " <> output.callId <> ":\n")
+            : toolResultContentBlocks output.output)
     CustomToolCallOutputItem output ->
-        labelled
-            ("Tool result " <> output.callId)
-            (renderRawJson output.output)
+        Just (UserTextBlock ("Tool result " <> output.callId <> ":\n")
+            : toolResultContentBlocks output.output)
     ComputerCallItem item ->
         labelled "Assistant computer call" (renderJsonValue (Aeson.toJSON item))
     ComputerCallOutputItem item ->
@@ -746,6 +745,50 @@ roleLabel = \case
     RoleSystem -> "System"
     RoleDeveloper -> "Developer"
     RoleUnknown role -> role
+
+-- Decode canonical multimodal outputs before rendering history. Each array
+-- element owns its bytes before a second decoder reads it; malformed parts
+-- must not turn an entire image-bearing array into raw JSON prompt text.
+toolResultContentBlocks :: RawJson -> [UserContentBlock]
+toolResultContentBlocks raw =
+    case Json.decodeEither containsContentDecoder (rawJsonBytes raw) of
+        Right False -> [UserTextBlock (renderRawJson raw)]
+        _ -> either (const unavailable) id $
+            Json.decodeEither decoder (rawJsonBytes raw)
+  where
+    unavailable = [UserTextBlock "[Historical tool result content unavailable]"]
+    -- Classification is independent of validity: malformed image parts must
+    -- never select the legacy raw-JSON fallback. Inspect nested objects too.
+    containsContentDecoder = Json.withType \case
+        Json.VArray -> or <$> Json.list (containsImageDecoder True)
+        _ -> containsImageDecoder False
+    containsImageDecoder isContentPart = Json.withType \case
+        Json.VArray -> or <$> Json.list (containsImageDecoder False)
+        Json.VObject -> do
+            fields <- Json.objectAsKeyValues pure $
+                Json.withOwnedRawJson pure
+            pure $ any (\(key, bytes) ->
+                key `elem` ["image_url", "imageUrl"]
+                    || (key == "type" && case Json.decodeEither Json.text bytes of
+                        Right tag ->
+                            tag `elem` ["input_image", "image", "image_url"]
+                                || (isContentPart && tag `elem`
+                                    [ "input_text", "output_text", "text", "refusal"
+                                    , "summary_text", "input_file", "input_audio"
+                                    , "reasoning_text", "encrypted_content"
+                                    ])
+                        Left _ -> False)
+                    || either (const True) id
+                        (Json.decodeEither (containsImageDecoder False) bytes)) fields
+        _ -> pure False
+    decoder = Json.withType \case
+        Json.VArray -> concat . intersperse [UserTextBlock "\n"] <$>
+            Json.list (Json.withOwnedRawJson \bytes ->
+                pure $ case Json.decodeEither responseContentPartDecoder bytes of
+                    Right UnknownContentPart{} -> unavailable
+                    Right part -> contentPartBlocks part
+                    Left _ -> unavailable)
+        _ -> pure unavailable
 
 messageContentBlocks :: MessageContent -> [UserContentBlock]
 messageContentBlocks = \case

--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -17,7 +17,7 @@ import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Cancel (newCancelFlag, requestCancel)
 import qualified Agent.Loop as Loop
 import Agent.Tools.Types (mkToolRegistry)
-import Agent.Json (rawJsonBytes)
+import Agent.Json (rawJsonBytes, rawJsonFromEncoding)
 import Agent.Loop
     ( Backend(..)
     , BackendContinuation(..)
@@ -65,6 +65,7 @@ import Control.Exception.Safe (bracket, finally)
 import Control.Concurrent.MVar (newEmptyMVar, takeMVar)
 import Control.Monad (when)
 import qualified Data.Foldable as Foldable
+import qualified Data.Aeson as Aeson
 import Data.IORef
     ( IORef
     , atomicModifyIORef'
@@ -524,6 +525,113 @@ spec = do
                             | FunctionCallOutputItem output <- history
                             ]
                             `shouldBe` ["\"Tool reference: WebFetch\\nloaded\""]
+
+        it "preserves tool-result images as typed content across a fresh SDK session" $
+            withFakeClaude \fake ->
+                withEnvironmentVariables [("FAKE_CLAUDE_IMAGE_RESULT", Just "1")] do
+                    transcript <- newIORef []
+                    events <- newIORef []
+                    let options = defaultClaudeCodeOptions fake.executable fake.workingDirectory
+                        runTurn = do
+                            initialHistory <- readIORef transcript
+                            state <- newIORef (initialBackendSnapshot initialHistory)
+                            withClaudeCodeBackend options Nothing
+                                (pure defaultResponseCreateParams) transcript \backend ->
+                                    submitBackendWithState state backend Nothing [UserMessage "inspect"]
+                                        (\event -> modifyIORef' events (<> [event]))
+                    first <- timeout 5_000_000 runTurn
+                    first `shouldSatisfy` \case
+                        Just (Right _) -> True
+                        _ -> False
+                    history <- readIORef transcript
+                    let outputs = [output.output | FunctionCallOutputItem output <- history]
+                        image mime payload = InputImagePart
+                            { detail = Nothing, fileId = Nothing
+                            , imageUrl = Just ("data:" <> mime <> ";base64," <> payload)
+                            , promptCacheBreakpoint = Nothing
+                            }
+                    map (Aeson.decodeStrict' . rawJsonBytes) outputs `shouldBe`
+                        [Just (Aeson.toJSON
+                            [ InputTextPart "before" Nothing
+                            , image "image/png" "b25l"
+                            , InputTextPart "between" Nothing
+                            , image "image/jpeg" "dHdv"
+                            , InputTextPart "after" Nothing
+                            ])]
+                    observed <- readIORef events
+                    observed `shouldContain`
+                        [ToolFinished expectedFakeToolResult
+                            { output = "before\n[image image/png]\nbetween\n[image image/jpeg]\nafter" }]
+                    second <- timeout 5_000_000 runTurn
+                    second `shouldSatisfy` \case
+                        Just (Right _) -> True
+                        _ -> False
+                    submitted <- readFile fake.promptLog
+                    Text.count "\"type\":\"image\"" (Text.pack submitted) `shouldBe` 2
+                    submitted `shouldContain` "\"data\":\"b25l\""
+                    submitted `shouldContain` "\"data\":\"dHdv\""
+                    submitted `shouldContain` "Tool result fake-tool"
+                    submitted `shouldNotContain` "data:image/"
+                    submitted `shouldNotContain` "[image image/png]"
+
+        it "retains ordinary JSON tool-result arrays and text-tagged objects during fresh import" $
+            withFakeClaude \fake -> do
+                let output = rawJsonFromEncoding (Aeson.toEncoding ([1, 2] :: [Int]))
+                let textObject = rawJsonFromEncoding $ Aeson.toEncoding $
+                        Aeson.object ["type" Aeson..= ("text" :: Text), "text" Aeson..= ("legacy object" :: Text)]
+                transcript <- newIORef [FunctionCallOutputItem FunctionCallOutput
+                    { itemId = Nothing, callId = "legacy-json", name = Nothing
+                    , namespace = Nothing, provider = Nothing, output = value
+                    , status = Nothing, async = Nothing, localOutcome = Nothing
+                    } | value <- [output, textObject]]
+                initialHistory <- readIORef transcript
+                state <- newIORef (initialBackendSnapshot initialHistory)
+                result <- timeout 5_000_000 $
+                    withClaudeCodeBackend
+                        (defaultClaudeCodeOptions fake.executable fake.workingDirectory)
+                        Nothing (pure defaultResponseCreateParams) transcript \backend ->
+                            submitBackendWithState state backend Nothing [UserMessage "continue"] (const (pure ()))
+                result `shouldSatisfy` \case
+                    Just (Right _) -> True
+                    _ -> False
+                submitted <- readFile fake.promptLog
+                submitted `shouldContain` "[1,2]"
+                submitted `shouldContain` "legacy object"
+                submitted `shouldNotContain` "content unavailable"
+
+        it "isolates malformed historical tool images without losing valid siblings or leaking payloads" $
+            withFakeClaude \fake -> do
+                let output = rawJsonFromEncoding $ Aeson.toEncoding
+                        [ Aeson.object ["type" Aeson..= ("input_text" :: Text), "text" Aeson..= ("before" :: Text)]
+                        , Aeson.object ["type" Aeson..= ("input_image" :: Text), "image_url" Aeson..= ("data:image/png;base64,SECRET_BAD!" :: Text)]
+                        , Aeson.object ["type" Aeson..= ("input_image" :: Text), "image_url" Aeson..= (42 :: Int)]
+                        , Aeson.object ["type" Aeson..= ("input_image" :: Text), "image_url" Aeson..= ("data:image/png;base64,b25l" :: Text)]
+                        , Aeson.object ["type" Aeson..= ("input_text" :: Text), "text" Aeson..= ("after" :: Text)]
+                        ]
+                transcript <- newIORef [FunctionCallOutputItem FunctionCallOutput
+                    { itemId = Nothing, callId = "malformed-image", name = Nothing
+                    , namespace = Nothing, provider = Nothing, output
+                    , status = Nothing, async = Nothing, localOutcome = Nothing
+                    }]
+                initialHistory <- readIORef transcript
+                state <- newIORef (initialBackendSnapshot initialHistory)
+                result <- timeout 5_000_000 $
+                    withClaudeCodeBackend
+                        (defaultClaudeCodeOptions fake.executable fake.workingDirectory)
+                        Nothing (pure defaultResponseCreateParams) transcript \backend ->
+                            submitBackendWithState state backend Nothing [UserMessage "continue"] (const (pure ()))
+                result `shouldSatisfy` \case
+                    Just (Right _) -> True
+                    _ -> False
+                submitted <- readFile fake.promptLog
+                submitted `shouldContain` "before"
+                submitted `shouldContain` "after"
+                submitted `shouldContain` "Historical image unavailable"
+                submitted `shouldContain` "Historical tool result content unavailable"
+                submitted `shouldContain` "\"data\":\"b25l\""
+                Text.count "\"type\":\"image\"" (Text.pack submitted) `shouldBe` 1
+                submitted `shouldNotContain` "SECRET_BAD"
+                submitted `shouldNotContain` "data:image/"
 
         it "starts from partial tool records and enriches canonical arguments" $
             withFakeClaude \fake ->
@@ -1929,7 +2037,9 @@ fakeClaudeScript promptLog startLog argumentLog =
         , "  fi"
         , "  if [ \"$FAKE_CLAUDE_PAUSE_AFTER_TOOL\" = 1 ]; then sleep 1; fi"
         , "  if [ \"$FAKE_CLAUDE_RECOVERY_PROGRESS\" = 1 ]; then printf '%s' saved > recovery-side-effect; fi"
-        , "  if [ \"$FAKE_CLAUDE_STRUCTURED_RESULT\" = 1 ]; then"
+        , "  if [ \"$FAKE_CLAUDE_IMAGE_RESULT\" = 1 ]; then"
+        , "    printf '{\"type\":\"user\",\"uuid\":\"tool-result-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"fake-tool\",\"content\":[{\"type\":\"text\",\"text\":\"before\"},{\"type\":\"image\",\"source\":{\"type\":\"base64\",\"media_type\":\"image/png\",\"data\":\"b25l\"}},{\"type\":\"text\",\"text\":\"between\"},{\"type\":\"image\",\"source\":{\"type\":\"base64\",\"media_type\":\"image/jpeg\",\"data\":\"dHdv\"}},{\"type\":\"text\",\"text\":\"after\"}]}]}}\\n' \"$turn\" \"$session_id\""
+        , "  elif [ \"$FAKE_CLAUDE_STRUCTURED_RESULT\" = 1 ]; then"
         , "    printf '{\"type\":\"user\",\"uuid\":\"tool-result-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"fake-tool\",\"content\":[{\"type\":\"tool_reference\",\"tool_name\":\"WebFetch\"},{\"type\":\"text\",\"text\":\"loaded\"}]}]}}\\n' \"$turn\" \"$session_id\""
         , "  else"
         , "    printf '{\"type\":\"user\",\"uuid\":\"tool-result-%s\",\"session_id\":\"%s\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"fake-tool\",\"content\":\"fake contents\"}]}}\\n' \"$turn\" \"$session_id\""

--- a/packages/agent-claude/test/Agent/Claude/RecoverySpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/RecoverySpec.hs
@@ -109,6 +109,7 @@ spec = describe "Claude interrupted-work recovery" do
         let content = ToolResultContent
                 { raw = json "[{\"type\":\"text\",\"text\":\"useful\"},{\"type\":\"image\",\"source\":{\"data\":\"IMAGE_SECRET\"}},{\"credential\":\"SECRET_FIELD\"}]"
                 , renderedText = "UNSAFE_FALLBACK"
+                , blocks = []
                 }
             rendered = summary $ recordRecoveryMessage
                 (user [ToolResultBlock "call" (Just content) Nothing]) emptyRecovery
@@ -148,6 +149,7 @@ result :: Text -> ToolResultContent
 result text = ToolResultContent
     { raw = rawJsonFromEncoding (Encoding.text text)
     , renderedText = text
+    , blocks = []
     }
 
 assistant :: Text -> [ContentBlock] -> Message

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec/Compatibility.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec/Compatibility.hs
@@ -9,6 +9,7 @@ import Agent.CLI.Request (requestParams)
 import Agent.CLI.Session.StoreCodec (fromStoredResponseItem, toStoredResponseItem)
 import Agent.Dialect (DialectId(..))
 import Agent.Provider (Provider(..))
+import Agent.Responses.LoopBackend (withRequestInput)
 import Agent.Responses.Types
 import Agent.Store.SessionItem
 import Control.Concurrent (newEmptyMVar, putMVar, readMVar, takeMVar)
@@ -184,6 +185,39 @@ spec = do
                         ("unexpected stored item: " <> show stored)
             fromStoredResponseItem (toStoredResponseItem item)
                 `shouldBe` Right item
+
+        it "preserves ordered Claude tool-result images through storage and Responses replay" do
+            let parts =
+                    [ InputTextPart "before" Nothing
+                    , InputImagePart Nothing Nothing
+                        (Just "data:image/png;base64,cG5nLWJ5dGVz") Nothing
+                    , InputTextPart "after" Nothing
+                    ]
+                output = FunctionCallOutput
+                    { localOutcome = Nothing
+                    , itemId = Nothing
+                    , callId = "claude-image-read"
+                    , name = Nothing
+                    , namespace = Nothing
+                    , provider = Just "claude-code"
+                    , output = rawJsonValue (Aeson.toJSON parts)
+                    , status = Just ItemCompleted
+                    , async = Nothing
+                    }
+                item = FunctionCallOutputItem output
+            restored <- either (fail . show) pure
+                (fromStoredResponseItem (toStoredResponseItem item))
+            restored `shouldBe` item
+            let request = withRequestInput defaultResponseCreateParams [restored]
+            case request.input of
+                Just (ResponseInputItems [FunctionCallOutputItem replayed]) -> do
+                    replayed.callId `shouldBe` output.callId
+                    replayed.provider `shouldBe` Just "claude-code"
+                    replayed.status `shouldBe` Nothing
+                    -- This must stay a typed content array on the wire, never
+                    -- a JSON string containing base64 masquerading as text.
+                    Aeson.toJSON replayed.output `shouldBe` Aeson.toJSON parts
+                other -> expectationFailure ("unexpected replay input: " <> show other)
 
         it "keeps hosted and malformed attachment URLs as text" do
             let item = MessageItem ResponseMessage

--- a/packages/agent-gemini/src/Agent/Gemini/Request.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Request.hs
@@ -7,7 +7,10 @@ module Agent.Gemini.Request
     ) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Json (RawJson, rawJsonBytes)
+import qualified Agent.Json.Decode as Json
 import Agent.Responses.Types
+import Agent.Responses.Types.Content (responseContentPartDecoder)
 import Control.Applicative ((<|>))
 import Control.Monad (foldM)
 import Data.Aeson
@@ -279,12 +282,18 @@ projectCustomToolOutput projection callOutput =
 
 projectFunctionOutput :: Projection -> FunctionCallOutput -> Projection
 projectFunctionOutput projection callOutput =
-    appendContent "user" [part] projection
+    appendContent "user" (part : imageContent) projection
   where
     callName = fromMaybe "tool"
         (callOutput.name
             <|> Map.lookup callOutput.callId projection.callNames)
-    result = toJSON callOutput.output
+    -- A canonical image-bearing result is not ordinary JSON tool data:
+    -- send its ordered content as native user parts, never base64 in response
+    -- text. Keep the function response itself for call/result association.
+    (result, imageContent) = case toolImageContent callOutput.output of
+        Just parts ->
+            (String "Tool result content follows.", parts)
+        Nothing -> (toJSON callOutput.output, [])
     responseObject = case result of
         Object objectValue -> Object objectValue
         value -> object ["result" .= value]
@@ -295,6 +304,23 @@ projectFunctionOutput projection callOutput =
             , "response" .= responseObject
             ]
         ]
+
+toolImageContent :: RawJson -> Maybe [Value]
+toolImageContent raw =
+    case Json.decodeEither decoder (rawJsonBytes raw) of
+        Right parts | any fst parts -> Just (concatMap (project . snd) parts)
+        _ -> Nothing
+  where
+    decoder = Json.list (Json.withOwnedRawJson \bytes -> pure
+        ( Json.decodeEither (Json.object (Json.atKey "type" Json.text)) bytes
+            == Right "input_image"
+        , Json.decodeEither responseContentPartDecoder bytes
+        ))
+    -- Classify by the tag independently of decoding the payload so malformed
+    -- image-only results cannot fall back to raw JSON containing image bytes.
+    project (Right part@InputImagePart{}) = contentPart part
+    project (Right part@InputTextPart{}) = contentPart part
+    project _ = [textPart "[Unsupported tool result content omitted]"]
 
 appendContent :: Text -> [Value] -> Projection -> Projection
 appendContent _ [] projection = projection

--- a/packages/agent-gemini/test/Agent/Gemini/RequestSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/RequestSpec.hs
@@ -4,6 +4,8 @@ import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Gemini.Request
 import Agent.Responses.Types
 import Data.Aeson (Value(..), object, (.=))
+import qualified Data.Aeson as Aeson
+import Agent.Json (rawJsonFromEncoding)
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Set as Set
@@ -12,6 +14,76 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Gemini request projection" do
+    it "projects Claude tool-result images as ordered native parts, not JSON text" do
+        let parts =
+                [ InputTextPart "before" Nothing
+                , InputImagePart Nothing Nothing
+                    (Just "data:image/png;base64,cG5nLWJ5dGVz") Nothing
+                , InputTextPart "after" Nothing
+                ]
+            output = FunctionCallOutputItem FunctionCallOutput
+                { localOutcome = Nothing, itemId = Nothing
+                , callId = "claude-image-read", name = Just "Read"
+                , namespace = Nothing, provider = Just "claude-code"
+                , output = rawJsonFromEncoding (Aeson.toEncoding parts)
+                , status = Just ItemCompleted, async = Nothing
+                }
+            params :: ResponseCreateParams
+            params = defaultResponseCreateParams
+                { input = Just (ResponseInputItems [output]) }
+        fmap (.requestBody) (buildRequest "gemini-test" params)
+            `shouldBe` Right (object
+                [ "contents" .= [object
+                    [ "role" .= ("user" :: Text)
+                    , "parts" .=
+                        [ object ["functionResponse" .= object
+                            [ "id" .= ("claude-image-read" :: Text)
+                            , "name" .= ("Read" :: Text)
+                            , "response" .= object
+                                ["result" .= ("Tool result content follows." :: Text)]
+                            ]]
+                        , object ["text" .= ("before" :: Text)]
+                        , object ["inlineData" .= object
+                            [ "mimeType" .= ("image/png" :: Text)
+                            , "data" .= ("cG5nLWJ5dGVz" :: Text)
+                            ]]
+                        , object ["text" .= ("after" :: Text)]
+                        ]
+                    ]]
+                ])
+
+    it "omits malformed image-only tool results instead of exposing raw image JSON" do
+        let malformed = [object
+                [ "type" .= ("input_image" :: Text)
+                , "image_url" .= object
+                    ["url" .= ("data:image/png;base64,cG5nLWJ5dGVz" :: Text)]
+                ]]
+            output = FunctionCallOutputItem FunctionCallOutput
+                { localOutcome = Nothing, itemId = Nothing
+                , callId = "malformed-image", name = Just "Read"
+                , namespace = Nothing, provider = Just "claude-code"
+                , output = rawJsonFromEncoding (Aeson.toEncoding malformed)
+                , status = Just ItemCompleted, async = Nothing
+                }
+            params :: ResponseCreateParams
+            params = defaultResponseCreateParams
+                { input = Just (ResponseInputItems [output]) }
+        fmap (.requestBody) (buildRequest "gemini-test" params)
+            `shouldBe` Right (object
+                [ "contents" .= [object
+                    [ "role" .= ("user" :: Text)
+                    , "parts" .=
+                        [ object ["functionResponse" .= object
+                            [ "id" .= ("malformed-image" :: Text)
+                            , "name" .= ("Read" :: Text)
+                            , "response" .= object
+                                ["result" .= ("Tool result content follows." :: Text)]
+                            ]]
+                        , object ["text" .= ("[Unsupported tool result content omitted]" :: Text)]
+                        ]
+                    ]]
+                ])
+
     it "projects instructions, user text, and model normalization" do
         let params = defaultResponseCreateParams
                 { model = Just " models/gemini-test "

--- a/packages/agent-openrouter/test/Agent/OpenRouter/RequestSpec.hs
+++ b/packages/agent-openrouter/test/Agent/OpenRouter/RequestSpec.hs
@@ -31,6 +31,38 @@ spec = do
             mapModel options "gpt-4o" `shouldBe` "openai/gpt-5.1"
 
     describe "buildRequest" do
+        it "keeps Claude tool-result images as ordered typed content" do
+            let parts =
+                    [ InputTextPart "before" Nothing
+                    , InputImagePart Nothing Nothing
+                        (Just "data:image/png;base64,cG5nLWJ5dGVz") Nothing
+                    , InputTextPart "after" Nothing
+                    ]
+                output = FunctionCallOutputItem FunctionCallOutput
+                    { localOutcome = Nothing
+                    , itemId = Nothing
+                    , callId = "claude-image-read"
+                    , name = Nothing
+                    , namespace = Nothing
+                    , provider = Just "claude-code"
+                    , output = rawJsonFromEncoding (Aeson.toEncoding parts)
+                    , status = Just ItemCompleted
+                    , async = Nothing
+                    }
+                params :: ResponseCreateParams
+                params = sampleRequest
+                    { input = Just (ResponseInputItems [output]) }
+            object <- expectObject (requestValue defaultClientOptions params)
+            items <- expectArray (KeyMap.lookup "input" object)
+            case items of
+                [item] -> do
+                    wireOutput <- expectObject item
+                    KeyMap.lookup "call_id" wireOutput
+                        `shouldBe` Just (Aeson.String "claude-image-read")
+                    KeyMap.lookup "output" wireOutput
+                        `shouldBe` Just (Aeson.toJSON parts)
+                other -> expectationFailure ("unexpected input: " <> show other)
+
         it "forces a stateless streaming Responses request" do
             let value = requestValue defaultClientOptions sampleRequest
             object <- expectObject value

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/MessageParser.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/MessageParser.hs
@@ -15,6 +15,8 @@ import Claude.Agent.SDK.Types
 import Control.Monad (join)
 import qualified Data.Aeson.Encoding as Aeson
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Base64 as Base64
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe)
@@ -306,7 +308,46 @@ toolResultContentDecoder = do
     pure ToolResultContent
         { raw
         , renderedText = renderToolResultBytes (rawJsonBytes raw)
+        , blocks = either (const [ToolResultText "[unavailable tool result]"]) id
+            (Json.decodeEither toolResultPartsDecoder (rawJsonBytes raw))
         }
+
+-- Decode the owned value, not the already-consumed Hermes array tape.
+-- Each image is isolated so a malformed sibling cannot discard good images.
+toolResultPartsDecoder :: Json.Decoder [ToolResultPart]
+toolResultPartsDecoder = Json.withType \case
+    Json.VArray -> concat <$> Json.list toolResultPartsDecoder
+    Json.VObject -> Json.withOwnedRawJson \bytes -> pure
+        [case Json.decodeEither toolResultImageDecoder bytes of
+            Right (Just image) -> image
+            _ -> ToolResultText (renderToolResultBlock bytes)]
+    _ -> (\text -> [ToolResultText text]) <$> renderedToolResultDecoder
+
+toolResultImageDecoder :: Json.Decoder (Maybe ToolResultPart)
+toolResultImageDecoder = Json.object do
+    blockType <- optionalText "type"
+    source <- join <$> optionalTyped "source" imageSourceDecoder
+    pure $ if blockType == Just "image" then source else Nothing
+
+imageSourceDecoder :: Json.Decoder (Maybe ToolResultPart)
+imageSourceDecoder = Json.withType \case
+    Json.VObject -> Json.object do
+        sourceType <- optionalText "type"
+        mime <- optionalText "media_type"
+        encoded <- optionalText "data"
+        pure do
+            "base64" <- sourceType
+            mediaType <- mime
+            if mediaType `elem` ["image/png", "image/jpeg", "image/gif", "image/webp"]
+                then pure ()
+                else Nothing
+            dataText <- encoded
+            imageBytes <- either (const Nothing) Just
+                (Base64.decode (TextEncoding.encodeUtf8 dataText))
+            if ByteString.null imageBytes
+                then Nothing
+                else Just ToolResultImage{mediaType, imageBytes}
+    _ -> pure Nothing
 
 renderToolResultBytes :: ByteString -> Text
 renderToolResultBytes bytes =
@@ -345,11 +386,11 @@ toolResultBlockDecoder = Json.object do
     toolName <- optionalNonEmptyText "tool_name"
     mediaType <- join <$> optionalTyped "source" imageSourceMediaTypeDecoder
     pure case (blockType, textValue) of
+        (Just "image", _) ->
+            Just ("[image" <> maybe "" (" " <>) mediaType <> "]")
         (_, Just text) -> Just text
         (Just "tool_reference", Nothing) ->
             ("Tool reference: " <>) <$> toolName
-        (Just "image", Nothing) ->
-            Just ("[image" <> maybe "" (" " <>) mediaType <> "]")
         _ -> Nothing
 
 imageSourceMediaTypeDecoder :: Json.Decoder (Maybe Text)

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Types.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Types.hs
@@ -15,6 +15,7 @@ module Claude.Agent.SDK.Types
     , UserContentBlock(..)
     , ContentBlock(..)
     , ToolResultContent(..)
+    , ToolResultPart(..)
     , StreamToolUse(..)
     , OpaqueMessage(..)
     , UserMessage(..)
@@ -277,12 +278,26 @@ data ContentBlock
         }
     deriving (Eq, Show)
 
--- | Opaque tool-result JSON plus the protocol-specific text projection used
--- for loop events and persisted tool output.
+-- | Opaque wire JSON, a display projection, and ordered typed content for
+-- persistence and model input. Image payloads never belong in display text.
 data ToolResultContent = ToolResultContent
     { raw :: !RawJson
     , renderedText :: !Text
+    , blocks :: ![ToolResultPart]
     } deriving (Eq, Show)
+
+data ToolResultPart
+    = ToolResultText !Text
+    | ToolResultImage
+        { mediaType :: !Text
+        , imageBytes :: !ByteString
+        }
+    deriving (Eq)
+
+instance Show ToolResultPart where
+    show (ToolResultText text) = "ToolResultText " <> show text
+    show ToolResultImage{mediaType} =
+        "ToolResultImage " <> show mediaType <> " <redacted>"
 
 data StreamToolUse = StreamToolUse
     { toolUseId :: !Text

--- a/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/MessageParserSpec.hs
+++ b/packages/claude-agent-sdk-haskell/test/Claude/Agent/SDK/MessageParserSpec.hs
@@ -73,6 +73,46 @@ spec = describe "decodeMessageLine" do
             renderedTextOf block `shouldBe`
                 Just "{\"type\":\"mystery\",\"value\":2}"
 
+        it "preserves typed images and surrounding text in wire order" do
+            block <- decodeToolResult
+                "[{\"type\":\"text\",\"text\":\"before\"},\
+                \{\"type\":\"image\",\"source\":{\"type\":\"base64\",\
+                \\"media_type\":\"image/png\",\"data\":\"b25l\"}},\
+                \{\"type\":\"text\",\"text\":\"between\"},\
+                \{\"type\":\"image\",\"source\":{\"type\":\"base64\",\
+                \\"media_type\":\"image/jpeg\",\"data\":\"dHdv\"}},\
+                \{\"type\":\"text\",\"text\":\"after\"}]"
+            fmap (.blocks) block.content `shouldBe` Just
+                [ ToolResultText "before"
+                , ToolResultImage "image/png" "one"
+                , ToolResultText "between"
+                , ToolResultImage "image/jpeg" "two"
+                , ToolResultText "after"
+                ]
+            renderedTextOf block `shouldBe`
+                Just "before\n[image image/png]\nbetween\n[image image/jpeg]\nafter"
+
+        it "isolates invalid image sources without exposing their payloads" do
+            mapM_ (\source -> do
+                block <- decodeToolResult $
+                    "[{\"type\":\"image\",\"source\":" <> source <> "},"
+                        <> "{\"type\":\"image\",\"source\":{\"type\":\"base64\","
+                        <> "\"media_type\":\"image/webp\",\"data\":\"b2s=\"}}]"
+                case fmap (.blocks) block.content of
+                    Just [ToolResultText label, ToolResultImage "image/webp" "ok"] ->
+                        label `shouldSatisfy` \text -> text == "[image]"
+                            || text == "[image image/png]"
+                            || text == "[image image/svg+xml]"
+                    other -> expectationFailure (show other)
+                ) [ "{\"type\":\"base64\",\"media_type\":\"image/png\",\"data\":\"!secret!\"}"
+                  , "{\"type\":\"base64\",\"media_type\":\"image/png\",\"data\":\"\"}"
+                  , "{\"type\":\"base64\",\"media_type\":\"image/svg+xml\",\"data\":\"c2VjcmV0\"}"
+                  , "{\"type\":\"url\",\"media_type\":\"image/png\",\"url\":\"https://secret.invalid\"}"
+                  , "{\"type\":\"base64\",\"media_type\":7,\"data\":\"c2VjcmV0\"}"
+                  , "null"
+                  , "[]"
+                  ]
+
         it "renders mixed arrays including scalars and nested arrays" do
             block <- decodeToolResult
                 "[\"plain\",7,true,null,[{\"type\":\"text\",\"text\":\"deep\"}]]"


### PR DESCRIPTION
## Summary
- Preserve successful Claude SDK tool-result images as validated, ordered typed content instead of persisting only `[image …]` display text.
- Import canonical tool-result images into fresh Claude sessions as native image blocks; retain legacy text/JSON outputs and safely omit malformed image parts.
- Project image-bearing tool results into Gemini native image parts while retaining function-call association; cover existing Responses/OpenRouter conversion and session storage round trips.

Image bytes are never dumped as raw JSON prompt text. SDK parsing uses owned Hermes input, supported image MIME types, and validated nonempty base64. Display output remains safe text.

Scope: audited bug #2 (tool-result images) only. Builds on the merged historical user-image work in #1073. No concurrency or UI changes.

## Validation
GHCi/Hspec in the Nix development environment, using `cabal repl` test targets:
- Claude SDK full suite: 104 examples, 0 failures
- Claude backend full suite: 74 examples, 0 failures, including fresh-session image replay and malformed/legacy output regressions
- Gemini full suite: 55 examples, 0 failures
- OpenRouter request conversion suite: 15 examples, 0 failures
- Runtime session compatibility/storage regressions: 19 examples, 0 failures

`git diff --check`
