### PR TITLE
Send versioned client User-Agent headers to gateways

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -588,9 +588,16 @@
                                 }));
                         agent-core = localPackage (
                             pkgs.haskell.lib.addTestToolDepends
-                            (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-core/package.nix { }) {
+                            ((pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-core/package.nix { }) {
                                 src = agentCoreSource;
-                            })
+                            }).overrideAttrs (old: {
+                                # Match the CLI's production build identity,
+                                # while retaining stable check-package caches.
+                                configureFlags = (old.configureFlags or [ ])
+                                    ++ pkgs.lib.optionals (packageMode != "check") [
+                                        "--ghc-option=-DAGENT_BUILD_COMMIT=\"${agentBuildCommit}\""
+                                    ];
+                            }))
                             [
                                 pkgs.git
                                 bun_1_4

--- a/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Catalog.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Catalog.hs
@@ -19,6 +19,7 @@ module Agent.CLI.Gateway.Catalog
 import Agent.CLI.Gateway.Credentials (validateGatewayCredential)
 import Agent.CLI.Gateway.Dictation (transcribeGatewayPcmWith)
 import Agent.CLI.Gateway.Usage (fetchGatewayUsageWithCredential)
+import Agent.ClientIdentity (gatewayUserAgent)
 import Agent.OpenAI.Usage (UsageSnapshot)
 import Agent.Server.Client.GatewayIdentity (GatewayCredential(..))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
@@ -240,6 +241,7 @@ fetchGatewayModels credential =
         Left _ -> pure (Left "Gateway credential is invalid.")
         Right () -> do
             response <- tryAny do
+                userAgent <- gatewayUserAgent
                 manager <- newTlsManager
                 initial <-
                     HTTP.parseRequest
@@ -257,6 +259,7 @@ fetchGatewayModels credential =
                                         credential.gatewayAccessToken
                               )
                             , (hAccept, "application/json")
+                            , ("User-Agent", userAgent)
                             ]
                         , HTTP.checkResponse = \_ _ -> pure ()
                         -- Never follow a redirect with the gateway bearer.

--- a/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Dictation.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Dictation.hs
@@ -7,6 +7,7 @@ import Agent.CLI.Gateway.Credentials
     , withGatewayCredentialTurnLease
     )
 import Agent.CLI.Gateway.Http (gatewayMaxResponseBytes, readBoundedBody)
+import Agent.ClientIdentity (gatewayUserAgent)
 import Agent.OpenAI.Transcription
     ( ChatGPTDictationStreamFailure(..)
     , encodePcm16Wav
@@ -50,6 +51,7 @@ transcribeGatewayPcmWith admitted produceAudio onTranscript =
                     case gatewayDictationWebSocketUrl current of
                         Left err -> pure (Left err)
                         Right websocketUrl -> do
+                            userAgent <- gatewayUserAgent
                             chunks <- newIORef []
                             capturedBytes <- newIORef 0
                             let captureAndBuffer sendAudio =
@@ -72,6 +74,7 @@ transcribeGatewayPcmWith admitted produceAudio onTranscript =
                                         <> TextEncoding.encodeUtf8
                                             current.gatewayAccessToken
                                   )
+                                , ("User-Agent", userAgent)
                                 ]
                                 captureAndBuffer
                                 onTranscript >>= \case
@@ -190,6 +193,7 @@ postGatewayTranscription credential wav =
                         (Text.strip credential.gatewayBaseUrl)
                         <> "/v1/audio/transcriptions"
             outcome <- tryAny do
+                userAgent <- gatewayUserAgent
                 manager <- newTlsManager
                 initial <- HTTP.parseRequest (Text.unpack endpoint)
                 let baseRequest =
@@ -202,6 +206,7 @@ postGatewayTranscription credential wav =
                                             credential.gatewayAccessToken
                                   )
                                 , (hAccept, "application/json")
+                                , ("User-Agent", userAgent)
                                 ]
                             , HTTP.checkResponse = \_ _ -> pure ()
                             -- Never forward the gateway bearer to a redirect.

