### PR TITLE
Avoid image coercion probes for macOS text pastes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -311,6 +311,7 @@
                     root = ./packages/agent-cli;
                     include = [
                         "app"
+                        "cbits"
                         "data"
                         "eval"
                         "skills"
@@ -324,6 +325,7 @@
                     root = ./packages/agent-cli;
                     include = [
                         "app"
+                        "cbits"
                         "data"
                         "eval"
                         "skills"

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -366,6 +366,9 @@ library
                     , vty-crossplatform >= 0.4 && < 0.5
                     , wai
                     , warp
+    if os(darwin)
+        c-sources:    cbits/ClipboardTypes.c
+        frameworks:   ApplicationServices CoreServices
 executable agent-cli
     import:           common-options
     hs-source-dirs:   app

--- a/packages/agent-cli/benchmark/ClipboardLatency.hs
+++ b/packages/agent-cli/benchmark/ClipboardLatency.hs
@@ -5,7 +5,7 @@ import Agent.CLI.Clipboard
     , readClipboard
     , readClipboardImages
     , readClipboardImagesForPaste
-    , readClipboardImagesImageFirst
+    , readClipboardImagesImageFirstWith
     )
 import Agent.Loop (ImageAttachment(..))
 import Control.Exception.Safe (bracket)
@@ -100,7 +100,10 @@ oldImagePaste =
 
 newImagePaste :: IO Int
 newImagePaste =
-    imageResultChecksum <$> readClipboardImagesImageFirst
+    -- This workload supplies a bitmap through fake osascript, so its metadata
+    -- must also be controlled rather than inspecting the user's clipboard.
+    -- Native metadata latency is measured by ClipboardTypesLatency.c.
+    imageResultChecksum <$> readClipboardImagesImageFirstWith (pure True)
 
 imageResultChecksum :: Either Text.Text [ImageAttachment] -> Int
 imageResultChecksum = \case

--- a/packages/agent-cli/benchmark/ClipboardTypesLatency.c
+++ b/packages/agent-cli/benchmark/ClipboardTypesLatency.c
@@ -1,0 +1,106 @@
+/* Conservative subprocess-overhead model for text-only bracketed pastes.
+ * Baseline runs three real osascript processes, each returning false without
+ * clipboard coercion. Thus this excludes (rather than invents) the additional
+ * failed-coercion latency of the old implementation. Both paths return the
+ * same "no image" result. Native inspection uses a private named pasteboard.
+ */
+#include <ApplicationServices/../Frameworks/HIServices.framework/Headers/Pasteboard.h>
+#include <assert.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+extern char **environ;
+int agent_cli_pasteboard_may_contain_images(CFStringRef name);
+
+static double milliseconds(clockid_t clock)
+{
+    struct timespec value;
+    assert(clock_gettime(clock, &value) == 0);
+    return value.tv_sec * 1000.0 + value.tv_nsec / 1000000.0;
+}
+
+static int baseline(void)
+{
+    for (int index = 0; index < 3; ++index) {
+        char *arguments[] = {"osascript", "-e", "return", NULL};
+        pid_t process;
+        int status;
+        assert(posix_spawn(&process, "/usr/bin/osascript", NULL, NULL,
+                           arguments, environ) == 0);
+        assert(waitpid(process, &status, 0) == process);
+        assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    }
+    return 0;
+}
+
+static int compare(const void *left, const void *right)
+{
+    double first = *(const double *)left;
+    double second = *(const double *)right;
+    return (first > second) - (first < second);
+}
+
+int main(int count, char **arguments)
+{
+    unsigned int samples = count > 1 ? (unsigned int)atoi(arguments[1]) : 7;
+    assert(samples >= 3 && samples <= 100);
+    char name[128];
+    snprintf(name, sizeof(name), "org.haskell-agent.clipboard-benchmark.%ld",
+             (long)getpid());
+    CFStringRef clipboard_name =
+        CFStringCreateWithCString(NULL, name, kCFStringEncodingUTF8);
+    PasteboardRef clipboard = NULL;
+    assert(PasteboardCreate(clipboard_name, &clipboard) == noErr);
+    const size_t sizes[] = {32, 1024, 65536, 32};
+    volatile int checksum = 0;
+    for (size_t index = 0; index < sizeof(sizes) / sizeof(sizes[0]); ++index) {
+        size_t size = sizes[index];
+        UInt8 *bytes = malloc(size);
+        assert(bytes != NULL);
+        memset(bytes, 'a', size);
+        memcpy(bytes, "https://example.org/", 20);
+        CFDataRef data = CFDataCreate(NULL, bytes, (CFIndex)size);
+        free(bytes);
+        assert(PasteboardClear(clipboard) == noErr);
+        assert(PasteboardPutItemFlavor(clipboard, (PasteboardItemID)1,
+                                      CFSTR("public.utf8-plain-text"),
+                                      data, 0) == noErr);
+        CFRelease(data);
+        assert(agent_cli_pasteboard_may_contain_images(clipboard_name) == 0);
+        double elapsed[2][100], cpu[2][100];
+        for (unsigned int sample = 0; sample < samples; ++sample) {
+            for (unsigned int order = 0; order < 2; ++order) {
+                unsigned int method = (sample + order) % 2;
+                double before_cpu = milliseconds(CLOCK_PROCESS_CPUTIME_ID);
+                double before_elapsed = milliseconds(CLOCK_MONOTONIC);
+                int result = method
+                    ? agent_cli_pasteboard_may_contain_images(clipboard_name)
+                    : baseline();
+                elapsed[method][sample] =
+                    milliseconds(CLOCK_MONOTONIC) - before_elapsed;
+                cpu[method][sample] =
+                    milliseconds(CLOCK_PROCESS_CPUTIME_ID) - before_cpu;
+                assert(result == 0);
+                checksum += result + 1;
+            }
+        }
+        for (unsigned int method = 0; method < 2; ++method) {
+            qsort(elapsed[method], samples, sizeof(double), compare);
+            qsort(cpu[method], samples, sizeof(double), compare);
+            printf("%s bytes=%zu samples=%u elapsed-ms=%.6f cpu-ms=%.6f\n",
+                   method ? "native-metadata" : "three-process-baseline",
+                   size, samples, elapsed[method][samples / 2],
+                   cpu[method][samples / 2]);
+        }
+    }
+    assert(PasteboardClear(clipboard) == noErr);
+    CFRelease(clipboard);
+    CFRelease(clipboard_name);
+    printf("checksum=%d\n", checksum);
+    return 0;
+}

--- a/packages/agent-cli/benchmark/ClipboardTypesLatency.md
+++ b/packages/agent-cli/benchmark/ClipboardTypesLatency.md
@@ -1,0 +1,46 @@
+# Clipboard metadata validation
+
+Run from the repository root:
+
+```sh
+nix develop -c bash scripts/test-clipboard-types.sh
+nix develop -c bash scripts/benchmark-clipboard-types.sh 7
+```
+
+Both programs compile the production metadata implementation with the Nix
+development shell's C compiler at `-O2`. They create private named pasteboards;
+they neither read nor replace the user's general clipboard.
+
+The regression tests cover empty clipboards, browser URL and rich-text
+representations, PNG/JPEG/TIFF with accompanying text, Finder file
+representations, promised image data, and inspection failure. A promise keeper
+asserts that metadata inspection never requests the image payload.
+
+The benchmark compares native metadata inspection with a conservative model of
+the removed three-process text-paste failure path. The baseline launches three
+real `osascript` processes executing an empty return. It deliberately excludes
+the additional latency of failed image/file coercion and Haskell temporary-file
+handling. These are **subprocess-overhead measurements**, not end-to-end prompt
+latency or an exact timing of the previous implementation.
+
+Inputs contain 32, 1,024, and 65,536 bytes of URL-shaped text, with 32 bytes
+repeated to check stability. Fixture creation is outside the measured interval.
+Methods are interleaved, all classification results are checked, and a volatile
+checksum keeps the result observable. Output reports median elapsed time and
+parent-process CPU time over the requested samples; CPU excludes subprocess
+CPU. This is a latency change, not a claimed allocation optimization.
+
+## Reference measurement
+
+2026-09-07, aarch64 macOS, Nix Clang 21.1.8, `-O2`, seven samples:
+
+| Text bytes | Three-process elapsed ms | Native elapsed ms | Three-process CPU ms | Native CPU ms |
+| ---: | ---: | ---: | ---: | ---: |
+| 32 | 152.754 | 0.251 | 0.957 | 0.147 |
+| 1,024 | 148.641 | 0.272 | 0.941 | 0.155 |
+| 65,536 | 153.209 | 0.231 | 0.944 | 0.145 |
+| 32 (repeat) | 156.091 | 0.218 | 0.905 | 0.136 |
+
+The native check removes roughly 150 ms of process startup overhead in this
+model, without reading the text payload. It adds a metadata query before
+image/file candidates; their existing decoding and AppleScript work remains.

--- a/packages/agent-cli/cbits/ClipboardTypes.c
+++ b/packages/agent-cli/cbits/ClipboardTypes.c
@@ -1,0 +1,73 @@
+/* Inspect advertised representations without requesting clipboard payloads.
+ * In particular, do not ask macOS to coerce ordinary text into an image or
+ * a Finder file list: those failed coercions can take seconds.
+ */
+/* Include only the required subframework headers. The umbrella headers pull
+ * in unrelated Carbon filesystem declarations and collide with libuuid's
+ * headers in the Nix development environment.
+ */
+#include <ApplicationServices/../Frameworks/HIServices.framework/Headers/Pasteboard.h>
+#include <CoreServices/../Frameworks/LaunchServices.framework/Headers/UTType.h>
+
+int agent_cli_clipboard_flavor_may_contain_images(CFStringRef flavor)
+{
+    if (flavor == NULL)
+        return -1;
+    return UTTypeConformsTo(flavor, CFSTR("public.image")) ||
+           UTTypeConformsTo(flavor, CFSTR("public.file-url")) ||
+           CFEqual(flavor, CFSTR("NSFilenamesPboardType")) ||
+           CFEqual(flavor, CFSTR("com.apple.pasteboard.promised-file-url")) ||
+           CFEqual(flavor, CFSTR("com.apple.pasteboard.promised-file-content-type")) ||
+           CFEqual(flavor, CFSTR("com.apple.pasteboard.finder-node"));
+}
+
+/* Return 0 only after a successful inspection, 1 for image/file candidates,
+ * and -1 on failure so callers can retain their existing clipboard readers.
+ * Each call owns its PasteboardRef; no shared mutable state or AppKit main
+ * thread is required.
+ */
+int agent_cli_pasteboard_may_contain_images(CFStringRef pasteboard_name)
+{
+    PasteboardRef clipboard = NULL;
+    ItemCount item_count = 0;
+    int result = 0;
+
+    if (pasteboard_name == NULL ||
+        PasteboardCreate(pasteboard_name, &clipboard) != noErr)
+        return -1;
+    PasteboardSynchronize(clipboard);
+    if (PasteboardGetItemCount(clipboard, &item_count) != noErr) {
+        CFRelease(clipboard);
+        return -1;
+    }
+
+    for (ItemCount item_index = 1; item_index <= item_count; ++item_index) {
+        PasteboardItemID item_identifier;
+        CFArrayRef flavors = NULL;
+        if (PasteboardGetItemIdentifier(clipboard, item_index,
+                                       &item_identifier) != noErr ||
+            PasteboardCopyItemFlavors(clipboard, item_identifier,
+                                     &flavors) != noErr) {
+            result = -1;
+            break;
+        }
+        for (CFIndex flavor_index = 0;
+             flavor_index < CFArrayGetCount(flavors); ++flavor_index) {
+            CFStringRef flavor = CFArrayGetValueAtIndex(flavors, flavor_index);
+            if (agent_cli_clipboard_flavor_may_contain_images(flavor)) {
+                result = 1;
+                break;
+            }
+        }
+        CFRelease(flavors);
+        if (result != 0)
+            break;
+    }
+    CFRelease(clipboard);
+    return result;
+}
+
+int agent_cli_clipboard_may_contain_images(void)
+{
+    return agent_cli_pasteboard_may_contain_images(kPasteboardClipboard);
+}

--- a/packages/agent-cli/src/Agent/CLI/Clipboard.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Clipboard
     , readClipboardImage
     , readClipboardImages
     , readClipboardImagesImageFirst
+    , readClipboardImagesImageFirstWith
     , readClipboardImagesForPaste
     , readClipboardText
     , nonEmptyClipboardImages
@@ -23,6 +24,7 @@ import Agent.CLI.Clipboard.Linux
     )
 import Agent.CLI.Clipboard.MacOS
     ( readMacClipboardImage
+    , readMacClipboardMayContainImages
     , readMacClipboardPaths
     , readMacClipboardText
     )
