### PR TITLE
Replace native CLI options hook with typed startup policy

### DIFF
--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -6,6 +6,10 @@
 
 - `Request`: typed native turn requests and validation, independent of
   `CliOptions`. Existing CLI exports remain compatibility reexports.
+- `StartupPolicy`: host-owned permissions for workspace instruction/skill
+  context and host startup facilities. Native hooks carry this typed policy,
+  not an arbitrary CLI-options transformation. The server selects the restricted
+  preset for sandbox turns; the desktop bridge retains the host preset.
 - `Compaction`: the installed automatic-compaction checkpoint.
 - `TurnState`: preparation, conversation patches, interrupted-turn retention,
   response-chain invalidation, startup-context merging, and checkpoint rebasing.
@@ -27,6 +31,21 @@ The extraction deliberately preserves the exception scope and ordering:
 execute loop with exceptional rollback; read the compaction checkpoint outside
 that handler; clear thinking and capture timing; consume the restart request;
 finalize. A failure after loop execution must not retroactively roll it back.
+
+### Native startup policy boundary
+
+`Agent.CLI.NativeRuntime` remains the legacy execution adapter. It translates
+the native startup policy after preparing typed requests or legacy arguments.
+Restricted startup pins the admitted cwd and disables worktrees, automatic
+approval, startup input files, computer use, and code mode; supplied-context-only
+startup disables AGENTS.md and skills. These are the previous server sandbox
+restrictions, now enforced in the adapter rather than through server-owned
+`CliOptions` mutation. Host policy preserves legacy desktop options unchanged.
+Typed native turns independently retain their stricter request invariants.
+
+This removes CLI options from the server startup contract, not the server's
+dependency on CLI orchestration. Shared startup/session composition still needs
+extraction before server and CLI can call the same frontend-neutral entry point.
 
 Finalization preserves this precedence:
 

--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -58,6 +58,7 @@ library
                     , Agent.Runtime.SessionState
                     , Agent.CLI.NativeProcess
                     , Agent.Runtime.Request
+                    , Agent.Runtime.StartupPolicy
                     , Agent.Runtime.TurnEngine
                     , Agent.Runtime.TurnExecution
                     , Agent.Runtime.TurnState
@@ -142,6 +143,7 @@ test-suite agent-cli-runtime-test
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Agent.Runtime.RequestSpec
+                    , Agent.Runtime.StartupPolicySpec
                     , Agent.Runtime.ConversationStoreSpec
                     , Agent.Runtime.ConversationSessionSpec
                     , Agent.Runtime.TurnEngineSpec

--- a/packages/agent-cli-runtime/src/Agent/Runtime/StartupPolicy.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/StartupPolicy.hs
@@ -1,0 +1,41 @@
+-- | Host-owned startup permissions, independent of command-line options.
+module Agent.Runtime.StartupPolicy
+    ( NativeStartupPolicy(..)
+    , NativeContextSources(..)
+    , NativeExecutionFacilities(..)
+    , hostNativeStartupPolicy
+    , restrictedNativeStartupPolicy
+    ) where
+
+-- | Whether startup may augment supplied context with workspace instruction
+-- files and skills. Workspace discovery itself is configured separately.
+data NativeContextSources
+    = WorkspaceContextAllowed
+    | SuppliedContextOnly
+    deriving (Eq, Show)
+
+-- | Legacy host embeddings may request host startup facilities. A restricted
+-- embedding executes only the supplied turn: no workspace switching, startup
+-- input files, automatic approval, computer use, or code-mode startup.
+data NativeExecutionFacilities
+    = HostStartupFacilities
+    | TurnScopedFacilities
+    deriving (Eq, Show)
+
+data NativeStartupPolicy = NativeStartupPolicy
+    { nativeContextSources :: !NativeContextSources
+    , nativeExecutionFacilities :: !NativeExecutionFacilities
+    }
+    deriving (Eq, Show)
+
+hostNativeStartupPolicy :: NativeStartupPolicy
+hostNativeStartupPolicy = NativeStartupPolicy
+    { nativeContextSources = WorkspaceContextAllowed
+    , nativeExecutionFacilities = HostStartupFacilities
+    }
+
+restrictedNativeStartupPolicy :: NativeStartupPolicy
+restrictedNativeStartupPolicy = NativeStartupPolicy
+    { nativeContextSources = SuppliedContextOnly
+    , nativeExecutionFacilities = TurnScopedFacilities
+    }

