### PR TITLE
Render harness-owned tool results as readable text

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -295,8 +295,14 @@ spec = do
             formatToolOutput spawn
                 "{\"nickname\":null,\"task_name\":\"/root/reviewer\"}"
                 `shouldBe` "Agent: /root/reviewer"
+            formatToolOutput spawn
+                "Agent: /root/reviewer"
+                `shouldBe` "Agent: /root/reviewer"
             formatToolOutput wait
                 "{\"message\":\"agent updates: reviewer=completed\",\"timed_out\":false}"
+                `shouldBe` "agent updates: reviewer=completed"
+            formatToolOutput wait
+                "agent updates: reviewer=completed"
                 `shouldBe` "agent updates: reviewer=completed"
             formatToolOutput agents
                 "{\"agents\":[{\"agent_name\":\"/root/reviewer\",\

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -20,7 +20,6 @@ import Agent.Subagents
     , RootTurnId
     , SubagentStatus(..)
     , defaultWaitTimeoutMs
-    , encodeStatus
     , interruptSubagent
     , listAgents
     , queueMessageFromForTurn
@@ -71,18 +70,13 @@ import Agent.Tools.Types
 import Control.Concurrent.MVar (modifyMVar, newMVar)
 import Control.Exception.Safe (mask, onException)
 import Control.Monad (void)
-import Data.Aeson (Value(..), object, (.=))
+import Data.Aeson (object, (.=))
 import Data.List (sortOn)
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Key
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.ByteString.Lazy as LBS
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
 
 data SubagentWorktree = SubagentWorktree
     { subagentWorktreePath :: !OsPath
@@ -231,13 +225,15 @@ spawnAgentDescription =
     "Spawns an agent to work on the specified task. If your current task is \
     \/root/task1 and you spawn_agent with task_name \"task_3\" the agent will \
     \have canonical task name /root/task1/task_3. You may refer to this agent \
-    \as task_3 or /root/task1/task_3. Returns the canonical task_name."
+    \as task_3 or /root/task1/task_3. Returns labeled text with the canonical \
+    \task name."
 
 spawnAgentInWorktreeDescription :: Text
 spawnAgentInWorktreeDescription =
     "Creates a dedicated git worktree and spawns an agent inside it. The \
     \worktree is owned by the child agent and removed when that agent is \
-    \closed. Returns the canonical task_name and worktree path."
+    \closed. Returns labeled text with the canonical task name and worktree \
+    \path."
 
 data SpawnWorkspace
     = SharedWorkspace
@@ -345,13 +341,16 @@ spawnInWorkspace ctx call args resolvedModel childCwd worktree = mask \restore -
     case result of
         Left err -> cleanupFailedWorktree ownedWorktree err
         Right (_agentId, path) ->
-            pure $ Right $ encodeJson $ object $
-                [ "task_name" .= taskPathText path
-                , "nickname" .= Aeson.Null
-                ]
-                    <> maybe []
-                        (\lease -> ["worktree" .= toText lease.subagentWorktreePath])
-                        ownedWorktree
+            pure $ Right $ renderSpawnResult path ownedWorktree
+
+renderSpawnResult :: TaskPath -> Maybe SubagentWorktree -> Text
+renderSpawnResult path worktree =
+    Text.intercalate "\n" $
+        ("Agent: " <> taskPathText path)
+            : maybe
+                []
+                (\lease -> ["Worktree: " <> toText lease.subagentWorktreePath])
+                worktree
 
 resolveSpawnWorkspace
     :: MultiAgentContext
@@ -510,8 +509,8 @@ waitAgentTool ctx = jsonTool "wait_agent" waitAgentDescription
 waitAgentDescription :: Text
 waitAgentDescription =
     "Wait for a mailbox update from live agents, including final-status \
-    \notifications. Returns a summary of which agents have updates, or a \
-    \timeout summary if no activity arrives before the deadline."
+    \notifications. Returns labeled text summarizing which agents have \
+    \updates, or a timeout notice if no activity arrives before the deadline."
 
 runWait :: MultiAgentContext -> WaitAgentArgs -> IO (Either Text Text)
 runWait ctx args = do
@@ -520,10 +519,7 @@ runWait ctx args = do
         Nothing -> do
             (statuses, timedOut) <-
                 waitAnyLive ctx.multiRegistry ctx.multiSelfId timeoutMs
-            pure $ Right $ encodeJson $ object
-                [ "message" .= waitSummary timedOut statuses
-                , "timed_out" .= timedOut
-                ]
+            pure $ Right $ renderWaitResult timedOut statuses False
         Just [] -> pure (Left "targets must be non-empty when provided")
         Just targets -> do
             resolved <- mapM (resolveAgentTarget ctx.multiRegistry ctx.multiTaskPath) targets
@@ -533,11 +529,23 @@ runWait ctx args = do
                     (statuses, timedOut) <-
                         waitSubagentsFrom
                             ctx.multiRegistry ctx.multiSelfId ids timeoutMs
-                    pure $ Right $ encodeJson $ object
-                        [ "message" .= waitSummary timedOut statuses
-                        , "timed_out" .= timedOut
-                        , "status" .= statusObject statuses
-                        ]
+                    pure $ Right $ renderWaitResult timedOut statuses True
+
+renderWaitResult :: Bool -> Map SubagentId SubagentStatus -> Bool -> Text
+renderWaitResult timedOut statuses includeStatus =
+    Text.intercalate "\n" $
+        waitSummary timedOut statuses
+            : if includeStatus && not (Map.null statuses)
+                then "" : map renderWaitStatus (Map.toList statuses)
+                else []
+
+renderWaitStatus :: (SubagentId, SubagentStatus) -> Text
+renderWaitStatus (agentId, status) =
+    Text.intercalate "\n" $
+        [ agentId.unSubagentId
+        , "  Status: " <> agentListStatus status
+        ]
+            <> agentListDetails status
 
 waitSummary :: Bool -> Map SubagentId SubagentStatus -> Text
 waitSummary timedOut statuses
@@ -558,13 +566,6 @@ shortStatus = \case
     Running -> "running"
     Pending -> "pending"
     NotFound -> "not_found"
-
-statusObject :: Map SubagentId SubagentStatus -> Value
-statusObject =
-    Object
-        . KeyMap.fromList
-        . map (\(SubagentId tid, status) -> (Key.fromText tid, encodeStatus status))
-        . Map.toList
 
 --------------------------------------------------------------------------------
 -- send_message / followup_task
@@ -798,8 +799,9 @@ interruptAgentTool ctx = jsonTool "interrupt_agent" interruptDescription
 
 interruptDescription :: Text
 interruptDescription =
-    "Interrupt an agent's current turn, if any, and return its previous status. \
-    \The agent remains available for messages and follow-up tasks."
+    "Interrupt an agent's current turn, if any, and return its previous status \
+    \as labeled text. The agent remains available for messages and follow-up \
+    \tasks."
 
 encryptedString :: Text -> PropertyType
 encryptedString description = PropertyRaw $ object
@@ -817,10 +819,10 @@ runInterrupt ctx args = do
             result <- interruptSubagent ctx.multiRegistry agentId
             pure $ case result of
                 Left err -> Left err
-                Right previous ->
-                    Right $ encodeJson $ object
-                        [ "previous_status" .= encodeStatus previous
-                        ]
+                Right previous -> Right (renderInterruptStatus previous)
 
-encodeJson :: Value -> Text
-encodeJson = Text.decodeUtf8 . LBS.toStrict . Aeson.encode
+renderInterruptStatus :: SubagentStatus -> Text
+renderInterruptStatus previous =
+    Text.intercalate "\n" $
+        ("Previous status: " <> agentListStatus previous)
+            : agentListDetails previous

--- a/packages/agent-core/src/Agent/Tools/Secret.hs
+++ b/packages/agent-core/src/Agent/Tools/Secret.hs
@@ -42,14 +42,7 @@ import Control.Exception.Safe
     , tryIO
     )
 import Control.Monad (void)
