### PR TITLE
Delegate Telegram feature work to agent sessions

### DIFF
--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Turn.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Turn.hs
@@ -496,7 +496,15 @@ telegramAgentPrompt prompt =
         \this initial update. Skip it when you can answer immediately \
         \or when no reply should be sent. Your answer and available \
         \reasoning summaries are shown to the user as a live Telegram draft \
-        \while you work, followed by your normal final response. If the best \
+        \while you work, followed by your normal final response. When the user \
+        \asks you to implement a non-trivial software feature and the \
+        \create_agent_session and wait_agent_session tools are available, act \
+        \as the coordinator: delegate implementation and testing to a new \
+        \persisted session, wait for its current turn with wait_agent_session \
+        \(waiting again after a timeout when needed), inspect its result, and \
+        \retain responsibility for verification and the final answer. Do not \
+        \use this indirection for small edits or questions, and do not modify \
+        \the same files concurrently with the delegated session. If the best \
         \complete response \
         \is only a lightweight acknowledgement, you may instead respond with \
         \exactly one standard Telegram reaction emoji. Do not mention these \

--- a/packages/agent-telegram/test/Agent/TelegramSpec.hs
+++ b/packages/agent-telegram/test/Agent/TelegramSpec.hs
@@ -74,6 +74,14 @@ spec = describe "Agent.Telegram" do
                 Text.isInfixOf "Follow the language and style"
             prompt `shouldSatisfy`
                 Text.isInfixOf "For example: I'll take a quick look."
+            prompt `shouldSatisfy`
+                Text.isInfixOf "create_agent_session and wait_agent_session"
+            prompt `shouldSatisfy`
+                Text.isInfixOf "delegate implementation and testing"
+            prompt `shouldSatisfy`
+                Text.isInfixOf "retain responsibility for verification"
+            prompt `shouldSatisfy`
+                Text.isInfixOf "Do not use this indirection for small edits"
             prompt `shouldNotSatisfy` Text.isInfixOf "Ich schaue"
             prompt `shouldSatisfy`
                 Text.isPrefixOf "Inspect the failing tests"


### PR DESCRIPTION
## Summary
- instruct the Telegram agent to coordinate non-trivial feature implementation through persisted agent sessions
- wait for delegated work, inspect its result, and keep final verification with the Telegram agent
- keep small edits and questions local and avoid concurrent edits to the same files
- cover the delegation guidance in the Telegram prompt test

## Testing
- `nix develop -c cabal repl agent-telegram:test:agent-telegram-test` (`:main`): 73 examples, 0 failures
- `git diff --check`