### PR TITLE
Add snapshot-backed worktree GC with automatic adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,65 @@ remote is selected from the current branch's configured remote, then
 fetch failure aborts worktree creation rather than falling back to a stale
 commit.
 
+### Worktree recovery and cleanup
+
+New managed worktrees are enrolled in snapshot-backed cleanup. After seven
+days of inactivity, an inactive, unprotected checkout may be collected even
+when it contains uncommitted work. Before removal, recovery refs preserve its
+commits, staged changes, working-tree changes, and non-ignored untracked files.
+Conversation history is not deleted; resuming a collected session restores
+its checkout. Recovery snapshots do not automatically expire.
+
+**Ignored untracked files are not backed up.** This includes ignored `.env`
+files, build output, and local databases. Move important ignored data outside
+the checkout or protect the worktree before relying on it.
+
+Existing agent worktrees are automatically adopted only when their managed-root
+location, reciprocal linked-Git metadata, and saved-session provenance verify
+ownership. Their latest saved-session activity (including archived sessions and
+sessions in checkout subdirectories) initializes inactivity; adoption does not
+reset old worktrees to today. Missing or ambiguous ownership/activity retains
+the checkout. Database errors or incompatible session metadata defer adoption;
+stale legacy JSON and directory names/mtime are not activity fallbacks.
+Review the simulated adoption and retention reasons first:
+
+```console
+agent-cli worktree gc --dry-run
+agent-cli worktree enroll /absolute/path/to/managed/worktree
+agent-cli worktree protect /absolute/path/to/managed/worktree
+agent-cli worktree unprotect /absolute/path/to/managed/worktree
+agent-cli worktree restore /absolute/path/to/managed/worktree
+```
+
+`gc --dry-run` reports eligibility, retained reasons, and per-checkout and total
+estimated bytes without writing registry entries or snapshots or collecting
+checkouts. Estimates are gross apparent checkout bytes, excluding snapshot
+overhead and filesystem/APFS sharing, not guaranteed net reclaimed disk space.
+Adoption reads the existing session database
+without starting it, migrating it, or importing old sessions. Manual `enroll`
+remains available for a checkout whose provenance cannot be established and
+starts its inactivity clock now. `gc` runs a bounded collection pass.
+Active leases, explicit protection, unsupported Git state, incomplete snapshots,
+or detected concurrent edits prevent deletion. Restoration refuses to overwrite
+an existing directory and never resets a branch that moved after collection.
+Restored checkouts use a detached HEAD. Recovery requires the original shared
+Git repository and the registry under `~/.haskell-agent/worktrees/.registry`;
+these local snapshots are not an off-machine backup. An interrupted restore
+that leaves a directory requires manual recovery rather than overwriting it.
+External editors do not participate in agent leases: protect a checkout while
+using it outside the agent, since edits after the final verification can race
+with removal.
+Existing saved-session lifetime and turn locks are also probed without creating
+lock files; an active or unverifiable lock retains its checkout even if its last
+saved activity is old. Stop pre-upgrade agents before explicit collection:
+their locks can be observed, but an old binary starting after the final probe
+does not participate in the new worktree lease protocol.
+
+Configure a positive whole number of days with
+`"worktree": {"inactivityDays": 14}` in `~/.haskell-agent/config.json`, or use
+`worktree gc --inactivity-days 14` for one pass. Saving a conversation does not
+protect a checkout forever; use `worktree protect` for long-lived work.
+
 Use `--provider openai`, `--provider xai`, `--provider openrouter`,
 `--provider gemini`, or `--provider claude-code` to override automatic
 provider detection. Claude Code is selected explicitly rather than by

--- a/README.md
+++ b/README.md
@@ -282,6 +282,24 @@ commits, staged changes, working-tree changes, and non-ignored untracked files.
 Conversation history is not deleted; resuming a collected session restores
 its checkout. Recovery snapshots do not automatically expire.
 
+A checkout whose exact `HEAD` is already an ancestor of the repository's
+default branch is eligible after **24 hours of inactivity**, rather than the
+normal configured interval. This means idle time, not 24 hours since merge;
+commit author/committer timestamps are not activity or merge clocks. Additional
+commits not incorporated into the default branch disqualify this fast path.
+Dirty checkouts still require the same verified recovery snapshot, and all
+ownership, active-session, protection and safety checks still apply.
+
+Maintenance resolves the selected remote's existing local symbolic
+`refs/remotes/<remote>/HEAD`, using the branch's configured remote, then
+`upstream`, `origin`, or a sole remaining remote. It does not fetch, guess
+`master`/`main`, or use the currently checked-out branch as the default.
+Missing default-branch evidence keeps the normal interval. Locally cached refs
+can be stale: this proves incorporation into the available ref, not the current
+server state, and may miss recent merges. Squash/rebase merges without exact
+ancestry proof also keep the normal interval; matching commit messages or trees
+are not merge evidence.
+
 **Ignored untracked files are not backed up.** This includes ignored `.env`
 files, build output, and local databases. Move important ignored data outside
 the checkout or protect the worktree before relying on it.

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -273,6 +273,11 @@ library
                     , Agent.CLI.WebFetch
                     , Agent.CLI.WindowTitle
                     , Agent.CLI.Worktree
+                    , Agent.CLI.WorktreeAdmin
+                    , Agent.CLI.Worktree.Registry
+                    , Agent.CLI.Worktree.ReadOnlyLock
+                    , Agent.CLI.Worktree.Provenance
+                    , Agent.CLI.Worktree.Snapshot
     reexported-modules:
                       agent-external-session:Agent.CLI.ExternalSession as Agent.CLI.ExternalSession
                     , agent-cli-runtime:Agent.CLI.Auth as Agent.CLI.Auth
@@ -571,6 +576,9 @@ test-suite agent-cli-test
                     , Agent.CLI.UsageSpec
                     , Agent.CLI.WebLspSpec
                     , Agent.CLI.WorktreeSpec
+                    , Agent.CLI.WorktreeAdminSpec
+                    , Agent.CLI.Worktree.SnapshotSpec
+                    , Agent.CLI.Worktree.ProvenanceSpec
     build-depends:    agent-cli
                     , agent-cli-runtime
                     , agent-connectivity
@@ -601,6 +609,8 @@ test-suite agent-cli-test
                     , filepath
                     , haskeline >= 0.8 && < 0.9
                     , hspec >= 2.11 && < 2.12
+                    , filelock
+                    , temporary
                     , http-client
                     , http-types
                     , JuicyPixels

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -9,8 +9,9 @@
 , filepath, haskeline, hasql-pool, hspec, http-client
 , http-client-tls, http-types, JuicyPixels, lib, memory, mtl
 , network, network-uri, optparse-applicative, process, QuickCheck
-, retry, safe-exceptions, scientific, stm, tagsoup, text, time
-, transformers, unix, vector, vty, vty-crossplatform, wai, warp
+, retry, safe-exceptions, scientific, stm, tagsoup, temporary, text
+, time, transformers, unix, vector, vty, vty-crossplatform, wai
+, warp
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -43,9 +44,9 @@ mkDerivation {
     agent-json agent-mcp agent-openai agent-openrouter agent-responses
     agent-responses-types agent-store agent-tui agent-xai ansi-terminal
     async base brick bytestring colour containers dbus directory
-    filepath haskeline hspec http-client http-types JuicyPixels process
-    QuickCheck safe-exceptions stm text time transformers unix vty wai
-    warp
+    filelock filepath haskeline hspec http-client http-types
+    JuicyPixels process QuickCheck safe-exceptions stm temporary text
+    time transformers unix vty wai warp
   ];
   benchmarkHaskellDepends = [
     aeson agent-core agent-json agent-mcp agent-responses

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -220,6 +220,7 @@ data LspConfig = LspConfig
 -- default, while local-only repositories continue to branch from @HEAD@.
 data WorktreeConfig = WorktreeConfig
     { worktreeFetchLatestUpstream :: !Bool
+    , worktreeInactiveDays :: !Int
     }
     deriving (Eq, Show)
 
@@ -330,6 +331,7 @@ instance Aeson.ToJSON WorktreeConfig where
         Aeson.object
             [ "fetchLatestUpstream"
                 Aeson..= config.worktreeFetchLatestUpstream
+            , "inactivityDays" Aeson..= config.worktreeInactiveDays
             ]
 
 data HarnessConfig = HarnessConfig
@@ -376,6 +378,7 @@ defaultHarnessConfig = HarnessConfig
         }
     , configWorktree = WorktreeConfig
         { worktreeFetchLatestUpstream = True
+        , worktreeInactiveDays = 7
         }
     , configMaxConcurrentAgents = Nothing
     }
@@ -481,6 +484,7 @@ worktreeConfigDecoder =
     Hermes.object $
         WorktreeConfig
             <$> defaultKey True "fetchLatestUpstream" Hermes.bool
+            <*> defaultKey 7 "inactivityDays" Hermes.int
 
 harnessConfigDecoder :: Hermes.Decoder HarnessConfig
 harnessConfigDecoder =
@@ -789,6 +793,8 @@ updateHarnessConfig home update =
 
 validateHarnessConfig :: HarnessConfig -> Either Text HarnessConfig
 validateHarnessConfig config = do
+    when (config.configWorktree.worktreeInactiveDays <= 0) $
+        Left "worktree.inactivityDays must be a positive integer"
     unless (config.configVersion == harnessConfigSchemaVersion) $
         Left
             ( "Unsupported harness config version "

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -348,7 +348,7 @@ worktreeParser = Worktree <$> Options.hsubparser
                     (Options.long "dry-run" <> Options.help "Simulate adoption and report eligibility, reasons and estimated bytes without writing or collecting")
                 <*> Options.optional (Options.option (positiveIntReader "--inactivity-days")
                     (Options.long "inactivity-days" <> Options.metavar "DAYS"
-                        <> Options.help "Override configured inactivity expiry (default 7 days)")))
+                        <> Options.help "Override normal inactivity expiry (default 7 days; incorporated HEADs expire after 24h idle)")))
             (Options.progDesc "Adopt verified agent worktrees, then snapshot and collect inactive checkouts; ignored files are NOT recovered"))
     <> pathCommand "enroll" WorktreeEnroll "Explicitly enroll an existing checkout in automatic collection"
     <> pathCommand "restore" WorktreeRestore "Restore a collected checkout without overwriting existing paths"

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Options
     , SessionOutputFormat(..)
     , SessionPageRequest(..)
     , StorageCommand(..)
+    , WorktreeCommand(..)
     , defaultCliOptions
     , defaultEffortFor
     , freshSessionOptions
@@ -60,7 +61,16 @@ data Command
     | WaitSession Text
     | ImportSession (Maybe OsPath)
     | Storage StorageCommand
+    | Worktree WorktreeCommand
     | RunAgent CliOptions
+    deriving (Eq, Show)
+
+data WorktreeCommand
+    = WorktreeGC !Bool !(Maybe Int)
+    | WorktreeEnroll !OsPath
+    | WorktreeRestore !OsPath
+    | WorktreeProtect !OsPath
+    | WorktreeUnprotect !OsPath
     deriving (Eq, Show)
 
 data SessionPageRequest
@@ -262,7 +272,7 @@ parseArgs args
 isRunInvocation :: [String] -> Bool
 isRunInvocation = \case
     command : _ ->
-        command `notElem` ["gateway", "login", "mcp", "sessions", "storage"]
+        command `notElem` ["gateway", "login", "mcp", "sessions", "storage", "worktree"]
     [] -> True
 
 parserPreferences :: Options.ParserPrefs
@@ -323,8 +333,33 @@ commandParser =
             <> Options.command "storage"
                 (Options.info storageParser
                     (Options.progDesc "Administer managed PostgreSQL storage"))
+            <> Options.command "worktree"
+                (Options.info worktreeParser
+                    (Options.progDesc "Collect and recover inactive managed worktrees"))
         )
         Options.<|> (RunAgent <$> runOptionsParser)
+
+worktreeParser :: Options.Parser Command
+worktreeParser = Worktree <$> Options.hsubparser
+    ( Options.command "gc"
+        (Options.info
+            (WorktreeGC
+                <$> Options.switch
+                    (Options.long "dry-run" <> Options.help "Simulate adoption and report eligibility, reasons and estimated bytes without writing or collecting")
+                <*> Options.optional (Options.option (positiveIntReader "--inactivity-days")
+                    (Options.long "inactivity-days" <> Options.metavar "DAYS"
+                        <> Options.help "Override configured inactivity expiry (default 7 days)")))
+            (Options.progDesc "Adopt verified agent worktrees, then snapshot and collect inactive checkouts; ignored files are NOT recovered"))
+    <> pathCommand "enroll" WorktreeEnroll "Explicitly enroll an existing checkout in automatic collection"
+    <> pathCommand "restore" WorktreeRestore "Restore a collected checkout without overwriting existing paths"
+    <> pathCommand "protect" WorktreeProtect "Protect an enrolled checkout from collection"
+    <> pathCommand "unprotect" WorktreeUnprotect "Allow inactivity-based collection again"
+    )
+  where
+    pathCommand name constructor description =
+        Options.command name (Options.info
+            (constructor <$> (unsafeEncodeUtf <$> Options.argument Options.str (Options.metavar "PATH")))
+            (Options.progDesc description))
 
 gatewayParser :: Options.Parser Command
 gatewayParser = Gateway <$> Options.hsubparser
@@ -680,6 +715,8 @@ usage = unlines
     , "       agent-cli mcp login <url> [--scope SCOPE]..."
     , "       agent-cli mcp logout <url>"
     , "       agent-cli storage <status|start|stop|migrate|doctor>"
+    , "       agent-cli worktree gc [--dry-run] [--inactivity-days DAYS]"
+    , "       agent-cli worktree <enroll|restore|protect|unprotect> PATH"
     , ""
     , "  -p, --prompt TEXT       Run one prompt and exit"
     , "      --prompt-file FILE  Read the one-shot prompt from a file"

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -38,6 +38,7 @@ import Agent.CLI.McpOAuth
     , loginMcpWith
     , logoutMcp
     )
+import Agent.CLI.WorktreeAdmin (runWorktreeAdmin)
 import Agent.CLI.McpStatus
     ( formatMcpModelNotice
     , formatMcpModelNoticeFor
@@ -167,6 +168,8 @@ devMainResume resumeId = do
         Right (ImportSession cwd) -> runImportSession cwd >> pure DevQuit
         Right (Storage command) ->
             runStorageAdmin command >> pure DevQuit
+        Right (Worktree command) ->
+            runWorktreeAdmin command >> pure DevQuit
         Right (RunAgent options) -> do
             result <- runAgentWithRestarts options
             case result of
@@ -193,6 +196,7 @@ run = do
         Right (WaitSession sessionId) -> runWaitSession sessionId
         Right (ImportSession cwd) -> runImportSession cwd
         Right (Storage command) -> runStorageAdmin command
+        Right (Worktree command) -> runWorktreeAdmin command
         Right (RunAgent options) -> do
             result <- runAgentWithRestarts options
             case result of

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -139,7 +139,8 @@ import Agent.CLI.Terminal
       resolveColor,
       TerminalCapabilities(terminalNativeProgress) )
 import Agent.CLI.Worktree
-    ( createManagedWorktreeFromConfigWithProgress, worktreeProgressMessage )
+    ( createManagedWorktreeFromConfigWithProgress, worktreeProgressMessage
+    , restoreManagedWorktree, worktreeRoot )
 import Agent.Cancel ( requestCancel )
 import Agent.OsPath ( toText )
 import Agent.Provider ( Provider(OpenAIProvider) )
@@ -763,6 +764,13 @@ prepareAgentIterationResources request = do
                     getCurrentDirectory
                     makeAbsolute
                     request.iterationRunMode.runCwdHint
+    -- Native resumes supply optCwd too. Restore the selected effective cwd,
+    -- not an unrelated historical path when the caller overrides it.
+    forM_ resumed $ \_ ->
+        restoreManagedWorktree (worktreeRoot home) source >>= \case
+            Left err -> failAgentIterationPreparation request
+                ("Could not restore session worktree: " <> err)
+            Right () -> pure ()
     pure AgentIterationResources
         { iterationStartedAt = startedAt
         , iterationStartupTimings = startupTimingsRef

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Scratch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Scratch.hs
@@ -7,6 +7,7 @@ module Agent.CLI.Runtime.Orchestration.Tools.Scratch
     ) where
 
 import Agent.CLI.Error (formatException)
+import Agent.CLI.Config (HarnessConfig(..), WorktreeConfig(..))
 import Agent.CLI.ExternalSession (defaultExternalSessionEnv, externalSessionTool)
 import Agent.CLI.ManagedTurn (ManagedTurnRequest(..))
 import Agent.CLI.Models (ModelTarget(..))
@@ -19,9 +20,9 @@ import Agent.CLI.Runtime.Orchestration.Tools.Request
 import Agent.CLI.Runtime.Orchestration.Types (AgentProcessRuntime(..), NativeRunCapabilities(..))
 import Agent.CLI.Runtime.Persistence (preparePersistence)
 import Agent.CLI.Session
