### PR TITLE
Fix dictation recording startup latency

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -192,6 +192,7 @@ library
                     , Agent.CLI.Database.Storage
                     , Agent.CLI.Desktop
                     , Agent.CLI.Dictation
+                    , Agent.CLI.Dictation.Capture
                     , Agent.CLI.Dialects
                     , Agent.CLI.ExternalProgram
                     , Agent.CLI.FileUri
@@ -505,6 +506,7 @@ test-suite agent-cli-test
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Agent.CLI.ActiveAccountSpec
+                    , Agent.CLI.DictationCaptureSpec
                     , Agent.CLI.AccountSelectionSpec
                     , Agent.CLI.ApprovalSpec
                     , Agent.CLI.AgentSessionsSpec

--- a/packages/agent-cli/benchmark/DictationStartup.hs
+++ b/packages/agent-cli/benchmark/DictationStartup.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+-- Synthetic startup benchmark: no microphone, credentials or network needed.
+-- The baseline models opening the microphone after provider setup; buffered
+-- uses the production capture helper with identical PCM and setup delays.
+module Main (main) where
+
+import Agent.CLI.Dictation.Capture (withBufferedCapture)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.MVar
+import Control.Exception (evaluate)
+import Control.Monad (forM_, replicateM, unless)
+import qualified Data.ByteString as BS
+import Data.IORef
+import Data.List (sort)
+import GHC.Clock (getMonotonicTimeNSec)
+import Text.Printf (printf)
+
+main :: IO ()
+main = forM_ [200_000, 1_000_000, 200_000] \setupDelay ->
+    forM_ [10, 100] \chunkCount ->
+        forM_ [False, True] \buffered -> do
+            samples <- replicateM 5 (sample buffered setupDelay chunkCount)
+            let (ready, total) = unzip samples
+            printf "%s setup=%dms chunks=%d ready=%.2fms total=%.2fms\n"
+                (if buffered then "buffered" else "baseline" :: String)
+                (setupDelay `div` 1000) chunkCount (median ready) (median total)
+
+sample :: Bool -> Int -> Int -> IO (Double, Double)
+sample buffered setupDelay chunkCount = do
+    -- Force fixture outside the measured interval.
+    let chunk = BS.replicate 4800 7
+    expected <- evaluate (chunkCount * BS.length chunk)
+    _ <- evaluate (BS.foldl' (\a b -> a + fromIntegral b) (0 :: Int) chunk)
+    ready <- newEmptyMVar
+    received <- newIORef (0 :: Int)
+    let onRecording = getMonotonicTimeNSec >>= putMVar ready
+        capture send = do
+            threadDelay 20_000 -- same simulated hardware startup in both paths
+            forM_ [1 .. chunkCount] \_ -> send chunk
+        consume produce = do
+            threadDelay setupDelay
+            produce \bytes -> modifyIORef' received (+ BS.length bytes)
+    start <- getMonotonicTimeNSec
+    if buffered
+        then withBufferedCapture (32 * 1024 * 1024) onRecording capture consume
+        else consume \send -> do
+            first <- newIORef True
+            capture \bytes -> do
+                isFirst <- atomicModifyIORef' first (\old -> (False, old))
+                if isFirst then onRecording else pure ()
+                send bytes
+    end <- getMonotonicTimeNSec
+    firstAudio <- takeMVar ready
+    actual <- readIORef received
+    unless (actual == expected) (fail "audio lost in benchmark")
+    pure (fromIntegral (firstAudio - start) / 1e6, fromIntegral (end - start) / 1e6)
+
+median :: [Double] -> Double
+median xs = sort xs !! (length xs `div` 2)

--- a/packages/agent-cli/benchmark/DictationStartup.md
+++ b/packages/agent-cli/benchmark/DictationStartup.md
@@ -1,0 +1,33 @@
+# Dictation startup benchmark
+
+Run from the repository root inside the Nix development shell:
+
+```sh
+out=$(mktemp -d "$TMPDIR/dictation-bench.XXXXXX")
+ghc -O2 -threaded -XGHC2021 -XBlockArguments -XLambdaCase \
+  -ipackages/agent-cli/src -outputdir "$out" \
+  packages/agent-cli/benchmark/DictationStartup.hs -o "$out/bench"
+"$out/bench"
+```
+
+This isolates serial provider-then-capture startup versus `withBufferedCapture`.
+Fixtures use a simulated 20 ms microphone startup, 200/1000 ms provider setup,
+and 10/100 chunks of 4800 PCM bytes. Each result is the median of five runs;
+all runs verify the complete byte count. No microphone or network is used.
+
+GHC 9.10.3, optimized macOS run:
+
+| Setup | Chunks | Serial ready | Buffered ready | Serial total | Buffered total |
+| --- | --- | --- | --- | --- | --- |
+| 200 ms | 10 | 222.09 ms | 21.07 ms | 222.09 ms | 201.16 ms |
+| 200 ms | 100 | 221.95 ms | 20.80 ms | 221.96 ms | 201.56 ms |
+| 1000 ms | 10 | 1022.37 ms | 20.99 ms | 1022.37 ms | 1001.32 ms |
+| 1000 ms | 100 | 1022.35 ms | 20.99 ms | 1022.35 ms | 1001.51 ms |
+
+Repeating the 200 ms case at the end gave 221.58–222.11 ms serial readiness
+versus 20.82–21.05 ms buffered readiness.
+
+These are scheduling measurements, not end-to-end transcription timings.
+A separate local FFmpeg AVFoundation probe delivered first PCM at 729 ms.
+Adding `-probesize 32 -analyzeduration 1` yielded 835 ms, so those flags were
+not changed. Device startup remains; provider setup no longer precedes it.

--- a/packages/agent-cli/src/Agent/CLI/Dictation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dictation.hs
@@ -24,6 +24,7 @@ import Agent.CLI.Auth
     , loadAuth
     , loadOpenAiDictationAuth
     )