--- a/packages/agent-cli-runtime/test/Agent/Runtime/StartupPolicySpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/Runtime/StartupPolicySpec.hs
@@ -1,0 +1,14 @@
+module Agent.Runtime.StartupPolicySpec (spec) where
+
+import Agent.Runtime.StartupPolicy
+import Test.Hspec
+
+spec :: Spec
+spec = describe "native startup permissions" do
+    it "requires both context and execution restrictions for the restricted preset" do
+        restrictedNativeStartupPolicy
+            `shouldBe` NativeStartupPolicy SuppliedContextOnly TurnScopedFacilities
+
+    it "retains both legacy host permissions for the host preset" do
+        hostNativeStartupPolicy
+            `shouldBe` NativeStartupPolicy WorkspaceContextAllowed HostStartupFacilities

--- a/packages/agent-cli-runtime/test/Spec.hs
+++ b/packages/agent-cli-runtime/test/Spec.hs
@@ -16,6 +16,7 @@ import qualified Agent.CLI.ModelsSpec as ModelsSpec
 import qualified Agent.CLI.NativeProcessSpec as NativeProcessSpec
 import qualified Agent.CLI.SessionSpec as SessionSpec
 import qualified Agent.Runtime.RequestSpec as RuntimeRequestSpec
+import qualified Agent.Runtime.StartupPolicySpec as StartupPolicySpec
 import qualified Agent.Runtime.ConversationStoreSpec as ConversationStoreSpec
 import qualified Agent.Runtime.ConversationSessionSpec as ConversationSessionSpec
 import qualified Agent.Runtime.TurnEngineSpec as TurnEngineSpec
@@ -44,6 +45,7 @@ main = hspec do
     NativeProcessSpec.spec
     SessionSpec.spec
     RuntimeRequestSpec.spec
+    StartupPolicySpec.spec
     ConversationStoreSpec.spec
     ConversationSessionSpec.spec
     TurnEngineSpec.spec

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -15,6 +15,7 @@ module Agent.CLI.NativeRuntime
     , closeNativeProcessRuntime
     , newNativeProcessRuntime
     , nativeTurnOptions
+    , applyNativeStartupPolicy
     , restartNativeMcpRuntime
     , runNativeAgent
     , runNativeTurn
@@ -31,6 +32,11 @@ import Agent.CLI.NativeProcess
     , closeNativeProcessRuntime
     , newNativeProcessRuntime
     , restartNativeMcpRuntime
