### PR TITLE
Avoid TLS catalog request stalls with TCP_NODELAY

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -590,6 +590,12 @@
                                     ver = "1.2.3.1";
                                     sha256 = "sha256-EteEnSgJB4MXixv/58D2Qo70L/AfZxNGin/pYiIjVhY=";
                                 } { });
+                        # Avoid Nagle/delayed-ACK stalls between TLS and the first
+                        # HTTP request. Patch the existing socket path rather
+                        # than replacing its proxy/fallback/cleanup behavior.
+                        crypton-connection = pkgs.haskell.lib.appendPatch
+                            previous.crypton-connection
+                            ./patches/crypton-connection-nodelay.patch;
                         vty-unix = pkgs.haskell.lib.appendPatch
                             previous.vty-unix
                             ./patches/vty-unix-all-motion.patch;

--- a/patches/crypton-connection-nodelay.patch
+++ b/patches/crypton-connection-nodelay.patch
@@ -1,0 +1,14 @@
+--- a/Network/Connection.hs
++++ b/Network/Connection.hs
+@@ -239,7 +239,10 @@
+             E.bracketOnError
+                 (socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr))
+                 (close)
+-                (\sock -> connect sock (addrAddress addr) >> return (sock, addrAddress addr))
++                (\sock -> do
++                    setSocketOption sock NoDelay 1
++                    connect sock (addrAddress addr)
++                    return (sock, addrAddress addr))
+         firstSuccessful = go []
+           where
+             go :: [E.IOException] -> [IO a] -> IO a

--- a/scripts/CertificateStoreProbe.hs
+++ b/scripts/CertificateStoreProbe.hs
@@ -1,0 +1,14 @@
+-- Isolate trust-store loading without DNS, sockets, TLS or credentials.
+import Control.Exception (evaluate)
+import Control.Monad (replicateM_)
+import Data.X509.CertificateStore (listCertificates)
+import GHC.Clock (getMonotonicTimeNSec)
+import System.X509 (getSystemCertificateStore)
+
+main :: IO ()
+main = replicateM_ 3 $ do
+    start <- getMonotonicTimeNSec
+    store <- getSystemCertificateStore
+    count <- evaluate (length (listCertificates store))
+    end <- getMonotonicTimeNSec
+    print (count, fromIntegral (end - start) / 1000000 :: Double)

--- a/scripts/GatewayCatalogProbe.hs
+++ b/scripts/GatewayCatalogProbe.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- Authenticated, read-only catalog benchmark. Never prints credentials/body.
+import Control.Exception.Safe (bracket, try)
+import Control.Exception (evaluate)
+import Control.Monad (unless)
+import Data.Aeson
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy.Char8 as Output
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import Network.HTTP.Client
+import Network.HTTP.Client.TLS (newTlsManager)
+import Network.HTTP.Types.Status (statusCode)
+import System.Directory (getHomeDirectory)
+
+data Credential = Credential Text Text
+instance FromJSON Credential where
+    parseJSON = withObject "credential" $ \o ->
+        Credential <$> o .: "base_url" <*> o .: "access_token"
+
+main :: IO ()
+main = do
+    home <- getHomeDirectory
+    bytes <- LBS.readFile (home <> "/.haskell-agent/credentials/gateway.json")
+    Credential origin token <- case eitherDecode bytes of
+        Left _ -> fail "Cannot decode gateway credential"
+        Right c -> pure c
+    unless (origin `elem`
+        ["https://platform.digitallyinduced.com", "https://platform.digitallyinduced.com/",
+         "https://platform.digitallyinduced.com/v1", "https://platform.digitallyinduced.com/v1/"]) $
+        fail "Credential origin mismatch"
+    initial <- parseRequest "https://platform.digitallyinduced.com/v1/models"
+    let request = initial
+            { requestHeaders = [("Authorization", "Bearer " <> Text.encodeUtf8 token),
+                                ("Accept", "application/json")]
+            , redirectCount = 0
+            , responseTimeout = responseTimeoutMicro 5000000
+            }
+    start <- getMonotonicTimeNSec
+    bracket newTlsManager closeManager $ \manager -> do
+        result <- try (httpLbs request manager)
+        response <- case result of
+            Left (_ :: HttpException) -> fail "Catalog transport failed; details omitted"
+            Right r -> pure r
+        unless (statusCode (responseStatus response) == 200) $
+            fail "Catalog request failed; response omitted"
+        value <- case eitherDecode (responseBody response) :: Either String Value of
+            Left _ -> fail "Invalid catalog JSON"
+            Right v -> pure v
+        checksum <- evaluate (LBS.length (encode value))
+        end <- getMonotonicTimeNSec
+        Output.putStrLn $ encode $ object
+            [ "total_ms" .= (fromIntegral (end - start) / 1000000 :: Double)
+            , "checksum" .= checksum
+            ]

