### PR TITLE
fix(cli): quit agent sessions on confirmed Ctrl-C

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Interrupt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Interrupt.hs
@@ -1,5 +1,5 @@
 -- | Double Ctrl-C: first press soft-cancels a turn (or warns at the idle
--- prompt); a second press forces process exit with the usual --resume hint.
+-- prompt); a second press requests session exit with the usual --resume hint.
 module Agent.CLI.Interrupt
     ( InterruptState
     , CtrlCContext(..)
@@ -18,9 +18,7 @@ module Agent.CLI.Interrupt
     ) where
 
 import Agent.Cancel (CancelFlag, isCancelled, requestCancel)
-import Control.Concurrent (ThreadId, myThreadId, threadDelay, throwTo)
-import Control.Concurrent.Async (withAsync)
-import Control.Concurrent.MVar (MVar, newEmptyMVar, takeMVar, tryPutMVar)
+import Control.Concurrent (ThreadId, myThreadId, throwTo)
 import Control.Exception
     ( AsyncException(UserInterrupt)
     , fromException
@@ -38,11 +36,9 @@ import Control.Exception.Safe
     , throwIO
     )
 import Control.Monad (void)
-import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Text (Text)
 import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
-import System.Exit (ExitCode(ExitFailure))
-import System.Posix.Process (exitImmediately)
 import System.Posix.Signals
     ( Handler(..)
     , installHandler
@@ -86,16 +82,10 @@ decideCtrlC (TurnActive alreadyCancelled) _
     | otherwise = SoftCancel
 decideCtrlC Exiting _ = ForceExit
 
--- | How long a confirmed quit may spend in teardown before the process is
--- killed. Uninterruptible MCP/store joins must not outlive this window.
-exitWatchdogMicros :: Int
-exitWatchdogMicros = 5_000_000
-
 data InterruptState = InterruptState
     { interruptActiveCancel :: !(IORef (Maybe CancelFlag))
     , interruptLastWarn :: !(IORef (Maybe UTCTime))
     , interruptExiting :: !(IORef Bool)
-    , interruptKillRequest :: !(MVar ())
     , interruptOnMessage :: !(Text -> IO ())
     }
 
@@ -105,20 +95,18 @@ newInterruptState onMessage = do
     active <- newIORef Nothing
     lastWarn <- newIORef Nothing
     exiting <- newIORef False
-    killRequest <- newEmptyMVar
     pure InterruptState
         { interruptActiveCancel = active
         , interruptLastWarn = lastWarn
         , interruptExiting = exiting
-        , interruptKillRequest = killRequest
         , interruptOnMessage = onMessage
         }
 
 -- | Install SIGINT/SIGHUP/SIGTERM handlers for the dynamic extent of @action@.
 -- Restores the previous handlers afterward. Force-exit rethrows
--- 'UserInterrupt' on the thread that entered this wrapper. A second force-exit
--- (or a hung teardown after the watchdog) terminates the process so Ctrl-C
--- cannot leave an orphaned agent session.
+-- 'UserInterrupt' on the thread that entered this wrapper. This session-level
+-- handler must never terminate its host process: the owner may be GHCi or an
+-- embedded runtime, and remains responsible for releasing session resources.
 --
 -- The inline editor reads Ctrl-C directly while a prompt is active; use
 -- 'noteIdleCtrlC' from that path instead. Fullscreen raw mode uses
@@ -128,24 +116,17 @@ withCtrlCHandler state action = do
     mainTid <- myThreadId
     let sigint = Catch (onSigInt mainTid state)
         hangup = Catch (onHangup mainTid state)
-    bracket
-        (do
-            previousInt <- installHandler sigINT sigint Nothing
-            previousHup <- installHandler sigHUP hangup Nothing
-            previousTerm <- installHandler sigTERM hangup Nothing
-            pure (previousInt, previousHup, previousTerm))
-        (\(previousInt, previousHup, previousTerm) -> do
-            void (installHandler sigINT previousInt Nothing)
-            void (installHandler sigHUP previousHup Nothing)
-            void (installHandler sigTERM previousTerm Nothing))
-        (\_ ->
-            -- The watchdog is blocked on the kill latch until force-exit.
-            -- Cancelling it on the normal path is interruptible.
-            withAsync
-                (takeMVar state.interruptKillRequest
-                    >> threadDelay exitWatchdogMicros
-                    >> exitImmediately (ExitFailure 130))
-                (\_ -> action))
+    withHandler sigINT sigint $
+        withHandler sigHUP hangup $
+            withHandler sigTERM hangup action
+  where
+    -- Nest acquisition so a later installation failure also restores every
+    -- handler already installed.
+    withHandler signal handler continuation =
+        bracket
+            (installHandler signal handler Nothing)
+            (\previous -> void (installHandler signal previous Nothing))
+            (const continuation)
 
 -- | Mark @cancel@ as the in-flight turn target for soft Ctrl-C.
 withTurnCancel :: InterruptState -> CancelFlag -> IO a -> IO a
@@ -232,16 +213,11 @@ armForceExit :: InterruptState -> IO ()
 armForceExit state = do
     writeIORef state.interruptExiting True
     writeIORef state.interruptLastWarn Nothing
-    void $ tryPutMVar state.interruptKillRequest ()
 
 requestForceExit :: ThreadId -> InterruptState -> IO ()
 requestForceExit mainTid state = do
-    already <- atomicModifyIORef' state.interruptExiting \was -> (True, was)
-    writeIORef state.interruptLastWarn Nothing
-    void $ tryPutMVar state.interruptKillRequest ()
-    if already
-        then exitImmediately (ExitFailure 130)
-        else throwTo mainTid UserInterrupt
+    armForceExit state
+    throwTo mainTid UserInterrupt
 
 isWithinWarnWindow :: InterruptState -> UTCTime -> IO Bool
 isWithinWarnWindow state now = do

--- a/packages/agent-cli/src/Agent/CLI/Interrupt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Interrupt.hs
@@ -18,7 +18,9 @@ module Agent.CLI.Interrupt
     ) where
 
 import Agent.Cancel (CancelFlag, isCancelled, requestCancel)
-import Control.Concurrent (ThreadId, myThreadId, throwTo)
+import Control.Concurrent (ThreadId, myThreadId, threadDelay, throwTo)
+import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.MVar (MVar, newEmptyMVar, takeMVar, tryPutMVar)
 import Control.Exception
     ( AsyncException(UserInterrupt)
     , fromException
@@ -36,13 +38,17 @@ import Control.Exception.Safe
     , throwIO
     )
 import Control.Monad (void)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
 import Data.Text (Text)
 import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
+import System.Exit (ExitCode(ExitFailure))
+import System.Posix.Process (exitImmediately)
 import System.Posix.Signals
     ( Handler(..)
     , installHandler
+    , sigHUP
     , sigINT
+    , sigTERM
     )
 
 -- | How long after a warning a second Ctrl-C still means exit.
@@ -53,6 +59,9 @@ data CtrlCContext
     = Idle
     -- | @True@ when the active turn's cancel flag is already latched.
     | TurnActive Bool
+    -- | A confirmed quit is already in flight; further signals stay ForceExit
+    -- instead of returning to the idle warning.
+    | Exiting
     deriving (Eq, Show)
 
 data CtrlCDecision
@@ -75,10 +84,18 @@ decideCtrlC Idle withinWindow
 decideCtrlC (TurnActive alreadyCancelled) _
     | alreadyCancelled = ForceExit
     | otherwise = SoftCancel
+decideCtrlC Exiting _ = ForceExit
+
+-- | How long a confirmed quit may spend in teardown before the process is
+-- killed. Uninterruptible MCP/store joins must not outlive this window.
+exitWatchdogMicros :: Int
+exitWatchdogMicros = 5_000_000
 
 data InterruptState = InterruptState
     { interruptActiveCancel :: !(IORef (Maybe CancelFlag))
     , interruptLastWarn :: !(IORef (Maybe UTCTime))
+    , interruptExiting :: !(IORef Bool)
+    , interruptKillRequest :: !(MVar ())
     , interruptOnMessage :: !(Text -> IO ())
     }
 
@@ -87,26 +104,48 @@ newInterruptState :: (Text -> IO ()) -> IO InterruptState
 newInterruptState onMessage = do
     active <- newIORef Nothing
     lastWarn <- newIORef Nothing