+    )
+import Agent.Runtime.StartupPolicy
+    ( NativeStartupPolicy(..)
+    , NativeContextSources(..)
+    , NativeExecutionFacilities(..)
     )
 import Agent.Loop
     ( TurnAttachment(ImageAttachmentItem)
@@ -161,29 +167,53 @@ runNativeOptions
     -> CliOptions
     -> IO (Either Text ())
 runNativeOptions runtime output cwd hooks options =
-    case hooks.nativePrepareOptions options of
-        Left err -> pure (Left err)
-        Right preparedOptions ->
-            runAgentWithRuntime
-                AgentProcessRuntime
-                    { processMcpSupervisor = runtime.nativeMcpSupervisor
-                    , processSessionThreads = runtime.nativeSessionThreads
-                    , processStartCleanup = runtime.nativeStartCleanup
-                    , processMcpElicitation = runtime.nativeMcpElicitation
-                    , processNetworkRecovery =
-                        networkRecovery runtime.nativeNetworkRecovery
-                    }
-                (nativeRunMode output cwd hooks)
-                (shellOptions preparedOptions) >>= \case
-                    DevQuit -> pure (Right ())
-                    DevReload _ ->
-                        pure (Left
-                            "native turn unexpectedly requested a reload")
+    runAgentWithRuntime
+        AgentProcessRuntime
+            { processMcpSupervisor = runtime.nativeMcpSupervisor
+            , processSessionThreads = runtime.nativeSessionThreads
+            , processStartCleanup = runtime.nativeStartCleanup
+            , processMcpElicitation = runtime.nativeMcpElicitation
+            , processNetworkRecovery =
+                networkRecovery runtime.nativeNetworkRecovery
+            }
+        (nativeRunMode output cwd hooks)
+        (applyNativeStartupPolicy hooks.nativeStartupPolicy cwd
+            (shellOptions options)) >>= \case
+            DevQuit -> pure (Right ())
+            DevReload _ ->
+                pure (Left
+                    "native turn unexpectedly requested a reload")
   where
     shellOptions prepared =
         prepared
             { optGhci = nativeGhciEnabled hooks.nativeShellMode
             , optBash = nativeBashEnabled hooks.nativeShellMode
+            }
+
+-- | The only legacy-options translation of native startup permissions.
+-- Apply after request/argument preparation so conflicting options cannot
+-- relax the embedding's restrictions. Typed-turn invariants are enforced
+-- independently by 'nativeTurnOptions'.
+applyNativeStartupPolicy :: NativeStartupPolicy -> OsPath -> CliOptions -> CliOptions
+applyNativeStartupPolicy policy cwd = restrictContext . restrictFacilities
+  where
+    restrictContext options = case policy.nativeContextSources of
+        WorkspaceContextAllowed -> options
+        SuppliedContextOnly -> options
+            { optAgentsMd = False
+            , optSkills = False
+            }
+    restrictFacilities options = case policy.nativeExecutionFacilities of
+        HostStartupFacilities -> options
+        TurnScopedFacilities -> options
+            { optCwd = Just cwd
+            , optWorktree = False
+            , optYolo = False
+            , optNoYolo = True
+            , optPromptFile = Nothing
+            , optManagedTurnFile = Nothing
+            , optComputerUse = False
+            , optCodeMode = False
             }
 
 nativeGhciEnabled :: NativeShellMode -> Bool

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -18,13 +18,13 @@ module Agent.CLI.Runtime.Orchestration.Types
 
 import Agent.CLI.AgentSessions ( SessionThreadManager )
 import Agent.CLI.AgentViewport ( AgentEntry )
-import Agent.CLI.Options ( CliOptions )
 import Agent.CLI.Project ( ProjectSettings )
 import Agent.Connectivity.NetworkPath ( NetworkRecovery )
 import Agent.CLI.Permission ( PermissionChoice )
 import Agent.Loop ( LoopEvent, TurnInput )
 import Agent.Provider ( Credential, TokenProvider )
 import Agent.Runtime.Request (NativeInteractionMode(..), NativeShellMode(..))
+import Agent.Runtime.StartupPolicy (NativeStartupPolicy)
 import Agent.Store.Postgres ( Store )
 import Agent.ToolDispatch ( ToolCall )
 import Agent.Tools.PlanMode ( PlanModeHooks )
@@ -138,8 +138,8 @@ data NativeRunHooks = NativeRunHooks
     , nativeDatabaseScopeNamespace :: !(Maybe Text)
     , nativeWorkspaceDiscovery :: !NativeWorkspaceDiscovery
     , nativeCapabilities :: !NativeRunCapabilities
-    -- | Last-mile option policy owned by the embedding.
-    , nativePrepareOptions :: !(CliOptions -> Either Text CliOptions)
+    -- | Startup permissions owned by the embedding, not an options callback.
+    , nativeStartupPolicy :: !NativeStartupPolicy
     }
 
 data AgentRunMode = AgentRunMode

--- a/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
@@ -10,12 +10,17 @@ import Agent.CLI.NativeRuntime
     , nativeLoadsHostWorkspaceContext
     , nativePreparedDiscovery
     , nativeTurnOptions
+    , applyNativeStartupPolicy
     )
 import Agent.CLI.Options
     ( CliOptions(..)
     , ScreenMode(..)
+    , defaultCliOptions
     )
