### PR TITLE
Disambiguate the built-in integration MCP server

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/IntegrationGateway.hs
+++ b/packages/agent-cli/src/Agent/CLI/IntegrationGateway.hs
@@ -2,11 +2,13 @@
 module Agent.CLI.IntegrationGateway
     ( gatewayIntegrationAuthority
     , gatewayIntegrationMcpConfig
+    , availableIntegrationServerName
     ) where
 
 import Agent.CLI.GatewayClient (GatewayCredential(..))
 import Agent.Integration.API (IntegrationAuthority(..))
 import Agent.MCP (McpServerConfig(..), McpProtocolPreference(..))
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 
 gatewayIntegrationAuthority :: Maybe GatewayCredential -> IntegrationAuthority
@@ -32,3 +34,16 @@ gatewayIntegrationMcpConfig credential = McpServerConfig
     , mcpServerSamplingEnabled = False
     , mcpServerLogLevel = Nothing
     }
+
+availableIntegrationServerName :: [Text.Text] -> Text.Text
+availableIntegrationServerName configuredNames =
+    choose 1
+  where
+    configured = Set.fromList configuredNames
+    choose index
+        | Set.member candidate configured = choose (index + 1)
+        | otherwise = candidate
+      where
+        candidate
+            | index == 1 = "integrations"
+            | otherwise = "integrations-" <> Text.pack (show index)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs
@@ -8,6 +8,7 @@ import Agent.CLI.Config
     ( HarnessConfig(..), McpServerConfig(..)
     , mcpServersForRuntime, useProgressiveMcp )
 import Agent.CLI.FileUri (fileUri)
+import Agent.CLI.IntegrationGateway (availableIntegrationServerName)
 import Agent.CLI.McpElicitation (cliMcpElicitation)
 import Agent.CLI.McpOAuthStore (mcpOAuthStorePath)
 import Agent.CLI.McpStatus
@@ -132,11 +133,19 @@ acquireMcpRuntime request@AgentToolsRequest
     } integrationRuntime = do
     let (configuredServers, configuredProgressive) =
             mcpConfiguration request toolStartup
+        integrationServerName =
+            availableIntegrationServerName
+                [ serverName
+                | MCP.McpServerConfig
+                    { MCP.mcpServerName = serverName
+                    } <- configuredServers
+                ]
         remoteServers =
-            [config | runtime <- maybeToList integrationRuntime
+            [ config { MCP.mcpServerName = integrationServerName }
+            | runtime <- maybeToList integrationRuntime
             , RemoteIntegrationEndpoint config <- [integrationRuntimeEndpoint runtime]]
         inMemoryServers =
-            [(integrationsMcpConfig, server)
+            [(integrationsMcpConfig integrationServerName, server)
             | runtime <- maybeToList integrationRuntime
             , LocalIntegrationEndpoint server <- [integrationRuntimeEndpoint runtime]]
         -- Include the in-memory name in the reported configuration too: callers
@@ -287,9 +296,9 @@ acquireMcpRuntime request@AgentToolsRequest
             finishRuntime fleet
                 (MCP.closeMcpFleet fleet `finally` clearMcpHostHooks)
 
-integrationsMcpConfig :: MCP.McpServerConfig
-integrationsMcpConfig = MCP.McpServerConfig
-    { MCP.mcpServerName = "integrations"
+integrationsMcpConfig :: Text -> MCP.McpServerConfig
+integrationsMcpConfig serverName = MCP.McpServerConfig
+    { MCP.mcpServerName = serverName
     , MCP.mcpServerUrl = Nothing
     , MCP.mcpServerCommand = ""
     , MCP.mcpServerArgs = []

--- a/packages/agent-cli/test/Agent/CLI/IntegrationGatewaySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/IntegrationGatewaySpec.hs
@@ -1,7 +1,8 @@
 module Agent.CLI.IntegrationGatewaySpec (spec) where
 
 import Agent.CLI.GatewayClient (GatewayCredential(..))
-import Agent.CLI.IntegrationGateway (gatewayIntegrationMcpConfig)
+import Agent.CLI.IntegrationGateway
+    (availableIntegrationServerName, gatewayIntegrationMcpConfig)
 import Agent.MCP (McpServerConfig(..))
 import Test.Hspec
 
@@ -18,3 +19,8 @@ spec = describe "generic gateway integrations" do
         config.mcpServerEnv `shouldBe` [("MCP_ACCESS_TOKEN", "private-test-token")]
         show config `shouldNotContain` "private-test-token"
         config.mcpServerCommand `shouldBe` ""
+
+    it "keeps the built-in endpoint when configured server names collide" do
+        availableIntegrationServerName
+            ["integrations", "integrations-2", "another-server"]
+            `shouldBe` "integrations-3"


### PR DESCRIPTION
Avoid aborting MCP fleet startup when a user already configured a server named `integrations`. The product integration endpoint now takes the first available `integrations-N` name while leaving user configuration intact.

This is a focused follow-up to #1118 and includes a regression test for consecutive collisions.
