### PR TITLE
Notify parent sessions when background child turns finish

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -10,6 +10,8 @@ module Agent.CLI.AgentSessions
     , closeSessionThreadManager
     , closeSessionProcessManager
     , launchSessionThread
+    , launchSessionThreadNotifying
+    , formatSessionCompletionNotice
     , launchManagedTurn
     , launchManagedTurnBounded
     , launchSessionTurn
@@ -164,6 +166,21 @@ launchSessionThread
     -> IO (Either Text ())
     -> IO (Either Text Text)
 launchSessionThread manager sessionId action =
+    launchSessionThreadNotifying manager sessionId (const (pure ())) action
+
+-- | Enqueue one completion notification for this particular turn. The sink
+-- runs in the tracked worker while the manager lock is held, immediately
+-- before publishing the terminal state. It must be nonblocking and must not
+-- call back into the manager. This makes notification delivery and readiness
+-- for a follow-up atomic to callers, without an unowned notification thread.
+-- Rejected launches and manager shutdown do not emit completion notices.
+launchSessionThreadNotifying
+    :: SessionThreadManager
+    -> Text
+    -> (Text -> IO ())
+    -> IO (Either Text ())
+    -> IO (Either Text Text)
+launchSessionThreadNotifying manager sessionId notify action =
     mask \_ -> do
         launched <- modifyMVar manager.threadManagerState \state ->
             if state.threadManagerClosed
@@ -190,20 +207,24 @@ launchSessionThread manager sessionId action =
                                             ManagedSessionThreadFailed err
                                         Right (Right ()) ->
                                             ManagedSessionThreadCompleted
+                                let status = case terminal of
+                                        ManagedSessionThreadFailed err -> "failed (" <> err <> ")"
+                                        _ -> "completed"
                                 modifyMVar_ manager.threadManagerState \current ->
-                                    pure $
-                                        if current.threadManagerClosed
-                                            then current
-                                            else current
+                                    if current.threadManagerClosed
+                                        then pure current
+                                        else do
+                                            -- A notification failure must not
+                                            -- replace the child turn's outcome.
+                                            void (tryAny (notify status))
+                                            pure current
                                                 { managedThreads =
                                                     Map.insert
                                                         sessionId
                                                         terminal
                                                         current.managedThreads
                                                 }
-                                pure $ case terminal of
-                                    ManagedSessionThreadFailed err -> "failed (" <> err <> ")"
-                                    _ -> "completed"
+                                pure status
                         case started of
                             Left err ->
                                 pure
@@ -226,6 +247,16 @@ launchSessionThread manager sessionId action =
                                     , Right ("started session " <> sessionId)
                                     )
         pure launched
+
+formatSessionCompletionNotice :: Text -> Text -> Text
+formatSessionCompletionNotice sessionId status =
+    "<agent_session_notification>\n"
+        <> "The agent session turn you started has finished.\n"
+        <> "Session ID: " <> sessionId <> "\n"
+        <> "Status: " <> status <> "\n"
+        <> "Use read_agent_session with this session_id to inspect its response, "
+        <> "or send_agent_session_message to provide further input.\n"
+        <> "</agent_session_notification>"
 
 sessionThreadStatus :: SessionThreadManager -> Text -> IO Text
 sessionThreadStatus manager sessionId =
@@ -414,7 +445,7 @@ createAgentSessionArgsDecoder = Hermes.object $
 createAgentSessionTool :: AgentSessionToolsEnv -> AppTool
 createAgentSessionTool env = jsonTool
     "create_agent_session"