--- a/scripts/GatewayTLSProbe.hs
+++ b/scripts/GatewayTLSProbe.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- Credential-free GET with explicit DNS/TCP/TLS boundaries and Nagle control.
+import Control.Exception.Safe (bracket, bracketOnError)
+import Control.Monad (forM_)
+import Data.Aeson (encode, object, (.=))
+import Data.Default.Class (def)
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import GHC.Clock (getMonotonicTimeNSec)
+import qualified Network.Connection as C
+import qualified Network.Socket as S
+import System.Timeout (timeout)
+
+main :: IO ()
+main = forM_ [False, True, True, False, False, True, True, False] $ \noDelay -> do
+    outcome <- timeout 10000000 $ do
+        start <- getMonotonicTimeNSec
+        context <- C.initConnectionContext
+        contextReady <- getMonotonicTimeNSec
+        addresses <- S.getAddrInfo
+            (Just S.defaultHints { S.addrFlags = [S.AI_ADDRCONFIG], S.addrSocketType = S.Stream })
+            (Just "platform.digitallyinduced.com") (Just "443")
+        dnsReady <- getMonotonicTimeNSec
+        address <- case addresses of
+            a : _ -> pure a
+            [] -> fail "No address"
+        let acquire = bracketOnError
+                (S.socket (S.addrFamily address) S.Stream (S.addrProtocol address)) S.close $ \sock -> do
+                    S.setSocketOption sock S.NoDelay (if noDelay then 1 else 0)
+                    S.connect sock (S.addrAddress address)
+                    tcpReady <- getMonotonicTimeNSec
+                    conn <- C.connectFromSocket context sock C.ConnectionParams
+                        { C.connectionHostname = "platform.digitallyinduced.com"
+                        , C.connectionPort = 443
+                        , C.connectionUseSecure = Just def
+                        , C.connectionUseSocks = Nothing
+                        }
+                    tlsReady <- getMonotonicTimeNSec
+                    pure (conn, tcpReady, tlsReady)
+        bracket acquire (\(conn, _, _) -> C.connectionClose conn) $ \(conn, tcpReady, tlsReady) -> do
+            C.connectionPut conn "GET /v1/models HTTP/1.1\r\nHost: platform.digitallyinduced.com\r\nConnection: close\r\n\r\n"
+            _ <- C.connectionGetLine 4096 conn
+            headersReady <- getMonotonicTimeNSec
+            let ms a b = fromIntegral (b - a) / 1000000 :: Double
+            LBS.putStrLn $ encode $ object
+                [ "nodelay" .= noDelay
+                , "context_ms" .= ms start contextReady
+                , "dns_ms" .= ms contextReady dnsReady
+                , "tcp_ms" .= ms dnsReady tcpReady
+                , "tls_ms" .= ms tcpReady tlsReady
+                , "first_line_ms" .= ms tlsReady headersReady
+                , "total_ms" .= ms start headersReady
+                ]
+    case outcome of
+        Nothing -> fail "Probe timed out"
+        Just () -> pure ()

