### PR TITLE
Return list_agents results as labeled text

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -302,6 +302,10 @@ spec = do
                 "{\"agents\":[{\"agent_name\":\"/root/reviewer\",\
                 \\"agent_id\":\"agent-1\",\"agent_status\":\"running\"}]}"
                 `shouldBe` "/root/reviewer · running"
+            formatToolOutput agents
+                "Agent: /root/reviewer\n  ID: agent-1\n  Status: running"
+                `shouldBe`
+                    "Agent: /root/reviewer\n  ID: agent-1\n  Status: running"
 
         it "falls back to the original output when JSON is malformed" do
             let call = functionToolCall "c1" "collaboration.spawn_agent" "{}"

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -72,6 +72,7 @@ import Control.Concurrent.MVar (modifyMVar, newMVar)
 import Control.Exception.Safe (mask, onException)
 import Control.Monad (void)
 import Data.Aeson (Value(..), object, (.=))
+import Data.List (sortOn)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -732,20 +733,50 @@ listAgentsTool ctx = jsonTool "list_agents" listAgentsDescription
 listAgentsDescription :: Text
 listAgentsDescription =
     "List live agents in the current root thread tree. Optionally filter by \
-    \task-path prefix."
+    \task-path prefix. Returns readable labeled text, not JSON."
 
 runListAgents :: MultiAgentContext -> ListAgentsArgs -> IO (Either Text Text)
 runListAgents ctx args = do
     agents <- listAgents ctx.multiRegistry args.pathPrefix
-    let payload =
-            [ object
-                [ "agent_name" .= taskPathText path
-                , "agent_id" .= agentId.unSubagentId
-                , "agent_status" .= encodeStatus status
-                ]
-            | (path, agentId, status) <- agents
-            ]
-    pure $ Right $ encodeJson $ object [ "agents" .= payload ]
+    pure $ Right $ renderAgentList agents
+
+renderAgentList :: [(TaskPath, SubagentId, SubagentStatus)] -> Text
+renderAgentList agents =
+    case sortOn (\(path, _, _) -> taskPathText path) agents of
+        [] -> "(no live agents)"
+        sorted -> Text.intercalate "\n\n" (map renderAgentListEntry sorted)
+
+renderAgentListEntry :: (TaskPath, SubagentId, SubagentStatus) -> Text
+renderAgentListEntry (path, agentId, status) =
+    Text.intercalate "\n" $
+        [ "Agent: " <> taskPathText path
+        , "  ID: " <> agentId.unSubagentId
+        , "  Status: " <> agentListStatus status
+        ]
+            <> agentListDetails status
+
+agentListStatus :: SubagentStatus -> Text
+agentListStatus = \case
+    Pending -> "pending_init"
+    Running -> "running"
+    Completed _ -> "completed"
+    Errored _ -> "errored"
+    Interrupted -> "interrupted"
+    Closed -> "shutdown"
+    NotFound -> "not_found"
+
+agentListDetails :: SubagentStatus -> [Text]
+agentListDetails = \case
+    Completed (Just text) -> labeledField "Final" text
+    Errored err -> labeledField "Error" err
+    _ -> []
+
+labeledField :: Text -> Text -> [Text]
+labeledField label value =
+    case Text.lines (Text.strip value) of
+        [] -> []
+        first : rest ->
+            ("  " <> label <> ": " <> first) : map ("    " <>) rest
 
 --------------------------------------------------------------------------------
 -- interrupt_agent

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -606,6 +606,30 @@ spec = describe "Agent.Tools.MultiAgents" do
         atomically (writeTVar parentGate True)
         closeSubagentRegistry registry
 
+    it "returns labeled text for live agents instead of JSON" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure (resultWithText "review done"))
+            (\_ _ -> pure ())
+        Right (agentId, _) <-
+            spawnSubagentAt registry Nothing taskPathRoot 0 "reviewer"
+                (plainInterAgentContent "review") Nothing
+        _ <- waitSubagents registry [agentId] 15000
+        let handlers =
+                appToolHandlers (multiAgentTools (rootContext registry Nothing))
+        listed <- dispatchToolCall defaultLoopDispatch handlers
+            (ToolCall "list-live" "collaboration.list_agents" "{}"
+                FunctionCallKind False)
+        listed.output `shouldBe`
+            "Agent: /root/reviewer\n  ID: "
+                <> agentId.unSubagentId
+                <> "\n  Status: completed\n  Final: review done"
+        emptyListed <- dispatchToolCall defaultLoopDispatch handlers
+            (ToolCall "list-prefix" "collaboration.list_agents"
+                "{\"path_prefix\":\"/root/missing\"}"
+                FunctionCallKind False)
+        emptyListed.output `shouldBe` "(no live agents)"
+        closeSubagentRegistry registry
+
     it "accepts non-object input for optional-only collaboration tools" do
         registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
             (\_ _ _ _ -> pure (resultWithText "child"))

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -609,6 +609,10 @@ spec = describe "tool presentation" do
         formatToolOutput call
             "{\"agents\":[{\"agent_status\":\"running\"},null]}"
             `shouldBe` "(no live agents)"
+        formatToolOutput call
+            "Agent: /root/reviewer\n  ID: agent-1\n  Status: running"
+            `shouldBe`
+                "Agent: /root/reviewer\n  ID: agent-1\n  Status: running"
         let worktreeSpawn = functionToolCall
                 "spawn" "collaboration.spawn_agent_in_worktree"
                 "{\"task_name\":\"worker\",\"message\":\"task\"}"


### PR DESCRIPTION
## Summary
- change `list_agents` to return readable labeled text instead of a JSON object
- include task path, agent id, status, and any completion or error details
- keep JSON decoding in TUI/CLI presentation so older transcripts still render

## Validation
- `cabal repl agent-core:test:agent-core-test` `--match Agent.Tools.MultiAgents` (28 examples, 0 failures)
- `cabal repl agent-tui:test:agent-tui-test` `--match "formats structured collaboration output"` (1 example, 0 failures)
- `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code` `--match "renders structured collaboration results"` (1 example, 0 failures)
- `git diff --check`