### PR TITLE
Add bounded wait_agent_session primitive

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/SessionLock.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/SessionLock.hs
@@ -8,18 +8,26 @@ module Agent.CLI.SessionLock
     , acquireSessionActivityLock
     , releaseSessionLock
     , sessionActivityLockPath
+    , sessionActivityGeneration
+    , sessionActivitySnapshot
     , sessionLockFilePath
     , sessionLockIsActive
     , sessionLockPath
     ) where
 
 import Agent.CLI.Error (formatException)
+import Agent.CLI.PrivateFileLock (withPrivateFileLock)
+import Agent.FileRetry (writeLazyFileAtomically)
 import Agent.OsPath (unsafeToFilePath)
-import Control.Exception.Safe (SomeException, try)
+import Control.Exception.Safe (SomeException, bracketOnError, try, tryAny)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Text (Text)
 import qualified System.FileLock as FileLock
 import qualified System.FilePath as FilePath
-import System.OsPath (OsPath)
+import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
+import System.IO.Error (isDoesNotExistError, catchIOError)
+import Text.Read (readMaybe)
 
 data SessionLock = SessionLock
     { lockFilePath :: !FilePath
@@ -45,8 +53,57 @@ acquireSessionActivityLock
     :: OsPath
     -> Text
     -> IO (Either Text SessionLock)
-acquireSessionActivityLock sessionDir sessionId =
-    acquireLockAt (sessionActivityLockPath sessionDir) sessionId
+acquireSessionActivityLock sessionDir sessionId = do
+    result <- tryAny $
+        withPrivateFileLock (activityAdmissionPath sessionDir) $
+            bracketOnError
+                (acquireLockAt (sessionActivityLockPath sessionDir) sessionId)
+                (either (const (pure ())) releaseSessionLock)
+                \case
+                    Left err -> pure (Left err)
+                    Right lock -> do
+                        generation <- sessionActivityGeneration sessionDir
+                        writeLazyFileAtomically (activityGenerationPath sessionDir) 0o600
+                            (LBS.pack (show (maybe 1 (+ 1) generation)))
+                        pure (Right lock)
+    pure $ case result of
+        Left err -> Left
+            ("failed to mark session activity " <> sessionId <> ": "
+                <> formatException err)
+        Right acquired -> acquired
+
+-- | Observe activity and its generation under the same short-lived admission
+-- gate used by writers. In particular, never observe an acquired activity lock
+-- before that turn's generation has been published. Releasing an activity lock
+-- needs no gate: it cannot change the generation, and any following acquisition
+-- must wait until this snapshot has completed.
+sessionActivitySnapshot :: OsPath -> IO (Maybe Integer, Bool)
+sessionActivitySnapshot sessionDir =
+    withPrivateFileLock (activityAdmissionPath sessionDir) $ do
+        generation <- sessionActivityGeneration sessionDir
+        active <- sessionLockIsActive (sessionActivityLockPath sessionDir)
+        pure (generation, active)
+
+-- A monotonically increasing generation distinguishes rapid consecutive turns
+-- even if a cross-process waiter never observes the unlocked interval. The
+-- activity lock serializes writers; atomic replacement prevents partial reads.
+sessionActivityGeneration :: OsPath -> IO (Maybe Integer)
+sessionActivityGeneration sessionDir =
+    (do
+        bytes <- BS.readFile (unsafeToFilePath (activityGenerationPath sessionDir))
+        case readMaybe (BS.unpack bytes) of
+            Just value | value > 0 -> pure (Just value)
+            _ -> ioError (userError "invalid session activity generation"))
+        `catchIOError` \err ->
+            if isDoesNotExistError err then pure Nothing else ioError err
+
+activityGenerationPath :: OsPath -> OsPath
+activityGenerationPath sessionDir =
+    sessionDir </> unsafeEncodeUtf ".agent-turn-generation"
+
+activityAdmissionPath :: OsPath -> OsPath
+activityAdmissionPath sessionDir =
+    sessionDir </> unsafeEncodeUtf ".agent-turn-admission.lock"
 
 acquireLockAt :: FilePath -> Text -> IO (Either Text SessionLock)
 acquireLockAt path sessionId = do

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -160,6 +160,7 @@ library
                     , Agent.CLI.AccountPicker
                     , Agent.CLI.AccountSelection
                     , Agent.CLI.AgentSessions
+                    , Agent.CLI.AgentSessions.WaitGraph
                     , Agent.CLI.AgentViewport
                     , Agent.CLI.AgentViewport.Runtime
                     , Agent.CLI.Approval
@@ -487,6 +488,7 @@ test-suite agent-cli-test
                     , Agent.CLI.AccountSelectionSpec
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec
+                    , Agent.CLI.AgentSessionsWaitGraphSpec
                     , Agent.CLI.ArtifactSpec
                     , Agent.CLI.AgentViewportSpec
                     , Agent.CLI.AgentViewportRuntimeSpec

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -18,6 +18,7 @@ module Agent.CLI.AgentSessions
     , newSessionProcessManagerWithLifetime
     , signalManagedSessionReady
     , sessionThreadStatus
+    , prepareSessionThreadWait
     , sessionProcessStatus
     ) where
 
