### PR TITLE
Use native provider transports for organization gateway models

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,24 @@ remote is selected from the current branch's configured remote, then
 fetch failure aborts worktree creation rather than falling back to a stale
 commit.
 
+### Organization gateway model routing
+
+Connected organization gateways must include `provider` and `protocol` for every
+entry in `/v1/models`. Supported pairs are `openai`/`responses`,
+`xai`/`responses`, and `anthropic`/`anthropic`. Upgrade the gateway before the
+client; missing or incompatible metadata fails closed.
+
+The catalog selects the native provider transport, not the model name or a local
+dialect override. OpenAI uses the OpenAI transport, Grok uses xAI with its native
+compaction, and Claude uses the Claude gateway integration. Requests retain the
+organization's model alias and gateway credential/endpoint; provider environment
+variables cannot redirect gateway xAI requests to a personal endpoint.
+
+Startup, resume, model switching, and child model selection use this catalog.
+Legacy top-level gateway sessions re-resolve their saved alias to its current
+provider. In-process subagents support OpenAI and xAI; Claude requires a separate
+child session.
+
 ### Worktree recovery and cleanup
 
 New managed worktrees are enrolled in snapshot-backed cleanup. After seven

--- a/packages/agent-cli-runtime/src/Agent/CLI/Auth.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Auth.hs
@@ -16,6 +16,7 @@ module Agent.CLI.Auth
     , gatewayAuthSelectionId
     , gatewayLoadedAuthForProvider
     , gatewayRouterTokenProvider
+    , gatewayTokenProviderForProvider
     , isGatewayLoadedAuth
     , geminiAuthStateFromJson
     , geminiAuthStateToJson
@@ -96,6 +97,7 @@ import Agent.CLI.Environment (lookupNonEmpty)
 import Agent.CLI.GatewayClient
     ( GatewayCredential (..)
     , loadGatewayCredential
+    , validateGatewayCredential
     )
 import Agent.Error (ApiError(..))
 import Agent.OpenAI.WebSocketClient
@@ -210,14 +212,38 @@ gatewayLoadedAuthForProvider
     :: Maybe Provider
     -> GatewayCredential
     -> Either Text LoadedAuth
-gatewayLoadedAuthForProvider requestedProvider gateway =
+gatewayLoadedAuthForProvider requestedProvider gateway = do
+    validateGatewayCredential gateway
     case requestedProvider of
         Nothing -> gatewayLoadedAuth gateway
         Just OpenAIProvider -> gatewayLoadedAuth gateway
+        Just XAIProvider -> Right (gatewayXaiLoadedAuth gateway)
         Just ClaudeCodeProvider -> Right (gatewayClaudeLoadedAuth gateway)
         Just _ ->
             Left
                 "organization gateway is active; disconnect it before selecting another provider"
+
+gatewayXaiLoadedAuth :: GatewayCredential -> LoadedAuth
+gatewayXaiLoadedAuth gateway =
+    LoadedAuth
+        { loadedProvider = XAIProvider
+        , loadedTokenProvider =
+            staticCredentialProvider SubscriptionBilled
+                (gatewayXaiCredential gateway)
+        , loadedAccountLabel =
+            const (pure ("xAI via " <> gateway.gatewayBaseUrl))
+        , loadedSelectionId = Just gatewayAuthSelectionId
+        , loadedOpenAiPool = Nothing
+        }
+
+gatewayXaiCredential :: GatewayCredential -> Credential
+gatewayXaiCredential gateway =
+    Credential
+        { accessToken = gateway.gatewayAccessToken
+        , accountId = gateway.gatewayBaseUrl
+        , leaseId = Nothing
+        , provider = XAIProvider
+        }
 
 gatewayClaudeLoadedAuth :: GatewayCredential -> LoadedAuth
 gatewayClaudeLoadedAuth gateway =
@@ -261,6 +287,30 @@ gatewayRouterTokenProvider provider =
                         \send an organization model with direct OpenAI credentials"
             Left err -> pure (Left err)
 
+-- | Bind a native provider token source to the immutable gateway credential
+-- snapshot. Account rotation must never introduce a direct-provider token or
+-- credentials belonging to a different organization connection.
+gatewayTokenProviderForProvider
+    :: Provider
+    -> GatewayCredential
+    -> TokenProvider
+    -> TokenProvider
+gatewayTokenProviderForProvider selectedProvider gateway tokenProvider =
+    tokenProviderWithNextToken tokenProvider \failed ->
+        getNextToken tokenProvider failed >>= \case
+            Right credential
+                | selectedProvider == OpenAIProvider
+                , credential == credentialForGateway gateway ->
+                    pure (Right credential)
+                | selectedProvider == XAIProvider
+                , credential == gatewayXaiCredential gateway ->
+                    pure (Right credential)
+                | otherwise ->
+                    pure $ Left $ CredentialError
+                        "the connected gateway credential does not match the \
+                        \selected provider and organization connection"
+            Left err -> pure (Left err)
+
 -- | Load one specific account for providers whose HTTP backends can swap
 -- token sources without reconnecting a long-lived transport.
 --
@@ -273,9 +323,8 @@ loadAuthForAccount provider selectionId =
         Left err ->
             pure (Left ("cannot load gateway credential: " <> err))
         Right (Just gateway)
-            | provider == OpenAIProvider
-            , selectionId == gatewayAuthSelectionId ->
-                pure (gatewayLoadedAuth gateway)
+            | selectionId == gatewayAuthSelectionId ->
+                pure (gatewayLoadedAuthForProvider (Just provider) gateway)
             | otherwise ->
                 pure
                     (Left

--- a/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Catalog.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Catalog.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Gateway.Catalog
     ( GatewayModel(..)
     , GatewayModelCatalogResponse(..)
     , GatewayModelProtocol(..)
+    , GatewayModelProvider(..)
     , GatewayModelAccess
     , newGatewayModelAccess
     , newGatewayModelAccessWith
@@ -48,9 +49,17 @@ data GatewayModelProtocol
     | GatewayAnthropicProtocol
     deriving (Eq, Show)
 
+-- | Provider identity is independent of the shared Responses wire protocol.
+data GatewayModelProvider
+    = GatewayOpenAIProvider
+    | GatewayXAIProvider
+    | GatewayAnthropicProvider
+    deriving (Eq, Show)
+
 data GatewayModel = GatewayModel
     { gatewayModelId :: !Text
     , gatewayModelProtocol :: !GatewayModelProtocol
+    , gatewayModelProvider :: !GatewayModelProvider
     }
     deriving (Eq, Show)
 
@@ -68,10 +77,28 @@ instance Aeson.FromJSON GatewayModelCatalogResponse where
 
 instance Aeson.FromJSON GatewayModel where
     parseJSON =
-        Aeson.withObject "GatewayModel" \object ->
-            GatewayModel
-                <$> object .: "id"
-                <*> object .: "protocol"
+        Aeson.withObject "GatewayModel" \object -> do
+            modelId <- object .: "id"
+            protocol <- object .: "protocol"
+            provider <- object .: "provider"
+            if compatibleGatewayProtocol provider protocol
+                then pure (GatewayModel modelId protocol provider)
+                else fail "Gateway model provider and protocol are incompatible."
+
+instance Aeson.FromJSON GatewayModelProvider where
+    parseJSON =
+        Aeson.withText "GatewayModelProvider" \case
+            "openai" -> pure GatewayOpenAIProvider
+            "xai" -> pure GatewayXAIProvider
+            "anthropic" -> pure GatewayAnthropicProvider
+            _ -> fail "Gateway model provider is invalid."
+
+compatibleGatewayProtocol :: GatewayModelProvider -> GatewayModelProtocol -> Bool
+compatibleGatewayProtocol provider protocol =
+    protocol == case provider of
+        GatewayOpenAIProvider -> GatewayResponsesProtocol
+        GatewayXAIProvider -> GatewayResponsesProtocol
+        GatewayAnthropicProvider -> GatewayAnthropicProtocol
 
 instance Aeson.FromJSON GatewayModelProtocol where
     parseJSON =

--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -7,6 +7,7 @@ module Agent.CLI.GatewayClient
     , GatewayModel(..)
     , GatewayModelCatalogResponse(..)
     , GatewayModelProtocol(..)
+    , GatewayModelProvider(..)
     , GatewayModelAccess
     , GatewayAuthorization(..)
     , GatewayAuthorizationCodeResponse(..)

--- a/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/ModelConfig.hs
@@ -296,15 +296,15 @@ connectionBuiltinProvider connection = case connection.connectionKind of
     OrganizationGatewayConnection -> Nothing
 
 -- | Validate persisted model-facing protocol identity against its routing
--- connection. Organization gateways use the OpenAI transport while supporting
--- any Responses-hostable agent dialect.
+-- connection. Older gateway sessions stored every Responses model as OpenAI;
+-- keep those records readable so startup can resolve their current provider
+-- from the authoritative gateway catalog before opening a transport.
 connectionSupportsDialect :: Text -> Provider -> DialectId -> Bool
-connectionSupportsDialect connection provider dialect
-    | connection == organizationGatewayConnectionId =
-        (provider == OpenAIProvider && gatewaySupportsDialect dialect)
-            || (provider == ClaudeCodeProvider
-                && dialect == ClaudeCodeDialect)
-    | otherwise = providerSupportsDialect provider dialect
+connectionSupportsDialect connection provider dialect =
+    providerSupportsDialect provider dialect
+        || (connection == organizationGatewayConnectionId
+            && provider == OpenAIProvider
+            && dialect /= ClaudeCodeDialect)
 
 catalogDefaultForProvider :: ModelCatalog -> Provider -> CatalogModel
 catalogDefaultForProvider catalog = \case
@@ -846,13 +846,6 @@ modelMergeKey model =
 allBuiltinProviders :: [Provider]
 allBuiltinProviders =
     [OpenAIProvider, XAIProvider, OpenRouterProvider, GeminiProvider, ClaudeCodeProvider]
-
-gatewaySupportsDialect :: DialectId -> Bool
-gatewaySupportsDialect = \case
-    CodexDialect -> True
-    GrokBuildDialect -> True
-    GenericResponsesDialect -> True
-    ClaudeCodeDialect -> False
 
 nonEmptyText :: Text -> Maybe Text
 nonEmptyText value

--- a/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Models.hs
@@ -42,7 +42,6 @@ import Agent.CLI.ModelConfig
     , catalogDefaultForProvider
     , catalogGatewayModelById
     , catalogModelById
-    , connectionSupportsDialect
     )
 import Agent.Dialect
     ( DialectId(..)
@@ -227,8 +226,8 @@ rawModelOption provider model =
         }
 
 -- | Convert the exact aliases advertised by an organization gateway into
--- model options.  Catalog entries may contribute presentation metadata and
--- dialect identity, but never transport identity: every option remains pinned
+-- model options. Catalog entries may contribute presentation metadata, but
+-- never provider or dialect identity: every option remains pinned
 -- to the active gateway connection and sends the advertised alias verbatim.
 gatewayModelOptions
     :: ModelCatalog
@@ -246,10 +245,6 @@ gatewayModelOptions catalog provider =
                 catalogGatewayModelById catalog modelId >>= \model ->
                     if model.catalogModelConnectionId
                             == organizationGatewayConnectionId
-                        && connectionSupportsDialect
-                            organizationGatewayConnectionId
-                            provider
-                            model.catalogModelDialect
                     then Just model
                     else Nothing
         in ModelOption
@@ -258,11 +253,7 @@ gatewayModelOptions catalog provider =
                 , targetConnectionId = organizationGatewayConnectionId
                 , targetModelId = modelId
                 , targetWireModelId = modelId
-                , targetDialect =
-                    maybe
-                        (dialectIdForModel provider modelId)
-                        (.catalogModelDialect)
-                        configured
+                , targetDialect = dialectIdForModel provider modelId
                 }
             , modelContextWindow =
                 configured >>= (.catalogModelContextWindow)

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
@@ -63,14 +63,14 @@ spec = describe "gateway device authorization" do
                 putMVar received (Wai.requestHeaders request)
                 respond $ Wai.responseLBS status200
                     [(hContentType, "application/json")]
