### PR TITLE
Allow Darwin session temp parent inspection for Nix and tmux

### DIFF
--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -25,6 +25,7 @@ module Agent.Tools.IO
     , configuredProcess
     , configuredProcessEnv
     , sessionTempProcessEnv
+    , sessionSandboxProfile
     , writeShellCommandInput
     , interruptShellCommand
     , stopShellCommand
@@ -103,12 +104,14 @@ import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
 import System.Environment (getEnvironment)
 import System.Exit (ExitCode(..))
-#if defined(darwin_HOST_OS)
-import qualified System.Directory as Directory
 import System.FilePath
     ( takeDirectory
     , takeFileName
+    , (</>)
     )
+#if defined(darwin_HOST_OS)
+import qualified System.Directory as Directory
+import System.Posix.User (getRealUserID)
 #endif
 import System.IO (Handle, hClose, hFlush)
 import System.Posix.Signals
@@ -454,8 +457,8 @@ startShellCommandWithStdin keepStdin env workdir command onComplete = do
         Right running -> pure (Right running)
 
 -- | Apply the session-private environment and, on macOS, a Seatbelt profile
--- that denies the shared temp namespace. Managed session layouts also hide
--- sibling scratch directories while allowing the current one.
+-- that denies shared temp contents. Managed session layouts hide sibling
+-- scratch files while leaving the parent directory itself inspectable.
 configuredProcess :: ToolEnv -> CreateProcess -> IO CreateProcess
 configuredProcess env spec = do
     sessionTmp <- readIORef env.toolSessionTmp
@@ -477,7 +480,9 @@ configuredCommandSpec sessionTmp command =
             let sandboxExecutable = "/usr/bin/sandbox-exec"
             canonicalTemp <-
                 Directory.canonicalizePath (unsafeToFilePath temp)
-            let profile = sessionSandboxProfile canonicalTemp
+            rawUid <- getRealUserID
+            let uid = fromIntegral rawUid :: Int
+                profile = sessionSandboxProfile canonicalTemp uid
                 wrapped = case command of
                     RawCommand executable arguments ->
                         executable : arguments
@@ -490,9 +495,13 @@ configuredCommandSpec sessionTmp command =
 configuredCommandSpec _ command = pure command
 #endif
 
-#if defined(darwin_HOST_OS)
-sessionSandboxProfile :: FilePath -> String
-sessionSandboxProfile temp =
+-- | Deny shared temp contents and sibling session scratch without denying the
+-- parent directories that Darwin @realpath@ and Nix @posix_stat@ inspect.
+-- Restore the current session directory and the calling user's tmux sockets.
+-- Darwin shells apply this via @sandbox-exec@; other platforms keep the
+-- builder so tests can check the deny list without macOS.
+sessionSandboxProfile :: FilePath -> Int -> String
+sessionSandboxProfile temp uid =
     unwords $
         [ "(version 1)"
         , "(allow default)"
@@ -500,19 +509,39 @@ sessionSandboxProfile temp =
         , "  (subpath \"/tmp\")"
         , "  (subpath \"/private/tmp\")"
         ]
-        <> managedParentRule
+        <> managedDescendantRule
         <> [")"]
         <> [ "(allow file-read* file-write*"
            , "  (subpath " <> sandboxString temp <> "))"
+           , "(allow file-read-metadata"
+           , "  (literal \"/tmp\")"
+           , "  (literal \"/private/tmp\"))"
+           , "(allow file-read-data"
+           , "  (literal \"/tmp\"))"
+           , "(allow file-read* file-write*"
+           , "  (subpath " <> sandboxString ("/private/tmp" </> tmuxDir) <> ")"
+           , "  (subpath " <> sandboxString ("/tmp" </> tmuxDir) <> "))"
            ]
   where
     parent = takeDirectory temp
     grandparent = takeDirectory parent
-    managedParentRule
+    tmuxDir = "tmux-" <> show uid
+    managedDescendantRule
         | takeFileName parent == "sessions"
         , takeFileName grandparent == "tmp" =
-            ["  (subpath " <> sandboxString parent <> ")"]
+            [ "  (regex "
+                <> sandboxString
+                    ("^" <> sandboxRegexLiteral parent <> "/.+")
+                <> ")"
+            ]
         | otherwise = []
+
+sandboxRegexLiteral :: String -> String
+sandboxRegexLiteral = concatMap escapeRegex
+  where
+    escapeRegex char
+        | char `elem` ("\\^$.|?*+()[]{}" :: String) = ['\\', char]
+        | otherwise = [char]
 
 sandboxString :: String -> String
 sandboxString value =
@@ -524,7 +553,6 @@ sandboxString value =
     escape '\r' = "\\r"
     escape '\t' = "\\t"
     escape char = [char]
-#endif
 
 configuredProcessEnv :: ToolEnv -> IO (Maybe [(String, String)])
 configuredProcessEnv env =

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -26,6 +26,7 @@ import Agent.Tools.IO
     , runShellCommandStreaming
     , runningLiveOutput
     , sessionTempProcessEnv
