### PR TITLE
Parse proposed plans at the stream boundary

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayBridge.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayBridge.hs
@@ -463,6 +463,13 @@ updateManagedActivity event state =
                 , accumulatorResponse =
                     appendTextBuffer delta state.accumulatorResponse
                 }
+        PlanDelta delta ->
+            state
+                { accumulatorKind = "writing"
+                , accumulatorMessage = "Writing plan…"
+                , accumulatorResponse =
+                    appendTextBuffer delta state.accumulatorResponse
+                }
         ActivityUpdated message ->
             state
                 { accumulatorKind = "activity"

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -11,6 +11,12 @@ module Agent.CLI.Plan
     , initialPlanExitState
     , renderPlanEnterFrame
     , renderPlanExitFrame
+    , ProposedPlanSegment(..)
+    , ProposedPlanStream
+    , initialProposedPlanStream
+    , feedProposedPlanStream
+    , finishProposedPlanStream
+    , proposedPlanVisibleText
     , extractProposedPlan
     , resumedPlanNeedsApproval
     , stripProposedPlan
@@ -390,20 +396,145 @@ resumedPlanNeedsApproval assistantTexts =
         lastText : _ -> isJust (extractProposedPlan lastText)
         _ -> False
 
--- | Remove proposed_plan tags for display after the approval UI shows the body.
+-- | Typed pieces produced by the Codex plan protocol stream.
+data ProposedPlanSegment
+    = AssistantText !Text
+    | ProposedPlanStart
+    | ProposedPlanDelta !Text
+    | ProposedPlanEnd
+    deriving (Eq, Show)
+
+-- | Incremental parser state. A possibly incomplete line is held until the
+-- parser can decide whether it is protocol markup. This mirrors Codex's
+-- tagged-line protocol: tags only have control meaning when alone on a line.
+data ProposedPlanStream = ProposedPlanStream
+    { proposedPlanInside :: !Bool
+    , proposedPlanPendingLine :: !Text
+    , proposedPlanPassingLine :: !Bool
+    } deriving (Eq, Show)
+
+initialProposedPlanStream :: ProposedPlanStream
+initialProposedPlanStream = ProposedPlanStream False "" False
+
+feedProposedPlanStream
+    :: ProposedPlanStream
+    -> Text
+    -> (ProposedPlanStream, [ProposedPlanSegment])
+feedProposedPlanStream state chunk =
+    consumeStream
+        state.proposedPlanInside
+        state.proposedPlanPassingLine
+        (state.proposedPlanPendingLine <> chunk)
+
+finishProposedPlanStream :: ProposedPlanStream -> [ProposedPlanSegment]
+finishProposedPlanStream state =
+    segments <> [ProposedPlanEnd | inside]
+  where
+    (inside, segments)
+        | state.proposedPlanPassingLine =
+            ( state.proposedPlanInside
+            , textSegment
+                state.proposedPlanInside
+                state.proposedPlanPendingLine
+            )
+        | otherwise =
+            consumeLine
+                state.proposedPlanInside
+                state.proposedPlanPendingLine
+
+proposedPlanVisibleText :: [ProposedPlanSegment] -> Text
+proposedPlanVisibleText = Text.concat . foldr collect []
+  where
+    collect (AssistantText text) rest = text : rest
+    collect _ rest = rest
+
+consumeStream
+    :: Bool
+    -> Bool
+    -> Text
+    -> (ProposedPlanStream, [ProposedPlanSegment])
+consumeStream inside passing input
+    | passing =
+        case Text.breakOn "\n" input of
+            (line, rest)
+                | Text.null rest ->
+                    ( ProposedPlanStream inside "" True
+                    , textSegment inside line
+                    )
+                | otherwise ->
+                    let completeLine = line <> "\n"
+                        remaining = Text.drop 1 rest
+                        (nextState, following) =
+                            consumeStream inside False remaining
+                    in ( nextState
+                       , textSegment inside completeLine <> following
+                       )
+    | otherwise =
+    case Text.breakOn "\n" input of
+        (_, rest)
+            | Text.null rest && couldBecomeControlLine inside input ->
+                (ProposedPlanStream inside input False, [])
+            | Text.null rest ->
+                ( ProposedPlanStream inside "" True
+                , textSegment inside input
+                )
+        (line, rest) ->
+            let completeLine = line <> "\n"
+                remaining = Text.drop 1 rest
+                (nextInside, segments) = consumeLine inside completeLine
+                (nextState, following) =
+                    consumeStream nextInside False remaining
+            in (nextState, segments <> following)
+
+couldBecomeControlLine :: Bool -> Text -> Bool
+couldBecomeControlLine inside line =
+    couldBecomeTag expected (Text.dropWhile isHorizontalSpace line)
+  where
+    expected = if inside then closeTag else openTag
+
+couldBecomeTag :: Text -> Text -> Bool
+couldBecomeTag tag candidate =
+    candidate `Text.isPrefixOf` tag
+        || ( tag `Text.isPrefixOf` candidate
+            && Text.all isHorizontalSpace
+                (Text.drop (Text.length tag) candidate)
+           )
+
+isHorizontalSpace :: Char -> Bool
+isHorizontalSpace character =
+    character == ' ' || character == '\t' || character == '\r'
+
+consumeLine :: Bool -> Text -> (Bool, [ProposedPlanSegment])
+consumeLine inside line
+    | stripped == openTag && not inside =
+        (True, [ProposedPlanStart])
+    | stripped == closeTag && inside =
+        (False, [ProposedPlanEnd])
+    | otherwise =
+        (inside, textSegment inside line)
+  where
+    stripped = Text.strip line
+
+textSegment :: Bool -> Text -> [ProposedPlanSegment]
+textSegment _ text | Text.null text = []
+textSegment True text = [ProposedPlanDelta text]
+textSegment False text = [AssistantText text]
+
+openTag :: Text
+openTag = "<proposed_plan>"
+
+closeTag :: Text
+closeTag = "</proposed_plan>"
+
+-- | Remove Codex plan protocol blocks from assistant presentation. The plan
+-- body is presented through the typed plan approval hook instead.
 stripProposedPlan :: Text -> Text
 stripProposedPlan text =
-    case Text.breakOn "<proposed_plan>" text of
-        (before, afterOpen)
-            | Text.null afterOpen -> text
-            | otherwise ->
-                let rest = Text.drop (Text.length "<proposed_plan>") afterOpen
-                    (_, afterClose) = Text.breakOn "</proposed_plan>" rest
-                    after =
-                        if Text.null afterClose
-                            then ""
-                            else Text.drop (Text.length "</proposed_plan>") afterClose
-                in Text.strip (before <> after)
+    proposedPlanVisibleText
+        (segments <> finishProposedPlanStream state)
+  where
+    (state, segments) =
+        feedProposedPlanStream initialProposedPlanStream text
 
 putTextLn :: Handle -> Text -> IO ()
 putTextLn handle text = do

--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -526,6 +526,17 @@ renderEventUnlocked config = \case
                     (state{statePrintedText = True}, ())
                 Text.hPutStr config.renderStdout delta
                 hFlush config.renderStdout
+    PlanDelta delta -> do
+        modifyRenderState config \state ->
+            (countGenerationChars delta state, ())
+        commitThinkingUnlocked config
+        if config.renderColor
+            then streamAssistantDelta config delta
+            else do
+                modifyRenderState config \state ->
+                    (state{statePrintedText = True}, ())
+                Text.hPutStr config.renderStdout delta
+                hFlush config.renderStdout
     ReasoningDelta delta -> do
         modifyRenderState config \state ->
             (countGenerationChars delta state, ())

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -42,6 +42,14 @@ import Agent.CLI.Notification
     )
 import Agent.CLI.Approval
 import Agent.CLI.Permission (promptPermission, promptRootAccess)