@@ -34,6 +35,7 @@ import Agent.CLI.AgentSessions.Process
     , signalManagedSessionReady
     )
 import Agent.CLI.AgentSessions.Render (renderAgentSession)
+import Agent.CLI.AgentSessions.WaitGraph (withSessionWaitEdge)
 import Agent.CLI.Error (formatException)
 import Agent.CLI.Session
     ( SessionCreate(..)
@@ -51,6 +53,7 @@ import Agent.Store.Postgres.Connection (StorePool)
 import Agent.CLI.SessionLock
     ( sessionLockIsActive
     , sessionLockPath
+    , sessionActivitySnapshot
     )
 import Agent.CLI.Models
     ( ModelOption(..)
@@ -75,11 +78,13 @@ import Agent.Tools.Types
     )
 import Control.Concurrent.Async
     ( Async
+    , AsyncCancelled
     , asyncWithUnmask
     , cancel
     , poll
     , waitCatch
     )
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar
     ( MVar
     , modifyMVar
@@ -87,16 +92,20 @@ import Control.Concurrent.MVar
     , newEmptyMVar
     , newMVar
     , putMVar
+    , readMVar
     , takeMVar
     )
 import Control.Exception.Safe
     ( mask
+    , SomeException
+    , fromException
     , tryAny
     )
 import Control.Monad (void)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust)
+import System.Timeout (timeout)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
@@ -117,10 +126,12 @@ data AgentSessionToolsEnv = AgentSessionToolsEnv
     , toolsCurrentSessionId :: !(IO (Maybe Text))
     , toolsLaunchTurn :: !(SessionHandle -> Text -> IO (Either Text Text))
     , toolsSessionStatus :: !(Text -> IO Text)
+    -- | Capture the current run now, then wait without following later runs.
+    , toolsPrepareSessionWait :: !(Text -> IO (IO Text))
     }
 
 data ManagedSessionThread
-    = ManagedSessionThreadRunning !(Async ())
+    = ManagedSessionThreadRunning !(Async Text)
     | ManagedSessionThreadCompleted
     | ManagedSessionThreadFailed !Text
 
@@ -190,6 +201,9 @@ launchSessionThread manager sessionId action =
                                                         terminal
                                                         current.managedThreads
                                                 }
+                                pure $ case terminal of
+                                    ManagedSessionThreadFailed err -> "failed (" <> err <> ")"
+                                    _ -> "completed"
                         case started of
                             Left err ->
                                 pure
@@ -223,8 +237,12 @@ sessionThreadStatus manager sessionId =
             Just (ManagedSessionThreadRunning worker) ->
                 poll worker >>= \case
                     Nothing -> pure (state, "running")
-                    Just (Right ()) ->
-                        settle state ManagedSessionThreadCompleted "completed"
+                    Just (Right status) ->
+                        settle state
+                            (if status == "completed"
+                                then ManagedSessionThreadCompleted
+                                else ManagedSessionThreadFailed status)
+                            status
                     Just (Left err) ->
                         let message = "failed (" <> formatException err <> ")"
                         in settle state
@@ -261,6 +279,37 @@ sessionThreadStatus manager sessionId =
         locked <- lockIsActive
         pure (state, if locked then "running" else terminal)
 
