### PR TITLE
Provision GitHub repositories for cloud sessions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -920,6 +920,10 @@
                 agentCliRuntimeTools = [
                     pkgs.ffmpeg
                     bun_1_4
+                    pkgs.curl
+                    pkgs.gh
+                    pkgs.git
+                    pkgs.jq
                     pkgs.postgresql_18
                     pkgs.ripgrep
                     pkgs.zstd

--- a/nix/sandbox-rootfs.nix
+++ b/nix/sandbox-rootfs.nix
@@ -16,6 +16,7 @@ let
       file
       findutils
       gawk
+      gh
       gitMinimal
       gnugrep
       gnused

--- a/packages/agent-server/agent-server.cabal
+++ b/packages/agent-server/agent-server.cabal
@@ -53,6 +53,7 @@ library
                     , Agent.Server.Identifier
                     , Agent.Server.PrivateFile
                     , Agent.Server.Runtime
+                    , Agent.Server.RepositoryCheckout
                     , Agent.Server.Runtime.TurnStore
                     , Agent.Server.Sandbox
                     , Agent.Server.Sandbox.Worker
@@ -110,6 +111,7 @@ test-suite agent-server-test
                     , Agent.Server.AuthSpec
                     , Agent.Server.ConfigSpec
                     , Agent.Server.EventSpec
+                    , Agent.Server.RepositoryCheckoutSpec
                     , Agent.Server.SandboxSpec
                     , Agent.Server.SupervisorSpec
                     , Agent.Server.TenantSpec

--- a/packages/agent-server/src/Agent/Server/RepositoryCheckout.hs
+++ b/packages/agent-server/src/Agent/Server/RepositoryCheckout.hs
@@ -1,0 +1,232 @@
+module Agent.Server.RepositoryCheckout
+    ( RepositoryCheckout(..)
+    , prepareRepositoryCheckout
+    , cleanupRepositoryCheckout
+    , validateDescriptor
+    , credentialHelperScript
+    , ghWrapperScript
+    ) where
+
+import Control.Exception.Safe (tryAny)
+import Data.Char (isAlphaNum, isAscii, isControl, isSpace)
+import Data.List (isPrefixOf)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import System.Directory
+    ( createDirectoryIfMissing
+    , getPermissions
+    , removePathForcibly
+    , setOwnerExecutable
+    , setPermissions
+    )
+import System.Environment (getEnvironment)
+import System.Exit (ExitCode(..))
+import System.FilePath (normalise, splitDirectories, takeDirectory, (</>))
+import System.Posix.Files (setFileMode)
+import System.Process
+    ( CreateProcess(..)
+    , StdStream(NoStream)
+    , createProcess
+    , interruptProcessGroupOf
+    , proc
+    , waitForProcess
+    )
+import System.Timeout qualified as Timeout
+import Agent.Server.Types (RepositoryDescriptor(..))
+
+data RepositoryCheckout = RepositoryCheckout
+    { checkoutPath :: !FilePath
+    , checkoutBranch :: !Text
+    , cleanupCheckout :: !(IO ())
+    }
+
+prepareRepositoryCheckout
+    :: FilePath
+    -> Text
+    -> RepositoryDescriptor
+    -> IO (Either Text RepositoryCheckout)
+prepareRepositoryCheckout workspaceRoot correlation descriptor =
+    case validateDescriptor descriptor of
+        Left err -> pure (Left err)
+        Right () -> do
+            let root = workspaceRoot </> ".haskell-agent" </> "repositories" </> Text.unpack correlation
+                checkout = root </> "checkout"
+                credentials = root </> "credentials"
+                helper = credentials </> "git-credential-github-app"
+                ghWrapper = credentials </> "gh"
+                branch = "agent/" <> correlation
+                cleanup = removePathForcibly root
+            outcome <- tryAny do
+                createDirectoryIfMissing True credentials
+                setFileMode credentials 0o700
+                writeFile (credentials </> "endpoint") (Text.unpack descriptor.repositoryCredentialBrokerUrl)
+                writeFile (credentials </> "lease") (Text.unpack descriptor.repositoryCredentialLease)
+                writeFile (credentials </> "repository") (Text.unpack descriptor.repositoryFullName)
+                setFileMode (credentials </> "endpoint") 0o600
+                setFileMode (credentials </> "lease") 0o600
+                setFileMode (credentials </> "repository") 0o600
+                writeFile helper credentialHelperScript
+                makeExecutable helper
+                writeFile ghWrapper ghWrapperScript
+                makeExecutable ghWrapper
+                runGit workspaceRoot
+                    [ "-c", "credential.helper=" <> helper
+                    , "-c", "credential.useHttpPath=true"
+                    , "clone", "--single-branch"
+                    , "--branch", Text.unpack descriptor.repositoryDefaultBranch
+                    , Text.unpack descriptor.repositoryCloneUrl
+                    , checkout
+                    ]
+                runGit workspaceRoot ["-C", checkout, "config", "credential.helper", helper]
+                runGit workspaceRoot ["-C", checkout, "config", "credential.useHttpPath", "true"]
+                runGit workspaceRoot ["-C", checkout, "switch", "-c", Text.unpack branch]
+                writeFile
+                    (root </> "README")
+                    ("GitHub CLI wrapper: " <> ghWrapper <> "\n")
+            case outcome of
+                Left _ -> do
+                    _ <- tryAny cleanup
+                    pure (Left "could not prepare repository checkout")
+                Right () ->
+                    pure (Right RepositoryCheckout{checkoutPath = checkout, checkoutBranch = branch, cleanupCheckout = cleanup})
+
+-- | Remove only checkouts created by 'prepareRepositoryCheckout'. The strict
+-- shape check prevents an arbitrary session cwd from becoming a deletion
+-- target.
+cleanupRepositoryCheckout :: FilePath -> IO ()
+cleanupRepositoryCheckout checkoutPath =
+    case reverse (splitDirectories (normalise checkoutPath)) of
+        "checkout" : correlation : "repositories" : ".haskell-agent" : _
+            | validCorrelation correlation -> do
+                _ <- tryAny (removePathForcibly (takeDirectory checkoutPath))
+                pure ()
+        _ -> pure ()
+  where
+    validCorrelation value =
+        not (null value)
+            && length value <= 64
+            && all (\char -> isAlphaNum char || char == '-') value
+
+validateDescriptor :: RepositoryDescriptor -> Either Text ()
+validateDescriptor descriptor
+    | descriptor.repositoryCloneUrl /= expectedCloneUrl =
+        Left "repository clone URL does not match the GitHub repository name"
+    | not (validFullName descriptor.repositoryFullName) =
+        Left "repository full name is invalid"
+    | not (validRef descriptor.repositoryDefaultBranch) =
+        Left "repository default branch is invalid"
+    | not (validBrokerUrl descriptor.repositoryCredentialBrokerUrl) =
+        Left "repository credential broker URL must use HTTPS or loopback HTTP"
+    | Text.null descriptor.repositoryCredentialLease
+        || Text.length descriptor.repositoryCredentialLease > 512
+        || Text.any isControl descriptor.repositoryCredentialLease =
+        Left "repository credential lease is invalid"
+    | otherwise = Right ()
+  where
+    expectedCloneUrl =
+        "https://github.com/" <> descriptor.repositoryFullName <> ".git"
+
+validFullName :: Text -> Bool
+validFullName value =
+    case Text.splitOn "/" value of
+        [owner, repository] -> validPart owner && validPart repository
+        _ -> False
+  where
+    validPart part =
+        not (Text.null part)
+            && Text.length part <= 100
+            && Text.all (\char -> isAscii char && (isAlphaNum char || char `elem` ("._-" :: String))) part
+
+validRef :: Text -> Bool
+validRef ref =
+    not (Text.null ref)
+        && Text.length ref <= 255
+        && not (Text.isPrefixOf "-" ref)
+        && not (Text.isPrefixOf "/" ref)
+        && not (Text.isSuffixOf "/" ref)
+        && not (".." `Text.isInfixOf` ref)
+        && Text.all (\char -> isAscii char && (isAlphaNum char || char `elem` ("._/-" :: String))) ref
+
+validBrokerUrl :: Text -> Bool
+validBrokerUrl url =
+    Text.all (\char -> isAscii char && not (isControl char) && not (isSpace char)) url
+        && not ("@" `Text.isInfixOf` url)
+        && not ("#" `Text.isInfixOf` url)
+        && ( "https://" `Text.isPrefixOf` url
+                || "http://127.0.0.1:" `Text.isPrefixOf` url
+                || "http://localhost:" `Text.isPrefixOf` url
+           )
+
+makeExecutable :: FilePath -> IO ()
+makeExecutable path = do
+    permissions <- getPermissions path
+    setPermissions path (setOwnerExecutable True permissions)
+    setFileMode path 0o700
+
+runGit :: FilePath -> [String] -> IO ()
+runGit cwd arguments = do
+    inherited <- getEnvironment
+    let safeEnvironment =
+            filter
+                (\(name, _) ->
+                    not ("GIT_" `isPrefixOf` name)
+                        && name `notElem` ["GH_TOKEN", "GITHUB_TOKEN", "SSH_AUTH_SOCK"])
+                inherited
+        command =
+            (proc "git" arguments)
+                { cwd = Just cwd
+                , env = Just (("GIT_TERMINAL_PROMPT", "0") : safeEnvironment)
+                , std_in = NoStream
+                , std_out = NoStream
+                , std_err = NoStream
+                , create_group = True
+                }
+    (_, _, _, processHandle) <- createProcess command
+    Timeout.timeout (120 * 1_000_000) (waitForProcess processHandle) >>= \case
+        Nothing -> do
+            interruptProcessGroupOf processHandle
+            _ <- waitForProcess processHandle
+            fail "git command timed out"
+        Just ExitSuccess -> pure ()
+        Just (ExitFailure _) -> fail "git command failed"
+
+credentialHelperScript :: String
+credentialHelperScript =
+    unlines
+        [ "#!/bin/sh"
+        , "set -eu"
+        , "[ \"${1:-}\" = get ] || exit 0"
+        , "dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)"
+        , "protocol= host= path="
+        , "while IFS='=' read -r key value; do"
+        , "  case \"$key\" in"
+        , "    protocol) protocol=$value ;;"
+        , "    host) host=$value ;;"
+        , "    path) path=$value ;;"
+        , "  esac"
+        , "done"
+        , "[ \"$protocol\" = https ] || exit 0"
+        , "[ \"$host\" = github.com ] || exit 0"
+        , "[ \"${path%.git}\" = \"$(cat \"$dir/repository\")\" ] || exit 0"
+        , "payload=$(jq -cn --arg lease \"$(cat \"$dir/lease\")\" '{lease: $lease}')"
+        , "response=$(curl --fail --silent --show-error --max-time 15 \\"
+        , "  -H 'Content-Type: application/json' -H 'Accept: application/json' \\"
+        , "  --data \"$payload\" \"$(cat \"$dir/endpoint\")\")"
+        , "token=$(printf '%s' \"$response\" | jq -er '.password | select(type == \"string\" and length > 0)')"
+        , "printf 'username=x-access-token\\npassword=%s\\n' \"$token\""
+        ]
+
+ghWrapperScript :: String
+ghWrapperScript =
+    unlines
+        [ "#!/bin/sh"
+        , "set -eu"
+        , "dir=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)"
+        , "payload=$(jq -cn --arg lease \"$(cat \"$dir/lease\")\" '{lease: $lease}')"
+        , "response=$(curl --fail --silent --show-error --max-time 15 \\"
+        , "  -H 'Content-Type: application/json' -H 'Accept: application/json' \\"
+        , "  --data \"$payload\" \"$(cat \"$dir/endpoint\")\")"
+        , "GH_TOKEN=$(printf '%s' \"$response\" | jq -er '.password | select(type == \"string\" and length > 0)')"
+        , "export GH_TOKEN"
+        , "exec gh \"$@\""
+        ]

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -94,6 +94,7 @@ import Agent.Server.Event
 import Agent.Server.Identifier (newUUIDv7Text)
 import Agent.Server.Runtime.SessionCodec
 import Agent.Server.Runtime.Attachments (withMaterializedTurnFiles)
+import Agent.Server.RepositoryCheckout qualified as RepositoryCheckout
 import Agent.Server.Runtime.TurnStore qualified as TurnStore
 import Agent.Server.Sandbox
     ( TenantSandbox
@@ -927,7 +928,8 @@ listSessions environment boundary archiveFilter rawCursor limit =
                                                     (\(meta, archived) ->
                                                         sessionValue
                                                             archived
-                                                            meta)
+                                                            meta
+                                                            Nothing)
                                                     sessions
                                             , "nextCursor"
                                                 .= fmap encodeCursor
@@ -942,26 +944,26 @@ createSessionForBoundary
     -> CreateSessionRequest
     -> IO (Either ApiError Value)
 createSessionForBoundary environment boundary request =
-    resolveTenantWorkspacePath
+    resolveCreateSessionWorkspace
         environment.environmentConfig
         boundary.accessTenantId
-        request.createSessionCwd >>= \case
+        request >>= \case
             Left err -> pure (Left err)
-            Right cwd ->
+            Right (cwd, cleanupOnFailure, repositoryBranch) ->
                 loadModelOptions environment boundary cwd >>= \case
-                    Left err -> pure (Left err)
+                    Left err -> cleanupOnFailure >> pure (Left err)
                     Right (catalog, options) ->
                         case selectModel
                             boundary
                             catalog
                             options
                             request.createSessionModel of
-                                Left err -> pure (Left err)
+                                Left err -> cleanupOnFailure >> pure (Left err)
                                 Right option ->
                                     case resolveEffort
                                         option.modelTarget.targetProvider
                                         request.createSessionEffort of
-                                            Left err -> pure (Left err)
+                                            Left err -> cleanupOnFailure >> pure (Left err)
                                             Right effort -> do
                                                 created <- tryAny $
                                                     createSession SessionCreate
@@ -986,16 +988,57 @@ createSessionForBoundary environment boundary request =
                                                                 (const True)
                                                                 request.createSessionTitle
                                                         }