-                    "{\"data\":[{\"id\":\"company-model\",\"protocol\":\"responses\"}]}"
+                    "{\"data\":[{\"id\":\"company-model\",\"protocol\":\"responses\",\"provider\":\"openai\"}]}"
         Warp.testWithApplication (pure application) \port -> do
             let base = "http://127.0.0.1:" <> Text.pack (show port)
                 credential = GatewayCredential base
                     (Text.replace "http://" "ws://" base <> "/v1/responses")
                     "test-token"
             fetchGatewayModels credential `shouldReturn`
-                Right [GatewayModel "company-model" GatewayResponsesProtocol]
+                Right [GatewayModel "company-model" GatewayResponsesProtocol GatewayOpenAIProvider]
             headers <- takeMVar received
             lookup "User-Agent" headers `shouldBe` Just expected
             lookup "Authorization" headers `shouldBe` Just "Bearer test-token"
@@ -108,25 +108,47 @@ spec = describe "gateway device authorization" do
 
     it "decodes, trims, and deduplicates the typed gateway catalog" do
         decodeGatewayModels
-            "{\"object\":\"list\",\"data\":[{\"id\":\" gpt-5.6-sol \",\"protocol\":\"responses\"},{\"id\":\"\",\"protocol\":\"responses\"},{\"id\":\"gpt-5.6-sol\",\"protocol\":\"responses\"},{\"id\":\"sonnet\",\"protocol\":\"anthropic\"},{\"id\":\"bad id\",\"protocol\":\"responses\"}]}"
+            "{\"object\":\"list\",\"data\":[{\"id\":\" gpt-5.6-sol \",\"protocol\":\"responses\",\"provider\":\"openai\"},{\"id\":\"\",\"protocol\":\"responses\",\"provider\":\"openai\"},{\"id\":\"gpt-5.6-sol\",\"protocol\":\"responses\",\"provider\":\"openai\"},{\"id\":\"sonnet\",\"protocol\":\"anthropic\",\"provider\":\"anthropic\"},{\"id\":\"bad id\",\"protocol\":\"responses\",\"provider\":\"openai\"}]}"
             `shouldBe`
                 Right