-    "Create a persisted top-level agent session and start its first turn in the background. Use only when the user explicitly requests independent/background work or a separate session; do not offload the entire current task here. For bounded subtasks, use subagents and retain responsibility for integration, verification, and the final answer. Returns the session id and status as readable text, not a completed result."
+    "Create a persisted top-level agent session and start its first turn in the background. Use only when the user explicitly requests independent/background work or a separate session; do not offload the entire current task here. For bounded subtasks, use subagents and retain responsibility for integration, verification, and the final answer. Returns the session id and status as readable text, not a completed result. The interactive parent session is notified when the background turn finishes; use read_agent_session to inspect its response or send_agent_session_message to continue it."
     [ PropertySchema "message" PropertyString True $ Just
         "Initial task or message for the new agent session."
     , PropertySchema "title" PropertyString False $ Just
@@ -619,7 +650,7 @@ sendAgentSessionMessageArgsDecoder = Hermes.object $
 sendAgentSessionMessageTool :: AgentSessionToolsEnv -> AppTool
 sendAgentSessionMessageTool env = jsonTool
     "send_agent_session_message"
-    "Send a message to a persisted agent session by starting a resumed background turn. Use for explicitly requested independent/background work or continuation of that separate session, not to transfer responsibility for the current task. Returns the session id and status as readable text, not a completed result; fails if that session is already running."
+    "Send a message to a persisted agent session by starting a resumed background turn. Use for explicitly requested independent/background work or continuation of that separate session, not to transfer responsibility for the current task. Returns the session id and status as readable text, not a completed result; fails if that session is already running. The interactive parent session is notified when this turn finishes."
     [ PropertySchema "session_id" PropertyString True $ Just
         "Persisted target session id."
     , PropertySchema "message" PropertyString True $ Just

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -11,7 +11,8 @@ import Agent.CLI.Runtime.Orchestration.Tools.Mcp
 import Agent.CLI.Runtime.Orchestration.Tools.HostHooks
 import Agent.CLI.AgentSessions
     ( agentSessionTools,
-      launchSessionThread,
+      launchSessionThreadNotifying,
+      formatSessionCompletionNotice,
       sessionThreadStatus,
       prepareSessionThreadWait,
       AgentSessionToolsEnv(toolsSessionStatus, AgentSessionToolsEnv,
@@ -117,16 +118,19 @@ import Agent.Tools.PlanMode
 import Agent.Tools.Types
     ( AppTool
     , AppToolGroup(..)
+    , BackgroundTaskHooks(..)
+    , BackgroundTaskNotice(..)
     , ToolEnv(..)
     , appToolsFromGroups
     )
 import Control.Concurrent.Async ( concurrently, concurrently_ )
 import Control.Exception.Safe
     ( SomeException, bracketOnError, finally, throwIO, try )
-import Control.Monad ( forM_, join, when )
+import Control.Monad ( forM_, join, when, void )
 import Data.IORef
     (IORef, newIORef, readIORef, writeIORef)
 import Data.Maybe (isJust)
+import Data.Unique (newUnique, hashUnique)
 import System.Info (os)
 import System.OsPath (OsPath)
 import qualified Agent.MCP as MCP
@@ -134,7 +138,7 @@ import qualified Agent.MCP as MCP
       mcpFleetMetaTools,
       mcpFleetResourceTools,
       mcpFleetTools )
-import qualified Data.Text as Text (unpack)
+import qualified Data.Text as Text (unpack, pack)
 
 data LocalToolRuntime = LocalToolRuntime
     { localCoding :: CodingTools
@@ -459,6 +463,7 @@ newSessionControlRuntime
     -> IO SessionControlRuntime
 newSessionControlRuntime AgentToolsRequest
     { options
+    , baseToolEnv
     , startup
     , root
     , gatewayIdentity
@@ -536,10 +541,20 @@ newSessionControlRuntime AgentToolsRequest
                                     (Right
                                         ("completed session "
                                             <> handle.sessionMeta.metaId))
-                    else
-                        launchSessionThread
+                    else do
+                        -- Capture the launching conversation's sink, rather
+                        -- than looking up whichever session is open later.
+                        hooks <- readIORef baseToolEnv.toolBackgroundTaskHooks
+                        turnKey <- Text.pack . show . hashUnique <$> newUnique
+                        launchSessionThreadNotifying
                             processRuntime.processSessionThreads
                             handle.sessionMeta.metaId
+                            (\status -> void $ hooks.backgroundTaskCompleted
+                                BackgroundTaskNotice
+                                    { noticeKey = "agent-session:" <> turnKey
+                                    , noticeBody = formatSessionCompletionNotice
+                                        handle.sessionMeta.metaId status
+                                    })
                             action
             , toolsSessionStatus =
                 sessionThreadStatus processRuntime.processSessionThreads

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -358,6 +358,22 @@ data SessionControlRuntime = SessionControlRuntime
     , controlAgentViewport :: !AgentViewportEnv
     }
 
+installBackgroundTaskSteering :: ToolEnv -> SteeringInputs -> IO ()
+installBackgroundTaskSteering toolEnv steeringInputs = do
+    enqueueCompletion <- prepareBackgroundCompletion steeringInputs
+    setBackgroundTaskHooks toolEnv BackgroundTaskHooks
+        { backgroundTaskCompleted = \notice ->
+            enqueueCompletion
+                notice.noticeKey
+                (UserMessage notice.noticeBody) >>= \case
+                    -- Completion callbacks hold a delivery gate. Keep this
+                    -- non-blocking; UI reporting can backpressure.
+                    Left _ -> pure False
+                    Right inserted -> pure inserted
+        , backgroundTaskDismissed =
+            dismissBackgroundCompletion steeringInputs
+        }
+
 newSessionControlRuntime
     :: SessionHostRuntime
     -> SessionRequest
@@ -365,20 +381,7 @@ newSessionControlRuntime
 newSessionControlRuntime host SessionRequest{..} = do
     toolRegistry <- requireToolRegistry allTools
     steeringInputs <- newSteeringInputs
-    setBackgroundTaskHooks toolEnv BackgroundTaskHooks
-        { backgroundTaskCompleted = \notice ->
-            enqueueBackgroundCompletion
-                steeringInputs
-                notice.noticeKey
-                (UserMessage notice.noticeBody) >>= \case
-                    -- Completion callbacks run while their delivery gate is
-                    -- held. Keep this hook non-blocking; UI reporting can
-                    -- backpressure on a full mailbox.
-                    Left _ -> pure False
-                    Right inserted -> pure inserted
-        , backgroundTaskDismissed =
-            dismissBackgroundCompletion steeringInputs
-        }
+    installBackgroundTaskSteering toolEnv steeringInputs
     spinnerRef <- newIORef Nothing
     renderStateRef <- newIORef emptyRenderState
     allowedToolsRef <- newIORef Set.empty
@@ -605,6 +608,7 @@ buildSkillContextRuntime
             Nothing -> pure ()
         clearPendingInputs pendingNotices
         clearSteeringInputs steeringInputs
+        installBackgroundTaskSteering toolEnv steeringInputs
         readIORef toolEnv.toolSessionTmp >>= mapM_ resetToolSessionTemp
         reloadGeneratedContext
     refreshSkills queueContext = do

--- a/packages/agent-cli/src/Agent/CLI/SteeringInputs.hs
+++ b/packages/agent-cli/src/Agent/CLI/SteeringInputs.hs
@@ -10,6 +10,7 @@ module Agent.CLI.SteeringInputs
     , hasBackgroundCompletionWake
     , hasBackgroundCompletions
     , newSteeringInputs
+    , prepareBackgroundCompletion
     , readSteeringInputs
     , steeringInputByteLimit
     , steeringInputCountLimit
@@ -51,13 +52,14 @@ data SteeringEntry = SteeringEntry
 data SteeringState = SteeringState
     { steeringQueue :: !(Seq.Seq SteeringEntry)
     , steeringBytes :: !Int
+    , steeringEpoch :: !Word
     }
 
 newtype SteeringInputs = SteeringInputs (TVar SteeringState)
 
 newSteeringInputs :: IO SteeringInputs
 newSteeringInputs =
-    SteeringInputs <$> newTVarIO (SteeringState Seq.empty 0)
+    SteeringInputs <$> newTVarIO (SteeringState Seq.empty 0 0)
 
 enqueueSteeringInputs
     :: SteeringInputs
@@ -89,7 +91,7 @@ enqueueSteeringInputs (SteeringInputs ref) inputs =
                 pure $ Left
                     "Steering queue is full; wait for the active turn to consume guidance."
             else do
-                writeTVar ref SteeringState
+                writeTVar ref state
                     { steeringQueue =
                         state.steeringQueue Seq.>< Seq.fromList measured
                     , steeringBytes = nextBytes
@@ -103,11 +105,29 @@ enqueueBackgroundCompletion
     -> Text
     -> TurnInput
     -> IO (Either Text Bool)
-enqueueBackgroundCompletion (SteeringInputs ref) key input =
+enqueueBackgroundCompletion = enqueueBackgroundCompletionForEpoch Nothing
+
+-- | Capture the owning conversation, so a late child completion cannot wake
+-- or inject input into a different conversation after a session reset.
+prepareBackgroundCompletion
+    :: SteeringInputs
+    -> IO (Text -> TurnInput -> IO (Either Text Bool))
+prepareBackgroundCompletion inputs@(SteeringInputs ref) = do
+    state <- readTVarIO ref
+    pure (enqueueBackgroundCompletionForEpoch (Just state.steeringEpoch) inputs)
+
+enqueueBackgroundCompletionForEpoch
+    :: Maybe Word
+    -> SteeringInputs
+    -> Text
+    -> TurnInput
+    -> IO (Either Text Bool)
+enqueueBackgroundCompletionForEpoch epoch (SteeringInputs ref) key input =
     atomically do
         state <- readTVar ref
-        if any ((== Just key) . (.steeringBackgroundKey))
-                state.steeringQueue
+        if maybe False (/= state.steeringEpoch) epoch
+                || any ((== Just key) . (.steeringBackgroundKey))
+                    state.steeringQueue
             then pure (Right False)
             else do
                 let bytes = logicalTurnInputBytes input
@@ -190,12 +210,12 @@ commitSteeringInputs (SteeringInputs ref) count =
                     entry.steeringBytes `saturatingAdd` total)
                 0
                 removed
-        in SteeringState
+        in state
             { steeringQueue = remaining
             , steeringBytes = max 0 (state.steeringBytes - removedBytes)
             }
 
 clearSteeringInputs :: SteeringInputs -> IO ()
 clearSteeringInputs (SteeringInputs ref) =
-    atomically $ modifyTVar' ref \_ ->
-        SteeringState Seq.empty 0
+    atomically $ modifyTVar' ref \state ->
+        SteeringState Seq.empty 0 (state.steeringEpoch + 1)

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -7,8 +7,12 @@ import Agent.CLI.ManagedTurn (managedTurnRequestFromText)
 import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.CLI.Session
 import Agent.CLI.SessionLock
+import Agent.CLI.SteeringInputs
+    ( awaitBackgroundCompletion, clearSteeringInputs, commitSteeringInputs
+    , hasBackgroundCompletionWake, newSteeringInputs
+    , prepareBackgroundCompletion, readSteeringInputs )
 import Agent.Dialect (DialectId(..))
-import Agent.Loop (defaultLoopDispatch)
+import Agent.Loop (TurnInput(..), defaultLoopDispatch)
 import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf, (</>))
 import Agent.Provider (Provider(..))
 import Agent.ToolDispatch
@@ -39,8 +43,10 @@ import Agent.Store.Types (renderStoreError)
 import Control.Concurrent (threadDelay)
 import qualified Control.Concurrent.Async as Async
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
-import Control.Exception.Safe (SomeException, bracket, finally, try)
+import Control.Concurrent.STM (atomically)
+import Control.Exception.Safe (SomeException, bracket, finally, try, throwIO)
 import Data.IORef
+import Control.Monad (void)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
@@ -487,6 +493,119 @@ spec = describe "Agent.CLI.AgentSessions" do
             launched `shouldBe` Right "started session same-process"
             takeMVar observedPid `shouldReturn` parentPid
             waitForThreadStatus manager "same-process" "completed"
+
+    it "notifies the launching parent once per completed session turn and permits follow-up" $
+        withTempSessionThreadManager ["child"] \_ manager -> do
+            notices <- newIORef []
+            let notify status =
+                    atomicModifyIORef' notices \previous ->
+                        (previous <> [formatSessionCompletionNotice "child" status], ())
+            launchSessionThreadNotifying manager "child" notify (pure (Right ()))
+                `shouldReturn` Right "started session child"
+            waitForThreadStatus manager "child" "completed"
+            readIORef notices `shouldReturn` [formatSessionCompletionNotice "child" "completed"]
+            -- A resumed turn gets a new notification; status reads do not.
+            sessionThreadStatus manager "child" `shouldReturn` "completed"
+            launchSessionThreadNotifying manager "child" notify (pure (Left "follow-up failed"))
+                `shouldReturn` Right "started session child"
+            waitForThreadStatus manager "child" "failed (follow-up failed)"
+            readIORef notices `shouldReturn`
+                [ formatSessionCompletionNotice "child" "completed"
+                , formatSessionCompletionNotice "child" "failed (follow-up failed)"
+                ]
+
+    it "routes concurrent session turn completions only to their launching parents" $
+        withTempSessionThreadManager ["first", "second"] \_ manager -> do
+            firstNotices <- newIORef []
+            secondNotices <- newIORef []
+            let notify ref status =
+                    atomicModifyIORef' ref \previous -> (previous <> [status], ())
+            _ <- launchSessionThreadNotifying manager "first"
+                (notify firstNotices) (pure (Right ()))
+            _ <- launchSessionThreadNotifying manager "second"
+                (notify secondNotices) (pure (Left "second failed"))
+            waitForThreadStatus manager "first" "completed"
+            waitForThreadStatus manager "second" "failed (second failed)"
+            readIORef firstNotices `shouldReturn` ["completed"]
+            readIORef secondNotices `shouldReturn` ["failed (second failed)"]
+
+    it "notifies the parent when a session turn throws" $
+        withTempSessionThreadManager ["child"] \_ manager -> do
+            notice <- newEmptyMVar
+            _ <- launchSessionThreadNotifying manager "child" (putMVar notice)
+                (throwIO (userError "child exception"))
+            observed <- timeout 1000000 (takeMVar notice)
+            observed `shouldSatisfy` maybe False (Text.isInfixOf "child exception")
+            sessionThreadStatus manager "child" `shouldReturn`
+                maybe "missing notification" id observed
+
+    it "does not notify for rejected launches or shutdown cancellation" $
+        withTempSessionThreadManager ["child"] \_ manager -> do
+            notices <- newIORef []
+            gate <- newEmptyMVar
+            let notify status =
+                    atomicModifyIORef' notices \previous -> (previous <> [status], ())
+            _ <- launchSessionThreadNotifying manager "child" notify
+                (takeMVar gate >> pure (Right ()))
+            launchSessionThreadNotifying manager "child" notify (pure (Right ()))
+                `shouldReturn` Left "session child is already running"
+            closeSessionThreadManager manager
+            launchSessionThreadNotifying manager "child" notify (pure (Right ()))
+                `shouldReturn` Left "agent session manager is closed"
+            readIORef notices `shouldReturn` []
+
+    it "preserves session outcome when a completion sink fails" $
+        withTempSessionThreadManager ["child"] \_ manager -> do
+            _ <- launchSessionThreadNotifying manager "child"
+                (\_ -> throwIO (userError "notification failed"))
+                (pure (Right ()))
+            waitForThreadStatus manager "child" "completed"
+
+    it "includes the session id and inspection/follow-up tools in completion notices" $ do
+        let notice = formatSessionCompletionNotice "child-id" "completed"
+        notice `shouldSatisfy` Text.isInfixOf "Session ID: child-id"
+        notice `shouldSatisfy` Text.isInfixOf "Status: completed"
+        notice `shouldSatisfy` Text.isInfixOf "read_agent_session"
+        notice `shouldSatisfy` Text.isInfixOf "send_agent_session_message"
+
+    it "wakes an idle parent and retains child completion until the provider commits it" $
+        withTempSessionThreadManager ["child"] \_ manager -> do
+            steering <- newSteeringInputs
+            enqueue <- prepareBackgroundCompletion steering
+            let notice = UserMessage (formatSessionCompletionNotice "child" "completed")
+            _ <- launchSessionThreadNotifying manager "child"
+                (\status -> void $ enqueue "child:turn-1" $
+                    UserMessage (formatSessionCompletionNotice "child" status))
+                (pure (Right ()))
+            timeout 1000000 (atomically (awaitBackgroundCompletion steering))
+                `shouldReturn` Just ()
+            -- Consuming the idle-wake edge must not consume the model input.
+            readSteeringInputs steering `shouldReturn` [notice]
+            hasBackgroundCompletionWake steering `shouldReturn` False
+            readSteeringInputs steering `shouldReturn` [notice]
+            commitSteeringInputs steering 1
+            readSteeringInputs steering `shouldReturn` []
+
+    it "does not deliver a late child completion into a reset parent conversation" $
+        withTempSessionThreadManager ["child"] \_ manager -> do
+            steering <- newSteeringInputs
+            enqueue <- prepareBackgroundCompletion steering
+            gate <- newEmptyMVar
+            _ <- launchSessionThreadNotifying manager "child"
+                (\status -> void $ enqueue "child:turn-1" $
+                    UserMessage (formatSessionCompletionNotice "child" status))
+                (takeMVar gate >> pure (Right ()))
+            clearSteeringInputs steering
+            putMVar gate ()
+            waitForThreadStatus manager "child" "completed"
+            readSteeringInputs steering `shouldReturn` []
+            hasBackgroundCompletionWake steering `shouldReturn` False
+            -- New work belongs to the new conversation and can wake it.
+            current <- prepareBackgroundCompletion steering
+            current "child:turn-2" (UserMessage "new completion")
+                `shouldReturn` Right True
+            readSteeringInputs steering `shouldReturn` [UserMessage "new completion"]
+            hasBackgroundCompletionWake steering `shouldReturn` True
 
     it "serializes and reports in-process session turns" $
         withTempSessionThreadManager ["blocked", "failed"] \_ manager -> do


### PR DESCRIPTION
## Summary
- Notify the launching interactive parent when a background persisted-session turn completes or fails, including resumed follow-up turns.
- Reuse background-completion steering for active-turn delivery and idle-parent wakeup, with session ID and read/send tool hints.
- Capture conversation-scoped completion hooks to prevent late notifications reaching a different conversation after reset.
- Keep notification delivery within the tracked worker lifecycle and synchronize it with readiness for follow-up.

## Validation
- Added eight regression tests covering completion/failure, repeated turns, parent isolation, rejected launches/shutdown, sink failure, idle wakeup, retained inputs, and conversation reset.
- `git diff --check` passes.
- GHCi/test execution was blocked before code loading: `nix develop -c cabal repl agent-cli:lib:agent-cli --offline` fails with a filesystem `Operation not permitted` error while inspecting the session temporary-directory ancestor. Tests have not been run locally.

## Scope
Notifications are for background turns launched by the interactive runtime. One-shot calls continue returning their result synchronously. This does not add durable cross-process notification delivery.