### PR TITLE
Speed up MCP shutdown and report slow servers

### DIFF
--- a/packages/agent-mcp/src/Agent/MCP/Client/Internal/Runtime.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Client/Internal/Runtime.hs
@@ -45,7 +45,11 @@ import Agent.MCP.Types
       projectRawOr,
       emptyInputSchema )
 import Agent.ToolDispatch ()
-import Agent.Tools.IO ( terminateProcessGroup )
+import Agent.Process
+    ( ProcessTerminationPolicy(..)
+    , defaultProcessTerminationPolicy
+    , terminateProcessGroupWithEscalation
+    )
 import Agent.Tools.Types ()
 import Control.Concurrent ( threadDelay )
 import Control.Concurrent.Async
@@ -99,7 +103,7 @@ import Network.HTTP.Client
 import Network.HTTP.Client.TLS ( newTlsManager )
 import Network.HTTP.Types ( Header, statusCode )
 import System.Environment ( getEnvironment )
-import System.IO ( Handle, hClose, hFlush )
+import System.IO ( Handle, hClose, hFlush, hPutStrLn, stderr )
 import System.IO.Unsafe ( unsafePerformIO )
 import System.Process ( ProcessHandle )
 import System.Timeout ( timeout )
@@ -1454,7 +1458,9 @@ closeMcpClient client =
                 case client.clientTransport of
                     McpClientStdio transport -> do
                         void $ tryAny (hClose transport.stdioInput)
-                        terminateProcessGroup
+                        terminateProcessGroupWithEscalation
+                            mcpProcessTerminationPolicy
+                            (reportSlowMcpShutdown client.clientConfig.mcpServerName)
                             transport.stdioGroupId
                             transport.stdioProcess
                         readIORef transport.stdioReader >>= mapM_ stopWorker
@@ -1464,6 +1470,24 @@ closeMcpClient client =
                 failClient client.clientRequestRegistry client.clientFailure
                     "MCP server closed"
                 pure True
+
+-- Stdio MCP servers are disposable session helpers, so quitting the CLI should
+-- not inherit the longer grace periods used by shells and other user jobs.
+-- We still escalate through INT, TERM, and KILL and wait for the whole process
+-- group, but bound the cooperative stages to keep Ctrl-C shutdown responsive.
+mcpProcessTerminationPolicy :: ProcessTerminationPolicy
+mcpProcessTerminationPolicy =
+    defaultProcessTerminationPolicy
+        { firstWaitMilliseconds = 50
+        , secondWaitMilliseconds = 100
+        }
+
+reportSlowMcpShutdown :: Text -> IO ()
+reportSlowMcpShutdown serverName = do
+    hPutStrLn stderr $
+        "MCP server '" <> Text.unpack serverName
+            <> "' is slow to stop; terminating it..."
+    hFlush stderr
 
 -- Legacy Streamable HTTP sessions are explicitly terminated with DELETE when
 -- the server assigned a session id.  Failure is intentionally ignored during

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -80,6 +80,7 @@ import Data.IORef
 import Data.List (find)
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Text as Text
+import GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import System.Directory
     ( createDirectory
     , getTemporaryDirectory
@@ -88,7 +89,14 @@ import System.Directory
     , removeFile
     , withCurrentDirectory
     )
-import System.IO (hClose, openTempFile)
+import System.IO
+    ( SeekMode(AbsoluteSeek)
+    , hClose
+    , hFlush
+    , hSeek
+    , openTempFile
+    , stderr
+    )
 import System.Posix.Files (setFileMode)
 import System.Timeout (timeout)
 import Test.Hspec
@@ -185,6 +193,26 @@ spec = describe "Agent.MCP" do
                                         "stdio stderr reader was not started"
                         McpClientHttp _ ->
                             expectationFailure "expected a stdio transport"
+
+        it "bounds shutdown of an uncooperative stdio server" $
+            withBodyServer
+                "agent-mcp-stubborn.sh"
+                stubbornFakeServer
+                \script ->
+                    bracket
+                        ( startMcpFleetProgressive
+                            (const (pure ()))
+                            [baseConfig "stubborn" script]
+                        )
+                        closeMcpFleet
+                        \fleet -> do
+                            waitForServerReady fleet "stubborn"
+                            (closed, capturedStderr) <-
+                                captureStandardError $
+                                    timeout 500000 (closeMcpFleet fleet)
+                            closed `shouldBe` Just ()
+                            capturedStderr `shouldBe`
+                                "MCP server 'stubborn' is slow to stop; terminating it...\n"
 
     describe "client worker lifecycle" do
         it "does not start owned workers after the client is closed" $