+import Agent.CLI.Plan
+    ( ProposedPlanSegment(..)
+    , ProposedPlanStream
+    , feedProposedPlanStream
+    , finishProposedPlanStream
+    , initialProposedPlanStream
+    , stripProposedPlan
+    )
 import Agent.CLI.ProviderTransition (PendingTurn)
 import Agent.CLI.Recap
 import Agent.CLI.CancelWatch
@@ -716,10 +724,12 @@ buildSessionLoopEventRuntime
     :: SessionHostRuntime
     -> SessionControlRuntime
     -> SessionRequest
+    -> IORef (Maybe ProposedPlanStream)
     -> (LoopEvent -> IO ())
     -> SessionLoopEventRuntime
 buildSessionLoopEventRuntime
-        host controls SessionRequest{..} managedLoopPublisher =
+        host controls SessionRequest{..}
+        proposedPlanStreamRef managedLoopPublisher =
     SessionLoopEventRuntime
         { loopEventRender = render
         , loopEventEmit = emitLoop
@@ -745,7 +755,9 @@ buildSessionLoopEventRuntime
         , renderMotionMode = options.optMotionMode
         , renderWorkspace = toText workspace.cwd
         }
-    emitLoop event = do
+    emitLoop event =
+        projectPlanProtocol event >>= mapM_ emitPresentedLoop
+    emitPresentedLoop event = do
         recordAgentViewportEvent agentViewportRuntime event
         forM_ startup.startupNativeHooks \hooks ->
             hooks.nativeOnLoopEvent event