--- a/packages/agent-cli-runtime/src/Agent/CLI/Gateway/OAuth.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Gateway/OAuth.hs
@@ -13,6 +13,7 @@ module Agent.CLI.Gateway.OAuth
     , pollUntilAuthorized
     ) where
 
+import Agent.ClientIdentity (gatewayUserAgent)
 import Agent.CLI.Gateway.Credentials
     ( saveGatewayCredential
     , saveGatewayCredentialWith
@@ -362,6 +363,7 @@ postJson
     -> Hermes.Decoder value
     -> IO (Either Text value)
 postJson manager url payload decoder = do
+    userAgent <- gatewayUserAgent
     parsed <- tryAny (HTTP.parseRequest (Text.unpack url))
     case parsed of
         Left exception -> pure (Left (Text.pack (show exception)))
@@ -371,7 +373,10 @@ postJson manager url payload decoder = do
                     HTTP.httpLbs
                         initial
                             { HTTP.method = "POST"
-                            , HTTP.requestHeaders = [(hContentType, "application/json")]
+                            , HTTP.requestHeaders =
+                                [ (hContentType, "application/json")
+                                , ("User-Agent", userAgent)
+                                ]
                             , HTTP.requestBody = HTTP.RequestBodyLBS (Aeson.encode payload)
                             , HTTP.checkResponse = \_ _ -> pure ()
                             }
@@ -475,6 +480,7 @@ postGatewayOAuthForm
     -> [(Text, Text)]
     -> IO (Either Text GatewayAuthorizationCodeResponse)
 postGatewayOAuthForm manager url fields = do
+    userAgent <- gatewayUserAgent
     parsed <- tryAny (HTTP.parseRequest (Text.unpack url))
     case parsed of
         Left _ ->
@@ -489,6 +495,7 @@ postGatewayOAuthForm manager url fields = do
                                 [ ( hContentType
                                   , "application/x-www-form-urlencoded"
                                   )
+                                , ("User-Agent", userAgent)
                                 ]
                             , HTTP.requestBody =
                                 HTTP.RequestBodyLBS $

--- a/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Usage.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Usage.hs
@@ -7,6 +7,7 @@ import Agent.CLI.Gateway.Credentials
     , withGatewayCredentialLease
     )
 import Agent.CLI.Gateway.Http (gatewayMaxResponseBytes, readBoundedBody)
+import Agent.ClientIdentity (gatewayUserAgent)
 import Agent.OpenAI.Usage (UsageSnapshot, decodeUsageResponse)
 import Agent.Server.Client.GatewayIdentity (GatewayCredential(..))
 import Control.Exception.Safe (tryAny)
@@ -59,6 +60,7 @@ requestGatewayUsage credential model =
                         <> "/backend-api/wham/usage"
                         <> query
             outcome <- tryAny do
+                userAgent <- gatewayUserAgent
                 manager <- newTlsManager
                 initial <- HTTP.parseRequest (Text.unpack endpoint)
                 let request =
@@ -71,6 +73,7 @@ requestGatewayUsage credential model =
                                             credential.gatewayAccessToken
                                   )
                                 , (hAccept, "application/json")
+                                , ("User-Agent", userAgent)
                                 ]
                             , HTTP.checkResponse = \_ _ -> pure ()
                             -- Never forward the gateway bearer to a redirect.

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.GatewayClientSpec (spec) where
 
 import Agent.CLI.GatewayClient
+import Agent.ClientIdentity (gatewayUserAgent)
 import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Agent.Json.Decode qualified as Hermes
 import Control.Concurrent
@@ -55,6 +56,25 @@ decodeGatewayModels bytes =
 
 spec :: Spec
 spec = describe "gateway device authorization" do
