### PR TITLE
Temporarily disable OpenAI provider smoke tests

### DIFF
--- a/.github/workflows/provider-smoke-test.yml
+++ b/.github/workflows/provider-smoke-test.yml
@@ -17,7 +17,10 @@ concurrency:
 jobs:
   openai:
     name: OpenAI hello world
-    if: ${{ github.repository == 'digitallyinduced/haskell-agent' && github.ref == 'refs/heads/master' }}
+    # Temporarily disabled while the CI OpenAI account has no
+    # verified available usage. Keep package/unit checks enabled.
+    if: false
+    # if: ${{ github.repository == 'digitallyinduced/haskell-agent' && github.ref == 'refs/heads/master' }}
     runs-on: [self-hosted, haskell-agent, office-builder, x86_64-linux]
     timeout-minutes: 15
     env:

--- a/flake.nix
+++ b/flake.nix
@@ -1501,9 +1501,11 @@
                 } // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
                     agent-cli-macos-bundle = agentCliMacosRelease.bundle;
                 } // pkgs.lib.optionalAttrs functionalTestEnabled {
-                    agent-cli-functional-openai-hello-world =
-                        agentCliHelloWorldFunctional "openai"
-                            (functionalTestModel "OPENAI" "gpt-5.6-terra");
+                    # Temporarily disabled while the CI OpenAI account has no
+                    # verified available usage. Keep package/unit checks enabled.
+                    # agent-cli-functional-openai-hello-world =
+                    #     agentCliHelloWorldFunctional "openai"
+                    #         (functionalTestModel "OPENAI" "gpt-5.6-terra");
                     # Temporarily disabled while the CI Grok account has no
                     # verified available usage. Keep package/unit checks enabled.
                     # agent-cli-functional-xai-hello-world =


### PR DESCRIPTION
The master-only Provider smoke test has been failing on every recent merge with:

```
no openai account has verified available usage
```

`.codex/auth.json` is present on office-builder; ChatGPT usage cannot be verified with remaining capacity. This is the same class of failure that already disabled the Grok hello-world check.

This comments out `agent-cli-functional-openai-hello-world` in `flake.nix` and skips the GitHub Actions job so master CI stops going red. Package/unit tests stay enabled. Re-enable both once the CI OpenAI account has verified usage.