### PR TITLE
Preserve completed tool results across interrupted turns

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/Runtime/TurnState.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/TurnState.hs
@@ -424,8 +424,8 @@ inputOnlyTurnItems = turnInputsToItems . (.preparedTurnInputs)
 -- Tool calls left without a result are closed with a synthetic output that
 -- states the abort reason. After a user cancel such a call may never have
 -- started or may have been stopped mid-run, so the output says it was
--- interrupted rather than claiming it never ran; a failure before tool
--- execution reports that the call was not executed. A user-initiated cancel
+-- interrupted rather than claiming it never ran; failures without a recorded
+-- completion likewise have unknown outcomes. A user-initiated cancel
 -- also appends 'turnAbortedNote' so the next request explains the gap.
 --
 -- While nothing committed — or when the committed state no longer extends
@@ -518,8 +518,9 @@ abortedToolOutput abort call =
                     <> "It was not run, or was stopped before finishing and "
                     <> "may have partially executed."
             TurnAbortedByFailure reason ->
-                "Tool `" <> call.name <> "` was not executed: "
-                    <> reason <> "."
+                "Tool `" <> call.name <> "` was interrupted: "
+                    <> reason <> ". No completed result was recorded; "
+                    <> "its outcome is unknown and it may have partially executed."
         , callKind = call.callKind
         , toolResultMode = BlockingToolCall
         , toolResultImages = []

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec/Persistence.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec/Persistence.hs
@@ -10,6 +10,7 @@ import Agent.Dialect (DialectId(..))
 import Agent.Loop (TokenUsage(..))
 import Agent.Provider (Provider(..))
 import Agent.Responses.Types
+import Agent.Runtime.TurnStateSpec (managedRecoveryRoundTrip)
 import Agent.Store.Postgres (trustedPool)
 import qualified Agent.Store.Postgres.Session as Store
 import Agent.Tools.TaskPlan
@@ -34,6 +35,13 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "interrupted tool recovery persistence" do
+        it "persists completed batch results and resumes without rerunning them after cancellation" $
+            managedRecoveryRoundTrip persistRecovery False
+
+        it "persists attributed precommit work and resumes without replaying failed provider output" $
+            managedRecoveryRoundTrip persistRecovery True
+
     describe "PostgreSQL session persistence" do
         it "materializes and round-trips task plans through persistence hooks" $
             withTempStore \store root -> do
@@ -1039,3 +1047,25 @@ spec = do
                 _ <- newActivePersistence handle
                 doesDirectoryExist handle.sessionTempDir `shouldReturn` True
                 modeOf handle.sessionTempDir `shouldReturn` 0o700
+
+persistRecovery :: [ResponseItem] -> [ResponseItem] -> IO [ResponseItem]
+persistRecovery items displayItems =
+    withTempStore \store root -> do
+        handle <- createSession (testCreate (trustedPool store) root)
+        let persisted = SessionTurn
+                { turnAt = fixedTime
+                , turnUserText = "fix it"
+                , turnAssistantText = Nothing
+                , turnError = Just "interrupted"
+                , turnResponseId = Nothing
+                , turnItems = items
+                , turnDisplayItems = displayItems
+                , turnUsage = Nothing
+                , turnEffect = TranscriptAppend
+                , turnProviderTelemetry = []
+                }
+        saved <- appendTurn handle persisted
+        (_, turns) <- loadSessionHandle (trustedPool store) root saved.sessionMeta.metaId
+            >>= either (fail . Text.unpack) pure
+        turns `shouldBe` [persisted]
+        pure (concatMap (.turnItems) turns)

--- a/packages/agent-cli-runtime/test/Agent/Runtime/TurnStateSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/Runtime/TurnStateSpec.hs
@@ -1,23 +1,39 @@
 module Agent.Runtime.TurnStateSpec (spec) where
 
 import Agent.Error (ApiError(..))
+import Agent.Cancel (newCancelFlag, requestCancel)
+import Agent.CLI.Session
+import Agent.CLI.SessionSpec.Fixtures (fixedTime, testCreate, withTempStore)
+import Agent.Json (rawJsonBytes)
+import qualified Agent.Json.Decode as Json
 import Agent.Loop
-    ( LoopError(..)
-    , LoopEvent(..)
-    , LoopExecution(..)
-    , LoopProgress(..)
-    , TokenUsage(..)
-    , TurnInput(..)
-    )
 import Agent.Responses.LoopBackend (toolResultToItem, turnInputsToItems)
-import Agent.Responses.Types (ResponseItem)
+import Agent.Responses.Types
+import Agent.Responses.Types.Items (responseItemDecoder)
 import Agent.Runtime.Compaction (AutomaticCompactionBoundary(..))
 import Agent.Runtime.TurnState
-import Agent.ToolDispatch (ToolCallKind(..), ToolCallMode(..), ToolCallResult(..))
+import Agent.Store.Postgres (trustedPool)
+import Agent.ToolDispatch
+import Agent.Tools.Types
+    ( AppTool, ApprovalRule(..), ToolExecutionPolicy(..)
+    , jsonAppToolWithExecution, mkToolRegistry, withAsyncToolCalls
+    )
+import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, threadDelay, tryReadMVar)
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Exception.Safe (finally)
+import Data.IORef
+import qualified Data.Text as Text
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
 spec = describe "frontend-neutral turn policy" do
+    it "persists completed batch results and resumes without rerunning them after cancellation" $
+        managedRecoveryRoundTrip False
+
+    it "persists attributed precommit work and resumes without replaying failed provider output" $
+        managedRecoveryRoundTrip True
+
     it "keeps failed streamed output out of retryable model inputs" do
         let execution = failedExecution
                 { executionUncommittedAssistantText = Just "partial answer"
@@ -129,3 +145,154 @@ failedExecution = LoopExecution
     , executionProviderTelemetry = []
     , executionResult = Left (LoopTransport (ConnectionError "offline"))
     }