+    , sessionSandboxProfile
     , startShellCommand
     , startShellCommandWithInput
     , stopShellCommand
@@ -49,7 +50,7 @@ import Control.Monad (replicateM)
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Data.Either (isLeft, isRight)
 import Data.IORef
-import Data.List (sort)
+import Data.List (isInfixOf, sort)
 import qualified Data.Text as Text
 import System.Directory
     ( canonicalizePath
@@ -547,6 +548,51 @@ spec = describe "Agent.Tools.IO" do
                 result.commandExitCode `shouldNotBe` Just 0
                 result.commandStdout `shouldNotBe` "sibling-secret"
 
+    it "denies sibling session scratch without denying the parent directory" do
+        let profile =
+                sessionSandboxProfile
+                    "/Users/x/.haskell-agent/tmp/sessions/current"
+                    501
+        profile `shouldNotSatisfy`
+            isInfixOf "(subpath \"/Users/x/.haskell-agent/tmp/sessions\")"
+        profile `shouldSatisfy`
+            isInfixOf
+                "(regex \"^/Users/x/\\\\.haskell-agent/tmp/sessions/.+\")"
+        profile `shouldSatisfy` isInfixOf "(literal \"/tmp\")"
+        profile `shouldSatisfy` isInfixOf "/private/tmp/tmux-501"
+
+    it "lets tools canonicalize a managed session temp directory" do
+        if os /= "darwin"
+            then pendingWith "the process-level Seatbelt boundary is macOS-only"
+            else withTempDir \dir -> do
+                requireProcessSandbox
+                let workspace = dir </> "workspace"
+                    sessions =
+                        dir </> ".haskell-agent" </> "tmp" </> "sessions"
+                    scratch = sessions </> "current"
+                    sibling = sessions </> "other"
+                    secret = sibling </> "secret"
+                mapM_ (createDirectoryIfMissing True)
+                    [workspace, scratch, sibling]
+                writeFile secret "sibling-secret"
+                env <- defaultToolEnv (fromFilePath workspace)
+                setToolSessionTmp env (Just (fromFilePath scratch))
+                realpathResult <- runShellCommand env (fromFilePath workspace)
+                    libcRealpathOfTmpdirCommand
+                    5000
+                realpathResult.commandExitCode `shouldBe` Just 0
+                parentResult <- runShellCommand env (fromFilePath workspace)
+                    "python3 -c \"import os; os.stat(os.path.dirname(os.environ['TMPDIR'])); print('parent-ok')\""
+                    5000
+                parentResult.commandExitCode `shouldBe` Just 0
+                parentResult.commandStdout `shouldSatisfy`
+                    Text.isInfixOf "parent-ok"
+                siblingResult <- runShellCommand env (fromFilePath workspace)
+                    "cat \"$TMPDIR/../other/secret\""
+                    5000
+                siblingResult.commandExitCode `shouldNotBe` Just 0
+                siblingResult.commandStdout `shouldNotBe` "sibling-secret"
+
     it "replaces inherited temp variables without exposing host temp" do
         let scratch = fromFilePath "/session/private"
         sessionTempProcessEnv scratch
@@ -751,6 +797,20 @@ checkBackgroundOutputCap dir = do
     result <- readMVar running.runningResult
     Text.length result.commandStdout `shouldSatisfy` (< 128)
     result.commandStdout `shouldSatisfy` Text.isInfixOf "[truncated"
+
+libcRealpathOfTmpdirCommand :: Text.Text
+libcRealpathOfTmpdirCommand =
+    Text.concat
+        [ "python3 -c '"
+        , "import ctypes, ctypes.util, os; "
+        , "libc = ctypes.CDLL(ctypes.util.find_library(\"c\"), use_errno=True); "
+        , "fn = libc.realpath; "
+        , "fn.argtypes = [ctypes.c_char_p, ctypes.c_char_p]; "
+        , "fn.restype = ctypes.c_char_p; "
+        , "buf = ctypes.create_string_buffer(1024); "
+        , "raise SystemExit(0 if fn(os.environ[\"TMPDIR\"].encode(), buf) else 1)"
+        , "'"
+        ]
 
 requireProcessSandbox :: IO ()
 requireProcessSandbox


### PR DESCRIPTION
## Summary
- keep Darwin session-temp isolation for sibling scratch files, but stop denying the managed `tmp/sessions` parent directory
- that parent deny made Darwin `realpath` and Nix `posix_stat` fail on the session temp directory, which blocked `nix develop` and tmux socket discovery
- allow metadata on `/tmp` and `/private/tmp`, plus the calling user's `tmux-<uid>` socket directory, without reopening shared temp contents

## Validation
- `cabal repl agent-core:lib:agent-core` (75 modules loaded)
- `cabal repl agent-core:test:agent-core-test` `--match "sibling session scratch"` (1 example, 0 failures)
- process-boundary Seatbelt examples remain pending inside a live agent (`sandbox_apply: Operation not permitted` for nested `sandbox-exec`); they run on a host that is not already sandboxed
- `git diff --check`
