### PR TITLE
Keep task ownership in the current agent session

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -304,7 +304,7 @@ createAgentSessionArgsDecoder = Hermes.object $
 createAgentSessionTool :: AgentSessionToolsEnv -> AppTool
 createAgentSessionTool env = jsonTool
     "create_agent_session"
-    "Create a persisted top-level agent session and start its first turn in the background. Returns the session id and status as readable text."
+    "Create a persisted top-level agent session and start its first turn in the background. Use only when the user explicitly requests independent/background work or a separate session; do not offload the entire current task here. For bounded subtasks, use subagents and retain responsibility for integration, verification, and the final answer. Returns the session id and status as readable text, not a completed result."
     [ PropertySchema "message" PropertyString True $ Just
         "Initial task or message for the new agent session."
     , PropertySchema "title" PropertyString False $ Just
@@ -509,7 +509,7 @@ sendAgentSessionMessageArgsDecoder = Hermes.object $
 sendAgentSessionMessageTool :: AgentSessionToolsEnv -> AppTool
 sendAgentSessionMessageTool env = jsonTool
     "send_agent_session_message"
-    "Send a message to a persisted agent session by starting a resumed background turn. Returns the session id and status as readable text; fails if that session is already running."
+    "Send a message to a persisted agent session by starting a resumed background turn. Use for explicitly requested independent/background work or continuation of that separate session, not to transfer responsibility for the current task. Returns the session id and status as readable text, not a completed result; fails if that session is already running."
     [ PropertySchema "session_id" PropertyString True $ Just
         "Persisted target session id."
     , PropertySchema "message" PropertyString True $ Just

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -92,6 +92,7 @@ systemPrompt dialect model effort cwd sessionTmp today isNonInteractive =
     Text.intercalate "\n\n" $
         filter (not . Text.null)
             [ base
+            , delegationOwnershipGuidance
             , sessionTempGuidance sessionTmp
             , commitAttributionGuidance model effort
             , ghciGuidanceForDialect dialect
@@ -141,6 +142,7 @@ systemPromptForToolsWithHostedSearch includeHostedSearch
     Text.intercalate "\n\n" $
         filter (not . Text.null)
             [ base
+            , delegationOwnershipGuidance
             , sessionTempGuidance sessionTmp
             , commitAttributionGuidanceForTools
                 dialect
@@ -209,6 +211,7 @@ systemPromptForCatalogModelWithHostedSearch
         filter (not . Text.null)
             [ Text.strip
                 (renderModelInstructions ModelPersonalityDefault info)
+            , delegationOwnershipGuidance
             , sessionTempGuidance sessionTmp
             , commitAttributionGuidanceForTools
                 dialect
@@ -226,6 +229,23 @@ systemPromptForCatalogModelWithHostedSearch
     available =
         Set.fromList
             (hostedSearchToolNamesWhen includeHostedSearch dialect ++ toolNames)
+
+-- | Shared across dialects and catalog templates. Delegation is an execution
+-- aid, not a transfer of responsibility for the user's current request.
+delegationOwnershipGuidance :: Text
+delegationOwnershipGuidance = Text.unwords
+    [ "Keep ownership of the user's task in the current session."
+    , "Do the work directly by default. When delegation tools are available,"
+    , "use subagents for bounded subtasks; retain responsibility for integration,"
+    , "verification, and the final answer. Do not delegate the entire current"
+    , "task to another session and end your turn with only a session id or"
+    , "an 'implementation is running' update."
+    , "Create or resume an independent background session only when the user"
+    , "explicitly requests independent/background work or a separate session."
+    , "Approval to implement a plan is not permission to move that work elsewhere."
+    , "When delegated work is needed for your answer, collect and review its"
+    , "results before reporting completion; a launch acknowledgement is not a result."
+    ]
 
 -- | The upstream @<environment_context>@ user fragment: working directory,
 -- shell, date, and timezone. Sent as conversation context rather than inside

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -63,6 +63,19 @@ toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = describe "Agent.CLI.AgentSessions" do
+    it "describes background session launches as explicit work, not completed results" $
+        withTempEnv \env _ -> do
+            let launchTools = filter
+                    (\tool -> tool.appToolName `elem`
+                        ["create_agent_session", "send_agent_session_message"])
+                    (agentSessionTools env)
+            length launchTools `shouldBe` 2
+            mapM_ (\tool -> do
+                tool.appToolDescription `shouldSatisfy` Text.isInfixOf "explicitly"
+                tool.appToolDescription `shouldSatisfy` Text.isInfixOf "current task"
+                tool.appToolDescription `shouldSatisfy` Text.isInfixOf "not a completed result"
+                ) launchTools
+
     it "registers create/read/message tools with mutating flags" $
         withTempEnv \env _ -> do
             map (\tool -> (tool.appToolName, isReadOnly tool.appToolApproval))

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -14,6 +14,7 @@ import Agent.Dialect
     , grokBuildDialect
     )
 import Agent.Provider (BillingMode(..), Provider(..))
+import Agent.OpenAI.Models (ModelsResponse(..), loadBundledModelsOrThrow)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (Day, fromGregorian)
@@ -51,6 +52,38 @@ systemPromptForToolsWithHostedSearch includeHostedSearch dialect =
 
 spec :: Spec
 spec = describe "systemPrompt" do
+    it "keeps ownership guidance after bundled catalog instructions" do
+        catalog <- loadBundledModelsOrThrow
+        catalog.models `shouldSatisfy` (not . null)
+        mapM_ (\info ->
+            systemPromptForCatalogModel codexDialect "gpt-5.6-sol" "high"
+                info ["create_agent_session"] Nothing
+                `shouldSatisfy` Text.isInfixOf
+                    "Keep ownership of the user's task in the current session."
+            ) catalog.models
+
+    it "keeps task ownership in the current session across all dialects and filtered tools" do
+        let day = fromGregorian 2026 9 6
+            cwd = fromFilePath "/tmp/repo"
+            dialects = [codexDialect, grokBuildDialect, genericResponsesDialect, claudeCodeDialect]
+            prompts = concatMap
+                (\dialect ->
+                    [ systemPrompt dialect cwd Nothing day False
+                    , systemPromptForTools dialect [] cwd Nothing day False
+                    , systemPromptForTools dialect ["create_agent_session"] cwd Nothing day False
+                    ])
+                dialects
+        mapM_ (\prompt -> do
+            prompt `shouldSatisfy` Text.isInfixOf
+                "Keep ownership of the user's task in the current session."
+            prompt `shouldSatisfy` Text.isInfixOf
+                "use subagents for bounded subtasks"
+            prompt `shouldSatisfy` Text.isInfixOf
+                "Approval to implement a plan is not permission"
+            prompt `shouldSatisfy` Text.isInfixOf
+                "a launch acknowledgement is not a result."
+            ) prompts
+
     it "names grok-build tools for xAI and Codex tools for OpenAI" do
         let day = fromGregorian 2026 8 19
             grok =


### PR DESCRIPTION
## Summary
- Keep ownership and completion of the user's task in the current session.
- Allow bounded subagent work while retaining integration, verification, and the final answer.
- Reserve independent/background sessions for explicit user requests; plan approval alone does not authorize moving the task elsewhere.
- Reinforce the rule in create/message tool descriptions and every prompt entrypoint.

## Validation
- Nix-provided GHCi: PromptSpec — 22 examples, 0 failures.
- Nix-provided GHCi: AgentSessions — 29 examples, 0 failures.
- Regression coverage includes dialects, filtered tool sets, bundled catalogs, and session tool descriptions.

Independent of the companion `wait_agent_session` PR.