+
+-- These exercise the real manager, frontend interruption policy, PostgreSQL
+-- codecs and a new loop/state store reconstructed solely from persisted turns.
+managedRecoveryRoundTrip :: Bool -> IO ()
+managedRecoveryRoundTrip precommit =
+    withTempStore \store root -> do
+        blocked <- newEmptyMVar
+        joined <- newEmptyMVar
+        invocations <- newIORef (0 :: Int)
+        let mode = if precommit then AsyncToolCall else BlockingToolCall
+            first = withToolCallMode mode (functionToolCall "saved" "save" "{}")
+            second = withToolCallMode mode (functionToolCall "blocked" "block" "{}")
+            -- TurnSequential makes B's start a deterministic acknowledgement
+            -- that A has completed through the manager, not only the UI.
+            makeTool name action =
+                (if precommit then withAsyncToolCalls else id) $
+                    jsonAppToolWithExecution name "" [] AlwaysReadOnly
+                        TurnSequential (noArgsTool name action)
+            tools =
+                [ makeTool "save" do
+                    modifyIORef' invocations (+ 1)
+                    pure (Right "file saved exactly once")
+                , makeTool "block" $
+                    (putMVar blocked () >> threadDelay maxBound
+                        >> pure (Right "must not finish"))
+                        `finally` putMVar joined ()
+                ]
+            backend = backendWithCallbacks \state _ inputs callbacks ->
+                if precommit
+                    then do
+                        callbacks.onAsyncToolCall first
+                        callbacks.onAsyncToolCall second
+                        await "blocked precommit tool" (takeMVar blocked)
+                        callbacks.onLoopEvent (TextDelta "untrusted unfinished answer")
+                        pure (Left (ConnectionError "stream failed before commit"))
+                    else pure $ Right BackendResult
+                        { backendOutput =
+                            emptyTurnOutput "committed-tools" [first, second] Nothing
+                        , backendState = advanceBackendSnapshot state
+                            (state.backendItems <> turnInputsToItems inputs
+                                <> recoveryCallItems) Nothing
+                        }
+        config <- recoveryConfig backend tools history
+        execution <- if precommit
+            then await "failed provider cleanup"
+                (runLoopInputsDetailed config Nothing prepared.preparedTurnInputs)
+            else withAsync
+                (runLoopInputsDetailed config Nothing prepared.preparedTurnInputs)
+                \running -> do
+                    await "blocked committed tool" (takeMVar blocked)
+                    requestCancel config.loopCancel
+                    await "cancelled tool cleanup" (wait running)
+        tryReadMVar joined `shouldReturn` Just ()
+        readIORef invocations `shouldReturn` 1
+        let abort = if precommit
+                then TurnAbortedByFailure "offline"
+                else TurnAbortedByUser
+            retained = interruptedTurnItems prepared execution abort
+            updated = applyConversationPatch
+                (finishConversation prepared (ConversationFailed retained))
+                runningState
+        updated.conversationPreviousResponseId `shouldBe` Nothing
+        show retained `shouldNotContain` "untrusted unfinished answer"
+        if precommit
+            then do
+                show retained `shouldContain` "file saved exactly once"
+                retained `shouldSatisfy` all (\case MessageItem{} -> True; _ -> False)
+                show retained `shouldContain` "saved"
+                show retained `shouldContain` "blocked"
+                show retained `shouldContain` "save"
+                show retained `shouldContain` "unknown outcomes"
+                show retained `shouldNotContain` "was not executed"
+            else do
+                let outputs = [output | FunctionCallOutputItem output <- retained]
+                map (.callId) outputs `shouldBe` ["saved", "blocked"]
+                case outputs of
+                    [saved, unfinished] -> do
+                        Json.decodeEither Json.text (rawJsonBytes saved.output)
+                            `shouldBe` Right "file saved exactly once"
+                        saved.localOutcome `shouldBe` Just ToolSucceeded
+                        case Json.decodeEither Json.text (rawJsonBytes unfinished.output) of
+                            Left err -> expectationFailure (show err)
+                            Right text -> do
+                                text `shouldSatisfy` (not . Text.isInfixOf "was not executed")
+                                text `shouldSatisfy` Text.isInfixOf "partially"
+                    _ -> expectationFailure "expected exactly one output per tool"
+        handle <- createSession (testCreate (trustedPool store) root)
+        let persisted = SessionTurn
+                { turnAt = fixedTime
+                , turnUserText = "fix it"
+                , turnAssistantText = Nothing
+                , turnError = Just "interrupted"
+                , turnResponseId = Nothing
+                , turnItems = updated.conversationTranscript
+                , turnDisplayItems = uncommittedDisplayItems execution
+                , turnUsage = Nothing
+                , turnEffect = TranscriptAppend
+                , turnProviderTelemetry = []
+                }
+        saved <- appendTurn handle persisted
+        (_, turns) <- loadSessionHandle (trustedPool store) root saved.sessionMeta.metaId
+            >>= either (fail . Text.unpack) pure
+        turns `shouldBe` [persisted]
+        let restored = concatMap (.turnItems) turns
+        restored `shouldBe` updated.conversationTranscript
+        seen <- newIORef []
+        let resumed = Backend \state previous inputs _ -> do
+                previous `shouldBe` Nothing
+                inputs `shouldBe` [UserMessage "go"]
+                writeIORef seen state.backendItems
+                pure $ Right BackendResult
+                    { backendOutput = emptyTurnOutput "resumed" [] (Just "verified saved file")
+                    , backendState = advanceBackendSnapshot state
+                        (state.backendItems <> turnInputsToItems inputs) Nothing
+                    }
+        resumeConfig <- recoveryConfig resumed tools restored
+        continued <- runLoopInputsDetailed resumeConfig Nothing [UserMessage "go"]
+        continued.executionResult `shouldSatisfy` either (const False) (const True)
+        readIORef seen `shouldReturn` restored
+        readIORef invocations `shouldReturn` 1
+
+recoveryConfig :: Backend -> [AppTool] -> [ResponseItem] -> IO LoopConfig
+recoveryConfig backend tools items = do
+    cancel <- newCancelFlag
+    state <- newIORef (advanceBackendSnapshot emptyBackendSnapshot items Nothing)
+    registry <- either (fail . Text.unpack) pure (mkToolRegistry tools)
+    pure LoopConfig
+        { loopBackend = backend
+        , loopBackendState = BackendStateStore
+            { readBackendState = readIORef state
+            , commitBackendState = \snapshot -> writeIORef state snapshot >> pure snapshot
+            }
+        , loopTools = registry
+        , loopDispatch = defaultLoopDispatch
+        , loopMaxTurns = defaultLoopMaxTurns
+        , loopOnEvent = const (pure ())
+        , loopApprove = const (pure (Right True))
+        , loopReadSteering = pure []
+        , loopCommitSteering = const (pure ())
+        , loopInterrupt = pure ()
+        , loopCancel = cancel
+        }
+
+recoveryCallItems :: [ResponseItem]
+recoveryCallItems = either (error . show) id $
+    Json.decodeEither (Json.list responseItemDecoder)
+        "[{\"type\":\"function_call\",\"call_id\":\"saved\",\"name\":\"save\",\"arguments\":\"{}\"},{\"type\":\"function_call\",\"call_id\":\"blocked\",\"name\":\"block\",\"arguments\":\"{}\"}]"
+
+await :: String -> IO a -> IO a
+await label action = timeout 5000000 action
+    >>= maybe (fail ("timed out waiting for " <> label)) pure

--- a/packages/agent-cli-runtime/test/Agent/Runtime/TurnStateSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/Runtime/TurnStateSpec.hs
@@ -1,9 +1,7 @@
-module Agent.Runtime.TurnStateSpec (spec) where
+module Agent.Runtime.TurnStateSpec (spec, managedRecoveryRoundTrip) where
 
 import Agent.Error (ApiError(..))
 import Agent.Cancel (newCancelFlag, requestCancel)
-import Agent.CLI.Session
-import Agent.CLI.SessionSpec.Fixtures (fixedTime, testCreate, withTempStore)
 import Agent.Json (rawJsonBytes)
 import qualified Agent.Json.Decode as Json
 import Agent.Loop
@@ -12,7 +10,6 @@ import Agent.Responses.Types
 import Agent.Responses.Types.Items (responseItemDecoder)
 import Agent.Runtime.Compaction (AutomaticCompactionBoundary(..))
 import Agent.Runtime.TurnState