-                    [ GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol
-                    , GatewayModel "sonnet" GatewayAnthropicProtocol
+                    [ GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol GatewayOpenAIProvider
+                    , GatewayModel "sonnet" GatewayAnthropicProtocol GatewayAnthropicProvider
                     ]
 
     it "rejects unknown gateway model protocols" do
         decodeGatewayModels
-            "{\"object\":\"list\",\"data\":[{\"id\":\"model\",\"protocol\":\"router\"}]}"
+            "{\"object\":\"list\",\"data\":[{\"id\":\"model\",\"protocol\":\"router\",\"provider\":\"openai\"}]}"
+            `shouldSatisfy` isLeft
+
+    it "decodes xAI identity independently of the Responses protocol" do
+        decodeGatewayModels
+            "{\"data\":[{\"id\":\"company-model\",\"protocol\":\"responses\",\"provider\":\"xai\"}]}"
+            `shouldBe`
+                Right [GatewayModel "company-model" GatewayResponsesProtocol GatewayXAIProvider]
+
+    it "rejects missing or unsupported provider identity instead of assuming OpenAI" do
+        decodeGatewayModels
+            "{\"data\":[{\"id\":\"grok-4.6\",\"protocol\":\"responses\"}]}"
+            `shouldSatisfy` isLeft
+        decodeGatewayModels
+            "{\"data\":[{\"id\":\"company-model\",\"protocol\":\"responses\",\"provider\":\"unknown\"}]}"
+            `shouldSatisfy` isLeft
+
+    it "rejects incompatible provider and protocol combinations" do
+        decodeGatewayModels
+            "{\"data\":[{\"id\":\"company-model\",\"protocol\":\"anthropic\",\"provider\":\"xai\"}]}"
+            `shouldSatisfy` isLeft
+        decodeGatewayModels
+            "{\"data\":[{\"id\":\"company-model\",\"protocol\":\"responses\",\"provider\":\"anthropic\"}]}"
             `shouldSatisfy` isLeft
 
     it "clears cached gateway models when refresh fails" do
         results <- newIORef
             [ Right
-                [ GatewayModel " gpt-5.6-sol " GatewayResponsesProtocol
-                , GatewayModel "" GatewayResponsesProtocol
-                , GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol
-                , GatewayModel "sonnet" GatewayAnthropicProtocol
+                [ GatewayModel " gpt-5.6-sol " GatewayResponsesProtocol GatewayOpenAIProvider
+                , GatewayModel "" GatewayResponsesProtocol GatewayOpenAIProvider
+                , GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol GatewayOpenAIProvider
+                , GatewayModel "sonnet" GatewayAnthropicProtocol GatewayAnthropicProvider
                 ]
             , Left "gateway unavailable"
             ]
@@ -138,14 +160,14 @@ spec = describe "gateway device authorization" do
         refreshGatewayModels access
             `shouldReturn`
                 Right
-                    [ GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol
-                    , GatewayModel "sonnet" GatewayAnthropicProtocol
+                    [ GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol GatewayOpenAIProvider
+                    , GatewayModel "sonnet" GatewayAnthropicProtocol GatewayAnthropicProvider
                     ]
         cachedGatewayModels access
             `shouldReturn`
                 Just
-                    [ GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol
-                    , GatewayModel "sonnet" GatewayAnthropicProtocol
+                    [ GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol GatewayOpenAIProvider
+                    , GatewayModel "sonnet" GatewayAnthropicProtocol GatewayAnthropicProvider
                     ]
         refreshGatewayModels access
             `shouldReturn` Left "gateway unavailable"
@@ -181,7 +203,8 @@ spec = describe "gateway device authorization" do
                 (pure (Right
                     [GatewayModel
                         "company-model"
-                        GatewayResponsesProtocol]))
+                        GatewayResponsesProtocol
+                        GatewayOpenAIProvider]))
                 (\produceAudio onTranscript -> do
                     produceAudio \chunk ->
                         atomicModifyIORef' events \current ->
@@ -215,12 +238,13 @@ spec = describe "gateway device authorization" do
                                 [ GatewayModel
                                     "company-model"
                                     GatewayResponsesProtocol
+                                    GatewayOpenAIProvider
                                 ])
                     else throwString "transport details"
         refreshGatewayModels access
             `shouldReturn`
                 Right
-                    [GatewayModel "company-model" GatewayResponsesProtocol]
+                    [GatewayModel "company-model" GatewayResponsesProtocol GatewayOpenAIProvider]
         refreshGatewayModels access
             `shouldReturn`
                 Left "Could not refresh organization gateway models."

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
@@ -191,6 +191,16 @@ spec = describe "Agent.CLI.ModelConfig" do
             `shouldBe` True
         connectionSupportsDialect
             organizationGatewayConnectionId
+            OpenAIProvider
+            GrokBuildDialect
+            `shouldBe` True
+        connectionSupportsDialect
+            organizationGatewayConnectionId
+            XAIProvider
+            GrokBuildDialect
+            `shouldBe` True
+        connectionSupportsDialect
+            organizationGatewayConnectionId
             ClaudeCodeProvider
             ClaudeCodeDialect
             `shouldBe` True

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -218,12 +218,12 @@ spec = do
                 `shouldBe` True
 
         it "uses Grok capabilities for the gateway Grok model" do
-            gatewayModelOptions catalog OpenAIProvider ["grok-4.6"]
+            gatewayModelOptions catalog XAIProvider ["grok-4.6"]
                 `shouldBe`
                     [ ModelOption
                         { modelTarget =
                             ModelTarget
-                                OpenAIProvider
+                                XAIProvider
                                 organizationGatewayConnectionId
                                 "grok-4.6"
                                 "grok-4.6"
@@ -363,7 +363,7 @@ spec = do
                                 organizationGatewayConnectionId
                                 "gpt-5.6-sol"
                                 "gpt-5.6-sol"
-                                GenericResponsesDialect
+                                CodexDialect
                         , modelContextWindow = Just 777_777
                         , modelLabel = Just "company standard alias"
                         , modelFallbackPriority = Nothing
@@ -383,7 +383,7 @@ spec = do
                                 organizationGatewayConnectionId
                                 "company-known"
                                 "company-known"
-                                GenericResponsesDialect
+                                CodexDialect
                     active.modelLabel `shouldBe` Just "company label"
                     active.modelFallbackPriority `shouldBe` Just 9
                     foreignOption.modelTarget

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec/JsonCodec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec/JsonCodec.hs
@@ -111,6 +111,32 @@ spec = do
                 (LBS.toStrict (Aeson.encode legacyJson))
                 `shouldBe` Right (meta { metaGatewayIdentity = Nothing })
 
+        it "round-trips native xAI gateway provider identity" do
+            let prompt =
+                    (testPromptSnapshot "gateway-xai-session")
+                        { promptSnapshotProvider = XAIProvider
+                        , promptSnapshotConnection = organizationGatewayConnectionId
+                        , promptSnapshotModel = "company-coder"
+                        , promptSnapshotDialect = GrokBuildDialect
+                        }
+                meta =
+                    (testMeta "gateway-xai-session")
+                        { metaProvider = XAIProvider
+                        , metaConnection = organizationGatewayConnectionId
+                        , metaGatewayIdentity = Just "gateway-sha256:test-tenant"
+                        , metaModel = "company-coder"
+                        , metaTransportModel = Just "company-coder"
+                        , metaDialect = GrokBuildDialect
+                        , metaPromptSnapshot = Just prompt
+                        }
+            Hermes.decodeEither sessionMetaDecoder
+                (LBS.toStrict (Aeson.encode meta))
+                `shouldBe` Right meta
+            fromStoredMetadata (toStoredMetadata meta)
+                `shouldBe` Right (meta { metaPromptSnapshot = Nothing })
+            fromStoredPromptSnapshot (toStoredPromptSnapshot prompt)
+                `shouldBe` Right prompt
+
         it "infers transcript effects when importing legacy JSON turns" do
             let legacy userText items = Aeson.object
                     [ "at" Aeson..= fixedTime

--- a/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
@@ -1,17 +1,17 @@
 -- | Load the authoritative model options exposed by a connected organization
 -- gateway for native clients that do not own a long-running CLI session.
 module Agent.CLI.GatewayModels
-    ( gatewayProviderForStartup
-    , loadGatewayModelOptionsAt
+    ( loadGatewayModelOptionsAt
     , loadGatewayModelOptionsWithCredentialAt
     , modelOptionsForGatewayModels
     , modelOptionsForGatewayState
+    , selectGatewayModelOption
     ) where
 
 import Agent.CLI.GatewayClient
     ( GatewayCredential
     , GatewayModel(..)
-    , GatewayModelProtocol(..)
+    , GatewayModelProvider(..)
     , loadGatewayCredentialAt
     , newGatewayModelAccess
     , refreshGatewayModels
@@ -21,29 +21,59 @@ import Agent.CLI.ModelConfig
     , loadModelCatalogAt
     )
 import Agent.CLI.Models
-    ( ModelOption
-    , ModelTarget(targetProvider)
+    ( ModelOption(modelTarget)
+    , ModelTarget(targetProvider, targetModelId)
     , gatewayModelOptions
     , modelCatalog
+    , resolveModelOptionById
     )
 import Agent.Provider
-    ( Provider (ClaudeCodeProvider, OpenAIProvider) )
-import Control.Applicative ((<|>))
-import Data.Maybe (fromMaybe)
+    ( Provider (ClaudeCodeProvider, OpenAIProvider, XAIProvider) )
+import Data.List (find, nubBy)
+import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import System.OsPath (OsPath)
 
-gatewayProviderForStartup
-    :: Maybe ModelTarget
+-- | Select from the authoritative gateway catalog before authentication.
+-- Saved targets supply an alias preference, never provider identity: older
+-- gateway sessions recorded Grok aliases as OpenAI targets.
+selectGatewayModelOption
+    :: [ModelOption]
+    -> Maybe Text
     -> Maybe Provider
-    -> Maybe Provider
-    -> Provider
-gatewayProviderForStartup targetHint requestedProvider resumedProvider =
-    fromMaybe OpenAIProvider $
-        (.targetProvider) <$> targetHint
-            <|> requestedProvider
-            <|> resumedProvider
+    -> [ModelTarget]
+    -> Either Text ModelOption
+selectGatewayModelOption options requestedModel requestedProvider targetHints =
+    case requestedModel of
+        Just modelId ->
+            case resolveModelOptionById options modelId of
+                Nothing ->
+                    Left
+                        ("Model " <> modelId
+                            <> " is not offered by the organization gateway.")
+                Just option
+                    | matchesProvider option -> Right option
+                    | otherwise ->
+                        Left
+                            "The selected gateway model does not use the requested provider."
+        Nothing ->
+            case find matchesProvider (preferredOptions <> options) of
+                Just option -> Right option
+                Nothing ->
+                    Left
+                        (case requestedProvider of
+                            Just _ ->
+                                "The organization gateway does not offer any models for the requested provider."
+                            Nothing ->
+                                "The organization gateway does not offer any models.")
+  where
+    preferredOptions =
+        mapMaybe
+            (resolveModelOptionById options . (.targetModelId))
+            targetHints
+    matchesProvider option =
+        maybe True (== option.modelTarget.targetProvider) requestedProvider
 
 loadGatewayModelOptionsAt
     :: OsPath
@@ -91,31 +121,26 @@ modelOptionsForGatewayModels
     -> [GatewayModel]
     -> [ModelOption]
 modelOptionsForGatewayModels catalog models =
-    gatewayModelOptions catalog OpenAIProvider responseIds
-        <> gatewayModelOptions catalog ClaudeCodeProvider anthropicIds
+    concatMap modelOptions $
+        nubBy (\first second -> first.gatewayModelId == second.gatewayModelId)
+            (filter (publicAlias . (.gatewayModelId)) models)
   where
-    responseIds =
-        [ model.gatewayModelId
-        | model <- models
-        , model.gatewayModelProtocol == GatewayResponsesProtocol
-        , publicAlias model.gatewayModelId
-        ]
-    anthropicIds =
-        [ model.gatewayModelId
-        | model <- models
-        , model.gatewayModelProtocol == GatewayAnthropicProtocol
-        , publicAlias model.gatewayModelId
-        , model.gatewayModelId `notElem` responseIds
-        ]
+    modelOptions model =
+        gatewayModelOptions catalog
+            (case model.gatewayModelProvider of
+                GatewayOpenAIProvider -> OpenAIProvider
+                GatewayXAIProvider -> XAIProvider
+                GatewayAnthropicProvider -> ClaudeCodeProvider)
+            [model.gatewayModelId]
     publicAlias modelId =
         not ("router-" `Text.isPrefixOf` modelId)
             && modelId /= "traumimmo-translation"
 
 modelOptionsForGatewayState
     :: ModelCatalog
-    -> Maybe [Text]
+    -> Maybe [GatewayModel]
     -> [ModelOption]
 modelOptionsForGatewayState catalog = \case
     Nothing -> modelCatalog catalog
-    Just modelIds ->
-        gatewayModelOptions catalog OpenAIProvider modelIds
+    Just models ->
+        modelOptionsForGatewayModels catalog models

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -24,7 +24,7 @@ import Agent.CLI.Auth
                  loadedProvider, loadedTokenProvider, loadedSelectionId),
       gatewayAuthSelectionId,
       gatewayLoadedAuthForProvider,
-      gatewayRouterTokenProvider,
+      gatewayTokenProviderForProvider,
       isGatewayLoadedAuth,
       preferredOpenAiTokenProvider,
       loadAuth,
@@ -42,7 +42,8 @@ import Agent.CLI.GatewayClient
     , newGatewayModelAccess
     , refreshGatewayModels
     )
-import Agent.CLI.GatewayModels (gatewayProviderForStartup)
+import Agent.CLI.GatewayModels
+    ( modelOptionsForGatewayModels, selectGatewayModelOption )
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , catalogConnection,
@@ -57,7 +58,7 @@ import Agent.CLI.Models
       resolveSavedModelTarget,
       validateResumedGatewayBoundary,
       ModelOption(modelTarget),
-      ModelTarget(targetWireModelId, targetConnectionId, targetProvider,
+      ModelTarget(ModelTarget, targetWireModelId, targetConnectionId, targetProvider,
                   targetModelId, targetDialect) )
 import Agent.CLI.Options
     ( CliOptions(optModel, optProvider, optSkills, optYolo) )
@@ -148,7 +149,7 @@ import Control.Concurrent.MVar
 import Control.Exception.Safe ( onException )
 import Control.Monad ( forM_, void, when )
 import Data.IORef ( IORef, newIORef, writeIORef )
-import Data.Maybe ( isNothing, fromMaybe, isJust )
+import Data.Maybe ( isNothing, fromMaybe, isJust, catMaybes )
 import Data.Text ( Text )
 import System.Environment ( lookupEnv )
 import System.OsPath ( OsPath, (</>), decodeFS, unsafeEncodeUtf )
@@ -192,6 +193,7 @@ data InitializedWorkspace = InitializedWorkspace
 
 data InitializedTargets = InitializedTargets
     { initializedGatewayIdentity :: Maybe Text
+    , initializedGatewayModelAccess :: Maybe GatewayModelAccess
     , initializedTransitionTarget :: Maybe ModelTarget
     , initializedConfiguredTarget :: Maybe ModelTarget
     , initializedResumedTarget :: Maybe ModelTarget
@@ -468,14 +470,22 @@ resolveInitializedTargets request workspace = do
                                         Just option.modelTarget
                                 _ -> Nothing
                 Just meta ->
-                    Just <$> resolveSavedModelTarget
-                        catalog
-                        (isJust connectedGateway)
-                        meta.metaProvider
-                        meta.metaConnection
-                        meta.metaModel
-                        meta.metaTransportModel
-                        meta.metaDialect
+                    if isJust connectedGateway
+                    then Right $ Just ModelTarget
+                        { targetProvider = meta.metaProvider
+                        , targetConnectionId = meta.metaConnection
+                        , targetModelId = meta.metaModel
+                        , targetWireModelId = fromMaybe meta.metaModel meta.metaTransportModel
+                        , targetDialect = meta.metaDialect
+                        }
+                    else Just <$> resolveSavedModelTarget
+                            catalog
+                            False
+                            meta.metaProvider
+                            meta.metaConnection
+                            meta.metaModel
+                            meta.metaTransportModel
+                            meta.metaDialect
         projectTargetResult
             | isJust transitionTarget
                 || isJust options.optModel
@@ -526,7 +536,24 @@ resolveInitializedTargets request workspace = do
         either (startupDie startup) pure resumedTargetResult
     projectTarget <-
         either (startupDie startup) pure projectTargetResult
+    (gatewayModelAccess, gatewayTarget) <- case connectedGateway of
+        Nothing -> pure (Nothing, Nothing)
+        Just credential -> do
+            access <- newGatewayModelAccess credential
+            models <- refreshGatewayModels access
+                >>= either (startupDie startup) pure
+            selected <- either (startupDie startup) pure $
+                selectGatewayModelOption
+                    (modelOptionsForGatewayModels catalog models)
+                    options.optModel
+                    (if isJust transition then Nothing else options.optProvider)
+                    (catMaybes
+                        [ transitionTarget, configuredOptionTarget
+                        , resumedTarget, projectTarget
+                        ])
+            pure (Just access, Just selected.modelTarget)
     let targetHint =
+            gatewayTarget <|>
             transitionTarget
                 <|> configuredOptionTarget
                 <|> resumedTarget
@@ -534,12 +561,7 @@ resolveInitializedTargets request workspace = do
                     then projectTarget
                     else Nothing
         requestedProvider
-            | isJust connectedGateway =
-                Just $
-                    gatewayProviderForStartup
-                        targetHint
-                        options.optProvider
-                        ((.metaProvider) . fst <$> resumed)
+            | Just target <- gatewayTarget = Just target.targetProvider
             | otherwise =
                 (.targetProvider) <$> targetHint
                     <|> options.optProvider
@@ -567,6 +589,7 @@ resolveInitializedTargets request workspace = do
                 && isNothing options.optModel
     pure InitializedTargets
         { initializedGatewayIdentity = connectedGatewayIdentity
+        , initializedGatewayModelAccess = gatewayModelAccess
         , initializedTransitionTarget = transitionTarget
         , initializedConfiguredTarget = configuredOptionTarget
         , initializedResumedTarget = resumedTarget
@@ -824,18 +847,13 @@ validateInitializedAuth request targets loaded = do
 
 newInitializedAccountRefs
     :: InitializedRequest
+    -> InitializedTargets
     -> InitializedAuth
     -> IO InitializedAccountRefs
-newInitializedAccountRefs request auth = do
+newInitializedAccountRefs request targets auth = do
     let loaded = auth.initializedLoaded
         startupAccountIds = auth.initializedStartupAccountIds
-    initialGatewayModels <-
-        loadGatewayModelAccess
-            request.initializedConnectedGateway
-            loaded >>= either
-                (startupDie request.initializedStartup)
-                pure
-    gatewayModelsRef <- newIORef initialGatewayModels
+    gatewayModelsRef <- newIORef targets.initializedGatewayModelAccess
     activeAccountRef <- newActiveAccount ActiveAccount
         { activeAccountId = maybe "" snd startupAccountIds
         , activeSelectionId =
@@ -858,8 +876,11 @@ newInitializedAccountRefs request auth = do
                 Nothing ->
                     loaded.loadedTokenProvider
         selectableTokenProvider
-            | isGatewayLoadedAuth loaded =
-                gatewayRouterTokenProvider
+            | Just credential <- request.initializedConnectedGateway
+            , loaded.loadedProvider /= ClaudeCodeProvider =
+                gatewayTokenProviderForProvider
+                    loaded.loadedProvider
+                    credential
                     unguardedSelectableTokenProvider
             | otherwise =
                 unguardedSelectableTokenProvider
@@ -905,7 +926,9 @@ initializeActiveHttpAuth targets auth refs = do
                             , activeAccountLabel = label
                             }
                         pure
-                            ( usable.loadedTokenProvider
+                            ( if isGatewayLoadedAuth loaded
+                                then selectableTokenProvider
+                                else usable.loadedTokenProvider
                             , usable.loadedAccountLabel
                             , credential.accountId
                             )
@@ -1124,7 +1147,7 @@ runInitialized request = do
         request
         targets
         initializedAuth.initializedLoaded
-    accountRefs <- newInitializedAccountRefs request initializedAuth
+    accountRefs <- newInitializedAccountRefs request targets initializedAuth
     activeHttpAuth <-
         initializeActiveHttpAuth
             targets

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers.hs
@@ -18,7 +18,8 @@ withProviderRuntime
     -> IO a
 withProviderRuntime config host use = case config of
     OpenAiProviderConfig openAi -> withOpenAiProvider openAi host use
-    XaiProviderConfig tokens hostedTools -> withXaiProvider tokens hostedTools host use
+    XaiProviderConfig tokens hostedTools gateway ->
+        withXaiProvider tokens hostedTools gateway host use
     GeminiProviderConfig tokens -> withGeminiProvider tokens host use
     OpenRouterProviderConfig openRouter -> withOpenRouterProvider openRouter host use
     ClaudeProviderConfig claude -> withClaudeProvider claude host use

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Types.hs
@@ -15,6 +15,7 @@ import Agent.CLI.Session.Request
     ( SessionRequestState
     )
 import Agent.CLI.Compaction (CompactOutcome, CompactionInstall, OccupancySnapshot)
+import Agent.CLI.GatewayClient (GatewayCredential)
 import Agent.CLI.Session.History (LiveConversation)
 import Agent.CLI.Session.Runtime.Types (SessionBackend)
 import Agent.Claude (ClaudeCodeAuth)
@@ -35,7 +36,7 @@ import qualified Agent.Responses.GenericClient as GenericResponses
 -- | Only the selected provider's configuration crosses the provider boundary.
 data ProviderConfig
     = OpenAiProviderConfig OpenAiConfig
-    | XaiProviderConfig TokenProvider Bool
+    | XaiProviderConfig TokenProvider Bool (Maybe GatewayCredential)
     | GeminiProviderConfig TokenProvider
     | OpenRouterProviderConfig OpenRouterConfig
     | ClaudeProviderConfig ClaudeConfig

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/XAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/XAI.hs
@@ -5,6 +5,8 @@ module Agent.CLI.Runtime.Orchestration.Providers.XAI
 import Agent.CLI.Session.Request
     ( readSessionRequestParams
     )
+import Agent.CLI.Auth (gatewayTokenProviderForProvider)
+import Agent.CLI.GatewayClient (GatewayCredential(..))
 import Agent.CLI.Compaction
     ( autoCompactBackendWith
     , boundCompletedToolContinuations
@@ -25,11 +27,12 @@ import Agent.CLI.Session.History (readLiveTranscript)
 import Agent.CLI.Session.Runtime.Types
     ( SessionBackend(..)
     )
-import Agent.Provider (TokenProvider, runWithTokenProvider)
+import Agent.Provider (Provider(XAIProvider), TokenProvider, runWithTokenProvider)
 import Agent.Responses.Types (ResponseCreateParams(model))
 import Agent.XAI.LoopBackend (xaiBackendWithClientOptions)
 import Data.IORef (newIORef)
 import Data.Maybe (fromMaybe)
+import qualified Data.Text as Text
 import qualified Agent.XAI.Client as XAIClient
 import qualified Agent.XAI.Options as XAI
 import qualified Agent.XAI.Request as XAIRequest
@@ -37,13 +40,24 @@ import qualified Agent.XAI.Request as XAIRequest
 withXaiProvider
     :: TokenProvider
     -> Bool
+    -> Maybe GatewayCredential
     -> ProviderHost
     -> (ProviderRuntime -> IO a)
     -> IO a
-withXaiProvider tokenProvider hostedTools
+withXaiProvider unguardedTokenProvider hostedTools gateway
         ProviderHost{compaction = ProviderCompaction{..}, networkRecovery} use = do
-    xaiOptions0 <- XAI.clientOptionsFromEnv
-    let xaiOptions =
+    xaiOptions0 <- case gateway of
+        Nothing -> XAI.clientOptionsFromEnv
+        Just credential ->
+            pure (XAI.gatewayClientOptions
+                (Text.unpack credential.gatewayBaseUrl))
+    let tokenProvider =
+            maybe unguardedTokenProvider
+                (\credential ->
+                    gatewayTokenProviderForProvider
+                        XAIProvider credential unguardedTokenProvider)
+                gateway
+        xaiOptions =
             xaiOptions0
                 { XAI.hostedXSearchEnabled =
                     hostedTools

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -19,6 +19,8 @@ import Agent.CLI.CancelWatch (StdinControl)
 import Agent.CLI.Auth
     ( LoadedAuth(loadedTokenProvider, loadedOpenAiPool)
     , isGatewayLoadedAuth
+    , gatewayLoadedAuthForProvider
+    , gatewayTokenProviderForProvider
     )
 import Agent.CLI.Claude
     ( approveClaudeRegisteredTool
@@ -43,7 +45,7 @@ import Agent.CLI.Database.Store (DatabaseScopes)
 import Agent.CLI.Dialects (CodingTools(..))
 import Agent.CLI.Error (formatApiErrorAt)
 import Agent.CLI.GatewayClient
-    ( GatewayCredential
+    ( GatewayCredential(gatewayBaseUrl)
     , GatewayModelAccess
     , gatewayCredentialIdentity
     )
@@ -58,6 +60,7 @@ import Agent.CLI.ModelConfig
     ( ModelCatalog
     , catalogContextWindowForTransport
     , catalogSupportsAsyncToolCallsForTransport
+    , organizationGatewayConnectionId
     )
 import Agent.CLI.Models (ModelTarget(targetConnectionId))
 import Agent.CLI.Options
@@ -169,6 +172,7 @@ import Agent.CLI.StartupContext
 import Agent.CLI.Style ( cliWindowTitle, roleMuted, glyphWarn, roleWarn )
 import Agent.CLI.Subagents.Runtime
     ( runCodexSubagent, runHttpSubagent, runXaiParentSubagent
+    , runGatewaySubagent, runXaiSubagent
     , SubagentRuntime(subagentOpenAiChild, SubagentRuntime,
                       subagentOptions, subagentNetworkRecovery,
                       subagentGhciEnabled, subagentBashEnabled,
@@ -197,11 +201,12 @@ import Agent.Claude
 import Agent.Claude.Control
     ( ClaudeCodeHostHandlers(..), ClaudeCodeMcpRequest(..), defaultClaudeCodeHostHandlers )
 import Agent.CLI.ClaudeGatewayProxy (withClaudeGatewayProxy)
-import Agent.Dialect (Dialect, dialectId)
+import Agent.Dialect (Dialect, dialectId, dialectForId)
 import Agent.Error (ApiError)
 import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs)
 import Agent.Loop
     ( ImageAttachment
+    , LoopError(LoopUnexpected)
     , TokenUsage
     , TurnInput
     , addTokenUsage
@@ -223,7 +228,9 @@ import Agent.Subagents (SubagentRegistry, setSubagentRunner)
 import Agent.Subagents.Types (RootTurnId, SubagentId)
 import Agent.TUI.Model (UiEvent(UiSystemMessage))
 import Agent.Tools.MultiAgents
-    (CollaborationModelTarget, MultiAgentContext(..), SubagentWorktree)
+    (CollaborationModelTarget(..), MultiAgentContext(..), SubagentWorktree)
+import Agent.XAI.LoopBackend (xaiBackendWithClientOptions)
+import qualified Agent.XAI.Options as XAI
 import Agent.Tools.PlanMode (PlanModeEnv, PlanModeHooks)
 import Agent.ToolDispatch (canonicalToolName, ToolDispatchConfig(..))
 import Agent.Tools.Types
@@ -247,6 +254,7 @@ import Data.Map.Strict (Map)
 import Data.Maybe ( isJust, isNothing, fromMaybe )
 import Data.Set (Set)
 import Data.Text (Text)
+import qualified Data.Text as Text
 import Data.Time.Clock ( getCurrentTime, utctDay )
 import System.Environment ( getProgName )
 import System.IO (Handle, stderr)
@@ -736,7 +744,8 @@ buildSessionSubagentRuntime AgentSessionRequest
         , subagentCreateWorktree = Just createSubagentWorktree
         , subagentSessionTmp = toolEnv.toolSessionTmp
         , subagentSpawnModelGuidance =
-            if provider == OpenAIProvider && isJust allowedChildModels
+            if inferredTarget.targetConnectionId == organizationGatewayConnectionId
+                || (provider == OpenAIProvider && isJust allowedChildModels)
                 then Nothing
                 else
                     subscriptionSubagentModelGuidance
@@ -1203,6 +1212,7 @@ prepareProviderConfig request promptRuntime nativeCapabilities = case request.pr
         }
     XAIProvider -> pure $ XaiProviderConfig request.tokenProvider
         nativeCapabilities.nativeProviderHostedTools
+        request.connectedGateway
     GeminiProvider -> pure $ GeminiProviderConfig request.tokenProvider
     OpenRouterProvider -> pure $ OpenRouterProviderConfig OpenRouterConfig
         { tokenProvider = request.tokenProvider
@@ -1266,6 +1276,9 @@ installProviderSubagents request liveRuntime capabilities =
                 install = setSubagentRunner ctx.multiRegistry
             case capabilities of
                 NoProviderSubagents -> pure ()
+                _ | Just credential <- request.connectedGateway ->
+                    install $ runGatewaySubagent runtime
+                        (gatewayRunner credential ctx.multiSendToRoot)
                 CodexSubagents gatewayOnly -> install $
                     runCodexSubagent gatewayOnly runtime request.selectableTokenProvider
                         ctx.multiSendToRoot
@@ -1275,6 +1288,57 @@ installProviderSubagents request liveRuntime capabilities =
                 XaiSubagents contextWindow threshold makeBackend -> install $
                     runXaiParentSubagent runtime request.dialect ctx.multiSendToRoot
                         contextWindow threshold makeBackend
+  where
+    gatewayRunner credential sendToRoot target runtime env previous prompt onEvent =
+        case gatewayLoadedAuthForProvider
+                (Just target.collaborationTargetProvider) credential of
+            Left err -> pure (Left (LoopUnexpected err))
+            Right loaded ->
+                let tokens = gatewayTokenProviderForProvider
+                        target.collaborationTargetProvider credential
+                        loaded.loadedTokenProvider
+                in case target.collaborationTargetProvider of
+                    OpenAIProvider ->
+                        runCodexSubagent True runtime tokens sendToRoot
+                            env previous prompt onEvent
+                    XAIProvider ->
+                        let nativeCapabilities =
+                                maybe fullNativeRunCapabilities (.nativeCapabilities)
+                                    request.startup.startupNativeHooks
+                            options = (XAI.gatewayClientOptions
+                                (Text.unpack credential.gatewayBaseUrl))
+                                    { XAI.hostedXSearchEnabled =
+                                        nativeCapabilities.nativeProviderHostedTools
+                                    }
+                            contextWindow params =
+                                let childModel = fromMaybe
+                                        target.collaborationTargetEffectiveModel
+                                        params.model
+                                in fromMaybe XAI.grokDefaultContextWindow $
+                                    catalogContextWindowForTransport
+                                        request.catalog
+                                        target.collaborationTargetConnection
+                                        childModel
+                                        childModel
+                            threshold params =
+                                let window = contextWindow params
+                                in max 1 $ min window $
+                                    fromMaybe
+                                        (XAI.grokAutoCompactTokenLimit
+                                            (fromMaybe options.defaultModel params.model)
+                                            window)
+                                        request.options.optCompactThreshold
+                            optionsFor params =
+                                options
+                                    { XAI.autoCompactTokenLimit = Just (threshold params) }
+                            makeBackend params =
+                                xaiBackendWithClientOptions optionsFor tokens (pure params)
+                        in runXaiSubagent runtime
+                            (dialectForId target.collaborationTargetDialect)
+                            sendToRoot contextWindow threshold makeBackend
+                            env previous prompt onEvent
+                    _ -> pure (Left (LoopUnexpected
+                        "This provider requires a separate child session; it cannot run as an in-process gateway subagent."))
 
 handleOpenAiStartupResult
     :: AgentSessionRequest closeResult windowTitleResult

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Collaboration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Collaboration.hs
@@ -129,6 +129,7 @@ newCollaborationRuntime AgentToolsRequest
     collaborationAgentTypes <- newIORef Map.empty
     collaborationOpenAiChild <-
         if not nativeCapabilities.nativeCollaboration
+            || isJust gatewayAllowedChildModels
             then pure Nothing
             else case provider of
                 XAIProvider -> do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Model.hs
@@ -9,11 +9,11 @@ module Agent.CLI.Runtime.Orchestration.Tools.Model
 import Agent.CLI.Auth (LoadedAuth(..), isGatewayLoadedAuth)
 import Agent.CLI.Config (HarnessConfig)
 import Agent.CLI.GatewayClient (cachedGatewayModels, gatewayCredentialIdentity)
-import Agent.CLI.GatewayModels (modelOptionsForGatewayModels)
+import Agent.CLI.GatewayModels (modelOptionsForGatewayModels, selectGatewayModelOption)
 import Agent.CLI.ModelConfig (ResponsesConnection(..), builtinConnectionId)
 import Agent.CLI.Models
     ( ModelOption(..), ModelTarget(..), defaultModelFor, rawModelOption
-    , resolveConfiguredModel, resolveModelOptionById, resolvePersistedDialect )
+    , resolveConfiguredModel, resolvePersistedDialect )
 import Agent.CLI.Options
     ( ApprovalPolicy(..), CliOptions(..), defaultEffortFor
     , normalizeReasoningEffortForDialect, resolveApprovalPolicy )
@@ -30,10 +30,9 @@ import qualified Agent.OpenRouter as OpenRouter
 import Agent.Provider (Provider(..))
 import Agent.ReasoningEffort (parseReasoningEffort, reasoningEffortText)
 import Agent.Responses.GenericClient (GenericClientOptions(..))
-import Control.Applicative ((<|>))
 import Control.Monad (when)
 import Data.IORef (readIORef)
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe, isJust, catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -124,27 +123,13 @@ selectGatewayModels AgentToolsRequest
                             "The organization gateway does not offer any models."
                     firstAvailable : remainingAvailable -> do
                         let available = firstAvailable : remainingAvailable
-                            resolveTarget target =
-                                resolveModelOptionById
-                                    available
-                                    target.targetModelId
-                        selected <- case options.optModel of
-                            Just requested ->
-                                case resolveModelOptionById available requested of
-                                    Nothing ->
-                                        startupDie startup $
-                                            "Model '"
-                                                <> requested
-                                                <> "' is not available through your organization gateway."
-                                    Just selected -> pure selected
-                            Nothing ->
-                                pure $
-                                    fromMaybe firstAvailable $
-                                        (transitionTarget >>= resolveTarget)
-                                            <|> (configuredOptionTarget >>= resolveTarget)
-                                            <|> (resumedTarget >>= resolveTarget)
-                                            <|> (projectTarget >>= resolveTarget)
-                                            <|> (targetHint >>= resolveTarget)
+                        selected <- either (startupDie startup) pure $
+                            selectGatewayModelOption available options.optModel
+                                (Just loaded.loadedProvider)
+                                (catMaybes
+                                    [ targetHint, transitionTarget, configuredOptionTarget
+                                    , resumedTarget, projectTarget
+                                    ])
                         pure
                             ( Just selected
                             , Just (map (.modelTarget.targetModelId) available)

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -31,7 +31,6 @@ import Agent.CLI.Models
     ( ModelOption(..)
     , ModelTarget(..)
     , PickerState(..)
-    , gatewayModelOptions
     , initialPickerStateForOptions
     , initialPickerStateResolvedWith
     , rawModelOption
@@ -156,7 +155,7 @@ modelChoiceWithEffort
                                 "organization gateway"
                                 options
                                 gatewayConnectionId
-                                OpenAIProvider
+                                provider
                                 current
                                 currentDialect
                         usage <- loadGatewayModelUsage access options

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -7,7 +7,8 @@ module Agent.CLI.Subagents.Runtime
     , pinSubagentSession, unpinSubagentSession
     , persistSubagentSnapshotWithStatus, prepareCollaborationSpawn
     , restoreAgentFromDisk, resolveChildModelAndEffort, runCodexSubagent
-    , runHttpSubagent, runXaiParentSubagent, grokSpawnedChildIdentity
+    , runHttpSubagent, runXaiParentSubagent, runGatewaySubagent
+    , runXaiSubagent, resolveGatewaySubagentTarget, grokSpawnedChildIdentity
     , usesOpenAiChildTransport, validatePersistedSubagentTarget
     ) where
 import Agent.CLI.Session.Request
@@ -65,7 +66,8 @@ import Agent.CLI.SteeringInputs
     , newSteeringInputs
     , readSteeringInputs
     )
-import Agent.CLI.ModelConfig (connectionSupportsDialect)
+import Agent.CLI.ModelConfig
+    (connectionSupportsDialect, organizationGatewayConnectionId)
 import Agent.CLI.Tools
     (hostedSearchToolNames, requireToolRegistry, schemasFromAppTools)
 import Agent.CLI.Dialects
@@ -78,7 +80,8 @@ import Agent.CLI.Dialects
 import Agent.Codex.Dialect.Subagent (codexSubagentSuffix)
 import Agent.Dialect
     (ChildAgentProtocol(..), Dialect, DialectId, codexDialect,
-     dialectChildAgentProtocol, dialectForId, dialectId, dialectIdForModel)
+     dialectChildAgentProtocol, dialectForId, dialectId, dialectIdForModel,
+     providerSupportsDialect)
 import Agent.InterAgentMessage (InterAgentMessage, interAgentMessagePayload)
 import Agent.Loop
     (Backend(..), BackendMiddleware, BackendSnapshot(..),
@@ -446,6 +449,102 @@ restoreAgentFromDisk
             Left err -> Left err
             Right _ -> Right ()
 
+-- | Select the organization alias before choosing a child transport. Persisted
+-- and inherited aliases are looked up again in the authoritative catalog; a
+-- provider name or a model-name prefix is never a transport-routing input.
+resolveGatewaySubagentTarget
+    :: (Text -> IO (Maybe CollaborationModelTarget))
+    -> Maybe Text
+    -> Maybe Text
+    -> Maybe Text
+    -> Text
+    -> IO (Either Text CollaborationModelTarget)
+resolveGatewaySubagentTarget
+        resolve requestedModel childModel parentModel rootModel =
+    resolve selectedModel >>= \case
+        Nothing ->
+            pure (Left "The child model is not allowed by this organization.")
+        Just target
+            | target.collaborationTargetConnection
+                /= organizationGatewayConnectionId ->
+                    pure (Left "The child model does not use the organization gateway.")
+            | not (providerSupportsDialect
+                target.collaborationTargetProvider
+                target.collaborationTargetDialect) ->
+                    pure (Left "The child model has an incompatible provider dialect.")
+            | otherwise -> pure (Right target)
+  where
+    selectedModel = fromMaybe rootModel
+        (requestedModel <|> childModel <|> parentModel)
+
+-- | Dispatch every child invocation, including follow-ups and descendants,
+-- through its catalog-selected provider. Runners supplied by the gateway owner
+-- must capture that owner's immutable credential and endpoint snapshot.
+runGatewaySubagent
+    :: SubagentRuntime
+    -> (CollaborationModelTarget -> SubagentRuntime -> RunSubagent)
+    -> RunSubagent
+runGatewaySubagent runtime runner env previous prompt onEvent =
+    case runtime.subagentResolveChildModel of
+        Nothing ->
+            pure (Left (LoopUnexpected
+                "The organization gateway model catalog is unavailable."))
+        Just resolve -> do
+            requestedModel <- lookupAgentModel runtime.subagentTypes env.subId
+            sessions <- readIORef runtime.subagentSessions
+            identity <- getSubagentIdentity runtime.subagentRegistry env.subId
+            rootParams <- readSessionRequestParams runtime.subagentParams
+            let childSession = Map.lookup env.subId sessions
+                parentSession = do
+                    parentId <- identity >>= (.identityParent)
+                    Map.lookup parentId sessions
+            resolveGatewaySubagentTarget
+                resolve
+                requestedModel
+                ((.subSessionEffectiveModel) <$> childSession)
+                ((.subSessionEffectiveModel) <$> parentSession)
+                (fromMaybe "" rootParams.model) >>= \case
+                    Left err -> pure (Left (LoopUnexpected err))
+                    Right target -> do
+                        session <- lookupOrCreateSubagentSession
+                            runtime.subagentSessions
+                            runtime.subagentStoreRoot
+                            runtime.subagentTypes
+                            target.collaborationTargetProvider
+                            target.collaborationTargetConnection
+                            runtime.subagentLegacyTarget
+                            target.collaborationTargetEffectiveModel
+                            target.collaborationTargetDialect
+                            env.subId
+                        case activeSubagentTargetError
+                                target.collaborationTargetProvider
+                                target.collaborationTargetConnection
+                                target.collaborationTargetEffectiveModel
+                                session of
+                            Just err -> pure (Left (LoopUnexpected err))
+                            Nothing ->
+                                runner target
+                                    runtime
+                                        { subagentConnection =
+                                            target.collaborationTargetConnection
+                                        , subagentMapModel = id
+                                        }
+                                    env previous prompt onEvent
+
+runXaiSubagent
+    :: SubagentRuntime
+    -> Dialect
+    -> Maybe (InterAgentMessage -> IO (Either Text Text))
+    -> (ResponseCreateParams -> Int)
+    -> (ResponseCreateParams -> Int)
+    -> (ResponseCreateParams -> Backend)
+    -> RunSubagent
+runXaiSubagent runtime dialect sendToRoot contextWindowFor compactThresholdFor
+        makeBackend =
+    runHttpSubagentWith
+        runtime dialect XAIProvider sendToRoot makeBackend
+        (compactXaiChildBackend contextWindowFor compactThresholdFor makeBackend)
+
 -- | XAI parent runner: Grok children stay on xAI; Luna and its descendants
 -- use Codex/OpenAI.
 runXaiParentSubagent
@@ -493,16 +592,13 @@ runXaiParentSubagent
                         prompt
                         onEvent
             else
-                runHttpSubagentWith
+                runXaiSubagent
                     runtime
                     dialect
-                    XAIProvider
                     sendToRoot
+                    contextWindowFor
+                    compactThresholdFor
                     mkBackend
-                    (compactXaiChildBackend
-                        contextWindowFor
-                        compactThresholdFor
-                        mkBackend)
                     env
                     previous
                     prompt

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Identity.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Identity.hs
@@ -6,6 +6,7 @@ module Agent.CLI.Subagents.Runtime.Identity
     ) where
 
 import Agent.CLI.Subagents.Runtime.Types (SubagentRuntime(..))
+import Agent.CLI.ModelConfig (organizationGatewayConnectionId)
 import Agent.Dialect
     ( DialectId
     , codexDialect
@@ -53,6 +54,9 @@ grokSpawnedChildIdentity
             )
 
 inheritedGrokChildModel :: SubagentRuntime -> Text -> Text
+inheritedGrokChildModel runtime parentModel
+    | runtime.subagentConnection == organizationGatewayConnectionId =
+        parentModel
 inheritedGrokChildModel runtime parentModel =
     case runtime.subagentAllowedChildModels of
         Nothing -> parentModel

--- a/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AuthSpec.hs
@@ -362,23 +362,29 @@ spec = do
                             expectationFailure
                                 "expected an invalid gateway to block local auth"
 
-        it "does not let an explicit non-OpenAI provider bypass the gateway" $
+        it "uses native xAI gateway credentials instead of direct xAI credentials" $
             withTempHome \home ->
                 withCleanGrokEnv $
                 withEnv "GROK_ACCESS_TOKEN" (Just "xai-token") do
                     saveTestGateway home
                     loadAuth (Just XAIProvider) >>= \case
-                        Left err ->
-                            err `shouldSatisfy`
-                                Text.isInfixOf
-                                    "organization gateway is active"
-                        Right _ ->
-                            expectationFailure
-                                "expected the gateway to block direct xAI auth"
+                        Left err -> expectationFailure (Text.unpack err)
+                        Right loaded -> do
+                            loaded.loadedProvider `shouldBe` XAIProvider
+                            loaded.loadedSelectionId
+                                `shouldBe` Just gatewayAuthSelectionId
+                            credential <-
+                                getNextToken loaded.loadedTokenProvider Nothing
+                                    >>= expectRightResult
+                            credential.provider `shouldBe` XAIProvider
+                            credential.accessToken
+                                `shouldBe` testGatewayCredential.gatewayAccessToken
+                            credential.accountId
+                                `shouldBe` testGatewayCredential.gatewayBaseUrl
 
-        it "rejects an explicit provider against an exact gateway snapshot" do
+        it "rejects unsupported providers against an exact gateway snapshot" do
             case gatewayLoadedAuthForProvider
-                    (Just XAIProvider)
+                    (Just GeminiProvider)
                     testGatewayCredential of
                 Left err ->
                     err `shouldSatisfy`
@@ -386,7 +392,7 @@ spec = do
                             "organization gateway is active"
                 Right _ ->
                     expectationFailure
-                        "expected exact gateway auth to block direct xAI"
+                        "expected exact gateway auth to block direct Gemini"
             case gatewayLoadedAuthForProvider
                     (Just ClaudeCodeProvider)
                     testGatewayCredential of
@@ -395,6 +401,29 @@ spec = do
                 Left err ->
                     expectationFailure
                         ("expected gateway Claude auth, got " <> Text.unpack err)
+
+        it "binds native xAI credentials to the exact gateway snapshot" do
+            loaded <- expectRightResult $
+                gatewayLoadedAuthForProvider (Just XAIProvider) testGatewayCredential
+            credential <- getNextToken loaded.loadedTokenProvider Nothing
+                >>= expectRightResult
+            let guardCredential candidate =
+                    getNextToken
+                        (gatewayTokenProviderForProvider
+                            XAIProvider
+                            testGatewayCredential
+                            (staticCredentialProvider SubscriptionBilled candidate))
+                        Nothing
+            guardCredential credential `shouldReturn` Right credential
+            mapM_
+                (\candidate ->
+                    guardCredential candidate >>= \case
+                        Left CredentialError{} -> pure ()
+                        _ -> expectationFailure "expected gateway credential mismatch")
+                [ (credential :: Credential) { accessToken = "direct-xai-token" }
+                , (credential :: Credential) { accountId = "https://different-gateway.example" }
+                , (credential :: Credential) { provider = OpenAIProvider }
+                ]
 
     describe "loadOpenAiDictationAuth" do
         it "loads ChatGPT OAuth as subscription-billed OpenAI auth" $

--- a/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
@@ -4,13 +4,15 @@ import Agent.CLI.GatewayModels
 import Agent.CLI.GatewayClient
     ( GatewayModel(..)
     , GatewayModelProtocol(..)
+    , GatewayModelProvider(..)
     )
 import Agent.CLI.ModelConfig
 import Agent.CLI.Models (ModelOption(..), ModelTarget(..))
 import Agent.Dialect (DialectId(..))
-import Agent.Provider (Provider(ClaudeCodeProvider, OpenAIProvider))
+import Agent.Provider (Provider(ClaudeCodeProvider, GeminiProvider, OpenAIProvider, XAIProvider))
 import Data.Aeson qualified as Aeson
 import Data.Aeson ((.=))
+import Data.Either (isLeft)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Test.Hspec
@@ -21,7 +23,11 @@ spec = describe "Agent.CLI.GatewayModels" do
         let options =
                 modelOptionsForGatewayState
                     testCatalog
-                    (Just ["company-b", "company-a", "company-b"])
+                    (Just
+                        [ GatewayModel "company-b" GatewayResponsesProtocol GatewayOpenAIProvider
+                        , GatewayModel "company-a" GatewayResponsesProtocol GatewayXAIProvider
+                        , GatewayModel "company-b" GatewayResponsesProtocol GatewayOpenAIProvider
+                        ])
         map (.modelTarget.targetModelId) options
             `shouldBe` ["company-b", "company-a"]
         map (.modelTarget.targetConnectionId) options
@@ -29,7 +35,7 @@ spec = describe "Agent.CLI.GatewayModels" do
         map (.modelTarget.targetWireModelId) options
             `shouldBe` ["company-b", "company-a"]
         map (.modelTarget.targetDialect) options
-            `shouldBe` [CodexDialect, GenericResponsesDialect]
+            `shouldBe` [CodexDialect, GrokBuildDialect]
         map (.modelLabel) options
             `shouldBe` [Nothing, Just "Company A"]
 
@@ -40,40 +46,98 @@ spec = describe "Agent.CLI.GatewayModels" do
         map (.modelTarget.targetConnectionId) options
             `shouldBe` ["openai", "xai", "gemini", "openrouter", "claude-code"]
 
-    it "maps the unified catalog to Responses and Claude transports" do
+    it "maps shared Responses models to their distinct native transports" do
         let options =
                 modelOptionsForGatewayModels
                     testCatalog
-                    [ GatewayModel "company-a" GatewayResponsesProtocol
-                    , GatewayModel "sonnet" GatewayAnthropicProtocol
-                    , GatewayModel "router-default" GatewayResponsesProtocol
+                    [ GatewayModel "company-a" GatewayResponsesProtocol GatewayOpenAIProvider
+                    , GatewayModel "company-grok" GatewayResponsesProtocol GatewayXAIProvider
+                    , GatewayModel "sonnet" GatewayAnthropicProtocol GatewayAnthropicProvider
+                    , GatewayModel "router-default" GatewayResponsesProtocol GatewayOpenAIProvider
                     ]
         map (.modelTarget.targetProvider) options
-            `shouldBe` [OpenAIProvider, ClaudeCodeProvider]
+            `shouldBe` [OpenAIProvider, XAIProvider, ClaudeCodeProvider]
         map (.modelTarget.targetModelId) options
-            `shouldBe` ["company-a", "sonnet"]
+            `shouldBe` ["company-a", "company-grok", "sonnet"]
         map (.modelTarget.targetConnectionId) options
-            `shouldBe` replicate 2 organizationGatewayConnectionId
+            `shouldBe` replicate 3 organizationGatewayConnectionId
         map (.modelTarget.targetDialect) options
-            `shouldBe` [GenericResponsesDialect, ClaudeCodeDialect]
+            `shouldBe` [CodexDialect, GrokBuildDialect, ClaudeCodeDialect]
 
-    it "aligns gateway auth with a resumed Claude model target" do
-        let options =
-                modelOptionsForGatewayModels
-                    testCatalog
-                    [GatewayModel "sonnet" GatewayAnthropicProtocol]
-        case options of
-            [option] ->
-                gatewayProviderForStartup
-                    (Just option.modelTarget)
-                    Nothing
-                    (Just OpenAIProvider)
-                    `shouldBe` ClaudeCodeProvider
-            _ -> expectationFailure "expected one Claude gateway model"
+    it "uses provider metadata rather than model names or local dialect overrides" do
+        let options = modelOptionsForGatewayModels testCatalog
+                [ GatewayModel "gpt-company" GatewayResponsesProtocol GatewayXAIProvider
+                , GatewayModel "grok-company" GatewayResponsesProtocol GatewayOpenAIProvider
+                , GatewayModel "company-a" GatewayResponsesProtocol GatewayXAIProvider
+                ]
+        map (.modelTarget.targetProvider) options
+            `shouldBe` [XAIProvider, OpenAIProvider, XAIProvider]
+        map (.modelTarget.targetDialect) options
+            `shouldBe` [GrokBuildDialect, CodexDialect, GrokBuildDialect]
+        map (.modelTarget.targetWireModelId) options
+            `shouldBe` ["gpt-company", "grok-company", "company-a"]
+        map (.modelLabel) options
+            `shouldBe` [Nothing, Nothing, Just "Company A"]
 
-    it "defaults gateway auth to OpenAI without a target or provider hint" $
-        gatewayProviderForStartup Nothing Nothing Nothing
-            `shouldBe` OpenAIProvider
+    describe "selectGatewayModelOption" do
+        let options = modelOptionsForGatewayModels testCatalog
+                [ GatewayModel "company-openai" GatewayResponsesProtocol GatewayOpenAIProvider
+                , GatewayModel "company-xai" GatewayResponsesProtocol GatewayXAIProvider
+                , GatewayModel "company-claude" GatewayAnthropicProtocol GatewayAnthropicProvider
+                ]
+            savedTarget provider model =
+                ModelTarget provider organizationGatewayConnectionId model model CodexDialect
+            selectedProvider model provider hints =
+                (.modelTarget.targetProvider)
+                    <$> selectGatewayModelOption options model provider hints
+
+        it "selects an explicit alias using its advertised provider" $
+            selectedProvider (Just "company-xai") Nothing []
+                `shouldBe` Right XAIProvider
+
+        it "rejects an explicit alias absent from the authorized catalog" $
+            selectGatewayModelOption options (Just "unlisted") Nothing []
+                `shouldSatisfy` isLeft
+
+        it "rejects an explicit provider that conflicts with the explicit alias" $
+            selectGatewayModelOption options
+                (Just "company-xai") (Just OpenAIProvider) []
+                `shouldSatisfy` isLeft
+
+        it "accepts an explicit provider matching the explicit alias" $
+            selectedProvider (Just "company-xai") (Just XAIProvider) []
+                `shouldBe` Right XAIProvider
+
+        it "resolves a saved Grok alias without trusting its old OpenAI provider" $
+            selectedProvider Nothing Nothing
+                [savedTarget OpenAIProvider "company-xai"]
+                `shouldBe` Right XAIProvider
+
+        it "uses the first available saved alias preference" $
+            selectedProvider Nothing Nothing
+                [ savedTarget OpenAIProvider "removed-alias"
+                , savedTarget OpenAIProvider "company-xai"
+                , savedTarget ClaudeCodeProvider "company-claude"
+                ]
+                `shouldBe` Right XAIProvider
+
+        it "filters saved alias preferences and defaults by explicit provider" $
+            selectedProvider Nothing (Just XAIProvider)
+                [savedTarget OpenAIProvider "company-openai"]
+                `shouldBe` Right XAIProvider
+
+        it "defaults to the first authorized model when no preference resolves" $
+            selectedProvider Nothing Nothing
+                [savedTarget OpenAIProvider "removed-alias"]
+                `shouldBe` Right OpenAIProvider
+
+        it "rejects a provider with no authorized models" $
+            selectGatewayModelOption options Nothing (Just GeminiProvider) []
+                `shouldSatisfy` isLeft
+
+        it "rejects an empty authorized catalog" $
+            selectGatewayModelOption [] Nothing Nothing []
+                `shouldSatisfy` isLeft
 
 -- Exercise the same validated construction boundary as production. A catalog
 -- now always includes a default for each builtin provider.

--- a/packages/agent-cli/test/Agent/CLI/ProviderRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderRuntimeSpec.hs
@@ -2,24 +2,32 @@ module Agent.CLI.ProviderRuntimeSpec (spec) where
 
 import Agent.CLI.Session.Request (newSessionRequestState, readSessionRequestParams, setSessionRequestModel)
 import Agent.CLI.Session (Persistence(..))
+import Agent.CLI.Auth (LoadedAuth(..), gatewayLoadedAuthForProvider)
+import Agent.CLI.GatewayClient (GatewayCredential(..))
 import qualified Data.Text as Text
-import Agent.CLI.Compaction (CompactionInstall(..), reportedOccupancy)
+import qualified Data.Text.Encoding as Text
+import qualified Data.ByteString.Lazy as LBS
+import Agent.CLI.Compaction (CompactOutcome(..), CompactionInstall(..), reportedOccupancy)
 import Agent.CLI.ProviderRuntime
 import Agent.CLI.Session.ConversationStore (newConversationStore)
 import Agent.CLI.Session.History (readLivePreviousResponseId, readLiveTranscript)
 import Agent.Provider (Provider(..), BillingMode(..), TokenProvider, tokenProvider)
 import Agent.Responses.Types (defaultResponseCreateParams)
+import Agent.OpenAI.Compaction (userTextItem, compactionTriggerItem)
 import qualified Agent.Responses.Types as Responses (ResponseCreateParams(model))
 import Control.Exception.Safe (throwString)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Test.Hspec
 import qualified Agent.OpenRouter.Options as OpenRouter
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
+import Network.HTTP.Types (status200)
 
 spec :: Spec
 spec = describe "provider runtime composition" do
     mapM_ checkProvider
         [ ("Gemini", GeminiProviderConfig noNetworkTokens)
-        , ("xAI", XaiProviderConfig noNetworkTokens False)
+        , ("xAI", XaiProviderConfig noNetworkTokens False Nothing)
         , ("OpenRouter", OpenRouterProviderConfig OpenRouterConfig
             { tokenProvider = noNetworkTokens
             , clientOptions = OpenRouter.defaultClientOptions
@@ -28,6 +36,51 @@ spec = describe "provider runtime composition" do
             , transportModel = id
             })
         ]
+    it "compacts gateway xAI history with a native summary request, not a Codex trigger" do
+        observed <- newIORef Nothing
+        let application request respond = do
+                body <- Wai.strictRequestBody request
+                writeIORef observed (Just
+                    (Wai.rawPathInfo request, Wai.requestHeaders request, body))
+                respond $ Wai.responseLBS status200
+                    [("Content-Type", "text/event-stream")]
+                    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"summary-response\",\"created_at\":0,\"model\":\"organization-research\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Retained summary\"}]}]}}\n\n"
+        Warp.testWithApplication (pure application) \port -> do
+            let origin = "http://127.0.0.1:" <> Text.pack (show port)
+                gateway = GatewayCredential
+                    { gatewayBaseUrl = origin
+                    , gatewayWebSocketUrl =
+                        "ws://127.0.0.1:" <> Text.pack (show port) <> "/v1/responses"
+                    , gatewayAccessToken = "gateway-token"
+                    }
+            loaded <- either (fail . Text.unpack) pure $
+                gatewayLoadedAuthForProvider (Just XAIProvider) gateway
+            host <- newHost
+            setSessionRequestModel host.compaction.paramsRef
+                XAIProvider "organization-research"
+            history <- newConversationStore (Just "previous-response")
+                [userTextItem "Retain the current task", compactionTriggerItem] []
+            writeIORef host.compaction.conversationRef history
+            withProviderRuntime
+                (XaiProviderConfig loaded.loadedTokenProvider False (Just gateway))
+                host \runtime -> do
+                    result <- runtime.compactRunner Nothing
+                    case result of
+                        Left message -> expectationFailure (Text.unpack message)
+                        Right outcome ->
+                            outcome.compactHistory `shouldSatisfy` (not . null)
+            readLivePreviousResponseId host.compaction.conversationRef
+                `shouldReturn` Nothing
+        readIORef observed >>= \case
+            Nothing -> expectationFailure "the gateway did not receive a summary request"
+            Just (path, headers, body) -> do
+                path `shouldBe` "/v1/responses"
+                lookup "Authorization" headers `shouldBe` Just "Bearer gateway-token"
+                lookup "X-XAI-Token-Auth" headers `shouldBe` Just "xai-grok-cli"
+                let requestText = Text.decodeUtf8 (LBS.toStrict body)
+                requestText `shouldSatisfy` Text.isInfixOf "\"model\":\"organization-research\""
+                requestText `shouldSatisfy` (not . Text.isInfixOf "compaction_trigger")
+                requestText `shouldSatisfy` (not . Text.isInfixOf "previous_response_id")
   where
     checkProvider (name, config) = describe name do
         it "observes model changes after the runtime is constructed" do

--- a/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SubagentStoreSpec.hs
@@ -22,6 +22,7 @@ import Agent.CLI.Subagents.Runtime
     , grokSpawnedChildIdentity
     , restoreAgentFromDisk
     , resolveChildModelAndEffort
+    , resolveGatewaySubagentTarget
     , unpinSubagentSession
     , usesOpenAiChildTransport
     , validatePersistedSubagentTarget
@@ -66,6 +67,61 @@ toFilePath path = either (error . show) id (decodeUtf path)
 
 spec :: Spec
 spec = describe "Agent.CLI.SubagentStore" do
+    describe "gateway subagent transport selection" do
+        let target provider model dialect = CollaborationModelTarget
+                { collaborationTargetProvider = provider
+                , collaborationTargetConnection = organizationGatewayConnectionId
+                , collaborationTargetEffectiveModel = model
+                , collaborationTargetDialect = dialect
+                }
+            openaiTarget = target OpenAIProvider "company-code" CodexDialect
+            xaiTarget = target XAIProvider "company-analysis" GrokBuildDialect
+            resolve model = pure $ Map.lookup model $ Map.fromList
+                [ ("company-code", openaiTarget)
+                , ("company-analysis", xaiTarget)
+                ]
+        it "routes an explicit xAI child independently of its OpenAI parent" do
+            resolveGatewaySubagentTarget resolve
+                (Just "company-analysis") Nothing (Just "company-code") "company-code"
+                `shouldReturn` Right xaiTarget
+        it "routes an explicit OpenAI child independently of its xAI parent" do
+            resolveGatewaySubagentTarget resolve
+                (Just "company-code") Nothing (Just "company-analysis") "company-analysis"
+                `shouldReturn` Right openaiTarget
+        it "retains the child's own provider for follow-ups" do
+            resolveGatewaySubagentTarget resolve
+                Nothing (Just "company-code") (Just "company-analysis") "company-analysis"
+                `shouldReturn` Right openaiTarget
+        it "inherits the immediate parent's alias rather than the root's alias" do
+            resolveGatewaySubagentTarget resolve
+                Nothing Nothing (Just "company-analysis") "company-code"
+                `shouldReturn` Right xaiTarget
+        it "inherits the root alias when no child or parent session exists" do
+            resolveGatewaySubagentTarget resolve
+                Nothing Nothing Nothing "company-code"
+                `shouldReturn` Right openaiTarget
+        it "fails closed for an unavailable explicit alias instead of inheriting" do
+            resolveGatewaySubagentTarget resolve
+                (Just "unavailable") Nothing (Just "company-analysis") "company-code"
+                `shouldReturn` Left "The child model is not allowed by this organization."
+        it "rejects a catalog resolver that supplies a direct-provider connection" do
+            resolveGatewaySubagentTarget
+                (const (pure (Just openaiTarget
+                    { collaborationTargetConnection = "openai" })))
+                (Just "company-code") Nothing Nothing "company-code"
+                `shouldReturn` Left "The child model does not use the organization gateway."
+        it "rejects a provider-dialect mismatch before acquiring a transport" do
+            resolveGatewaySubagentTarget
+                (const (pure (Just xaiTarget
+                    { collaborationTargetDialect = CodexDialect })))
+                (Just "company-analysis") Nothing Nothing "company-code"
+                `shouldReturn` Left "The child model has an incompatible provider dialect."
+        it "does not use legacy OpenAI-Grok decode compatibility for live routing" do
+            resolveGatewaySubagentTarget
+                (const (pure (Just openaiTarget
+                    { collaborationTargetDialect = GrokBuildDialect })))
+                (Just "company-code") Nothing Nothing "company-code"
+                `shouldReturn` Left "The child model has an incompatible provider dialect."
     describe "nested subagent model inheritance" do
         it "inherits the immediate parent's model and effort for full-history forks" do
             sessionsRef <- newIORef Map.empty

--- a/packages/agent-xai/src/Agent/XAI/Client.hs
+++ b/packages/agent-xai/src/Agent/XAI/Client.hs
@@ -41,6 +41,7 @@ import Control.Retry
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.Text.Encoding as Text
 import Network.HTTP.Simple hiding (Response)
+import qualified Network.HTTP.Client as HttpClient
 
 type StreamEventCallback = HttpSSE.StreamEventCallback
 
@@ -139,7 +140,9 @@ xaiProviderConfig options credential request = ProviderClientConfig
     , providerRequestTimeoutSeconds = options.requestTimeoutSeconds
     , providerBuildRequest = buildRequest options
     , providerConfigureRequest =
-        configureCompactionHeaders
+        (\httpRequest -> httpRequest
+            { HttpClient.redirectCount = options.requestRedirectCount })
+            . configureCompactionHeaders
             options
             (projectXaiOrLegacyCompactionHistory request)
             . setRequestHeader "Authorization"

--- a/packages/agent-xai/src/Agent/XAI/Options.hs
+++ b/packages/agent-xai/src/Agent/XAI/Options.hs
@@ -2,6 +2,7 @@
 module Agent.XAI.Options
     ( ClientOptions(..)
     , defaultClientOptions
+    , gatewayClientOptions
     , clientOptionsFromEnv
     , defaultGrokClientVersion
     , grokAutoCompactThresholdPercent
@@ -107,6 +108,10 @@ data ClientOptions = ClientOptions
       -- ^ Exact-match request-model to xAI-model overrides.
     , defaultModel :: !Text
       -- ^ Target for non-Grok model names without an explicit override.
+    , preserveModelNames :: !Bool
+      -- ^ Preserve authoritative gateway aliases instead of mapping them.
+    , requestRedirectCount :: !Int
+      -- ^ Maximum redirects. Gateway requests must remain at their endpoint.
     , autoCompactTokenLimit :: !(Maybe Int)
       -- ^ Explicit automatic-compaction threshold. 'Nothing' uses the
       -- model-specific Grok Build default.
@@ -123,11 +128,24 @@ defaultClientOptions = ClientOptions
     { baseUrl = "https://cli-chat-proxy.grok.com/v1"
     , modelOverrides = Map.empty
     , defaultModel = "grok-4.6"
+    , preserveModelNames = False
+    , requestRedirectCount = 10
     , autoCompactTokenLimit = Nothing
     , requestTimeoutSeconds = 600
     , clientVersion = defaultGrokClientVersion
     , hostedXSearchEnabled = True
     }
+
+-- | Use the native xAI protocol through an organization gateway. Routing and
+-- model aliases are authoritative, so environment overrides and redirects
+-- must not select a different destination.
+gatewayClientOptions :: String -> ClientOptions
+gatewayClientOptions gatewayBaseUrl =
+    defaultClientOptions
+        { baseUrl = reverse (dropWhile (== '/') (reverse gatewayBaseUrl)) <> "/v1"
+        , preserveModelNames = True
+        , requestRedirectCount = 0
+        }
 
 -- | Load optional transport overrides from the environment.
 clientOptionsFromEnv :: IO ClientOptions
@@ -141,6 +159,8 @@ clientOptionsFromEnv = do
         { baseUrl = Maybe.fromMaybe defaultClientOptions.baseUrl baseUrl
         , modelOverrides = maybe Map.empty (parseModelOverrides . Text.pack) modelMap
         , defaultModel = maybe defaultClientOptions.defaultModel Text.pack defaultModel
+        , preserveModelNames = False
+        , requestRedirectCount = defaultClientOptions.requestRedirectCount
         , autoCompactTokenLimit = Nothing
         , requestTimeoutSeconds = Maybe.fromMaybe defaultClientOptions.requestTimeoutSeconds
             timeoutSeconds

--- a/packages/agent-xai/src/Agent/XAI/Request.hs
+++ b/packages/agent-xai/src/Agent/XAI/Request.hs
@@ -32,12 +32,14 @@ import qualified Data.Text as Text
 -- | Apply an exact model override, preserve an existing Grok model name, or
 -- use the configured default.
 mapModel :: ClientOptions -> Text -> Text
-mapModel options model =
-    selectConfiguredModel
-        options.modelOverrides
-        (Text.isPrefixOf "grok")
-        options.defaultModel
-        (Just model)
+mapModel options model
+    | options.preserveModelNames = model
+    | otherwise =
+        selectConfiguredModel
+            options.modelOverrides
+            (Text.isPrefixOf "grok")
+            options.defaultModel
+            (Just model)
 
 -- | Build the typed Responses request sent to xAI.
 --
@@ -54,11 +56,7 @@ buildRequest options request =
             mapResponseTools xaiTool $
                 forceStatelessStreaming defaultResponseCreateParams
                     { model = Just $
-                        selectConfiguredModel
-                            options.modelOverrides
-                            (Text.isPrefixOf "grok")
-                            options.defaultModel
-                            request.model
+                        maybe options.defaultModel (mapModel options) request.model
                     , input = Just
                         (ResponseInputItems
                             (systemItems <> requestInputItems projectedHistory))

--- a/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ClientSpec.hs
@@ -41,6 +41,52 @@ import Test.Hspec
 spec :: Spec
 spec = do
     describe "createResponseWith" do
+        it "uses the native xAI request format and exact alias through a gateway" do
+            recorded <- newIORef []
+            let handler _request = pure $ sseResponse
+                    [ outputItemDone (assistantMessage "gateway response")
+                    , completedEvent "gateway-response" []
+                    ]
+            withMockGrok recorded handler \localOptions -> do
+                let options = (gatewayClientOptions "https://gateway.example")
+                        { baseUrl = localOptions.baseUrl }
+                    request = (helloRequest "hi" :: ResponseCreateParams)
+                        { model = Just "organization-research" }
+                response <- createResponseWith options
+                    (xaiCredential "gateway-token") request >>= expectRight
+                response.responseId `shouldBe` "gateway-response"
+            [sent] <- readIORef recorded
+            sent.path `shouldBe` "/v1/responses"
+            lookup "Authorization" sent.headers
+                `shouldBe` Just "Bearer gateway-token"
+            lookup "X-XAI-Token-Auth" sent.headers
+                `shouldBe` Just grokTokenAuthValue
+            requestModel sent `shouldBe` Just "organization-research"
+            requestInputRoles sent `shouldBe` Just ["system", "user"]
+
+        it "does not follow gateway redirects to another endpoint" do
+            redirectedRequests <- newIORef (0 :: Int)
+            let redirectedApplication _request respond = do
+                    modifyIORef' redirectedRequests (+ 1)
+                    respond (Wai.responseLBS HTTP.status200 [] "")
+            withLoopbackApplication (pure redirectedApplication) \port -> do
+                recorded <- newIORef []
+                let destination =
+                        "http://127.0.0.1:" <> Text.pack (show port) <> "/responses"
+                    handler _request = pure $
+                        Wai.responseLBS HTTP.status307
+                            [("Location", Text.encodeUtf8 destination)] ""
+                withMockGrok recorded handler \localOptions -> do
+                    let options = (gatewayClientOptions "https://gateway.example")
+                            { baseUrl = localOptions.baseUrl }
+                    result <- createResponseWith options
+                        (xaiCredential "gateway-token") (helloRequest "hi")
+                    case result of
+                        Left _ -> pure ()
+                        Right _ -> expectationFailure "gateway redirect was accepted"
+                length <$> readIORef recorded `shouldReturn` 1
+            readIORef redirectedRequests `shouldReturn` 0
+
         it "POSTs the mapped request with subscription headers and parses the SSE response" do
             recorded <- newIORef []
             let handler _request = do

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -33,6 +33,17 @@ spec = do
             mapModel options "grok-3" `shouldBe` "grok-3"
             mapModel options "gpt-5.6-terra" `shouldBe` "grok-4.6"
 
+        it "preserves authoritative gateway aliases instead of inferring models" do
+            let options = gatewayClientOptions "https://gateway.example/"
+            options.baseUrl `shouldBe` "https://gateway.example/v1"
+            options.requestRedirectCount `shouldBe` 0
+            mapModel options "organization-research"
+                `shouldBe` "organization-research"
+            mapModel options "x-ai/grok-4.6" `shouldBe` "x-ai/grok-4.6"
+            (buildRequest options
+                (setModel (Just "organization-research") sampleRequest)).model
+                `shouldBe` Just "organization-research"
+
     describe "buildRequest" do
         it "maps canonical Responses fields onto the Grok proxy dialect" do
             let value = requestValue defaultClientOptions sampleRequest


### PR DESCRIPTION
## Summary
Use each gateway model's native provider transport rather than routing all Responses models through OpenAI:
- OpenAI uses the OpenAI WebSocket transport; Grok uses xAI SSE and native compaction; Claude retains the Anthropic transport.
- Resolve provider/protocol from the authoritative gateway catalog before authentication, preserving exact organization aliases.
- Apply selection across startup, resume, model switching, and subagents; re-resolve legacy top-level gateway sessions.
- Pin xAI gateway endpoints and credentials, reject redirects, and prevent direct-provider environment overrides.
- Add routing, authentication, persistence, subagent, and native compaction regression tests.

This replaces the approach proposed in #1114 rather than adding Grok-specific compaction behavior to the OpenAI transport.

## Dependency and rollout
Companion gateway PR: https://github.com/digitallyinduced/haskell-agent-gateway/pull/114

**Deploy the gateway first.** This client requires the new provider/protocol catalog metadata and fails closed against old or unsupported catalogs.

## Validation
- CLI library and all 94 CLI test modules load successfully in GHCi.
- 128 focused CLI tests passed (catalog, authentication, subagent routing/persistence, and provider runtime).
- xAI suite: 73 examples, 0 failures, 1 pending live-credential test.
- Runtime suite: 254 examples, 231 passed; all 23 failures were PostgreSQL socket-path-length errors under the required local temporary directory.
- `git diff --check` passed.

No deployment or merge performed.
