### PR TITLE
Reduce root TUI rendering work with measured viewport composition

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -269,6 +269,7 @@ library
                     , Agent.CLI.TUI.ImagePreview
                     , Agent.CLI.TUI.Scroll
                     , Agent.CLI.TUI.Transcript
+                    , Agent.CLI.TUI.MeasuredViewport
                     , Agent.CLI.TUI.Types
                     , Agent.CLI.Turn
                     , Agent.CLI.TurnState
@@ -589,6 +590,7 @@ test-suite agent-cli-test
                     , Agent.CLI.TUIHistorySpec
                     , Agent.CLI.TUIScrollSpec
                     , Agent.CLI.TUITranscriptSpec
+                    , Agent.CLI.TUIMeasuredViewportSpec
                     , Agent.CLI.UsageSpec
                     , Agent.CLI.WebLspSpec
                     , Agent.CLI.WorktreeSpec

--- a/packages/agent-cli/benchmark/MeasuredViewport.md
+++ b/packages/agent-cli/benchmark/MeasuredViewport.md
@@ -1,0 +1,91 @@
+# Measured viewport rendering
+
+Status: root conversation integration locally validated. These are local
+renderer benchmarks, not released UI or terminal-I/O measurements.
+
+The adapter measures retained chunks, delegates scroll resolution to Brick,
+and composes only intersecting results plus touching neighbors for border
+joins. This still visits every chunk on each frame; it is not constant-time
+virtualization or a persistent height index.
+
+## Reproduce
+
+```sh
+nix develop -c cabal build --offline agent-cli:bench:transcript-scrolling-bench
+B=$(nix develop -c cabal list-bin agent-cli:bench:transcript-scrolling-bench)
+for n in 100 600 1200 1200; do
+  "$B" history-chunk-cache "$n" 3 7 +RTS -T
+  "$B" history-measured-viewport "$n" 3 7 +RTS -T
+done
+```
+
+Same fixture, compiler settings, forcing, and timing method as
+[HistoryRendering.md](HistoryRendering.md). Seven samples, median wall-time
+sample, 25 warm redraws per sample, 100×32 viewport, no scrollbar. These are
+stationary redraws, not terminal I/O.
+
+## Initial results (2026-09-07, aarch64 macOS)
+
+Warm totals, milliseconds / decimal MB allocated:
+
+| Blocks | Retained chunk cache | Measured viewport |
+|---:|---:|---:|
+| 100 | 15.176 / 124.425 | 12.715 / 101.805 |
+| 600 | 106.015 / 520.850 | 78.102 / 332.970 |
+| 1200 | 206.503 / 991.565 | 150.497 / 607.369 |
+| 1200 repeat | 206.269 / 991.565 | 146.573 / 607.375 |
+
+Repeated 1200-block run: approximately 29% less wall time and 39% less
+allocation. Setup plus first render: 182.822 → 172.127 ms and
+639.580 → 612.248 MB.
+
+## Scrolling and resize trace
+
+```sh
+for n in 100 600 1200 1200; do
+  "$B" history-chunk-cache-trace "$n" 3 7 +RTS -T
+  "$B" history-measured-viewport-trace "$n" 3 7 +RTS -T
+done
+```
+
+Both trace modes use the same retained chunks, production right-hand scrollbar
+renderer, and Brick visibility requests. Each 25-frame sample cycles requested
+rows `0, 400, 1200, 80, 2400, 600, 3600, 160` and display regions
+100×32, 76×24, 120×40, and 92×28. The benchmark forces rendered characters,
+attributes, widths, and extent counts. The baseline preserves the production
+`padLeftRight 2 (drawTranscript state)` hierarchy.
+
+Warm trace totals, milliseconds / decimal MB allocated:
+
+| Blocks | Retained chunk cache | Measured viewport |
+|---:|---:|---:|
+| 100 | 12.010 / 91.163 | 11.139 / 88.680 |
+| 600 | 113.239 / 511.666 | 81.876 / 335.826 |
+| 1200 | 223.479 / 1038.043 | 159.535 / 616.728 |
+| 1200 repeat | 222.619 / 1038.349 | 150.843 / 616.728 |
+
+The repeated 1200-block trace used about **32% less wall time and 41% less
+allocation**. Setup plus first render was 194.547 → 173.844 ms and
+659.198 → 612.292 MB.
+
+Long-body trace (`100 30 7`): 79.870 → 66.526 ms and
+390.607 → 319.399 MB warm; setup plus first render was 78.139 → 58.765 ms and
+319.494 → 291.026 MB.
+
+At the smallest trace size, setup plus first render was faster
+(14.111 → 12.695 ms) but allocated 2.4% more (52.107 → 53.374 MB).
+
+## Validation and scope
+
+- Combined history, application, and measured-viewport suite: 173 examples,
+  zero failures after a clean GHCi reload.
+- Twelve differential cases compare actual characters/attributes, extents,
+  cursor positions, and mouse dispatch with Brick's ordinary viewport,
+  including narrow/empty viewports, scrollbar styling, and dynamic borders.
+- Live fullscreen tmux smoke passed with a deterministic 600-block history:
+  typing/cursor movement, page scrolling, resizing while scrolled, and returning
+  to live output preserved the composer and right scrollbar. No provider calls
+  were made.
+- Only the root conversation path is integrated. Child-agent viewports and the
+  empty welcome path remain unchanged.
+- Stage-level profiling is deferred; measurement/cache lookup is still linear.