-import Agent.Store.Postgres (trustedPool)
 import Agent.ToolDispatch
 import Agent.Tools.Types
     ( AppTool, ApprovalRule(..), ToolExecutionPolicy(..)
@@ -28,12 +25,6 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "frontend-neutral turn policy" do
-    it "persists completed batch results and resumes without rerunning them after cancellation" $
-        managedRecoveryRoundTrip False
-
-    it "persists attributed precommit work and resumes without replaying failed provider output" $
-        managedRecoveryRoundTrip True
-
     it "keeps failed streamed output out of retryable model inputs" do
         let execution = failedExecution
                 { executionUncommittedAssistantText = Just "partial answer"
@@ -146,125 +137,112 @@ failedExecution = LoopExecution
     , executionResult = Left (LoopTransport (ConnectionError "offline"))
     }
 
--- These exercise the real manager, frontend interruption policy, PostgreSQL
--- codecs and a new loop/state store reconstructed solely from persisted turns.
-managedRecoveryRoundTrip :: Bool -> IO ()
-managedRecoveryRoundTrip precommit =
-    withTempStore \store root -> do
-        blocked <- newEmptyMVar
-        joined <- newEmptyMVar
-        invocations <- newIORef (0 :: Int)
-        let mode = if precommit then AsyncToolCall else BlockingToolCall
-            first = withToolCallMode mode (functionToolCall "saved" "save" "{}")
-            second = withToolCallMode mode (functionToolCall "blocked" "block" "{}")
-            -- TurnSequential makes B's start a deterministic acknowledgement
-            -- that A has completed through the manager, not only the UI.
-            makeTool name action =
-                (if precommit then withAsyncToolCalls else id) $
-                    jsonAppToolWithExecution name "" [] AlwaysReadOnly
-                        TurnSequential (noArgsTool name action)
-            tools =
-                [ makeTool "save" do
-                    modifyIORef' invocations (+ 1)
-                    pure (Right "file saved exactly once")
-                , makeTool "block" $
-                    (putMVar blocked () >> threadDelay maxBound
-                        >> pure (Right "must not finish"))
-                        `finally` putMVar joined ()
-                ]
-            backend = backendWithCallbacks \state _ inputs callbacks ->
-                if precommit
-                    then do
-                        callbacks.onAsyncToolCall first
-                        callbacks.onAsyncToolCall second
-                        await "blocked precommit tool" (takeMVar blocked)
-                        callbacks.onLoopEvent (TextDelta "untrusted unfinished answer")
-                        pure (Left (ConnectionError "stream failed before commit"))
-                    else pure $ Right BackendResult
-                        { backendOutput =
-                            emptyTurnOutput "committed-tools" [first, second] Nothing
-                        , backendState = advanceBackendSnapshot state
-                            (state.backendItems <> turnInputsToItems inputs
-                                <> recoveryCallItems) Nothing
-                        }
-        config <- recoveryConfig backend tools history
-        execution <- if precommit
-            then await "failed provider cleanup"
-                (runLoopInputsDetailed config Nothing prepared.preparedTurnInputs)
-            else withAsync
-                (runLoopInputsDetailed config Nothing prepared.preparedTurnInputs)
-                \running -> do
-                    await "blocked committed tool" (takeMVar blocked)
-                    requestCancel config.loopCancel
-                    await "cancelled tool cleanup" (wait running)
-        tryReadMVar joined `shouldReturn` Just ()
-        readIORef invocations `shouldReturn` 1
-        let abort = if precommit
-                then TurnAbortedByFailure "offline"
-                else TurnAbortedByUser
-            retained = interruptedTurnItems prepared execution abort
-            updated = applyConversationPatch
-                (finishConversation prepared (ConversationFailed retained))
-                runningState
-        updated.conversationPreviousResponseId `shouldBe` Nothing
-        show retained `shouldNotContain` "untrusted unfinished answer"
-        if precommit
-            then do
-                show retained `shouldContain` "file saved exactly once"
-                retained `shouldSatisfy` all (\case MessageItem{} -> True; _ -> False)
-                show retained `shouldContain` "saved"
-                show retained `shouldContain` "blocked"
-                show retained `shouldContain` "save"
-                show retained `shouldContain` "unknown outcomes"
-                show retained `shouldNotContain` "was not executed"
-            else do
-                let outputs = [output | FunctionCallOutputItem output <- retained]
-                map (.callId) outputs `shouldBe` ["saved", "blocked"]
-                case outputs of
-                    [saved, unfinished] -> do
-                        Json.decodeEither Json.text (rawJsonBytes saved.output)
-                            `shouldBe` Right "file saved exactly once"
-                        saved.localOutcome `shouldBe` Just ToolSucceeded
-                        case Json.decodeEither Json.text (rawJsonBytes unfinished.output) of
-                            Left err -> expectationFailure (show err)
-                            Right text -> do
-                                text `shouldSatisfy` (not . Text.isInfixOf "was not executed")
-                                text `shouldSatisfy` Text.isInfixOf "partially"
-                    _ -> expectationFailure "expected exactly one output per tool"
-        handle <- createSession (testCreate (trustedPool store) root)
-        let persisted = SessionTurn
-                { turnAt = fixedTime
-                , turnUserText = "fix it"
-                , turnAssistantText = Nothing
-                , turnError = Just "interrupted"
-                , turnResponseId = Nothing
-                , turnItems = updated.conversationTranscript
-                , turnDisplayItems = uncommittedDisplayItems execution
-                , turnUsage = Nothing
-                , turnEffect = TranscriptAppend
-                , turnProviderTelemetry = []
-                }
-        saved <- appendTurn handle persisted
-        (_, turns) <- loadSessionHandle (trustedPool store) root saved.sessionMeta.metaId
-            >>= either (fail . Text.unpack) pure
-        turns `shouldBe` [persisted]
-        let restored = concatMap (.turnItems) turns
-        restored `shouldBe` updated.conversationTranscript
-        seen <- newIORef []
-        let resumed = Backend \state previous inputs _ -> do
-                previous `shouldBe` Nothing
-                inputs `shouldBe` [UserMessage "go"]
-                writeIORef seen state.backendItems
-                pure $ Right BackendResult
-                    { backendOutput = emptyTurnOutput "resumed" [] (Just "verified saved file")
+-- Exercise the real manager and interruption policy, then resume solely from
+-- the supplied persistence adapter's restored transcript. The adapter belongs
+-- to the session integration specs so this kernel fixture stays frontend-neutral.
+managedRecoveryRoundTrip
+    :: ([ResponseItem] -> [ResponseItem] -> IO [ResponseItem])
+    -> Bool
+    -> IO ()
+managedRecoveryRoundTrip roundTrip precommit = do
+    blocked <- newEmptyMVar
+    joined <- newEmptyMVar
+    invocations <- newIORef (0 :: Int)
+    let mode = if precommit then AsyncToolCall else BlockingToolCall
+        first = withToolCallMode mode (functionToolCall "saved" "save" "{}")
+        second = withToolCallMode mode (functionToolCall "blocked" "block" "{}")
+        -- TurnSequential makes B's start a deterministic acknowledgement
+        -- that A has completed through the manager, not only the UI.
+        makeTool name action =
+            (if precommit then withAsyncToolCalls else id) $
+                jsonAppToolWithExecution name "" [] AlwaysReadOnly
+                    TurnSequential (noArgsTool name action)
+        tools =
+            [ makeTool "save" do
+                modifyIORef' invocations (+ 1)
+                pure (Right "file saved exactly once")
+            , makeTool "block" $
+                (putMVar blocked () >> threadDelay maxBound
+                    >> pure (Right "must not finish"))
+                    `finally` putMVar joined ()
+            ]
+        backend = backendWithCallbacks \state _ inputs callbacks ->
+            if precommit
+                then do
+                    callbacks.onAsyncToolCall first
+                    callbacks.onAsyncToolCall second
+                    await "blocked precommit tool" (takeMVar blocked)
+                    callbacks.onLoopEvent (TextDelta "untrusted unfinished answer")
+                    pure (Left (ConnectionError "stream failed before commit"))
+                else pure $ Right BackendResult
+                    { backendOutput =
+                        emptyTurnOutput "committed-tools" [first, second] Nothing
                     , backendState = advanceBackendSnapshot state
-                        (state.backendItems <> turnInputsToItems inputs) Nothing
+                        (state.backendItems <> turnInputsToItems inputs
+                            <> recoveryCallItems) Nothing
                     }
-        resumeConfig <- recoveryConfig resumed tools restored
-        continued <- runLoopInputsDetailed resumeConfig Nothing [UserMessage "go"]
-        continued.executionResult `shouldSatisfy` either (const False) (const True)
-        readIORef seen `shouldReturn` restored
-        readIORef invocations `shouldReturn` 1
+    config <- recoveryConfig backend tools history
+    execution <- if precommit
+        then await "failed provider cleanup"
+            (runLoopInputsDetailed config Nothing prepared.preparedTurnInputs)
+        else withAsync
+            (runLoopInputsDetailed config Nothing prepared.preparedTurnInputs)
+            \running -> do
+                await "blocked committed tool" (takeMVar blocked)
+                requestCancel config.loopCancel
+                await "cancelled tool cleanup" (wait running)
+    tryReadMVar joined `shouldReturn` Just ()
+    readIORef invocations `shouldReturn` 1
+    let abort = if precommit
+            then TurnAbortedByFailure "offline"
+            else TurnAbortedByUser
+        retained = interruptedTurnItems prepared execution abort
+        updated = applyConversationPatch
+            (finishConversation prepared (ConversationFailed retained))
+            runningState
+    updated.conversationPreviousResponseId `shouldBe` Nothing
+    show retained `shouldNotContain` "untrusted unfinished answer"
+    if precommit
+        then do
+            show retained `shouldContain` "file saved exactly once"
+            retained `shouldSatisfy` all (\case MessageItem{} -> True; _ -> False)
+            show retained `shouldContain` "saved"
+            show retained `shouldContain` "blocked"
+            show retained `shouldContain` "save"
+            show retained `shouldContain` "unknown outcomes"
+            show retained `shouldNotContain` "was not executed"
+        else do
+            let outputs = [output | FunctionCallOutputItem output <- retained]
+            map (.callId) outputs `shouldBe` ["saved", "blocked"]
+            case outputs of
+                [saved, unfinished] -> do
+                    Json.decodeEither Json.text (rawJsonBytes saved.output)
+                        `shouldBe` Right "file saved exactly once"
+                    saved.localOutcome `shouldBe` Just ToolSucceeded
+                    case Json.decodeEither Json.text (rawJsonBytes unfinished.output) of
+                        Left err -> expectationFailure (show err)
+                        Right text -> do
+                            text `shouldSatisfy` (not . Text.isInfixOf "was not executed")
+                            text `shouldSatisfy` Text.isInfixOf "partially"
+                _ -> expectationFailure "expected exactly one output per tool"
+    restored <- roundTrip updated.conversationTranscript
+        (uncommittedDisplayItems execution)
+    restored `shouldBe` updated.conversationTranscript
+    seen <- newIORef []
+    let resumed = Backend \state previous inputs _ -> do
+            previous `shouldBe` Nothing
+            inputs `shouldBe` [UserMessage "go"]
+            writeIORef seen state.backendItems
+            pure $ Right BackendResult
+                { backendOutput = emptyTurnOutput "resumed" [] (Just "verified saved file")
+                , backendState = advanceBackendSnapshot state
+                    (state.backendItems <> turnInputsToItems inputs) Nothing
+                }
+    resumeConfig <- recoveryConfig resumed tools restored
+    continued <- runLoopInputsDetailed resumeConfig Nothing [UserMessage "go"]
+    continued.executionResult `shouldSatisfy` either (const False) (const True)
+    readIORef seen `shouldReturn` restored
+    readIORef invocations `shouldReturn` 1
 
 recoveryConfig :: Backend -> [AppTool] -> [ResponseItem] -> IO LoopConfig
 recoveryConfig backend tools items = do

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -504,7 +504,7 @@ spec = do
                         <> [ toolResultToItem
                                 (ToolCallResult
                                     "c-ok"
-                                    "Tool `read` was not executed: the response was cut off (max_output_tokens)."
+                                    "Tool `read` was interrupted: the response was cut off (max_output_tokens). No completed result was recorded; its outcome is unknown and it may have partially executed."
                                     FunctionCallKind BlockingToolCall [] Nothing)
                            ]
 

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -26,7 +26,7 @@ import Agent.Loop.Input
 import Agent.Loop.InputItems (turnInputsToItems)
 import Agent.Loop.Output
 import Agent.Loop.TokenUsage
-import Agent.Responses.Types (ResponseItem)
+import Agent.Responses.Types
 import Agent.Telemetry (TurnTelemetry)
 import Agent.ToolDispatch
     ( ToolCall(..)
@@ -66,11 +66,13 @@ import Control.Concurrent.STM
     , newEmptyTMVar
     , newEmptyTMVarIO
     , newTQueueIO
+    , newTVar
     , newTVarIO
     , putTMVar
     , readTMVar
     , readTQueue
     , readTVar
+    , retry
     , throwSTM
     , tryPutTMVar
     , tryReadTMVar
@@ -88,6 +90,8 @@ import Control.Exception.Safe
     , tryAny
     )
 import Control.Monad (when)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef, writeIORef)
 import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
@@ -95,8 +99,11 @@ import qualified Data.IntSet as IntSet
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Data.Maybe (catMaybes)
+import Data.List (sortOn)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 import System.Timeout (timeout)
 
 maxEmptyContinuations :: Int
@@ -304,6 +311,7 @@ data LoopRuntime = LoopRuntime
     , loopRuntimeAsyncToolManager :: Maybe AsyncToolManager
     , loopRuntimeProgressRef :: IORef (BackendSnapshot, LoopProgress)
     , loopRuntimePendingRef :: IORef [TurnInput]
+    , loopRuntimePendingSteeringRef :: IORef Int
     , loopRuntimeUncommittedTextRef :: IORef ([[Text]], [Text])
     , loopRuntimeUncommittedDisplayEventsRef
         :: IORef DisplayJournal
@@ -340,6 +348,7 @@ initializeLoopRuntime config0 initialState firstInputs = do
     providerTelemetryRef <- newIORef []
     initialSteering <- config0.loopReadSteering
     pendingRef <- newIORef (firstInputs <> initialSteering)
+    pendingSteeringRef <- newIORef (length initialSteering)
     let config = config0
             { loopOnEvent = \event ->
                 -- Provider streaming and async host tools can publish at the
@@ -359,6 +368,7 @@ initializeLoopRuntime config0 initialState firstInputs = do
         , loopRuntimeAsyncToolManager = Nothing
         , loopRuntimeProgressRef = progressRef
         , loopRuntimePendingRef = pendingRef
+        , loopRuntimePendingSteeringRef = pendingSteeringRef
         , loopRuntimeUncommittedTextRef = uncommittedTextRef
         , loopRuntimeUncommittedDisplayEventsRef =
             uncommittedDisplayEventsRef
@@ -496,6 +506,7 @@ runLoopCursor runtime cursor = do
     writeIORef runtime.loopRuntimeProgressRef
         (cursor.cursorState, cursor.cursorProgress)
     writeIORef runtime.loopRuntimePendingRef cursor.cursorInputs
+    writeIORef runtime.loopRuntimePendingSteeringRef cursor.cursorSteeringCount
     if cursor.cursorTurnsUsed >= config.loopMaxTurns
         then finishLoopCursor runtime cursor $ case cursor.cursorLastOutput of
             Just turn -> Left (LoopMaxTurns turn)
@@ -581,10 +592,15 @@ submitLoopTurn runtime cursor = do
                                 Nothing
                         committed <-
                             config.loopBackendState.commitBackendState candidate
+                        acknowledgeManagedTools
+                            (asyncToolManager runtime)
+                            cursor.cursorInputs
+                            []
                         writeIORef runtime.loopRuntimeProgressRef
                             (committed, ResponseCommitted)
                         writeIORef runtime.loopRuntimePendingRef []
                         config.loopCommitSteering cursor.cursorSteeringCount
+                        writeIORef runtime.loopRuntimePendingSteeringRef 0
                 _ -> pure ()
     let onBackendEvent event = do
             case event of
@@ -620,9 +636,12 @@ submitLoopTurn runtime cursor = do
                     (normalizeTurnInputs cursor.cursorInputs)
                     BackendCallbacks
                         { onLoopEvent = onBackendEvent
-                        , onAsyncToolCall =
-                            admitAsyncToolCall
-                                (asyncToolManager runtime)
+                        , onAsyncToolCall = \call ->
+                            withMVar recovery \(active, _) ->
+                                when active $
+                                    admitAsyncToolCall
+                                        (asyncToolManager runtime)
+                                        call
                         , onRecoveryCheckpoint = checkpoint
                         })
             \submission -> do
@@ -652,6 +671,10 @@ submitLoopTurn runtime cursor = do
                             committed <-
                                 config.loopBackendState.commitBackendState
                                     backendState
+                            acknowledgeManagedTools
+                                (asyncToolManager runtime)
+                                cursor.cursorInputs
+                                backendOutput.toolCalls
                             writeIORef runtime.loopRuntimeProgressRef
                                 (committed, ResponseCommitted)
                             pure
@@ -723,6 +746,7 @@ continueCommittedLoop runtime cursor turn = do
                             (Left (LoopIncomplete turn))
                     TurnCompleted -> do
                         config.loopCommitSteering cursor.cursorSteeringCount
+                        writeIORef runtime.loopRuntimePendingSteeringRef 0
                         racedResults <-
                             race
                                 (waitCancel config.loopCancel)
@@ -837,6 +861,14 @@ runLoopWithEventPump runtime initialState previousResponseId firstInputs =
                                 >>= maybe
                                     (pure completed)
                                     handleManagerFailure
+        -- Only inspect outcomes once the manager scope has cancelled and
+        -- joined every worker. A result waiter can lose its race while some
+        -- of its sibling tools have already finished successfully.
+        recovered <- tryAny (recoverManagedTools managedRuntime manager execution) >>= \case
+            Right recovered -> pure recovered
+            Left exception -> do
+                (state, progress) <- readIORef runtime.loopRuntimeProgressRef
+                unexpectedLoopExecution runtime state progress exception
         flushEventPump runtime.loopRuntimeEventPump >>= \case
             Left failure ->
                 readIORef runtime.loopRuntimeProgressRef
@@ -846,7 +878,154 @@ runLoopWithEventPump runtime initialState previousResponseId firstInputs =
                             state
                             progress
                             failure
-            Right () -> pure execution
+            Right () -> pure recovered
+
+-- | A tool result is acknowledged only when the response consuming it commits,
+-- not when a waiter drains it. Keep that fact across history compaction.
+acknowledgeManagedTools :: AsyncToolManager -> [TurnInput] -> [ToolCall] -> IO ()
+acknowledgeManagedTools manager inputs calls = atomically do
+    modifyTVar' manager.asyncToolAcknowledged $
+        Set.union (Set.fromList [result.callId | CompletedTool result <- inputs])
+    modifyTVar' manager.asyncToolCommittedCalls $
+        Map.union (Map.fromList [(call.callId, call) | call <- calls])
+
+recoverManagedTools
+    :: LoopRuntime
+    -> AsyncToolManager
+    -> LoopExecution
+    -> IO LoopExecution
+recoverManagedTools runtime manager execution = do
+    (records, acknowledged, committedCalls) <- atomically do
+        calls <- readTVar manager.asyncToolCalls
+        records <- traverse
+            (\record -> do
+                result <- readTVar record.managedTrustedResult
+                pure (record, result))
+            (sortOn (.managedAdmissionSequence) (Map.elems calls))
+        acknowledged <- readTVar manager.asyncToolAcknowledged
+        committedCalls <- readTVar manager.asyncToolCommittedCalls
+        pure (records, acknowledged, committedCalls)
+    let unacknowledged =
+            [ (record.managedCall, result)
+            | (record, result) <- records
+            , Set.notMember record.managedCall.callId acknowledged
+            ]
+        retainedCallIds = Set.fromList (concatMap retainedCallId execution.executionState)
+        canonical call =
+            Map.lookup call.callId committedCalls == Just call
+                && Set.member call.callId retainedCallIds
+        orphanIds = Set.fromList
+            [call.callId | (call, _) <- unacknowledged, not (canonical call)]
+        safePending = filter
+            (\case
+                CompletedTool completed -> Set.notMember completed.callId orphanIds
+                _ -> True)
+            execution.executionPendingInputs
+        pendingIds = Set.fromList
+            [ result.callId
+            | CompletedTool result <- safePending
+            ]
+        salvaged =
+            [ result
+            | (call, Just result) <- unacknowledged
+            , canonical call
+            , Set.notMember result.callId pendingIds
+            ]
+        pending = safePending <> map CompletedTool salvaged
+        orphans = [(call, result) | (call, result) <- unacknowledged, not (canonical call)]
+        result = case execution.executionResult of
+            Left (LoopCancelled previous) ->
+                Left (LoopCancelled (previous <> filter
+                    (\completed -> all ((/= completed.callId) . (.callId)) previous)
+                    salvaged))
+            other -> other
+    writeIORef runtime.loopRuntimePendingRef pending
+    if null orphans
+        then pure execution
+            { executionPendingInputs = pending
+            , executionResult = result
+            }
+        else do
+            (owned, _) <- readIORef runtime.loopRuntimeProgressRef
+            current <- runtime.loopRuntimeConfig.loopBackendState.readBackendState
+            -- Reset/compaction may have installed a newer checkpoint. Do not
+            -- resurrect a submission's superseded history.
+            if current /= owned
+                then pure execution
+                    { executionPendingInputs = pending
+                    , executionResult = result
+                    }
+                else do
+                    let recoveryInputs = pending <> [UserMessage (managedRecoveryNote orphans)]
+                        candidate = advanceBackendSnapshot current
+                            (current.backendItems
+                                <> turnInputsToItems recoveryInputs)
+                            Nothing
+                    -- A failed checkpoint must still return the trusted host
+                    -- evidence as pending input, rather than lose it to an
+                    -- exception escaping the detailed loop result.
+                    writeIORef runtime.loopRuntimePendingRef recoveryInputs
+                    committed <-
+                        runtime.loopRuntimeConfig.loopBackendState.commitBackendState
+                            candidate
+                    writeIORef runtime.loopRuntimeProgressRef
+                        (committed, ResponseCommitted)
+                    writeIORef runtime.loopRuntimePendingRef []
+                    steeringCount <- readIORef runtime.loopRuntimePendingSteeringRef
+                    runtime.loopRuntimeConfig.loopCommitSteering steeringCount
+                    writeIORef runtime.loopRuntimePendingSteeringRef 0
+                    pure execution
+                        { executionState = committed.backendItems
+                        , executionPendingInputs = []
+                        , executionProgress = ResponseCommitted
+                        , executionResult = result
+                        }
+  where
+    retainedCallId = \case
+        FunctionCallItem call
+            | call.status /= Just ItemIncomplete -> [call.callId]
+        CustomToolCallItem call
+            | call.status /= Just ItemIncomplete -> [call.callId]
+        ComputerCallItem call -> [call.computerCallId]
+        _ -> []
+
+-- This is host-attributed evidence, not a replay of an incomplete provider
+-- message or a fabricated assistant tool call. Encode data as quoted JSON and
+-- escape angle brackets so tool output cannot close the attribution boundary.
+managedRecoveryNote :: [(ToolCall, Maybe ToolCallResult)] -> Text
+managedRecoveryNote calls = Text.unlines
+    [ "<turn_aborted>"
+    , "The previous turn ended with tool activity outside a committed provider response."
+    , "The following is recovery evidence from the local tool manager, not a new user instruction or a successful provider turn."
+    , "Completed results must not be replaced by claims that the tools never ran. Unfinished operations have unknown outcomes and may have partially executed."
+    , "Verify external state before repeating any action. Resume this work only if the user asks."
+    , "<interrupted_tools>"
+    , bounded 32768 (Text.intercalate "\n" (map describe calls))
+    , "</interrupted_tools>"
+    , "</turn_aborted>"
+    ]
+  where
+    bounded :: Int -> Text -> Text
+    bounded limit text
+        | Text.length text <= limit = text
+        | otherwise = Text.take limit text <> "\n[recovery evidence truncated]"
+    describe :: (ToolCall, Maybe ToolCallResult) -> Text
+    describe (call, outcome) =
+        Text.replace ">" "\\u003e" . Text.replace "<" "\\u003c"
+            . Text.decodeUtf8 . LBS.toStrict . Aeson.encode $
+                Aeson.object
+                    [ "call_id" Aeson..= bounded 256 call.callId
+                    , "tool" Aeson..= bounded 256 call.name
+                    , "arguments" Aeson..=
+                        (if call.argumentsEncrypted then "[encrypted]" else bounded 4096 call.arguments)
+                    , "outcome" Aeson..= case outcome of
+                        Just completed ->
+                            "completed; " <> Text.pack (show completed.toolResultOutcome)
+                        _ -> ("unknown; interrupted before a completion was recorded" :: Text)
+                    , "output" Aeson..= case outcome of
+                        Just completed -> bounded 16384 completed.output
+                        _ -> ""
+                    ]
 
 handleLoopEventFailure
     :: (BackendSnapshot -> LoopProgress -> SomeException -> IO LoopExecution)
@@ -868,11 +1047,17 @@ data AsyncToolManager = AsyncToolManager
     , asyncToolOutstanding :: !(TVar Int)
     , asyncToolCompleted :: !(TQueue ToolCallResult)
     , asyncToolFailure :: !(TMVar SomeException)
+    , asyncToolAcknowledged :: !(TVar (Set.Set Text))
+    , asyncToolCommittedCalls :: !(TVar (Map Text ToolCall))
     }
 
 data ManagedToolCall = ManagedToolCall
     { managedCall :: !ToolCall
     , managedResult :: !(TMVar (Maybe ToolCallResult))
+    -- Recorded by the worker before event delivery; unlike managedResult,
+    -- this does not release scheduling barriers or normal result waiters.
+    , managedTrustedResult :: !(TVar (Maybe ToolCallResult))
+    , managedAdmissionSequence :: !Int
     }
 
 data ManagedToolRequest = ManagedToolRequest
