### PR TITLE
Avoid cascading rebuilds from revision metadata

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -588,16 +588,9 @@
                                 }));
                         agent-core = localPackage (
                             pkgs.haskell.lib.addTestToolDepends
-                            ((pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-core/package.nix { }) {
+                            (pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-core/package.nix { }) {
                                 src = agentCoreSource;
-                            }).overrideAttrs (old: {
-                                # Match the CLI's production build identity,
-                                # while retaining stable check-package caches.
-                                configureFlags = (old.configureFlags or [ ])
-                                    ++ pkgs.lib.optionals (packageMode != "check") [
-                                        "--ghc-option=-DAGENT_BUILD_COMMIT=\"${agentBuildCommit}\""
-                                    ];
-                            }))
+                            })
                             [
                                 pkgs.git
                                 bun_1_4
@@ -806,6 +799,16 @@
                                             then agentNativeBridgeCheckSource
                                             else agentNativeBridgeProductionSource;
                                 }).overrideAttrs (old: {
+                                    # Keep revision volatility in this final
+                                    # frontend instead of agent-core, where it
+                                    # would invalidate every dependent package.
+                                    configureFlags =
+                                        (old.configureFlags or [ ])
+                                        ++ pkgs.lib.optionals
+                                            (packageMode != "check")
+                                            [
+                                                "--ghc-option=-optc-DAGENT_BUILD_COMMIT=${agentBuildCommit}"
+                                            ];
                                     # GHC's Darwin native-shared output is
                                     # already linked for runtime loading.
                                     # Stripping it in the package can turn it

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -92,7 +92,7 @@ import Control.Exception.Safe ( finally, mask_, onException )
 import Data.Text ( Text )
 import System.Directory.OsPath
     ( getCurrentDirectory, getHomeDirectory, makeAbsolute )
-import System.Environment ( getArgs )
+import System.Environment ( getArgs, setEnv )
 import System.Exit ( die )
 import System.IO ( stderr )
 
@@ -140,6 +140,7 @@ devMain = devMainResume Nothing
 -- reload state.
 devMainResume :: Maybe Text -> IO DevResult
 devMainResume resumeId = do
+    configureClientIdentity
     home <- getHomeDirectory
     underWorktree <- case resumeId of
         Just _ -> pure True
@@ -178,6 +179,7 @@ devMainResume resumeId = do
 
 run :: IO ()
 run = do
+    configureClientIdentity
     args <- getArgs
     case parseArgs args of
         Left err -> die err
@@ -203,6 +205,10 @@ run = do
                 DevQuit -> pure ()
                 DevReload _ ->
                     die ":reload is only available under `repl` (nix develop)"
+
+configureClientIdentity :: IO ()
+configureClientIdentity =
+    setEnv "AGENT_BUILD_COMMIT" (Text.unpack agentBuildInfo.buildCommit)
 
 -- | Tear down and rebuild provider-specific auth, tools, prompt, and transport.
 -- Automatic transitions carry the exact failed turn in memory and commit

--- a/packages/agent-core/src/Agent/ClientIdentity.hs
+++ b/packages/agent-core/src/Agent/ClientIdentity.hs
@@ -1,18 +1,14 @@
-{-# LANGUAGE CPP #-}
-
 -- | Non-secret client identity for requests to the organization gateway.
 module Agent.ClientIdentity (gatewayUserAgent) where
 
+import Data.Char (isAscii, isAlphaNum)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
+import Data.Maybe (fromMaybe)
 import Data.Version (showVersion)
 import qualified Paths_agent_core as Paths
-import System.Environment (getProgName)
+import System.Environment (getProgName, lookupEnv)
 import System.Info (arch, os)
-
-#ifndef AGENT_BUILD_COMMIT
-#define AGENT_BUILD_COMMIT "development"
-#endif
 
 -- | Native's @ha_runtime_init@ explicitly sets the RTS program name to
 -- @haskell-agent-macos@ before any Haskell gateway calls. Do not infer the
@@ -21,10 +17,23 @@ import System.Info (arch, os)
 gatewayUserAgent :: IO ByteString
 gatewayUserAgent = do
     program <- getProgName
+    commit <- validatedCommit <$> lookupEnv "AGENT_BUILD_COMMIT"
     let product
             | program == "haskell-agent-macos" = "haskell-agent-macos"
             | otherwise = "agent-cli"
     pure $ BS.pack $
         product <> "/" <> showVersion Paths.version
             <> " (" <> os <> "; " <> arch
-            <> "; commit " <> AGENT_BUILD_COMMIT <> ")"
+            <> "; commit " <> commit <> ")"
+
+validatedCommit :: Maybe String -> String
+validatedCommit value =
+    fromMaybe "development" do
+        commit <- value
+        if not (null commit) && all validCommitCharacter commit
+            then Just commit
+            else Nothing
+  where
+    validCommitCharacter character =
+        isAscii character
+            && (isAlphaNum character || character `elem` ("-._" :: String))

--- a/packages/agent-core/test/Agent/ClientIdentitySpec.hs
+++ b/packages/agent-core/test/Agent/ClientIdentitySpec.hs
@@ -1,8 +1,9 @@
 module Agent.ClientIdentitySpec (spec) where
 
 import Agent.ClientIdentity (gatewayUserAgent)
+import Control.Exception.Safe (bracket)
 import qualified Data.ByteString.Char8 as BS
-import System.Environment (withProgName)
+import System.Environment (lookupEnv, setEnv, unsetEnv, withProgName)
 import Test.Hspec
 
 spec :: Spec
@@ -22,3 +23,20 @@ spec = describe "gatewayUserAgent" do
         cli <- withProgName "agent-cli" gatewayUserAgent
         native <- withProgName "haskell-agent-macos" gatewayUserAgent
         BS.dropWhile (/= '/') cli `shouldBe` BS.dropWhile (/= '/') native
+    it "reads a frontend-owned build revision at runtime" do
+        value <- withEnvironment "AGENT_BUILD_COMMIT" "abcdef12" gatewayUserAgent
+        value `shouldSatisfy` BS.isInfixOf "; commit abcdef12)"
+    it "rejects unsafe runtime revision text" do
+        value <-
+            withEnvironment
+                "AGENT_BUILD_COMMIT"
+                "bad\r\nInjected: value"
+                gatewayUserAgent
+        value `shouldSatisfy` BS.isInfixOf "; commit development)"
+
+withEnvironment :: String -> String -> IO a -> IO a
+withEnvironment name value =
+    bracket
+        (lookupEnv name <* setEnv name value)
+        (maybe (unsetEnv name) (setEnv name))
+        . const

--- a/packages/agent-native-bridge/cbits/HaskellAgentBridgeRuntime.c
+++ b/packages/agent-native-bridge/cbits/HaskellAgentBridgeRuntime.c
@@ -2,6 +2,14 @@
 
 #include <HsFFI.h>
 #include <pthread.h>
+#include <stdlib.h>
+
+#ifndef AGENT_BUILD_COMMIT
+#define AGENT_BUILD_COMMIT development
+#endif
+
+#define HA_STRINGIFY_INNER(value) #value
+#define HA_STRINGIFY(value) HA_STRINGIFY_INNER(value)
 
 static pthread_mutex_t runtime_lock = PTHREAD_MUTEX_INITIALIZER;
 static unsigned int runtime_references = 0;
@@ -16,6 +24,7 @@ int32_t ha_runtime_init(void) {
         char *argv[] = {"haskell-agent-macos", NULL};
         char **argv_pointer = argv;
         hs_init(&argc, &argv_pointer);
+        setenv("AGENT_BUILD_COMMIT", HA_STRINGIFY(AGENT_BUILD_COMMIT), 1);
         runtime_initialized = 1;
     }
     runtime_references += 1;


### PR DESCRIPTION
## Summary

- stop compiling volatile Git revision metadata into the foundational `agent-core` derivation
- configure gateway client identity at the final CLI and native-bridge frontends instead
- validate runtime revision text before including it in the user agent

## Cache validation

Compared clean Git flakes before and after a revision-only empty commit:

| Package | Result |
| --- | --- |
| `agent-core` | unchanged |
| `agent-openai` | unchanged |
| `agent-cli` | changed as intended |
| `agent-native-bridge-library` | changed as intended |

The final committed Git-flake build reused `agent-core` and rebuilt only `agent-cli` and `agent-native-bridge`.

## Tests

- `cabal repl agent-core:test:agent-core-test`, `:main --match gatewayUserAgent` (6 examples, 0 failures)
- `cabal repl agent-cli:lib:agent-cli` (234 modules loaded)
- `nix build .#checks.x86_64-linux.agent-core .#agent-native-bridge-library --no-link --print-out-paths`
- native bridge C preprocessor check for the injected revision value
- `git diff --check`