--- a/packages/agent-cli/benchmark/TranscriptScrolling.hs
+++ b/packages/agent-cli/benchmark/TranscriptScrolling.hs
@@ -10,12 +10,15 @@ import Agent.CLI.AgentViewport (AgentEntry(..), AgentTarget(..))
 import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.TUI.App
     ( initialFullscreenAppState
+    , conversationScrollbarRenderer
     , drawBlock
     , drawConversationBlocks
     , drawTranscript
+    , drawTranscriptChunks
     , newFullscreenInputBuffer
     , newFullscreenRuntimeWithSyntaxLoader
     )
+import Agent.CLI.TUI.MeasuredViewport (measuredViewport)
 import Agent.CLI.TUI.History
     ( HistoryCursor(..)
     , HistoryGeneration(..)
@@ -40,10 +43,13 @@ import Agent.TUI.Model
 import Agent.TUI.Motion (MotionMode(..))
 import Brick
     ( Padding(..)
+    , Location(..)
     , ViewportType(..)
+    , VScrollBarOrientation(..)
     , Widget
     , attrMap
     , cached
+    , emptyWidget
     , hBox
     , padBottom
     , padLeftRight
@@ -51,7 +57,10 @@ import Brick
     , txt
     , txtWrap
     , vBox
+    , visibleRegion
     , viewport
+    , withVScrollBars
+    , withVScrollBarRenderer
     )
 import Brick.Types (RenderState)
 import Control.DeepSeq (force)
@@ -63,10 +72,12 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LazyText
 import GHC.Clock (getMonotonicTimeNSec)
 import GHC.Stats (RTSStats(..), getRTSStats)
 import qualified Graphics.Vty as V
 import Graphics.Vty.PictureToSpans (displayOpsForPic)
+import Graphics.Vty.Span (SpanOp(..))
 import System.CPUTime (getCPUTime)
 import System.Environment (getArgs)
 import System.Mem (performGC)
@@ -74,8 +85,12 @@ import System.Mem (performGC)
 data Workload
     = HistoryPerBlock
     | HistoryChunkCache
+    | HistoryMeasuredViewport
+    | HistoryChunkCacheTrace
+    | HistoryMeasuredViewportTrace
     | PerBlockCache
     | ChunkCache
+    deriving (Eq)
 
 data Sample = Sample
     { elapsedMillis :: !Double
@@ -95,24 +110,30 @@ main = do
             rawState <- benchmarkState blockCount bodyLines
             let state = prepareHistory workload rawState 0
             let widgetForFrame = productionWidget workload state
-            initialState <- warmCache (widgetForFrame 0)
+            initialState <- warmCache
+                (regionForFrame workload 0)
+                (widgetForFrame 0)
             stateRef <- newIORef initialState
             samples <-
                 replicateM sampleCount $
-                    measure redrawsPerSample widgetForFrame stateRef
+                    measure workload redrawsPerSample widgetForFrame stateRef
             printSample workloadText blockCount bodyLines sampleCount redrawsPerSample
                 (median samples)
             coldSamples <- mapM
                 (\frame -> measureAction $
-                    warmCache (productionWidget workload
-                        (prepareHistory workload rawState frame) frame))
+                    warmCache
+                        (regionForFrame workload frame)
+                        (productionWidget workload
+                            (prepareHistory workload rawState frame)
+                            frame))
                 [1 .. sampleCount]
             printSample (workloadText <> "-setup-first-render")
                 blockCount bodyLines sampleCount 1 (median coldSamples)
         _ ->
             error
                 "usage: transcript-scrolling-bench \
-                \(history-per-block|history-chunk-cache|\
+                \(history-per-block|history-chunk-cache|history-measured-viewport|\
+                \history-chunk-cache-trace|history-measured-viewport-trace|\
                 \per-block-cache|chunk-cache) \
                 \BLOCKS BODY_LINES SAMPLES"
 
@@ -120,6 +141,9 @@ parseWorkload :: String -> IO Workload
 parseWorkload = \case
     "history-per-block" -> pure HistoryPerBlock
     "history-chunk-cache" -> pure HistoryChunkCache
+    "history-measured-viewport" -> pure HistoryMeasuredViewport
+    "history-chunk-cache-trace" -> pure HistoryChunkCacheTrace
+    "history-measured-viewport-trace" -> pure HistoryMeasuredViewportTrace
     "per-block-cache" -> pure PerBlockCache
     "chunk-cache" -> pure ChunkCache
     other -> error ("unknown workload: " <> other)
@@ -127,12 +151,37 @@ parseWorkload = \case
 {-# NOINLINE productionWidget #-}
 productionWidget :: Workload -> AppState -> Int -> Widget Name
 productionWidget workload state frame =
-    viewport ConversationViewport Vertical $ padLeftRight 2 $
-        case workload of
-            HistoryPerBlock -> oldHistoryWidget framedState
-            HistoryChunkCache -> drawTranscript framedState
-            PerBlockCache -> syntheticTranscriptWidget PerBlockCache framedState
-            ChunkCache -> syntheticTranscriptWidget ChunkCache framedState
+    case workload of
+        HistoryMeasuredViewport ->
+            measuredViewport ConversationViewport 0 $
+                map (padLeftRight 2) (drawTranscriptChunks framedState)
+        HistoryChunkCacheTrace ->
+            withVScrollBarRenderer conversationScrollbarRenderer $
+            withVScrollBars OnRight $
+                viewport ConversationViewport Vertical $
+                    vBox
+                        [ traceMarker frame
+                        , padLeftRight 2 (drawTranscript framedState)
+                        ]
+        HistoryMeasuredViewportTrace ->
+            withVScrollBarRenderer conversationScrollbarRenderer $
+            withVScrollBars OnRight $
+                measuredViewport ConversationViewport 1 $
+                    traceMarker frame
+                        : map (padLeftRight 2)
+                            (drawTranscriptChunks framedState)
+        _ ->
+            viewport ConversationViewport Vertical $ padLeftRight 2 $
+                case workload of
+                    HistoryPerBlock -> oldHistoryWidget framedState
+                    HistoryChunkCache -> drawTranscript framedState
+                    HistoryMeasuredViewport -> error "unreachable"
+                    HistoryChunkCacheTrace -> error "unreachable"
+                    HistoryMeasuredViewportTrace -> error "unreachable"
+                    PerBlockCache ->
+                        syntheticTranscriptWidget PerBlockCache framedState
+                    ChunkCache ->
+                        syntheticTranscriptWidget ChunkCache framedState
   where
     framedState = state
         { appUi = state.appUi{uiElapsedMillis = frame} }
@@ -146,6 +195,9 @@ prepareHistory workload state frame =
         { appUi = state.appUi{uiElapsedMillis = frame}
         , appHistoryWindow = case workload of
             HistoryChunkCache -> setHistoryWindowTurns turns window
+            HistoryMeasuredViewport -> setHistoryWindowTurns turns window
+            HistoryChunkCacheTrace -> setHistoryWindowTurns turns window
+            HistoryMeasuredViewportTrace -> setHistoryWindowTurns turns window
             HistoryPerBlock -> window
                 { historyWindowTurnsByCursor = Map.fromList
                     [(turn.historyTurnCursor, turn) | turn <- toList turns]
@@ -311,47 +363,83 @@ redrawsPerSample = 25
 benchmarkRegion :: V.DisplayRegion
 benchmarkRegion = (100, 32)
 
-warmCache :: Widget Name -> IO (RenderState Name)
-warmCache widget = do
+warmCache :: V.DisplayRegion -> Widget Name -> IO (RenderState Name)
+warmCache region widget = do
     let (renderState, picture, _, _) =
             renderFinal
                 (attrMap V.defAttr [])
                 [widget]
-                benchmarkRegion
+                region
                 (const Nothing)
                 emptyRenderState
-    let !_ = force (show (displayOpsForPic picture benchmarkRegion))
+    let !_ = force (pictureScore region picture)
     pure renderState
 
+-- Force one visibility request per frame. Moving this request through the
+-- content exercises Brick's real viewport scroll-resolution path.
+traceMarker :: Int -> Widget n
+traceMarker frame =
+    visibleRegion
+        (Location (0, traceRows !! (frame `mod` length traceRows)))
+        (1, 1)
+        emptyWidget
+  where
+    traceRows = [0, 400, 1200, 80, 2400, 600, 3600, 160]
+
+regionForFrame :: Workload -> Int -> V.DisplayRegion
+regionForFrame workload frame
+    | workload `elem` [HistoryChunkCacheTrace, HistoryMeasuredViewportTrace] =
+        traceRegions !! (frame `mod` length traceRegions)
+    | otherwise = benchmarkRegion
+  where
+    traceRegions = [(100, 32), (76, 24), (120, 40), (92, 28)]
+
 measure
-    :: Int
+    :: Workload
+    -> Int
     -> (Int -> Widget Name)
     -> IORef (RenderState Name)
     -> IO Sample
-measure iterations widgetForFrame stateRef =
+measure workload iterations widgetForFrame stateRef =
     measureAction (redraw iterations 0)
   where
     redraw remaining checksum
         | remaining <= 0 = pure $! checksum
         | otherwise = do
             renderState <- readIORef stateRef
-            let widget = widgetForFrame (iterations - remaining)
+            let frame = iterations - remaining
+                region = regionForFrame workload frame
+                widget = widgetForFrame frame
                 (nextState, picture, _, extents) =
                     renderFinal
                         (attrMap V.defAttr [])
                         [widget]
-                        benchmarkRegion
+                        region
                         (const Nothing)
                         renderState
                 !rendered =
                     force
-                        ( show (displayOpsForPic picture benchmarkRegion)
+                        ( pictureScore region picture
                         , length extents
                         )
             writeIORef stateRef $! nextState
             redraw
                 (remaining - 1)
-                (checksum + length (fst rendered) + snd rendered)
+                (checksum + fst rendered + snd rendered)
+
+pictureScore :: V.DisplayRegion -> V.Picture -> Int
+pictureScore region picture =
+    sum
+        [ spanScore span
+        | row <- toList (displayOpsForPic picture region)
+        , span <- toList row
+        ]
+  where
+    spanScore (TextSpan attr outputWidth charWidth text) =
+        length (show attr) + outputWidth + charWidth
+            + fromIntegral (LazyText.length text)
+    spanScore (Skip width) = width
+    spanScore (RowEnd width) = width
 
 measureAction :: IO a -> IO Sample
 measureAction action = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -23,6 +23,7 @@ module Agent.CLI.TUI.App
     , drawBlock
     , drawConversationBlocks
     , drawTranscript
+    , drawTranscriptChunks
     , elapsedMillisSince
     , appEventLogicalBytes
     , emitUiEvent
@@ -117,6 +118,7 @@ import Agent.CLI.TUI.Render.Blocks (drawBlock)
 import Agent.CLI.TUI.Render.Transcript
     ( drawConversationBlocks
     , drawTranscript
+    , drawTranscriptChunks
     )
 import Agent.CLI.TUI.LambdaArt
 import Agent.CLI.TUI.App.Runtime

--- a/packages/agent-cli/src/Agent/CLI/TUI/MeasuredViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/MeasuredViewport.hs
@@ -1,0 +1,79 @@
+-- | Viewport composition for fixed-height transcript chunks.
+module Agent.CLI.TUI.MeasuredViewport (measuredViewport) where
+
+import Brick
+import Control.Monad.Reader (local)
+import qualified Graphics.Vty as V
+
+-- | Measure fixed-height chunks, resolve scrolling using Brick's viewport,
+-- then compose only intersecting results. The reservation is the width of a
+-- right-hand vertical scrollbar; horizontal/left scrollbars are not supported.
+-- Measurements still visit every chunk (usually a cache hit); only image
+-- composition is restricted to the visible range.
+measuredViewport :: (Ord n, Show n) => n -> Int -> [Widget n] -> Widget n
+measuredViewport name scrollbarWidth chunks
+    | null chunks || any ((== Greedy) . vSize) chunks =
+        viewport name Vertical (vBox chunks)
+    | otherwise = Widget Greedy Greedy do
+        results <- local (\c -> c
+            { availHeight = 100000
+            , availWidth = max 0 (availWidth c - scrollbarWidth)
+            }) $
+            measureChunks 100000 chunks
+        let offsets = scanl (+) 0 (map (V.imageHeight . image) results)
+            positioned = zip offsets results
+            totalHeight = sum (map (V.imageHeight . image) results)
+            totalWidth = maximum (0 : map (V.imageWidth . image) results)
+            requests = concat
+                [ visibilityRequests (addResultOffset (Location (0, y)) result)
+                | (y, result) <- positioned
+                ]
+            geometry = emptyResult
+                { image = V.backgroundFill totalWidth totalHeight
+                , visibilityRequests = requests
+                }
+        resolved <- render $ viewport name Vertical $
+            Widget Fixed Fixed (pure geometry)
+        finalViewport <- unsafeLookupViewport name
+        case finalViewport of
+            Nothing -> pure resolved
+            Just (VP left top (width, height) _) -> do
+                let visibleChunks =
+                        [ (y, result)
+                        | (y, result) <- positioned
+                        -- Include touching neighbors so dynamic borders can
+                        -- join across the edge of the visible region.
+                        , y <= top + height
+                        , y + V.imageHeight (image result) >= top
+                        ]
+                    firstY = case visibleChunks of
+                        [] -> top
+                        (y, _) : _ -> y
+                combined <- local (\c -> c { availHeight = 100000 }) $
+                    render $ vBox
+                        [Widget Fixed Fixed (pure result) | (_, result) <- visibleChunks]
+                content <- render $
+                    vLimit height $ hLimit width $
+                    padBottom Max $ padRight Max $
+                    translateBy (Location (-left, firstY - top)) $
+                    Widget Fixed Fixed (pure combined)
+                pure content
+                    { image = if scrollbarWidth == 0
+                        then image content
+                        else V.horizJoin (image content)
+                            (V.cropLeft scrollbarWidth (image resolved))
+                    -- Match viewport's outer-to-inner extent ordering so
+                    -- child click targets take precedence over the viewport.
+                    , extents = extents resolved <> extents content
+                    , visibilityRequests = []
+                    }
+
+-- Match vBox's decreasing height budget, including Brick's release limit.
+-- Measuring every child at 100000 would incorrectly expose content which an
+-- ordinary viewport truncates when the combined transcript exceeds that cap.
+measureChunks :: Int -> [Widget n] -> RenderM n [Result n]
+measureChunks _ [] = pure []
+measureChunks remaining (chunk : rest) = do
+    result <- render (vLimit remaining chunk)
+    results <- measureChunks (remaining - V.imageHeight (image result)) rest
+    pure (result : results)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
@@ -1,6 +1,7 @@
 -- | Internal fullscreen rendering helpers.
 module Agent.CLI.TUI.Render.Transcript
     ( drawTranscript
+    , drawTranscriptChunks
     , historyRangeWidgets
     , stickyPromptLayers
     , drawEmptyConversation
@@ -162,15 +163,23 @@ terminalTxtWrap = txtWrap . displayTerminalText
 drawTranscript :: AppState -> Widget Name
 drawTranscript state =
     vBox $
-        [ vBox $
-            olderGap
-                <> map
-                    (drawTranscriptChunk state AgentRoot state.appUi)
-                    state.appHistoryWindow.historyWindowTranscriptChunks
-                <> newerGap
-                <> [drawConversationBlocks state AgentRoot state.appUi]
-        ]
-            <> conversationReserveWidgets anchor
+        [vBox (drawTranscriptContentChunks state)]
+            <> conversationReserveWidgets state.appConversationAnchor
+
+-- | Retain chunk boundaries so the viewport can compose only visible results.
+drawTranscriptChunks :: AppState -> [Widget Name]
+drawTranscriptChunks state =
+    drawTranscriptContentChunks state
+        <> conversationReserveWidgets state.appConversationAnchor
+
+drawTranscriptContentChunks :: AppState -> [Widget Name]
+drawTranscriptContentChunks state =
+    olderGap
+        <> map
+            (drawTranscriptChunk state AgentRoot state.appUi)
+            state.appHistoryWindow.historyWindowTranscriptChunks
+        <> newerGap
+        <> [drawConversationBlocks state AgentRoot state.appUi]
   where
     olderGap =
         historyGapWidget
@@ -182,7 +191,6 @@ drawTranscript state =
             HistoryNewer
             state.appHistoryWindow.historyWindowHasNewer
             state.appHistoryWindow.historyWindowPending
-    anchor = state.appConversationAnchor
 
 -- | Cache completed transcript blocks in moderately sized groups.
 --

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Workspace.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Workspace.hs
@@ -40,8 +40,10 @@ import Agent.CLI.TUI.History ( HistoryWindow(historyWindowTurns) )
 import Agent.CLI.TUI.ImagePreview ()
 import Agent.CLI.TUI.LambdaArt ()
 import Agent.CLI.TUI.Motion ( isBackgroundAgentActive )
+import Agent.CLI.TUI.MeasuredViewport ( measuredViewport )
 import Agent.CLI.TUI.Render.Transcript
     ( drawTranscript,
+      drawTranscriptChunks,
       historyRangeWidgets,
       drawEmptyConversation,
       drawConversationBlocks )
@@ -210,9 +212,9 @@ drawConversationPane state =
                                 withVScrollBarRenderer
                                     conversationScrollbarRenderer $
                                     withVScrollBars OnRight $
-                                        viewport ConversationViewport Vertical $
-                                            padLeftRight 2
-                                                (drawTranscript state)
+                                        measuredViewport ConversationViewport 1 $
+                                            map (padLeftRight 2)
+                                                (drawTranscriptChunks state)
                            ]
 
 selectedChildEntry :: AppState -> Maybe AgentEntry

--- a/packages/agent-cli/test/Agent/CLI/TUIMeasuredViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIMeasuredViewportSpec.hs
@@ -1,0 +1,413 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Agent.CLI.TUIMeasuredViewportSpec (spec) where
+
+import Agent.CLI.TUI.MeasuredViewport (measuredViewport)
+import Brick
+    ( App(..)
+    , AttrMap
+    , BrickEvent(..)
+    , CursorLocation
+    , EventM
+    , Location(..)
+    , VScrollbarRenderer(..)
+    , ViewportType(Vertical)
+    , Widget
+    , attrMap
+    , attrName
+    , cached
+    , clickable
+    , emptyWidget
+    , fill
+    , hBox
+    , joinBorders
+    , withVScrollBars
+    , withVScrollBarRenderer
+    , withAttr
+    , VScrollBarOrientation(OnRight)
+    , vLimit
+    , customMain
+    , halt
+    , makeVisible
+    , neverShowCursor
+    , lookupExtent
+    , lookupViewport
+    , reportExtent
+    , showCursor
+    , showFirstCursor
+    , txtWrap
+    , vBox
+    , viewport
+    , viewportScroll
+    , vScrollBy
+    , vScrollToEnd
+    )
+import Brick.BChan (newBChan, writeBChan)
+import Brick.Widgets.Border (hBorder, vBorder)
+import Control.Concurrent.STM
+    ( atomically
+    , newTChanIO
+    , readTChan
+    , retry
+    , writeTChan
+    )
+import Control.Monad.IO.Class (liftIO)
+import Data.IORef
+    ( IORef
+    , modifyIORef'
+    , newIORef
+    , readIORef
+    , writeIORef
+    )
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LazyText
+import Data.Foldable (toList)
+import qualified Graphics.Vty as V
+import qualified Graphics.Vty.Output.Mock as VMock
+import Graphics.Vty.PictureToSpans (displayOpsForPic)
+import Graphics.Vty.Span (SpanOp(..))
+import Test.Hspec
+
+data Name
+    = Transcript
+    | Chunk !Int
+    | ChunkCache !Int
+    deriving (Eq, Ord, Show)
+
+data Renderer = Ordinary | Measured | OrdinaryScrollbar | MeasuredScrollbar
+
+data ScriptEvent
+    = ScrollBy !Int
+    | ScrollEnd
+    | Reveal !Name
+    | RevealMany ![Name]
+    | Resize !V.DisplayRegion
+    | Snapshot
+    | Stop
+
+spec :: Spec
+spec =
+    describe "measuredViewport" do
+        it "uses an oracle which detects rendered text differences" do
+            first <- runScript Ordinary (20, 3)
+                [txtWrap "expected text"] [Stop]
+            second <- runScript Ordinary (20, 3)
+                [txtWrap "different text"] [Stop]
+            first `shouldNotBe` second
+
+        it "matches an ordinary viewport across arbitrary scrolling" do
+            let script =
+                    [ ScrollBy 17
+                    , ScrollBy 31
+                    , ScrollBy (-9)
+                    , ScrollEnd
+                    , ScrollBy (-23)
+                    , Stop
+                    ]
+            ordinary <- runScript Ordinary (42, 9) chunks script
+            measured <- runScript Measured (42, 9) chunks script
+            measured `shouldBe` ordinary
+
+        it "preserves the right scrollbar through scroll and resize" do
+            let script = [ScrollBy 17, ScrollEnd, Resize (25, 11), ScrollBy (-9), Stop]
+            ordinary <- runScript OrdinaryScrollbar (42, 9) chunks script
+            measured <- runScript MeasuredScrollbar (42, 9) chunks script
+            measured `shouldBe` ordinary
+
+        it "matches short and narrow scrollbar viewports" do
+            mapM_
+                (\(bounds, content) -> do
+                    let script = [ScrollEnd, ScrollBy (-3), Stop]
+                    ordinary <- runScript OrdinaryScrollbar bounds content script
+                    measured <- runScript MeasuredScrollbar bounds content script
+                    measured `shouldBe` ordinary)
+                [(bounds, content) | bounds <- [(40, 12), (2, 3), (1, 1)]
+                                   , content <- [[], take 1 chunks]]
+
+        it "joins borders at offscreen chunk boundaries" do
+            let content = concat $ replicate 20
+                    [hBorder, vLimit 3 (hBox [vBorder, fill 'x', vBorder])]
+                script = [ScrollBy 4, ScrollBy 3, ScrollEnd, Stop]
+            ordinary <- runScript Ordinary (38, 8) content script
+            measured <- runScript Measured (38, 8) content script
+            measured `shouldBe` ordinary
+
+        it "preserves visible cursor positions while scrolling" do
+            let content = zipWith
+                    (\index chunk ->
+                        showCursor (Chunk index) (Location (2, 0)) chunk)
+                    [0 ..] chunks
+                script = [ScrollBy 17, ScrollEnd, ScrollBy (-9), Stop]
+            ordinary <- runScriptChoosing showFirstCursor Ordinary
+                (38, 8) content script
+            measured <- runScriptChoosing showFirstCursor Measured
+                (38, 8) content script
+            measured `shouldBe` ordinary
+
+        it "dispatches actual Vty mouse input to the same clickable chunk" do
+            let content = zipWith
+                    (\index chunk -> clickable (Chunk index) chunk)
+                    [0 ..] chunks
+            ordinary <- runMouseScript Ordinary (38, 8) content
+            measured <- runMouseScript Measured (38, 8) content
+            measured `shouldBe` ordinary
+            measured `shouldSatisfy` (not . null)
+
+        it "matches visibility requests for a distant extent" do
+            let script =
+                    [ Reveal (Chunk 23)
+                    , RevealMany [Chunk 3, Chunk 28, Chunk 11]
+                    , Reveal (Chunk 2)
+                    , Reveal (Chunk 37)
+                    , Stop
+                    ]
+            ordinary <- runScript Ordinary (38, 8) chunks script
+            measured <- runScript Measured (38, 8) chunks script
+            measured `shouldBe` ordinary
+
+        it "remeasures wrapped chunks after a terminal resize" do
+            let script =
+                    [ ScrollBy 29
+                    , Resize (25, 11)
+                    , ScrollEnd
+                    , Resize (51, 7)
+                    , Reveal (Chunk 12)
+                    , Stop
+                    ]
+            ordinary <- runScript Ordinary (43, 9) chunks script
+            measured <- runScript Measured (43, 9) chunks script
+            measured `shouldBe` ordinary
+
+        it "matches empty and viewport-short transcripts" do
+            mapM_
+                (\content -> do
+                    ordinary <- runScript Ordinary (40, 12) content [Stop]
+                    measured <- runScript Measured (40, 12) content [Stop]
+                    measured `shouldBe` ordinary)
+                [[], take 2 chunks]
+
+        it "preserves cached clickable extents and visibility requests" do
+            let content = zipWith
+                    (\index chunk -> cached (ChunkCache index) $
+                        clickable (Chunk index) chunk)
+                    [0 ..] chunks
+                script = [ScrollEnd, Reveal (Chunk 3), Reveal (Chunk 28), Stop]
+            ordinary <- runScript Ordinary (38, 8) content script
+            measured <- runScript Measured (38, 8) content script
+            measured `shouldBe` ordinary
+
+        it "matches Brick's combined released-height limit" do
+            let content = [vLimit 60000 (fill 'a'), vLimit 60000 (fill 'b')]
+                script = [ScrollEnd, ScrollBy (-10), Stop]
+            ordinary <- runScript Ordinary (38, 8) content script
+            measured <- runScript Measured (38, 8) content script
+            measured `shouldBe` ordinary
+
+-- Compare every picture rather than only the final frame. This catches a
+-- one-frame blank viewport when Brick applies a queued jump after rendering
+-- the child.
+runScript
+    :: Renderer
+    -> V.DisplayRegion
+    -> [Widget Name]
+    -> [ScriptEvent]
+    -> IO ([(V.DisplayRegion, String)], [String])
+runScript renderer initialBounds content script = do
+    runScriptChoosing neverShowCursor renderer initialBounds content script
+
+runScriptChoosing
+    :: (() -> [CursorLocation Name] -> Maybe (CursorLocation Name))
+    -> Renderer
+    -> V.DisplayRegion
+    -> [Widget Name]
+    -> [ScriptEvent]
+    -> IO ([(V.DisplayRegion, String)], [String])
+runScriptChoosing chooseCursor renderer initialBounds content script = do
+    let observedScript = concatMap withSnapshot script
+        withSnapshot Stop = [Stop]
+        withSnapshot event = [event, Snapshot]
+    events <- newBChan (max 1 (length observedScript))
+    mapM_ (writeBChan events) observedScript
+    boundsRef <- newIORef initialBounds
+    picturesRef <- newIORef []
+    observationsRef <- newIORef []
+    (_, mockOutput) <- VMock.mockTerminal initialBounds
+    let output = mockOutput
+            { V.displayBounds = readIORef boundsRef
+            , V.setDisplayBounds = writeIORef boundsRef
+            }
+    internalEvents <- newTChanIO
+    let vty = V.Vty
+            { V.update = \picture -> do
+                bounds <- readIORef boundsRef
+                let normalized = show
+                        ( map (concatMap spanCharacters . toList) $
+                            toList (displayOpsForPic picture bounds)
+                        , V.picCursor picture
+                        )
+                modifyIORef' picturesRef ((bounds, normalized) :)
+                displayContext <- V.mkDisplayContext output output bounds
+                V.outputPicture displayContext picture
+            , V.nextEvent = atomically retry
+            , V.nextEventNonblocking = pure Nothing
+            , V.inputIface = V.Input
+                { V.eventChannel = internalEvents
+                , V.shutdownInput = pure ()
+                , V.restoreInputState = pure ()
+                , V.inputLogMsg = const (pure ())
+                }
+            , V.outputIface = output
+            , V.refresh = pure ()
+            , V.shutdown = pure ()
+            , V.isShutdown = pure False
+            }
+        app = App
+            { appDraw = const [drawRenderer renderer content]
+            , appChooseCursor = chooseCursor
+            , appHandleEvent = handleScript boundsRef observationsRef
+            , appStartEvent = pure ()
+            , appAttrMap = const testAttrMap
+            }
+    _ <- customMain vty (pure vty) (Just events) app ()
+    (,) <$> (reverse <$> readIORef picturesRef)
+        <*> (reverse <$> readIORef observationsRef)
+
+-- Feed mouse input through Vty so Brick performs its normal extent hit test
+-- and translates the terminal coordinate to a named MouseDown event.
+runMouseScript
+    :: Renderer
+    -> V.DisplayRegion
+    -> [Widget Name]
+    -> IO [String]
+runMouseScript renderer bounds content = do
+    (_, mockOutput) <- VMock.mockTerminal bounds
+    inputEvents <- newTChanIO
+    internalEvents <- newTChanIO
+    mapM_ (atomically . writeTChan inputEvents)
+        [ V.EvKey (V.KChar 's') []
+        , V.EvMouseDown 2 1 V.BLeft []
+        , V.EvKey V.KEsc []
+        ]
+    hitsRef <- newIORef []
+    displayContext <- V.mkDisplayContext mockOutput mockOutput bounds
+    let vty = V.Vty
+            { V.update = V.outputPicture displayContext
+            , V.nextEvent = atomically (readTChan inputEvents)
+            , V.nextEventNonblocking = Nothing <$ pure ()
+            , V.inputIface = V.Input
+                { V.eventChannel = internalEvents
+                , V.shutdownInput = pure ()
+                , V.restoreInputState = pure ()
+                , V.inputLogMsg = const (pure ())
+                }
+            , V.outputIface = mockOutput
+            , V.refresh = pure ()
+            , V.shutdown = pure ()
+            , V.isShutdown = pure False
+            }
+        app = App
+            { appDraw = const [drawRenderer renderer content]
+            , appChooseCursor = neverShowCursor
+            , appHandleEvent = \case
+                VtyEvent (V.EvKey (V.KChar 's') []) ->
+                    vScrollBy (viewportScroll Transcript) 17
+                MouseDown name button modifiers location -> do
+                    liftIO $ modifyIORef' hitsRef
+                        ((show name <> " " <> show button <> " "
+                            <> show modifiers <> " " <> show location) :)
+                    halt
+                VtyEvent (V.EvKey V.KEsc []) ->
+                    halt
+                _ ->
+                    pure ()
+            , appStartEvent = pure ()
+            , appAttrMap = const testAttrMap
+            }
+    _ <- customMain vty (pure vty) Nothing app ()
+    reverse <$> readIORef hitsRef
+
+-- SpanOp's Show instance omits text, and equivalent pictures can split spans
+-- differently. Compare attributed characters rather than debug descriptions.
+spanCharacters :: SpanOp -> [(V.Attr, Char)]
+spanCharacters (TextSpan attr _ _ text) =
+    map (\char -> (attr, char)) (LazyText.unpack text)
+spanCharacters (Skip width) = replicate width (V.defAttr, ' ')
+spanCharacters (RowEnd width) = replicate width (V.defAttr, ' ')
+
+handleScript
+    :: IORef V.DisplayRegion
+    -> IORef [String]
+    -> BrickEvent Name ScriptEvent
+    -> EventM Name () ()
+handleScript boundsRef observationsRef = \case
+    AppEvent (ScrollBy rows) ->
+        vScrollBy (viewportScroll Transcript) rows
+    AppEvent ScrollEnd ->
+        vScrollToEnd (viewportScroll Transcript)
+    AppEvent (Reveal name) ->
+        makeVisible name
+    AppEvent (RevealMany names) ->
+        mapM_ makeVisible names
+    AppEvent (Resize bounds) ->
+        liftIO (writeIORef boundsRef bounds)
+    AppEvent Snapshot -> do
+        currentViewport <- lookupViewport Transcript
+        currentExtents <- mapM lookupExtent [Chunk index | index <- [0 .. 39]]
+        liftIO $
+            modifyIORef' observationsRef
+                ((show currentViewport <> " " <> show currentExtents) :)
+    AppEvent Stop ->
+        halt
+    _ ->
+        pure ()
+
+drawRenderer :: Renderer -> [Widget Name] -> Widget Name
+drawRenderer renderer content =
+    joinBorders $ case renderer of
+        Ordinary -> viewport Transcript Vertical (vBox content)
+        Measured -> measuredViewport Transcript 0 content
+        OrdinaryScrollbar ->
+            withVScrollBarRenderer testScrollbarRenderer $
+                withVScrollBars OnRight $
+                    viewport Transcript Vertical (vBox content)
+        MeasuredScrollbar ->
+            withVScrollBarRenderer testScrollbarRenderer $
+                withVScrollBars OnRight $
+                    measuredViewport Transcript 1 content
+
+testScrollbarRenderer :: VScrollbarRenderer Name
+testScrollbarRenderer =
+    VScrollbarRenderer
+        { renderVScrollbar =
+            withAttr (attrName "scrollbar-thumb") (fill '┃')
+        , renderVScrollbarTrough =
+            withAttr (attrName "scrollbar-trough") (fill '│')
+        , renderVScrollbarHandleBefore = emptyWidget
+        , renderVScrollbarHandleAfter = emptyWidget
+        , scrollbarWidthAllocation = 1
+        }
+
+testAttrMap :: AttrMap
+testAttrMap =
+    attrMap V.defAttr
+        [ (attrName "scrollbar-thumb", V.defAttr `V.withForeColor` V.red)
+        , (attrName "scrollbar-trough", V.defAttr `V.withForeColor` V.blue)
+        ]
+
+chunks :: [Widget Name]
+chunks =
+    [ reportExtent (Chunk index) $
+        vBox
+            [ txtWrap
+                ("chunk " <> tshow index <> " line " <> tshow line <> suffix)
+            | line <- [1 .. 1 + index `mod` 5]
+            ]
+    | index <- [0 .. 39]
+    ]
+  where
+    suffix =
+        " — wrapping text which changes height at narrow terminal widths"
+
+tshow :: Show a => a -> Text
+tshow = Text.pack . show

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -107,6 +107,7 @@ import qualified Agent.CLI.TUIHistorySpec as TUIHistorySpec
 import qualified Agent.CLI.TUIPropertySpec as TUIPropertySpec
 import qualified Agent.CLI.TUIScrollSpec as TUIScrollSpec
 import qualified Agent.CLI.TUITranscriptSpec as TUITranscriptSpec
+import qualified Agent.CLI.TUIMeasuredViewportSpec as TUIMeasuredViewportSpec
 import qualified Agent.CLI.UsageSpec as UsageSpec
 import qualified Agent.CLI.WebLspSpec as WebLspSpec
 import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
@@ -237,6 +238,7 @@ specs = do
     TUIPropertySpec.spec
     TUIScrollSpec.spec
     TUITranscriptSpec.spec
+    TUIMeasuredViewportSpec.spec
     UsageSpec.spec
     WebLspSpec.spec
     WorktreeSpec.spec


### PR DESCRIPTION
## Summary
- Measure retained transcript chunks, delegate scrolling to Brick, and compose only visible chunks plus border neighbors.
- Integrate the root conversation only; leave child-agent and empty welcome views unchanged.
- Preserve the old rendering baseline and add differential tests and optimized scrolling/resize benchmarks.

## Performance
GHC 9.10.3, aarch64 macOS, benchmark component built with -O2, RTS statistics enabled. Seven samples, median wall-time sample, 25 warm frames/sample. Equivalent retained-history fixtures and production scrollbar; trace cycles 100x32, 76x24, 120x40, 92x28 regions. Rendered text/attributes/widths are forced; CPU time and allocated bytes are also measured. Terminal I/O is excluded.

Repeated 1200-block trace: **222.619 → 150.843 ms (32% less)** and **1038.349 → 616.728 MB (41% less)**. Cold setup/first render: 194.547 → 173.844 ms, 659.198 → 612.292 MB. Tested 100, 600, 1200 blocks, repeated 1200, and 100 blocks with long bodies.

Reproduce:
```sh
nix develop -c cabal build --offline agent-cli:bench:transcript-scrolling-bench
nix develop -c sh -c 'B=$(cabal list-bin agent-cli:bench:transcript-scrolling-bench); for n in 100 600 1200 1200; do for mode in history-chunk-cache-trace history-measured-viewport-trace; do "$B" "$mode" "$n" 3 7 +RTS -T; done; done'
```
Full results and stationary modes: `packages/agent-cli/benchmark/MeasuredViewport.md`.

## Validation
- Focused history/application/measured-viewport tests in macOS object-code Cabal REPL: **173 examples, 0 failures**.
- 12 renderer differential cases cover characters/attributes, mouse dispatch, cursor positions, extents, resize, scrollbar styling, dynamic borders, narrow/empty views, and Brick height cap.
- Live fullscreen tmux smoke with deterministic 600-block history passed: typing/cursor movement, page scrolling, resize while scrolled, return to live output; composer preserved. No provider calls.
- Optimized benchmark build and git diff --check pass; cabal2nix expression verified unchanged.

## Draft / merge gate
The smallest 100-block trace cold render allocates **2.4% more** (52.107 → 53.374 MB), despite improving wall time. Resolve this performance boundary before marking ready/merging, per repository policy. Measurement/cache lookup remains linear; stage profiling is deferred. This is not constant-time virtualization.