+-- | Waiting on the captured Async (not repeated map lookups) prevents a quick
+-- resume from moving the waiter onto a different run. The waiter never owns or
+-- cancels the target. External interactive sessions use the turn activity lock,
+-- not the lifetime lock, which remains held while the prompt is idle.
+prepareSessionThreadWait :: SessionThreadManager -> Text -> IO (IO Text)
+prepareSessionThreadWait manager sessionId = do
+    state <- readMVar manager.threadManagerState
+    case Map.lookup sessionId state.managedThreads of
+        Just (ManagedSessionThreadRunning worker) ->
+            pure $ either waitExceptionStatus id <$> waitCatch worker
+        _ -> do
+            (generation, active) <- sessionActivitySnapshot sessionDir
+            if active
+                then pure (waitExternal generation)
+                else pure $ pure $ case Map.lookup sessionId state.managedThreads of
+                    Just ManagedSessionThreadCompleted -> "completed"
+                    Just (ManagedSessionThreadFailed err) -> "failed (" <> err <> ")"
+                    _ -> "idle"
+  where
+    sessionDir = manager.threadManagerRoot </> unsafeEncodeUtf (Text.unpack sessionId)
+    waitExternal generation = do
+        (current, active) <- sessionActivitySnapshot sessionDir
+        if active && (generation == current || generation == Nothing)
+            then threadDelay 100000 >> waitExternal current
+            else pure "idle"
+
+waitExceptionStatus :: SomeException -> Text
+waitExceptionStatus err
+    | isJust (fromException err :: Maybe AsyncCancelled) = "cancelled"
+    | otherwise = "failed (" <> formatException err <> ")"
+
 closeSessionThreadManager :: SessionThreadManager -> IO ()
 closeSessionThreadManager manager = do
     workers <- modifyMVar manager.threadManagerState \state ->
@@ -284,7 +333,68 @@ agentSessionTools env =
     [ createAgentSessionTool env
     , readAgentSessionTool env
     , sendAgentSessionMessageTool env
+    , waitAgentSessionTool env
     ]
