### PR TITLE
Retry Codex overload after partial model output

### DIFF
--- a/packages/agent-openai/CHANGELOG.md
+++ b/packages/agent-openai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Retry Codex overload and service-unavailable failures after partial model
+  output instead of ending the turn as `replay_unsafe`. Visible text is kept
+  behind a restart boundary; hidden activity is discarded.
 - Surface dropped Codex WebSocket frames as loop warnings, including the
   decode error and a truncated payload, instead of swallowing them.
 - Remove the deprecated `Agent.OpenAI.Responses.Types`,

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -668,17 +668,21 @@ openAiBackendWithReasoningVisibility showRawReasoning =
         showRawReasoning
         transientStreamingResultPolicy
 
--- | Transient server errors are retried only until the loop has observed
--- output. Server error events themselves are not loop-visible, so transient
--- Codex failures can wait and retry without printing an error or duplicating
--- output.
+-- | Transient server errors are retried in place until the loop has observed
+-- output. Server error events themselves are not loop-visible, so a Codex
+-- failure before any sample can wait and retry without printing an error or
+-- duplicating output.
 --
--- A connection that dies mid-response is different: the dead socket committed
--- nothing on either side, so the same request is resubmitted even after
--- output streamed. Partial text or reasoning stays visible behind a restart
--- boundary and hidden activity is discarded, then the transport (a
--- reconnecting sender or a per-request dial) opens a fresh connection. Codex
--- retries its sampling request the same way before falling back to HTTPS.
+-- Overload and service-unavailable failures are retried the same way even
+-- after output streamed: the provider is asking the client to try later, so
+-- the sample was not completed. Partial text or reasoning stays visible
+-- behind a restart boundary and hidden activity is discarded.
+--
+-- A connection that dies mid-response is the other replay-safe case. The dead
+-- socket committed nothing on either side, so the same request is resubmitted
+-- even after output streamed. The transport (a reconnecting sender or a
+-- per-request dial) then opens a fresh connection. Codex retries its sampling
+-- request the same way before falling back to HTTPS.
 openAiBackendWithRetryPolicy
     :: RetryPolicyM IO
     -> (ResponseCreateParams
@@ -827,31 +831,33 @@ openAiBackendWithRetryPoliciesAndReasoningVisibility
                     | emitted
                     , not observation.observedAsyncTool
                     , isReconnectableTransportFailure apiError ->
-                        applyPolicy reconnectPolicy reconnectStatus >>= \case
-                            Nothing -> settle observation apiError result
-                            Just nextStatus -> do
-                                let delayMicros =
-                                        fromMaybe 0 nextStatus.rsPreviousDelay
-                                    attempt = nextStatus.rsIterNumber
-                                callbacks.onLoopEvent $ ActivityUpdated $
-                                    formatReconnectScheduled
-                                        apiError attempt delayMicros
-                                threadDelay delayMicros
-                                -- Close the interrupted attempt in every
-                                -- renderer before the replay streams. Visible
-                                -- partial output stays on screen marked as
-                                -- failed; hidden activity such as an announced
-                                -- tool call is removed.
-                                if observation.observedVisibleOutput
-                                    then callbacks.onLoopEvent
-                                        (ResponseRestarted
-                                            connectionRestartMessage)
-                                    else callbacks.onLoopEvent
-                                        ResponseAttemptDiscarded
-                                callbacks.onLoopEvent $ ActivityUpdated $
-                                    "Reconnecting to Codex (attempt "
-                                        <> Text.pack (show attempt) <> ")…"
-                                go transientStatus nextStatus
+                        replayAfterOutput
+                            reconnectPolicy
+                            reconnectStatus
+                            formatReconnectScheduled
+                            connectionRestartMessage
+                            reconnectingAttemptMessage
+                            (\nextStatus -> go transientStatus nextStatus)
+                            observation
+                            apiError
+                            result
+                    -- Overload and unavailability mean the sample did not
+                    -- finish. Replay behind the same restart boundary used
+                    -- for a mid-response socket drop rather than ending the
+                    -- turn as replay-unsafe.
+                    | emitted
+                    , not observation.observedAsyncTool
+                    , isReplayableCapacityFailure apiError ->
+                        replayAfterOutput
+                            transientPolicy
+                            transientStatus
+                            formatRetryScheduled
+                            capacityRestartMessage
+                            retryingAttemptMessage
+                            (\nextStatus -> go nextStatus reconnectStatus)
+                            observation
+                            apiError
+                            result
                     | not emitted
                     , isInlineRetryableProviderResponseError apiError ->
                         applyPolicy transientPolicy transientStatus >>= \case
@@ -864,21 +870,57 @@ openAiBackendWithRetryPoliciesAndReasoningVisibility
                                     formatRetryScheduled apiError attempt delayMicros
                                 threadDelay delayMicros
                                 callbacks.onLoopEvent $ ActivityUpdated $
-                                    "Retrying Codex request (attempt "
-                                        <> Text.pack (show attempt) <> ")…"
+                                    retryingAttemptMessage attempt
                                 go nextStatus reconnectStatus
                     | emitted -> settle observation apiError result
                 _ -> pure result
           where
+            replayAfterOutput
+                    policy
+                    status
+                    formatScheduled
+                    restartMessage
+                    retryingMessage
+                    continue
+                    observation
+                    apiError
+                    result =
+                applyPolicy policy status >>= \case
+                    Nothing -> settle observation apiError result
+                    Just nextStatus -> do
+                        let delayMicros =
+                                fromMaybe 0 nextStatus.rsPreviousDelay
+                            attempt = nextStatus.rsIterNumber
+                        callbacks.onLoopEvent $ ActivityUpdated $
+                            formatScheduled apiError attempt delayMicros
+                        threadDelay delayMicros
+                        -- Close the interrupted attempt in every renderer
+                        -- before the replay streams. Visible partial output
+                        -- stays on screen marked as failed; hidden activity
+                        -- such as an announced tool call is removed.
+                        emitAttemptBoundary observation restartMessage
+                        callbacks.onLoopEvent $ ActivityUpdated $
+                            retryingMessage attempt
+                        continue nextStatus
+
+            emitAttemptBoundary observation restartMessage =
+                if observation.observedVisibleOutput
+                    then callbacks.onLoopEvent
+                        (ResponseRestarted restartMessage)
+                    else callbacks.onLoopEvent ResponseAttemptDiscarded
+
             -- The transport fallback may still replay a dropped connection
-            -- after this backend gives up; every other failure after output
-            -- is terminal because the provider may have committed the sample.
+            -- after this backend gives up. Capacity failures are also left
+            -- unwrapped so an outer recovery layer can wait and retry.
+            -- Every other failure after output is terminal because the
+            -- provider may have committed the sample.
             settle observation apiError result = do
                 pure $ if observation.observedAsyncTool
                         then Left (replayUnsafeError
                             "asynchronous tool call" apiError)
                     else if observation.observedVisibleOutput
                         || isReconnectableTransportFailure apiError
+                        || isReplayableCapacityFailure apiError
                     then result
                     else Left (replayUnsafeError "model output" apiError)
 
@@ -980,10 +1022,36 @@ isReconnectableTransportFailure = \case
     ProviderError WebSocketConnectionLimitReached _ _ -> True
     _ -> False
 
+-- | Failures that mean the provider did not complete the sample. These remain
+-- safe to resubmit after partial output, unlike a generic server error that
+-- may already have committed a response.
+isReplayableCapacityFailure :: ApiError -> Bool
+isReplayableCapacityFailure = \case
+    ProviderError OverloadedError _ _ -> True
+    ProviderError ServiceUnavailableError _ _ -> True
+    _ -> False
+
 connectionRestartMessage :: Text
 connectionRestartMessage =
     "Connection interrupted the response; restarting automatically. "
         <> "The new attempt may repeat partial output shown above."
+
+capacityRestartMessage :: Text
+capacityRestartMessage =
+    "Provider interrupted the response; restarting automatically. "
+        <> "The new attempt may repeat partial output shown above."
+
+reconnectingAttemptMessage :: Int -> Text
+reconnectingAttemptMessage attempt =
+    "Reconnecting to Codex (attempt "
+        <> Text.pack (show attempt)
+        <> ")…"
+
+retryingAttemptMessage :: Int -> Text
+retryingAttemptMessage attempt =
+    "Retrying Codex request (attempt "
+        <> Text.pack (show attempt)
+        <> ")…"
 
 fallbackRestartMessage :: Text
 fallbackRestartMessage =

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec/StateSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec/StateSpec.hs
@@ -481,6 +481,157 @@ spec = do
             observedEvents <- readIORef events
             reverse observedEvents `shouldBe` [TextDelta "partial"]
 
+        it "resubmits after overload behind a restart boundary" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            events <- newIORef []
+            let overload = ProviderError OverloadedError
+                    "Our servers are currently overloaded. Please try again later. (code: server_is_overloaded)"
+                    Nothing
+                send _request _previous onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    attempt <- readIORef attempts
+                    if attempt == 1
+                        then do
+                            onEvent (deltaEvent EventOutputTextDelta "partial")
+                            pure (Left overload)
+                        else do
+                            onEvent (deltaEvent EventOutputTextDelta "complete")
+                            pure (Right
+                                (testResponse "resp-replayed"
+                                    [assistantItem "complete"]))
+                backend = openAiBackendWithRetryPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    send
+                    (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-replayed" [] (Just "complete"))
+            readIORef attempts `shouldReturn` 2
+            reverse <$> readIORef events `shouldReturn`
+                [ TextDelta "partial"
+                , ActivityUpdated
+                    "Codex is overloaded; retrying in 0s (attempt 1)…"
+                , ResponseRestarted
+                    "Provider interrupted the response; restarting automatically. The new attempt may repeat partial output shown above."
+                , ActivityUpdated "Retrying Codex request (attempt 1)…"
+                , TextDelta "complete"
+                ]
+
+        it "discards hidden model output before retrying an overload" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            events <- newIORef []
+            let overload = ProviderError OverloadedError "busy" Nothing
+                send _request _previous onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    attempt <- readIORef attempts
+                    if attempt == 1
+                        then do
+                            onEvent ResponseOutputItemAddedEvent
+                                { item = assistantItem "partial"
+                                , outputIndex = Just 0
+                                , sequenceNumber = Nothing
+                                }
+                            pure (Left overload)
+                        else do
+                            onEvent (deltaEvent EventOutputTextDelta "complete")
+                            pure (Right
+                                (testResponse "resp-replayed"
+                                    [assistantItem "complete"]))
+                backend = openAiBackendWithRetryPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    send
+                    (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-replayed" [] (Just "complete"))
+            readIORef attempts `shouldReturn` 2
+            reverse <$> readIORef events `shouldReturn`
+                [ ActivityUpdated
+                    "Codex is overloaded; retrying in 0s (attempt 1)…"
+                , ResponseAttemptDiscarded
+                , ActivityUpdated "Retrying Codex request (attempt 1)…"
+                , TextDelta "complete"
+                ]
+
+        it "returns the overload once the retry policy is exhausted" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            events <- newIORef []
+            let overload = ProviderError OverloadedError
+                    "Our servers are currently overloaded"
+                    Nothing
+                send _request _previous onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    onEvent ResponseOutputItemAddedEvent
+                        { item = assistantItem "partial"
+                        , outputIndex = Just 0
+                        , sequenceNumber = Nothing
+                        }
+                    pure (Left overload)
+                backend = openAiBackendWithRetryPolicy
+                    (constantDelay 0 <> limitRetries 2)
+                    send
+                    (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            -- Leave the typed overload unwrapped so an outer recovery layer
+            -- can still wait and retry instead of treating it as replay-unsafe.
+            result `shouldBe` Left overload
+            readIORef attempts `shouldReturn` 3
+            recorded <- reverse <$> readIORef events
+            recorded `shouldBe`
+                [ ActivityUpdated
+                    "Codex is overloaded; retrying in 0s (attempt 1)…"
+                , ResponseAttemptDiscarded
+                , ActivityUpdated "Retrying Codex request (attempt 1)…"
+                , ActivityUpdated
+                    "Codex is overloaded; retrying in 0s (attempt 2)…"
+                , ResponseAttemptDiscarded
+                , ActivityUpdated "Retrying Codex request (attempt 2)…"
+                ]
+
+        it "resubmits after unavailability behind a restart boundary" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            events <- newIORef []
+            let unavailable = ProviderError ServiceUnavailableError
+                    "service unavailable"
+                    Nothing
+                send _request _previous onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    attempt <- readIORef attempts
+                    if attempt == 1
+                        then do
+                            onEvent (deltaEvent EventOutputTextDelta "partial")
+                            pure (Left unavailable)
+                        else do
+                            onEvent (deltaEvent EventOutputTextDelta "complete")
+                            pure (Right
+                                (testResponse "resp-replayed"
+                                    [assistantItem "complete"]))
+                backend = openAiBackendWithRetryPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    send
+                    (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-replayed" [] (Just "complete"))
+            readIORef attempts `shouldReturn` 2
+            reverse <$> readIORef events `shouldReturn`
+                [ TextDelta "partial"
+                , ActivityUpdated
+                    "Codex is unavailable; retrying in 0s (attempt 1)…"
+                , ResponseRestarted
+                    "Provider interrupted the response; restarting automatically. The new attempt may repeat partial output shown above."
+                , ActivityUpdated "Retrying Codex request (attempt 1)…"
+                , TextDelta "complete"
+                ]
+
         it "blocks credential failover after a tool call was streamed" do
             transcript <- newIORef []
             events <- newIORef []
@@ -546,6 +697,54 @@ spec = do
                 , ActivityUpdated "Reconnecting to Codex (attempt 1)…"
                 , TextDelta "complete"
                 ]
+
+        it "does not replay an overload after admitting a completed async tool call" do
+            attempts <- newIORef (0 :: Int)
+            admitted <- newIORef []
+            let overload = ProviderError OverloadedError "busy" Nothing
+                asyncCall =
+                    FunctionCallItem FunctionCall
+                        { itemId = Nothing
+                        , callId = "fc-async"
+                        , name = "shell"
+                        , namespace = Nothing
+                        , provider = Nothing
+                        , arguments = "{}"
+                        , encryptedFunctionArgs = Nothing
+                        , status = Just ItemCompleted
+                        , async = Just True
+                        }
+                send _request _previous onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    onEvent ResponseOutputItemDoneEvent
+                        { item = asyncCall
+                        , outputIndex = Just 0
+                        , sequenceNumber = Nothing
+                        }
+                    pure (Left overload)
+                backend = openAiBackendWithRetryPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    send
+                    (pure baseParams)
+            result <- backend.submitTurnWithCallbacks
+                emptyBackendSnapshot
+                Nothing
+                [UserMessage "one"]
+                BackendCallbacks
+                    { onLoopEvent = const (pure ())
+                    , onRecoveryCheckpoint = const (pure ())
+                    , onAsyncToolCall =
+                        \call -> modifyIORef' admitted (call.callId :)
+                    }
+            result `shouldBe` Left (ProviderError
+                (UnknownErrorType "replay_unsafe")
+                ( "provider failed after asynchronous tool call; "
+                    <> "refusing to replay: "
+                    <> Text.pack (show overload)
+                )
+                Nothing)
+            readIORef attempts `shouldReturn` 1
+            readIORef admitted `shouldReturn` ["fc-async"]
 
         it "does not replay after admitting a completed async tool call" do
             attempts <- newIORef (0 :: Int)


### PR DESCRIPTION
## Summary
- retry Codex overload and service-unavailable failures after partial model output instead of ending the turn as `replay_unsafe`
- reuse the mid-response restart boundary: keep visible text marked failed, discard hidden activity such as an output item with no loop delta
- leave the typed capacity error unwrapped if retries are exhausted so outer recovery can still wait, and keep `replay_unsafe` for admitted async tool calls and generic `server_error` after output

## Validation
- `cabal repl agent-openai:test:agent-openai-test` `--match "/openAiBackendWith/"` (27 examples, 0 failures)
- `git diff --check`