+    it "sends the versioned User-Agent when discovering gateway models" do
+        received <- newEmptyMVar
+        expected <- gatewayUserAgent
+        let application request respond = do
+                putMVar received (Wai.requestHeaders request)
+                respond $ Wai.responseLBS status200
+                    [(hContentType, "application/json")]
+                    "{\"data\":[{\"id\":\"company-model\",\"protocol\":\"responses\"}]}"
+        Warp.testWithApplication (pure application) \port -> do
+            let base = "http://127.0.0.1:" <> Text.pack (show port)
+                credential = GatewayCredential base
+                    (Text.replace "http://" "ws://" base <> "/v1/responses")
+                    "test-token"
+            fetchGatewayModels credential `shouldReturn`
+                Right [GatewayModel "company-model" GatewayResponsesProtocol]
+            headers <- takeMVar received
+            lookup "User-Agent" headers `shouldBe` Just expected
+            lookup "Authorization" headers `shouldBe` Just "Bearer test-token"
+
     it "binds sessions to the exact gateway credential without exposing it" do
         let first =
                 GatewayCredential
@@ -323,7 +343,10 @@ spec = describe "gateway device authorization" do
 
     it "serves and shuts down a successful loopback callback" do
         baseUrlVar <- newEmptyMVar
-        let gatewayApplication _request respond = do
+        expectedUserAgent <- gatewayUserAgent
+        let gatewayApplication request respond = do
+                lookup "User-Agent" (Wai.requestHeaders request)
+                    `shouldBe` Just expectedUserAgent
                 baseUrl <- readMVar baseUrlVar
                 let websocketUrl =
                         Text.replace "http://" "ws://" baseUrl

--- a/packages/agent-cli/src/Agent/CLI/ClaudeGatewayProxy.hs
+++ b/packages/agent-cli/src/Agent/CLI/ClaudeGatewayProxy.hs
@@ -5,6 +5,7 @@ import Agent.CLI.GatewayClient
     , validateGatewayCredential
     )
 import Agent.Claude (ClaudeCodeTransport(..))
+import Agent.ClientIdentity (gatewayUserAgent)
 import Control.Concurrent.Async (withAsync)
 import Control.Exception.Safe (bracket, tryAny)
 import Control.Monad (unless)
@@ -98,6 +99,7 @@ forward
     -> (Response -> IO ResponseReceived)
     -> IO ResponseReceived
 forward manager credential downstream body respond = do
+    userAgent <- gatewayUserAgent
     initial <-
         HTTP.parseRequest $
             Text.unpack credential.gatewayBaseUrl <> "/anthropic/v1/messages"
@@ -105,17 +107,18 @@ forward manager credential downstream body respond = do
         initial
             { HTTP.method = "POST"
             , HTTP.requestHeaders =
-                ( hAuthorization
-                , "Bearer " <> Text.encodeUtf8 credential.gatewayAccessToken
-                )
-                    : filter
+                [ (hUserAgent, userAgent)
+                , ( hAuthorization
+                  , "Bearer " <> Text.encodeUtf8 credential.gatewayAccessToken
+                  )
+                ]
+                    <> filter
                         (\(name, _) ->
                             name `elem`
                                 [ hAccept
                                 , hContentType
                                 , "anthropic-version"
                                 , "anthropic-beta"
-                                , hUserAgent
                                 ])
                         downstream.requestHeaders
             , HTTP.requestBody = HTTP.RequestBodyBS body

--- a/packages/agent-cli/test/Agent/CLI/ClaudeGatewayProxySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ClaudeGatewayProxySpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.ClaudeGatewayProxySpec (spec) where
 import Agent.CLI.ClaudeGatewayProxy (withClaudeGatewayProxy)
 import Agent.CLI.GatewayClient (GatewayCredential(..))
 import Agent.Claude (ClaudeCodeTransport(..))
+import Agent.ClientIdentity (gatewayUserAgent)
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as LBS
 import Data.IORef
@@ -18,6 +19,7 @@ import Test.Hspec
 spec :: Spec
 spec = describe "Claude gateway loopback proxy" do
     it "keeps the organization bearer in the parent process" do
+        userAgent <- gatewayUserAgent
         observed <- newIORef Nothing
         Warp.testWithApplication (pure (upstream observed)) \port -> do
             manager <- HTTP.newManager HTTP.defaultManagerSettings
@@ -49,6 +51,7 @@ spec = describe "Claude gateway loopback proxy" do
                                                 <> Text.encodeUtf8 gatewayToken
                                           )
                                         , (hContentType, "application/json")