@@ -1030,6 +1058,24 @@ withBodyServer template body action = do
         removeFile
         action
 
+captureStandardError :: IO value -> IO (value, BS.ByteString)
+captureStandardError action = do
+    temporary <- getTemporaryDirectory
+    bracket
+        (openTempFile temporary "agent-mcp-stderr")
+        (\(path, handle) -> hClose handle `finally` removeFile path)
+        \(_, capturedHandle) ->
+            bracket (hDuplicate stderr) hClose \originalStderr -> do
+                hDuplicateTo capturedHandle stderr
+                value <-
+                    action `finally` do
+                        hFlush stderr
+                        hDuplicateTo originalStderr stderr
+                hFlush capturedHandle
+                hSeek capturedHandle AbsoluteSeek 0
+                captured <- BS.hGetContents capturedHandle
+                BS.length captured `seq` pure (value, captured)
+
 withCountingFakeServer :: (FilePath -> FilePath -> IO a) -> IO a
 withCountingFakeServer = withCountingServer countingFakeServer
 
@@ -1241,6 +1287,27 @@ fakeServer =
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"second response\"}]}}'\n\
     \        printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$first_id\"',\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"first response\"}]}}'\n\
     \      fi\n\
+    \      ;;\n\
+    \  esac\n\
+    \done\n"
+
+stubbornFakeServer :: LBS.ByteString
+stubbornFakeServer =
+    "#!/bin/sh\n\
+    \trap '' INT TERM\n\
+    \while IFS= read -r line; do\n\
+    \  id=$(printf '%s' \"$line\" | sed -n 's/.*\"id\":\\([0-9][0-9]*\\).*/\\1/p')\n\
+    \  case \"$line\" in\n\
+    \    *'\"method\":\"server/discover\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"initialize\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"serverInfo\":{\"name\":\"stubborn\",\"version\":\"1\"}}}'\n\
+    \      ;;\n\
+    \    *'\"method\":\"notifications/initialized\"'*) ;;\n\
+    \    *'\"method\":\"tools/list\"'*)\n\
+    \      printf '%s\\n' '{\"jsonrpc\":\"2.0\",\"id\":'\"$id\"',\"result\":{\"tools\":[]}}'\n\
+    \      while :; do sleep 1; done\n\
     \      ;;\n\
     \  esac\n\
     \done\n"

--- a/packages/agent-process/src/Agent/Process.hs
+++ b/packages/agent-process/src/Agent/Process.hs
@@ -4,6 +4,7 @@ module Agent.Process
     , terminateThenKillPolicy
     , terminateProcessGroup
     , terminateProcessGroupWith
+    , terminateProcessGroupWithEscalation
     ) where
 
 import Control.Concurrent (threadDelay)
@@ -65,7 +66,19 @@ terminateProcessGroupWith
     -> Maybe ProcessGroupID
     -> ProcessHandle
     -> IO ()
-terminateProcessGroupWith policy groupId processHandle = do
+terminateProcessGroupWith policy =
+    terminateProcessGroupWithEscalation policy (pure ())
+
+-- | Stop a child process and its descendants, running an action when the
+-- first grace period expires and escalation begins. Exceptions from the
+-- notification action are ignored so diagnostics cannot prevent cleanup.
+terminateProcessGroupWithEscalation
+    :: ProcessTerminationPolicy
+    -> IO ()
+    -> Maybe ProcessGroupID
+    -> ProcessHandle
+    -> IO ()
+terminateProcessGroupWithEscalation policy onEscalation groupId processHandle = do
     alive <- processGroupAlive groupId processHandle
     whenAlive alive do
         signalGroup (firstSignal policy)
@@ -74,6 +87,7 @@ terminateProcessGroupWith policy groupId processHandle = do
             processHandle
             (firstWaitMilliseconds policy)
         unless interrupted do
+            void $ try @_ @SomeException onEscalation
             mapM_ signalGroup (secondSignal policy)
             void $ try @_ @SomeException (terminateProcess processHandle)
             terminated <- waitForProcessGroupExit


### PR DESCRIPTION
## Summary
- shorten cooperative shutdown waits for disposable stdio MCP servers
- report named MCP servers to stderr when shutdown escalation begins
- expose an escalation callback in shared process termination and cover stubborn servers

## Testing
- `printf ":load Agent.MCPSpec\n:quit\n" | cabal repl agent-mcp-test`
- `cabal test agent-mcp-test --test-show-details=direct` (102 examples)