### PR TITLE
Make the startup editor available before storage loads

### DIFF
--- a/packages/agent-cli/benchmark/Startup.md
+++ b/packages/agent-cli/benchmark/Startup.md
@@ -1,0 +1,119 @@
+# Interactive startup latency
+
+Use `scripts/benchmark-startup.py` from `nix develop` with **compiled, optimized**
+before/after binaries. The script launches a 120×40 PTY, never submits a model
+request, records each sample as JSON, and reports medians after discarded warmups.
+Do not substitute GHCi timings or compare an unrelated installed version.
+
+It measures:
+
+- `first_frame_ms`: launch to the fullscreen renderer restoring the visible
+  cursor after its first frame.
+- `editable_ms`: launch to rendering `startup-probe`, which is injected after the
+  first frame once terminal echo is disabled. This is an observed upper bound on
+  input readiness, including processing/rendering the probe, not just drawing an
+  empty editor.
+- `ready_ms`: launch to displaying the existing `startup: … ready …` diagnostic.
+- `internal_ready_ms`: the diagnostic's own elapsed time, excluding process
+  loading and early initialization before its timer starts.
+
+External measurements use a monotonic clock immediately before process creation.
+The renderer must be `--fullscreen`; it does not use the inline editor's
+synchronized-output boundary. Timings are PTY-observed, not terminal-emulator
+pixel presentation times. Inspect raw captures when renderer changes invalidate
+the cursor/diagnostic markers; a missing milestone fails the run.
+
+## Procedure
+
+1. Save the base revision and build its executable with:
+
+   ```
+   nix develop -c cabal build --offline -O2 agent-cli:exe:agent-cli
+   nix develop -c cabal list-bin -O2 agent-cli:exe:agent-cli
+   ```
+
+   Keep that executable and its data files available, then build the changed
+   revision with the same options. If using separate worktrees, ensure dependency
+   versions, RTS options and data-file lookup are equivalent.
+
+2. Create a **dedicated, short-path HOME** with mode 0700. Do not copy real OAuth
+   tokens or benchmark against your daily session database. A dummy Gemini key
+   and an explicit model suffice for a no-request startup. Initialize this HOME
+   once before measuring warm startup; PostgreSQL cold provisioning is a separate
+   workload. Run from `nix develop` so PostgreSQL and other runtime tools are
+   available.
+
+   ```
+   export GOOGLE_API_KEY=startup-benchmark
+   python3 scripts/benchmark-startup.py \
+     --home "$BENCH_HOME" --cwd "$PROJECT" \
+     --samples 7 --warmups 1 --output-dir "$RESULTS/before" \
+     -- "$BEFORE" --provider gemini --model gemini-2.5-flash \
+       --fullscreen --no-computer-use --yolo
+   ```
+
+   Repeat with `$AFTER`, identical HOME/project/options/environment, then repeat
+   the before case to check stability. The script terminates and joins the agent
+   after the milestones; it never sends Enter. A separately daemonized managed
+   PostgreSQL instance intentionally remains warm between samples. Stop it with
+   `HOME="$BENCH_HOME" "$AFTER" storage stop` when done.
+   To measure restarting an already-provisioned database, add `--cold-store`:
+   this invokes that binary's `storage stop` against the dedicated HOME before
+   each sample, outside the timed interval. It does not delete/reinitialize data.
+
+3. Cover more than one workload: empty directory, representative repository with
+   skills/instructions, and a resumed session with representative history sizes.
+   Measure `--worktree` separately because creating a checkout is real extra
+   work. Do not mix those results with ordinary no-worktree launches.
+
+4. Keep the raw sample JSON and record hardware, GHC version, optimization/RTS
+   settings, revision identities, workload dimensions and medians. Avoid running
+   builds concurrently with timed samples. For allocation/GC optimizations, add
+   allocation measurements rather than treating these latency-only results as
+   allocation evidence.
+
+5. Separately smoke-test the changed executable in **tmux**. Confirm that text
+   typed during loading survives into the idle composer, resize/redraw remains
+   sound, and startup failure/cancellation restores the terminal. A PTY
+   benchmark alone is not the required tmux visual check.
+
+## Early-shell change: local measurement
+
+Baseline `d2df3d9f66fe080eb0c1bffb20bafcb216e4835d` versus the early-shell
+`Flow.hs` / workspace-timing `Initialized.hs` changes, built from the same
+source archive with GHC 9.10.3, Cabal `-O2`, unchanged compiled RTS defaults and
+`GHCRTS` unset. Apple M3 Max, 36 GiB RAM, arm64, macOS 26.6.1. Seven measured
+samples after one warmup per case; before → after → before-repeat order.
+The after cases were subsequently repeated with the corrected ready parser;
+those corrected runs are shown below.
+Workload: this repository, default skills enabled, dedicated pre-provisioned
+HOME, dummy Gemini credentials, fullscreen, `--no-computer-use --yolo`, no turn.
+
+Median launch-to-observation times, milliseconds:
+
+| Store state | Binary | First frame | Editable | Rendered ready |
+| --- | --- | ---: | ---: | ---: |
+| Running | Before | 36.5 | 59.9 | 117.7 |
+| Running | After | 31.0 | 52.1 | 127.1 |
+| Running | Before repeat | 39.1 | 70.7 | 125.6 |
+| Restarted each launch | Before | 193.3 | 211.9 | 273.8 |
+| Restarted each launch | After | 29.6 | 51.0 | 269.2 |
+| Restarted each launch | Before repeat | 194.1 | 219.8 | 275.5 |
+
+The clear improvement is an editable UI while storage starts: about **161 ms /
+76% less waiting** in the database-restart case. Total readiness did not
+meaningfully improve. Warm startup's rendered-ready median increased by 9 ms
+versus the first baseline (2 ms versus the repeat), so do not claim a
+total-startup speedup from these results. The original parser matched an
+intermediate “workspace scopes ready” checkpoint, invalidating both its
+rendered-ready and internal-ready values. The corrected runs require the
+standalone ready checkpoint; internal-ready medians were 47 ms warm and
+191 ms with the database restarted.
+These are local no-request measurements, not first-install provisioning,
+authenticated production-account, resumed-history, or Grok Build comparisons.
+
+Modified-binary tmux checks also passed: text entered during “Opening session
+storage…” survived into the idle composer and a 120×40 → 100×30 resize.
+An unknown resume UUID displayed the startup-failure dialog; selecting Exit
+restored canonical input and echo. Double Ctrl-C during “Opening session
+storage…” also exited and restored those terminal settings. No turn was sent.

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -161,7 +161,7 @@ import Control.Applicative ( (<|>) )
 import Control.Concurrent.MVar
     ( MVar, newEmptyMVar, newMVar, readMVar, tryPutMVar )
 import Control.Exception.Safe
