### PR TITLE
Isolate integration artifacts by session

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -30,7 +30,6 @@ import Agent.Integration.API
     , newIntegrationSupervisor
     , IntegrationProvider
     , emptyIntegrationProvider
-    , integrationSupervisorArtifactDirectory
     )
 import Agent.Runtime.StartupPolicy
     ( NativeStartupPolicy(..)
@@ -97,8 +96,6 @@ newNativeProcessRuntimeWithIntegrations provider root = mask \restore -> do
         restore (newIntegrationSupervisor provider integrationToolEnv)
     core <- restore (NativeProcess.newNativeProcessRuntimeWithMcpHooks
         MCP.defaultMcpHostHooks
-            { MCP.mcpHostArtifactDirectory =
-                Just (integrationSupervisorArtifactDirectory integrations) }
         root) `onException` closeIntegrationSupervisor integrations
     pure NativeProcessRuntime
         { nativeProcessCore = core

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -49,7 +49,6 @@ import Agent.Integration.API
     ( closeIntegrationSupervisor
     , newIntegrationSupervisor
     , emptyIntegrationProvider
-    , integrationSupervisorArtifactDirectory
     )
 import Agent.CLI.Options
     ( CliOptions
@@ -245,9 +244,6 @@ runAgentWithRestarts options =
                                 { MCP.mcpHostElicit = readIORef elicitationRef
                                 , MCP.mcpHostRoots = readIORef rootsRef
                                 , MCP.mcpHostSample = readIORef samplingRef
-                                , MCP.mcpHostArtifactDirectory = Just
-                                    (integrationSupervisorArtifactDirectory
-                                        integrationSupervisor)
                                 }
                             `onException`
                                 closeIntegrationSupervisor integrationSupervisor

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -307,6 +307,7 @@ data AgentSessionRequest closeResult windowTitleResult = AgentSessionRequest
     , learnedSkillAppTools :: [AppTool]
     , legacySubagentTarget :: Maybe LegacySubagentTarget
     , mcpFleet :: MCP.McpFleet
+    , mcpRegistrations :: [MCP.McpToolRegistration]
     , mcpInstructions :: [(Text, Text)]
     , mcpTools :: [AppTool]
     , mcpSamplingRef
@@ -418,7 +419,7 @@ validateSessionMcpTools AgentSessionRequest
     , gatewayTools
     , databaseAppTools
     , learnedSkillAppTools
-    , mcpFleet
+    , mcpRegistrations
     , startup
     } =
     case
@@ -430,7 +431,7 @@ validateSessionMcpTools AgentSessionRequest
                     ++ databaseAppTools
                     ++ learnedSkillAppTools
                 )
-                mcpFleet.mcpFleetRegistrations
+                mcpRegistrations
         of
             Just err ->
                 startupDie startup
@@ -992,7 +993,7 @@ buildProviderSessionRequest
                 request.coding.codingResetSessionTemp
             , grokRuntime = request.coding.codingGrokRuntime
             , mcpRegistrations =
-                request.mcpFleet.mcpFleetRegistrations
+                request.mcpRegistrations
             , mcpWarnings = request.mcpFleet.mcpFleetWarnings
             , mcpInstructions = request.mcpInstructions
             , mcpFleet = Just request.mcpFleet

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -46,8 +46,8 @@ import Agent.CLI.IntegrationGateway (gatewayIntegrationAuthority)
 import Agent.Integration.API
     ( IntegrationRuntime
     , acquireIntegrationRuntime
-    , prepareIntegrationSupervisorForSession
     )
+import Agent.OsPath (unsafeToFilePath)
 import Agent.CLI.ModelConfig (builtinConnectionId)
 import Agent.CLI.Models (ModelTarget(targetConnectionId, targetWireModelId))
 import Agent.CLI.Options
@@ -143,10 +143,11 @@ import Data.Unique (newUnique, hashUnique)
 import System.Info (os)
 import System.OsPath (OsPath)
 import qualified Agent.MCP as MCP
-    ( mcpFleetGrokMetaTools,
-      mcpFleetMetaTools,
+    ( mcpFleetGrokMetaToolsForArtifactDirectory,
+      mcpFleetMetaToolsForArtifactDirectory,
+      mcpFleetRegistrationsForArtifactDirectory,
       mcpFleetResourceTools,
-      mcpFleetTools )
+      mcpFleetToolsForArtifactDirectory )
 import qualified Data.Text as Text (unpack, pack)
 
 data LocalToolRuntime = LocalToolRuntime
@@ -324,12 +325,9 @@ acquireSessionIntegrationRuntime
     :: AgentToolsRequest windowTitleResult
     -> IO (Maybe IntegrationRuntime)
 acquireSessionIntegrationRuntime request =
-    prepareIntegrationSupervisorForSession
+    acquireIntegrationRuntime
         request.processRuntime.processIntegrationSupervisor
-        request.baseToolEnv
-        >> acquireIntegrationRuntime
-            request.processRuntime.processIntegrationSupervisor
-            authority >>= \case
+        authority >>= \case
         Left err -> do
             reportStartupWarning request.startup err
             pure Nothing
@@ -646,6 +644,7 @@ assembleSessionToolsRuntime AgentToolsRequest
     { scratchPromptRequest = promptRequest
     , scratchImageGenerationHistory = imageGenerationHistory
     , scratchExternalSessionTools = externalSessionAppTools
+    , scratchSessionTmp = sessionTmp
     , scratchCleanup = cleanupScratch
     } McpRuntime
     { runtimeMcpServerConfigs = mcpServerConfigs
@@ -662,15 +661,25 @@ assembleSessionToolsRuntime AgentToolsRequest
     , controlCodeModeCloseRef = codeModeCloseRef
     , controlSessionTools = persistedSessionTools
     } = do
-    let sessionMcpTools =
+    let artifactDirectory = Just (unsafeToFilePath sessionTmp)
+        sessionMcpTools =
             if null mcpServerConfigs
                 then []
                 else
                     (if dialectId == GrokBuildDialect
-                        then MCP.mcpFleetGrokMetaTools mcpFleet
+                        then
+                            MCP.mcpFleetGrokMetaToolsForArtifactDirectory
+                                artifactDirectory
+                                mcpFleet
                         else if progressiveMcp
-                            then MCP.mcpFleetMetaTools mcpFleet
-                            else MCP.mcpFleetTools mcpFleet)
+                            then
+                                MCP.mcpFleetMetaToolsForArtifactDirectory
+                                    artifactDirectory
+                                    mcpFleet
+                            else
+                                MCP.mcpFleetToolsForArtifactDirectory
+                                    artifactDirectory
+                                    mcpFleet)
                         <> MCP.mcpFleetResourceTools mcpFleet
         databaseToolsEnv =
             databaseToolsEnvForStore
@@ -858,6 +867,10 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
     forM_ startup.startupNativeHooks \hooks ->
         when (hooks.nativeInteractionMode == NativePlan) $
             writeIORef planMode.planStateRef PlanPending
