### PR TITLE
fix(cli): stop Kitty-encoded Shift+Tab from leaking into the composer

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -26,6 +26,7 @@ module Agent.CLI.Input
     , isClipboardPasteCsiBody
     , isClipboardPasteKey
     , isShiftEnterCsiBody
+    , isShiftTabCsiBody
     , submissionPromptText
     , appendReplHistory
     , readReplHistory
@@ -498,6 +499,7 @@ readCsiKey =
         Left err -> pure (EditorInputError err)
         Right body
             | isShiftEnterCsiBody body -> pure (EditorChar '\n')
+            | isShiftTabCsiBody body -> pure EditorCycleMode
             | isClipboardPasteCsiBody body -> readClipboardEditorKey
             | Just key <- decodeKittyEditorKey body -> pure key
             | otherwise -> case body of

--- a/packages/agent-cli/src/Agent/CLI/Input/KeyDecoder.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/KeyDecoder.hs
@@ -12,6 +12,7 @@ module Agent.CLI.Input.KeyDecoder
     , isClipboardPasteKey
     , isClipboardPasteCsiBody
     , isShiftEnterCsiBody
+    , isShiftTabCsiBody
     , splitFields
     , listAt
     , stripFinal
@@ -19,7 +20,7 @@ module Agent.CLI.Input.KeyDecoder
     ) where
 
 import Agent.CLI.Input.Types (EditorKey(..), KittyKey(..))
-import Agent.CLI.Terminal (shiftEnterCsiBodies)
+import Agent.CLI.Terminal (shiftEnterCsiBodies, shiftTabCsiBodies)
 import Data.Bits ((.&.))
 import Data.Char (ord)
 import Data.Maybe (fromMaybe)
@@ -48,6 +49,9 @@ isClipboardPasteCsiBody body =
 
 isShiftEnterCsiBody :: String -> Bool
 isShiftEnterCsiBody body = body `elem` shiftEnterCsiBodies
+
+isShiftTabCsiBody :: String -> Bool
+isShiftTabCsiBody body = body `elem` shiftTabCsiBodies
 
 parseKittyKey :: String -> Maybe KittyKey
 parseKittyKey body = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -82,6 +82,7 @@ import Agent.CLI.Terminal ( TerminalCapabilities(..)
     , kittyKeyboardPop
     , kittySuperCsiBodies
     , shiftEnterCsiBodies
+    , shiftTabCsiBodies
     )
 import qualified Agent.TUI.Theme as Theme
 import qualified Agent.CLI.TUI.Bridge as Bridge
@@ -835,6 +836,13 @@ fullscreenVtyConfig =
               , V.EvKey V.KEnter [V.MShift]
               )
             | body <- shiftEnterCsiBodies
+            ]
+            <>
+            [ ( Nothing
+              , "\ESC[" <> body
+              , V.EvKey V.KBackTab []
+              )
+            | body <- shiftTabCsiBodies
             ]
             <> [ ( Nothing
                  , "\ESC[" <> body

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -27,6 +27,7 @@ module Agent.CLI.Terminal
     , kittySuperCsiBodies
     , kittySuperVCsiBodies
     , shiftEnterCsiBodies
+    , shiftTabCsiBodies
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPush
     , kittyKeyboardPop
@@ -244,6 +245,19 @@ shiftEnterCsiBodies :: [String]
 shiftEnterCsiBodies =
     [ "27;2;13~"
     , "13;2u"
+    ]
+
+-- | CSI bodies used by enhanced-keyboard protocols for Shift+Tab.
+--
+-- Xterm's modifyOtherKeys protocol uses @CSI 27;2;9~@, while Kitty's
+-- keyboard protocol uses @CSI 9;2u@. Event type 1 is an explicit key
+-- press; terminals may omit it. Unmapped bodies leak into the composer
+-- as literal text (observed as @[9;2u@).
+shiftTabCsiBodies :: [String]
+shiftTabCsiBodies =
+    [ "27;2;9~"
+    , "9;2u"
+    , "9;2:1u"
     ]
 
 -- | CSI bodies emitted by Kitty's keyboard protocol for Ctrl+letter chords.

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -12,6 +12,7 @@ import Agent.CLI.Input
     , isClipboardPasteCsiBody
     , isClipboardPasteKey
     , isShiftEnterCsiBody
+    , isShiftTabCsiBody
     , parseChoiceKey
     , replHistoryPath
     , submissionPromptText
@@ -239,6 +240,20 @@ spec = do
             isShiftEnterCsiBody "27;2;13~" `shouldBe` True
             isShiftEnterCsiBody "13;2u" `shouldBe` True
             isShiftEnterCsiBody "13u" `shouldBe` False
+
+    describe "Shift+Tab" do
+        it "recognizes xterm modifyOtherKeys and Kitty CSI-u encodings" do
+            isShiftTabCsiBody "27;2;9~" `shouldBe` True
+            isShiftTabCsiBody "9;2u" `shouldBe` True
+            isShiftTabCsiBody "9;2:1u" `shouldBe` True
+            isShiftTabCsiBody "9u" `shouldBe` False
+            isShiftTabCsiBody "13;2u" `shouldBe` False
+
+        it "decodes Kitty press events as mode cycle and ignores releases" do
+            decodeKittyEditorKey "9;2u" `shouldBe` Just EditorCycleMode
+            decodeKittyEditorKey "9;2:1u" `shouldBe` Just EditorCycleMode
+            decodeKittyEditorKey "9;2:3u" `shouldBe` Just EditorIgnore
+            decodeKittyEditorKey "9u" `shouldBe` Just EditorIgnore
 
     describe "inline editor reducer" do
         it "reduces common editing keys without performing IO" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1124,6 +1124,18 @@ spec = do
                   , "\ESC[13;2u"
                   , V.EvKey V.KEnter [V.MShift]
                   )
+                , ( Nothing
+                  , "\ESC[27;2;9~"
+                  , V.EvKey V.KBackTab []
+                  )
+                , ( Nothing
+                  , "\ESC[9;2u"
+                  , V.EvKey V.KBackTab []
+                  )
+                , ( Nothing
+                  , "\ESC[9;2:1u"
+                  , V.EvKey V.KBackTab []
+                  )
                 ]
             mapM_
                 (\mapping -> mappings `shouldContain` [mapping])


### PR DESCRIPTION
## Problem

Shift+Tab is supposed to cycle idle modes (`ask` → `plan` → `yolo`). On Kitty/Ghostty/WezTerm, the fullscreen TUI enables Kitty keyboard reporting, so Shift+Tab arrives as `CSI 9;2u`. Vty had no mapping for that sequence and inserted the payload as typed text (`[9;2u`) instead of cycling the mode.

The line editor already decoded this via `decodeKittyEditorKey`; only the Brick/Vty path was missing.

## Fix

- Add `shiftTabCsiBodies` for Kitty (`9;2u`, `9;2:1u`) and xterm modifyOtherKeys (`27;2;9~`).
- Map those sequences to `KBackTab` in `fullscreenVtyConfig`.
- Treat the same bodies as `EditorCycleMode` in the line editor.

## Validation

- `cabal test agent-cli:test:agent-cli-test --test-option='-m' --test-option='Shift+Tab' --test-option='-m' --test-option='fullscreenVtyConfig'` — 4 examples, 0 failures.
- Live tmux check: injected `ESC[9;2u` into a `--yolo` composer. Status changed from `yolo` to `ask` with `Switched to ask mode.` and the composer stayed empty (no `[9;2u`).