### PR TITLE
Add explicit yolo mode to agent server turns

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/Runtime/Request.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/Request.hs
@@ -24,8 +24,7 @@ data NativeInteractionMode
     | NativePlan
     -- ^ Begin this turn with plan mode active.
     | NativeYolo
-    -- ^ Auto-approve mutating tools. Typed native turns reject this mode;
-    -- legacy embedding hooks still use the shared interaction vocabulary.
+    -- ^ Auto-approve mutating tools.
     deriving (Eq, Show)
 
 data NativeShellMode
@@ -43,8 +42,8 @@ data NativeSessionTarget
     deriving (Eq, Show)
 
 -- | Native turns exclude CLI-only capabilities such as worktree creation,
--- computer use, prompt files, and implicit non-interactive auto-approval.
--- The executing adapter must supply interactive approval and plan callbacks.
+-- computer use, and prompt files. The executing adapter supplies approval
+-- and plan callbacks for the selected interaction mode.
 data NativeTurnRequest = NativeTurnRequest
     { nativeTurnPrompt :: !Text
     , nativeTurnImages :: ![ImageAttachment]
@@ -62,8 +61,6 @@ data NativeTurnRequest = NativeTurnRequest
 -- Workspace, provider, and session resolution remain execution-time concerns.
 validateNativeTurnRequest :: NativeTurnRequest -> Either Text ()
 validateNativeTurnRequest request
-    | request.nativeTurnInteractionMode == NativeYolo =
-        Left "typed native turns do not support auto-approval"
     | NativeResumeSession sessionId <- request.nativeTurnSession
     , Text.null (Text.strip sessionId) =
         Left "native resume session id must not be empty"

--- a/packages/agent-cli-runtime/test/Agent/Runtime/RequestSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/Runtime/RequestSpec.hs
@@ -12,7 +12,7 @@ spec = describe "validateNativeTurnRequest" do
             request { nativeTurnSession = NativeResumeSession "session-1" }
             `shouldBe` Right ()
 
-    it "accepts ask and plan interaction with every shell mode" do
+    it "accepts every interaction and shell mode" do
         mapM_ (\mode ->
             mapM_ (\shell ->
                 validateNativeTurnRequest request
@@ -21,12 +21,7 @@ spec = describe "validateNativeTurnRequest" do
                     }
                     `shouldBe` Right ())
                 [NativeShellNone, NativeShellBash, NativeShellGhci, NativeShellBoth])
-            [NativeAsk, NativePlan]
-
-    it "rejects auto-approval before execution" do
-        validateNativeTurnRequest
-            request { nativeTurnInteractionMode = NativeYolo }
-            `shouldBe` Left "typed native turns do not support auto-approval"
+            [NativeAsk, NativePlan, NativeYolo]
 
     it "rejects empty and whitespace-only resume identifiers" do
         mapM_ (\sessionId ->
@@ -35,12 +30,12 @@ spec = describe "validateNativeTurnRequest" do
                 `shouldBe` Left "native resume session id must not be empty")
             ["", " \n\t"]
 
-    it "preserves auto-approval error precedence for invalid resume requests" do
+    it "rejects invalid resume requests in auto-approval mode" do
         validateNativeTurnRequest request
             { nativeTurnInteractionMode = NativeYolo
             , nativeTurnSession = NativeResumeSession ""
             }
-            `shouldBe` Left "typed native turns do not support auto-approval"
+            `shouldBe` Left "native resume session id must not be empty"
 
 request :: NativeTurnRequest
 request = NativeTurnRequest

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -120,9 +120,8 @@ nativeProcessIntegrationSupervisor = (.nativeIntegrationSupervisor)
 -- | Execute one typed native turn without reconstructing command-line
 -- arguments.
 --
--- Auto-approval is deliberately unavailable through this entry point. Native
--- HTTP and embedding transports must surface approval requests through hooks
--- instead of silently inheriting the CLI's non-interactive yolo behavior.
+-- Approval behavior is explicit on the typed request and is carried through
+-- native hooks rather than inferred from CLI flags.
 runNativeTurn
     :: NativeProcessRuntime
     -> Handle

--- a/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
@@ -79,7 +79,7 @@ spec = describe "nativeTurnOptions" do
 
     forM_ [hostNativeStartupPolicy, restrictedNativeStartupPolicy] \policy ->
         forM_ [NativeNewSession, NativeResumeSession "existing"] \session ->
-            forM_ [NativeAsk, NativePlan] \interaction ->
+            forM_ [NativeAsk, NativePlan, NativeYolo] \interaction ->
                 forM_ [NativeShellNone, NativeShellGhci, NativeShellBash, NativeShellBoth] \shell ->
                     it ("preserves typed turn fields under " <> show (policy, session, interaction, shell)) do
                         let request = baseRequest
@@ -148,21 +148,23 @@ spec = describe "nativeTurnOptions" do
             )
             `shouldBe` Left "native resume session id must not be empty"
 
-    it "does not expose auto-approval through typed turns" do
-        nativeTurnOptions
-            (baseRequest
-                { nativeTurnInteractionMode = NativeYolo }
-            )
-            `shouldBe` Left "typed native turns do not support auto-approval"
+    it "accepts explicit auto-approval without leaking it into CLI flags" do
+        options <- shouldReturnRight $
+            nativeTurnOptions
+                (baseRequest
+                    { nativeTurnInteractionMode = NativeYolo }
+                )
+        options.optYolo `shouldBe` False
+        options.optNoYolo `shouldBe` True
 
-    it "keeps approval validation ahead of resume validation under either policy" do
+    it "rejects an invalid resume in auto-approval mode under either policy" do
         forM_ [hostNativeStartupPolicy, restrictedNativeStartupPolicy] \policy -> do
             let request = baseRequest
                     { nativeTurnInteractionMode = NativeYolo
                     , nativeTurnSession = NativeResumeSession " "
                     }
             (applyNativeStartupPolicy policy request.nativeTurnCwd <$> nativeTurnOptions request)
