### PR TITLE
Keep agent scratch work in the session temp directory

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -286,6 +286,7 @@ sessionTempGuidance = \case
         Text.unlines
             [ "Session temporary directory: " <> toText path
             , "Use this private directory for clones, downloads, extracted files, generated assets, and other scratch work."
+            , "This is the only scratch root for the session. Do not create alternate temporary directories in the home directory, the workspace, or elsewhere under ~/.haskell-agent; create task-specific subdirectories under $TMPDIR instead."
             , "Filesystem tools may access both the workspace and this directory; relative paths still resolve against the workspace."
             , "Filesystem-tool paths under /tmp or /private/tmp are redirected into this directory."
             , "HASKELL_AGENT_TMPDIR and TMPDIR point to this directory for shell commands; use $TMPDIR instead of a literal /tmp or /private/tmp path."

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -516,6 +516,12 @@ spec = describe "systemPrompt" do
             "/Users/test/.haskell-agent/tmp/sessions/2026-08-19-abcd1234"
         rootPrompt `shouldSatisfy` Text.isInfixOf
             "clones, downloads, extracted files, generated assets"
+        rootPrompt `shouldSatisfy` Text.isInfixOf
+            "only scratch root for the session"
+        childPrompt `shouldSatisfy` Text.isInfixOf
+            "Do not create alternate temporary directories"
+        childPrompt `shouldSatisfy` Text.isInfixOf
+            "task-specific subdirectories under $TMPDIR"
         childPrompt `shouldSatisfy` Text.isInfixOf
             "relative paths still resolve against the workspace"
         rootPrompt `shouldSatisfy` Text.isInfixOf

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -205,7 +205,7 @@ shellDescription :: Text
 shellDescription =
     "Runs a shell command and returns its output.\n\
     \- `workdir` is optional; omit it to use the turn cwd. Do not use `cd` unless absolutely necessary.\n\
-    \- Use `$TMPDIR` for temporary files; literal `/tmp` and `/private/tmp` paths are rejected.\n\
+    \- Use `$TMPDIR` as the only temporary-file root. Put task-specific subdirectories there; do not create alternate scratch directories in the home directory or workspace. Literal `/tmp` and `/private/tmp` paths are rejected.\n\
     \- By default, a command that is still running after 10000 ms is retained and returned with a session_id. Completion is reported automatically; do not poll or run sleep commands while waiting.\n\
     \- Set `timeout_ms` only when the command should be stopped after a fixed runtime, or `yield_time_ms` to change the initial wait.\n\
     \- Use `write_stdin` only to send input, interrupt, inspect a current snapshot, or perform one bounded wait."

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Monitor.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Monitor.hs
@@ -51,7 +51,7 @@ monitorDescription :: Text
 monitorDescription =
     "Start a background monitor that streams events from a long-running script. Each stdout line is an event; exit ends the watch.\n\n\
     \Print only meaningful status changes. Use line-buffered commands in pipes so events are not delayed.\n\n\
-    \Use `$TMPDIR` for temporary files; literal `/tmp` and `/private/tmp` paths are rejected.\n\n\
+    \Use `$TMPDIR` as the only temporary-file root. Put task-specific subdirectories there; do not create alternate scratch directories in the home directory or workspace. Literal `/tmp` and `/private/tmp` paths are rejected.\n\n\
     \Set persistent=true for session-length watches. Otherwise the monitor stops at timeout_ms (default 10h)."
 
 runMonitor :: GrokSession -> MonitorArgs -> IO (Either Text Text)

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
@@ -89,7 +89,7 @@ terminalDescription :: Text
 terminalDescription =
     "Run a bash command and return its output.\n\
     \- Always set a timeout for commands that may hang.\n\
-    \- Use `$TMPDIR` for temporary files; literal `/tmp` and `/private/tmp` paths are rejected.\n\
+    \- Use `$TMPDIR` as the only temporary-file root. Put task-specific subdirectories there; do not create alternate scratch directories in the home directory or workspace. Literal `/tmp` and `/private/tmp` paths are rejected.\n\
     \- Prefer dedicated tools (read_file, grep, list_dir, search_replace) over shell equivalents when they exist."
 
 runTerminal


### PR DESCRIPTION
Summary: Make the per-session temporary directory the only scratch root in agent guidance; mirror the requirement in Codex and Grok tool descriptions; cover the wording in prompt tests. Testing: focused object-code GHCi example passed with 1 example and 0 failures; edited libraries loaded in multi-package GHCi; diff check passed.