### PR TITLE
Improve loaded-history TUI rendering with chunk caching

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -443,11 +443,13 @@ benchmark history-eviction-bench
     hs-source-dirs:   benchmark, src
     main-is:          HistoryEviction.hs
     other-modules:    Agent.CLI.TUI.History
+                    , Agent.CLI.TUI.Transcript
                     , HistoryEvictionBaseline
     ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
     build-depends:    agent-tui
                     , base >= 4.17 && < 5
                     , containers
+                    , text
 
 benchmark accessibility-delta-bench
     import:           common-options
@@ -682,8 +684,10 @@ benchmark transcript-scrolling-bench
     main-is:          TranscriptScrolling.hs
     ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
     build-depends:    agent-cli
+                    , agent-tui
                     , base >= 4.17 && < 5
                     , brick >= 2.9 && < 3
+                    , containers
                     , deepseq
                     , text
                     , vty >= 6.4 && < 7

--- a/packages/agent-cli/benchmark/HistoryRendering.md
+++ b/packages/agent-cli/benchmark/HistoryRendering.md
@@ -1,0 +1,69 @@
+# Loaded-history rendering
+
+The history setter now retains the per-turn coalesced display projection,
+chunked across turns. Redraws reuse the existing 32-block image cache. Selected,
+hovered, expanded, incomplete, and partial chunks retain the existing dynamic
+rendering policy. Live transcript projection is unchanged.
+
+## Reproduce
+
+```sh
+nix develop -c cabal build --offline agent-cli:bench:transcript-scrolling-bench
+B=$(nix develop -c cabal list-bin agent-cli:bench:transcript-scrolling-bench)
+for n in 100 600 1200 1200; do
+  "$B" history-per-block "$n" 3 7 +RTS -T
+  "$B" history-chunk-cache "$n" 3 7 +RTS -T
+done
+```
+
+Measured on aarch64 macOS, GHC 9.10.3, Brick 2.9. Benchmark module uses
+`-O2`; linked local libraries use Cabal's default `-O1`, identically for both
+workloads. These are compiled results, not GHCi timings.
+
+The fixture uses completed assistant blocks and every fifth block is a tool,
+with Markdown bodies, ten blocks per history turn, and a 100×32 vertical
+viewport with production horizontal padding. Both workloads call production
+block rendering; the baseline preserves the old per-frame flatten/coalesce.
+Each redraw constructs a fresh widget with a changing elapsed-time field and
+carries Brick's render state forward. Picture display spans and extent counts
+are forced. This measures rendering, not terminal I/O or the full event loop.
+
+Seven samples; table reports the median wall-time sample and its CPU/allocation
+measurements. Warm samples contain 25 redraws after an untimed cache warm-up.
+Cold samples include history indexes/projection and one render with an empty
+image cache; input blocks/runtime are prepared outside timing. GC runs before
+each sample and after timing to flush nursery allocation counters.
+
+## Results
+
+Warm totals (milliseconds and decimal MB allocated per 25 redraws):
+
+| Blocks | Old wall / CPU / MB | New wall / CPU / MB |
+|---:|---:|---:|
+| 100 | 31.173 / 31.142 / 210.416 | 27.634 / 27.615 / 193.131 |
+| 600 | 147.352 / 147.106 / 694.032 | 115.802 / 115.717 / 589.562 |
+| 1200 | 287.987 / 287.777 / 1278.144 | 212.507 / 212.354 / 1060.277 |
+| 1200 repeat | 285.953 / 285.720 / 1278.140 | 212.165 / 211.897 / 1060.277 |
+
+At 1200 blocks this is about **26% less redraw time and 17% less allocation**,
+or 11.52 → 8.50 ms per redraw. Cost still grows with history size; chunk
+caching does not eliminate Brick's extent/viewport bookkeeping.
+
+Setup plus first render (one render per sample):
+
+| Blocks | Old wall / CPU / MB | New wall / CPU / MB |
+|---:|---:|---:|
+| 100 | 14.474 / 14.449 / 57.647 | 14.641 / 14.621 / 57.668 |
+| 600 | 85.845 / 85.667 / 324.629 | 86.569 / 86.400 / 323.350 |
+| 1200 | 175.582 / 175.477 / 645.470 | 175.888 / 175.749 / 642.333 |
+| 1200 repeat | 180.500 / 179.672 / 645.503 | 178.466 / 178.167 / 642.333 |
+
+Cold cost is approximately unchanged, rather than hiding a substantial
+first-render penalty behind the warm-cache improvement.
+
+Longer-body check (`100 30 7`, including fenced code): warm old
+100.971 ms / 100.893 CPU ms / 553.564 MB versus new
+94.183 ms / 94.128 CPU ms / 514.257 MB. Cold old
+62.771 ms / 62.725 CPU ms / 303.831 MB versus new
+64.996 ms / 64.962 CPU ms / 303.852 MB: about 2.2 ms more first-render
+time in this sample, with essentially identical allocation.

--- a/packages/agent-cli/benchmark/TranscriptScrolling.hs
+++ b/packages/agent-cli/benchmark/TranscriptScrolling.hs
@@ -1,10 +1,43 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
--- | Benchmark retained transcript redraws, the dominant work triggered by
--- scrolling a long Brick viewport.
+-- | Benchmark production retained-history redraws. The old workload preserves
+-- the pre-chunking renderer so changes remain directly comparable.
 module Main (main) where
 