@@ -766,6 +778,9 @@ buildSessionLoopEventRuntime
                     case event of
                         TurnStarted -> beginRenderTurn now state
                         TextDelta delta ->
+                            countGenerationChars delta
+                                state{statePrintedText = True}
+                        PlanDelta delta ->
                             countGenerationChars delta
                                 state{statePrintedText = True}
                         ReasoningDelta delta ->
@@ -793,6 +808,55 @@ buildSessionLoopEventRuntime
                                         history))
                                 contextWindow
                     _ -> pure ()
+    projectPlanProtocol = \case
+        TurnStarted -> do
+            planActive <-
+                if dialectId dialect == CodexDialect
+                    then isPlanModeActive planMode
+                    else pure False
+            writeIORef proposedPlanStreamRef $
+                if planActive
+                    then Just initialProposedPlanStream
+                    else Nothing
+            pure [TurnStarted]
+        TextDelta delta ->
+            atomicModifyIORef' proposedPlanStreamRef \case
+                Nothing -> (Nothing, [TextDelta delta])
+                Just stream ->
+                    let (next, segments) =
+                            feedProposedPlanStream stream delta
+                    in ( Just next
+                       , concatMap proposedPlanSegmentEvents segments
+                       )
+        ResponseRestarted message -> do
+            modifyIORef' proposedPlanStreamRef $
+                fmap (const initialProposedPlanStream)
+            pure [ResponseRestarted message]
+        ResponseAttemptDiscarded -> do
+            modifyIORef' proposedPlanStreamRef $
+                fmap (const initialProposedPlanStream)
+            pure [ResponseAttemptDiscarded]
+        TurnFinished output ->
+            atomicModifyIORef' proposedPlanStreamRef \case
+                Nothing -> (Nothing, [TurnFinished output])
+                Just stream ->
+                    let projectedOutput =
+                            output
+                                { assistantText =
+                                    stripProposedPlan <$> output.assistantText
+                                }
+                        tailEvents =
+                            concatMap
+                                proposedPlanSegmentEvents
+                                (finishProposedPlanStream stream)
+                    in (Nothing, tailEvents <> [TurnFinished projectedOutput])
+        event -> pure [event]
+
+    proposedPlanSegmentEvents = \case
+        AssistantText text -> [TextDelta text | not (Text.null text)]
+        ProposedPlanDelta text -> [PlanDelta text | not (Text.null text)]
+        ProposedPlanStart -> []
+        ProposedPlanEnd -> []
 
 data SessionApprovalRuntime = SessionApprovalRuntime
     { approvalApproveClassified
@@ -1244,11 +1308,12 @@ newSessionLoopRuntime host controls request@SessionRequest{..} sessionBackend = 
             (pure (const (pure ())))
             newManagedLoopEventPublisher
             promptRequest
+    proposedPlanStreamRef <- newIORef Nothing
     sessionDir <- readIORef planMode.planSessionDir
     forM_ sessionDir (writeIORef storeRoot . Just)
     let eventRuntime =
             buildSessionLoopEventRuntime
-                host controls request managedLoopPublisher
+                host controls request proposedPlanStreamRef managedLoopPublisher
         shellRuntime = buildSessionShellRuntime host controls request
         approvalRuntime =
             buildSessionApprovalRuntime host controls request

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -304,6 +304,7 @@ handleEvent event = do
 
     loopEventMaySkipUnfocusedRedraw = \case
         TextDelta{} -> True
+        PlanDelta{} -> True
         ReasoningDelta{} -> True
         ActivityUpdated{} -> True
         ToolUpdated{} -> True

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -217,14 +217,20 @@ uiFrameBatchLimit = 256
 enqueueAppEvent :: FullscreenRuntime -> AppEvent -> IO ()
 enqueueAppEvent runtime = \case
     AppUi (UiLoop (TextDelta text)) ->
-        enqueueStreamingText runtime False text
+        enqueueStreamingText runtime TextDelta text
+    AppUi (UiLoop (PlanDelta text)) ->
+        enqueueStreamingText runtime PlanDelta text
     AppUi (UiLoop (ReasoningDelta text)) ->
-        enqueueStreamingText runtime True text
+        enqueueStreamingText runtime ReasoningDelta text
     event ->
         atomically (enqueueMailboxEvent runtime.runtimeMailbox event)
 
-enqueueStreamingText :: FullscreenRuntime -> Bool -> Text -> IO ()
-enqueueStreamingText runtime reasoning = go
+enqueueStreamingText
+    :: FullscreenRuntime
+    -> (Text -> LoopEvent)
+    -> Text
+    -> IO ()
+enqueueStreamingText runtime toLoopEvent = go
   where
     go text
         | Text.null text =
@@ -242,9 +248,7 @@ enqueueStreamingText runtime reasoning = go
                 runtime.runtimeMailbox
                 (AppUi
                     (UiLoop
-                        (if reasoning
-                            then ReasoningDelta text
-                            else TextDelta text))))
+                        (toLoopEvent text))))
 
 enqueueMotionTick :: FullscreenRuntime -> IO ()
 enqueueMotionTick runtime =