+    let mcpRegistrations =
+            MCP.mcpFleetRegistrationsForArtifactDirectory
+                (Just (unsafeToFilePath sessionTmp))
+                mcpFleet
     runAgentSession AgentSessionRequest
         { loaded
         , connectedGateway
@@ -901,6 +914,7 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
         , learnedSkillAppTools
         , legacySubagentTarget
         , mcpFleet
+        , mcpRegistrations
         , mcpInstructions
         , mcpTools
         , mcpSamplingRef = processRuntime.processMcpSampling

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs
@@ -27,7 +27,7 @@ import Agent.CLI.Session.Runtime.Types (StartupRuntime(..))
 import Agent.CLI.Startup.Auth (setStartupNotice, startupDie)
 import Agent.CLI.TUI.App (emitUiEvent)
 import Agent.Integration.API
-    (IntegrationRuntime(..), IntegrationEndpoint(..), integrationSupervisorArtifactDirectory)
+    (IntegrationRuntime(..), IntegrationEndpoint(..))
 import Agent.Loop (TurnInput(..))
 import qualified Agent.MCP as MCP
 import Agent.OsPath (unsafeToFilePath)
@@ -153,7 +153,7 @@ acquireMcpRuntime request@AgentToolsRequest
         runtimeMcpServerConfigs = configuredServers <> remoteServers
             <> map fst inMemoryServers
         transportServers = configuredServers <> remoteServers
-        runtimeProgressiveMcp = configuredProgressive && null inMemoryServers
+        runtimeProgressiveMcp = configuredProgressive
     startStaleResourceCleanup request sessionTmp
     mcpStatusPhaseRef <- newIORef (Nothing :: Maybe Bool)
     mcpFleetRef <- newIORef (Nothing :: Maybe MCP.McpFleet)
@@ -225,11 +225,19 @@ acquireMcpRuntime request@AgentToolsRequest
                 runtimeMcpFleet.mcpFleetWarnings
             setStartupNotice startup.startupFullscreen "Loading built-in tools…"
             pure McpRuntime{..}
-    if null inMemoryServers
-        then do
-            let acquireMcpLease =
-                    try @_ @SomeException
-                        (if runtimeProgressiveMcp
+        reportBlockingMcp names =
+            setStartupNotice startup.startupFullscreen
+                (if null names
+                    then "Loading built-in tools…"
+                    else
+                        "Loading tools: "
+                            <> Text.intercalate ", " names
+                            <> "…")
+        acquireMcpLease =
+            try @_ @SomeException
+                (if null inMemoryServers
+                    then
+                        if runtimeProgressiveMcp
                             then
                                 MCP.acquireMcpFleetProgressive
                                     mcpSupervisor
@@ -238,63 +246,36 @@ acquireMcpRuntime request@AgentToolsRequest
                             else
                                 MCP.acquireMcpFleetWithProgress
                                     mcpSupervisor
-                                    (\names ->
-                                        setStartupNotice startup.startupFullscreen
-                                            (if null names
-                                                then "Loading built-in tools…"
-                                                else
-                                                    "Loading tools: "
-                                                        <> Text.intercalate ", " names
-                                                        <> "…"))
-                                    runtimeMcpServerConfigs)
-                        >>= \case
-                            Left exception ->
-                                startupDie startup
-                                    ("Failed to initialize MCP tools: "
-                                        <> Text.pack (show exception))
-                            Right lease -> pure lease
-            bracketOnError
-                (acquireMcpLease `onException` clearMcpHostHooks)
-                (\lease ->
-                    MCP.releaseMcpFleetLease lease
-                        `finally` clearMcpHostHooks)
-                \runtimeMcpLease -> finishRuntime runtimeMcpLease.mcpLeaseFleet
-                    (MCP.releaseMcpFleetLease runtimeMcpLease
-                        `finally` clearMcpHostHooks)
-        else do
-            fleet <-
-                ( try @_ @SomeException
-                    (MCP.startMcpFleetWithInMemory
-                        MCP.defaultMcpHostHooks
-                            { MCP.mcpHostElicit =
-                                readIORef processRuntime.processMcpElicitation
-                            , MCP.mcpHostRoots =
-                                readIORef processRuntime.processMcpRoots
-                            , MCP.mcpHostSample =
-                                readIORef processRuntime.processMcpSampling
-                            , MCP.mcpHostArtifactDirectory = Just
-                                (integrationSupervisorArtifactDirectory
-                                    processRuntime.processIntegrationSupervisor)
-                            }
-                        (\names ->
-                            setStartupNotice startup.startupFullscreen
-                                (if null names
-                                    then "Loading built-in tools…"
-                                    else
-                                        "Loading tools: "
-                                            <> Text.intercalate ", " names
-                                            <> "…"))
-                        transportServers
-                        inMemoryServers)
-                    >>= \case
-                        Left exception ->
-                            startupDie startup
-                                ("Failed to initialize MCP tools: "
-                                    <> Text.pack (show exception))
-                        Right value -> pure value
-                ) `onException` clearMcpHostHooks
-            finishRuntime fleet
-                (MCP.closeMcpFleet fleet `finally` clearMcpHostHooks)
+                                    reportBlockingMcp
+                                    runtimeMcpServerConfigs
+                    else
+                        if runtimeProgressiveMcp
+                            then
+                                MCP.acquireMcpFleetProgressiveWithInMemory
+                                    mcpSupervisor
+                                    reportProgressiveMcp
+                                    transportServers
+                                    inMemoryServers
+                            else
+                                MCP.acquireMcpFleetWithInMemory
+                                    mcpSupervisor
+                                    reportBlockingMcp
+                                    transportServers
+                                    inMemoryServers)
+                >>= \case
+                    Left exception ->
+                        startupDie startup
+                            ("Failed to initialize MCP tools: "
+                                <> Text.pack (show exception))
+                    Right lease -> pure lease
+    bracketOnError
+        (acquireMcpLease `onException` clearMcpHostHooks)
+        (\lease ->
+            MCP.releaseMcpFleetLease lease
+                `finally` clearMcpHostHooks)
+        \runtimeMcpLease -> finishRuntime runtimeMcpLease.mcpLeaseFleet
+            (MCP.releaseMcpFleetLease runtimeMcpLease
+                `finally` clearMcpHostHooks)
 
 integrationsMcpConfig :: Text -> MCP.McpServerConfig
 integrationsMcpConfig serverName = MCP.McpServerConfig

--- a/packages/agent-integration-api/agent-integration-api.cabal
+++ b/packages/agent-integration-api/agent-integration-api.cabal
@@ -20,7 +20,7 @@ library
     hs-source-dirs: src
     exposed-modules: Agent.Integration.API
     build-depends: base >= 4.17 && < 5, agent-core, agent-json, agent-mcp,
-                   aeson, directory, filepath, safe-exceptions, temporary, text
+                   aeson, text
 
 test-suite agent-integration-api-test
     import: options
@@ -28,5 +28,5 @@ test-suite agent-integration-api-test
     hs-source-dirs: test
     main-is: Spec.hs
     build-depends: base >= 4.17 && < 5, agent-integration-api, agent-core,
-                   agent-mcp, async, directory, filepath, hspec >= 2.11 && < 2.12,
+                   agent-mcp, async, filepath, hspec >= 2.11 && < 2.12,
                    safe-exceptions, temporary

--- a/packages/agent-integration-api/package.nix
+++ b/packages/agent-integration-api/package.nix
@@ -1,18 +1,15 @@
 { mkDerivation, aeson, agent-core, agent-json, agent-mcp, async
-, base, directory, filepath, hspec, lib, safe-exceptions, temporary
-, text
+, base, filepath, hspec, lib, safe-exceptions, temporary, text
 }:
 mkDerivation {
   pname = "agent-integration-api";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson agent-core agent-json agent-mcp base directory filepath
-    safe-exceptions temporary text
+    aeson agent-core agent-json agent-mcp base text
   ];
   testHaskellDepends = [
-    agent-core agent-mcp async base directory filepath hspec
-    safe-exceptions temporary
+    agent-core agent-mcp async base filepath hspec safe-exceptions temporary
   ];
   description = "Provider-neutral integration embedding API";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-integration-api/src/Agent/Integration/API.hs
+++ b/packages/agent-integration-api/src/Agent/Integration/API.hs
@@ -10,21 +10,15 @@ module Agent.Integration.API
     , emptyIntegrationProvider
     , newIntegrationSupervisor
     , acquireIntegrationRuntime
-    , prepareIntegrationSupervisorForSession
-    , integrationSupervisorArtifactDirectory
     , closeIntegrationSupervisor
     ) where
 
 import Agent.Json (RawJson, rawJsonFromEncoding)
 import Agent.MCP (McpServerConfig, McpToolServer)