+import Agent.Runtime.StartupPolicy
+import Control.Monad (forM_)
 import Agent.Provider (Provider(..))
+import Agent.Loop (ImageAttachment(..))
 import Agent.CLI.Project (defaultProjectSettings)
 import Agent.ReasoningEffort (ReasoningEffort(..))
 import Agent.TUI.Motion (MotionMode(..))
@@ -24,6 +29,78 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "nativeTurnOptions" do
+    it "preserves legacy host startup options exactly" do
+        applyNativeStartupPolicy hostNativeStartupPolicy
+            (unsafeEncodeUtf "/admitted") conflictingOptions
+            `shouldBe` conflictingOptions
+
+    it "enforces every restricted startup setting against conflicting options" do
+        let cwd = unsafeEncodeUtf "/admitted"
+            actual = applyNativeStartupPolicy restrictedNativeStartupPolicy cwd
+                conflictingOptions
+            expected = conflictingOptions
+                { optCwd = Just cwd
+                , optWorktree = False
+                , optYolo = False
+                , optNoYolo = True
+                , optPromptFile = Nothing
+                , optManagedTurnFile = Nothing
+                , optAgentsMd = False
+                , optSkills = False
+                , optComputerUse = False
+                , optCodeMode = False
+                }
+        actual `shouldBe` expected
+        applyNativeStartupPolicy restrictedNativeStartupPolicy cwd actual
+            `shouldBe` actual
+
+    it "can exclude workspace context without changing execution facilities" do
+        let policy = hostNativeStartupPolicy
+                { nativeContextSources = SuppliedContextOnly }
+        applyNativeStartupPolicy policy (unsafeEncodeUtf "/admitted") conflictingOptions
+            `shouldBe` conflictingOptions { optAgentsMd = False, optSkills = False }
+
+    it "does not re-enable caller-disabled context under host policy" do
+        let options = defaultCliOptions { optAgentsMd = False, optSkills = False }
+        applyNativeStartupPolicy hostNativeStartupPolicy (unsafeEncodeUtf "/admitted") options
+            `shouldBe` options
+
+    it "accepts image-only typed requests without introducing startup input files" do
+        let request = baseRequest
+                { nativeTurnPrompt = ""
+                , nativeTurnImages = [ImageAttachment "image/png" "image bytes"]
+                }
+        lowered <- shouldReturnRight (nativeTurnOptions request)
+        forM_ [hostNativeStartupPolicy, restrictedNativeStartupPolicy] \policy -> do
+            let options = applyNativeStartupPolicy policy request.nativeTurnCwd lowered
+            options.optPrompt `shouldBe` Just ""
+            options.optPromptFile `shouldBe` Nothing
+            options.optManagedTurnFile `shouldBe` Nothing
+
+    forM_ [hostNativeStartupPolicy, restrictedNativeStartupPolicy] \policy ->
+        forM_ [NativeNewSession, NativeResumeSession "existing"] \session ->
+            forM_ [NativeAsk, NativePlan] \interaction ->
+                forM_ [NativeShellNone, NativeShellGhci, NativeShellBash, NativeShellBoth] \shell ->
+                    it ("preserves typed turn fields under " <> show (policy, session, interaction, shell)) do
+                        let request = baseRequest
+                                { nativeTurnSession = session
+                                , nativeTurnInteractionMode = interaction
+                                , nativeTurnShellMode = shell
+                                }
+                        lowered <- shouldReturnRight (nativeTurnOptions request)
+                        let options = applyNativeStartupPolicy policy request.nativeTurnCwd lowered
+                        options.optPrompt `shouldBe` lowered.optPrompt
+                        options.optResume `shouldBe` lowered.optResume
+                        options.optGhci `shouldBe` lowered.optGhci
+                        options.optBash `shouldBe` lowered.optBash
+                        options.optCwd `shouldBe` Just request.nativeTurnCwd
+                        options.optYolo `shouldBe` False
+                        options.optNoYolo `shouldBe` True
+                        options.optWorktree `shouldBe` False
+                        options.optPromptFile `shouldBe` Nothing
+                        options.optManagedTurnFile `shouldBe` Nothing
+                        options.optComputerUse `shouldBe` False
+
     it "lowers a new typed turn without enabling native-only capabilities" do
         let cwd = unsafeEncodeUtf "/tmp/project"
             request = NativeTurnRequest