@@ -339,6 +343,8 @@ appendAppEventAccounted event pending oldBytes =
         bytes = case event of
             AppUi (UiLoop (TextDelta delta)) ->
                 saturatingAdd oldBytes (logicalTextChunkBytes delta)
+            AppUi (UiLoop (PlanDelta delta)) ->
+                saturatingAdd oldBytes (logicalTextChunkBytes delta)
             AppUi (UiLoop (ReasoningDelta delta)) ->
                 saturatingAdd oldBytes (logicalTextChunkBytes delta)
             _ ->
@@ -362,6 +368,14 @@ appendAppEvent event pending = case event of
             _ ->
                 pending |> PendingUi
                     (PendingTextDeltas (Seq.singleton delta))
+    AppUi (UiLoop (PlanDelta delta)) ->
+        case Seq.viewr pending of
+            rest :> PendingUi (PendingPlanDeltas deltas) ->
+                rest |> PendingUi
+                    (PendingPlanDeltas (deltas |> delta))
+            _ ->
+                pending |> PendingUi
+                    (PendingPlanDeltas (Seq.singleton delta))
     AppUi (UiLoop (ReasoningDelta delta)) ->
         case Seq.viewr pending of
             rest :> PendingUi (PendingReasoningDeltas deltas) ->
@@ -474,10 +488,12 @@ pendingEventBarrier :: PendingAppEvent -> Bool
 pendingEventBarrier event =
     case event of
         PendingUi (PendingTextDeltas _) -> False
+        PendingUi (PendingPlanDeltas _) -> False
         PendingUi (PendingReasoningDeltas _) -> False
         PendingUi (PendingExactUi (UiLoop loopEvent)) ->
             case loopEvent of
                 TextDelta _ -> False
+                PlanDelta _ -> False
                 ReasoningDelta _ -> False
                 ActivityUpdated _ -> False
                 ToolUpdated _ -> False
@@ -544,6 +560,8 @@ pendingUiEvent = \case
     PendingExactUi event -> event
     PendingTextDeltas deltas ->
         UiLoop (TextDelta (Text.concat (toList deltas)))
+    PendingPlanDeltas deltas ->
+        UiLoop (PlanDelta (Text.concat (toList deltas)))
     PendingReasoningDeltas deltas ->
         UiLoop (ReasoningDelta (Text.concat (toList deltas)))
 
@@ -563,6 +581,8 @@ pendingUiEventLogicalBytes :: PendingUiEvent -> Int
 pendingUiEventLogicalBytes = \case
     PendingTextDeltas deltas ->
         foldl' (\size text -> saturatingAdd size (logicalTextChunkBytes text)) 0 deltas
+    PendingPlanDeltas deltas ->
+        foldl' (\size text -> saturatingAdd size (logicalTextChunkBytes text)) 0 deltas
     PendingReasoningDeltas deltas ->
         foldl' (\size text -> saturatingAdd size (logicalTextChunkBytes text)) 0 deltas
     PendingExactUi event ->
@@ -573,6 +593,7 @@ uiEventLogicalBytes = \case
     UiLoop event ->
         case event of
             TextDelta text -> logicalTextBytes text
+            PlanDelta text -> logicalTextBytes text
             ReasoningDelta text -> logicalTextBytes text
             ActivityUpdated text -> logicalTextBytes text
             ProviderLimitUpdated
@@ -1056,6 +1077,7 @@ isControlAppEvent = \case
     AppUi (UiLoop event) ->
         case event of
             TextDelta _ -> False
+            PlanDelta _ -> False
             ReasoningDelta _ -> False
             ActivityUpdated _ -> False
             ToolUpdated _ -> False

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -66,6 +66,8 @@ mergeUiEvents :: UiEvent -> UiEvent -> Maybe UiEvent
 mergeUiEvents older newer = case (older, newer) of
     (UiLoop (TextDelta left), UiLoop (TextDelta right)) ->
         Just (UiLoop (TextDelta (left <> right)))
