### PR TITLE
Bound MCP HTTP cleanup to prevent shutdown hangs

### DIFF
--- a/packages/agent-mcp/agent-mcp.cabal
+++ b/packages/agent-mcp/agent-mcp.cabal
@@ -94,6 +94,7 @@ test-suite agent-mcp-test
                     , directory
                     , filepath
                     , hspec
+                    , network
                     , QuickCheck >= 2.14 && < 2.16
                     , safe-exceptions
                     , stm

--- a/packages/agent-mcp/package.nix
+++ b/packages/agent-mcp/package.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, agent-core, agent-json, agent-process, async
 , base, base64-bytestring, bytestring, containers, directory
 , filelock, filepath, hspec, http-client, http-client-tls
-, http-types, lib, network-uri, process, QuickCheck
+, http-types, lib, network, network-uri, process, QuickCheck
 , safe-exceptions, scientific, stm, text, time, transformers, unix
 , vector
 }:
@@ -17,8 +17,8 @@ mkDerivation {
   ];
   testHaskellDepends = [
     aeson agent-core agent-json async base bytestring containers
-    directory filepath hspec QuickCheck safe-exceptions stm text time
-    unix
+    directory filepath hspec network QuickCheck safe-exceptions stm
+    text time unix
   ];
   benchmarkHaskellDepends = [
     base bytestring directory safe-exceptions text unix

--- a/packages/agent-mcp/src/Agent/MCP/Client/Internal/Runtime.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Client/Internal/Runtime.hs
@@ -69,7 +69,8 @@ import Agent.Process
 import Agent.Tools.Types ()
 import Control.Concurrent ( threadDelay )
 import Control.Concurrent.Async
-    ( Async, async, asyncWithUnmask, cancel, poll, waitCatch )
+    ( Async, async, asyncWithUnmask, cancel, poll, wait, waitCatch
+    , withAsyncWithUnmask )
 import Control.Concurrent.MVar ( modifyMVar_, withMVar, readMVar )
 import Control.Concurrent.STM
     ( atomically,
@@ -1825,22 +1826,32 @@ closeHttpSession client transport = do
     era <- mcpClientEra client
     case (session, era) of
         (Just sessionId, era')
-            | era' /= Just McpEraModern -> void $ tryAny do
-                request <- parseRequest (Text.unpack transport.httpUrl)
-                bearer <- either (const Nothing) id <$> configuredAccessToken client
-                let request' = request
-                        { HC.method = "DELETE"
-                        , HC.requestHeaders =
-                            [ ("Mcp-Session-Id", TextEncoding.encodeUtf8 sessionId)
-                            ]
-                            <> maybe [] (\token ->
-                                [ ("Authorization", "Bearer " <> TextEncoding.encodeUtf8 token) ])
-                                bearer
-                        , HC.redirectCount = 0
-                        }
-                void $ timeout (secondsToMicros client.clientConfig.mcpServerRequestTimeoutSeconds)
-                    (HC.httpNoBody request' mcpHttpManager)
+            | era' /= Just McpEraModern -> void $ tryAny $
+                -- The enclosing client/fleet finalizer may be uninterruptibly
+                -- masked. Give the deadline an unmasked, scoped owner so a
+                -- blocked token refresh or DELETE cannot prevent shutdown.
+                withAsyncWithUnmask
+                    (\unmask -> unmask $
+                        void $ timeout
+                            (secondsToMicros (min 1 client.clientConfig.mcpServerRequestTimeoutSeconds))
+                            (terminateSession sessionId))
+                    wait
         _ -> pure ()
+  where
+    terminateSession sessionId = do
+        request <- parseRequest (Text.unpack transport.httpUrl)
+        bearer <- either (const Nothing) id <$> configuredAccessToken client
+        let request' = request
+                { HC.method = "DELETE"
+                , HC.requestHeaders =
+                    [ ("Mcp-Session-Id", TextEncoding.encodeUtf8 sessionId)
+                    ]
+                    <> maybe [] (\token ->
+                        [ ("Authorization", "Bearer " <> TextEncoding.encodeUtf8 token) ])
+                        bearer
+                , HC.redirectCount = 0
+                }
+        void $ HC.httpNoBody request' mcpHttpManager
 
 stopWorker :: Async () -> IO ()
 stopWorker worker = do

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -94,6 +94,7 @@ import Agent.Tools.Types
     , toolAllowsWithoutPrompt
     )
 import Control.Exception.Safe (bracket, finally)
+import Control.Exception (MaskingState(MaskedUninterruptible), getMaskingState)
 import Control.Concurrent
     ( newEmptyMVar
     , putMVar
@@ -113,11 +114,13 @@ import Data.IORef
     , modifyIORef'
     , newIORef
     , readIORef
+    , writeIORef
     )
 import Data.List (find)
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.Text as Text
 import GHC.IO.Handle (hDuplicate, hDuplicateTo)
+import qualified Network.Socket as Socket
 import System.Directory
     ( createDirectory
     , getTemporaryDirectory
@@ -128,8 +131,11 @@ import System.Directory
     )
 import System.IO
     ( SeekMode(AbsoluteSeek)
+    , IOMode(ReadWriteMode)
     , hClose
     , hFlush
+    , hGetLine
+    , hPutStr
     , hSeek
     , openTempFile
     , stderr
@@ -296,6 +302,62 @@ spec = describe "Agent.MCP" do
                         readIORef transport.httpSession `shouldReturn` Nothing
                     _ ->
                         expectationFailure "expected an HTTP transport"
+
+        it "bounds HTTP session shutdown under an uninterruptible finalizer" $
+            Socket.withSocketsDo $
+                bracket
+                    (Socket.socket Socket.AF_INET Socket.Stream Socket.defaultProtocol)
+                    Socket.close
+                    \listener -> do
+                        Socket.bind listener
+                            (Socket.SockAddrInet 0 (Socket.tupleToHostAddress (127, 0, 0, 1)))
+                        Socket.listen listener 1
+                        address <- Socket.getSocketName listener
+                        port <- case address of
+                            Socket.SockAddrInet port _ -> pure port
+                            _ -> fail "expected an IPv4 listener"
+                        requestStarted <- newEmptyMVar
+                        releaseResponse <- newEmptyMVar
+                        finalizerMask <- newIORef Nothing
+                        let serve =
+                                bracket
+                                    (Socket.accept listener >>= \(connection, _) ->
+                                        Socket.socketToHandle connection ReadWriteMode)
+                                    hClose
+                                    \connection -> do
+                                        request <- hGetLine connection
+                                        putMVar requestStarted request
+                                        takeMVar releaseResponse
+                                        hPutStr connection
+                                            "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n"
+                                        hFlush connection
+                            config = workerClientConfig
+                                { mcpServerUrl = Just $
+                                    "http://127.0.0.1:" <> Text.pack (show port) <> "/mcp"
+                                , mcpServerRequestTimeoutSeconds = 60
+                                }
+                        withAsync serve \_ ->
+                            bracket (startMcpClient config) closeMcpClient \client -> do
+                                case client.clientTransport of
+                                    McpClientHttp transport ->
+                                        writeIORef transport.httpSession (Just "shutdown-session")
+                                    _ -> fail "expected an HTTP transport"
+                                let close = do
+                                        getMaskingState >>= writeIORef finalizerMask . Just
+                                        closeMcpClient client
+                                withAsync (pure () `finally` close) \closing ->
+                                    (do
+                                        timeout 2000000 (takeMVar requestStarted)
+                                            `shouldReturn` Just "DELETE /mcp HTTP/1.1\r"
+                                        readIORef finalizerMask
+                                            `shouldReturn` Just MaskedUninterruptible
+                                        timeout 2000000 (wait closing)
+                                            `shouldReturn` Just ())
+                                    `finally` do
+                                        -- Release the server before scope exit
+                                        -- joins the closer, including on the
+                                        -- defective implementation's failure.
+                                        void (tryPutMVar releaseResponse ())
 
         it "stores only process state for a stdio client" $
             withFakeServer \script ->


### PR DESCRIPTION
## Summary
- Run HTTP session termination in an unmasked, scoped worker so its timeout remains effective under uninterruptible finalizers.
- Include credential refresh in the cleanup deadline and cap cleanup at one second.
- Add a local HTTP regression that withholds the DELETE response and asserts shutdown completes under an uninterruptible finalizer; regenerate the Nix expression for the test dependency.

## Validation
- `nix develop -c cabal repl agent-mcp:test:agent-mcp-test --offline --repl-options=-ignore-dot-ghci`, then `:main`: 139 examples, 0 failures.
- `git diff --check` passed.
- Existing installed CLI passed an idle double-Ctrl+C tmux smoke test; this does not constitute live validation of the modified binary.

## Scope
This fixes a concrete MCP shutdown blocker found while investigating Ctrl+C hangs. The exact cause of the originally reported terminal hang has not been confirmed.