### PR TITLE
Fix async tools in Responses Lite requests

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/Request.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Request.hs
@@ -272,7 +272,8 @@ responsesLiteToolValues tools =
                 <> drop insertionIndex ungroupedValues
   where
     (firstGroupedPosition, groupedValues, namespaceDescription, ungroupedValues) =
-        foldl collect (Nothing, [], "", []) tools
+        foldl collect (Nothing, [], "", [])
+            (map withoutAsyncCapability tools)
 
     collect (firstPosition, grouped, description, ungrouped) tool =
         case groupedToolValues tool of
@@ -288,6 +289,20 @@ responsesLiteToolValues tools =
                 , description
                 , ungrouped <> [encodeTool tool]
                 )
+
+-- Responses Lite does not accept API-native async tool declarations. Keep
+-- async capability on the provider-neutral schemas so conventional Responses
+-- requests can use it, but remove it recursively at the Lite wire boundary.
+withoutAsyncCapability :: ResponseTool -> ResponseTool
+withoutAsyncCapability = \case
+    FunctionToolValue tool ->
+        FunctionToolValue tool { async = Nothing }
+    CustomToolValue tool ->
+        CustomToolValue tool { async = Nothing }
+    NamespaceToolValue namespace ->
+        NamespaceToolValue namespace
+            { tools = map withoutAsyncCapability namespace.tools }
+    tool -> tool
 
 groupedToolValues :: ResponseTool -> Maybe ([RawJson], Maybe Text)
 groupedToolValues tool = case tool of

--- a/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RequestSpec.hs
@@ -190,6 +190,48 @@ spec = describe "requestParams" do
                         map Just ["lookup", "exec", "existing", "last"]
             _ -> expectationFailure "expected three top-level Lite tools"
 
+    it "omits async tool declarations from GPT-6 Astra Responses Lite" do
+        let params =
+                requestParams
+                    OpenAIProvider
+                    "gpt-6-astra"
+                    "base instructions"
+                    [ setToolAsync (functionTool "lookup")
+                    , setToolAsync (customTool "exec")
+                    , namespaceTool
+                        "editor"
+                        Nothing
+                        [setToolAsync (functionTool "edit")]
+                    ]
+                    "high"
+            tools = additionalToolValues params
+            functions = functionsNamespaceTools tools
+            editor = maybe [] (jsonArrayField "tools") $
+                findValue
+                    (\value -> toolIdentity value
+                        == (Just "namespace", Just "editor"))
+                    tools
+
+        map (jsonValueField "async") functions
+            `shouldBe` [Nothing, Nothing]
+        map (jsonValueField "async") editor
+            `shouldBe` [Nothing]
+
+    it "keeps async tool declarations on conventional Responses requests" do
+        let asyncFunction = setToolAsync (functionTool "lookup")
+            params =
+                requestParams
+                    OpenRouterProvider
+                    "gpt-6-astra"
+                    "base instructions"
+                    [asyncFunction]
+                    "high"
+
+        params.tools `shouldBe` Just [asyncFunction]
+        map (jsonValueField "async")
+            (jsonArrayField "tools" (Aeson.toJSON params))
+            `shouldBe` [Just (Aeson.Bool True)]
+
     it "refreshes the Lite prefix without dropping pending input" do
         let computerTool = functionTool computerFunctionName
             pending = userMessage "keep me"
@@ -407,6 +449,14 @@ namespaceTool namespaceName namespaceDescription nestedTools =
         , tools = nestedTools
         }
 
+setToolAsync :: ResponseTool -> ResponseTool
+setToolAsync = \case
+    FunctionToolValue tool ->
+        FunctionToolValue tool { async = Just True }
+    CustomToolValue tool ->
+        CustomToolValue tool { async = Just True }
+    tool -> tool
+
 userMessage :: Text -> ResponseItem
 userMessage value = MessageItem ResponseMessage
     { messageId = Nothing
@@ -464,6 +514,11 @@ toolIdentity value =
     ( jsonTextField "type" value
     , jsonTextField "name" value
     )
+
+jsonValueField :: Text -> Aeson.Value -> Maybe Aeson.Value
+jsonValueField fieldName = \case
+    Aeson.Object object -> KeyMap.lookup (Key.fromText fieldName) object
+    _ -> Nothing
 
 jsonTextField :: Text -> Aeson.Value -> Maybe Text
 jsonTextField fieldName = \case


### PR DESCRIPTION
## Summary
- strip API-native `async` declarations when converting tools to Responses Lite `additional_tools`
- preserve async declarations for conventional Responses requests
- handle function, custom, and recursively nested namespace tools

## Root cause
GPT-6 Astra supports async tool calling, but Responses Lite does not accept the API-native `async` field. The shared tool schemas were previously forwarded unchanged into the Lite wire format.

## Test plan
- `TMPDIR="$HOME/.haskell-agent/tmp" nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`
- GHCi: `:main --match "requestParams"`
- 16 examples, 0 failures
- `git diff --check`