@@ -897,6 +1082,8 @@ newAsyncToolManager =
         <*> newTVarIO 0
         <*> newTQueueIO
         <*> newEmptyTMVarIO
+        <*> newTVarIO Set.empty
+        <*> newTVarIO Map.empty
 
 asyncToolManager :: LoopRuntime -> AsyncToolManager
 asyncToolManager runtime =
@@ -939,10 +1126,13 @@ admitManagedToolCall manager call = do
                         ("Conflicting tool calls reused call_id " <> call.callId)
         Nothing -> do
             result <- newEmptyTMVar
+            trustedResult <- newTVar Nothing
             sequenceNumber <- readTVar manager.asyncToolNextSequence
             let record = ManagedToolCall
                     { managedCall = call
                     , managedResult = result
+                    , managedTrustedResult = trustedResult
+                    , managedAdmissionSequence = sequenceNumber
                     }
             writeTVar
                 manager.asyncToolCalls
@@ -966,7 +1156,25 @@ runManagedToolCalls manager calls = do
     blocking <- catMaybes <$> traverse admit calls
     blockingResults <-
         catMaybes <$> traverse (atomically . readTMVar) blocking
-    completedAsync <- atomically (takeAsyncToolCompletions manager)
+    completedAsync <- atomically do
+        ready <- takeAsyncToolCompletions manager
+        admitted <- readTVar manager.asyncToolCalls
+        committed <- readTVar manager.asyncToolCommittedCalls
+        -- A restarted provider stream may omit a call that already executed.
+        -- Keep its trusted evidence for host-attributed recovery, but never
+        -- submit an unmatched native tool result on the normal path.
+        let canonical =
+                [ result
+                | result <- ready
+                , Just record <- [Map.lookup result.callId admitted]
+                , Map.lookup result.callId committed == Just record.managedCall
+                ]
+        outstanding <- readTVar manager.asyncToolOutstanding
+        -- An orphan-only batch is not the end of the turn while other
+        -- asynchronous tools are still running. Retry also restores the queue.
+        if null canonical && outstanding > 0
+            then retry
+            else pure canonical
     pure (blockingResults <> completedAsync)
   where
     admit call =