+    exiting <- newIORef False
+    killRequest <- newEmptyMVar
     pure InterruptState
         { interruptActiveCancel = active
         , interruptLastWarn = lastWarn
+        , interruptExiting = exiting
+        , interruptKillRequest = killRequest
         , interruptOnMessage = onMessage
         }
 
--- | Install a SIGINT handler for the dynamic extent of @action@.
--- Restores the previous handler afterward. Force-exit rethrows
--- 'UserInterrupt' on the thread that entered this wrapper.
+-- | Install SIGINT/SIGHUP/SIGTERM handlers for the dynamic extent of @action@.
+-- Restores the previous handlers afterward. Force-exit rethrows
+-- 'UserInterrupt' on the thread that entered this wrapper. A second force-exit
+-- (or a hung teardown after the watchdog) terminates the process so Ctrl-C
+-- cannot leave an orphaned agent session.
 --
 -- The inline editor reads Ctrl-C directly while a prompt is active; use
--- 'noteIdleCtrlC' from that path instead.
+-- 'noteIdleCtrlC' from that path instead. Fullscreen raw mode uses
+-- 'noteFullscreenCtrlC'.
 withCtrlCHandler :: InterruptState -> IO a -> IO a
 withCtrlCHandler state action = do
     mainTid <- myThreadId
-    let handler = Catch (onSigInt mainTid state)
+    let sigint = Catch (onSigInt mainTid state)
+        hangup = Catch (onHangup mainTid state)
     bracket
-        (installHandler sigINT handler Nothing)
-        (\previous -> void (installHandler sigINT previous Nothing))
-        (\_ -> action)
+        (do
+            previousInt <- installHandler sigINT sigint Nothing
+            previousHup <- installHandler sigHUP hangup Nothing
+            previousTerm <- installHandler sigTERM hangup Nothing
+            pure (previousInt, previousHup, previousTerm))
+        (\(previousInt, previousHup, previousTerm) -> do
+            void (installHandler sigINT previousInt Nothing)
+            void (installHandler sigHUP previousHup Nothing)
+            void (installHandler sigTERM previousTerm Nothing))
+        (\_ ->
+            -- The watchdog is blocked on the kill latch until force-exit.
+            -- Cancelling it on the normal path is interruptible.
+            withAsync
+                (takeMVar state.interruptKillRequest
+                    >> threadDelay exitWatchdogMicros
+                    >> exitImmediately (ExitFailure 130))
+                (\_ -> action))
 
 -- | Mark @cancel@ as the in-flight turn target for soft Ctrl-C.
 withTurnCancel :: InterruptState -> CancelFlag -> IO a -> IO a
@@ -119,14 +158,15 @@ withTurnCancel state cancel =
 noteIdleCtrlC :: InterruptState -> IO IdleCtrlCResult
 noteIdleCtrlC state = do
     now <- getCurrentTime
+    context <- ctrlCContext state
     withinWindow <- isWithinWarnWindow state now
-    case decideCtrlC Idle withinWindow of
+    case decideCtrlC context withinWindow of
         WarnExit -> do
             writeIORef state.interruptLastWarn (Just now)
             notify state "Press Ctrl-C again to exit"
             pure ContinuePrompt
         ForceExit -> do
-            writeIORef state.interruptLastWarn Nothing
+            armForceExit state
             pure QuitProcess
         SoftCancel ->
             pure ContinuePrompt
@@ -138,10 +178,7 @@ noteFullscreenCtrlC state = do
     now <- getCurrentTime
     mCancel <- readIORef state.interruptActiveCancel
     withinWindow <- isWithinWarnWindow state now
-    context <- case mCancel of
-        Nothing -> pure Idle
-        Just cancel ->
-            TurnActive <$> isCancelled cancel
+    context <- ctrlCContext state
     let decision = decideCtrlC context withinWindow
     case decision of
         SoftCancel -> do
@@ -152,7 +189,7 @@ noteFullscreenCtrlC state = do
         WarnExit ->
             writeIORef state.interruptLastWarn (Just now)
         ForceExit ->
-            writeIORef state.interruptLastWarn Nothing
+            armForceExit state
     pure decision
 
 onSigInt :: ThreadId -> InterruptState -> IO ()
@@ -160,11 +197,7 @@ onSigInt mainTid state = do
     now <- getCurrentTime
     mCancel <- readIORef state.interruptActiveCancel
     withinWindow <- isWithinWarnWindow state now
-    ctx <- case mCancel of
-        Nothing -> pure Idle
-        Just cancel -> do
-            already <- isCancelled cancel
-            pure (TurnActive already)
+    ctx <- ctrlCContext state
     case decideCtrlC ctx withinWindow of
         SoftCancel -> do
             case mCancel of
@@ -175,9 +208,40 @@ onSigInt mainTid state = do
         WarnExit -> do
             writeIORef state.interruptLastWarn (Just now)
             notify state "Press Ctrl-C again to exit"
-        ForceExit -> do
-            writeIORef state.interruptLastWarn Nothing
-            throwTo mainTid UserInterrupt
+        ForceExit ->
+            requestForceExit mainTid state
+
+-- | Closing the terminal or SIGTERM is a confirmed quit: there is no second
+-- keypress, and GHCi ignores SIGHUP by default so the agent must handle it.
+onHangup :: ThreadId -> InterruptState -> IO ()
+onHangup = requestForceExit
+
+ctrlCContext :: InterruptState -> IO CtrlCContext
+ctrlCContext state = do
+    exiting <- readIORef state.interruptExiting
+    if exiting
+        then pure Exiting
+        else do
+            mCancel <- readIORef state.interruptActiveCancel
+            case mCancel of
+                Nothing -> pure Idle
+                Just cancel ->
+                    TurnActive <$> isCancelled cancel
+
+armForceExit :: InterruptState -> IO ()
+armForceExit state = do
+    writeIORef state.interruptExiting True
+    writeIORef state.interruptLastWarn Nothing
+    void $ tryPutMVar state.interruptKillRequest ()
+
+requestForceExit :: ThreadId -> InterruptState -> IO ()
+requestForceExit mainTid state = do
+    already <- atomicModifyIORef' state.interruptExiting \was -> (True, was)
+    writeIORef state.interruptLastWarn Nothing
+    void $ tryPutMVar state.interruptKillRequest ()
+    if already
+        then exitImmediately (ExitFailure 130)
+        else throwTo mainTid UserInterrupt
 
 isWithinWarnWindow :: InterruptState -> UTCTime -> IO Bool
 isWithinWarnWindow state now = do

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -269,18 +269,18 @@ continueAfterTurn
 continueAfterTurn continuation env
     | env.sessionBackground = pure RunQuit
     | otherwise = do
-    queued <- case env.sessionFullscreen of
-        Nothing -> pure False
-        Just runtime -> hasQueuedFullscreenInput runtime
-    backgroundCompletion <-
-        hasBackgroundCompletionWake env.sessionSteeringInputs
-    failedTurn <- readIORef env.sessionLastFailedTurn
-    let willWake = case env.sessionFullscreen of
-            Just _ -> backgroundCompletion && isNothing failedTurn
-            Nothing -> False
-    when (not queued && not willWake && not env.sessionBackground) $
-        notifyAttention env.sessionRender.renderStderr InputRequested
-    continuation.resumeSession env
+        queued <- case env.sessionFullscreen of
+            Nothing -> pure False
+            Just runtime -> hasQueuedFullscreenInput runtime
+        backgroundCompletion <-
+            hasBackgroundCompletionWake env.sessionSteeringInputs
+        failedTurn <- readIORef env.sessionLastFailedTurn
+        let willWake = case env.sessionFullscreen of
+                Just _ -> backgroundCompletion && isNothing failedTurn
+                Nothing -> False
+        when (not queued && not willWake) $
+            notifyAttention env.sessionRender.renderStderr InputRequested
+        continuation.resumeSession env
 
 putTrailingNewline :: RenderConfig -> IO ()
 putTrailingNewline render = do

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -56,7 +56,7 @@ import Agent.CLI.Turn (retryCheckpointedTurn, runOneTurn)
 import Agent.Tools.PlanMode (PlanModeEnv(..))
 import Agent.TUI.Model (UiEvent(..))
 import Control.Exception.Safe (throwIO)
