### PR TITLE
Add AX-first native computer control

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayBridge.hs
@@ -514,6 +514,8 @@ updateManagedActivity event state =
             state
         NativeAgentFinished{} ->
             state
+        ModelContextReset ->
+            state
         TurnFinished _ ->
             state
                 { accumulatorKind = "finished"

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -181,6 +181,7 @@ library
                     , Agent.CLI.ComputerUse.Linux.Logind
                     , Agent.CLI.ComputerUse.Linux.Portal
                     , Agent.CLI.ComputerUse.Linux.X11
+                    , Agent.CLI.ComputerUse.Accessibility
                     , Agent.CLI.Config
                     , Agent.CLI.McpOAuthStore
                     , Agent.CLI.McpOAuth
@@ -440,6 +441,17 @@ benchmark history-eviction-bench
     build-depends:    agent-tui
                     , base >= 4.17 && < 5
                     , containers
+
+benchmark accessibility-delta-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          AccessibilityDelta.hs
+    ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-cli
+                    , aeson
+                    , base >= 4.17 && < 5
+                    , bytestring
                     , text
 
 benchmark concurrency-bench

--- a/packages/agent-cli/benchmark/AccessibilityDelta.hs
+++ b/packages/agent-cli/benchmark/AccessibilityDelta.hs
@@ -1,0 +1,212 @@
+module Main (main) where
+
+import Agent.CLI.ComputerUse
+    ( AccessibilityObservation(..)
+    , AccessibilitySnapshot(..)
+    , advanceAccessibilityObservation
+    , initialAccessibilityDeltaState
+    )
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import Data.List (sortOn)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload = Static | SmallChange | HighChurn
+    deriving (Eq, Show)
+
+data Policy = AlwaysFull | RevisionedDelta
+    deriving (Eq, Show)
+
+data Sample = Sample
+    { sampleElapsedMillis :: !Double
+    , sampleCpuMillis :: !Double
+    , sampleAllocatedBytes :: !Integer
+    , sampleOutputBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    statsEnabled <- getRTSStatsEnabled
+    if statsEnabled
+        then pure ()
+        else die "RTS statistics are disabled; run with +RTS -T"
+    getArgs >>= \case
+        [] -> runMatrix
+        [workloadArg, nodesArg, revisionsArg, samplesArg] -> do
+            workload <- parseWorkload workloadArg
+            nodes <- parsePositive "nodes" nodesArg
+            revisions <- parsePositive "revisions" revisionsArg
+            sampleCount <- parsePositive "samples" samplesArg
+            putStrLn csvHeader
+            runScenario sampleCount revisions nodes workload
+        _ -> die $
+            "usage: accessibility-delta-bench [WORKLOAD NODES REVISIONS SAMPLES]\n"
+                <> "workloads: static, small-change, high-churn\n"
+                <> "output: " <> csvHeader
+
+runMatrix :: IO ()
+runMatrix = do
+    putStrLn csvHeader
+    mapM_ (\nodes ->
+        mapM_ (runScenario 5 24 nodes) [Static, SmallChange, HighChurn])
+        [100, 500, 1000]
+
+runScenario :: Int -> Int -> Int -> Workload -> IO ()
+runScenario sampleCount revisions nodes workload = do
+    -- Build the same native snapshot stream once so measurements cover only
+    -- policy/diff work and JSON encoding, not fixture construction.
+    let snapshots =
+            [ makeSnapshot workload nodes revision
+            | revision <- [1 .. revisions]
+            ]
+    -- Warm both code paths before reading allocation and timing counters.
+    _ <- runPolicy AlwaysFull snapshots
+    _ <- runPolicy RevisionedDelta snapshots
+    mapM_ (\policy -> do
+        samples <- sequence
+            [ measure policy snapshots
+            | _ <- [1 .. sampleCount]
+            ]
+        printSample workload policy nodes revisions (median samples))
+        [AlwaysFull, RevisionedDelta]
+
+measure :: Policy -> [AccessibilitySnapshot] -> IO Sample
+measure policy snapshots = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    outputBytes <- runPolicy policy snapshots
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    afterStats <- getRTSStats
+    pure Sample
+        { sampleElapsedMillis =
+            fromIntegral (afterElapsed - beforeElapsed) / 1.0e6
+        , sampleCpuMillis =
+            fromIntegral (afterCpu - beforeCpu) / 1.0e9
+        , sampleAllocatedBytes =
+            fromIntegral
+                (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        , sampleOutputBytes = outputBytes
+        }
+
+runPolicy :: Policy -> [AccessibilitySnapshot] -> IO Integer
+runPolicy policy snapshots = do
+    totalRef <- newIORef 0
+    case policy of
+        AlwaysFull ->
+            mapM_ (\(revision, snapshot) ->
+                addEncoded totalRef (AccessibilityFull revision snapshot))
+                (zip [1 ..] snapshots)
+        RevisionedDelta ->
+            go initialAccessibilityDeltaState snapshots totalRef
+    readIORef totalRef
+  where
+    go _ [] _ = pure ()
+    go state (snapshot : rest) totalRef = do
+        let (observation, successor) =
+                advanceAccessibilityObservation state snapshot
+        addEncoded totalRef observation
+        go successor rest totalRef
+
+addEncoded :: Aeson.ToJSON value => IORef Integer -> value -> IO ()
+addEncoded totalRef value = do
+    let bytes = fromIntegral (LBS.length (Aeson.encode value))
+    atomicModifyIORef' totalRef \total -> (total + bytes, ())
+
+makeSnapshot :: Workload -> Int -> Int -> AccessibilitySnapshot
+makeSnapshot workload nodes revision = AccessibilitySnapshot
+    { accessibilitySnapshotSchemaVersion = 1
+    , accessibilitySnapshotScope = Aeson.object
+        [ "application_bundle_identifier" Aeson..=
+            ("com.example.benchmark" :: Text)
+        , "window" Aeson..= Aeson.object
+            [ "identifier" Aeson..= ("main" :: Text) ]
+        ]
+    , accessibilitySnapshotContents = Aeson.object
+        [ "role" Aeson..= ("AXWindow" :: Text)
+        , "children" Aeson..= Aeson.Object (KeyMap.fromList
+            [ (Key.fromText (Text.pack (show index)), makeNode index)
+            | index <- [0 .. nodes - 1]
+            ])
+        ]
+    }
+  where
+    changedIndex = revision `mod` nodes
+    makeNode index = Aeson.object
+        [ "role" Aeson..= ("AXStaticText" :: Text)
+        , "identifier" Aeson..= ("row-" <> Text.pack (show index))
+        , "title" Aeson..= nodeTitle index
+        , "enabled" Aeson..= True
+        , "position" Aeson..= Aeson.object
+            [ "x" Aeson..= (index `mod` 80)
+            , "y" Aeson..= (index `div` 80)
+            ]
+        ]
+    nodeTitle index =
+        case workload of
+            Static -> "unchanged"
+            SmallChange
+                | index == changedIndex ->
+                    "changed-" <> Text.pack (show revision)
+                | otherwise -> "unchanged"
+            HighChurn ->
+                "revision-" <> Text.pack (show revision)
+                    <> "-node-" <> Text.pack (show index)
+
+median :: [Sample] -> Sample
+median samples =
+    sortOn (.sampleElapsedMillis) samples !! (length samples `div` 2)
+
+printSample :: Workload -> Policy -> Int -> Int -> Sample -> IO ()
+printSample workload policy nodes revisions sample =
+    printf
+        "%s,%s,%d,%d,%.3f,%.3f,%d,%d\n"
+        (workloadName workload)
+        (policyName policy)
+        nodes
+        revisions
+        sample.sampleElapsedMillis
+        sample.sampleCpuMillis
+        sample.sampleAllocatedBytes
+        sample.sampleOutputBytes
+
+csvHeader :: String
+csvHeader =
+    "workload,policy,nodes,revisions,elapsed_ms,cpu_ms,allocated_bytes,output_bytes"
+
+workloadName :: Workload -> String
+workloadName = \case
+    Static -> "static"
+    SmallChange -> "small-change"
+    HighChurn -> "high-churn"
+
+policyName :: Policy -> String
+policyName = \case
+    AlwaysFull -> "always-full"
+    RevisionedDelta -> "revisioned-delta"
+
+parseWorkload :: String -> IO Workload
+parseWorkload = \case
+    "static" -> pure Static
+    "small-change" -> pure SmallChange
+    "high-churn" -> pure HighChurn
+    other -> die ("unknown workload: " <> other)
+
+parsePositive :: String -> String -> IO Int
+parsePositive label raw =
+    case reads raw of
+        [(value, "")] | value > 0 -> pure value
+        _ -> die ("invalid " <> label <> ": " <> raw)

--- a/packages/agent-cli/benchmark/AccessibilityDelta.hs
+++ b/packages/agent-cli/benchmark/AccessibilityDelta.hs
@@ -11,7 +11,7 @@ import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
-import Data.List (sortOn)
+import Data.List (sort)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import GHC.Clock (getMonotonicTimeNSec)
@@ -167,8 +167,17 @@ makeSnapshot workload nodes revision = AccessibilitySnapshot
                     <> "-node-" <> Text.pack (show index)
 
 median :: [Sample] -> Sample
-median samples =
-    sortOn (.sampleElapsedMillis) samples !! (length samples `div` 2)
+median samples = Sample
+    { sampleElapsedMillis = medianValue (map (.sampleElapsedMillis) samples)
+    , sampleCpuMillis = medianValue (map (.sampleCpuMillis) samples)
+    , sampleAllocatedBytes =
+        medianValue (map (.sampleAllocatedBytes) samples)
+    , sampleOutputBytes = medianValue (map (.sampleOutputBytes) samples)
+    }
+
+medianValue :: Ord value => [value] -> value
+medianValue values =
+    sort values !! (length values `div` 2)
 
 printSample :: Workload -> Policy -> Int -> Int -> Sample -> IO ()
 printSample workload policy nodes revisions sample =

--- a/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
@@ -168,6 +168,7 @@ projectCodeModeTools mode tools = case mode of
     isHostedComputerTool tool =
         case tool.appToolSchema of
             HostedComputerSchema -> True
+            HostedComputerFunctionSchema _ -> True
             _ -> False
 
 projectCodeModeToolsFor

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -1568,6 +1568,7 @@ autoCompactOpenAiBackendWithLimit getLimit absorbCompletedTools compactAction
         -- keep passing the inputs normally.
         installation <-
             onCompacted outcome inputs `onException` rollback
+        callbacks.onLoopEvent ModelContextReset
         let (continuationHistory, continuationInputs, rollbackIfDeferred) =
                 case installation of
                     CompactionInstalled -> (durableHistory, [], pure ())

--- a/packages/agent-cli/src/Agent/CLI/Compaction/Continuation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction/Continuation.hs
@@ -11,8 +11,10 @@ import Agent.CLI.Compaction.Projection
 import Agent.CLI.Compaction.Types
 import Agent.Loop
     ( Backend(..)
+    , BackendCallbacks(..)
     , BackendMiddleware
     , BackendSnapshot(..)
+    , LoopEvent(..)
     , TurnInput(..)
     , advanceBackendSnapshot
     , backendWithCallbacks
@@ -96,8 +98,10 @@ boundCompletedToolContinuations contextWindowFor getParams contextTokensRef back
                     then backend.submitTurnWithCallbacks
                         snapshot previous inputs callbacks
                     else if requestTokens truncated <= contextWindow
-                        then backend.submitTurnWithCallbacks
-                            snapshot previous truncated callbacks
+                        then do
+                            callbacks.onLoopEvent ModelContextReset
+                            backend.submitTurnWithCallbacks
+                                snapshot previous truncated callbacks
                         else submitTrimmedHistory
                             params
                             contextWindow
@@ -127,9 +131,11 @@ boundCompletedToolContinuations contextWindowFor getParams contextTokensRef back
                     params
                     (fittedHistory <> turnInputsToItems inputs)
         if fittedTokens <= contextWindow
-            then backend.submitTurnWithCallbacks
-                (advanceBackendSnapshot snapshot fittedHistory Nothing)
-                Nothing inputs callbacks
+            then do
+                callbacks.onLoopEvent ModelContextReset
+                backend.submitTurnWithCallbacks
+                    (advanceBackendSnapshot snapshot fittedHistory Nothing)
+                    Nothing inputs callbacks
             else pure (Left toolContinuationTooLargeError)
 
 pendingToolCallIds :: [TurnInput] -> [Text]

--- a/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
@@ -49,6 +49,13 @@ import Agent.CLI.ComputerUse.Backend
     )
 import qualified Agent.CLI.ComputerUse.Input as Input
 import qualified Agent.CLI.ComputerUse.Linux as Linux
+import Agent.ComputerUse.Protocol
+    ( SemanticComputerAction(..)
+    , SemanticComputerRequest(..)
+    , SemanticComputerScalar(..)
+    , decodeSemanticComputerRequest
+    , semanticComputerRequestWantsScreenshot
+    )
 import qualified Agent.Json.Decode as Json
 import Agent.Loop (ImageAttachment(..))
 import Agent.CLI.ComputerUse.Accessibility
@@ -92,7 +99,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isControl, isDigit)
-import Data.Foldable (toList)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -1243,92 +1250,60 @@ summarizeComputerToolCall call
                                 else "Computer: " <> detail
 
 summarizeSemanticComputerCall :: Text -> Maybe Text
-summarizeSemanticComputerCall arguments = do
-    Aeson.Object object <-
-        Aeson.decodeStrict' (TextEncoding.encodeUtf8 arguments)
-    Aeson.String operation <- KeyMap.lookup "operation" object
-    let screenshotSuffix =
-            case KeyMap.lookup "include_screenshot" object of
-                Just (Aeson.Bool True) -> " and capture a screenshot"
-                _ -> ""
-    case operation of
-        "list_targets" -> Just "list accessible windows"
-        "bind" ->
-            case KeyMap.lookup "target_id" object of
-                Just (Aeson.String targetId) ->
-                    Just
-                        ( "bind accessible target "
-                            <> safeQuoted 128 targetId
-                            <> screenshotSuffix
-                        )
-                _ -> Just ("bind an accessible window" <> screenshotSuffix)
-        "observe" ->
-            Just ("inspect the bound accessible window" <> screenshotSuffix)
-        "act" -> do
-            Aeson.Array actions <- KeyMap.lookup "actions" object
-            let summaries =
-                    take 64
-                        (map summarizeSemanticAction (toList actions))
-            Just $
-                Text.intercalate "; " summaries
-                    <> screenshotSuffix
-        _ -> Nothing
+summarizeSemanticComputerCall arguments =
+    either (const Nothing) (Just . summarize) $
+        decodeSemanticComputerRequest arguments
   where
+    summarize request =
+        case request of
+            ListComputerTargets -> "list accessible windows"
+            BindComputerTarget targetId _ ->
+                "bind accessible target "
+                    <> safeQuoted 128 targetId
+                    <> screenshotSuffix request
+            ObserveComputerTarget _ ->
+                "inspect the bound accessible window"
+                    <> screenshotSuffix request
+            ActOnComputerTarget actions _ ->
+                Text.intercalate
+                    "; "
+                    (map summarizeSemanticAction (NonEmpty.toList actions))
+                    <> screenshotSuffix request
+    screenshotSuffix request
+        | semanticComputerRequestWantsScreenshot request =
+            " and capture a screenshot"
+        | otherwise = ""
     summarizeSemanticAction = \case
-        Aeson.Object object ->
-            case KeyMap.lookup "type" object of
-                Just (Aeson.String "perform") ->
-                    case
-                        ( KeyMap.lookup "action" object
-                        , semanticElement object
-                        ) of
-                        (Just (Aeson.String action), Just element) ->
-                            "perform " <> safeQuoted 64 action
-                                <> " on accessibility element "
-                                <> element
-                        _ -> "perform an accessibility action"
-                Just (Aeson.String "set_value") ->
-                    case semanticElement object of
-                        Just element ->
-                            "set "
-                                <> semanticValueDescription
-                                    (KeyMap.lookup "value" object)
-                                <> " on accessibility element "
-                                <> element
-                        Nothing -> "set an accessibility value"
-                Just (Aeson.String "replace_selected_text") ->
-                    case
-                        ( KeyMap.lookup "text" object
-                        , semanticElement object
-                        ) of
-                        (Just (Aeson.String text), Just element) ->
-                            let prefix = Text.take 8193 text
-                                count = Text.length prefix
-                            in if count > 8192
-                                then
-                                    "replace more than 8192 selected characters on "
-                                        <> "accessibility element "
-                                        <> element
-                                else "replace "
-                                    <> Text.pack (show count)
-                                    <> " selected characters on accessibility element "
-                                    <> element
-                        _ -> "replace selected text"
-                _ -> "run an accessibility action"
-        _ -> "run an accessibility action"
-    semanticElement object =
-        case KeyMap.lookup "element_id" object of
-            Just (Aeson.String elementId) -> Just (safeQuoted 128 elementId)
-            _ -> Nothing
+        PerformComputerAction elementId action ->
+            "perform " <> safeQuoted 64 action
+                <> " on accessibility element "
+                <> safeQuoted 128 elementId
+        SetComputerValue elementId value ->
+            "set "
+                <> semanticValueDescription value
+                <> " on accessibility element "
+                <> safeQuoted 128 elementId
+        ReplaceComputerSelectedText elementId text ->
+            let prefix = Text.take 8193 text
+                count = Text.length prefix
+                element = safeQuoted 128 elementId
+            in if count > 8192
+                then
+                    "replace more than 8192 selected characters on "
+                        <> "accessibility element "
+                        <> element
+                else "replace "
+                    <> Text.pack (show count)
+                    <> " selected characters on accessibility element "
+                    <> element
     semanticValueDescription = \case
-        Just (Aeson.String value) ->
+        ComputerText value ->
             let count = Text.length (Text.take 8193 value)
             in if count > 8192
                 then "a text value longer than 8192 characters"
                 else "a " <> Text.pack (show count) <> "-character text value"
-        Just (Aeson.Number _) -> "a numeric value"
-        Just (Aeson.Bool _) -> "a boolean value"
-        _ -> "an accessibility value"
+        ComputerNumber _ -> "a numeric value"
+        ComputerBool _ -> "a boolean value"
 
 computerToolCallHasPendingSafetyChecks :: ToolCall -> Bool
 computerToolCallHasPendingSafetyChecks call

--- a/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
@@ -1,6 +1,16 @@
 -- | Function-based computer use backed by local desktop capture and input.
 module Agent.CLI.ComputerUse
     ( ComputerObservation(..)
+    , AccessibilitySnapshot(..)
+    , AccessibilityPatchOperation(..)
+    , AccessibilityObservation(..)
+    , AccessibilityDeltaState
+    , initialAccessibilityDeltaState
+    , decodeAccessibilitySnapshot
+    , advanceAccessibilityObservation
+    , unavailableAccessibilityObservation
+    , resetAccessibilityDeltaState
+    , applyAccessibilityPatch
     , ComputerUseBackend(..)
     , ScreenshotEncoding(..)
     , ComputerUseRuntime
@@ -41,6 +51,7 @@ import qualified Agent.CLI.ComputerUse.Input as Input
 import qualified Agent.CLI.ComputerUse.Linux as Linux
 import qualified Agent.Json.Decode as Json
 import Agent.Loop (ImageAttachment(..))
+import Agent.CLI.ComputerUse.Accessibility
 import Agent.Responses.Types
     ( ComputerAction(..)
     , ComputerCall(..)
@@ -329,7 +340,7 @@ executeComputerCall =
 
 data ComputerObservation = ComputerObservation
     { computerObservationImage :: !ImageAttachment
-    , computerObservationAccessibility :: !(Maybe Text)
+    , computerObservationAccessibility :: !(Maybe AccessibilityObservation)
     } deriving (Eq, Show)
 
 -- | One computer-use transaction. The backend owns display discovery,
@@ -658,7 +669,7 @@ encodeComputerOutput call observation =
             , computerOutputStatus = Nothing
             , computerOutputExtra = maybe
                 KeyMap.empty
-                (KeyMap.singleton "accessibility_state" . Aeson.String)
+                (KeyMap.singleton "accessibility_state" . Aeson.toJSON)
                 observation.computerObservationAccessibility
             }
   where

--- a/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
@@ -92,6 +92,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isControl, isDigit)
+import Data.Foldable (toList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -1228,15 +1229,106 @@ summarizeComputerToolCall call
     | call.name /= computerToolName
         || not (isComputerToolCallKind call.callKind) = Nothing
     | otherwise =
-        case Json.decodeText computerToolInputDecoder call.arguments of
-            Left _ -> Just "Computer action"
-            Right input ->
-                let computerCall = computerCallFromInput call input
-                    detail = summarizeComputerCall computerCall
-                in Just $
-                    if Text.null detail
-                        then "Computer action"
-                        else "Computer: " <> detail
+        case summarizeSemanticComputerCall call.arguments of
+            Just detail -> Just ("Computer: " <> detail)
+            Nothing ->
+                case Json.decodeText computerToolInputDecoder call.arguments of
+                    Left _ -> Just "Computer action"
+                    Right input ->
+                        let computerCall = computerCallFromInput call input
+                            detail = summarizeComputerCall computerCall
+                        in Just $
+                            if Text.null detail
+                                then "Computer action"
+                                else "Computer: " <> detail
+
+summarizeSemanticComputerCall :: Text -> Maybe Text
+summarizeSemanticComputerCall arguments = do
+    Aeson.Object object <-
+        Aeson.decodeStrict' (TextEncoding.encodeUtf8 arguments)
+    Aeson.String operation <- KeyMap.lookup "operation" object
+    let screenshotSuffix =
+            case KeyMap.lookup "include_screenshot" object of
+                Just (Aeson.Bool True) -> " and capture a screenshot"
+                _ -> ""
+    case operation of
+        "list_targets" -> Just "list accessible windows"
+        "bind" ->
+            case KeyMap.lookup "target_id" object of
+                Just (Aeson.String targetId) ->
+                    Just
+                        ( "bind accessible target "
+                            <> safeQuoted 128 targetId
+                            <> screenshotSuffix
+                        )
+                _ -> Just ("bind an accessible window" <> screenshotSuffix)
+        "observe" ->
+            Just ("inspect the bound accessible window" <> screenshotSuffix)
+        "act" -> do
+            Aeson.Array actions <- KeyMap.lookup "actions" object
+            let summaries =
+                    take 64
+                        (map summarizeSemanticAction (toList actions))
+            Just $
+                Text.intercalate "; " summaries
+                    <> screenshotSuffix
+        _ -> Nothing
+  where
+    summarizeSemanticAction = \case
+        Aeson.Object object ->
+            case KeyMap.lookup "type" object of
+                Just (Aeson.String "perform") ->
+                    case
+                        ( KeyMap.lookup "action" object
+                        , semanticElement object
+                        ) of
+                        (Just (Aeson.String action), Just element) ->
+                            "perform " <> safeQuoted 64 action
+                                <> " on accessibility element "
+                                <> element
+                        _ -> "perform an accessibility action"
+                Just (Aeson.String "set_value") ->
+                    case semanticElement object of
+                        Just element ->
+                            "set "
+                                <> semanticValueDescription
+                                    (KeyMap.lookup "value" object)
+                                <> " on accessibility element "
+                                <> element
+                        Nothing -> "set an accessibility value"
+                Just (Aeson.String "replace_selected_text") ->
+                    case
+                        ( KeyMap.lookup "text" object
+                        , semanticElement object
+                        ) of
+                        (Just (Aeson.String text), Just element) ->
+                            let prefix = Text.take 8193 text
+                                count = Text.length prefix
+                            in if count > 8192
+                                then
+                                    "replace more than 8192 selected characters on "
+                                        <> "accessibility element "
+                                        <> element
+                                else "replace "
+                                    <> Text.pack (show count)
+                                    <> " selected characters on accessibility element "
+                                    <> element
+                        _ -> "replace selected text"
+                _ -> "run an accessibility action"
+        _ -> "run an accessibility action"
+    semanticElement object =
+        case KeyMap.lookup "element_id" object of
+            Just (Aeson.String elementId) -> Just (safeQuoted 128 elementId)
+            _ -> Nothing
+    semanticValueDescription = \case
+        Just (Aeson.String value) ->
+            let count = Text.length (Text.take 8193 value)
+            in if count > 8192
+                then "a text value longer than 8192 characters"
+                else "a " <> Text.pack (show count) <> "-character text value"
+        Just (Aeson.Number _) -> "a numeric value"
+        Just (Aeson.Bool _) -> "a boolean value"
+        _ -> "an accessibility value"
 
 computerToolCallHasPendingSafetyChecks :: ToolCall -> Bool
 computerToolCallHasPendingSafetyChecks call

--- a/packages/agent-cli/src/Agent/CLI/ComputerUse/Accessibility.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse/Accessibility.hs
@@ -1,0 +1,324 @@
+-- | Revisioned accessibility observations for computer use.
+module Agent.CLI.ComputerUse.Accessibility
+    ( AccessibilitySnapshot(..)
+    , AccessibilityPatchOperation(..)
+    , AccessibilityObservation(..)
+    , AccessibilityDeltaState
+    , initialAccessibilityDeltaState
+    , decodeAccessibilitySnapshot
+    , advanceAccessibilityObservation
+    , unavailableAccessibilityObservation
+    , resetAccessibilityDeltaState
+    , applyAccessibilityPatch
+    ) where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Vector as Vector
+
+-- | A versioned native snapshot. @scope@ identifies the foreground
+-- application/window and @contents@ contains the bounded AX tree.
+data AccessibilitySnapshot = AccessibilitySnapshot
+    { accessibilitySnapshotSchemaVersion :: !Int
+    , accessibilitySnapshotScope :: !Aeson.Value
+    , accessibilitySnapshotContents :: !Aeson.Value
+    } deriving (Eq, Show)
+
+instance Aeson.ToJSON AccessibilitySnapshot where
+    toJSON snapshot = Aeson.object
+        [ "schema_version" Aeson..=
+            snapshot.accessibilitySnapshotSchemaVersion
+        , "scope" Aeson..= snapshot.accessibilitySnapshotScope
+        , "contents" Aeson..= snapshot.accessibilitySnapshotContents
+        ]
+
+instance Aeson.FromJSON AccessibilitySnapshot where
+    parseJSON = Aeson.withObject "AccessibilitySnapshot" \object -> do
+        schemaVersion <- object Aeson..: "schema_version"
+        if schemaVersion /= (1 :: Int)
+            then fail "unsupported accessibility snapshot schema_version"
+            else AccessibilitySnapshot schemaVersion
+                <$> object Aeson..: "scope"
+                <*> object Aeson..: "contents"
+
+-- | The subset of RFC 6902 operations emitted by the snapshot differ.
+data AccessibilityPatchOperation
+    = AccessibilityAdd !Text !Aeson.Value
+    | AccessibilityRemove !Text
+    | AccessibilityReplace !Text !Aeson.Value
+    deriving (Eq, Show)
+
+instance Aeson.ToJSON AccessibilityPatchOperation where
+    toJSON = \case
+        AccessibilityAdd path value -> Aeson.object
+            [ "op" Aeson..= ("add" :: Text)
+            , "path" Aeson..= path
+            , "value" Aeson..= value
+            ]
+        AccessibilityRemove path -> Aeson.object
+            [ "op" Aeson..= ("remove" :: Text)
+            , "path" Aeson..= path
+            ]
+        AccessibilityReplace path value -> Aeson.object
+            [ "op" Aeson..= ("replace" :: Text)
+            , "path" Aeson..= path
+            , "value" Aeson..= value
+            ]
+
+data AccessibilityObservation
+    = AccessibilityFull !Int !AccessibilitySnapshot
+    | AccessibilityDelta
+        !Int
+        !Int
+        ![AccessibilityPatchOperation]
+    | AccessibilityUnavailable !Int !Text
+    deriving (Eq, Show)
+
+instance Aeson.ToJSON AccessibilityObservation where
+    toJSON = \case
+        AccessibilityFull revision snapshot -> Aeson.object
+            [ "kind" Aeson..= ("full" :: Text)
+            , "revision" Aeson..= revision
+            , "snapshot" Aeson..= snapshot
+            ]
+        AccessibilityDelta baseRevision revision patch -> Aeson.object
+            [ "kind" Aeson..= ("delta" :: Text)
+            , "base_revision" Aeson..= baseRevision
+            , "revision" Aeson..= revision
+            , "patch" Aeson..= patch
+            ]
+        AccessibilityUnavailable revision reason -> Aeson.object
+            [ "kind" Aeson..= ("unavailable" :: Text)
+            , "revision" Aeson..= revision
+            , "reason" Aeson..= reason
+            ]
+
+data AccessibilityDeltaState = AccessibilityDeltaState
+    { deltaRevision :: !Int
+    , deltaBaseline :: !(Maybe AccessibilitySnapshot)
+    , deltaCountSinceFull :: !Int
+    } deriving (Eq, Show)
+
+initialAccessibilityDeltaState :: AccessibilityDeltaState
+initialAccessibilityDeltaState = AccessibilityDeltaState 0 Nothing 0
+
+resetAccessibilityDeltaState
+    :: AccessibilityDeltaState
+    -> AccessibilityDeltaState
+resetAccessibilityDeltaState state =
+    state { deltaBaseline = Nothing, deltaCountSinceFull = 0 }
+
+decodeAccessibilitySnapshot
+    :: BS.ByteString
+    -> Either Text AccessibilitySnapshot
+decodeAccessibilitySnapshot bytes =
+    case Aeson.eitherDecodeStrict' bytes of
+        Left err -> Left (Text.pack err)
+        Right snapshot -> Right snapshot
+
+-- | Advance the model-visible accessibility stream. Large or periodically
+-- checkpointed changes are sent as a full snapshot.
+advanceAccessibilityObservation
+    :: AccessibilityDeltaState
+    -> AccessibilitySnapshot
+    -> (AccessibilityObservation, AccessibilityDeltaState)
+advanceAccessibilityObservation state snapshot =
+    case state.deltaBaseline of
+        Nothing -> full
+        Just baseline
+            | baseline.accessibilitySnapshotSchemaVersion
+                /= snapshot.accessibilitySnapshotSchemaVersion -> full
+            | baseline.accessibilitySnapshotScope
+                /= snapshot.accessibilitySnapshotScope -> full
+            | state.deltaCountSinceFull >= 8 -> full
+            | patchSize * 5 >= fullSize * 3 -> full
+            | otherwise ->
+                ( AccessibilityDelta state.deltaRevision revision patch
+                , AccessibilityDeltaState
+                    revision
+                    (Just snapshot)
+                    (state.deltaCountSinceFull + 1)
+                )
+          where
+            patch = diffValue "" (Aeson.toJSON baseline) (Aeson.toJSON snapshot)
+            patchSize = encodedSize patch
+            fullSize = encodedSize snapshot
+  where
+    revision = state.deltaRevision + 1
+    full =
+        ( AccessibilityFull revision snapshot
+        , AccessibilityDeltaState revision (Just snapshot) 0
+        )
+
+unavailableAccessibilityObservation
+    :: Text
+    -> AccessibilityDeltaState
+    -> (AccessibilityObservation, AccessibilityDeltaState)
+unavailableAccessibilityObservation reason state =
+    ( AccessibilityUnavailable revision reason
+    , AccessibilityDeltaState revision Nothing 0
+    )
+  where
+    revision = state.deltaRevision + 1
+
+encodedSize :: Aeson.ToJSON value => value -> Int
+encodedSize = fromIntegral . LBS.length . Aeson.encode
+
+diffValue
+    :: Text
+    -> Aeson.Value
+    -> Aeson.Value
+    -> [AccessibilityPatchOperation]
+diffValue _ old new
+    | old == new = []
+diffValue path (Aeson.Object old) (Aeson.Object new) =
+    removals <> changes
+  where
+    removals =
+        [ AccessibilityRemove (childPath path key)
+        | (key, _) <- KeyMap.toAscList old
+        , not (KeyMap.member key new)
+        ]
+    changes = concat
+        [ case KeyMap.lookup key old of
+            Nothing -> [AccessibilityAdd (childPath path key) value]
+            Just oldValue -> diffValue (childPath path key) oldValue value
+        | (key, value) <- KeyMap.toAscList new
+        ]
+-- Equal-length arrays can be compared by index, which keeps ordinary AX
+-- property changes small. Structural array changes use one exact replacement
+-- and let the checkpoint-size policy decide whether a full snapshot is better.
+diffValue path (Aeson.Array old) new@(Aeson.Array values)
+    | Vector.length old == Vector.length values =
+        concat
+            [ diffValue
+                (path <> "/" <> Text.pack (show index))
+                oldValue
+                newValue
+            | (index, (oldValue, newValue)) <-
+                zip [0 :: Int ..]
+                    (zip (Vector.toList old) (Vector.toList values))
+            ]
+    | otherwise = [AccessibilityReplace path new]
+diffValue path _ new = [AccessibilityReplace path new]
+
+childPath :: Text -> Key.Key -> Text
+childPath parent key =
+    parent <> "/" <> escapePointerToken (Key.toText key)
+
+escapePointerToken :: Text -> Text
+escapePointerToken = Text.replace "/" "~1" . Text.replace "~" "~0"
+
+-- | Apply emitted operations. Exported primarily for protocol consumers and
+-- reconstruction-property tests.
+applyAccessibilityPatch
+    :: Aeson.Value
+    -> [AccessibilityPatchOperation]
+    -> Either Text Aeson.Value
+applyAccessibilityPatch = foldl' step . Right
+  where
+    step result operation = result >>= \value -> applyOne value operation
+
+applyOne
+    :: Aeson.Value
+    -> AccessibilityPatchOperation
+    -> Either Text Aeson.Value
+applyOne value operation =
+    case operation of
+        AccessibilityAdd path replacement ->
+            updateAt True path (const (Right replacement)) value
+        AccessibilityRemove path ->
+            removeAt path value
+        AccessibilityReplace path replacement ->
+            updateAt False path (const (Right replacement)) value
+
+updateAt
+    :: Bool
+    -> Text
+    -> (Aeson.Value -> Either Text Aeson.Value)
+    -> Aeson.Value
+    -> Either Text Aeson.Value
+updateAt allowMissing path update root
+    | Text.null path = update root
+    | otherwise = descend (pointerTokens path) root
+  where
+    descend [] value = update value
+    descend (token : rest) (Aeson.Object object)
+        | null rest
+        , allowMissing =
+            Right (Aeson.Object
+                (KeyMap.insert (Key.fromText token)
+                    (either (const Aeson.Null) id (update Aeson.Null))
+                    object))
+        | otherwise = do
+            child <- maybe
+                (Left ("JSON Pointer does not exist: " <> path))
+                Right
+                (KeyMap.lookup (Key.fromText token) object)
+            replacement <- descend rest child
+            Right (Aeson.Object
+                (KeyMap.insert (Key.fromText token) replacement object))
+    descend (token : rest) (Aeson.Array values) = do
+        index <- parseIndex token
+        child <- maybe
+            (Left ("JSON Pointer does not exist: " <> path))
+            Right
+            (values Vector.!? index)
+        replacement <- descend rest child
+        Right (Aeson.Array (values Vector.// [(index, replacement)]))
+    descend _ _ = Left ("JSON Pointer does not identify a container: " <> path)
+
+removeAt :: Text -> Aeson.Value -> Either Text Aeson.Value
+removeAt path root
+    | Text.null path = Left "cannot remove the document root"
+    | otherwise = descend (pointerTokens path) root
+  where
+    descend [] _ = Left "cannot remove the document root"
+    descend [token] (Aeson.Object object)
+        | KeyMap.member key object =
+            Right (Aeson.Object (KeyMap.delete key object))
+        | otherwise = Left ("JSON Pointer does not exist: " <> path)
+      where
+        key = Key.fromText token
+    descend [token] (Aeson.Array values) = do
+        index <- parseIndex token
+        if index < Vector.length values
+            then Right (Aeson.Array
+                (Vector.take index values <> Vector.drop (index + 1) values))
+            else Left ("JSON Pointer does not exist: " <> path)
+    descend (token : rest) (Aeson.Object object) = do
+        child <- maybe
+            (Left ("JSON Pointer does not exist: " <> path))
+            Right
+            (KeyMap.lookup key object)
+        replacement <- descend rest child
+        Right (Aeson.Object (KeyMap.insert key replacement object))
+      where
+        key = Key.fromText token
+    descend (token : rest) (Aeson.Array values) = do
+        index <- parseIndex token
+        child <- maybe
+            (Left ("JSON Pointer does not exist: " <> path))
+            Right
+            (values Vector.!? index)
+        replacement <- descend rest child
+        Right (Aeson.Array (values Vector.// [(index, replacement)]))
+    descend _ _ = Left ("JSON Pointer does not identify a container: " <> path)
+
+pointerTokens :: Text -> [Text]
+pointerTokens =
+    map unescapePointerToken . Text.splitOn "/" . Text.drop 1
+
+unescapePointerToken :: Text -> Text
+unescapePointerToken = Text.replace "~1" "/" . Text.replace "~0" "~"
+
+parseIndex :: Text -> Either Text Int
+parseIndex token =
+    case reads (Text.unpack token) of
+        [(index, "")] | index >= 0 -> Right index
+        _ -> Left ("invalid JSON Pointer array index: " <> token)

--- a/packages/agent-cli/src/Agent/CLI/ComputerUse/Accessibility.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse/Accessibility.hs
@@ -40,7 +40,7 @@ instance Aeson.ToJSON AccessibilitySnapshot where
 instance Aeson.FromJSON AccessibilitySnapshot where
     parseJSON = Aeson.withObject "AccessibilitySnapshot" \object -> do
         schemaVersion <- object Aeson..: "schema_version"
-        if schemaVersion /= (1 :: Int)
+        if schemaVersion `notElem` ([1, 2] :: [Int])
             then fail "unsupported accessibility snapshot schema_version"
             else AccessibilitySnapshot schemaVersion
                 <$> object Aeson..: "scope"

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -632,6 +632,8 @@ renderEventUnlocked config = \case
         pure ()
     NativeAgentFinished{} ->
         pure ()
+    ModelContextReset ->
+        pure ()
 
 renderToolStartedUnlocked :: RenderConfig -> ToolCall -> IO ()
 renderToolStartedUnlocked config call = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -581,6 +581,7 @@ uiEventLogicalBytes = \case
                 logicalTextBytes text
             WarningRaised text -> logicalTextBytes text
             ResponseRestarted text -> logicalTextBytes text
+            ModelContextReset -> 128
             TurnStarted -> 128
             TurnFinished output -> turnOutputLogicalBytes output
             ToolStarted call -> toolCallLogicalBytes call

--- a/packages/agent-cli/src/Agent/CLI/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Tools.hs
@@ -58,7 +58,9 @@ import Agent.Tools.Types
     )
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
+import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Foldable as Foldable
 import Data.List (partition)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
@@ -77,7 +79,7 @@ requireToolRegistry tools
   where
     reservesComputerFunction tool =
         canonicalToolName tool.appToolName == computerFunctionName
-            && tool.appToolSchema /= HostedComputerSchema
+            && not (isHostedComputerSchema tool.appToolSchema)
 
 lookupAppTool :: Text -> [AppTool] -> Maybe AppTool
 lookupAppTool name tools =
@@ -202,7 +204,7 @@ isImageGenerationTool tool =
 schemaFromAppTool :: Bool -> Dialect -> AppTool -> Maybe ResponseTool
 schemaFromAppTool _ _ tool
     | canonicalToolName tool.appToolName == computerFunctionName
-    , tool.appToolSchema /= HostedComputerSchema =
+    , not (isHostedComputerSchema tool.appToolSchema) =
         Nothing
 schemaFromAppTool modelSupportsAsync dialect tool =
     fmap (setAsyncCapability supportsAsync) $
@@ -217,6 +219,19 @@ schemaFromAppTool modelSupportsAsync dialect tool =
                             (rawJsonFromEncoding
                                 (Aeson.toEncoding computerFunctionParameters))
                         , strict = Just True
+                        , async = Nothing
+                        })
+                    else Nothing
+            HostedComputerFunctionSchema parameters ->
+                if os == "darwin" && dialectId dialect == CodexDialect
+                    then Just (FunctionToolValue FunctionTool
+                        { name = computerFunctionName
+                        , description = Just tool.appToolDescription
+                        , parameters = Just
+                            (rawJsonFromEncoding
+                                (Aeson.toEncoding parameters))
+                        , strict = Just
+                            (isStrictHostedFunctionSchema parameters)
                         , async = Nothing
                         })
                     else Nothing
@@ -360,6 +375,70 @@ namespaceTool modelSupportsAsync namespaceName namespaceDescription tools =
         FreeformApplyPatchSchema -> Aeson.object []
         FreeformGrammarSchema _ _ -> Aeson.object []
         HostedComputerSchema -> Aeson.object []
+        HostedComputerFunctionSchema _ -> Aeson.object []
+
+isHostedComputerSchema :: ToolSchema -> Bool
+isHostedComputerSchema = \case
+    HostedComputerSchema -> True
+    HostedComputerFunctionSchema _ -> True
+    _ -> False
+
+isStrictHostedFunctionSchema :: Aeson.Value -> Bool
+isStrictHostedFunctionSchema value@(Aeson.Object object) =
+    KeyMap.lookup "type" object == Just (Aeson.String "object")
+        && strictSchemaNode value
+isStrictHostedFunctionSchema _ = False
+
+strictSchemaNode :: Aeson.Value -> Bool
+strictSchemaNode (Aeson.Object object)
+    | any (`KeyMap.member` object)
+        ["allOf", "oneOf", "not", "if", "then", "else", "$ref"] =
+        False
+    | schemaIncludesType "object" object =
+        case
+            ( KeyMap.lookup "properties" object
+            , KeyMap.lookup "required" object
+            , KeyMap.lookup "additionalProperties" object
+            ) of
+            ( Just (Aeson.Object properties)
+                , Just (Aeson.Array required)
+                , Just (Aeson.Bool False)
+                ) ->
+                    let propertyNames =
+                            map (Key.toText) (KeyMap.keys properties)
+                        requiredNames =
+                            [ name
+                            | Aeson.String name <- Foldable.toList required
+                            ]
+                    in length requiredNames == Foldable.length required
+                        && length requiredNames == length propertyNames
+                        && all (`elem` requiredNames) propertyNames
+                        && all strictSchemaNode properties
+            _ -> False
+    | schemaIncludesType "array" object =
+        maybe False strictSchemaNode (KeyMap.lookup "items" object)
+            && strictAlternatives object
+    | otherwise = strictAlternatives object
+strictSchemaNode (Aeson.Array values) =
+    all strictSchemaNode values
+strictSchemaNode _ = True
+
+strictAlternatives :: Aeson.Object -> Bool
+strictAlternatives object =
+    case KeyMap.lookup "anyOf" object of
+        Nothing -> True
+        Just (Aeson.Array alternatives) ->
+            not (Foldable.null alternatives)
+                && all strictSchemaNode alternatives
+        Just _ -> False
+
+schemaIncludesType :: Text -> Aeson.Object -> Bool
+schemaIncludesType expected object =
+    case KeyMap.lookup "type" object of
+        Just (Aeson.String actual) -> actual == expected
+        Just (Aeson.Array actual) ->
+            Aeson.String expected `elem` Foldable.toList actual
+        _ -> False
 
 -- | Codex registers apply_patch as a Responses custom tool with a Lark grammar.
 applyPatchCustomTool :: Text -> Text -> ResponseTool

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -1563,7 +1563,10 @@ spec = do
                     expectationFailure
                         ("expected one compacted continuation, got "
                             <> show (length seen))
-            readIORef events `shouldReturn` [ModelContextReset]
+            readIORef events `shouldReturn`
+                [ ActivityUpdated "Compacting context…"
+                , ModelContextReset
+                ]
 
         it "rejects an oversized first turn before provider submission" do
             let params = defaultResponseCreateParams

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -1527,6 +1527,7 @@ spec = do
             contextState <- newIORef Nothing
             compactCalls <- newIORef (0 :: Int)
             seenHistory <- newIORef []
+            events <- newIORef []
             let sender _request = do
                     modifyIORef' compactCalls (+ 1)
                     pure (Right remoteCompactionResponse)
@@ -1550,7 +1551,8 @@ spec = do
                         contextState
                         base
             result <- backend.submitTurn (initialBackendSnapshot history) Nothing
-                [UserMessage pendingText] (const (pure ()))
+                [UserMessage pendingText]
+                (\event -> modifyIORef' events (<> [event]))
             result `shouldSatisfy` either (const False) (const True)
             readIORef compactCalls `shouldReturn` 1
             readIORef seenHistory >>= \case
@@ -1561,6 +1563,7 @@ spec = do
                     expectationFailure
                         ("expected one compacted continuation, got "
                             <> show (length seen))
+            readIORef events `shouldReturn` [ModelContextReset]
 
         it "rejects an oversized first turn before provider submission" do
             let params = defaultResponseCreateParams
@@ -1704,7 +1707,9 @@ spec = do
             readIORef contextState `shouldReturn`
                 Just (reportedOccupancy 25 (length compactedHistory))
             readIORef events `shouldReturn`
-                [ActivityUpdated "Compacting context…"]
+                [ ActivityUpdated "Compacting context…"
+                , ModelContextReset
+                ]
 
         it "records active-session compaction usage before a failed continuation" do
             let history = [userTextItem "old"]
@@ -1715,6 +1720,7 @@ spec = do
             requests <- newIORef []
             recordedUsage <- newIORef []
             hookCalls <- newIORef (0 :: Int)
+            events <- newIORef []
             let sender request = do
                     modifyIORef' requests (<> [request])
                     pure (Right remoteCompactionResponse)
@@ -1733,7 +1739,8 @@ spec = do
                         contextState
                         base
             backend.submitTurn (initialBackendSnapshot history) Nothing
-                [UserMessage "new"] (const (pure ()))
+                [UserMessage "new"]
+                (\event -> modifyIORef' events (<> [event]))
                 `shouldReturn` Left (ConnectionError "continuation failed")
             map requestItems <$> readIORef requests
                 `shouldReturn` [history <> [compactionTriggerItem]]
@@ -1741,6 +1748,10 @@ spec = do
             readIORef contextState >>= (`shouldSatisfy`
                 (/= oldContextState))
             readIORef hookCalls `shouldReturn` 1
+            readIORef events `shouldReturn`
+                [ ActivityUpdated "Compacting context…"
+                , ModelContextReset
+                ]
 
         it "rolls back deferred compacted state when the continuation is cancelled" do
             let history = [userTextItem "old"]
@@ -1941,6 +1952,7 @@ spec = do
             compactCalls <- newIORef (0 :: Int)
             seenPrevious <- newIORef []
             seenInputs <- newIORef []
+            events <- newIORef []
             let sender _request = do
                     modifyIORef' compactCalls (+ 1)
                     pure (Right remoteCompactionResponse)
@@ -1965,7 +1977,7 @@ spec = do
                         contextState
                         base
             result <- backend.submitTurn (initialBackendSnapshot oldHistory) (Just "resp-tool") inputs
-                (const (pure ()))
+                (\event -> modifyIORef' events (<> [event]))
             result `shouldSatisfy` either (const False) (const True)
             readIORef compactCalls `shouldReturn` 0
             readIORef seenPrevious `shouldReturn` [Just "resp-tool"]
@@ -1989,6 +2001,7 @@ spec = do
                     expectationFailure
                         ("expected one bounded tool result, got "
                             <> show submitted)
+            readIORef events `shouldReturn` [ModelContextReset]
 
         it "records provider-reported occupancy after a successful turn" do
             let history = [userTextItem "old"]
@@ -2332,6 +2345,7 @@ spec = do
             contextState <- newIORef Nothing
             compactCalls <- newIORef (0 :: Int)
             seenHistory <- newIORef []
+            events <- newIORef []
             let sender _request = do
                     modifyIORef' compactCalls (+ 1)
                     pure (Right remoteCompactionResponse)
@@ -2355,7 +2369,7 @@ spec = do
                         contextState
                         base
             result <- backend.submitTurn (initialBackendSnapshot oldHistory) Nothing inputs
-                (const (pure ()))
+                (\event -> modifyIORef' events (<> [event]))
             result `shouldSatisfy` either (const False) (const True)
             readIORef compactCalls `shouldReturn` 1
             readIORef seenHistory >>= \case
@@ -2366,6 +2380,11 @@ spec = do
                     expectationFailure
                         ("expected one compacted continuation, got "
                             <> show (length seen))
+            readIORef events `shouldReturn`
+                [ ModelContextReset
+                , ActivityUpdated "Compacting context…"
+                , ModelContextReset
+                ]
 
         it "preserves typed provider failures from automatic compaction" do
             let history = [userTextItem "old"]

--- a/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
@@ -23,6 +23,7 @@ import Agent.CLI.ComputerUse
     , parseSessionLocked
     , pointerScript
     , summarizeComputerCall
+    , summarizeComputerToolCall
     , validateComputerCall
     , validateComputerCallForDisplay
     )
@@ -2202,9 +2203,21 @@ spec = do
                         (Aeson.object ["pid" Aeson..= (42 :: Int)])
                         (Aeson.toJSON ([] :: [Int])))
 
+        it "accepts normalized native snapshot schema v2" do
+            decodeAccessibilitySnapshot
+                "{\"schema_version\":2,\"scope\":{\"pid\":42},\"contents\":{\"roots\":[],\"nodes\":{}}}"
+                `shouldBe` Right
+                    (AccessibilitySnapshot
+                        2
+                        (Aeson.object ["pid" Aeson..= (42 :: Int)])
+                        (Aeson.object
+                            [ "roots" Aeson..= ([] :: [Text.Text])
+                            , "nodes" Aeson..= Aeson.object []
+                            ]))
+
         it "rejects unsupported snapshot schema versions" do
             decodeAccessibilitySnapshot
-                "{\"schema_version\":2,\"scope\":{},\"contents\":[]}"
+                "{\"schema_version\":3,\"scope\":{},\"contents\":[]}"
                 `shouldSatisfy` either
                     (Text.isInfixOf "unsupported")
                     (const False)
@@ -2612,6 +2625,56 @@ spec = do
                 `shouldBe` Right ()
 
     describe "computer approval summaries" do
+        it "identifies the AX target being bound" do
+            let call = ToolCall
+                    { callId = "call-bind"
+                    , name = "computer"
+                    , arguments =
+                        "{\"operation\":\"bind\",\"target_id\":\"target-42\",\
+                        \\"actions\":null,\"include_screenshot\":false}"
+                    , argumentsEncrypted = False
+                    , callKind = ComputerFunctionCallKind
+                    }
+            summarizeComputerToolCall call `shouldBe`
+                Just "Computer: bind accessible target \"target-42\""
+
+        it "describes semantic AX actions without exposing entered text" do
+            let call = ToolCall
+                    { callId = "call-ax"
+                    , name = "computer"
+                    , arguments =
+                        "{\"operation\":\"act\",\"target_id\":null,\
+                        \\"actions\":[\
+                        \{\"type\":\"perform\",\"element_id\":\"element-1\",\
+                        \\"action\":\"AXPress\",\"value\":null,\"text\":null},\
+                        \{\"type\":\"set_value\",\"element_id\":\"element-value\",\
+                        \\"action\":null,\"value\":\"another secret\",\"text\":null},\
+                        \{\"type\":\"replace_selected_text\",\
+                        \\"element_id\":\"element-2\",\"action\":null,\
+                        \\"value\":null,\"text\":\"top secret\"}],\
+                        \\"include_screenshot\":true}"
+                    , argumentsEncrypted = False
+                    , callKind = ComputerFunctionCallKind
+                    }
+                summary = summarizeComputerToolCall call
+            summary `shouldSatisfy` maybe False
+                ("perform \"AXPress\"" `Text.isInfixOf`)
+            summary `shouldSatisfy` maybe False
+                ("\"element-1\"" `Text.isInfixOf`)
+            summary `shouldSatisfy` maybe False
+                ("a 14-character text value" `Text.isInfixOf`)
+            summary `shouldSatisfy` maybe False
+                ("\"element-value\"" `Text.isInfixOf`)
+            summary `shouldSatisfy` maybe False
+                ("replace 10 selected characters on accessibility element \"element-2\""
+                    `Text.isInfixOf`)
+            summary `shouldSatisfy` maybe False
+                ("capture a screenshot" `Text.isInfixOf`)
+            summary `shouldSatisfy` maybe False
+                (not . ("top secret" `Text.isInfixOf`))
+            summary `shouldSatisfy` maybe False
+                (not . ("another secret" `Text.isInfixOf`))
+
         it "redacts typed text while surfacing actions and safety checks" do
             let call = ComputerCall
                     { computerCallItemId = Nothing

--- a/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ComputerUseSpec.hs
@@ -1,14 +1,21 @@
 module Agent.CLI.ComputerUseSpec (spec) where
 
 import Agent.CLI.ComputerUse
-    ( ComputerObservation(..)
+    ( AccessibilityObservation(..)
+    , AccessibilityPatchOperation(..)
+    , AccessibilitySnapshot(..)
+    , ComputerObservation(..)
     , ComputerUseBackend(..)
     , ScreenshotEncoding(..)
+    , advanceAccessibilityObservation
+    , applyAccessibilityPatch
     , closeComputerUseRuntime
     , computerApprovalPrompt
+    , decodeAccessibilitySnapshot
     , executeComputerCallWithBackend
     , executeComputerCallWithDesktopBackend
     , executeComputerCallWithRuntime
+    , initialAccessibilityDeltaState
     , keyCombinationScript
     , newLeasedDesktopComputerUseBackend
     , newComputerUseRuntimeWithBackend
@@ -2185,7 +2192,90 @@ spec = do
             display.computerDisplayFrameHeight `shouldBe` 720
             display
                 `shouldNotBe` portalDisplayForStream sessionPath portalStream
+    describe "accessibility observations" do
+        it "decodes the versioned native snapshot schema" do
+            decodeAccessibilitySnapshot
+                "{\"schema_version\":1,\"scope\":{\"pid\":42},\"contents\":[]}"
+                `shouldBe` Right
+                    (AccessibilitySnapshot
+                        1
+                        (Aeson.object ["pid" Aeson..= (42 :: Int)])
+                        (Aeson.toJSON ([] :: [Int])))
 
+        it "rejects unsupported snapshot schema versions" do
+            decodeAccessibilitySnapshot
+                "{\"schema_version\":2,\"scope\":{},\"contents\":[]}"
+                `shouldSatisfy` either
+                    (Text.isInfixOf "unsupported")
+                    (const False)
+
+        it "emits a full snapshot followed by an empty delta" do
+            let (first, state) =
+                    advanceAccessibilityObservation
+                        initialAccessibilityDeltaState
+                        exampleAccessibilitySnapshot
+                (second, _) =
+                    advanceAccessibilityObservation
+                        state
+                        exampleAccessibilitySnapshot
+            first `shouldBe`
+                AccessibilityFull 1 exampleAccessibilitySnapshot
+            second `shouldBe` AccessibilityDelta 1 2 []
+
+        it "emits reconstructable patches with escaped JSON Pointer paths" do
+            let oldSnapshot = largeAccessibilitySnapshot
+                    (Aeson.object ["label/with~escape" Aeson..= ("old" :: Text.Text)])
+                newSnapshot = largeAccessibilitySnapshot
+                    (Aeson.object ["label/with~escape" Aeson..= ("new" :: Text.Text)])
+                (_, state) =
+                    advanceAccessibilityObservation
+                        initialAccessibilityDeltaState
+                        oldSnapshot
+                (observation, _) =
+                    advanceAccessibilityObservation state newSnapshot
+            case observation of
+                AccessibilityDelta 1 2 patch -> do
+                    patch `shouldContain`
+                        [AccessibilityReplace
+                            "/contents/change/label~1with~0escape"
+                            (Aeson.String "new")]
+                    applyAccessibilityPatch
+                        (Aeson.toJSON oldSnapshot)
+                        patch
+                        `shouldBe` Right (Aeson.toJSON newSnapshot)
+                _ -> expectationFailure "expected an accessibility delta"
+
+        it "checkpoints when the application/window scope changes" do
+            let (_, state) =
+                    advanceAccessibilityObservation
+                        initialAccessibilityDeltaState
+                        exampleAccessibilitySnapshot
+                changed = exampleAccessibilitySnapshot
+                    { accessibilitySnapshotScope =
+                        Aeson.object ["pid" Aeson..= (99 :: Int)]
+                    }
+                (observation, _) =
+                    advanceAccessibilityObservation state changed
+            observation `shouldBe` AccessibilityFull 2 changed
+
+        it "encodes accessibility state as structured JSON" do
+            let backend = ComputerUseBackend
+                    { computerRunTransaction = \_ _ _ ->
+                        pure (Right
+                            (ComputerObservation
+                                (ImageAttachment "image/png" "observation")
+                                (Just (AccessibilityFull
+                                    1
+                                    exampleAccessibilitySnapshot))))
+                    }
+            result <- executeComputerCallWithBackend
+                backend
+                ScreenshotPng
+                exampleCall { computerActions = [ScreenshotAction] }
+            result `shouldSatisfy` either
+                (const False)
+                (Text.isInfixOf
+                    "\"accessibility_state\":{\"kind\":\"full\"")
     describe "computer action validation" do
         it "preserves supported mouse buttons and modifiers" do
             pointerScript (ClickAction 12 34 "back" ["shift"])
@@ -2646,6 +2736,24 @@ spec = do
                 (not . ("top secret" `Text.isInfixOf`))
             encoded `shouldSatisfy`
                 (not . ("large-private-payload" `Text.isInfixOf`))
+
+exampleAccessibilitySnapshot :: AccessibilitySnapshot
+exampleAccessibilitySnapshot = AccessibilitySnapshot
+    1
+    (Aeson.object
+        [ "pid" Aeson..= (42 :: Int)
+        , "window" Aeson..= ("main" :: Text.Text)
+        ])
+    (Aeson.object ["role" Aeson..= ("AXWindow" :: Text.Text)])
+
+largeAccessibilitySnapshot :: Aeson.Value -> AccessibilitySnapshot
+largeAccessibilitySnapshot change = AccessibilitySnapshot
+    1
+    (Aeson.object ["pid" Aeson..= (42 :: Int)])
+    (Aeson.object
+        [ "change" Aeson..= change
+        , "unchanged" Aeson..= Text.replicate 512 "x"
+        ])
 
 toolCall :: ComputerCall -> ToolCall
 toolCall call = ToolCall

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -212,6 +212,10 @@ spec = describe "fullscreen TUI bridge" do
             ]
             `shouldBe` ["canonical"]
 
+    it "accounts model-context reset mailbox overhead" do
+        appEventLogicalBytes (AppUi (UiLoop ModelContextReset))
+            `shouldBe` 128
+
     it "backpressures a single streaming mailbox node by payload bytes" do
         runtime <- newBridgeTestRuntime
         let exactBudgetText =

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -90,6 +90,52 @@ spec = describe "schemasFromAppTools" do
             else schemasFromAppTools codexDialect [computerUseTool]
                 `shouldBe` [webSearchTool]
 
+    it "advertises a privileged host-supplied computer schema verbatim" do
+        let parameters = Aeson.object
+                [ "type" Aeson..= ("object" :: Text)
+                , "properties" Aeson..= Aeson.object
+                    [ "operation" Aeson..= Aeson.object
+                        ["const" Aeson..= ("observe" :: Text)]
+                    ]
+                , "required" Aeson..= ["operation" :: Text]
+                , "additionalProperties" Aeson..= False
+                ]
+            nativeComputer = computerUseTool
+                { appToolSchema = HostedComputerFunctionSchema parameters }
+        if os == "darwin"
+            then case schemasFromAppTools codexDialect [nativeComputer] of
+                [_, FunctionToolValue function] -> do
+                    function.name `shouldBe` computerFunctionName
+                    function.strict `shouldBe` Just True
+                    fmap (Aeson.decodeStrict' . rawJsonBytes)
+                        function.parameters
+                        `shouldBe` Just (Just parameters)
+                other -> expectationFailure
+                    ("expected semantic computer function, got " <> show other)
+            else schemasFromAppTools codexDialect [nativeComputer]
+                `shouldBe` [webSearchTool]
+
+    it "does not claim strictness for an optional host computer schema" do
+        let parameters = Aeson.object
+                [ "type" Aeson..= ("object" :: Text)
+                , "properties" Aeson..= Aeson.object
+                    [ "operation" Aeson..= Aeson.object
+                        ["type" Aeson..= ("string" :: Text)]
+                    ]
+                , "required" Aeson..= ([] :: [Text])
+                , "additionalProperties" Aeson..= False
+                ]
+            nativeComputer = computerUseTool
+                { appToolSchema = HostedComputerFunctionSchema parameters }
+        if os == "darwin"
+            then case schemasFromAppTools codexDialect [nativeComputer] of
+                [_, FunctionToolValue function] ->
+                    function.strict `shouldBe` Just False
+                other -> expectationFailure
+                    ("expected semantic computer function, got " <> show other)
+            else schemasFromAppTools codexDialect [nativeComputer]
+                `shouldBe` [webSearchTool]
+
     it "reserves the model-facing computer_use function identity" do
         let collision =
                 jsonAppTool computerFunctionName "Unrelated MCP function" []
@@ -98,6 +144,18 @@ spec = describe "schemasFromAppTools" do
         schemasFromAppTools codexDialect [collision]
             `shouldBe` [webSearchTool]
         requireToolRegistry [computerUseTool, collision]
+            `shouldThrow` anyIOException
+
+    it "keeps the host-supplied computer schema privileged" do
+        let parameters = Aeson.object ["type" Aeson..= ("object" :: Text)]
+            nativeComputer = computerUseTool
+                { appToolSchema = HostedComputerFunctionSchema parameters }
+            collision =
+                rawJsonAppTool computerFunctionName "Unrelated MCP function"
+                    parameters
+                    AlwaysPrompt
+                    (noArgsTool computerFunctionName (pure (Right "ok")))
+        requireToolRegistry [nativeComputer, collision]
             `shouldThrow` anyIOException
 
     it "keeps an unrelated function named computer as a function" do

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -14,6 +14,7 @@ category:           Development
 build-type:         Simple
 extra-source-files: README.md
 data-files:         data/code-mode/worker.mjs
+                  , data/computer-use/protocol-v1.json
 
 common common-opts
     default-language: Haskell2010
@@ -41,6 +42,7 @@ library
     exposed-modules:  Agent.Auth.JWT
                     , Agent.Cancel
                     , Agent.Concurrent
+                    , Agent.ComputerUse.Protocol
                     , Agent.Dialect
                     , Agent.Error
                     , Agent.FileRetry
@@ -130,6 +132,7 @@ library
                     , retry >= 0.9.3.1 && < 0.10
                     , resourcet
                     , safe-exceptions
+                    , scientific
                     , stm
                     , template-haskell
                     , text
@@ -278,6 +281,7 @@ test-suite agent-core-test
     main-is:          Spec.hs
     other-modules:    Agent.Auth.JWTSpec
                     , Agent.CancelSpec
+                    , Agent.ComputerUse.ProtocolSpec
                     , Agent.Tools.CodeMode.HostSpec
                     , Agent.Tools.CodeMode.ProtocolSpec
                     , Agent.ConcurrentSpec
@@ -316,6 +320,8 @@ test-suite agent-core-test
                     , Agent.Tools.ViewImageSpec
                     , Agent.ToolDSLSpec
                     , Agent.Transport.WebSocketSpec
+                    , Paths_agent_core
+    autogen-modules:  Paths_agent_core
     build-depends:    base >= 4.14 && < 5
                     , agent-core
                     , agent-json

--- a/packages/agent-core/benchmark/LoopEvents.hs
+++ b/packages/agent-core/benchmark/LoopEvents.hs
@@ -368,6 +368,7 @@ eventWeight = \case
     ToolRetracted callId -> Text.length callId
     ResponseAttemptDiscarded -> 1
     ResponseAttemptFailed -> 1
+    ModelContextReset -> 1
     NativeAgentStarted identifier parent label model ->
         sum
             [ Text.length identifier

--- a/packages/agent-core/data/computer-use/protocol-v1.json
+++ b/packages/agent-core/data/computer-use/protocol-v1.json
@@ -1,0 +1,66 @@
+[
+  {
+    "protocol_version": 1,
+    "operation": "list_targets",
+    "target_id": null,
+    "actions": null,
+    "include_screenshot": false
+  },
+  {
+    "protocol_version": 1,
+    "operation": "bind",
+    "target_id": "target-1",
+    "actions": null,
+    "include_screenshot": true
+  },
+  {
+    "protocol_version": 1,
+    "operation": "observe",
+    "target_id": null,
+    "actions": null,
+    "include_screenshot": false
+  },
+  {
+    "protocol_version": 1,
+    "operation": "act",
+    "target_id": null,
+    "actions": [
+      {
+        "type": "perform",
+        "element_id": "button-1",
+        "action": "AXPress",
+        "value": null,
+        "text": null
+      },
+      {
+        "type": "set_value",
+        "element_id": "field-1",
+        "action": null,
+        "value": "hello",
+        "text": null
+      },
+      {
+        "type": "set_value",
+        "element_id": "slider-1",
+        "action": null,
+        "value": 42,
+        "text": null
+      },
+      {
+        "type": "set_value",
+        "element_id": "check-1",
+        "action": null,
+        "value": true,
+        "text": null
+      },
+      {
+        "type": "replace_selected_text",
+        "element_id": "field-2",
+        "action": null,
+        "value": null,
+        "text": "world"
+      }
+    ],
+    "include_screenshot": true
+  }
+]

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -2,8 +2,9 @@
 , agent-responses-types, async, base, base64-bytestring, bytestring
 , containers, crypton-connection, directory, filepath, hspec
 , JuicyPixels, lib, process, QuickCheck, resourcet, retry
-, safe-exceptions, stm, template-haskell, text, text-builder, time
-, tls, transformers, unix, vector, websockets, yaml, zlib
+, safe-exceptions, scientific, stm, template-haskell, text
+, text-builder, time, tls, transformers, unix, vector, websockets
+, yaml, zlib
 }:
 mkDerivation {
   pname = "agent-core";
@@ -14,8 +15,8 @@ mkDerivation {
     aeson agent-json agent-process agent-responses-types async base
     base64-bytestring bytestring containers crypton-connection
     directory filepath JuicyPixels process resourcet retry
-    safe-exceptions stm template-haskell text time tls transformers
-    unix vector websockets yaml zlib
+    safe-exceptions scientific stm template-haskell text time tls
+    transformers unix vector websockets yaml zlib
   ];
   testHaskellDepends = [
     aeson agent-json agent-responses-types async base base64-bytestring

--- a/packages/agent-core/src/Agent/ComputerUse/Protocol.hs
+++ b/packages/agent-core/src/Agent/ComputerUse/Protocol.hs
@@ -1,0 +1,495 @@
+-- | Typed, versioned protocol for accessibility-first computer use.
+--
+-- Model arguments are decoded directly into domain types. Only the native
+-- callback boundary encodes them again, using one canonical fixed envelope
+-- with an independent protocol version.
+module Agent.ComputerUse.Protocol
+    ( SemanticComputerAction(..)
+    , SemanticComputerOperation(..)
+    , SemanticComputerRequest(..)
+    , SemanticComputerScalar(..)
+    , decodeSemanticComputerRequest
+    , decodeSemanticComputerWireRequest
+    , encodeSemanticComputerRequest
+    , semanticComputerProtocolVersion
+    , semanticComputerRequestDecoder
+    , semanticComputerRequestOperation
+    , semanticComputerRequestSchema
+    , semanticComputerRequestWantsScreenshot
+    , semanticComputerRequestWireValue
+    ) where
+
+import Control.Monad (unless, when)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Scientific (Scientific, fromFloatDigits, toRealFloat)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import qualified Agent.Json.Decode as Json
+
+data SemanticComputerRequest
+    = ListComputerTargets
+    | BindComputerTarget !Text !Bool
+    | ObserveComputerTarget !Bool
+    | ActOnComputerTarget !(NonEmpty SemanticComputerAction) !Bool
+    deriving (Eq, Show)
+
+data SemanticComputerAction
+    = PerformComputerAction !Text !Text
+    | SetComputerValue !Text !SemanticComputerScalar
+    | ReplaceComputerSelectedText !Text !Text
+    deriving (Eq, Show)
+
+data SemanticComputerScalar
+    = ComputerText !Text
+    | ComputerNumber !Scientific
+    | ComputerBool !Bool
+    deriving (Eq, Show)
+
+data SemanticComputerOperation
+    = ListComputerTargetsOperation
+    | BindComputerTargetOperation
+    | ObserveOrActOnComputerTargetOperation
+    deriving (Eq, Show)
+
+semanticComputerProtocolVersion :: Int
+semanticComputerProtocolVersion = 1
+
+semanticComputerRequestOperation
+    :: SemanticComputerRequest
+    -> SemanticComputerOperation
+semanticComputerRequestOperation = \case
+    ListComputerTargets -> ListComputerTargetsOperation
+    BindComputerTarget{} -> BindComputerTargetOperation
+    ObserveComputerTarget{} -> ObserveOrActOnComputerTargetOperation
+    ActOnComputerTarget{} -> ObserveOrActOnComputerTargetOperation
+
+semanticComputerRequestWantsScreenshot :: SemanticComputerRequest -> Bool
+semanticComputerRequestWantsScreenshot = \case
+    ListComputerTargets -> False
+    BindComputerTarget _ includeScreenshot -> includeScreenshot
+    ObserveComputerTarget includeScreenshot -> includeScreenshot
+    ActOnComputerTarget _ includeScreenshot -> includeScreenshot
+
+-- | Strict decoder for the model-facing function arguments.
+semanticComputerRequestDecoder :: Json.Decoder SemanticComputerRequest
+semanticComputerRequestDecoder = requestDecoder ModelArguments
+
+decodeSemanticComputerRequest :: Text -> Either Text SemanticComputerRequest
+decodeSemanticComputerRequest arguments =
+    case Json.decodeText semanticComputerRequestDecoder arguments of
+        Left (Json.JsonError err) -> Left err
+        Right request -> Right request
+
+-- | Decode and version-check the canonical public-runtime to native-host wire
+-- representation. This is primarily useful to contract tests and alternate
+-- native hosts; normal execution already carries the typed request.
+decodeSemanticComputerWireRequest
+    :: BS.ByteString
+    -> Either Text SemanticComputerRequest
+decodeSemanticComputerWireRequest bytes =
+    if BS.length bytes > semanticComputerRequestCapacity
+        then Left "computer request exceeds the native protocol capacity"
+        else case Json.decodeEither (requestDecoder NativeWire) bytes of
+            Left (Json.JsonError err) -> Left err
+            Right request -> Right request
+
+encodeSemanticComputerRequest :: SemanticComputerRequest -> BS.ByteString
+encodeSemanticComputerRequest =
+    LBS.toStrict . Aeson.encode . semanticComputerRequestWireValue
+
+semanticComputerRequestWireValue :: SemanticComputerRequest -> Aeson.Value
+semanticComputerRequestWireValue request =
+    requestValue operation target actions includeScreenshot
+  where
+    includeScreenshot = semanticComputerRequestWantsScreenshot request
+    (operation, target, actions) = case request of
+        ListComputerTargets ->
+            ("list_targets", Aeson.Null, Aeson.Null)
+        BindComputerTarget targetId _ ->
+            ("bind", Aeson.String targetId, Aeson.Null)
+        ObserveComputerTarget{} ->
+            ("observe", Aeson.Null, Aeson.Null)
+        ActOnComputerTarget semanticActions _ ->
+            ( "act"
+            , Aeson.Null
+            , Aeson.toJSON
+                (map semanticActionValue (NonEmpty.toList semanticActions))
+            )
+
+data Envelope
+    = ModelArguments
+    | NativeWire
+    deriving (Eq)
+
+data RequiredField a
+    = MissingField
+    | PresentField !a
+
+data RequestFields = RequestFields
+    { requestVersion :: !(RequiredField Int)
+    , requestOperation :: !(RequiredField Text)
+    , requestTarget :: !(RequiredField (Maybe Text))
+    , requestActions :: !(RequiredField (Maybe [SemanticComputerAction]))
+    , requestScreenshot :: !(RequiredField Bool)
+    }
+
+emptyRequestFields :: RequestFields
+emptyRequestFields = RequestFields
+    { requestVersion = MissingField
+    , requestOperation = MissingField
+    , requestTarget = MissingField
+    , requestActions = MissingField
+    , requestScreenshot = MissingField
+    }
+
+requestDecoder :: Envelope -> Json.Decoder SemanticComputerRequest
+requestDecoder envelope = do
+    fields <- Json.objectFold emptyRequestFields (decodeRequestField envelope)
+    validateRequest envelope fields
+
+decodeRequestField
+    :: Envelope
+    -> Text
+    -> RequestFields
+    -> Json.Decoder RequestFields
+decodeRequestField envelope key fields =
+    case key of
+        "protocol_version"
+            | envelope == NativeWire ->
+                decodeRequired key fields.requestVersion Json.int
+                    \field -> fields { requestVersion = field }
+        "operation" ->
+            decodeRequired key fields.requestOperation Json.text
+                \field -> fields { requestOperation = field }
+        "target_id" ->
+            decodeRequired key fields.requestTarget (Json.nullable Json.text)
+                \field -> fields { requestTarget = field }
+        "actions" ->
+            decodeRequired
+                key
+                fields.requestActions
+                (Json.nullable (Json.list semanticActionDecoder))
+                \field -> fields { requestActions = field }
+        "include_screenshot" ->
+            decodeRequired key fields.requestScreenshot Json.bool
+                \field -> fields { requestScreenshot = field }
+        _ -> fail ("unexpected computer argument field: " <> Text.unpack key)
+
+validateRequest
+    :: Envelope
+    -> RequestFields
+    -> Json.Decoder SemanticComputerRequest
+validateRequest envelope fields = do
+    case envelope of
+        ModelArguments -> pure ()
+        NativeWire -> do
+            version <- requireField "protocol_version" fields.requestVersion
+            unless (version == semanticComputerProtocolVersion) $
+                fail "unsupported computer protocol version"
+    operation <- requireField "operation" fields.requestOperation
+    target <- requireField "target_id" fields.requestTarget
+    actions <- requireField "actions" fields.requestActions
+    includeScreenshot <-
+        requireField "include_screenshot" fields.requestScreenshot
+    request <- case operation of
+        "list_targets" -> do
+            requireNothing "target_id" target
+            requireNothing "actions" actions
+            when includeScreenshot $
+                fail "list_targets cannot include a screenshot"
+            pure ListComputerTargets
+        "bind" -> do
+            targetId <- requireJust "target_id" target
+            validateText "target_id" False 1024 targetId
+            requireNothing "actions" actions
+            pure (BindComputerTarget targetId includeScreenshot)
+        "observe" -> do
+            requireNothing "target_id" target
+            requireNothing "actions" actions
+            pure (ObserveComputerTarget includeScreenshot)
+        "act" -> do
+            requireNothing "target_id" target
+            rawActions <- requireJust "actions" actions
+            when (null rawActions) $
+                fail "act requires at least one semantic action"
+            when (length rawActions > 64) $
+                fail "act accepts at most 64 semantic actions"
+            case NonEmpty.nonEmpty rawActions of
+                Nothing -> fail "act requires at least one semantic action"
+                Just semanticActions ->
+                    pure (ActOnComputerTarget
+                        semanticActions
+                        includeScreenshot)
+        _ -> fail "unsupported computer operation"
+    when (BS.length (encodeSemanticComputerRequest request)
+            > semanticComputerRequestCapacity) $
+        fail "computer request exceeds the native protocol capacity"
+    pure request
+
+data ActionFields = ActionFields
+    { actionType :: !(RequiredField Text)
+    , actionElementId :: !(RequiredField Text)
+    , actionName :: !(RequiredField (Maybe Text))
+    , actionValueField :: !(RequiredField (Maybe SemanticComputerScalar))
+    , actionText :: !(RequiredField (Maybe Text))
+    }
+
+emptyActionFields :: ActionFields
+emptyActionFields = ActionFields
+    { actionType = MissingField
+    , actionElementId = MissingField
+    , actionName = MissingField
+    , actionValueField = MissingField
+    , actionText = MissingField
+    }
+
+semanticActionDecoder :: Json.Decoder SemanticComputerAction
+semanticActionDecoder = do
+    fields <- Json.objectFold emptyActionFields decodeActionField
+    validateAction fields
+
+decodeActionField
+    :: Text
+    -> ActionFields
+    -> Json.Decoder ActionFields
+decodeActionField key fields =
+    case key of
+        "type" ->
+            decodeRequired key fields.actionType Json.text
+                \field -> fields { actionType = field }
+        "element_id" ->
+            decodeRequired key fields.actionElementId Json.text
+                \field -> fields { actionElementId = field }
+        "action" ->
+            decodeRequired key fields.actionName (Json.nullable Json.text)
+                \field -> fields { actionName = field }
+        "value" ->
+            decodeRequired
+                key
+                fields.actionValueField
+                (Json.nullable semanticScalarDecoder)
+                \field -> fields { actionValueField = field }
+        "text" ->
+            decodeRequired key fields.actionText (Json.nullable Json.text)
+                \field -> fields { actionText = field }
+        _ -> fail ("unexpected semantic computer action field: "
+            <> Text.unpack key)
+
+validateAction :: ActionFields -> Json.Decoder SemanticComputerAction
+validateAction fields = do
+    actionType <- requireField "type" fields.actionType
+    elementId <- requireField "element_id" fields.actionElementId
+    validateText "element_id" False 1024 elementId
+    action <- requireField "action" fields.actionName
+    value <- requireField "value" fields.actionValueField
+    replacement <- requireField "text" fields.actionText
+    case actionType of
+        "perform" -> do
+            actionName <- requireJust "action" action
+            validateText "action" False 1024 actionName
+            requireNothing "value" value
+            requireNothing "text" replacement
+            pure (PerformComputerAction elementId actionName)
+        "set_value" -> do
+            requireNothing "action" action
+            scalar <- requireJust "value" value
+            requireNothing "text" replacement
+            pure (SetComputerValue elementId scalar)
+        "replace_selected_text" -> do
+            requireNothing "action" action
+            requireNothing "value" value
+            text <- requireJust "text" replacement
+            validateText "text" True 65536 text
+            pure (ReplaceComputerSelectedText elementId text)
+        _ -> fail "unsupported semantic computer action"
+
+semanticScalarDecoder :: Json.Decoder SemanticComputerScalar
+semanticScalarDecoder =
+    Json.getType >>= \case
+        Json.VString -> do
+            value <- Json.text
+            validateText "value" True 65536 value
+            pure (ComputerText value)
+        Json.VNumber -> do
+            value <- Json.scientific
+            validateDouble value
+            pure (ComputerNumber value)
+        Json.VBoolean -> ComputerBool <$> Json.bool
+        _ -> fail "set_value.value must be a string, number, or boolean"
+
+validateText :: Text -> Bool -> Int -> Text -> Json.Decoder ()
+validateText name allowEmpty maximumBytes value =
+    unless ( (allowEmpty || not (Text.null value))
+                && BS.length (TextEncoding.encodeUtf8 value) <= maximumBytes) $
+        fail (Text.unpack name <> " is outside its protocol limit")
+
+validateDouble :: Scientific -> Json.Decoder ()
+validateDouble value =
+    let asDouble = toRealFloat value :: Double
+    in unless (not (isInfinite asDouble)
+                && not (isNaN asDouble)
+                && fromFloatDigits asDouble == value) $
+        fail "set_value.value must be a finite IEEE-754 double"
+
+semanticComputerRequestCapacity :: Int
+semanticComputerRequestCapacity = 1024 * 1024
+
+decodeRequired
+    :: Text
+    -> RequiredField a
+    -> Json.Decoder a
+    -> (RequiredField a -> state)
+    -> Json.Decoder state
+decodeRequired key current decoder update =
+    case current of
+        MissingField -> update . PresentField <$> decoder
+        PresentField _ ->
+            fail ("duplicate computer argument field: " <> Text.unpack key)
+
+requireField
+    :: Text
+    -> RequiredField value
+    -> Json.Decoder value
+requireField key = \case
+    MissingField -> fail ("missing required field: " <> Text.unpack key)
+    PresentField value -> pure value
+
+requireNothing :: Text -> Maybe value -> Json.Decoder ()
+requireNothing _ Nothing = pure ()
+requireNothing key (Just _) =
+    fail (Text.unpack key <> " must be null for this operation")
+
+requireJust :: Text -> Maybe value -> Json.Decoder value
+requireJust key = \case
+    Nothing -> fail (Text.unpack key <> " must not be null for this operation")
+    Just value -> pure value
+
+requestValue
+    :: Text
+    -> Aeson.Value
+    -> Aeson.Value
+    -> Bool
+    -> Aeson.Value
+requestValue operation target actions includeScreenshot =
+    Aeson.object
+        [ "protocol_version" Aeson..= semanticComputerProtocolVersion
+        , "operation" Aeson..= operation
+        , "target_id" Aeson..= target
+        , "actions" Aeson..= actions
+        , "include_screenshot" Aeson..= includeScreenshot
+        ]
+
+semanticActionValue :: SemanticComputerAction -> Aeson.Value
+semanticActionValue = \case
+    PerformComputerAction elementId action ->
+        actionValue "perform" elementId
+            (Aeson.String action)
+            Aeson.Null
+            Aeson.Null
+    SetComputerValue elementId value ->
+        actionValue "set_value" elementId
+            Aeson.Null
+            (semanticScalarValue value)
+            Aeson.Null
+    ReplaceComputerSelectedText elementId replacement ->
+        actionValue "replace_selected_text" elementId
+            Aeson.Null
+            Aeson.Null
+            (Aeson.String replacement)
+
+actionValue
+    :: Text
+    -> Text
+    -> Aeson.Value
+    -> Aeson.Value
+    -> Aeson.Value
+    -> Aeson.Value
+actionValue actionType elementId action value replacement =
+    Aeson.object
+        [ "type" Aeson..= actionType
+        , "element_id" Aeson..= elementId
+        , "action" Aeson..= action
+        , "value" Aeson..= value
+        , "text" Aeson..= replacement
+        ]
+
+semanticScalarValue :: SemanticComputerScalar -> Aeson.Value
+semanticScalarValue = \case
+    ComputerText value -> Aeson.String value
+    ComputerNumber value -> Aeson.Number value
+    ComputerBool value -> Aeson.Bool value
+
+-- | Strict model-facing JSON schema for 'semanticComputerRequestDecoder'.
+semanticComputerRequestSchema :: Aeson.Value
+semanticComputerRequestSchema = strictObject
+    [ ("operation", Aeson.object
+        [ "type" Aeson..= ("string" :: Text)
+        , "enum" Aeson..=
+            (["list_targets", "bind", "observe", "act"] :: [Text])
+        ])
+    , ("target_id", nullableStringParameter 1024)
+    , ("actions", Aeson.object
+        [ "type" Aeson..= (["array", "null"] :: [Text])
+        , "minItems" Aeson..= (1 :: Int)
+        , "maxItems" Aeson..= (64 :: Int)
+        , "items" Aeson..= semanticActionParameters
+        ])
+    , ("include_screenshot", screenshotParameter)
+    ]
+    ["operation", "target_id", "actions", "include_screenshot"]
+
+semanticActionParameters :: Aeson.Value
+semanticActionParameters = strictObject
+    [ ("type", Aeson.object
+        [ "type" Aeson..= ("string" :: Text)
+        , "enum" Aeson..=
+            (["perform", "set_value", "replace_selected_text"] :: [Text])
+        ])
+    , ("element_id", boundedStringParameter False 1024)
+    , ("action", nullableStringParameter 1024)
+    , ("value", Aeson.object
+        [ "type" Aeson..=
+            (["string", "number", "boolean", "null"] :: [Text])
+        , "maxLength" Aeson..= (65536 :: Int)
+        ])
+    , ("text", nullableStringParameter 65536)
+    ]
+    ["type", "element_id", "action", "value", "text"]
+
+strictObject :: [(Text, Aeson.Value)] -> [Text] -> Aeson.Value
+strictObject properties requiredFields = Aeson.object
+    [ "type" Aeson..= ("object" :: Text)
+    , "additionalProperties" Aeson..= False
+    , "properties" Aeson..= Aeson.object
+        [ Key.fromText name Aeson..= schema | (name, schema) <- properties ]
+    , "required" Aeson..= requiredFields
+    ]
+
+nullableStringParameter :: Int -> Aeson.Value
+nullableStringParameter maximumLength = Aeson.object
+    [ "type" Aeson..= (["string", "null"] :: [Text])
+    , "maxLength" Aeson..= maximumLength
+    ]
+
+boundedStringParameter :: Bool -> Int -> Aeson.Value
+boundedStringParameter allowEmpty maximumLength = Aeson.object $
+    [ "type" Aeson..= ("string" :: Text)
+    , "maxLength" Aeson..= maximumLength
+    ]
+    <> [ "minLength" Aeson..= (1 :: Int) | not allowEmpty ]
+
+screenshotParameter :: Aeson.Value
+screenshotParameter = Aeson.object
+    [ "type" Aeson..= ("boolean" :: Text)
+    , "description" Aeson..=
+        ( "Set false unless visual evidence is necessary; screenshots are "
+        <> "never returned implicitly."
+        :: Text
+        )
+    ]

--- a/packages/agent-core/src/Agent/Loop/InputItems.hs
+++ b/packages/agent-core/src/Agent/Loop/InputItems.hs
@@ -154,8 +154,7 @@ toolResultToItem result = case result.callKind of
             , name = Nothing
             , namespace = Nothing
             , provider = Nothing
-            , output = rawJsonFromEncoding . Aeson.toEncoding $
-                computerFunctionTextOutput result.output
+            , output = computerFunctionToolResultOutput result
             , status = Nothing
             , async = Nothing
             }
@@ -167,21 +166,30 @@ toolResultToItem result = case result.callKind of
             , name = Nothing
             , namespace = Nothing
             , provider = Nothing
-            , output = rawJsonFromEncoding . Aeson.toEncoding $
-                computerFunctionTextOutput result.output
+            , output = computerFunctionToolResultOutput result
             , status = Nothing
             , async = Nothing
             }
 
 toolResultOutput :: ToolCallResult -> RawJson
 toolResultOutput result =
-    case toolCallResultImages result of
-        [] -> rawJsonFromEncoding (Aeson.toEncoding result.output)
-        images ->
+    richToolResultOutput result.output (toolCallResultImages result)
+
+computerFunctionToolResultOutput :: ToolCallResult -> RawJson
+computerFunctionToolResultOutput result =
+    richToolResultOutput
+        (computerFunctionTextOutput result.output)
+        (toolCallResultImages result)
+
+richToolResultOutput :: Text -> [ToolResultImage] -> RawJson
+richToolResultOutput output images =
+    case images of
+        [] -> rawJsonFromEncoding (Aeson.toEncoding output)
+        nonEmptyImages ->
             rawJsonFromEncoding . Aeson.toEncoding $
-                map imagePart images
-                    <> [ InputTextPart result.output Nothing
-                       | not (Text.null (Text.strip result.output))
+                map imagePart nonEmptyImages
+                    <> [ InputTextPart output Nothing
+                       | not (Text.null (Text.strip output))
                        ]
   where
     imagePart :: ToolResultImage -> ResponseContentPart
@@ -197,19 +205,85 @@ computerFunctionTextOutput :: Text -> Text
 computerFunctionTextOutput rawOutput =
     case Json.decodeEither computerCallOutputDecoder (Text.encodeUtf8 rawOutput) of
         Right output ->
-            case KeyMap.lookup "accessibility_state" output.computerOutputExtra of
-                Just (Aeson.String state)
-                    | not (Text.null (Text.strip state)) ->
-                        "Computer action completed.\n\n"
-                            <> "Current macOS accessibility state:\n"
-                            <> state
-                Just state@(Aeson.Object fields) ->
-                    "Computer action completed.\n\n"
-                        <> accessibilityStateHeading fields
-                        <> "\n"
-                        <> jsonValueText state
-                _ -> "Computer action completed."
-        Left _ -> rawOutput
+            maybe
+                "Computer action completed."
+                renderComputerAccessibility
+                ( KeyMap.lookup
+                    "accessibility_state"
+                    output.computerOutputExtra
+                    >>= computerAccessibilityFromValue
+                )
+        Left _ ->
+            case Json.decodeEither
+                    nativeComputerAccessibilityDecoder
+                    (Text.encodeUtf8 rawOutput) of
+                Right accessibility ->
+                    renderComputerAccessibility accessibility
+                Left _ -> rawOutput
+
+data ComputerAccessibility
+    = TextComputerAccessibility !Text
+    | StructuredComputerAccessibility !Aeson.Object
+
+renderComputerAccessibility :: ComputerAccessibility -> Text
+renderComputerAccessibility accessibility =
+    "Computer action completed.\n\n"
+        <> case accessibility of
+            TextComputerAccessibility state ->
+                "Current macOS accessibility state:\n" <> state
+            StructuredComputerAccessibility fields ->
+                accessibilityStateHeading fields
+                    <> "\n"
+                    <> jsonValueText (Aeson.Object fields)
+
+computerAccessibilityFromValue
+    :: Aeson.Value
+    -> Maybe ComputerAccessibility
+computerAccessibilityFromValue = \case
+    Aeson.String state
+        | not (Text.null (Text.strip state)) ->
+            Just (TextComputerAccessibility state)
+    Aeson.Object fields ->
+        Just (StructuredComputerAccessibility fields)
+    _ -> Nothing
+
+-- Native hosts return their result object directly, without the provider's
+-- @computer_call_output.call_id@ envelope. Only claim such an object when it
+-- carries the accessibility projection; list-target results must stay intact.
+nativeComputerAccessibilityDecoder :: Json.Decoder ComputerAccessibility
+nativeComputerAccessibilityDecoder = do
+    accessibility <- Json.objectFold Nothing decodeField
+    maybe
+        (fail "native computer result has no accessibility_state")
+        pure
+        accessibility
+  where
+    decodeField key current
+        | key /= "accessibility_state" =
+            current <$ Json.withOwnedRawJson (const (pure ()))
+        | Just _ <- current =
+            fail "duplicate native computer accessibility_state"
+        | otherwise =
+            Just <$> computerAccessibilityDecoder
+
+computerAccessibilityDecoder :: Json.Decoder ComputerAccessibility
+computerAccessibilityDecoder =
+    Json.getType >>= \case
+        Json.VString -> do
+            state <- Json.text
+            if Text.null (Text.strip state)
+                then fail "native computer accessibility_state is empty"
+                else pure (TextComputerAccessibility state)
+        Json.VObject ->
+            Json.withOwnedRawJson \raw ->
+                case Aeson.eitherDecodeStrict' raw of
+                    Right (Aeson.Object fields) ->
+                        pure (StructuredComputerAccessibility fields)
+                    Right _ ->
+                        fail "native computer accessibility_state is not an object"
+                    Left err -> fail err
+        _ ->
+            fail "native computer accessibility_state must be text or an object"
 
 accessibilityStateHeading :: Aeson.Object -> Text
 accessibilityStateHeading fields =
@@ -250,12 +324,20 @@ latestComputerScreenshot inputs =
         , isComputerToolCallKind result.callKind
         ]
         >>= \result ->
-            case Json.decodeEither computerCallOutputDecoder
-                    (Text.encodeUtf8 result.output) of
-                Right ComputerCallOutput{screenshotDataUrl} ->
-                    Just screenshotDataUrl
-                Left _ -> Nothing
+            case lastMaybe (toolCallResultImages result)
+                    >>= nonEmptyImageUrl . (.imageUrl) of
+                Just imageUrl -> Just imageUrl
+                Nothing -> legacyComputerScreenshot result.output
   where
+    legacyComputerScreenshot output =
+        case Json.decodeEither computerCallOutputDecoder
+                (Text.encodeUtf8 output) of
+            Right ComputerCallOutput{screenshotDataUrl} ->
+                nonEmptyImageUrl screenshotDataUrl
+            Left _ -> Nothing
+    nonEmptyImageUrl imageUrl
+        | Text.null (Text.strip imageUrl) = Nothing
+        | otherwise = Just imageUrl
     lastMaybe [] = Nothing
     lastMaybe values = Just (last values)
 

--- a/packages/agent-core/src/Agent/Loop/InputItems.hs
+++ b/packages/agent-core/src/Agent/Loop/InputItems.hs
@@ -30,6 +30,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Agent.Json.Decode as Json
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Maybe (maybeToList)
 import Data.Text (Text)
@@ -202,8 +203,44 @@ computerFunctionTextOutput rawOutput =
                         "Computer action completed.\n\n"
                             <> "Current macOS accessibility state:\n"
                             <> state
+                Just state@(Aeson.Object fields) ->
+                    "Computer action completed.\n\n"
+                        <> accessibilityStateHeading fields
+                        <> "\n"
+                        <> jsonValueText state
                 _ -> "Computer action completed."
         Left _ -> rawOutput
+
+accessibilityStateHeading :: Aeson.Object -> Text
+accessibilityStateHeading fields =
+    case KeyMap.lookup "kind" fields of
+        Just (Aeson.String "full") ->
+            "Full macOS accessibility snapshot"
+                <> revisionSuffix "revision"
+                <> ":"
+        Just (Aeson.String "delta") ->
+            "macOS accessibility changes"
+                <> case (fieldText "base_revision", fieldText "revision") of
+                    (Just baseRevision, Just revision) ->
+                        ", revision " <> baseRevision <> " -> " <> revision
+                    _ -> ""
+                <> ":"
+        Just (Aeson.String "unavailable") ->
+            "macOS accessibility state unavailable"
+                <> revisionSuffix "revision"
+                <> ":"
+        _ -> "Current macOS accessibility state:"
+  where
+    revisionSuffix key =
+        maybe "" (", revision " <>) (fieldText key)
+    fieldText key =
+        jsonValueText <$> KeyMap.lookup key fields
+
+jsonValueText :: Aeson.Value -> Text
+jsonValueText =
+    Text.decodeUtf8
+        . LBS.toStrict
+        . Aeson.encode
 
 latestComputerScreenshot :: [TurnInput] -> Maybe Text
 latestComputerScreenshot inputs =

--- a/packages/agent-core/src/Agent/Loop/Output.hs
+++ b/packages/agent-core/src/Agent/Loop/Output.hs
@@ -51,6 +51,9 @@ data LoopEvent
     | ReasoningDelta Text
     -- | Ephemeral transport/tool activity for the live CLI status line.
     | ActivityUpdated Text
+    -- | The model-visible history was rewritten or truncated. Stateful tools
+    -- must discard baselines that referred to the previous context.
+    | ModelContextReset
     -- | Latest provider-reported limit status for retained prompt chrome.
     | ProviderLimitUpdated
         { providerLimitText :: !Text

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
@@ -214,6 +214,7 @@ buildNestedTools =
   where
     add current spec
         | HostedComputerSchema <- tool.appToolSchema = Right current
+        | HostedComputerFunctionSchema _ <- tool.appToolSchema = Right current
         | codeName `elem` ["exec", "wait"] = Right current
         | Map.member codeName current =
             -- Match Codex's stable first-wins projection when two provider

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -98,6 +98,10 @@ data ToolSchema
     -- caller-defined JSON functions prevents an unrelated MCP tool from
     -- acquiring the desktop-control handler or its output encoding.
     | HostedComputerSchema
+    -- | A host-supplied schema for the privileged local computer function.
+    -- Native embeddings use this to expose semantic accessibility operations
+    -- without allowing an ordinary raw-JSON tool to acquire computer calls.
+    | HostedComputerFunctionSchema !Value
     deriving (Eq, Show)
 
 -- | Whether a tool may be selected for provider-requested asynchronous calls.
@@ -529,6 +533,9 @@ toolAcceptsCall tool call =
         (HostedComputerSchema, ComputerCallKind) -> True
         (HostedComputerSchema, ComputerFunctionCallKind) -> True
         (HostedComputerSchema, _) -> False
+        (HostedComputerFunctionSchema _, ComputerCallKind) -> True
+        (HostedComputerFunctionSchema _, ComputerFunctionCallKind) -> True
+        (HostedComputerFunctionSchema _, _) -> False
         (_, ComputerCallKind) -> False
         (_, ComputerFunctionCallKind) -> False
         _ -> True
@@ -540,6 +547,7 @@ jsonToolParameters tool = case tool.appToolSchema of
     FreeformApplyPatchSchema -> Nothing
     FreeformGrammarSchema _ _ -> Nothing
     HostedComputerSchema -> Nothing
+    HostedComputerFunctionSchema _ -> Nothing
 
 -- | Compatibility helper for direct handler consumers. New dispatch paths
 -- should retain and use 'ToolRegistry' instead.

--- a/packages/agent-core/test/Agent/ComputerUse/ProtocolSpec.hs
+++ b/packages/agent-core/test/Agent/ComputerUse/ProtocolSpec.hs
@@ -1,0 +1,172 @@
+module Agent.ComputerUse.ProtocolSpec (spec) where
+
+import Agent.ComputerUse.Protocol
+import Control.Monad (forM_)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TextEncoding
+import Paths_agent_core (getDataFileName)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "semantic computer protocol" do
+    it "decodes every operation and scalar into typed requests" do
+        decode requestList `shouldBe` Right ListComputerTargets
+        decode requestBind `shouldBe`
+            Right (BindComputerTarget "target-1" True)
+        decode requestObserve `shouldBe`
+            Right (ObserveComputerTarget False)
+        decode requestAct `shouldBe`
+            Right fixtureActRequest
+
+    it "round-trips every request through the versioned native wire" do
+        forM_ fixtureRequests \request ->
+            decodeSemanticComputerWireRequest
+                (encodeSemanticComputerRequest request)
+                `shouldBe` Right request
+
+    it "matches the shared protocol-v1 golden fixture" do
+        fixturePath <-
+            getDataFileName "data/computer-use/protocol-v1.json"
+        fixtureBytes <- BS.readFile fixturePath
+        case (Aeson.eitherDecodeStrict' fixtureBytes
+                :: Either String Aeson.Value) of
+            Left err -> expectationFailure err
+            Right fixtureValue ->
+                fixtureValue `shouldBe`
+                    Aeson.toJSON
+                        (map semanticComputerRequestWireValue fixtureRequests)
+
+    it "derives ABI metadata from the typed request" do
+        semanticComputerRequestOperation ListComputerTargets
+            `shouldBe` ListComputerTargetsOperation
+        semanticComputerRequestOperation (BindComputerTarget "target-1" True)
+            `shouldBe` BindComputerTargetOperation
+        semanticComputerRequestOperation (ObserveComputerTarget False)
+            `shouldBe` ObserveOrActOnComputerTargetOperation
+        semanticComputerRequestWantsScreenshot
+            (ObserveComputerTarget True) `shouldBe` True
+
+    it "rejects shape drift before approval or execution" do
+        decode
+            "{\"operation\":\"observe\",\"target_id\":null,\"actions\":null}"
+            `shouldSatisfy` isLeft
+        decode
+            ( "{\"operation\":\"observe\",\"target_id\":null,\"actions\":null,"
+            <> "\"include_screenshot\":false,\"x\":1}"
+            )
+            `shouldSatisfy` isLeft
+        decode
+            ( "{\"operation\":\"list_targets\",\"target_id\":null,"
+            <> "\"actions\":null,\"include_screenshot\":true}"
+            )
+            `shouldSatisfy` isLeft
+        decode
+            ( "{\"operation\":\"act\",\"target_id\":null,\"actions\":[],"
+            <> "\"include_screenshot\":false}"
+            )
+            `shouldSatisfy` isLeft
+        decode
+            ( "{\"operation\":\"act\",\"target_id\":null,\"actions\":["
+            <> "{\"type\":\"set_value\",\"element_id\":\"field\","
+            <> "\"action\":null,\"value\":null,\"text\":null}],"
+            <> "\"include_screenshot\":false}"
+            )
+            `shouldSatisfy` isLeft
+        decode
+            ( "{\"operation\":\"bind\",\"target_id\":\"\",\"actions\":null,"
+            <> "\"include_screenshot\":false}"
+            )
+            `shouldSatisfy` isLeft
+        decode
+            ( "{\"operation\":\"act\",\"target_id\":null,\"actions\":["
+            <> "{\"type\":\"set_value\",\"element_id\":\"field\","
+            <> "\"action\":null,\"value\":1e400,\"text\":null}],"
+            <> "\"include_screenshot\":false}"
+            )
+            `shouldSatisfy` isLeft
+        decode
+            ( "{\"operation\":\"act\",\"target_id\":null,\"actions\":["
+            <> "{\"type\":\"set_value\",\"element_id\":\"field\","
+            <> "\"action\":null,\"value\":9007199254740993,\"text\":null}],"
+            <> "\"include_screenshot\":false}"
+            )
+            `shouldSatisfy` isLeft
+
+    it "rejects oversized, missing, duplicate, and unsupported wire input" do
+        decodeSemanticComputerWireRequest
+            (BS.replicate (1024 * 1024 + 1) 0x20)
+            `shouldBe`
+                Left "computer request exceeds the native protocol capacity"
+        wireDecode
+            ( "{\"operation\":\"observe\",\"target_id\":null,"
+            <> "\"actions\":null,\"include_screenshot\":false}"
+            )
+            `shouldSatisfy` isLeft
+        wireDecode
+            ( "{\"protocol_version\":2,\"operation\":\"observe\","
+            <> "\"target_id\":null,\"actions\":null,"
+            <> "\"include_screenshot\":false}"
+            )
+            `shouldSatisfy` isLeft
+        wireDecode
+            ( "{\"protocol_version\":1,\"protocol_version\":1,"
+            <> "\"operation\":\"observe\",\"target_id\":null,"
+            <> "\"actions\":null,\"include_screenshot\":false}"
+            )
+            `shouldSatisfy` isLeft
+  where
+    decode :: Text -> Either Text SemanticComputerRequest
+    decode = decodeSemanticComputerRequest
+    wireDecode :: Text -> Either Text SemanticComputerRequest
+    wireDecode =
+        decodeSemanticComputerWireRequest . TextEncoding.encodeUtf8
+
+requestList :: Text
+requestList =
+    "{\"operation\":\"list_targets\",\"target_id\":null,\"actions\":null,\"include_screenshot\":false}"
+
+requestBind :: Text
+requestBind =
+    "{\"operation\":\"bind\",\"target_id\":\"target-1\",\"actions\":null,\"include_screenshot\":true}"
+
+requestObserve :: Text
+requestObserve =
+    "{\"operation\":\"observe\",\"target_id\":null,\"actions\":null,\"include_screenshot\":false}"
+
+requestAct :: Text
+requestAct =
+    "{\"operation\":\"act\",\"target_id\":null,\"actions\":[\
+    \{\"type\":\"perform\",\"element_id\":\"button-1\",\"action\":\"AXPress\",\"value\":null,\"text\":null},\
+    \{\"type\":\"set_value\",\"element_id\":\"field-1\",\"action\":null,\"value\":\"hello\",\"text\":null},\
+    \{\"type\":\"set_value\",\"element_id\":\"slider-1\",\"action\":null,\"value\":42,\"text\":null},\
+    \{\"type\":\"set_value\",\"element_id\":\"check-1\",\"action\":null,\"value\":true,\"text\":null},\
+    \{\"type\":\"replace_selected_text\",\"element_id\":\"field-2\",\"action\":null,\"value\":null,\"text\":\"world\"}],\
+    \\"include_screenshot\":true}"
+
+fixtureRequests :: [SemanticComputerRequest]
+fixtureRequests =
+    [ ListComputerTargets
+    , BindComputerTarget "target-1" True
+    , ObserveComputerTarget False
+    , fixtureActRequest
+    ]
+
+fixtureActRequest :: SemanticComputerRequest
+fixtureActRequest =
+    ActOnComputerTarget
+        ( PerformComputerAction "button-1" "AXPress"
+            NonEmpty.:| [ SetComputerValue "field-1" (ComputerText "hello")
+                       , SetComputerValue "slider-1" (ComputerNumber 42)
+                       , SetComputerValue "check-1" (ComputerBool True)
+                       , ReplaceComputerSelectedText "field-2" "world"
+                       ]
+        )
+        True
+
+isLeft :: Either a b -> Bool
+isLeft = \case
+    Left _ -> True
+    Right _ -> False

--- a/packages/agent-core/test/Agent/ToolDispatchSpec.hs
+++ b/packages/agent-core/test/Agent/ToolDispatchSpec.hs
@@ -18,6 +18,7 @@ import Agent.Tools.Types
     , withAsyncToolCalls
     )
 import qualified Control.Exception as Exception
+import qualified Data.Aeson as Aeson
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -369,6 +370,10 @@ spec = describe "dispatchToolCall" do
 
     it "accepts only privileged computer kinds at the hosted handler" do
         let hosted = computerTool (pure (Right "ok"))
+            native = hosted
+                { appToolSchema =
+                    HostedComputerFunctionSchema (Aeson.object [])
+                }
             ordinary =
                 hosted
                     { appToolSchema = JsonFunctionSchema []
@@ -381,6 +386,13 @@ spec = describe "dispatchToolCall" do
                 , argumentsEncrypted = False
                 }
         map (toolAcceptsCall hosted . call)
+            [ FunctionCallKind
+            , CustomCallKind
+            , ComputerCallKind
+            , ComputerFunctionCallKind
+            ]
+            `shouldBe` [False, False, True, True]
+        map (toolAcceptsCall native . call)
             [ FunctionCallKind
             , CustomCallKind
             , ComputerCallKind

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import qualified Agent.Auth.JWTSpec as JWTSpec
 import qualified Agent.CancelSpec as CancelSpec
 import qualified Agent.ConcurrentSpec as ConcurrentSpec
+import qualified Agent.ComputerUse.ProtocolSpec as ComputerUseProtocolSpec
 import qualified Agent.DialectSpec as DialectSpec
 import qualified Agent.ErrorSpec as ErrorSpec
 import qualified Agent.Http.HeaderSpec as HttpHeaderSpec
@@ -44,6 +45,7 @@ main = hspec do
     JWTSpec.spec
     CancelSpec.spec
     ConcurrentSpec.spec
+    ComputerUseProtocolSpec.spec
     DialectSpec.spec
     ErrorSpec.spec
     HttpHeaderSpec.spec

--- a/packages/agent-mcp/src/Agent/MCP/InProcess.hs
+++ b/packages/agent-mcp/src/Agent/MCP/InProcess.hs
@@ -225,6 +225,7 @@ schemaValue = \case
     FreeformApplyPatchSchema -> object []
     FreeformGrammarSchema _ _ -> object []
     HostedComputerSchema -> object []
+    HostedComputerFunctionSchema _ -> object []
 
 hasJsonSchema :: ToolSchema -> Bool
 hasJsonSchema = \case
@@ -233,6 +234,7 @@ hasJsonSchema = \case
     FreeformApplyPatchSchema -> False
     FreeformGrammarSchema _ _ -> False
     HostedComputerSchema -> False
+    HostedComputerFunctionSchema _ -> False
 
 isStaticallyReadOnly :: ApprovalRule -> Bool
 isStaticallyReadOnly = \case

--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -157,6 +157,7 @@ test-suite agent-native-bridge-test
                     , agent-mcp
                     , agent-runtime-daemon
                     , agent-store
+                    , aeson
                     , async
                     , base >= 4.17 && < 5
                     , base64-bytestring
@@ -226,7 +227,6 @@ test-suite agent-native-bridge-test
                      , agent-openrouter
                      , agent-responses-types
                      , agent-xai
-                     , aeson
                      , filelock
                      , JuicyPixels
                      , time

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
@@ -9,6 +9,7 @@ module Agent.CLI.MacOS.ComputerBridge
     , ComputerRegistration(..)
     , ComputerSession
     , computerActionStructSize
+    , computerAccessibilityCapacity
     , computerErrorCapacity
     , computerOutputCapacity
     , computerStatusMessage
@@ -25,6 +26,14 @@ import Agent.CLI.ComputerUse
     , ComputerUseBackend(..)
     , ScreenshotEncoding(..)
     , computerUseToolWith
+    )
+import Agent.CLI.ComputerUse.Accessibility
+    ( AccessibilityDeltaState
+    , AccessibilityObservation
+    , advanceAccessibilityObservation
+    , decodeAccessibilitySnapshot
+    , initialAccessibilityDeltaState
+    , unavailableAccessibilityObservation
     )
 import Agent.Loop (ImageAttachment(..))
 import Agent.Responses.Types
@@ -142,6 +151,9 @@ type ComputerCallback =
     -> Ptr Word8
     -> CSize
     -> Ptr CSize
+    -> Ptr Word8
+    -> CSize
+    -> Ptr CSize
     -> Ptr Word64
     -> Ptr CInt
     -> Ptr CInt
@@ -161,14 +173,22 @@ newtype ComputerHost = ComputerHost
     }
 
 newtype ComputerSession = ComputerSession
-    { computerSessionObservation :: MVar (Maybe NativeComputerDisplay)
+    { computerSessionState :: MVar ComputerSessionState
+    }
+
+data ComputerSessionState = ComputerSessionState
+    { computerSessionDisplay :: !(Maybe NativeComputerDisplay)
+    , computerSessionAccessibility :: !AccessibilityDeltaState
     }
 
 newComputerHost :: IO ComputerHost
 newComputerHost = ComputerHost <$> newMVar Nothing
 
 newComputerSession :: IO ComputerSession
-newComputerSession = ComputerSession <$> newMVar Nothing
+newComputerSession = ComputerSession <$> newMVar ComputerSessionState
+    { computerSessionDisplay = Nothing
+    , computerSessionAccessibility = initialAccessibilityDeltaState
+    }
 
 computerToolWhenEnabled :: ComputerHost -> IO (Maybe AppTool)
 computerToolWhenEnabled host =
@@ -349,10 +369,11 @@ invokeComputerTransaction
     -> ((Int, Int) -> Either Text ())
     -> IO (Either Text ComputerObservation)
 invokeComputerTransaction host encoding actions validateDisplay =
-    fmap (fmap fst) $
+    fmap (fmap (\(observation, _, _) -> observation)) $
         invokeComputerTransactionWithLease
             host
             Nothing
+            initialAccessibilityDeltaState
             encoding
             actions
             validateDisplay
@@ -369,38 +390,49 @@ invokeComputerSessionTransaction
     -> ((Int, Int) -> Either Text ())
     -> IO (Either Text ComputerObservation)
 invokeComputerSessionTransaction host session encoding actions validateDisplay =
-    modifyMVar session.computerSessionObservation \previous -> do
+    modifyMVar session.computerSessionState \previous -> do
         result <-
             if null actions
                 then invokeComputerTransactionWithLease
-                    host Nothing encoding actions validateDisplay
-                else case previous of
+                    host Nothing previous.computerSessionAccessibility
+                    encoding actions validateDisplay
+                else case previous.computerSessionDisplay of
                     Nothing -> pure (Left
                         "Take a fresh computer screenshot before sending input actions.")
                     Just display ->
                         invokeComputerTransactionWithLease
                             host
                             (Just display)
+                            previous.computerSessionAccessibility
                             encoding
                             actions
                             validateDisplay
         case result of
             Left err -> pure (previous, Left err)
-            Right (observation, successor) ->
-                pure (Just successor, Right observation)
+            Right (observation, successor, accessibilityState) ->
+                pure
+                    ( ComputerSessionState
+                        (Just successor)
+                        accessibilityState
+                    , Right observation
+                    )
 
 invokeComputerTransactionWithLease
     :: ComputerHost
     -> Maybe NativeComputerDisplay
+    -> AccessibilityDeltaState
     -> ScreenshotEncoding
     -> [ComputerAction]
     -> ((Int, Int) -> Either Text ())
     -> IO
         (Either
             Text
-            (ComputerObservation, NativeComputerDisplay))
+            ( ComputerObservation
+            , NativeComputerDisplay
+            , AccessibilityDeltaState
+            ))
 invokeComputerTransactionWithLease
-        host priorDisplay encoding actions validateDisplay =
+        host priorDisplay accessibilityState encoding actions validateDisplay =
     case encodeComputerActions actions of
         Left err -> pure (Left err)
         Right batch ->
@@ -424,6 +456,7 @@ invokeComputerTransactionWithLease
                                     invokeComputerRunAndObserve
                                         registration
                                         display
+                                        accessibilityState
                                         encoding
                                         batch)
                 >>= \case
@@ -435,10 +468,11 @@ invokeComputerDisplay
     :: ComputerRegistration
     -> IO (Either Text NativeComputerDisplay)
 invokeComputerDisplay registration =
-    invokeComputer computerErrorCapacity registration query >>= \case
+    invokeComputer computerErrorCapacity 0 registration query >>= \case
         Left err -> pure (Left err)
-        Right (bytes, token, width, height, imageFormat)
+        Right (bytes, accessibility, token, width, height, imageFormat)
             | not (BS.null bytes)
+                || not (BS.null accessibility)
                 || token == 0
                 || width <= 0
                 || height <= 0
@@ -452,12 +486,13 @@ invokeComputerDisplay registration =
                     , nativeDisplayHeight = height
                     })
   where
-    query registration' output capacity outputLength outputToken
+    query registration' output capacity outputLength accessibilityOutput
+            accessibilityCapacity accessibilityLength outputToken
             width height imageFormat =
         invokeComputerCallback
             registration'.computerCallback
             registration'.computerContext
-            1
+            2
             1
             0
             0
@@ -472,6 +507,9 @@ invokeComputerDisplay registration =
             output
             capacity
             outputLength
+            accessibilityOutput
+            accessibilityCapacity
+            accessibilityLength
             outputToken
             width
             height
@@ -480,18 +518,24 @@ invokeComputerDisplay registration =
 invokeComputerRunAndObserve
     :: ComputerRegistration
     -> NativeComputerDisplay
+    -> AccessibilityDeltaState
     -> ScreenshotEncoding
     -> ComputerBatch
     -> IO
         (Either
             Text
-            (ComputerObservation, NativeComputerDisplay))
-invokeComputerRunAndObserve registration display encoding batch =
+            ( ComputerObservation
+            , NativeComputerDisplay
+            , AccessibilityDeltaState
+            ))
+invokeComputerRunAndObserve
+        registration display accessibilityState encoding batch =
     withArray batch.computerBatchActions \actionPointer ->
         withArray batch.computerBatchPoints \pointPointer ->
             BS.useAsCStringLen batch.computerBatchText
                 \(textPointer, textLength) ->
-                    invokeComputer computerOutputCapacity registration
+                    invokeComputer computerOutputCapacity
+                        computerAccessibilityCapacity registration
                         (run
                             actionPointer
                             pointPointer
@@ -499,7 +543,7 @@ invokeComputerRunAndObserve registration display encoding batch =
                             textLength)
                         >>= \case
                             Left err -> pure (Left err)
-                            Right (bytes, token, width, height, imageFormat)
+                            Right (bytes, accessibility, token, width, height, imageFormat)
                                 | token == 0
                                     || token == display.nativeDisplayToken
                                     || width /= display.nativeDisplayWidth
@@ -516,10 +560,17 @@ invokeComputerRunAndObserve registration display encoding batch =
                                     case imageMime imageFormat bytes of
                                         Left err -> pure (Left err)
                                         Right mime ->
-                                            pure (Right
+                                            let
+                                                ( accessibilityObservation
+                                                  , successorAccessibilityState
+                                                  ) =
+                                                    decodeAccessibility
+                                                        accessibility
+                                                        accessibilityState
+                                            in pure (Right
                                                 ( ComputerObservation
                                                     (ImageAttachment mime bytes)
-                                                    Nothing
+                                                    accessibilityObservation
                                                 , NativeComputerDisplay
                                                     { nativeDisplayToken =
                                                         token
@@ -528,18 +579,20 @@ invokeComputerRunAndObserve registration display encoding batch =
                                                     , nativeDisplayHeight =
                                                         height
                                                     }
+                                                , successorAccessibilityState
                                                 ))
   where
     requestedFormat = case encoding of
         ScreenshotPng -> 1
         ScreenshotJpeg -> 2
     run actionPointer pointPointer textPointer textLength
-            registration' output capacity outputLength outputToken
+            registration' output capacity outputLength accessibilityOutput
+            accessibilityCapacity accessibilityLength outputToken
             width height imageFormat =
         invokeComputerCallback
             registration'.computerCallback
             registration'.computerContext
-            1
+            2
             2
             display.nativeDisplayToken
             display.nativeDisplayWidth
@@ -554,6 +607,9 @@ invokeComputerRunAndObserve registration display encoding batch =
             output
             capacity
             outputLength
+            accessibilityOutput
+            accessibilityCapacity
+            accessibilityLength
             outputToken
             width
             height
@@ -561,6 +617,9 @@ invokeComputerRunAndObserve registration display encoding batch =
 
 type ComputerInvocation =
     ComputerRegistration
+    -> Ptr Word8
+    -> CSize
+    -> Ptr CSize
     -> Ptr Word8
     -> CSize
     -> Ptr CSize
@@ -572,46 +631,67 @@ type ComputerInvocation =
 
 invokeComputer
     :: Int
+    -> Int
     -> ComputerRegistration
     -> ComputerInvocation
-    -> IO (Either Text (BS.ByteString, Word64, CInt, CInt, CInt))
-invokeComputer capacity registration invocation =
+    -> IO (Either Text (BS.ByteString, BS.ByteString, Word64, CInt, CInt, CInt))
+invokeComputer capacity accessibilityCapacity registration invocation =
     bracket (mallocBytes capacity) free \output -> do
         fillBytes output 0 capacity
-        allocaResult \outputLength outputToken width height imageFormat -> do
-            status <- invocation
-                registration
-                output
-                (fromIntegral capacity)
-                outputLength
-                outputToken
-                width
-                height
-                imageFormat
-            CSize length <- peek outputLength
-            observedToken <- peek outputToken
-            observedWidth <- peek width
-            observedHeight <- peek height
-            observedFormat <- peek imageFormat
-            if length > fromIntegral capacity
-                then pure (Left
-                    "The native computer host reported output beyond its buffer.")
-                else do
-                    bytes <- BS.packCStringLen
-                        (castPtr output, fromIntegral length)
-                    if status == 0
-                        then pure (Right
-                            ( bytes
-                            , observedToken
-                            , observedWidth
-                            , observedHeight
-                            , observedFormat
-                            ))
-                        else pure (Left
-                            (computerFailureMessage status bytes))
+        bracket (mallocBytes (max 1 accessibilityCapacity)) free
+            \accessibilityOutputBuffer -> do
+            fillBytes accessibilityOutputBuffer 0 accessibilityCapacity
+            let accessibilityOutput
+                    | accessibilityCapacity == 0 = nullPtr
+                    | otherwise = accessibilityOutputBuffer
+            allocaResult \outputLength accessibilityLength outputToken width height imageFormat -> do
+                status <- invocation
+                    registration
+                    output
+                    (fromIntegral capacity)
+                    outputLength
+                    accessibilityOutput
+                    (fromIntegral accessibilityCapacity)
+                    accessibilityLength
+                    outputToken
+                    width
+                    height
+                    imageFormat
+                CSize length <- peek outputLength
+                CSize accessibilityLengthValue <- peek accessibilityLength
+                observedToken <- peek outputToken
+                observedWidth <- peek width
+                observedHeight <- peek height
+                observedFormat <- peek imageFormat
+                if length > fromIntegral capacity
+                    then pure (Left
+                        "The native computer host reported output beyond its buffer.")
+                    else if accessibilityLengthValue
+                            > fromIntegral accessibilityCapacity
+                        then pure (Left
+                            "The native computer host reported accessibility output beyond its buffer.")
+                    else do
+                        bytes <- BS.packCStringLen
+                            (castPtr output, fromIntegral length)
+                        accessibility <- BS.packCStringLen
+                            ( castPtr accessibilityOutputBuffer
+                            , fromIntegral accessibilityLengthValue
+                            )
+                        if status == 0
+                            then pure (Right
+                                ( bytes
+                                , accessibility
+                                , observedToken
+                                , observedWidth
+                                , observedHeight
+                                , observedFormat
+                                ))
+                            else pure (Left
+                                (computerFailureMessage status bytes))
 
 allocaResult
     :: ( Ptr CSize
+        -> Ptr CSize
         -> Ptr Word64
         -> Ptr CInt
         -> Ptr CInt
@@ -621,18 +701,21 @@ allocaResult
     -> IO value
 allocaResult action =
     allocaBytes (sizeOf (undefined :: CSize)) \outputLength ->
-        allocaBytes (sizeOf (undefined :: Word64)) \outputToken ->
+        allocaBytes (sizeOf (undefined :: CSize)) \accessibilityLength ->
+          allocaBytes (sizeOf (undefined :: Word64)) \outputToken ->
             allocaBytes (sizeOf (undefined :: CInt)) \width ->
                 allocaBytes (sizeOf (undefined :: CInt)) \height ->
                     allocaBytes (sizeOf (undefined :: CInt))
                         \imageFormat -> do
                             poke outputLength 0
+                            poke accessibilityLength 0
                             poke outputToken 0
                             poke width 0
                             poke height 0
                             poke imageFormat 0
                             action
                                 outputLength
+                                accessibilityLength
                                 outputToken
                                 width
                                 height
@@ -683,3 +766,32 @@ computerErrorCapacity = 64 * 1024
 
 computerOutputCapacity :: Int
 computerOutputCapacity = 16 * 1024 * 1024
+
+computerAccessibilityCapacity :: Int
+computerAccessibilityCapacity = 512 * 1024
+
+decodeAccessibility
+    :: BS.ByteString
+    -> AccessibilityDeltaState
+    -> (Maybe AccessibilityObservation, AccessibilityDeltaState)
+decodeAccessibility bytes state
+    | BS.null bytes =
+        let (observation, successor) =
+                unavailableAccessibilityObservation
+                    "Native accessibility snapshot unavailable."
+                    state
+        in (Just observation, successor)
+    | otherwise =
+        case decodeAccessibilitySnapshot bytes of
+            Left err ->
+                let (observation, successor) =
+                        unavailableAccessibilityObservation
+                            ( "The native computer host returned invalid accessibility JSON: "
+                                <> err
+                            )
+                            state
+                in (Just observation, successor)
+            Right snapshot ->
+                let (observation, successor) =
+                        advanceAccessibilityObservation state snapshot
+                in (Just observation, successor)

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
@@ -1,34 +1,30 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 
+-- | The native-only, accessibility-first macOS computer service.
+--
+-- The standalone CLI computer backend intentionally remains in
+-- "Agent.CLI.ComputerUse". Native turns use this module's semantic JSON
+-- protocol instead: models name stable AX elements and never provide pixels.
 module Agent.CLI.MacOS.ComputerBridge
-    ( CComputerAction(..)
-    , CComputerPoint(..)
-    , ComputerBatch(..)
-    , ComputerCallback
-    , ComputerHost(..)
+    ( ComputerCallback
+    , ComputerHost
     , ComputerRegistration(..)
     , ComputerSession
-    , computerActionStructSize
+    , NativeComputerResult(..)
+    , closeComputerSession
     , computerAccessibilityCapacity
     , computerErrorCapacity
-    , computerOutputCapacity
+    , computerImageCapacity
+    , computerResultCapacity
     , computerStatusMessage
-    , computerToolWhenEnabled
     , computerToolSessionWhenEnabled
-    , encodeComputerActions
-    , invokeComputerTransaction
-    , invokeComputerSessionTransaction
+    , invokeComputerSessionRequest
     , newComputerHost
     , newComputerSession
+    , replaceComputerRegistration
     , resetComputerSessionAccessibility
     ) where
 
-import Agent.CLI.ComputerUse
-    ( ComputerObservation(..)
-    , ComputerUseBackend(..)
-    , ScreenshotEncoding(..)
-    , computerUseToolWith
-    )
 import Agent.CLI.ComputerUse.Accessibility
     ( AccessibilityDeltaState
     , AccessibilityObservation
@@ -37,23 +33,41 @@ import Agent.CLI.ComputerUse.Accessibility
     , initialAccessibilityDeltaState
     , unavailableAccessibilityObservation
     )
-import Agent.Loop (ImageAttachment(..))
-import Agent.Responses.Types
-    ( ComputerAction(..)
-    , ComputerPoint(..)
+import Agent.ToolDispatch
+    ( ToolHandlerResult(..)
+    , ToolResultImage(..)
+    , streamingRichTextTool
     )
-import Agent.Tools.Types (AppTool)
-import Control.Exception.Safe (bracket, tryAny)
-import Control.Monad (foldM)
-import Control.Concurrent.MVar
-    ( MVar
-    , modifyMVar
-    , modifyMVar_
-    , newMVar
-    , withMVar
+import Agent.Tools.Types
+    ( AppTool(..)
+    , ApprovalRule(..)
+    , ToolAsyncCapability(..)
+    , ToolExecutionPolicy(..)
+    , ToolSchema(..)
     )
+import Codec.Picture
+    ( DynamicImage
+    , dynamicMap
+    , imageHeight
+    , imageWidth
+    , pixelAt
+    )
+import Codec.Picture.Jpg (decodeJpeg)
+import Codec.Picture.Png (decodePng)
+import qualified Control.Concurrent.MVar as MVar
+import Control.Exception (evaluate)
+import qualified Control.Exception.Safe as Exception
+import Control.Exception.Safe (finally, mask_, onException, tryAny)
+import Control.Monad (guard, unless, when)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Aeson.Types as AesonTypes
+import Data.Bits ((.&.), complement, shiftR, xor)
 import qualified Data.ByteString as BS
-import Data.Bits ((.|.))
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (IORef, atomicModifyIORef', newIORef)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -61,101 +75,32 @@ import Data.Word (Word8, Word32, Word64)
 import Foreign
     ( FunPtr
     , Ptr
-    , Storable(..)
     , castPtr
     , nullPtr
     , peek
-    , peekByteOff
     , poke
-    , pokeByteOff
     )
 import Foreign.C.Types (CInt(..), CSize(..))
-import Foreign.Marshal.Alloc (allocaBytes, free, mallocBytes)
-import Foreign.Marshal.Array (withArray)
+import Foreign.Marshal.Alloc (alloca, free, mallocBytes)
 import Foreign.Marshal.Utils (fillBytes)
 
-data CComputerPoint = CComputerPoint
-    { cComputerPointX :: !CInt
-    , cComputerPointY :: !CInt
-    } deriving (Eq, Show)
-
-instance Storable CComputerPoint where
-    sizeOf _ = 8
-    alignment _ = alignment (undefined :: CInt)
-    peek pointer =
-        CComputerPoint
-            <$> peekByteOff pointer 0
-            <*> peekByteOff pointer 4
-    poke pointer point = do
-        pokeByteOff pointer 0 point.cComputerPointX
-        pokeByteOff pointer 4 point.cComputerPointY
-
-data CComputerAction = CComputerAction
-    { cComputerStructSize :: !Word32
-    , cComputerAction :: !CInt
-    , cComputerX :: !CInt
-    , cComputerY :: !CInt
-    , cComputerDeltaX :: !CInt
-    , cComputerDeltaY :: !CInt
-    , cComputerButton :: !CInt
-    , cComputerModifiers :: !Word32
-    , cComputerTextOffset :: !Word64
-    , cComputerTextLength :: !Word64
-    , cComputerPointOffset :: !Word64
-    , cComputerPointCount :: !Word64
-    } deriving (Eq, Show)
-
-instance Storable CComputerAction where
-    sizeOf _ = computerActionStructSize
-    alignment _ = alignment (undefined :: Word64)
-    peek pointer =
-        CComputerAction
-            <$> peekByteOff pointer 0
-            <*> peekByteOff pointer 4
-            <*> peekByteOff pointer 8
-            <*> peekByteOff pointer 12
-            <*> peekByteOff pointer 16
-            <*> peekByteOff pointer 20
-            <*> peekByteOff pointer 24
-            <*> peekByteOff pointer 28
-            <*> peekByteOff pointer 32
-            <*> peekByteOff pointer 40
-            <*> peekByteOff pointer 48
-            <*> peekByteOff pointer 56
-    poke pointer action = do
-        pokeByteOff pointer 0 action.cComputerStructSize
-        pokeByteOff pointer 4 action.cComputerAction
-        pokeByteOff pointer 8 action.cComputerX
-        pokeByteOff pointer 12 action.cComputerY
-        pokeByteOff pointer 16 action.cComputerDeltaX
-        pokeByteOff pointer 20 action.cComputerDeltaY
-        pokeByteOff pointer 24 action.cComputerButton
-        pokeByteOff pointer 28 action.cComputerModifiers
-        pokeByteOff pointer 32 action.cComputerTextOffset
-        pokeByteOff pointer 40 action.cComputerTextLength
-        pokeByteOff pointer 48 action.cComputerPointOffset
-        pokeByteOff pointer 56 action.cComputerPointCount
-
-data ComputerBatch = ComputerBatch
-    { computerBatchActions :: ![CComputerAction]
-    , computerBatchPoints :: ![CComputerPoint]
-    , computerBatchText :: !BS.ByteString
-    } deriving (Eq, Show)
-
+-- | ABI v3 callback. Every buffer is callback-scoped. OPEN returns a nonzero
+-- opaque token; all subsequent operations carry it. Result JSON, AX JSON,
+-- image bytes, and errors have independent buffers so an oversized optional
+-- channel cannot destroy another successful channel.
 type ComputerCallback =
     Ptr ()
     -> Word32
     -> CInt
     -> Word64
-    -> CInt
-    -> CInt
-    -> Ptr CComputerAction
-    -> CSize
-    -> Ptr CComputerPoint
+    -> Ptr Word8
     -> CSize
     -> Ptr Word8
     -> CSize
-    -> CInt
+    -> Ptr CSize
+    -> Ptr Word8
+    -> CSize
+    -> Ptr CSize
     -> Ptr Word8
     -> CSize
     -> Ptr CSize
@@ -163,8 +108,6 @@ type ComputerCallback =
     -> CSize
     -> Ptr CSize
     -> Ptr Word64
-    -> Ptr CInt
-    -> Ptr CInt
     -> Ptr CInt
     -> IO CInt
 
@@ -176,586 +119,895 @@ data ComputerRegistration = ComputerRegistration
     , computerContext :: !(Ptr ())
     }
 
+data RegistrationGeneration = RegistrationGeneration
+    { generationRegistration :: !ComputerRegistration
+    , generationSessions :: !Int
+    }
+
+data ComputerHostState = ComputerHostState
+    { hostCurrentGeneration :: !(Maybe Word64)
+    , hostGenerations :: !(Map.Map Word64 RegistrationGeneration)
+    , hostNextGeneration :: !Word64
+    }
+
 newtype ComputerHost = ComputerHost
-    { computerRegistration :: MVar (Maybe ComputerRegistration)
+    { computerHostState :: IORef ComputerHostState
     }
 
-newtype ComputerSession = ComputerSession
-    { computerSessionState :: MVar ComputerSessionState
+data ComputerSession = ComputerSession
+    { computerSessionHost :: !ComputerHost
+    , computerSessionGeneration :: !Word64
+    , computerSessionRegistration :: !ComputerRegistration
+    , computerSessionState :: !(MVar.MVar ComputerSessionState)
     }
 
-data ComputerSessionState = ComputerSessionState
-    { computerSessionDisplay :: !(Maybe NativeComputerDisplay)
-    , computerSessionAccessibility :: !AccessibilityDeltaState
-    }
+data ComputerSessionState
+    = ComputerSessionOpen !Word64 !AccessibilityDeltaState
+    | ComputerSessionClosed
+
+data NativeComputerResult = NativeComputerResult
+    { nativeComputerResultValue :: !Aeson.Value
+    , nativeComputerAccessibility :: !(Maybe AccessibilityObservation)
+    , nativeComputerImage :: !(Maybe ToolResultImage)
+    } deriving (Eq, Show)
 
 newComputerHost :: IO ComputerHost
-newComputerHost = ComputerHost <$> newMVar Nothing
+newComputerHost =
+    ComputerHost <$> newIORef ComputerHostState
+        { hostCurrentGeneration = Nothing
+        , hostGenerations = Map.empty
+        , hostNextGeneration = 1
+        }
 
-newComputerSession :: IO ComputerSession
-newComputerSession = ComputerSession <$> newMVar ComputerSessionState
-    { computerSessionDisplay = Nothing
-    , computerSessionAccessibility = initialAccessibilityDeltaState
-    }
-
-computerToolWhenEnabled :: ComputerHost -> IO (Maybe AppTool)
-computerToolWhenEnabled host =
-    fmap (fmap fst) (computerToolSessionWhenEnabled host)
-
-computerToolSessionWhenEnabled :: ComputerHost -> IO (Maybe (AppTool, IO ()))
-computerToolSessionWhenEnabled host =
-    withMVar host.computerRegistration \case
-        Nothing -> pure Nothing
-        Just _ -> do
-            session <- newComputerSession
-            pure . Just $
-                ( computerUseToolWith $
-                    ComputerUseBackend
-                        { computerRunTransaction =
-                            invokeComputerSessionTransaction host session
-                        }
-                , resetComputerSessionAccessibility session
+-- | Publish a new callback immediately for new sessions. Existing sessions
+-- retain their generation and keep using it until their CLOSE completes.
+replaceComputerRegistration
+    :: ComputerHost
+    -> Maybe ComputerRegistration
+    -> IO ()
+replaceComputerRegistration host replacement =
+    atomicModifyIORef' host.computerHostState \state ->
+        let withoutUnusedOld = case state.hostCurrentGeneration of
+                Nothing -> state.hostGenerations
+                Just oldGeneration ->
+                    Map.update
+                        (\generation ->
+                            if generation.generationSessions == 0
+                                then Nothing
+                                else Just generation)
+                        oldGeneration
+                        state.hostGenerations
+        in case replacement of
+            Nothing ->
+                ( state
+                    { hostCurrentGeneration = Nothing
+                    , hostGenerations = withoutUnusedOld
+                    }
+                , ()
                 )
+            Just registration ->
+                let generation = state.hostNextGeneration
+                in
+                    ( state
+                        { hostCurrentGeneration = Just generation
+                        , hostGenerations = Map.insert generation
+                            (RegistrationGeneration registration 0)
+                            withoutUnusedOld
+                        , hostNextGeneration = generation + 1
+                        }
+                    , ()
+                    )
+
+newComputerSession :: ComputerHost -> IO (Either Text ComputerSession)
+newComputerSession host =
+    newComputerSessionWhenEnabled host >>= \case
+        Left err -> pure (Left err)
+        Right Nothing -> pure (Left "Native computer control is not active.")
+        Right (Just session) -> pure (Right session)
+
+newComputerSessionWhenEnabled
+    :: ComputerHost
+    -> IO (Either Text (Maybe ComputerSession))
+newComputerSessionWhenEnabled host = mask_ do
+    leased <- acquireCurrentGeneration host
+    case leased of
+        Nothing -> pure (Right Nothing)
+        Just (generation, registration) -> do
+            opened <-
+                invokeComputerRaw registration operationOpen 0 False BS.empty
+                    `onException` releaseGeneration host generation
+            case opened of
+                Left err -> do
+                    releaseGeneration host generation
+                    pure (Left err)
+                Right response
+                    | response.rawSessionToken == 0 -> do
+                        releaseGeneration host generation
+                        pure (Left
+                            "The native computer host returned an invalid session token.")
+                    | not (rawChannelsEmpty response) -> do
+                        closeInvalidOpen registration response.rawSessionToken
+                        releaseGeneration host generation
+                        pure (Left
+                            "The native computer host returned data while opening a session.")
+                    | otherwise -> do
+                        (do
+                            state <- MVar.newMVar
+                                (ComputerSessionOpen
+                                    response.rawSessionToken
+                                    initialAccessibilityDeltaState)
+                            pure (Right (Just ComputerSession
+                                { computerSessionHost = host
+                                , computerSessionGeneration = generation
+                                , computerSessionRegistration = registration
+                                , computerSessionState = state
+                                })))
+                            `onException`
+                                (closeInvalidOpen
+                                    registration
+                                    response.rawSessionToken
+                                    `finally`
+                                        releaseGeneration host generation)
+
+closeComputerSession :: ComputerSession -> IO ()
+closeComputerSession session = mask_ do
+    token <- MVar.modifyMVar
+        session.computerSessionState \case
+            ComputerSessionClosed -> pure (ComputerSessionClosed, Nothing)
+            ComputerSessionOpen sessionToken _ ->
+                pure (ComputerSessionClosed, Just sessionToken)
+    case token of
+        Nothing -> pure ()
+        Just sessionToken ->
+            (do
+                _ <- tryAny
+                    (invokeComputerRaw
+                        session.computerSessionRegistration
+                        operationClose
+                        sessionToken
+                        False
+                        BS.empty)
+                pure ())
+            `finally`
+                releaseGeneration
+                    session.computerSessionHost
+                    session.computerSessionGeneration
 
 resetComputerSessionAccessibility :: ComputerSession -> IO ()
 resetComputerSessionAccessibility session =
-    modifyMVar_ session.computerSessionState \state ->
-        pure state
-            { computerSessionAccessibility = initialAccessibilityDeltaState
-            }
+    MVar.modifyMVar_
+        session.computerSessionState \case
+            ComputerSessionClosed -> pure ComputerSessionClosed
+            ComputerSessionOpen token _ ->
+                pure (ComputerSessionOpen token initialAccessibilityDeltaState)
 
-encodeComputerActions :: [ComputerAction] -> Either Text ComputerBatch
-encodeComputerActions actions = do
-    batch <- foldM appendAction emptyBatch actions
-    if length batch.computerBatchActions > 10
-        then Left "Computer callback action count exceeds 10."
-        else if length batch.computerBatchPoints > 10240
-            then Left "Computer callback point count exceeds 10240."
-            else if BS.length batch.computerBatchText > 327680
-                then Left "Computer callback text exceeds 327680 UTF-8 bytes."
-                else Right batch
-  where
-    emptyBatch = ComputerBatch [] [] BS.empty
+computerToolSessionWhenEnabled
+    :: ComputerHost
+    -> IO (Either Text (Maybe (AppTool, IO (), IO ())))
+computerToolSessionWhenEnabled host =
+    newComputerSessionWhenEnabled host >>= \case
+        Left err -> pure (Left err)
+        Right Nothing -> pure (Right Nothing)
+        Right (Just session) ->
+            pure (Right (Just
+                ( computerTool session
+                , resetComputerSessionAccessibility session
+                , closeComputerSession session
+                )))
 
-appendAction :: ComputerBatch -> ComputerAction -> Either Text ComputerBatch
-appendAction batch action = case action of
-    ClickAction{clickX, clickY, clickButton, clickKeys} -> do
-        button <- computerButtonCode clickButton
-        modifiers <- computerModifierMask clickKeys
-        pure (addAction batch ((plainAction 1)
-            { cComputerX = int32 clickX
-            , cComputerY = int32 clickY
-            , cComputerButton = button
-            , cComputerModifiers = modifiers
-            }))
-    DoubleClickAction{doubleClickX, doubleClickY, doubleClickKeys} -> do
-        modifiers <- computerModifierMask doubleClickKeys
-        pure (addAction batch ((plainAction 2)
-            { cComputerX = int32 doubleClickX
-            , cComputerY = int32 doubleClickY
-            , cComputerModifiers = modifiers
-            }))
-    ScrollAction{scrollX, scrollY, scrollDx, scrollDy, scrollKeys} -> do
-        modifiers <- computerModifierMask scrollKeys
-        pure (addAction batch ((plainAction 3)
-            { cComputerX = int32 scrollX
-            , cComputerY = int32 scrollY
-            , cComputerDeltaX = int32 scrollDx
-            , cComputerDeltaY = int32 scrollDy
-            , cComputerModifiers = modifiers
-            }))
-    MoveAction{moveX, moveY, moveKeys} -> do
-        modifiers <- computerModifierMask moveKeys
-        pure (addAction batch ((plainAction 4)
-            { cComputerX = int32 moveX
-            , cComputerY = int32 moveY
-            , cComputerModifiers = modifiers
-            }))
-    DragAction{dragPath, dragKeys} -> do
-        modifiers <- computerModifierMask dragKeys
-        let offset = length batch.computerBatchPoints
-            encodedPoints =
-                [ CComputerPoint (int32 pointX) (int32 pointY)
-                | ComputerPoint{pointX, pointY} <- dragPath
-                ]
-            encoded = (plainAction 5)
-                { cComputerModifiers = modifiers
-                , cComputerPointOffset = fromIntegral offset
-                , cComputerPointCount = fromIntegral (length encodedPoints)
-                }
-        pure (addAction
-            (batch
-                { computerBatchPoints =
-                    batch.computerBatchPoints <> encodedPoints
-                })
-            encoded)
-    TypeAction value ->
-        pure (addTextAction batch 6 value 0)
-    KeypressAction keys -> case reverse keys of
-        [] -> Left "Computer key combination is empty."
-        key : reversedModifiers -> do
-            modifiers <- computerModifierMask (reverse reversedModifiers)
-            pure (addTextAction batch 7 (Text.strip key) modifiers)
-    WaitAction ->
-        pure (addAction batch (plainAction 8))
-    ScreenshotAction ->
-        Left "Computer screenshot must not cross the native action ABI."
-    UnknownComputerAction _ ->
-        Left "Unsupported computer action crossed the native action ABI."
-
-addAction :: ComputerBatch -> CComputerAction -> ComputerBatch
-addAction batch action =
-    batch { computerBatchActions = batch.computerBatchActions <> [action] }
-
-addTextAction
-    :: ComputerBatch
-    -> CInt
-    -> Text
-    -> Word32
-    -> ComputerBatch
-addTextAction batch actionCode value modifiers =
-    let bytes = TextEncoding.encodeUtf8 value
-        offset = BS.length batch.computerBatchText
-        action = (plainAction actionCode)
-            { cComputerModifiers = modifiers
-            , cComputerTextOffset = fromIntegral offset
-            , cComputerTextLength = fromIntegral (BS.length bytes)
-            }
-    in addAction
-        (batch { computerBatchText = batch.computerBatchText <> bytes })
-        action
-
-plainAction :: CInt -> CComputerAction
-plainAction action = CComputerAction
-    { cComputerStructSize = fromIntegral computerActionStructSize
-    , cComputerAction = action
-    , cComputerX = 0
-    , cComputerY = 0
-    , cComputerDeltaX = 0
-    , cComputerDeltaY = 0
-    , cComputerButton = 0
-    , cComputerModifiers = 0
-    , cComputerTextOffset = 0
-    , cComputerTextLength = 0
-    , cComputerPointOffset = 0
-    , cComputerPointCount = 0
+computerTool :: ComputerSession -> AppTool
+computerTool session = AppTool
+    { appToolName = "computer"
+    , appToolDescription =
+        "Inspect and control macOS through the accessibility tree. "
+            <> "Use stable target_id and element_id values; screenshots are "
+            <> "optional and returned only when include_screenshot is true."
+    , appToolSchema = HostedComputerFunctionSchema computerToolParameters
+    , appToolHandler = streamingRichTextTool "computer" \_emit arguments ->
+        normalizeRequest arguments >>= \case
+            Left err -> pure (Left err)
+            Right request ->
+                invokeComputerSessionRequest session request >>= \case
+                    Left err -> pure (Left err)
+                    Right result ->
+                        pure (Right ToolHandlerResult
+                            { resultText = encodeJson result.nativeComputerResultValue
+                            , resultImages =
+                                maybe [] pure result.nativeComputerImage
+                            })
+    , appToolApproval = AlwaysPrompt
+    , appToolExecution = TurnSequential
+    , appToolResourceClaims = Nothing
+    , appToolAsyncCapability = BlockingOnly
     }
 
-computerButtonCode :: Text -> Either Text CInt
-computerButtonCode raw = case normalize raw of
-    "left" -> Right 1
-    "right" -> Right 2
-    "wheel" -> Right 3
-    "middle" -> Right 3
-    "back" -> Right 4
-    "forward" -> Right 5
-    value -> Left ("Unsupported computer mouse button: " <> value)
+invokeComputerSessionRequest
+    :: ComputerSession
+    -> BS.ByteString
+    -> IO (Either Text NativeComputerResult)
+invokeComputerSessionRequest session request =
+    MVar.modifyMVar session.computerSessionState \case
+        ComputerSessionClosed ->
+            pure (ComputerSessionClosed, Left
+                "The native computer session is closed.")
+        ComputerSessionOpen token accessibilityState -> do
+            case decodeOperation request of
+                Left err ->
+                    pure
+                        ( ComputerSessionOpen token accessibilityState
+                        , Left err
+                        )
+                Right (operation, includeScreenshot) -> do
+                    attempted <- tryAny
+                        (invokeComputerRaw
+                            session.computerSessionRegistration
+                            operation
+                            token
+                            includeScreenshot
+                            request)
+                    let failed err =
+                            pure
+                                ( ComputerSessionOpen token accessibilityState
+                                , Left err
+                                )
+                    case attempted of
+                        Left exception -> failed (Text.pack (show exception))
+                        Right (Left err) -> failed err
+                        Right (Right response) -> do
+                            validated <- validateResponse
+                                operation
+                                includeScreenshot
+                                accessibilityState
+                                response
+                            case validated of
+                                Left err -> failed err
+                                Right (result, successorAccessibility) ->
+                                    pure
+                                        ( ComputerSessionOpen
+                                            token
+                                            successorAccessibility
+                                        , Right result
+                                        )
 
-computerModifierMask :: [Text] -> Either Text Word32
-computerModifierMask =
-    fmap (foldr (.|.) 0) . traverse modifier . map normalize
-  where
-    modifier = \case
-        "shift" -> Right 1
-        "ctrl" -> Right 2
-        "control" -> Right 2
-        "alt" -> Right 4
-        "option" -> Right 4
-        "cmd" -> Right 8
-        "command" -> Right 8
-        "meta" -> Right 8
-        "fn" -> Right 16
-        "function" -> Right 16
-        value -> Left ("Unsupported computer modifier: " <> value)
-
-normalize :: Text -> Text
-normalize = Text.toLower . Text.strip
-
-int32 :: Int -> CInt
-int32 = fromIntegral
-
-data NativeComputerDisplay = NativeComputerDisplay
-    { nativeDisplayToken :: !Word64
-    , nativeDisplayWidth :: !CInt
-    , nativeDisplayHeight :: !CInt
+data RawComputerResponse = RawComputerResponse
+    { rawResult :: !BS.ByteString
+    , rawAccessibility :: !BS.ByteString
+    , rawImage :: !BS.ByteString
+    , rawSessionToken :: !Word64
+    , rawImageFormat :: !CInt
     }
 
--- | Hold the callback registration for the complete query, display-specific
--- validation, and run sequence. This both serializes desktop transactions in
--- one engine and makes callback replacement quiescent across the whole
--- sequence rather than between its two native calls.
-invokeComputerTransaction
-    :: ComputerHost
-    -> ScreenshotEncoding
-    -> [ComputerAction]
-    -> ((Int, Int) -> Either Text ())
-    -> IO (Either Text ComputerObservation)
-invokeComputerTransaction host encoding actions validateDisplay =
-    fmap (fmap (\(observation, _, _) -> observation)) $
-        invokeComputerTransactionWithLease
-            host
-            Nothing
-            initialAccessibilityDeltaState
-            encoding
-            actions
-            validateDisplay
-
--- | A tool instance retains the lease returned with its last screenshot.
--- Mutation batches therefore execute against the exact observation that the
--- model saw instead of minting a new lease after the model chose coordinates.
--- An explicit screenshot has no native actions and safely refreshes the lease.
-invokeComputerSessionTransaction
-    :: ComputerHost
-    -> ComputerSession
-    -> ScreenshotEncoding
-    -> [ComputerAction]
-    -> ((Int, Int) -> Either Text ())
-    -> IO (Either Text ComputerObservation)
-invokeComputerSessionTransaction host session encoding actions validateDisplay =
-    modifyMVar session.computerSessionState \previous -> do
-        result <-
-            if null actions
-                then invokeComputerTransactionWithLease
-                    host Nothing previous.computerSessionAccessibility
-                    encoding actions validateDisplay
-                else case previous.computerSessionDisplay of
-                    Nothing -> pure (Left
-                        "Take a fresh computer screenshot before sending input actions.")
-                    Just display ->
-                        invokeComputerTransactionWithLease
-                            host
-                            (Just display)
-                            previous.computerSessionAccessibility
-                            encoding
-                            actions
-                            validateDisplay
-        case result of
-            Left err -> pure (previous, Left err)
-            Right (observation, successor, accessibilityState) ->
+validateResponse
+    :: CInt
+    -> Bool
+    -> AccessibilityDeltaState
+    -> RawComputerResponse
+    -> IO (Either Text (NativeComputerResult, AccessibilityDeltaState))
+validateResponse operation includeScreenshot accessibilityState response =
+    case validateMetadata of
+        Left err -> pure (Left err)
+        Right (object, accessibility, successorAccessibility) -> do
+            decodedImage <- decodeImage
+                includeScreenshot
+                response.rawImageFormat
+                response.rawImage
+            pure do
+                image <- decodedImage
+                let resultObject = maybe object
+                        (\observation ->
+                            KeyMap.insert
+                                "accessibility_state"
+                                (Aeson.toJSON observation)
+                                object)
+                        accessibility
                 pure
-                    ( ComputerSessionState
-                        (Just successor)
-                        accessibilityState
-                    , Right observation
+                    ( NativeComputerResult
+                        { nativeComputerResultValue = Aeson.Object resultObject
+                        , nativeComputerAccessibility = accessibility
+                        , nativeComputerImage = image
+                        }
+                    , successorAccessibility
                     )
+  where
+    validateMetadata = do
+        when (response.rawSessionToken /= 0) $
+            Left "The native computer host changed a live session token."
+        value <- case Aeson.eitherDecodeStrict' response.rawResult of
+            Left err -> Left
+                ("The native computer host returned invalid result JSON: "
+                    <> Text.pack err)
+            Right decoded -> Right decoded
+        object <- case value of
+            Aeson.Object fields -> Right fields
+            _ -> Left "The native computer host result must be a JSON object."
+        when (containsDataImage value) $
+            Left "The native computer host embedded screenshot data in result JSON."
+        when (operation == operationList
+                && not (BS.null response.rawAccessibility)) $
+            Left "The native computer host returned accessibility data for list_targets."
+        let (observation, newAccessibilityState) =
+                decodeAccessibility response.rawAccessibility accessibilityState
+            (accessibility, successorAccessibility)
+                | operation == operationList =
+                    (Nothing, accessibilityState)
+                | otherwise =
+                    (Just observation, newAccessibilityState)
+        pure (object, accessibility, successorAccessibility)
 
-invokeComputerTransactionWithLease
+decodeAccessibility
+    :: BS.ByteString
+    -> AccessibilityDeltaState
+    -> (AccessibilityObservation, AccessibilityDeltaState)
+decodeAccessibility bytes state
+    | BS.null bytes =
+        unavailableAccessibilityObservation
+            "Native accessibility snapshot unavailable."
+            state
+    | otherwise =
+        case decodeAccessibilitySnapshot bytes of
+            Left err ->
+                unavailableAccessibilityObservation
+                    ( "The native computer host returned invalid accessibility JSON: "
+                        <> err
+                    )
+                    state
+            Right snapshot ->
+                advanceAccessibilityObservation state snapshot
+
+decodeImage
+    :: Bool
+    -> CInt
+    -> BS.ByteString
+    -> IO (Either Text (Maybe ToolResultImage))
+decodeImage includeScreenshot imageFormat bytes
+    | BS.null bytes && imageFormat == imageNone = pure (Right Nothing)
+    | not includeScreenshot =
+        pure (Left "The native computer host returned an unrequested screenshot.")
+    | BS.null bytes =
+        pure (Left "The native computer host returned an empty screenshot.")
+    | otherwise = do
+        decodedMime <- imageMime imageFormat bytes
+        pure do
+            mime <- decodedMime
+            pure (Just (ToolResultImage
+                ( "data:"
+                    <> mime
+                    <> ";base64,"
+                    <> encodeBase64 bytes
+                )
+                Nothing))
+
+normalizeRequest :: Text -> IO (Either Text BS.ByteString)
+normalizeRequest arguments =
+    pure case Aeson.eitherDecodeStrict'
+            (TextEncoding.encodeUtf8 arguments) of
+        Left err -> Left ("Invalid computer arguments: " <> Text.pack err)
+        Right value ->
+            case AesonTypes.parseEither parseRequest value of
+                Left err -> Left (Text.pack err)
+                Right normalized -> Right
+                    (LBS.toStrict (Aeson.encode normalized))
+
+parseRequest :: Aeson.Value -> AesonTypes.Parser Aeson.Value
+parseRequest = Aeson.withObject "computer arguments" \object -> do
+    requireOnly object
+        ["operation", "target_id", "actions", "include_screenshot"]
+    operation <- object Aeson..: "operation"
+    includeScreenshot <- object Aeson..: "include_screenshot"
+    case (operation :: Text) of
+        "list_targets" -> do
+            requireNull object "target_id"
+            requireNull object "actions"
+            when includeScreenshot $
+                fail "list_targets cannot include a screenshot"
+            pure (Aeson.object
+                [ "operation" Aeson..= operation
+                , "include_screenshot" Aeson..= False
+                ])
+        "bind" -> do
+            targetId <- object Aeson..: "target_id"
+            requireNull object "actions"
+            pure (Aeson.object
+                [ "operation" Aeson..= operation
+                , "target_id" Aeson..= (targetId :: Text)
+                , "include_screenshot" Aeson..= includeScreenshot
+                ])
+        "observe" -> do
+            requireNull object "target_id"
+            requireNull object "actions"
+            pure (Aeson.object
+                [ "operation" Aeson..= operation
+                , "include_screenshot" Aeson..= includeScreenshot
+                ])
+        "act" -> do
+            requireNull object "target_id"
+            rawActions <-
+                object Aeson..: "actions"
+                    :: AesonTypes.Parser [Aeson.Value]
+            actions <- traverse parseSemanticAction rawActions
+            when (null actions) $
+                fail "act requires at least one semantic action"
+            when (length actions > 64) $
+                fail "act accepts at most 64 semantic actions"
+            pure (Aeson.object
+                [ "operation" Aeson..= operation
+                , "actions" Aeson..= actions
+                , "include_screenshot" Aeson..= includeScreenshot
+                ])
+        _ -> fail "unsupported computer operation"
+
+parseSemanticAction :: Aeson.Value -> AesonTypes.Parser Aeson.Value
+parseSemanticAction = Aeson.withObject "semantic computer action" \object -> do
+    requireOnly object ["type", "element_id", "action", "value", "text"]
+    actionType <- object Aeson..: "type"
+    elementId <- object Aeson..: "element_id"
+    case (actionType :: Text) of
+        "perform" -> do
+            action <- object Aeson..: "action"
+            requireNull object "value"
+            requireNull object "text"
+            pure (Aeson.object
+                [ "type" Aeson..= actionType
+                , "element_id" Aeson..= (elementId :: Text)
+                , "action" Aeson..= (action :: Text)
+                ])
+        "set_value" -> do
+            requireNull object "action"
+            requireNull object "text"
+            value <- object Aeson..: "value"
+            case (value :: Aeson.Value) of
+                Aeson.String _ -> pure ()
+                Aeson.Number _ -> pure ()
+                Aeson.Bool _ -> pure ()
+                _ -> fail "set_value.value must be a string, number, or boolean"
+            pure (Aeson.object
+                [ "type" Aeson..= actionType
+                , "element_id" Aeson..= (elementId :: Text)
+                , "value" Aeson..= value
+                ])
+        "replace_selected_text" -> do
+            requireNull object "action"
+            requireNull object "value"
+            text <- object Aeson..: "text"
+            pure (Aeson.object
+                [ "type" Aeson..= actionType
+                , "element_id" Aeson..= (elementId :: Text)
+                , "text" Aeson..= (text :: Text)
+                ])
+        _ -> fail "unsupported semantic computer action"
+
+requireOnly :: Aeson.Object -> [Text] -> AesonTypes.Parser ()
+requireOnly object allowed =
+    unless (null unexpected) $
+        fail ("unexpected computer argument fields: "
+            <> Text.unpack (Text.intercalate ", " unexpected))
+  where
+    unexpected =
+        filter (`notElem` allowed) (map Key.toText (KeyMap.keys object))
+
+requireNull :: Aeson.Object -> Text -> AesonTypes.Parser ()
+requireNull object fieldName =
+    case KeyMap.lookup (Key.fromText fieldName) object of
+        Just Aeson.Null -> pure ()
+        Just _ -> fail (Text.unpack fieldName <> " must be null for this operation")
+        Nothing -> fail ("missing required field: " <> Text.unpack fieldName)
+
+decodeOperation :: BS.ByteString -> Either Text (CInt, Bool)
+decodeOperation bytes =
+    case Aeson.eitherDecodeStrict' bytes of
+        Left err -> Left ("Invalid normalized computer request: " <> Text.pack err)
+        Right value ->
+            case AesonTypes.parseEither parser value of
+                Left err -> Left (Text.pack err)
+                Right result -> Right result
+  where
+    parser = Aeson.withObject "computer request" \object -> do
+        operation <- object Aeson..: "operation"
+        includeScreenshot <- object Aeson..: "include_screenshot"
+        command <- case (operation :: Text) of
+            "list_targets" -> pure operationList
+            "bind" -> pure operationBind
+            "observe" -> pure operationObserveOrAct
+            "act" -> pure operationObserveOrAct
+            _ -> fail "unsupported computer operation"
+        pure (command, includeScreenshot)
+
+acquireCurrentGeneration
     :: ComputerHost
-    -> Maybe NativeComputerDisplay
-    -> AccessibilityDeltaState
-    -> ScreenshotEncoding
-    -> [ComputerAction]
-    -> ((Int, Int) -> Either Text ())
-    -> IO
-        (Either
-            Text
-            ( ComputerObservation
-            , NativeComputerDisplay
-            , AccessibilityDeltaState
-            ))
-invokeComputerTransactionWithLease
-        host priorDisplay accessibilityState encoding actions validateDisplay =
-    case encodeComputerActions actions of
-        Left err -> pure (Left err)
-        Right batch ->
-            tryAny
-                (withMVar host.computerRegistration \case
-                    Nothing ->
-                        pure (Left "Native computer control is not active.")
-                    Just registration ->
-                        maybe
-                            (invokeComputerDisplay registration)
-                            (pure . Right)
-                            priorDisplay >>= \case
-                            Left err -> pure (Left err)
-                            Right display
-                                | Left err <- validateDisplay
-                                    ( fromIntegral display.nativeDisplayWidth
-                                    , fromIntegral display.nativeDisplayHeight
-                                    ) ->
-                                    pure (Left err)
-                                | otherwise ->
-                                    invokeComputerRunAndObserve
-                                        registration
-                                        display
-                                        accessibilityState
-                                        encoding
-                                        batch)
-                >>= \case
-                    Left exception ->
-                        pure (Left (Text.pack (show exception)))
-                    Right result -> pure result
+    -> IO (Maybe (Word64, ComputerRegistration))
+acquireCurrentGeneration host =
+    atomicModifyIORef' host.computerHostState \state ->
+        case state.hostCurrentGeneration of
+            Nothing -> (state, Nothing)
+            Just generation ->
+                case Map.lookup generation state.hostGenerations of
+                    Nothing -> (state, Nothing)
+                    Just entry ->
+                        ( state
+                            { hostGenerations = Map.insert generation
+                                entry
+                                    { generationSessions =
+                                        entry.generationSessions + 1
+                                    }
+                                state.hostGenerations
+                            }
+                        , Just (generation, entry.generationRegistration)
+                        )
 
-invokeComputerDisplay
+releaseGeneration :: ComputerHost -> Word64 -> IO ()
+releaseGeneration host generation =
+    atomicModifyIORef' host.computerHostState \state ->
+        let updated = Map.update
+                (\entry ->
+                    let sessions = max 0 (entry.generationSessions - 1)
+                    in if sessions == 0
+                            && state.hostCurrentGeneration /= Just generation
+                        then Nothing
+                        else Just entry { generationSessions = sessions })
+                generation
+                state.hostGenerations
+        in (state { hostGenerations = updated }, ())
+
+invokeComputerRaw
     :: ComputerRegistration
-    -> IO (Either Text NativeComputerDisplay)
-invokeComputerDisplay registration =
-    invokeComputer computerErrorCapacity 0 registration query >>= \case
-        Left err -> pure (Left err)
-        Right (bytes, accessibility, token, width, height, imageFormat)
-            | not (BS.null bytes)
-                || not (BS.null accessibility)
-                || token == 0
-                || width <= 0
-                || height <= 0
-                || imageFormat /= 0 ->
-                pure (Left
-                    "The native computer host returned an invalid display lease.")
-            | otherwise ->
-                pure (Right NativeComputerDisplay
-                    { nativeDisplayToken = token
-                    , nativeDisplayWidth = width
-                    , nativeDisplayHeight = height
-                    })
-  where
-    query registration' output capacity outputLength accessibilityOutput
-            accessibilityCapacity accessibilityLength outputToken
-            width height imageFormat =
-        invokeComputerCallback
-            registration'.computerCallback
-            registration'.computerContext
-            2
-            1
-            0
-            0
-            0
-            nullPtr
-            0
-            nullPtr
-            0
-            nullPtr
-            0
-            0
-            output
-            capacity
-            outputLength
-            accessibilityOutput
-            accessibilityCapacity
-            accessibilityLength
-            outputToken
-            width
-            height
-            imageFormat
-
-invokeComputerRunAndObserve
-    :: ComputerRegistration
-    -> NativeComputerDisplay
-    -> AccessibilityDeltaState
-    -> ScreenshotEncoding
-    -> ComputerBatch
-    -> IO
-        (Either
-            Text
-            ( ComputerObservation
-            , NativeComputerDisplay
-            , AccessibilityDeltaState
-            ))
-invokeComputerRunAndObserve
-        registration display accessibilityState encoding batch =
-    withArray batch.computerBatchActions \actionPointer ->
-        withArray batch.computerBatchPoints \pointPointer ->
-            BS.useAsCStringLen batch.computerBatchText
-                \(textPointer, textLength) ->
-                    invokeComputer computerOutputCapacity
-                        computerAccessibilityCapacity registration
-                        (run
-                            actionPointer
-                            pointPointer
-                            (castPtr textPointer)
-                            textLength)
-                        >>= \case
-                            Left err -> pure (Left err)
-                            Right (bytes, accessibility, token, width, height, imageFormat)
-                                | token == 0
-                                    || token == display.nativeDisplayToken
-                                    || width /= display.nativeDisplayWidth
-                                    || height /= display.nativeDisplayHeight ->
-                                    pure (Left
-                                        "The native computer host returned an invalid successor display lease.")
-                                | imageFormat /= requestedFormat ->
-                                    pure (Left
-                                        "The native computer host returned a screenshot in the wrong format.")
-                                | BS.null bytes ->
-                                    pure (Left
-                                        "The native computer host returned an empty screenshot.")
-                                | otherwise ->
-                                    case imageMime imageFormat bytes of
-                                        Left err -> pure (Left err)
-                                        Right mime ->
-                                            let
-                                                ( accessibilityObservation
-                                                  , successorAccessibilityState
-                                                  ) =
-                                                    decodeAccessibility
-                                                        accessibility
-                                                        accessibilityState
-                                            in pure (Right
-                                                ( ComputerObservation
-                                                    (ImageAttachment mime bytes)
-                                                    accessibilityObservation
-                                                , NativeComputerDisplay
-                                                    { nativeDisplayToken =
-                                                        token
-                                                    , nativeDisplayWidth =
-                                                        width
-                                                    , nativeDisplayHeight =
-                                                        height
-                                                    }
-                                                , successorAccessibilityState
-                                                ))
-  where
-    requestedFormat = case encoding of
-        ScreenshotPng -> 1
-        ScreenshotJpeg -> 2
-    run actionPointer pointPointer textPointer textLength
-            registration' output capacity outputLength accessibilityOutput
-            accessibilityCapacity accessibilityLength outputToken
-            width height imageFormat =
-        invokeComputerCallback
-            registration'.computerCallback
-            registration'.computerContext
-            2
-            2
-            display.nativeDisplayToken
-            display.nativeDisplayWidth
-            display.nativeDisplayHeight
-            actionPointer
-            (fromIntegral (length batch.computerBatchActions))
-            pointPointer
-            (fromIntegral (length batch.computerBatchPoints))
-            textPointer
-            (fromIntegral textLength)
-            requestedFormat
-            output
-            capacity
-            outputLength
-            accessibilityOutput
-            accessibilityCapacity
-            accessibilityLength
-            outputToken
-            width
-            height
-            imageFormat
-
-type ComputerInvocation =
-    ComputerRegistration
-    -> Ptr Word8
-    -> CSize
-    -> Ptr CSize
-    -> Ptr Word8
-    -> CSize
-    -> Ptr CSize
-    -> Ptr Word64
-    -> Ptr CInt
-    -> Ptr CInt
-    -> Ptr CInt
-    -> IO CInt
-
-invokeComputer
-    :: Int
-    -> Int
-    -> ComputerRegistration
-    -> ComputerInvocation
-    -> IO (Either Text (BS.ByteString, BS.ByteString, Word64, CInt, CInt, CInt))
-invokeComputer capacity accessibilityCapacity registration invocation =
-    bracket (mallocBytes capacity) free \output -> do
-        fillBytes output 0 capacity
-        bracket (mallocBytes (max 1 accessibilityCapacity)) free
-            \accessibilityOutputBuffer -> do
-            fillBytes accessibilityOutputBuffer 0 accessibilityCapacity
-            let accessibilityOutput
-                    | accessibilityCapacity == 0 = nullPtr
-                    | otherwise = accessibilityOutputBuffer
-            allocaResult \outputLength accessibilityLength outputToken width height imageFormat -> do
-                status <- invocation
-                    registration
-                    output
-                    (fromIntegral capacity)
-                    outputLength
-                    accessibilityOutput
-                    (fromIntegral accessibilityCapacity)
-                    accessibilityLength
-                    outputToken
-                    width
-                    height
-                    imageFormat
-                CSize length <- peek outputLength
-                CSize accessibilityLengthValue <- peek accessibilityLength
-                observedToken <- peek outputToken
-                observedWidth <- peek width
-                observedHeight <- peek height
-                observedFormat <- peek imageFormat
-                if length > fromIntegral capacity
-                    then pure (Left
-                        "The native computer host reported output beyond its buffer.")
-                    else if accessibilityLengthValue
-                            > fromIntegral accessibilityCapacity
-                        then pure (Left
-                            "The native computer host reported accessibility output beyond its buffer.")
-                    else do
-                        bytes <- BS.packCStringLen
-                            (castPtr output, fromIntegral length)
-                        accessibility <- BS.packCStringLen
-                            ( castPtr accessibilityOutputBuffer
-                            , fromIntegral accessibilityLengthValue
-                            )
-                        if status == 0
-                            then pure (Right
-                                ( bytes
-                                , accessibility
-                                , observedToken
-                                , observedWidth
-                                , observedHeight
-                                , observedFormat
-                                ))
-                            else pure (Left
-                                (computerFailureMessage status bytes))
-
-allocaResult
-    :: ( Ptr CSize
-        -> Ptr CSize
-        -> Ptr Word64
-        -> Ptr CInt
-        -> Ptr CInt
-        -> Ptr CInt
-        -> IO value
-       )
-    -> IO value
-allocaResult action =
-    allocaBytes (sizeOf (undefined :: CSize)) \outputLength ->
-        allocaBytes (sizeOf (undefined :: CSize)) \accessibilityLength ->
-          allocaBytes (sizeOf (undefined :: Word64)) \outputToken ->
-            allocaBytes (sizeOf (undefined :: CInt)) \width ->
-                allocaBytes (sizeOf (undefined :: CInt)) \height ->
-                    allocaBytes (sizeOf (undefined :: CInt))
-                        \imageFormat -> do
-                            poke outputLength 0
-                            poke accessibilityLength 0
-                            poke outputToken 0
-                            poke width 0
-                            poke height 0
-                            poke imageFormat 0
-                            action
-                                outputLength
+    -> CInt
+    -> Word64
+    -> Bool
+    -> BS.ByteString
+    -> IO (Either Text RawComputerResponse)
+invokeComputerRaw registration operation sessionToken includeScreenshot request =
+    if BS.length request > computerRequestCapacity
+        then pure (Left "The native computer request exceeds its bounded buffer.")
+        else withOutput computerResultCapacity \result resultCapacity resultLength ->
+      withOutput computerAccessibilityCapacity
+        \accessibility accessibilityCapacity accessibilityLength ->
+          withOptionalOutput includeScreenshot computerImageCapacity
+            \image imageCapacity imageLength ->
+            withOutput computerErrorCapacity \err errorCapacity errorLength ->
+              alloca \outputSessionToken ->
+                alloca \outputImageFormat -> do
+                    poke outputSessionToken 0
+                    poke outputImageFormat imageNone
+                    status <- BS.useAsCStringLen request
+                        \(requestPointer, requestLength) ->
+                            invokeComputerCallback registration.computerCallback
+                                registration.computerContext
+                                computerAbiVersion
+                                operation
+                                sessionToken
+                                (if requestLength == 0
+                                    then nullPtr
+                                    else castPtr requestPointer)
+                                (fromIntegral requestLength)
+                                result resultCapacity resultLength
+                                accessibility accessibilityCapacity
                                 accessibilityLength
-                                outputToken
-                                width
-                                height
-                                imageFormat
+                                image imageCapacity imageLength
+                                err errorCapacity errorLength
+                                outputSessionToken
+                                outputImageFormat
+                    resultBytes <- readOutput
+                        "result" computerResultCapacity result resultLength
+                    accessibilityBytes <- readOutput
+                        "accessibility"
+                        computerAccessibilityCapacity
+                        accessibility
+                        accessibilityLength
+                    imageBytes <- readOutput
+                        "image" (fromIntegral imageCapacity) image imageLength
+                    errorBytes <- readOutput
+                        "error" computerErrorCapacity err errorLength
+                    observedToken <- peek outputSessionToken
+                    observedFormat <- peek outputImageFormat
+                    case sequence
+                            [resultBytes, accessibilityBytes, imageBytes, errorBytes] of
+                        Left boundsError -> pure (Left boundsError)
+                        Right [resultValue, accessibilityValue, imageValue, errorValue]
+                            | status /= 0 ->
+                                pure (Left
+                                    (computerFailureMessage status errorValue))
+                            | not (BS.null errorValue) ->
+                                pure (Left
+                                    "The native computer host returned an error on success.")
+                            | otherwise ->
+                                pure (Right RawComputerResponse
+                                    { rawResult = resultValue
+                                    , rawAccessibility = accessibilityValue
+                                    , rawImage = imageValue
+                                    , rawSessionToken = observedToken
+                                    , rawImageFormat = observedFormat
+                                    })
+                        Right _ -> pure (Left "Internal computer buffer mismatch.")
 
-imageMime :: CInt -> BS.ByteString -> Either Text Text
+withOutput
+    :: Int
+    -> (Ptr Word8 -> CSize -> Ptr CSize -> IO value)
+    -> IO value
+withOutput capacity action =
+    Exception.bracket
+        (mallocBytes capacity)
+        free
+        \buffer -> do
+            fillBytes buffer 0 capacity
+            alloca \lengthPointer -> do
+                poke lengthPointer 0
+                action
+                    buffer
+                    (fromIntegral capacity)
+                    lengthPointer
+
+withOptionalOutput
+    :: Bool
+    -> Int
+    -> (Ptr Word8 -> CSize -> Ptr CSize -> IO value)
+    -> IO value
+withOptionalOutput enabled capacity action
+    | enabled = withOutput capacity action
+    | otherwise = alloca \lengthPointer -> do
+        poke lengthPointer 0
+        action nullPtr 0 lengthPointer
+
+readOutput
+    :: Text
+    -> Int
+    -> Ptr Word8
+    -> Ptr CSize
+    -> IO (Either Text BS.ByteString)
+readOutput label capacity buffer lengthPointer = do
+    CSize lengthValue <- peek lengthPointer
+    if lengthValue > fromIntegral capacity
+        then pure (Left
+            ("The native computer host reported " <> label
+                <> " output beyond its buffer."))
+        else if lengthValue == 0
+            then pure (Right BS.empty)
+            else if buffer == nullPtr
+                then pure (Left
+                    ("The native computer host reported " <> label
+                        <> " output without a buffer."))
+                else Right <$> BS.packCStringLen
+                    (castPtr buffer, fromIntegral lengthValue)
+
+rawChannelsEmpty :: RawComputerResponse -> Bool
+rawChannelsEmpty response =
+    BS.null response.rawResult
+        && BS.null response.rawAccessibility
+        && BS.null response.rawImage
+        && response.rawImageFormat == imageNone
+
+closeInvalidOpen :: ComputerRegistration -> Word64 -> IO ()
+closeInvalidOpen registration token =
+    when (token /= 0) do
+        _ <- tryAny
+            (invokeComputerRaw registration operationClose token False BS.empty)
+        pure ()
+
+imageMime :: CInt -> BS.ByteString -> IO (Either Text Text)
 imageMime imageFormat bytes = case imageFormat of
-    1
-        | BS.take 8 bytes == BS.pack [137, 80, 78, 71, 13, 10, 26, 10] ->
-            Right "image/png"
-        | otherwise ->
-            Left "The native computer host returned malformed PNG data."
-    2
-        | BS.take 2 bytes == BS.pack [255, 216] ->
-            Right "image/jpeg"
-        | otherwise ->
-            Left "The native computer host returned malformed JPEG data."
-    _ -> Left "The native computer host returned an unsupported image format."
+    1 -> validateDecodedImage
+        "image/png"
+        "The native computer host returned malformed PNG data."
+        (validPng bytes)
+    2 -> validateDecodedImage
+        "image/jpeg"
+        "The native computer host returned malformed JPEG data."
+        (validJpeg bytes)
+    _ -> pure
+        (Left "The native computer host returned an unsupported image format.")
+
+validateDecodedImage :: Text -> Text -> Bool -> IO (Either Text Text)
+validateDecodedImage mime malformed valid = do
+    attempted <- tryAny (evaluate valid)
+    pure case attempted of
+        Right True -> Right mime
+        Right False -> Left malformed
+        Left _ -> Left malformed
+
+containsDataImage :: Aeson.Value -> Bool
+containsDataImage = \case
+    Aeson.Object object -> any containsDataImage object
+    Aeson.Array values -> any containsDataImage values
+    Aeson.String value ->
+        "data:image/" `Text.isPrefixOf` Text.toLower value
+    _ -> False
+
+validPng :: BS.ByteString -> Bool
+validPng bytes =
+    case pngEnvelope bytes of
+        Nothing -> False
+        Just dimensions ->
+            decodedImageMatches dimensions (decodePng bytes)
+
+pngEnvelope :: BS.ByteString -> Maybe (Int, Int)
+pngEnvelope bytes = do
+    guard (BS.length bytes >= 45)
+    guard (BS.take 8 bytes == pngSignature)
+    validChunks True False Nothing (BS.drop 8 bytes)
+  where
+    pngSignature = BS.pack [137, 80, 78, 71, 13, 10, 26, 10]
+    validChunks firstChunk sawImageData dimensions remaining = do
+        guard (BS.length remaining >= 12)
+        guard (chunkLength <= BS.length remaining - 12)
+        guard (chunkChecksum == crc32 checksumInput)
+        if firstChunk
+            then do
+                guard (chunkType == "IHDR")
+                guard (chunkLength == 13)
+                headerDimensions <- validHeader chunkData
+                validChunks False False (Just headerDimensions) rest
+            else case chunkType of
+                "IHDR" -> Nothing
+                "IDAT" ->
+                    validChunks False True dimensions rest
+                "IEND" -> do
+                    guard (chunkLength == 0)
+                    guard sawImageData
+                    guard (BS.null rest)
+                    dimensions
+                _ ->
+                    validChunks False sawImageData dimensions rest
+      where
+        chunkLength = word32At remaining 0
+        chunkType = BS.take 4 (BS.drop 4 remaining)
+        chunkData = BS.take chunkLength (BS.drop 8 remaining)
+        checksumInput =
+            BS.take (4 + chunkLength) (BS.drop 4 remaining)
+        chunkChecksum =
+            fromIntegral (word32At remaining (8 + chunkLength))
+        rest = BS.drop (12 + chunkLength) remaining
+    validHeader header = do
+        guard (BS.length header == 13)
+        let width = word32At header 0
+            height = word32At header 4
+        guard (dimensionsSafeToDecode (width, height))
+        guard (BS.index header 10 == 0)
+        guard (BS.index header 11 == 0)
+        guard (BS.index header 12 <= 1)
+        pure (width, height)
+
+validJpeg :: BS.ByteString -> Bool
+validJpeg bytes =
+    case jpegDimensions bytes of
+        Nothing -> False
+        Just dimensions ->
+            decodedImageMatches dimensions (decodeJpeg bytes)
+
+jpegDimensions :: BS.ByteString -> Maybe (Int, Int)
+jpegDimensions bytes = do
+    guard (BS.length bytes >= 14)
+    guard (BS.take 2 bytes == BS.pack [255, 216])
+    guard (BS.drop (BS.length bytes - 2) bytes == BS.pack [255, 217])
+    validSegments Nothing (BS.drop 2 bytes)
+  where
+    validSegments dimensions remaining =
+        case nextMarker remaining of
+            Nothing -> Nothing
+            Just (marker, afterMarker)
+                | marker == 0xd9 -> Nothing
+                | standaloneMarker marker ->
+                    validSegments dimensions afterMarker
+                | BS.length afterMarker < 2 -> Nothing
+                | segmentLength < 2
+                    || segmentLength > BS.length afterMarker -> Nothing
+                | marker == 0xda -> dimensions
+                | startOfFrame marker -> do
+                    guard (segmentLength >= 8)
+                    let height = word16At afterMarker 3
+                        width = word16At afterMarker 5
+                    guard (dimensionsSafeToDecode (width, height))
+                    validSegments
+                        (Just (width, height))
+                        (BS.drop segmentLength afterMarker)
+                | otherwise ->
+                    validSegments dimensions
+                        (BS.drop segmentLength afterMarker)
+              where
+                segmentLength = word16At afterMarker 0
+    nextMarker remaining =
+        case BS.elemIndex 255 remaining of
+            Nothing -> Nothing
+            Just markerStart ->
+                let markerBytes = BS.drop markerStart remaining
+                    afterFill = BS.dropWhile (== 255) markerBytes
+                in case BS.uncons afterFill of
+                    Nothing -> Nothing
+                    Just (0, rest) -> nextMarker rest
+                    Just (marker, rest) -> Just (marker, rest)
+    standaloneMarker marker =
+        marker == 0x01
+            || marker == 0xd8
+            || (marker >= 0xd0 && marker <= 0xd7)
+    startOfFrame marker =
+        marker >= 0xc0
+            && marker <= 0xcf
+            && marker `notElem` [0xc4, 0xc8, 0xcc]
+
+decodedImageMatches
+    :: (Int, Int)
+    -> Either String DynamicImage
+    -> Bool
+decodedImageMatches expectedDimensions = \case
+    Left _ -> False
+    Right image ->
+        dynamicMap
+            (\raster ->
+                let width = imageWidth raster
+                    height = imageHeight raster
+                in
+                    (width, height) == expectedDimensions
+                        && (pixelAt raster (width - 1) (height - 1)
+                            `seq` True))
+            image
+
+dimensionsSafeToDecode :: (Int, Int) -> Bool
+dimensionsSafeToDecode (width, height) =
+    width > 0
+        && height > 0
+        && width <= maximumDecodedImageSide
+        && height <= maximumDecodedImageSide
+        && toInteger width * toInteger height <= maximumDecodedImagePixels
+
+maximumDecodedImageSide :: Int
+maximumDecodedImageSide = 8192
+
+maximumDecodedImagePixels :: Integer
+maximumDecodedImagePixels = 25000000
+
+crc32 :: BS.ByteString -> Word32
+crc32 = complement . BS.foldl' update maxBound
+  where
+    update :: Word32 -> Word8 -> Word32
+    update checksum byte =
+        advance 8 (checksum `xor` fromIntegral byte)
+
+    advance :: Int -> Word32 -> Word32
+    advance 0 value = value
+    advance count value =
+        advance (count - 1)
+            (if value .&. 1 == 1
+                then (value `shiftR` 1) `xor` 0xedb88320
+                else value `shiftR` 1)
+
+word16At :: BS.ByteString -> Int -> Int
+word16At bytes offset =
+    fromIntegral (BS.index bytes offset) * 256
+        + fromIntegral (BS.index bytes (offset + 1))
+
+word32At :: BS.ByteString -> Int -> Int
+word32At bytes offset =
+    fromIntegral (BS.index bytes offset) * 16777216
+        + fromIntegral (BS.index bytes (offset + 1)) * 65536
+        + fromIntegral (BS.index bytes (offset + 2)) * 256
+        + fromIntegral (BS.index bytes (offset + 3))
+
+encodeBase64 :: BS.ByteString -> Text
+encodeBase64 = Text.pack . go . BS.unpack
+  where
+    alphabet =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    at value = alphabet !! value
+    go = \case
+        [] -> []
+        [a] ->
+            [ at (fromIntegral a `div` 4)
+            , at ((fromIntegral a `mod` 4) * 16)
+            , '='
+            , '='
+            ]
+        [a, b] ->
+            [ at (fromIntegral a `div` 4)
+            , at (((fromIntegral a `mod` 4) * 16) + (fromIntegral b `div` 16))
+            , at ((fromIntegral b `mod` 16) * 4)
+            , '='
+            ]
+        a : b : c : rest ->
+            at (fromIntegral a `div` 4)
+                : at (((fromIntegral a `mod` 4) * 16)
+                    + (fromIntegral b `div` 16))
+                : at (((fromIntegral b `mod` 16) * 4)
+                    + (fromIntegral c `div` 64))
+                : at (fromIntegral c `mod` 64)
+                : go rest
 
 computerFailureMessage :: CInt -> BS.ByteString -> Text
 computerFailureMessage status bytes =
@@ -768,52 +1020,103 @@ computerStatusMessage = \case
     1 -> "The native computer host rejected an invalid argument."
     2 -> "Native computer control is unavailable."
     3 -> "The native computer operation timed out."
-    4 -> "Accessibility or Screen Recording permission is required."
+    4 -> "Accessibility permission is required."
     5 -> "The native computer host does not support this operation."
     6 -> "The native computer host failed internally."
-    7 -> "The native computer screenshot exceeded the 16 MiB output limit."
+    7 -> "A native computer output exceeded its bounded buffer."
     8 -> "Computer use is unavailable while the macOS session is locked."
-    9 ->
-        "The main display changed during computer use; take a fresh screenshot before continuing."
+    9 -> "The selected application or window is stale."
     status ->
         "The native computer operation failed (status "
             <> Text.pack (show status)
             <> ")."
 
-computerActionStructSize :: Int
-computerActionStructSize = 64
+encodeJson :: Aeson.Value -> Text
+encodeJson = TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode
 
-computerErrorCapacity :: Int
-computerErrorCapacity = 64 * 1024
+computerAbiVersion :: Word32
+computerAbiVersion = 3
 
-computerOutputCapacity :: Int
-computerOutputCapacity = 16 * 1024 * 1024
+computerToolParameters :: Aeson.Value
+computerToolParameters = strictObject
+    [ ("operation", Aeson.object
+        [ "type" Aeson..= ("string" :: Text)
+        , "enum" Aeson..=
+            (["list_targets", "bind", "observe", "act"] :: [Text])
+        ])
+    , ("target_id", nullableStringParameter)
+    , ("actions", Aeson.object
+        [ "type" Aeson..= (["array", "null"] :: [Text])
+        , "minItems" Aeson..= (1 :: Int)
+        , "maxItems" Aeson..= (64 :: Int)
+        , "items" Aeson..= semanticActionParameters
+        ])
+    , ("include_screenshot", screenshotParameter)
+    ]
+    ["operation", "target_id", "actions", "include_screenshot"]
 
-computerAccessibilityCapacity :: Int
+semanticActionParameters :: Aeson.Value
+semanticActionParameters = strictObject
+    [ ("type", Aeson.object
+        [ "type" Aeson..= ("string" :: Text)
+        , "enum" Aeson..=
+            (["perform", "set_value", "replace_selected_text"] :: [Text])
+        ])
+    , ("element_id", stringParameter)
+    , ("action", nullableStringParameter)
+    , ("value", Aeson.object
+        [ "type" Aeson..=
+            (["string", "number", "boolean", "null"] :: [Text])
+        ])
+    , ("text", nullableStringParameter)
+    ]
+    ["type", "element_id", "action", "value", "text"]
+
+strictObject :: [(Text, Aeson.Value)] -> [Text] -> Aeson.Value
+strictObject properties requiredFields = Aeson.object
+    [ "type" Aeson..= ("object" :: Text)
+    , "additionalProperties" Aeson..= False
+    , "properties" Aeson..= Aeson.object
+        [ Key.fromText name Aeson..= schema | (name, schema) <- properties ]
+    , "required" Aeson..= requiredFields
+    ]
+
+stringParameter :: Aeson.Value
+stringParameter = scalarParameter "string"
+
+nullableStringParameter :: Aeson.Value
+nullableStringParameter = Aeson.object
+    [ "type" Aeson..= (["string", "null"] :: [Text]) ]
+
+scalarParameter :: Text -> Aeson.Value
+scalarParameter parameterType = Aeson.object
+    [ "type" Aeson..= parameterType ]
+
+screenshotParameter :: Aeson.Value
+screenshotParameter = Aeson.object
+    [ "type" Aeson..= ("boolean" :: Text)
+    , "description" Aeson..=
+        ( "Set false unless visual evidence is necessary; screenshots are "
+        <> "never returned implicitly."
+        :: Text
+        )
+    ]
+
+operationOpen, operationList, operationBind, operationObserveOrAct, operationClose
+    :: CInt
+operationOpen = 1
+operationList = 2
+operationBind = 3
+operationObserveOrAct = 4
+operationClose = 5
+
+imageNone :: CInt
+imageNone = 0
+
+computerRequestCapacity, computerResultCapacity, computerAccessibilityCapacity, computerImageCapacity,
+    computerErrorCapacity :: Int
+computerRequestCapacity = 1024 * 1024
+computerResultCapacity = 1024 * 1024
 computerAccessibilityCapacity = 512 * 1024
-
-decodeAccessibility
-    :: BS.ByteString
-    -> AccessibilityDeltaState
-    -> (Maybe AccessibilityObservation, AccessibilityDeltaState)
-decodeAccessibility bytes state
-    | BS.null bytes =
-        let (observation, successor) =
-                unavailableAccessibilityObservation
-                    "Native accessibility snapshot unavailable."
-                    state
-        in (Just observation, successor)
-    | otherwise =
-        case decodeAccessibilitySnapshot bytes of
-            Left err ->
-                let (observation, successor) =
-                        unavailableAccessibilityObservation
-                            ( "The native computer host returned invalid accessibility JSON: "
-                                <> err
-                            )
-                            state
-                in (Just observation, successor)
-            Right snapshot ->
-                let (observation, successor) =
-                        advanceAccessibilityObservation state snapshot
-                in (Just observation, successor)
+computerImageCapacity = 16 * 1024 * 1024
+computerErrorCapacity = 64 * 1024

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
@@ -33,10 +33,19 @@ import Agent.CLI.ComputerUse.Accessibility
     , initialAccessibilityDeltaState
     , unavailableAccessibilityObservation
     )
+import Agent.ComputerUse.Protocol
+    ( SemanticComputerOperation(..)
+    , SemanticComputerRequest
+    , encodeSemanticComputerRequest
+    , semanticComputerRequestDecoder
+    , semanticComputerRequestOperation
+    , semanticComputerRequestSchema
+    , semanticComputerRequestWantsScreenshot
+    )
 import Agent.ToolDispatch
     ( ToolHandlerResult(..)
     , ToolResultImage(..)
-    , streamingRichTextTool
+    , typedStreamingRichTool
     )
 import Agent.Tools.Types
     ( AppTool(..)
@@ -58,13 +67,12 @@ import qualified Control.Concurrent.MVar as MVar
 import Control.Exception (evaluate)
 import qualified Control.Exception.Safe as Exception
 import Control.Exception.Safe (finally, mask_, onException, tryAny)
-import Control.Monad (guard, unless, when)
+import Control.Monad (guard, when)
 import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.Aeson.Types as AesonTypes
 import Data.Bits ((.&.), complement, shiftR, xor)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import qualified Data.Map.Strict as Map
@@ -302,11 +310,13 @@ computerTool session = AppTool
         "Inspect and control macOS through the accessibility tree. "
             <> "Use stable target_id and element_id values; screenshots are "
             <> "optional and returned only when include_screenshot is true."
-    , appToolSchema = HostedComputerFunctionSchema computerToolParameters
-    , appToolHandler = streamingRichTextTool "computer" \_emit arguments ->
-        normalizeRequest arguments >>= \case
-            Left err -> pure (Left err)
-            Right request ->
+    , appToolSchema =
+        HostedComputerFunctionSchema semanticComputerRequestSchema
+    , appToolHandler =
+        typedStreamingRichTool
+            "computer"
+            semanticComputerRequestDecoder
+            \_emit request ->
                 invokeComputerSessionRequest session request >>= \case
                     Left err -> pure (Left err)
                     Right result ->
@@ -323,7 +333,7 @@ computerTool session = AppTool
 
 invokeComputerSessionRequest
     :: ComputerSession
-    -> BS.ByteString
+    -> SemanticComputerRequest
     -> IO (Either Text NativeComputerResult)
 invokeComputerSessionRequest session request =
     MVar.modifyMVar session.computerSessionState \case
@@ -331,43 +341,42 @@ invokeComputerSessionRequest session request =
             pure (ComputerSessionClosed, Left
                 "The native computer session is closed.")
         ComputerSessionOpen token accessibilityState -> do
-            case decodeOperation request of
-                Left err ->
+            let operation =
+                    computerOperationCode
+                        (semanticComputerRequestOperation request)
+                includeScreenshot =
+                    semanticComputerRequestWantsScreenshot request
+                requestBytes = encodeSemanticComputerRequest request
+            attempted <- tryAny
+                (invokeComputerRaw
+                    session.computerSessionRegistration
+                    operation
+                    token
+                    includeScreenshot
+                    requestBytes)
+            let failed err =
                     pure
                         ( ComputerSessionOpen token accessibilityState
                         , Left err
                         )
-                Right (operation, includeScreenshot) -> do
-                    attempted <- tryAny
-                        (invokeComputerRaw
-                            session.computerSessionRegistration
-                            operation
-                            token
-                            includeScreenshot
-                            request)
-                    let failed err =
+            case attempted of
+                Left exception -> failed (Text.pack (show exception))
+                Right (Left err) -> failed err
+                Right (Right response) -> do
+                    validated <- validateResponse
+                        operation
+                        includeScreenshot
+                        accessibilityState
+                        response
+                    case validated of
+                        Left err -> failed err
+                        Right (result, successorAccessibility) ->
                             pure
-                                ( ComputerSessionOpen token accessibilityState
-                                , Left err
+                                ( ComputerSessionOpen
+                                    token
+                                    successorAccessibility
+                                , Right result
                                 )
-                    case attempted of
-                        Left exception -> failed (Text.pack (show exception))
-                        Right (Left err) -> failed err
-                        Right (Right response) -> do
-                            validated <- validateResponse
-                                operation
-                                includeScreenshot
-                                accessibilityState
-                                response
-                            case validated of
-                                Left err -> failed err
-                                Right (result, successorAccessibility) ->
-                                    pure
-                                        ( ComputerSessionOpen
-                                            token
-                                            successorAccessibility
-                                        , Right result
-                                        )
 
 data RawComputerResponse = RawComputerResponse
     { rawResult :: !BS.ByteString
@@ -473,144 +482,9 @@ decodeImage includeScreenshot imageFormat bytes
                 ( "data:"
                     <> mime
                     <> ";base64,"
-                    <> encodeBase64 bytes
+                    <> TextEncoding.decodeUtf8 (Base64.encode bytes)
                 )
                 Nothing))
-
-normalizeRequest :: Text -> IO (Either Text BS.ByteString)
-normalizeRequest arguments =
-    pure case Aeson.eitherDecodeStrict'
-            (TextEncoding.encodeUtf8 arguments) of
-        Left err -> Left ("Invalid computer arguments: " <> Text.pack err)
-        Right value ->
-            case AesonTypes.parseEither parseRequest value of
-                Left err -> Left (Text.pack err)
-                Right normalized -> Right
-                    (LBS.toStrict (Aeson.encode normalized))
-
-parseRequest :: Aeson.Value -> AesonTypes.Parser Aeson.Value
-parseRequest = Aeson.withObject "computer arguments" \object -> do
-    requireOnly object
-        ["operation", "target_id", "actions", "include_screenshot"]
-    operation <- object Aeson..: "operation"
-    includeScreenshot <- object Aeson..: "include_screenshot"
-    case (operation :: Text) of
-        "list_targets" -> do
-            requireNull object "target_id"
-            requireNull object "actions"
-            when includeScreenshot $
-                fail "list_targets cannot include a screenshot"
-            pure (Aeson.object
-                [ "operation" Aeson..= operation
-                , "include_screenshot" Aeson..= False
-                ])
-        "bind" -> do
-            targetId <- object Aeson..: "target_id"
-            requireNull object "actions"
-            pure (Aeson.object
-                [ "operation" Aeson..= operation
-                , "target_id" Aeson..= (targetId :: Text)
-                , "include_screenshot" Aeson..= includeScreenshot
-                ])
-        "observe" -> do
-            requireNull object "target_id"
-            requireNull object "actions"
-            pure (Aeson.object
-                [ "operation" Aeson..= operation
-                , "include_screenshot" Aeson..= includeScreenshot
-                ])
-        "act" -> do
-            requireNull object "target_id"
-            rawActions <-
-                object Aeson..: "actions"
-                    :: AesonTypes.Parser [Aeson.Value]
-            actions <- traverse parseSemanticAction rawActions
-            when (null actions) $
-                fail "act requires at least one semantic action"
-            when (length actions > 64) $
-                fail "act accepts at most 64 semantic actions"
-            pure (Aeson.object
-                [ "operation" Aeson..= operation
-                , "actions" Aeson..= actions
-                , "include_screenshot" Aeson..= includeScreenshot
-                ])
-        _ -> fail "unsupported computer operation"
-
-parseSemanticAction :: Aeson.Value -> AesonTypes.Parser Aeson.Value
-parseSemanticAction = Aeson.withObject "semantic computer action" \object -> do
-    requireOnly object ["type", "element_id", "action", "value", "text"]
-    actionType <- object Aeson..: "type"
-    elementId <- object Aeson..: "element_id"
-    case (actionType :: Text) of
-        "perform" -> do
-            action <- object Aeson..: "action"
-            requireNull object "value"
-            requireNull object "text"
-            pure (Aeson.object
-                [ "type" Aeson..= actionType
-                , "element_id" Aeson..= (elementId :: Text)
-                , "action" Aeson..= (action :: Text)
-                ])
-        "set_value" -> do
-            requireNull object "action"
-            requireNull object "text"
-            value <- object Aeson..: "value"
-            case (value :: Aeson.Value) of
-                Aeson.String _ -> pure ()
-                Aeson.Number _ -> pure ()
-                Aeson.Bool _ -> pure ()
-                _ -> fail "set_value.value must be a string, number, or boolean"
-            pure (Aeson.object
-                [ "type" Aeson..= actionType
-                , "element_id" Aeson..= (elementId :: Text)
-                , "value" Aeson..= value
-                ])
-        "replace_selected_text" -> do
-            requireNull object "action"
-            requireNull object "value"
-            text <- object Aeson..: "text"
-            pure (Aeson.object
-                [ "type" Aeson..= actionType
-                , "element_id" Aeson..= (elementId :: Text)
-                , "text" Aeson..= (text :: Text)
-                ])
-        _ -> fail "unsupported semantic computer action"
-
-requireOnly :: Aeson.Object -> [Text] -> AesonTypes.Parser ()
-requireOnly object allowed =
-    unless (null unexpected) $
-        fail ("unexpected computer argument fields: "
-            <> Text.unpack (Text.intercalate ", " unexpected))
-  where
-    unexpected =
-        filter (`notElem` allowed) (map Key.toText (KeyMap.keys object))
-
-requireNull :: Aeson.Object -> Text -> AesonTypes.Parser ()
-requireNull object fieldName =
-    case KeyMap.lookup (Key.fromText fieldName) object of
-        Just Aeson.Null -> pure ()
-        Just _ -> fail (Text.unpack fieldName <> " must be null for this operation")
-        Nothing -> fail ("missing required field: " <> Text.unpack fieldName)
-
-decodeOperation :: BS.ByteString -> Either Text (CInt, Bool)
-decodeOperation bytes =
-    case Aeson.eitherDecodeStrict' bytes of
-        Left err -> Left ("Invalid normalized computer request: " <> Text.pack err)
-        Right value ->
-            case AesonTypes.parseEither parser value of
-                Left err -> Left (Text.pack err)
-                Right result -> Right result
-  where
-    parser = Aeson.withObject "computer request" \object -> do
-        operation <- object Aeson..: "operation"
-        includeScreenshot <- object Aeson..: "include_screenshot"
-        command <- case (operation :: Text) of
-            "list_targets" -> pure operationList
-            "bind" -> pure operationBind
-            "observe" -> pure operationObserveOrAct
-            "act" -> pure operationObserveOrAct
-            _ -> fail "unsupported computer operation"
-        pure (command, includeScreenshot)
 
 acquireCurrentGeneration
     :: ComputerHost
@@ -980,35 +854,6 @@ word32At bytes offset =
         + fromIntegral (BS.index bytes (offset + 2)) * 256
         + fromIntegral (BS.index bytes (offset + 3))
 
-encodeBase64 :: BS.ByteString -> Text
-encodeBase64 = Text.pack . go . BS.unpack
-  where
-    alphabet =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-    at value = alphabet !! value
-    go = \case
-        [] -> []
-        [a] ->
-            [ at (fromIntegral a `div` 4)
-            , at ((fromIntegral a `mod` 4) * 16)
-            , '='
-            , '='
-            ]
-        [a, b] ->
-            [ at (fromIntegral a `div` 4)
-            , at (((fromIntegral a `mod` 4) * 16) + (fromIntegral b `div` 16))
-            , at ((fromIntegral b `mod` 16) * 4)
-            , '='
-            ]
-        a : b : c : rest ->
-            at (fromIntegral a `div` 4)
-                : at (((fromIntegral a `mod` 4) * 16)
-                    + (fromIntegral b `div` 16))
-                : at (((fromIntegral b `mod` 16) * 4)
-                    + (fromIntegral c `div` 64))
-                : at (fromIntegral c `mod` 64)
-                : go rest
-
 computerFailureMessage :: CInt -> BS.ByteString -> Text
 computerFailureMessage status bytes =
     case TextEncoding.decodeUtf8' bytes of
@@ -1037,70 +882,11 @@ encodeJson = TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode
 computerAbiVersion :: Word32
 computerAbiVersion = 3
 
-computerToolParameters :: Aeson.Value
-computerToolParameters = strictObject
-    [ ("operation", Aeson.object
-        [ "type" Aeson..= ("string" :: Text)
-        , "enum" Aeson..=
-            (["list_targets", "bind", "observe", "act"] :: [Text])
-        ])
-    , ("target_id", nullableStringParameter)
-    , ("actions", Aeson.object
-        [ "type" Aeson..= (["array", "null"] :: [Text])
-        , "minItems" Aeson..= (1 :: Int)
-        , "maxItems" Aeson..= (64 :: Int)
-        , "items" Aeson..= semanticActionParameters
-        ])
-    , ("include_screenshot", screenshotParameter)
-    ]
-    ["operation", "target_id", "actions", "include_screenshot"]
-
-semanticActionParameters :: Aeson.Value
-semanticActionParameters = strictObject
-    [ ("type", Aeson.object
-        [ "type" Aeson..= ("string" :: Text)
-        , "enum" Aeson..=
-            (["perform", "set_value", "replace_selected_text"] :: [Text])
-        ])
-    , ("element_id", stringParameter)
-    , ("action", nullableStringParameter)
-    , ("value", Aeson.object
-        [ "type" Aeson..=
-            (["string", "number", "boolean", "null"] :: [Text])
-        ])
-    , ("text", nullableStringParameter)
-    ]
-    ["type", "element_id", "action", "value", "text"]
-
-strictObject :: [(Text, Aeson.Value)] -> [Text] -> Aeson.Value
-strictObject properties requiredFields = Aeson.object
-    [ "type" Aeson..= ("object" :: Text)
-    , "additionalProperties" Aeson..= False
-    , "properties" Aeson..= Aeson.object
-        [ Key.fromText name Aeson..= schema | (name, schema) <- properties ]
-    , "required" Aeson..= requiredFields
-    ]
-
-stringParameter :: Aeson.Value
-stringParameter = scalarParameter "string"
-
-nullableStringParameter :: Aeson.Value
-nullableStringParameter = Aeson.object
-    [ "type" Aeson..= (["string", "null"] :: [Text]) ]
-
-scalarParameter :: Text -> Aeson.Value
-scalarParameter parameterType = Aeson.object
-    [ "type" Aeson..= parameterType ]
-
-screenshotParameter :: Aeson.Value
-screenshotParameter = Aeson.object
-    [ "type" Aeson..= ("boolean" :: Text)
-    , "description" Aeson..=
-        ( "Set false unless visual evidence is necessary; screenshots are "
-        <> "never returned implicitly."
-        :: Text
-        )
-    ]
+computerOperationCode :: SemanticComputerOperation -> CInt
+computerOperationCode = \case
+    ListComputerTargetsOperation -> operationList
+    BindComputerTargetOperation -> operationBind
+    ObserveOrActOnComputerTargetOperation -> operationObserveOrAct
 
 operationOpen, operationList, operationBind, operationObserveOrAct, operationClose
     :: CInt

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
@@ -14,11 +14,13 @@ module Agent.CLI.MacOS.ComputerBridge
     , computerOutputCapacity
     , computerStatusMessage
     , computerToolWhenEnabled
+    , computerToolSessionWhenEnabled
     , encodeComputerActions
     , invokeComputerTransaction
     , invokeComputerSessionTransaction
     , newComputerHost
     , newComputerSession
+    , resetComputerSessionAccessibility
     ) where
 
 import Agent.CLI.ComputerUse
@@ -43,7 +45,13 @@ import Agent.Responses.Types
 import Agent.Tools.Types (AppTool)
 import Control.Exception.Safe (bracket, tryAny)
 import Control.Monad (foldM)
-import Control.Concurrent.MVar (MVar, modifyMVar, newMVar, withMVar)
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , modifyMVar_
+    , newMVar
+    , withMVar
+    )
 import qualified Data.ByteString as BS
 import Data.Bits ((.|.))
 import Data.Text (Text)
@@ -192,15 +200,29 @@ newComputerSession = ComputerSession <$> newMVar ComputerSessionState
 
 computerToolWhenEnabled :: ComputerHost -> IO (Maybe AppTool)
 computerToolWhenEnabled host =
+    fmap (fmap fst) (computerToolSessionWhenEnabled host)
+
+computerToolSessionWhenEnabled :: ComputerHost -> IO (Maybe (AppTool, IO ()))
+computerToolSessionWhenEnabled host =
     withMVar host.computerRegistration \case
         Nothing -> pure Nothing
         Just _ -> do
             session <- newComputerSession
-            pure . Just . computerUseToolWith $
-                ComputerUseBackend
-                    { computerRunTransaction =
-                        invokeComputerSessionTransaction host session
-                    }
+            pure . Just $
+                ( computerUseToolWith $
+                    ComputerUseBackend
+                        { computerRunTransaction =
+                            invokeComputerSessionTransaction host session
+                        }
+                , resetComputerSessionAccessibility session
+                )
+
+resetComputerSessionAccessibility :: ComputerSession -> IO ()
+resetComputerSessionAccessibility session =
+    modifyMVar_ session.computerSessionState \state ->
+        pure state
+            { computerSessionAccessibility = initialAccessibilityDeltaState
+            }
 
 encodeComputerActions :: [ComputerAction] -> Either Text ComputerBatch
 encodeComputerActions actions = do

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineHandle.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineHandle.hs
@@ -4,7 +4,8 @@
 module Agent.CLI.MacOS.EngineHandle () where
 
 import Agent.CLI.MacOS.BrowserBridge (BrowserHost(..))
-import Agent.CLI.MacOS.ComputerBridge (ComputerHost(..), newComputerHost)
+import Agent.CLI.MacOS.ComputerBridge
+    ( newComputerHost, replaceComputerRegistration )
 import Agent.CLI.MacOS.EngineEvents (EventCallback, sendEvent, failureEvent)
 import Agent.CLI.MacOS.EngineLifecycle (workerLifecycle)
 import Agent.CLI.MacOS.EngineMailbox (newEngineMailboxIO, closeEngineMailbox)
@@ -88,13 +89,13 @@ ha_engine_destroy pointer
     | pointer == nullPtr = pure ()
     | otherwise = void $ tryAny do
         let stable = castPtrToStablePtr pointer :: StablePtr Engine
-        (do
-            engine <- deRefStablePtr stable
-            modifyMVar_
-                engine.engineComputer.computerRegistration
-                (const (pure Nothing))
+        engine <- deRefStablePtr stable
+        ((do
             _ <- atomically
                 (closeEngineMailbox engine.engineCommands EngineStop)
             void (waitCatch engine.engineWorker)
             modifyMVar_ engine.engineBrowser.browserRegistration (const (pure Nothing)))
-            `finally` freeStablePtr stable
+            `finally`
+                replaceComputerRegistration engine.engineComputer Nothing)
+            `finally`
+                freeStablePtr stable

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineHostRegistration.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineHostRegistration.hs
@@ -4,7 +4,11 @@
 module Agent.CLI.MacOS.EngineHostRegistration () where
 
 import Agent.CLI.MacOS.BrowserBridge (BrowserHost(..), BrowserRegistration(..), BrowserCallback, BrowserCancelCallback)
-import Agent.CLI.MacOS.ComputerBridge (ComputerHost(..), ComputerRegistration(..), ComputerCallback)
+import Agent.CLI.MacOS.ComputerBridge
+    ( ComputerCallback
+    , ComputerRegistration(..)
+    , replaceComputerRegistration
+    )
 import Agent.CLI.MacOS.EngineState (Engine(..))
 import Agent.CLI.MacOS.InteractionState
     ( InteractionCallback
@@ -66,14 +70,13 @@ ha_engine_set_computer_callback pointer callback context
         updated <- tryAny do
             let stable = castPtrToStablePtr pointer :: StablePtr Engine
             engine <- deRefStablePtr stable
-            modifyMVar_ engine.engineComputer.computerRegistration $ \_ ->
-                pure
-                    if callback == nullFunPtr
-                        then Nothing
-                        else Just ComputerRegistration
-                            { computerCallback = callback
-                            , computerContext = context
-                            }
+            replaceComputerRegistration engine.engineComputer $
+                if callback == nullFunPtr
+                    then Nothing
+                    else Just ComputerRegistration
+                        { computerCallback = callback
+                        , computerContext = context
+                        }
         pure $ case updated of
             Left _ -> 2
             Right () -> 0

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
@@ -15,6 +15,9 @@ import Agent.ToolDispatch
     , ToolCallResult(..)
     , isComputerToolCallKind
     )
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
@@ -47,11 +50,11 @@ encodeNativeLoopEvent turnId event =
         ToolFinished result ->
             toolEvent 5 flags finishedFields
           where
-            safeOutput
+            eventOutput
                 | isComputerToolCallKind result.callKind =
-                    "Screenshot captured"
+                    redactComputerScreenshot result.output
                 | otherwise = result.output
-            (output, truncated) = boundedEventText safeOutput
+            (output, truncated) = boundedEventText eventOutput
             flags =
                 (if truncated then 2 else 0)
                     + (if toolCallResultMode result == AsyncToolCall
@@ -136,3 +139,35 @@ boundedEventText :: Text -> (Text, Bool)
 boundedEventText value =
     let (visible, remainder) = Text.splitAt 8192 value
     in (visible, not (Text.null remainder))
+
+redactComputerScreenshot :: Text -> Text
+redactComputerScreenshot output
+    | hasDataImagePrefix output =
+        screenshotOmitted
+    | otherwise =
+        case Aeson.decodeStrict' (TextEncoding.encodeUtf8 output) of
+            Just value ->
+                TextEncoding.decodeUtf8
+                    (LBS.toStrict (Aeson.encode (redactValue value)))
+            Nothing
+                | "data:image/" `Text.isInfixOf` Text.toLower output ->
+                    screenshotOmitted
+                | otherwise -> output
+  where
+    redactValue = \case
+        Aeson.Object object ->
+            Aeson.Object (KeyMap.mapMaybeWithKey redactField object)
+        Aeson.Array values -> Aeson.Array (fmap redactValue values)
+        Aeson.String value
+            | hasDataImagePrefix value ->
+                Aeson.String screenshotOmitted
+        value -> value
+    redactField key value
+        | normalizeKey key == "screenshotdataurl" = Nothing
+        | otherwise = Just (redactValue value)
+    normalizeKey = Text.filter (/= '_') . Text.toLower . Key.toText
+    hasDataImagePrefix value =
+        "data:image/" `Text.isPrefixOf` Text.toLower value
+
+screenshotOmitted :: Text
+screenshotOmitted = "Screenshot omitted from event"

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
@@ -5,7 +5,8 @@ module Agent.CLI.MacOS.NativeSupervisor
 
 import Agent.CLI.MacOS.AgentSnapshot (activeAgentSnapshot)
 import Agent.CLI.MacOS.BrowserBridge (BrowserHost, browserToolsWhenEnabled)
-import Agent.CLI.MacOS.ComputerBridge (ComputerHost, computerToolWhenEnabled)
+import Agent.CLI.MacOS.ComputerBridge
+    ( ComputerHost, computerToolSessionWhenEnabled )
 import Agent.CLI.MacOS.EngineCallbacks (invokeTaskSnapshotCallback)
 import Agent.CLI.MacOS.EngineEvents
 import Agent.CLI.MacOS.EngineMailbox
@@ -406,7 +407,7 @@ supervisorLoop
             start.turnStartSessionId
             interactions
         nativeBrowserTools <- browserToolsWhenEnabled browser start.turnStartId
-        nativeComputerTool <- computerToolWhenEnabled computer
+        nativeComputerSession <- computerToolSessionWhenEnabled computer
         worker <- launchTrackedWorker start.turnStartId do
             withGatewayCredentialTurnLease $
                 ensureNativeGatewayIdentity
@@ -440,7 +441,7 @@ supervisorLoop
                                     processRuntime
                                     control
                                     nativeBrowserTools
-                                    nativeComputerTool
+                                    nativeComputerSession
                                     start
                                     pending.pendingTurnImages
                                     pending.pendingTurnOptions

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
@@ -38,7 +38,7 @@ import Agent.Store.Postgres (ManagedPostgresConfig, Store)
 import Control.Concurrent.Async (asyncWithUnmask, cancel, waitCatch)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, takeMVar, putMVar)
 import Control.Concurrent.STM
-import Control.Exception.Safe (finally, mask, tryAny)
+import Control.Exception.Safe (bracket, finally, mask, tryAny)
 import Control.Monad (filterM, foldM, forM_, void, when)
 import Data.Aeson ((.:?))
 import qualified Data.Aeson as Aeson
@@ -407,45 +407,61 @@ supervisorLoop
             start.turnStartSessionId
             interactions
         nativeBrowserTools <- browserToolsWhenEnabled browser start.turnStartId
-        nativeComputerSession <- computerToolSessionWhenEnabled computer
-        worker <- launchTrackedWorker start.turnStartId do
-            withGatewayCredentialTurnLease $
-                ensureNativeGatewayIdentity
-                    pending.pendingTurnGatewayIdentity >>= \case
-                        Left err ->
-                            pure
-                                TurnOutcome
-                                    { turnOutcomeSessionId =
-                                        start.turnStartSessionId
-                                    , turnOutcomeError = Just err
-                                    , turnOutcomeUsage = emptyTokenUsage
-                                    , turnOutcomeProviderCostUSD = Nothing
-                                    }
-                        Right () ->
-                            do
-                                sendTaskState
-                                    start.turnStartId
-                                    start.turnStartSessionId
-                                    "running"
-                                sendTurnStatus
-                                    callback
-                                    context
-                                    start.turnStartId
-                                    (if start.turnStartWorktree
-                                        then "Creating worktree…"
-                                        else "Starting…")
-                                runNativeTurn
-                                    callback
-                                    context
-                                    commands
-                                    processRuntime
-                                    control
-                                    nativeBrowserTools
-                                    nativeComputerSession
-                                    start
-                                    pending.pendingTurnImages
-                                    pending.pendingTurnOptions
-                                    interactions
+        worker <- launchTrackedWorker start.turnStartId $
+            bracket
+                (if start.turnStartComputerUse
+                    then computerToolSessionWhenEnabled computer
+                    else pure (Right Nothing))
+                (\case
+                    Right (Just (_, _, close)) -> close
+                    _ -> pure ())
+                (\case
+                    Left err -> pure TurnOutcome
+                        { turnOutcomeSessionId = start.turnStartSessionId
+                        , turnOutcomeError = Just err
+                        , turnOutcomeUsage = emptyTokenUsage
+                        , turnOutcomeProviderCostUSD = Nothing
+                        }
+                    Right nativeComputerTool ->
+                        withGatewayCredentialTurnLease $
+                            ensureNativeGatewayIdentity
+                                pending.pendingTurnGatewayIdentity >>= \case
+                                    Left err ->
+                                        pure
+                                            TurnOutcome
+                                                { turnOutcomeSessionId =
+                                                    start.turnStartSessionId
+                                                , turnOutcomeError = Just err
+                                                , turnOutcomeUsage =
+                                                    emptyTokenUsage
+                                                , turnOutcomeProviderCostUSD =
+                                                    Nothing
+                                                }
+                                    Right () ->
+                                        do
+                                            sendTaskState
+                                                start.turnStartId
+                                                start.turnStartSessionId
+                                                "running"
+                                            sendTurnStatus
+                                                callback
+                                                context
+                                                start.turnStartId
+                                                (if start.turnStartWorktree
+                                                    then "Creating worktree…"
+                                                    else "Starting…")
+                                            runNativeTurn
+                                                callback
+                                                context
+                                                commands
+                                                processRuntime
+                                                control
+                                                nativeBrowserTools
+                                                nativeComputerTool
+                                                start
+                                                pending.pendingTurnImages
+                                                pending.pendingTurnOptions
+                                                interactions)
         let runningTurn =
                 RunningTurn
                     { runningTurnControl = control

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
@@ -63,7 +63,7 @@ runNativeTurn
     -> NativeProcessRuntime
     -> TurnControl
     -> [AppTool]
-    -> Maybe AppTool
+    -> Maybe (AppTool, IO ())
     -> TurnStart
     -> [ImageAttachment]
     -> NativeTurnOptions
@@ -71,7 +71,7 @@ runNativeTurn
     -> IO TurnOutcome
 runNativeTurn
         callback context commands processRuntime control nativeBrowserTools
-        nativeComputerTool start images turnOptions interactions = do
+        nativeComputerSession start images turnOptions interactions = do
     sessionIdRef <- newIORef start.turnStartSessionId
     completedRef <- newIORef False
     usageRef <- newIORef emptyTokenUsage
@@ -81,6 +81,8 @@ runNativeTurn
                     TurnFinished output -> do
                         writeIORef completedRef True
                         modifyIORef' usageRef (<> output.tokenUsage)
+                    ModelContextReset ->
+                        forM_ nativeComputerSession snd
                     _ -> pure ()
                 case encodeNativeLoopEvent control.turnControlId event of
                     Just bytes -> sendBinaryEvent callback context bytes
@@ -113,7 +115,7 @@ runNativeTurn
                 requestRootAccessFromClient callback context control
             , nativeToolGroups = [HostToolGroup nativeBrowserTools]
             , nativeComposeTools =
-                composeNativeTools nativeComputerTool
+                composeNativeTools (fst <$> nativeComputerSession)
             , nativePlanHooks =
                 nativePlanModeHooks control interactions
             , nativeInteractionMode =

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
@@ -63,7 +63,7 @@ runNativeTurn
     -> NativeProcessRuntime
     -> TurnControl
     -> [AppTool]
-    -> Maybe (AppTool, IO ())
+    -> Maybe (AppTool, IO (), IO ())
     -> TurnStart
     -> [ImageAttachment]
     -> NativeTurnOptions
@@ -82,7 +82,7 @@ runNativeTurn
                         writeIORef completedRef True
                         modifyIORef' usageRef (<> output.tokenUsage)
                     ModelContextReset ->
-                        forM_ nativeComputerSession snd
+                        forM_ nativeComputerSession \(_, reset, _) -> reset
                     _ -> pure ()
                 case encodeNativeLoopEvent control.turnControlId event of
                     Just bytes -> sendBinaryEvent callback context bytes
@@ -115,7 +115,8 @@ runNativeTurn
                 requestRootAccessFromClient callback context control
             , nativeToolGroups = [HostToolGroup nativeBrowserTools]
             , nativeComposeTools =
-                composeNativeTools (fst <$> nativeComputerSession)
+                composeNativeTools
+                    ((\(tool, _, _) -> tool) <$> nativeComputerSession)
             , nativePlanHooks =
                 nativePlanModeHooks control interactions
             , nativeInteractionMode =

--- a/packages/agent-native-bridge/include/HaskellAgentBridge.h
+++ b/packages/agent-native-bridge/include/HaskellAgentBridge.h
@@ -231,37 +231,12 @@ int32_t ha_engine_set_browser_callback(
 );
 
 enum {
-    HA_COMPUTER_ABI_VERSION = 2,
-    HA_COMPUTER_QUERY_DISPLAY = 1,
-    HA_COMPUTER_RUN_AND_OBSERVE = 2
-};
-
-enum {
-    HA_COMPUTER_ACTION_CLICK = 1,
-    HA_COMPUTER_ACTION_DOUBLE_CLICK = 2,
-    HA_COMPUTER_ACTION_SCROLL = 3,
-    HA_COMPUTER_ACTION_MOVE = 4,
-    HA_COMPUTER_ACTION_DRAG = 5,
-    HA_COMPUTER_ACTION_TYPE = 6,
-    HA_COMPUTER_ACTION_KEYPRESS = 7,
-    HA_COMPUTER_ACTION_WAIT = 8
-};
-
-enum {
-    HA_COMPUTER_BUTTON_NONE = 0,
-    HA_COMPUTER_BUTTON_LEFT = 1,
-    HA_COMPUTER_BUTTON_RIGHT = 2,
-    HA_COMPUTER_BUTTON_MIDDLE = 3,
-    HA_COMPUTER_BUTTON_BACK = 4,
-    HA_COMPUTER_BUTTON_FORWARD = 5
-};
-
-enum {
-    HA_COMPUTER_MODIFIER_SHIFT = 1 << 0,
-    HA_COMPUTER_MODIFIER_CONTROL = 1 << 1,
-    HA_COMPUTER_MODIFIER_OPTION = 1 << 2,
-    HA_COMPUTER_MODIFIER_COMMAND = 1 << 3,
-    HA_COMPUTER_MODIFIER_FUNCTION = 1 << 4
+    HA_COMPUTER_ABI_VERSION = 3,
+    HA_COMPUTER_OPEN = 1,
+    HA_COMPUTER_LIST = 2,
+    HA_COMPUTER_BIND = 3,
+    HA_COMPUTER_OBSERVE_OR_ACT = 4,
+    HA_COMPUTER_CLOSE = 5
 };
 
 enum {
@@ -280,157 +255,93 @@ enum {
     HA_COMPUTER_STATUS_FAILED = 6,
     HA_COMPUTER_STATUS_OUTPUT_TOO_LARGE = 7,
     HA_COMPUTER_STATUS_SESSION_LOCKED = 8,
-    HA_COMPUTER_STATUS_DISPLAY_CHANGED = 9
+    HA_COMPUTER_STATUS_TARGET_STALE = 9,
+    /* Source compatibility for early ABI-v3 adopters. */
+    HA_COMPUTER_STATUS_DISPLAY_CHANGED = HA_COMPUTER_STATUS_TARGET_STALE
 };
 
 enum {
-    HA_COMPUTER_ACTION_STRUCT_SIZE_V1 = 64,
-    HA_COMPUTER_MAX_ACTIONS = 10,
-    HA_COMPUTER_MAX_POINTS_PER_ACTION = 1024,
-    HA_COMPUTER_MAX_TOTAL_POINTS = 10240,
-    HA_COMPUTER_MAX_TEXT_BYTES = 327680,
+    HA_COMPUTER_REQUEST_MAX_BYTES = 1048576,
+    HA_COMPUTER_RESULT_CAPACITY = 1048576,
     HA_COMPUTER_ERROR_CAPACITY = 65536,
-    HA_COMPUTER_OUTPUT_CAPACITY = 16777216,
+    HA_COMPUTER_IMAGE_CAPACITY = 16777216,
     HA_COMPUTER_ACCESSIBILITY_CAPACITY = 524288
 };
 
-typedef struct ha_computer_point_v1 {
-    int32_t x;
-    int32_t y;
-} ha_computer_point_v1;
-
 /*
- * Fixed-width action record for HA_COMPUTER_ABI_VERSION. struct_size must be
- * HA_COMPUTER_ACTION_STRUCT_SIZE_V1. text_offset/text_length select UTF-8 in
- * the callback's text buffer. point_offset/point_count select records in its
- * point buffer. Offsets and lengths are element counts, not byte pointers.
+ * Host accessibility-first computer callback for native agent turns.
  *
- * Pointer coordinates are integer logical pixels in the final screenshot's
- * top-left coordinate space: 0 <= x < output_width and
- * 0 <= y < output_height. CLICK uses x/y, button, and modifiers.
- * DOUBLE_CLICK and MOVE use x/y and modifiers. SCROLL uses x/y,
- * delta_x/delta_y, and modifiers; positive deltas follow browser-wheel
- * convention and move the viewport right/down. DRAG uses at least two ordered
- * points, including its start and end, and the left button. TYPE uses a text
- * range. KEYPRESS uses a nonempty text range for the final key and modifiers
- * for the chord. WAIT has no fields and waits two seconds. Every field not
- * named for an action must be zero.
- */
-typedef struct ha_computer_action_v1 {
-    uint32_t struct_size;
-    int32_t action;
-    int32_t x;
-    int32_t y;
-    int32_t delta_x;
-    int32_t delta_y;
-    int32_t button;
-    uint32_t modifiers;
-    uint64_t text_offset;
-    uint64_t text_length;
-    uint64_t point_offset;
-    uint64_t point_count;
-} ha_computer_action_v1;
-
-/*
- * Host computer-control callback for native agent turns.
+ * OPEN has session_token zero and an empty request. It returns a nonzero,
+ * opaque output_session_token and no other output. LIST, BIND, and
+ * OBSERVE_OR_ACT carry that token and a UTF-8 JSON request. CLOSE carries the
+ * token and an empty request, produces no output, and is issued exactly once.
+ * Calls for one token are sequential; calls for different tokens may overlap.
  *
- * QUERY_DISPLAY requires zero actions/points/text, expected display token and
- * dimensions and requested_image_format zero, and a writable error buffer. On
- * success it writes a nonzero opaque lease to output_display_token and positive
- * logical main-display dimensions to output_width and output_height, sets
- * output_image_format, output_length, and accessibility_output_length to zero,
- * and does not write image or accessibility bytes.
+ * LIST receives {"operation":"list_targets"}. BIND receives operation "bind",
+ * a target_id, and include_screenshot (default false). OBSERVE_OR_ACT receives
+ * operation "observe" or "act"; act contains 1..64 semantic element actions
+ * only. Their exact JSON forms are
+ * {"type":"perform","element_id":"...","action":"AXPress"},
+ * {"type":"set_value","element_id":"...","value":...} (where value is a
+ * string, number, or boolean), and
+ * {"type":"replace_selected_text","element_id":"...","text":"..."}.
+ * The perform action string is one advertised by the AX snapshot.
+ * Model-provided coordinates are not part of this ABI. The selected target is
+ * session-local.
  *
- * RUN_AND_OBSERVE executes the complete ordered action batch, waits for the UI
- * to settle, and captures exactly one final main-display observation. It must
- * verify expected_display_token is the host's current unconsumed lease for the
- * same main display and that the logical display remains expected_width by
- * expected_height before changing input state. A stale lease must fail with
- * HA_COMPUTER_STATUS_DISPLAY_CHANGED before any side effect. The host must
- * serialize leases across every callback context controlling the same desktop
- * and invalidate a lease when a transaction starts changing input state.
- * requested_image_format is PNG or JPEG. On success, output contains encoded
- * image bytes, output_length is their length, accessibility_output contains
- * an optional UTF-8 JSON accessibility snapshot shaped as
- * {"schema_version":1,"scope":<JSON>,"contents":<JSON>}, and
- * accessibility_output_length is its length. scope must identify the focused
- * application/window closely enough that a scope change invalidates a prior
- * tree; contents is the bounded, redacted accessibility tree.
- * output_display_token is a
- * nonzero successor lease distinct from expected_display_token,
- * output_width/output_height are the observed logical image dimensions, and
- * output_image_format is PNG or JPEG. The encoded image is normalized to
- * exactly output_width by output_height pixels, including on Retina displays,
- * so action coordinates map one-to-one to image pixels. Every successful RUN
- * consumes its input lease, including an observation-only run with zero
- * actions.
+ * Successful non-lifecycle calls write a UTF-8 JSON object to result. BIND,
+ * OBSERVE, and ACT normally write a schema-versioned AX snapshot to
+ * accessibility. Image is optional and must remain empty with
+ * output_image_format HA_COMPUTER_IMAGE_NONE unless include_screenshot was
+ * explicitly true. Screenshot failure is nonfatal and is described in result.
+ * The host must capture only the bound window, never fall back to a display.
  *
- * Actions contain no screenshot record: the Haskell runtime removes a final
- * screenshot marker and rejects an earlier one. actions may be NULL only when
- * action_count is zero. points and text follow the same rule. All ranges must
- * be contained in their corresponding buffers. The host must reject unknown
- * versions, operations, action values, modifiers, image formats, nonzero
- * unused fields, malformed UTF-8, and counts above the HA_COMPUTER_MAX_*
- * limits with HA_COMPUTER_STATUS_INVALID_ARGUMENT.
+ * Each length must not exceed its independent capacity. A channel that is
+ * absent has length zero. On failure all success-channel lengths and
+ * output_session_token/output_image_format are zero; error may contain a
+ * useful UTF-8 message. Input and output pointers are callback-scoped.
  *
- * output/output_length/accessibility_output_length/output_display_token,
- * output_width/output_height and output_image_format are nonnull
- * callback-scoped writable pointers. accessibility_output may be NULL only
- * when accessibility_output_capacity is zero (as it is for QUERY_DISPLAY).
- * A successful RUN may report an empty accessibility snapshot without
- * failing the screenshot. On
- * failure, set the display token, dimensions, and image format to zero and
- * write a useful UTF-8 error to output when possible. Never report
- * output_length above output_capacity. On failure also set
- * accessibility_output_length to zero. The runtime supplies
- * HA_COMPUTER_ERROR_CAPACITY for QUERY_DISPLAY and HA_COMPUTER_OUTPUT_CAPACITY
- * for RUN_AND_OBSERVE, plus HA_COMPUTER_ACCESSIBILITY_CAPACITY for its
- * accessibility buffer. Never report accessibility_output_length above
- * accessibility_output_capacity.
- *
- * The callback runs synchronously on an agent tool worker, never the setter's
- * caller or AppKit main thread, and must not call engine functions. No input
- * or output buffer remains valid after it returns. The host owns callback and
- * context. ha_engine_set_computer_callback may wait for an in-flight callback;
- * after it returns, a replaced callback/context will not be used again. Keep
- * the installed callback/context valid until replacement, disable, or engine
- * destruction returns.
+ * Actions must use direct AX APIs and must not synthesize pointer or keyboard
+ * input. Consequently sessions do not share the system cursor. Same-process
+ * AX calls may be serialized while sessions bound to different processes
+ * remain concurrent.
  */
 typedef int32_t (*ha_computer_callback)(
     void *context,
     uint32_t abi_version,
     int32_t operation,
-    uint64_t expected_display_token,
-    int32_t expected_width,
-    int32_t expected_height,
-    const ha_computer_action_v1 *actions,
-    size_t action_count,
-    const ha_computer_point_v1 *points,
-    size_t point_count,
-    const uint8_t *text,
-    size_t text_length,
-    int32_t requested_image_format,
-    uint8_t *output,
-    size_t output_capacity,
-    size_t *output_length,
-    uint8_t *accessibility_output,
-    size_t accessibility_output_capacity,
-    size_t *accessibility_output_length,
-    uint64_t *output_display_token,
-    int32_t *output_width,
-    int32_t *output_height,
+    uint64_t session_token,
+    const uint8_t *request,
+    size_t request_length,
+    uint8_t *result,
+    size_t result_capacity,
+    size_t *result_length,
+    uint8_t *accessibility,
+    size_t accessibility_capacity,
+    size_t *accessibility_length,
+    uint8_t *image,
+    size_t image_capacity,
+    size_t *image_length,
+    uint8_t *error,
+    size_t error_capacity,
+    size_t *error_length,
+    uint64_t *output_session_token,
     int32_t *output_image_format
 );
 
 /*
  * Installs native computer control for future turns. A turn replaces the
  * local macOS backend only when its turn.start enables computer use and this
- * callback is nonnull. Passing NULL disables native computer control; context
- * is ignored. Tools retained by an already-started turn fail as inactive.
+ * callback is nonnull. Passing NULL disables support for new sessions; context
+ * is ignored.
  *
  * Returns 0 on success, 1 for a null engine, or 2 for an internal failure.
- * Calls must be serialized with ha_engine_destroy. This function may block
- * until a running computer callback returns.
+ * Calls must be serialized with ha_engine_destroy. Replacement is visible to
+ * new sessions immediately. Existing sessions retain the callback/context
+ * generation they opened with and finish with CLOSE on that generation.
+ * Therefore the host must retain an old callback/context until its final CLOSE
+ * returns. Engine destruction first stops turn workers, then CLOSEs remaining
+ * sessions, and only then releases registrations.
  */
 int32_t ha_engine_set_computer_callback(
     void *engine,

--- a/packages/agent-native-bridge/include/HaskellAgentBridge.h
+++ b/packages/agent-native-bridge/include/HaskellAgentBridge.h
@@ -231,7 +231,7 @@ int32_t ha_engine_set_browser_callback(
 );
 
 enum {
-    HA_COMPUTER_ABI_VERSION = 1,
+    HA_COMPUTER_ABI_VERSION = 2,
     HA_COMPUTER_QUERY_DISPLAY = 1,
     HA_COMPUTER_RUN_AND_OBSERVE = 2
 };
@@ -290,7 +290,8 @@ enum {
     HA_COMPUTER_MAX_TOTAL_POINTS = 10240,
     HA_COMPUTER_MAX_TEXT_BYTES = 327680,
     HA_COMPUTER_ERROR_CAPACITY = 65536,
-    HA_COMPUTER_OUTPUT_CAPACITY = 16777216
+    HA_COMPUTER_OUTPUT_CAPACITY = 16777216,
+    HA_COMPUTER_ACCESSIBILITY_CAPACITY = 524288
 };
 
 typedef struct ha_computer_point_v1 {
@@ -337,8 +338,8 @@ typedef struct ha_computer_action_v1 {
  * dimensions and requested_image_format zero, and a writable error buffer. On
  * success it writes a nonzero opaque lease to output_display_token and positive
  * logical main-display dimensions to output_width and output_height, sets
- * output_image_format and output_length to zero, and does not write image
- * bytes.
+ * output_image_format, output_length, and accessibility_output_length to zero,
+ * and does not write image or accessibility bytes.
  *
  * RUN_AND_OBSERVE executes the complete ordered action batch, waits for the UI
  * to settle, and captures exactly one final main-display observation. It must
@@ -349,7 +350,13 @@ typedef struct ha_computer_action_v1 {
  * serialize leases across every callback context controlling the same desktop
  * and invalidate a lease when a transaction starts changing input state.
  * requested_image_format is PNG or JPEG. On success, output contains encoded
- * image bytes, output_length is their length, output_display_token is a
+ * image bytes, output_length is their length, accessibility_output contains
+ * an optional UTF-8 JSON accessibility snapshot shaped as
+ * {"schema_version":1,"scope":<JSON>,"contents":<JSON>}, and
+ * accessibility_output_length is its length. scope must identify the focused
+ * application/window closely enough that a scope change invalidates a prior
+ * tree; contents is the bounded, redacted accessibility tree.
+ * output_display_token is a
  * nonzero successor lease distinct from expected_display_token,
  * output_width/output_height are the observed logical image dimensions, and
  * output_image_format is PNG or JPEG. The encoded image is normalized to
@@ -366,13 +373,20 @@ typedef struct ha_computer_action_v1 {
  * unused fields, malformed UTF-8, and counts above the HA_COMPUTER_MAX_*
  * limits with HA_COMPUTER_STATUS_INVALID_ARGUMENT.
  *
- * output/output_length/output_display_token/output_width/output_height and
- * output_image_format are nonnull callback-scoped writable pointers. On
+ * output/output_length/accessibility_output_length/output_display_token,
+ * output_width/output_height and output_image_format are nonnull
+ * callback-scoped writable pointers. accessibility_output may be NULL only
+ * when accessibility_output_capacity is zero (as it is for QUERY_DISPLAY).
+ * A successful RUN may report an empty accessibility snapshot without
+ * failing the screenshot. On
  * failure, set the display token, dimensions, and image format to zero and
  * write a useful UTF-8 error to output when possible. Never report
- * output_length above output_capacity. The runtime supplies
+ * output_length above output_capacity. On failure also set
+ * accessibility_output_length to zero. The runtime supplies
  * HA_COMPUTER_ERROR_CAPACITY for QUERY_DISPLAY and HA_COMPUTER_OUTPUT_CAPACITY
- * for RUN_AND_OBSERVE.
+ * for RUN_AND_OBSERVE, plus HA_COMPUTER_ACCESSIBILITY_CAPACITY for its
+ * accessibility buffer. Never report accessibility_output_length above
+ * accessibility_output_capacity.
  *
  * The callback runs synchronously on an agent tool worker, never the setter's
  * caller or AppKit main thread, and must not call engine functions. No input
@@ -399,6 +413,9 @@ typedef int32_t (*ha_computer_callback)(
     uint8_t *output,
     size_t output_capacity,
     size_t *output_length,
+    uint8_t *accessibility_output,
+    size_t accessibility_output_capacity,
+    size_t *accessibility_output_length,
     uint64_t *output_display_token,
     int32_t *output_width,
     int32_t *output_height,

--- a/packages/agent-native-bridge/package.nix
+++ b/packages/agent-native-bridge/package.nix
@@ -20,11 +20,11 @@ mkDerivation {
     filelock JuicyPixels safe-exceptions stm
   ];
   testHaskellDepends = [
-    agent-cli agent-core agent-mcp agent-runtime-daemon agent-store
+    aeson agent-cli agent-core agent-mcp agent-runtime-daemon agent-store
     async base base64-bytestring bytestring containers directory filepath hspec
     safe-exceptions stm text unix
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    aeson agent-cli-runtime agent-openai agent-openrouter
+    agent-cli-runtime agent-openai agent-openrouter
     agent-repository agent-responses-types agent-xai filelock JuicyPixels time
   ];
   description = "Native host integration for the agent harness";

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
@@ -7,6 +7,9 @@ import Agent.CLI.ComputerUse
     , ScreenshotEncoding(..)
     , computerUseTool
     )
+import Agent.CLI.ComputerUse.Accessibility
+    ( AccessibilityObservation(..)
+    )
 import Agent.CLI.MacOS.Bridge (composeNativeTools)
 import Agent.CLI.MacOS.ComputerBridge
     ( CComputerAction(..)
@@ -140,12 +143,13 @@ spec = describe "native computer bridge" do
             result `shouldBe` Right
                 (ComputerObservation
                     (ImageAttachment "image/png" pngSignature)
-                    Nothing)
+                    (Just (AccessibilityUnavailable 1
+                        "Native accessibility snapshot unavailable.")))
             readIORef observed `shouldReturn`
                 [ ObservedComputerInvocation
-                    1 1 0 0 0 [] [] BS.empty 0 65536
+                    2 1 0 0 0 [] [] BS.empty 0 65536 0
                 , ObservedComputerInvocation
-                    1 2 41 100 80
+                    2 2 41 100 80
                     [ (plainObservedAction 1)
                         { cComputerX = 10
                         , cComputerY = 20
@@ -164,6 +168,7 @@ spec = describe "native computer bridge" do
                     (BS.pack [206, 187])
                     1
                     16777216
+                    524288
                 ]
 
     it "executes later actions against the lease from the model's screenshot" do
@@ -182,7 +187,8 @@ spec = describe "native computer bridge" do
                 `shouldReturn` Right
                     (ComputerObservation
                         (ImageAttachment "image/png" pngSignature)
-                        Nothing)
+                        (Just (AccessibilityUnavailable 1
+                            "Native accessibility snapshot unavailable.")))
             invokeComputerSessionTransaction
                 host session ScreenshotPng
                 [ClickAction 10 20 "left" []]
@@ -190,10 +196,51 @@ spec = describe "native computer bridge" do
                 `shouldReturn` Right
                     (ComputerObservation
                         (ImageAttachment "image/png" pngSignature)
-                        Nothing)
+                        (Just (AccessibilityUnavailable 2
+                            "Native accessibility snapshot unavailable.")))
             invocations <- readIORef observed
             map observedOperationAndToken invocations `shouldBe`
                 [(1, 0), (2, 41), (2, 42)]
+
+    it "emits a full accessibility snapshot followed by an empty delta" do
+        observed <- newIORef []
+        withComputerHost (accessibilityComputerCallback observed) \host -> do
+            session <- newComputerSession
+            first <- invokeComputerSessionTransaction
+                host session ScreenshotPng [] (const (Right ()))
+            second <- invokeComputerSessionTransaction
+                host session ScreenshotPng [] (const (Right ()))
+            case (first, second) of
+                ( Right ComputerObservation
+                    { computerObservationAccessibility =
+                        Just (AccessibilityFull 1 _)
+                    }
+                  , Right ComputerObservation
+                    { computerObservationAccessibility =
+                        Just (AccessibilityDelta 1 2 [])
+                    }
+                  ) -> pure ()
+                values -> expectationFailure
+                    ("unexpected accessibility observations: " <> show values)
+
+    it "keeps a valid screenshot when accessibility JSON is malformed" do
+        observed <- newIORef []
+        withComputerHost
+            (accessibilityComputerCallbackWith "{" observed)
+            \host -> do
+                session <- newComputerSession
+                result <- invokeComputerSessionTransaction
+                    host session ScreenshotPng [] (const (Right ()))
+                case result of
+                    Right ComputerObservation
+                        { computerObservationImage =
+                            ImageAttachment "image/png" bytes
+                        , computerObservationAccessibility =
+                            Just (AccessibilityUnavailable 1 _)
+                        } ->
+                            bytes `shouldBe` pngSignature
+                    value -> expectationFailure
+                        ("unexpected malformed accessibility result: " <> show value)
 
     it "waits for an in-flight transaction before disabling its callback" do
         runEntered <- newEmptyMVar
@@ -201,7 +248,9 @@ spec = describe "native computer bridge" do
         observed <- newIORef []
         let blockingCallback context abi operation token width height
                 actions actionCount points pointCount text textLength
-                imageFormat output outputCapacity outputLength outputToken
+                imageFormat output outputCapacity outputLength
+                accessibilityOutput accessibilityCapacity accessibilityLength
+                outputToken
                 outputWidth outputHeight outputImageFormat = do
                     if operation == 2
                         then putMVar runEntered () >> takeMVar releaseRun
@@ -210,7 +259,9 @@ spec = describe "native computer bridge" do
                         context abi operation token width height
                         actions actionCount points pointCount text textLength
                         imageFormat output outputCapacity outputLength
-                        outputToken outputWidth outputHeight outputImageFormat
+                        accessibilityOutput accessibilityCapacity
+                        accessibilityLength outputToken outputWidth outputHeight
+                        outputImageFormat
         withCallback blockingCallback \callback -> do
             registration <- newMVar
                 (Just (ComputerRegistration callback nullPtr))
@@ -235,7 +286,8 @@ spec = describe "native computer bridge" do
                             wait running `shouldReturn` Right
                                 (ComputerObservation
                                     (ImageAttachment "image/png" pngSignature)
-                                    Nothing)
+                                    (Just (AccessibilityUnavailable 1
+                                        "Native accessibility snapshot unavailable.")))
                             wait disabling
             invokeComputerTransaction host ScreenshotPng [] (const (Right ()))
                 `shouldReturn` Left "Native computer control is not active."
@@ -280,6 +332,7 @@ data ObservedComputerInvocation = ObservedComputerInvocation
     !BS.ByteString
     !CInt
     !CSize
+    !CSize
     deriving (Eq, Show)
 
 recordingComputerCallback
@@ -287,17 +340,19 @@ recordingComputerCallback
     -> ComputerCallback
 recordingComputerCallback observed _ abi operation token width height
         actions actionCount points pointCount text textLength imageFormat
-        output outputCapacity outputLength outputToken outputWidth outputHeight
-        outputImageFormat = do
+        output outputCapacity outputLength _accessibilityOutput
+        accessibilityCapacity accessibilityLength outputToken outputWidth
+        outputHeight outputImageFormat = do
     decodedActions <- peekValues actions actionCount
     decodedPoints <- peekValues points pointCount
     decodedText <- peekBytes text textLength
     modifyIORef' observed (<> [ObservedComputerInvocation
         abi operation token width height decodedActions decodedPoints
-        decodedText imageFormat outputCapacity])
+        decodedText imageFormat outputCapacity accessibilityCapacity])
     case operation of
         1 -> do
             poke outputLength 0
+            poke accessibilityLength 0
             poke outputToken 41
             poke outputWidth 100
             poke outputHeight 80
@@ -306,12 +361,39 @@ recordingComputerCallback observed _ abi operation token width height
         2 -> do
             status <- writeBytes pngSignature
                 output outputCapacity outputLength
+            poke accessibilityLength 0
             poke outputToken (token + 1)
             poke outputWidth 100
             poke outputHeight 80
             poke outputImageFormat 1
             pure status
         _ -> pure 1
+
+accessibilityComputerCallback
+    :: IORef [ObservedComputerInvocation]
+    -> ComputerCallback
+accessibilityComputerCallback =
+    accessibilityComputerCallbackWith accessibilitySnapshotBytes
+
+accessibilityComputerCallbackWith
+    :: BS.ByteString
+    -> IORef [ObservedComputerInvocation]
+    -> ComputerCallback
+accessibilityComputerCallbackWith accessibilityBytes observed
+        context abi operation token width height
+        actions actionCount points pointCount text textLength imageFormat
+        output outputCapacity outputLength accessibilityOutput
+        accessibilityCapacity accessibilityLength outputToken outputWidth
+        outputHeight outputImageFormat = do
+    status <- recordingComputerCallback observed context abi operation token
+        width height actions actionCount points pointCount text textLength
+        imageFormat output outputCapacity outputLength accessibilityOutput
+        accessibilityCapacity accessibilityLength outputToken outputWidth
+        outputHeight outputImageFormat
+    if status == 0 && operation == 2
+        then writeBytes accessibilityBytes
+            accessibilityOutput accessibilityCapacity accessibilityLength
+        else pure status
 
 peekValues :: Storable value => Ptr value -> CSize -> IO [value]
 peekValues _ (CSize 0) = pure []
@@ -368,9 +450,13 @@ plainObservedAction action = CComputerAction
 pngSignature :: BS.ByteString
 pngSignature = BS.pack [137, 80, 78, 71, 13, 10, 26, 10]
 
+accessibilitySnapshotBytes :: BS.ByteString
+accessibilitySnapshotBytes =
+    "{\"schema_version\":1,\"scope\":{\"bundle_id\":\"test\"},\"contents\":{\"role\":\"AXWindow\"}}"
+
 observedOperationAndToken
     :: ObservedComputerInvocation
     -> (CInt, Word64)
 observedOperationAndToken
-        (ObservedComputerInvocation _ operation token _ _ _ _ _ _ _) =
+        (ObservedComputerInvocation _ operation token _ _ _ _ _ _ _ _) =
     (operation, token)

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
@@ -18,6 +18,12 @@ import Agent.CLI.MacOS.ComputerBridge
     , replaceComputerRegistration
     , resetComputerSessionAccessibility
     )
+import Agent.ComputerUse.Protocol
+    ( SemanticComputerAction(..)
+    , SemanticComputerRequest(..)
+    , SemanticComputerScalar(..)
+    , semanticComputerRequestWireValue
+    )
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
@@ -53,6 +59,7 @@ import Data.IORef
     , newIORef
     , readIORef
     )
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -195,32 +202,19 @@ spec = describe "native AX-first computer bridge" do
                     listScreenshot.toolDispatchSucceeded `shouldBe` False
                     close
             readIORef requests `shouldReturn`
-                [Aeson.object
-                    [ "operation" Aeson..= ("observe" :: Text)
-                    , "include_screenshot" Aeson..= False
+                map semanticComputerRequestWireValue
+                    [ ObserveComputerTarget False
+                    , ActOnComputerTarget
+                        ( PerformComputerAction "e1" "AXPress"
+                            NonEmpty.:|
+                                [ SetComputerValue
+                                    "e2"
+                                    (ComputerNumber 42)
+                                , ReplaceComputerSelectedText "e3" "hello"
+                                ]
+                        )
+                        False
                     ]
-                , Aeson.object
-                    [ "operation" Aeson..= ("act" :: Text)
-                    , "actions" Aeson..=
-                        [ Aeson.object
-                            [ "type" Aeson..= ("perform" :: Text)
-                            , "element_id" Aeson..= ("e1" :: Text)
-                            , "action" Aeson..= ("AXPress" :: Text)
-                            ]
-                        , Aeson.object
-                            [ "type" Aeson..= ("set_value" :: Text)
-                            , "element_id" Aeson..= ("e2" :: Text)
-                            , "value" Aeson..= (42 :: Int)
-                            ]
-                        , Aeson.object
-                            [ "type" Aeson..=
-                                ("replace_selected_text" :: Text)
-                            , "element_id" Aeson..= ("e3" :: Text)
-                            , "text" Aeson..= ("hello" :: Text)
-                            ]
-                        ]
-                    , "include_screenshot" Aeson..= False
-                    ]]
 
     it "returns an image only when explicitly requested" do
         requests <- newIORef []
@@ -228,9 +222,9 @@ spec = describe "native AX-first computer bridge" do
         withHost (recordingCallback "image" requests closes) \host -> do
             Right session <- newComputerSession host
             withoutImage <- invokeComputerSessionRequest session
-                "{\"operation\":\"observe\",\"include_screenshot\":false}"
+                (ObserveComputerTarget False)
             withImage <- invokeComputerSessionRequest session
-                "{\"operation\":\"observe\",\"include_screenshot\":true}"
+                (ObserveComputerTarget True)
             fmap (.nativeComputerImage) withoutImage `shouldBe` Right Nothing
             case fmap (.nativeComputerImage) withImage of
                 Right (Just image) ->
@@ -249,7 +243,7 @@ spec = describe "native AX-first computer bridge" do
             \host -> do
                 Right session <- newComputerSession host
                 result <- invokeComputerSessionRequest session
-                    "{\"operation\":\"observe\",\"include_screenshot\":true}"
+                    (ObserveComputerTarget True)
                 result `shouldBe`
                     Left "The native computer host returned malformed PNG data."
                 closeComputerSession session
@@ -261,7 +255,7 @@ spec = describe "native AX-first computer bridge" do
             \host -> do
                 Right session <- newComputerSession host
                 result <- invokeComputerSessionRequest session
-                    "{\"operation\":\"observe\",\"include_screenshot\":true}"
+                    (ObserveComputerTarget True)
                 result `shouldBe`
                     Left "The native computer host returned malformed PNG data."
                 closeComputerSession session
@@ -273,7 +267,7 @@ spec = describe "native AX-first computer bridge" do
             \host -> do
                 Right session <- newComputerSession host
                 result <- invokeComputerSessionRequest session
-                    "{\"operation\":\"observe\",\"include_screenshot\":true}"
+                    (ObserveComputerTarget True)
                 result `shouldBe`
                     Left "The native computer host returned malformed PNG data."
                 closeComputerSession session
@@ -285,7 +279,7 @@ spec = describe "native AX-first computer bridge" do
             \host -> do
                 Right session <- newComputerSession host
                 result <- invokeComputerSessionRequest session
-                    "{\"operation\":\"observe\",\"include_screenshot\":true}"
+                    (ObserveComputerTarget True)
                 result `shouldBe`
                     Left "The native computer host returned malformed JPEG data."
                 closeComputerSession session
@@ -297,7 +291,7 @@ spec = describe "native AX-first computer bridge" do
             \host -> do
                 Right session <- newComputerSession host
                 result <- invokeComputerSessionRequest session
-                    "{\"operation\":\"observe\",\"include_screenshot\":false}"
+                    (ObserveComputerTarget False)
                 result `shouldBe`
                     Left
                         "The native computer host embedded screenshot data in result JSON."
@@ -307,7 +301,7 @@ spec = describe "native AX-first computer bridge" do
         withHost (fixedCallback "{\"ok\":true}" Nothing True) \host -> do
             Right session <- newComputerSession host
             result <- invokeComputerSessionRequest session
-                "{\"operation\":\"observe\",\"include_screenshot\":false}"
+                (ObserveComputerTarget False)
             result `shouldBe`
                 Left
                     "The native computer host reported image output beyond its buffer."
@@ -328,9 +322,9 @@ spec = describe "native AX-first computer bridge" do
                 (Just (ComputerRegistration new nullPtr))
             Right newSession <- newComputerSession host
             oldResult <- invokeComputerSessionRequest oldSession
-                "{\"operation\":\"list_targets\",\"include_screenshot\":false}"
+                ListComputerTargets
             newResult <- invokeComputerSessionRequest newSession
-                "{\"operation\":\"list_targets\",\"include_screenshot\":false}"
+                ListComputerTargets
             resultHost oldResult `shouldBe` Just "old"
             resultHost newResult `shouldBe` Just "new"
             closeComputerSession oldSession
@@ -355,9 +349,9 @@ spec = describe "native AX-first computer bridge" do
             Right second <- newComputerSession host
             outcome <- concurrently
                 (invokeComputerSessionRequest first
-                    "{\"operation\":\"observe\",\"include_screenshot\":false}")
+                    (ObserveComputerTarget False))
                 (invokeComputerSessionRequest second
-                    "{\"operation\":\"observe\",\"include_screenshot\":false}")
+                    (ObserveComputerTarget False))
             fst outcome `shouldSatisfy` isRight
             snd outcome `shouldSatisfy` isRight
             readIORef maximumActive `shouldReturn` 2
@@ -378,9 +372,8 @@ spec = describe "native AX-first computer bridge" do
             accessibilityKind third `shouldBe` Just "full"
             closeComputerSession session
 
-observeRequest :: BS.ByteString
-observeRequest =
-    "{\"operation\":\"observe\",\"include_screenshot\":false}"
+observeRequest :: SemanticComputerRequest
+observeRequest = ObserveComputerTarget False
 
 runTool :: AppTool -> ToolCall -> IO ToolDispatchOutcome
 runTool tool =
@@ -673,7 +666,7 @@ expectedComputerParameters = strictObjectSchema
         , "enum" Aeson..=
             (["list_targets", "bind", "observe", "act"] :: [Text])
         ])
-    , ("target_id", nullableStringSchema)
+    , ("target_id", nullableStringSchema 1024)
     , ("actions", Aeson.object
         [ "type" Aeson..= (["array", "null"] :: [Text])
         , "minItems" Aeson..= (1 :: Int)
@@ -688,14 +681,14 @@ expectedComputerParameters = strictObjectSchema
                       ] :: [Text]
                     )
                 ])
-            , ("element_id", Aeson.object
-                ["type" Aeson..= ("string" :: Text)])
-            , ("action", nullableStringSchema)
+            , ("element_id", boundedStringSchema False 1024)
+            , ("action", nullableStringSchema 1024)
             , ("value", Aeson.object
                 [ "type" Aeson..=
                     (["string", "number", "boolean", "null"] :: [Text])
+                , "maxLength" Aeson..= (65536 :: Int)
                 ])
-            , ("text", nullableStringSchema)
+            , ("text", nullableStringSchema 65536)
             ]
             ["type", "element_id", "action", "value", "text"]
         ])
@@ -719,6 +712,15 @@ strictObjectSchema properties requiredFields = Aeson.object
     , "required" Aeson..= requiredFields
     ]
 
-nullableStringSchema :: Aeson.Value
-nullableStringSchema =
-    Aeson.object ["type" Aeson..= (["string", "null"] :: [Text])]
+nullableStringSchema :: Int -> Aeson.Value
+nullableStringSchema maximumLength = Aeson.object
+    [ "type" Aeson..= (["string", "null"] :: [Text])
+    , "maxLength" Aeson..= maximumLength
+    ]
+
+boundedStringSchema :: Bool -> Int -> Aeson.Value
+boundedStringSchema allowEmpty maximumLength = Aeson.object $
+    [ "type" Aeson..= ("string" :: Text)
+    , "maxLength" Aeson..= maximumLength
+    ]
+    <> [ "minLength" Aeson..= (1 :: Int) | not allowEmpty ]

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
@@ -23,6 +23,7 @@ import Agent.CLI.MacOS.ComputerBridge
     , invokeComputerSessionTransaction
     , invokeComputerTransaction
     , newComputerSession
+    , resetComputerSessionAccessibility
     )
 import Agent.Loop (ImageAttachment(..))
 import Agent.Responses.Types
@@ -222,6 +223,39 @@ spec = describe "native computer bridge" do
                   ) -> pure ()
                 values -> expectationFailure
                     ("unexpected accessibility observations: " <> show values)
+
+    it "resets accessibility to a full snapshot without discarding the display lease" do
+        observed <- newIORef []
+        withComputerHost (accessibilityComputerCallback observed) \host -> do
+            session <- newComputerSession
+            first <- invokeComputerSessionTransaction
+                host session ScreenshotPng [] (const (Right ()))
+            second <- invokeComputerSessionTransaction
+                host session ScreenshotPng [] (const (Right ()))
+            resetComputerSessionAccessibility session
+            third <- invokeComputerSessionTransaction
+                host session ScreenshotPng
+                [ClickAction 10 20 "left" []]
+                (const (Right ()))
+            case (first, second, third) of
+                ( Right ComputerObservation
+                    { computerObservationAccessibility =
+                        Just (AccessibilityFull 1 _)
+                    }
+                  , Right ComputerObservation
+                    { computerObservationAccessibility =
+                        Just (AccessibilityDelta 1 2 [])
+                    }
+                  , Right ComputerObservation
+                    { computerObservationAccessibility =
+                        Just (AccessibilityFull 1 _)
+                    }
+                  ) -> pure ()
+                values -> expectationFailure
+                    ("unexpected reset accessibility observations: " <> show values)
+            invocations <- readIORef observed
+            map observedOperationAndToken invocations `shouldBe`
+                [(1, 0), (2, 41), (1, 0), (2, 41), (2, 42)]
 
     it "keeps a valid screenshot when accessibility JSON is malformed" do
         observed <- newIORef []

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/ComputerBridgeSpec.hs
@@ -2,48 +2,61 @@
 
 module Agent.CLI.MacOS.ComputerBridgeSpec (spec) where
 
-import Agent.CLI.ComputerUse
-    ( ComputerObservation(..)
-    , ScreenshotEncoding(..)
-    , computerUseTool
-    )
 import Agent.CLI.ComputerUse.Accessibility
     ( AccessibilityObservation(..)
     )
-import Agent.CLI.MacOS.Bridge (composeNativeTools)
 import Agent.CLI.MacOS.ComputerBridge
-    ( CComputerAction(..)
-    , CComputerPoint(..)
-    , ComputerBatch(..)
-    , ComputerCallback
-    , ComputerHost(..)
+    ( ComputerCallback
+    , ComputerHost
     , ComputerRegistration(..)
-    , computerActionStructSize
-    , encodeComputerActions
-    , invokeComputerSessionTransaction
-    , invokeComputerTransaction
+    , NativeComputerResult(..)
+    , closeComputerSession
+    , computerToolSessionWhenEnabled
+    , invokeComputerSessionRequest
+    , newComputerHost
     , newComputerSession
+    , replaceComputerRegistration
     , resetComputerSessionAccessibility
     )
-import Agent.Loop (ImageAttachment(..))
-import Agent.Responses.Types
-    ( ComputerAction(..)
-    , ComputerPoint(..)
+import Agent.ToolDispatch
+    ( ToolCall(..)
+    , ToolCallKind(..)
+    , ToolDispatchConfig(..)
+    , ToolDispatchOutcome(..)
+    , ToolResultImage(..)
+    , dispatchToolHandlerDetailed
+    , toolCallResultImages
     )
-import Agent.Tools.Types (AppTool(..), AppToolGroup(..))
-import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (poll, wait, withAsync)
+import Agent.Tools.Types
+    ( AppTool(..)
+    , ApprovalRule(..)
+    , ToolExecutionPolicy(..)
+    , ToolSchema(..)
+    )
+import Control.Concurrent.Async (concurrently)
 import Control.Concurrent.MVar
-    ( modifyMVar_
+    ( MVar
     , newEmptyMVar
-    , newMVar
     , putMVar
     , takeMVar
     )
 import Control.Exception.Safe (bracket)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
-import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
-import Data.Word (Word8, Word32, Word64)
+import Data.Either (isRight)
+import Data.IORef
+    ( IORef
+    , atomicModifyIORef'
+    , modifyIORef'
+    , newIORef
+    , readIORef
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word8)
 import Foreign
     ( FunPtr
     , Ptr
@@ -51,11 +64,9 @@ import Foreign
     , copyBytes
     , freeHaskellFunPtr
     , nullPtr
-    , peekArray
     , poke
     )
 import Foreign.C.Types (CInt(..), CSize(..))
-import Foreign.Storable (Storable, sizeOf)
 import Test.Hspec
     ( Spec
     , describe
@@ -63,6 +74,7 @@ import Test.Hspec
     , it
     , shouldBe
     , shouldReturn
+    , shouldSatisfy
     )
 
 foreign import ccall "ha_computer_callback_abi_smoke"
@@ -72,391 +84,510 @@ foreign import ccall "wrapper"
     wrapComputerCallback :: ComputerCallback -> IO (FunPtr ComputerCallback)
 
 spec :: Spec
-spec = describe "native computer bridge" do
-    it "keeps the Haskell records aligned with the versioned C ABI" do
-        sizeOf (undefined :: CComputerPoint) `shouldBe` 8
-        sizeOf (undefined :: CComputerAction) `shouldBe` 64
-        computerActionStructSize `shouldBe` 64
+spec = describe "native AX-first computer bridge" do
+    it "matches the authoritative v3 C ABI" do
         computerCallbackABISmoke `shouldReturn` 0
 
-    it "encodes UTF-8, drag ranges, buttons, and modifier masks" do
-        let result = encodeComputerActions
-                [ ClickAction 10 20 "back" ["shift", "fn"]
-                , TypeAction "hé"
-                , DragAction
-                    [ComputerPoint 1 2, ComputerPoint 3 4]
-                    ["cmd"]
-                , KeypressAction ["ctrl", "A"]
-                , WaitAction
-                ]
-        case result of
-            Left err -> fail (show err)
-            Right batch -> do
-                batch.computerBatchText `shouldBe`
-                    BS.pack [104, 195, 169, 65]
-                batch.computerBatchPoints `shouldBe`
-                    [CComputerPoint 1 2, CComputerPoint 3 4]
-                case batch.computerBatchActions of
-                    [click, typed, drag, keypress, waited] -> do
-                        ( click.cComputerAction
-                            , click.cComputerX
-                            , click.cComputerY
-                            , click.cComputerButton
-                            , click.cComputerModifiers
-                            ) `shouldBe` (1, 10, 20, 4, 17)
-                        ( typed.cComputerAction
-                            , typed.cComputerTextOffset
-                            , typed.cComputerTextLength
-                            ) `shouldBe` (6, 0, 3)
-                        ( drag.cComputerAction
-                            , drag.cComputerPointOffset
-                            , drag.cComputerPointCount
-                            , drag.cComputerModifiers
-                            ) `shouldBe` (5, 0, 2, 8)
-                        ( keypress.cComputerAction
-                            , keypress.cComputerTextOffset
-                            , keypress.cComputerTextLength
-                            , keypress.cComputerModifiers
-                            ) `shouldBe` (7, 3, 1, 2)
-                        waited.cComputerAction `shouldBe` 8
-                    actions -> fail ("unexpected actions: " <> show actions)
-
-    it "never sends screenshot markers through the native action ABI" do
-        encodeComputerActions [ScreenshotAction] `shouldBe`
-            Left "Computer screenshot must not cross the native action ABI."
-
-    it "round-trips the display lease and typed batch through the callback" do
-        observed <- newIORef []
-        withComputerHost (recordingComputerCallback observed) \host -> do
-            result <- invokeComputerTransaction
-                host
-                ScreenshotPng
-                [ ClickAction 10 20 "left" ["shift"]
-                , TypeAction "λ"
-                , DragAction
-                    [ComputerPoint 1 2, ComputerPoint 3 4]
-                    ["cmd"]
-                ]
-                (\dimensions ->
-                    if dimensions == (100, 80)
-                        then Right ()
-                        else Left "unexpected dimensions")
-            result `shouldBe` Right
-                (ComputerObservation
-                    (ImageAttachment "image/png" pngSignature)
-                    (Just (AccessibilityUnavailable 1
-                        "Native accessibility snapshot unavailable.")))
-            readIORef observed `shouldReturn`
-                [ ObservedComputerInvocation
-                    2 1 0 0 0 [] [] BS.empty 0 65536 0
-                , ObservedComputerInvocation
-                    2 2 41 100 80
-                    [ (plainObservedAction 1)
-                        { cComputerX = 10
-                        , cComputerY = 20
-                        , cComputerButton = 1
-                        , cComputerModifiers = 1
-                        }
-                    , (plainObservedAction 6)
-                        { cComputerTextLength = 2
-                        }
-                    , (plainObservedAction 5)
-                        { cComputerModifiers = 8
-                        , cComputerPointCount = 2
-                        }
+    it "publishes only semantic operations and defaults screenshots off" do
+        requests <- newIORef []
+        closes <- newIORef 0
+        withHost (recordingCallback "current" requests closes) \host -> do
+            computerToolSessionWhenEnabled host >>= \case
+                Left err -> expectationFailure (Text.unpack err)
+                Right Nothing -> expectationFailure "native computer tool was disabled"
+                Right (Just (tool, _, close)) -> do
+                    case tool.appToolSchema of
+                        HostedComputerFunctionSchema parameters -> do
+                            let serialized = Aeson.encode parameters
+                            Aeson.decode serialized `shouldBe` Just parameters
+                            parameters `shouldBe` expectedComputerParameters
+                        schema -> expectationFailure
+                            ("unexpected computer schema: " <> show schema)
+                    case tool.appToolApproval of
+                        AlwaysPrompt -> pure ()
+                        _ -> expectationFailure
+                            "native computer tool must always require approval"
+                    case tool.appToolExecution of
+                        TurnSequential -> pure ()
+                        _ -> expectationFailure
+                            "native computer tool must run sequentially"
+                    result <- runTool tool
+                        (ToolCall
+                            "call"
+                            "computer"
+                            ( "{\"operation\":\"observe\",\"target_id\":null,"
+                            <> "\"actions\":null,\"include_screenshot\":false}"
+                            )
+                            ComputerFunctionCallKind
+                            False)
+                    result.toolDispatchSucceeded `shouldBe` True
+                    toolCallResultImages result.toolDispatchResult `shouldBe` []
+                    semantic <- runTool tool
+                        (ToolCall
+                            "semantic"
+                            "computer"
+                            ( "{\"operation\":\"act\",\"target_id\":null,"
+                            <> "\"actions\":["
+                            <> "{\"type\":\"perform\",\"element_id\":\"e1\","
+                            <> "\"action\":\"AXPress\",\"value\":null,\"text\":null},"
+                            <> "{\"type\":\"set_value\",\"element_id\":\"e2\","
+                            <> "\"action\":null,\"value\":42,\"text\":null},"
+                            <> "{\"type\":\"replace_selected_text\","
+                            <> "\"element_id\":\"e3\",\"action\":null,\"value\":null,"
+                            <> "\"text\":\"hello\"}],\"include_screenshot\":false}"
+                            )
+                            ComputerFunctionCallKind
+                            False)
+                    semantic.toolDispatchSucceeded `shouldBe` True
+                    coordinates <- runTool tool
+                        (ToolCall
+                            "coordinates"
+                            "computer"
+                            ( "{\"operation\":\"act\",\"target_id\":null,"
+                                <> "\"actions\":["
+                                <> "{\"type\":\"perform\",\"element_id\":\"e1\","
+                                <> "\"action\":\"AXPress\",\"value\":null,"
+                                <> "\"text\":null,\"x\":20,\"y\":30}],"
+                                <> "\"include_screenshot\":false}"
+                            )
+                            ComputerFunctionCallKind
+                            False)
+                    coordinates.toolDispatchSucceeded `shouldBe` False
+                    nullScreenshot <- runTool tool
+                        (ToolCall
+                            "null-screenshot"
+                            "computer"
+                            ( "{\"operation\":\"observe\",\"target_id\":null,"
+                            <> "\"actions\":null,\"include_screenshot\":null}"
+                            )
+                            ComputerFunctionCallKind
+                            False)
+                    nullScreenshot.toolDispatchSucceeded `shouldBe` False
+                    missingScreenshot <- runTool tool
+                        (ToolCall
+                            "missing-screenshot"
+                            "computer"
+                            ( "{\"operation\":\"observe\",\"target_id\":null,"
+                            <> "\"actions\":null}"
+                            )
+                            ComputerFunctionCallKind
+                            False)
+                    missingScreenshot.toolDispatchSucceeded `shouldBe` False
+                    stringScreenshot <- runTool tool
+                        (ToolCall
+                            "string-screenshot"
+                            "computer"
+                            ( "{\"operation\":\"observe\",\"target_id\":null,"
+                            <> "\"actions\":null,\"include_screenshot\":\"false\"}"
+                            )
+                            ComputerFunctionCallKind
+                            False)
+                    stringScreenshot.toolDispatchSucceeded `shouldBe` False
+                    listScreenshot <- runTool tool
+                        (ToolCall
+                            "list-screenshot"
+                            "computer"
+                            ( "{\"operation\":\"list_targets\",\"target_id\":null,"
+                            <> "\"actions\":null,\"include_screenshot\":true}"
+                            )
+                            ComputerFunctionCallKind
+                            False)
+                    listScreenshot.toolDispatchSucceeded `shouldBe` False
+                    close
+            readIORef requests `shouldReturn`
+                [Aeson.object
+                    [ "operation" Aeson..= ("observe" :: Text)
+                    , "include_screenshot" Aeson..= False
                     ]
-                    [CComputerPoint 1 2, CComputerPoint 3 4]
-                    (BS.pack [206, 187])
-                    1
-                    16777216
-                    524288
-                ]
+                , Aeson.object
+                    [ "operation" Aeson..= ("act" :: Text)
+                    , "actions" Aeson..=
+                        [ Aeson.object
+                            [ "type" Aeson..= ("perform" :: Text)
+                            , "element_id" Aeson..= ("e1" :: Text)
+                            , "action" Aeson..= ("AXPress" :: Text)
+                            ]
+                        , Aeson.object
+                            [ "type" Aeson..= ("set_value" :: Text)
+                            , "element_id" Aeson..= ("e2" :: Text)
+                            , "value" Aeson..= (42 :: Int)
+                            ]
+                        , Aeson.object
+                            [ "type" Aeson..=
+                                ("replace_selected_text" :: Text)
+                            , "element_id" Aeson..= ("e3" :: Text)
+                            , "text" Aeson..= ("hello" :: Text)
+                            ]
+                        ]
+                    , "include_screenshot" Aeson..= False
+                    ]]
 
-    it "executes later actions against the lease from the model's screenshot" do
-        observed <- newIORef []
-        withComputerHost (recordingComputerCallback observed) \host -> do
-            session <- newComputerSession
-            invokeComputerSessionTransaction
-                host session ScreenshotPng
-                [ClickAction 10 20 "left" []]
-                (const (Right ()))
-                `shouldReturn` Left
-                    "Take a fresh computer screenshot before sending input actions."
-            readIORef observed `shouldReturn` []
-            invokeComputerSessionTransaction
-                host session ScreenshotPng [] (const (Right ()))
-                `shouldReturn` Right
-                    (ComputerObservation
-                        (ImageAttachment "image/png" pngSignature)
-                        (Just (AccessibilityUnavailable 1
-                            "Native accessibility snapshot unavailable.")))
-            invokeComputerSessionTransaction
-                host session ScreenshotPng
-                [ClickAction 10 20 "left" []]
-                (const (Right ()))
-                `shouldReturn` Right
-                    (ComputerObservation
-                        (ImageAttachment "image/png" pngSignature)
-                        (Just (AccessibilityUnavailable 2
-                            "Native accessibility snapshot unavailable.")))
-            invocations <- readIORef observed
-            map observedOperationAndToken invocations `shouldBe`
-                [(1, 0), (2, 41), (2, 42)]
+    it "returns an image only when explicitly requested" do
+        requests <- newIORef []
+        closes <- newIORef 0
+        withHost (recordingCallback "image" requests closes) \host -> do
+            Right session <- newComputerSession host
+            withoutImage <- invokeComputerSessionRequest session
+                "{\"operation\":\"observe\",\"include_screenshot\":false}"
+            withImage <- invokeComputerSessionRequest session
+                "{\"operation\":\"observe\",\"include_screenshot\":true}"
+            fmap (.nativeComputerImage) withoutImage `shouldBe` Right Nothing
+            case fmap (.nativeComputerImage) withImage of
+                Right (Just image) ->
+                    Text.isPrefixOf "data:image/png;base64,"
+                        image.imageUrl `shouldBe` True
+                value -> expectationFailure
+                    ("unexpected screenshot result: " <> show value)
+            closeComputerSession session
 
-    it "emits a full accessibility snapshot followed by an empty delta" do
-        observed <- newIORef []
-        withComputerHost (accessibilityComputerCallback observed) \host -> do
-            session <- newComputerSession
-            first <- invokeComputerSessionTransaction
-                host session ScreenshotPng [] (const (Right ()))
-            second <- invokeComputerSessionTransaction
-                host session ScreenshotPng [] (const (Right ()))
-            case (first, second) of
-                ( Right ComputerObservation
-                    { computerObservationAccessibility =
-                        Just (AccessibilityFull 1 _)
-                    }
-                  , Right ComputerObservation
-                    { computerObservationAccessibility =
-                        Just (AccessibilityDelta 1 2 [])
-                    }
-                  ) -> pure ()
-                values -> expectationFailure
-                    ("unexpected accessibility observations: " <> show values)
-
-    it "resets accessibility to a full snapshot without discarding the display lease" do
-        observed <- newIORef []
-        withComputerHost (accessibilityComputerCallback observed) \host -> do
-            session <- newComputerSession
-            first <- invokeComputerSessionTransaction
-                host session ScreenshotPng [] (const (Right ()))
-            second <- invokeComputerSessionTransaction
-                host session ScreenshotPng [] (const (Right ()))
-            resetComputerSessionAccessibility session
-            third <- invokeComputerSessionTransaction
-                host session ScreenshotPng
-                [ClickAction 10 20 "left" []]
-                (const (Right ()))
-            case (first, second, third) of
-                ( Right ComputerObservation
-                    { computerObservationAccessibility =
-                        Just (AccessibilityFull 1 _)
-                    }
-                  , Right ComputerObservation
-                    { computerObservationAccessibility =
-                        Just (AccessibilityDelta 1 2 [])
-                    }
-                  , Right ComputerObservation
-                    { computerObservationAccessibility =
-                        Just (AccessibilityFull 1 _)
-                    }
-                  ) -> pure ()
-                values -> expectationFailure
-                    ("unexpected reset accessibility observations: " <> show values)
-            invocations <- readIORef observed
-            map observedOperationAndToken invocations `shouldBe`
-                [(1, 0), (2, 41), (1, 0), (2, 41), (2, 42)]
-
-    it "keeps a valid screenshot when accessibility JSON is malformed" do
-        observed <- newIORef []
-        withComputerHost
-            (accessibilityComputerCallbackWith "{" observed)
+    it "rejects malformed screenshots and embedded image data" do
+        withHost
+            (fixedCallback
+                "{\"ok\":true}"
+                (Just pngSignature)
+                False)
             \host -> do
-                session <- newComputerSession
-                result <- invokeComputerSessionTransaction
-                    host session ScreenshotPng [] (const (Right ()))
-                case result of
-                    Right ComputerObservation
-                        { computerObservationImage =
-                            ImageAttachment "image/png" bytes
-                        , computerObservationAccessibility =
-                            Just (AccessibilityUnavailable 1 _)
-                        } ->
-                            bytes `shouldBe` pngSignature
-                    value -> expectationFailure
-                        ("unexpected malformed accessibility result: " <> show value)
+                Right session <- newComputerSession host
+                result <- invokeComputerSessionRequest session
+                    "{\"operation\":\"observe\",\"include_screenshot\":true}"
+                result `shouldBe`
+                    Left "The native computer host returned malformed PNG data."
+                closeComputerSession session
+        withHost
+            (fixedCallback
+                "{\"ok\":true}"
+                (Just corruptPngCrc)
+                False)
+            \host -> do
+                Right session <- newComputerSession host
+                result <- invokeComputerSessionRequest session
+                    "{\"operation\":\"observe\",\"include_screenshot\":true}"
+                result `shouldBe`
+                    Left "The native computer host returned malformed PNG data."
+                closeComputerSession session
+        withHost
+            (fixedCallback
+                "{\"ok\":true}"
+                (Just corruptPngImageData)
+                False)
+            \host -> do
+                Right session <- newComputerSession host
+                result <- invokeComputerSessionRequest session
+                    "{\"operation\":\"observe\",\"include_screenshot\":true}"
+                result `shouldBe`
+                    Left "The native computer host returned malformed PNG data."
+                closeComputerSession session
+        withHost
+            (fixedImageCallback
+                "{\"ok\":true}"
+                (Just (2, invalidJpeg))
+                False)
+            \host -> do
+                Right session <- newComputerSession host
+                result <- invokeComputerSessionRequest session
+                    "{\"operation\":\"observe\",\"include_screenshot\":true}"
+                result `shouldBe`
+                    Left "The native computer host returned malformed JPEG data."
+                closeComputerSession session
+        withHost
+            (fixedCallback
+                "{\"nested\":{\"preview\":\"DATA:IMAGE/png;base64,secret\"}}"
+                Nothing
+                False)
+            \host -> do
+                Right session <- newComputerSession host
+                result <- invokeComputerSessionRequest session
+                    "{\"operation\":\"observe\",\"include_screenshot\":false}"
+                result `shouldBe`
+                    Left
+                        "The native computer host embedded screenshot data in result JSON."
+                closeComputerSession session
 
-    it "waits for an in-flight transaction before disabling its callback" do
-        runEntered <- newEmptyMVar
-        releaseRun <- newEmptyMVar
-        observed <- newIORef []
-        let blockingCallback context abi operation token width height
-                actions actionCount points pointCount text textLength
-                imageFormat output outputCapacity outputLength
-                accessibilityOutput accessibilityCapacity accessibilityLength
-                outputToken
-                outputWidth outputHeight outputImageFormat = do
-                    if operation == 2
-                        then putMVar runEntered () >> takeMVar releaseRun
-                        else pure ()
-                    recordingComputerCallback observed
-                        context abi operation token width height
-                        actions actionCount points pointCount text textLength
-                        imageFormat output outputCapacity outputLength
-                        accessibilityOutput accessibilityCapacity
-                        accessibilityLength outputToken outputWidth outputHeight
-                        outputImageFormat
-        withCallback blockingCallback \callback -> do
-            registration <- newMVar
-                (Just (ComputerRegistration callback nullPtr))
-            let host = ComputerHost registration
-            withAsync
-                (invokeComputerTransaction
-                    host
-                    ScreenshotPng
-                    []
-                    (const (Right ())))
-                \running -> do
-                    takeMVar runEntered
-                    withAsync
-                        (modifyMVar_ registration (const (pure Nothing)))
-                        \disabling -> do
-                            threadDelay 20000
-                            poll disabling >>= \case
-                                Nothing -> pure ()
-                                Just _ -> expectationFailure
-                                    "callback disabled during a transaction"
-                            putMVar releaseRun ()
-                            wait running `shouldReturn` Right
-                                (ComputerObservation
-                                    (ImageAttachment "image/png" pngSignature)
-                                    (Just (AccessibilityUnavailable 1
-                                        "Native accessibility snapshot unavailable.")))
-                            wait disabling
-            invokeComputerTransaction host ScreenshotPng [] (const (Right ()))
-                `shouldReturn` Left "Native computer control is not active."
+    it "rejects image lengths reported without an allocated image buffer" do
+        withHost (fixedCallback "{\"ok\":true}" Nothing True) \host -> do
+            Right session <- newComputerSession host
+            result <- invokeComputerSessionRequest session
+                "{\"operation\":\"observe\",\"include_screenshot\":false}"
+            result `shouldBe`
+                Left
+                    "The native computer host reported image output beyond its buffer."
+            closeComputerSession session
 
-    it "replaces the generic computer tool once without enabling it" do
-        let genericComputer = computerUseTool
-            nativeComputer = genericComputer
-                { appToolDescription = "native computer"
-                }
-            otherTool = genericComputer
-                { appToolName = "other"
-                }
-            names tools = map (\tool -> tool.appToolName) tools
-            descriptions tools =
-                map (\tool -> tool.appToolDescription) tools
-        names (composeNativeTools
-            (Just nativeComputer)
-            [ ExecutionToolGroup [genericComputer, otherTool]
-            , HostToolGroup [genericComputer]
-            ]) `shouldBe` ["computer", "other"]
-        descriptions (composeNativeTools
-            (Just nativeComputer)
-            [ExecutionToolGroup [genericComputer]]) `shouldBe`
-                ["native computer"]
-        names (composeNativeTools
-            (Just nativeComputer)
-            [ExecutionToolGroup [otherTool]]) `shouldBe` ["other"]
-        names (composeNativeTools
-            Nothing
-            [ ExecutionToolGroup [genericComputer, otherTool]
-            , HostToolGroup [genericComputer]
-            ]) `shouldBe` ["computer", "other", "computer"]
+    it "keeps old generations alive while replacements serve new sessions" do
+        oldRequests <- newIORef []
+        newRequests <- newIORef []
+        oldCloses <- newIORef 0
+        newCloses <- newIORef 0
+        withCallback (recordingCallback "old" oldRequests oldCloses) \old -> do
+          withCallback (recordingCallback "new" newRequests newCloses) \new -> do
+            host <- newComputerHost
+            replaceComputerRegistration host
+                (Just (ComputerRegistration old nullPtr))
+            Right oldSession <- newComputerSession host
+            replaceComputerRegistration host
+                (Just (ComputerRegistration new nullPtr))
+            Right newSession <- newComputerSession host
+            oldResult <- invokeComputerSessionRequest oldSession
+                "{\"operation\":\"list_targets\",\"include_screenshot\":false}"
+            newResult <- invokeComputerSessionRequest newSession
+                "{\"operation\":\"list_targets\",\"include_screenshot\":false}"
+            resultHost oldResult `shouldBe` Just "old"
+            resultHost newResult `shouldBe` Just "new"
+            closeComputerSession oldSession
+            closeComputerSession oldSession
+            closeComputerSession newSession
+            readIORef oldCloses `shouldReturn` 1
+            readIORef newCloses `shouldReturn` 1
 
-data ObservedComputerInvocation = ObservedComputerInvocation
-    !Word32
-    !CInt
-    !Word64
-    !CInt
-    !CInt
-    ![CComputerAction]
-    ![CComputerPoint]
-    !BS.ByteString
-    !CInt
-    !CSize
-    !CSize
-    deriving (Eq, Show)
+    it "propagates native OPEN failures instead of disabling the tool" do
+        withHost openFailureCallback \host ->
+            computerToolSessionWhenEnabled host >>= \case
+                Left err -> err `shouldBe` "Accessibility permission is required."
+                Right _ -> expectationFailure "OPEN failure was silently ignored"
 
-recordingComputerCallback
-    :: IORef [ObservedComputerInvocation]
+    it "serializes calls per session but permits distinct sessions to overlap" do
+        release <- newEmptyMVar
+        active <- newIORef (0 :: Int)
+        maximumActive <- newIORef (0 :: Int)
+        let callback = blockingCallback release active maximumActive
+        withHost callback \host -> do
+            Right first <- newComputerSession host
+            Right second <- newComputerSession host
+            outcome <- concurrently
+                (invokeComputerSessionRequest first
+                    "{\"operation\":\"observe\",\"include_screenshot\":false}")
+                (invokeComputerSessionRequest second
+                    "{\"operation\":\"observe\",\"include_screenshot\":false}")
+            fst outcome `shouldSatisfy` isRight
+            snd outcome `shouldSatisfy` isRight
+            readIORef maximumActive `shouldReturn` 2
+            closeComputerSession first
+            closeComputerSession second
+
+    it "resets only accessibility delta history for a live session" do
+        requests <- newIORef []
+        closes <- newIORef 0
+        withHost (recordingCallback "ax" requests closes) \host -> do
+            Right session <- newComputerSession host
+            first <- invokeComputerSessionRequest session observeRequest
+            second <- invokeComputerSessionRequest session observeRequest
+            resetComputerSessionAccessibility session
+            third <- invokeComputerSessionRequest session observeRequest
+            accessibilityKind first `shouldBe` Just "full"
+            accessibilityKind second `shouldBe` Just "delta"
+            accessibilityKind third `shouldBe` Just "full"
+            closeComputerSession session
+
+observeRequest :: BS.ByteString
+observeRequest =
+    "{\"operation\":\"observe\",\"include_screenshot\":false}"
+
+runTool :: AppTool -> ToolCall -> IO ToolDispatchOutcome
+runTool tool =
+    dispatchToolHandlerDetailed
+        ToolDispatchConfig
+            { toolDispatchUnknownTool = ("unknown tool: " <>)
+            , toolDispatchFormatResult = either id id
+            , toolDispatchFormatException = \_ exception ->
+                Text.pack (show exception)
+            , toolDispatchOnException = \_ _ -> pure ()
+            , toolDispatchOnOutput = \_ _ -> pure ()
+            , toolDispatchFinalizeOutput = \_ output -> pure output
+            }
+        (Just tool.appToolHandler)
+
+accessibilityKind
+    :: Either Text NativeComputerResult
+    -> Maybe Text
+accessibilityKind (Right result) =
+    case result.nativeComputerAccessibility of
+        Just AccessibilityFull{} -> Just "full"
+        Just AccessibilityDelta{} -> Just "delta"
+        Just AccessibilityUnavailable{} -> Just "unavailable"
+        Nothing -> Nothing
+accessibilityKind _ = Nothing
+
+resultHost :: Either Text NativeComputerResult -> Maybe Text
+resultHost (Right result) =
+    case result.nativeComputerResultValue of
+        Aeson.Object object ->
+            case KeyMap.lookup "host" object of
+                Just (Aeson.String value) -> Just value
+                _ -> Nothing
+        _ -> Nothing
+resultHost _ = Nothing
+
+recordingCallback
+    :: Text
+    -> IORef [Aeson.Value]
+    -> IORef Int
     -> ComputerCallback
-recordingComputerCallback observed _ abi operation token width height
-        actions actionCount points pointCount text textLength imageFormat
-        output outputCapacity outputLength _accessibilityOutput
-        accessibilityCapacity accessibilityLength outputToken outputWidth
-        outputHeight outputImageFormat = do
-    decodedActions <- peekValues actions actionCount
-    decodedPoints <- peekValues points pointCount
-    decodedText <- peekBytes text textLength
-    modifyIORef' observed (<> [ObservedComputerInvocation
-        abi operation token width height decodedActions decodedPoints
-        decodedText imageFormat outputCapacity accessibilityCapacity])
-    case operation of
-        1 -> do
-            poke outputLength 0
-            poke accessibilityLength 0
-            poke outputToken 41
-            poke outputWidth 100
-            poke outputHeight 80
-            poke outputImageFormat 0
-            pure 0
-        2 -> do
-            status <- writeBytes pngSignature
-                output outputCapacity outputLength
-            poke accessibilityLength 0
-            poke outputToken (token + 1)
-            poke outputWidth 100
-            poke outputHeight 80
-            poke outputImageFormat 1
-            pure status
-        _ -> pure 1
-
-accessibilityComputerCallback
-    :: IORef [ObservedComputerInvocation]
-    -> ComputerCallback
-accessibilityComputerCallback =
-    accessibilityComputerCallbackWith accessibilitySnapshotBytes
-
-accessibilityComputerCallbackWith
-    :: BS.ByteString
-    -> IORef [ObservedComputerInvocation]
-    -> ComputerCallback
-accessibilityComputerCallbackWith accessibilityBytes observed
-        context abi operation token width height
-        actions actionCount points pointCount text textLength imageFormat
-        output outputCapacity outputLength accessibilityOutput
-        accessibilityCapacity accessibilityLength outputToken outputWidth
-        outputHeight outputImageFormat = do
-    status <- recordingComputerCallback observed context abi operation token
-        width height actions actionCount points pointCount text textLength
-        imageFormat output outputCapacity outputLength accessibilityOutput
-        accessibilityCapacity accessibilityLength outputToken outputWidth
-        outputHeight outputImageFormat
-    if status == 0 && operation == 2
-        then writeBytes accessibilityBytes
-            accessibilityOutput accessibilityCapacity accessibilityLength
-        else pure status
-
-peekValues :: Storable value => Ptr value -> CSize -> IO [value]
-peekValues _ (CSize 0) = pure []
-peekValues pointer (CSize count) =
-    peekArray (fromIntegral count) pointer
-
-peekBytes :: Ptr value -> CSize -> IO BS.ByteString
-peekBytes _ (CSize 0) = pure BS.empty
-peekBytes pointer (CSize length) =
-    BS.packCStringLen (castPtr pointer, fromIntegral length)
-
-writeBytes :: BS.ByteString -> Ptr Word8 -> CSize -> Ptr CSize -> IO CInt
-writeBytes bytes output (CSize capacity) outputLength
-    | BS.length bytes > fromIntegral capacity = pure 7
-    | otherwise = do
-        BS.useAsCStringLen bytes \(source, length) ->
-            copyBytes output (castPtr source) length
-        poke outputLength (fromIntegral (BS.length bytes))
+recordingCallback label requests closes _context abi operation _token
+        request requestLength result resultCapacity resultLength
+        accessibility accessibilityCapacity accessibilityLength
+        image imageCapacity imageLength _err _errorCapacity errorLength
+        outputToken outputImageFormat
+    | abi /= 3 = pure 1
+    | operation == 1 = do
+        poke outputToken 73
+        zeroLengths resultLength accessibilityLength imageLength errorLength
+        poke outputImageFormat 0
         pure 0
+    | operation == 5 = do
+        modifyIORef' closes (+ 1)
+        zeroLengths resultLength accessibilityLength imageLength errorLength
+        poke outputImageFormat 0
+        pure 0
+    | otherwise = do
+        requestBytes <- peekBytes request requestLength
+        case Aeson.decodeStrict' requestBytes of
+            Just value -> modifyIORef' requests (<> [value])
+            Nothing -> pure ()
+        resultStatus <- writeBytes
+            (TextEncoding.encodeUtf8
+                ("{\"host\":\"" <> label <> "\",\"ok\":true}"))
+            result
+            resultCapacity
+            resultLength
+        accessibilityStatus <-
+            if operation == 2
+                then poke accessibilityLength 0 >> pure 0
+                else writeBytes snapshotBytes accessibility
+                    accessibilityCapacity accessibilityLength
+        let wantsImage =
+                maybe False requestIncludesScreenshot
+                    (Aeson.decodeStrict' requestBytes)
+        imageStatus <-
+            if wantsImage
+                then do
+                    poke outputImageFormat 1
+                    writeBytes minimalPng image imageCapacity imageLength
+                else if image /= nullPtr || imageCapacity /= 0
+                    then pure 9
+                else do
+                    poke outputImageFormat 0
+                    poke imageLength 0
+                    pure 0
+        poke errorLength 0
+        pure (maximum [resultStatus, accessibilityStatus, imageStatus])
 
-withComputerHost
-    :: ComputerCallback
-    -> (ComputerHost -> IO value)
-    -> IO value
-withComputerHost callback action =
-    withCallback callback \funPtr -> do
-        registration <- newMVar
-            (Just (ComputerRegistration funPtr nullPtr))
-        action (ComputerHost registration)
+blockingCallback
+    :: MVar ()
+    -> IORef Int
+    -> IORef Int
+    -> ComputerCallback
+blockingCallback release active maximumActive _context abi operation
+        _token _request _requestLength result resultCapacity resultLength
+        accessibility accessibilityCapacity accessibilityLength
+        _image _imageCapacity imageLength _err _errorCapacity errorLength
+        outputToken outputImageFormat
+    | abi /= 3 = pure 1
+    | operation == 1 = do
+        poke outputToken 91
+        zeroLengths resultLength accessibilityLength imageLength errorLength
+        poke outputImageFormat 0
+        pure 0
+    | operation == 5 = do
+        zeroLengths resultLength accessibilityLength imageLength errorLength
+        poke outputImageFormat 0
+        pure 0
+    | otherwise = do
+        now <- atomicModifyIORef' active \value ->
+            let next = value + 1 in (next, next)
+        atomicModifyIORef' maximumActive \value -> (max value now, ())
+        if now == 1
+            then takeMVar release
+            else putMVar release ()
+        atomicModifyIORef' active \value -> (value - 1, ())
+        resultStatus <- writeBytes "{\"ok\":true}"
+            result resultCapacity resultLength
+        accessibilityStatus <- writeBytes snapshotBytes accessibility
+            accessibilityCapacity accessibilityLength
+        poke imageLength 0
+        poke errorLength 0
+        poke outputImageFormat 0
+        pure (max resultStatus accessibilityStatus)
+
+requestIncludesScreenshot :: Aeson.Value -> Bool
+requestIncludesScreenshot (Aeson.Object object) =
+    KeyMap.lookup "include_screenshot" object == Just (Aeson.Bool True)
+requestIncludesScreenshot _ = False
+
+fixedCallback
+    :: BS.ByteString
+    -> Maybe BS.ByteString
+    -> Bool
+    -> ComputerCallback
+fixedCallback resultBytes imageBytes =
+    fixedImageCallback
+        resultBytes
+        (fmap (\bytes -> (1, bytes)) imageBytes)
+
+fixedImageCallback
+    :: BS.ByteString
+    -> Maybe (CInt, BS.ByteString)
+    -> Bool
+    -> ComputerCallback
+fixedImageCallback resultBytes imageBytes reportImageWithoutBuffer
+        _context abi operation _token _request _requestLength
+        result resultCapacity resultLength
+        accessibility accessibilityCapacity accessibilityLength
+        image imageCapacity imageLength
+        _err _errorCapacity errorLength outputToken outputImageFormat
+    | abi /= 3 = pure 1
+    | operation == 1 = do
+        poke outputToken 101
+        zeroLengths resultLength accessibilityLength imageLength errorLength
+        poke outputImageFormat 0
+        pure 0
+    | operation == 5 = do
+        zeroLengths resultLength accessibilityLength imageLength errorLength
+        poke outputImageFormat 0
+        pure 0
+    | otherwise = do
+        resultStatus <-
+            writeBytes resultBytes result resultCapacity resultLength
+        accessibilityStatus <-
+            if operation == 2
+                then poke accessibilityLength 0 >> pure 0
+                else writeBytes snapshotBytes accessibility
+                    accessibilityCapacity accessibilityLength
+        imageStatus <- case imageBytes of
+            Just (imageFormat, bytes) -> do
+                poke outputImageFormat imageFormat
+                writeBytes bytes image imageCapacity imageLength
+            Nothing
+                | reportImageWithoutBuffer -> do
+                    poke outputImageFormat 1
+                    poke imageLength 1
+                    pure 0
+                | otherwise -> do
+                    poke outputImageFormat 0
+                    poke imageLength 0
+                    pure 0
+        poke errorLength 0
+        pure (maximum [resultStatus, accessibilityStatus, imageStatus])
+
+openFailureCallback :: ComputerCallback
+openFailureCallback _context _abi operation _token _request _requestLength
+        _result _resultCapacity resultLength
+        _accessibility _accessibilityCapacity accessibilityLength
+        image imageCapacity imageLength
+        _err _errorCapacity errorLength outputToken outputImageFormat = do
+    zeroLengths resultLength accessibilityLength imageLength errorLength
+    poke outputToken 0
+    poke outputImageFormat 0
+    if operation == 1 && image == nullPtr && imageCapacity == 0
+        then pure 4
+        else pure 1
+
+withHost :: ComputerCallback -> (ComputerHost -> IO value) -> IO value
+withHost callback action =
+    withCallback callback \pointer -> do
+        host <- newComputerHost
+        replaceComputerRegistration host
+            (Just (ComputerRegistration pointer nullPtr))
+        action host
 
 withCallback
     :: ComputerCallback
@@ -465,32 +596,129 @@ withCallback
 withCallback callback =
     bracket (wrapComputerCallback callback) freeHaskellFunPtr
 
-plainObservedAction :: CInt -> CComputerAction
-plainObservedAction action = CComputerAction
-    { cComputerStructSize = 64
-    , cComputerAction = action
-    , cComputerX = 0
-    , cComputerY = 0
-    , cComputerDeltaX = 0
-    , cComputerDeltaY = 0
-    , cComputerButton = 0
-    , cComputerModifiers = 0
-    , cComputerTextOffset = 0
-    , cComputerTextLength = 0
-    , cComputerPointOffset = 0
-    , cComputerPointCount = 0
-    }
+peekBytes :: Ptr value -> CSize -> IO BS.ByteString
+peekBytes _ (CSize 0) = pure BS.empty
+peekBytes pointer (CSize lengthValue) =
+    BS.packCStringLen (castPtr pointer, fromIntegral lengthValue)
+
+writeBytes :: BS.ByteString -> Ptr Word8 -> CSize -> Ptr CSize -> IO CInt
+writeBytes bytes output (CSize capacity) outputLength
+    | BS.length bytes > fromIntegral capacity = pure 7
+    | otherwise = do
+        BS.useAsCStringLen bytes \(source, lengthValue) ->
+            copyBytes output (castPtr source) lengthValue
+        poke outputLength (fromIntegral (BS.length bytes))
+        pure 0
+
+zeroLengths :: Ptr CSize -> Ptr CSize -> Ptr CSize -> Ptr CSize -> IO ()
+zeroLengths a b c d = do
+    poke a 0
+    poke b 0
+    poke c 0
+    poke d 0
 
 pngSignature :: BS.ByteString
 pngSignature = BS.pack [137, 80, 78, 71, 13, 10, 26, 10]
 
-accessibilitySnapshotBytes :: BS.ByteString
-accessibilitySnapshotBytes =
+minimalPng :: BS.ByteString
+minimalPng = BS.pack
+    [ 137, 80, 78, 71, 13, 10, 26, 10
+    , 0, 0, 0, 13, 73, 72, 68, 82
+    , 0, 0, 0, 1, 0, 0, 0, 1
+    , 8, 4, 0, 0, 0, 181, 28, 12, 2
+    , 0, 0, 0, 11, 73, 68, 65, 84
+    , 120, 218, 99, 100, 248, 15, 0, 1
+    , 5, 1, 1, 39, 24, 227, 102
+    , 0, 0, 0, 0, 73, 69, 78, 68
+    , 174, 66, 96, 130
+    ]
+
+corruptPngCrc :: BS.ByteString
+corruptPngCrc =
+    BS.take 32 minimalPng <> BS.singleton 3 <> BS.drop 33 minimalPng
+
+-- The IDAT checksum is valid, but the zlib header is not. Envelope-only PNG
+-- validation used to accept this payload.
+corruptPngImageData :: BS.ByteString
+corruptPngImageData = BS.pack
+    [ 137, 80, 78, 71, 13, 10, 26, 10
+    , 0, 0, 0, 13, 73, 72, 68, 82
+    , 0, 0, 0, 1, 0, 0, 0, 1
+    , 8, 4, 0, 0, 0, 181, 28, 12, 2
+    , 0, 0, 0, 11, 73, 68, 65, 84
+    , 121, 218, 99, 100, 248, 15, 0, 1
+    , 5, 1, 1, 230, 150, 60, 166
+    , 0, 0, 0, 0, 73, 69, 78, 68
+    , 174, 66, 96, 130
+    ]
+
+-- The marker envelope and one-pixel SOF are present, but there is no valid
+-- component table or compressed scan.
+invalidJpeg :: BS.ByteString
+invalidJpeg = BS.pack
+    [ 255, 216
+    , 255, 192, 0, 8, 8, 0, 1, 0, 1, 1
+    , 255, 218, 0, 2
+    , 255, 217
+    ]
+
+snapshotBytes :: BS.ByteString
+snapshotBytes =
     "{\"schema_version\":1,\"scope\":{\"bundle_id\":\"test\"},\"contents\":{\"role\":\"AXWindow\"}}"
 
-observedOperationAndToken
-    :: ObservedComputerInvocation
-    -> (CInt, Word64)
-observedOperationAndToken
-        (ObservedComputerInvocation _ operation token _ _ _ _ _ _ _ _) =
-    (operation, token)
+expectedComputerParameters :: Aeson.Value
+expectedComputerParameters = strictObjectSchema
+    [ ("operation", Aeson.object
+        [ "type" Aeson..= ("string" :: Text)
+        , "enum" Aeson..=
+            (["list_targets", "bind", "observe", "act"] :: [Text])
+        ])
+    , ("target_id", nullableStringSchema)
+    , ("actions", Aeson.object
+        [ "type" Aeson..= (["array", "null"] :: [Text])
+        , "minItems" Aeson..= (1 :: Int)
+        , "maxItems" Aeson..= (64 :: Int)
+        , "items" Aeson..= strictObjectSchema
+            [ ("type", Aeson.object
+                [ "type" Aeson..= ("string" :: Text)
+                , "enum" Aeson..=
+                    ( [ "perform"
+                      , "set_value"
+                      , "replace_selected_text"
+                      ] :: [Text]
+                    )
+                ])
+            , ("element_id", Aeson.object
+                ["type" Aeson..= ("string" :: Text)])
+            , ("action", nullableStringSchema)
+            , ("value", Aeson.object
+                [ "type" Aeson..=
+                    (["string", "number", "boolean", "null"] :: [Text])
+                ])
+            , ("text", nullableStringSchema)
+            ]
+            ["type", "element_id", "action", "value", "text"]
+        ])
+    , ("include_screenshot", Aeson.object
+        [ "type" Aeson..= ("boolean" :: Text)
+        , "description" Aeson..=
+            ( "Set false unless visual evidence is necessary; screenshots are "
+            <> "never returned implicitly."
+            :: Text
+            )
+        ])
+    ]
+    ["operation", "target_id", "actions", "include_screenshot"]
+
+strictObjectSchema :: [(Text, Aeson.Value)] -> [Text] -> Aeson.Value
+strictObjectSchema properties requiredFields = Aeson.object
+    [ "type" Aeson..= ("object" :: Text)
+    , "additionalProperties" Aeson..= False
+    , "properties" Aeson..= Aeson.object
+        [ Key.fromText name Aeson..= schema | (name, schema) <- properties ]
+    , "required" Aeson..= requiredFields
+    ]
+
+nullableStringSchema :: Aeson.Value
+nullableStringSchema =
+    Aeson.object ["type" Aeson..= (["string", "null"] :: [Text])]

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/NativeLoopEventSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/NativeLoopEventSpec.hs
@@ -115,9 +115,53 @@ spec = describe "native loop event binary encoding" do
         case encodeNativeLoopEvent "turn" (ToolFinished result) of
             Nothing -> expectationFailure "native tool event failed to encode"
             Just encoded -> do
-                encoded `shouldSatisfy` BS.isInfixOf "Screenshot captured"
+                encoded `shouldSatisfy` BS.isInfixOf "Screenshot omitted from event"
                 encoded `shouldNotSatisfy`
                     BS.isInfixOf (TextEncoding.encodeUtf8 secret)
+
+    it "redacts nested JSON screenshot fields and image data" do
+        let secret = "DATA:IMAGE/png;base64,nested-secret" :: Text.Text
+            output =
+                "{\"nested\":{\"screenshot_data_url\":\"discard\",\
+                \\"preview\":\"" <> secret <> "\"}}"
+            result = ToolCallResult
+                { callId = "computer-nested"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
+                , output
+                , callKind = ComputerFunctionCallKind
+                }
+        case encodeNativeLoopEvent "turn" (ToolFinished result) of
+            Nothing -> expectationFailure "native tool event failed to encode"
+            Just encoded -> do
+                encoded `shouldSatisfy`
+                    BS.isInfixOf "Screenshot omitted from event"
+                encoded `shouldNotSatisfy`
+                    BS.isInfixOf (TextEncoding.encodeUtf8 secret)
+                encoded `shouldNotSatisfy`
+                    BS.isInfixOf "screenshot_data_url"
+
+    it "redacts legacy JSON screenshots but preserves accessibility JSON" do
+        let secret = "data:image/png;base64,private-screenshot" :: Text.Text
+            accessibility = "\"accessibility_state\":{\"kind\":\"full\"}"
+            result = ToolCallResult
+                { callId = "computer-json"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
+                , output =
+                    "{\"screenshotDataUrl\":\"" <> secret <> "\","
+                        <> accessibility <> "}"
+                , callKind = ComputerFunctionCallKind
+                }
+        case encodeNativeLoopEvent "turn" (ToolFinished result) of
+            Nothing -> expectationFailure "native tool event failed to encode"
+            Just encoded -> do
+                encoded `shouldNotSatisfy`
+                    BS.isInfixOf (TextEncoding.encodeUtf8 secret)
+                encoded `shouldSatisfy`
+                    BS.isInfixOf (TextEncoding.encodeUtf8 accessibility)
 
     it "encodes terminal provider token usage without inventing cost" do
         let output =

--- a/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeComputerSmoke.c
+++ b/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeComputerSmoke.c
@@ -49,6 +49,9 @@ static int32_t computer_callback(
     uint8_t *output,
     size_t output_capacity,
     size_t *output_length,
+    uint8_t *accessibility_output,
+    size_t accessibility_output_capacity,
+    size_t *accessibility_output_length,
     uint64_t *output_display_token,
     int32_t *output_width,
     int32_t *output_height,
@@ -66,12 +69,17 @@ static int32_t computer_callback(
             || text != NULL || text_length != 0
             || requested_image_format != HA_COMPUTER_IMAGE_NONE
             || output == NULL || output_capacity != HA_COMPUTER_ERROR_CAPACITY
-            || output_length == NULL || output_display_token == NULL
+            || output_length == NULL
+            || accessibility_output != NULL
+            || accessibility_output_capacity != 0
+            || accessibility_output_length == NULL
+            || output_display_token == NULL
             || output_width == NULL
             || output_height == NULL || output_image_format == NULL) {
         return HA_COMPUTER_STATUS_INVALID_ARGUMENT;
     }
     *output_length = 0;
+    *accessibility_output_length = 0;
     *output_display_token = 42;
     *output_width = 1440;
     *output_height = 900;
@@ -82,18 +90,21 @@ static int32_t computer_callback(
 int ha_computer_callback_abi_smoke(void) {
     uint8_t output[HA_COMPUTER_ERROR_CAPACITY];
     size_t output_length = 17;
+    size_t accessibility_output_length = 17;
     uint64_t output_display_token = 0;
     int32_t output_width = 0;
     int32_t output_height = 0;
     int32_t output_image_format = -1;
     ha_computer_callback callback = computer_callback;
 
-    if (HA_COMPUTER_ACTION_STRUCT_SIZE_V1 != 64
+    if (HA_COMPUTER_ABI_VERSION != 2
+            || HA_COMPUTER_ACTION_STRUCT_SIZE_V1 != 64
             || HA_COMPUTER_MAX_ACTIONS != 10
             || HA_COMPUTER_MAX_POINTS_PER_ACTION != 1024
             || HA_COMPUTER_MAX_TOTAL_POINTS != 10240
             || HA_COMPUTER_MAX_TEXT_BYTES != 327680
             || HA_COMPUTER_OUTPUT_CAPACITY != 16777216
+            || HA_COMPUTER_ACCESSIBILITY_CAPACITY != 524288
             || HA_COMPUTER_STATUS_DISPLAY_CHANGED != 9) {
         return 1;
     }
@@ -115,6 +126,9 @@ int ha_computer_callback_abi_smoke(void) {
         output,
         sizeof(output),
         &output_length,
+        NULL,
+        0,
+        &accessibility_output_length,
         &output_display_token,
         &output_width,
         &output_height,
@@ -122,6 +136,7 @@ int ha_computer_callback_abi_smoke(void) {
     );
     if (status != HA_COMPUTER_STATUS_SUCCESS
             || output_length != 0
+            || accessibility_output_length != 0
             || output_display_token != 42
             || output_width != 1440
             || output_height != 900

--- a/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeComputerSmoke.c
+++ b/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeComputerSmoke.c
@@ -3,143 +3,114 @@
 #include <stddef.h>
 #include <string.h>
 
-_Static_assert(sizeof(ha_computer_point_v1) == 8,
-    "ha_computer_point_v1 must remain 8 bytes");
-_Static_assert(sizeof(ha_computer_action_v1) == 64,
-    "ha_computer_action_v1 must remain 64 bytes");
-_Static_assert(offsetof(ha_computer_action_v1, struct_size) == 0,
-    "unexpected struct_size offset");
-_Static_assert(offsetof(ha_computer_action_v1, action) == 4,
-    "unexpected action offset");
-_Static_assert(offsetof(ha_computer_action_v1, x) == 8,
-    "unexpected x offset");
-_Static_assert(offsetof(ha_computer_action_v1, y) == 12,
-    "unexpected y offset");
-_Static_assert(offsetof(ha_computer_action_v1, delta_x) == 16,
-    "unexpected delta_x offset");
-_Static_assert(offsetof(ha_computer_action_v1, delta_y) == 20,
-    "unexpected delta_y offset");
-_Static_assert(offsetof(ha_computer_action_v1, button) == 24,
-    "unexpected button offset");
-_Static_assert(offsetof(ha_computer_action_v1, modifiers) == 28,
-    "unexpected modifiers offset");
-_Static_assert(offsetof(ha_computer_action_v1, text_offset) == 32,
-    "unexpected text_offset offset");
-_Static_assert(offsetof(ha_computer_action_v1, text_length) == 40,
-    "unexpected text_length offset");
-_Static_assert(offsetof(ha_computer_action_v1, point_offset) == 48,
-    "unexpected point_offset offset");
-_Static_assert(offsetof(ha_computer_action_v1, point_count) == 56,
-    "unexpected point_count offset");
-
 static int32_t computer_callback(
     void *context,
     uint32_t abi_version,
     int32_t operation,
-    uint64_t expected_display_token,
-    int32_t expected_width,
-    int32_t expected_height,
-    const ha_computer_action_v1 *actions,
-    size_t action_count,
-    const ha_computer_point_v1 *points,
-    size_t point_count,
-    const uint8_t *text,
-    size_t text_length,
-    int32_t requested_image_format,
-    uint8_t *output,
-    size_t output_capacity,
-    size_t *output_length,
-    uint8_t *accessibility_output,
-    size_t accessibility_output_capacity,
-    size_t *accessibility_output_length,
-    uint64_t *output_display_token,
-    int32_t *output_width,
-    int32_t *output_height,
+    uint64_t session_token,
+    const uint8_t *request,
+    size_t request_length,
+    uint8_t *result,
+    size_t result_capacity,
+    size_t *result_length,
+    uint8_t *accessibility,
+    size_t accessibility_capacity,
+    size_t *accessibility_length,
+    uint8_t *image,
+    size_t image_capacity,
+    size_t *image_length,
+    uint8_t *error,
+    size_t error_capacity,
+    size_t *error_length,
+    uint64_t *output_session_token,
     int32_t *output_image_format
 ) {
-    const char *expected_context = "computer-context";
+    (void)result;
+    (void)accessibility;
+    (void)image;
+    (void)error;
     if (context == NULL
-            || strcmp((const char *)context, expected_context) != 0
+            || strcmp((const char *)context, "computer-context") != 0
             || abi_version != HA_COMPUTER_ABI_VERSION
-            || operation != HA_COMPUTER_QUERY_DISPLAY
-            || expected_display_token != 0
-            || expected_width != 0 || expected_height != 0
-            || actions != NULL || action_count != 0
-            || points != NULL || point_count != 0
-            || text != NULL || text_length != 0
-            || requested_image_format != HA_COMPUTER_IMAGE_NONE
-            || output == NULL || output_capacity != HA_COMPUTER_ERROR_CAPACITY
-            || output_length == NULL
-            || accessibility_output != NULL
-            || accessibility_output_capacity != 0
-            || accessibility_output_length == NULL
-            || output_display_token == NULL
-            || output_width == NULL
-            || output_height == NULL || output_image_format == NULL) {
+            || operation != HA_COMPUTER_OPEN
+            || session_token != 0
+            || request != NULL
+            || request_length != 0
+            || result_capacity != HA_COMPUTER_RESULT_CAPACITY
+            || accessibility_capacity != HA_COMPUTER_ACCESSIBILITY_CAPACITY
+            || image_capacity != HA_COMPUTER_IMAGE_CAPACITY
+            || error_capacity != HA_COMPUTER_ERROR_CAPACITY
+            || result_length == NULL
+            || accessibility_length == NULL
+            || image_length == NULL
+            || error_length == NULL
+            || output_session_token == NULL
+            || output_image_format == NULL) {
         return HA_COMPUTER_STATUS_INVALID_ARGUMENT;
     }
-    *output_length = 0;
-    *accessibility_output_length = 0;
-    *output_display_token = 42;
-    *output_width = 1440;
-    *output_height = 900;
+    *result_length = 0;
+    *accessibility_length = 0;
+    *image_length = 0;
+    *error_length = 0;
+    *output_session_token = 42;
     *output_image_format = HA_COMPUTER_IMAGE_NONE;
     return HA_COMPUTER_STATUS_SUCCESS;
 }
 
 int ha_computer_callback_abi_smoke(void) {
-    uint8_t output[HA_COMPUTER_ERROR_CAPACITY];
-    size_t output_length = 17;
-    size_t accessibility_output_length = 17;
-    uint64_t output_display_token = 0;
-    int32_t output_width = 0;
-    int32_t output_height = 0;
+    static uint8_t result[HA_COMPUTER_RESULT_CAPACITY];
+    static uint8_t accessibility[HA_COMPUTER_ACCESSIBILITY_CAPACITY];
+    static uint8_t image[HA_COMPUTER_IMAGE_CAPACITY];
+    static uint8_t error[HA_COMPUTER_ERROR_CAPACITY];
+    size_t result_length = 1;
+    size_t accessibility_length = 1;
+    size_t image_length = 1;
+    size_t error_length = 1;
+    uint64_t output_session_token = 0;
     int32_t output_image_format = -1;
     ha_computer_callback callback = computer_callback;
 
-    if (HA_COMPUTER_ABI_VERSION != 2
-            || HA_COMPUTER_ACTION_STRUCT_SIZE_V1 != 64
-            || HA_COMPUTER_MAX_ACTIONS != 10
-            || HA_COMPUTER_MAX_POINTS_PER_ACTION != 1024
-            || HA_COMPUTER_MAX_TOTAL_POINTS != 10240
-            || HA_COMPUTER_MAX_TEXT_BYTES != 327680
-            || HA_COMPUTER_OUTPUT_CAPACITY != 16777216
-            || HA_COMPUTER_ACCESSIBILITY_CAPACITY != 524288
-            || HA_COMPUTER_STATUS_DISPLAY_CHANGED != 9) {
+    if (HA_COMPUTER_ABI_VERSION != 3
+            || HA_COMPUTER_OPEN != 1
+            || HA_COMPUTER_LIST != 2
+            || HA_COMPUTER_BIND != 3
+            || HA_COMPUTER_OBSERVE_OR_ACT != 4
+            || HA_COMPUTER_CLOSE != 5
+            || HA_COMPUTER_REQUEST_MAX_BYTES != 1048576
+            || HA_COMPUTER_RESULT_CAPACITY != 1048576
+            || HA_COMPUTER_IMAGE_CAPACITY != 16777216
+            || HA_COMPUTER_ACCESSIBILITY_CAPACITY != 524288) {
         return 1;
     }
 
     int32_t status = callback(
         (void *)"computer-context",
         HA_COMPUTER_ABI_VERSION,
-        HA_COMPUTER_QUERY_DISPLAY,
-        0,
-        0,
+        HA_COMPUTER_OPEN,
         0,
         NULL,
         0,
-        NULL,
-        0,
-        NULL,
-        0,
-        HA_COMPUTER_IMAGE_NONE,
-        output,
-        sizeof(output),
-        &output_length,
-        NULL,
-        0,
-        &accessibility_output_length,
-        &output_display_token,
-        &output_width,
-        &output_height,
+        result,
+        sizeof(result),
+        &result_length,
+        accessibility,
+        sizeof(accessibility),
+        &accessibility_length,
+        image,
+        sizeof(image),
+        &image_length,
+        error,
+        sizeof(error),
+        &error_length,
+        &output_session_token,
         &output_image_format
     );
     if (status != HA_COMPUTER_STATUS_SUCCESS
-            || output_length != 0
-            || accessibility_output_length != 0
-            || output_display_token != 42
-            || output_width != 1440
-            || output_height != 900
+            || result_length != 0
+            || accessibility_length != 0
+            || image_length != 0
+            || error_length != 0
+            || output_session_token != 42
             || output_image_format != HA_COMPUTER_IMAGE_NONE) {
         return 2;
     }

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -362,6 +362,110 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
             other -> expectationFailure
                 ("unexpected native computer continuation: " <> show other)
 
+    it "labels a structured full accessibility snapshot with its revision" do
+        let accessibilityState = Aeson.object
+                [ "kind" Aeson..= ("full" :: Text.Text)
+                , "revision" Aeson..= (1 :: Int)
+                , "snapshot" Aeson..= Aeson.object
+                    ["application" Aeson..= ("TextEdit" :: Text.Text)]
+                ]
+            encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                ComputerCallOutput
+                    { computerOutputItemId = Nothing
+                    , computerOutputCallId = "ignored"
+                    , screenshotDataUrl = "data:image/jpeg;base64,AA=="
+                    , acknowledgedChecks = []
+                    , computerOutputStatus = Nothing
+                    , computerOutputExtra = KeyMap.singleton
+                        "accessibility_state"
+                        accessibilityState
+                    }
+            result = ToolCallResult
+                { callId = "call-native-full"
+                , output = encoded
+                , callKind = ComputerFunctionCallKind
+                }
+        case turnInputsToItems [CompletedTool result] of
+            FunctionCallOutputItem output : _ ->
+                case Aeson.toJSON output.output of
+                    Aeson.String rendered -> do
+                        rendered `shouldSatisfy` Text.isInfixOf
+                            "Full macOS accessibility snapshot, revision 1:"
+                        rendered `shouldSatisfy` Text.isInfixOf
+                            "\"kind\":\"full\""
+                    other -> expectationFailure
+                        ("expected text output, got " <> show other)
+            other -> expectationFailure
+                ("unexpected native computer continuation: " <> show other)
+
+    it "labels accessibility deltas with their base and new revisions" do
+        let accessibilityState = Aeson.object
+                [ "kind" Aeson..= ("delta" :: Text.Text)
+                , "base_revision" Aeson..= (3 :: Int)
+                , "revision" Aeson..= (4 :: Int)
+                , "patch" Aeson..= ([] :: [Aeson.Value])
+                ]
+            encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                ComputerCallOutput
+                    { computerOutputItemId = Nothing
+                    , computerOutputCallId = "ignored"
+                    , screenshotDataUrl = "data:image/jpeg;base64,AA=="
+                    , acknowledgedChecks = []
+                    , computerOutputStatus = Nothing
+                    , computerOutputExtra = KeyMap.singleton
+                        "accessibility_state"
+                        accessibilityState
+                    }
+            result = ToolCallResult
+                { callId = "call-native-delta"
+                , output = encoded
+                , callKind = ComputerFunctionCallKind
+                }
+        case turnInputsToItems [CompletedTool result] of
+            FunctionCallOutputItem output : _ ->
+                Aeson.toJSON output.output `shouldSatisfy` \case
+                    Aeson.String rendered ->
+                        "macOS accessibility changes, revision 3 -> 4:"
+                            `Text.isInfixOf` rendered
+                            && "\"patch\":[]" `Text.isInfixOf` rendered
+                    _ -> False
+            other -> expectationFailure
+                ("unexpected native computer continuation: " <> show other)
+
+    it "labels structured accessibility capture failures" do
+        let accessibilityState = Aeson.object
+                [ "kind" Aeson..= ("unavailable" :: Text.Text)
+                , "revision" Aeson..= (2 :: Int)
+                , "reason" Aeson..= ("AX timeout" :: Text.Text)
+                ]
+            encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                ComputerCallOutput
+                    { computerOutputItemId = Nothing
+                    , computerOutputCallId = "ignored"
+                    , screenshotDataUrl = "data:image/jpeg;base64,AA=="
+                    , acknowledgedChecks = []
+                    , computerOutputStatus = Nothing
+                    , computerOutputExtra = KeyMap.singleton
+                        "accessibility_state"
+                        accessibilityState
+                    }
+            result = ToolCallResult
+                { callId = "call-native-unavailable"
+                , output = encoded
+                , callKind = ComputerFunctionCallKind
+                }
+        case turnInputsToItems [CompletedTool result] of
+            FunctionCallOutputItem output : _ ->
+                Aeson.toJSON output.output `shouldSatisfy` \case
+                    Aeson.String rendered ->
+                        "macOS accessibility state unavailable, revision 2:"
+                            `Text.isInfixOf` rendered
+                            && "\"reason\":\"AX timeout\""
+                                `Text.isInfixOf` rendered
+                    _ -> False
+            other -> expectationFailure
+                ("unexpected native computer continuation: " <> show other)
+
     it "keeps computer output before its observation in standard and Lite requests" do
         let encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
                 ComputerCallOutput

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -362,6 +362,53 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
             other -> expectationFailure
                 ("unexpected native computer continuation: " <> show other)
 
+    it "keeps AX-only computer results text-only" do
+        let result = ToolCallResult
+                { callId = "call-ax-only"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
+                , output = "Current macOS accessibility state"
+                , callKind = ComputerFunctionCallKind
+                }
+        case toolResultToItem result of
+            FunctionCallOutputItem output ->
+                Aeson.toJSON output.output `shouldBe`
+                    Aeson.String "Current macOS accessibility state"
+            other -> expectationFailure
+                ("expected text-only computer output, got " <> show other)
+
+    it "preserves explicitly requested computer screenshots as image content" do
+        let result = ToolCallResult
+                { callId = "call-ax-image"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages =
+                    [ ToolResultImage
+                        { imageUrl = "data:image/png;base64,AA=="
+                        , imageDetail = Just "high"
+                        }
+                    ]
+                , toolResultOutcome = Nothing
+                , output = "Current macOS accessibility state"
+                , callKind = ComputerFunctionCallKind
+                }
+        case toolResultToItem result of
+            FunctionCallOutputItem output ->
+                Aeson.toJSON output.output `shouldBe` Aeson.toJSON
+                    [ InputImagePart
+                        { detail = Just "high"
+                        , fileId = Nothing
+                        , imageUrl = Just "data:image/png;base64,AA=="
+                        , promptCacheBreakpoint = Nothing
+                        }
+                    , InputTextPart
+                        { text = "Current macOS accessibility state"
+                        , promptCacheBreakpoint = Nothing
+                        }
+                    ]
+            other -> expectationFailure
+                ("expected rich computer output, got " <> show other)
+
     it "labels a structured full accessibility snapshot with its revision" do
         let accessibilityState = Aeson.object
                 [ "kind" Aeson..= ("full" :: Text.Text)

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -382,6 +382,9 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
                     }
             result = ToolCallResult
                 { callId = "call-native-full"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
                 , output = encoded
                 , callKind = ComputerFunctionCallKind
                 }
@@ -418,6 +421,9 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
                     }
             result = ToolCallResult
                 { callId = "call-native-delta"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
                 , output = encoded
                 , callKind = ComputerFunctionCallKind
                 }
@@ -451,6 +457,9 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
                     }
             result = ToolCallResult
                 { callId = "call-native-unavailable"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
                 , output = encoded
                 , callKind = ComputerFunctionCallKind
                 }

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -334,33 +334,74 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
             other -> expectationFailure
                 ("unexpected computer continuation: " <> show other)
 
-    it "returns native accessibility state beside the screenshot" do
+    it "returns native computer accessibility state beside the screenshot" do
         let encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
-                ComputerCallOutput
-                    { computerOutputItemId = Nothing
-                    , computerOutputCallId = "ignored"
-                    , screenshotDataUrl = "data:image/jpeg;base64,AA=="
-                    , acknowledgedChecks = []
-                    , computerOutputStatus = Nothing
-                    , computerOutputExtra = KeyMap.singleton
-                        "accessibility_state"
-                        (Aeson.String
-                            "app=\"TextEdit\"\n[1] AXButton \"Save\"")
-                    }
+                (Aeson.object
+                    [ "operation" Aeson..= ("observe" :: Text.Text)
+                    , "mode" Aeson..= ("accessibility" :: Text.Text)
+                    , "accessibility_state" Aeson..=
+                        ("app=\"TextEdit\"\n[1] AXButton \"Save\"" :: Text.Text)
+                    ])
             result = ToolCallResult
                 { callId = "call-native"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages =
+                    [ ToolResultImage
+                        { imageUrl = "data:image/jpeg;base64,AA=="
+                        , imageDetail = Just "auto"
+                        }
+                    ]
+                , toolResultOutcome = Nothing
+                , output = encoded
+                , callKind = ComputerFunctionCallKind
+                }
+        case turnInputsToItems [CompletedTool result] of
+            [ FunctionCallOutputItem output
+                , MessageItem ResponseMessage
+                    { content =
+                        MessageContentParts
+                            [ InputTextPart{}
+                                , InputImagePart{imageUrl}
+                            ]
+                    }
+                ] -> do
+                Aeson.toJSON output.output `shouldBe` Aeson.toJSON
+                    [ InputImagePart
+                        { detail = Just "auto"
+                        , fileId = Nothing
+                        , imageUrl = Just "data:image/jpeg;base64,AA=="
+                        , promptCacheBreakpoint = Nothing
+                        }
+                    , InputTextPart
+                        { text =
+                            "Computer action completed.\n\nCurrent macOS accessibility state:\napp=\"TextEdit\"\n[1] AXButton \"Save\""
+                        , promptCacheBreakpoint = Nothing
+                        }
+                    ]
+                imageUrl `shouldBe` Just "data:image/jpeg;base64,AA=="
+            other -> expectationFailure
+                ("unexpected native computer continuation: " <> show other)
+
+    it "preserves native computer list-target results without accessibility state" do
+        let encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                (Aeson.object
+                    [ "operation" Aeson..= ("list_targets" :: Text.Text)
+                    , "mode" Aeson..= ("accessibility" :: Text.Text)
+                    , "targets" Aeson..= ([] :: [Aeson.Value])
+                    ])
+            result = ToolCallResult
+                { callId = "call-native-targets"
                 , toolResultMode = BlockingToolCall
                 , toolResultImages = []
                 , toolResultOutcome = Nothing
                 , output = encoded
                 , callKind = ComputerFunctionCallKind
                 }
-        case turnInputsToItems [CompletedTool result] of
-            FunctionCallOutputItem output : _ ->
-                Aeson.toJSON output.output `shouldBe` Aeson.String
-                    "Computer action completed.\n\nCurrent macOS accessibility state:\napp=\"TextEdit\"\n[1] AXButton \"Save\""
+        case toolResultToItem result of
+            FunctionCallOutputItem output ->
+                Aeson.toJSON output.output `shouldBe` Aeson.String encoded
             other -> expectationFailure
-                ("unexpected native computer continuation: " <> show other)
+                ("unexpected native list-target output: " <> show other)
 
     it "keeps AX-only computer results text-only" do
         let result = ToolCallResult
@@ -379,7 +420,7 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
                 ("expected text-only computer output, got " <> show other)
 
     it "preserves explicitly requested computer screenshots as image content" do
-        let result = ToolCallResult
+        let result callKind = ToolCallResult
                 { callId = "call-ax-image"
                 , toolResultMode = BlockingToolCall
                 , toolResultImages =
@@ -390,24 +431,64 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
                     ]
                 , toolResultOutcome = Nothing
                 , output = "Current macOS accessibility state"
-                , callKind = ComputerFunctionCallKind
+                , callKind
                 }
-        case toolResultToItem result of
-            FunctionCallOutputItem output ->
-                Aeson.toJSON output.output `shouldBe` Aeson.toJSON
-                    [ InputImagePart
-                        { detail = Just "high"
-                        , fileId = Nothing
-                        , imageUrl = Just "data:image/png;base64,AA=="
-                        , promptCacheBreakpoint = Nothing
-                        }
-                    , InputTextPart
-                        { text = "Current macOS accessibility state"
-                        , promptCacheBreakpoint = Nothing
+            assertKind callKind =
+                case toolResultToItem (result callKind) of
+                    FunctionCallOutputItem output ->
+                        Aeson.toJSON output.output `shouldBe` Aeson.toJSON
+                            [ InputImagePart
+                                { detail = Just "high"
+                                , fileId = Nothing
+                                , imageUrl = Just "data:image/png;base64,AA=="
+                                , promptCacheBreakpoint = Nothing
+                                }
+                            , InputTextPart
+                                { text = "Current macOS accessibility state"
+                                , promptCacheBreakpoint = Nothing
+                                }
+                            ]
+                    other -> expectationFailure
+                        ("expected rich computer output, got " <> show other)
+        mapM_ assertKind [ComputerCallKind, ComputerFunctionCallKind]
+
+    it "prefers out-of-band computer screenshots for the fresh observation" do
+        let legacyOutput = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
+                ComputerCallOutput
+                    { computerOutputItemId = Nothing
+                    , computerOutputCallId = "call-ax-image"
+                    , screenshotDataUrl = "data:image/png;base64,LEGACY"
+                    , acknowledgedChecks = []
+                    , computerOutputStatus = Nothing
+                    , computerOutputExtra = KeyMap.empty
+                    }
+            result = ToolCallResult
+                { callId = "call-ax-image"
+                , toolResultMode = BlockingToolCall
+                , toolResultImages =
+                    [ ToolResultImage
+                        { imageUrl = "data:image/png;base64,NATIVE"
+                        , imageDetail = Just "high"
                         }
                     ]
+                , toolResultOutcome = Nothing
+                , output = legacyOutput
+                , callKind = ComputerFunctionCallKind
+                }
+        case turnInputsToItems [CompletedTool result] of
+            [ FunctionCallOutputItem{}
+                , MessageItem ResponseMessage
+                    { content =
+                        MessageContentParts
+                            [ InputTextPart{}
+                                , InputImagePart{imageUrl}
+                            ]
+                    }
+                ] ->
+                    imageUrl `shouldBe`
+                        Just "data:image/png;base64,NATIVE"
             other -> expectationFailure
-                ("expected rich computer output, got " <> show other)
+                ("expected the native screenshot observation, got " <> show other)
 
     it "labels a structured full accessibility snapshot with its revision" do
         let accessibilityState = Aeson.object
@@ -417,16 +498,11 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
                     ["application" Aeson..= ("TextEdit" :: Text.Text)]
                 ]
             encoded = TextEncoding.decodeUtf8 $ LBS.toStrict $ Aeson.encode
-                ComputerCallOutput
-                    { computerOutputItemId = Nothing
-                    , computerOutputCallId = "ignored"
-                    , screenshotDataUrl = "data:image/jpeg;base64,AA=="
-                    , acknowledgedChecks = []
-                    , computerOutputStatus = Nothing
-                    , computerOutputExtra = KeyMap.singleton
-                        "accessibility_state"
-                        accessibilityState
-                    }
+                (Aeson.object
+                    [ "operation" Aeson..= ("observe" :: Text.Text)
+                    , "mode" Aeson..= ("accessibility" :: Text.Text)
+                    , "accessibility_state" Aeson..= accessibilityState
+                    ])
             result = ToolCallResult
                 { callId = "call-native-full"
                 , toolResultMode = BlockingToolCall

--- a/packages/agent-server/src/Agent/Server/Event.hs
+++ b/packages/agent-server/src/Agent/Server/Event.hs
@@ -134,6 +134,10 @@ projectLoopEvent = \case
             , "status" .= nativeAgentStatusText status
             ]
         )
+    ModelContextReset ->
+        ( "model.context.reset"
+        , object ["displayOnly" .= True]
+        )
 
 -- | Public agent snapshots intentionally omit transcripts and retained UI
 -- state. Those may contain arbitrarily large or sensitive model/tool output.

--- a/packages/agent-server/test/Agent/Server/EventSpec.hs
+++ b/packages/agent-server/test/Agent/Server/EventSpec.hs
@@ -73,6 +73,11 @@ spec = describe "public loop-event projection" do
         LBS8.unpack (encode failed)
             `shouldContain` "\"displayOnly\":true"
 
+    it "projects model-context resets as display-only" do
+        let (eventType, value) = projectLoopEvent ModelContextReset
+        eventType `shouldBe` "model.context.reset"
+        value `shouldBe` object ["displayOnly" .= True]
+
     it "redacts encrypted durable values and applies a total budget" do
         let public = projectPublicValue $
                 object

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -402,6 +402,7 @@ reduceLoop event state = case event of
                 }
     ActivityUpdated activity ->
         state { uiActivity = activity }
+    ModelContextReset -> state
     ProviderLimitUpdated
         { providerLimitText = text
         , providerLimitWarning = warning

--- a/packages/agent-tui/test/Agent/TUI/ModelPropertySpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelPropertySpec.hs
@@ -186,6 +186,7 @@ generatedLoopEvent = frequency
     , (3, WarningRaised <$> generatedText)
     , (2, ResponseRestarted <$> generatedText)
     , (2, pure TurnStarted)
+    , (1, pure ModelContextReset)
     ]
 
 generatedNotice :: Gen (Maybe UiNotice)


### PR DESCRIPTION
## Summary

- centralize the model-facing computer contract in one typed `Agent.ComputerUse.Protocol` module: the strict schema, request decoder, semantic ADTs, approval metadata, and native wire encoding now share one source of truth
- decode each tool call once, then pass a canonical versioned (`protocol_version: 1`) payload across the native boundary; the private macOS host performs one matching typed `Codable` decode rather than reparsing dictionaries in the bridge and AX service
- expose only target-bound semantic accessibility operations (`list_targets`, `bind`, `observe`, and `act`), returning bounded revisioned AX state by default and screenshots only when explicitly requested
- preserve requested screenshots as structured image content (preferring the native out-of-band image) while keeping screenshot data out of ordinary output and native event frames
- project native host results without assuming the provider-only `call_id` envelope, while preserving list-target payloads that have no accessibility state

The remaining dynamic JSON is deliberately at representation boundaries: model/provider envelopes on the public side and Accessibility/result serialization on the AppKit side. It is no longer used as the internal request model.

## Stack

- based on #1049 so the native host keeps its typed asynchronous browser lifecycle while adding the AX session lifecycle
- intentionally carries the three commits from #1050; if #1050 lands first, this branch can be restacked to drop those duplicate commits
- private macOS host counterpart: https://github.com/digitallyinduced/haskell-agent-macos/pull/172

## Validation

- semantic computer protocol: 6 examples, 0 failures (all operations/scalars, typed/native round trips, shared golden fixture, ABI metadata, and shape/version rejection)
- Responses computer projection: 17 examples, 0 failures; accessibility projection: 5 examples, 0 failures, including no-`call_id` native results, structured state, raw list-target preservation, and explicit/out-of-band screenshot handling
- native AX-first bridge: 9 examples, 0 failures
- native loop-event binary encoding/redaction: 13 examples, 0 failures
- CLI schemas: 29 examples, 0 failures; computer approval/redaction summaries: 6 examples, 0 failures
- exact `x86_64-linux` extracted native-bridge Nix check: 54 examples, 0 failures
- private counterpart: typed protocol 4/4, AX service 19/19, native bridge 7/7
- public/private protocol-v1 fixtures and C headers are byte-identical
- accessibility benchmark (`small-change`, 1000 nodes, 24 revisions): revisioned output 346,485 bytes versus 2,737,254 bytes for always-full output
