### PR TITLE
Add CLI commands to list, enable, and disable MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,8 @@ for details.
 ### Local MCP servers
 
 Use `/mcp` to manage local stdio MCP servers, or configure them in
-`~/.haskell-agent/config.json`. See the [MCP guide](docs/mcp.md) for the
+`~/.haskell-agent/config.json`. `agent-cli mcp list`, `enable`, and `disable`
+toggle that catalog from the command line. See the [MCP guide](docs/mcp.md) for the
 configuration schema, startup strategies, and tool exposure rules.
 
 ### Meta Console

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -26,6 +26,21 @@ The harness is an MCP client for the current specification revision
 }
 ```
 
+Manage configured servers from the command line without starting a session:
+
+```
+agent-cli mcp list
+agent-cli mcp list --json
+agent-cli mcp enable github
+agent-cli mcp disable github
+```
+
+`list` prints every server in `~/.haskell-agent/config.json`, marking disabled
+ones and never showing environment values. `enable` / `disable` persist
+`enabled` on that named entry; they are idempotent and exit 1 when the name
+is not configured. The next session (or `/mcp` `r` in a running one) picks up
+the change.
+
 In an interactive session, `/mcp` opens the server manager. Use the arrow
 keys or `j`/`k` to navigate, Enter to inspect tools, `a` to add a server,
 Space to enable or disable it, `x` to remove it, and `r` to restart the MCP

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -186,6 +186,7 @@ library
                     , Agent.CLI.ComputerUse.Linux.X11
                     , Agent.CLI.ComputerUse.Accessibility
                     , Agent.CLI.Config
+                    , Agent.CLI.McpCatalog
                     , Agent.CLI.McpOAuthStore
                     , Agent.CLI.McpOAuth
                     , Agent.CLI.Database
@@ -549,6 +550,7 @@ test-suite agent-cli-test
                     , Agent.CLI.LoginSpec
                     , Agent.CLI.LearnedSkillsSpec
                     , Agent.CLI.MarkdownSpec
+                    , Agent.CLI.McpCatalogSpec
                     , Agent.CLI.McpManagerSpec
                     , Agent.CLI.McpSamplingSpec
                     , Agent.CLI.MetaConsoleSpec

--- a/packages/agent-cli/data/CHANGELOG.md
+++ b/packages/agent-cli/data/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 
+- **MCP catalog commands** list, enable, and disable configured servers with `agent-cli mcp list`, `enable`, and `disable`.
 - **Release notes** are now available from `/changelog` and the start screen.
 - **Secret requests** now notify the terminal when the agent needs sensitive input.
 - **Plan questions** now accept custom replies in addition to predefined choices.

--- a/packages/agent-cli/src/Agent/CLI/McpCatalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpCatalog.hs
@@ -1,0 +1,232 @@
+-- | Non-interactive MCP catalog commands: list, enable, and disable servers
+-- in @~/.haskell-agent/config.json@. Environment values are never shown.
+module Agent.CLI.McpCatalog
+    ( McpCatalogChange(..)
+    , McpCatalogEntry(..)
+    , McpCatalogError(..)
+    , formatMcpCatalogChange
+    , formatMcpCatalogHuman
+    , formatMcpCatalogJSON
+    , listMcpCatalog
+    , mcpCatalogEntries
+    , mcpCatalogTransport
+    , runMcpCommand
+    , setMcpCatalogEnabled
+    ) where
+
+import Agent.CLI.Config
+    ( HarnessConfig(..)
+    , McpServerConfig(..)
+    , loadHarnessConfig
+    , modifyHarnessConfig
+    )
+import Agent.CLI.McpOAuth
+    ( LoginOptions(..)
+    , defaultLoginOptions
+    , loginMcpWith
+    , logoutMcp
+    )
+import Agent.CLI.Options
+    ( McpCommand(..)
+    , SessionOutputFormat(..)
+    )
+import Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+import Data.Char (isAlphaNum)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import System.Directory.OsPath (getHomeDirectory)
+import System.Exit (die)
+import System.OsPath (OsPath)
+
+data McpCatalogError
+    = McpCatalogNotFound !Text
+    | McpCatalogInvalid !Text
+    deriving (Eq, Show)
+
+data McpCatalogEntry = McpCatalogEntry
+    { mcpCatalogName :: !Text
+    , mcpCatalogEnabled :: !Bool
+    , mcpCatalogUrl :: !(Maybe Text)
+    , mcpCatalogCommand :: !Text
+    , mcpCatalogArgs :: ![Text]
+    , mcpCatalogCwd :: !(Maybe Text)
+    , mcpCatalogEnvKeys :: ![Text]
+    }
+    deriving (Eq, Show)
+
+data McpCatalogChange = McpCatalogChange
+    { mcpCatalogChanged :: !Bool
+    , mcpCatalogEntry :: !McpCatalogEntry
+    }
+    deriving (Eq, Show)
+
+runMcpCommand :: McpCommand -> IO ()
+runMcpCommand = \case
+    McpLogin url scopes ->
+        loginMcpWith defaultLoginOptions { loginAdditionalScopes = scopes } url
+    McpLogout url -> logoutMcp url
+    McpList outputFormat -> runMcpList outputFormat
+    McpEnable name -> runMcpSetEnabled True name
+    McpDisable name -> runMcpSetEnabled False name
+
+runMcpList :: SessionOutputFormat -> IO ()
+runMcpList outputFormat = do
+    home <- getHomeDirectory
+    listMcpCatalog home >>= \case
+        Left err -> die (Text.unpack (catalogErrorText err))
+        Right entries ->
+            case outputFormat of
+                SessionHuman -> Text.putStr (formatMcpCatalogHuman entries)
+                SessionJSON -> LBS8.putStrLn (formatMcpCatalogJSON entries)
+
+runMcpSetEnabled :: Bool -> Text -> IO ()
+runMcpSetEnabled enabled name = do
+    home <- getHomeDirectory
+    setMcpCatalogEnabled home name enabled >>= \case
+        Left err -> die (Text.unpack (catalogErrorText err))
+        Right change -> Text.putStrLn (formatMcpCatalogChange enabled change)
+
+listMcpCatalog :: OsPath -> IO (Either McpCatalogError [McpCatalogEntry])
+listMcpCatalog home =
+    loadHarnessConfig home >>= \case
+        Left err -> pure (Left (McpCatalogInvalid err))
+        Right config -> pure (Right (mcpCatalogEntries config))
+
+setMcpCatalogEnabled
+    :: OsPath
+    -> Text
+    -> Bool
+    -> IO (Either McpCatalogError McpCatalogChange)
+setMcpCatalogEnabled home name enabled
+    | Text.null trimmed =
+        pure (Left (McpCatalogInvalid "MCP server name must not be empty"))
+    | otherwise =
+        modifyHarnessConfig home (\_ config -> change config) >>= \case
+            Left err
+                | Just missing <- Text.stripPrefix notFoundPrefix err ->
+                    pure (Left (McpCatalogNotFound missing))
+                | otherwise ->
+                    pure (Left (McpCatalogInvalid err))
+            Right (_, _, result) -> pure (Right result)
+  where
+    trimmed = Text.strip name
+    change config =
+        case Map.lookup trimmed config.configMcpServers of
+            Nothing -> Left (notFoundPrefix <> trimmed)
+            Just server ->
+                let updated = server { mcpEnabled = enabled }
+                    next =
+                        config
+                            { configMcpServers =
+                                Map.insert trimmed updated
+                                    config.configMcpServers
+                            }
+                in Right
+                    ( next
+                    , McpCatalogChange
+                        { mcpCatalogChanged = server.mcpEnabled /= enabled
+                        , mcpCatalogEntry = catalogEntry trimmed updated
+                        }
+                    )
+
+mcpCatalogEntries :: HarnessConfig -> [McpCatalogEntry]
+mcpCatalogEntries config =
+    [ catalogEntry name server
+    | (name, server) <- Map.toAscList config.configMcpServers
+    ]
+
+mcpCatalogTransport :: McpCatalogEntry -> Text
+mcpCatalogTransport entry =
+    case entry.mcpCatalogUrl of
+        Just _ -> "http"
+        Nothing -> "stdio"
+
+formatMcpCatalogHuman :: [McpCatalogEntry] -> Text
+formatMcpCatalogHuman [] = "No MCP servers configured\n"
+formatMcpCatalogHuman entries =
+    Text.unlines (map (formatHumanLine width) entries)
+  where
+    width = maximum (map (Text.length . catalogLabel) entries)
+
+formatMcpCatalogJSON :: [McpCatalogEntry] -> LBS.ByteString
+formatMcpCatalogJSON = Aeson.encode . map mcpCatalogEntryJSON
+
+formatMcpCatalogChange :: Bool -> McpCatalogChange -> Text
+formatMcpCatalogChange enabled change =
+    if change.mcpCatalogChanged
+        then verb <> " MCP server " <> name
+        else "MCP server " <> name <> " is already " <> state
+  where
+    name = change.mcpCatalogEntry.mcpCatalogName
+    verb = if enabled then "Enabled" else "Disabled"
+    state = if enabled then "enabled" else "disabled"
+
+catalogEntry :: Text -> McpServerConfig -> McpCatalogEntry
+catalogEntry name server =
+    McpCatalogEntry
+        { mcpCatalogName = name
+        , mcpCatalogEnabled = server.mcpEnabled
+        , mcpCatalogUrl = server.mcpUrl
+        , mcpCatalogCommand = server.mcpCommand
+        , mcpCatalogArgs = server.mcpArgs
+        , mcpCatalogCwd = server.mcpCwd
+        , mcpCatalogEnvKeys = Map.keys server.mcpEnv
+        }
+
+catalogLabel :: McpCatalogEntry -> Text
+catalogLabel entry =
+    entry.mcpCatalogName
+        <> if entry.mcpCatalogEnabled then "" else " (disabled)"
+
+formatHumanLine :: Int -> McpCatalogEntry -> Text
+formatHumanLine width entry =
+    Text.justifyLeft width ' ' (catalogLabel entry)
+        <> "  "
+        <> mcpCatalogTransport entry
+        <> "  "
+        <> catalogTarget entry
+
+catalogTarget :: McpCatalogEntry -> Text
+catalogTarget entry =
+    case entry.mcpCatalogUrl of
+        Just url -> url
+        Nothing ->
+            Text.unwords
+                (map shellQuote (entry.mcpCatalogCommand : entry.mcpCatalogArgs))
+
+mcpCatalogEntryJSON :: McpCatalogEntry -> Aeson.Value
+mcpCatalogEntryJSON entry =
+    Aeson.object
+        [ "name" .= entry.mcpCatalogName
+        , "enabled" .= entry.mcpCatalogEnabled
+        , "transport" .= mcpCatalogTransport entry
+        , "url" .= entry.mcpCatalogUrl
+        , "command" .= entry.mcpCatalogCommand
+        , "args" .= entry.mcpCatalogArgs
+        , "cwd" .= entry.mcpCatalogCwd
+        , "envKeys" .= entry.mcpCatalogEnvKeys
+        ]
+
+catalogErrorText :: McpCatalogError -> Text
+catalogErrorText = \case
+    McpCatalogNotFound name ->
+        "MCP server " <> name <> " is not configured"
+    McpCatalogInvalid err -> err
+
+notFoundPrefix :: Text
+notFoundPrefix = "not-found:"
+
+shellQuote :: Text -> Text
+shellQuote value
+    | not (Text.null value)
+    , Text.all safe value = value
+    | otherwise =
+        "'" <> Text.replace "'" "'\\''" value <> "'"
+  where
+    safe char =
+        isAlphaNum char || char `elem` ("-._/:@+=," :: String)

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -87,6 +87,9 @@ data SessionOutputFormat
 data McpCommand
     = McpLogin Text [Text]
     | McpLogout Text
+    | McpList SessionOutputFormat
+    | McpEnable Text
+    | McpDisable Text
     deriving (Eq, Show)
 
 -- | Administrative commands for the harness-managed PostgreSQL server.
@@ -329,7 +332,7 @@ commandParser =
                     (Options.progDesc "Administer persisted sessions"))
             <> Options.command "mcp"
                 (Options.info mcpParser
-                    (Options.progDesc "Authorize remote MCP servers"))
+                    (Options.progDesc "Manage MCP servers"))
             <> Options.command "storage"
                 (Options.info storageParser
                     (Options.progDesc "Administer managed PostgreSQL storage"))
@@ -440,7 +443,19 @@ storageParser =
 
 mcpParser :: Options.Parser Command
 mcpParser = Mcp <$> Options.hsubparser
-    ( Options.command "login"
+    ( Options.command "list"
+        (Options.info
+            (McpList <$> sessionOutputFormatParser)
+            (Options.progDesc "List configured MCP servers"))
+    <> Options.command "enable"
+        (Options.info
+            (McpEnable <$> mcpNameArgument)
+            (Options.progDesc "Enable a configured MCP server"))
+    <> Options.command "disable"
+        (Options.info
+            (McpDisable <$> mcpNameArgument)
+            (Options.progDesc "Disable a configured MCP server"))
+    <> Options.command "login"
         (Options.info
             (McpLogin
                 <$> (Text.pack <$> Options.argument Options.str (Options.metavar "URL"))
@@ -456,6 +471,10 @@ mcpParser = Mcp <$> Options.hsubparser
             (McpLogout . Text.pack <$> Options.argument Options.str (Options.metavar "URL"))
             (Options.progDesc "Remove saved MCP OAuth credentials"))
     )
+
+mcpNameArgument :: Options.Parser Text
+mcpNameArgument =
+    Text.pack <$> Options.argument Options.str (Options.metavar "NAME")
 
 type OptionUpdate = CliOptions -> CliOptions
 
@@ -712,6 +731,9 @@ usage = unlines
     , "       agent-cli gateway <status|disconnect>"
     , "       agent-cli sessions [list]"
     , "       agent-cli sessions show <session-id>"
+    , "       agent-cli mcp list [--json]"
+    , "       agent-cli mcp enable <name>"
+    , "       agent-cli mcp disable <name>"
     , "       agent-cli mcp login <url> [--scope SCOPE]..."
     , "       agent-cli mcp logout <url>"
     , "       agent-cli storage <status|start|stop|migrate|doctor>"

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -32,12 +32,7 @@ import Agent.CLI.AgentSessions
 import Agent.CLI.GatewayClient (runGatewayCommand)
 import Agent.CLI.Interrupt ( catchUserInterrupt )
 import Agent.CLI.Login ( runLoginManager )
-import Agent.CLI.McpOAuth
-    ( LoginOptions(..)
-    , defaultLoginOptions
-    , loginMcpWith
-    , logoutMcp
-    )
+import Agent.CLI.McpCatalog (runMcpCommand)
 import Agent.CLI.WorktreeAdmin (runWorktreeAdmin)
 import Agent.CLI.McpStatus
     ( formatMcpModelNotice
@@ -53,7 +48,6 @@ import Agent.Integration.API
 import Agent.CLI.Options
     ( CliOptions
     , Command(..)
-    , McpCommand(..)
     , parseArgs
     , usage
     )
@@ -165,8 +159,7 @@ devMainResume resumeId = do
             runLoginManager color
             pure DevQuit
         Right (Gateway command) -> runGatewayCommand command >> pure DevQuit
-        Right (Mcp (McpLogin url scopes)) -> loginMcpWithScopes scopes url >> pure DevQuit
-        Right (Mcp (McpLogout url)) -> logoutMcp url >> pure DevQuit
+        Right (Mcp command) -> runMcpCommand command >> pure DevQuit
         Right (ListSessions outputFormat) ->
             runListSessions outputFormat >> pure DevQuit
         Right (ShowSession sessionId outputFormat pageRequest) ->
@@ -196,8 +189,7 @@ run = do
             color <- resolveColor stderr
             runLoginManager color
         Right (Gateway command) -> runGatewayCommand command
-        Right (Mcp (McpLogin url scopes)) -> loginMcpWithScopes scopes url
-        Right (Mcp (McpLogout url)) -> logoutMcp url
+        Right (Mcp command) -> runMcpCommand command
         Right (ListSessions outputFormat) -> runListSessions outputFormat
         Right (ShowSession sessionId outputFormat pageRequest) ->
             runShowSession sessionId outputFormat pageRequest
@@ -284,6 +276,3 @@ runAgentWithRestarts options =
                                                 integrationSupervisor)))
         (pure DevQuit)
 
-loginMcpWithScopes :: [Text] -> Text -> IO ()
-loginMcpWithScopes scopes =
-    loginMcpWith defaultLoginOptions { loginAdditionalScopes = scopes }

--- a/packages/agent-cli/test/Agent/CLI/McpCatalogSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpCatalogSpec.hs
@@ -1,0 +1,193 @@
+module Agent.CLI.McpCatalogSpec (spec) where
+
+import Agent.CLI.Config
+    ( HarnessConfig(..)
+    , McpServerConfig(..)
+    , defaultHarnessConfig
+    , loadHarnessConfig
+    , saveHarnessConfig
+    )
+import Agent.CLI.McpCatalog
+import Agent.MCP (McpProtocolPreference(..))
+import Control.Exception.Safe (bracket)
+import qualified Data.Aeson as Aeson
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
+import System.Directory.OsPath (getTemporaryDirectory)
+import qualified System.Directory as Directory
+import qualified System.FilePath as FilePath
+import System.OsPath (OsPath, decodeUtf, unsafeEncodeUtf)
+import System.Posix.Temp (mkdtemp)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.CLI.McpCatalog" do
+    it "lists configured servers without exposing environment values" $
+        withTempDir \home -> do
+            saveHarnessConfig home catalogConfig `shouldReturn` Right ()
+            listMcpCatalog home `shouldReturn` Right
+                [ docsEntry False
+                , remoteEntry
+                ]
+            formatMcpCatalogHuman
+                [ docsEntry False
+                , remoteEntry
+                ]
+                `shouldBe` Text.unlines
+                    [ "docs (disabled)  stdio  mcp-docs --stdio"
+                    , Text.justifyLeft 15 ' ' "remote"
+                        <> "  http  https://example.test/mcp"
+                    ]
+            formatMcpCatalogHuman [docsEntry False, remoteEntry]
+                `shouldSatisfy` (not . Text.isInfixOf "top-secret")
+            show (docsEntry False) `shouldNotContain` "top-secret"
+            Aeson.decode (formatMcpCatalogJSON [docsEntry False, remoteEntry])
+                `shouldBe` Just (Aeson.toJSON
+                    [ Aeson.object
+                        [ "name" Aeson..= ("docs" :: Text.Text)
+                        , "enabled" Aeson..= False
+                        , "transport" Aeson..= ("stdio" :: Text.Text)
+                        , "url" Aeson..= Aeson.Null
+                        , "command" Aeson..= ("mcp-docs" :: Text.Text)
+                        , "args" Aeson..= ["--stdio" :: Text.Text]
+                        , "cwd" Aeson..= ("/tmp" :: Text.Text)
+                        , "envKeys" Aeson..= ["TOKEN" :: Text.Text]
+                        ]
+                    , Aeson.object
+                        [ "name" Aeson..= ("remote" :: Text.Text)
+                        , "enabled" Aeson..= True
+                        , "transport" Aeson..= ("http" :: Text.Text)
+                        , "url" Aeson..= ("https://example.test/mcp" :: Text.Text)
+                        , "command" Aeson..= ("" :: Text.Text)
+                        , "args" Aeson..= ([] :: [Text.Text])
+                        , "cwd" Aeson..= Aeson.Null
+                        , "envKeys" Aeson..= ([] :: [Text.Text])
+                        ]
+                    ])
+
+    it "says when no servers are configured" do
+        formatMcpCatalogHuman []
+            `shouldBe` "No MCP servers configured\n"
+
+    it "enables and disables a named server idempotently" $
+        withTempDir \home -> do
+            saveHarnessConfig home catalogConfig `shouldReturn` Right ()
+            setMcpCatalogEnabled home "docs" False `shouldReturn`
+                Right McpCatalogChange
+                    { mcpCatalogChanged = False
+                    , mcpCatalogEntry = docsEntry False
+                    }
+            setMcpCatalogEnabled home "docs" True `shouldReturn`
+                Right McpCatalogChange
+                    { mcpCatalogChanged = True
+                    , mcpCatalogEntry = docsEntry True
+                    }
+            fmap (fmap (Map.lookup "docs" . (.configMcpServers)))
+                (loadHarnessConfig home)
+                `shouldReturn` Right (Just docsServer { mcpEnabled = True })
+            setMcpCatalogEnabled home "docs" True `shouldReturn`
+                Right McpCatalogChange
+                    { mcpCatalogChanged = False
+                    , mcpCatalogEntry = docsEntry True
+                    }
+            formatMcpCatalogChange True McpCatalogChange
+                { mcpCatalogChanged = True
+                , mcpCatalogEntry = docsEntry True
+                }
+                `shouldBe` "Enabled MCP server docs"
+            formatMcpCatalogChange False McpCatalogChange
+                { mcpCatalogChanged = False
+                , mcpCatalogEntry = docsEntry False
+                }
+                `shouldBe` "MCP server docs is already disabled"
+
+    it "rejects unknown and empty names without rewriting config" $
+        withTempDir \home -> do
+            saveHarnessConfig home catalogConfig `shouldReturn` Right ()
+            setMcpCatalogEnabled home "missing" False
+                `shouldReturn` Left (McpCatalogNotFound "missing")
+            setMcpCatalogEnabled home "  " True
+                `shouldReturn` Left
+                    (McpCatalogInvalid "MCP server name must not be empty")
+            loadHarnessConfig home `shouldReturn` Right catalogConfig
+
+docsEntry :: Bool -> McpCatalogEntry
+docsEntry enabled =
+    McpCatalogEntry
+        { mcpCatalogName = "docs"
+        , mcpCatalogEnabled = enabled
+        , mcpCatalogUrl = Nothing
+        , mcpCatalogCommand = "mcp-docs"
+        , mcpCatalogArgs = ["--stdio"]
+        , mcpCatalogCwd = Just "/tmp"
+        , mcpCatalogEnvKeys = ["TOKEN"]
+        }
+
+remoteEntry :: McpCatalogEntry
+remoteEntry =
+    McpCatalogEntry
+        { mcpCatalogName = "remote"
+        , mcpCatalogEnabled = True
+        , mcpCatalogUrl = Just "https://example.test/mcp"
+        , mcpCatalogCommand = ""
+        , mcpCatalogArgs = []
+        , mcpCatalogCwd = Nothing
+        , mcpCatalogEnvKeys = []
+        }
+
+catalogConfig :: HarnessConfig
+catalogConfig =
+    defaultHarnessConfig
+        { configMcpServers =
+            Map.fromList
+                [ ("docs", docsServer)
+                , ("remote", remoteServer)
+                ]
+        }
+
+docsServer :: McpServerConfig
+docsServer =
+    McpServerConfig
+        { mcpEnabled = False
+        , mcpUrl = Nothing
+        , mcpCommand = "mcp-docs"
+        , mcpArgs = ["--stdio"]
+        , mcpCwd = Just "/tmp"
+        , mcpEnv = Map.singleton "TOKEN" "top-secret"
+        , mcpStartupTimeoutSeconds = 30
+        , mcpRequestTimeoutSeconds = 60
+        , mcpOAuth = Nothing
+        , mcpProtocol = McpProtocolAuto
+        , mcpRoots = False
+        , mcpSampling = False
+        , mcpLogLevel = Nothing
+        }
+
+remoteServer :: McpServerConfig
+remoteServer =
+    McpServerConfig
+        { mcpEnabled = True
+        , mcpUrl = Just "https://example.test/mcp"
+        , mcpCommand = ""
+        , mcpArgs = []
+        , mcpCwd = Nothing
+        , mcpEnv = Map.empty
+        , mcpStartupTimeoutSeconds = 30
+        , mcpRequestTimeoutSeconds = 60
+        , mcpOAuth = Nothing
+        , mcpProtocol = McpProtocolAuto
+        , mcpRoots = False
+        , mcpSampling = False
+        , mcpLogLevel = Nothing
+        }
+
+withTempDir :: (OsPath -> IO a) -> IO a
+withTempDir action = do
+    tmp <- getTemporaryDirectory
+    bracket
+        (mkdtemp (filePath tmp FilePath.</> "mcp-catalog-"))
+        Directory.removeDirectoryRecursive
+        (action . unsafeEncodeUtf)
+
+filePath :: OsPath -> FilePath
+filePath value = either (error . show) id (decodeUtf value)

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -249,6 +249,22 @@ spec = do
             parseArgs ["login"] `shouldBe` Right Login
             parseArgs ["login", "openai"] `shouldSatisfy` isLeft
 
+        it "parses MCP catalog commands" do
+            parseArgs ["mcp", "list"]
+                `shouldBe` Right (Mcp (McpList SessionHuman))
+            parseArgs ["mcp", "list", "--json"]
+                `shouldBe` Right (Mcp (McpList SessionJSON))
+            parseArgs ["mcp", "enable", "github"]
+                `shouldBe` Right (Mcp (McpEnable "github"))
+            parseArgs ["mcp", "disable", "github"]
+                `shouldBe` Right (Mcp (McpDisable "github"))
+            parseArgs ["mcp", "login", "https://example.com/mcp"]
+                `shouldBe` Right (Mcp (McpLogin "https://example.com/mcp" []))
+            parseArgs ["mcp", "enable"] `shouldSatisfy` isLeft
+            parseArgs ["mcp", "disable"] `shouldSatisfy` isLeft
+            usage `shouldContain` "agent-cli mcp list [--json]"
+            usage `shouldContain` "agent-cli mcp enable <name>"
+            usage `shouldContain` "agent-cli mcp disable <name>"
 
         it "parses session administration commands" do
             parseArgs ["sessions"]

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -62,6 +62,7 @@ import qualified Agent.CLI.InterruptSpec as InterruptSpec
 import qualified Agent.CLI.LoginSpec as LoginSpec
 import qualified Agent.CLI.LearnedSkillsSpec as LearnedSkillsSpec
 import qualified Agent.CLI.MarkdownSpec as MarkdownSpec
+import qualified Agent.CLI.McpCatalogSpec as McpCatalogSpec
 import qualified Agent.CLI.McpManagerSpec as McpManagerSpec
 import qualified Agent.CLI.McpSamplingSpec as McpSamplingSpec
 import qualified Agent.CLI.MetaConsoleSpec as MetaConsoleSpec
@@ -196,6 +197,7 @@ specs = do
     LoginSpec.spec
     LearnedSkillsSpec.spec
     MarkdownSpec.spec
+    McpCatalogSpec.spec
     McpManagerSpec.spec
     McpSamplingSpec.spec
     MetaConsoleSpec.spec


### PR DESCRIPTION
## Summary
- Add `agent-cli mcp list [--json]`, `enable <name>`, and `disable <name>` so a configured server can be toggled without an interactive `/mcp` session.
- Persist the same `enabled` field in `~/.haskell-agent/config.json` that the TUI already uses. `list` never prints environment values; enable/disable are idempotent and exit 1 for unknown names.

## Test plan
- [x] `Agent.CLI.McpCatalog` and `parseArgs` MCP catalog examples
- [ ] CI on this branch