-import Data.Aeson
-    ( Value
-    , object
-    , (.=)
-    )
-import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (readIORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -145,7 +138,8 @@ askSecretDescription :: Text
 askSecretDescription =
     "Ask the user for a secret without placing it in chat or tool arguments. "
         <> "The harness writes the exact value to a private temporary file and "
-        <> "returns only its path. Never read, print, or echo the file contents."
+        <> "returns labeled text with only its path. Never read, print, or echo "
+        <> "the file contents."
 
 runAskSecret :: SecretStore -> AskSecretArgs -> IO (Either Text Text)
 runAskSecret store args
@@ -179,15 +173,12 @@ storeSecret store secret =
                 then do
                     removeSecretArtifact artifact
                     pure (Left "Secret storage is already closed.")
-                else pure $ Right $ encodeJson $ object
-                    [ "secret_file" .= Text.pack artifact.artifactFile
-                    , "message" .=
-                        ( "Secret saved to a private temporary file. Pass this "
-                            <> "path directly to the consuming program without "
-                            <> "reading or echoing the contents. Delete the file "
-                            <> "as soon as it has been consumed."
-                            :: Text
-                        )
+                else pure $ Right $ Text.intercalate "\n"
+                    [ "Secret file: " <> Text.pack artifact.artifactFile
+                    , "Secret saved to a private temporary file. Pass this \
+                      \path directly to the consuming program without \
+                      \reading or echoing the contents. Delete the file \
+                      \as soon as it has been consumed."
                     ]
 
 createSecretArtifact
@@ -249,6 +240,3 @@ closeAndRemove handle artifact = do
 
 exceptionText :: SomeException -> Text
 exceptionText = Text.pack . displayException
-
-encodeJson :: Value -> Text
-encodeJson = Text.decodeUtf8 . LBS.toStrict . Aeson.encode

--- a/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/MultiAgentsSpec.hs
@@ -103,7 +103,7 @@ spec = describe "Agent.Tools.MultiAgents" do
             (Just "gpt-5.6-luna")
             (Just "high")
             (Just "none")
-        result `shouldSatisfy` isRightResult
+        result `shouldBe` Right "Agent: /root/artifact_analysis"
         (agentId, options) <- atomically (takeTMVar prepared)
         path <- getTaskPath registry agentId
         taskPathText <$> path
@@ -506,7 +506,8 @@ spec = describe "Agent.Tools.MultiAgents" do
                 }
         result <- dispatchToolCall defaultLoopDispatch
             (appToolHandlers (multiAgentTools context)) call
-        result.output `shouldSatisfy` Text.isInfixOf "/tmp/worktree"
+        result.output `shouldBe`
+            "Agent: /root/worker\nWorktree: /tmp/worktree"
         atomically (takeTMVar childCwd) `shouldReturn` worktreePath
         readIORef cleaned `shouldReturn` False
         closeSubagentRegistry registry
@@ -604,6 +605,43 @@ spec = describe "Agent.Tools.MultiAgents" do
         result.output `shouldSatisfy` Text.isInfixOf child.unSubagentId
         result.output `shouldNotSatisfy` Text.isInfixOf parent.unSubagentId
         atomically (writeTVar parentGate True)
+        closeSubagentRegistry registry
+
+    it "returns text for targeted waits and preserves completed output on interruption" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> pure (resultWithText "review done"))
+            (\_ _ -> pure ())
+        Right (agentId, _) <-
+            spawnSubagentAt registry Nothing taskPathRoot 0 "reviewer"
+                (plainInterAgentContent "review") Nothing
+        _ <- waitSubagents registry [agentId] 15000
+        let handlers =
+                appToolHandlers (multiAgentTools (rootContext registry Nothing))
+        waited <- dispatchToolCall defaultLoopDispatch handlers
+            (ToolCall "wait-target" "collaboration.wait_agent"
+                "{\"targets\":[\"reviewer\"],\"timeout_ms\":1}"
+                FunctionCallKind False)
+        waited.output `shouldSatisfy` Text.isInfixOf
+            (agentId.unSubagentId <> "\n  Status: completed\n  Final: review done")
+        waited.output `shouldNotSatisfy` Text.isPrefixOf "{"
+        interrupted <- dispatchToolCall defaultLoopDispatch handlers
+            (ToolCall "interrupt-target" "collaboration.interrupt_agent"
+                "{\"target\":\"reviewer\"}" FunctionCallKind False)
+        interrupted.output `shouldBe`
+            "Previous status: completed\n  Final: review done"
+        closeSubagentRegistry registry
+
+    it "returns a plain timeout notice while an agent remains active" do
+        gate <- newEmptyTMVarIO
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath "/tmp")
+            (\_ _ _ _ -> atomically (takeTMVar gate) >> pure (resultWithText "done"))
+            (\_ _ -> pure ())
+        Right _ <- spawnSubagentAt registry Nothing taskPathRoot 0 "reviewer"
+            (plainInterAgentContent "review") Nothing
+        result <- dispatchToolCall defaultLoopDispatch
+            (appToolHandlers (multiAgentTools (rootContext registry Nothing)))
+            (waitCall { arguments = "{\"timeout_ms\":1}" })
+        result.output `shouldBe` "timed out waiting for agent updates"
         closeSubagentRegistry registry
 
     it "returns labeled text for live agents instead of JSON" do