+
+data WaitAgentSessionArgs = WaitAgentSessionArgs
+    { sessionId :: Text
+    , timeoutMs :: Maybe Int
+    }
+
+waitAgentSessionTool :: AgentSessionToolsEnv -> AppTool
+waitAgentSessionTool env = jsonTool
+    "wait_agent_session"
+    "Wait for another persisted session's current turn, not the lifetime of its conversation. Returns status and latest saved output, or timed_out. Already idle sessions return immediately. Locally managed turns report completed, failed, or cancelled; external turns report idle when their activity ends (the exit reason is unknown). Recent output may include a later resume. Use this instead of polling read_agent_session. Cancelling or timing out this wait does not cancel the target."
+    [ PropertySchema "session_id" PropertyString True $ Just
+        "Persisted target session id. Self-waits and circular waits are rejected."
+    , PropertySchema "timeout_ms" PropertyInteger False $ Just
+        "Maximum wait in milliseconds, from 1 to 300000. Defaults to 30000."
+    ]
+    True
+    ParallelSafe
+    (typedTool "wait_agent_session"
+        (Hermes.object $ WaitAgentSessionArgs
+            <$> Hermes.atKey "session_id" Hermes.text
+            <*> optionalKey "timeout_ms" Hermes.int)
+        (runWaitAgentSession env))
+
+runWaitAgentSession :: AgentSessionToolsEnv -> WaitAgentSessionArgs -> IO (Either Text Text)
+runWaitAgentSession env args
+    | milliseconds < 1 || milliseconds > 300000 =
+        pure (Left "timeout_ms must be between 1 and 300000")
+    | otherwise = do
+        current <- env.toolsCurrentSessionId
+        if current == Just args.sessionId
+            then pure (Left "cannot wait for the current agent session")
+            else loadSessionMeta env.toolsPool env.toolsRoot args.sessionId >>= \case
+                Left err -> pure (Left err)
+                Right meta -> case validateToolSessionBoundary env meta of
+                    Left err -> pure (Left err)
+                    Right () -> do
+                        -- Authorization precedes all status, transcript, and
+                        -- coordination access, matching read_agent_session.
+                        result <- timeout (milliseconds * 1000) $
+                            case current of
+                                Nothing -> waitForTurn meta
+                                Just caller -> do
+                                    guarded <- withSessionWaitEdge
+                                        env.toolsRoot caller args.sessionId
+                                        (waitForTurn meta)
+                                    pure (guarded >>= id)
+                        pure $ fromMaybe
+                            (Right ("Session: " <> args.sessionId
+                                <> "\nStatus: timed_out\nThe target was not cancelled."))
+                            result
+  where
+    milliseconds = fromMaybe 30000 args.timeoutMs
+    waitForTurn meta = do
+        wait <- env.toolsPrepareSessionWait args.sessionId
+        status <- wait
+        loadRecentSessionTurns env.toolsPool env.toolsRoot args.sessionId 1 >>= \case
+            Left err -> pure (Left err)
+            Right page -> pure $ Right $
+                renderAgentSession meta status Nothing (map snd page.pageTurns)
+                    <> "\nOutput is the latest saved turn at read time; it may include a later resume."
 
 data CreateAgentSessionArgs = CreateAgentSessionArgs
     { message :: Text

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions/WaitGraph.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions/WaitGraph.hs
@@ -1,0 +1,108 @@
+-- | Crash-safe, cross-process admission for session waits.
+module Agent.CLI.AgentSessions.WaitGraph
+    ( withSessionWaitEdge
+    ) where
+
+import Agent.CLI.PrivateFileLock (withPrivateFileLock)
+import Agent.OsPath (unsafeToFilePath)
+import Control.Exception.Safe (bracket, finally, onException)
+import Control.Monad (forM)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.List (isPrefixOf)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified System.Directory as Directory
+import qualified System.FileLock as FileLock
+import qualified System.FilePath as FilePath
+import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
+import System.Posix.Temp (mkdtemp)
+
+data WaitEdge = WaitEdge !FilePath !FileLock.FileLock
+
+-- | Register one scoped wait. Admission is serialized across processes and
+-- includes every live outgoing edge, not just one target per session. Session
+-- identifiers are metadata only and never become filesystem paths.
+--
+-- Each registration owns a distinct OS lease. Crashes release that lease, so
+-- later admissions can discard stale edges without PID/clock heuristics.
+-- The caller supplies the wait deadline; cancelling the action removes only
+-- this edge and never affects the session being waited on.
+withSessionWaitEdge
+    :: OsPath
+    -> Text
+    -> Text
+    -> IO a
+    -> IO (Either Text a)
+withSessionWaitEdge root source target action
+    | source == target = pure (Left "cannot wait for the current agent session")
+    | otherwise =
+        bracket
+            (withPrivateFileLock gate acquire)
+            release
+            \case
+                Left err -> pure (Left err)
+                Right _ -> Right <$> action
+  where
+    directory = root </> unsafeEncodeUtf ".agent-session-waits"
+    gate = directory </> unsafeEncodeUtf "admission.lock"
+
+    acquire = do
+        edges <- liveEdges (unsafeToFilePath directory)
+        case edges of
+            Left err -> pure (Left err)
+            Right graph
+                | reachable graph target source ->
+                    pure (Left "circular agent session wait rejected")
+                | otherwise -> do
+                    path <- mkdtemp
+                        (unsafeToFilePath directory FilePath.</> "edge-")
+                    (do
+                        lease <- FileLock.lockFile
+                            (path FilePath.</> "lease") FileLock.Exclusive
+                        (do
+                            LBS.writeFile (path FilePath.</> "edge.json")
+                                (Aeson.encode (source, target))
+                            pure (Right (WaitEdge path lease)))
+                            `onException` FileLock.unlockFile lease)
+                        `onException` Directory.removeDirectoryRecursive path
+
+    release (Left _) = pure ()
+    release (Right (WaitEdge path lease)) =
+        -- Remove the unique name while still leased and under the admission
+        -- gate. Nobody can probe or recreate that lease during its removal.
+        withPrivateFileLock gate (Directory.removeDirectoryRecursive path)
+            `finally` FileLock.unlockFile lease
+
+liveEdges :: FilePath -> IO (Either Text [(Text, Text)])
+liveEdges directory = do
+    names <- filter ("edge-" `isPrefixOf`) <$> Directory.listDirectory directory
+    results <- forM names \name -> do
+        let path = directory FilePath.</> name
+        bracket
+            (FileLock.tryLockFile (path FilePath.</> "lease") FileLock.Exclusive)
+            (maybe (pure ()) FileLock.unlockFile)
+            \case
+                Just _ -> do
+                    Directory.removeDirectoryRecursive path
+                    pure (Right [])
+                Nothing -> do
+                    bytes <- BS.readFile (path FilePath.</> "edge.json")
+                    pure $ case Aeson.eitherDecodeStrict' bytes of
+                        Left err ->
+                            Left ("invalid live session wait edge: " <> Text.pack err)
+                        Right edge -> Right [edge]
+    pure (concat <$> sequence results)
+
+reachable :: [(Text, Text)] -> Text -> Text -> Bool
+reachable graph start goal = visit Set.empty [start]
+  where
+    visit _ [] = False
+    visit seen (node : remaining)
+        | node == goal = True
+        | Set.member node seen = visit seen remaining
+        | otherwise =
+            visit (Set.insert node seen)
+                ([target | (source, target) <- graph, source == node] <> remaining)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -13,12 +13,13 @@ import Agent.CLI.AgentSessions
     ( agentSessionTools,
       launchSessionThread,
       sessionThreadStatus,
+      prepareSessionThreadWait,
       AgentSessionToolsEnv(toolsSessionStatus, AgentSessionToolsEnv,
                            toolsPool, toolsRoot, toolsProvider, toolsConnection, toolsModel,
                            toolsTransportModel, toolsDialect, toolsAllowedModels,
                            toolsResolveModelOption,
                            toolsGatewayIdentity, toolsCwd, toolsEffort,
-                           toolsCurrentSessionId, toolsLaunchTurn) )
+                           toolsCurrentSessionId, toolsLaunchTurn, toolsPrepareSessionWait) )
 import Agent.CLI.Auth (isGatewayLoadedAuth)
 import qualified Agent.CLI.ComputerUse as ComputerUse
 import Agent.CLI.Config (HarnessConfig(..))