@@ -78,6 +155,15 @@ spec = describe "nativeTurnOptions" do
             )
             `shouldBe` Left "typed native turns do not support auto-approval"
 
+    it "keeps approval validation ahead of resume validation under either policy" do
+        forM_ [hostNativeStartupPolicy, restrictedNativeStartupPolicy] \policy -> do
+            let request = baseRequest
+                    { nativeTurnInteractionMode = NativeYolo
+                    , nativeTurnSession = NativeResumeSession " "
+                    }
+            (applyNativeStartupPolicy policy request.nativeTurnCwd <$> nativeTurnOptions request)
+                `shouldBe` Left "typed native turns do not support auto-approval"
+
     it "requires prepared discovery whenever host discovery is disabled" do
         let root = unsafeEncodeUtf "/prepared/root"
             prepared = NativeDiscoveryContext
@@ -122,6 +208,22 @@ baseRequest = NativeTurnRequest
     , nativeTurnEffort = Nothing
     , nativeTurnInteractionMode = NativeAsk
     , nativeTurnShellMode = NativeShellNone
+    }
+
+conflictingOptions :: CliOptions
+conflictingOptions = defaultCliOptions
+    { optCwd = Just (unsafeEncodeUtf "/untrusted")
+    , optWorktree = True
+    , optYolo = True
+    , optNoYolo = False
+    , optPromptFile = Just (unsafeEncodeUtf "/untrusted/prompt")
+    , optManagedTurnFile = Just (unsafeEncodeUtf "/untrusted/turn")
+    , optAgentsMd = True
+    , optSkills = True
+    , optComputerUse = True
+    , optCodeMode = True
+    , optPrompt = Just "preserve supplied input"
+    , optResume = Just "preserve-session"
     }
 
 shouldReturnRight :: (Show err) => Either err value -> IO value

--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -111,6 +111,7 @@ foreign-library haskell-agent-bridge
     build-depends:    agent-native-bridge
                     , agent-repository >= 0.1 && < 0.2
                     , agent-cli >= 0.1 && < 0.2
+                    , agent-cli-runtime >= 0.1 && < 0.2
                     , agent-runtime-daemon >= 0.1 && < 0.2
                     , agent-core >= 0.1 && < 0.2
                     , agent-responses-types >= 0.1 && < 0.2

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
@@ -27,6 +27,7 @@ import Agent.CLI.NativeRuntime
     )
 import Agent.Loop
     ( ImageAttachment, LoopEvent(..), TurnOutput(..), emptyTokenUsage )
+import Agent.Runtime.StartupPolicy (hostNativeStartupPolicy)
 import Agent.Tools.Types (AppTool(..), AppToolGroup(..), appToolsFromGroups)
 import Control.Concurrent.STM (atomically, writeTVar)
 import Control.Exception.Safe (SomeException, fromException, tryAny)
@@ -127,7 +128,7 @@ runNativeTurn
             , nativeDatabaseScopeNamespace = Nothing
             , nativeWorkspaceDiscovery = DiscoverHostWorkspace
             , nativeCapabilities = fullNativeRunCapabilities
-            , nativePrepareOptions = Right
+            , nativeStartupPolicy = hostNativeStartupPolicy
             }
         args = nativeTurnArguments start
     result <- tryAny $

--- a/packages/agent-native-bridge/package.nix
+++ b/packages/agent-native-bridge/package.nix
@@ -15,7 +15,7 @@ mkDerivation {
     agent-cli agent-core agent-json agent-mcp agent-store base
     base64-bytestring bytestring containers filepath network-uri text time transformers
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    aeson agent-openai agent-openrouter agent-repository
+    aeson agent-cli-runtime agent-openai agent-openrouter agent-repository
     agent-responses-types agent-runtime-daemon agent-xai async directory
     filelock JuicyPixels safe-exceptions stm
   ];

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -48,7 +48,8 @@ import Agent.Runtime.Request
     , NativeShellMode(..)
     , NativeTurnRequest(..)
     )