+                                        , (hUserAgent, "claude-code/downstream")
                                         ]
                                     , HTTP.requestBody =
                                         HTTP.RequestBodyLBS
@@ -63,16 +66,21 @@ spec = describe "Claude gateway loopback proxy" do
                         ( ["anthropic", "v1", "messages"]
                         , Just "Bearer organization-secret"
                         , "{\"model\":\"sonnet\"}"
+                        , [userAgent]
                         )
 
 upstream
-    :: IORef (Maybe ([Text], Maybe ByteString, LBS.ByteString))
+    :: IORef (Maybe ([Text], Maybe ByteString, LBS.ByteString, [ByteString]))
     -> Application
 upstream observed request respond = do
     body <- strictRequestBody request
     writeIORef observed $
         Just
-            (request.pathInfo, lookup hAuthorization request.requestHeaders, body)
+            ( request.pathInfo
+            , lookup hAuthorization request.requestHeaders
+            , body
+            , [value | (name, value) <- request.requestHeaders, name == hUserAgent]
+            )
     respond $
         responseLBS
             status200

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -40,6 +40,7 @@ common common-opts
 library
     import:           common-opts
     exposed-modules:  Agent.Auth.JWT
+                    , Agent.ClientIdentity
                     , Agent.Cancel
                     , Agent.Concurrent
                     , Agent.ComputerUse.Protocol
@@ -280,6 +281,7 @@ test-suite agent-core-test
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Agent.Auth.JWTSpec
+                    , Agent.ClientIdentitySpec
                     , Agent.CancelSpec
                     , Agent.ComputerUse.ProtocolSpec
                     , Agent.Tools.CodeMode.HostSpec

--- a/packages/agent-core/src/Agent/ClientIdentity.hs
+++ b/packages/agent-core/src/Agent/ClientIdentity.hs
@@ -4,9 +4,9 @@
 module Agent.ClientIdentity (gatewayUserAgent) where
 
 import Data.ByteString (ByteString)
-import Data.ByteString.Char8 qualified as BS
+import qualified Data.ByteString.Char8 as BS
 import Data.Version (showVersion)
-import Paths_agent_core qualified as Paths
+import qualified Paths_agent_core as Paths
 import System.Environment (getProgName)
 import System.Info (arch, os)
 

--- a/packages/agent-core/src/Agent/ClientIdentity.hs
+++ b/packages/agent-core/src/Agent/ClientIdentity.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE CPP #-}
+
+-- | Non-secret client identity for requests to the organization gateway.
+module Agent.ClientIdentity (gatewayUserAgent) where
+
+import Data.ByteString (ByteString)
+import Data.ByteString.Char8 qualified as BS
+import Data.Version (showVersion)
+import Paths_agent_core qualified as Paths
+import System.Environment (getProgName)
+import System.Info (arch, os)
+
+#ifndef AGENT_BUILD_COMMIT
+#define AGENT_BUILD_COMMIT "development"
+#endif
+
+-- | Native's @ha_runtime_init@ explicitly sets the RTS program name to
+-- @haskell-agent-macos@ before any Haskell gateway calls. Do not infer the
+-- frontend from the OS: the CLI also runs on macOS. The version describes
+-- the shared agent runtime, not the separately versioned native UI bundle.
+gatewayUserAgent :: IO ByteString
+gatewayUserAgent = do
+    program <- getProgName
+    let product
+            | program == "haskell-agent-macos" = "haskell-agent-macos"
+            | otherwise = "agent-cli"
+    pure $ BS.pack $
+        product <> "/" <> showVersion Paths.version
+            <> " (" <> os <> "; " <> arch
+            <> "; commit " <> AGENT_BUILD_COMMIT <> ")"

--- a/packages/agent-core/test/Agent/ClientIdentitySpec.hs
+++ b/packages/agent-core/test/Agent/ClientIdentitySpec.hs
@@ -1,7 +1,7 @@
 module Agent.ClientIdentitySpec (spec) where
 
 import Agent.ClientIdentity (gatewayUserAgent)