+                                                case created of
+                                                    Left _ -> cleanupOnFailure
+                                                    Right _ -> pure ()
                                                 pure case created of
                                                     Left _ ->
-                                                        Left
-                                                            (internalApiError
-                                                                "could not create the session")
+                                                        Left (internalApiError "could not create the session")
                                                     Right handle ->
-                                                        Right
-                                                            (sessionValue
-                                                                False
-                                                                handle.sessionMeta)
+                                                        Right (sessionValue False handle.sessionMeta repositoryBranch)
+
+resolveCreateSessionWorkspace
+    :: ResolvedServerConfig
+    -> TenantId
+    -> CreateSessionRequest
+    -> IO (Either ApiError (FilePath, IO (), Maybe Text))
+resolveCreateSessionWorkspace config tenantId request =
+    case request.createSessionRepository of
+        Nothing ->
+            fmap (, pure (), Nothing) <$> resolveTenantWorkspacePath config tenantId request.createSessionCwd
+        Just descriptor
+            | Just _ <- request.createSessionCwd ->
+                pure $
+                    Left ApiError
+                        { apiErrorStatus = 422
+                        , apiErrorCode = "repository_with_cwd"
+                        , apiErrorMessage = "repository and cwd cannot be supplied together"
+                        , apiErrorDetails = Nothing
+                        }
+            | otherwise ->
+                resolveTenantWorkspacePath config tenantId Nothing >>= \case
+                    Left err -> pure (Left err)
+                    Right workspaceRoot -> do
+                        correlation <- newUUIDv7Text
+                        RepositoryCheckout.prepareRepositoryCheckout
+                            workspaceRoot
+                            correlation
+                            descriptor >>= \case
+                                Left message ->
+                                    pure $
+                                        Left ApiError
+                                            { apiErrorStatus = 422
+                                            , apiErrorCode = "repository_checkout_failed"
+                                            , apiErrorMessage = message
+                                            , apiErrorDetails = Nothing
+                                            }
+                                Right checkout ->
+                                    pure $
+                                        Right
+                                            ( checkout.checkoutPath
+                                            , checkout.cleanupCheckout
+                                            , Just checkout.checkoutBranch
+                                            )
 
 getSessionForBoundary
     :: RuntimeEnvironment