@@ -542,6 +543,8 @@ newSessionControlRuntime AgentToolsRequest
                             action
             , toolsSessionStatus =
                 sessionThreadStatus processRuntime.processSessionThreads
+            , toolsPrepareSessionWait =
+                prepareSessionThreadWait processRuntime.processSessionThreads
             }
         -- Persisted agent-session tools recursively start another native
         -- runtime, so they require an explicit collaboration capability from

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -37,6 +37,7 @@ import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Postgres.Managed (stopManagedPostgres)
 import Agent.Store.Types (renderStoreError)
 import Control.Concurrent (threadDelay)
+import qualified Control.Concurrent.Async as Async
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Exception.Safe (SomeException, bracket, finally, try)
 import Data.IORef
@@ -49,6 +50,7 @@ import qualified System.FilePath as FilePath
 import System.Posix.Temp (mkdtemp)
 import System.Posix.Process (forkProcess, getProcessID, getProcessStatus)
 import System.Posix.Signals (sigKILL, signalProcess)
+import System.Timeout (timeout)
 import Test.Hspec
 
 isReadOnly :: ApprovalRule -> Bool
@@ -61,9 +63,142 @@ fromFilePath = unsafeEncodeUtf
 toFilePath :: OsPath -> FilePath
 toFilePath path = either (error . show) id (decodeUtf path)
 
+waitPayload :: SessionHandle -> Int -> Text.Text
+waitPayload handle milliseconds =
+    "{\"session_id\":\"" <> handle.sessionMeta.metaId
+        <> "\",\"timeout_ms\":" <> Text.pack (show milliseconds) <> "}"
+
+waitTestTurn :: Text.Text -> SessionTurn
+waitTestTurn answer = SessionTurn
+    { turnAt = fixedTime
+    , turnUserText = "question"
+    , turnAssistantText = Just answer
+    , turnError = Nothing
+    , turnResponseId = Nothing
+    , turnItems = []
+    , turnDisplayItems = []
+    , turnUsage = Nothing
+    , turnEffect = TranscriptAppend
+    , turnProviderTelemetry = []
+    }
+
 spec :: Spec
 spec = describe "Agent.CLI.AgentSessions" do