+import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
+import Agent.CLI.Interrupt (CtrlCDecision(..))
+import Agent.CLI.TUI.App
+    ( initialFullscreenAppState
+    , drawBlock
+    , drawConversationBlocks
+    , drawTranscript
+    , newFullscreenInputBuffer
+    , newFullscreenRuntimeWithSyntaxLoader
+    )
+import Agent.CLI.TUI.History
+    ( HistoryCursor(..)
+    , HistoryGeneration(..)
+    , HistoryTurn(..)
+    , HistoryWindow(..)
+    , emptyHistoryWindow
+    , setHistoryWindowTurns
+    )
+import Agent.CLI.TUI.Transcript
+    ( coalesceInspectionBlocks
+    , transcriptChunkSize
+    )
+import Agent.CLI.TUI.Types (AppState(..), Name(..))
+import Agent.TUI.Model
+    ( BlockId(..)
+    , BlockKind(..)
+    , BlockState(..)
+    , UiBlock(..)
+    , UiState(..)
+    , initialUiState
+    )
+import Agent.TUI.Motion (MotionMode(..))
 import Brick
     ( Padding(..)
     , ViewportType(..)
@@ -13,6 +46,7 @@ import Brick
     , cached
     , hBox
     , padBottom
+    , padLeftRight
     , renderFinal
     , txt
     , txtWrap
@@ -20,32 +54,27 @@ import Brick
     , viewport
     )
 import Brick.Types (RenderState)
-import Agent.CLI.TUI.Transcript (transcriptChunkSize)
 import Control.DeepSeq (force)
 import Control.Monad (replicateM)
+import Data.Foldable (toList)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.List (sortOn)
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
 import GHC.Clock (getMonotonicTimeNSec)
-import GHC.Stats
-    ( RTSStats(..)
-    , getRTSStats
-    )
+import GHC.Stats (RTSStats(..), getRTSStats)
 import qualified Graphics.Vty as V
 import Graphics.Vty.PictureToSpans (displayOpsForPic)
 import System.CPUTime (getCPUTime)
 import System.Environment (getArgs)
 import System.Mem (performGC)
 
-data Name
-    = TranscriptViewport
-    | TranscriptBlock !Int
-    | TranscriptChunk !Int !Int
-    deriving (Eq, Ord, Read, Show)
-
 data Workload
-    = PerBlockCache
+    = HistoryPerBlock
+    | HistoryChunkCache
+    | PerBlockCache
     | ChunkCache
 
 data Sample = Sample
@@ -63,63 +92,218 @@ main = do
             let blockCount = read blockCountText
                 bodyLines = read bodyLinesText
                 sampleCount = read sampleCountText
-                widget = transcriptWidget workload blockCount bodyLines
-            initialState <- warmCache widget
+            rawState <- benchmarkState blockCount bodyLines
+            let state = prepareHistory workload rawState 0
+            let widgetForFrame = productionWidget workload state
+            initialState <- warmCache (widgetForFrame 0)
             stateRef <- newIORef initialState
             samples <-
                 replicateM sampleCount $
-                    measure redrawsPerSample widget stateRef
-            printSample
-                workloadText
-                blockCount
-                bodyLines
-                sampleCount
+                    measure redrawsPerSample widgetForFrame stateRef
+            printSample workloadText blockCount bodyLines sampleCount redrawsPerSample
                 (median samples)
+            coldSamples <- mapM
+                (\frame -> measureAction $
+                    warmCache (productionWidget workload
+                        (prepareHistory workload rawState frame) frame))
+                [1 .. sampleCount]
+            printSample (workloadText <> "-setup-first-render")
+                blockCount bodyLines sampleCount 1 (median coldSamples)
         _ ->
             error
                 "usage: transcript-scrolling-bench \
-                \(per-block-cache|chunk-cache) BLOCKS BODY_LINES SAMPLES"
+                \(history-per-block|history-chunk-cache|\
+                \per-block-cache|chunk-cache) \
+                \BLOCKS BODY_LINES SAMPLES"
 
 parseWorkload :: String -> IO Workload
 parseWorkload = \case
+    "history-per-block" -> pure HistoryPerBlock
+    "history-chunk-cache" -> pure HistoryChunkCache
     "per-block-cache" -> pure PerBlockCache
     "chunk-cache" -> pure ChunkCache
     other -> error ("unknown workload: " <> other)
 