@@ -79,21 +81,40 @@ readClipboardImages = do
 -- images usually expose bitmap data directly; checking Finder file coercions
 -- first is especially expensive on macOS because AppleScript may spend close
 -- to a second attempting to turn the bitmap into a file list.
+-- Inspect native macOS type metadata first so ordinary text does not attempt
+-- either image or file-list coercion. Image/file candidates and inspection
+-- failures retain the existing bitmap-first readers.
 readClipboardImagesImageFirst :: IO (Either Text [ImageAttachment])
-readClipboardImagesImageFirst = do
-    bitmap <- readClipboardImageBytes
-    case bitmap of
-        Right image -> pure (Right [image])
-        Left bitmapError -> do
-            paths <- readClipboardPaths
-            imagePaths <- filterM isImageFile paths
-            case imagePaths of
-                [] -> pure (Left bitmapError)
-                ps ->
-                    readImageFilesBounded ps >>= \case
-                        Right images@(_:_) -> pure (Right images)
-                        Right [] -> pure (Left bitmapError)
-                        Left err -> pure (Left err)
+readClipboardImagesImageFirst =
+    readClipboardImagesImageFirstWith $
+        if os == "darwin"
+        then readMacClipboardMayContainImages
+        else pure True
+
+-- | Supply metadata inspection independently of the payload readers. This
+-- permits deterministic reader tests and benchmarks without replacing the
+-- user's system clipboard. Return 'True' when inspection is unavailable.
+readClipboardImagesImageFirstWith
+    :: IO Bool
+    -> IO (Either Text [ImageAttachment])
+readClipboardImagesImageFirstWith inspectClipboardTypes = do
+    mayContainImages <- inspectClipboardTypes
+    if not mayContainImages
+        then pure (Left "no image found on the clipboard")
+        else do
+            bitmap <- readClipboardImageBytes
+            case bitmap of
+                Right image -> pure (Right [image])
+                Left bitmapError -> do
+                    paths <- readClipboardPaths
+                    imagePaths <- filterM isImageFile paths
+                    case imagePaths of
+                        [] -> pure (Left bitmapError)
+                        ps ->
+                            readImageFilesBounded ps >>= \case
+                                Right images@(_:_) -> pure (Right images)
+                                Right [] -> pure (Left bitmapError)
+                                Left err -> pure (Left err)
 
 -- | Read images for an explicit image-paste action and produce the richer
 -- text/path diagnostics without probing the clipboard a second time.