-    ( displayException, finally, onException, throwIO, try, tryAny )
+    ( bracketOnError, displayException, finally, onException, throwIO, try, tryAny )
 import Control.Monad ( when, forM_, void, unless )
 import Data.IORef
     ( IORef, atomicModifyIORef', newIORef, readIORef, writeIORef )
@@ -633,7 +633,10 @@ data AgentIterationRequest = AgentIterationRequest
     , iterationTransition :: Maybe ProviderTransition
     }
 
-data AgentIterationResources = AgentIterationResources
+-- | Only the local information needed to draw the first editable frame.
+-- Database connections, gateway credentials and resumed history belong to the
+-- backend worker, not the terminal's initialization path.
+data AgentIterationBootstrap = AgentIterationBootstrap
     { iterationStartedAt :: UTCTime
     , iterationStartupTimings :: IORef [(Text, NominalDiffTime)]
     , iterationSyntaxLoadDuration :: IORef (Maybe NominalDiffTime)
@@ -642,6 +645,11 @@ data AgentIterationResources = AgentIterationResources
     , iterationConfiguredTheme :: ThemeKind
     , iterationHome :: OsPath
     , iterationRoot :: OsPath
+    , iterationInitialSource :: OsPath
+    }
+
+data AgentIterationResources = AgentIterationResources
+    { iterationBootstrap :: AgentIterationBootstrap
     , iterationDatabaseStore :: Store
     , iterationConnectedGateway :: Maybe GatewayCredential
     , iterationResumed :: Maybe (SessionMeta, [SessionTurn])
@@ -655,7 +663,7 @@ data AgentIterationInterface = AgentIterationInterface
     , iterationUiRuntimeRef :: IORef (Maybe FullscreenRuntime)
     , iterationCancelToolRef :: IORef (IO ())
     , iterationInstallToolRuntime :: ToolEnv -> IO ()
-    , iterationBuildStartupRuntime :: ToolEnv -> StartupRuntime
+    , iterationBuildStartupRuntime :: Store -> ToolEnv -> StartupRuntime
     }
 
 prepareAgentIterationTracked
