### PR TITLE
Fix encryption classification for collaboration tool aliases

### DIFF
--- a/packages/agent-responses/src/Agent/Responses/LoopBackend/Output.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend/Output.hs
@@ -24,6 +24,7 @@ import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
     , ToolCallMode(..)
+    , canonicalToolName
     , toolCallMode
     , withToolCallMode
     )
@@ -196,10 +197,10 @@ isSensitiveComputerAction = \case
 
 encryptedCollaborationArguments :: Text -> Maybe [Text] -> Bool
 encryptedCollaborationArguments toolName encryptedFunctionArgs =
-    toolName `elem`
-        [ "collaboration.spawn_agent"
-        , "collaboration.send_message"
-        , "collaboration.followup_task"
+    canonicalToolName toolName `elem`
+        [ "spawn_agent"
+        , "send_message"
+        , "followup_task"
         ]
         && encryptedFunctionArgs /= Just []
 

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -219,6 +219,39 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
         Json.decodeEither responseItemDecoder payload
             `shouldSatisfy` isLeft
 
+    it "preserves encryption for bare and namespaced collaboration calls" do
+        mapM_ (\(callName, callNamespace, encryptionMetadata) -> do
+            let call = FunctionCall
+                    { itemId = Nothing
+                    , callId = "collaboration-encryption"
+                    , name = callName
+                    , namespace = callNamespace
+                    , provider = Nothing
+                    , arguments = "{\"message\":\"opaque-payload\"}"
+                    , encryptedFunctionArgs = encryptionMetadata
+                    , status = Nothing
+                    , async = Nothing
+                    }
+            case responseItemToToolCall (FunctionCallItem call) of
+                Just projected ->
+                    projected.argumentsEncrypted
+                        `shouldBe` (encryptionMetadata /= Just [])
+                Nothing -> expectationFailure "collaboration call was not projected"
+            )
+            [ (callName, callNamespace, encryptionMetadata)
+            | bareName <- ["send_message", "spawn_agent", "followup_task"]
+            , (callName, callNamespace) <-
+                [ (bareName, Nothing)
+                , (bareName, Just "collaboration")
+                , ("collaboration." <> bareName, Nothing)
+                , ("collaboration" <> bareName, Nothing)
+                , (bareName, Just "multi_agent_v1")
+                , ("multi_agent_v1." <> bareName, Nothing)
+                , ("multi_agent_v1" <> bareName, Nothing)
+                ]
+            , encryptionMetadata <- [Nothing, Just ["message"], Just []]
+            ]
+
     it "routes the reserved ordinary computer function to the harness" do
         let call = FunctionCall
                 { itemId = Nothing


### PR DESCRIPTION
## Summary
- Normalize collaboration tool names with the same canonicalization used by dispatch before classifying encrypted arguments.
- Preserve encryption for bare, namespaced, and legacy aliases of spawn_agent, send_message, and followup_task.
- Preserve the explicit empty encrypted_function_args plaintext override.

## Root cause
Dispatch accepts bare collaboration tool names, but encryption classification previously recognized only collaboration-prefixed names. Encrypted message arguments from bare calls were consequently delivered as input_text rather than encrypted_content, making instructions unreadable to recipients.

## Validation
- Reproduced the regression before the fix: bare send_message with absent encryption metadata was incorrectly classified as plaintext.
- Full Agent.Responses.LoopBackendSpec passed through Nix-provided GHCi: 67 examples, 0 failures.
- New regression covers 63 combinations of tool names, namespace representations, legacy aliases, and absent/present/empty encryption metadata.
- Local GHCi execution used temporary source copies with package-specific Cabal LANGUAGE defaults because the ordinary Cabal REPL was blocked by an unavailable Hermes source checkout. No production logic was changed in the copies.
- git diff --check passed.