--- a/packages/agent-cli/src/Agent/CLI/Clipboard/MacOS.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard/MacOS.hs
@@ -1,6 +1,10 @@
--- | macOS clipboard readers backed by pbpaste and AppleScript.
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+-- | macOS clipboard metadata and readers backed by pbpaste and AppleScript.
 module Agent.CLI.Clipboard.MacOS
     ( readMacClipboardImage
+    , readMacClipboardMayContainImages
     , readMacClipboardPaths
     , readMacClipboardText
     ) where
@@ -23,6 +27,22 @@ import System.IO
     , withBinaryFile
     )
 import System.Process (readProcessWithExitCode)
+
+#if defined(darwin_HOST_OS)
+import Foreign.C.Types (CInt(..))
+
+foreign import ccall safe "agent_cli_clipboard_may_contain_images"
+    clipboardMayContainImages :: IO CInt
+#endif
+
+-- | Check advertised types without coercing or reading clipboard payloads.
+-- Inspection failures conservatively retain the existing image readers.
+readMacClipboardMayContainImages :: IO Bool
+#if defined(darwin_HOST_OS)
+readMacClipboardMayContainImages = (/= 0) <$> clipboardMayContainImages
+#else
+readMacClipboardMayContainImages = pure True
+#endif
 
 readMacClipboardImage :: IO (Either Text ImageAttachment)
 readMacClipboardImage = do