@@ -692,26 +700,33 @@ prepareTrackedAgentIteration request = do
     forM_
         request.iterationActiveFullscreen
         resetFullscreenSessionActions
-    resources <- prepareAgentIterationResources request
-    interface <- prepareAgentIterationInterface request resources
-    resumeLock <- readIORef request.iterationResumeLockRef
-    let action =
+    bootstrap <- prepareAgentIterationBootstrap request
+    interface <- prepareAgentIterationInterface request bootstrap
+    -- Run resource preparation inside the existing fullscreen worker. Input
+    -- can be edited/queued immediately, but no session action or model request
+    -- is installed until initialization and resume validation have succeeded.
+    let activeRequest =
+            request
+                { iterationActiveFullscreen = interface.iterationFullscreen }
+        action = do
+            resources <- prepareAgentIterationResources activeRequest bootstrap
+            resumeLock <- readIORef request.iterationResumeLockRef
             prepareAgentIterationAction
                 request
                 resources
                 interface
                 resumeLock
         cleanup =
-            cleanupAgentIteration request resources interface
+            cleanupAgentIteration request interface
     pure PreparedAgent
         { preparedFullscreen = interface.iterationFullscreen
         , preparedRun = action `finally` cleanup
         }
 
-prepareAgentIterationResources
+prepareAgentIterationBootstrap
     :: AgentIterationRequest
-    -> IO AgentIterationResources
-prepareAgentIterationResources request = do
+    -> IO AgentIterationBootstrap
+prepareAgentIterationBootstrap request = do
     startedAt <- getCurrentTime
     startupTimingsRef <- newIORef []
     syntaxLoadDurationRef <- newIORef Nothing
@@ -726,52 +741,14 @@ prepareAgentIterationResources request = do
             Right config -> pure config
     let configuredTheme = harnessConfig.configTheme
     let root = sessionsRoot home