-import Agent.Tools.Types (ToolEnv, addToolAllowedRoot, setToolSessionTmp)
+import Agent.Tools.Types (ToolEnv)
 import Control.Concurrent.MVar (MVar, modifyMVar, newMVar)
-import Control.Exception.Safe (bracketOnError, finally)
 import qualified Data.Aeson as Aeson
 import Data.Text (Text)
-import System.Directory (removePathForcibly)
-import System.IO.Temp (createTempDirectory, getCanonicalTemporaryDirectory)
-import System.OsPath (unsafeEncodeUtf)
 
 data IntegrationError
     = IntegrationInvalidInput !Text
@@ -60,7 +54,6 @@ data IntegrationSupervisor = IntegrationSupervisor
     { supervisorState :: !(MVar SupervisorState)
     , supervisorProvider :: !IntegrationProvider
     , supervisorToolEnv :: !ToolEnv
-    , supervisorScratch :: !FilePath
     }
 
 -- | Public distributions deliberately contain no local implementation.
@@ -80,15 +73,8 @@ emptyRuntime = IntegrationRuntime
 
 newIntegrationSupervisor :: IntegrationProvider -> ToolEnv -> IO IntegrationSupervisor
 newIntegrationSupervisor supervisorProvider supervisorToolEnv = do
-    root <- getCanonicalTemporaryDirectory
-    bracketOnError
-        (createTempDirectory root "haskell-agent-integrations-")
-        removePathForcibly
-        \supervisorScratch -> do
-            setToolSessionTmp supervisorToolEnv
-                (Just (unsafeEncodeUtf supervisorScratch))
-            supervisorState <- newMVar (Open Nothing)
-            pure IntegrationSupervisor{..}
+    supervisorState <- newMVar (Open Nothing)
+    pure IntegrationSupervisor{..}
 
 -- | Organization acquisition never evaluates the local provider, even when
 -- the remote endpoint is unavailable. The ordinary MCP supervisor owns that
@@ -114,20 +100,9 @@ acquireIntegrationRuntime supervisor authority =
                         Left err -> pure (state, Left err)
                         Right runtime -> pure (Open (Just runtime), Right runtime)
 
-prepareIntegrationSupervisorForSession :: IntegrationSupervisor -> ToolEnv -> IO ()
-prepareIntegrationSupervisorForSession supervisor toolEnv =
-    addToolAllowedRoot toolEnv (unsafeEncodeUtf supervisor.supervisorScratch)
-
--- | A host may materialize authenticated MCP artifacts here. Its MCP workers
--- must be closed before closing this supervisor and removing the directory.
-integrationSupervisorArtifactDirectory :: IntegrationSupervisor -> FilePath
-integrationSupervisorArtifactDirectory = supervisorScratch
-
 closeIntegrationSupervisor :: IntegrationSupervisor -> IO ()
 closeIntegrationSupervisor supervisor = do
     previous <- modifyMVar supervisor.supervisorState \state -> pure (Closed, state)
     case previous of
         Closed -> pure ()
-        Open local ->
-            maybe (pure ()) closeIntegrationRuntime local
-                `finally` removePathForcibly supervisor.supervisorScratch
+        Open local -> maybe (pure ()) closeIntegrationRuntime local

--- a/packages/agent-integration-api/test/Spec.hs
+++ b/packages/agent-integration-api/test/Spec.hs
@@ -2,11 +2,10 @@ module Main (main) where
 
 import Agent.Integration.API
 import Agent.MCP (McpServerConfig(..), McpProtocolPreference(..))
-import Agent.Tools.Types (ToolEnv(..), defaultToolEnv)
+import Agent.Tools.Types (ToolEnv, defaultToolEnv)
 import Control.Concurrent.Async (mapConcurrently_)
 import Control.Exception.Safe (bracket)
-import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
-import System.Directory.OsPath (doesDirectoryExist)
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import System.IO.Temp (withSystemTempDirectory)
 import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
@@ -28,7 +27,7 @@ main = hspec do
                             Right runtime -> case integrationRuntimeEndpoint runtime of
                                 RemoteIntegrationEndpoint config -> config `shouldBe` remoteConfig
                                 _ -> expectationFailure "wrong endpoint authority"
-        it "removes scratch even when provider cleanup fails" $
+        it "closes idempotently even when provider cleanup fails" $
             withEnvironment \env -> do
                 let provider toolEnv = emptyIntegrationProvider toolEnv >>= \case
                         Left err -> pure (Left err)
@@ -37,8 +36,6 @@ main = hspec do
                 supervisor <- newIntegrationSupervisor provider env
                 _ <- acquireIntegrationRuntime supervisor LocalIntegrationAuthority
                 closeIntegrationSupervisor supervisor `shouldThrow` anyIOException
-                doesDirectoryExist (unsafeEncodeUtf
-                    (integrationSupervisorArtifactDirectory supervisor)) `shouldReturn` False
                 closeIntegrationSupervisor supervisor
         it "shares one local runtime and closes it exactly once" $
             withEnvironment \env -> do
@@ -62,24 +59,6 @@ main = hspec do
                 case acquired of
                     Left _ -> pure ()
                     Right _ -> expectationFailure "closed supervisor accepted acquisition"