@@ -1086,7 +1294,10 @@ runManagedToolWorker config manager request prepared plan = do
                     scheduled
     race
         (waitCancel config.loopCancel)
-        (runPreparedToolCall config prepared)
+        (runPreparedToolCallWithCompletion
+            (atomically . writeTVar request.managedRecord.managedTrustedResult . Just)
+            config
+            prepared)
         >>= \case
             Left () -> pure Nothing
             Right result -> pure result
@@ -1289,7 +1500,14 @@ runPreparedToolCall
     :: LoopConfig
     -> PreparedToolCall
     -> IO (Maybe ToolCallResult)
-runPreparedToolCall config (PreparedToolCall call approval) = do
+runPreparedToolCall = runPreparedToolCallWithCompletion (const (pure ()))
+
+runPreparedToolCallWithCompletion
+    :: (ToolCallResult -> IO ())
+    -> LoopConfig
+    -> PreparedToolCall
+    -> IO (Maybe ToolCallResult)
+runPreparedToolCallWithCompletion completed config (PreparedToolCall call approval) = do
     cancelled <- isCancelled config.loopCancel
     if cancelled
         then pure Nothing
@@ -1326,5 +1544,9 @@ runPreparedToolCall config (PreparedToolCall call approval) = do
                             }
                         config.loopTools
                         call