-    it "registers create/read/message tools with mutating flags" $
+    it "waits for idle sessions immediately and includes their last response" $
+        withTempEnv \env _ -> do
+            handle <- createSession (testCreate env.toolsPool env.toolsRoot)
+            _ <- appendTurn handle (waitTestTurn "done")
+            result <- runTool env "wait_agent_session" (waitPayload handle 1000)
+            result `shouldSatisfy` Text.isInfixOf "Status: idle"
+            result `shouldSatisfy` Text.isInfixOf "Assistant:\n  done"
+
+    it "labels recent output separately when the target has already resumed" $
+        withTempEnv \env _ -> do
+            handle <- createSession (testCreate env.toolsPool env.toolsRoot)
+            _ <- appendTurn handle (waitTestTurn "old")
+            let waiting = env { toolsPrepareSessionWait = \_ -> pure do
+                    next <- appendTurn handle (waitTestTurn "first result")
+                    _ <- appendTurn next (waitTestTurn "later result")
+                    pure "completed" }
+            result <- runTool waiting "wait_agent_session" (waitPayload handle 1000)
+            result `shouldSatisfy` Text.isInfixOf "later result"
+            result `shouldSatisfy` Text.isInfixOf "may include a later resume"
+            result `shouldNotSatisfy` Text.isInfixOf "Assistant:\n  old"
+
+    it "rejects invalid wait deadlines and self waits before preparing a wait" $
+        withTempEnv \env _ -> do
+            handle <- createSession (testCreate env.toolsPool env.toolsRoot)
+            let forbidden = env
+                    { toolsPrepareSessionWait = \_ -> error "must not prepare"
+                    , toolsCurrentSessionId = pure (Just handle.sessionMeta.metaId)
+                    }
+            mapM_ (\ms -> runTool forbidden "wait_agent_session" (waitPayload handle ms)
+                >>= (`shouldSatisfy` Text.isInfixOf "timeout_ms must be")) [0, -1, 300001]
+            result <- runTool forbidden "wait_agent_session" (waitPayload handle 1000)
+            result `shouldSatisfy` Text.isInfixOf "cannot wait for the current"
+
+    it "enforces the session boundary before preparing a wait" $
+        withTempEnv \env _ -> do
+            handle <- createSession (testCreate env.toolsPool env.toolsRoot)
+            let forbidden = env
+                    { toolsConnection = organizationGatewayConnectionId
+                    , toolsGatewayIdentity = Just "different-organization"
+                    , toolsPrepareSessionWait = \_ -> error "must not prepare"
+                    }
+            result <- runTool forbidden "wait_agent_session" (waitPayload handle 1000)
+            result `shouldNotSatisfy` Text.isInfixOf "Status:"
+
+    it "times out without cancelling the captured target and permits another wait" $
+        withTempEnv \env _ -> do
+            handle <- createSession (testCreate env.toolsPool env.toolsRoot)
+            bracket (newSessionThreadManager env.toolsRoot) closeSessionThreadManager \manager -> do
+                gate <- newEmptyMVar
+                _ <- launchSessionThread manager handle.sessionMeta.metaId
+                    (takeMVar gate >> pure (Right ()))
+                let waiting = env { toolsPrepareSessionWait = prepareSessionThreadWait manager }
+                result <- runTool waiting "wait_agent_session" (waitPayload handle 30)
+                result `shouldSatisfy` Text.isInfixOf "Status: timed_out"
+                sessionThreadStatus manager handle.sessionMeta.metaId `shouldReturn` "running"
+                putMVar gate ()
+                result2 <- runTool waiting "wait_agent_session" (waitPayload handle 1000)
+                result2 `shouldSatisfy` Text.isInfixOf "Status: completed"
+
+    it "keeps a captured wait attached to its run after a rapid resume" $
+        withTempEnv \env _ ->
+            bracket (newSessionThreadManager env.toolsRoot) closeSessionThreadManager \manager -> do
+                gate <- newEmptyMVar
+                _ <- launchSessionThread manager "target" (takeMVar gate >> pure (Left "original failure"))
+                original <- prepareSessionThreadWait manager "target"
+                putMVar gate ()
+                original `shouldReturn` "failed (original failure)"
+                nextGate <- newEmptyMVar
+                _ <- launchSessionThread manager "target" (takeMVar nextGate >> pure (Right ()))
+                timeout 100000 original `shouldReturn` Just "failed (original failure)"
+
+    it "cancels only the waiter, not its target" $
+        withTempEnv \env _ ->
+            bracket (newSessionThreadManager env.toolsRoot) closeSessionThreadManager \manager -> do
+                gate <- newEmptyMVar
+                _ <- launchSessionThread manager "target" (takeMVar gate >> pure (Right ()))
+                wait <- prepareSessionThreadWait manager "target"
+                Async.withAsync wait \waiter -> do
+                    Async.cancel waiter
+                    sessionThreadStatus manager "target" `shouldReturn` "running"
+                putMVar gate ()
+                wait `shouldReturn` "completed"
+
+    it "reports target cancellation to an existing waiter" $
+        withTempEnv \env _ -> do
+            manager <- newSessionThreadManager env.toolsRoot
+            gate <- newEmptyMVar
+            _ <- launchSessionThread manager "target" (takeMVar gate >> pure (Right ()))
+            wait <- prepareSessionThreadWait manager "target"
+            closeSessionThreadManager manager
+            wait `shouldReturn` "cancelled"
+
+    it "does not wait on an idle interactive session's lifetime lock" $
+        withTempEnv \env _ -> do
+            handle <- createSession (testCreate env.toolsPool env.toolsRoot)
+            Right lock <- acquireSessionLock handle.sessionDir handle.sessionMeta.metaId
+            flip finally (releaseSessionLock lock) $
+                bracket (newSessionThreadManager env.toolsRoot) closeSessionThreadManager \manager -> do
+                    wait <- prepareSessionThreadWait manager handle.sessionMeta.metaId
+                    timeout 100000 wait `shouldReturn` Just "idle"
+
+    it "stops waiting when an external session rapidly starts its next turn" $
+        withTempEnv \env _ -> do
+            handle <- createSession (testCreate env.toolsPool env.toolsRoot)
+            bracket (newSessionThreadManager env.toolsRoot) closeSessionThreadManager \manager -> do
+                Right first <- acquireSessionActivityLock handle.sessionDir handle.sessionMeta.metaId
+                wait <- prepareSessionThreadWait manager handle.sessionMeta.metaId
+                timeout 10000 wait `shouldReturn` Nothing
+                releaseSessionLock first
+                Right second <- acquireSessionActivityLock handle.sessionDir handle.sessionMeta.metaId
+                flip finally (releaseSessionLock second) $ do
+                    sessionActivityGeneration handle.sessionDir `shouldReturn` Just 2
+                    timeout 100000 wait `shouldReturn` Just "idle"
+
+    it "registers create/read/message/wait tools with mutating flags" $
         withTempEnv \env _ -> do
             map (\tool -> (tool.appToolName, isReadOnly tool.appToolApproval))
                 (agentSessionTools env)