+    (UiLoop (PlanDelta left), UiLoop (PlanDelta right)) ->
+        Just (UiLoop (PlanDelta (left <> right)))
     (UiLoop (ReasoningDelta left), UiLoop (ReasoningDelta right)) ->
         Just (UiLoop (ReasoningDelta (left <> right)))
     (UiLoop (ActivityUpdated _), UiLoop (ActivityUpdated latest)) ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
@@ -14,6 +14,13 @@ import Agent.CLI.Session
     )
 import Agent.CLI.Session.Types (TranscriptEffect(..))
 import Agent.CLI.Render (renderToolOutputValue)
+import Agent.CLI.Plan
+    ( ProposedPlanSegment(..)
+    , feedProposedPlanStream
+    , finishProposedPlanStream
+    , initialProposedPlanStream
+    , stripProposedPlan
+    )
 import Agent.CLI.TurnState
     ( isDisplayAttemptBoundary
     , isTurnAbortedNote
@@ -111,11 +118,12 @@ addResetTurn :: UiState -> SessionTurn -> UiState
 addResetTurn state turn =
     case turn.turnAssistantText of
         Nothing -> state
-        Just text -> reduceUi (UiHistory text) state
+        Just text -> projectAssistantText False UiHistory text state
 
 addRegularTurn :: [ResponseItem] -> UiState -> SessionTurn -> UiState
 addRegularTurn items state turn =
-    let withUser =
+    let projectPlanProtocol = turnUsesProposedPlanProtocol turn
+        withUser =
             if Text.null (Text.strip turn.turnUserText)
                 then state
                 else reduceUi
@@ -127,13 +135,19 @@ addRegularTurn items state turn =
         -- visible after the live turn is replaced by durable history.
         withItems =
             completeProjectedStreams
-                (foldl' projectItem withUser (dropWhile isUserMessage items))
+                (foldl'
+                    (projectItem projectPlanProtocol)
+                    withUser
+                    (dropWhile isUserMessage items))
         -- The failed provider attempt is intentionally separate from
         -- canonical context. Project it as live activity so the terminal turn
         -- state can mark unfinished text/tools failed while keeping completed
         -- tool results complete.
         withDisplayItems =
-            foldl' projectDisplayItem withItems turn.turnDisplayItems
+            foldl'
+                (projectDisplayItem projectPlanProtocol)
+                withItems
+                turn.turnDisplayItems
         -- A successful turn stores its final assistant text, which its items
         -- already project. An interrupted turn stores the text of the sample
         -- that never committed, which its retained items cannot contain; an
@@ -150,7 +164,11 @@ addRegularTurn items state turn =
                 | hasAssistantBlockText text withDisplayItems ->
                     withDisplayItems
                 | otherwise ->
-                    reduceUi (UiAssistantHistory text) withDisplayItems
+                    projectAssistantText
+                        False
+                        UiAssistantHistory
+                        text
+                        withDisplayItems
         terminalState =
             if turn.turnError == Nothing
                 then BlockComplete
@@ -183,11 +201,15 @@ lastMatchingUserIndex prompt =
         Nothing
         . zip [0 ..]
 
-projectItem :: UiState -> ResponseItem -> UiState
-projectItem state = \case
+projectItem :: Bool -> UiState -> ResponseItem -> UiState
+projectItem projectPlanProtocol state = \case
     MessageItem message
         | message.role == RoleAssistant ->
-            appendText (UiLoop . TextDelta) (messageText message.content) state
+            projectAssistantText
+                projectPlanProtocol
+                (UiLoop . TextDelta)
+                (messageText message.content)
+                state
         | message.role == RoleUser
         , not (isGeneratedUserText (messageText message.content)) ->
             appendText UiInputSteered (messageText message.content) state
@@ -251,8 +273,8 @@ projectItem state = \case
             state
     _ -> state
 
-projectDisplayItem :: UiState -> ResponseItem -> UiState
-projectDisplayItem state item
+projectDisplayItem :: Bool -> UiState -> ResponseItem -> UiState
+projectDisplayItem projectPlanProtocol state item
     | isDisplayAttemptBoundary item =
         reduceUi
             (UiLoop (ResponseRestarted "Retrying response…"))
@@ -275,7 +297,7 @@ projectDisplayItem state item
                                 output.callId
                                 (renderToolOutputValue output.output)))
                         state
-            _ -> projectItem state item
+            _ -> projectItem projectPlanProtocol state item
 
 isUserMessage :: ResponseItem -> Bool
 isUserMessage = \case