-import Data.ByteString.Char8 qualified as BS
+import qualified Data.ByteString.Char8 as BS
 import System.Environment (withProgName)
 import Test.Hspec
 

--- a/packages/agent-core/test/Agent/ClientIdentitySpec.hs
+++ b/packages/agent-core/test/Agent/ClientIdentitySpec.hs
@@ -1,0 +1,24 @@
+module Agent.ClientIdentitySpec (spec) where
+
+import Agent.ClientIdentity (gatewayUserAgent)
+import Data.ByteString.Char8 qualified as BS
+import System.Environment (withProgName)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "gatewayUserAgent" do
+    it "identifies CLI requests, including CLI running on macOS" do
+        value <- withProgName "agent-cli" gatewayUserAgent
+        value `shouldSatisfy` BS.isPrefixOf "agent-cli/"
+        value `shouldSatisfy` BS.isInfixOf "; commit "
+    it "uses the explicit native RTS identity" do
+        value <- withProgName "haskell-agent-macos" gatewayUserAgent
+        value `shouldSatisfy` BS.isPrefixOf "haskell-agent-macos/"
+    it "does not include an arbitrary executable name in the header" do
+        value <- withProgName "private-name\r\nInjected: value" gatewayUserAgent
+        value `shouldSatisfy` BS.isPrefixOf "agent-cli/"
+        value `shouldSatisfy` BS.all (\c -> c >= ' ' && c <= '~')
+    it "reports the same runtime version and build for each frontend" do
+        cli <- withProgName "agent-cli" gatewayUserAgent
+        native <- withProgName "haskell-agent-macos" gatewayUserAgent
+        BS.dropWhile (/= '/') cli `shouldBe` BS.dropWhile (/= '/') native

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import qualified Agent.Auth.JWTSpec as JWTSpec
+import qualified Agent.ClientIdentitySpec as ClientIdentitySpec
 import qualified Agent.CancelSpec as CancelSpec
 import qualified Agent.ConcurrentSpec as ConcurrentSpec
 import qualified Agent.ComputerUse.ProtocolSpec as ComputerUseProtocolSpec
@@ -43,6 +44,7 @@ import Test.Hspec (hspec)
 main :: IO ()
 main = hspec do
     JWTSpec.spec
+    ClientIdentitySpec.spec
     CancelSpec.spec
     ConcurrentSpec.spec
     ComputerUseProtocolSpec.spec