-                `shouldBe` Left "typed native turns do not support auto-approval"
+                `shouldBe` Left "native resume session id must not be empty"
 
     it "requires prepared discovery whenever host discovery is disabled" do
         let root = unsafeEncodeUtf "/prepared/root"

--- a/packages/agent-server/src/Agent/Server/Config.hs
+++ b/packages/agent-server/src/Agent/Server/Config.hs
@@ -97,6 +97,7 @@ data ServerConfig = ServerConfig
     , serverTenantRegistry :: !(Maybe FilePath)
     , serverTenantStateRoot :: !(Maybe FilePath)
     , serverSandboxRunner :: !(Maybe FilePath)
+    , serverYolo :: !Bool
     , serverCorsOrigins :: ![String]
     , serverWorkspaceRoots :: ![FilePath]
     , serverMaxConcurrentTurns :: !Int
@@ -130,6 +131,7 @@ data ResolvedServerConfig = ResolvedServerConfig
     , resolvedHome :: !FilePath
     , resolvedStateDirectory :: !FilePath
     , resolvedServerMode :: !ResolvedServerMode
+    , resolvedYolo :: !Bool
     , resolvedMaxConcurrentTurns :: !Int
     , resolvedMaxConcurrentTurnsPerTenant :: !Int
     , resolvedMaxQueuedTurns :: !Int
@@ -150,6 +152,7 @@ defaultServerConfig = ServerConfig
     , serverTenantRegistry = Nothing
     , serverTenantStateRoot = Nothing
     , serverSandboxRunner = Nothing
+    , serverYolo = False
     , serverCorsOrigins = []
     , serverWorkspaceRoots = []
     , serverMaxConcurrentTurns = 3
@@ -228,6 +231,10 @@ serverConfigParser =
                     <> help
                         "Prebuilt per-tenant microVM runner executable"
                 ))
+        <*> switch
+            ( long "yolo"
+                <> help "Auto-approve mutating tools for server turns"
+            )
         <*> manyStringOption
             "cors-origin"
             "ORIGIN"
@@ -376,6 +383,7 @@ resolveServerConfigWithTrustPolicy trustPolicy config
                 , resolvedHome = home
                 , resolvedStateDirectory = home </> ".haskell-agent"
                 , resolvedServerMode = mode
+                , resolvedYolo = config.serverYolo
                 , resolvedMaxConcurrentTurns =
                     config.serverMaxConcurrentTurns
                 , resolvedMaxConcurrentTurnsPerTenant =

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -1277,7 +1277,8 @@ runTurn environment control spec =
                                                     , nativeTurnEffort =
                                                         Just effort
                                                     , nativeTurnInteractionMode =
-                                                        NativeAsk
+                                                        serverInteractionMode
+                                                            environment
                                                     , nativeTurnShellMode =
                                                         tenantShellMode environment
                                                     }
@@ -1344,7 +1345,7 @@ nativeHooks environment control sessionId cwd dialect = NativeRunHooks
             Just sandbox ->
                 composeSandboxTools sandbox sessionId cwd dialect
     , nativePlanHooks = planHooks control
-    , nativeInteractionMode = NativeAsk
+    , nativeInteractionMode = serverInteractionMode environment
     , nativeShellMode = tenantShellMode environment
     , nativeHome =
         case environment.environmentSandbox of
@@ -1393,6 +1394,11 @@ tenantShellMode environment =
     case environment.environmentSandbox of
         Nothing -> NativeShellBoth
         Just _ -> NativeShellBash
+
+serverInteractionMode :: RuntimeEnvironment -> NativeInteractionMode
+serverInteractionMode environment
+    | environment.environmentConfig.resolvedYolo = NativeYolo
+    | otherwise = NativeAsk
 
 requestToolApproval
     :: TurnControl

--- a/packages/agent-server/test/Agent/Server/ConfigSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ConfigSpec.hs
@@ -28,6 +28,7 @@ import System.Environment
     ( lookupEnv
     , setEnv
     , unsetEnv
+    , withArgs
     )
 import System.FilePath ((</>))
 import System.IO
@@ -40,6 +41,24 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "server configuration" do
+    it "keeps approval prompting enabled by default" do
+        defaultServerConfig.serverYolo `shouldBe` False
+
+    it "parses --yolo as explicit auto-approval" do
+        config <- withArgs ["--yolo"] parseServerConfig
+        config.serverYolo `shouldBe` True
+
+    it "preserves explicit auto-approval during resolution" do
+        withTokenEnvironmentUnset do
+            resolved <-
+                resolveServerConfig
+                    defaultServerConfig { serverYolo = True }
+            case resolved of
+                Left err ->
+                    expectationFailure (Text.unpack err)
+                Right config ->
+                    config.resolvedYolo `shouldBe` True
+
     it "reads a newline-terminated private token file through EOF" do
         withTokenEnvironmentUnset $
             withPrivateTokenFile "correct-token\n" \path -> do


### PR DESCRIPTION
## Summary
- add an opt-in `agent-server --yolo` switch
- map server turns to the existing typed `NativeYolo` / `ApproveAll` policy
- keep prompting as the default and preserve restricted startup capabilities

## Verification
- agent server library typecheck
- `validateNativeTurnRequest`: 4 examples, 0 failures
- `nativeTurnOptions`: 59 examples, 0 failures
- server configuration: 8 examples, 0 failures
- `git diff --check`

The broader local runtime suite also compiled and ran; unrelated persistence cases fail only because PostgreSQL Unix socket paths exceed the macOS limit in this deeply nested worktree.