@@ -291,6 +313,55 @@ appendText :: (Text.Text -> UiEvent) -> Text.Text -> UiState -> UiState
 appendText event text state
     | Text.null (Text.strip text) = state
     | otherwise = reduceUi (event text) state
+
+projectAssistantText
+    :: Bool
+    -> (Text.Text -> UiEvent)
+    -> Text.Text
+    -> UiState
+    -> UiState
+projectAssistantText projectPlanProtocol ordinaryEvent text state
+    | not projectPlanProtocol =
+        appendText ordinaryEvent text state
+    | any isPlanBoundary segments =
+        foldl' projectSegment state segments
+    | otherwise =
+        appendText ordinaryEvent text state
+  where
+    (stream, streamed) =
+        feedProposedPlanStream initialProposedPlanStream text
+    segments = streamed <> finishProposedPlanStream stream
+
+    projectSegment current = \case
+        AssistantText body -> appendText ordinaryEvent body current
+        ProposedPlanDelta body ->
+            appendText (UiLoop . PlanDelta) body current
+        ProposedPlanStart -> current
+        ProposedPlanEnd -> current
+
+    isPlanBoundary ProposedPlanStart = True
+    isPlanBoundary ProposedPlanEnd = True
+    isPlanBoundary _ = False
+
+-- The durable turn keeps raw canonical response items, while TurnFinished
+-- stores the already-presented assistant text. Their difference is a
+-- provenance signal that this response passed through the Codex plan
+-- protocol. It avoids interpreting literal tag examples from other dialects.
+turnUsesProposedPlanProtocol :: SessionTurn -> Bool
+turnUsesProposedPlanProtocol turn =
+    case turn.turnAssistantText of
+        Nothing -> False
+        Just presented ->
+            any (matchesPresentedText presented) $
+                turn.turnItems <> turn.turnDisplayItems
+  where
+    matchesPresentedText presented = \case
+        MessageItem message
+            | message.role == RoleAssistant ->
+                let raw = messageText message.content
+                    stripped = stripProposedPlan raw
+                in stripped /= raw && stripped == presented
+        _ -> False
 
 hasAssistantBlock :: UiState -> Bool
 hasAssistantBlock =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -213,6 +213,7 @@ data PendingAppEvent
 data PendingUiEvent
     = PendingExactUi !UiEvent
     | PendingTextDeltas !(Seq Text)
+    | PendingPlanDeltas !(Seq Text)
     | PendingReasoningDeltas !(Seq Text)
 
 data AppEventMailboxState = AppEventMailboxState

--- a/packages/agent-cli/test/Agent/CLI/PlanSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PlanSpec.hs
@@ -66,6 +66,67 @@ spec = do
             extractProposedPlan "no plan here" `shouldBe` Nothing
             extractProposedPlan "<proposed_plan>\nunclosed" `shouldBe` Nothing
 
+    describe "proposed plan stream protocol" do
+        it "separates assistant text from a typed plan stream" do
+            let segments =
+                    parsePlanChunks
+                        [ "intro\n<proposed"
+                        , "_plan>\n# Plan\n"
+                        , "</proposed_"
+                        , "plan>\nout"
+                        ]
+            proposedPlanVisibleText segments `shouldBe` "intro\nout"
+            [text | ProposedPlanDelta text <- segments]
+                `shouldBe` ["# Plan\n"]
+            segments `shouldSatisfy` elem ProposedPlanStart
+            segments `shouldSatisfy` elem ProposedPlanEnd
+
+        it "handles every split point without exposing protocol tags" do
+            let source =
+                    "before\n<proposed_plan>\nplan\n</proposed_plan>\nafter"
+                expectedVisible = "before\nafter"
+                expectedPlan = "plan\n"
+                splits =
+                    [ [Text.take index source, Text.drop index source]
+                    | index <- [0 .. Text.length source]
+                    ]
+            map (proposedPlanVisibleText . parsePlanChunks) splits
+                `shouldBe` replicate (length splits) expectedVisible
+            map
+                ( Text.concat
+                    . map (\case ProposedPlanDelta text -> text; _ -> "")
+                    . parsePlanChunks
+                )
+                splits
+                `shouldBe` replicate (length splits) expectedPlan
+
+        it "preserves tag-like text that is not alone on a line" do
+            let source = "literal <proposed_plan> text\n"
+            parsePlanChunks [source] `shouldBe` [AssistantText source]
+
+        it "releases ordinary text before the line ends" do
+            let (_, segments) =
+                    feedProposedPlanStream
+                        initialProposedPlanStream
+                        "ordinary text"
+            proposedPlanVisibleText segments `shouldBe` "ordinary text"
+
+        it "allows whitespace around a protocol tag" do
+            parsePlanChunks ["  <proposed_plan> \nbody\n </proposed_plan>  \n"]
+                `shouldBe`
+                    [ ProposedPlanStart
+                    , ProposedPlanDelta "body\n"
+                    , ProposedPlanEnd
+                    ]
+
+        it "closes an unterminated plan when the stream finishes" do
+            parsePlanChunks ["<proposed_plan>\nbody"]
+                `shouldBe`
+                    [ ProposedPlanStart
+                    , ProposedPlanDelta "body"
+                    , ProposedPlanEnd
+                    ]
+
     describe "resumedPlanNeedsApproval" do
         it "restores approval when the latest assistant turn is a proposal" do
             resumedPlanNeedsApproval