-import Control.Monad (unless, when)
+import Control.Monad (when)
 import Data.IORef
     ( readIORef
     , writeIORef
@@ -170,14 +170,14 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
         case env.sessionFullscreen of
             Nothing -> putTrailingNewline env.sessionRender
             Just _ -> pure ()
-        if exitAfter
+        if shouldQuitAfterTurn env exitAfter
             then pure RunQuit
             else continueAfterTurn continuation env
     TurnCancelled -> do
         case env.sessionFullscreen of
             Nothing -> putTrailingNewline env.sessionRender
             Just _ -> pure ()
-        if exitAfter
+        if shouldQuitAfterTurn env exitAfter
             then pure RunQuit
             else continuation.resumeSession env
     TurnFailed pending -> do
@@ -245,20 +245,30 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
                                             (StartupFailure
                                                 "agent provider unavailable")
                                         else exitFailure
-                                else do
-                                    unless env.sessionBackground $
+                                else if env.sessionBackground
+                                    then pure RunQuit
+                                    else do
                                         notifyAttention
                                             env.sessionRender.renderStderr
                                             InputRequested
-                                    continuation.resumeSessionWithDraft
-                                        env
-                                        pending.pendingPromptText
+                                        continuation.resumeSessionWithDraft
+                                            env
+                                            pending.pendingPromptText
+
+-- | One-shot and in-process background turns must not fall through to the
+-- interactive REPL. Background sessions share the parent's stdin, so a stray
+-- prompt would steal the TTY and ignore Ctrl-C installed on the child path.
+shouldQuitAfterTurn :: SessionEnv -> Bool -> Bool
+shouldQuitAfterTurn env exitAfter =
+    exitAfter || env.sessionBackground
 
 continueAfterTurn
     :: SessionContinuation
     -> SessionEnv
     -> IO RunResult
-continueAfterTurn continuation env = do
+continueAfterTurn continuation env
+    | env.sessionBackground = pure RunQuit
+    | otherwise = do
     queued <- case env.sessionFullscreen of
         Nothing -> pure False
         Just runtime -> hasQueuedFullscreenInput runtime

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -1783,6 +1783,10 @@ runSessionInteraction
                                 , isNothing host.hostInitialPrevious ->
                                     runInteractiveInitialPrompt
                                         onboardingPrompt
+                            _ | startup.startupBackground ->
+                                -- Background turns are one-shot. Do not inherit
+                                -- the parent's stdin by opening an idle REPL.
+                                pure RunQuit
                             _ ->
                                 readIORef
                                     startup.startupSessionState.sessionDraft

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -26,6 +26,8 @@ module Agent.CLI.TUI.App
     , drawTranscriptChunks
     , elapsedMillisSince
     , appEventLogicalBytes
+    , closeAppEventMailbox
+    , closeFullscreenChannels
     , emitUiEvent
     , enqueueAppEvent
     , externalUrlCommand
@@ -79,6 +81,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenSecret
     , requestFullscreenText
     , runFullscreen
+    , withFullscreenWorker
     , commitFullscreenImagePreviews
     , commitFullscreenHistoryTurn
     , beginFullscreenLiveHistory

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -1492,5 +1492,7 @@ handleCtrlC = do
                         warningNotice
                             "Press Ctrl-C again to exit."
         ForceExit ->
-            liftIO (throwIO UserInterrupt)
+            -- Halt Brick so runFullscreen can EOF the worker. Throwing from
+            -- EventM skips the bounded worker join and can leave GHCi stuck.
+            halt
     pure decision

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -1492,7 +1492,7 @@ handleCtrlC = do
                         warningNotice
                             "Press Ctrl-C again to exit."
         ForceExit ->
-            -- Halt Brick so runFullscreen can EOF the worker. Throwing from
-            -- EventM skips the bounded worker join and can leave GHCi stuck.
+            -- Halt Brick so its owner can close the input and output channels
+            -- before joining the session worker.
             halt
     pure decision

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -286,49 +286,64 @@ appEventMailboxTextChunkCodeUnits :: Int
 appEventMailboxTextChunkCodeUnits =
     (appEventMailboxPayloadBudgetBytes - 64) `div` 4
 
+-- | Retire display output before joining session workers. Closing never waits
+-- for capacity, releases retained display data, and wakes producers that may
+-- be publishing from masked finalizers after Brick has stopped consuming.
+-- This is terminal: a subsequent fullscreen run requires a new runtime.
+closeAppEventMailbox :: AppEventMailbox -> STM ()
+closeAppEventMailbox (AppEventMailbox stateRef) = do
+    state <- readTVar stateRef
+    writeTVar stateRef state
+        { mailboxClosed = True
+        , mailboxPendingEvents = Seq.empty
+        , mailboxPendingCount = 0
+        , mailboxPendingBytes = 0
+        }
+
 enqueueMailboxEvent :: AppEventMailbox -> AppEvent -> STM ()
 enqueueMailboxEvent (AppEventMailbox stateRef) event = do
     state <- readTVar stateRef
-    let (pending, payloadBytes) =
-            appendAppEventAccounted
-                event
-                state.mailboxPendingEvents
-                state.mailboxPendingBytes
-        count = Seq.length pending
-        control = isControlAppEvent event
-        countLimit =
-            appEventMailboxCapacity
-                + if control then appEventMailboxControlReserve else 0
-        byteLimit =
-            appEventMailboxPayloadBudgetBytes
-                + if control then appEventMailboxControlReserveBytes else 0
-        -- An indivisible event may itself exceed the budget. Refusing that
-        -- first event would retry forever even though the mailbox is empty;
-        -- admitting exactly one lets the consumer make progress while still
-        -- preventing any additional payload from accumulating behind it.
-        firstOversizedSingleton =
-            Seq.null state.mailboxPendingEvents
-                && count == 1
-        oversizedKeyedReplacement =
-            Seq.length state.mailboxPendingEvents == 1
-                && count == 1
-                && isJust (appEventCoalesceKey event)
-    check
-        ( count <= countLimit
-            && ( payloadBytes <= byteLimit
-                || firstOversizedSingleton
-                || oversizedKeyedReplacement
-               )
-        )
-    writeTVar stateRef state
-        { mailboxPendingEvents = pending
-        , mailboxPendingCount = count
-        , mailboxPendingBytes = payloadBytes
-        , mailboxHighWaterCount =
-            max state.mailboxHighWaterCount count
-        , mailboxHighWaterBytes =
-            max state.mailboxHighWaterBytes payloadBytes
-        }
+    unless state.mailboxClosed do
+        let (pending, payloadBytes) =
+                appendAppEventAccounted
+                    event
+                    state.mailboxPendingEvents
+                    state.mailboxPendingBytes
+            count = Seq.length pending
+            control = isControlAppEvent event
+            countLimit =
+                appEventMailboxCapacity
+                    + if control then appEventMailboxControlReserve else 0
+            byteLimit =
+                appEventMailboxPayloadBudgetBytes
+                    + if control then appEventMailboxControlReserveBytes else 0
+            -- An indivisible event may itself exceed the budget. Refusing that
+            -- first event would retry forever even though the mailbox is empty;
+            -- admitting exactly one lets the consumer make progress while still
+            -- preventing any additional payload from accumulating behind it.
+            firstOversizedSingleton =
+                Seq.null state.mailboxPendingEvents
+                    && count == 1
+            oversizedKeyedReplacement =
+                Seq.length state.mailboxPendingEvents == 1
+                    && count == 1
+                    && isJust (appEventCoalesceKey event)
+        check
+            ( count <= countLimit
+                && ( payloadBytes <= byteLimit
+                    || firstOversizedSingleton
+                    || oversizedKeyedReplacement
+                   )
+            )
+        writeTVar stateRef state
+            { mailboxPendingEvents = pending
+            , mailboxPendingCount = count
+            , mailboxPendingBytes = payloadBytes
+            , mailboxHighWaterCount =
+                max state.mailboxHighWaterCount count
+            , mailboxHighWaterBytes =
+                max state.mailboxHighWaterBytes payloadBytes
+            }
 
 appendAppEventAccounted
     :: AppEvent

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
@@ -1005,5 +1005,5 @@ handleCtrlC = do
             Just $ warningNotice "Interrupted; press Ctrl-C again to exit."
         WarnExit -> applyLocalUiEvent $ UiSetNotice $
             Just $ warningNotice "Press Ctrl-C again to exit."
-        ForceExit -> liftIO (throwIO UserInterrupt)
+        ForceExit -> halt
     pure decision

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -1080,5 +1080,5 @@ handleCtrlC = do
         WarnExit ->
             applyLocalUiEvent $ UiSetNotice $
                 Just $ warningNotice "Press Ctrl-C again to exit."
-        ForceExit -> liftIO (throwIO UserInterrupt)
+        ForceExit -> halt
     pure decision

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -24,11 +24,7 @@ import Agent.CLI.AgentViewport ( AgentEntry(..)
     , agentStatusGlyph
     , lookupAgentEntry
     )
-import Agent.CLI.Interrupt
-    ( CtrlCDecision(..)
-    , catchUserInterrupt
-    , isWrappedUserInterrupt
-    )
+import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.ImagePreview ( ImagePreviewProtocol(..)
     , detectImagePreviewProtocol
     , kittyDeleteImageSequence
@@ -143,24 +139,20 @@ import Codec.Picture (pixelAt)
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async
     ( Async
-    , AsyncCancelled(..)
-    , asyncThreadId
-    , asyncWithUnmask
+    , poll
+    , wait
     , waitCatch
     , withAsync
+    , withAsyncWithUnmask
     )
-import Control.Concurrent (threadDelay, throwTo)
+import Control.Concurrent (threadDelay)
 import Control.Monad (forever, unless, void, when, (>=>))
 import Control.Concurrent.STM ( STM , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , writeTQueue , writeTVar )
 import Agent.CLI.Recap ( autoRecapAwayThreshold , autoRecapIdleThreshold , autoRecapRetryInterval )
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
-import Control.Exception.Safe (SomeException, finally, mask, onException, throwIO, tryAny)
-import Control.Exception
-    ( AsyncException(UserInterrupt)
-    , fromException
-    , toException
-    )
+import Control.Exception.Safe (finally, onException, throwIO, tryAny)
+import Control.Exception (AsyncException(UserInterrupt))
 import Data.Char (isControl, isSpace)
 import Data.Foldable (toList)
 import Data.IORef ( atomicModifyIORef' , modifyIORef' , newIORef , readIORef , writeIORef )
@@ -191,6 +183,32 @@ import Agent.CLI.TUI.App.Runtime
 import Agent.CLI.TUI.App.Mailbox
 import Agent.CLI.TUI.App.History
 import Agent.CLI.TUI.App.Event
+
+-- | The UI owns the session worker until it has terminated, including when
+-- the UI fails. Closing input is a nonblocking, idempotent operation, not an
+-- EOF insertion into the bounded prompt queue.
+--
+-- The grace interval bounds cooperative shutdown only. If it expires, scope
+-- exit cancels and joins the worker; we never abandon it or kill the host
+-- process. Resource finalizers must themselves provide interruptible cleanup.
+withFullscreenWorker :: (Async a -> IO ()) -> IO a -> (Async a -> IO ()) -> IO a
+withFullscreenWorker closeChannels workerAction runUi =
+    withAsyncWithUnmask (\unmask -> unmask workerAction) \worker -> do
+        runUi worker `finally` closeChannels worker
+        timeout 2_000_000 (wait worker) >>= \case
+            Just result -> pure result
+            Nothing -> throwIO UserInterrupt
+
+closeFullscreenChannels :: FullscreenRuntime -> Async a -> IO ()
+closeFullscreenChannels runtime worker = do
+    workerResult <- poll worker
+    atomically do
+        closeAppEventMailbox runtime.runtimeMailbox
+        -- Completed workers may return a session/provider transition. The
+        -- outer flow reuses their input buffer, including queued prompts.
+        case workerResult of
+            Nothing -> Composer.closeFullscreenInputBuffer runtime.runtimeInput
+            Just _ -> pure ()
 
 runFullscreen :: FullscreenRuntime -> IO a -> IO a
 runFullscreen runtime workerAction = do
@@ -245,29 +263,18 @@ runFullscreen runtime workerAction = do
             writeTVar
                 runtime.runtimeMotionSchedule
                 (initialDemand, initialDelay, 0)
-        -- Own the worker explicitly: withAsync's exception path waits
-        -- unbounded for cancellation, which is how Ctrl-C left GHCi sessions
-        -- stuck after the TUI had already died.
-        mask \restore -> do
-            worker <- asyncWithUnmask \unmask -> unmask workerAction
-            interrupted <- restore $
-                catchUserInterrupt
-                    (runFullscreenUi
-                        runtime
-                        worker
-                        initialVty
-                        buildVty
-                        initialState
-                        initialAgent
-                        initialAgents
-                        >> pure False)
-                    (pure True)
-            shutdownFullscreenWorker runtime worker >>= \case
-                Right value -> pure value
-                Left err
-                    | interrupted || isFullscreenQuitException err ->
-                        throwIO UserInterrupt
-                    | otherwise -> throwIO err
+        withFullscreenWorker
+            (closeFullscreenChannels runtime)
+            workerAction
+            \worker ->
+                runFullscreenUi
+                    runtime
+                    worker
+                    initialVty
+                    buildVty
+                    initialState
+                    initialAgent
+                    initialAgents
   where
     runFullscreenUi
             runtime worker initialVty buildVty initialState
@@ -297,45 +304,11 @@ runFullscreen runtime workerAction = do
                                                     fullscreenApp
                                                     initialState
                                                 `finally`
-                                                    runtime.runtimeNativeProgress False
+                                                    (closeFullscreenChannels runtime worker
+                                                        >> runtime.runtimeNativeProgress False)
                                             mapM_
                                                 (`Composer.requestDictationStop` True)
                                                 finalState.appDictation
-                                            when (not finalState.appWorkerStopped) $
-                                                enqueueFullscreenEof runtime
-
-    enqueueFullscreenEof currentRuntime =
-        void $ atomically $
-            Composer.appendFullscreenInput
-                currentRuntime.runtimeInput
-                FullscreenInput
-                    { fullscreenInputLine = ReplEof
-                    , fullscreenInputQueued = False
-                    , fullscreenInputDisplay = Nothing
-                    }
-
-    shutdownFullscreenWorker currentRuntime worker = do
-        enqueueFullscreenEof currentRuntime
-        waitCatchWithTimeout worker >>= \case
-            Just result -> pure result
-            Nothing -> do
-                throwTo (asyncThreadId worker) AsyncCancelled
-                waitCatchWithTimeout worker >>= \case
-                    Just result -> pure result
-                    Nothing ->
-                        pure (Left (toException UserInterrupt))
-
-    waitCatchWithTimeout worker =
-        timeout fullscreenWorkerJoinMicros (waitCatch worker)
-
-    fullscreenWorkerJoinMicros = 2_000_000
-
-    isFullscreenQuitException err =
-        isJust (fromException err :: Maybe AsyncCancelled)
-            || case fromException err of
-                Just UserInterrupt -> True
-                _ -> isWrappedUserInterrupt err
-
     recapTicker _runtime = forever do
         threadDelay 20_000_000
         enqueueAppEvent runtime AppRecapPoll

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -24,7 +24,11 @@ import Agent.CLI.AgentViewport ( AgentEntry(..)
     , agentStatusGlyph
     , lookupAgentEntry
     )
-import Agent.CLI.Interrupt (CtrlCDecision(..))
+import Agent.CLI.Interrupt
+    ( CtrlCDecision(..)
+    , catchUserInterrupt
+    , isWrappedUserInterrupt
+    )
 import Agent.CLI.ImagePreview ( ImagePreviewProtocol(..)
     , detectImagePreviewProtocol
     , kittyDeleteImageSequence
@@ -137,15 +141,26 @@ import Brick.Widgets.Border.Style (unicodeRounded)
 import Brick.Widgets.Center (center, centerLayer, hCenter)
 import Codec.Picture (pixelAt)
 import Control.Applicative ((<|>))
-import Control.Concurrent.Async (wait, waitCatch, withAsync)
-import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async
+    ( Async
+    , AsyncCancelled(..)
+    , asyncThreadId
+    , asyncWithUnmask
+    , waitCatch
+    , withAsync
+    )
+import Control.Concurrent (threadDelay, throwTo)
 import Control.Monad (forever, unless, void, when, (>=>))
 import Control.Concurrent.STM ( STM , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , writeTQueue , writeTVar )
 import Agent.CLI.Recap ( autoRecapAwayThreshold , autoRecapIdleThreshold , autoRecapRetryInterval )
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
-import Control.Exception.Safe (finally, mask, onException, throwIO, tryAny)
-import Control.Exception (AsyncException(UserInterrupt))
+import Control.Exception.Safe (SomeException, finally, mask, onException, throwIO, tryAny)
+import Control.Exception
+    ( AsyncException(UserInterrupt)
+    , fromException
+    , toException
+    )
 import Data.Char (isControl, isSpace)
 import Data.Foldable (toList)
 import Data.IORef ( atomicModifyIORef' , modifyIORef' , newIORef , readIORef , writeIORef )
@@ -153,6 +168,7 @@ import Data.List ( find , findIndex , intersperse , nub , sort , sortOn )
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isJust, isNothing, mapMaybe, maybeToList)
+import System.Timeout (timeout)
 import Data.Sequence (Seq, ViewL(..), ViewR(..), (|>))
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
@@ -229,55 +245,97 @@ runFullscreen runtime workerAction = do
             writeTVar
                 runtime.runtimeMotionSchedule
                 (initialDemand, initialDelay, 0)
-        withAsync workerAction \worker ->
-            withAsync uiTicker \_uiTicker ->
-                withAsync (agentTicker (initialAgent, initialAgents)) \_agentTicker ->
-                    withAsync (eventPump runtime) \_eventPump ->
-                        withAsync (recapTicker runtime) \_recapTicker ->
-                            withAsync
-                                historyLoader
-                                \_historyLoader ->
-                                withAsync
-                                    dictationWorker
-                                    \_dictationWorker ->
-                                    withAsync
-                                        (runSyntaxHighlighterForRuntime runtime)
-                                        \_syntaxLoader ->
-                                            withAsync
-                                                (void (waitCatch worker)
-                                                    >> enqueueAppEvent runtime AppStop)
-                                                \_notifier -> do
-                                                    finalState <-
-                                                        customMain
-                                                            initialVty
-                                                            buildVty
-                                                            (Just runtime.runtimeEvents)
-                                                            fullscreenApp
-                                                            initialState
-                                                        `finally`
-                                                            runtime.runtimeNativeProgress False
-                                                    mapM_
-                                                        (`Composer.requestDictationStop` True)
-                                                        finalState.appDictation
-                                                    when (not finalState.appWorkerStopped) $
-                                                        atomically do
-                                                            queued <-
-                                                                Composer.appendFullscreenInput
-                                                                    runtime.runtimeInput
-                                                                    FullscreenInput
-                                                                        { fullscreenInputLine =
-                                                                            ReplEof
-                                                                        , fullscreenInputQueued =
-                                                                            False
-                                                                        , fullscreenInputDisplay =
-                                                                            Nothing
-                                                                        }
-                                                            either
-                                                                (const retry)
-                                                                pure
-                                                                queued
-                                                    wait worker
+        -- Own the worker explicitly: withAsync's exception path waits
+        -- unbounded for cancellation, which is how Ctrl-C left GHCi sessions
+        -- stuck after the TUI had already died.
+        mask \restore -> do
+            worker <- asyncWithUnmask \unmask -> unmask workerAction
+            interrupted <- restore $
+                catchUserInterrupt
+                    (runFullscreenUi
+                        runtime
+                        worker
+                        initialVty
+                        buildVty
+                        initialState
+                        initialAgent
+                        initialAgents
+                        >> pure False)
+                    (pure True)
+            shutdownFullscreenWorker runtime worker >>= \case
+                Right value -> pure value
+                Left err
+                    | interrupted || isFullscreenQuitException err ->
+                        throwIO UserInterrupt
+                    | otherwise -> throwIO err
   where
+    runFullscreenUi
+            runtime worker initialVty buildVty initialState
+            initialAgent initialAgents =
+        withAsync uiTicker \_uiTicker ->
+            withAsync (agentTicker (initialAgent, initialAgents)) \_agentTicker ->
+                withAsync (eventPump runtime) \_eventPump ->
+                    withAsync (recapTicker runtime) \_recapTicker ->
+                        withAsync
+                            historyLoader
+                            \_historyLoader ->
+                            withAsync
+                                dictationWorker
+                                \_dictationWorker ->
+                                withAsync
+                                    (runSyntaxHighlighterForRuntime runtime)
+                                    \_syntaxLoader ->
+                                    withAsync
+                                        (void (waitCatch worker)
+                                            >> enqueueAppEvent runtime AppStop)
+                                        \_notifier -> do
+                                            finalState <-
+                                                customMain
+                                                    initialVty
+                                                    buildVty
+                                                    (Just runtime.runtimeEvents)
+                                                    fullscreenApp
+                                                    initialState
+                                                `finally`
+                                                    runtime.runtimeNativeProgress False
+                                            mapM_
+                                                (`Composer.requestDictationStop` True)
+                                                finalState.appDictation
+                                            when (not finalState.appWorkerStopped) $
+                                                enqueueFullscreenEof runtime
+
+    enqueueFullscreenEof currentRuntime =
+        void $ atomically $
+            Composer.appendFullscreenInput
+                currentRuntime.runtimeInput
+                FullscreenInput
+                    { fullscreenInputLine = ReplEof
+                    , fullscreenInputQueued = False
+                    , fullscreenInputDisplay = Nothing
+                    }
+
+    shutdownFullscreenWorker currentRuntime worker = do
+        enqueueFullscreenEof currentRuntime
+        waitCatchWithTimeout worker >>= \case
+            Just result -> pure result
+            Nothing -> do
+                throwTo (asyncThreadId worker) AsyncCancelled
+                waitCatchWithTimeout worker >>= \case
+                    Just result -> pure result
+                    Nothing ->
+                        pure (Left (toException UserInterrupt))
+
+    waitCatchWithTimeout worker =
+        timeout fullscreenWorkerJoinMicros (waitCatch worker)
+
+    fullscreenWorkerJoinMicros = 2_000_000
+
+    isFullscreenQuitException err =
+        isJust (fromException err :: Maybe AsyncCancelled)
+            || case fromException err of
+                Just UserInterrupt -> True
+                _ -> isWrappedUserInterrupt err
+
     recapTicker _runtime = forever do
         threadDelay 20_000_000
         enqueueAppEvent runtime AppRecapPoll

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -292,7 +292,8 @@ newFullscreenRuntimeWithSyntaxLoaderAndTheme
     initial = do
         events <- newBChan appEventChannelCapacity
         mailbox <- AppEventMailbox <$> newTVarIO AppEventMailboxState
-            { mailboxPendingEvents = Seq.empty
+            { mailboxClosed = False
+            , mailboxPendingEvents = Seq.empty
             , mailboxPendingCount = 0
             , mailboxPendingBytes = 0
             , mailboxHighWaterCount = 0

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -4,6 +4,7 @@ module Agent.CLI.TUI.Composer
     , KillDirection(..)
     , activateSlashAt
     , appendFullscreenInput
+    , closeFullscreenInputBuffer
     , applyComposerUiEvent
     , combineKill
     , composerEscapeAction

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Buffer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Buffer.hs
@@ -1,6 +1,7 @@
 -- | Buffered input submitted through the fullscreen composer.
 module Agent.CLI.TUI.Composer.Buffer
     ( appendFullscreenInput
+    , closeFullscreenInputBuffer
     , fullscreenInputByteLimit
     , fullscreenInputCountLimit
     , newFullscreenInputBuffer
@@ -44,6 +45,16 @@ newFullscreenInputBuffer :: IO FullscreenInputBuffer
 newFullscreenInputBuffer = FullscreenInputBuffer
     <$> newTVarIO Seq.empty
     <*> newTVarIO 0
+    <*> newTVarIO False
+
+-- | End input independently of queue capacity. Pending prompts are discarded:
+-- once shutdown is requested, no additional turn should start. Closing is
+-- idempotent and wakes readers blocked on an empty buffer.
+closeFullscreenInputBuffer :: FullscreenInputBuffer -> STM ()
+closeFullscreenInputBuffer (FullscreenInputBuffer inputs retainedBytes closed) = do
+    writeTVar closed True
+    writeTVar inputs Seq.empty
+    writeTVar retainedBytes 0
 
 queuedFullscreenInputDisplays
     :: FullscreenInputBuffer
@@ -61,25 +72,28 @@ queuedFullscreenInputDisplays inputBuffer =
 readFullscreenInputs
     :: FullscreenInputBuffer
     -> STM (Seq FullscreenInput)
-readFullscreenInputs (FullscreenInputBuffer inputs _) =
+readFullscreenInputs (FullscreenInputBuffer inputs _ _) =
     readTVar inputs
 
 appendFullscreenInput
     :: FullscreenInputBuffer
     -> FullscreenInput
     -> STM (Either Text ())
-appendFullscreenInput (FullscreenInputBuffer inputs retainedBytes) input = do
+appendFullscreenInput (FullscreenInputBuffer inputs retainedBytes closed) input = do
+    isClosed <- readTVar closed
     queued <- readTVar inputs
     bytes <- readTVar retainedBytes
     let inputBytes = fullscreenInputBytes input
         nextBytes = bytes `saturatingAdd` inputBytes
-    if Seq.length queued >= fullscreenInputCountLimit
-            || nextBytes > fullscreenInputByteLimit
-        then pure (Left fullscreenQueueFullMessage)
-        else do
-            writeTVar inputs (queued Seq.|> input)
-            writeTVar retainedBytes nextBytes
-            pure (Right ())
+    if isClosed
+        then pure (Left fullscreenInputClosedMessage)
+        else if Seq.length queued >= fullscreenInputCountLimit
+                || nextBytes > fullscreenInputByteLimit
+            then pure (Left fullscreenQueueFullMessage)
+            else do
+                writeTVar inputs (queued Seq.|> input)
+                writeTVar retainedBytes nextBytes
+                pure (Right ())
 
 -- | Put an interruptive prompt ahead of already queued prompts. Clipboard
 -- actions entered after the last submitted prompt belong to the current draft,
@@ -88,20 +102,23 @@ promoteFullscreenInput
     :: FullscreenInputBuffer
     -> FullscreenInput
     -> STM (Either Text ())
-promoteFullscreenInput (FullscreenInputBuffer inputs retainedBytes) input = do
+promoteFullscreenInput (FullscreenInputBuffer inputs retainedBytes closed) input = do
+    isClosed <- readTVar closed
     queued <- readTVar inputs
     bytes <- readTVar retainedBytes
     let inputBytes = fullscreenInputBytes input
         nextBytes = bytes `saturatingAdd` inputBytes
-    if Seq.length queued >= fullscreenInputCountLimit
-            || nextBytes > fullscreenInputByteLimit
-        then pure (Left fullscreenQueueFullMessage)
-        else do
-            let (remaining, prelude) = splitTrailingPromptPrelude queued
-            writeTVar inputs $
-                prelude Seq.>< Seq.singleton input Seq.>< remaining
-            writeTVar retainedBytes nextBytes
-            pure (Right ())
+    if isClosed
+        then pure (Left fullscreenInputClosedMessage)
+        else if Seq.length queued >= fullscreenInputCountLimit
+                || nextBytes > fullscreenInputByteLimit
+            then pure (Left fullscreenQueueFullMessage)
+            else do
+                let (remaining, prelude) = splitTrailingPromptPrelude queued
+                writeTVar inputs $
+                    prelude Seq.>< Seq.singleton input Seq.>< remaining
+                writeTVar retainedBytes nextBytes
+                pure (Right ())
 
 splitTrailingPromptPrelude
     :: Seq FullscreenInput
@@ -125,16 +142,23 @@ isPromptPrelude input =
 takeFullscreenInput
     :: FullscreenInputBuffer
     -> STM FullscreenInput
-takeFullscreenInput (FullscreenInputBuffer inputs retainedBytes) = do
+takeFullscreenInput (FullscreenInputBuffer inputs retainedBytes closed) = do
+    isClosed <- readTVar closed
     queued <- readTVar inputs
-    case Seq.viewl queued of
-        EmptyL -> retry
-        input :< rest -> do
-            writeTVar inputs rest
-            bytes <- readTVar retainedBytes
-            writeTVar retainedBytes
-                (max 0 (bytes - fullscreenInputBytes input))
-            pure input
+    if isClosed
+        then pure FullscreenInput
+            { fullscreenInputLine = ReplEof
+            , fullscreenInputQueued = False
+            , fullscreenInputDisplay = Nothing
+            }
+        else case Seq.viewl queued of
+            EmptyL -> retry
+            input :< rest -> do
+                writeTVar inputs rest
+                bytes <- readTVar retainedBytes
+                writeTVar retainedBytes
+                    (max 0 (bytes - fullscreenInputBytes input))
+                pure input
 
 -- | Prefer a prompt that has already been queued over a simultaneous
 -- session-level wakeup, so provider restarts cannot consume and lose Enter.
@@ -157,3 +181,7 @@ fullscreenInputBytes input =
 fullscreenQueueFullMessage :: Text
 fullscreenQueueFullMessage =
     "Prompt queue is full; wait for a queued prompt to be consumed."
+
+fullscreenInputClosedMessage :: Text
+fullscreenInputClosedMessage =
+    "Prompt input is closed."

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -217,7 +217,8 @@ data PendingUiEvent
     | PendingReasoningDeltas !(Seq Text)
 
 data AppEventMailboxState = AppEventMailboxState
-    { mailboxPendingEvents :: !(Seq PendingAppEvent)
+    { mailboxClosed :: !Bool
+    , mailboxPendingEvents :: !(Seq PendingAppEvent)
     , mailboxPendingCount :: !Int
     , mailboxPendingBytes :: !Int
     , mailboxHighWaterCount :: !Int
@@ -248,6 +249,7 @@ data FullscreenInputBuffer =
     FullscreenInputBuffer
         !(TVar (Seq FullscreenInput))
         !(TVar Int)
+        !(TVar Bool)
 
 data FullscreenHistorySource = FullscreenHistorySource
     { historySourceKey :: !Text

--- a/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
@@ -3,8 +3,10 @@ module Agent.CLI.InterruptSpec (spec) where
 import Agent.CLI.Interrupt
 import qualified Control.Exception as Base
 import Control.Exception (AsyncException(ThreadKilled, UserInterrupt))
-import Control.Exception.Safe (finally, throwIO, toSyncException)
+import Control.Exception.Safe (bracket, finally, throwIO, toSyncException)
+import Control.Monad (forM_, void)
 import Data.IORef
+import System.Posix.Signals (Handler(..), Signal, installHandler, sigHUP, sigINT, sigTERM)
 import Test.Hspec
 
 spec :: Spec
@@ -40,6 +42,43 @@ spec = do
             noteFullscreenCtrlC state `shouldReturn` WarnExit
             noteFullscreenCtrlC state `shouldReturn` ForceExit
             noteFullscreenCtrlC state `shouldReturn` ForceExit
+
+    describe "withCtrlCHandler" do
+        it "keeps repeated confirmed interrupts within the session boundary" do
+            state <- newInterruptState (const (pure ()))
+            withCtrlCHandler state do
+                noteIdleCtrlC state `shouldReturn` ContinuePrompt
+                noteIdleCtrlC state `shouldReturn` QuitProcess
+                forM_ [1 :: Int, 2] \_ ->
+                    catchUserInterrupt
+                        (invokeInstalledHandler sigINT >> pure False)
+                        (pure True)
+                        `shouldReturn` True
+
+        it "treats hangup and termination as confirmed session quit" do
+            forM_ [sigHUP, sigTERM] \signal -> do
+                state <- newInterruptState (const (pure ()))
+                catchUserInterrupt
+                    (withCtrlCHandler state
+                        (invokeInstalledHandler signal >> pure False))
+                    (pure True)
+                    `shouldReturn` True
+                noteIdleCtrlC state `shouldReturn` QuitProcess
+
+        it "restores previous signal handlers after an exceptional session exit" do
+            forM_ [sigINT, sigHUP, sigTERM] \signal -> do
+                restored <- newIORef False
+                bracket
+                    (installHandler signal
+                        (Catch (writeIORef restored True)) Nothing)
+                    (\previous -> void (installHandler signal previous Nothing))
+                    \_ -> do
+                        state <- newInterruptState (const (pure ()))
+                        catchUserInterrupt
+                            (withCtrlCHandler state (Base.throwIO UserInterrupt))
+                            (pure ())
+                        invokeInstalledHandler signal
+                        readIORef restored `shouldReturn` True
 
     describe "isWrappedUserInterrupt" do
         it "recognizes a synchronously wrapped UserInterrupt" do
@@ -96,3 +135,15 @@ spec = do
                     >> Base.throwIO UserInterrupt)
                 `shouldThrow` (== UserInterrupt)
             readIORef attempts `shouldReturn` 2
+
+-- Invoke the installed callback directly rather than deliver a process-wide
+-- signal to the test runner or GHCi. The callback still targets the session's
+-- owning thread, exercising the same exception path as the signal dispatcher.
+invokeInstalledHandler :: Signal -> IO ()
+invokeInstalledHandler signal =
+    bracket
+        (installHandler signal Ignore Nothing)
+        (\previous -> void (installHandler signal previous Nothing))
+        \case
+            Catch handler -> handler
+            _ -> expectationFailure "Expected a session signal handler"

--- a/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
@@ -23,6 +23,24 @@ spec = do
         it "force-exits when Ctrl-C arrives after the turn is already cancelled" do
             decideCtrlC (TurnActive True) False `shouldBe` ForceExit
 
+        it "stays on force-exit once a confirmed quit is in flight" do
+            decideCtrlC Exiting False `shouldBe` ForceExit
+            decideCtrlC Exiting True `shouldBe` ForceExit
+
+    describe "noteIdleCtrlC" do
+        it "keeps quitting after the first confirmed idle Ctrl-C" do
+            state <- newInterruptState (const (pure ()))
+            noteIdleCtrlC state `shouldReturn` ContinuePrompt
+            noteIdleCtrlC state `shouldReturn` QuitProcess
+            noteIdleCtrlC state `shouldReturn` QuitProcess
+
+    describe "noteFullscreenCtrlC" do
+        it "keeps force-exiting after a confirmed fullscreen quit" do
+            state <- newInterruptState (const (pure ()))
+            noteFullscreenCtrlC state `shouldReturn` WarnExit
+            noteFullscreenCtrlC state `shouldReturn` ForceExit
+            noteFullscreenCtrlC state `shouldReturn` ForceExit
+
     describe "isWrappedUserInterrupt" do
         it "recognizes a synchronously wrapped UserInterrupt" do
             isWrappedUserInterrupt (toSyncException UserInterrupt) `shouldBe` True

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -9,7 +9,7 @@ import Agent.CLI.AgentViewport
     , AgentTarget(..)
     )
 import Agent.CLI.Input (ReplLine(..), terminalTextWidth)
-import Agent.CLI.Interrupt (CtrlCDecision(..))
+import Agent.CLI.Interrupt (CtrlCDecision(..), catchUserInterrupt)
 import Agent.CLI.Command
     ( SlashCatalog(..)
     , defaultSlashCatalog
@@ -20,6 +20,8 @@ import Agent.CLI.Resume
     )
 import Agent.CLI.TUI.App
     ( applyStoredFullscreenWindowTitle
+    , closeFullscreenChannels
+    , withFullscreenWorker
     , applyMetaConsoleEdit
     , applyTextPromptEdit
     , adjustChoiceValue
@@ -152,7 +154,11 @@ import Agent.TUI.Presentation
     , TodoDisplayStatus(..)
     )
 import Agent.TUI.Motion
-import Control.Concurrent (newEmptyMVar)
+import Control.Concurrent (newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent.Async (waitCatch)
+import Control.Exception.Safe (bracket_)
+import Control.Exception (AsyncException(UserInterrupt))
+import qualified Control.Exception as Exception
 import Control.Concurrent.STM
     ( atomically
     , newEmptyTMVarIO
@@ -160,7 +166,7 @@ import Control.Concurrent.STM
     , retry
     , tryReadTMVar
     )
-import Control.Monad (replicateM_)
+import Control.Monad (replicateM_, void)
 import qualified Data.ByteString as ByteString
 import Data.Foldable (find, toList)
 import Data.IORef
@@ -188,6 +194,119 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "fullscreen worker ownership" do
+        it "closes input and preserves a cooperative worker result" do
+            closed <- newEmptyMVar
+            timeout 1_000_000
+                (withFullscreenWorker
+                    (const (putMVar closed ()))
+                    (takeMVar closed >> pure (42 :: Int))
+                    (const (pure ())))
+                `shouldReturn` Just 42
+
+        it "closes input and joins the worker when the UI fails" do
+            started <- newEmptyMVar
+            blocked <- newEmptyMVar
+            closed <- newIORef False
+            stopped <- newIORef False
+            let worker =
+                    bracket_
+                        (putMVar started ())
+                        (writeIORef stopped True)
+                        (takeMVar blocked :: IO ())
+            timeout 1_000_000
+                (withFullscreenWorker
+                    (const (writeIORef closed True))
+                    worker
+                    (\_ -> takeMVar started >> ioError (userError "UI failure")))
+                `shouldThrow` anyIOException
+            readIORef closed `shouldReturn` True
+            readIORef stopped `shouldReturn` True
+
+        it "closes input and joins the worker when the UI is interrupted" do
+            started <- newEmptyMVar
+            blocked <- newEmptyMVar
+            closed <- newIORef False
+            stopped <- newIORef False
+            let worker =
+                    bracket_
+                        (putMVar started ())
+                        (writeIORef stopped True)
+                        (takeMVar blocked :: IO ())
+            timeout 1_000_000
+                (catchUserInterrupt
+                    (withFullscreenWorker
+                        (const (writeIORef closed True))
+                        worker
+                        -- Preserve the asynchronous exception classification;
+                        -- safe-exceptions' throwIO would wrap UserInterrupt.
+                        (\_ -> takeMVar started >> Exception.throwIO UserInterrupt)
+                        >> pure False)
+                    (pure True))
+                `shouldReturn` Just True
+            readIORef closed `shouldReturn` True
+            readIORef stopped `shouldReturn` True
+
+        it "cancels and joins an interruptible worker after the grace interval" do
+            started <- newEmptyMVar
+            blocked <- newEmptyMVar
+            closed <- newIORef False
+            stopped <- newIORef False
+            let worker =
+                    bracket_
+                        (putMVar started ())
+                        (writeIORef stopped True)
+                        (takeMVar blocked :: IO ())
+            timeout 5_000_000
+                (catchUserInterrupt
+                    (withFullscreenWorker
+                        (const (writeIORef closed True))
+                        worker
+                        (\_ -> takeMVar started)
+                        >> pure False)
+                    (pure True))
+                `shouldReturn` Just True
+            readIORef closed `shouldReturn` True
+            readIORef stopped `shouldReturn` True
+
+        it "closes input and preserves worker failures" do
+            closed <- newIORef False
+            withFullscreenWorker
+                (const (writeIORef closed True))
+                (ioError (userError "Worker failure") :: IO ())
+                (void . waitCatch)
+                `shouldThrow` anyIOException
+            readIORef closed `shouldReturn` True
+
+        it "preserves queued and future input when the worker completes a transition" do
+            runtime <- newScriptRuntime initialUiState
+            let input = FullscreenInput
+                    { fullscreenInputLine = ReplText "queued prompt"
+                    , fullscreenInputQueued = True
+                    , fullscreenInputDisplay = Just "queued prompt"
+                    }
+            atomically (Composer.appendFullscreenInput runtime.runtimeInput input)
+                `shouldReturn` Right ()
+            withFullscreenWorker
+                (closeFullscreenChannels runtime)
+                (pure (42 :: Int))
+                (void . waitCatch)
+                `shouldReturn` 42
+            queued <- atomically (Composer.readFullscreenInputs runtime.runtimeInput)
+            fmap (.fullscreenInputLine) (toList queued)
+                `shouldBe` [ReplText "queued prompt"]
+            atomically (Composer.appendFullscreenInput runtime.runtimeInput input)
+                `shouldReturn` Right ()
+
+        it "closes input when the UI exits before the worker completes" do
+            runtime <- newScriptRuntime initialUiState
+            result <- timeout 1_000_000 $
+                withFullscreenWorker
+                    (closeFullscreenChannels runtime)
+                    (atomically (Composer.takeFullscreenInput runtime.runtimeInput))
+                    (const (pure ()))
+            fmap (.fullscreenInputLine) result `shouldBe` Just ReplEof
+
     describe "dictation readiness" do
         it "does not erase a transcript that arrives before the ready event" do
             stop <- newEmptyMVar

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -11,6 +11,7 @@ import Agent.CLI.Dictation (DictationTarget(..))
 import Agent.CLI.Interrupt (CtrlCDecision(..))
 import Agent.CLI.TUI.App
     ( appEventLogicalBytes
+    , closeAppEventMailbox
     , emitUiEvent
     , enqueueAppEvent
     , loadSyntaxHighlighterForRuntime
@@ -42,8 +43,9 @@ import Agent.Subagents (SubagentId(..))
 import Agent.ToolDispatch (ToolCall(..), functionToolCall)
 import Agent.TUI.Motion (MotionMode(..))
 import Control.Concurrent.Async (wait, withAsync)
-import Control.Concurrent.STM (readTVarIO)
-import Control.Exception.Safe (throwString)
+import Control.Concurrent.STM (atomically, readTVarIO)
+import Control.Exception (MaskingState(MaskedUninterruptible), getMaskingState)
+import Control.Exception.Safe (finally, throwString)
 import Control.Monad (replicateM_)
 import qualified Data.ByteString as BS
 import Data.Foldable (toList)
@@ -215,6 +217,51 @@ spec = describe "fullscreen TUI bridge" do
     it "accounts model-context reset mailbox overhead" do
         appEventLogicalBytes (AppUi (UiLoop ModelContextReset))
             `shouldBe` 128
+
+    it "closes the display mailbox idempotently and discards subsequent output" do
+        runtime <- newBridgeTestRuntime
+        emitUiEvent runtime (UiLoop (TextDelta "retained"))
+        let close = atomically (closeAppEventMailbox runtime.runtimeMailbox)
+            AppEventMailbox stateRef = runtime.runtimeMailbox
+        close
+        close
+        completed <- timeout 2000000 $
+            replicateM_ 2000 do
+                emitUiEvent runtime (UiLoop (TextDelta "discarded"))
+                emitUiEvent runtime (UiLoop TurnStarted)
+                enqueueAppEvent runtime AppStop
+        completed `shouldBe` Just ()
+        state <- readTVarIO stateRef
+        state.mailboxClosed `shouldBe` True
+        null state.mailboxPendingEvents `shouldBe` True
+        state.mailboxPendingCount `shouldBe` 0
+        state.mailboxPendingBytes `shouldBe` 0
+        state.mailboxHighWaterCount `shouldBe` 1
+
+    it "releases a masked finalizer blocked on a full display mailbox" do
+        runtime <- newBridgeTestRuntime
+        let exactBudgetText =
+                Text.replicate
+                    ((16 * 1024 * 1024 - 64) `div` 4)
+                    "x"
+            close = atomically (closeAppEventMailbox runtime.runtimeMailbox)
+        emitUiEvent runtime (UiLoop (TextDelta exactBudgetText))
+        withAsync
+            (pure () `finally` do
+                getMaskingState `shouldReturn` MaskedUninterruptible
+                emitUiEvent runtime (UiLoop (TextDelta "cleanup")))
+            \publishing ->
+                (do
+                    timeout 100000 (wait publishing)
+                        `shouldReturn` Nothing
+                    close
+                    timeout 2000000 (wait publishing)
+                        `shouldReturn` Just ()
+                    let AppEventMailbox stateRef = runtime.runtimeMailbox
+                    state <- readTVarIO stateRef
+                    state.mailboxPendingCount `shouldBe` 0
+                    state.mailboxPendingBytes `shouldBe` 0)
+                `finally` close
 
     it "backpressures a single streaming mailbox node by payload bytes" do
         runtime <- newBridgeTestRuntime

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -39,6 +39,7 @@ import Agent.TUI.TextWidth
     , previousGraphemeBoundary
     )
 import Control.Concurrent (newEmptyMVar, readMVar)
+import Control.Concurrent.Async (withAsync, wait)
 import Control.Concurrent.STM (atomically)
 import Data.IORef (newIORef)
 import qualified Data.ByteString as ByteString
@@ -52,6 +53,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Graphics.Vty as V
 import Test.Hspec
+import System.Timeout (timeout)
 import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
 import qualified Graphics.Vty as V
 import Test.QuickCheck
@@ -531,6 +533,44 @@ spec = describe "fullscreen composer" do
         _ <- atomically (takeFullscreenInput buffer)
         atomically (appendFullscreenInput buffer (prompt 129))
             `shouldReturn` Right ()
+
+    it "closes a full prompt queue without consuming queued turns" do
+        buffer <- newFullscreenInputBuffer
+        accepted <- atomically $
+            mapM (appendFullscreenInput buffer . input . ReplText)
+                (replicate fullscreenInputCountLimit "pending")
+        accepted `shouldSatisfy` all (== Right ())
+        timeout 1_000_000 (atomically (closeFullscreenInputBuffer buffer))
+            `shouldReturn` Just ()
+        (.fullscreenInputLine) <$> atomically (takeFullscreenInput buffer)
+            `shouldReturn` ReplEof
+        Seq.null <$> atomically (readFullscreenInputs buffer)
+            `shouldReturn` True
+
+    it "keeps closed input at EOF and rejects appended or promoted prompts" do
+        buffer <- newFullscreenInputBuffer
+        atomically (closeFullscreenInputBuffer buffer)
+        atomically (closeFullscreenInputBuffer buffer)
+        (.fullscreenInputLine) <$> atomically (takeFullscreenInput buffer)
+            `shouldReturn` ReplEof
+        (.fullscreenInputLine) <$> atomically (takeFullscreenInput buffer)
+            `shouldReturn` ReplEof
+        atomically (appendFullscreenInput buffer (input (ReplText "late")))
+            `shouldReturn` Left "Prompt input is closed."
+        atomically (promoteFullscreenInput buffer (input (ReplText "late")))
+            `shouldReturn` Left "Prompt input is closed."
+        fmap (.fullscreenInputLine) <$>
+            atomically (takeFullscreenInputOr buffer (pure ()))
+                `shouldReturn` Right ReplEof
+
+    it "wakes an empty prompt queue reader when input closes" do
+        buffer <- newFullscreenInputBuffer
+        withAsync
+            ((.fullscreenInputLine) <$> atomically (takeFullscreenInput buffer))
+            \reader -> do
+                timeout 20_000 (wait reader) `shouldReturn` Nothing
+                atomically (closeFullscreenInputBuffer buffer)
+                timeout 1_000_000 (wait reader) `shouldReturn` Just ReplEof
   where
     input replLine = FullscreenInput
         { fullscreenInputLine = replLine


### PR DESCRIPTION
## Problem

Confirmed Ctrl-C could reset to an idle warning, fullscreen shutdown could lose worker ownership or block on bounded queues, and in-process background turns could fall through to the interactive REPL.

## Design

- Latch confirmed exit; SIGINT repeats and SIGHUP/SIGTERM request session shutdown. Restore installed handlers with nested brackets.
- Keep the fullscreen worker structurally scoped through UI success, failure, and asynchronous interruption. No detached worker, process-killing watchdog, or `exitImmediately`.
- Close input as an idempotent STM state transition, not an EOF insertion that can fail when the prompt queue is full. Wake readers and reject subsequent prompts.
- Retire the display mailbox before joining UI/session workers. Blocked producers, including masked finalizers, wake and discard output once the consumer has gone.
- Preserve queued input when a completed worker returns a session/provider transition; the outer flow reuses that input buffer.
- Keep one-shot background turns out of the interactive REPL.

The two-second grace period bounds cooperative waiting only. Scope exit then cancels and joins the worker; it is not a total shutdown deadline, and genuinely uninterruptible resource cleanup still needs to be fixed at its owner.

## Validation

Using the Nix development shell and GHCi (`cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`):

- Interrupt: 8 examples, 0 failures.
- CtrlC: 10 examples, 0 failures.
- Fullscreen worker ownership: 7 examples, 0 failures.
- Fullscreen composer: 50 examples, 0 failures.
- Full fullscreen TUI bridge suite: 23 examples, 0 failures.
- Library and test modules loaded successfully; `git diff --check` passed.
- Live tmux fullscreen startup-dialog check: double Ctrl-C returned to GHCi, restored the terminal, and a subsequent host command ran successfully. The configured gateway rejected the dummy Gemini model, so this exercised startup shutdown rather than an active model turn.