-        it "authorizes its stable scratch root without redirecting session writes" $
-            withEnvironment \env ->
-                bracket
-                    (newIntegrationSupervisor emptyIntegrationProvider env)
-                    closeIntegrationSupervisor \supervisor -> do
-                        session <- defaultToolEnv (unsafeEncodeUtf ".")
-                        writeIORef session.toolSessionTmp (Just (unsafeEncodeUtf "session-only"))
-                        prepareIntegrationSupervisorForSession supervisor session
-                        readIORef session.toolSessionTmp
-                            `shouldReturn` Just (unsafeEncodeUtf "session-only")
-                        root <- readIORef env.toolSessionTmp
-                        roots <- readIORef session.toolAllowedRoots
-                        case root of
-                            Nothing -> expectationFailure "missing process scratch"
-                            Just path -> do
-                                roots `shouldContain` [path]
-                                closeIntegrationSupervisor supervisor
-                                doesDirectoryExist path `shouldReturn` False
         it "does not let a failed local provider affect remote acquisition" $
             withEnvironment \env ->
                 bracket

--- a/packages/agent-mcp/src/Agent/MCP.hs
+++ b/packages/agent-mcp/src/Agent/MCP.hs
@@ -61,6 +61,8 @@ module Agent.MCP
     , acquireMcpFleet
     , acquireMcpFleetWithProgress
     , acquireMcpFleetProgressive
+    , acquireMcpFleetWithInMemory
+    , acquireMcpFleetProgressiveWithInMemory
     , releaseMcpFleetLease
     , closeMcpSupervisor
     , restartMcpSupervisor
@@ -68,6 +70,7 @@ module Agent.MCP
     , startMcpFleetWithProgress
     , startMcpFleetWithProgressHooks
     , startMcpFleetWithInMemory
+    , startMcpFleetProgressiveWithInMemoryHooks
     , McpToolServer(..)
     , McpTool(..)
     , emptyServerCapabilities
@@ -77,8 +80,12 @@ module Agent.MCP
     , startMcpFleetProgressiveHooks
     , closeMcpFleet
     , mcpFleetTools
+    , mcpFleetToolsForArtifactDirectory
+    , mcpFleetRegistrationsForArtifactDirectory
     , mcpFleetMetaTools
+    , mcpFleetMetaToolsForArtifactDirectory
     , mcpFleetGrokMetaTools
+    , mcpFleetGrokMetaToolsForArtifactDirectory
     , mcpFleetResourceTools
     , mcpFleetStatuses
     , mcpFleetServerInfos