-import Agent.CLI.Options (CliOptions(..))
+import Agent.Runtime.StartupPolicy
+    ( hostNativeStartupPolicy, restrictedNativeStartupPolicy )
 import Agent.CLI.Project (defaultProjectSettings)
 import Agent.CLI.Permission.Types (PermissionChoice(..))
 import Agent.CLI.Runtime.Options (defaultEffortFor)
@@ -1383,26 +1384,11 @@ nativeHooks environment control sessionId cwd dialect = NativeRunHooks
                 , nativeCollaboration = False
                 , nativeProviderNativeTools = False
                 }
-    , nativePrepareOptions =
+    , nativeStartupPolicy =
         case environment.environmentSandbox of
-            Nothing -> Right
-            Just _ -> Right . restrictSandboxOptions cwd
+            Nothing -> hostNativeStartupPolicy
+            Just _ -> restrictedNativeStartupPolicy
     }
-
-restrictSandboxOptions :: FilePath -> CliOptions -> CliOptions
-restrictSandboxOptions cwd options =
-    options
-        { optCwd = Just (unsafeEncodeUtf cwd)
-        , optWorktree = False
-        , optYolo = False
-        , optNoYolo = True
-        , optPromptFile = Nothing
-        , optManagedTurnFile = Nothing
-        , optAgentsMd = False
-        , optSkills = False
-        , optComputerUse = False
-        , optCodeMode = False
-        }
 
 tenantShellMode :: RuntimeEnvironment -> NativeShellMode
 tenantShellMode environment =

--- a/scripts/check-package-boundaries.sh
+++ b/scripts/check-package-boundaries.sh
@@ -50,6 +50,13 @@ moved_modules=(
   Agent.CLI.MacOS.ResourceAdmin
 )
 
+if rg --line-number 'CliOptions|Agent\.CLI\.Options|nativePrepareOptions' \
+  "$root/packages/agent-server/src/Agent/Server/Runtime.hs" \
+  "$root/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs" \
+  "$root/packages/agent-cli-runtime/src/Agent/Runtime/StartupPolicy.hs"; then
+  fail "native startup contracts and server runtime must not depend on CLI options"
+fi
+
 for module in "${moved_modules[@]}"; do
   if rg --line-number --fixed-strings "$module" "$cli"; then
     fail "$module leaked back into agent-cli"
@@ -99,6 +106,7 @@ for registration in \
 done
 
 required_files=(
+  packages/agent-cli-runtime/src/Agent/Runtime/StartupPolicy.hs
   packages/agent-cli-runtime/src/Agent/Runtime/ConversationStore.hs
   packages/agent-cli-runtime/src/Agent/Runtime/SessionState.hs
   packages/agent-cli-runtime/test/Agent/Runtime/ConversationStoreSpec.hs


### PR DESCRIPTION
## Summary
- Introduce frontend-neutral native startup policy in Agent.Runtime, separating workspace context sources from startup facilities.
- Replace nativePrepareOptions with typed policy; migrate server and macOS bridge while keeping legacy option translation in the CLI adapter.
- Preserve existing sandbox restrictions and host behavior; remove CliOptions from server runtime and add boundary checks.
- Add policy and adapter regression cases and document the remaining orchestration boundary.

## Validation
- 350 modules loaded successfully in package-aware GHCi, including runtime, CLI, server and macOS bridge foreign library.
- 7 focused runtime policy/request tests pass.
- Package-boundary checks and git diff --check pass.
- Regenerated affected Nix expressions; retained documented Darwin foreign-library dependencies.

## Limitations
- The 43-case CLI NativeRuntimeSpec was not executed locally: the object-code test REPL dependency build was stopped before tests when free disk dropped to approximately 402 MB. CI must validate these cases.
- nix develop remains blocked by a local filesystem permission error; validation used the inherited Nix toolchain and verified flake-pinned prompt/model assets.
- This removes the CLI-shaped startup-policy contract, not the broader server-to-CLI orchestration dependency. No UI behavior change or performance claim.