@@ -89,7 +150,7 @@ spec = do
         it "removes the tagged block and keeps surrounding text" do
             stripProposedPlan
                 "before\n<proposed_plan>\nplan\n</proposed_plan>\nafter"
-                `shouldBe` "before\n\nafter"
+                `shouldBe` "before\nafter"
 
     describe "renderPlanMarkdown" do
         it "leaves plan Markdown unchanged when color is off" do
@@ -122,3 +183,13 @@ spec = do
 
         it "does not continue after cancellation" do
             planDecisionFollowUp PlanCancel `shouldBe` Nothing
+
+parsePlanChunks :: [Text.Text] -> [ProposedPlanSegment]
+parsePlanChunks chunks =
+    reverse reversed <> finishProposedPlanStream finalState
+  where
+    (finalState, reversed) =
+        foldl' feed (initialProposedPlanStream, []) chunks
+    feed (state, accumulated) chunk =
+        let (next, segments) = feedProposedPlanStream state chunk
+        in (next, reverse segments <> accumulated)

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -891,6 +891,55 @@ spec = describe "bounded fullscreen history window" do
                   )
                 ]
 
+    it "reprojects stored proposed plans without protocol tags" do
+        let raw =
+                "<proposed_plan>\n# Plan\n\n- edit parser\n</proposed_plan>"
+            turnValue =
+                (sessionTurn
+                        TranscriptAppend
+                        "plan this"
+                        [ userMessage "plan this"
+                        , assistantMessage raw
+                        ])
+                    { turnAssistantText = Just ""
+                    }
+            projected = sessionHistoryTurn (22 :: Int) turnValue
+            blocks = toList projected.historyTurnBlocks
+        map (.blockKind) blocks `shouldBe` [BlockUser, BlockAssistant]
+        map (.blockBody) blocks `shouldBe` ["plan this", "# Plan\n- edit parser\n"]
+        Text.concat (map (.blockBody) blocks)
+            `shouldNotSatisfy` Text.isInfixOf "<proposed_plan>"
+
+    it "preserves literal proposed-plan examples without protocol provenance" do
+        let raw =
+                "<proposed_plan>\n# Example\n</proposed_plan>"
+            turnValue =
+                (sessionTurn
+                    TranscriptAppend
+                    "show the format"
+                    [userMessage "show the format", assistantMessage raw])
+                    { turnAssistantText = Just raw
+                    }
+            blocks = toList $
+                (sessionHistoryTurn (23 :: Int) turnValue).historyTurnBlocks
+        map (.blockBody) blocks `shouldBe` ["show the format", raw]
+
+    it "does not duplicate a failed stored proposed plan" do
+        let raw =
+                "<proposed_plan>\n# Plan\n\n- edit parser\n</proposed_plan>"
+            turnValue =
+                (sessionTurn
+                    TranscriptAppend
+                    "plan this"
+                    [userMessage "plan this", assistantMessage raw])
+                    { turnAssistantText = Just ""
+                    , turnError = Just "connection interrupted"
+                    }
+            blocks = toList $
+                (sessionHistoryTurn (24 :: Int) turnValue).historyTurnBlocks
+        map (.blockBody) blocks
+            `shouldBe` ["plan this", "# Plan\n- edit parser\n", "connection interrupted"]
+
     it "does not rematerialise the compacted prefix of replacement turns" do
         let projected =
                 sessionHistoryTurn

--- a/packages/agent-connectivity/src/Agent/Connectivity.hs
+++ b/packages/agent-connectivity/src/Agent/Connectivity.hs
@@ -273,6 +273,7 @@ maxTransientRetries = 2
 isStreamOutput :: LoopEvent -> Bool
 isStreamOutput = \case
     TextDelta _ -> True
