### PR TITLE
fix: keep Codex compaction_trigger off Grok Responses

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Compaction
     , autoCompactOpenAiBackendWithSender
     , autoCompactOpenAiBackendWithSenderAndHook
     , autoCompactOpenAiBackendWithSenderHookAndDecorator
+    , autoCompactOpenAiBackendForDialect
     , autoCompactOpenAiBackendWith
     , autoCompactOpenAiBackendWithApi
     , autoCompactBackendWith
@@ -93,6 +94,10 @@ import Agent.OpenAI.Compaction
     , trimRemoteCompactionRequestToFit
     , trimResponseHistoryToFit
     , userTextItem
+    )
+import Agent.Dialect
+    ( DialectId(..)
+    , supportsCodexRemoteCompaction
     )
 import Agent.OpenAI.ModelMetadata
     ( codexAutoCompactTokenLimitFor
@@ -894,6 +899,15 @@ compactOpenAIAttempt
     -> Maybe Text
     -> IO (CompactAttempt ApiError)
 compactOpenAIAttempt send params history before focus
+    | not (supportsCodexRemoteCompaction CodexDialect params.model) =
+        summarizeLocalAttemptWith
+            XAI.grokDefaultContextWindow
+            prepareXaiLocalSummaryHistory
+            send
+            params
+            history
+            before
+            focus
     | hasFocus focus =
         summarizeLocalAttempt send params history before focus
     | otherwise =
@@ -1246,9 +1260,37 @@ autoCompactOpenAiBackendWithSenderHookAndDecorator
 autoCompactOpenAiBackendWithSenderHookAndDecorator
         configuredThreshold send recordUsage getParams decorateOutcome
         onCompacted contextTokensRef backend =
-    rejectOversizedInitialRequest getParams $
+    autoCompactOpenAiBackendForDialect
+        CodexDialect
+        (pure Nothing)
+        configuredThreshold
+        send
+        recordUsage
+        getParams
+        decorateOutcome
+        onCompacted
+        contextTokensRef
+        backend
+
+-- | OpenAI-transport automatic compaction that selects Codex remote v2 or
+-- Grok-safe local summarization from the live dialect and model name.
+autoCompactOpenAiBackendForDialect
+    :: DialectId
+    -> IO (Maybe Int)
+    -> Maybe Int
+    -> OpenAiCompactionSender
+    -> (TokenUsage -> IO ())
+    -> IO ResponseCreateParams
+    -> (CompactOutcome -> IO CompactOutcome)
+    -> (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
+    -> IORef (Maybe OccupancySnapshot)
+    -> BackendMiddleware
+autoCompactOpenAiBackendForDialect
+        dialectId getCatalogWindow configuredThreshold send recordUsage
+        getParams decorateOutcome onCompacted contextTokensRef backend =
+    rejectOversizedInitialRequest contextWindowFor getParams $
         boundCompletedToolContinuations
-            (codexEffectiveContextWindowFor . (.model))
+            contextWindowFor
             getParams
             contextTokensRef $
             autoCompactOpenAiBackendWithLimit
@@ -1261,24 +1303,24 @@ autoCompactOpenAiBackendWithSenderHookAndDecorator
                 contextTokensRef
                 backend
   where
+    contextWindowFor params =
+        openAiCompactContextWindow dialectId Nothing params
     getLimit = do
         params <- getParams
-        let configuredLimit =
-                fromMaybe
-                    (codexAutoCompactTokenLimitFor params.model)
-                    configuredThreshold
-        pure $
-            min
-                configuredLimit
-                (codexEffectiveContextWindowFor params.model)
+        catalogWindow <- getCatalogWindow
+        pure (openAiCompactTokenLimit
+            dialectId configuredThreshold catalogWindow params)
     compactAction history inputs = do
         params <- getParams
+        catalogWindow <- getCatalogWindow
         tokenLimit <- getLimit
-        let fixedRequestTokens =
+        let useRemote =
+                supportsCodexRemoteCompaction dialectId params.model
+            fixedRequestTokens =
                 estimateRequestTokensWithItems params []
             pendingItems = turnInputsToItems inputs
             contextWindow =
-                codexEffectiveContextWindowFor params.model
+                openAiCompactContextWindow dialectId catalogWindow params
             continuationBaseTokens checkpoint =
                 estimateRequestTokensWithItems
                     params
@@ -1305,12 +1347,23 @@ autoCompactOpenAiBackendWithSenderHookAndDecorator
                     Left (thresholdError fixedRequestTokens)
             else do
                 rawAttempt <-
-                    compactRemoteV2AttemptWithRetainedBudget
-                        send
-                        params
-                        history
-                        (estimateItemsTokens history)
-                        retainedBudget
+                    if useRemote
+                        then
+                            compactRemoteV2AttemptWithRetainedBudget
+                                send
+                                params
+                                history
+                                (estimateItemsTokens history)
+                                retainedBudget
+                        else
+                            summarizeLocalAttemptWith
+                                contextWindow
+                                prepareXaiLocalSummaryHistory
+                                send
+                                params
+                                history
+                                (estimateItemsTokens history)
+                                Nothing
                 attempt <-
                     case rawAttempt.compactAttemptResult of
                         Left _ -> pure rawAttempt
@@ -1375,10 +1428,40 @@ autoCompactOpenAiBackendWithSenderHookAndDecorator
         params <- getParams
         pure (projectRequestTokens (Just params) occupancy history inputs)
 
+openAiCompactContextWindow
+    :: DialectId
+    -> Maybe Int
+    -> ResponseCreateParams
+    -> Int
+openAiCompactContextWindow dialect catalogWindow params
+    | supportsCodexRemoteCompaction dialect params.model =
+        codexEffectiveContextWindowFor params.model
+    | otherwise =
+        fromMaybe XAI.grokDefaultContextWindow catalogWindow
+
+openAiCompactTokenLimit
+    :: DialectId
+    -> Maybe Int
+    -> Maybe Int
+    -> ResponseCreateParams
+    -> Int
+openAiCompactTokenLimit dialect configuredThreshold catalogWindow params =
+    let window = openAiCompactContextWindow dialect catalogWindow params
+        defaultLimit
+            | supportsCodexRemoteCompaction dialect params.model =
+                codexAutoCompactTokenLimitFor params.model
+            | otherwise =
+                XAI.grokAutoCompactTokenLimit
+                    (fromMaybe "grok-4.6" params.model)
+                    window
+        configuredLimit = fromMaybe defaultLimit configuredThreshold
+    in max 1 (min configuredLimit window)
+
 rejectOversizedInitialRequest
-    :: IO ResponseCreateParams
+    :: (ResponseCreateParams -> Int)
+    -> IO ResponseCreateParams
     -> BackendMiddleware
-rejectOversizedInitialRequest getParams backend =
+rejectOversizedInitialRequest contextWindowFor getParams backend =
     backendWithCallbacks \snapshot previous inputs callbacks ->
         if null snapshot.backendItems
             then do
@@ -1387,8 +1470,7 @@ rejectOversizedInitialRequest getParams backend =
                         estimateRequestTokensWithItems
                             params
                             (turnInputsToItems inputs)
-                    contextWindow =
-                        codexEffectiveContextWindowFor params.model
+                    contextWindow = contextWindowFor params
                 if requestTokens > contextWindow
                     then
                         pure $

--- a/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
@@ -9,7 +9,7 @@ import Agent.CLI.Compaction
     , CompactionInstall
     , OccupancySnapshot
     , OpenAiCompactionSender
-    , autoCompactOpenAiBackendWithSenderHookAndDecorator
+    , autoCompactOpenAiBackendForDialect
     )
 import Agent.Connectivity (withConnectionRecoveryOn)
 import Agent.Connectivity.NetworkPath (NetworkRecovery)
@@ -40,6 +40,7 @@ import Agent.Provider
 import Agent.Responses.LoopBackend
     ( statelessResponsesBackendWithRawReasoning
     )
+import Agent.Dialect (DialectId)
 import Agent.Responses.Types (ResponseCreateParams)
 import Control.Concurrent.MVar
     ( MVar
@@ -64,6 +65,8 @@ lockedOpenAiSession
     -> Bool
     -- ^ When true, every model and compaction request must remain on the
     -- gateway WebSocket; direct provider HTTP fallback is forbidden.
+    -> DialectId
+    -> IO (Maybe Int)
     -> Maybe Int
     -> Bool
     -> MVar ()
@@ -76,7 +79,8 @@ lockedOpenAiSession
     -> (CompactOutcome -> IO CompactOutcome)
     -> (CompactOutcome -> [TurnInput] -> IO CompactionInstall)
     -> (OpenAiCompactionSender, Backend)
-lockedOpenAiSession networkRecovery gatewayOnly compactThreshold
+lockedOpenAiSession networkRecovery gatewayOnly dialectId getContextWindow
+        compactThreshold
         showRawReasoning wsLock fallbackActive provider activeConnection
         getParams contextTokens
         recordCompactionUsage decorateCompaction onCompacted =
@@ -165,7 +169,9 @@ lockedOpenAiSession networkRecovery gatewayOnly compactThreshold
                                 sendHttpCompaction request
                         _ -> pure result
         compactingBackend =
-            autoCompactOpenAiBackendWithSenderHookAndDecorator
+            autoCompactOpenAiBackendForDialect
+                dialectId
+                getContextWindow
                 compactThreshold
                 compactSender
                 recordCompactionUsage

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/OpenAI.hs
@@ -343,6 +343,8 @@ withConnectedOpenAiProvider OpenAiConfig{..}
                 networkRecovery
                 (isGatewayWebSocketCredential
                     credential)
+                dialectId
+                (currentModelContextWindow transportModel)
                 compactThreshold
                 showRawReasoning
                 wsLock

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Types.hs
@@ -20,6 +20,7 @@ import Agent.CLI.Session.Runtime.Types (SessionBackend)
 import Agent.Claude (ClaudeCodeAuth)
 import Agent.Claude.Control (ClaudeCodeHostHandlers)
 import Agent.Connectivity.NetworkPath (NetworkRecovery)
+import Agent.Dialect (DialectId)
 import Agent.Error (ApiError)
 import Agent.Loop (Backend, TokenUsage, TurnInput)
 import Agent.OpenAI.Auth (Pool)
@@ -44,6 +45,7 @@ data OpenAiConfig = OpenAiConfig
     { tokenProvider :: TokenProvider
     , showRawReasoning :: Bool
     , transportModel :: Text -> Text
+    , dialectId :: !DialectId
     , accounts :: OpenAiAccounts
     }
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -1186,6 +1186,7 @@ prepareProviderConfig request promptRuntime nativeCapabilities = case request.pr
         { tokenProvider = request.tokenProvider
         , showRawReasoning = request.options.optShowRawReasoning
         , transportModel = request.transportModel
+        , dialectId = dialectId request.dialect
         , accounts = OpenAiAccounts
             { selectablePool = if isGatewayLoadedAuth request.loaded
                 then Nothing else request.loaded.loadedOpenAiPool

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -18,7 +18,7 @@ import Agent.CLI.Btw (trimDanglingToolSuffix)
 import Agent.CLI.Compaction
     ( CompactionInstall(CompactionNotInstalled)
     , autoCompactBackendWith
-    , autoCompactOpenAiBackendWithSenderHookAndDecorator
+    , autoCompactOpenAiBackendForDialect
     , boundCompletedToolContinuations
     , decorateCompactOutcomeWithTaskPlan
     , runXaiBackendCompactHistoryWithContextWindow
@@ -879,7 +879,9 @@ runCodexChildBackend
                         tokenProvider
                         request
         compactingBackend =
-            autoCompactOpenAiBackendWithSenderHookAndDecorator
+            autoCompactOpenAiBackendForDialect
+                (dialectId preparation.codexPreparationDialect)
+                (pure Nothing)
                 runtime.subagentOptions.optCompactThreshold
                 compactSender
                 (const (pure ()))

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -12,6 +12,7 @@ import Agent.CLI.Compaction
     , autoCompactOpenAiBackendWithSender
     , autoCompactOpenAiBackendWithSenderAndHook
     , autoCompactOpenAiBackendWithSenderHookAndDecorator
+    , autoCompactOpenAiBackendForDialect
     , autoCompactOpenAiBackendWithThreshold
     , codexAutoCompactTokenLimit
     , claudeAutoCompactTokenLimit
@@ -43,6 +44,7 @@ import Agent.OpenAI.Compaction
     , summarizationPrompt
     , userTextItem
     )
+import Agent.Dialect (DialectId(..))
 import Agent.OpenAI.ModelMetadata (codexEffectiveContextWindowFor)
 import Agent.ToolDispatch
     ( ToolCallKind(..)
@@ -128,6 +130,41 @@ spec = do
             map requestItems <$> readIORef requests
                 `shouldReturn` [history <> [compactionTriggerItem]]
             readIORef recordedUsage `shouldReturn` [compactionUsage]
+
+        it "summarizes Grok models locally instead of sending compaction_trigger" do
+            params <- testRequestState
+                (withModel (Just "grok-4.6") defaultResponseCreateParams)
+            let history = [userTextItem "old context"]
+            transcript <- newIORef history
+            requests <- newIORef []
+            result <-
+                runProviderCompactWith
+                    (Just \request -> do
+                        modifyIORef' requests (<> [request])
+                        pure (Right (summaryResponse "local summary")))
+                    (const (pure ()))
+                    OpenAIProvider
+                    Nothing
+                    params
+                    transcript
+                    Nothing
+            case result of
+                Left err -> expectationFailure (show err)
+                Right outcome -> do
+                    outcome.compactSummary `shouldBe` "local summary"
+                    outcome.compactHistory
+                        `shouldBe`
+                            [ userTextItem "old context"
+                            , assistantSummaryItem "local summary"
+                            ]
+            seen <- readIORef requests
+            length seen `shouldBe` 1
+            map (.tools) seen `shouldBe` [Nothing]
+            map (.parallelToolCalls) seen `shouldBe` [Just False]
+            map (elem compactionTriggerItem . requestItems) seen
+                `shouldBe` [False]
+            map (last . requestItems) seen
+                `shouldBe` [userTextItem (summarizationPrompt Nothing)]
 
         it "records completed-response usage with asynchronous exceptions masked" do
             params <- testRequestState defaultResponseCreateParams
@@ -1378,6 +1415,103 @@ spec = do
     ManualOpenAI.spec
 
     TaskPlan.spec
+
+    describe "autoCompactOpenAiBackendForDialect" do
+        it "summarizes Grok Build dialect locally instead of sending compaction_trigger" do
+            let history = [userTextItem "old context"]
+                threshold = 2_000
+                params = withModel (Just "grok-4.6") defaultResponseCreateParams
+            contextState <- newIORef
+                (Just (reportedOccupancy threshold (length history)))
+            requests <- newIORef []
+            continuationHistory <- newIORef []
+            let sender request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right (summaryResponse "local summary"))
+                base = Backend \state _previous _inputs _onEvent -> do
+                    writeIORef continuationHistory state.backendItems
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        , contextUsage = Just (TokenUsage 20 5 0)
+                        , providerTelemetry = Nothing
+                        , completion = TurnCompleted
+                        }
+                backend =
+                    autoCompactOpenAiBackendForDialect
+                        GrokBuildDialect
+                        (pure Nothing)
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure params)
+                        pure
+                        (\_outcome _inputs -> pure CompactionInstalled)
+                        contextState
+                        base
+            result <-
+                backend.submitTurn
+                    (initialBackendSnapshot history)
+                    Nothing
+                    [UserMessage "new"]
+                    (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            seen <- readIORef requests
+            length seen `shouldBe` 1
+            map (.tools) seen `shouldBe` [Nothing]
+            map (elem compactionTriggerItem . requestItems) seen
+                `shouldBe` [False]
+            map (last . requestItems) seen
+                `shouldBe` [userTextItem (summarizationPrompt Nothing)]
+            readIORef continuationHistory
+                `shouldReturn`
+                    [ userTextItem "old context"
+                    , assistantSummaryItem "local summary"
+                    , userTextItem "new"
+                    ]
+
+        it "keeps Codex remote compaction v2 for Codex-hosted non-Grok models" do
+            let history = [userTextItem "old context"]
+                threshold = 2_000
+            contextState <- newIORef
+                (Just (reportedOccupancy threshold (length history)))
+            requests <- newIORef []
+            let sender request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right remoteCompactionResponse)
+                base = Backend \state _previous _inputs _onEvent ->
+                    pure $ successful state TurnOutput
+                        { responseId = "resp-new"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 20 5 0
+                        , contextUsage = Just (TokenUsage 20 5 0)
+                        , providerTelemetry = Nothing
+                        , completion = TurnCompleted
+                        }
+                backend =
+                    autoCompactOpenAiBackendForDialect
+                        CodexDialect
+                        (pure Nothing)
+                        (Just threshold)
+                        sender
+                        (const (pure ()))
+                        (pure defaultResponseCreateParams)
+                        pure
+                        (\_outcome _inputs -> pure CompactionInstalled)
+                        contextState
+                        base
+            result <-
+                backend.submitTurn
+                    (initialBackendSnapshot history)
+                    Nothing
+                    [UserMessage "new"]
+                    (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            map requestItems <$> readIORef requests
+                `shouldReturn` [history <> [compactionTriggerItem]]
 
     describe "autoCompactOpenAiBackendWith" do
         it "decorates before publishing and continuing automatic compaction" do

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec/ManualOpenAI.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec/ManualOpenAI.hs
@@ -60,6 +60,41 @@ spec = do
             map requestItems seen
                 `shouldBe` [history <> [compactionTriggerItem]]
 
+        it "summarizes Grok models locally instead of sending compaction_trigger" do
+            requests <- newIORef []
+            let provider = tokenProvider SubscriptionBilled \_ ->
+                    error "local summarization unexpectedly requested credentials"
+                send _ request = do
+                    modifyIORef' requests (<> [request])
+                    pure (Right (summaryResponse "local summary"))
+                history = [userTextItem "old context"]
+                params = withModel (Just "grok-4.6") defaultResponseCreateParams
+                    { instructions = Just "keep these instructions"
+                    , tools = Just []
+                    }
+            result <- runExceptT $
+                compactOpenAIWith send
+                    (Just provider)
+                    params
+                    history
+                    100
+                    Nothing
+            case result of
+                Left err -> expectationFailure (show err)
+                Right outcome -> do
+                    outcome.compactSummary `shouldBe` "local summary"
+                    outcome.compactHistory
+                        `shouldBe`
+                            [ userTextItem "old context"
+                            , assistantSummaryItem "local summary"
+                            ]
+            seen <- readIORef requests
+            length seen `shouldBe` 1
+            map (.tools) seen `shouldBe` [Nothing]
+            map (.parallelToolCalls) seen `shouldBe` [Just False]
+            map (elem compactionTriggerItem . requestItems) seen
+                `shouldBe` [False]
+
         it "disables parallel tool calls for Responses Lite remote compaction" do
             requests <- newIORef []
             let provider = tokenProvider SubscriptionBilled \_ ->

--- a/packages/agent-core/src/Agent/Dialect.hs
+++ b/packages/agent-core/src/Agent/Dialect.hs
@@ -29,6 +29,8 @@ module Agent.Dialect
     , dialectForModel
     , legacyDialectIdForProvider
     , providerSupportsDialect
+    , isGrokModelName
+    , supportsCodexRemoteCompaction
     , grokBuildPublicToolName
     , grokBuildCanonicalToolName
     , claudeCodeCanonicalToolName
@@ -246,6 +248,20 @@ providerSupportsDialect provider dialect = case provider of
     OpenRouterProvider -> dialect /= ClaudeCodeDialect
     GeminiProvider -> dialect == GenericResponsesDialect
     ClaudeCodeProvider -> dialect == ClaudeCodeDialect
+
+-- | Grok Build model ids, including OpenRouter's @x-ai/grok-*@ slugs.
+isGrokModelName :: Text -> Bool
+isGrokModelName model =
+    let normalized = Text.toLower (Text.strip model)
+    in "grok" `Text.isPrefixOf` normalized
+        || "x-ai/grok" `Text.isPrefixOf` normalized
+
+-- | Codex remote compaction v2 appends a @compaction_trigger@ input item.
+-- Only ChatGPT Codex Responses hosts implement that protocol. Grok models
+-- reject the tag even when they are routed over the OpenAI transport.
+supportsCodexRemoteCompaction :: DialectId -> Maybe Text -> Bool
+supportsCodexRemoteCompaction dialect model =
+    dialect == CodexDialect && not (maybe False isGrokModelName model)
 
 -- | Current public Grok Build names for stable internal tool identifiers.
 grokBuildPublicToolName :: Text -> Text

--- a/packages/agent-core/test/Agent/DialectSpec.hs
+++ b/packages/agent-core/test/Agent/DialectSpec.hs
@@ -95,6 +95,28 @@ spec = describe "Agent.Dialect" do
             providerSupportsDialect OpenRouterProvider ClaudeCodeDialect
                 `shouldBe` False
 
+    describe "Codex remote compaction eligibility" do
+        it "recognizes Grok model ids including OpenRouter slugs" do
+            isGrokModelName "grok-4.6" `shouldBe` True
+            isGrokModelName " GROK-4.5 " `shouldBe` True
+            isGrokModelName "x-ai/grok-4" `shouldBe` True
+            isGrokModelName "gpt-5.6-sol" `shouldBe` False
+            isGrokModelName "acme-coder" `shouldBe` False
+
+        it "enables remote compaction v2 only for Codex-hosted non-Grok models" do
+            supportsCodexRemoteCompaction CodexDialect (Just "gpt-5.6-sol")
+                `shouldBe` True
+            supportsCodexRemoteCompaction CodexDialect Nothing
+                `shouldBe` True
+            supportsCodexRemoteCompaction CodexDialect (Just "grok-4.6")
+                `shouldBe` False
+            supportsCodexRemoteCompaction GrokBuildDialect (Just "grok-4.6")
+                `shouldBe` False
+            supportsCodexRemoteCompaction GrokBuildDialect (Just "acme-coder")
+                `shouldBe` False
+            supportsCodexRemoteCompaction GenericResponsesDialect (Just "gpt-5.6-sol")
+                `shouldBe` False
+
     describe "static profiles" do
         it "defines the Codex model-facing contract" do
             dialectProfile codexDialect `shouldBe`

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -144,6 +144,7 @@ test-suite agent-openai-test
                     , Agent.OpenAI.ModelsManagerSpec
                     , Agent.OpenAI.ModelsTypesSpec
                     , Agent.OpenAI.CompactionSpec
+                    , Agent.OpenAI.RequestSpec
                     , Agent.OpenAI.ToolDSLSpec
                     , Agent.OpenAI.TestSupport
                     , Agent.OpenAI.TranscriptionSpec

--- a/packages/agent-openai/src/Agent/OpenAI/Request.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Request.hs
@@ -3,10 +3,12 @@ module Agent.OpenAI.Request
     ( sanitizeCodexRequest
     ) where
 
+import Agent.Dialect (isGrokModelName)
 import Agent.OpenAI.ModelMetadata (isCodexResponsesLiteModel)
 import Agent.Responses.Request
     ( filterRequestCompactionCheckpointsByOrigin
     , stripLocalCompactionMarker
+    , stripRequestCompactionTriggers
     , stripReplayedInputStatus
     )
 import Agent.Responses.Types
@@ -39,25 +41,30 @@ sanitizeCodexRequest ResponseCreateParams
         , parallelToolCalls
         , ..
         } =
-    stripLocalCompactionMarker $
-        filterRequestCompactionCheckpointsByOrigin
-            keepOpenAiOrLegacyCheckpoint $
-            ResponseCreateParams
-                { promptCacheRetention = Nothing
-                , input =
-                    fmap
-                        (stripReplayedInputStatus . stripContentItemKindsInput)
-                        input
-                , parallelToolCalls =
-                    if maybe False isCodexResponsesLiteModel model
-                        then Just False
-                        else parallelToolCalls
-                , ..
-                }
+    grokIncompatibleItems $
+        stripLocalCompactionMarker $
+            filterRequestCompactionCheckpointsByOrigin
+                keepOpenAiOrLegacyCheckpoint $
+                ResponseCreateParams
+                    { promptCacheRetention = Nothing
+                    , input =
+                        fmap
+                            (stripReplayedInputStatus . stripContentItemKindsInput)
+                            input
+                    , parallelToolCalls =
+                        if maybe False isCodexResponsesLiteModel model
+                            then Just False
+                            else parallelToolCalls
+                    , ..
+                    }
   where
     keepOpenAiOrLegacyCheckpoint = \case
         Nothing -> True
         Just origin -> origin == "openai"
+    grokIncompatibleItems request
+        | maybe False isGrokModelName model =
+            stripRequestCompactionTriggers request
+        | otherwise = request
 
 stripContentItemKindsInput :: ResponseInput -> ResponseInput
 stripContentItemKindsInput = \case

--- a/packages/agent-openai/test/Agent/OpenAI/RequestSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/RequestSpec.hs
@@ -1,0 +1,28 @@
+module Agent.OpenAI.RequestSpec (spec) where
+
+import Agent.OpenAI.Compaction (compactionTriggerItem, userTextItem)
+import Agent.OpenAI.Request (sanitizeCodexRequest)
+import Agent.Responses.Types
+import Test.Hspec
+
+spec :: Spec
+spec = describe "sanitizeCodexRequest" do
+    it "keeps compaction_trigger items for Codex-hosted models" do
+        let history = [userTextItem "hello", compactionTriggerItem]
+            request = sanitizeCodexRequest defaultResponseCreateParams
+                { model = Just "gpt-5.6-sol"
+                , input = Just (ResponseInputItems history)
+                }
+        requestItems request `shouldBe` history
+
+    it "drops compaction_trigger items for Grok models on the OpenAI transport" do
+        let history = [userTextItem "hello", compactionTriggerItem]
+            request = sanitizeCodexRequest defaultResponseCreateParams
+                { model = Just "grok-4.6"
+                , input = Just (ResponseInputItems history)
+                }
+        requestItems request `shouldBe` [userTextItem "hello"]
+  where
+    requestItems request = case request.input of
+        Just (ResponseInputItems items) -> items
+        _ -> []

--- a/packages/agent-openai/test/Spec.hs
+++ b/packages/agent-openai/test/Spec.hs
@@ -14,6 +14,7 @@ import qualified Agent.OpenAI.ModelsClientSpec as ModelsClientSpec
 import qualified Agent.OpenAI.ModelsManagerSpec as ModelsManagerSpec
 import qualified Agent.OpenAI.ModelsTypesSpec as ModelsTypesSpec
 import qualified Agent.OpenAI.CompactionSpec as CompactionSpec
+import qualified Agent.OpenAI.RequestSpec as RequestSpec
 import qualified Agent.OpenAI.ToolDSLSpec as ToolDSLSpec
 import qualified Agent.OpenAI.TranscriptionSpec as TranscriptionSpec
 import qualified Agent.OpenAI.UsageSpec as UsageSpec
@@ -33,6 +34,7 @@ main = hspec do
     ModelsManagerSpec.spec
     ModelsTypesSpec.spec
     CompactionSpec.spec
+    RequestSpec.spec
     ToolDSLSpec.spec
     TranscriptionSpec.spec
     UsageSpec.spec

--- a/packages/agent-responses/src/Agent/Responses/Request.hs
+++ b/packages/agent-responses/src/Agent/Responses/Request.hs
@@ -8,6 +8,8 @@ module Agent.Responses.Request
     , filterRequestCompactionCheckpointsByOrigin
     , isServerCompactionCheckpoint
     , stripLocalCompactionMarker
+    , stripRequestCompactionTriggers
+    , isCompactionTriggerItem
     , stripReplayedItemStatus
     , stripReplayedInputStatus
     ) where
@@ -17,6 +19,7 @@ import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import qualified Data.Maybe as Maybe
 import Data.Text (Text)
+import qualified Data.Text as Text
 
 -- | Disable remote transcript state and require a streaming response.
 forceStatelessStreaming
@@ -117,6 +120,31 @@ isServerCompactionCheckpoint = \case
     KnownResponseItem ItemCompaction _ -> True
     KnownResponseItem ItemContextCompaction _ -> True
     _ -> False
+
+-- | Codex remote-compaction-v2 sentinel. Grok and other non-Codex Responses
+-- hosts reject this item type.
+isCompactionTriggerItem :: ResponseItem -> Bool
+isCompactionTriggerItem = \case
+    CompactionTriggerItemValue{} -> True
+    KnownResponseItem ItemCompactionTrigger _ -> True
+    UnknownResponseItem tagged ->
+        Text.toLower (Text.strip tagged.tag) == "compaction_trigger"
+    _ -> False
+
+-- | Drop Codex @compaction_trigger@ items before a non-Codex host sees them.
+stripRequestCompactionTriggers
+    :: ResponseCreateParams
+    -> ResponseCreateParams
+stripRequestCompactionTriggers ResponseCreateParams { input, .. } =
+    ResponseCreateParams
+        { input = stripInput <$> input
+        , ..
+        }
+  where
+    stripInput = \case
+        ResponseInputItems items ->
+            ResponseInputItems (filter (not . isCompactionTriggerItem) items)
+        other -> other
 
 -- | Remove host-only compaction metadata. These markers remain in persisted
 -- state so compaction policy can recognize local summaries and the provider

--- a/packages/agent-xai/src/Agent/XAI/Request.hs
+++ b/packages/agent-xai/src/Agent/XAI/Request.hs
@@ -10,6 +10,7 @@ module Agent.XAI.Request
 import Agent.Responses.Request
     ( filterRequestCompactionCheckpointsByOrigin
     , forceStatelessStreaming
+    , isCompactionTriggerItem
     , isServerCompactionCheckpoint
     , mapResponseTools
     , selectConfiguredModel
@@ -188,7 +189,8 @@ xaiReasoningEffort value =
 
 requestInputItems :: ResponseCreateParams -> [ResponseItem]
 requestInputItems request = case request.input of
-    Just (ResponseInputItems items) -> map normalizeInputItem items
+    Just (ResponseInputItems items) ->
+        map normalizeInputItem (filter (not . isCompactionTriggerItem) items)
     Just (ResponseInputText inputText) ->
         [ MessageItem ResponseMessage
             { messageId = Nothing

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -115,6 +115,31 @@ spec = do
                 , Just (Aeson.String "function_call")
                 ]
 
+        it "drops Codex compaction_trigger items the Grok proxy cannot decode" do
+            let trigger = CompactionTriggerItemValue CompactionTriggerItem
+                unknownTrigger = UnknownResponseItem
+                    (TaggedObject "compaction_trigger")
+                message = MessageItem ResponseMessage
+                    { messageId = Just "msg_1"
+                    , content = MessageContentParts
+                        [InputTextPart "hello" Nothing]
+                    , role = RoleUser
+                    , status = Nothing
+                    , phase = Nothing
+                    , passthrough = Nothing
+                    }
+                request = setInstructions Nothing $
+                    setInput
+                        (Just (ResponseInputItems
+                            [message, trigger, unknownTrigger]))
+                        sampleRequest
+                value = requestValue defaultClientOptions request
+            object <- expectObject value
+            input <- expectArray (KeyMap.lookup "input" object)
+            itemObjects <- traverse expectObject input
+            map (KeyMap.lookup "type") itemObjects `shouldBe`
+                [Just (Aeson.String "message")]
+
         it "flattens resumed OpenAI agent messages into Grok user messages" do
             let agentMessage = AgentMessageItem ResponseAgentMessage
                     { messageId = Nothing


### PR DESCRIPTION
## Summary
- Automatic compaction for organization-gateway `grok-4.6` was using Codex remote compaction v2 because the gateway rides the OpenAI transport.
- That path appends a `compaction_trigger` input item, which Grok's Responses proxy cannot deserialize.
- Compaction now follows the live dialect and model name: Codex-hosted non-Grok models keep remote v2; Grok Build and Grok model ids use local summarization.
- Leftover `compaction_trigger` items are stripped at the xAI wire boundary and when sanitizing OpenAI requests for Grok models.

## Root cause
Compact protocol was chosen from `OpenAIProvider`, not from the model-facing dialect. Gateway Grok sessions therefore sent a Codex-only sentinel to a host that does not implement that protocol.

## Validation
- GHCi `agent-core-test --match "Codex remote compaction eligibility"`: 2 examples, 0 failures
- GHCi `agent-openai-test --match sanitizeCodexRequest`: 2 examples, 0 failures
- GHCi `agent-xai-test --match compaction_trigger`: 1 example, 0 failures
- GHCi `agent-cli-test --repl-options=-fobject-code`:
  - `runProviderCompact`: 21 examples, 0 failures
  - `compactOpenAIWith`: 6 examples, 0 failures
  - `autoCompactOpenAiBackend`: 24 examples, 0 failures