@@ -124,22 +131,27 @@ import Agent.MCP.InProcess
     )
 import Agent.MCP.Fleet
     ( startMcpFleetWithInMemory
+    , startMcpFleetProgressiveWithInMemoryHooks
     , closeMcpFleet
     , mcpFleetComplete
     , mcpFleetGetPrompt
     , mcpFleetGetSkill
     , mcpFleetGrokMetaTools
+    , mcpFleetGrokMetaToolsForArtifactDirectory
     , mcpFleetInstructions
     , mcpFleetListPrompts
     , mcpFleetListResourceTemplates
     , mcpFleetListResources
     , mcpFleetMetaTools
+    , mcpFleetMetaToolsForArtifactDirectory
     , mcpFleetReadResource
     , mcpFleetResourceTools
     , mcpFleetServerInfos
     , mcpFleetSkillRegistrations
     , mcpFleetStatuses
+    , mcpFleetRegistrationsForArtifactDirectory
     , mcpFleetTools
+    , mcpFleetToolsForArtifactDirectory
     , startMcpFleet
     , startMcpFleetProgressive
     , startMcpFleetProgressiveHooks
@@ -149,6 +161,8 @@ import Agent.MCP.Fleet
 import Agent.MCP.Supervisor
     ( acquireMcpFleet
     , acquireMcpFleetProgressive
+    , acquireMcpFleetProgressiveWithInMemory
+    , acquireMcpFleetWithInMemory
     , acquireMcpFleetWithProgress
     , closeMcpSupervisor
     , newMcpSupervisor

--- a/packages/agent-mcp/src/Agent/MCP/Client/Internal/Operations.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Client/Internal/Operations.hs
@@ -522,7 +522,18 @@ completeMcpArgument client ref argumentName partial context = do
 -- * Tools
 
 appToolFor :: McpClient -> McpTool -> AppTool
-appToolFor client tool = AppTool
+appToolFor client =
+    appToolForArtifactDirectory client.clientHooks.mcpHostArtifactDirectory client
+
+-- | Project a discovered tool into one caller-owned artifact directory.
+-- Fleets can outlive sessions, so the destination belongs to the projected
+-- handler rather than the cached client.
+appToolForArtifactDirectory
+    :: Maybe FilePath
+    -> McpClient
+    -> McpTool
+    -> AppTool
+appToolForArtifactDirectory artifactDirectory client tool = AppTool
     { appToolName = qualifiedName
     , appToolDescription = describeTool tool
     -- Tool schemas enter the legacy Aeson-valued tool API here. Their wire
@@ -543,6 +554,7 @@ appToolFor client tool = AppTool
                         -- appended to the text already shown for this call.
                         shown <- newIORef Text.empty
                         callDiscoveredToolWith
+                            artifactDirectory
                             client
                             tool
                             arguments
@@ -622,26 +634,37 @@ qualifiedMcpToolName serverName toolName =
 
 callDiscoveredTool :: McpClient -> McpTool -> RawJson -> IO (Either Text Text)
 callDiscoveredTool client tool arguments =
-    callDiscoveredToolWith client tool arguments Nothing
+    callDiscoveredToolWith
+        client.clientHooks.mcpHostArtifactDirectory
+        client
+        tool
+        arguments
+        Nothing
 
 callDiscoveredToolWith
-    :: McpClient
+    :: Maybe FilePath
+    -> McpClient
     -> McpTool
     -> RawJson
     -> Maybe (McpProgress -> IO ())
     -> IO (Either Text Text)
-callDiscoveredToolWith client tool arguments _
+callDiscoveredToolWith artifactDirectory client tool arguments _
     | McpClientInMemory server _ <- client.clientTransport = do
         state <- readTVarIO client.clientLifecycle
         case state of
             ClientClosed -> pure (Left "MCP server closed")
             _ -> do
                 outcome <- tryAny $
-                    server.toolServerCallTool (McpCallToolRequest tool.discoveredName arguments Nothing)
+                    server.toolServerCallTool
+                        (McpCallToolRequest
+                            tool.discoveredName
+                            arguments
+                            Nothing
+                            artifactDirectory)
                 pure $ case outcome of
                     Left _ -> Left "Internal MCP tool error"
                     Right result -> either (Left . renderMcpError) renderInMemoryToolResult result
-callDiscoveredToolWith client tool arguments onProgress = do
+callDiscoveredToolWith artifactDirectory client tool arguments onProgress = do
     let parameters =
             "name" .= tool.discoveredName
                 <> AesonEncoding.pair "arguments" (rawJsonEncoding arguments)
@@ -656,7 +679,7 @@ callDiscoveredToolWith client tool arguments onProgress = do
         Left err -> pure (Left (renderMcpError err))
         Right result -> case normalizeMcpToolResult result of
             Left err -> pure (Left err)
-            Right rendered -> case client.clientHooks.mcpHostArtifactDirectory of
+            Right rendered -> case artifactDirectory of
                 Nothing -> pure (Right rendered)
                 Just directory ->
                     materializeArtifacts directory

--- a/packages/agent-mcp/src/Agent/MCP/Fleet.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Fleet.hs
@@ -106,6 +106,28 @@ sameServerConfigs left right =
 mcpFleetTools :: McpFleet -> [AppTool]
 mcpFleetTools = map (.mcpRegistrationTool) . (.mcpFleetRegistrations)
 
+mcpFleetToolsForArtifactDirectory
+    :: Maybe FilePath
+    -> McpFleet
+    -> [AppTool]
+mcpFleetToolsForArtifactDirectory artifactDirectory =
+    map (.mcpRegistrationTool)
+        . mcpFleetRegistrationsForArtifactDirectory artifactDirectory
+
+mcpFleetRegistrationsForArtifactDirectory
+    :: Maybe FilePath
+    -> McpFleet
+    -> [McpToolRegistration]
+mcpFleetRegistrationsForArtifactDirectory artifactDirectory =
+    map
+        (\registration ->
+            registration
+                { mcpRegistrationTool =
+                    registration.mcpRegistrationToolForArtifactDirectory
+                        artifactDirectory
+                })
+        . (.mcpFleetRegistrations)
+
 -- | Snapshot the metadata advertised by every Skills-over-MCP server.  The
 -- server name is deliberately retained alongside each URI: URIs are only
 -- unique within an MCP server.
@@ -404,6 +426,9 @@ startMcpFleetWithInMemory hooks reportActive external inMemory = mask \restore -
     registrationFor client tool = McpToolRegistration
         { mcpRegistrationServer = client.clientConfig.mcpServerName
         , mcpRegistrationTool = appToolFor client tool
+        , mcpRegistrationToolForArtifactDirectory =
+            \directory ->
+                appToolForArtifactDirectory directory client tool
         }
 
     startupWarningFromText :: McpServerConfig -> Text -> Text
@@ -459,7 +484,20 @@ startMcpFleetProgressiveHooks
     -> ([McpServerStatus] -> IO ())
     -> [McpServerConfig]
     -> IO McpFleet
-startMcpFleetProgressiveHooks hooks reportStatuses configs = mask \restore -> do
+startMcpFleetProgressiveHooks hooks reportStatuses configs =
+    startMcpFleetProgressiveWithInMemoryHooks
+        hooks reportStatuses configs []
+
+-- | Progressive startup for external and trusted host-owned servers. The
+-- returned fleet owns both kinds of client under one lifecycle.
+startMcpFleetProgressiveWithInMemoryHooks
+    :: McpHostHooks
+    -> ([McpServerStatus] -> IO ())
+    -> [McpServerConfig]
+    -> [(McpServerConfig, McpToolServer)]
+    -> IO McpFleet
+startMcpFleetProgressiveWithInMemoryHooks
+    hooks reportStatuses external inMemory = mask \restore -> do
     validateServerNames configs
     closed <- newMVar False
     workers <- newMVar []
@@ -558,12 +596,22 @@ startMcpFleetProgressiveHooks hooks reportStatuses configs = mask \restore -> do
     pure fleet
         `onException` closeMcpFleet fleet
   where
+    configs = external <> map fst inMemory
+
+    startClient config =
+        case lookup config.mcpServerName
+            [ (entry.mcpServerName, server)
+            | (entry, server) <- inMemory
+            ] of
+            Just server -> startInMemoryMcpClient hooks config server
+            Nothing -> startMcpClientWith hooks Nothing config
+
     startClientTracked ownedClients semaphore config = mask \restore -> do
         attempt <-
             bracket_
                 (waitQSem semaphore)
                 (signalQSem semaphore)
-                (tryAny (restore (startMcpClientWith hooks Nothing config)))
+                (tryAny (restore (startClient config)))
         case attempt of
             Left exception -> pure (Left exception)
             Right client -> do
@@ -766,14 +814,32 @@ refreshServerTools fleet client expectedRevision =
 -- catalog. These schemas do not change as servers become ready.
 mcpFleetMetaTools :: McpFleet -> [AppTool]
 mcpFleetMetaTools fleet =
+    mcpFleetMetaToolsForArtifactDirectory
+        fleet.mcpFleetHooks.mcpHostArtifactDirectory
+        fleet
+
+mcpFleetMetaToolsForArtifactDirectory
+    :: Maybe FilePath
+    -> McpFleet
+    -> [AppTool]
+mcpFleetMetaToolsForArtifactDirectory artifactDirectory fleet =
     [ mcpSearchTool fleet
-    , mcpCallTool fleet
+    , mcpCallTool artifactDirectory fleet
     ]
 
 mcpFleetGrokMetaTools :: McpFleet -> [AppTool]
 mcpFleetGrokMetaTools fleet =
+    mcpFleetGrokMetaToolsForArtifactDirectory
+        fleet.mcpFleetHooks.mcpHostArtifactDirectory
+        fleet
+
+mcpFleetGrokMetaToolsForArtifactDirectory
+    :: Maybe FilePath
+    -> McpFleet
+    -> [AppTool]
+mcpFleetGrokMetaToolsForArtifactDirectory artifactDirectory fleet =
     [ grokSearchTool fleet
-    , grokUseTool fleet
+    , grokUseTool artifactDirectory fleet
     ]
 
 -- | Read-only tools for browsing and reading server resources. They are
@@ -944,16 +1010,22 @@ grokSearchTool fleet = AppTool
     }
 
 callCatalogEntryWithReconnect
-    :: McpFleet
+    :: Maybe FilePath
+    -> McpFleet
     -> Text
     -> McpCatalogEntry
     -> RawJson
     -> IO (Either Text Text)
-callCatalogEntryWithReconnect fleet qualifiedName entry arguments =
+callCatalogEntryWithReconnect artifactDirectory fleet qualifiedName entry arguments =
     catalogEntryIsLive entry >>= \case
         False -> pure (Left changedCatalogEntryMessage)
         True ->
-            callDiscoveredTool entry.catalogClient entry.catalogTool arguments
+            callDiscoveredToolWith
+                artifactDirectory
+                entry.catalogClient
+                entry.catalogTool
+                arguments
+                Nothing
                 >>= \case
                     Right result -> pure (Right result)
                     Left originalError
@@ -992,10 +1064,12 @@ callCatalogEntryWithReconnect fleet qualifiedName entry arguments =
                                                             (Left
                                                                 changedCatalogEntryMessage)
                                                     else
-                                                        callDiscoveredTool
+                                                        callDiscoveredToolWith
+                                                            artifactDirectory
                                                             replacement.catalogClient
                                                             replacement.catalogTool
                                                             arguments
+                                                            Nothing
 
 catalogEntryIsLive :: McpCatalogEntry -> IO Bool
 catalogEntryIsLive entry = do
@@ -1008,12 +1082,13 @@ catalogEntryIsLive entry = do
 -- A generation change is allowed only when every advertised tool property
 -- still matches the snapshot that the parent approved.
 callApprovedCatalogTool
-    :: McpFleet
+    :: Maybe FilePath
+    -> McpFleet
     -> ToolCall
     -> Text
     -> RawJson
     -> IO (Either Text Text)
-callApprovedCatalogTool fleet call name toolArguments = do
+callApprovedCatalogTool artifactDirectory fleet call name toolArguments = do
     approved <- atomically do
         approvals <- readTVar fleet.mcpFleetApprovedCalls
         writeTVar fleet.mcpFleetApprovedCalls
@@ -1042,6 +1117,7 @@ callApprovedCatalogTool fleet call name toolArguments = do
                             then pure (Left changedCatalogEntryMessage)
                             else
                                 callCatalogEntryWithReconnect
+                                    artifactDirectory
                                     fleet
                                     name
                                     selected
@@ -1217,8 +1293,8 @@ reconnectCatalogEntry fleet qualifiedName failedEntry =
                                     Just replacement ->
                                         pure (Right replacement)
 
-mcpCallTool :: McpFleet -> AppTool
-mcpCallTool fleet = AppTool
+mcpCallTool :: Maybe FilePath -> McpFleet -> AppTool
+mcpCallTool artifactDirectory fleet = AppTool
     { appToolName = "mcp_call"
     , appToolDescription =
         "Call a currently available MCP tool by its qualified server__tool name. Mutating tools require user approval."
@@ -1233,7 +1309,8 @@ mcpCallTool fleet = AppTool
         ]
     , appToolHandler = typedToolWithCall "mcp_call" callArgumentsDecoder
         \call (name, toolArguments) ->
-            callApprovedCatalogTool fleet call name toolArguments
+            callApprovedCatalogTool
+                artifactDirectory fleet call name toolArguments
     , appToolApproval =
         ClassifyApproval
             (catalogCallApproval fleet callArgumentsDecoder)
@@ -1242,8 +1319,8 @@ mcpCallTool fleet = AppTool
     , appToolAsyncCapability = BlockingOnly
     }
 
-grokUseTool :: McpFleet -> AppTool
-grokUseTool fleet = AppTool
+grokUseTool :: Maybe FilePath -> McpFleet -> AppTool
+grokUseTool artifactDirectory fleet = AppTool
     { appToolName = "use_tool"
     , appToolDescription =
         "Call an MCP integration tool.\n\n\
@@ -1264,7 +1341,8 @@ grokUseTool fleet = AppTool
         ]
     , appToolHandler = typedToolWithCall "use_tool" grokCallArgumentsDecoder
         \call (name, toolArguments) ->
-            callApprovedCatalogTool fleet call name toolArguments
+            callApprovedCatalogTool
+                artifactDirectory fleet call name toolArguments
     , appToolApproval =
         ClassifyApproval
             (catalogCallApproval fleet grokCallArgumentsDecoder)

--- a/packages/agent-mcp/src/Agent/MCP/InProcess.hs
+++ b/packages/agent-mcp/src/Agent/MCP/InProcess.hs
@@ -205,7 +205,8 @@ handleRequest server requestId method parameters =
                             (Just (case requestId of
                                 String ident -> ident
                                 _ -> TextEncoding.decodeUtf8
-                                    (rawJsonBytes (rawJsonFromEncoding (Aeson.toEncoding requestId))))))
+                                    (rawJsonBytes (rawJsonFromEncoding (Aeson.toEncoding requestId)))))
+                            Nothing)
                     pure $ either (encodeError requestId)
                         (\result -> rpcSuccess requestId $ object $
                             [ "content" .= [object ["type" .= ("text" :: Text), "text" .= text]

--- a/packages/agent-mcp/src/Agent/MCP/Supervisor.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Supervisor.hs
@@ -4,6 +4,8 @@ module Agent.MCP.Supervisor
     , acquireMcpFleet
     , acquireMcpFleetWithProgress
     , acquireMcpFleetProgressive
+    , acquireMcpFleetWithInMemory
+    , acquireMcpFleetProgressiveWithInMemory
     , acquireMcpFleetWith
     , releaseMcpFleetLease
     , closeMcpSupervisor
@@ -18,6 +20,8 @@ import Agent.MCP.Fleet
     , resolveEffectiveCwds
     , sameServerConfigs
     , startMcpFleetProgressiveHooks
+    , startMcpFleetProgressiveWithInMemoryHooks
+    , startMcpFleetWithInMemory
     , startMcpFleetWithProgressHooks
     )
 import Agent.MCP.Types
@@ -53,6 +57,7 @@ import Data.IORef
 import Data.List (find)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import GHC.StableName (StableName, makeStableName)
 
 newMcpSupervisor :: IO McpSupervisor
 newMcpSupervisor = newMcpSupervisorWith defaultMcpHostHooks
@@ -98,10 +103,64 @@ acquireMcpFleetProgressive supervisor report configs =
     resolveEffectiveCwds configs >>= acquireMcpFleetWith supervisor True
         (startMcpFleetProgressiveHooks supervisor.supervisorHooks report)
 
+acquireMcpFleetWithInMemory
+    :: McpSupervisor
+    -> ([Text] -> IO ())
+    -> [McpServerConfig]
+    -> [(McpServerConfig, McpToolServer)]
+    -> IO McpFleetLease
+acquireMcpFleetWithInMemory supervisor report external inMemory = do
+    resolvedExternal <- resolveEffectiveCwds external
+    resolvedConfigs <- resolveEffectiveCwds (map fst inMemory)
+    let resolvedInMemory = zip resolvedConfigs (map snd inMemory)
+        configs = resolvedExternal <> resolvedConfigs
+    identities <- mapM
+        (\(_, server) -> makeStableName $! server)
+        resolvedInMemory
+    acquireMcpFleetWithIdentity
+        supervisor
+        False
+        identities
+        (const
+            (startMcpFleetWithInMemory
+                supervisor.supervisorHooks
+                report
+                resolvedExternal
+                resolvedInMemory))
+        configs
+
+acquireMcpFleetProgressiveWithInMemory
+    :: McpSupervisor
+    -> ([McpServerStatus] -> IO ())
+    -> [McpServerConfig]
+    -> [(McpServerConfig, McpToolServer)]
+    -> IO McpFleetLease
+acquireMcpFleetProgressiveWithInMemory
+    supervisor report external inMemory = do
+        resolvedExternal <- resolveEffectiveCwds external
+        resolvedConfigs <- resolveEffectiveCwds (map fst inMemory)
+        let resolvedInMemory = zip resolvedConfigs (map snd inMemory)
+            configs = resolvedExternal <> resolvedConfigs
+        identities <- mapM
+            (\(_, server) -> makeStableName $! server)
+            resolvedInMemory
+        acquireMcpFleetWithIdentity
+            supervisor
+            True
+            identities
+            (const
+                (startMcpFleetProgressiveWithInMemoryHooks
+                    supervisor.supervisorHooks
+                    report
+                    resolvedExternal
+                    resolvedInMemory))
+            configs
+
 data McpAcquireRequest = McpAcquireRequest
     { acquireProgressive :: Bool
     , acquireStart :: [McpServerConfig] -> IO McpFleet
     , acquireConfigs :: [McpServerConfig]
+    , acquireInMemoryIdentities :: ![StableName McpToolServer]
     }
 
 data McpAcquirePlan = McpAcquirePlan
@@ -116,11 +175,23 @@ acquireMcpFleetWith
     -> [McpServerConfig]
     -> IO McpFleetLease
 acquireMcpFleetWith supervisor progressive start configs =
+    acquireMcpFleetWithIdentity supervisor progressive [] start configs
+
+acquireMcpFleetWithIdentity
+    :: McpSupervisor
+    -> Bool
+    -> [StableName McpToolServer]
+    -> ([McpServerConfig] -> IO McpFleet)
+    -> [McpServerConfig]
+    -> IO McpFleetLease
+acquireMcpFleetWithIdentity
+    supervisor progressive identities start configs =
   mask \restore -> do
     let request = McpAcquireRequest
             { acquireProgressive = progressive
             , acquireStart = start
             , acquireConfigs = configs
+            , acquireInMemoryIdentities = identities
             }
     plan <- prepareMcpAcquire supervisor request
     case plan.acquireDecision of
@@ -220,6 +291,8 @@ preparePendingMcpAcquire request state healthyEntries failedIdle =
                     , supervisorPendingProgressive =
                         request.acquireProgressive
                     , supervisorPendingConfigs = request.acquireConfigs
+                    , supervisorPendingInMemoryIdentities =
+                        request.acquireInMemoryIdentities
                     , supervisorPendingResult = completion
                     , supervisorPendingWorker = workerSlot
                     , supervisorPendingLeases = 1
@@ -349,7 +422,10 @@ findPendingMcpAcquire request = go
             == request.acquireProgressive
         , sameServerConfigs
             pending.supervisorPendingConfigs request.acquireConfigs =
-            Just pending
+            if pending.supervisorPendingInMemoryIdentities
+                == request.acquireInMemoryIdentities
+                then Just pending
+                else go rest
         | otherwise = go rest
 
 replaceMcpPending
@@ -416,6 +492,8 @@ publishMcpPending supervisor request entryId completion fleet =
                                 request.acquireProgressive
                             , supervisorEntryConfigs =
                                 request.acquireConfigs
+                            , supervisorEntryInMemoryIdentities =
+                                request.acquireInMemoryIdentities
                             , supervisorEntryFleet = fleet
                             , supervisorEntryLeases =
                                 pending.supervisorPendingLeases
@@ -446,7 +524,9 @@ findMatchingMcpEntry request = go
         | entry.supervisorEntryProgressive /= request.acquireProgressive
             || not
                 (sameServerConfigs
-                    entry.supervisorEntryConfigs request.acquireConfigs) =
+                    entry.supervisorEntryConfigs request.acquireConfigs)
+            || entry.supervisorEntryInMemoryIdentities
+                /= request.acquireInMemoryIdentities =
                 go rest
         | otherwise = do
             statuses <- mcpFleetStatuses entry.supervisorEntryFleet

--- a/packages/agent-mcp/src/Agent/MCP/Types.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Types.hs
@@ -31,6 +31,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Text.Encoding.Error (lenientDecode)
+import GHC.StableName (StableName)
 import System.IO (Handle)
 import System.Posix.Types (ProcessGroupID)
 import System.Process (ProcessHandle)
@@ -301,6 +302,8 @@ encodeElicitResult result = rawJsonFromEncoding . Aeson.toEncoding $ case result
 data McpToolRegistration = McpToolRegistration
     { mcpRegistrationServer :: !Text
     , mcpRegistrationTool :: !AppTool
+    , mcpRegistrationToolForArtifactDirectory
+        :: !(Maybe FilePath -> AppTool)
     }
 
 data McpCatalogEntry = McpCatalogEntry
@@ -658,6 +661,8 @@ data McpSupervisorEntry = McpSupervisorEntry
     { supervisorEntryId :: !Int
     , supervisorEntryProgressive :: !Bool
     , supervisorEntryConfigs :: ![McpServerConfig]
+    , supervisorEntryInMemoryIdentities
+        :: ![StableName McpToolServer]
     , supervisorEntryFleet :: !McpFleet
     , supervisorEntryLeases :: !Int
     }
@@ -666,6 +671,8 @@ data McpSupervisorPending = McpSupervisorPending
     { supervisorPendingId :: !Int
     , supervisorPendingProgressive :: !Bool
     , supervisorPendingConfigs :: ![McpServerConfig]
+    , supervisorPendingInMemoryIdentities
+        :: ![StableName McpToolServer]
     , supervisorPendingResult :: !(TMVar (Either Text McpFleet))
     , supervisorPendingWorker ::
         !(TMVar (Async (Either Text McpFleet)))
@@ -723,6 +730,9 @@ data McpCallToolRequest = McpCallToolRequest
     { callToolName :: !Text
     , callToolArguments :: !RawJson
     , callToolRequestId :: !(Maybe Text)
+    -- | Trusted host-only destination for artifacts produced by this call.
+    -- This context is never serialized to an external MCP server.
+    , callToolArtifactDirectory :: !(Maybe FilePath)
     }
 
 data McpCallToolResult = McpCallToolResult

--- a/packages/agent-mcp/test/Agent/MCP/InProcessSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCP/InProcessSpec.hs
@@ -5,7 +5,19 @@ import Agent.Json (rawJsonFromEncoding)
 import Agent.Loop (defaultLoopDispatch)
 import Agent.MCP.InProcess
 import Agent.MCP.Client (startInMemoryMcpClient, ensureMcpClientReady, closeMcpClient, callDiscoveredTool)
-import Agent.MCP.Fleet (startMcpFleetWithInMemory, closeMcpFleet, mcpFleetInstructions)
+import Agent.MCP.Fleet
+    ( startMcpFleetWithInMemory
+    , closeMcpFleet
+    , mcpFleetInstructions
+    , mcpFleetToolsForArtifactDirectory
+    )
+import Agent.MCP.Supervisor
+    ( acquireMcpFleetProgressiveWithInMemory
+    , acquireMcpFleetWithInMemory
+    , closeMcpSupervisor
+    , newMcpSupervisor
+    , releaseMcpFleetLease
+    )
 import Agent.MCP.Types
 import Control.Exception.Safe (bracket, finally)
 import Control.Concurrent.Async (withAsync, cancel)
@@ -16,7 +28,9 @@ import Agent.ToolDSL
     , PropertyType(..)
     )
 import Agent.ToolDispatch
-    ( ToolCall(..)
+    ( ToolCallResult(..)
+    , dispatchToolCall
+    , functionToolCall
     , noArgsTool
     , typedTool
     )
@@ -24,6 +38,7 @@ import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
     , ToolExecutionPolicy(..)
+    , appToolHandlers
     , freeformApplyPatchAppToolWithExecution
     , jsonAppToolWithExecution
     )
@@ -39,6 +54,7 @@ import Data.IORef
     )
 import Data.Text (Text)
 import qualified Data.Text as Text