+    PlanDelta _ -> True
     ReasoningDelta _ -> True
     -- A tool call announced from the stream is already a visible running
     -- block; the replayed attempt must close it with the same restart

--- a/packages/agent-core/benchmark/LoopEvents.hs
+++ b/packages/agent-core/benchmark/LoopEvents.hs
@@ -351,6 +351,7 @@ forceStreamingFailure execution =
 eventWeight :: LoopEvent -> Int
 eventWeight = \case
     TextDelta text -> Text.length text
+    PlanDelta text -> Text.length text
     ReasoningDelta text -> Text.length text
     ActivityUpdated text -> Text.length text
     ProviderLimitUpdated

--- a/packages/agent-core/src/Agent/Loop/Output.hs
+++ b/packages/agent-core/src/Agent/Loop/Output.hs
@@ -48,6 +48,9 @@ emptyTurnOutput responseId toolCalls assistantText = TurnOutput
 
 data LoopEvent
     = TextDelta Text
+    -- | Plan markdown separated from ordinary assistant text by a
+    -- protocol-aware stream parser. Renderers never receive provider tags.
+    | PlanDelta Text
     | ReasoningDelta Text
     -- | Ephemeral transport/tool activity for the live CLI status line.
     | ActivityUpdated Text
@@ -104,6 +107,7 @@ data NativeAgentStatus
 visibleResponseActivity :: LoopEvent -> Bool
 visibleResponseActivity = \case
     TextDelta _ -> True
+    PlanDelta _ -> True
     ReasoningDelta _ -> True
     ToolStarted _ -> True
     ToolUpdated _ -> True

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
@@ -41,6 +41,7 @@ encodeNativeLoopEvent turnId event =
     case event of
         ReasoningDelta text -> textEvent 1 turnId text
         TextDelta text -> textEvent 2 turnId text
+        PlanDelta text -> textEvent 2 turnId text
         ActivityUpdated status -> textEvent 3 turnId status
         WarningRaised warning -> textEvent 3 turnId warning
         ResponseRestarted message -> textEvent 3 turnId message

--- a/packages/agent-server/src/Agent/Server/Event.hs
+++ b/packages/agent-server/src/Agent/Server/Event.hs
@@ -41,6 +41,8 @@ projectLoopEvent :: LoopEvent -> (Text, Value)
 projectLoopEvent = \case
     TextDelta delta ->
         ("response.text.delta", textPayload delta)
+    PlanDelta delta ->
+        ("response.text.delta", textPayload delta)
     ReasoningDelta delta ->
         ("response.reasoning.delta", textPayload delta)
     ActivityUpdated message ->

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -400,6 +400,11 @@ reduceLoop event state = case event of
             appendGenerationChars delta state
                 { uiActivity = "Writing…"
                 }
+    PlanDelta delta ->
+        appendOrExtend BlockAssistant "Plan" delta BlockStreaming $
+            appendGenerationChars delta state
+                { uiActivity = "Writing plan…"
+                }
     ActivityUpdated activity ->
         state { uiActivity = activity }
     ModelContextReset -> state

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -67,6 +67,22 @@ spec = describe "fullscreen UI reducer" do
             `shouldBe` ["hello", "checking", "answer"]
         state.uiRunning `shouldBe` False
 
+    it "renders typed plan content without provider protocol markup" do
+        let state =
+                apply
+                    [ UiLoop TurnStarted
+                    , UiLoop (PlanDelta "# Plan\n\n- Update the parser")
+                    , UiLoop
+                        (TurnFinished
+                            (emptyTurnOutput "r1" [] (Just "# Plan")))
+                    ]
+            blocks = Foldable.toList state.uiBlocks
+        map (.blockKind) blocks `shouldBe` [BlockAssistant]
+        map (.blockBody) blocks
+            `shouldBe` ["# Plan\n\n- Update the parser"]
+        Text.concat (map (.blockBody) blocks)
+            `shouldNotSatisfy` Text.isInfixOf "<proposed_plan>"
+
     it "shows compact provider telemetry in the completion status" do
         let telemetry = TurnTelemetry
                 { telemetryDurationMs = Just 1250


### PR DESCRIPTION
## Summary
- parse Codex proposed-plan protocol incrementally at the dialect-aware stream boundary
- emit typed `PlanDelta` events so renderers never inspect provider markup
- preserve canonical response items while safely replaying presented history without reinterpreting literal tag examples

## Validation
- `agent-cli` test suite: 1,903 examples, 0 failures, 1 pending
- `agent-tui` test suite: 261 examples, 0 failures
- `agent-core:bench:loop-events-bench` builds
- real tmux minimal-UI smoke test passes
- `git diff --check` passes