@@ -52,23 +72,25 @@ readMacClipboardPaths = do
     result <- tryAny $
         readProcessWithExitCode "osascript"
             [ "-e"
-            , "try\n\
-              \  set theFiles to the clipboard as list\n\
-              \  set paths to {}\n\
-              \  repeat with f in theFiles\n\
-              \    try\n\
-              \      set end of paths to POSIX path of f\n\
-              \    end try\n\
-              \  end repeat\n\
-              \  set AppleScript's text item delimiters to linefeed\n\
-              \  return paths as text\n\
-              \on error\n\
-              \  try\n\
-              \    return POSIX path of (the clipboard as «class furl»)\n\
-              \  on error\n\
-              \    return \"\"\n\
-              \  end try\n\
-              \end try"
+            , unlines
+                [ "try"
+                , "  set theFiles to the clipboard as list"
+                , "  set paths to {}"
+                , "  repeat with f in theFiles"
+                , "    try"
+                , "      set end of paths to POSIX path of f"
+                , "    end try"
+                , "  end repeat"
+                , "  set AppleScript's text item delimiters to linefeed"
+                , "  return paths as text"
+                , "on error"
+                , "  try"
+                , "    return POSIX path of (the clipboard as «class furl»)"
+                , "  on error"
+                , "    return \"\""
+                , "  end try"
+                , "end try"
+                ]
             ]
             ""
     pure $ case result of