--- a/scripts/LocalGatewayProbe.hs
+++ b/scripts/LocalGatewayProbe.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- Transport-only reproduction of Gateway.Catalog's newTlsManager/httpLbs path.
+-- No credential store, database, terminal, or model request is involved.
+import Control.Exception.Safe (bracket)
+import Control.Exception (evaluate)
+import Control.Monad (forM_, unless)
+import Data.Aeson (Value, eitherDecodeStrict', encode, object, (.=))
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import GHC.Clock (getMonotonicTimeNSec)
+import Network.HTTP.Client
+import Network.HTTP.Client.TLS (newTlsManager)
+import Network.HTTP.Types.Status (statusCode)
+import System.Environment (getArgs)
+import Text.Read (readMaybe)
+
+main :: IO ()
+main = do
+    args <- getArgs
+    case args of
+        [url, countText] | Just count <- readMaybe countText, count > (0 :: Int) -> do
+            initial <- parseRequest url
+            unless (host initial == "127.0.0.1" || host initial == "localhost") $
+                fail "Only loopback fixtures are allowed"
+            let request = initial
+                    { requestHeaders = [("Authorization", "Bearer benchmark-only"), ("Accept", "application/json")]
+                    , redirectCount = 0
+                    , responseTimeout = responseTimeoutMicro 5000000
+                    }
+            forM_ [0 .. count - 1] $ \sample -> do
+                start <- getMonotonicTimeNSec
+                bracket newTlsManager closeManager $ \manager -> do
+                    created <- getMonotonicTimeNSec
+                    forM_ [0 :: Int, 1] $ \reuse -> do
+                        sent <- getMonotonicTimeNSec
+                        response <- httpLbs request manager
+                        received <- getMonotonicTimeNSec
+                        unless (statusCode (responseStatus response) == 200) $
+                            fail "Fixture returned non-200"
+                        value <- either fail pure
+                            (eitherDecodeStrict' (LBS.toStrict (responseBody response)) :: Either String Value)
+                        -- Force the complete JSON tree, not just the outer constructor.
+                        checksum <- evaluate (LBS.length (encode value))
+                        decoded <- getMonotonicTimeNSec
+                        let ms a b = fromIntegral (b - a) / 1000000 :: Double
+                        LBS.putStrLn $ encode $ object
+                            [ "sample" .= sample, "reuse" .= reuse
+                            , "manager_ms" .= ms start created
+                            , "http_ms" .= ms sent received
+                            , "decode_ms" .= ms received decoded
+                            , "total_ms" .= ms (if reuse == 0 then start else sent) decoded
+                            , "checksum" .= checksum
+                            ]
+        _ -> fail "Usage: local-gateway-probe LOOPBACK_URL COUNT"

--- a/scripts/LocalGatewayProbe.md
+++ b/scripts/LocalGatewayProbe.md
@@ -1,0 +1,199 @@
+# Local catalog transport reproduction
+
+This is a **transport isolation test**, not a complete CLI startup benchmark.
+It exercises the `newTlsManager` → `httpLbs` sequence used by
+`Agent.CLI.Gateway.Catalog`, with the same bearer/Accept headers, redirect refusal
+and five-second request timeout. It deliberately avoids PostgreSQL, session
+scratch allocation, UI, real credentials and production traffic.
+
+The local HTTP/HTTPS server returns synthetic model catalogs without injected
+latency. HTTPS uses an ephemeral localhost certificate, added only to the child
+process's CA bundle; certificate verification remains enabled. No keychain,
+global trust or user settings are changed.
+
+## Run
+
+From the repository root:
+
+```sh
+mkdir -p .startup-tmp
+export TMPDIR="$PWD/.startup-tmp"
+nix develop
+# Quick typecheck first:
+ghci -ignore-dot-ghci scripts/LocalGatewayProbe.hs -e ':quit'
+# Optimized timings, not interpreted GHCi timings:
+ghc -O2 -threaded -rtsopts -with-rtsopts=-N4 \
+  -outputdir .startup-tmp/local-probe-build \
+  scripts/LocalGatewayProbe.hs -o .startup-tmp/local-gateway-probe
+python3 -B scripts/test-benchmark-local-gateway.py
+python3 -B scripts/benchmark-local-gateway.py \
+  --client .startup-tmp/local-gateway-probe --samples 7 --models 10
+```
+
+Repeat with `--models 1`, `100`, and `1000`, then repeat the 10-model case.
+Stay inside the same Nix shell; shell evaluation/build time is not part of
+request measurements.
+
+Three controls run: `http-system-trust` preserves the caller's trust
+environment; `http` and `https` use the temporary CA bundle. To explicitly
+exercise macOS's default certificate-store path rather than a bundle supplied
+by the Nix shell, also run:
+
+```sh
+env -u SSL_CERT_FILE python3 -B scripts/benchmark-local-gateway.py \
+  --client .startup-tmp/local-gateway-probe --samples 7 --models 10
+```
+
+This changes only the benchmark subprocess environment, not user settings.
+
+Each independent process makes two requests per manager and creates several
+managers. Compare:
+
+- `sample=0,reuse=0`: first manager and first request in a fresh process;
+- `sample>0,reuse=0`: new manager/connection in an existing process;
+- `reuse=1`: a second request using the same manager.
+
+`manager_ms` measures manager creation, `http_ms` measures `httpLbs` including
+connection setup and complete response-body reading, and `decode_ms` includes
+generic Aeson decoding and re-encoding to force the whole result. `total_ms`
+includes manager creation only for the first request on that manager.
+The repeated `manager_ms` on reuse rows is descriptive, not additional work.
+JSON decoding here is not the production catalog normalization algorithm.
+Process wall time includes both requests, output, cleanup, loader and RTS.
+
+## Interpretation
+
+Do not simulate the unexplained 180 ms with a sleep and call it reproduced.
+First establish whether a slow manager initialization or first TLS request
+appears on loopback without delay. HTTP controls for TLS; reused connections
+control for connection setup. The fixture does not reproduce WAN RTT,
+production certificates/proxy/load, or the full launch-to-request critical path.
+Only claim a reproduction when the measured slow stage is observed.
+
+## Local results (2026-09-07, macOS ARM64)
+
+Optimized probe, seven independent processes per transport/size, three
+managers per process, two requests per manager. Median request totals in ms:
+
+| Models | HTTP, first manager | HTTPS, first manager | HTTPS, later fresh manager | HTTPS, first connection reused |
+|---:|---:|---:|---:|---:|
+| 1 | 2.07 | 24.16 | 2.99 | 0.18 |
+| 10 | 2.27 | 24.09 | 2.78 | 0.20 |
+| 1000 | 2.89 | 24.47 | 4.25 | 1.41 |
+
+An earlier independent 10-model run gave 25.28 ms for first HTTPS and
+3.13 ms for a later fresh manager. The HTTP control with `SSL_CERT_FILE`
+unset gave 2.18 ms for 10 models; no expensive eager manager initialization
+was observed. This does not rule out certificate work deferred until TLS.
+
+The reproducible finding is a roughly 21 ms process-first HTTPS overhead
+relative to later fresh managers, not the full 180 ms catalog interval seen
+in the CLI trace. The remaining gap needs the actual CLI/catalog path and
+its environment reproduced; these results do not justify a server-side
+optimization or a claim that startup is fixed. Six fixture/parser tests pass.
+
+## Deeper investigation: client socket behavior
+
+Verified the actual benchmark/CLI dependencies: GHC 9.10.3,
+`http-client-tls-0.3.6.4`, `crypton-connection-0.4.5`,
+`crypton-x509-system-1.6.8`, `tls-2.1.8`.
+
+The catalog refresh constructs a fresh, uncontended MVar and performs pure
+credential validation, followed by `newTlsManager` and `httpLbs`. There is no
+hidden database query or credential refresh in the catalog timing interval.
+
+Two relevant dependency behaviors:
+
+1. `http-client-tls` passes a lazy, process-global `ConnectionContext` created
+   by `unsafePerformIO initConnectionContext`. Its CA store can be forced
+   during first TLS rather than manager creation. `CertificateStoreProbe.hs`
+   directly loads and forces the certificate list: roughly 23 ms for 162
+   certificates on this machine. Merely timing HTTP cannot exclude this cost.
+2. `crypton-connection`'s `resolve'/tryToConnect` creates and connects the
+   socket **without setting `NoDelay`**. Small consecutive TLS/application
+   writes are consequently subject to Nagle/ACK delays.
+
+`GatewayTLSProbe.hs` isolates DNS, TCP, TLS, and the subsequent HTTP status-line
+wait. It uses the same connection/TLS dependencies and verified certificates,
+with alternating `TCP_NODELAY=0/1`. It sends a credential-free GET to the fixed
+production origin, not a model request, and prints neither response nor tokens.
+This is a transport diagnostic, not an authenticated full catalog benchmark.
+
+```sh
+# Inside nix develop:
+ghci -ignore-dot-ghci scripts/GatewayTLSProbe.hs -e ':quit'
+ghc -O2 -threaded -rtsopts -with-rtsopts=-N4 \
+  -outputdir .startup-tmp/tls-probe-build \
+  scripts/GatewayTLSProbe.hs -o .startup-tmp/gateway-tls-probe
+.startup-tmp/gateway-tls-probe
+```
+
+First alternating run (four samples per setting): post-TLS status-line wait
+was 71.88–84.77 ms with Nagle enabled versus 16.01–21.49 ms with `TCP_NODELAY`.
+TCP and TLS timings remained similar. This experimentally identifies a
+substantial client-side socket-option penalty; packet-level ACK timing is not
+captured by this probe. Loopback's near-zero RTT masked this behavior.
+
+A second alternating run reproduced the difference. Across both runs (eight
+samples per setting), median post-TLS wait was **78.65 ms → 18.48 ms**;
+median total through status line was **151.12 ms → 80.47 ms**. These are
+credential-free transport measurements, not authenticated catalog or
+launch-to-first-request results. Raw runs are in the local
+`.startup-tmp/tls-stages{,-repeat}.jsonl` artifacts.
+
+The fix should target the HTTPS socket creation path while preserving proxy
+support, address fallback, certificate validation and cleanup—not bypass
+discovery authorization or weaken TLS. Validate the actual catalog and
+launch-to-first-request path before claiming the complete 180 ms is explained
+or that a production fix is ready.
+
+## Dependency patch and authenticated validation
+
+`flake.nix` now applies `patches/crypton-connection-nodelay.patch`.
+It sets `NoDelay` inside the existing `bracketOnError`, before connect.
+Failures still close the socket and enter the existing address fallback.
+No TLS verification, authorization, or proxy selection code is replaced.
+This affects consumers of this flake's patched dependency; an already installed
+CLI or a Cabal build using an old dependency does not acquire the fix.
+
+`GatewayCatalogProbe.hs` uses `newTlsManager`/`httpLbs`, the stored credential
+only after checking its production origin, no redirects, and full JSON forcing.
+It prints only elapsed time and encoded JSON length (called `checksum`, not a
+cryptographic content hash). Transport errors are redacted. Credential-file IO
+is outside the interval; first-use TLS trust initialization remains inside it.
+
+Build this same source in baseline and patched Nix shells, with distinct output
+directories and executables:
+
+```sh
+ghci -ignore-dot-ghci scripts/GatewayCatalogProbe.hs -e ':quit'
+ghc -O2 -threaded -rtsopts -with-rtsopts=-N4 \
+  -outputdir .startup-tmp/catalog-new-build \
+  scripts/GatewayCatalogProbe.hs -o .startup-tmp/catalog-new
+# Baseline: same command in the unpatched shell, using catalog-old-build/catalog-old.
+# Both comparisons run inside nix develop:
+python3 -B scripts/benchmark-catalog-pair.py \
+  .startup-tmp/catalog-old .startup-tmp/catalog-new
+```
+
+Two runs, seven independent processes per implementation each, alternating
+order, authenticated GET `/v1/models`, 1,102-byte re-encoded JSON:
+
+| Run | Baseline median | Patched median | Difference |
+| --- | ---: | ---: | ---: |
+| First | 462.177 ms | 408.445 ms | -53.732 ms |
+| Repeat | 202.825 ms | 146.698 ms | -56.127 ms |
+
+Absolute latency was noisy; both runs support a roughly 55 ms reduction in this
+catalog workload, not an absolute latency target. Raw samples:
+`.startup-tmp/catalog-pair{,-repeat}.jsonl`. This is still not a full
+launch-to-first-request measurement.
+
+Patched local HTTP/TLS fixtures also ran with 1, 10, and 1,000 models.
+Seven fixture/parser tests pass, including rejection of an untrusted certificate
+by the patched Haskell client:
+
+```sh
+LOCAL_GATEWAY_CLIENT="$PWD/.startup-tmp/local-gateway-nodelay" \
+  python3 -B scripts/test-benchmark-local-gateway.py
+```

--- a/scripts/benchmark-catalog-pair.py
+++ b/scripts/benchmark-catalog-pair.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Compare optimized GatewayCatalogProbe binaries; run inside nix develop."""
+import argparse
+import json
+import math
+import statistics
+import subprocess
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("before")
+    parser.add_argument("after")
+    parser.add_argument("--samples", type=int, default=7)
+    args = parser.parse_args()
+    if args.samples < 3:
+        parser.error("Use at least three samples")
+    results = {"before": [], "after": []}
+    checksums = set()
+    for sample in range(args.samples):
+        order = ("before", "after") if sample % 2 == 0 else ("after", "before")
+        for mode in order:
+            process = subprocess.run(
+                [getattr(args, mode)], capture_output=True, text=True, timeout=15)
+            if process.returncode:
+                raise SystemExit(f"{mode} failed; diagnostic output suppressed")
+            row = json.loads(process.stdout)
+            elapsed = row["total_ms"]
+            if isinstance(elapsed, bool) or not math.isfinite(elapsed) or elapsed < 0:
+                raise SystemExit("Invalid timing")
+            checksums.add(row["checksum"])
+            results[mode].append(elapsed)
+            print(json.dumps({"mode": mode, "sample": sample, **row}), flush=True)
+    if len(checksums) != 1:
+        raise SystemExit("Catalog sizes changed; comparison rejected")
+    print(json.dumps({"median_ms": {
+        mode: statistics.median(rows) for mode, rows in results.items()}}))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark-local-gateway.py
+++ b/scripts/benchmark-local-gateway.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Run an optimized catalog client against a private loopback HTTP/TLS fixture.
+
+Run inside nix develop (Python and openssl required):
+  python3 -B scripts/benchmark-local-gateway.py --client /path/to/client
+
+The client receives the full /v1/models URL and manager COUNT, uses only
+"Bearer benchmark-only", and emits JSON object lines. Each process starts cold;
+the client makes two requests per manager. Numeric *_ms fields are summarized
+by reuse and first/later manager, never by every individual sample.
+No real credentials are read, no HOME is changed, and no delays are injected.
+"""
+import argparse
+from collections import defaultdict
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import math
+import os
+from pathlib import Path
+import socket
+import ssl
+import statistics
+import subprocess
+import tempfile
+import threading
+import time
+
+
+def catalog_payload(count):
+    return json.dumps({"data": [
+        {"id": f"benchmark-model-{i}", "protocol": "responses"}
+        for i in range(count)]}, separators=(",", ":")).encode()
+
+
+@contextmanager
+def fixture(payload, context=None, requests=None):
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def setup(self):
+            super().setup()
+            self.connection.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            self.connection.settimeout(10)
+
+        def do_GET(self):
+            status = 200 if (
+                self.path == "/v1/models"
+                and self.headers.get("Authorization") == "Bearer benchmark-only"
+            ) else 403
+            body = payload if status == 200 else b"{}"
+            if requests is not None:
+                requests.append(status)
+            # One write prevents fixture header/body packet splitting from
+            # manufacturing a delayed-ACK stall in the client benchmark.
+            headers = (
+                f"HTTP/1.1 {status} {'OK' if status == 200 else 'Forbidden'}\r\n"
+                "Content-Type: application/json\r\n"
+                "Cache-Control: no-store\r\n"
+                f"Content-Length: {len(body)}\r\n\r\n"
+            ).encode()
+            self.wfile.write(headers + body)
+
+        def log_message(self, *_):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    if context is not None:
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        scheme = "https" if context is not None else "http"
+        yield f"{scheme}://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+
+def make_certificate(directory):
+    cert, key = directory / "cert.pem", directory / "key.pem"
+    subprocess.run([
+        "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+        "-keyout", str(key), "-out", str(cert), "-days", "1",
+        "-subj", "/CN=localhost",
+        "-addext", "subjectAltName=DNS:localhost,IP:127.0.0.1",
+        "-addext", "basicConstraints=critical,CA:TRUE",
+    ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    return cert, key
+
+
+def child_environment(cert, directory):
+    env = dict(os.environ)
+    # Preserve bundle workload (important when certificate loading is slow),
+    # adding the fixture root only in this child's private bundle.
+    bundle = directory / "bundle.pem"
+    original = ssl.get_default_verify_paths().cafile
+    contents = Path(original).read_bytes() if original else b""
+    bundle.write_bytes(contents + b"\n" + cert.read_bytes())
+    env["SSL_CERT_FILE"] = str(bundle)
+    # Only localhost is used. Do not accidentally send fixture auth to a proxy.
+    for name in tuple(env):
+        if name.lower() in ("http_proxy", "https_proxy", "all_proxy"):
+            del env[name]
+    env["NO_PROXY"] = env["no_proxy"] = "localhost,127.0.0.1"
+    return env
+
+
+def parse_rows(output):
+    rows = []
+    for line in output.splitlines():
+        row = json.loads(line)
+        if not isinstance(row, dict):
+            raise ValueError("client must emit JSON objects")
+        for key, value in row.items():
+            if key.endswith("_ms") and (
+                    isinstance(value, bool) or not isinstance(value, (int, float))
+                    or not math.isfinite(value) or value < 0):
+                raise ValueError(f"invalid timing field: {key}")
+        rows.append(row)
+    if not rows:
+        raise ValueError("client emitted no measurements")
+    return rows
+
+
+def validate_probe_rows(rows, count, payload_bytes):
+    expected = {(sample, reuse) for sample in range(count) for reuse in (0, 1)}
+    observed = set()
+    for row in rows:
+        if not {"sample", "reuse", "checksum", "manager_ms", "http_ms",
+                "decode_ms", "total_ms"} <= row.keys():
+            raise ValueError("probe omitted required measurement fields")
+        if any(type(row[key]) is not int for key in ("sample", "reuse", "checksum")):
+            raise ValueError("probe indices and checksum must be integers")
+        if row["checksum"] != payload_bytes:
+            raise ValueError("probe decoded an unexpected catalog")
+        observed.add((row["sample"], row["reuse"]))
+    if len(rows) != 2 * count or observed != expected:
+        raise ValueError("probe emitted missing or duplicate request measurements")
+
+
+def summaries(rows):
+    groups = defaultdict(lambda: defaultdict(list))
+    for row in rows:
+        label = tuple((key, row[key]) for key in ("mode", "stage", "phase")
+                      if key in row)
+        if "reuse" in row:
+            label += (("reuse", row["reuse"]),)
+        if "sample" in row:
+            label += (("manager_phase", "first_manager" if row["sample"] == 0
+                       else "later_manager"),)
+        for key, value in row.items():
+            if key.endswith("_ms"):
+                groups[label][key].append(value)
+    return [dict(label=dict(label), median_ms={
+        key: statistics.median(values) for key, values in metrics.items()
+    }, samples={key: len(values) for key, values in metrics.items()})
+        for label, metrics in groups.items()]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--client", type=Path, required=True)
+    parser.add_argument("--samples", type=int, default=7,
+                        help="independent client processes per transport")
+    parser.add_argument("--requests", type=int, default=3,
+                        help="manager COUNT passed to each client (2 requests each)")
+    parser.add_argument("--models", type=int, default=10)
+    parser.add_argument("--timeout", type=float, default=30)
+    args = parser.parse_args()
+    if (min(args.samples, args.requests, args.models) < 1
+            or not math.isfinite(args.timeout) or args.timeout <= 0):
+        parser.error("counts and timeout must be positive")
+    with tempfile.TemporaryDirectory(prefix="gateway-local-") as name:
+        directory = Path(name)
+        cert, key = make_certificate(directory)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(cert, key)
+        env = child_environment(cert, directory)
+        payload = catalog_payload(args.models)
+        # The unmodified trust control matters even without TLS: manager
+        # creation may eagerly load the system keychain. Replacing its bundle
+        # before timing could otherwise hide the very startup cost under study.
+        system_trust_env = dict(env)
+        if "SSL_CERT_FILE" in os.environ:
+            system_trust_env["SSL_CERT_FILE"] = os.environ["SSL_CERT_FILE"]
+        else:
+            system_trust_env.pop("SSL_CERT_FILE", None)
+        for transport, tls, client_env in (
+                ("http-system-trust", None, system_trust_env),
+                ("http", None, env), ("https", context, env)):
+            collected = []
+            elapsed = []
+            requests = []
+            with fixture(payload, tls, requests) as url:
+                for sample in range(args.samples):
+                    before_requests = len(requests)
+                    started = time.perf_counter()
+                    result = subprocess.run(
+                        [str(args.client.resolve()), url + "/v1/models",
+                         str(args.requests)],
+                        env=client_env, capture_output=True, text=True,
+                        timeout=args.timeout, check=True)
+                    elapsed.append((time.perf_counter() - started) * 1000)
+                    observed = requests[before_requests:]
+                    if len(observed) != 2 * args.requests or any(
+                            status != 200 for status in observed):
+                        raise ValueError(
+                            "client must make two authorized requests per manager; "
+                            f"expected {2 * args.requests}, observed {observed}")
+                    rows = parse_rows(result.stdout)
+                    validate_probe_rows(rows, args.requests, len(payload))
+                    collected.extend(rows)
+                    for row in rows:
+                        print(json.dumps({"transport": transport, "sample": sample,
+                                          "measurement": row}), flush=True)
+            print(json.dumps({
+                "summary": transport, "models": args.models,
+                "payload_bytes": len(payload), "process_samples": args.samples,
+                "process_wall_median_ms": statistics.median(elapsed),
+                "measurements": summaries(collected),
+            }), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-benchmark-local-gateway.py
+++ b/scripts/test-benchmark-local-gateway.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+import http.client
+import os
+import subprocess
+import json
+from pathlib import Path
+import runpy
+import ssl
+import tempfile
+import unittest
+from urllib.parse import urlsplit
+
+
+BENCH = runpy.run_path(str(Path(__file__).with_name("benchmark-local-gateway.py")))
+
+
+class LocalGatewayTest(unittest.TestCase):
+    @unittest.skipUnless(os.environ.get("LOCAL_GATEWAY_CLIENT"),
+                         "set LOCAL_GATEWAY_CLIENT to test the Haskell TLS client")
+    def test_haskell_client_rejects_untrusted_certificate(self):
+        with tempfile.TemporaryDirectory(prefix="gateway-trust-") as name:
+            directory = Path(name)
+            trusted = directory / "trusted"
+            untrusted = directory / "untrusted"
+            trusted.mkdir()
+            untrusted.mkdir()
+            trusted_cert, _ = BENCH["make_certificate"](trusted)
+            server_cert, server_key = BENCH["make_certificate"](untrusted)
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(server_cert, server_key)
+            env = BENCH["child_environment"](trusted_cert, directory)
+            with BENCH["fixture"](BENCH["catalog_payload"](1), context) as url:
+                result = subprocess.run(
+                    [str(Path(os.environ["LOCAL_GATEWAY_CLIENT"]).resolve()),
+                     url + "/v1/models", "1"],
+                    env=env, capture_output=True, timeout=10)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, b"")
+
+    def test_http_auth_and_keepalive(self):
+        payload = BENCH["catalog_payload"](3)
+        requests = []
+        with BENCH["fixture"](payload, requests=requests) as url:
+            conn = http.client.HTTPConnection(urlsplit(url).netloc)
+            try:
+                conn.request("GET", "/v1/models")
+                response = conn.getresponse()
+                self.assertEqual(response.status, 403)
+                response.read()
+                first_socket = conn.sock
+                for _ in range(2):
+                    conn.request("GET", "/v1/models", headers={
+                        "Authorization": "Bearer benchmark-only"})
+                    response = conn.getresponse()
+                    self.assertEqual(response.status, 200)
+                    self.assertEqual(response.getheader("Cache-Control"), "no-store")
+                    self.assertEqual(response.read(), payload)
+                    self.assertIs(conn.sock, first_socket)
+            finally:
+                conn.close()
+        self.assertEqual(requests, [403, 200, 200])
+
+    def test_tls_certificate_verification(self):
+        with tempfile.TemporaryDirectory(prefix="gateway-test-") as name:
+            directory = Path(name)
+            cert, key = BENCH["make_certificate"](directory)
+            server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            server_context.load_cert_chain(cert, key)
+            client_context = ssl.create_default_context(cafile=str(cert))
+            with BENCH["fixture"](BENCH["catalog_payload"](1), server_context) as url:
+                untrusted = http.client.HTTPSConnection(
+                    urlsplit(url).netloc,
+                    context=ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
+                try:
+                    with self.assertRaises(ssl.SSLCertVerificationError):
+                        untrusted.request("GET", "/v1/models")
+                finally:
+                    untrusted.close()
+                conn = http.client.HTTPSConnection(
+                    urlsplit(url).netloc, context=client_context)
+                try:
+                    conn.request("GET", "/v1/models", headers={
+                        "Authorization": "Bearer benchmark-only"})
+                    response = conn.getresponse()
+                    self.assertEqual(response.status, 200)
+                    self.assertEqual(len(json.loads(response.read())["data"]), 1)
+                finally:
+                    conn.close()
+
+    def test_reject_invalid_timings(self):
+        for output in ('', '[]', '{"time_ms":-1}', '{"time_ms":NaN}',
+                       '{"time_ms":true}'):
+            with self.assertRaises(ValueError):
+                BENCH["parse_rows"](output)
+
+    def test_summary_separates_modes(self):
+        rows = BENCH["parse_rows"](
+            '{"mode":"cold","time_ms":3}\n'
+            '{"mode":"cold","time_ms":5}\n'
+            '{"mode":"warm","time_ms":1}\n')
+        result = BENCH["summaries"](rows)
+        self.assertEqual(result[0]["median_ms"]["time_ms"], 4)
+        self.assertEqual(result[1]["median_ms"]["time_ms"], 1)
+
+    def test_summary_separates_process_and_connection_warmth(self):
+        rows = [
+            {"sample": 0, "reuse": 0, "total_ms": 100},
+            {"sample": 0, "reuse": 1, "total_ms": 2},
+            {"sample": 1, "reuse": 0, "total_ms": 10},
+            {"sample": 2, "reuse": 0, "total_ms": 12},
+        ]
+        result = BENCH["summaries"](rows)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0]["label"],
+                         {"reuse": 0, "manager_phase": "first_manager"})
+        self.assertEqual(result[2]["median_ms"]["total_ms"], 11)
+
+    def test_probe_requires_all_rows_and_payload_checksum(self):
+        rows = [dict(sample=0, reuse=reuse, checksum=20, manager_ms=1,
+                     http_ms=1, decode_ms=1, total_ms=3) for reuse in (0, 1)]
+        BENCH["validate_probe_rows"](rows, 1, 20)
+        for invalid in (rows[:1], [rows[0], rows[0]],
+                        [dict(rows[0], checksum=21), rows[1]],
+                        [dict(sample=0, reuse=0), rows[1]]):
+            with self.assertRaises(ValueError):
+                BENCH["validate_probe_rows"](invalid, 1, 20)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Enable `TCP_NODELAY` in the existing `crypton-connection` socket acquisition path through a Nix dependency patch.
- Preserve exception cleanup, address fallback, proxy selection, and TLS certificate verification.
- Include local HTTP/TLS fixtures, certificate/transport probes, and an alternating authenticated catalog benchmark.
- Keep unfinished startup orchestration/tracing work out of this PR.

## Evidence

macOS ARM64, GHC 9.10.3, `crypton-connection-0.4.5`, `http-client-tls-0.3.6.4`, `tls-2.1.8`. Both benchmark binaries use the same source, built in baseline/patched Nix shells with `ghc -O2 -threaded -rtsopts -with-rtsopts=-N4` and separate output directories.

Authenticated `GET /v1/models`: seven fresh processes per implementation, alternating order, repeated twice; full JSON decoding/re-encoding forced, 1,102-byte encoded result. Credential-file IO is excluded; first-use trust loading, manager construction, connection setup, and full response reading are included.

| Run | Before median | After median | Saved |
| --- | ---: | ---: | ---: |
| First | 462.177 ms | 408.445 ms | 53.732 ms |
| Repeat | 202.825 ms | 146.698 ms | 56.127 ms |

Absolute latency was noisy. This supports roughly 55 ms less catalog-fetch latency, **not** a full launch-to-first-request improvement. The installed CLI has not been updated.

Loopback fixtures with 1, 10, and 1,000 models showed no material regression. Near-zero loopback RTT masks the WAN socket penalty; the fixture is an isolation/control benchmark, not a claim that all startup slowness is reproduced locally.

## Validation and reproduction

- GHCi typechecking before optimized probe builds.
- Patched dependency and HTTP client probe builds succeeded.
- Seven fixture/parser tests passed, including actual Haskell-client rejection of an untrusted TLS certificate.
- Repeated authenticated before/after benchmarks and multi-size local fixtures passed.
- `git diff --check`.

Inside `nix develop`, build `scripts/GatewayCatalogProbe.hs` in both baseline and patched environments with:

```sh
ghci -ignore-dot-ghci scripts/GatewayCatalogProbe.hs -e ':quit'
ghc -O2 -threaded -rtsopts -with-rtsopts=-N4 \
  -outputdir .startup-tmp/catalog-new-build \
  scripts/GatewayCatalogProbe.hs -o .startup-tmp/catalog-new
# Use catalog-old-build/catalog-old in the unpatched environment.
python3 -B scripts/benchmark-catalog-pair.py \
  .startup-tmp/catalog-old .startup-tmp/catalog-new --samples 7
# Repeat the comparison.
LOCAL_GATEWAY_CLIENT="$PWD/.startup-tmp/local-gateway-nodelay" \
  python3 -B scripts/test-benchmark-local-gateway.py
```

See `scripts/LocalGatewayProbe.md` for local probe build commands, workload dimensions, controls, and detailed findings. Production probes are opt-in, read-only, use a fixed origin, and do not print credentials or response bodies.