-transcriptWidget :: Workload -> Int -> Int -> Widget Name
-transcriptWidget workload blockCount bodyLines =
-    viewport TranscriptViewport Vertical $
+{-# NOINLINE productionWidget #-}
+productionWidget :: Workload -> AppState -> Int -> Widget Name
+productionWidget workload state frame =
+    viewport ConversationViewport Vertical $ padLeftRight 2 $
         case workload of
-            PerBlockCache -> vBox blocks
-            ChunkCache ->
-                vBox
-                    [ if length widgets == transcriptChunkSize
-                        then
+            HistoryPerBlock -> oldHistoryWidget framedState
+            HistoryChunkCache -> drawTranscript framedState
+            PerBlockCache -> syntheticTranscriptWidget PerBlockCache framedState
+            ChunkCache -> syntheticTranscriptWidget ChunkCache framedState
+  where
+    framedState = state
+        { appUi = state.appUi{uiElapsedMillis = frame} }
+
+-- Include the changed setter in cold measurements, not just warm redraws.
+-- Input blocks/runtime are prepared outside timing; indexes/projection are not.
+{-# NOINLINE prepareHistory #-}
+prepareHistory :: Workload -> AppState -> Int -> AppState
+prepareHistory workload state frame =
+    state
+        { appUi = state.appUi{uiElapsedMillis = frame}
+        , appHistoryWindow = case workload of
+            HistoryChunkCache -> setHistoryWindowTurns turns window
+            HistoryPerBlock -> window
+                { historyWindowTurnsByCursor = Map.fromList
+                    [(turn.historyTurnCursor, turn) | turn <- toList turns]
+                , historyWindowBlocksById = Map.fromList
+                    [(block.blockId, block)
+                    | turn <- toList turns
+                    , block <- toList turn.historyTurnBlocks]
+                }
+            PerBlockCache -> window
+            ChunkCache -> window
+        }
+  where
+    window = state.appHistoryWindow
+    turns = window.historyWindowTurns
+
+-- The renderer replaced by the optimization: normalize and flatten the whole
+-- history on every frame, then combine one cached image per block.
+oldHistoryWidget :: AppState -> Widget Name
+oldHistoryWidget state =
+    vBox
+        [ vBox $
+            map
+                (drawBlock state AgentRoot state.appUi)
+                historicalBlocks
+        , drawConversationBlocks state AgentRoot state.appUi
+        ]
+  where
+    historicalBlocks =
+        concatMap
+            (toList . coalesceInspectionBlocks . (.historyTurnBlocks))
+            (toList state.appHistoryWindow.historyWindowTurns)
+
+-- Retain the original synthetic microbenchmark modes for longitudinal
+-- comparisons. Production history measurements above remain the default
+-- modes used to evaluate this change.
+syntheticTranscriptWidget :: Workload -> AppState -> Widget Name
+syntheticTranscriptWidget workload state =
+    case workload of
+        PerBlockCache -> vBox blocks
+        ChunkCache ->
+            vBox
+                [ case (widgets, blockChunk) of
+                    (_, firstBlock Seq.:<| _)
+                        | length widgets == transcriptChunkSize ->
                             cached
-                                (TranscriptChunk
-                                    first
-                                    (first + length widgets - 1))
+                                (ConversationChunkCache
+                                    AgentRoot
+                                    firstBlock.blockId
+                                    (Seq.index blockChunk
+                                        (Seq.length blockChunk - 1)).blockId)
                                 rendered
-                        else rendered
-                    | (first, widgets) <-
-                        zip [1, 1 + transcriptChunkSize ..]
-                            (chunksOf transcriptChunkSize blocks)
-                    , let rendered = vBox widgets
-                    ]
+                    _ -> rendered
+                | blockChunk <- chunks
+                , let widgets = fmap syntheticBlock (toList blockChunk)
+                      rendered = vBox widgets
+                ]
+        _ -> error "syntheticTranscriptWidget: production workload"
+  where
+    historyBlocks =
+        foldMap (.historyTurnBlocks) state.appHistoryWindow.historyWindowTurns
+    chunks = chunksOfSeq transcriptChunkSize historyBlocks
+    blocks = fmap syntheticBlock (toList historyBlocks)
+    syntheticBlock block =
+        cached
+            (ConversationBlockCache
+                AgentRoot block.blockId False False Nothing) $
+            padBottom (Pad 1) $
+                hBox [txt "  ", txtWrap block.blockBody]
+
+benchmarkState :: Int -> Int -> IO AppState
+benchmarkState blockCount bodyLines = do
+    input <- newFullscreenInputBuffer
+    runtime <-
+        newFullscreenRuntimeWithSyntaxLoader
+            (pure (Left "disabled in transcript benchmark"))
+            input
+            (pure ())
+            (const (pure ()))
+            (pure WarnExit)
+            (const (pure True))
+            (const (pure ()))
+            (const (pure ()))
+            (pure (AgentRoot, [rootEntry]))
+            (const (pure ()))
+            (pure ())
+            (const (pure ()))
+            MotionOff
+            False
+            initialUiState
+    let base =
+            initialFullscreenAppState runtime [] AgentRoot [rootEntry] 0
+        turns =
+            Seq.fromList
+                [ HistoryTurn
+                    { historyTurnCursor = HistoryCursor (fromIntegral cursor)
+                    , historyTurnBlocks = Seq.fromList turnBlocks
+                    }
+                | (cursor, turnBlocks) <-
+                    zip [0 :: Int ..] (chunksOf 10 blocks)
+                ]
+        history =
+            (emptyHistoryWindow
+                    (HistoryGeneration 0)
+                    (max 1 (Seq.length turns))
+                    (max 1 blockCount)
+                    maxBound)
+                { historyWindowTurns = turns }
+    let !_ = force (show turns)
+    pure base{appHistoryWindow = history}
   where
     body =
         Text.intercalate "\n" $
-            replicate bodyLines representativeLine
+            take bodyLines (cycle representativeLines)
     blocks =
-        [ cached (TranscriptBlock index) $
-            padBottom (Pad 1) $
-                hBox [txt "  ", txtWrap body]
+        [ UiBlock
+            { blockId = BlockId (-index)
+            , blockKind =
+                if index `mod` 5 == 0
+                    then BlockTool
+                    else BlockAssistant
+            , blockTitle =
+                if index `mod` 5 == 0
+                    then "read_file"
+                    else "Assistant"
+            , blockBody = body
+            , blockTimestamp = ""
+            , blockDetail =
+                if index `mod` 5 == 0
+                    then "packages/agent-cli/src/Agent/CLI/TUI/Render.hs"
+                    else ""
+            , blockState = BlockComplete
+            , blockExpanded = False
+            , blockCallId = Nothing
+            , blockInspectionGroupable = False
+            }
         | index <- [1 .. blockCount]
         ]
 
-representativeLine :: Text
-representativeLine =
-    "Representative retained transcript text that wraps across the viewport."
+rootEntry :: AgentEntry
+rootEntry =
+    AgentEntry
+        { agentTarget = AgentRoot
+        , agentPath = "/root"
+        , agentStatus = "running"
+        , agentModel = Nothing
+        , agentSteps = []
+        , agentTranscript = []
+        , agentConversation = initialUiState
+        }
+
+representativeLines :: [Text]
+representativeLines =
+    [ "Representative **Markdown** text with a [link](https://example.com)."
+    , "- A retained list item that wraps across the viewport."
+    , "```haskell"
+    , "rendered = cached key (markdownWidget body)"
+    , "```"
+    ]
 
 redrawsPerSample :: Int
 redrawsPerSample = 25
@@ -141,41 +325,25 @@ warmCache widget = do
 
 measure
     :: Int
-    -> Widget Name
+    -> (Int -> Widget Name)
     -> IORef (RenderState Name)
     -> IO Sample
-measure iterations widget stateRef = do
-    performGC
-    beforeStats <- getRTSStats
-    beforeCpu <- getCPUTime
-    beforeTime <- getMonotonicTimeNSec
-    checksum <- redraw iterations 0
-    checksum `seq` pure ()
-    afterTime <- getMonotonicTimeNSec
-    afterCpu <- getCPUTime
-    afterStats <- getRTSStats
-    pure Sample
-        { elapsedMillis =
-            fromIntegral (afterTime - beforeTime) / 1.0e6
-        , cpuMillis =
-            fromIntegral (afterCpu - beforeCpu) / 1.0e9
-        , allocatedBytes =
-            fromIntegral
-                (allocated_bytes afterStats - allocated_bytes beforeStats)
-        }
+measure iterations widgetForFrame stateRef =
+    measureAction (redraw iterations 0)
   where
     redraw remaining checksum
-        | remaining <= 0 = pure checksum
+        | remaining <= 0 = pure $! checksum
         | otherwise = do
             renderState <- readIORef stateRef
-            let (nextState, picture, _, extents) =
+            let widget = widgetForFrame (iterations - remaining)
+                (nextState, picture, _, extents) =
                     renderFinal
                         (attrMap V.defAttr [])
                         [widget]
                         benchmarkRegion
                         (const Nothing)
                         renderState
-            let !rendered =
+                !rendered =
                     force
                         ( show (displayOpsForPic picture benchmarkRegion)
                         , length extents
@@ -185,18 +353,39 @@ measure iterations widget stateRef = do
                 (remaining - 1)
                 (checksum + length (fst rendered) + snd rendered)
 
+measureAction :: IO a -> IO Sample
+measureAction action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeTime <- getMonotonicTimeNSec
+    result <- action
+    result `seq` pure ()
+    afterTime <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    -- Flush nursery allocation into RTS counters, outside the timed interval.
+    performGC
+    afterStats <- getRTSStats
+    pure Sample
+        { elapsedMillis = fromIntegral (afterTime - beforeTime) / 1.0e6
+        , cpuMillis = fromIntegral (afterCpu - beforeCpu) / 1.0e9
+        , allocatedBytes =
+            fromIntegral
+                (allocated_bytes afterStats - allocated_bytes beforeStats)
+        }
+
 median :: [Sample] -> Sample
 median samples =
     sortOn (.elapsedMillis) samples !! (length samples `div` 2)
 
-printSample :: String -> Int -> Int -> Int -> Sample -> IO ()
-printSample workload blockCount bodyLines sampleCount sample =
+printSample :: String -> Int -> Int -> Int -> Int -> Sample -> IO ()
+printSample workload blockCount bodyLines sampleCount redrawCount sample =
     putStrLn $
         unwords
             [ workload
             , "blocks=" <> show blockCount
             , "body_lines=" <> show bodyLines
-            , "redraws_per_sample=" <> show redrawsPerSample
+            , "redraws_per_sample=" <> show redrawCount
             , "samples=" <> show sampleCount
             , "elapsed_ms=" <> show sample.elapsedMillis
             , "cpu_ms=" <> show sample.cpuMillis
@@ -209,6 +398,12 @@ chunksOf size values =
     let (prefix, suffix) = splitAt size values
     in prefix : chunksOf size suffix
 
+chunksOfSeq :: Int -> Seq.Seq a -> [Seq.Seq a]
+chunksOfSeq _ Seq.Empty = []
+chunksOfSeq size values =
+    let (prefix, suffix) = Seq.splitAt size values
+    in prefix : chunksOfSeq size suffix
+
 emptyRenderState :: RenderState Name
 emptyRenderState =
     read
@@ -216,3 +411,9 @@ emptyRenderState =
         \observedNames = fromList [], renderCache = fromList [], \
         \clickableNames = [], requestedVisibleNames_ = fromList [], \
         \reportedExtents = fromList []}"
+
+-- Brick exposes Read but not the constructor/all fields of RenderState.
+-- Its empty representation contains no names, so this benchmark-only instance
+-- deliberately rejects every name rather than inventing a production parser.
+instance Read Name where
+    readsPrec _ _ = []

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -20,6 +20,9 @@ module Agent.CLI.TUI.App
     , choiceClosesOnUiTransition
     , adjustChoiceValue
     , drawApp
+    , drawBlock
+    , drawConversationBlocks
+    , drawTranscript
     , elapsedMillisSince
     , appEventLogicalBytes
     , emitUiEvent
@@ -110,6 +113,11 @@ module Agent.CLI.TUI.App
 import Agent.CLI.TUI.Types
 import Agent.CLI.TUI.Motion
 import Agent.CLI.TUI.Render
+import Agent.CLI.TUI.Render.Blocks (drawBlock)
+import Agent.CLI.TUI.Render.Transcript
+    ( drawConversationBlocks
+    , drawTranscript
+    )
 import Agent.CLI.TUI.LambdaArt
 import Agent.CLI.TUI.App.Runtime
 import Agent.CLI.TUI.App.Mailbox

--- a/packages/agent-cli/src/Agent/CLI/TUI/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/History.hs
@@ -41,6 +41,7 @@ module Agent.CLI.TUI.History
     , unarchivedLiveStart
     ) where
 
+import Agent.CLI.TUI.Transcript (coalesceInspectionBlocks, transcriptChunks)
 import Agent.TUI.Model (BlockId, UiBlock(..))
 import Data.Foldable (toList)
 import Data.Int (Int64)
@@ -95,6 +96,10 @@ data HistoryWindow = HistoryWindow
     , historyWindowTurns :: !(Seq HistoryTurn)
     , historyWindowTurnsByCursor :: !(Map HistoryCursor HistoryTurn)
     , historyWindowBlocksById :: !(Map BlockId UiBlock)
+    -- | Block-only display projection, shared by redraws until turns change.
+    -- Coalesce within each turn (never across turn boundaries), then chunk
+    -- across the window so short turns benefit from image caching too.
+    , historyWindowTranscriptChunks :: ![Seq UiBlock]
     , historyWindowHasOlder :: !Bool
     , historyWindowHasNewer :: !Bool
     , historyWindowMaxTurns :: !Int
@@ -125,6 +130,7 @@ emptyHistoryWindow generation maxTurns maxBlocks maxBytes =
         , historyWindowTurns = Seq.empty
         , historyWindowTurnsByCursor = Map.empty
         , historyWindowBlocksById = Map.empty
+        , historyWindowTranscriptChunks = []
         , historyWindowHasOlder = False
         , historyWindowHasNewer = False
         , historyWindowMaxTurns = max 1 maxTurns
@@ -141,6 +147,9 @@ setHistoryWindowTurns :: Seq HistoryTurn -> HistoryWindow -> HistoryWindow
 setHistoryWindowTurns turns window =
     window
         { historyWindowTurns = turns
+        , historyWindowTranscriptChunks =
+            transcriptChunks $
+                foldMap (coalesceInspectionBlocks . (.historyTurnBlocks)) turns
         , historyWindowTurnsByCursor =
             Map.fromList
                 [ (turn.historyTurnCursor, turn)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
@@ -38,16 +38,17 @@ import Agent.CLI.Startup.Format
 import Agent.CLI.Style ()
 import Agent.CLI.TUI.History
     ( HistoryWindow(historyWindowTurns, historyWindowTotalTurns,
+                    historyWindowTranscriptChunks,
                     historyWindowGenerationStart, historyWindowHasNewer,
                     historyWindowHasOlder, historyWindowPending),
-      HistoryTurn(historyTurnCursor, historyTurnBlocks),
+      HistoryTurn(historyTurnCursor),
       HistoryDirection(..),
       HistoryCursor(HistoryCursor) )
 import Agent.CLI.TUI.ImagePreview ()
 import Agent.CLI.TUI.LambdaArt ( lambdaArtWidget )
 import Agent.TUI.Accent ()
 import Agent.CLI.TUI.Types
-    ( AppState(appConversationAnchor, appHoveredControl,
+    ( AppState(appConversationAnchor, appHoveredControl, appHistorySelectedBlock,
                appAgentEntries, appSlashCatalog, appHistoryWindow, appUi,
                appAgentSelected),
       Name(QuickStartModel, CodeCopy, ConversationChunkCache,
@@ -164,20 +165,13 @@ drawTranscript state =
         [ vBox $
             olderGap
                 <> map
-                    (drawBlock state AgentRoot state.appUi)
-                    historicalBlocks
+                    (drawTranscriptChunk state AgentRoot state.appUi)
+                    state.appHistoryWindow.historyWindowTranscriptChunks
                 <> newerGap
                 <> [drawConversationBlocks state AgentRoot state.appUi]
         ]
             <> conversationReserveWidgets anchor
   where
-    historicalBlocks =
-        concatMap
-            ( toList
-                . Transcript.coalesceInspectionBlocks
-                . (.historyTurnBlocks)
-            )
-            (toList state.appHistoryWindow.historyWindowTurns)
     olderGap =
         historyGapWidget
             HistoryOlder
@@ -229,6 +223,12 @@ drawTranscriptChunk state target ui blocks =
         , state.appAgentSelected == target
         , blockId <- maybeToList ui.uiSelectedBlock
         ]
+            <> [ blockId
+               | target == AgentRoot
+               , state.appUi.uiFocus == FocusScrollback
+               , state.appAgentSelected == target
+               , blockId <- maybeToList state.appHistorySelectedBlock
+               ]
             <> [ blockId
                | Just (CodeCopy hoveredTarget blockId _) <-
                     [state.appHoveredControl]

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -103,6 +103,8 @@ import Agent.CLI.TUI.History
     , HistoryWindow(..)
     , applyHistoryPage
     , emptyHistoryWindow
+    , historyWindowBlock
+    , setHistoryWindowTurns
     )
 import Agent.CLI.TUI.ImagePreview
     ( NativePreviewPlacement(..)
@@ -159,7 +161,12 @@ import Control.Concurrent.STM
 import Control.Monad (replicateM_)
 import qualified Data.ByteString as ByteString
 import Data.Foldable (find, toList)
-import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
+import Data.IORef
+    ( modifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
 import Data.Maybe (isNothing)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
@@ -1873,6 +1880,15 @@ spec = do
             timeout 2_000_000 (replacementPreservesFollow False)
                 `shouldReturn` Just True
 
+    describe "history transcript chunk cache" do
+        it "redraws and clears a historical selection after warming the cache" do
+            timeout 2_000_000 cachedHistorySelectionRenders
+                `shouldReturn` Just True
+
+        it "renders expansion without losing it on deselection" do
+            timeout 2_000_000 cachedHistoryExpansionRenders
+                `shouldReturn` Just True
+
     describe "submitted image history retention" do
         it "remaps a live preview onto its committed durable block" do
             timeout 2_000_000 committedPreviewKeys
@@ -2491,6 +2507,24 @@ runFullscreenScriptWithState
     -> [FullscreenScriptEvent]
     -> IO (ByteString.ByteString, AppState)
 runFullscreenScriptWithState initialState script = do
+    (rendered, _, finalState) <-
+        runFullscreenScriptDetailed initialState script
+    pure (rendered, finalState)
+
+runFullscreenScriptFramesWithState
+    :: AppState
+    -> [FullscreenScriptEvent]
+    -> IO ([V.Picture], AppState)
+runFullscreenScriptFramesWithState initialState script = do
+    (_, frames, finalState) <-
+        runFullscreenScriptDetailed initialState script
+    pure (frames, finalState)
+
+runFullscreenScriptDetailed
+    :: AppState
+    -> [FullscreenScriptEvent]
+    -> IO (ByteString.ByteString, [V.Picture], AppState)
+runFullscreenScriptDetailed initialState script = do
     let scriptedApp = App
             { appDraw = fullscreenApp.appDraw
             , appChooseCursor = fullscreenApp.appChooseCursor
@@ -2520,6 +2554,7 @@ runFullscreenScriptWithState initialState script = do
     let bounds = (80, 24)
     (_, mockOutput) <- VMock.mockTerminal bounds
     outputBytes <- newIORef ByteString.empty
+    renderedFrames <- newIORef []
     let output = mockOutput
             { V.outputByteBuffer = \bytes ->
                 modifyIORef' outputBytes (<> bytes)
@@ -2527,7 +2562,9 @@ runFullscreenScriptWithState initialState script = do
     context <- V.mkDisplayContext output output bounds
     internalEvents <- newTChanIO
     let vty = V.Vty
-            { V.update = V.outputPicture context
+            { V.update = \picture -> do
+                modifyIORef' renderedFrames (picture :)
+                V.outputPicture context picture
             , V.nextEvent = atomically retry
             , V.nextEventNonblocking = pure Nothing
             , V.inputIface = V.Input
@@ -2544,7 +2581,8 @@ runFullscreenScriptWithState initialState script = do
     finalState <-
         customMain vty (pure vty) (Just events) scriptedApp initialState
     rendered <- readIORef outputBytes
-    pure (rendered, finalState)
+    frames <- reverse <$> readIORef renderedFrames
+    pure (rendered, frames, finalState)
 
 markerBlock :: BlockId -> Text -> UiBlock
 markerBlock blockId body = UiBlock
@@ -2559,6 +2597,118 @@ markerBlock blockId body = UiBlock
     , blockCallId = Nothing
     , blockInspectionGroupable = False
     }
+
+cachedHistorySelectionRenders :: IO Bool
+cachedHistorySelectionRenders = do
+    let selectedId = BlockId (-32)
+        selectedBlock =
+            (markerBlock selectedId "selected body")
+                { blockKind = BlockTool
+                , blockTitle = "cached selection"
+                }
+        blocks =
+            selectedBlock
+                : [ markerBlock
+                        (BlockId ident)
+                        ("cached history " <> Text.pack (show ident))
+                  | ident <- [-31 .. -1]
+                  ]
+    initialState <- cachedHistoryState blocks
+    (frames, finalState) <-
+        runFullscreenScriptFramesWithState
+            initialState
+            [ FullscreenScriptVty (V.EvKey V.KDown [])
+            , FullscreenScriptVty (V.EvKey V.KEsc [])
+            , FullscreenScriptHalt
+            ]
+    let rendered = map renderedPictureText frames
+        selectedMarker text =
+            markerBeforeTitle (Text.lines text)
+        markerBeforeTitle = \case
+            [] -> False
+            line : rest ->
+                ( Text.isInfixOf "❯ " line
+                    && any
+                        (Text.isInfixOf "cached selection")
+                        (take 2 rest)
+                )
+                    || markerBeforeTitle rest
+    pure $ case rendered of
+        initialFrame : laterFrames ->
+            not (selectedMarker initialFrame)
+                && any selectedMarker laterFrames
+                && maybe False (not . selectedMarker) (lastMaybe rendered)
+                && finalState.appHistorySelectedBlock == Nothing
+        [] -> False
+
+cachedHistoryExpansionRenders :: IO Bool
+cachedHistoryExpansionRenders = do
+    let expandingId = BlockId (-32)
+        expandingBlock =
+            (markerBlock
+                expandingId
+                (Text.unlines
+                    [ "visible one"
+                    , "visible two"
+                    , "visible three"
+                    , "expanded history marker"
+                    ]))
+                { blockKind = BlockTool
+                , blockTitle = "cached expansion"
+                }
+        blocks =
+            expandingBlock
+                : [ markerBlock
+                        (BlockId ident)
+                        ("cached history " <> Text.pack (show ident))
+                  | ident <- [-31 .. -1]
+                  ]
+    initialState <- cachedHistoryState blocks
+    (frames, finalState) <-
+        runFullscreenScriptFramesWithState
+            initialState
+            [ FullscreenScriptVty (V.EvKey V.KDown [])
+            , FullscreenScriptVty (V.EvKey V.KEnter [])
+            , FullscreenScriptVty (V.EvKey V.KEsc [])
+            , FullscreenScriptHalt
+            ]
+    let rendered = map renderedPictureText frames
+        expansionVisible =
+            Text.isInfixOf "expanded history marker"
+    pure $ case rendered of
+        initialFrame : laterFrames ->
+            not (expansionVisible initialFrame)
+                && any expansionVisible laterFrames
+                && finalState.appHistorySelectedBlock == Nothing
+                && maybe
+                    False
+                    (.blockExpanded)
+                    (historyWindowBlock
+                        expandingId
+                        finalState.appHistoryWindow)
+        [] -> False
+
+cachedHistoryState :: [UiBlock] -> IO AppState
+cachedHistoryState blocks = do
+    let ui = reduceUi (UiFocusChanged FocusScrollback) initialUiState
+        turn = HistoryTurn
+            { historyTurnCursor = HistoryCursor 0
+            , historyTurnBlocks = Seq.fromList blocks
+            }
+        window =
+            setHistoryWindowTurns
+                (Seq.singleton turn)
+                (emptyHistoryWindow
+                    (HistoryGeneration 0)
+                    64
+                    1_000
+                    1_000_000)
+    runtime <- newScriptRuntime ui
+    pure $
+        (initialFullscreenAppState runtime [] AgentRoot [] 0)
+            { appUi = ui
+            , appHistoryWindow = window
+            }
 
 visiblePromptRepairsStaleAnchor :: IO Bool
 visiblePromptRepairsStaleAnchor = do
@@ -2597,18 +2747,32 @@ visiblePromptRepairsStaleAnchor = do
 
 renderedAppText :: (Int, Int) -> AppState -> Text
 renderedAppText size state =
+    renderedPictureTextAt size (renderWidget Nothing (drawApp state) size)
+
+renderedPictureText :: V.Picture -> Text
+renderedPictureText picture =
+    let image = V.picImage picture
+    in renderedPictureTextAt
+        (V.imageWidth image, V.imageHeight image)
+        picture
+
+renderedPictureTextAt :: (Int, Int) -> V.Picture -> Text
+renderedPictureTextAt size picture =
     Text.unlines $
         map
             (Text.concat . map spanText . toList)
             (toList
-                (displayOpsForPic
-                    (renderWidget Nothing (drawApp state) size)
-                    size))
+                (displayOpsForPic picture size))
   where
     spanText = \case
         TextSpan _ _ _ text -> LazyText.toStrict text
         Skip width -> Text.replicate width " "
         RowEnd width -> Text.replicate width " "
+
+lastMaybe :: [a] -> Maybe a
+lastMaybe = \case
+    [] -> Nothing
+    values -> Just (last values)
 
 encoded :: Text -> ByteString.ByteString
 encoded = TextEncoding.encodeUtf8

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -45,6 +45,112 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "bounded fullscreen history window" do
+    it "projects history in order, coalescing within turns but not across turn boundaries" do
+        let regular = Seq.fromList [block identifier | identifier <- [1 .. 31]]
+            readBlock = inspectionBlock 32 "Read a.hs"
+            listedBlock = inspectionBlock 33 "Listed src"
+            searchedBlock = inspectionBlock 34 "Searched needle"
+            fetchedBlock = inspectionBlock 35 "Fetched docs"
+            turns =
+                Seq.fromList
+                    [ HistoryTurn (HistoryCursor 1) (regular Seq.|> readBlock)
+                    , HistoryTurn (HistoryCursor 2) (Seq.singleton listedBlock)
+                    , HistoryTurn
+                        (HistoryCursor 3)
+                        (Seq.fromList [searchedBlock, fetchedBlock])
+                    ]
+            window =
+                setHistoryWindowTurns turns $
+                    emptyHistoryWindow (HistoryGeneration 1) 10 100 1_000_000
+            chunks = window.historyWindowTranscriptChunks
+            projected = concatMap toList chunks
+        map Seq.length chunks `shouldBe` [32, 2]
+        map (.blockId) projected
+            `shouldBe` map BlockId ([1 .. 33] <> [35])
+        -- The adjacent calls in the third turn merge under the newest ID,
+        -- while the calls straddling the first/second turn boundary do not.
+        map (.blockTitle) (drop 31 projected)
+            `shouldBe`
+                [ "Read a.hs"
+                , "Listed src"
+                , "Searched 1 query, Fetched 1 source"
+                ]
+
+    it "refreshes projected history after pages, append, eviction, generation reset, and tail reset" do
+        let generation = HistoryGeneration 11
+            initial = emptyHistoryWindow generation 2 100 1_000_000
+            page direction turns_ older newer =
+                HistoryPage
+                    { historyPageGeneration = generation
+                    , historyPageDirection = direction
+                    , historyPageTurns = Seq.fromList turns_
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 4
+                    , historyPageHasOlder = older
+                    , historyPageHasNewer = newer
+                    }
+        loaded <-
+            expectRight $
+                applyHistoryPage
+                    (page HistoryNewer [turn 2 1] True False)
+                    initial
+        projectedBlockIds loaded `shouldBe` [BlockId 20]
+        paged <-
+            expectRight $
+                applyHistoryPage
+                    (page HistoryOlder [turn 1 1] False True)
+                    loaded
+        projectedBlockIds paged `shouldBe` map BlockId [10, 20]
+        let appended = appendHistoryTurn (turn 3 1) paged
+        -- Appending at a disconnected (non-tail) page resets to the new tail.
+        projectedBlockIds appended `shouldBe` [BlockId 30]
+        let atTail = appended { historyWindowHasNewer = False }
+            evicted =
+                appendHistoryTurn (turn 5 1) $
+                    appendHistoryTurn (turn 4 2) atTail
+        projectedBlockIds evicted `shouldBe` map BlockId [40, 41, 50]
+        projectedBlockIds
+            (historyWindowSetGeneration (HistoryGeneration 12) evicted)
+            `shouldBe` []
+
+    it "refreshes projected history when a persisted block is expanded" do
+        let historyTurn =
+                HistoryTurn
+                    (HistoryCursor 7)
+                    (Seq.fromList
+                        [ inspectionBlock 70 "Searched first"
+                        , inspectionBlock 71 "Searched second"
+                        ])
+            original =
+                setHistoryWindowTurns (Seq.singleton historyTurn) $
+                    emptyHistoryWindow
+                        (HistoryGeneration 13)
+                        10
+                        100
+                        1_000_000
+            updated =
+                setHistoryWindowTurns
+                    (fmap
+                        (\turn_ ->
+                            turn_
+                                { historyTurnBlocks =
+                                    fmap
+                                        (\value ->
+                                            if value.blockId == BlockId 71
+                                                then
+                                                    value
+                                                        { blockExpanded = True
+                                                        }
+                                                else value)
+                                        turn_.historyTurnBlocks
+                                })
+                        original.historyWindowTurns)
+                    original
+        map (.blockExpanded) (projectedBlocks original)
+            `shouldBe` [False]
+        map (.blockExpanded) (projectedBlocks updated)
+            `shouldBe` [True]
+
     it "preserves execution facts through storage and history without sending them to providers" do
         let cases =
                 [ (ToolSucceeded, "Error: quoted log entry", BlockComplete)
@@ -928,6 +1034,22 @@ block identifier =
         , blockCallId = Nothing
         , blockInspectionGroupable = False
         }
+
+inspectionBlock :: Int -> Text.Text -> UiBlock
+inspectionBlock identifier title =
+    (block identifier)
+        { blockKind = BlockInspect
+        , blockTitle = title
+        , blockInspectionGroupable = True
+        }
+
+projectedBlocks :: HistoryWindow -> [UiBlock]
+projectedBlocks =
+    concatMap toList . (.historyWindowTranscriptChunks)
+
+projectedBlockIds :: HistoryWindow -> [BlockId]
+projectedBlockIds =
+    map (.blockId) . projectedBlocks
 
 isRight :: Either a b -> Bool
 isRight value =


### PR DESCRIPTION
## Summary
- Retain the loaded-history display projection and reuse 32-block image caches across redraws.
- Preserve dynamic selection, hover, expansion and partial-chunk behavior.

## Validation
- Focused GHCi tests: History 34/34; App + Transcript 133/133 (167 total).
- Live tmux smoke: history selection, paging/scrolling and terminal resize passed.
- Optimized production-rendering benchmark built and ran; baseline retained.
- Ancillary history-eviction benchmark compiled but local linker ran out of disk space.
- Native-resize mock regression was not retained; resize was checked in the live TTY.

## Benchmark evidence
# Loaded-history rendering

The history setter now retains the per-turn coalesced display projection,
chunked across turns. Redraws reuse the existing 32-block image cache. Selected,
hovered, expanded, incomplete, and partial chunks retain the existing dynamic
rendering policy. Live transcript projection is unchanged.

## Reproduce

```sh
nix develop -c cabal build --offline agent-cli:bench:transcript-scrolling-bench
B=$(nix develop -c cabal list-bin agent-cli:bench:transcript-scrolling-bench)
for n in 100 600 1200 1200; do
  "$B" history-per-block "$n" 3 7 +RTS -T
  "$B" history-chunk-cache "$n" 3 7 +RTS -T
done
```

Measured on aarch64 macOS, GHC 9.10.3, Brick 2.9. Benchmark module uses
`-O2`; linked local libraries use Cabal's default `-O1`, identically for both
workloads. These are compiled results, not GHCi timings.

The fixture uses completed assistant blocks and every fifth block is a tool,
with Markdown bodies, ten blocks per history turn, and a 100×32 vertical
viewport with production horizontal padding. Both workloads call production
block rendering; the baseline preserves the old per-frame flatten/coalesce.
Each redraw constructs a fresh widget with a changing elapsed-time field and
carries Brick's render state forward. Picture display spans and extent counts
are forced. This measures rendering, not terminal I/O or the full event loop.

Seven samples; table reports the median wall-time sample and its CPU/allocation
measurements. Warm samples contain 25 redraws after an untimed cache warm-up.
Cold samples include history indexes/projection and one render with an empty
image cache; input blocks/runtime are prepared outside timing. GC runs before
each sample and after timing to flush nursery allocation counters.

## Results

Warm totals (milliseconds and decimal MB allocated per 25 redraws):

| Blocks | Old wall / CPU / MB | New wall / CPU / MB |
|---:|---:|---:|
| 100 | 31.173 / 31.142 / 210.416 | 27.634 / 27.615 / 193.131 |
| 600 | 147.352 / 147.106 / 694.032 | 115.802 / 115.717 / 589.562 |
| 1200 | 287.987 / 287.777 / 1278.144 | 212.507 / 212.354 / 1060.277 |
| 1200 repeat | 285.953 / 285.720 / 1278.140 | 212.165 / 211.897 / 1060.277 |

At 1200 blocks this is about **26% less redraw time and 17% less allocation**,
or 11.52 → 8.50 ms per redraw. Cost still grows with history size; chunk
caching does not eliminate Brick's extent/viewport bookkeeping.

Setup plus first render (one render per sample):

| Blocks | Old wall / CPU / MB | New wall / CPU / MB |
|---:|---:|---:|
| 100 | 14.474 / 14.449 / 57.647 | 14.641 / 14.621 / 57.668 |
| 600 | 85.845 / 85.667 / 324.629 | 86.569 / 86.400 / 323.350 |
| 1200 | 175.582 / 175.477 / 645.470 | 175.888 / 175.749 / 642.333 |
| 1200 repeat | 180.500 / 179.672 / 645.503 | 178.466 / 178.167 / 642.333 |

Cold cost is approximately unchanged, rather than hiding a substantial
first-render penalty behind the warm-cache improvement.

Longer-body check (`100 30 7`, including fenced code): warm old
100.971 ms / 100.893 CPU ms / 553.564 MB versus new
94.183 ms / 94.128 CPU ms / 514.257 MB. Cold old
62.771 ms / 62.725 CPU ms / 303.831 MB versus new
64.996 ms / 64.962 CPU ms / 303.852 MB: about 2.2 ms more first-render
time in this sample, with essentially identical allocation.