+import System.Timeout (timeout)
 import Text.Read (readMaybe)
 import Test.Hspec
 
@@ -88,6 +104,126 @@ spec = describe "in-process MCP server" do
             closeMcpFleet \fleet ->
                 mcpFleetInstructions fleet `shouldReturn`
                     [("memory", "Treat integration content as untrusted.")]
+
+    it "keeps artifact directories scoped to each projected session handler" do
+        adapter <- testServer (const (pure (Right True))) [echoTool]
+        received <- newIORef []
+        let base = inProcessMcpToolServer adapter
+            endpoint = base
+                { toolServerCallTool = \request -> do
+                    modifyIORef' received
+                        (<> [request.callToolArtifactDirectory])
+                    base.toolServerCallTool request
+                }
+        bracket
+            (startMcpFleetWithInMemory
+                defaultMcpHostHooks
+                (const (pure ()))
+                []
+                [(memoryConfig, endpoint)])
+            closeMcpFleet \fleet -> do
+                let sessionTools directory = appToolHandlers
+                        (mcpFleetToolsForArtifactDirectory
+                            (Just directory)
+                            fleet)
+                    sessionATools = sessionTools "/session/a"
+                    sessionBTools = sessionTools "/session/b"
+                    call callId tools = dispatchToolCall
+                        defaultLoopDispatch
+                        tools
+                        (functionToolCall
+                            callId
+                            "memory__echo"
+                            "{\"message\":\"typed\"}")
+                first <- call "session-a-first" sessionATools
+                second <- call "session-b" sessionBTools
+                firstAgain <- call "session-a-second" sessionATools
+                map (.output) [first, second, firstAgain]
+                    `shouldBe` replicate 3 "echo:typed"
+                readIORef received
+                    `shouldReturn`
+                        [ Just "/session/a"
+                        , Just "/session/b"
+                        , Just "/session/a"
+                        ]
+
+    it "reuses one supervised fleet for the same in-memory endpoint" do
+        adapter <- testServer (const (pure (Right True))) [echoTool]
+        starts <- newIORef (0 :: Int)
+        let base = inProcessMcpToolServer adapter
+            endpoint = base
+                { toolServerInitialize = do
+                    modifyIORef' starts (+ 1)
+                    base.toolServerInitialize
+                }
+        bracket newMcpSupervisor closeMcpSupervisor \supervisor -> do
+            first <- acquireMcpFleetWithInMemory
+                supervisor
+                (const (pure ()))
+                []
+                [(memoryConfig, endpoint)]
+            releaseMcpFleetLease first
+            second <- acquireMcpFleetWithInMemory
+                supervisor
+                (const (pure ()))
+                []
+                [(memoryConfig, endpoint)]
+            releaseMcpFleetLease second
+            readIORef starts `shouldReturn` 1
+
+    it "replaces a supervised fleet when the in-memory endpoint changes" do
+        adapter <- testServer (const (pure (Right True))) [echoTool]
+        firstStarts <- newIORef (0 :: Int)
+        secondStarts <- newIORef (0 :: Int)
+        let base = inProcessMcpToolServer adapter
+            firstEndpoint = base
+                { toolServerInitialize = do
+                    modifyIORef' firstStarts (+ 1)
+                    base.toolServerInitialize
+                }
+            secondEndpoint = base
+                { toolServerInitialize = do
+                    modifyIORef' secondStarts (+ 1)
+                    base.toolServerInitialize
+                }
+        bracket newMcpSupervisor closeMcpSupervisor \supervisor -> do
+            first <- acquireMcpFleetWithInMemory
+                supervisor
+                (const (pure ()))
+                []
+                [(memoryConfig, firstEndpoint)]
+            releaseMcpFleetLease first
+            second <- acquireMcpFleetWithInMemory
+                supervisor
+                (const (pure ()))
+                []
+                [(memoryConfig, secondEndpoint)]
+            releaseMcpFleetLease second
+            readIORef firstStarts `shouldReturn` 1
+            readIORef secondStarts `shouldReturn` 1
+
+    it "returns a progressive supervised fleet before an in-memory catalog settles" do
+        adapter <- testServer (const (pure (Right True))) [echoTool]
+        releaseCatalog <- newEmptyMVar
+        let base = inProcessMcpToolServer adapter
+            endpoint = base
+                { toolServerListTools =
+                    takeMVar releaseCatalog >> base.toolServerListTools
+                }
+        bracket newMcpSupervisor closeMcpSupervisor \supervisor -> do
+            acquired <- timeout 1000000 $
+                acquireMcpFleetProgressiveWithInMemory
+                    supervisor
+                    (const (pure ()))
+                    []
+                    [(memoryConfig, endpoint)]
+            case acquired of
+                Nothing ->
+                    expectationFailure
+                        "progressive acquisition blocked on the in-memory catalog"
+                Just lease -> do
+                    putMVar releaseCatalog ()
+                    releaseMcpFleetLease lease
 
     it "unsubscribes exactly once when an in-memory client closes" do
         adapter <- testServer (const (pure (Right True))) [echoTool]

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -1207,12 +1207,16 @@ spec = describe "Agent.MCP" do
         withDistinctWorkingDirectories \directory _ ->
             withCountingServer artifactFakeServer \script log -> do
                 setFileMode directory 0o700