@@ -1006,7 +1049,7 @@ getSessionForBoundary environment boundary sessionId =
     fmap
         (fmap
             (\(meta, archived) ->
-                sessionValue archived meta)) $
+                sessionValue archived meta Nothing)) $
         loadAuthorizedSession environment boundary sessionId
 
 patchSessionForBoundary
@@ -1055,12 +1098,18 @@ deleteSessionForBoundary
 deleteSessionForBoundary environment boundary sessionId =
     loadAuthorizedMeta environment boundary sessionId >>= \case
         Left err -> pure (Left err)
-        Right _ ->
-            first sessionOperationError
-                <$> deleteSession
-                    (trustedPool environment.environmentStore)
-                    environment.environmentRoot
-                    sessionId
+        Right meta -> do
+            deleted <-
+                first sessionOperationError
+                    <$> deleteSession
+                        (trustedPool environment.environmentStore)
+                        environment.environmentRoot
+                        sessionId
+            case deleted of
+                Right () ->
+                    RepositoryCheckout.cleanupRepositoryCheckout (unsafeToFilePath meta.metaCwd)
+                Left _ -> pure ()
+            pure deleted
 
 sessionHistoryForBoundary
     :: RuntimeEnvironment
@@ -1163,7 +1212,8 @@ forkSessionForBoundary environment boundary sessionId request =
                                         Right
                                             (sessionValue
                                                 False
-                                                forked.sessionMeta)
+                                                forked.sessionMeta
+                                                Nothing)
 
 runTurn
     :: RuntimeEnvironment