+            -- The trusted result must survive cancellation or a failing event
+            -- consumer after the tool has returned. The manager's monitor is
+            -- not authoritative: its own scope can be cancelled first.
+            completed result
             config.loopOnEvent (ToolFinished result)
             pure (Just result)

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -18,6 +18,7 @@ import Agent.Responses.Types
     , ResponseMessage(..)
     , ResponseRole(..)
     )
+import Agent.Responses.Types.Items (responseItemDecoder)
 import Agent.ToolDispatch
 import Agent.Telemetry (TurnTelemetry(..))
 import Agent.Tools.Scheduling
@@ -32,6 +33,7 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , jsonAppToolWithExecution
     , toolExecutionPolicyFor
+    , withAsyncToolCalls
     , withToolResourceClaims
     )
 import Codec.Picture
@@ -1566,7 +1568,7 @@ spec = describe "runLoop" do
 
     it "returns the last committed state after a later transport failure" do
         submissions <- newIORef []
-        backend <- scriptedBackend submissions
+        backend <- retainingEchoCall <$> scriptedBackend submissions
             [ Right $ emptyTurnOutput "resp-1"
                 [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
                 Nothing
@@ -1591,7 +1593,7 @@ spec = describe "runLoop" do
 
     it "exposes tool results awaiting submission after a later transport failure" do
         submissions <- newIORef []
-        backend <- scriptedBackend submissions
+        backend <- retainingEchoCall <$> scriptedBackend submissions
             [ Right $ emptyTurnOutput "resp-1"
                 [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
                 Nothing
@@ -1672,7 +1674,7 @@ spec = describe "runLoop" do
     it "keeps completed tool results pending when cancelled during the next model step" do
         started <- newEmptyMVar
         calls <- newIORef (0 :: Int)
-        config0 <- testConfig $ Backend \state _prev _inputs _onEvent -> do
+        config0 <- testConfig $ retainingEchoCall $ Backend \state _prev _inputs _onEvent -> do
             call <- atomicModifyIORef' calls \n -> (n + 1, n + 1)
             if call == 1
                 then pure $ Right BackendResult
@@ -1935,6 +1937,94 @@ spec = describe "runLoop" do
             timeout 1000000 (wait running)
                 `shouldReturn` Just (Left (LoopCancelled []))
             tryReadMVar stopped `shouldReturn` Just ()
+
+    it "salvages a completed blocking result when cancellation interrupts the remaining batch" do
+        blocked <- newEmptyMVar
+        joined <- newEmptyMVar
+        invocations <- newIORef (0 :: Int)
+        let first = functionToolCall "saved" "save" "{}"
+            second = functionToolCall "blocked" "block" "{}"
+            -- The shared scheduling resource makes starting B proof that A's
+            -- manager completion was recorded, not merely painted by the UI.
+            tools =
+                [ resourceTool "save" "recovery-test" do
+                    modifyIORef' invocations (+ 1)
+                    pure (Right "file saved exactly once")
+                , resourceTool "block" "recovery-test" $
+                    (putMVar blocked () >> threadDelay maxBound
+                        >> pure (Right "must not finish"))
+                        `Exception.finally` putMVar joined ()
+                ]
+            callItems = either (error . show) id $
+                Json.decodeEither (Json.list responseItemDecoder)
+                    "[{\"type\":\"function_call\",\"call_id\":\"saved\",\"name\":\"save\",\"arguments\":\"{}\"},{\"type\":\"function_call\",\"call_id\":\"blocked\",\"name\":\"block\",\"arguments\":\"{}\"}]"
+            backend = Backend \state _ inputs _ ->
+                pure $ Right BackendResult
+                    { backendOutput = emptyTurnOutput "committed-tools" [first, second] Nothing
+                    , backendState = advanceBackendSnapshot state
+                        (state.backendItems <> turnInputsToItems inputs <> callItems) Nothing
+                    }
+        config0 <- testConfig backend
+        let config = config0 { loopTools = registryFromTools tools }
+        withAsync (runLoopInputsDetailed config Nothing [UserMessage "fix it"]) \running -> do
+            timeout concurrencyProbeMicros (takeMVar blocked) `shouldReturn` Just ()
+            requestCancel config.loopCancel
+            execution <- timeout concurrencyProbeMicros (wait running)
+                >>= maybe (fail "cancel did not join tool workers") pure
+            execution.executionProgress `shouldBe` ResponseCommitted
+            execution.executionPendingInputs `shouldBe`
+                [CompletedTool (functionResult "saved" "file saved exactly once")]
+            execution.executionResult `shouldBe`
+                Left (LoopCancelled [functionResult "saved" "file saved exactly once"])
+            tryReadMVar joined `shouldReturn` Just ()
+        readIORef invocations `shouldReturn` 1
+
+    it "recovers attributed precommit tool work without replaying failed provider output" do
+        blocked <- newEmptyMVar
+        joined <- newEmptyMVar
+        invocations <- newIORef (0 :: Int)
+        acknowledgements <- newIORef []
+        let first = asyncFunctionToolCall "saved" "save" "{}"
+            second = asyncFunctionToolCall "blocked" "block" "{}"
+            tools =
+                [ withAsyncToolCalls $ resourceTool "save" "recovery-test" do
+                    modifyIORef' invocations (+ 1)
+                    pure (Right "file saved exactly once")
+                , withAsyncToolCalls $ resourceTool "block" "recovery-test" $
+                    (putMVar blocked () >> threadDelay maxBound
+                        >> pure (Right "must not finish"))
+                        `Exception.finally` putMVar joined ()
+                ]
+            backend = backendWithCallbacks \_ _ _ callbacks -> do
+                callbacks.onAsyncToolCall first
+                callbacks.onAsyncToolCall second
+                timeout concurrencyProbeMicros (takeMVar blocked)
+                    >>= maybe (fail "second tool did not start") pure
+                callbacks.onLoopEvent (TextDelta "untrusted unfinished answer")
+                pure (Left (ConnectionError "stream failed before commit"))
+        config0 <- testConfig backend
+        let config = config0
+                { loopTools = registryFromTools tools
+                , loopReadSteering = pure [UserMessage "also update tests"]
+                , loopCommitSteering = \count ->
+                    modifyIORef' acknowledgements (<> [count])
+                }
+        execution <- timeout concurrencyProbeMicros
+            (runLoopInputsDetailed config Nothing [UserMessage "fix it"])
+            >>= maybe (fail "provider failure did not join tool workers") pure
+        execution.executionProgress `shouldBe` ResponseCommitted
+        take 2 execution.executionState `shouldBe`
+            turnInputsToItems [UserMessage "fix it", UserMessage "also update tests"]
+        readIORef acknowledgements `shouldReturn` [1]
+        show execution.executionState `shouldContain` "file saved exactly once"
+        show execution.executionState `shouldContain` "saved"
+        show execution.executionState `shouldContain` "blocked"
+        show execution.executionState `shouldNotContain` "untrusted unfinished answer"
+        execution.executionState `shouldSatisfy` all (\case
+            MessageItem{} -> True
+            _ -> False)
+        tryReadMVar joined `shouldReturn` Just ()
+        readIORef invocations `shouldReturn` 1
 
     it "does not render a rejected tool when approval cancels the turn" do
         events <- newIORef []
@@ -2538,6 +2628,18 @@ imageDataUrl mime bytes =
         <> mime
         <> ";base64,"
         <> TextEncoding.decodeUtf8 (Base64.encode bytes)
+
+-- These continuation tests need an actual committed call, not just the
+-- scripted backend's marker: only canonical calls may receive tool outputs.
+retainingEchoCall :: Backend -> Backend
+retainingEchoCall backend = backendWithCallbacks \state previous inputs callbacks ->
+    fmap (fmap \result -> result
+        { backendState = advanceBackendSnapshot result.backendState echoCallItems Nothing })
+        (backend.submitTurnWithCallbacks state previous inputs callbacks)
+  where
+    echoCallItems = either (error . show) id $
+        Json.decodeEither (Json.list responseItemDecoder)
+            "[{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"echo\",\"arguments\":\"{\\\"message\\\":\\\"hi\\\"}\"}]"
 
 rawJsonFixture :: ByteString.ByteString -> RawJson
 rawJsonFixture bytes =

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -1,6 +1,8 @@
 module Agent.Responses.LoopBackendSpec (spec) where
 
 import Agent.Error (ApiError(..), ErrorType(..))
+import Agent.Cancel (newCancelFlag)
+import qualified Agent.Loop as Loop
 import Agent.Loop
     ( Backend(..)
     , BackendCallbacks(..)
@@ -76,6 +78,8 @@ import Agent.Responses.Types.Items (responseItemDecoder)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import System.Timeout (timeout)
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Either (isLeft)
 import qualified Data.Text as Text
@@ -87,6 +91,14 @@ import Agent.ToolDispatch
     , ToolCallResult(..)
     , ToolResultImage(..)
     , toolCallMode
+    , noArgsTool
+    )
+import Agent.Tools.Types
+    ( ApprovalRule(..)
+    , ToolExecutionPolicy(..)
+    , jsonAppToolWithExecution
+    , mkToolRegistry
+    , withAsyncToolCalls
     )
 import Test.Hspec
 
@@ -912,6 +924,98 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
         map (.callId) calls `shouldBe` ["async-call"]
         map toolCallMode calls `shouldBe` [AsyncToolCall]
         map (.arguments) calls `shouldBe` ["{\"path\":\"README.md\"}"]
+
+    it "recovers a completed host side effect when the stream fails after output_item.done" do
+        finished <- newEmptyMVar
+        sideEffects <- newIORef (0 :: Int)
+        state <- newIORef emptyBackendSnapshot
+        cancel <- newCancelFlag
+        let call = FunctionCall
+                { itemId = Just "uncommitted-item"
+                , callId = "side-effect-call"
+                , name = "write_receipt"
+                , namespace = Nothing
+                , provider = Nothing
+                , arguments = "{}"
+                , encryptedFunctionArgs = Nothing
+                , status = Just ItemCompleted
+                , async = Just True
+                }
+            send _params onStreamEvent = do
+                onStreamEvent ResponseOutputItemDoneEvent
+                    { item = FunctionCallItem call
+                    , outputIndex = Just 0
+                    , sequenceNumber = Just 1
+                    }
+                -- The event sink acknowledges the real host result before
+                -- failing the still-open provider stream. No timing sleeps.
+                takeMVar finished
+                onStreamEvent ResponseOutputItemAddedEvent
+                    { item = FunctionCallItem call
+                        { callId = "malformed-never-admitted"
+                        , arguments = "{\"unfinished\":"
+                        , status = Just ItemIncomplete
+                        }
+                    , outputIndex = Just 1
+                    , sequenceNumber = Just 2
+                    }
+                pure (Left (ConnectionError "stream broke after side effect"))
+            backend = statelessResponsesBackend send
+                (pure defaultResponseCreateParams)
+            tool = withAsyncToolCalls $
+                jsonAppToolWithExecution "write_receipt" "" []
+                    AlwaysReadOnly ParallelSafe $
+                    noArgsTool "write_receipt" do
+                        modifyIORef' sideEffects (+ 1)
+                        pure (Right "receipt-4711 persisted")
+            registry = either (error . Text.unpack) id (mkToolRegistry [tool])
+            config = Loop.LoopConfig
+                { loopBackend = backend
+                , loopBackendState = Loop.BackendStateStore
+                    { readBackendState = readIORef state
+                    , commitBackendState = \snapshot ->
+                        writeIORef state snapshot >> pure snapshot
+                    }
+                , loopTools = registry
+                , loopDispatch = Loop.defaultLoopDispatch
+                , loopMaxTurns = Loop.defaultLoopMaxTurns
+                , loopOnEvent = \case
+                    ToolFinished _ -> putMVar finished ()
+                    _ -> pure ()
+                , loopApprove = const (pure (Right True))
+                , loopReadSteering = pure []
+                , loopCommitSteering = const (pure ())
+                , loopInterrupt = pure ()
+                , loopCancel = cancel
+                }
+        outcome <- timeout 5000000 $
+            Loop.runLoopInputsDetailed config Nothing [UserMessage "write once"]
+        execution <- case outcome of
+            Nothing -> expectationFailure "stream recovery timed out" >> fail "timeout"
+            Just value -> pure value
+        execution.executionResult `shouldSatisfy` isLeft
+        readIORef sideEffects `shouldReturn` 1
+        let history = execution.executionState
+            encodedHistory = TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode history))
+        encodedHistory `shouldSatisfy` Text.isInfixOf "receipt-4711 persisted"
+        encodedHistory `shouldSatisfy` Text.isInfixOf "write_receipt"
+        encodedHistory `shouldSatisfy` (not . Text.isInfixOf "malformed-never-admitted")
+        history `shouldSatisfy` all (\case MessageItem{} -> True; _ -> False)
+        -- Feed the recovered snapshot into a fresh provider submission. The
+        -- observation must reach the wire without recreating executable calls.
+        resumedRequests <- newIORef []
+        let resumedBackend = statelessResponsesBackend
+                (\params _ -> do
+                    modifyIORef' resumedRequests (<> [params.input])
+                    pure (Right (responseWithOutput [])))
+                (pure defaultResponseCreateParams)
+        recovered <- readIORef state
+        _ <- resumedBackend.submitTurn recovered Nothing [UserMessage "continue"]
+            (const (pure ()))
+        requests <- readIORef resumedRequests
+        requests `shouldBe`
+            [Just (ResponseInputItems (history <> turnInputsToItems [UserMessage "continue"]))]
+        readIORef sideEffects `shouldReturn` 1
 
     it "can hide raw reasoning while retaining reasoning summaries" do
         events <- newIORef []


### PR DESCRIPTION
## Summary

Fix audited bug #1: completed tool side effects could lose their results when a sibling blocked and the turn was cancelled, or when a Responses stream failed after admitting an early asynchronous tool.

- Capture trusted manager completions before event delivery and recover them only after structured cancellation and joining of all workers.
- Preserve real results for committed calls; describe unfinished operations as unknown, potentially partially executed, rather than claiming they never ran.
- Recover precommit tool activity as bounded, escaped, host-attributed evidence, without replaying malformed provider output or fabricating assistant tool calls.
- Track result acknowledgement at response commit and keep unmatched asynchronous results off the normal provider-input path.
- Preserve pending steering and invalidate provider continuation when committing host recovery evidence.

## Regression coverage

- Deterministic completed-tool A / blocked-tool B cancellation.
- Early Responses `output_item.done` tool completion followed by malformed provider output and stream failure.
- PostgreSQL persistence/load/resume for both failure variants, including real completed output, unknown unfinished outcomes, safe native history, and no repeated side effects.
- Fixtures decode provider-native items through Hermes.

## Review

Independent production and regression-test review completed with no remaining production blockers. Uses structured concurrency; no low-level masking or bare async added.

## Validation

Executed targeted specs in Nix/GHCi (`cabal repl <package>:test:<package>-test --disable-multi-repl --offline`, invoking each spec with Hspec):

- `Agent.LoopSpec`: 109 examples, 0 failures.
- `Agent.Responses.LoopBackendSpec`: 59 examples, 0 failures.
- `Agent.Runtime.TurnStateSpec`: 8 examples, 0 failures, including actual PostgreSQL persistence and resume (not skipped).
- Multi-package source typecheck and `git diff --check` passed.

On macOS, Nix used a worktree-local temporary directory; PostgreSQL tests used a short inner temporary path to stay within the Unix socket path limit.


## CI follow-up validation

- Corrected the CLI incomplete-response expectation to retain unknown-outcome semantics.
- Moved the PostgreSQL persistence adapter to the existing session integration specs, preserving frontend-neutral runtime test boundaries.
- Nix/GHCi: `Agent.CLI.TurnSpec` — 35 examples, 0 failures (`-fobject-code` for macOS FFI).
- Nix/GHCi: `Agent.Runtime.TurnStateSpec` plus `Agent.CLI.SessionSpec.Persistence` — 29 examples, 0 failures, including both real PostgreSQL recovery/resume regressions.
- `scripts/check-package-boundaries.sh` and `git diff --check` passed.