@@ -71,6 +206,7 @@ spec = describe "Agent.CLI.AgentSessions" do
                     [ ("create_agent_session", False)
                     , ("read_agent_session", True)
                     , ("send_agent_session_message", False)
+                    , ("wait_agent_session", True)
                     ]
 
     it "creates a persisted session and launches its first turn" $
@@ -744,6 +880,7 @@ withTempEnv action =
                 , toolsCurrentSessionId = pure Nothing
                 , toolsLaunchTurn = launch
                 , toolsSessionStatus = const (pure "running")
+                , toolsPrepareSessionWait = const (pure (pure "idle"))
                 }
         action env launched
 

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsWaitGraphSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsWaitGraphSpec.hs
@@ -1,0 +1,108 @@
+module Agent.CLI.AgentSessionsWaitGraphSpec (spec) where
+
+import Agent.CLI.AgentSessions.WaitGraph (withSessionWaitEdge)
+import Agent.OsPath (unsafeToFilePath)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (cancel, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Exception.Safe (bracket)
+import qualified System.Directory as Directory
+import qualified System.FilePath as FilePath
+import System.OsPath (OsPath, unsafeEncodeUtf)
+import System.IO.Error (tryIOError)
+import System.Posix.IO (closeFd, createPipe)
+import System.Posix.IO.ByteString (fdRead, fdWrite)
+import System.Posix.Process (forkProcess, getProcessStatus)
+import System.Posix.Signals (sigKILL, signalProcess)
+import System.Posix.Temp (mkdtemp)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.AgentSessions.WaitGraph" do
+    it "rejects self waits without running the action" $
+        withRoot \root ->
+            withSessionWaitEdge root "a" "a" (expectationFailure "ran")
+                `shouldReturn` Left "cannot wait for the current agent session"
+
+    it "rejects indirect cycles and permits unrelated waits" $
+        withRoot \root -> do
+            result <- withSessionWaitEdge root "a" "b" $
+                withSessionWaitEdge root "b" "c" do
+                    withSessionWaitEdge root "c" "a" (pure ())
+                        `shouldReturn` Left "circular agent session wait rejected"
+                    withSessionWaitEdge root "c" "d" (pure ())
+                        `shouldReturn` Right ()
+            result `shouldBe` Right (Right ())
+
+    it "retains every simultaneous outgoing edge from a session" $
+        withRoot \root -> do
+            result <- withSessionWaitEdge root "a" "b" $
+                withSessionWaitEdge root "a" "c" do
+                    withSessionWaitEdge root "b" "a" (pure ())
+                        `shouldReturn` Left "circular agent session wait rejected"
+                    withSessionWaitEdge root "c" "a" (pure ())
+                        `shouldReturn` Left "circular agent session wait rejected"
+            result `shouldBe` Right (Right ())
+
+    it "removes edges on cancellation without cancelling other waits" $
+        withRoot \root -> do
+            ready <- newEmptyMVar
+            never <- newEmptyMVar
+            withAsync
+                (withSessionWaitEdge root "a" "b"
+                    (putMVar ready () >> takeMVar never))
+                \worker -> do
+                    takeMVar ready
+                    withSessionWaitEdge root "b" "a" (pure ())
+                        `shouldReturn` Left "circular agent session wait rejected"
+                    cancel worker
+                    withSessionWaitEdge root "b" "a" (pure ())
+                        `shouldReturn` Right ()
+
+    it "prunes unlocked crash remnants before detecting cycles" $
+        withRoot \root -> do
+            -- Initialize the private graph directory with the public API.
+            withSessionWaitEdge root "a" "b" (pure ())
+                `shouldReturn` Right ()
+            -- A crashed registration has metadata but no live advisory lease.
+            let directory = unsafeToFilePath root FilePath.</> ".agent-session-waits"
+                    FilePath.</> "edge-crashed"
+            Directory.createDirectory directory
+            writeFile (directory FilePath.</> "edge.json") "[\"a\",\"b\"]"
+            withSessionWaitEdge root "b" "a" (pure ())
+                `shouldReturn` Right ()
+            Directory.doesDirectoryExist directory `shouldReturn` False
+
+    it "detects cross-process cycles and recovers after a process crash" $
+        withRoot \root ->
+            bracket createPipe (\(readFd, writeFd) -> closeFd readFd >> closeFd writeFd)
+                \(readFd, writeFd) -> do
+                    let child = do
+                            _ <- withSessionWaitEdge root "a" "b" do
+                                _ <- fdWrite writeFd "r"
+                                threadDelay 30000000
+                            pure ()
+                        stop pid = do
+                            tryIOError (getProcessStatus False False pid) >>= \case
+                                Right Nothing -> do
+                                    _ <- tryIOError (signalProcess sigKILL pid)
+                                    _ <- getProcessStatus True False pid
+                                    pure ()
+                                _ -> pure ()
+                    bracket (forkProcess child) stop \pid -> do
+                        timeout 5000000 (fdRead readFd 1) `shouldReturn` Just "r"
+                        withSessionWaitEdge root "b" "a" (pure ())
+                            `shouldReturn` Left "circular agent session wait rejected"
+                        signalProcess sigKILL pid
+                        _ <- getProcessStatus True False pid
+                        withSessionWaitEdge root "b" "a" (pure ())
+                            `shouldReturn` Right ()
+
+withRoot :: (OsPath -> IO a) -> IO a
+withRoot action = do
+    temporary <- Directory.getTemporaryDirectory
+    bracket
+        (mkdtemp (temporary FilePath.</> "agent-wait-graph-"))
+        Directory.removeDirectoryRecursive
+        (action . unsafeEncodeUtf)

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -30,6 +30,7 @@ import Text.Read (readMaybe)
 import qualified Agent.CLI.ActiveAccountSpec as ActiveAccountSpec
 import qualified Agent.CLI.AccountSelectionSpec as AccountSelectionSpec
 import qualified Agent.CLI.AgentSessionsSpec as AgentSessionsSpec
+import qualified Agent.CLI.AgentSessionsWaitGraphSpec as AgentSessionsWaitGraphSpec
 import qualified Agent.CLI.AgentViewportSpec as AgentViewportSpec
 import qualified Agent.CLI.AgentViewportRuntimeSpec as AgentViewportRuntimeSpec
 import qualified Agent.CLI.ApprovalSpec as ApprovalSpec
@@ -159,6 +160,7 @@ specs = do
     AgentViewportSpec.spec
     AgentViewportRuntimeSpec.spec
     AgentSessionsSpec.spec
+    AgentSessionsWaitGraphSpec.spec
     ApprovalSpec.spec
     ArtifactSpec.spec
     AuthSpec.spec


### PR DESCRIPTION
## Summary
- Add read-only `wait_agent_session(session_id, timeout_ms)` with a 30-second default and 5-minute maximum.
- Capture the current local run, keep timeout/cancellation isolated from the target, and return status plus clearly labeled recent output.
- Wait on external turn activity rather than conversation lifetime; synchronized generations distinguish rapid resumes.
- Reject self/circular waits across processes using crash-safe leased edges, after existing session-boundary authorization.

External sessions report `idle` when observed activity ends; their exit reason is not inferred from old transcript errors.

## Validation
- Nix-provided GHCi: AgentSessions and WaitGraph — 44 examples, 0 failures.
- Three additional focused activity-snapshot checks passed (generation progression, admission synchronization, failure cleanup).
- `git diff --check`.

Independent of the companion delegation-guidance PR.