--- a/packages/agent-core/test/Agent/Tools/SecretSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/SecretSpec.hs
@@ -1,6 +1,5 @@
 module Agent.Tools.SecretSpec (spec) where
 
-import qualified Agent.Json.Decode as Json
 import Agent.ToolDispatch
     ( ToolCallResult(..)
     , ToolDispatchConfig(..)
@@ -179,12 +178,12 @@ runTool tool arguments = do
 
 resultSecretPath :: Text -> IO FilePath
 resultSecretPath output =
-    case Json.decodeText
-            (Json.object (Json.atKey "secret_file" Json.text))
-            output of
-        Right path -> pure (Text.unpack path)
-        Left _ -> expectationFailure ("missing secret_file in output: " <> Text.unpack output)
-            >> pure ""
+    case Text.stripPrefix "Secret file: " (Text.takeWhile (/= '\n') output) of
+        Just path | not (Text.null (Text.strip path)) ->
+            pure (Text.unpack (Text.strip path))
+        _ ->
+            expectationFailure ("missing Secret file in output: " <> Text.unpack output)
+                >> pure ""
 
 modeOf :: FilePath -> IO Integer
 modeOf path =

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Goal.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Goal.hs
@@ -30,12 +30,9 @@ import Control.Concurrent.MVar
     , newMVar
     , readMVar
     )
-import Data.Aeson (object, (.=))
-import qualified Data.Aeson.Text as Aeson
 import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Lazy as LazyText
 
 data GoalStatus
     = GoalActive
@@ -217,7 +214,7 @@ runUpdateGoal (GoalRuntime state) args =
                     summary =
                         "Goal paused as blocked: " <> reason
                             <> maybe "" ("\nProgress: " <>) (nonBlank args.message)
-                pure (Just updated, Right (successOutput summary))
+                pure (Just updated, Right summary)
             | args.completed == Just True -> do
                 let updated = goal
                         { goalStatus = GoalComplete
@@ -228,13 +225,13 @@ runUpdateGoal (GoalRuntime state) args =
                     summary =
                         "Goal marked complete (automatic classifier verification is disabled in this host)."
                             <> maybe "" ("\nSummary: " <>) (nonBlank args.message)
-                pure (Just updated, Right (successOutput summary))
+                pure (Just updated, Right summary)
             | Just note <- nonBlank args.message -> do
                 let updated = goal
                         { goalProgress = goal.goalProgress <> [note] }
                 pure
                     ( Just updated
-                    , Right (successOutput ("Progress recorded: " <> note))
+                    , Right ("Progress recorded: " <> note)
                     )
             | otherwise ->
                 pure
@@ -253,13 +250,6 @@ nonBlank = (>>= keep)
     keep value =
         let stripped = Text.strip value
         in if Text.null stripped then Nothing else Just stripped
-
-successOutput :: Text -> Text
-successOutput summary =
-    LazyText.toStrict $ Aeson.encodeToLazyText $ object
-        [ "success" .= True
-        , "summary" .= summary
-        ]
 
 goalStatusName :: GoalStatus -> Text
 goalStatusName = \case

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Scheduler.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Scheduler.hs
@@ -67,8 +67,6 @@ import Control.Concurrent.MVar
     )
 import Control.Exception.Safe (tryAny)
 import Control.Monad (void)
-import Data.Aeson (Value, object, (.=))
-import qualified Data.Aeson.Text as Aeson
 import Data.Char (isDigit)
 import Data.List (sortOn)
 import Data.Map.Strict (Map)
@@ -76,7 +74,6 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Lazy as LazyText
 import Data.Time
     ( UTCTime
     , addUTCTime
@@ -489,15 +486,12 @@ runSchedulerDelete runtime args = do
                     }
             in pure (updated, existed)
     writeChan runtime.schedulerSignal SchedulerWake
-    pure $ Right $ jsonText $ object
-        [ "success" .= removed
-        , "message" .=
-            if removed
-                then "Scheduled task " <> taskId <> " cancelled."
-                else
-                    "No scheduled task with ID " <> taskId
-                        <> " found. Use scheduler_list to see active tasks."
-        ]
+    pure $ Right $
+        if removed
+            then "Scheduled task " <> taskId <> " cancelled."
+            else
+                "No scheduled task with ID " <> taskId
+                    <> " found. Use scheduler_list to see active tasks."
 
 data SchedulerListArgs = SchedulerListArgs
 
@@ -508,7 +502,7 @@ schedulerListTool :: SchedulerRuntime -> AppTool
 schedulerListTool runtime =
     jsonTool
         "scheduler_list"
-        "List all active scheduled tasks with their IDs, prompts, intervals, and next fire times."
+        "List all active scheduled tasks with their IDs, prompts, intervals, and next fire times. Returns readable labeled text."
         []
         True
         TurnSequential
@@ -529,30 +523,27 @@ listScheduledTasks runtime = do
 
 schedulerCreateOutput :: Bool -> ScheduledTask -> Text
 schedulerCreateOutput updated task =
