### PR TITLE
Warn on unknown inline skill mentions

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -130,7 +130,7 @@ import Agent.Runtime.SessionState qualified as RuntimeState
 import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.Skills
     ( formatSkillsListing
-    , resolvePromptSkillMentions
+    , resolvePromptSkillMentionsWithWarnings
     )
 import Agent.CLI.Status ( applyReplMode, cycleReplInteraction )
 import Agent.CLI.Style
@@ -155,7 +155,7 @@ import Agent.CLI.Terminal
     )
 import Agent.CLI.Turn ( runOneTurn )
 import Agent.Loop
-    ( LoopEvent(ActivityUpdated)
+    ( LoopEvent(ActivityUpdated, WarningRaised)
     , TurnAttachment(ImageAttachmentItem)
     , TurnInput(UserMessage)
     , userMessageWithAttachments
@@ -1606,13 +1606,21 @@ preparePromptSkillInputsWithPaste
     -> IO (Either Text [TurnInput])
 preparePromptSkillInputsWithPaste env pasted prompt inputs = do
     invocations <- readIORef env.sessionSkillInvocations
-    pure do
-        selected <- resolvePromptSkillMentions pasted invocations prompt
-        let activations =
-                [ UserMessage (formatSkillActivation invocation prompt)
-                | invocation <- selected
-                ]
-        pure (activations <> inputs)
+    let (warnings, selected) =
+            resolvePromptSkillMentionsWithWarnings pasted invocations prompt
+        activations =
+            [ UserMessage (formatSkillActivation invocation prompt)
+            | invocation <- selected
+            ]
+    mapM_ reportWarning warnings
+    pure (Right (activations <> inputs))
+  where
+    reportWarning warning =
+        let message = "Ignoring skill mention: " <> warning
+        in case env.sessionFullscreen of
+            Nothing -> renderEvent env.sessionRender (WarningRaised message)
+            Just runtime ->
+                emitUiEvent runtime (UiSystemMessage ("Warning: " <> message))
 
 putTrailingNewline :: RenderConfig -> IO ()
 putTrailingNewline render = do

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Skills
     , queueSkillCatalogContextWithOmissions
     , reservedSlashNames
     , resolvePromptSkillMentions
+    , resolvePromptSkillMentionsWithWarnings
     , skillInvocationCommand
     ) where
 
@@ -54,9 +55,17 @@ resolvePromptSkillMentions
     -> [SkillInvocation]
     -> Text
     -> Either Text [SkillInvocation]
-resolvePromptSkillMentions pasted invocations prompt
-    | pasted = Right []
-    | otherwise = resolveSkillMentions invocations prompt
+resolvePromptSkillMentions pasted invocations prompt =
+    Right (snd (resolvePromptSkillMentionsWithWarnings pasted invocations prompt))
+
+resolvePromptSkillMentionsWithWarnings
+    :: Bool
+    -> [SkillInvocation]
+    -> Text
+    -> ([Text], [SkillInvocation])
+resolvePromptSkillMentionsWithWarnings pasted invocations prompt
+    | pasted = ([], [])
+    | otherwise = resolveSkillMentionsWithWarnings invocations prompt
 
 loadSkillsCatalog
     :: CliOptions

--- a/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SkillsSpec.hs
@@ -201,9 +201,22 @@ spec = describe "Agent.CLI.Skills" do
         resolvePromptSkillMentions True invocations pastedSql
             `shouldBe` Right []
         resolvePromptSkillMentions False invocations pastedSql
-            `shouldSatisfy` isLeft
+            `shouldBe` Right []
         resolvePromptSkillMentions False invocations "please $deploy"
             `shouldBe` Right invocations
+
+    it "warns about unknown skill mentions without rejecting the prompt" do
+        let invocations = [SkillInvocation "deploy" fakeSkill True]
+        resolvePromptSkillMentionsWithWarnings
+            False
+            invocations
+            "compare $missing with $deploy"
+            `shouldBe`
+                ( [ "unknown skill: missing"
+                        <> " (available: deploy)"
+                  ]
+                , invocations
+                )
 
     it "installs a deferred catalog, invocations, and startup context together" do
         context <- newIORef (Just "agents")

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -17,6 +17,7 @@ module Agent.Skills
     , formatSkillActivation
     , resolveSkillInvocation
     , resolveSkillMentions
+    , resolveSkillMentionsWithWarnings
     ) where
 
 import Agent.Concurrent (mapConcurrentlyBounded)