--- a/packages/agent-native-bridge/cbits/HaskellAgentBridgeRuntime.c
+++ b/packages/agent-native-bridge/cbits/HaskellAgentBridgeRuntime.c
@@ -11,6 +11,8 @@ int32_t ha_runtime_init(void) {
     pthread_mutex_lock(&runtime_lock);
     if (!runtime_initialized) {
         int argc = 1;
+        /* Agent.ClientIdentity uses this explicit RTS product name to
+         * distinguish desktop traffic from the CLI (including CLI on macOS). */
         char *argv[] = {"haskell-agent-macos", NULL};
         char **argv_pointer = argv;
         hs_init(&argc, &argv_pointer);

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -18,6 +18,7 @@ module Agent.OpenAI.WebSocketClient
     , buildWsPayloadWithOptions
     , addTurnStateToPayload
     , buildCodexWsHeaders
+    , buildCodexWsHandshakeHeaders
     , WebSocketEndpoint(..)
     , gatewayWebSocketEndpoint
     , isGatewayWebSocketCredential
@@ -45,6 +46,7 @@ module Agent.OpenAI.WebSocketClient
 import Agent.OpenAI.Auth (Pool)
 import Agent.OpenAI.Credential (poolTokenProvider)
 import Agent.Error
+import Agent.ClientIdentity (gatewayUserAgent)
 import Agent.Http.Header (parseRetryAfterSeconds)
 import Agent.OpenAI.Error (isPreviousResponseIdError, mkOpenAIError)
 import Agent.OpenAI.Features (remoteCompactionV2Feature)
@@ -407,7 +409,7 @@ runConnectionAttemptWithPolicyAndTurnState _ _ credential _action
         Nothing
 runConnectionAttemptWithPolicyAndTurnState retryPolicy sharedTurnState
         credential action = do
-    let headers = buildCodexWsHeaders credential
+    headers <- buildCodexWsHandshakeHeaders credential
     case gatewayWebSocketEndpoint credential of
         Left err -> pure (Left (ConnectionError err))
         Right endpoint ->
@@ -528,7 +530,16 @@ runCredentialWebSocket endpoint headers action =
                     headers
                     action
 
--- | Pure handshake-header builder exported for transport contract tests.
+-- | Add the host application's identity only for organization gateways.
+-- Keeping this at the handshake boundary also covers reconnects and subagents.
+buildCodexWsHandshakeHeaders :: Credential -> IO WS.Headers
+buildCodexWsHandshakeHeaders credential
+    | isGatewayWebSocketCredential credential = do
+        userAgent <- gatewayUserAgent
+        pure (("User-Agent", userAgent) : buildCodexWsHeaders credential)
+    | otherwise = pure (buildCodexWsHeaders credential)
+
+-- | Pure authentication-header builder exported for transport contract tests.
 buildCodexWsHeaders :: Credential -> WS.Headers
 buildCodexWsHeaders credential =
     [ ("Authorization", "Bearer " <> Text.encodeUtf8 credential.accessToken)

--- a/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/WebSocketClientSpec.hs
@@ -2,6 +2,7 @@ module Agent.OpenAI.WebSocketClientSpec (spec) where
 
 import Test.Hspec
 import Agent.Error
+import Agent.ClientIdentity (gatewayUserAgent)
 import Agent.Provider (Credential(..), Provider(..))
 import Agent.Responses.Types
 import qualified Agent.Responses.Codec as ResponsesCodec
@@ -83,6 +84,23 @@ spec = do
         readCodexTurnState turnState `shouldReturn` Nothing
 
   describe "buildCodexWsHeaders" do
+    it "identifies gateway clients without changing direct-provider handshakes" do
+        let gateway = Credential
+                { accessToken = "gateway-token"
+                , accountId = "wss://gateway.example/v1/responses"
+                , leaseId = Nothing
+                , provider = OpenAIProvider
+                }
+            direct = gateway { accountId = "chatgpt-account" }
+        userAgent <- gatewayUserAgent
+        headers <- buildCodexWsHandshakeHeaders gateway
+        [value | (name, value) <- headers, name == "User-Agent"]
+            `shouldBe` [userAgent]
+        lookup "Authorization" headers `shouldBe` Just "Bearer gateway-token"
+        lookup "chatgpt-account-id" headers `shouldBe` Nothing
+        buildCodexWsHandshakeHeaders direct
+            `shouldReturn` buildCodexWsHeaders direct
+
     it "advertises remote compaction v2 on the session handshake" do
         let credential = Credential
                 { accessToken = "token"


### PR DESCRIPTION
## Summary
- Add a shared gateway User-Agent identifying CLI versus native macOS, runtime version, OS, architecture, and production build commit.
- Send it on gateway authentication, model discovery, usage, dictation HTTP/WebSocket requests, Responses WebSocket handshakes, and Claude proxy requests.
- Replace the Claude SDK User-Agent with the host identity; leave direct-provider headers unchanged.
- Add identity and gateway header regression tests.

The macOS version identifies the shared runtime, not the separately versioned native UI bundle.

## Validation
- Identity and full GatewayClientSpec Hspec tests passed (44 examples, 0 failures) in GHCi using the existing Nix shell and a temporary Paths_agent_core version fixture matching Cabal.
- `nix-instantiate --parse flake.nix` passed.
- `git diff --check` passed.
- Regenerated agent-core/package.nix with cabal2nix; no expression changes required.
- Responses WebSocket and Claude proxy tests remain unverified: nested nix develop hit local filesystem permissions; direct Cabal repl exhausted disk space compiling dependencies.