-                let hooks = defaultMcpHostHooks { mcpHostArtifactDirectory = Just directory }
                 bracket
-                    (startMcpFleetWithProgressHooks hooks (const (pure ()))
+                    (startMcpFleetWithProgressHooks defaultMcpHostHooks (const (pure ()))
                         [(baseConfig "artifacts" script) { mcpServerArgs = [log] }])
                     closeMcpFleet \fleet -> do
-                        result <- callFleetTool fleet "artifacts__download" "{}"
+                        result <- callFleetTools
+                            (mcpFleetToolsForArtifactDirectory
+                                (Just directory)
+                                fleet)
+                            "artifacts__download"
+                            "{}"
                         result.output `shouldSatisfy` Text.isInfixOf "[artifact] "
                         files <- listDirectory directory
                         length files `shouldBe` 1
@@ -1766,9 +1770,13 @@ schemaTool properties = McpTool
 
 callFleetTool :: McpFleet -> Text.Text -> Text.Text -> IO ToolCallResult
 callFleetTool fleet name arguments =
+    callFleetTools (mcpFleetTools fleet) name arguments
+
+callFleetTools :: [AppTool] -> Text.Text -> Text.Text -> IO ToolCallResult
+callFleetTools tools name arguments =
     dispatchToolCall
         defaultLoopDispatch
-        (appToolHandlers (mcpFleetTools fleet))
+        (appToolHandlers tools)
         (functionToolCall "call" name arguments)
 
 dispatchApprovedTool :: [AppTool] -> ToolCall -> IO ToolCallResult


### PR DESCRIPTION
A process-cached MCP fleet could materialize authenticated integration artifacts into one shared directory, allowing later sessions or credential switches to retain authority over earlier downloads. Native in-memory integrations also bypassed `McpSupervisor`, which disabled fleet reuse and progressive startup.

This change projects every MCP handler and registration into the calling session's scratch directory while keeping the underlying fleet reusable. In-memory endpoints now participate in supervised blocking and progressive acquisition, with endpoint identity included in the reuse key. The process-wide integration scratch root is removed.

Validation:
- package boundary check passes
- `agent-mcp-test`: 154 examples, 0 failures
- `agent-integration-api-test`: 4 examples, 0 failures
- `agent-cli-test`: 1,942 examples, 0 failures, 1 pending
