### PR TITLE
Load filesystem skills only from .agents/skills

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -460,8 +460,6 @@ skillSourceLabel skill =
         RepositorySkill _ False -> "repo"
     originLabel = \case
         AgentSkills -> "agents"
-        GrokSkills -> "grok"
-        CodexSkills -> "codex"
 
 formatSkillsListing
     :: Bool

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -73,10 +73,12 @@ import System.FilePath
     , (</>)
     )
 
+-- | Filesystem skill tree owned by this harness.
+-- Other coding harnesses keep skills under vendor directories such as
+-- @.codex/skills@, @.grok/skills@, and @.claude/skills@; those are not
+-- discovered.
 data SkillOrigin
     = AgentSkills
-    | GrokSkills
-    | CodexSkills
     deriving (Eq, Ord, Show)
 
 data SkillScope
@@ -314,31 +316,21 @@ skillRoots options = do
                 directoryChain (unsafeEncodeUtf projectRoot) (unsafeEncodeUtf cwd)
         projectRoots =
             [ ( RepositorySkill depth (dir == cwd)
-              , origin
-              , dir </> relativeRoot origin
+              , AgentSkills
+              , dir </> agentSkillsRelativeRoot
               )
             | (depth, dir) <- zip [0..] dirs
-            , origin <- origins
             ]
         userRoots =
-            [ (UserSkill, origin, home </> userRoot origin)
-            | origin <- origins
-            ]
+            [(UserSkill, AgentSkills, home </> agentSkillsRelativeRoot)]
         builtinRoots =
             [ (BuiltinSkill, origin, unsafeToFilePath root)
             | (origin, root) <- options.skillsBuiltinRoots
             ]
     pure (projectRoots <> userRoots <> builtinRoots)
-  where
-    origins = [AgentSkills, GrokSkills, CodexSkills]
-    relativeRoot = \case
-        AgentSkills -> ".agents" </> "skills"
-        GrokSkills -> ".grok" </> "skills"
-        CodexSkills -> ".codex" </> "skills"
-    userRoot = \case
-        AgentSkills -> ".agents" </> "skills"
-        GrokSkills -> ".grok" </> "skills"
-        CodexSkills -> ".codex" </> "skills"
+
+agentSkillsRelativeRoot :: FilePath
+agentSkillsRelativeRoot = ".agents" </> "skills"
 
 findSkillFiles :: Int -> FilePath -> IO ([FilePath], [SkillWarning])
 findSkillFiles maxDepth root = do
@@ -647,9 +639,7 @@ skillSortKey skill =
                     UserSkill -> (0, 0)
                     RepositorySkill d _ -> (1, d)
                 sourceOriginRank = case origin of
-                    AgentSkills -> 3
-                    GrokSkills -> 2
-                    CodexSkills -> 1
+                    AgentSkills -> 1
             in (rank, sourceDepth, sourceOriginRank)
 
 modelVisibleSkills :: SkillCatalog -> [Skill]
@@ -747,8 +737,6 @@ scopeQualifier skill = case skill.skillSource of
 originSlug :: SkillOrigin -> Text
 originSlug = \case
     AgentSkills -> "agents"
-    GrokSkills -> "grok"
-    CodexSkills -> "codex"
 
 sourceSlug :: Skill -> Text
 sourceSlug skill = case skill.skillSource of

--- a/packages/agent-core/test/Agent/SkillsSpec.hs
+++ b/packages/agent-core/test/Agent/SkillsSpec.hs
@@ -39,6 +39,28 @@ spec = describe "Agent.Skills" do
             map (.skillDescription) catalog.catalogSkills
                 `shouldBe` ["local commit", "root review", "user commit"]
 
+    it "does not discover skills from other harness directories" do
+        withTempDir \dir -> do
+            let home = dir </> "home"
+                repo = dir </> "repo"
+            writeSkill (home </> ".codex" </> "skills" </> "codex-home")
+                "codex-home" "codex home skill" []
+            writeSkill (home </> ".grok" </> "skills" </> "grok-home")
+                "grok-home" "grok home skill" []
+            writeSkill (home </> ".claude" </> "skills" </> "claude-home")
+                "claude-home" "claude home skill" []
+            writeSkill (repo </> ".codex" </> "skills" </> "codex-repo")
+                "codex-repo" "codex repo skill" []
+            writeSkill (repo </> ".grok" </> "skills" </> "grok-repo")
+                "grok-repo" "grok repo skill" []
+            writeSkill (repo </> ".claude" </> "skills" </> "claude-repo")
+                "claude-repo" "claude repo skill" []
+            writeSkill (repo </> ".agents" </> "skills" </> "ours")
+                "ours" "harness skill" []
+            catalog <- discoverSkills (options home repo repo)
+            map (.skillName) catalog.catalogSkills `shouldBe` ["ours"]
+            catalog.catalogWarnings `shouldBe` []
+
     it "parses Grok fields and Codex invocation policy" do
         withTempDir \dir -> do
             let home = dir </> "home"
@@ -164,7 +186,7 @@ spec = describe "Agent.Skills" do
 
     it "builds bare and qualified names while reserving built-ins" do
         let rootSkill = fakeSkill "review" "root" (RepositorySkill 0 False) AgentSkills
-            userSkill = fakeSkill "review" "user" UserSkill GrokSkills
+            userSkill = fakeSkill "review" "user" UserSkill AgentSkills
             uniqueSkill = fakeSkill "deploy" "deploy" UserSkill AgentSkills
             catalog = SkillCatalog [rootSkill, userSkill, uniqueSkill] []
             invocations = buildSkillInvocations ["review"] catalog


### PR DESCRIPTION
## Summary
- discover user and repository filesystem skills only from `.agents/skills`
- stop loading vendor skill trees such as `.codex/skills`, `.grok/skills`, and `.claude/skills`
- keep packaged built-in skills, MCP skills, and learned skills unchanged

## Validation
- `cabal repl agent-core:test:agent-core-test` `--match "Agent.Skills"` (18 examples, 0 failures)
- `cabal repl agent-cli:lib:agent-cli` (234 modules loaded)
- `git diff --check`