-    jsonText $ object
-        [ "id" .= task.scheduledId
-        , "humanSchedule" .=
-            intervalToHuman task.scheduledIntervalSeconds
-        , "updated" .= updated
+    Text.intercalate "\n"
+        [ (if updated then "Updated" else "Created")
+            <> " scheduled task "
+            <> task.scheduledId
+        , "  Interval: " <> intervalToHuman task.scheduledIntervalSeconds
         ]
 
 schedulerListOutput :: [ScheduledTaskSnapshot] -> Text
-schedulerListOutput tasks =
-    jsonText $ object
-        [ "tasks" .=
-            [ object
-                [ "id" .= task.scheduledTaskId
-                , "prompt" .= truncatePrompt task.scheduledTaskPrompt
-                , "intervalHuman" .=
-                    intervalToHuman task.scheduledTaskIntervalSeconds
-                , "nextFireAt" .=
-                    formatTimestamp task.scheduledTaskNextFireAt
-                , "createdAt" .=
-                    formatTimestamp task.scheduledTaskCreatedAt
-                , "recurring" .= True
-                ]
-            | task <- tasks
-            ]
+schedulerListOutput = \case
+    [] -> "(no scheduled tasks)"
+    tasks -> Text.intercalate "\n\n" (map renderScheduledTask tasks)
+
+renderScheduledTask :: ScheduledTaskSnapshot -> Text
+renderScheduledTask task =
+    Text.intercalate "\n"
+        [ "Task: " <> task.scheduledTaskId
+        , "  Prompt: " <> truncatePrompt task.scheduledTaskPrompt
+        , "  Interval: " <> intervalToHuman task.scheduledTaskIntervalSeconds
+        , "  Next fire: " <> formatTimestamp task.scheduledTaskNextFireAt
+        , "  Created: " <> formatTimestamp task.scheduledTaskCreatedAt
+        , "  Recurring: yes"
         ]
 
 taskSnapshot :: ScheduledTask -> ScheduledTaskSnapshot
@@ -799,6 +790,3 @@ nonBlank = (>>= keep)
     keep value =
         let stripped = Text.strip value
         in if Text.null stripped then Nothing else Just stripped
-
-jsonText :: Value -> Text
-jsonText = LazyText.toStrict . Aeson.encodeToLazyText

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Workflow.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Workflow.hs
@@ -44,15 +44,13 @@ import Control.Concurrent.MVar
     , newMVar
     , readMVar
     )
-import Data.Aeson (Value, object, (.=))
-import qualified Data.Aeson.Text as Aeson
+import Data.Aeson (object)
 import Data.List (sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Lazy as LazyText
 import Data.Time (UTCTime, getCurrentTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import System.OsPath (OsPath)
@@ -175,15 +173,11 @@ runWorkflow runtime rawArgs =
         Left err -> pure (Left err)
         Right (workflowName, objective)
             | rawArgs.validateOnly ->
-                pure $ Right $ jsonText $ object
-                    [ "run_id" .= ("" :: Text)
-                    , "task_id" .= ("" :: Text)
-                    , "name" .= workflowName
-                    , "message" .=
-                        ("Smoke check passed for workflow '"
-                            <> workflowName
-                            <> "'. This did not launch the workflow or exercise live dependencies.")
-                    ]
+                pure $ Right $ renderWorkflowNotice
+                    workflowName
+                    ("Smoke check passed for workflow '"
+                        <> workflowName
+                        <> "'. This did not launch the workflow or exercise live dependencies.")
             | otherwise -> launchWorkflow runtime workflowName objective
 
 normalizeWorkflowArgs :: WorkflowArgs -> WorkflowArgs
@@ -322,15 +316,23 @@ launchWorkflow runtime workflowName objective = do
                                 Map.insert runId created store.workflowRuns
                             }
                     pure (updated, created)
-            pure $ Right $ jsonText $ object
-                [ "run_id" .= run.workflowInternalRunId
-                , "task_id" .= run.workflowInternalRunId
-                , "name" .= run.workflowDisplayName
-                , "message" .=
-                    ("Workflow '"
-                        <> run.workflowDisplayName
-                        <> "' started in the background. Completion is reported automatically. The display name is user-facing; keep the structured run id internal.")
-                ]
+            pure $ Right $ renderWorkflowLaunch run
+
+renderWorkflowLaunch :: WorkflowRun -> Text
+renderWorkflowLaunch run =
+    renderWorkflowNotice
+        run.workflowDisplayName
+        ("Workflow '"
+            <> run.workflowDisplayName
+            <> "' started in the background. Completion is reported automatically. The display name is user-facing; keep the structured run id internal.")
+        <> "\n  Run ID: "
+        <> run.workflowInternalRunId
+        <> "\n  Task ID: "
+        <> run.workflowInternalRunId
+
+renderWorkflowNotice :: Text -> Text -> Text
+renderWorkflowNotice name message =
+    message <> "\n  Name: " <> name
 
 workflowRunSnapshots
     :: WorkflowRuntime
@@ -421,6 +423,3 @@ nonBlank = (>>= keep)
     keep value =
         let stripped = Text.strip value
         in if Text.null stripped then Nothing else Just stripped
-
-jsonText :: Value -> Text
-jsonText = LazyText.toStrict . Aeson.encodeToLazyText

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/RuntimeSpec.hs
@@ -120,8 +120,8 @@ spec = do
                         "scheduler_create"
                         "{\"interval\":\"30s\",\"prompt\":\"check deploy\",\
                         \\"fire_immediately\":true}"
-                    created.output `shouldSatisfy`
-                        Text.isInfixOf "\"humanSchedule\":\"every 1 minute\""
+                    created.output `shouldBe`
+                        "Created scheduled task sched-1\n  Interval: every 1 minute"
                     timeout 1000000 (takeMVar fired)
                         `shouldReturn` Just
                             (ScheduledFire
@@ -137,18 +137,39 @@ spec = do
                         [schedulerListTool runtime]
                         "scheduler_list"
                         "{}"
-                    listed.output `shouldSatisfy`
-                        Text.isInfixOf "\"intervalHuman\":\"every 1 minute\""
-                    listed.output `shouldSatisfy`
-                        Text.isInfixOf
-                            "\"createdAt\":\"2026-08-24T00:00:00Z\""
+                    listed.output `shouldBe` Text.intercalate "\n"
+                        [ "Task: sched-1"
+                        , "  Prompt: check deploy"
+                        , "  Interval: every 1 minute"
+                        , "  Next fire: 2026-08-24T00:01:00Z"
+                        , "  Created: 2026-08-24T00:00:00Z"
+                        , "  Recurring: yes"
+                        ]
                     deleted <- call
                         [schedulerDeleteTool runtime]
                         "scheduler_delete"
                         "{\"id\":\"sched-1\"}"
                     deleted.output `shouldSatisfy`
-                        Text.isInfixOf "\"success\":true"
+                        Text.isInfixOf "Scheduled task sched-1 cancelled."
                     listScheduledTasks runtime `shouldReturn` []
+
+        it "renders empty lists, updates, and missing deletions as text" do
+            bracket
+                (testScheduler (pure fixedTime) (\_ -> pure (Right testAgent)))
+                closeSchedulerRuntime
+                \runtime -> do
+                    empty <- call [schedulerListTool runtime] "scheduler_list" "{}"
+                    empty.output `shouldBe` "(no scheduled tasks)"
+                    _ <- call [schedulerCreateTool runtime] "scheduler_create"
+                        "{\"interval\":\"5m\",\"prompt\":\"check\"}"
+                    updated <- call [schedulerCreateTool runtime] "scheduler_create"
+                        "{\"task_id\":\"sched-1\",\"interval\":\"2h\"}"
+                    updated.output `shouldBe`
+                        "Updated scheduled task sched-1\n  Interval: every 2 hours"
+                    missing <- call [schedulerDeleteTool runtime] "scheduler_delete"
+                        "{\"id\":\"sched-2\"}"
+                    missing.output `shouldBe`
+                        "No scheduled task with ID sched-2 found. Use scheduler_list to see active tasks."
 
         it "rejects unsupported durable and foreground scheduling" do
             bracket
@@ -220,7 +241,7 @@ spec = do
                                 <> Text.pack (show index)
                                 <> "\"}")
                         result.output `shouldSatisfy`
-                            Text.isInfixOf "\"updated\":false"
+                            Text.isInfixOf "Created scheduled task"
                     writeIORef clock (addUTCTime 60 fixedTime)
                     _ <- call
                         [schedulerCreateTool runtime]
@@ -252,7 +273,7 @@ spec = do
                             "scheduler_create"
                             "{\"interval\":\"5m\",\"prompt\":\"check\"}"
                         result.output `shouldSatisfy`
-                            Text.isInfixOf "\"updated\":false"
+                            Text.isInfixOf "Created scheduled task"
                     overflow <- call
                         [schedulerCreateTool runtime]
                         "scheduler_create"
@@ -268,7 +289,7 @@ spec = do
                         "scheduler_create"
                         "{\"interval\":\"5m\",\"prompt\":\"replacement\"}"
                     replacement.output `shouldSatisfy`
-                        Text.isInfixOf "\"id\":\"sched-51\""
+                        Text.isInfixOf "Created scheduled task sched-51"
 
     describe "goal runtime" do
         it "tracks progress, blocking, resumption, and honest completion" do
@@ -285,13 +306,12 @@ spec = do
                 [updateGoalTool goals]
                 "update_goal"
                 "{\"message\":\"implemented core\"}"
-            progress.output `shouldSatisfy`
-                Text.isInfixOf "Progress recorded"
+            progress.output `shouldBe` "Progress recorded: implemented core"
             blocked <- call
                 [updateGoalTool goals]
                 "update_goal"
                 "{\"blocked_reason\":\"CI unavailable\"}"
-            blocked.output `shouldSatisfy` Text.isInfixOf "blocked"
+            blocked.output `shouldBe` "Goal paused as blocked: CI unavailable"
             fmap (.goalStatus) <$> readGoal goals
                 `shouldReturn` Just GoalBlocked
             _ <- resumeGoal goals
@@ -299,8 +319,8 @@ spec = do
                 [updateGoalTool goals]
                 "update_goal"
                 "{\"completed\":true,\"message\":\"verified locally\"}"
-            completed.output `shouldSatisfy`
-                Text.isInfixOf "classifier verification is disabled"
+            completed.output `shouldBe`
+                "Goal marked complete (automatic classifier verification is disabled in this host).\nSummary: verified locally"
             fmap (.goalStatus) <$> readGoal goals
                 `shouldReturn` Just GoalComplete
             clearGoal goals `shouldReturn` True
@@ -331,20 +351,35 @@ spec = do
                     "{\"name\":\"deep-research\",\
                     \\"args\":{\"query\":\"Haskell effects\"}}"
                 first.output `shouldSatisfy`
-                    Text.isInfixOf "\"name\":\"deep-research\""
+                    Text.isInfixOf "Name: deep-research"
+                first.output `shouldSatisfy`
+                    Text.isInfixOf "\n  Run ID: wf_1\n  Task ID: wf_1"
                 second <- call
                     [workflowTool runtime]
                     "workflow"
                     "{\"name\":\"deep-research\",\
                     \\"args\":\"GHC optimization\"}"
                 second.output `shouldSatisfy`
-                    Text.isInfixOf "\"name\":\"deep-research-2\""
+                    Text.isInfixOf "Name: deep-research-2"
                 runs <- workflowRunSnapshots runtime
                 map (.workflowRunName) runs
                     `shouldMatchList`
                         ["deep-research", "deep-research-2"]
                 map (.workflowRunId) runs
                     `shouldMatchList` ["wf_1", "wf_2"]
+
+        it "reports validation without a launch or a fabricated run identifier" do
+            withTempDir \dir -> withRegistry \registry -> do
+                specs <- newIORef Map.empty
+                runtime <- newWorkflowRuntime
+                    (unsafeEncodeUtf dir)
+                    (rootContext registry)
+                    specs
+                result <- call [workflowTool runtime] "workflow"
+                    "{\"name\":\"deep-research\",\"args\":\"Haskell effects\",\"validate_only\":true}"
+                result.output `shouldBe`
+                    "Smoke check passed for workflow 'deep-research'. This did not launch the workflow or exercise live dependencies.\n  Name: deep-research"
+                workflowRunSnapshots runtime `shouldReturn` []
 
         it "probes workflow run statuses concurrently and preserves run order" do
             withRegistry \registry -> do

--- a/packages/agent-mcp/src/Agent/MCP/Fleet.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Fleet.hs
@@ -63,7 +63,7 @@ import Control.Exception.Safe
     )
 import Control.Monad (forM, forM_, unless, void, when)
 import Data.Aeson
-    ( Value(..)
+    ( Value
     , object
     , (.=)
     )
@@ -789,7 +789,8 @@ mcpSearchTool :: McpFleet -> AppTool
 mcpSearchTool fleet = AppTool
     { appToolName = "mcp_search"
     , appToolDescription =
-        "Search currently available MCP tools. Servers may still be connecting."
+        "Search currently available MCP tools. Servers may still be connecting. \
+        \Returns readable labeled text."
     , appToolSchema = RawJsonFunctionSchema $ object
         [ "type" .= ("object" :: Text)
         , "properties" .= object
@@ -821,25 +822,7 @@ mcpSearchTool fleet = AppTool
                         (== entry.catalogClient.clientConfig.mcpServerName)
                         server
             found = take limit (filter matches (Map.toAscList entries))
-            payload = object
-                [ "tools" .=
-                    [ object $
-                        [ "name" .= name
-                        , "server" .=
-                            entry.catalogClient.clientConfig.mcpServerName
-                        , "description" .= describeTool entry.catalogTool
-                        , "inputSchema" .=
-                            entry.catalogTool.discoveredInputSchema
-                        , "readOnly" .= entry.catalogTool.discoveredReadOnly
-                        ]
-                        <> [ "outputSchema" .= schema
-                           | Just schema <- [entry.catalogTool.discoveredOutputSchema]
-                           ]
-                    | (name, entry) <- found
-                    ]
-                , "servers" .= map statusJson statuses
-                ]
-        pure (Right (compactJson payload))
+        pure (Right (renderMcpSearch statuses found))
     , appToolApproval = AlwaysReadOnly
     , appToolExecution = ParallelSafe
     , appToolResourceClaims = Nothing
@@ -850,7 +833,8 @@ grokSearchTool :: McpFleet -> AppTool
 grokSearchTool fleet = AppTool
     { appToolName = "search_tool"
     , appToolDescription =
-        "Search for MCP tools by keyword and retrieve their input schemas.\n\n\
+        "Search for MCP tools by keyword and retrieve their input schemas as \
+        \readable labeled text.\n\n\
         \If status is \"partial\", some servers may still be connecting."
     , appToolSchema = RawJsonFunctionSchema $ object
         [ "type" .= ("object" :: Text)
@@ -917,51 +901,42 @@ grokSearchTool fleet = AppTool
                             (\current pair@(name, entry) ->
                                 let server =
                                         entry.catalogClient.clientConfig.mcpServerName
-                                    toolJson = object
-                                        [ "tool_name" .= name
-                                        , "description" .=
+                                    toolMetadata = GrokSearchTool
+                                        { grokSearchToolName = name
+                                        , grokSearchToolDescription =
                                             truncateMcpDescription
                                                 (describeTool entry.catalogTool)
-                                        , "score" .= scoreEntry pair
-                                        , "input_schema" .=
+                                        , grokSearchToolScore = scoreEntry pair
+                                        , grokSearchToolSchema =
                                             entry.catalogTool.discoveredInputSchema
-                                        ]
+                                        }
                                     (before, rest) =
                                         break ((== server) . fst) current
                                 in case rest of
                                     [] ->
-                                        current <> [(server, [toolJson])]
+                                        current <> [(server, [toolMetadata])]
                                     (matchedServer, tools) : after ->
                                         before
                                             <> [ ( matchedServer
-                                                 , tools <> [toolJson]
+                                                 , tools <> [toolMetadata]
                                                  )
                                                ]
                                             <> after)
                             []
                             found
                     connecting = any isConnecting statuses
-                    payload = object
-                        [ "results" .=
-                            [ object
-                                [ "server" .= server
-                                , "tools" .= tools
-                                ]
-                            | (server, tools) <- grouped
-                            ]
-                        , "total_hidden_tools" .= Map.size entries
-                        , "status" .=
-                            (if connecting then ("partial" :: Text) else "ready")
-                        , "note" .=
-                            if connecting
-                                then Just
-                                    ("Some MCP servers are still connecting. Results may be incomplete." :: Text)
-                                else if Map.null entries
-                                    then Just
-                                        "No MCP tools are available in this session."
-                                    else Nothing
-                        ]
-                pure (Right (compactJson payload))
+                    note
+                        | connecting =
+                            Just
+                                ("Some MCP servers are still connecting. Results may be incomplete." :: Text)
+                        | Map.null entries =
+                            Just "No MCP tools are available in this session."
+                        | otherwise = Nothing
+                pure $ Right $ renderGrokSearch
+                    connecting
+                    (Map.size entries)
+                    note
+                    grouped
     , appToolApproval = AlwaysReadOnly
     , appToolExecution = ParallelSafe
     , appToolResourceClaims = Nothing
@@ -1303,7 +1278,8 @@ mcpListResourcesTool fleet = AppTool
     { appToolName = "mcp_list_resources"
     , appToolDescription =
         "List the resources and resource templates an MCP server exposes. \
-        \Omit `server` to query every connected server."
+        \Omit `server` to query every connected server. Returns readable \
+        \labeled text."
     , appToolSchema = RawJsonFunctionSchema $ object
         [ "type" .= ("object" :: Text)
         , "properties" .= object
@@ -1324,37 +1300,15 @@ mcpListResourcesTool fleet = AppTool
             listings <- forM selected \name -> do
                 resources <- mcpFleetListResources fleet name
                 templates <- mcpFleetListResourceTemplates fleet name
-                pure $ object
-                    [ "server" .= name
-                    , "resources" .= either (const []) (map resourceJson) resources
-                    , "resourceTemplates" .=
-                        either (const []) (map templateJson) templates
-                    , "error" .= either Just (const Nothing) resources
-                    ]
-            pure (Right (compactJson (object ["servers" .= listings])))
+                pure (renderMcpResourceServer name resources templates)
+            pure $ Right $ case listings of
+                [] -> "(no MCP resource servers)"
+                _ -> Text.intercalate "\n\n" listings
     , appToolApproval = AlwaysReadOnly
     , appToolExecution = ParallelSafe
     , appToolResourceClaims = Nothing
     , appToolAsyncCapability = BlockingOnly
     }
-  where
-    resourceJson :: McpResource -> Value
-    resourceJson resource = object
-        [ "uri" .= resource.resourceUri
-        , "name" .= resource.resourceName
-        , "title" .= resource.resourceTitle
-        , "description" .= resource.resourceDescription
-        , "mimeType" .= resource.resourceMimeType
-        , "size" .= resource.resourceSize
-        ]
-    templateJson :: McpResourceTemplate -> Value
-    templateJson template = object
-        [ "uriTemplate" .= template.templateUri
-        , "name" .= template.templateName
-        , "title" .= template.templateTitle
-        , "description" .= template.templateDescription
-        , "mimeType" .= template.templateMimeType
-        ]
 
 mcpReadResourceTool :: McpFleet -> AppTool
 mcpReadResourceTool fleet = AppTool
@@ -1531,17 +1485,139 @@ grokCallArgumentsDecoder = Json.object do
 emptyObject :: RawJson
 emptyObject = rawJsonFromEncoding (Aeson.toEncoding (object []))
 
-statusJson :: McpServerStatus -> Value
-statusJson status = object
-    [ "name" .= status.mcpStatusName
-    , "status" .= case status.mcpStatusState of
-        McpPending -> ("pending" :: Text)
-        McpInitializing -> "initializing"
-        McpReady -> "ready"
-        McpFailed _ -> "failed"
-        McpClosed -> "closed"
-    , "toolCount" .= status.mcpStatusToolCount
+data GrokSearchTool = GrokSearchTool
+    { grokSearchToolName :: !Text
+    , grokSearchToolDescription :: !Text
+    , grokSearchToolScore :: !Int
+    , grokSearchToolSchema :: !RawJson
+    }
+
+renderMcpSearch :: [McpServerStatus] -> [(Text, McpCatalogEntry)] -> Text
+renderMcpSearch statuses found =
+    Text.intercalate "\n\n" $
+        renderMcpServerStatuses statuses
+            : case found of
+                [] -> ["(no matching MCP tools)"]
+                _ -> map renderMcpSearchTool found
+
+renderMcpSearchTool :: (Text, McpCatalogEntry) -> Text
+renderMcpSearchTool (name, entry) =
+    Text.intercalate "\n" $
+        [ name
+        , "  Server: " <> entry.catalogClient.clientConfig.mcpServerName
+        , "  Description: " <> describeTool entry.catalogTool
+        , "  Read-only: "
+            <> if entry.catalogTool.discoveredReadOnly then "true" else "false"
+        , "  Input schema:"
+        ]
+            <> indentBlock (rawJsonText entry.catalogTool.discoveredInputSchema)
+            <> maybe
+                []
+                (\schema -> "  Output schema:" : indentBlock (rawJsonText schema))
+                entry.catalogTool.discoveredOutputSchema
+
+renderGrokSearch
+    :: Bool
+    -> Int
+    -> Maybe Text
+    -> [(Text, [GrokSearchTool])]
+    -> Text
+renderGrokSearch connecting hidden note grouped =
+    Text.intercalate "\n" $
+        [ "Status: " <> if connecting then "partial" else "ready"
+        , "Total hidden tools: " <> Text.pack (show hidden)
+        ]
+            <> maybe [] (\text -> ["Note: " <> text]) note
+            <> case grouped of
+                [] -> []
+                _ -> "" : Text.lines (Text.intercalate "\n\n" (map renderGrokServer grouped))
+
+renderGrokServer :: (Text, [GrokSearchTool]) -> Text
+renderGrokServer (server, tools) =
+    Text.intercalate "\n" $
+        server : concatMap renderGrokSearchMatch tools
+
+renderGrokSearchMatch :: GrokSearchTool -> [Text]
+renderGrokSearchMatch tool =
+    [ "  " <> tool.grokSearchToolName
+    , "    Score: " <> Text.pack (show tool.grokSearchToolScore)
+    , "    Description: " <> tool.grokSearchToolDescription
+    , "    Input schema:"
     ]
+        <> map ("      " <>) (Text.lines (rawJsonText tool.grokSearchToolSchema))
+
+renderMcpServerStatuses :: [McpServerStatus] -> Text
+renderMcpServerStatuses = \case
+    [] -> "Servers: (none)"
+    statuses ->
+        Text.intercalate "\n" $
+            "Servers:" : map renderMcpServerStatus statuses
+
+renderMcpServerStatus :: McpServerStatus -> Text
+renderMcpServerStatus status =
+    "  "
+        <> status.mcpStatusName
+        <> ": "
+        <> mcpStateLabel status.mcpStatusState
+        <> " ("
+        <> Text.pack (show status.mcpStatusToolCount)
+        <> if status.mcpStatusToolCount == 1 then " tool)" else " tools)"
+
+mcpStateLabel :: McpInitState -> Text
+mcpStateLabel = \case
+    McpPending -> "pending"
+    McpInitializing -> "initializing"
+    McpReady -> "ready"
+    McpFailed _ -> "failed"
+    McpClosed -> "closed"
+
+renderMcpResourceServer
+    :: Text
+    -> Either Text [McpResource]
+    -> Either Text [McpResourceTemplate]
+    -> Text
+renderMcpResourceServer name resources templates =
+    Text.intercalate "\n" $
+        [name]
+            <> case resources of
+                Left err ->
+                    ["  Error: " <> err, "  Resources: (none)"]
+                Right [] ->
+                    ["  Resources: (none)"]
+                Right items ->
+                    "  Resources:" : concatMap renderMcpResource items
+            <> case templates of
+                Left err -> ["  Resource templates error: " <> err]
+                Right [] -> ["  Resource templates: (none)"]
+                Right items ->
+                    "  Resource templates:" : concatMap renderMcpTemplate items
+
+renderMcpResource :: McpResource -> [Text]
+renderMcpResource resource =
+    ("    " <> resource.resourceName)
+        : ("      URI: " <> resource.resourceUri)
+        : catMaybes
+            [ ("      Title: " <>) <$> resource.resourceTitle
+            , ("      Description: " <>) <$> resource.resourceDescription
+            , ("      MIME type: " <>) <$> resource.resourceMimeType
+            , ("      Size: " <>) . Text.pack . show <$> resource.resourceSize
+            ]
+
+renderMcpTemplate :: McpResourceTemplate -> [Text]
+renderMcpTemplate template =
+    ("    " <> template.templateName)
+        : ("      URI template: " <> template.templateUri)
+        : catMaybes
+            [ ("      Title: " <>) <$> template.templateTitle
+            , ("      Description: " <>) <$> template.templateDescription
+            , ("      MIME type: " <>) <$> template.templateMimeType
+            ]
+
+rawJsonText :: RawJson -> Text
+rawJsonText = TextEncoding.decodeUtf8 . rawJsonBytes
+
+indentBlock :: Text -> [Text]
+indentBlock = map ("    " <>) . Text.lines
 
 isConnecting :: McpServerStatus -> Bool
 isConnecting status = case status.mcpStatusState of

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -4,6 +4,9 @@ import Agent.Loop (defaultLoopDispatch)
 import Agent.MCP
 import Agent.MCP.Fleet
     ( mcpFleetWaitForSkillRegistrations
+    , renderMcpSearch
+    , renderMcpResourceServer
+    , renderGrokSearch
     , spawnFleetWorker
     )
 import Agent.MCP.Supervisor (acquireMcpFleetWith)
@@ -141,6 +144,52 @@ testPendingRequest = do
 
 spec :: Spec
 spec = describe "Agent.MCP" do
+    describe "readable discovery results" do
+        it "labels an empty catalog without a JSON envelope" do
+            renderMcpSearch [] []
+                `shouldBe` "Servers: (none)\n\n(no matching MCP tools)"
+            renderGrokSearch False 0
+                (Just "No MCP tools are available in this session.") []
+                `shouldBe` "Status: ready\nTotal hidden tools: 0\nNote: No MCP tools are available in this session."
+
+        it "retains pending and failed server states" do
+            renderMcpSearch
+                [ McpServerStatus "connecting" McpInitializing 0
+                , McpServerStatus "unavailable" (McpFailed "offline") 0
+                , McpServerStatus "available" McpReady 1
+                ] []
+                `shouldBe` "Servers:\n  connecting: initializing (0 tools)\n  unavailable: failed (0 tools)\n  available: ready (1 tool)\n\n(no matching MCP tools)"
+
+        it "retains every resource and template metadata field" do
+            renderMcpResourceServer "documentation"
+                (Right [McpResource "file:///guide" "guide" (Just "Guide")
+                    (Just "Documentation") (Just "text/plain") (Just 42)])
+                (Right [McpResourceTemplate "file:///{name}" "document"
+                    (Just "Document") (Just "Named document") (Just "text/plain")])
+                `shouldBe` Text.intercalate "\n"
+                    [ "documentation"
+                    , "  Resources:"
+                    , "    guide"
+                    , "      URI: file:///guide"
+                    , "      Title: Guide"
+                    , "      Description: Documentation"
+                    , "      MIME type: text/plain"
+                    , "      Size: 42"
+                    , "  Resource templates:"
+                    , "    document"
+                    , "      URI template: file:///{name}"
+                    , "      Title: Document"
+                    , "      Description: Named document"
+                    , "      MIME type: text/plain"
+                    ]
+
+        it "distinguishes empty resource lists from listing failures" do
+            renderMcpResourceServer "empty" (Right []) (Right [])
+                `shouldBe` "empty\n  Resources: (none)\n  Resource templates: (none)"
+            renderMcpResourceServer "unavailable"
+                (Left "resources unavailable") (Left "templates unavailable")
+                `shouldBe` "unavailable\n  Error: resources unavailable\n  Resources: (none)\n  Resource templates error: templates unavailable"
+
     it "redacts configured environment values from Show" do
         let rendered = show McpServerConfig
                 { mcpServerName = "private"
@@ -626,8 +675,17 @@ spec = describe "Agent.MCP" do
                 waitUntilReady fleet
                 searched <- dispatch "search" "mcp_search"
                     "{\"query\":\"delayed\"}"
-                searched.output `shouldSatisfy`
-                    Text.isInfixOf "slow__delayed_read"
+                searched.output `shouldBe` Text.intercalate "\n"
+                    [ "Servers:"
+                    , "  slow: ready (1 tool)"
+                    , ""
+                    , "slow__delayed_read"
+                    , "  Server: slow"
+                    , "  Description: Delayed read."
+                    , "  Read-only: true"
+                    , "  Input schema:"
+                    , "    {\"type\":\"object\"}"
+                    ]
                 called <- dispatch "call" "mcp_call"
                     "{\"name\":\"slow__delayed_read\",\"arguments\":{}}"
                 called.output `shouldBe` "delayed response"
@@ -741,17 +799,17 @@ spec = describe "Agent.MCP" do
                 searched <- dispatch "search-grok" "search_tool"
                     "{\"query\":\"delayed\",\"limit\":5}"
                 searched.output `shouldSatisfy`
-                    Text.isInfixOf "\"tool_name\":\"grok__delayed_read\""
+                    Text.isInfixOf "grok__delayed_read"
                 searched.output `shouldSatisfy`
-                    Text.isInfixOf "\"status\":\"ready\""
+                    Text.isInfixOf "Status: ready"
                 searched.output `shouldSatisfy`
-                    Text.isInfixOf "\"total_hidden_tools\":1"
+                    Text.isInfixOf "Total hidden tools: 1"
                 searched.output `shouldSatisfy`
-                    Text.isInfixOf "\"score\":"
+                    Text.isInfixOf "Score:"
                 natural <- dispatch "search-natural" "search_tool"
                     "{\"query\":\"grok delayed read\"}"
                 natural.output `shouldSatisfy`
-                    Text.isInfixOf "\"tool_name\":\"grok__delayed_read\""
+                    Text.isInfixOf "grok__delayed_read"
                 invalidLimit <- dispatch "search-limit" "search_tool"
                     "{\"query\":\"delayed\",\"limit\":\"many\"}"
                 invalidLimit.output `shouldSatisfy`

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -659,6 +659,9 @@ spec = describe "tool presentation" do
         formatToolOutput worktreeSpawn
             "{\"task_name\":\"/root/worker\",\"worktree\":\"/tmp/worker\"}"
             `shouldBe` "Agent: /root/worker"
+        formatToolOutput worktreeSpawn
+            "Agent: /root/worker\nWorktree: /tmp/worker"
+            `shouldBe` "Agent: /root/worker\nWorktree: /tmp/worker"
 
     it "summarizes conversation search calls while preserving text output" do
         let call = functionToolCall


### PR DESCRIPTION
## Summary
- Replace JSON envelopes with readable labeled text for agent lifecycle, secure-secret, scheduler, goal, workflow, and MCP discovery tools.
- Preserve actual MCP payloads, structured schemas, and compatibility with historical JSON transcript rendering.
- Add regression coverage for result fields, empty results, timeouts, and discovery errors.

## Validation
- GHCi: core suites passed (39 examples).
- GHCi: MCP suite passed (70 examples).
- GHCi: dialect runtime suite passed (17 examples).
- git diff --check passed.
- Rendering assertions added but not executed: the available environment lacks aeson-pretty, and fresh nix develop is blocked by filesystem permissions. No production CLI rendering code changed.