--- a/packages/agent-server/src/Agent/Server/Runtime/SessionCodec.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime/SessionCodec.hs
@@ -27,8 +27,8 @@ import Data.Text qualified as Text
 import Data.Time.Clock (UTCTime)
 import Data.Time.Format (defaultTimeLocale, formatTime, parseTimeM)
 
-sessionValue :: Bool -> SessionMeta -> Value
-sessionValue archived meta = object
+sessionValue :: Bool -> SessionMeta -> Maybe Text -> Value
+sessionValue archived meta repositoryWorkingBranch = object
     [ "id" .= meta.metaId
     , "createdAt" .= meta.metaCreatedAt
     , "updatedAt" .= meta.metaUpdatedAt
@@ -42,6 +42,7 @@ sessionValue archived meta = object
     , "title" .= meta.metaTitle
     , "titleIsManual" .= meta.metaTitleIsManual
     , "archived" .= archived
+    , "repositoryWorkingBranch" .= repositoryWorkingBranch
     , "usage" .= object
         [ "input" .= meta.metaInputTokens
         , "output" .= meta.metaOutputTokens
@@ -62,7 +63,7 @@ modelOptionValue option = object
 
 historyValue :: SessionMeta -> Bool -> SessionTurnPage -> Value
 historyValue meta archived page = object
-    [ "session" .= sessionValue archived meta
+    [ "session" .= sessionValue archived meta Nothing
     , "data" .=
         [ object
             [ "index" .= index

--- a/packages/agent-server/src/Agent/Server/Types.hs
+++ b/packages/agent-server/src/Agent/Server/Types.hs
@@ -32,6 +32,7 @@ module Agent.Server.Types
     , ServerEvent(..)
     , EventSubscription(..)
     , ApiError(..)
+    , RepositoryDescriptor(..)
     , CreateSessionRequest(..)
     , PatchSessionRequest(..)
     , ForkSessionRequest(..)
@@ -339,11 +340,39 @@ data ApiError = ApiError
     }
     deriving (Eq, Show)
 
+data RepositoryDescriptor = RepositoryDescriptor
+    { repositoryFullName :: !Text
+    , repositoryCloneUrl :: !Text
+    , repositoryDefaultBranch :: !Text
+    , repositoryCredentialBrokerUrl :: !Text
+    , repositoryCredentialLease :: !Text
+    }
+    deriving (Eq, Show)
+
+instance FromJSON RepositoryDescriptor where
+    parseJSON = withObject "RepositoryDescriptor" \value -> do
+        rejectUnknownFields
+            "RepositoryDescriptor"
+            [ "fullName"
+            , "cloneUrl"
+            , "defaultBranch"
+            , "credentialBrokerUrl"
+            , "credentialLease"
+            ]
+            value
+        RepositoryDescriptor
+            <$> value .: "fullName"
+            <*> value .: "cloneUrl"
+            <*> value .: "defaultBranch"
+            <*> value .: "credentialBrokerUrl"
+            <*> value .: "credentialLease"
+
 data CreateSessionRequest = CreateSessionRequest
     { createSessionModel :: !(Maybe Text)
     , createSessionCwd :: !(Maybe FilePath)
     , createSessionEffort :: !(Maybe Text)
     , createSessionTitle :: !(Maybe Text)
+    , createSessionRepository :: !(Maybe RepositoryDescriptor)
     }
     deriving (Eq, Show)
 
@@ -351,13 +380,14 @@ instance FromJSON CreateSessionRequest where
     parseJSON = withObject "CreateSessionRequest" \value -> do
         rejectUnknownFields
             "CreateSessionRequest"
-            ["model", "cwd", "effort", "title"]
+            ["model", "cwd", "effort", "title", "repository"]
             value
         CreateSessionRequest
             <$> value .:? "model"
             <*> value .:? "cwd"
             <*> value .:? "effort"
             <*> value .:? "title"
+            <*> value .:? "repository"
 
 data PatchSessionRequest = PatchSessionRequest
     { patchSessionTitle :: !(Maybe Text)

--- a/packages/agent-server/test/Agent/Server/RepositoryCheckoutSpec.hs
+++ b/packages/agent-server/test/Agent/Server/RepositoryCheckoutSpec.hs
@@ -1,0 +1,76 @@
+module Agent.Server.RepositoryCheckoutSpec (spec) where
+
+import Data.List (isInfixOf)
+import Test.Hspec (Spec, describe, it, shouldSatisfy)
+import Agent.Server.RepositoryCheckout
+    ( credentialHelperScript
+    , ghWrapperScript
+    , validateDescriptor
+    )
+import Agent.Server.Types (RepositoryDescriptor(..))
+
+spec :: Spec
+spec =
+    describe "repository checkout descriptors" do
+        it "accepts a canonical GitHub repository with an HTTPS broker" do
+            validDescriptor `shouldSatisfy` isValid
+
+        it "rejects a clone URL that does not match the repository" do
+            validDescriptor
+                { repositoryCloneUrl = "https://github.com/other/repository.git"
+                }
+                `shouldSatisfy` isInvalid
+
+        it "rejects broker URLs with userinfo or fragments" do
+            validDescriptor
+                { repositoryCredentialBrokerUrl = "https://gateway.example@attacker.example/token"
+                }
+                `shouldSatisfy` isInvalid
+            validDescriptor
+                { repositoryCredentialBrokerUrl = "https://gateway.example/token#ignored"
+                }
+                `shouldSatisfy` isInvalid
+
+        it "uses the JSON lease broker contract without exposing the lease as bearer auth" do
+            credentialHelperScript `shouldSatisfy` isInfixOf "'{lease: $lease}'"
+            credentialHelperScript `shouldSatisfy` isInfixOf "Content-Type: application/json"
+            credentialHelperScript `shouldSatisfy` isInfixOf ".password"
+            credentialHelperScript `shouldSatisfy` (not . isInfixOf "Authorization: Bearer")
+            ghWrapperScript `shouldSatisfy` isInfixOf "'{lease: $lease}'"
+            ghWrapperScript `shouldSatisfy` isInfixOf ".password"
+
+        it "rejects refs and broker URLs containing unsafe characters" do
+            validDescriptor
+                { repositoryDefaultBranch = "--upload-pack=malicious"
+                }
+                `shouldSatisfy` isInvalid
+            validDescriptor
+                { repositoryCredentialBrokerUrl = "https://gateway.example/token\nAuthorization: injected"
+                }
+                `shouldSatisfy` isInvalid
+
+        it "allows loopback HTTP only for local brokers" do
+            validDescriptor
+                { repositoryCredentialBrokerUrl = "http://127.0.0.1:8080/token"
+                }
+                `shouldSatisfy` isValid
+            validDescriptor
+                { repositoryCredentialBrokerUrl = "http://gateway.example/token"
+                }
+                `shouldSatisfy` isInvalid
+
+validDescriptor :: RepositoryDescriptor
+validDescriptor =
+    RepositoryDescriptor
+        { repositoryFullName = "digitallyinduced/haskell-agent"
+        , repositoryCloneUrl = "https://github.com/digitallyinduced/haskell-agent.git"
+        , repositoryDefaultBranch = "main"
+        , repositoryCredentialBrokerUrl = "https://gateway.example/api/v1/github/repository-token"
+        , repositoryCredentialLease = "opaque-lease"
+        }
+
+isValid :: RepositoryDescriptor -> Bool
+isValid = either (const False) (const True) . validateDescriptor
+
+isInvalid :: RepositoryDescriptor -> Bool
+isInvalid = not . isValid

--- a/packages/agent-server/test/Spec.hs
+++ b/packages/agent-server/test/Spec.hs
@@ -5,6 +5,7 @@ import Agent.Server.ApplicationSpec qualified
 import Agent.Server.AuthSpec qualified
 import Agent.Server.ConfigSpec qualified
 import Agent.Server.EventSpec qualified
+import Agent.Server.RepositoryCheckoutSpec qualified
 import Agent.Server.SandboxSpec qualified
 import Agent.Server.SupervisorSpec qualified
 import Agent.Server.TenantSpec qualified
@@ -21,6 +22,7 @@ main = do
                 Agent.Server.AuthSpec.spec
                 Agent.Server.ConfigSpec.spec
                 Agent.Server.EventSpec.spec
+                Agent.Server.RepositoryCheckoutSpec.spec
                 Agent.Server.SupervisorSpec.spec
                 Agent.Server.TenantSpec.spec
                 Agent.Server.SandboxSpec.spec


### PR DESCRIPTION
## Summary
- accept and validate GitHub repository descriptors when cloud sessions are created
- clone repositories into isolated per-session workspaces through a short-lived lease credential helper
- expose authenticated `git` and `gh` access without persisting GitHub tokens, and clean up checkouts with the session
- include the required GitHub tooling in the sandbox root filesystem

## Testing
- `nix develop --impure -c cabal build agent-server`
- `nix develop --impure -c cabal test agent-server-test` (92 examples, 0 failures)

## Related
- Gateway integration: digitallyinduced/haskell-agent-gateway#93