+import Agent.CLI.Dictation.Capture (withBufferedCapture)
 import Agent.CLI.Transcription (transcribeAudio)
 import Agent.CLI.GatewayClient
     ( GatewayModelAccess
@@ -90,6 +91,7 @@ import System.Process
 
 data DictationControl = DictationControl
     { dictationWaitForStop :: IO ()
+    , dictationOnRecording :: IO ()
     , dictationOnTranscript :: Text -> IO ()
     }
 
@@ -274,10 +276,10 @@ dictateForTarget target = do
     result <-
         dictateWithTarget target
             DictationControl
-                { dictationWaitForStop = do
+                { dictationWaitForStop = waitForStopKey
+                , dictationOnRecording = do
                     Text.hPutStr stderr "● Listening… press Enter to stop"
                     hFlush stderr
-                    waitForStopKey
                 , dictationOnTranscript = renderLiveTranscript
                 }
             `finally` clearLiveTranscript
@@ -306,40 +308,60 @@ dictateWithTarget target control =
         requireExecutable "ffmpeg"
         case target of
             DirectDictation provider ->
-                selectDictationBackend provider loadDictationBackendAuth
-                    >>= \case
-                        Left err ->
-                            pure (DictationFailed err)
-                        Right (backend, loaded) ->
-                            runBackend backend loaded
+                case dictationBackendsForProvider provider of
+                    Left err ->
+                        pure (DictationFailed err)
+                    Right (backend :| []) ->
+                        capture (sampleRate backend) \produceAudio ->
+                            loadDictationBackendAuth backend >>= \case
+                                Left err ->
+                                    pure (DictationFailed (dictationAuthErrorText err))
+                                Right loaded ->
+                                    runBackend backend loaded produceAudio
+                    Right _ ->
+                        -- Borrowed backends use different PCM sample rates.
+                        -- Select the credential first, then start capture before
+                        -- token refresh and provider connection setup.
+                        selectDictationBackend provider loadDictationBackendAuth
+                            >>= \case
+                                Left err ->
+                                    pure (DictationFailed err)
+                                Right (backend, loaded) ->
+                                    capture (sampleRate backend)
+                                        (runBackend backend loaded)
             GatewayDictation gateway ->
-                transcribeGatewayPcm
-                    gateway
-                    (streamMicrophone
-                        openAITranscriptionSampleRate
-                        control.dictationWaitForStop)
-                    control.dictationOnTranscript >>= \case
-                        Left err -> pure (DictationFailed err)
-                        Right transcript ->
-                            pure
-                                (DictationTranscript
-                                    (Text.strip transcript))
-    runBackend backend loaded = case backend of
+                capture openAITranscriptionSampleRate \produceAudio ->
+                    transcribeGatewayPcm
+                        gateway
+                        produceAudio
+                        control.dictationOnTranscript >>= \case
+                            Left err -> pure (DictationFailed err)
+                            Right transcript ->
+                                pure
+                                    (DictationTranscript
+                                        (Text.strip transcript))
+    -- Retain up to 32 MiB for provider retries (~11 minutes of
+    -- 24 kHz mono PCM16), without unbounded startup buffering.
+    capture rate =
+        withBufferedCapture
+            (32 * 1024 * 1024)
+            control.dictationOnRecording
+            (streamMicrophone rate control.dictationWaitForStop)
+    sampleRate = \case
+        OpenAIDictation -> openAITranscriptionSampleRate
+        XAIDictation -> 16_000
+    runBackend backend loaded produceAudio = case backend of
         OpenAIDictation ->
             finish =<<
                 transcribePcmWithOpenAI
                     loaded.loadedTokenProvider
-                    (streamMicrophone
-                        openAITranscriptionSampleRate
-                        control.dictationWaitForStop)
+                    produceAudio
                     control.dictationOnTranscript
         XAIDictation ->
             finish =<<
                 transcribePcmWithXAI
                     loaded.loadedTokenProvider
-                    (streamMicrophone
-                        16_000
-                        control.dictationWaitForStop)
+                    produceAudio
                     control.dictationOnTranscript
     finish = \case
         Left err ->

--- a/packages/agent-cli/src/Agent/CLI/Dictation/Capture.hs
+++ b/packages/agent-cli/src/Agent/CLI/Dictation/Capture.hs
@@ -1,0 +1,60 @@
+-- | Scoped, replayable microphone capture independent of provider startup.
+module Agent.CLI.Dictation.Capture (withBufferedCapture) where
+
+import Control.Concurrent.Async (wait, waitEitherCatch, withAsync)
+import Control.Concurrent.STM
+    ( atomically, newTVarIO, readTVar, retry, throwSTM, writeTVar )
+import Control.Exception.Safe (throwIO)
+import Control.Monad (unless, when)
+import qualified Data.ByteString as BS
+import qualified Data.Sequence as Seq
+
+-- | Start capture before running the consumer (including its authentication
+-- and connection setup). Each invocation of the supplied producer replays the
+-- same recording from the beginning, so an authentication retry cannot lose
+-- the opening words or reopen the microphone after the user has stopped.
+--
+-- Retention is bounded in bytes. Overflow fails explicitly instead of silently
+-- dropping speech or blocking capture behind a stalled network connection.
+-- Both workers are cancelled and joined when this scope exits.
+withBufferedCapture
+    :: Int
+    -> IO ()
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (((BS.ByteString -> IO ()) -> IO ()) -> IO a)
+    -> IO a
+withBufferedCapture byteLimit onRecording capture consume = do
+    buffer <- newTVarIO (Seq.empty, 0 :: Int, False)
+    let append bytes = unless (BS.null bytes) do
+            first <- atomically do
+                (chunks, size, done) <- readTVar buffer
+                when (BS.length bytes > byteLimit - size) $
+                    throwSTM (userError "Dictation audio buffer limit exceeded")
+                writeTVar buffer
+                    (chunks Seq.|> BS.copy bytes, size + BS.length bytes, done)
+                pure (Seq.null chunks)
+            when first onRecording
+        record = do
+            capture append
+            atomically do
+                (chunks, size, _) <- readTVar buffer
+                writeTVar buffer (chunks, size, True)
+        replay send = loop 0
+          where
+            loop index = do
+                next <- atomically do
+                    (chunks, _, done) <- readTVar buffer
+                    case Seq.lookup index chunks of
+                        Just bytes -> pure (Just bytes)
+                        Nothing | done -> pure Nothing
+                        Nothing -> retry
+                case next of
+                    Nothing -> pure ()
+                    Just bytes -> send bytes >> loop (index + 1)
+    withAsync record \recorder ->
+        withAsync (consume replay) \consumer ->
+            waitEitherCatch recorder consumer >>= \case
+                Left (Left err) -> throwIO err
+                Left (Right ()) -> wait consumer
+                Right (Left err) -> throwIO err
+                Right (Right result) -> pure result

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -281,6 +281,7 @@ handleEvent event = do
             uiEventMaySkipUnfocusedRedraw uiEvent
         AppUiBatch uiEvents ->
             all uiEventMaySkipUnfocusedRedraw uiEvents
+        AppDictationRecording{} -> True
         AppDictationPartial{} -> True
         AppAgentSnapshot{} -> True
         AppSetWindowTitle{} -> True
@@ -405,6 +406,16 @@ handleAppEvent = \case
         handleCommitImagePreviewsEvent prepared
     AppToolImage callId preview ->
         handleToolImageEvent callId preview
+    AppDictationRecording stop -> do
+        state <- get
+        recording <-
+            liftIO (Composer.dictationSessionIsRecording stop state.appDictation)
+        -- A fast transcript can beat the readiness callback to the mailbox.
+        -- Only advance the startup notice; never erase an existing transcript.
+        when (recording
+            && state.appUi.uiNotice == Just Composer.dictationStartingNotice) $
+            applyLocalUiEvent
+                (UiSetNotice (Just (Composer.dictationProgressNotice "")))
     AppDictationPartial text ->
         handleDictationPartialEvent text
     AppDictationFinished result ->
@@ -609,7 +620,13 @@ handleDictationPartialEvent
     -> EventM Name AppState ()
 handleDictationPartialEvent text = do
     state <- get
-    when (isJust state.appDictation) $
+    recording <- liftIO $
+        case state.appDictation of
+            Nothing -> pure False
+            Just session ->
+                Composer.dictationSessionIsRecording
+                    session.dictationStop state.appDictation
+    when recording $
         applyLocalUiEvent
             (UiSetNotice (Just (Composer.dictationProgressNotice text)))
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -705,6 +705,7 @@ appEventLogicalBytes = \case
             (agentTargetLogicalBytes target)
             entries
     AppSetWindowTitle text -> logicalTextBytes text
+    AppDictationRecording _ -> 256
     AppDictationPartial text -> logicalTextBytes text
     AppDictationFinished result ->
         either logicalTextBytes logicalTextBytes result

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
@@ -179,7 +179,8 @@ handleNormalKey event = do
     state <- get
     case state.appDictation of
         Just session ->
-            Composer.handleDictationKey handleCtrlC session event
+            Composer.handleDictationKey
+                applyLocalUiEvent handleCtrlC session event
         Nothing
             | Bridge.isSendNowKey event ->
                 Composer.handleComposerKey

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -368,6 +368,10 @@ runFullscreen runtime workerAction = do
                     DictationControl
                         { dictationWaitForStop =
                             job.dictationJobWaitForStop
+                        , dictationOnRecording =
+                            enqueueAppEvent runtime $
+                                AppDictationRecording
+                                    job.dictationJobRecordingSession
                         , dictationOnTranscript =
                             enqueueAppEvent runtime . AppDictationPartial
                         }

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -14,6 +14,8 @@ module Agent.CLI.TUI.Composer
     , DictationKeyAction(..)
     , dictationKeyAction
     , dictationProgressNotice
+    , dictationStartingNotice
+    , dictationSessionIsRecording
     , draftCursorLocation
     , draftWindowStart
     , drawComposer
@@ -73,12 +75,12 @@ import Agent.TUI.TextWidth
     , previousGraphemeBoundary
     )
 import Brick
-import Control.Concurrent (newEmptyMVar, takeMVar, tryPutMVar)
+import Control.Concurrent (MVar, isEmptyMVar, newEmptyMVar, readMVar, tryPutMVar)
 import Control.Concurrent.STM (atomically, writeTQueue)
 import Control.Monad (void, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
-import Data.IORef (newIORef, writeIORef)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.List (elemIndex)
 import Data.Maybe (fromMaybe)
 import qualified Data.Sequence as Seq
@@ -110,6 +112,20 @@ dictationKeyAction = \case
             Just DictationAbort
     _ -> Nothing
 
+dictationStartingNotice :: UiNotice
+dictationStartingNotice =
+    progressNotice "Starting microphone… Enter to stop · Esc to cancel"
+
+-- | A ready event can arrive after stop or after the session has finished.
+-- Keep the stop signal filled so consuming it cannot revive the listening UI.
+dictationSessionIsRecording :: MVar () -> Maybe DictationSession -> IO Bool
+dictationSessionIsRecording stop = \case
+    Just session | session.dictationStop == stop -> do
+        notStopped <- isEmptyMVar stop
+        aborted <- readIORef session.dictationAbort
+        pure (notStopped && not aborted)
+    _ -> pure False
+
 dictationProgressNotice :: Text -> UiNotice
 dictationProgressNotice transcript =
     progressNotice $
@@ -125,16 +141,21 @@ requestDictationStop session abort = do
     void (tryPutMVar session.dictationStop ())
 
 handleDictationKey
-    :: EventM Name AppState CtrlCDecision
+    :: (UiEvent -> EventM Name AppState ())
+    -> EventM Name AppState CtrlCDecision
     -> DictationSession
     -> V.Event
     -> EventM Name AppState ()
-handleDictationKey handleCtrlC session event =
+handleDictationKey applyUiEvent handleCtrlC session event =
     case dictationKeyAction event of
-        Just DictationCommit ->
+        Just DictationCommit -> do
             liftIO (requestDictationStop session False)
+            applyUiEvent $
+                UiSetNotice (Just (progressNotice "Transcribing…"))
         Just DictationAbort -> do
             liftIO (requestDictationStop session True)
+            applyUiEvent $
+                UiSetNotice (Just (progressNotice "Cancelling dictation…"))
             case event of
                 V.EvKey (V.KChar 'c') modifiers
                     | V.MCtrl `elem` modifiers ->
@@ -525,13 +546,14 @@ startDictation applyUiEvent = do
                         , dictationAbort = abort
                         }
             applyUiEvent
-                (UiSetNotice (Just (dictationProgressNotice "")))
+                (UiSetNotice (Just dictationStartingNotice))
                 \state -> state { appDictation = Just session }
             liftIO $ atomically $
                 writeTQueue
                     current.appRuntime.runtimeDictationJobs
                     DictationJob
-                        { dictationJobWaitForStop = takeMVar stop
+                        { dictationJobWaitForStop = readMVar stop
+                        , dictationJobRecordingSession = stop
                         }
 
 submitRaw :: ApplyLocalUiEvent -> ReplLine -> EventM Name AppState ()

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -185,6 +185,7 @@ data AppEvent
     | AppToolImage !Text !TuiImagePreview
       -- ^ An image the agent displayed through @show_image@, keyed by the
       -- originating tool call id.
+    | AppDictationRecording !(MVar ())
     | AppDictationPartial !Text
     | AppDictationFinished !(Either Text Text)
     | AppAgentSnapshot !AgentTarget ![AgentEntry]
@@ -427,6 +428,7 @@ data FullscreenRuntime = FullscreenRuntime
 
 data DictationJob = DictationJob
     { dictationJobWaitForStop :: IO ()
+    , dictationJobRecordingSession :: !(MVar ())
     }
 
 data DictationSession = DictationSession

--- a/packages/agent-cli/test/Agent/CLI/DictationCaptureSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DictationCaptureSpec.hs
@@ -1,0 +1,122 @@
+module Agent.CLI.DictationCaptureSpec (spec) where
+
+import Agent.CLI.Dictation.Capture (withBufferedCapture)
+import Control.Concurrent.Async (cancel, withAsync)
+import Control.Concurrent.MVar
+    ( newEmptyMVar, putMVar, readMVar, takeMVar, tryReadMVar )
+import Control.Exception.Safe (finally)
+import qualified Data.ByteString as BS
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = around_ within $ describe "buffered dictation capture" do
+    it "captures opening words while provider startup is blocked" do
+        captured <- newEmptyMVar
+        stop <- newEmptyMVar
+        let capture send = do
+                () <- send "opening words"
+                putMVar captured ()
+                takeMVar stop
+                send " ending"
+        result <- withBufferedCapture 1024 (pure ()) capture \produce -> do
+            -- Simulate provider startup: do not request audio until capture
+            -- has already happened, then stop before the provider is ready.
+            takeMVar captured
+            putMVar stop ()
+            collect produce
+        result `shouldBe` "opening words ending"
+
+    it "announces recording once and only after nonempty PCM arrives" do
+        notices <- newIORef (0 :: Int)
+        let capture send = do
+                readIORef notices `shouldReturn` 0
+                () <- send BS.empty
+                readIORef notices `shouldReturn` 0
+                () <- send "first"
+                readIORef notices `shouldReturn` 1
+                send "second"
+        result <- withBufferedCapture 1024
+            (modifyIORef' notices (+ 1)) capture collect
+        result `shouldBe` "firstsecond"
+        readIORef notices `shouldReturn` 1
+
+    it "replays the same recording for retries without reopening capture" do
+        starts <- newIORef (0 :: Int)
+        let capture send = do
+                modifyIORef' starts (+ 1)
+                send "whole recording"
+        result <- withBufferedCapture 1024 (pure ()) capture \produce -> do
+            first <- collect produce
+            second <- collect produce
+            pure (first, second)
+        result `shouldBe` ("whole recording", "whole recording")
+        readIORef starts `shouldReturn` 1
+
+    it "propagates capture failure and joins a blocked provider" do
+        providerStarted <- newEmptyMVar
+        providerClosed <- newEmptyMVar
+        never <- newEmptyMVar
+        let capture _ =
+                takeMVar providerStarted >> fail "microphone failed"
+            consume _ =
+                (putMVar providerStarted () >> takeMVar never)
+                    `finally` putMVar providerClosed ()
+        withBufferedCapture 1024 (pure ()) capture consume
+            `shouldThrow` anyIOException
+        tryReadMVar providerClosed `shouldReturn` Just ()
+
+    it "joins microphone capture when authentication fails" do
+        captureStarted <- newEmptyMVar
+        captureClosed <- newEmptyMVar
+        never <- newEmptyMVar
+        let capture _ =
+                (putMVar captureStarted () >> takeMVar never)
+                    `finally` putMVar captureClosed ()
+            consume _ =
+                takeMVar captureStarted >> fail "authentication failed"
+        withBufferedCapture 1024 (pure ()) capture consume
+            `shouldThrow` anyIOException
+        tryReadMVar captureClosed `shouldReturn` Just ()
+
+    it "joins capture and provider on cancellation during startup" do
+        captureStarted <- newEmptyMVar
+        captureClosed <- newEmptyMVar
+        providerStarted <- newEmptyMVar
+        providerClosed <- newEmptyMVar
+        never <- newEmptyMVar
+        let capture _ =
+                (putMVar captureStarted () >> readMVar never)
+                    `finally` putMVar captureClosed ()
+            consume _ =
+                (putMVar providerStarted () >> readMVar never)
+                    `finally` putMVar providerClosed ()
+        withAsync (withBufferedCapture 1024 (pure ()) capture consume) \worker -> do
+            takeMVar captureStarted
+            takeMVar providerStarted
+            cancel worker
+        tryReadMVar captureClosed `shouldReturn` Just ()
+        tryReadMVar providerClosed `shouldReturn` Just ()
+
+    it "fails explicitly rather than losing speech when the buffer is full" do
+        never <- newEmptyMVar
+        let capture send = send "1234" >> send "5"
+        withBufferedCapture 4 (pure ()) capture (const (takeMVar never))
+            `shouldThrow` anyIOException
+
+    it "completes an empty recording without announcing readiness" do
+        notices <- newIORef (0 :: Int)
+        result <- withBufferedCapture 4 (modifyIORef' notices (+ 1))
+            (\send -> send BS.empty) collect
+        result `shouldBe` BS.empty
+        readIORef notices `shouldReturn` 0
+
+collect :: ((BS.ByteString -> IO ()) -> IO ()) -> IO BS.ByteString
+collect produce = do
+    chunks <- newIORef []
+    produce \bytes -> modifyIORef' chunks (bytes :)
+    BS.concat . reverse <$> readIORef chunks
+
+within :: IO () -> IO ()
+within action = timeout 2_000_000 action >>= (`shouldBe` Just ())

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -76,6 +76,7 @@ import Agent.CLI.TUI.Types
     , ChoiceSelection(..)
     , CommandPaletteAction(..)
     , CommandPaletteEntry(..)
+    , DictationSession(..)
     , FullscreenInput(..)
     , commandPaletteActionAt
     , commandPaletteEntries

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -151,6 +151,7 @@ import Agent.TUI.Presentation
     , TodoDisplayStatus(..)
     )
 import Agent.TUI.Motion
+import Control.Concurrent (newEmptyMVar)
 import Control.Concurrent.STM
     ( atomically
     , newEmptyTMVarIO
@@ -186,6 +187,26 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "dictation readiness" do
+        it "does not erase a transcript that arrives before the ready event" do
+            stop <- newEmptyMVar
+            abort <- newIORef False
+            let ui = reduceUi
+                    (UiSetNotice (Just Composer.dictationStartingNotice))
+                    initialUiState
+            runtime <- newScriptRuntime ui
+            let initialState =
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                        { appDictation = Just (DictationSession stop abort) }
+                script =
+                    [ FullscreenScriptApp (AppDictationPartial "opening words")
+                    , FullscreenScriptApp (AppDictationRecording stop)
+                    , FullscreenScriptHalt
+                    ]
+            (_, finalState) <- runFullscreenScriptWithState initialState script
+            finalState.appUi.uiNotice
+                `shouldBe` Just (Composer.dictationProgressNotice "opening words")
+
     describe "toolImageBlockId" do
         let started callId name =
                 reduceUi

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -38,7 +38,9 @@ import Agent.TUI.TextWidth
     , nextGraphemeBoundary
     , previousGraphemeBoundary
     )
+import Control.Concurrent (newEmptyMVar, readMVar)
 import Control.Concurrent.STM (atomically)
+import Data.IORef (newIORef)
 import qualified Data.ByteString as ByteString
 import Data.Char (isControl)
 import Data.Foldable (toList)
@@ -417,6 +419,31 @@ spec = describe "fullscreen composer" do
             `shouldBe` Just DictationAbort
         dictationKeyAction (V.EvKey (V.KChar 'x') [])
             `shouldBe` Nothing
+
+    it "does not claim to listen while the microphone is starting" do
+        dictationStartingNotice.noticeKind `shouldBe` NoticeProgress
+        dictationStartingNotice.noticeTransient `shouldBe` False
+        dictationStartingNotice.noticeText
+            `shouldBe` "Starting microphone… Enter to stop · Esc to cancel"
+
+    it "ignores readiness for stopped, aborted, finished, or replaced sessions" do
+        stop <- newEmptyMVar
+        abort <- newIORef False
+        let session = DictationSession stop abort
+        dictationSessionIsRecording stop (Just session) `shouldReturn` True
+        other <- newEmptyMVar
+        dictationSessionIsRecording other (Just session) `shouldReturn` False
+        dictationSessionIsRecording stop Nothing `shouldReturn` False
+        requestDictationStop session False
+        -- The worker must observe, not consume, the persistent stop signal.
+        readMVar stop
+        dictationSessionIsRecording stop (Just session) `shouldReturn` False
+        abortStop <- newEmptyMVar
+        aborted <- newIORef False
+        let abortSession = DictationSession abortStop aborted
+        requestDictationStop abortSession True
+        dictationSessionIsRecording abortStop (Just abortSession)
+            `shouldReturn` False
 
     it "renders a non-transient listening notice for live transcripts" do
         let idle = dictationProgressNotice ""

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -26,6 +26,7 @@ import Test.Hspec.Runner
     , runSpec
     )
 import Text.Read (readMaybe)
+import qualified Agent.CLI.DictationCaptureSpec as DictationCaptureSpec
 
 import qualified Agent.CLI.ActiveAccountSpec as ActiveAccountSpec
 import qualified Agent.CLI.AccountSelectionSpec as AccountSelectionSpec
@@ -158,6 +159,7 @@ main = do
 specs :: Spec
 specs = do
     ActiveAccountSpec.spec
+    DictationCaptureSpec.spec
     AccountSelectionSpec.spec
     AgentViewportSpec.spec
     AgentViewportRuntimeSpec.spec


### PR DESCRIPTION
## Summary
- Start microphone capture concurrently with authentication/provider connection setup, retaining opening audio in a bounded replayable buffer (32 MiB) for retries.
- Show `Starting microphone…` until the first PCM chunk, then `Listening…`; keep stop/cancel states from being overwritten by late readiness events or partial transcripts.
- Preserve an early transcript if it reaches the UI before the recording-ready event.
- Add capture lifecycle/retry/overflow regressions, UI readiness regressions, and a reproducible optimized startup benchmark.

## Validation
- Capture specs: 8 examples passed in GHCi with `-Wall -Werror`.
- Composer specs: 37 examples passed (including 800 generated property cases).
- Integrated GHCi load: 212 CLI modules passed before the final early-transcript readiness guard.
- Real tmux/Brick/Vty smoke with a synthetic dictation job passed: Starting → Listening, Enter during startup → Transcribing → insertion, Esc cancellation preserves draft.
- `cabal2nix` regeneration produced identical `package.nix`; `git diff --check` passed.
- Full authenticated app startup was blocked by an existing local migration-11 mismatch (archived sessions vs provider turn telemetry); no database changes made.

## Performance
GHC 9.10.3, `-O2 -threaded`, inside the Nix development shell. Median of five samples; identical simulated 20 ms microphone startup and 10/100 × 4800-byte PCM chunks, verifying all bytes arrive.

| Provider setup | Serial first audio | Buffered first audio |
| --- | --- | --- |
| 200 ms | ~222 ms | ~21 ms |
| 1000 ms | ~1022 ms | ~21 ms |

Repeated 200 ms cases remained stable. This isolates scheduling, not end-to-end transcription. A separate local AVFoundation probe still needed ~729 ms for first PCM; FFmpeg probe flags did not improve that and were left unchanged.

Reproduce inside `nix develop`:
```sh
out=$(mktemp -d "$TMPDIR/dictation-bench.XXXXXX")
ghc -O2 -threaded -XGHC2021 -XBlockArguments -XLambdaCase \
  -ipackages/agent-cli/src -outputdir "$out" \
  packages/agent-cli/benchmark/DictationStartup.hs -o "$out/bench"
"$out/bench"
```
Full results including total elapsed time: `packages/agent-cli/benchmark/DictationStartup.md`.

## Draft / remaining work
- The implementation was developed against `2e67ab9ed`; fetched master is substantially newer. Integrate with current master and repeat validation before merging.
- The final early-transcript readiness guard and new scripted TUIAppSpec regression need a completed validation rerun; its Nix shell startup was blocked by a busy local Nix SQLite database.