-    databaseStore <-
-        case
-            request.iterationRunMode.runNativeHooks
-                >>= (.nativeDatabaseStore)
-        of
-        Just borrowed -> pure borrowed
-        Nothing -> do
-            databaseConfig <- managedPostgresConfigForHome home
-            openStore databaseConfig >>= \case
-                Left err ->
-                    failAgentIterationPreparation request
-                        (renderStoreError err)
-                Right store -> do
-                    writeIORef request.iterationDatabaseStoreRef (Just store)
-                    pure store
-    connectedGateway <-
-        loadGatewayCredentialAt home >>= \case
-            Left err ->
-                failAgentIterationPreparation request
-                    ("Could not load gateway credentials: " <> err)
-            Right credential -> pure credential
-    let connectedGatewayIdentity =
-            gatewayCredentialIdentity <$> connectedGateway
-    resumed <-
-        loadAgentIterationResume
-            request
-            root
-            databaseStore
-            connectedGatewayIdentity
-    source <- case request.iterationOptions.optCwd of
-        Just requestedCwd -> makeAbsolute requestedCwd
-        Nothing -> case resumed of
-            Just (meta, _) -> makeAbsolute meta.metaCwd
-            Nothing ->
-                maybe
-                    getCurrentDirectory
-                    makeAbsolute
-                    request.iterationRunMode.runCwdHint
-    -- Native resumes supply optCwd too. Restore the selected effective cwd,
-    -- not an unrelated historical path when the caller overrides it.
-    forM_ resumed $ \_ ->
-        restoreManagedWorktree (worktreeRoot home) source >>= \case
-            Left err -> failAgentIterationPreparation request
-                ("Could not restore session worktree: " <> err)
-            Right () -> pure ()
-    pure AgentIterationResources
+    initialSource <-
+        maybe
+            getCurrentDirectory
+            makeAbsolute
+            (request.iterationOptions.optCwd
+                <|> request.iterationRunMode.runCwdHint)
+    recordStartupTiming startedAt startupTimingsRef "configuration"
+    pure AgentIterationBootstrap
         { iterationStartedAt = startedAt
         , iterationStartupTimings = startupTimingsRef
         , iterationSyntaxLoadDuration = syntaxLoadDurationRef
@@ -780,6 +757,72 @@ prepareAgentIterationResources request = do
         , iterationConfiguredTheme = configuredTheme
         , iterationHome = home
         , iterationRoot = root
+        , iterationInitialSource = initialSource
+        }
+
+prepareAgentIterationResources
+    :: AgentIterationRequest
+    -> AgentIterationBootstrap
+    -> IO AgentIterationResources
+prepareAgentIterationResources request bootstrap = do
+    let home = bootstrap.iterationHome
+        root = bootstrap.iterationRoot
+        recordStage =
+            recordStartupTiming
+                bootstrap.iterationStartedAt
+                bootstrap.iterationStartupTimings
+    setStartupNotice request.iterationActiveFullscreen "Opening session storage…"
+    databaseStore <-
+        case
+            request.iterationRunMode.runNativeHooks
+                >>= (.nativeDatabaseStore)
+        of
+        Just borrowed -> pure borrowed
+        Nothing -> do
+            databaseConfig <- managedPostgresConfigForHome home
+            trackPreparationResource
+                request.iterationDatabaseStoreRef
+                closeStore
+                (openStore databaseConfig) >>= \case
+                Left err ->
+                    failAgentIterationPreparation request
+                        (renderStoreError err)
+                Right store -> pure store
+    recordStage "database"
+    connectedGateway <-
+        loadGatewayCredentialAt home >>= \case
+            Left err ->
+                failAgentIterationPreparation request
+                    ("Could not load gateway credentials: " <> err)
+            Right credential -> pure credential
+    recordStage "gateway credentials"
+    let connectedGatewayIdentity =
+            gatewayCredentialIdentity <$> connectedGateway
+    resumed <-
+        loadAgentIterationResume
+            request
+            root
+            databaseStore
+            connectedGatewayIdentity
+    recordStage "resume"
+    source <- case request.iterationOptions.optCwd of
+        Just requestedCwd -> makeAbsolute requestedCwd
+        Nothing -> case resumed of
+            Just (meta, _) -> makeAbsolute meta.metaCwd
+            Nothing -> pure bootstrap.iterationInitialSource
+    -- Native resumes supply optCwd too. Restore the selected effective cwd,
+    -- not an unrelated historical path when the caller overrides it.
+    forM_ resumed $ \_ ->
+        restoreManagedWorktree (worktreeRoot home) source >>= \case
+            Left err -> failAgentIterationPreparation request
+                ("Could not restore session worktree: " <> err)
+            Right () -> pure ()
+    setStartupNotice request.iterationActiveFullscreen
+        (if request.iterationOptions.optWorktree && isNothing resumed
+            then "Creating worktree…"
+            else "Loading project…")
+    pure AgentIterationResources
+        { iterationBootstrap = bootstrap
         , iterationDatabaseStore = databaseStore
         , iterationConnectedGateway = connectedGateway
         , iterationResumed = resumed
@@ -808,12 +851,14 @@ loadAgentIterationResume request root databaseStore connectedGatewayIdentity =
                 let err = "session not found: " <> sessionId
                 signalAgentIterationReady request (Left err)
                 failAgentIterationPreparation request err
-            acquireSessionLock dir sessionId >>= \case
+            trackPreparationResource
+                request.iterationResumeLockRef
+                releaseSessionLock
+                (acquireSessionLock dir sessionId) >>= \case
                 Left err -> do
                     signalAgentIterationReady request (Left err)
                     failAgentIterationPreparation request err
-                Right lock -> do
-                    writeIORef request.iterationResumeLockRef (Just lock)
+                Right _ -> do
                     loadSessionMeta sessionPool root sessionId >>= \case
                         Left err -> do
                             signalAgentIterationReady request (Left err)
@@ -884,15 +929,15 @@ failAgentIterationPreparation request message =
 
 prepareAgentIterationInterface
     :: AgentIterationRequest
-    -> AgentIterationResources
+    -> AgentIterationBootstrap
     -> IO AgentIterationInterface
-prepareAgentIterationInterface request resources = do
+prepareAgentIterationInterface request bootstrap = do
     let runMode = request.iterationRunMode
         options = request.iterationOptions
         stdoutHandle = runMode.runStdout
         stderrHandle = runMode.runStderr
         background = runMode.runInBackground
-        initialCwd = resources.iterationSource
+        initialCwd = bootstrap.iterationInitialSource
     uiRuntimeRef <- newIORef Nothing
     cancelToolRef <- newIORef (pure ())
     interrupt <- newInterruptState \msg -> do
@@ -928,10 +973,7 @@ prepareAgentIterationInterface request resources = do
         initialFullscreenState =
             (reduceUi
                 (UiSetNotice
-                    (Just (progressNotice
-                        (if options.optWorktree
-                            then "Creating worktree…"
-                            else "Loading project…"))))
+                    (Just (progressNotice "Opening session storage…")))
                 (reduceUi
                     (UiSetRepository
                         ""
@@ -950,7 +992,7 @@ prepareAgentIterationInterface request resources = do
         Nothing
             | fullscreenEnabled ->
                 Just <$> newFullscreenRuntimeWithTheme
-                    resources.iterationConfiguredTheme
+                    bootstrap.iterationConfiguredTheme
                     request.iterationFullscreenInputs
                     (readIORef cancelToolRef >>= id)
                     (\level ->
@@ -968,12 +1010,12 @@ prepareAgentIterationInterface request resources = do
                     (\target -> readIORef agentSelectRef >>= ($ target))
                     (do
                         recordStartupTiming
-                            resources.iterationStartedAt
-                            resources.iterationStartupTimings
+                            bootstrap.iterationStartedAt
+                            bootstrap.iterationStartupTimings
                             "first frame"
                         void (tryPutMVar firstFrameReady ()))
                     (writeIORef
-                        resources.iterationSyntaxLoadDuration . Just)
+                        bootstrap.iterationSyntaxLoadDuration . Just)
                     options.optMotionMode
                     useColor
                     initialFullscreenState
@@ -1001,12 +1043,12 @@ prepareAgentIterationInterface request resources = do
                     (noteFullscreenCtrlC interrupt)
                     (readIORef agentSnapshotRef >>= id)
                     (\target -> readIORef agentSelectRef >>= ($ target))
-        buildStartupRuntime toolEnv = StartupRuntime
+        buildStartupRuntime databaseStore toolEnv = StartupRuntime
             { startupToolEnv = toolEnv
-            , startupHarnessConfig = resources.iterationHarnessConfig
+            , startupHarnessConfig = bootstrap.iterationHarnessConfig
             , startupNetworkRecovery =
                 request.iterationProcessRuntime.processNetworkRecovery
-            , startupDatabaseStore = resources.iterationDatabaseStore
+            , startupDatabaseStore = databaseStore
             , startupInterrupt = interrupt
             , startupStdinControl = stdinControl
             , startupUiRuntimeRef = uiRuntimeRef
@@ -1024,11 +1066,11 @@ prepareAgentIterationInterface request resources = do
             , startupAgentSnapshot = agentSnapshotRef
             , startupAgentSelect = agentSelectRef
             , startupRestartEffort = restartEffortActionRef
-            , startupStartedAt = resources.iterationStartedAt
-            , startupTimings = resources.iterationStartupTimings
+            , startupStartedAt = bootstrap.iterationStartedAt
+            , startupTimings = bootstrap.iterationStartupTimings
             , startupSyntaxLoadDuration =
-                resources.iterationSyntaxLoadDuration
-            , startupFinished = resources.iterationStartupFinished
+                bootstrap.iterationSyntaxLoadDuration
+            , startupFinished = bootstrap.iterationStartupFinished
             , startupSessionState = request.iterationSessionState
             , startupNativeHooks = runMode.runNativeHooks
             }
@@ -1095,14 +1137,17 @@ runPreparedAgentIteration
         terminalCwd
     toolEnv <- defaultToolEnv cwd
     interface.iterationInstallToolRuntime toolEnv
-    let startup = interface.iterationBuildStartupRuntime toolEnv
+    let startup =
+            interface.iterationBuildStartupRuntime
+                resources.iterationDatabaseStore
+                toolEnv
     runAgentInitialized
         (runAgentWithRuntime request.iterationProcessRuntime)
         request.iterationProcessRuntime
         request.iterationOptions
         request.iterationTransition
-        resources.iterationHome
-        resources.iterationRoot
+        resources.iterationBootstrap.iterationHome
+        resources.iterationBootstrap.iterationRoot
         resources.iterationResumed
         resumeLock
         cwd
@@ -1124,8 +1169,8 @@ resolveAgentIterationCwd request resources interface resumeLock =
                 readMVar interface.iterationFirstFrameReady
                 createManagedWorktreeFromConfigWithProgress
                     reportWorktreeProgress
-                    resources.iterationHarnessConfig
-                    resources.iterationHome
+                    resources.iterationBootstrap.iterationHarnessConfig
+                    resources.iterationBootstrap.iterationHome
                     resources.iterationSource
                     >>= either worktreeFailed worktreeCreated
             | otherwise -> pure resources.iterationSource
@@ -1160,31 +1205,54 @@ resolveAgentIterationCwd request resources interface resumeLock =
 
 cleanupAgentIteration
     :: AgentIterationRequest
-    -> AgentIterationResources
     -> AgentIterationInterface
     -> IO ()
-cleanupAgentIteration request resources interface = do
-    let runMode = request.iterationRunMode
-    forM_ runMode.runNativeHooks \hooks ->
-        hooks.nativeRegisterCancel (pure ())
-    writeIORef interface.iterationUiRuntimeRef Nothing
-    writeIORef interface.iterationCancelToolRef (pure ())
-    forM_
-        interface.iterationFullscreen
-        resetFullscreenSessionActions
-    case runMode.runNativeHooks >>= (.nativeDatabaseStore) of
-        Just _ -> pure ()
-        Nothing -> closeStore resources.iterationDatabaseStore
+cleanupAgentIteration request interface =
+    resetInterface `finally`
+        releasePreparationResources
+            request.iterationResumeLockRef
+            request.iterationDatabaseStoreRef
+  where
+    resetInterface = do
+        let runMode = request.iterationRunMode
+        forM_ runMode.runNativeHooks \hooks ->
+            hooks.nativeRegisterCancel (pure ())
+        writeIORef interface.iterationUiRuntimeRef Nothing
+        writeIORef interface.iterationCancelToolRef (pure ())
+        forM_
+            interface.iterationFullscreen
+            resetFullscreenSessionActions
 
 releasePreparationResources
     :: IORef (Maybe SessionLock)
     -> IORef (Maybe Store)
     -> IO ()
 releasePreparationResources resumeLockRef databaseStoreRef = do
+    -- Session storage may already have released a successfully resumed lock.
+    -- filelock guards unlockFile with an atomic alive flag, so this also covers
+    -- cancellation before that ownership handoff without unlocking twice.
     atomicModifyIORef' resumeLockRef (\current -> (Nothing, current))
         >>= mapM_ releaseSessionLock
     atomicModifyIORef' databaseStoreRef (\current -> (Nothing, current))
         >>= mapM_ closeStore
+
+-- | Transfer a freshly acquired resource into its initially empty tracking
+-- slot without leaking it if fullscreen cancellation lands during handoff.
+-- Once the callback returns, the enclosing iteration's finalizer owns it.
+trackPreparationResource
+    :: IORef (Maybe a)
+    -> (a -> IO ())
+    -> IO (Either e a)
+    -> IO (Either e a)
+trackPreparationResource ref release acquire =
+    bracketOnError
+        acquire
+        (mapM_ \resource -> do
+            writeIORef ref Nothing
+            release resource)
+        \result -> do
+            forM_ result (writeIORef ref . Just)
+            pure result
 
 resetFullscreenSessionActions :: FullscreenRuntime -> IO ()
 resetFullscreenSessionActions runtime =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -107,11 +107,13 @@ import Agent.CLI.Session.Runtime.Types
     ( StartupRuntime(startupToolEnv, startupStderr, startupStdout,
                      startupStdoutTty, startupStdinTty, startupFullscreen,
                      startupUiRuntimeRef, startupStdinControl, startupInterrupt,
-                     startupDatabaseStore, startupNativeHooks) )
+                     startupDatabaseStore, startupNativeHooks,
+                     startupStartedAt, startupTimings) )
 import Agent.CLI.SessionLock ( releaseSessionLock, SessionLock )
 import Agent.CLI.Skills ( loadSkillsCatalogQuiet )
 import Agent.CLI.Startup.Auth
-    ( loadStartupAuth, loadStartupAuthFromResult, markStartupStage, startupDie )
+    ( loadStartupAuth, loadStartupAuthFromResult, markStartupStage,
+      recordStartupTiming, startupDie )
 import Agent.CLI.Style ( setCliWindowTitle )
 import Agent.CLI.TUI.App
     ( setFullscreenHistorySource, setFullscreenWindowTitle )
@@ -348,6 +350,9 @@ prepareInitializedWorkspace request = do
         preparedDiscovery =
             nativePreparedDiscovery . (.nativeWorkspaceDiscovery)
                 =<< startup.startupNativeHooks
+        checkpoint =
+            recordStartupTiming startup.startupStartedAt startup.startupTimings
+    checkpoint "workspace discovery started"
     projectRoot <-
         maybe
             (resolveProjectRoot cwd)
@@ -364,6 +369,7 @@ prepareInitializedWorkspace request = do
             projectRootPath >>= \case
             Left err -> startupDie startup err
             Right scopes -> pure scopes
+    checkpoint "workspace scopes ready"
     let loadWorkspaceMetadata =
             concurrently
                 (concurrently
@@ -398,6 +404,7 @@ prepareInitializedWorkspace request = do
             else do
                 metadata <- loadWorkspaceMetadata
                 pure (metadata, SkillCatalog [] [])
+    checkpoint "workspace metadata and skills ready"
     let projectSettings =
             withInheritedLastModel projectSettings0 userSettings
     catalog <- either

--- a/scripts/benchmark-startup.py
+++ b/scripts/benchmark-startup.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Measure a compiled agent's startup through a real PTY, without sending a turn."""
+
+import argparse
+import errno
+import fcntl
+import json
+import os
+from pathlib import Path
+import pty
+import re
+import select
+import signal
+import statistics
+import struct
+import subprocess
+import termios
+import time
+
+
+ANSI = re.compile(rb"\x1b(?:\][^\x07\x1b]*(?:\x07|\x1b\\)|\[[0-?]*[ -/]*[@-~]|[()][A-Z0-9])")
+READY = re.compile(rb"(?:startup: |\xc2\xb7\s*)ready ([0-9.]+)(ms|s)\b")
+FRAME_END = b"\x1b[?25h"
+PROBE = b"startup-probe"
+
+
+def sample(args, index):
+    env = dict(os.environ, HOME=str(args.home), TERM="xterm-256color",
+               HASKELL_AGENT_STARTUP_TIMING="1")
+    for key, directory in (
+        ("XDG_CONFIG_HOME", ".config"),
+        ("XDG_CACHE_HOME", ".cache"),
+        ("XDG_DATA_HOME", ".local/share"),
+        ("XDG_STATE_HOME", ".local/state"),
+    ):
+        env[key] = str(args.home / directory)
+    # Do not inherit the outer harness's terminal/session identity.
+    for key in ("TMUX", "STY"):
+        env.pop(key, None)
+    if args.cold_store:
+        subprocess.run([args.command[0], "storage", "stop"], env=env,
+                       cwd=args.cwd, check=True, capture_output=True,
+                       timeout=args.timeout)
+    started = time.monotonic()
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.chdir(args.cwd)
+        os.execvpe(args.command[0], args.command, env)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 120, 0, 0))
+    output = bytearray()
+    result = {}
+    probe_sent = False
+    try:
+        while time.monotonic() - started < args.timeout:
+            readable, _, _ = select.select([fd], [], [], 0.05)
+            if not readable:
+                continue
+            try:
+                chunk = os.read(fd, 65536)
+            except OSError as exc:
+                if exc.errno == errno.EIO:
+                    break
+                raise
+            if not chunk:
+                break
+            output.extend(chunk)
+            elapsed = (time.monotonic() - started) * 1000
+            if FRAME_END in output and "first_frame_ms" not in result:
+                result["first_frame_ms"] = elapsed
+            # Respond to cursor-position queries as a terminal would.
+            if b"\x1b[6n" in chunk:
+                os.write(fd, b"\x1b[1;1R")
+            if ("first_frame_ms" in result and not probe_sent
+                    and not termios.tcgetattr(fd)[3] & termios.ECHO):
+                os.write(fd, PROBE)
+                probe_sent = True
+            plain = ANSI.sub(b"", bytes(output))
+            if probe_sent and PROBE in plain and "editable_ms" not in result:
+                result["editable_ms"] = elapsed
+            ready = READY.search(plain)
+            if ready and "ready_ms" not in result:
+                result["ready_ms"] = elapsed
+                result["internal_ready_ms"] = (
+                    float(ready[1]) * (1000 if ready[2] == b"s" else 1))
+            if all(key in result for key in
+                   ("first_frame_ms", "editable_ms", "ready_ms")):
+                break
+        if args.output_dir:
+            args.output_dir.mkdir(parents=True, exist_ok=True)
+            (args.output_dir / f"sample-{index}.tty").write_bytes(output)
+        missing = {"first_frame_ms", "editable_ms", "ready_ms"} - result.keys()
+        if missing:
+            raise RuntimeError(
+                f"sample {index}: missing {sorted(missing)}; "
+                f"last output: {ANSI.sub(b'', bytes(output[-3000:]))!r}")
+        return result
+    finally:
+        # Clear the unsubmitted probe and request a normal exit, allowing scoped
+        # workers and persistence to close. Drain output so terminal cleanup
+        # cannot block on a full PTY buffer.
+        try:
+            os.write(fd, b"\x15\x04")
+        except OSError:
+            pass
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            waited, _ = os.waitpid(pid, os.WNOHANG)
+            if waited:
+                break
+            readable, _, _ = select.select([fd], [], [], 0.02)
+            if readable:
+                try:
+                    os.read(fd, 65536)
+                except OSError:
+                    pass
+        else:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            os.waitpid(pid, 0)
+        os.close(fd)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--home", type=Path, required=True,
+                        help="dedicated pre-initialized home; do not use your real HOME")
+    parser.add_argument("--cwd", type=Path, default=Path.cwd())
+    parser.add_argument("--samples", type=int, default=7)
+    parser.add_argument("--warmups", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=30)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--cold-store", action="store_true",
+                        help="stop this dedicated HOME's store before each timed launch")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if args.command[:1] == ["--"]:
+        args.command.pop(0)
+    if not args.command or args.samples < 1 or args.warmups < 0:
+        parser.error("provide a command, positive samples, and nonnegative warmups")
+    args.home = args.home.resolve()
+    args.cwd = args.cwd.resolve()
+    if args.home == Path.home().resolve():
+        parser.error("--home must be a dedicated benchmark HOME, not your actual HOME")
+    if not args.home.is_dir():
+        parser.error("--home must already exist")
+    rows = []
+    for index in range(-args.warmups, args.samples):
+        row = sample(args, index)
+        print(json.dumps({"sample": index, **row}), flush=True)
+        if index >= 0:
+            rows.append(row)
+    print(json.dumps({
+        "command": args.command,
+        "cold_store": args.cold_store,
+        "samples": len(rows),
+        "median_ms": {key: statistics.median(row[key] for row in rows)
+                      for key in rows[0]},
+    }), flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Bring up the interactive shell before database, gateway, and resume preparation so users can type while startup finishes.
- Preserve queued input, resume validation, and exception-safe resource cleanup; add workspace timing checkpoints.
- Add a reproducible PTY startup benchmark and document results in `packages/agent-cli/benchmark/Startup.md`.

## Performance
Equivalent optimized baseline (`d2df3d9f6`) and changed binaries: GHC 9.10.3, Cabal `-O2`, unchanged compiled RTS defaults, `GHCRTS` unset, inside `nix develop`. Apple M3 Max / 36 GiB / macOS arm64. Repository workload with default skills, dedicated pre-provisioned HOME, dummy Gemini credentials, 120×40 fullscreen PTY, no model request. Seven samples after one warmup; baseline repeated for stability. Changed cases repeated after correcting the final-ready parser.

Median milliseconds:

| Store | Metric | Before | After | Before repeat |
| --- | --- | ---: | ---: | ---: |
| Restarted each launch | First frame | 193.3 | 29.6 | 194.1 |
| Restarted each launch | Editable | 211.9 | 51.0 | 219.8 |
| Restarted each launch | Rendered ready | 273.8 | 269.2 | 275.5 |
| Running | First frame | 36.5 | 31.0 | 39.1 |
| Running | Editable | 59.9 | 52.1 | 70.7 |
| Running | Rendered ready | 117.7 | 127.1 | 125.6 |

The improvement is **76% less waiting to type when storage needs restarting**, not reduced total backend work. Total readiness is approximately unchanged; warm rendered readiness is 9 ms above the first baseline and 2 ms above its repeat. No claim of allocation, first-install, resumed-history, or Grok Build performance improvement.

Build each revision with:
```sh
nix develop -c cabal build --offline -O2 agent-cli:exe:agent-cli
```
Run each compiled binary inside `nix develop` with its data files available:
```sh
GOOGLE_API_KEY=startup-benchmark python3 scripts/benchmark-startup.py \
  --home "$BENCH_HOME" --cwd "$PROJECT" --samples 7 --warmups 1 \
  --output-dir "$RESULTS" -- "$BIN" \
  --provider gemini --model gemini-2.5-flash --fullscreen --no-computer-use --yolo
```
Add `--cold-store` before `--` for database-restart measurements. Full setup and limitations are in the benchmark document.

## Validation
- GHCi: `cabal repl agent-cli:lib:agent-cli --builddir=dist-startup-repl --repl-options=-fno-code` in the Nix shell; all 232 modules loaded.
- Optimized baseline and changed executable builds passed.
- Corrected benchmark final-ready markers verified against raw captures.
- Live tmux: text typed during “Opening session storage…” survives into idle composer; resize 120×40 → 100×30 preserves it.
- Live tmux: unknown resume UUID shows failure dialog; Exit restores canonical input and echo.
- Live tmux: double Ctrl-C during storage startup exits and restores terminal settings.
- `git diff --check` passed. Full automated suite and separate forced database failure were not run.