@@ -649,19 +650,37 @@ resolveSkillMentions
     -> Text
     -> Either Text [SkillInvocation]
 resolveSkillMentions invocations text =
-    dedupe <$> traverse resolve mentioned
+    dedupe <$> traverse resolve (skillMentionNames text)
   where
-    mentioned =
-        [ Text.drop 1 token
-        | token <- Text.words text
-        , "$" `Text.isPrefixOf` token
-        , let name = Text.drop 1 token
-        , not (Text.null name)
-        , Text.all mentionChar name
-        ]
-    mentionChar c = isAlphaNum c || c `elem` ['-', ':']
     resolve = resolveSkillInvocation invocations
-    dedupe = go Set.empty
+
+resolveSkillMentionsWithWarnings
+    :: [SkillInvocation]
+    -> Text
+    -> ([Text], [SkillInvocation])
+resolveSkillMentionsWithWarnings invocations text =
+    ( [warning | Left warning <- resolved]
+    , dedupe [invocation | Right invocation <- resolved]
+    )
+  where
+    resolved =
+        map (resolveSkillInvocation invocations) (skillMentionNames text)
+
+skillMentionNames :: Text -> [Text]
+skillMentionNames text =
+    [ name
+    | token <- Text.words text
+    , "$" `Text.isPrefixOf` token
+    , let name = Text.drop 1 token
+    , not (Text.null name)
+    , Text.all mentionChar name
+    ]
+  where
+    mentionChar c = isAlphaNum c || c `elem` ['-', ':']
+
+dedupe :: [SkillInvocation] -> [SkillInvocation]
+dedupe = go Set.empty
+  where
     go :: Set OsPath -> [SkillInvocation] -> [SkillInvocation]
     go _ [] = []
     go seen (item:rest)

--- a/packages/agent-core/test/Agent/SkillsSpec.hs
+++ b/packages/agent-core/test/Agent/SkillsSpec.hs
@@ -216,6 +216,15 @@ spec = describe "Agent.Skills" do
             `shouldBe` Right [invocation]
         resolveSkillMentions [invocation] "use $missing"
             `shouldSatisfy` isLeft
+        resolveSkillMentionsWithWarnings
+            [invocation]
+            "use $missing then $deploy"
+            `shouldBe`
+                ( [ "unknown skill: missing"
+                        <> " (available: deploy)"
+                  ]
+                , [invocation]
+                )
         formatSkillActivation invocation "production"
             `shouldSatisfy` Text.isInfixOf "Invocation arguments: production"
 


### PR DESCRIPTION
## Summary
- Treat unknown `$skill` mentions as a warning instead of aborting the user prompt.
- Pasted or typed text that happens to contain `$1`, `$HOME`, or similar tokens can now submit; known skills still activate as before.
- Inline and fullscreen UIs both surface `Ignoring skill mention: unknown skill: ...`.

Pasting SQL, shell snippets, or other code with dollar signs used to fail with an invalid-skill error. Unknown mentions are now ignored after a warning so the turn continues.

## Testing
- `packages/agent-cli/test/Agent/CLI/SkillsSpec.hs`: unknown mentions no longer reject the prompt; warnings are collected alongside valid skill activations.
- `packages/agent-core/test/Agent/SkillsSpec.hs`: `resolveSkillMentionsWithWarnings` returns the unknown-skill warning and keeps known invocations.
- Live tmux smoke: character-by-character input of `$1` preserved the token, submission continued, and the warning rendered instead of aborting.