-    ( Persistence, SessionMeta(..), SessionTempCleanupReport(..)
+    ( Persistence, SessionTempCleanupReport(..)
     , acquireSessionTempLease, allocateSessionTemp, cleanupPendingPersistence
-    , cleanupStaleSessionTemps, defaultSessionTempKeepCount, listSessions
+    , cleanupStaleSessionTemps, defaultSessionTempKeepCount
     , loadCurrentTaskPlan, persistenceTempDir, releaseSessionTempLease
     , removeSessionTemp, taskPlanHooksForPersistence )
 import Agent.CLI.Session.History (foldSessionItems)
@@ -31,8 +32,9 @@ import Agent.CLI.Startup.Auth (startupDie)
 import Agent.CLI.TUI.App (clearFullscreenHistorySource, setFullscreenHistorySource)
 import Agent.CLI.TUI.History (HistoryGeneration(..))
 import Agent.CLI.Worktree
-    ( WorktreeCleanupReport(..), acquireWorktreeLease, cleanupStaleWorktrees
-    , defaultWorktreeKeepCount, releaseWorktreeLease, worktreeRoot )
+    ( WorktreeCleanupReport(..), acquireWorktreeLease, gcWorktreesWithActivity
+    , releaseWorktreeLease, worktreeRoot )
+import Agent.CLI.Worktree.Provenance (loadWorktreeActivity)
 import Agent.OpenAI.ImageGeneration
     ( ImageGenerationHistory, newImageGenerationHistory, recordImageGenerationResponseItems )
 import Agent.OsPath (unsafeToFilePath)
@@ -191,35 +193,24 @@ startStaleResourceCleanup AgentToolsRequest
     -- candidate. It must never delay interactive startup.
     _ <- processRuntime.processStartCleanup do
         cleanupResult <- try @_ @SomeException do
-            (sessions, sessionWarnings) <-
-                listSessions
-                    (trustedPool startup.startupDatabaseStore)
-                    root
-            let protectedWorktrees =
-                    -- Persisted sessions must remain resumable. A worktree
-                    -- becomes collectible after its session is deleted.
-                    cwd : map (.metaCwd) sessions
             (worktreeReport, tempReport) <- concurrently
-                (if null sessionWarnings
-                    then cleanupStaleWorktrees
-                        (worktreeRoot home)
-                        defaultWorktreeKeepCount
-                        protectedWorktrees
-                    -- A partial session catalog cannot prove that an old
-                    -- checkout is unreferenced.
-                    else pure mempty)
+                (gcWorktreesWithActivity
+                    (loadWorktreeActivity (trustedPool startup.startupDatabaseStore) (worktreeRoot home))
+                    (worktreeRoot home)
+                    startup.startupHarnessConfig.configWorktree.worktreeInactiveDays
+                    False
+                    [cwd])
                 (cleanupStaleSessionTemps
                     root
                     defaultSessionTempKeepCount
                     [sessionTmp])
-            pure (sessionWarnings, worktreeReport, tempReport)
+            pure (worktreeReport, tempReport)
         case cleanupResult of
             Left exception ->
                 reportStartupWarning startup
                     ("stale resource cleanup failed: "
                         <> formatException exception)
-            Right (sessionWarnings, worktreeReport, tempReport) -> do
-                mapM_ (reportStartupWarning startup) sessionWarnings
+            Right (worktreeReport, tempReport) -> do
                 forM_ worktreeReport.cleanupFailures \(path, err) ->
                     reportStartupWarning startup
                         ("could not clean stale worktree "

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -7,7 +7,11 @@ module Agent.CLI.Worktree
     , createManagedWorktreeFromConfigWithProgress
     , removeWorktree
     , cleanupStaleWorktrees
-    , defaultWorktreeKeepCount
+    , gcWorktrees
+    , gcWorktreesWithActivity
+    , enrollWorktree
+    , protectWorktree
+    , restoreManagedWorktree
     , WorktreeCleanupReport(..)
     , WorktreeLease
     , acquireWorktreeLease
@@ -25,6 +29,9 @@ import Agent.CLI.Config
     , loadHarnessConfig
     )
 import Agent.OsPath (unsafeToFilePath)
+import Agent.CLI.Worktree.Registry
+import Agent.CLI.Worktree.ReadOnlyLock (withExistingReadOnlyLock)
+import qualified Agent.CLI.Worktree.Snapshot as Snapshot
 import Control.Applicative ((<|>))
 import Control.Exception.Safe
     ( SomeException
@@ -33,8 +40,10 @@ import Control.Exception.Safe
     , mask
     , onException
     , tryAny
+    , catchIO
     )
-import Control.Monad (filterM, foldM, void)
+import Control.Monad (foldM, void, when, unless)
+import Data.IORef (newIORef, readIORef, modifyIORef')
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
     ( ExceptT(..)
@@ -44,25 +53,32 @@ import Control.Monad.Trans.Except
     )
 import qualified Data.ByteString as ByteString
 import Data.Char (isHexDigit)
-import Data.List (isPrefixOf, sortOn)
+import Data.List (isPrefixOf)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Maybe (listToMaybe)
-import Data.Ord (Down(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
 import Data.Time.Calendar (Day)
-import Data.Time.Clock (UTCTime(..), getCurrentTime, nominalDiffTimeToSeconds)
+import Data.Time.Clock (UTCTime(..), getCurrentTime, nominalDiffTimeToSeconds, diffUTCTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format (defaultTimeLocale, formatTime, parseTimeM)
 import Numeric (showHex)
+import System.IO.Error (isDoesNotExistError)
 import System.Directory.OsPath
     ( createDirectoryIfMissing
     , doesDirectoryExist
+    , doesFileExist
     , doesPathExist
     , listDirectory
     , pathIsSymbolicLink
     , removePathForcibly
     )
 import System.Entropy (getEntropy)
+import qualified System.Directory as Directory
+import qualified System.FilePath as FilePath
+import System.Timeout (timeout)
 import System.Exit (ExitCode(..))
 import qualified System.FileLock as FileLock
 import System.OsPath
@@ -96,15 +112,11 @@ worktreeProgressMessage = \case
     branchName ref =
         maybe ref id (Text.stripPrefix "refs/heads/" ref)
 
--- | Match Codex Desktop's default per-repository retention. Worktrees beyond
--- this count are only removed when they are inactive, clean, and their HEAD is
--- reachable from another branch or tag.
-defaultWorktreeKeepCount :: Int
-defaultWorktreeKeepCount = 15
-
 data WorktreeCleanupReport = WorktreeCleanupReport
     { cleanupRemoved :: ![OsPath]
     , cleanupFailures :: ![(OsPath, Text)]
+    , cleanupEligible :: ![(OsPath, Integer)]
+    , cleanupRetained :: ![(OsPath, Text)]
     }
     deriving (Eq, Show)
 
@@ -112,12 +124,14 @@ instance Semigroup WorktreeCleanupReport where
     left <> right = WorktreeCleanupReport
         { cleanupRemoved = left.cleanupRemoved <> right.cleanupRemoved
         , cleanupFailures = left.cleanupFailures <> right.cleanupFailures
+        , cleanupEligible = left.cleanupEligible <> right.cleanupEligible
+        , cleanupRetained = left.cleanupRetained <> right.cleanupRetained
         }
 
 instance Monoid WorktreeCleanupReport where
-    mempty = WorktreeCleanupReport [] []
+    mempty = WorktreeCleanupReport [] [] [] []
 
-newtype WorktreeLease = WorktreeLease FileLock.FileLock
+data WorktreeLease = WorktreeLease FileLock.FileLock (Maybe (OsPath, OsPath))
 
 -- | @~/.haskell-agent/worktrees@ given the user's home directory.
 worktreeRoot :: OsPath -> OsPath
@@ -203,12 +217,17 @@ createManagedWorktreeFromConfigWithProgress
     -> OsPath
     -> OsPath
     -> IO (Either Text OsPath)
-createManagedWorktreeFromConfigWithProgress report config home source =
-    createWorktreeWithFetchProgress
+createManagedWorktreeFromConfigWithProgress report config home source = do
+    created <- createWorktreeWithFetchProgress
         report
         config.configWorktree.worktreeFetchLatestUpstream
         source
         (worktreeRoot home)
+    case created of
+        Left err -> pure (Left err)
+        Right path -> enrollWorktree (worktreeRoot home) path >>= \case
+            Left err -> pure (Left ("Created checkout but enrollment failed; retained safely: " <> err))
+            Right () -> pure (Right path)
 
 -- | Remove a managed worktree and the branch created for it.
 removeWorktree :: OsPath -> OsPath -> IO (Either Text ())
@@ -227,289 +246,344 @@ acquireWorktreeLease
     :: OsPath
     -> OsPath
     -> IO (Either Text (Maybe WorktreeLease))
-acquireWorktreeLease root path =
+acquireWorktreeLease root path = mask $ \restore ->
     case managedWorktreePath root path of
         Nothing -> pure (Right Nothing)
         Just managed -> do
             let lockPath = worktreeLeasePath root managed
             result <- tryAny do
+                linked <- pathIsSymbolicLink root
+                when linked (ioError (userError "symlinked managed worktree root"))
                 createDirectoryIfMissing True (takeDirectory lockPath)
                 FileLock.tryLockFile
                     (unsafeToFilePath lockPath)
                     FileLock.Shared
-            pure case result of
+            case result of
                 Left exception ->
-                    Left
+                    pure $ Left
                         ("failed to lease managed worktree "
                             <> pathText managed
                             <> ": "
                             <> Text.pack (displayException exception))
                 Right Nothing ->
-                    Left
+                    pure $ Left
                         ("managed worktree is being cleaned up: "
                             <> pathText managed)
-                Right (Just lock) -> Right (Just (WorktreeLease lock))
+                Right (Just lock) -> do
+                    activity <- restore (touchWorktree root managed)
+                        `onException` FileLock.unlockFile lock
+                    case activity of
+                        Left err -> FileLock.unlockFile lock >> pure (Left err)
+                        Right () -> pure (Right (Just (WorktreeLease lock (Just (root, managed)))))
 
 releaseWorktreeLease :: WorktreeLease -> IO ()
-releaseWorktreeLease (WorktreeLease lock) = do
-    _ <- tryAny (FileLock.unlockFile lock)
-    pure ()
+releaseWorktreeLease (WorktreeLease lock activity) =
+    (case activity of
+        Nothing -> pure ()
+        Just (root, path) -> void (touchWorktree root path))
+    `finally` FileLock.unlockFile lock
 
--- | Remove old managed worktrees without risking unique Git work.
---
--- Retention is applied per repository directory. A candidate must use our
--- generated path and branch name, be a linked worktree with no tracked or
--- untracked changes, have no active lease, and have a HEAD reachable from
--- another local branch, remote-tracking branch, or tag. Removal deliberately
--- omits @--force@. The generated branch is then deleted with @-d@, leaving it
--- intact without treating that data-safe fallback as a cleanup failure
--- whenever Git's own merged-branch check is stricter than ours.
--- Worktrees created on the current UTC day are never considered stale; this
--- also closes the interval between checkout creation and lease acquisition.
+-- | Updating activity never enrolls legacy checkouts.
+touchWorktree :: OsPath -> OsPath -> IO (Either Text ())
+touchWorktree root path = readRecord root path >>= \case
+    Left err -> pure (Left err)
+    Right Nothing -> pure (Right ())
+    Right (Just _) -> do
+        now <- getCurrentTime
+        modifyRecord root path (Right . fmap (\r -> r { recordLastActivity = now }))
+
+-- | Explicit consent to the ignored-file exclusion and inactivity policy.
+-- Enrollment starts the inactivity clock now, not at the old checkout date.
+enrollWorktree :: OsPath -> OsPath -> IO (Either Text ())
+enrollWorktree root path = catchingWorktree $ withExclusiveManaged root path $ runExceptT do
+    common <- inspectManagedIdentity root path
+    now <- lift getCurrentTime
+    ExceptT $ modifyRecord root path $ \case
+        Just record
+            | record.recordCommonDir == unsafeToFilePath common ->
+                Right (Just record)
+            | otherwise -> Left "enrolled repository identity changed"
+        Nothing -> Right (Just WorktreeRecord
+            { recordVersion = 1
+            , recordCheckout = unsafeToFilePath path
+            , recordCommonDir = unsafeToFilePath common
+            , recordLastActivity = now
+            , recordProtected = False
+            , recordState = "present"
+            , recordSnapshot = Nothing
+            })
+
+protectWorktree :: OsPath -> OsPath -> Bool -> IO (Either Text ())
+protectWorktree root path protected = catchingWorktree $
+    withExclusiveManaged root path $
+        modifyRecord root path $ \case
+            Nothing -> Left "worktree is not enrolled; enroll explicitly first"
+            Just record -> Right (Just record { recordProtected = protected })
+
+-- | Resume only restores absent enrolled checkouts. It never overwrites a path
+-- or rewinds the old branch; snapshot restoration uses a detached HEAD.
+restoreManagedWorktree :: OsPath -> OsPath -> IO (Either Text ())
+restoreManagedWorktree root requested =
+    case managedWorktreePath root requested of
+        Nothing -> pure (Right ())
+        Just path -> catchingWorktree do
+            exists <- doesPathExist path
+            if exists then mask $ \restore ->
+                acquireWorktreeLease root path >>= \case
+                    Left err -> pure (Left err)
+                    Right Nothing -> pure (Left "managed checkout identity changed during resume")
+                    Right (Just lease) ->
+                        restore (do
+                            stillExists <- doesPathExist path
+                            if not stillExists
+                                then pure (Left "checkout was collected during resume; retry to restore")
+                                else readRecord root path >>= \case
+                                    Left err -> pure (Left err)
+                                    Right (Just record) | record.recordState /= "present" ->
+                                        pure (Left ("checkout exists in interrupted maintenance state "
+                                            <> record.recordState <> "; refusing to overwrite it"))
+                                    _ -> pure (Right ()))
+                        `finally` releaseWorktreeLease lease
+            else
+                withExclusiveManaged root path $ runExceptT do
+                    record <- ExceptT (readRecord root path) >>= maybe
+                        (throwE "missing worktree has no enrolled recovery record") pure
+                    unless (record.recordState `elem` ["collecting", "collected", "restoring"])
+                        (throwE "checkout disappeared outside collection; refusing a potentially stale snapshot")
+                    snapshot <- maybe
+                        (throwE "missing worktree has no verified recovery snapshot")
+                        pure record.recordSnapshot
+                    let common = unsafeEncodeUtf record.recordCommonDir
+                    ExceptT $ withGitWorktreeLockAt common $ runExceptT do
+                        links <- lift $ mapM pathIsSymbolicLink [root, takeDirectory path]
+                        when (or links) (throwE "symlinked restoration parent")
+                        -- Persist before restoration. Interrupted restore leaves
+                        -- a directory that future resumes will not overwrite.
+                        ExceptT $ writeRecord root path record { recordState = "restoring" }
+                        ExceptT $ Snapshot.restoreSnapshot common path snapshot
+                        now <- lift getCurrentTime
+                        ExceptT $ writeRecord root path record
+                            { recordState = "present", recordLastActivity = now }
+
+withExclusiveManaged :: OsPath -> OsPath -> IO (Either Text a) -> IO (Either Text a)
+withExclusiveManaged root path action = mask $ \restore ->
+    if managedWorktreePath root path /= Just path
+        || any (== unsafeEncodeUtf "..") (splitDirectories path)
+        then pure (Left "expected a managed checkout root, not a subdirectory or traversal")
+        else tryExclusiveWorktreeLease root path >>= \case
+            Left err -> pure (Left err)
+            Right Nothing -> pure (Left "worktree is active or another maintenance operation holds its lease")
+            Right (Just lease) -> restore action `finally` releaseWorktreeLease lease
+
+inspectManagedIdentity :: OsPath -> OsPath -> ExceptT Text IO OsPath
+inspectManagedIdentity root path = do
+    unless (managedWorktreePath root path == Just path)
+        (throwE "not a managed checkout root")
+    links <- lift $ mapM pathIsSymbolicLink [root, takeDirectory path, path]
+    when (or links) (throwE "symlinked managed checkout or repository directory")
+    top <- gitToplevel path
+    unless (equalFilePath (normalise top) (normalise path))
+        (throwE "checkout does not own its Git working directory")
+    common <- gitCommonDir path
+    gitDir <- Text.strip <$> ExceptT
+        (git path ["rev-parse", "--path-format=absolute", "--git-dir"])
+    when (gitDir == pathText common) (throwE "primary checkout cannot be collected")
+    let admin = unsafeEncodeUtf (Text.unpack gitDir)
+        dotGit = path </> unsafeEncodeUtf ".git"
+        backpointer = admin </> unsafeEncodeUtf "gitdir"
+    unless (equalFilePath (takeDirectory admin) (common </> unsafeEncodeUtf "worktrees"))
+        (throwE "linked Git administration is outside the repository worktree registry")
+    metadataLinks <- lift $ mapM pathIsSymbolicLink
+        [dotGit, common, takeDirectory admin, admin, backpointer]
+    when (or metadataLinks) (throwE "symlinked linked Git metadata")
+    regular <- lift $ mapM doesFileExist [dotGit, backpointer]
+    unless (and regular) (throwE "missing linked Git metadata")
+    reciprocal <- Text.strip <$> lift (Text.readFile (unsafeToFilePath backpointer))
+    unless (equalFilePath (normalise (unsafeEncodeUtf (Text.unpack reciprocal))) (normalise dotGit))
+        (throwE "linked Git metadata points at another checkout")
+    pure common
+
+-- The dry-run must not create even maintenance lock files. Existing lock
+-- files use the same OS advisory locks as filelock; closing the read-only
+-- handle releases the probe. An absent lock is only an observational result:
+-- a real pass always acquires the normal lease and checks everything again.
+withReadOnlyLock :: OsPath -> IO (Either Text a) -> IO (Either Text a)
+withReadOnlyLock path action = do
+    linked <- isLinkIfPresent path
+    parentLinked <- isLinkIfPresent (takeDirectory path)
+    if linked || parentLinked then pure (Left "symlinked maintenance lock")
+        else withExistingReadOnlyLock path action >>= pure . either Left id
+  where
+    isLinkIfPresent file = pathIsSymbolicLink file `catchIO` \err ->
+        if isDoesNotExistError err then pure False else ioError err
+
+catchingWorktree :: IO (Either Text a) -> IO (Either Text a)
+catchingWorktree action = tryAny action >>= \case
+    Left err -> pure (Left (exceptionText err))
+    Right result -> pure result
+
+-- | Snapshot-backed GC. Actual passes are bounded to eight eligible checkouts
+-- and sixty seconds; each snapshot/removal has a thirty-second deadline.
+-- Dry runs do not create snapshots, registry entries, or recovery refs.
+-- This compatibility entry point has no legacy provenance; production callers
+-- supply the saved-session reader through 'gcWorktreesWithActivity'.
+gcWorktrees :: OsPath -> Int -> Bool -> [OsPath] -> IO WorktreeCleanupReport
+gcWorktrees root = gcWorktreesWithActivity (pure (Right Map.empty)) root
+
+-- | The injected reader is also re-run immediately before collection, under
+-- the checkout lease, so newly saved session activity cannot be overwritten
+-- by the pass's discovery snapshot.
+gcWorktreesWithActivity
+    :: IO (Either Text (Map OsPath (Either Text UTCTime)))
+    -> OsPath -> Int -> Bool -> [OsPath] -> IO WorktreeCleanupReport
+gcWorktreesWithActivity loadActivity root days dryRun protected = do
+    exists <- doesDirectoryExist root
+    if not exists then pure mempty else do
+        result <- tryAny do
+            linked <- pathIsSymbolicLink root
+            when linked (ioError (userError "symlinked managed worktree root"))
+            started <- getCurrentTime
+            discovered <- timeout (30 * 1000000) (discoverManagedPaths root)
+            candidates <- maybe
+                (ioError (userError "worktree discovery deadline exceeded; no checkouts collected"))
+                pure discovered
+            activity <- timeout (30 * 1000000) loadActivity
+            attempts <- newIORef (0 :: Int)
+            foldM (visit started attempts (maybe (Left "session activity discovery deadline exceeded") id activity))
+                mempty candidates
+        pure $ either (cleanupFailure root) id result
+  where
+    retained path reason = mempty { cleanupRetained = [(path, reason)] }
+    visit started attempts activity report path = do
+        now <- getCurrentTime
+        attempted <- readIORef attempts
+        let exhausted = not dryRun &&
+                (attempted >= 8 || diffUTCTime now started >= 60)
+        if exhausted then pure (report <> retained path "pass budget exhausted") else do
+            result <- timeout (30 * 1000000) $ catchingWorktree $
+                checkoutLock path $ runExceptT do
+                    when (any (isUnderWorktreeRoot path . normalise) protected)
+                        (throwE "current session")
+                    existing <- ExceptT (readRecord root path)
+                    -- Persistent protection and recovery states take priority
+                    -- over missing provenance and never get silently replaced.
+                    case existing of
+                        Just record | record.recordProtected -> throwE "protected"
+                        Just record | record.recordState /= "present" ->
+                            throwE ("state: " <> record.recordState)
+                        _ -> pure ()
+                    record <- resolveRecord path activity existing
+                    if recent now record then pure (retained path "recent activity") else do
+                        lift $ modifyIORef' attempts (+ 1)
+                        common <- inspectManagedIdentity root path
+                        unless (unsafeToFilePath common == record.recordCommonDir)
+                            (throwE "enrolled repository identity changed")
+                        ExceptT $ repositoryLock common $ runExceptT do
+                            ExceptT $ Snapshot.checkSnapshotSupported path
+                            if dryRun then do
+                                bytes <- lift (estimateCheckoutBytes path)
+                                pure mempty { cleanupEligible = [(path, bytes)] }
+                            else do
+                                latest <- lift loadActivity
+                                refreshed <- resolveRecord path latest existing
+                                recheckedAt <- lift getCurrentTime
+                                when (recent recheckedAt refreshed)
+                                    (throwE "recent activity")
+                                unless (refreshed.recordCommonDir == record.recordCommonDir)
+                                    (throwE "repository identity changed during adoption")
+                                snapshot <- ExceptT $ Snapshot.createSnapshot path
+                                finalActivity <- lift loadActivity
+                                finalRecord <- resolveRecord path finalActivity existing
+                                finalAt <- lift getCurrentTime
+                                when (recent finalAt finalRecord)
+                                    (throwE "recent activity")
+                                finalCommon <- inspectManagedIdentity root path
+                                unless (finalCommon == common && finalRecord.recordCommonDir == record.recordCommonDir)
+                                    (throwE "repository identity changed during snapshot")
+                                -- Adoption is persisted with the original saved
+                                -- activity, never an artificial 'now' timestamp.
+                                let saved = finalRecord { recordSnapshot = Just snapshot, recordState = "collecting" }
+                                ExceptT $ writeRecord root path saved
+                                verified <- lift $ Snapshot.verifySnapshotUnchanged path snapshot
+                                case verified of
+                                    Right () -> pure ()
+                                    Left err -> do
+                                        ExceptT $ writeRecord root path saved { recordState = "present" }
+                                        throwE err
+                                void $ ExceptT $ git common ["worktree", "remove", "--force", unsafeToFilePath path]
+                                ExceptT $ writeRecord root path saved { recordState = "collected" }
+                                pure mempty { cleanupRemoved = [path] }
+            pure $ report <> case result of
+                Nothing -> retained path "maintenance deadline exceeded; recovery record retained"
+                Just (Left err) -> retained path err
+                Just (Right one) -> one
+    recent now record = diffUTCTime now record.recordLastActivity < fromIntegral (max 0 days) * 86400
+    checkoutLock path
+        | dryRun = withReadOnlyLock (worktreeLeasePath root path)
+        | otherwise = withExclusiveManaged root path
+    repositoryLock common
+        | dryRun = withReadOnlyLock (common </> unsafeEncodeUtf "haskell-agent-worktree.lock")
+        | otherwise = withGitWorktreeLockAt common
+    resolveRecord path activity existing = do
+        evidence <- either throwE pure activity
+        case (existing, Map.lookup path evidence) of
+            (_, Just (Left err)) -> throwE err
+            (Just record, savedActivity) -> pure record
+                { recordLastActivity = maybe record.recordLastActivity
+                    (either (const record.recordLastActivity) (max record.recordLastActivity))
+                    savedActivity }
+            (Nothing, Nothing) -> throwE "uncertain ownership: no saved-session provenance"
+            (Nothing, Just (Right lastActivity)) -> do
+                common <- inspectManagedIdentity root path
+                repository <- gitRepositoryName path
+                unless (repository == takeFileName (takeDirectory path))
+                    (throwE "uncertain ownership: managed repository directory does not match Git identity")
+                pure WorktreeRecord
+                    { recordVersion = 1
+                    , recordCheckout = unsafeToFilePath path
+                    , recordCommonDir = unsafeToFilePath common
+                    , recordLastActivity = lastActivity
+                    , recordProtected = False
+                    , recordState = "present"
+                    , recordSnapshot = Nothing
+                    }
+
+discoverManagedPaths :: OsPath -> IO [OsPath]
+discoverManagedPaths root = do
+    entries <- listDirectory root
+    fmap concat $ mapM discover entries
+  where
+    discover entry
+        | "." `isPrefixOf` unsafeToFilePath entry = pure []
+        | otherwise = do
+            let repo = root </> entry
+            linked <- pathIsSymbolicLink repo
+            directory <- doesDirectoryExist repo
+            if linked || not directory then pure [] else do
+                children <- listDirectory repo
+                pure [repo </> child | child <- children, isManagedWorktreeName child]
+
+-- Apparent bytes, including ignored cache data, without following symlinks.
+-- This is an estimate rather than filesystem-block accounting.
+estimateCheckoutBytes :: OsPath -> IO Integer
+estimateCheckoutBytes path = walk (unsafeToFilePath path)
+  where
+    walk file = do
+        linked <- Directory.pathIsSymbolicLink file
+        if linked then pure 0 else do
+            directory <- Directory.doesDirectoryExist file
+            if directory then do
+                children <- Directory.listDirectory file
+                sum <$> mapM (walk . (file FilePath.</>)) children
+            else Directory.getFileSize file
+
+-- | Bounded snapshot-backed cleanup. The second argument is inactivity days.
 cleanupStaleWorktrees
     :: OsPath
     -> Int
     -> [OsPath]
     -> IO WorktreeCleanupReport
-cleanupStaleWorktrees root requestedKeep protected = do
-    exists <- doesDirectoryExist root
-    if not exists
-        then pure mempty
-        else do
-            today <- utctDay <$> getCurrentTime
-            let cleanupLockPath =
-                    root </> unsafeEncodeUtf ".cleanup.lock"
-            lockResult <- tryAny $
-                FileLock.tryLockFile
-                    (unsafeToFilePath cleanupLockPath)
-                    FileLock.Exclusive
-            case lockResult of
-                Left exception ->
-                    pure $ cleanupFailure root exception
-                Right Nothing ->
-                    -- Another process is already doing the same best-effort GC.
-                    pure mempty
-                Right (Just lock) ->
-                    runCleanup today `finally` FileLock.unlockFile lock
-  where
-    keep = max 1 requestedKeep
-    protectedManaged =
-        [ normalise path
-        | path <- protected
-        ]
-
-    runCleanup today = do
-        discovered <- discoverStaleCandidates root keep today
-        case discovered of
-            Left failures ->
-                pure mempty { cleanupFailures = failures }
-            Right (candidates, discoveryFailures) -> do
-                cleaned <- foldM cleanupOne mempty candidates
-                pure $
-                    cleaned
-                        <> mempty { cleanupFailures = discoveryFailures }
-
-    cleanupOne report candidate
-        | any (isUnderWorktreeRoot candidate) protectedManaged =
-            pure report
-        | otherwise = do
-            result <- tryAny (cleanupCandidate root candidate)
-            pure $ report <> case result of
-                Left exception -> cleanupFailure candidate exception
-                Right candidateReport -> candidateReport
-
-discoverStaleCandidates
-    :: OsPath
-    -> Int
-    -> Day
-    -> IO (Either [(OsPath, Text)] ([OsPath], [(OsPath, Text)]))
-discoverStaleCandidates root keep today = do
-    listed <- tryAny (listDirectory root)
-    case listed of
-        Left exception ->
-            pure (Left [(root, exceptionText exception)])
-        Right entries ->
-            Right <$> foldM discoverRepository ([], []) entries
-  where
-    discoverRepository (candidates, failures) entry = do
-        let repository = root </> entry
-        isDirectory <- doesDirectoryExist repository
-        if not isDirectory
-            then pure (candidates, failures)
-            else do
-                listed <- tryAny (listDirectory repository)
-                case listed of
-                    Left exception ->
-                        pure
-                            ( candidates
-                            , failures <> [(repository, exceptionText exception)]
-                            )
-                    Right children -> do
-                        directories <- filterM
-                            (doesDirectoryExist . (repository </>))
-                            children
-                        let managed =
-                                sortOn
-                                    ( Down
-                                        . unsafeToFilePath
-                                        . takeFileName
-                                        . fst
-                                    )
-                                    [ (repository </> child, day)
-                                    | child <- directories
-                                    , Just day <- [managedWorktreeDay child]
-                                    ]
-                            stale =
-                                [ path
-                                | (path, day) <- drop keep managed
-                                , day < today
-                                ]
-                        pure (candidates <> stale, failures)
-
-cleanupCandidate :: OsPath -> OsPath -> IO WorktreeCleanupReport
-cleanupCandidate root candidate = do
-    leaseResult <- tryExclusiveWorktreeLease root candidate
-    case leaseResult of
-        Left err ->
-            pure mempty
-                { cleanupFailures = [(candidate, err)]
-                }
-        Right Nothing ->
-            pure mempty
-        Right (Just lease) ->
-            cleanupWithLease `finally` releaseWorktreeLease lease
-  where
-    cleanupWithLease = do
-        hasGitMetadata <-
-            doesPathExist (candidate </> unsafeEncodeUtf ".git")
-        -- A generated-looking directory can survive an interrupted
-        -- @git worktree remove@ after its .git marker is gone. Without
-        -- that ownership marker, preserve it rather than warning on
-        -- @git rev-parse@ or recursively deleting arbitrary files.
-        if hasGitMetadata
-            then cleanupGitWorktree
-            else pure mempty
-
-    cleanupGitWorktree =
-        inspectCleanupCandidate candidate >>= \case
-            Left err ->
-                pure mempty
-                    { cleanupFailures = [(candidate, err)]
-                    }
-            Right Nothing ->
-                pure mempty
-            Right (Just (commonDir, branch)) ->
-                withGitWorktreeLockAt commonDir $
-                    git commonDir
-                        [ "worktree"
-                        , "remove"
-                        , unsafeToFilePath candidate
-                        ] >>= \case
-                            Left err ->
-                                pure mempty
-                                    { cleanupFailures = [(candidate, err)]
-                                    }
-                            Right _ -> do
-                                -- The worktree is the resource governed by the
-                                -- retention policy. Branch deletion is best
-                                -- effort: @-d@ can reject a branch that is known
-                                -- to be reachable from another ref but is not
-                                -- merged into the repository's current branch.
-                                -- Retaining it is safe and should not surface as
-                                -- a startup warning.
-                                _ <- git commonDir
-                                    [ "branch"
-                                    , "-d"
-                                    , "--"
-                                    , Text.unpack branch
-                                    ]
-                                pure WorktreeCleanupReport
-                                    { cleanupRemoved = [candidate]
-                                    , cleanupFailures = []
-                                    }
-
-inspectCleanupCandidate
-    :: OsPath
-    -> IO (Either Text (Maybe (OsPath, Text)))
-inspectCleanupCandidate candidate = runExceptT do
-    candidateLink <- lift (pathIsSymbolicLink candidate)
-    repositoryLink <- lift (pathIsSymbolicLink (takeDirectory candidate))
-    if candidateLink || repositoryLink
-        then pure Nothing
-        else do
-            topLevel <- Text.strip <$> ExceptT
-                (git candidate
-                    [ "rev-parse"
-                    , "--path-format=absolute"
-                    , "--show-toplevel"
-                    ])
-            let topLevelPath = unsafeEncodeUtf (Text.unpack topLevel)
-            if not
-                (equalFilePath
-                    (normalise candidate)
-                    (normalise topLevelPath))
-                then pure Nothing
-                else do
-                    gitDir <- Text.strip <$> ExceptT
-                        (git candidate
-                            [ "rev-parse"
-                            , "--path-format=absolute"
-                            , "--git-dir"
-                            ])
-                    commonDirText <- Text.strip <$> ExceptT
-                        (git candidate
-                            [ "rev-parse"
-                            , "--path-format=absolute"
-                            , "--git-common-dir"
-                            ])
-                    if gitDir == commonDirText
-                        then pure Nothing
-                        else do
-                            branch <- Text.strip <$> ExceptT
-                                (git candidate
-                                    ["branch", "--show-current"])
-                            let expected = Text.pack
-                                    (unsafeToFilePath
-                                        (takeFileName candidate))
-                            if Text.null branch || branch /= expected
-                                then pure Nothing
-                                else do
-                                    status <- ExceptT $
-                                        git candidate
-                                            [ "status"
-                                            , "--porcelain=v1"
-                                            , "--untracked-files=all"
-                                            , "--ignore-submodules=none"
-                                            ]
-                                    if not (Text.null status)
-                                        then pure Nothing
-                                        else do
-                                            refs <- ExceptT $
-                                                git candidate
-                                                    [ "for-each-ref"
-                                                    , "--format=%(refname)"
-                                                    , "--contains=HEAD"
-                                                    , "refs/heads"
-                                                    , "refs/remotes"
-                                                    , "refs/tags"
-                                                    ]
-                                            let ownRef =
-                                                    "refs/heads/" <> branch
-                                                otherRefs =
-                                                    filter
-                                                        (\ref ->
-                                                            not (Text.null ref)
-                                                                && ref /= ownRef)
-                                                        (Text.lines refs)
-                                            pure $
-                                                if null otherRefs
-                                                    then Nothing
-                                                    else Just
-                                                        ( unsafeEncodeUtf
-                                                            (Text.unpack
-                                                                commonDirText)
-                                                        , branch
-                                                        )
+cleanupStaleWorktrees root days protected = gcWorktrees root days False protected
 
 tryExclusiveWorktreeLease
     :: OsPath
@@ -518,6 +592,8 @@ tryExclusiveWorktreeLease
 tryExclusiveWorktreeLease root candidate = do
     let lockPath = worktreeLeasePath root candidate
     result <- tryAny do
+        linked <- pathIsSymbolicLink root
+        when linked (ioError (userError "symlinked managed worktree root"))
         createDirectoryIfMissing True (takeDirectory lockPath)
         FileLock.tryLockFile
             (unsafeToFilePath lockPath)
@@ -528,7 +604,7 @@ tryExclusiveWorktreeLease root candidate = do
                 ("failed to lock stale worktree: "
                     <> exceptionText exception)
         Right Nothing -> Right Nothing
-        Right (Just lock) -> Right (Just (WorktreeLease lock))
+        Right (Just lock) -> Right (Just (WorktreeLease lock Nothing))
 
 managedWorktreePath :: OsPath -> OsPath -> Maybe OsPath
 managedWorktreePath rawRoot rawPath =

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -9,6 +9,7 @@ module Agent.CLI.Worktree
     , cleanupStaleWorktrees
     , gcWorktrees
     , gcWorktreesWithActivity
+    , worktreeInactive
     , enrollWorktree
     , protectWorktree
     , restoreManagedWorktree
@@ -473,7 +474,8 @@ gcWorktreesWithActivity loadActivity root days dryRun protected = do
                             throwE ("state: " <> record.recordState)
                         _ -> pure ()
                     record <- resolveRecord path activity existing
-                    if recent now record then pure (retained path "recent activity") else do
+                    isRecent <- lift (recent path now record)
+                    if isRecent then pure (retained path "recent activity") else do
                         lift $ modifyIORef' attempts (+ 1)
                         common <- inspectManagedIdentity root path
                         unless (unsafeToFilePath common == record.recordCommonDir)
@@ -487,7 +489,8 @@ gcWorktreesWithActivity loadActivity root days dryRun protected = do
                                 latest <- lift loadActivity
                                 refreshed <- resolveRecord path latest existing
                                 recheckedAt <- lift getCurrentTime
-                                when (recent recheckedAt refreshed)
+                                recheckedRecent <- lift (recent path recheckedAt refreshed)
+                                when recheckedRecent
                                     (throwE "recent activity")
                                 unless (refreshed.recordCommonDir == record.recordCommonDir)
                                     (throwE "repository identity changed during adoption")
@@ -495,7 +498,8 @@ gcWorktreesWithActivity loadActivity root days dryRun protected = do
                                 finalActivity <- lift loadActivity
                                 finalRecord <- resolveRecord path finalActivity existing
                                 finalAt <- lift getCurrentTime
-                                when (recent finalAt finalRecord)
+                                finalRecent <- lift (recent path finalAt finalRecord)
+                                when finalRecent
                                     (throwE "recent activity")
                                 finalCommon <- inspectManagedIdentity root path
                                 unless (finalCommon == common && finalRecord.recordCommonDir == record.recordCommonDir)
@@ -504,6 +508,11 @@ gcWorktreesWithActivity loadActivity root days dryRun protected = do
                                 -- activity, never an artificial 'now' timestamp.
                                 let saved = finalRecord { recordSnapshot = Just snapshot, recordState = "collecting" }
                                 ExceptT $ writeRecord root path saved
+                                removalAt <- lift getCurrentTime
+                                removalRecent <- lift (recent path removalAt finalRecord)
+                                when removalRecent do
+                                    ExceptT $ writeRecord root path saved { recordState = "present" }
+                                    throwE "recent activity or default-branch ancestry changed before removal"
                                 verified <- lift $ Snapshot.verifySnapshotUnchanged path snapshot
                                 case verified of
                                     Right () -> pure ()
@@ -517,7 +526,10 @@ gcWorktreesWithActivity loadActivity root days dryRun protected = do
                 Nothing -> retained path "maintenance deadline exceeded; recovery record retained"
                 Just (Left err) -> retained path err
                 Just (Right one) -> one
-    recent now record = diffUTCTime now record.recordLastActivity < fromIntegral (max 0 days) * 86400
+    recent path now record
+        | worktreeInactive days False now record.recordLastActivity = pure False
+        | not (worktreeInactive days True now record.recordLastActivity) = pure True
+        | otherwise = not <$> headInDefaultBranch path
     checkoutLock path
         | dryRun = withReadOnlyLock (worktreeLeasePath root path)
         | otherwise = withExclusiveManaged root path
@@ -547,6 +559,41 @@ gcWorktreesWithActivity loadActivity root days dryRun protected = do
                     , recordState = "present"
                     , recordSnapshot = Nothing
                     }
+
+-- | Inactivity, not commit age or time since merge. Exact ancestry proof permits
+-- the one-day fast path; uncertainty keeps the configured normal threshold.
+worktreeInactive :: Int -> Bool -> UTCTime -> UTCTime -> Bool
+worktreeInactive days incorporated now lastActivity =
+    diffUTCTime now lastActivity >= fromIntegral threshold * 86400
+  where
+    threshold = if incorporated then min 1 (max 0 days) else max 0 days
+
+-- | Resolve only an existing remote-default symbolic ref, never infer the
+-- default from a familiar branch name or from the current checkout. No fetch,
+-- network request or ref mutation is performed by maintenance. Stale/missing
+-- tracking refs can miss merges; squash/rebase equivalence is not ancestry.
+-- This proof is recomputed after snapshotting so newer commits cannot inherit
+-- an older HEAD's eligibility. Final snapshot verification also checks HEAD.
+headInDefaultBranch :: OsPath -> IO Bool
+headInDefaultBranch path = do
+    result <- runExceptT do
+        graftPath <- Text.strip <$> ExceptT
+            (git path ["rev-parse", "--path-format=absolute", "--git-path", "info/grafts"])
+        grafts <- lift $ Directory.doesPathExist (Text.unpack graftPath)
+        when grafts (throwE "grafted history is not merge evidence")
+        remote <- selectUpstreamRemote path >>= maybe (throwE "no default remote") pure
+        let prefix = "refs/remotes/" <> remote <> "/"
+        target <- Text.strip <$> ExceptT
+            (git path ["symbolic-ref", "--quiet", Text.unpack (prefix <> "HEAD")])
+        unless (prefix `Text.isPrefixOf` target && target /= prefix <> "HEAD")
+            (throwE "default branch is outside the selected remote")
+        base <- Text.strip <$> ExceptT
+            (git path ["--no-replace-objects", "rev-parse", "--verify", Text.unpack (target <> "^{commit}")])
+        headCommit <- Text.strip <$> ExceptT
+            (git path ["--no-replace-objects", "rev-parse", "--verify", "HEAD^{commit}"])
+        void $ ExceptT
+            (git path ["--no-replace-objects", "merge-base", "--is-ancestor", Text.unpack headCommit, Text.unpack base])
+    pure $ either (const False) (const True) result
 
 discoverManagedPaths :: OsPath -> IO [OsPath]
 discoverManagedPaths root = do

--- a/packages/agent-cli/src/Agent/CLI/Worktree/Provenance.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree/Provenance.hs
@@ -1,0 +1,140 @@
+-- | Read-only saved-session evidence for adopting older managed worktrees.
+--
+-- Session metadata is authoritative; checkout names, filesystem mtimes and
+-- stale pre-migration JSON files are deliberately not activity clocks.
+module Agent.CLI.Worktree.Provenance
+    ( WorktreeActivity
+    , loadWorktreeActivity
+    , worktreeActivityFromListing
+    , buildWorktreeActivity
+    , protectActiveSessions
+    , existingSessionLockActive
+    ) where
+
+import Agent.CLI.Session (listSessions, sessionDirForId)
+import Agent.CLI.SessionLock (sessionLockPath, sessionActivityLockPath)
+import Agent.CLI.Session.Types (SessionMeta(..))
+import Agent.CLI.Worktree.ReadOnlyLock (withExistingReadOnlyLock)
+import Agent.Store.Postgres.Connection (StorePool)
+import Control.Exception.Safe (tryAny, tryIO)
+import Control.Monad (foldM)
+import Data.List (isPrefixOf)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (UTCTime)
+import System.IO.Error (isDoesNotExistError)
+import qualified System.Posix.Files as Posix
+import System.OsPath
+    ( OsPath, decodeUtf, isAbsolute, normalise, splitDirectories, takeDirectory, unsafeEncodeUtf, (</>) )
+
+-- | A failed timestamp/provenance check poisons that checkout even if another
+-- session for it is valid. Omitting that failure could hide newer activity.
+type WorktreeActivity = Map OsPath (Either Text UTCTime)
+
+-- | Reads all non-deleted sessions, including archived sessions and sessions
+-- from other provider/gateway routes. The store uses a read-only transaction;
+-- this function never imports legacy sessions or initializes/migrates storage.
+-- The caller owns the pool and must not initialize it through a writing path
+-- merely to run a dry run.
+loadWorktreeActivity :: StorePool -> OsPath -> IO (Either Text WorktreeActivity)
+loadWorktreeActivity pool root =
+    tryAny (listSessions pool root) >>= \case
+        Left _ -> pure (Left "saved-session activity unavailable; adoption deferred")
+        Right listing@(sessions, _) -> case worktreeActivityFromListing root listing of
+            Left err -> pure (Left err)
+            Right activity -> Right <$> protectActiveSessions
+                (takeDirectory (normalise root) </> unsafeEncodeUtf "sessions")
+                root sessions activity
+
+-- | Pre-upgrade agents do not hold worktree leases, but they do hold session
+-- lifetime/turn locks. Probe every matching session, not just the newest one.
+-- This is a read-only observation, not a fence against an old binary starting
+-- after the final probe; such binaries must be stopped before explicit GC.
+protectActiveSessions :: OsPath -> OsPath -> [SessionMeta] -> WorktreeActivity -> IO WorktreeActivity
+protectActiveSessions sessionsRoot root sessions initial = foldM protect initial sessions
+  where
+    protect activity meta = case Map.keys (buildWorktreeActivity root [meta]) of
+        [] -> pure activity
+        checkout : _ -> do
+            blocked <- case sessionDirForId sessionsRoot meta.metaId of
+                Left _ -> pure True
+                Right dir -> do
+                    rootUnsafe <- uncertainSessionDirectory sessionsRoot
+                    if rootUnsafe then pure True else do
+                        dirUnsafe <- uncertainSessionDirectory dir
+                        if dirUnsafe then pure True else do
+                            lifetime <- existingSessionLockActive (sessionLockPath dir)
+                            turn <- existingSessionLockActive (sessionActivityLockPath dir)
+                            pure (lifetime || turn)
+            pure if blocked
+                then Map.insert checkout (Left "saved session is active or its session locks cannot be verified") activity
+                else activity
+
+-- Do not follow a substituted sessions root or session directory. Missing
+-- directories are normal for imported/archived metadata; all other failures
+-- and non-directory nodes are uncertain and retain the checkout.
+uncertainSessionDirectory :: OsPath -> IO Bool
+uncertainSessionDirectory path = do
+    result <- tryIO (decodeUtf path >>= Posix.getSymbolicLinkStatus)
+    pure case result of
+        Left err -> not (isDoesNotExistError err)
+        Right status -> not (Posix.isDirectory status)
+
+-- | Open without O_CREAT: unlike tryLockFile this cannot create missing locks
+-- even if a session directory disappears concurrently. Any non-ENOENT error,
+-- non-regular lock or failed flock retains the checkout. Closing releases the
+-- successful probe lock without modifying the file.
+existingSessionLockActive :: FilePath -> IO Bool
+existingSessionLockActive path =
+    either (const True) (const False) <$>
+        withExistingReadOnlyLock (unsafeEncodeUtf path) (pure ())
+
+-- | Do not silently use a partial listing: the undecodable session could be
+-- the newest session for any checkout. Avoid exposing session content in GC
+-- diagnostics.
+worktreeActivityFromListing
+    :: OsPath -> ([SessionMeta], [Text]) -> Either Text WorktreeActivity
+worktreeActivityFromListing root (sessions, warnings)
+    | not (null warnings) =
+        Left "saved-session metadata is incomplete or incompatible; adoption deferred"
+    | not (isAbsolute root) || containsTraversal root =
+        Left "managed worktree root is not an absolute, traversal-free path"
+    | otherwise = Right (buildWorktreeActivity root sessions)
+
+-- | Use the latest persisted activity across every session rooted at a
+-- checkout or one of its subdirectories. A saved session is evidence, not
+-- sufficient ownership proof by itself: GC additionally verifies the managed
+-- path and reciprocal linked-worktree Git metadata under its maintenance lease.
+buildWorktreeActivity :: OsPath -> [SessionMeta] -> WorktreeActivity
+buildWorktreeActivity rawRoot sessions = Map.fromListWith newest
+    [ (checkout, activity meta)
+    | meta <- sessions
+    , Just checkout <- [checkoutFor meta.metaCwd]
+    ]
+  where
+    root = normalise rawRoot
+    rootParts = splitDirectories root
+    checkoutFor cwd
+        | not (isAbsolute root && isAbsolute cwd) = Nothing
+        | not (rootParts `isPrefixOf` splitDirectories (normalise cwd)) = Nothing
+        | otherwise = case drop (length rootParts) (splitDirectories (normalise cwd)) of
+            repository : checkout : _ -> Just (root </> repository </> checkout)
+            _ -> Nothing
+    activity meta
+        | containsTraversal meta.metaCwd =
+            Left "saved-session path contains traversal; activity uncertain"
+        -- Session schema 1 records cwd and updatedAt with these semantics.
+        -- The storage listing independently rejects incompatible versions.
+        | meta.metaVersion /= 1 || Text.null (Text.strip meta.metaId) =
+            Left "saved-session provenance is invalid"
+        | meta.metaUpdatedAt < meta.metaCreatedAt =
+            Left "saved-session activity predates session creation"
+        | otherwise = Right meta.metaUpdatedAt
+    newest (Left err) _ = Left err
+    newest _ (Left err) = Left err
+    newest (Right first) (Right second) = Right (max first second)
+
+containsTraversal :: OsPath -> Bool
+containsTraversal = any (== unsafeEncodeUtf "..") . splitDirectories

--- a/packages/agent-cli/src/Agent/CLI/Worktree/ReadOnlyLock.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree/ReadOnlyLock.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+-- | Non-creating probes compatible with the filelock package's flock leases.
+module Agent.CLI.Worktree.ReadOnlyLock (withExistingReadOnlyLock) where
+
+import Control.Exception.Safe (bracket, tryIO)
+import Data.Text (Text)
+import Foreign.C.Types (CInt(..))
+import System.IO.Error (isDoesNotExistError)
+import System.OsPath (OsPath, decodeUtf)
+import qualified System.Posix.IO as Posix
+import qualified System.Posix.Files as Posix
+import System.Posix.Types (Fd(..))
+
+-- | Hold an existing regular lock throughout the callback, without O_CREAT
+-- or write access. An absent lock runs the callback without creating a fence;
+-- callers must treat this as observation only and validate parent directories.
+-- All unsafe nodes, contention and I/O failures fail closed. Callback failures
+-- also fail closed; asynchronous exceptions propagate and release the fd.
+withExistingReadOnlyLock :: OsPath -> IO a -> IO (Either Text a)
+withExistingReadOnlyLock path action = do
+    result <- tryIO do
+        decoded <- decodeUtf path
+        status <- tryIO (Posix.getSymbolicLinkStatus decoded)
+        case status of
+            Left err
+                | isDoesNotExistError err -> Right <$> action
+                | otherwise -> pure unavailable
+            Right before
+                | not (Posix.isRegularFile before) -> pure unavailable
+                | otherwise -> bracket
+                    (Posix.openFd decoded Posix.ReadOnly
+                        Posix.defaultFileFlags { Posix.nonBlock = True })
+                    Posix.closeFd
+                    (\fd@(Fd rawFd) -> do
+                        after <- Posix.getFdStatus fd
+                        if not (Posix.isRegularFile after)
+                            || Posix.fileID before /= Posix.fileID after
+                            || Posix.deviceID before /= Posix.deviceID after
+                            then pure unavailable
+                            else do
+                                locked <- c_flock rawFd 6
+                                if locked /= 0 then pure unavailable else Right <$> action)
+    pure (either (const unavailable) id result)
+  where
+    unavailable = Left "existing lock is busy, unsafe or cannot be verified"
+
+-- LOCK_EX (2) | LOCK_NB (4), identical on supported Linux/macOS targets.
+-- fcntl record locks are not compatible with filelock's flock leases.
+foreign import ccall unsafe "flock" c_flock :: CInt -> CInt -> IO CInt

--- a/packages/agent-cli/src/Agent/CLI/Worktree/Registry.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree/Registry.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+-- | Crash-safe per-checkout records. A missing record means /not enrolled/,
+-- never permission to collect a generated-looking directory.
+module Agent.CLI.Worktree.Registry
+    ( WorktreeRecord(..)
+    , readRecord
+    , writeRecord
+    , modifyRecord
+    , recordPath
+    ) where
+
+import Agent.CLI.Worktree.Snapshot (WorktreeSnapshot)
+import Agent.OsPath (unsafeToFilePath)
+import Control.Exception.Safe (bracket, tryAny, displayException)
+import Control.Monad (when)
+import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict', encode)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (UTCTime)
+import GHC.Generics (Generic)
+import qualified System.Directory as Directory
+import qualified System.FileLock as FileLock
+import qualified System.FilePath as FP
+import System.IO (openBinaryTempFile, hClose)
+import System.IO.Error (catchIOError, isDoesNotExistError)
+import System.OsPath (OsPath, takeDirectory, takeFileName, (</>), unsafeEncodeUtf)
+import System.Posix.IO (openFd, closeFd, defaultFileFlags, OpenMode(ReadOnly))
+import System.Posix.Unistd (fileSynchronise)
+
+data WorktreeRecord = WorktreeRecord
+    { recordVersion :: !Int
+    , recordCheckout :: !FilePath
+    , recordCommonDir :: !FilePath
+    , recordLastActivity :: !UTCTime
+    , recordProtected :: !Bool
+    , recordState :: !Text
+    , recordSnapshot :: !(Maybe WorktreeSnapshot)
+    } deriving (Eq, Show, Generic, FromJSON, ToJSON)
+
+recordPath :: OsPath -> OsPath -> OsPath
+recordPath root checkout =
+    root </> unsafeEncodeUtf ".registry"
+        </> takeFileName (takeDirectory checkout)
+        </> (takeFileName checkout <> unsafeEncodeUtf ".json")
+
+readRecord :: OsPath -> OsPath -> IO (Either Text (Maybe WorktreeRecord))
+readRecord root checkout = catching do
+    let path = unsafeToFilePath (recordPath root checkout)
+    validateRegistryPaths root checkout
+    exists <- Directory.doesPathExist path
+    if not exists then pure (Right Nothing) else do
+        bytes <- BS.readFile path
+        pure case eitherDecodeStrict' bytes of
+            Left err -> Left ("invalid worktree registry: " <> Text.pack err)
+            Right record
+                | record.recordVersion /= 1 -> Left "unsupported worktree registry version"
+                | record.recordCheckout /= unsafeToFilePath checkout ->
+                    Left "worktree registry checkout identity mismatch"
+                | otherwise -> Right (Just record)
+
+-- Callers hold a worktree lease. The short registry lock also serializes
+-- activity updates from multiple shared lease holders.
+writeRecord :: OsPath -> OsPath -> WorktreeRecord -> IO (Either Text ())
+writeRecord root checkout record =
+    modifyRecord root checkout (const (Right (Just record)))
+
+modifyRecord
+    :: OsPath -> OsPath
+    -> (Maybe WorktreeRecord -> Either Text (Maybe WorktreeRecord))
+    -> IO (Either Text ())
+modifyRecord root checkout change = catching do
+    let destination = unsafeToFilePath (recordPath root checkout)
+        directory = FP.takeDirectory destination
+    validateRegistryPaths root checkout
+    Directory.createDirectoryIfMissing True directory
+    -- Persist every newly-created directory entry too. A record's immediate
+    -- parent fsync alone cannot make .registry or its repo directory durable.
+    syncAncestors directory
+    FileLock.withFileLock (destination <> ".lock") FileLock.Exclusive $ \_ ->
+        readRecord root checkout >>= \case
+            Left err -> pure (Left err)
+            Right old -> case change old of
+                Left err -> pure (Left err)
+                Right Nothing -> pure (Right ())
+                Right (Just record) -> do
+                    -- Flush data before atomic rename, then flush the directory
+                    -- entry before allowing destructive worktree removal.
+                    bracket (openBinaryTempFile directory ".record-") cleanup $ \(temp, handle) -> do
+                        LBS.hPut handle (encode record)
+                        hClose handle
+                        sync temp
+                        Directory.renameFile temp destination
+                        sync directory
+                    pure (Right ())
+  where
+    cleanup (temp, handle) = do
+        _ <- tryAny (hClose handle)
+        _ <- tryAny (Directory.removeFile temp)
+        pure ()
+    sync path =
+        bracket (openFd path ReadOnly defaultFileFlags) closeFd fileSynchronise
+    syncAncestors path = do
+        sync path
+        let parent = FP.takeDirectory path
+        when (parent /= path) (syncAncestors parent)
+
+-- Never follow redirected metadata, including dangling symlinks which
+-- doesPathExist reports as absent. Missing parents are valid before enrollment.
+validateRegistryPaths :: OsPath -> OsPath -> IO ()
+validateRegistryPaths root checkout = mapM_ rejectLink
+    [ unsafeToFilePath root
+    , unsafeToFilePath root FP.</> ".registry"
+    , FP.takeDirectory destination
+    , destination
+    , destination <> ".lock"
+    ]
+  where
+    destination = unsafeToFilePath (recordPath root checkout)
+    rejectLink path = do
+        linked <- Directory.pathIsSymbolicLink path `catchIOError` \err ->
+            if isDoesNotExistError err then pure False else ioError err
+        when linked (ioError (userError "symlinked worktree registry path"))
+
+catching :: IO (Either Text a) -> IO (Either Text a)
+catching action = tryAny action >>= \case
+    Left err -> pure (Left (Text.pack (displayException err)))
+    Right result -> pure result

--- a/packages/agent-cli/src/Agent/CLI/Worktree/Snapshot.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree/Snapshot.hs
@@ -1,0 +1,353 @@
+-- | Recovery objects for worktree collection. Callers own the repository lock
+-- and exclusive checkout lease across capture, final verification and removal.
+-- No command writes the live index or moves its branch. Working files are
+-- stored as raw blobs (never through clean/smudge filters).
+module Agent.CLI.Worktree.Snapshot
+    ( WorktreeSnapshot(..)
+    , createSnapshot
+    , verifySnapshotUnchanged
+    , restoreSnapshot
+    , checkSnapshotSupported
+    ) where
+
+import Agent.OsPath (unsafeToFilePath)
+import Control.Exception.Safe (bracket, displayException, onException, tryAny)
+import Control.Monad (forM, forM_, unless, void, when)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Bits ((.&.))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+import Data.Char (toLower)
+import Data.List (isPrefixOf, nub, sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import GHC.Generics (Generic)
+import Numeric (showHex)
+import qualified System.Directory as Dir
+import System.Environment (getEnvironment)
+import System.Entropy (getEntropy)
+import System.Exit (ExitCode(..))
+import System.FilePath ((</>), takeDirectory, splitDirectories, isAbsolute)
+import System.IO (IOMode(..), hClose, withBinaryFile)
+import System.IO.Error (isDoesNotExistError, tryIOError)
+import System.OsPath (OsPath)
+import qualified System.Posix.Files as Posix
+import qualified System.Posix.Files.ByteString as PosixBytes
+import qualified System.Posix.IO as PosixIO
+import System.Posix.Temp (mkdtemp)
+import System.Posix.Types (FileMode)
+import System.Posix.Unistd (fileSynchronise)
+import System.Process
+    ( CreateProcess(..), StdStream(..), proc, withCreateProcess, waitForProcess )
+
+data WorktreeSnapshot = WorktreeSnapshot
+    { snapshotHead :: !Text
+    , snapshotIndexTree :: !Text
+    , snapshotWorkTree :: !Text
+    , snapshotRef :: !Text
+    , snapshotBranch :: !Text
+    } deriving (Eq, Show, Generic)
+
+instance ToJSON WorktreeSnapshot
+instance FromJSON WorktreeSnapshot
+
+-- | Recovery refs never expire automatically. A failed capture may leave
+-- harmless unreachable objects, but never authorizes deletion.
+createSnapshot :: OsPath -> IO (Either Text WorktreeSnapshot)
+createSnapshot path = result $ withScratch \tmp -> do
+    let repo = unsafeToFilePath path
+    (headOid, indexTree, workTree, branch) <- capture repo tmp
+    nonce <- concatMap (\b -> let s = showHex b "" in replicate (2 - length s) '0' <> s)
+        . BS.unpack <$> getEntropy 16
+    let ref = "refs/haskell-agent/snapshots/" <> nonce
+    indexCommit <- oid repo tmp [] ["commit-tree", indexTree, "-p", headOid]
+        "haskell-agent snapshot index\n"
+    commit <- oid repo tmp [] ["commit-tree", workTree, "-p", headOid, "-p", indexCommit]
+        "haskell-agent snapshot working files (ignored untracked files excluded)\n"
+    void $ git repo tmp [] ["update-ref", ref, commit, ""] ""
+    let snapshot = WorktreeSnapshot (Text.pack headOid) (Text.pack indexTree)
+            (Text.pack workTree) (Text.pack ref) (Text.pack branch)
+    verifyObjects repo tmp snapshot
+    checkUnchanged repo tmp snapshot
+    pure snapshot
+
+verifySnapshotUnchanged :: OsPath -> WorktreeSnapshot -> IO (Either Text ())
+verifySnapshotUnchanged path snapshot = result $ withScratch \tmp -> do
+    let repo = unsafeToFilePath path
+    verifyObjects repo tmp snapshot
+    checkUnchanged repo tmp snapshot
+
+checkUnchanged :: FilePath -> FilePath -> WorktreeSnapshot -> IO ()
+checkUnchanged repo tmp snapshot = do
+    actual <- capture repo tmp
+    unless (actual == (Text.unpack snapshot.snapshotHead,
+        Text.unpack snapshot.snapshotIndexTree, Text.unpack snapshot.snapshotWorkTree,
+        Text.unpack snapshot.snapshotBranch)) $
+        fail "checkout changed during snapshot; retained"
+
+-- | An existing destination, including an empty directory or dangling symlink,
+-- is never reused. Failure leaves the partial checkout and recovery ref intact
+-- for inspection; it never recursively deletes a potentially edited directory.
+-- Always restores detached so an independently moved branch is untouched.
+restoreSnapshot :: OsPath -> OsPath -> WorktreeSnapshot -> IO (Either Text ())
+restoreSnapshot source destination snapshot = result $ withScratch \tmp -> do
+    let repo = unsafeToFilePath source
+        target = unsafeToFilePath destination
+    verifyObjects repo tmp snapshot
+    -- Atomic mkdir reserves the name against another restore.
+    Dir.createDirectory target
+    -- One --force repairs only this missing checkout's stale registration.
+    -- Git still refuses a locked registration (which requires two --force).
+    void $ git repo tmp [] ["worktree", "add", "--force", "--detach", "--no-checkout",
+        "--", target, Text.unpack snapshot.snapshotHead] ""
+    entries <- treeEntries repo tmp (Text.unpack snapshot.snapshotWorkTree)
+    forM_ entries \(mode, object, name) -> do
+        validatePath name
+        let file = target </> name
+        Dir.createDirectoryIfMissing True (takeDirectory file)
+        checkParents target name
+        exists <- pathExists file
+        when exists $ fail "restore destination changed while restoring"
+        bytes <- git repo tmp [] ["cat-file", "blob", object] ""
+        case mode of
+            "120000" -> PosixBytes.createSymbolicLink bytes (Text.encodeUtf8 (Text.pack file))
+            "100644" -> writeExclusive file 0o644 bytes
+            "100755" -> writeExclusive file 0o755 bytes
+            _ -> fail "unsupported recovery file mode"
+    void $ git target tmp [] ["read-tree", Text.unpack snapshot.snapshotIndexTree] ""
+    (headOid, indexTree, workTree, _) <- capture target tmp
+    unless ((headOid, indexTree, workTree) ==
+        (Text.unpack snapshot.snapshotHead, Text.unpack snapshot.snapshotIndexTree,
+         Text.unpack snapshot.snapshotWorkTree)) $
+        fail "restored checkout verification failed; partial checkout retained"
+    -- Registry may mark this checkout present only after its bytes and all
+    -- newly created directory entries (including Git's private metadata) are
+    -- durable. Symlinks are persisted through their containing directory.
+    syncTree target
+    syncPath (takeDirectory target)
+    gitDir <- oid target tmp [] ["rev-parse", "--absolute-git-dir"] ""
+    syncTree gitDir
+    syncPath (takeDirectory gitDir)
+    syncPath (takeDirectory (takeDirectory gitDir))
+
+syncPath :: FilePath -> IO ()
+syncPath path = bracket
+    (PosixIO.openFd path PosixIO.ReadOnly PosixIO.defaultFileFlags
+        { PosixIO.nofollow = True })
+    PosixIO.closeFd fileSynchronise
+
+syncTree :: FilePath -> IO ()
+syncTree path = do
+    status <- Posix.getSymbolicLinkStatus path
+    if Posix.isDirectory status
+        then do
+            Dir.listDirectory path >>= mapM_ (syncTree . (path </>))
+            syncPath path
+        else unless (Posix.isSymbolicLink status) do
+            unless (Posix.isRegularFile status) $
+                fail "unsupported file appeared during restore durability check"
+            syncPath path
+
+-- O_EXCL also refuses a leaf created after the explicit existence check.
+writeExclusive :: FilePath -> FileMode -> BS.ByteString -> IO ()
+writeExclusive file mode bytes = bracket acquire hClose (`BS.hPut` bytes)
+  where
+    acquire = do
+        fd <- PosixIO.openFd file PosixIO.WriteOnly PosixIO.defaultFileFlags
+            { PosixIO.exclusive = True, PosixIO.nofollow = True, PosixIO.creat = Just mode }
+        PosixIO.fdToHandle fd `onException` PosixIO.closeFd fd
+
+-- | Read-only eligibility preflight. Only a private scratch copy of the index
+-- is used; no Git objects, refs, live index or working files are written.
+-- This is advisory: collection still recaptures and verifies under its lease.
+checkSnapshotSupported :: OsPath -> IO (Either Text ())
+checkSnapshotSupported path = result $ withScratch \tmp -> do
+    let repo = unsafeToFilePath path
+    (_, _, _, _, names) <- inspectCheckout repo tmp
+    mapM_ (void . readWorkingFile repo) names
+
+inspectCheckout :: FilePath -> FilePath -> IO (FilePath, String, String, BS.ByteString, [FilePath])
+inspectCheckout repo tmp = do
+    gitDir <- oid repo tmp [] ["rev-parse", "--absolute-git-dir"] ""
+    forM_ ["index.lock", "MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD",
+        "rebase-merge", "rebase-apply", "sequencer", "BISECT_LOG", "config.worktree"] \name ->
+        pathExists (gitDir </> name) >>= \present ->
+            when present $ fail ("unsupported Git state: " <> name)
+    headOid <- oid repo tmp [] ["rev-parse", "--verify", "HEAD^{commit}"] ""
+    branch <- oid repo tmp [] ["rev-parse", "--symbolic-full-name", "HEAD"] ""
+    -- Copy first: write-tree may refresh extensions, but only in this copy.
+    let index = tmp </> "index"
+        indexEnv = [("GIT_INDEX_FILE", index)]
+    original <- BS.readFile (gitDir </> "index")
+    BS.writeFile index original
+    stages <- git repo tmp indexEnv ["ls-files", "--stage", "-z"] ""
+    forM_ (nul stages) \entry -> do
+        let header = B8.words (B8.takeWhile (/= '\t') entry)
+        case header of
+            [mode, _, "0"] | mode `elem` ["100644", "100755", "120000"] -> pure ()
+            _ -> fail "unsupported Git index: conflict or submodule"
+    flags <- git repo tmp indexEnv ["ls-files", "-v", "-z"] ""
+    unless (all (BS.isPrefixOf "H ") (nul flags)) $
+        fail "unsupported Git index: assume-unchanged or sparse checkout"
+    visible <- git repo tmp indexEnv
+        ["diff", "--cached", "--raw", "--no-ext-diff", "--ita-visible-in-index", "-z"] ""
+    invisible <- git repo tmp indexEnv
+        ["diff", "--cached", "--raw", "--no-ext-diff", "--ita-invisible-in-index", "-z"] ""
+    unless (visible == invisible) $ fail "unsupported Git index: intent-to-add"
+    names <- git repo tmp indexEnv ["ls-files", "--cached", "--others",
+        "--exclude-standard", "-z"] "" >>= mapM utf8 . nul
+    pure (gitDir, headOid, branch, original, sort (nub names))
+
+capture :: FilePath -> FilePath -> IO (String, String, String, String)
+capture repo tmp = do
+    (gitDir, headOid, branch, original, names) <- inspectCheckout repo tmp
+    indexTree <- oid repo tmp [("GIT_INDEX_FILE", tmp </> "index")] ["write-tree"] ""
+    -- Build a completely fresh index from raw bytes; git add would apply
+    -- filters and lose CRLF, working-tree-encoding and other exact contents.
+    let workIndexEnv = [("GIT_INDEX_FILE", tmp </> "working-index")]
+    void $ git repo tmp workIndexEnv ["read-tree", "--empty"] ""
+    entries <- forM names \name ->
+        readWorkingFile repo name >>= \case
+            Nothing -> pure BS.empty
+            Just (mode, bytes) -> do
+                object <- oid repo tmp [] ["hash-object", "-w", "--no-filters", "--stdin"] bytes
+                pure $ mode <> " " <> B8.pack object <> "\t"
+                    <> Text.encodeUtf8 (Text.pack name) <> "\0"
+    void $ git repo tmp workIndexEnv ["update-index", "-z", "--index-info"] (BS.concat entries)
+    workTree <- oid repo tmp workIndexEnv ["write-tree"] ""
+    after <- BS.readFile (gitDir </> "index")
+    unless (original == after) $ fail "index changed during snapshot"
+    headAfter <- oid repo tmp [] ["rev-parse", "--verify", "HEAD^{commit}"] ""
+    unless (headOid == headAfter) $ fail "HEAD changed during snapshot"
+    pure (headOid, indexTree, workTree, branch)
+
+readWorkingFile :: FilePath -> FilePath -> IO (Maybe (BS.ByteString, BS.ByteString))
+readWorkingFile repo name = do
+    validatePath name
+    checkParents repo name
+    let path = repo </> name
+    status <- tryIOError (Posix.getSymbolicLinkStatus path)
+    case status of
+        Left err | isDoesNotExistError err -> pure Nothing
+        Left err -> ioError err
+        Right st
+            | Posix.isSymbolicLink st -> Just . ("120000",) <$>
+                PosixBytes.readSymbolicLink (Text.encodeUtf8 (Text.pack path))
+            | Posix.isRegularFile st -> Just .
+                (if Posix.fileMode st .&. 0o111 /= 0 then "100755" else "100644",)
+                <$> BS.readFile path
+            | otherwise -> fail "unsupported working file: directory, nested repository or special file"
+
+verifyObjects :: FilePath -> FilePath -> WorktreeSnapshot -> IO ()
+verifyObjects repo tmp snapshot = do
+    let ref = Text.unpack snapshot.snapshotRef
+    unless ("refs/haskell-agent/snapshots/" `isPrefixOf` ref) $
+        fail "invalid recovery ref"
+    void $ git repo tmp [] ["check-ref-format", ref] ""
+    forM_ [snapshot.snapshotHead, snapshot.snapshotIndexTree, snapshot.snapshotWorkTree] \value ->
+        unless (Text.length value `elem` [40, 64] &&
+            Text.all (`elem` ("0123456789abcdef" :: String)) value) $
+            fail "invalid snapshot object id"
+    commitTree <- oid repo tmp [] ["rev-parse", "--verify", ref <> "^{tree}"] ""
+    parent <- oid repo tmp [] ["rev-parse", "--verify", ref <> "^1"] ""
+    indexTree <- oid repo tmp [] ["rev-parse", "--verify", ref <> "^2^{tree}"] ""
+    unless ((parent, indexTree, commitTree) ==
+        (Text.unpack snapshot.snapshotHead, Text.unpack snapshot.snapshotIndexTree,
+         Text.unpack snapshot.snapshotWorkTree)) $ fail "recovery ref does not match registry"
+    void $ git repo tmp [] ["fsck", "--connectivity-only", "--no-reflogs", "--no-dangling", ref] ""
+    -- Walk and read all recovery blobs, not just tree roots. Missing/corrupt
+    -- objects must prevent collection before the original is removed.
+    forM_ [snapshot.snapshotIndexTree, snapshot.snapshotWorkTree] \tree -> do
+        entries <- treeEntries repo tmp (Text.unpack tree)
+        forM_ entries \(_, object, name) -> do
+            validatePath name
+            bytes <- git repo tmp [] ["cat-file", "blob", object] ""
+            hashed <- oid repo tmp [] ["hash-object", "--no-filters", "--stdin"] bytes
+            unless (hashed == object) $ fail "corrupt snapshot blob"
+
+treeEntries :: FilePath -> FilePath -> String -> IO [(String, String, FilePath)]
+treeEntries repo tmp tree = do
+    entries <- git repo tmp [] ["ls-tree", "-r", "-z", tree] ""
+    forM (nul entries) \entry -> do
+        let (header, name) = B8.break (== '\t') entry
+        case B8.words header of
+            [mode, "blob", object] | mode `elem` ["100644", "100755", "120000"] -> do
+                path <- utf8 (BS.drop 1 name)
+                pure (B8.unpack mode, B8.unpack object, path)
+            _ -> fail "unsupported recovery tree entry"
+
+validatePath :: FilePath -> IO ()
+validatePath name =
+    when (null name || isAbsolute name || any ((`elem` ["..", ".", ".git"]) . map toLower)
+        (splitDirectories name)) $ fail "unsafe snapshot path"
+
+checkParents :: FilePath -> FilePath -> IO ()
+checkParents root name =
+    forM_ (scanl (</>) root (dropLast (splitDirectories name))) \parent -> do
+        status <- tryIOError (Posix.getSymbolicLinkStatus parent)
+        case status of
+            Left err | isDoesNotExistError err -> pure ()
+            Left err -> ioError err
+            Right st -> unless (Posix.isDirectory st && not (Posix.isSymbolicLink st)) $
+                fail "unsupported working path: non-directory ancestor"
+  where
+    dropLast [] = []
+    dropLast [_] = []
+    dropLast (x : xs) = x : dropLast xs
+
+nul :: BS.ByteString -> [BS.ByteString]
+nul = filter (not . BS.null) . BS.split 0
+
+utf8 :: BS.ByteString -> IO String
+utf8 bytes = either (const (fail "unsupported non-UTF8 path")) (pure . Text.unpack)
+    (Text.decodeUtf8' bytes)
+
+pathExists :: FilePath -> IO Bool
+pathExists path = tryIOError (Posix.getSymbolicLinkStatus path) >>= \case
+    Right _ -> pure True
+    Left err | isDoesNotExistError err -> pure False
+    Left err -> ioError err
+
+result :: IO a -> IO (Either Text a)
+result action = either (Left . Text.pack . displayException) Right <$> tryAny action
+
+withScratch :: (FilePath -> IO a) -> IO a
+withScratch action = do
+    root <- Dir.getTemporaryDirectory
+    bracket (mkdtemp (root </> "agent-worktree-snapshot-")) Dir.removePathForcibly action
+
+oid :: FilePath -> FilePath -> [(String, String)] -> [String] -> BS.ByteString -> IO String
+oid repo tmp env args input = B8.unpack . B8.takeWhile (/= '\n') <$> git repo tmp env args input
+
+-- Files instead of pipes keep binary I/O exact and avoid pipe deadlocks.
+-- withCreateProcess scopes the child even when the caller's bounded pass is
+-- cancelled. Scratch directories are private (mkdtemp mode 0700).
+git :: FilePath -> FilePath -> [(String, String)] -> [String] -> BS.ByteString -> IO BS.ByteString
+git repo tmp overrides args input = do
+    inherited <- getEnvironment
+    let environment = overrides <>
+            [("GIT_OPTIONAL_LOCKS", "0"), ("GIT_NO_REPLACE_OBJECTS", "1"),
+             ("GIT_NO_LAZY_FETCH", "1"), ("GIT_TERMINAL_PROMPT", "0"),
+             ("GIT_AUTHOR_NAME", "haskell-agent"), ("GIT_AUTHOR_EMAIL", "snapshot@localhost"),
+             ("GIT_COMMITTER_NAME", "haskell-agent"), ("GIT_COMMITTER_EMAIL", "snapshot@localhost")]
+            <> filter (not . isPrefixOf "GIT_" . fst) inherited
+        inputPath = tmp </> "stdin"
+        outputPath = tmp </> "stdout"
+        errorPath = tmp </> "stderr"
+    BS.writeFile inputPath input
+    code <- withBinaryFile inputPath ReadMode \stdin ->
+        withBinaryFile outputPath WriteMode \stdout ->
+        withBinaryFile errorPath WriteMode \stderr ->
+        withCreateProcess (proc "git"
+            (["-c", "core.hooksPath=/dev/null", "-c", "core.fsmonitor=false",
+              "-c", "core.fsync=all", "-c", "core.fsyncMethod=fsync",
+              "-C", repo] <> args))
+            { env = Just environment, std_in = UseHandle stdin,
+              std_out = UseHandle stdout, std_err = UseHandle stderr } \_ _ _ child ->
+                waitForProcess child
+    case code of
+        ExitSuccess -> BS.readFile outputPath
+        ExitFailure _ -> do
+            err <- BS.readFile errorPath
+            fail ("git " <> unwords (take 2 args) <> ": " <> B8.unpack err)

--- a/packages/agent-cli/src/Agent/CLI/WorktreeAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/WorktreeAdmin.hs
@@ -1,0 +1,101 @@
+-- | Standalone recovery administration. Adoption reads existing session metadata
+-- without starting, migrating, or importing the database.
+module Agent.CLI.WorktreeAdmin (runWorktreeAdmin, renderWorktreeCleanupReport) where
+
+import Agent.CLI.Config (HarnessConfig(..), WorktreeConfig(..), loadHarnessConfig)
+import Agent.CLI.Options (WorktreeCommand(..))
+import Agent.CLI.SessionAdmin (managedPostgresConfigForHome)
+import Agent.CLI.Worktree.Provenance (WorktreeActivity, loadWorktreeActivity)
+import Agent.CLI.Worktree
+    ( WorktreeCleanupReport(..)
+    , enrollWorktree
+    , gcWorktreesWithActivity
+    , isUnderWorktreeRoot
+    , protectWorktree
+    , restoreManagedWorktree
+    , worktreeRoot
+    )
+import Agent.OsPath (unsafeToFilePath)
+import Agent.Store.Postgres.Connection (closeStorePool, defaultPoolConfig, openStorePool)
+import Control.Exception.Safe (bracket, tryAny)
+import Control.Monad (unless)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import System.Directory.OsPath (getCurrentDirectory, getHomeDirectory, makeAbsolute)
+import System.Exit (exitFailure)
+import System.IO (stderr)
+import System.OsPath (OsPath)
+
+runWorktreeAdmin :: WorktreeCommand -> IO ()
+runWorktreeAdmin command = do
+    home <- getHomeDirectory
+    let root = worktreeRoot home
+        administer requested action message = do
+            path <- makeAbsolute requested
+            unless (isUnderWorktreeRoot root path) $
+                failCommand "path is outside the managed worktree root"
+            action path >>= either failCommand (const $
+                Text.putStrLn (message <> ": " <> Text.pack (unsafeToFilePath path)))
+    case command of
+        WorktreeGC dryRun overrideDays -> do
+            config <- loadHarnessConfig home >>= either failCommand pure
+            cwd <- getCurrentDirectory
+            let days = fromMaybe config.configWorktree.worktreeInactiveDays overrideDays
+            report <- gcWorktreesWithActivity (readExistingActivity home root) root days dryRun [cwd]
+            Text.putStr (renderWorktreeCleanupReport dryRun days report)
+            unless (null report.cleanupFailures) exitFailure
+        WorktreeEnroll path ->
+            administer path (enrollWorktree root)
+                "Enrolled (ignored untracked files are NOT recoverable)"
+        WorktreeRestore path ->
+            administer path (restoreManagedWorktree root) "Checkout available"
+        WorktreeProtect path ->
+            administer path (\p -> protectWorktree root p True) "Protected"
+        WorktreeUnprotect path ->
+            administer path (\p -> protectWorktree root p False) "Unprotected"
+
+failCommand :: Text -> IO a
+failCommand message = Text.hPutStrLn stderr ("worktree: " <> message) >> exitFailure
+
+-- Open only an ordinary pool: withStoreForHome would start PostgreSQL and run
+-- migrations/imports, which are forbidden side effects for a dry run.
+readExistingActivity :: OsPath -> OsPath -> IO (Either Text WorktreeActivity)
+readExistingActivity home root = do
+    result <- tryAny do
+        config <- managedPostgresConfigForHome home
+        bracket (openStorePool config defaultPoolConfig)
+            (either (const (pure ())) closeStorePool)
+            (either (const (pure unavailable)) (\pool -> loadWorktreeActivity pool root))
+    pure (either (const unavailable) id result)
+  where
+    unavailable = Left "saved-session database unavailable; adoption deferred"
+
+renderWorktreeCleanupReport :: Bool -> Int -> WorktreeCleanupReport -> Text
+renderWorktreeCleanupReport dryRun days report = Text.unlines $
+    [ (if dryRun then "Dry run" else "Collection pass")
+        <> " — inactivity expiry: " <> tshow days <> " days"
+    , "Ignored untracked files are NOT backed up or restored."
+    , if dryRun then "Automatic adoption is simulated; no registry or snapshot is written."
+        else "Verified existing agent worktrees are adopted using saved-session activity."
+    ]
+    <> [ "eligible\t" <> pathText path <> "\testimated bytes: " <> tshow bytes
+       | (path, bytes) <- report.cleanupEligible ]
+    <> [ "retained\t" <> pathText path <> "\t" <> reason
+       | (path, reason) <- report.cleanupRetained ]
+    <> [ "collected\t" <> pathText path | path <- report.cleanupRemoved ]
+    <> [ "failed\t" <> pathText path <> "\t" <> reason
+       | (path, reason) <- report.cleanupFailures ]
+    <> [ tshow (length report.cleanupEligible) <> " eligible, "
+        <> tshow (length report.cleanupRemoved) <> " collected, "
+        <> tshow (length report.cleanupRetained) <> " retained, "
+        <> tshow (length report.cleanupFailures) <> " failed."
+       , "Eligible checkout gross apparent bytes: " <> tshow (sum (map snd report.cleanupEligible))
+           <> " (excludes snapshot overhead and APFS sharing; not guaranteed net disk savings)."
+       ]
+  where
+    -- Escape control characters in filenames so each decision stays on one line.
+    pathText = Text.pack . show . unsafeToFilePath
+    tshow :: Show a => a -> Text
+    tshow = Text.pack . show

--- a/packages/agent-cli/src/Agent/CLI/WorktreeAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/WorktreeAdmin.hs
@@ -76,6 +76,7 @@ renderWorktreeCleanupReport :: Bool -> Int -> WorktreeCleanupReport -> Text
 renderWorktreeCleanupReport dryRun days report = Text.unlines $
     [ (if dryRun then "Dry run" else "Collection pass")
         <> " — inactivity expiry: " <> tshow days <> " days"
+    , "HEAD incorporated into the resolved default branch: 24 hours of inactivity."
     , "Ignored untracked files are NOT backed up or restored."
     , if dryRun then "Automatic adoption is simulated; no registry or snapshot is written."
         else "Verified existing agent worktrees are adopted using saved-session activity."

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -243,6 +243,7 @@ spec = describe "Agent.CLI.Config" do
             fmap (.configWorktree) result
                 `shouldBe` Right WorktreeConfig
                     { worktreeFetchLatestUpstream = True
+                    , worktreeInactiveDays = 7
                     }
 
     it "loads the managed worktree fetch opt-out" $
@@ -253,7 +254,23 @@ spec = describe "Agent.CLI.Config" do
             fmap (.configWorktree) result
                 `shouldBe` Right WorktreeConfig
                     { worktreeFetchLatestUpstream = False
+                    , worktreeInactiveDays = 7
                     }
+
+    it "loads configurable worktree inactivity expiry" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home "{\"worktree\":{\"inactivityDays\":30}}"
+            result <- loadHarnessConfig home
+            fmap (.configWorktree.worktreeInactiveDays) result `shouldBe` Right 30
+
+    it "rejects nonpositive worktree inactivity expiry" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home "{\"worktree\":{\"inactivityDays\":0}}"
+            result <- loadHarnessConfig home
+            result `shouldSatisfy` either (Text.isInfixOf "inactivityDays") (const False)
+            writeConfig home "{\"worktree\":{\"inactivityDays\":-1}}"
+            resultNegative <- loadHarnessConfig home
+            resultNegative `shouldSatisfy` either (Text.isInfixOf "inactivityDays") (const False)
 
     it "decodes LSP maps and retains opaque JSON options" $
         withTempDir "agent-config-" \home -> do
@@ -367,6 +384,7 @@ spec = describe "Agent.CLI.Config" do
                     { configMcpServers = Map.singleton "seo-mcp" server
                     , configWorktree = WorktreeConfig
                         { worktreeFetchLatestUpstream = True
+                        , worktreeInactiveDays = 30
                         }
                     , configMaxConcurrentAgents = Just 48
                     }

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -13,6 +13,30 @@ fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = do
+    describe "worktree administration" do
+        it "parses dry-run and inactivity override" do
+            parseArgs ["worktree", "gc", "--dry-run"]
+                `shouldBe` Right (Worktree (WorktreeGC True Nothing))
+            parseArgs ["worktree", "gc", "--inactivity-days", "30"]
+                `shouldBe` Right (Worktree (WorktreeGC False (Just 30)))
+        it "requires a positive expiry" do
+            parseArgs ["worktree", "gc", "--inactivity-days", "0"]
+                `shouldSatisfy` either (const True) (const False)
+            parseArgs ["worktree", "gc", "--inactivity-days", "-1"]
+                `shouldSatisfy` either (const True) (const False)
+        it "parses explicit enrollment, recovery, and protection" do
+            let path = fromFilePath "/checkout"
+            parseArgs ["worktree", "enroll", "/checkout"]
+                `shouldBe` Right (Worktree (WorktreeEnroll path))
+            parseArgs ["worktree", "restore", "/checkout"]
+                `shouldBe` Right (Worktree (WorktreeRestore path))
+            parseArgs ["worktree", "protect", "/checkout"]
+                `shouldBe` Right (Worktree (WorktreeProtect path))
+            parseArgs ["worktree", "unprotect", "/checkout"]
+                `shouldBe` Right (Worktree (WorktreeUnprotect path))
+        it "does not reinterpret incomplete administration as a prompt" do
+            parseArgs ["worktree", "enroll"]
+                `shouldSatisfy` either (const True) (const False)
     describe "freshSessionOptions" do
         it "drops the old routing and resume state after a gateway change" do
             let cwd = fromFilePath "/tmp/company-work"

--- a/packages/agent-cli/test/Agent/CLI/Worktree/ProvenanceSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/Worktree/ProvenanceSpec.hs
@@ -1,0 +1,193 @@
+module Agent.CLI.Worktree.ProvenanceSpec (spec) where
+
+import Agent.CLI.Session.Types (SessionMeta(..))
+import Agent.CLI.SessionLock (sessionLockPath, sessionActivityLockPath)
+import Agent.CLI.Worktree.Provenance
+import Agent.CLI.Worktree.ReadOnlyLock (withExistingReadOnlyLock)
+import Agent.Dialect (DialectId(..))
+import Agent.Provider (Provider(..))
+import Data.Either (isLeft)
+import qualified Data.Map.Strict as Map
+import Data.Time.Clock (UTCTime, addUTCTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import qualified System.Directory as Dir
+import System.FileLock (withFileLock, SharedExclusive(..))
+import System.IO.Temp (withSystemTempDirectory)
+import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
+import Test.Hspec
+
+spec :: Spec
+spec = describe "worktree saved-session provenance" do
+    it "does not create missing session locks or directories" $
+        withSystemTempDirectory "worktree-provenance" \dir -> do
+            let absent = dir <> "/absent/lock"
+            existingSessionLockActive absent `shouldReturn` False
+            Dir.listDirectory dir `shouldReturn` []
+
+    it "observes real filelock leases and releases its read-only probe" $
+        withSystemTempDirectory "worktree-provenance" \dir -> do
+            let path = dir <> "/lock"
+                os = path
+            writeFile path "unchanged"
+            existingSessionLockActive os `shouldReturn` False
+            withFileLock path Exclusive \_ ->
+                existingSessionLockActive os `shouldReturn` True
+            existingSessionLockActive os `shouldReturn` False
+            readFile path `shouldReturn` "unchanged"
+
+    it "retains symlink and directory lock paths" $
+        withSystemTempDirectory "worktree-provenance" \dir -> do
+            existingSessionLockActive dir `shouldReturn` True
+            Dir.createFileLink (dir <> "/missing") (dir <> "/link")
+            existingSessionLockActive (dir <> "/link") `shouldReturn` True
+
+    it "holds read-only flock through the callback and releases it after callback failure" $
+        withSystemTempDirectory "worktree-provenance" \dir -> do
+            let path = dir <> "/lock"
+                os = unsafeEncodeUtf path
+            writeFile path "unchanged"
+            withExistingReadOnlyLock os (existingSessionLockActive path)
+                `shouldReturn` Right True
+            failed <- withExistingReadOnlyLock os (ioError (userError "injected") :: IO ())
+            failed `shouldSatisfy` isLeft
+            existingSessionLockActive path `shouldReturn` False
+            readFile path `shouldReturn` "unchanged"
+
+    it "retains old active sessions without a worktree lease, for either session lock" $
+        withSystemTempDirectory "worktree-provenance" \dir -> do
+            let sessionRoot = unsafeEncodeUtf dir
+                meta = sampleMeta checkout old
+                sessionDir = sessionRoot </> unsafeEncodeUtf "saved-session"
+                initial = buildWorktreeActivity root [meta]
+            Dir.createDirectory (dir <> "/saved-session")
+            mapM_ (\lockPath -> do
+                let path = lockPath sessionDir
+                withFileLock path Exclusive \_ -> do
+                    result <- protectActiveSessions sessionRoot root [meta] initial
+                    Map.lookup checkout result `shouldSatisfy` maybe False isLeft
+                protectActiveSessions sessionRoot root [meta] initial `shouldReturn` initial)
+                [sessionLockPath, sessionActivityLockPath]
+
+    it "retains symlinked session directories and session roots even with absent locks" $
+        withSystemTempDirectory "worktree-provenance" \dir -> do
+            let meta = sampleMeta checkout old
+                initial = buildWorktreeActivity root [meta]
+                blocked path = do
+                    result <- protectActiveSessions (unsafeEncodeUtf path) root [meta] initial
+                    Map.lookup checkout result `shouldSatisfy` maybe False isLeft
+            Dir.createDirectory (dir <> "/target")
+            Dir.createDirectoryLink (dir <> "/target") (dir <> "/saved-session")
+            blocked dir
+            Dir.createDirectoryLink (dir <> "/target") (dir <> "/root-link")
+            blocked (dir <> "/root-link")
+
+    it "allows missing session parents without creating them" $
+        withSystemTempDirectory "worktree-provenance" \dir -> do
+            let meta = sampleMeta checkout old
+                initial = buildWorktreeActivity root [meta]
+            protectActiveSessions (unsafeEncodeUtf (dir <> "/missing")) root [meta] initial
+                `shouldReturn` initial
+            Dir.listDirectory dir `shouldReturn` []
+
+    it "preserves persisted activity rather than adopting with today's time" do
+        buildWorktreeActivity root [sampleMeta checkout old]
+            `shouldBe` Map.singleton checkout (Right old)
+
+    it "uses newest session activity regardless of listing order" do
+        let older = sampleMeta checkout old
+            newer = (sampleMeta checkout recent) { metaId = "other-session" }
+        buildWorktreeActivity root [older, newer]
+            `shouldBe` Map.singleton checkout (Right recent)
+        buildWorktreeActivity root [newer, older]
+            `shouldBe` Map.singleton checkout (Right recent)
+
+    it "includes activity from sessions resumed in checkout subdirectories" do
+        buildWorktreeActivity root
+            [sampleMeta checkout old, sampleMeta (checkout </> unsafeEncodeUtf "src") recent]
+            `shouldBe` Map.singleton checkout (Right recent)
+
+    it "does not infer activity for a checkout without a saved session" do
+        Map.lookup checkout (buildWorktreeActivity root []) `shouldBe` Nothing
+
+    it "does not match sibling root prefixes or relative paths" do
+        buildWorktreeActivity root
+            [ sampleMeta (unsafeEncodeUtf "/managed/worktrees-other/repo/2020-01-01-deadbeef") old
+            , sampleMeta (unsafeEncodeUtf "managed/worktrees/repo/2020-01-01-deadbeef") old
+            , sampleMeta root old
+            , sampleMeta (root </> unsafeEncodeUtf "repo") old
+            ] `shouldBe` Map.empty
+
+    it "does not let valid older sessions conceal invalid activity" do
+        let invalid = (sampleMeta checkout old) { metaCreatedAt = recent }
+            valid = sampleMeta checkout recent
+        Map.lookup checkout (buildWorktreeActivity root [invalid, valid])
+            `shouldSatisfy` maybe False isLeft
+        Map.lookup checkout (buildWorktreeActivity root [valid, invalid])
+            `shouldSatisfy` maybe False isLeft
+
+    it "retains uncertain traversing session paths instead of using their timestamp" do
+        Map.lookup checkout (buildWorktreeActivity root
+            [sampleMeta (checkout </> unsafeEncodeUtf "src/..") old])
+            `shouldSatisfy` maybe False isLeft
+
+    it "retains invalid session provenance" do
+        Map.lookup checkout (buildWorktreeActivity root
+            [(sampleMeta checkout old) { metaId = "" }])
+            `shouldSatisfy` maybe False isLeft
+        Map.lookup checkout (buildWorktreeActivity root
+            [(sampleMeta checkout old) { metaVersion = 2 }])
+            `shouldSatisfy` maybe False isLeft
+
+    it "fails closed on incomplete listings instead of hiding a possibly newer session" do
+        worktreeActivityFromListing root ([sampleMeta checkout old], ["cannot decode another row"])
+            `shouldSatisfy` isLeft
+
+    it "does not filter valid sessions by provider, gateway route or title" do
+        let routed = (sampleMeta checkout recent)
+                { metaGatewayIdentity = Just "another-route", metaTitle = "archived session" }
+        worktreeActivityFromListing root ([sampleMeta checkout old, routed], [])
+            `shouldBe` Right (Map.singleton checkout (Right recent))
+
+    it "rejects ambiguous managed roots" do
+        worktreeActivityFromListing (unsafeEncodeUtf "relative") ([], [])
+            `shouldSatisfy` isLeft
+        worktreeActivityFromListing (unsafeEncodeUtf "/managed/../worktrees") ([], [])
+            `shouldSatisfy` isLeft
+
+root, checkout :: OsPath
+root = unsafeEncodeUtf "/managed/worktrees"
+checkout = root </> unsafeEncodeUtf "repo/2020-01-01-deadbeef"
+
+old, recent :: UTCTime
+old = posixSecondsToUTCTime 1000000000
+recent = addUTCTime 86400 old
+
+sampleMeta :: OsPath -> UTCTime -> SessionMeta
+sampleMeta cwd updated =
+    SessionMeta
+        { metaVersion = 1
+        , metaId = "saved-session"
+        , metaCreatedAt = old
+        , metaUpdatedAt = updated
+        , metaProvider = XAIProvider
+        , metaConnection = "xai"
+        , metaGatewayIdentity = Nothing
+        , metaModel = "grok-4.6"
+        , metaTransportModel = Nothing
+        , metaDialect = GrokBuildDialect
+        , metaLegacySubagentTarget = Nothing
+        , metaCwd = cwd
+        , metaEffort = "high"
+        , metaTitle = ""
+        , metaTitleIsManual = False
+        , metaTitleRefreshIndex = 0
+        , metaTitleUserTurns = 0
+        , metaLastResponseId = Nothing
+        , metaInputTokens = 0
+        , metaOutputTokens = 0
+        , metaCachedTokens = 0
+        , metaLastRecap = Nothing
+        , metaLastTurnSummary = Nothing
+        , metaLastRecapMainTurns = 0
+        , metaPromptSnapshot = Nothing
+        }

--- a/packages/agent-cli/test/Agent/CLI/Worktree/SnapshotSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/Worktree/SnapshotSpec.hs
@@ -1,0 +1,243 @@
+module Agent.CLI.Worktree.SnapshotSpec (spec) where
+
+import Agent.CLI.Worktree.Snapshot
+import Control.Concurrent.Async (concurrently)
+import Control.Exception.Safe (bracket)
+import Control.Monad (void)
+import qualified Data.ByteString as BS
+import Data.Either (isLeft, isRight)
+import qualified Data.Text as Text
+import qualified System.Directory as Dir
+import System.Exit (ExitCode(..))
+import System.FilePath ((</>))
+import System.OsPath (OsPath, unsafeEncodeUtf)
+import qualified System.Posix.Files as Posix
+import System.Posix.Temp (mkdtemp)
+import System.Process (proc, readCreateProcessWithExitCode)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "worktree recovery snapshots" do
+    it "preflights dirty checkouts without writing Git objects, refs or the live index" $
+        fixture \repo checkout -> do
+            writeFile (checkout </> "new") "not yet a Git object"
+            writeFile (checkout </> "tracked") "unstaged"
+            gitDir <- trim <$> gitOut checkout ["rev-parse", "--absolute-git-dir"]
+            originalIndex <- BS.readFile (gitDir </> "index")
+            objects <- gitOut repo ["count-objects", "-v"]
+            refs <- gitOut repo ["show-ref"]
+            checkSnapshotSupported (p checkout) `shouldReturn` Right ()
+            gitOut repo ["count-objects", "-v"] `shouldReturn` objects
+            gitOut repo ["show-ref"] `shouldReturn` refs
+            BS.readFile (gitDir </> "index") `shouldReturn` originalIndex
+            writeFile (gitDir </> "MERGE_HEAD") "pending"
+            checkSnapshotSupported (p checkout) >>= (`shouldSatisfy` isLeft)
+
+    it "round trips unique commits, index, raw bytes, symlinks, deletes and untracked names" $
+        fixture \repo checkout -> do
+            writeFile (checkout </> "tracked") "unique commit\n"
+            git checkout ["commit", "-am", "unique"]
+            unique <- gitOut checkout ["rev-parse", "HEAD"]
+            writeFile (checkout </> "tracked") "staged\n"
+            BS.writeFile (checkout </> "binary") (BS.pack [0, 128, 255, 10])
+            git checkout ["add", "tracked", "binary"]
+            writeFile (checkout </> "tracked") "unstaged\r\n"
+            BS.writeFile (checkout </> "binary") (BS.pack [255, 0, 1, 13, 10])
+            writeFile (checkout </> "untracked\n\tquote\"") "loose\n"
+            writeFile (checkout </> ".env") "excluded secret\n"
+            Posix.createSymbolicLink "missing-target" (checkout </> "link")
+            writeFile (checkout </> "script") "#!/bin/sh\n"
+            Posix.setFileMode (checkout </> "script") 0o755
+            git checkout ["rm", "deleted"]
+            -- Staged deletion with a replacement must remain untracked.
+            writeFile (checkout </> "deleted") "replacement\n"
+            gitDir <- trim <$> gitOut checkout ["rev-parse", "--absolute-git-dir"]
+            originalIndex <- BS.readFile (gitDir </> "index")
+            staged <- gitOut checkout ["diff", "--cached", "--binary"]
+            unstaged <- gitOut checkout ["diff", "--binary"]
+            snapshot <- expectRight =<< createSnapshot (p checkout)
+            BS.readFile (gitDir </> "index") `shouldReturn` originalIndex
+            gitOut checkout ["rev-parse", "HEAD"] `shouldReturn` unique
+            verifySnapshotUnchanged (p checkout) snapshot `shouldReturn` Right ()
+            git repo ["worktree", "remove", "--force", checkout]
+            git repo ["branch", "-D", "session"]
+            git repo ["gc", "--prune=now"]
+            restoreSnapshot (p repo) (p checkout) snapshot `shouldReturn` Right ()
+            gitOut checkout ["rev-parse", "HEAD"] `shouldReturn` unique
+            gitOut checkout ["diff", "--cached", "--binary"] `shouldReturn` staged
+            gitOut checkout ["diff", "--binary"] `shouldReturn` unstaged
+            BS.readFile (checkout </> "binary") `shouldReturn` BS.pack [255, 0, 1, 13, 10]
+            readFile (checkout </> "untracked\n\tquote\"") `shouldReturn` "loose\n"
+            Posix.readSymbolicLink (checkout </> "link") `shouldReturn` "missing-target"
+            executable <- Posix.fileMode <$> Posix.getFileStatus (checkout </> "script")
+            executable `shouldBe` 0o100755
+            Dir.doesPathExist (checkout </> ".env") `shouldReturn` False
+
+    it "never applies clean or smudge filters when saving working bytes" $
+        fixture \repo checkout -> do
+            git repo ["config", "filter.lossy.clean", "tr a-z A-Z"]
+            git repo ["config", "filter.lossy.smudge", "tr A-Z a-z"]
+            writeFile (checkout </> ".gitattributes") "tracked filter=lossy\n"
+            writeFile (checkout </> "tracked") "MiXeD\r\n"
+            git checkout ["add", ".gitattributes", "tracked"]
+            staged <- gitOut checkout ["show", ":tracked"]
+            snapshot <- expectRight =<< createSnapshot (p checkout)
+            git repo ["worktree", "remove", "--force", checkout]
+            restoreSnapshot (p repo) (p checkout) snapshot `shouldReturn` Right ()
+            BS.readFile (checkout </> "tracked") `shouldReturn` "MiXeD\r\n"
+            gitOut checkout ["show", ":tracked"] `shouldReturn` staged
+
+    it "detects edits, including newly created untracked files, but ignores ignored edits" $
+        fixture \_ checkout -> do
+            snapshot <- expectRight =<< createSnapshot (p checkout)
+            writeFile (checkout </> ".env") "ignored"
+            verifySnapshotUnchanged (p checkout) snapshot `shouldReturn` Right ()
+            writeFile (checkout </> "new") "valuable"
+            verifySnapshotUnchanged (p checkout) snapshot >>= (`shouldSatisfy` isLeft)
+            Dir.removeFile (checkout </> "new")
+            writeFile (checkout </> "tracked") "changed"
+            verifySnapshotUnchanged (p checkout) snapshot >>= (`shouldSatisfy` isLeft)
+
+    it "rejects incomplete recovery refs before creating a destination" $
+        fixture \repo checkout -> do
+            snapshot <- expectRight =<< createSnapshot (p checkout)
+            git repo ["update-ref", "-d", Text.unpack snapshot.snapshotRef]
+            let target = checkout <> "-restore"
+            restoreSnapshot (p repo) (p target) snapshot >>= (`shouldSatisfy` isLeft)
+            Dir.doesPathExist target `shouldReturn` False
+
+    it "rejects missing recovery blobs before authorizing collection or restoration" $
+        fixture \repo checkout -> do
+            writeFile (checkout </> "precious") "only in this untracked file\n"
+            snapshot <- expectRight =<< createSnapshot (p checkout)
+            object <- trim <$> gitOut repo
+                ["rev-parse", Text.unpack snapshot.snapshotWorkTree <> ":precious"]
+            let objectPath = repo </> ".git" </> "objects" </> take 2 object </> drop 2 object
+                target = checkout <> "-restore"
+            Dir.removeFile objectPath
+            verifySnapshotUnchanged (p checkout) snapshot >>= (`shouldSatisfy` isLeft)
+            restoreSnapshot (p repo) (p target) snapshot >>= (`shouldSatisfy` isLeft)
+            Dir.doesPathExist target `shouldReturn` False
+            readFile (checkout </> "precious") `shouldReturn` "only in this untracked file\n"
+
+    it "retains staged children beneath a replaced symlink parent" $
+        fixture \repo checkout -> do
+            Dir.createDirectory (checkout </> "directory")
+            writeFile (checkout </> "directory" </> "child") "staged"
+            git checkout ["add", "directory/child"]
+            Dir.removePathForcibly (checkout </> "directory")
+            Posix.createSymbolicLink repo (checkout </> "directory")
+            createSnapshot (p checkout) >>= (`shouldSatisfy` isLeft)
+            readFile (repo </> "tracked") `shouldReturn` "base\n"
+
+    it "does not overwrite an existing directory, file or dangling symlink" $
+        fixture \repo checkout -> do
+            snapshot <- expectRight =<< createSnapshot (p checkout)
+            let target = checkout <> "-restore"
+            Dir.createDirectory target
+            restoreSnapshot (p repo) (p target) snapshot >>= (`shouldSatisfy` isLeft)
+            Dir.removeDirectory target
+            writeFile target "keep"
+            restoreSnapshot (p repo) (p target) snapshot >>= (`shouldSatisfy` isLeft)
+            readFile target `shouldReturn` "keep"
+            Dir.removeFile target
+            Posix.createSymbolicLink "absent" target
+            restoreSnapshot (p repo) (p target) snapshot >>= (`shouldSatisfy` isLeft)
+            Posix.readSymbolicLink target `shouldReturn` "absent"
+
+    it "restores detached without resetting a moved branch" $
+        fixture \repo checkout -> do
+            snapshot <- expectRight =<< createSnapshot (p checkout)
+            git repo ["worktree", "remove", "--force", checkout]
+            git repo ["commit", "--allow-empty", "-m", "new"]
+            new <- gitOut repo ["rev-parse", "HEAD"]
+            git repo ["branch", "-f", "session", "HEAD"]
+            restoreSnapshot (p repo) (p checkout) snapshot `shouldReturn` Right ()
+            gitOut repo ["rev-parse", "session"] `shouldReturn` new
+            trim <$> gitOut checkout ["rev-parse", "--abbrev-ref", "HEAD"] `shouldReturn` "HEAD"
+
+    it "repairs only the missing destination's stale unlocked registration" $
+        fixture \repo checkout -> do
+            writeFile (checkout </> "loose") "recover this"
+            snapshot <- expectRight =<< createSnapshot (p checkout)
+            -- Simulate an interrupted removal: files gone, registration left.
+            Dir.removePathForcibly checkout
+            restoreSnapshot (p repo) (p checkout) snapshot `shouldReturn` Right ()
+            readFile (checkout </> "loose") `shouldReturn` "recover this"
+
+    it "does not override a stale locked registration" $
+        fixture \repo checkout -> do
+            snapshot <- expectRight =<< createSnapshot (p checkout)
+            git repo ["worktree", "lock", "--reason", "keep", checkout]
+            Dir.removePathForcibly checkout
+            restoreSnapshot (p repo) (p checkout) snapshot >>= (`shouldSatisfy` isLeft)
+            registrations <- gitOut repo ["worktree", "list", "--porcelain"]
+            registrations `shouldContain` "locked keep"
+
+    it "reserves a destination against concurrent restores" $
+        fixture \repo checkout -> do
+            snapshot <- expectRight =<< createSnapshot (p checkout)
+            let restore = restoreSnapshot (p repo) (p (checkout <> "-restore")) snapshot
+            (left, right) <- concurrently restore restore
+            length (filter isRight [left, right]) `shouldBe` 1
+            length (filter isLeft [left, right]) `shouldBe` 1
+
+    it "retains unsupported in-progress operations and special index states" $
+        fixture \_ checkout -> do
+            gitDir <- trim <$> gitOut checkout ["rev-parse", "--absolute-git-dir"]
+            writeFile (gitDir </> "MERGE_HEAD") "pending"
+            createSnapshot (p checkout) >>= (`shouldSatisfy` isLeft)
+            Dir.removeFile (gitDir </> "MERGE_HEAD")
+            git checkout ["update-index", "--assume-unchanged", "tracked"]
+            createSnapshot (p checkout) >>= (`shouldSatisfy` isLeft)
+            git checkout ["update-index", "--no-assume-unchanged", "tracked"]
+            writeFile (checkout </> "intent") "not staged"
+            git checkout ["add", "-N", "intent"]
+            createSnapshot (p checkout) >>= (`shouldSatisfy` isLeft)
+
+    it "retains nested repositories rather than losing their history" $
+        fixture \_ checkout -> do
+            Dir.createDirectory (checkout </> "nested")
+            git (checkout </> "nested") ["init"]
+            createSnapshot (p checkout) >>= (`shouldSatisfy` isLeft)
+
+p :: FilePath -> OsPath
+p = unsafeEncodeUtf
+
+trim :: String -> String
+trim = reverse . dropWhile (== '\n') . reverse
+
+expectRight :: Show e => Either e a -> IO a
+expectRight = either (fail . show) pure
+
+fixture :: (FilePath -> FilePath -> IO a) -> IO a
+fixture action = do
+    tmp <- Dir.getTemporaryDirectory
+    bracket (mkdtemp (tmp </> "snapshot-spec-")) Dir.removePathForcibly \root -> do
+        let repo = root </> "repo"
+            checkout = root </> "checkout"
+        Dir.createDirectory repo
+        git repo ["init"]
+        git repo ["config", "user.name", "Snapshot Test"]
+        git repo ["config", "user.email", "snapshot@example.invalid"]
+        git repo ["config", "commit.gpgsign", "false"]
+        writeFile (repo </> "tracked") "base\n"
+        writeFile (repo </> "deleted") "delete me\n"
+        writeFile (repo </> ".gitignore") ".env\n"
+        git repo ["add", "."]
+        git repo ["commit", "-m", "base"]
+        git repo ["worktree", "add", "-b", "session", checkout]
+        action repo checkout
+
+git :: FilePath -> [String] -> IO ()
+git repo = void . gitOut repo
+
+gitOut :: FilePath -> [String] -> IO String
+gitOut repo args = do
+    (code, output, err) <- readCreateProcessWithExitCode
+        (proc "git" (["-C", repo] <> args)) ""
+    unlessSuccess code err
+    pure output
+  where
+    unlessSuccess ExitSuccess _ = pure ()
+    unlessSuccess _ err = fail err

--- a/packages/agent-cli/test/Agent/CLI/WorktreeAdminSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeAdminSpec.hs
@@ -1,0 +1,43 @@
+module Agent.CLI.WorktreeAdminSpec (spec) where
+
+import Agent.CLI.Worktree (WorktreeCleanupReport(..))
+import Agent.CLI.WorktreeAdmin (renderWorktreeCleanupReport)
+import qualified Data.Text as Text
+import System.OsPath (unsafeEncodeUtf)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "worktree cleanup report" do
+    it "shows eligibility, estimates, retained reasons, failures and the ignored-file warning" do
+        let report = WorktreeCleanupReport
+                { cleanupRemoved = []
+                , cleanupFailures = [(unsafeEncodeUtf "/broken", "snapshot verification failed")]
+                , cleanupEligible = [(unsafeEncodeUtf "/ready", 1234)]
+                , cleanupRetained = [(unsafeEncodeUtf "/legacy", "unknown saved-session activity")]
+                }
+            rendered = renderWorktreeCleanupReport True 14 report
+        mapM_ (\part -> rendered `shouldSatisfy` Text.isInfixOf part)
+            [ "Dry run"
+            , "14 days"
+            , "estimated bytes: 1234"
+            , "unknown saved-session activity"
+            , "Automatic adoption is simulated; no registry or snapshot is written."
+            , "Eligible checkout gross apparent bytes: 1234"
+            , "snapshot verification failed"
+            , "Ignored untracked files are NOT backed up or restored."
+            , "1 eligible, 0 collected, 1 retained, 1 failed."
+            ]
+    it "escapes newlines in filenames" do
+        let report = mempty { cleanupRetained = [(unsafeEncodeUtf "/line\nbreak", "protected")] }
+            rendered = renderWorktreeCleanupReport True 7 report
+        rendered `shouldSatisfy` Text.isInfixOf "/line\\nbreak"
+        length (Text.lines rendered) `shouldBe` 6
+    it "sums only eligible estimates and does not describe estimates as recovered space" do
+        let report = mempty
+                { cleanupEligible = [(unsafeEncodeUtf "/one", 1234), (unsafeEncodeUtf "/two", 4321)]
+                , cleanupRetained = [(unsafeEncodeUtf "/protected", "protected")]
+                }
+            rendered = renderWorktreeCleanupReport True 7 report
+        rendered `shouldSatisfy` Text.isInfixOf "Eligible checkout gross apparent bytes: 5555"
+        rendered `shouldSatisfy` Text.isInfixOf "not guaranteed net disk savings"
+        rendered `shouldSatisfy` Text.isInfixOf "2 eligible, 0 collected, 1 retained, 0 failed."

--- a/packages/agent-cli/test/Agent/CLI/WorktreeAdminSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeAdminSpec.hs
@@ -19,6 +19,7 @@ spec = describe "worktree cleanup report" do
         mapM_ (\part -> rendered `shouldSatisfy` Text.isInfixOf part)
             [ "Dry run"
             , "14 days"
+            , "HEAD incorporated into the resolved default branch: 24 hours of inactivity."
             , "estimated bytes: 1234"
             , "unknown saved-session activity"
             , "Automatic adoption is simulated; no registry or snapshot is written."
@@ -31,7 +32,7 @@ spec = describe "worktree cleanup report" do
         let report = mempty { cleanupRetained = [(unsafeEncodeUtf "/line\nbreak", "protected")] }
             rendered = renderWorktreeCleanupReport True 7 report
         rendered `shouldSatisfy` Text.isInfixOf "/line\\nbreak"
-        length (Text.lines rendered) `shouldBe` 6
+        length (Text.lines rendered) `shouldBe` 7
     it "sums only eligible estimates and does not describe estimates as recovered space" do
         let report = mempty
                 { cleanupEligible = [(unsafeEncodeUtf "/one", 1234), (unsafeEncodeUtf "/two", 4321)]

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -2,14 +2,17 @@ module Agent.CLI.WorktreeSpec (spec) where
 
 import Agent.CLI.Config
 import Agent.CLI.Worktree
+import Agent.CLI.Worktree.Registry
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception.Safe (bracket)
+import Control.Monad (void)
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.List (dropWhileEnd, isInfixOf)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
-import Data.Time.Clock (getCurrentTime)
+import Data.Time.Clock (getCurrentTime, addUTCTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import qualified System.Directory as Directory
 import System.Directory.OsPath
@@ -23,6 +26,7 @@ import System.OsPath
     ( OsPath
     , addTrailingPathSeparator
     , decodeUtf
+    , takeDirectory
     , takeFileName
     , unsafeEncodeUtf
     , (</>)
@@ -164,7 +168,7 @@ spec = describe "Agent.CLI.Worktree" do
                 latest <- git updater ["rev-parse", "HEAD"]
                 local `shouldNotBe` latest
                 let config = defaultHarnessConfig
-                        { configWorktree = WorktreeConfig
+                        { configWorktree = defaultHarnessConfig.configWorktree
                             { worktreeFetchLatestUpstream = False
                             }
                         }
@@ -183,7 +187,7 @@ spec = describe "Agent.CLI.Worktree" do
                 latest <- git updater ["rev-parse", "HEAD"]
                 local `shouldNotBe` latest
                 let initialConfig = defaultHarnessConfig
-                        { configWorktree = WorktreeConfig
+                        { configWorktree = defaultHarnessConfig.configWorktree
                             { worktreeFetchLatestUpstream = False
                             }
                         }
@@ -271,7 +275,7 @@ spec = describe "Agent.CLI.Worktree" do
                 doesDirectoryExist first `shouldReturn` True
                 doesDirectoryExist second `shouldReturn` True
 
-        it "removes clean managed worktrees beyond the per-repository retention" $
+        it "never adopts legacy worktrees based on age or count without session provenance" $
             withTempGitRepo \repo ->
             withTempDir "agent-home-" \home -> do
                 let root = worktreeRoot home
@@ -281,13 +285,14 @@ spec = describe "Agent.CLI.Worktree" do
                 report <- cleanupStaleWorktrees root 1 []
 
                 report.cleanupFailures `shouldBe` []
-                report.cleanupRemoved `shouldBe` [older]
-                doesDirectoryExist older `shouldReturn` False
+                report.cleanupRemoved `shouldBe` []
+                report.cleanupRetained `shouldContain` [(older, "uncertain ownership: no saved-session provenance")]
+                doesDirectoryExist older `shouldReturn` True
                 doesDirectoryExist newer `shouldReturn` True
-                git repo ["branch", "--list", "2026-08-20-00000001"]
-                    `shouldReturn` ""
+                git repo ["branch", "--list", "--format=%(refname:short)", "2026-08-20-00000001"]
+                    `shouldReturn` "2026-08-20-00000001"
 
-        it "does not warn when Git conservatively retains the generated branch" $
+        it "retains unenrolled unique work even when another ref contains it" $
             withTempGitRepo \repo ->
             withTempDir "agent-home-" \home -> do
                 let root = worktreeRoot home
@@ -303,10 +308,10 @@ spec = describe "Agent.CLI.Worktree" do
 
                 report <- cleanupStaleWorktrees root 1 []
 
-                report.cleanupRemoved `shouldBe` [older]
+                report.cleanupRemoved `shouldBe` []
                 report.cleanupFailures `shouldBe` []
-                doesDirectoryExist older `shouldReturn` False
-                git repo ["branch", "--list", branch]
+                doesDirectoryExist older `shouldReturn` True
+                git repo ["branch", "--list", "--format=%(refname:short)", branch]
                     `shouldReturn` branch
 
         it "preserves stale worktrees with uncommitted files" $
@@ -382,8 +387,8 @@ spec = describe "Agent.CLI.Worktree" do
 
                 releaseWorktreeLease lease
                 fmap (.cleanupRemoved) (cleanupStaleWorktrees root 1 [])
-                    `shouldReturn` [older]
-                doesDirectoryExist older `shouldReturn` False
+                    `shouldReturn` []
+                doesDirectoryExist older `shouldReturn` True
 
         it "preserves explicitly protected stale worktrees" $
             withTempGitRepo \repo ->
@@ -427,6 +432,364 @@ spec = describe "Agent.CLI.Worktree" do
 
                 report.cleanupRemoved `shouldBe` []
                 doesDirectoryExist actual `shouldReturn` True
+
+    describe "snapshot-backed worktree GC" do
+        it "simulates verified legacy adoption without registry or lock writes" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                now <- getCurrentTime
+                let activity = pure (Right (Map.singleton path (Right (addUTCTime (-8 * 86400) now))))
+                writeFile (toFilePath (path </> fromFilePath ".gitignore")) "cache\n"
+                writeFile (toFilePath (path </> fromFilePath "cache")) (replicate 10000 'x')
+                before <- git repo ["show-ref"]
+                report <- gcWorktreesWithActivity activity root 7 True []
+                report.cleanupRetained `shouldBe` []
+                map fst report.cleanupEligible `shouldBe` [path]
+                sum (map snd report.cleanupEligible) `shouldSatisfy` (>= 10000)
+                readRecord root path `shouldReturn` Right Nothing
+                doesDirectoryExist (root </> fromFilePath ".registry") `shouldReturn` False
+                doesDirectoryExist (root </> fromFilePath ".locks") `shouldReturn` False
+                doesDirectoryExist (root </> fromFilePath ".leases") `shouldReturn` False
+                doesFileExist (repo </> fromFilePath ".git/haskell-agent-worktree.lock") `shouldReturn` False
+                git repo ["show-ref"] `shouldReturn` before
+
+        it "adopts and collects legacy dirty work with its original activity and restores it" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                now <- getCurrentTime
+                let old = addUTCTime (-8 * 86400) now
+                    activity = pure (Right (Map.singleton path (Right old)))
+                    file name = toFilePath (path </> fromFilePath name)
+                writeFile (file "README") "staged\n"
+                _ <- git path ["add", "README"]
+                writeFile (file "README") "unstaged\n"
+                writeFile (file "notes") "untracked\n"
+                writeFile (file ".gitignore") "cache\n"
+                writeFile (file "cache") "excluded\n"
+                report <- gcWorktreesWithActivity activity root 7 False []
+                report.cleanupRemoved `shouldBe` [path]
+                readRecord root path >>= \case
+                    Right (Just record) -> do
+                        record.recordLastActivity `shouldBe` old
+                        record.recordState `shouldBe` "collected"
+                    other -> expectationFailure (show other)
+                restoreManagedWorktree root path `shouldReturn` Right ()
+                git path ["show", ":README"] `shouldReturn` "staged"
+                readFile (file "README") `shouldReturn` "unstaged\n"
+                readFile (file "notes") `shouldReturn` "untracked\n"
+                Directory.doesFileExist (file "cache") `shouldReturn` False
+
+        it "retains legacy unknown activity and recent session activity without adoption" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                old <- addManagedWorktree repo root "2026-08-20-00000001"
+                recent <- addManagedWorktree repo root "2026-08-20-00000002"
+                now <- getCurrentTime
+                let activity = pure (Right (Map.fromList
+                        [(old, Left "unknown session activity"), (recent, Right now)]))
+                report <- gcWorktreesWithActivity activity root 7 False []
+                report.cleanupRemoved `shouldBe` []
+                report.cleanupRetained `shouldMatchList` [(old, "unknown session activity"), (recent, "recent activity")]
+                readRecord root old `shouldReturn` Right Nothing
+                readRecord root recent `shouldReturn` Right Nothing
+
+        it "dry-run lease probes retain an active legacy checkout without touching its activity" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                now <- getCurrentTime
+                let activity = pure (Right (Map.singleton path (Right (addUTCTime (-8 * 86400) now))))
+                bracket (acquireWorktreeLease root path) releaseLease $ \_ -> do
+                    report <- gcWorktreesWithActivity activity root 7 True []
+                    report.cleanupEligible `shouldBe` []
+                    map snd report.cleanupRetained `shouldSatisfy` any (Text.isInfixOf "existing lock is busy")
+                readRecord root path `shouldReturn` Right Nothing
+
+        it "rechecks session activity under the lease before adopting or snapshotting" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                now <- getCurrentTime
+                reads <- newIORef (0 :: Int)
+                let activity = do
+                        count <- readIORef reads
+                        modifyIORef' reads (+1)
+                        pure (Right (Map.singleton path (Right (if count == 0 then addUTCTime (-8 * 86400) now else now))))
+                report <- gcWorktreesWithActivity activity root 7 False []
+                report.cleanupRemoved `shouldBe` []
+                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+                readRecord root path `shouldReturn` Right Nothing
+                git repo ["for-each-ref", "--format=%(refname)", "refs/haskell-agent/worktree-snapshots"]
+                    `shouldReturn` ""
+
+        it "rejects copied linked metadata whose reciprocal pointer names another checkout" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                now <- getCurrentTime
+                let impostor = takeDirectory path </> fromFilePath "2026-08-20-00000002"
+                    activity = pure (Right (Map.singleton impostor (Right (addUTCTime (-8 * 86400) now))))
+                createDirectoryIfMissing True impostor
+                Directory.copyFile (toFilePath (path </> fromFilePath ".git"))
+                    (toFilePath (impostor </> fromFilePath ".git"))
+                report <- gcWorktreesWithActivity activity root 7 True []
+                report.cleanupEligible `shouldBe` []
+                report.cleanupRetained `shouldContain` [(impostor, "linked Git metadata points at another checkout")]
+                readRecord root impostor `shouldReturn` Right Nothing
+
+        it "retains legacy snapshot safety failures rather than adopting them" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                now <- getCurrentTime
+                let activity = pure (Right (Map.singleton path (Right (addUTCTime (-8 * 86400) now))))
+                _ <- git path ["update-index", "--assume-unchanged", "README"]
+                report <- gcWorktreesWithActivity activity root 7 False []
+                report.cleanupRemoved `shouldBe` []
+                report.cleanupRetained `shouldSatisfy` (not . null)
+                readRecord root path `shouldReturn` Right Nothing
+
+        it "concurrent adopters collect once and keep a restorable snapshot" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                now <- getCurrentTime
+                let activity = pure (Right (Map.singleton path (Right (addUTCTime (-8 * 86400) now))))
+                reports <- mapConcurrently (\_ -> gcWorktreesWithActivity activity root 7 False []) [1 :: Int .. 4]
+                concatMap (.cleanupRemoved) reports `shouldBe` [path]
+                restoreManagedWorktree root path `shouldReturn` Right ()
+                doesDirectoryExist path `shouldReturn` True
+
+        it "bounds eligible attempts even when every candidate fails preflight" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                paths <- mapM (\n -> do
+                    path <- addManagedWorktree repo root ("2026-08-20-0000000" <> show n)
+                    enrollWorktree root path `shouldReturn` Right ()
+                    ageRecord root path
+                    _ <- git path ["update-index", "--assume-unchanged", "README"]
+                    pure path) [1 :: Int .. 9]
+                report <- gcWorktrees root 7 False []
+                report.cleanupRemoved `shouldBe` []
+                length (filter ((== "pass budget exhausted") . snd) report.cleanupRetained) `shouldBe` 1
+                mapM_ (\path -> doesDirectoryExist path `shouldReturn` True) paths
+
+        it "enrollment starts a fresh inactivity window" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                enrollWorktree root path `shouldReturn` Right ()
+                report <- gcWorktrees root 7 False []
+                report.cleanupRemoved `shouldBe` []
+                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+
+        it "resuming an existing nested cwd refreshes activity before the runtime lease" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                let nested = path </> fromFilePath "nested"
+                createDirectoryIfMissing True nested
+                enrollWorktree root path `shouldReturn` Right ()
+                ageRecord root path
+                restoreManagedWorktree root nested `shouldReturn` Right ()
+                report <- gcWorktrees root 7 False []
+                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+
+        it "racing resume and collection retains a usable checkout or a restorable snapshot" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                enrollWorktree root path `shouldReturn` Right ()
+                ageRecord root path
+                _ <- mapConcurrently id
+                    [ void (gcWorktrees root 7 False [])
+                    , void (restoreManagedWorktree root path)
+                    ]
+                restoreManagedWorktree root path `shouldReturn` Right ()
+                doesDirectoryExist path `shouldReturn` True
+                report <- gcWorktrees root 7 False []
+                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+
+        it "dry runs preserve refs, registry, index, and checkout while estimating ignored bytes" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                writeFile (toFilePath (path </> fromFilePath ".gitignore")) "cache\n"
+                writeFile (toFilePath (path </> fromFilePath "cache")) (replicate 10000 'x')
+                enrollWorktree root path `shouldReturn` Right ()
+                ageRecord root path
+                before <- readRecord root path
+                refs <- git repo ["show-ref"]
+                status <- git path ["status", "--porcelain"]
+                report <- gcWorktrees root 7 True []
+                map fst report.cleanupEligible `shouldBe` [path]
+                sum (map snd report.cleanupEligible) `shouldSatisfy` (>= 10000)
+                readRecord root path `shouldReturn` before
+                git repo ["show-ref"] `shouldReturn` refs
+                git path ["status", "--porcelain"] `shouldReturn` status
+                doesDirectoryExist path `shouldReturn` True
+
+        it "collects dirty unique work and restores staged, unstaged and untracked files, not ignored data" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                let file name = toFilePath (path </> fromFilePath name)
+                writeFile (file "README") "unique commit\n"
+                _ <- git path ["add", "README"]
+                _ <- git path ["commit", "-m", "unique"]
+                headBefore <- git path ["rev-parse", "HEAD"]
+                writeFile (file "README") "staged\n"
+                _ <- git path ["add", "README"]
+                writeFile (file "README") "unstaged\n"
+                writeFile (file "notes") "untracked\n"
+                writeFile (file ".gitignore") "cache\n"
+                writeFile (file "cache") "excluded"
+                status <- git path ["status", "--porcelain", "--untracked-files=all"]
+                enrollWorktree root path `shouldReturn` Right ()
+                ageRecord root path
+                report <- gcWorktrees root 7 False []
+                report.cleanupRetained `shouldBe` []
+                report.cleanupRemoved `shouldBe` [path]
+                doesDirectoryExist path `shouldReturn` False
+                let originalBranch = toFilePath (takeFileName path)
+                _ <- git repo ["branch", "-f", originalBranch, "HEAD"]
+                movedBranch <- git repo ["rev-parse", originalBranch]
+                restoreManagedWorktree root path `shouldReturn` Right ()
+                git repo ["rev-parse", originalBranch] `shouldReturn` movedBranch
+                git path ["rev-parse", "HEAD"] `shouldReturn` headBefore
+                git path ["status", "--porcelain", "--untracked-files=all"] `shouldReturn` status
+                git path ["show", ":README"] `shouldReturn` "staged"
+                readFile (file "README") `shouldReturn` "unstaged\n"
+                readFile (file "notes") `shouldReturn` "untracked\n"
+                Directory.doesFileExist (file "cache") `shouldReturn` False
+
+        it "persistent protection and live leases independently prevent collection" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                enrollWorktree root path `shouldReturn` Right ()
+                ageRecord root path
+                protectWorktree root path True `shouldReturn` Right ()
+                report <- gcWorktrees root 7 False []
+                report.cleanupRetained `shouldBe` [(path, "protected")]
+                protectWorktree root path False `shouldReturn` Right ()
+                bracket (acquireWorktreeLease root path) releaseLease $ \lease -> do
+                    case lease of
+                        Right (Just _) -> pure ()
+                        _ -> expectationFailure "expected active lease"
+                    blocked <- gcWorktrees root 0 False []
+                    blocked.cleanupRemoved `shouldBe` []
+                fresh <- gcWorktrees root 7 False []
+                fresh.cleanupRetained `shouldBe` [(path, "recent activity")]
+
+        it "concurrent collectors only remove a checkout once and restoration remains available" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                enrollWorktree root path `shouldReturn` Right ()
+                ageRecord root path
+                reports <- mapConcurrently (\_ -> gcWorktrees root 7 False []) [1 :: Int .. 4]
+                concatMap (.cleanupRemoved) reports `shouldBe` [path]
+                restoreManagedWorktree root path `shouldReturn` Right ()
+                doesDirectoryExist path `shouldReturn` True
+
+        it "an interrupted maintenance state never overwrites an existing checkout" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                enrollWorktree root path `shouldReturn` Right ()
+                writeFile (toFilePath (path </> fromFilePath "sentinel")) "preserve"
+                modifyRecord root path (Right . fmap (\r -> r { recordState = "restoring" }))
+                    `shouldReturn` Right ()
+                restoreManagedWorktree root path
+                    >>= (`shouldSatisfy` either (const True) (const False))
+                readFile (toFilePath (path </> fromFilePath "sentinel")) `shouldReturn` "preserve"
+                report <- gcWorktrees root 0 False []
+                report.cleanupRemoved `shouldBe` []
+                report.cleanupRetained `shouldBe` [(path, "state: restoring")]
+
+        it "a missing legacy checkout is never recreated from a guessed branch" $
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                    path = root </> fromFilePath "repository" </> fromFilePath "2026-08-20-00000001"
+                createDirectoryIfMissing True (takeDirectory path)
+                restoreManagedWorktree root path
+                    >>= (`shouldSatisfy` either (const True) (const False))
+                doesDirectoryExist path `shouldReturn` False
+
+        it "rejects a symlinked registry without modifying redirected metadata" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                    outside = home </> fromFilePath "outside-registry"
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                createDirectoryIfMissing True outside
+                Directory.createDirectoryLink (toFilePath outside)
+                    (toFilePath (root </> fromFilePath ".registry"))
+                enrollWorktree root path
+                    >>= (`shouldSatisfy` either (const True) (const False))
+                report <- gcWorktrees root 0 False []
+                report.cleanupRemoved `shouldBe` []
+                Directory.listDirectory (toFilePath outside) `shouldReturn` []
+                doesDirectoryExist path `shouldReturn` True
+
+        it "rejects a symlinked managed root before leases or activity writes" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                    alias = home </> fromFilePath "alias"
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                Directory.createDirectoryLink (toFilePath root) (toFilePath alias)
+                let aliasedPath = alias </> takeFileName repo </> takeFileName path
+                rejected <- either (const True) (const False)
+                    <$> acquireWorktreeLease alias aliasedPath
+                rejected `shouldBe` True
+                report <- gcWorktrees alias 0 False []
+                report.cleanupRemoved `shouldBe` []
+                report.cleanupFailures `shouldSatisfy` (not . null)
+                doesDirectoryExist (root </> fromFilePath ".leases") `shouldReturn` False
+
+        it "a corrupt registry fails closed and cannot be silently replaced by enrollment" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                enrollWorktree root path `shouldReturn` Right ()
+                writeFile (toFilePath (recordPath root path)) "{broken"
+                report <- gcWorktrees root 0 False []
+                report.cleanupRemoved `shouldBe` []
+                enrollWorktree root path >>= (`shouldSatisfy` either (const True) (const False))
+                doesDirectoryExist path `shouldReturn` True
+
+ageRecord :: OsPath -> OsPath -> IO ()
+ageRecord root path = do
+    now <- getCurrentTime
+    modifyRecord root path (Right . fmap (\record ->
+        record { recordLastActivity = addUTCTime (-8 * 86400) now }))
+        `shouldReturn` Right ()
+
+releaseLease :: Either Text (Maybe WorktreeLease) -> IO ()
+releaseLease (Right (Just lease)) = releaseWorktreeLease lease
+releaseLease _ = pure ()
 
 expectRight :: Either Text OsPath -> IO OsPath
 expectRight = \case

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -12,7 +12,7 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
-import Data.Time.Clock (getCurrentTime, addUTCTime)
+import Data.Time.Clock (UTCTime, NominalDiffTime, getCurrentTime, addUTCTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import qualified System.Directory as Directory
 import System.Directory.OsPath
@@ -433,6 +433,152 @@ spec = describe "Agent.CLI.Worktree" do
                 report.cleanupRemoved `shouldBe` []
                 doesDirectoryExist actual `shouldReturn` True
 
+    describe "merged worktree inactivity" do
+        it "uses the exact inclusive 24-hour inactivity boundary for incorporated HEADs" do
+            now <- getCurrentTime
+            worktreeInactive 7 True now (addUTCTime (-86400 + 0.001) now) `shouldBe` False
+            worktreeInactive 7 True now (addUTCTime (-86400) now) `shouldBe` True
+            worktreeInactive 7 True now (addUTCTime (-86400 - 0.001) now) `shouldBe` True
+            worktreeInactive 7 True now (addUTCTime 1 now) `shouldBe` False
+
+        it "uses configured inactivity for unproven HEADs without a commit-date clock" do
+            now <- getCurrentTime
+            worktreeInactive 7 False now (addUTCTime (-86400) now) `shouldBe` False
+            worktreeInactive 7 False now (addUTCTime (-7 * 86400 + 0.001) now) `shouldBe` False
+            worktreeInactive 7 False now (addUTCTime (-7 * 86400) now) `shouldBe` True
+            worktreeInactive 14 False now (addUTCTime (-8 * 86400) now) `shouldBe` False
+            worktreeInactive 14 True now (addUTCTime (-86400) now) `shouldBe` True
+
+        mapM_ (\branch ->
+            it ("recognizes a normal merge into the resolved " <> branch <> " default branch") $
+                withMergedWorktree branch \_ root path -> do
+                    activity <- savedActivityDaysAgo path 2
+                    report <- gcWorktreesWithActivity activity root 7 True []
+                    map fst report.cleanupEligible `shouldBe` [path]
+                    report.cleanupRetained `shouldBe` []
+                    readRecord root path `shouldReturn` Right Nothing
+            ) ["master", "main", "release/stable"]
+
+        it "retains a merged checkout with less than 24 hours of inactivity" $
+            withMergedWorktree "main" \_ root path -> do
+                now <- getCurrentTime
+                let activity = pure (Right (Map.singleton path (Right (addUTCTime (-23 * 3600) now))))
+                report <- gcWorktreesWithActivity activity root 7 True []
+                report.cleanupEligible `shouldBe` []
+                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+
+        it "new commits after the merged head disqualify the short expiry" $
+            withMergedWorktree "main" \_ root path -> do
+                _ <- git path ["commit", "--allow-empty", "-m", "after merge"]
+                activity <- savedActivityDaysAgo path 2
+                report <- gcWorktreesWithActivity activity root 7 True []
+                report.cleanupEligible `shouldBe` []
+                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+
+        it "an absent default-branch target keeps the normal expiry" $
+            withMergedWorktree "main" \repo root path -> do
+                _ <- git repo ["update-ref", "-d", "refs/remotes/origin/main"]
+                activity <- savedActivityDaysAgo path 2
+                report <- gcWorktreesWithActivity activity root 7 True []
+                report.cleanupEligible `shouldBe` []
+                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+
+        it "does not guess a default branch from local branch names" $
+            withMergedWorktree "master" \repo root path -> do
+                _ <- git repo ["symbolic-ref", "--delete", "refs/remotes/origin/HEAD"]
+                activity <- savedActivityDaysAgo path 2
+                report <- gcWorktreesWithActivity activity root 7 True []
+                report.cleanupEligible `shouldBe` []
+                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+
+        it "keeps the normal expiry when legacy grafts make ancestry uncertain" $
+            withMergedWorktree "main" \repo root path -> do
+                writeFile (toFilePath (repo </> fromFilePath ".git/info/grafts")) ""
+                activity <- savedActivityDaysAgo path 2
+                report <- gcWorktreesWithActivity activity root 7 True []
+                report.cleanupEligible `shouldBe` []
+                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+
+        it "does not mistake squash-equivalent content for an incorporated HEAD" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                _ <- git repo ["branch", "-M", "main"]
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                writeFile (toFilePath (path </> fromFilePath "feature")) "feature\n"
+                _ <- git path ["add", "feature"]
+                _ <- git path ["commit", "-m", "feature"]
+                _ <- git repo ["merge", "--squash", toFilePath (takeFileName path)]
+                _ <- git repo ["commit", "-m", "squashed feature"]
+                configureDefaultRef repo "main"
+                activity <- savedActivityDaysAgo path 2
+                report <- gcWorktreesWithActivity activity root 7 True []
+                report.cleanupEligible `shouldBe` []
+                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+                oldActivity <- savedActivityDaysAgo path 8
+                oldReport <- gcWorktreesWithActivity oldActivity root 7 True []
+                map fst oldReport.cleanupEligible `shouldBe` [path]
+
+        it "snapshots dirty merged checkouts before collecting at two days" $
+            withMergedWorktree "main" \_ root path -> do
+                let file name = toFilePath (path </> fromFilePath name)
+                writeFile (file "README") "staged\n"
+                _ <- git path ["add", "README"]
+                writeFile (file "README") "unstaged\n"
+                writeFile (file "notes") "untracked\n"
+                writeFile (file ".gitignore") "cache\n"
+                writeFile (file "cache") "discarded\n"
+                headBefore <- git path ["rev-parse", "HEAD"]
+                activity <- savedActivityDaysAgo path 2
+                report <- gcWorktreesWithActivity activity root 7 False []
+                report.cleanupRemoved `shouldBe` [path]
+                restoreManagedWorktree root path `shouldReturn` Right ()
+                git path ["rev-parse", "HEAD"] `shouldReturn` headBefore
+                git path ["show", ":README"] `shouldReturn` "staged"
+                readFile (file "README") `shouldReturn` "unstaged\n"
+                readFile (file "notes") `shouldReturn` "untracked\n"
+                Directory.doesFileExist (file "cache") `shouldReturn` False
+
+        it "keeps active merged checkouts even after 24 hours" $
+            withMergedWorktree "main" \_ root path -> do
+                activity <- savedActivityDaysAgo path 2
+                bracket (acquireWorktreeLease root path) releaseLease $ \_ -> do
+                    report <- gcWorktreesWithActivity activity root 7 True []
+                    report.cleanupEligible `shouldBe` []
+                    map snd report.cleanupRetained `shouldSatisfy` any (Text.isInfixOf "existing lock is busy")
+                doesDirectoryExist path `shouldReturn` True
+
+        it "keeps protected merged checkouts even after 24 hours" $
+            withMergedWorktree "main" \_ root path -> do
+                enrollWorktree root path `shouldReturn` Right ()
+                now <- getCurrentTime
+                modifyRecord root path (Right . fmap (\record ->
+                    record { recordLastActivity = addUTCTime (-2 * 86400) now }))
+                    `shouldReturn` Right ()
+                protectWorktree root path True `shouldReturn` Right ()
+                activity <- savedActivityDaysAgo path 2
+                report <- gcWorktreesWithActivity activity root 7 False []
+                report.cleanupRemoved `shouldBe` []
+                report.cleanupRetained `shouldBe` [(path, "protected")]
+
+        mapM_ (\readNumber ->
+            it ("rechecks incorporated HEAD on activity read " <> show readNumber) $
+                withMergedWorktree "main" \_ root path -> do
+                    saved <- savedActivityDaysAgo path 2
+                    reads <- newIORef (0 :: Int)
+                    let activity = do
+                            modifyIORef' reads (+1)
+                            count <- readIORef reads
+                            if count == readNumber
+                                then void (git path ["commit", "--allow-empty", "-m", "concurrent new commit"])
+                                else pure ()
+                            saved
+                    report <- gcWorktreesWithActivity activity root 7 False []
+                    report.cleanupRemoved `shouldBe` []
+                    report.cleanupRetained `shouldBe` [(path, "recent activity")]
+                    doesDirectoryExist path `shouldReturn` True
+            ) [2, 3]
+
     describe "snapshot-backed worktree GC" do
         it "simulates verified legacy adoption without registry or lock writes" $
             withTempGitRepo \repo ->
@@ -779,6 +925,31 @@ spec = describe "Agent.CLI.Worktree" do
                 report.cleanupRemoved `shouldBe` []
                 enrollWorktree root path >>= (`shouldSatisfy` either (const True) (const False))
                 doesDirectoryExist path `shouldReturn` True
+
+withMergedWorktree :: String -> (OsPath -> OsPath -> OsPath -> IO a) -> IO a
+withMergedWorktree branch action =
+    withTempGitRepo \repo ->
+    withTempDir "agent-home-" \home -> do
+        let root = worktreeRoot home
+        _ <- git repo ["branch", "-M", branch]
+        path <- addManagedWorktree repo root "2026-08-20-00000001"
+        writeFile (toFilePath (path </> fromFilePath "feature")) "feature\n"
+        _ <- git path ["add", "feature"]
+        _ <- git path ["commit", "-m", "feature"]
+        _ <- git repo ["merge", "--no-ff", "-m", "merge feature", toFilePath (takeFileName path)]
+        configureDefaultRef repo branch
+        action repo root path
+
+configureDefaultRef :: OsPath -> String -> IO ()
+configureDefaultRef repo branch = do
+    _ <- git repo ["remote", "add", "origin", toFilePath repo]
+    _ <- git repo ["update-ref", "refs/remotes/origin/" <> branch, "HEAD"]
+    void $ git repo ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/" <> branch]
+
+savedActivityDaysAgo :: OsPath -> NominalDiffTime -> IO (IO (Either Text (Map.Map OsPath (Either Text UTCTime))))
+savedActivityDaysAgo path days = do
+    now <- getCurrentTime
+    pure (pure (Right (Map.singleton path (Right (addUTCTime (-days * 86400) now)))))
 
 ageRecord :: OsPath -> OsPath -> IO ()
 ageRecord root path = do

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -110,6 +110,9 @@ import qualified Agent.CLI.TUITranscriptSpec as TUITranscriptSpec
 import qualified Agent.CLI.UsageSpec as UsageSpec
 import qualified Agent.CLI.WebLspSpec as WebLspSpec
 import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
+import qualified Agent.CLI.WorktreeAdminSpec as WorktreeAdminSpec
+import qualified Agent.CLI.Worktree.SnapshotSpec as SnapshotSpec
+import qualified Agent.CLI.Worktree.ProvenanceSpec as ProvenanceSpec
 main :: IO ()
 main = do
     shard <- lookupEnv "AGENT_CLI_TEST_SHARD"
@@ -237,6 +240,9 @@ specs = do
     UsageSpec.spec
     WebLspSpec.spec
     WorktreeSpec.spec
+    WorktreeAdminSpec.spec
+    ProvenanceSpec.spec
+    SnapshotSpec.spec
 
 runShards :: Int -> IO ()
 runShards count = do


### PR DESCRIPTION
## Summary
- Add snapshot-backed worktree GC with configurable seven-day inactivity, durable registry, protection, bounded cleanup and restore-on-resume.
- Use **24 hours of inactivity** when exact HEAD is incorporated into the resolved default branch; otherwise keep the configured normal interval. This is idle time, not time since merge, and never uses commit timestamps.
- Automatically adopt existing worktrees only after managed-root, reciprocal linked-Git metadata and saved-session provenance checks. Preserve historical activity rather than resetting it to now; retain uncertain, active, protected or unsafe checkouts.
- Add read-only `worktree gc --dry-run` with eligibility, retention reasons and gross apparent byte estimates, plus enroll/protect/unprotect/restore commands.

## Safety and recovery contract
- Resolve the selected remote's existing local symbolic default-branch ref; do not hardcode `master`/`main`, fetch or guess. Ancestry is checked without replacement objects; legacy grafts, absent evidence and squash/rebase equivalence keep normal expiry. Cached refs can be stale: proof concerns the available ref, not current server state. New commits disqualify the fast path; ancestry is rechecked around snapshotting and before final snapshot verification/removal.
- Preserve commits, staged/index state, working-tree changes and non-ignored untracked content before removal. Recovery refs are verified and a durable collecting record is written before deletion; checkout/repository leases, activity and identity rechecks guard collection.
- **Ignored untracked files are deliberately NOT backed up and are discarded by collection**, including ignored `.env`, local databases and build outputs. Protect the checkout or move important ignored data outside it.
- Registry writes use fsync and atomic rename; snapshot Git writes request fsync. Recovery remains local, depends on the original shared Git repository and registry, and is not an off-machine backup. Recovery refs do not automatically expire.
- Restore is detached, does not reset moved branches and refuses to overwrite existing paths. Interrupted maintenance/partial restore may require manual recovery. Unsupported Git/index states and nested repositories fail closed.
- External editors and newly started pre-upgrade agents cannot be fully fenced: protect externally edited worktrees and stop old agents before collection.
- Actual passes are bounded to eight candidate attempts with a 60-second start budget and 30-second candidate deadlines; this is not a guarantee that all eligible worktrees are removed in one pass.

## Validation
macOS / GHC 9.10.3, inherited Nix-flake development environment, GHCi under tmux:

```console
cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code
```

After loading/reloading the test modules:
```haskell
Test.Hspec.hspec (Agent.CLI.WorktreeSpec.spec >> Agent.CLI.Worktree.SnapshotSpec.spec >> Agent.CLI.Worktree.ProvenanceSpec.spec >> Agent.CLI.WorktreeAdminSpec.spec >> Agent.CLI.ConfigSpec.spec >> Agent.CLI.OptionsSpec.spec)
```

**183 examples, 0 failures (36.2272 seconds)** on the final follow-up source, after restarting the test REPL to recompile the library and reloading the final tests. Original implementation passed 167 examples. The 16 added examples cover exact 24h boundaries, configurable fallback, `master`/`main`/`release/stable`, new commits before/during snapshotting, absent default refs, grafts, squash-equivalent content, dirty snapshot/restore and active/protected checkouts. Existing coverage includes destructive fixture round-trips, ignored-file exclusion, missing/corrupt recovery data, read-only adoption, ownership failures, activity/lease races, concurrent collectors/restorers and interrupted states.

Full repository suite and power-loss fault injection were not run. Nested `nix develop` hit a local permission error; validation used the existing Nix environment instead. The first follow-up fixture run also hit Git permissions under the session temp directory; the successful run used the existing checkout-local fixture directory with `TMPDIR` and `GIT_CEILING_DIRECTORIES` set to it. These were environment-only corrections, not weakened safety assertions.

Actual public CLI entry exercised under tmux/GHCi:
```haskell
import Agent.CLI
import System.Environment
withArgs ["worktree","gc","--dry-run"] Agent.CLI.run
```

Read-only real-backlog results on 2026-09-06:
| Result | Original seven-day run | Follow-up with 24h incorporated-HEAD policy |
|---|---:|---:|
| Examined | 341 | 340 |
| Eligible | 41 | 131 |
| Retained: missing saved-session provenance | 147 | 145 |
| Retained: recent activity | 125 | 50 |
| Retained: busy/unsafe/unverifiable locks | 28 | 14 |
| Collected / failed | 0 / 0 | 0 / 0 |

Eligible gross apparent checkout bytes: **2,236,049,852 (~2.24 GB)** originally; **14,415,570,891 (~14.42 GB)** in the follow-up. All original 41 remain eligible; 90 added (77 previously recent, 13 previously lock-blocked). These are separate observations of a live backlog, not a controlled policy-only comparison: session/lock state and total checkout count changed concurrently. Includes ignored build data; excludes snapshot overhead and APFS sharing, so this is **not guaranteed net reclaimed disk space**. Real registry remained absent. No real backlog enrollment/deletion or installation was performed.

Fresh `cabal2nix .` in `packages/agent-cli` matched checked-in `package.nix`; `git diff --check` and staged diff checks passed. All eight new modules/test files are included.