--- a/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ClipboardSpec.hs
@@ -6,12 +6,18 @@ import Control.Exception.Safe (bracket)
 import qualified Data.ByteString as BS
 import qualified Data.Text as Text
 import System.Directory
-    ( createDirectory
+    ( Permissions(executable)
+    , createDirectory
+    , doesFileExist
+    , getPermissions
     , getTemporaryDirectory
     , removeDirectory
     , removeFile
+    , removePathForcibly
+    , setPermissions
     )
 import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.FilePath ((</>), searchPathSeparator)
 import System.Info (os)
 import System.IO (hClose, openBinaryTempFile)
 import Test.Hspec
@@ -54,6 +60,24 @@ spec = do
                             \install wl-clipboard (Wayland) or xclip (X11). On a \
                             \remote server, upload the image and paste its \
                             \server-side path instead."
+
+    describe "readClipboardImagesImageFirstWith" do
+        it "skips every external image probe for a text-only clipboard" do
+            if os /= "darwin"
+                then pendingWith "macOS clipboard subprocess fixture"
+                else withClipboardImageFixture \probeLog -> do
+                    readClipboardImagesImageFirstWith (pure False)
+                        `shouldReturn` Left "no image found on the clipboard"
+                    doesFileExist probeLog `shouldReturn` False
+
+        it "retains the bitmap-first reader for image candidates" do
+            if os /= "darwin"
+                then pendingWith "macOS clipboard subprocess fixture"
+                else withClipboardImageFixture \probeLog -> do
+                    readClipboardImagesImageFirstWith (pure True)
+                        `shouldReturn`
+                            Right [ImageAttachment "image/png" "fixture-png"]
+                    readFile probeLog `shouldReturn` "png\n"
 
     describe "nonEmptyClipboardImages" do
         it "keeps only successful non-empty image reads" do
@@ -146,6 +170,46 @@ spec = do
                 \path -> do
                     result <- loadImagesFromPastedText (Text.pack path)
                     result `shouldBe` Nothing
+
+-- Keep fake subprocesses separate from the real clipboard. The script records
+-- every call, and only the PNG reader may succeed.
+withClipboardImageFixture :: (FilePath -> IO a) -> IO a
+withClipboardImageFixture action = do
+    temporary <- getTemporaryDirectory
+    bracket
+        (do
+            (directory, handle) <-
+                openBinaryTempFile temporary "agent-clipboard-fixture-"
+            hClose handle
+            removeFile directory
+            createDirectory directory
+            pure directory)
+        removePathForcibly
+        \directory -> do
+            let executablePath = directory </> "osascript"
+                probeLog = directory </> "probes"
+            writeFile executablePath
+                "#!/bin/sh\n\
+                \case \"$2\" in\n\
+                \  *\"class PNGf\"*)\n\
+                \    printf 'png\\n' >> \"${0%/*}/probes\"\n\
+                \    path=$(printf '%s\\n' \"$2\" | /usr/bin/sed -n \
+                \'s/.*open for access POSIX file \"\\([^\"]*\\)\".*/\\1/p')\n\
+                \    printf 'fixture-png' > \"$path\"\n\
+                \    exit 0 ;;\n\
+                \  *) printf 'unexpected\\n' >> \"${0%/*}/probes\"; exit 1 ;;\n\
+                \esac\n"
+            permissions <- getPermissions executablePath
+            setPermissions executablePath permissions { executable = True }
+            bracket
+                (do
+                    original <- lookupEnv "PATH"
+                    setEnv "PATH"
+                        (directory <> [searchPathSeparator]
+                            <> maybe "" id original)
+                    pure original)
+                (maybe (unsetEnv "PATH") (setEnv "PATH"))
+                (const (action probeLog))
 
 withEmptyPath :: IO a -> IO a
 withEmptyPath action = do

--- a/packages/agent-cli/test/ClipboardTypes.c
+++ b/packages/agent-cli/test/ClipboardTypes.c
@@ -1,0 +1,85 @@
+/* Standalone macOS regression tests. Only unique named pasteboards are used;
+ * the user's general clipboard is never read or modified.
+ */
+#include <ApplicationServices/../Frameworks/HIServices.framework/Headers/Pasteboard.h>
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int agent_cli_pasteboard_may_contain_images(CFStringRef name);
+
+static unsigned int promise_requests = 0;
+
+static OSStatus supply_promised_data(PasteboardRef clipboard,
+                                    PasteboardItemID item,
+                                    CFStringRef flavor, void *context)
+{
+    (void)clipboard;
+    (void)item;
+    (void)flavor;
+    (void)context;
+    ++promise_requests;
+    return badPasteboardFlavorErr;
+}
+
+static void put_flavor(PasteboardRef clipboard, unsigned int item,
+                       CFStringRef flavor)
+{
+    const UInt8 bytes[] = "https://example.org/document";
+    CFDataRef data = CFDataCreate(NULL, bytes, sizeof(bytes) - 1);
+    assert(data != NULL);
+    assert(PasteboardPutItemFlavor(clipboard, (PasteboardItemID)(uintptr_t)item,
+                                  flavor, data, 0) == noErr);
+    CFRelease(data);
+}
+
+int main(void)
+{
+    char name[128];
+    snprintf(name, sizeof(name), "org.haskell-agent.clipboard-types-test.%ld",
+             (long)getpid());
+    CFStringRef clipboard_name =
+        CFStringCreateWithCString(NULL, name, kCFStringEncodingUTF8);
+    PasteboardRef clipboard = NULL;
+    assert(PasteboardCreate(clipboard_name, &clipboard) == noErr);
+    assert(PasteboardClear(clipboard) == noErr);
+    assert(agent_cli_pasteboard_may_contain_images(clipboard_name) == 0);
+
+    put_flavor(clipboard, 1, CFSTR("public.utf8-plain-text"));
+    put_flavor(clipboard, 1, CFSTR("public.url"));
+    assert(agent_cli_pasteboard_may_contain_images(clipboard_name) == 0);
+    put_flavor(clipboard, 1, CFSTR("public.html"));
+    put_flavor(clipboard, 1, CFSTR("public.rtf"));
+    assert(agent_cli_pasteboard_may_contain_images(clipboard_name) == 0);
+
+    const CFStringRef image_flavors[] = {
+        CFSTR("public.png"), CFSTR("public.jpeg"), CFSTR("public.tiff"),
+        CFSTR("public.file-url"), CFSTR("NSFilenamesPboardType"),
+        CFSTR("com.apple.pasteboard.promised-file-url"),
+        CFSTR("com.apple.pasteboard.promised-file-content-type"),
+        CFSTR("com.apple.pasteboard.finder-node")
+    };
+    for (size_t index = 0;
+         index < sizeof(image_flavors) / sizeof(image_flavors[0]); ++index) {
+        assert(PasteboardClear(clipboard) == noErr);
+        put_flavor(clipboard, 1, CFSTR("public.utf8-plain-text"));
+        put_flavor(clipboard, 2, image_flavors[index]);
+        assert(agent_cli_pasteboard_may_contain_images(clipboard_name) == 1);
+    }
+
+    assert(PasteboardClear(clipboard) == noErr);
+    assert(PasteboardSetPromiseKeeper(clipboard, supply_promised_data, NULL)
+           == noErr);
+    assert(PasteboardPutItemFlavor(clipboard, (PasteboardItemID)1,
+                                  CFSTR("public.png"), NULL, 0) == noErr);
+    assert(agent_cli_pasteboard_may_contain_images(clipboard_name) == 1);
+    assert(promise_requests == 0);
+    assert(agent_cli_pasteboard_may_contain_images(NULL) == -1);
+
+    assert(PasteboardClear(clipboard) == noErr);
+    CFRelease(clipboard);
+    CFRelease(clipboard_name);
+    puts("Clipboard metadata: 13 cases passed; no promised payload requested.");
+    return 0;
+}

--- a/scripts/benchmark-clipboard-types.sh
+++ b/scripts/benchmark-clipboard-types.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run from the repository root inside `nix develop`.
+directory="$(mktemp -d "${TMPDIR:?}/clipboard-types-benchmark.XXXXXX")"
+trap 'rm -rf "$directory"' EXIT
+cc -O2 -Wall -Wextra -Werror -Wno-deprecated-declarations \
+    packages/agent-cli/cbits/ClipboardTypes.c \
+    packages/agent-cli/benchmark/ClipboardTypesLatency.c \
+    -framework ApplicationServices -framework CoreServices \
+    -o "$directory/clipboard-types-benchmark"
+"$directory/clipboard-types-benchmark" "${1:-7}"

--- a/scripts/test-clipboard-types.sh
+++ b/scripts/test-clipboard-types.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run from the repository root inside `nix develop`.
+if [[ "$(uname -s)" != Darwin ]]; then
+    echo "Clipboard metadata tests require macOS." >&2
+    exit 1
+fi
+directory="$(mktemp -d "${TMPDIR:?}/clipboard-types.XXXXXX")"
+trap 'rm -rf "$directory"' EXIT
+cc -O2 -Wall -Wextra -Werror -Wno-deprecated-declarations \
+    packages/agent-cli/cbits/ClipboardTypes.c \
+    packages/agent-cli/test/ClipboardTypes.c \
+    -framework ApplicationServices -framework CoreServices \
+    -o "$directory/clipboard-types-test"
+"$directory/clipboard-types-test"


### PR DESCRIPTION
## Summary

- Skip AppleScript image/file coercion probes for macOS text and URL pastes by inspecting native pasteboard type metadata first.
- Preserve bitmap-first image handling, Finder candidates, and conservative fallback when metadata inspection fails.
- Add native metadata regression tests, Haskell reader tests, and an optimized reproducible benchmark. No clipboard payload is requested by the metadata check.

## Validation

- GHCi: all 237 agent-cli library modules loaded successfully.
- ClipboardSpec in GHCi: 14 examples, 0 failures, 1 Linux-only pending.
- `nix develop -c bash scripts/test-clipboard-types.sh`: 13 cases passed, including promised images without requesting their payload.
- Live tmux/GHCi minimal prompt: bracketed URL paste appeared as text without an image attachment. Used isolated temporary HOME to avoid unrelated session allocation and PostgreSQL socket-path startup issues; no model request submitted.
- Regenerated package.nix with cabal2nix: unchanged. `git diff --check` clean.

## Performance

`nix develop -c bash scripts/benchmark-clipboard-types.sh 7`

aarch64 macOS, Nix Clang 21.1.8, `-O2`; seven samples per case, median elapsed time:

| URL-shaped text bytes | Three-process baseline | Native metadata |
| ---: | ---: | ---: |
| 32 | 152.754 ms | 0.251 ms |
| 1,024 | 148.641 ms | 0.272 ms |
| 65,536 | 153.209 ms | 0.231 ms |
| 32 repeated | 156.091 ms | 0.218 ms |

The baseline models the removed process-launch overhead with three real no-op osascript invocations. It excludes failed coercions and temporary-file handling: these are not end-to-end prompt timings or exact timings of the old implementation. Full methodology and parent-process CPU results are in `packages/agent-cli/benchmark/ClipboardTypesLatency.md`.
