### PR TITLE
Show the current pull request in the terminal sidebar

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -305,6 +305,7 @@ library
                     , agent-cli-runtime:Agent.CLI.Session.StoreCodec as Agent.CLI.Session.StoreCodec
                     , agent-cli-runtime:Agent.CLI.SessionLock as Agent.CLI.SessionLock
     build-depends:    agent-cli-runtime >= 0.1 && < 0.2
+                    , agent-repository >= 0.1 && < 0.2
                     , agent-external-session >= 0.1 && < 0.2
                     , agent-integration-api >= 0.1 && < 0.2
                     , agent-connectivity >= 0.1 && < 0.2

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -2,16 +2,17 @@
 , agent-codex-dialect, agent-connectivity, agent-core
 , agent-external-session, agent-gemini, agent-grok-build-dialect
 , agent-integration-api, agent-json, agent-mcp, agent-openai
-, agent-openrouter, agent-process, agent-responses
-, agent-responses-types, agent-store, agent-syntax, agent-tui
-, agent-xai, ansi-terminal, async, base, base64-bytestring, brick
-, bytestring, colour, containers, crypton, crypton-connection, dbus
-, deepseq, directory, entropy, filelock, filepath, haskeline
-, hasql-pool, hspec, http-client, http-client-tls, http-types
-, JuicyPixels, lib, memory, mtl, network, network-uri
-, optparse-applicative, process, QuickCheck, retry, safe-exceptions
-, scientific, stm, tagsoup, temporary, text, time, tls
-, transformers, unix, vector, vty, vty-crossplatform, wai, warp
+, agent-openrouter, agent-process, agent-repository
+, agent-responses, agent-responses-types, agent-store, agent-syntax
+, agent-tui, agent-xai, ansi-terminal, async, base
+, base64-bytestring, brick, bytestring, colour, containers, crypton
+, crypton-connection, dbus, deepseq, directory, entropy, filelock
+, filepath, haskeline, hasql-pool, hspec, http-client
+, http-client-tls, http-types, JuicyPixels, lib, memory, mtl
+, network, network-uri, optparse-applicative, process, QuickCheck
+, retry, safe-exceptions, scientific, stm, tagsoup, temporary, text
+, time, tls, transformers, unix, vector, vty, vty-crossplatform
+, wai, warp
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -24,15 +25,15 @@ mkDerivation {
     aeson agent-claude agent-cli-runtime agent-codex-dialect
     agent-connectivity agent-core agent-external-session agent-gemini
     agent-grok-build-dialect agent-integration-api agent-json agent-mcp
-    agent-openai agent-openrouter agent-process agent-responses
-    agent-responses-types agent-store agent-syntax agent-tui agent-xai
-    ansi-terminal async base base64-bytestring brick bytestring colour
-    containers crypton crypton-connection dbus directory entropy
-    filelock filepath haskeline hasql-pool http-client http-client-tls
-    http-types JuicyPixels memory mtl network network-uri
-    optparse-applicative process retry safe-exceptions scientific stm
-    tagsoup text time tls transformers unix vector vty
-    vty-crossplatform wai warp
+    agent-openai agent-openrouter agent-process agent-repository
+    agent-responses agent-responses-types agent-store agent-syntax
+    agent-tui agent-xai ansi-terminal async base base64-bytestring
+    brick bytestring colour containers crypton crypton-connection dbus
+    directory entropy filelock filepath haskeline hasql-pool
+    http-client http-client-tls http-types JuicyPixels memory mtl
+    network network-uri optparse-applicative process retry
+    safe-exceptions scientific stm tagsoup text time tls transformers
+    unix vector vty vty-crossplatform wai warp
   ];
   executableHaskellDepends = [
     aeson agent-cli-runtime agent-responses agent-responses-types

--- a/packages/agent-cli/src/Agent/CLI/Runtime/HistorySource.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/HistorySource.hs
@@ -4,20 +4,25 @@ module Agent.CLI.Runtime.HistorySource
     , emptyFullscreenHistoryPage
     , loadFullscreenHistoryPage
     , reloadFullscreenHistoryForHandle
+    , restoreFullscreenPullRequest
     ) where
 
 import Agent.CLI.Session
     ( SessionHandle(..)
     , SessionMeta(..)
+    , SessionTurnPage(..)
+    , loadSessionHistorySnapshot
+    , loadSessionHistoryTurnsRangeBounded
     , loadRecentSessionTurns
     , loadSessionTurnsAfter
     , loadSessionTurnsBefore
     )
 import Agent.CLI.TUI.App
-    ( FullscreenRuntime
-    , emitUiEvent
+    ( emitUiEvent
+    , enqueueAppEvent
     , reloadFullscreenHistorySource
     )
+import Agent.CLI.TUI.Types (AppEvent(..), FullscreenRuntime(..))
 import Agent.CLI.TUI.History
     ( HistoryCursor(..)
     , HistoryDirection(..)
@@ -25,7 +30,9 @@ import Agent.CLI.TUI.History
     , HistoryPage(..)
     , HistoryRequest(..)
     )
-import Agent.CLI.TUI.SessionHistory (sessionHistoryPage)
+import Agent.CLI.TUI.SessionHistory (sessionHistoryPage, sessionTurnPullRequestURL)
+import Data.Maybe (listToMaybe, mapMaybe)
+import Data.IORef (readIORef)
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.TUI.Model (UiEvent(..), warningNotice)
 import qualified Data.Sequence as Seq
@@ -73,6 +80,34 @@ loadFullscreenHistoryPage pool root sessionId request = do
             request.historyRequestDirection)
         <$> loadPage
 
+-- | Associations belong to the conversation, including turns before
+-- compaction or outside the bounded transcript window.
+restoreFullscreenPullRequest
+    :: FullscreenRuntime -> StorePool -> OsPath -> Text -> IO ()
+restoreFullscreenPullRequest runtime pool root sessionId = do
+    generation <- HistoryGeneration <$> readIORef runtime.runtimeHistoryGeneration
+    result <- loadSessionHistorySnapshot pool root sessionId >>= \case
+        Left err -> pure (Left err)
+        Right (_, _, total) -> scan total
+    case result of
+        Left _ -> pure ()
+        Right url ->
+            enqueueAppEvent runtime (AppSetPullRequestURL generation url)
+  where
+    scan end
+        | end <= 0 = pure (Right Nothing)
+        | otherwise = do
+            let start = max 0 (end - 32)
+            loadSessionHistoryTurnsRangeBounded
+                pool root sessionId start end 32 >>= \case
+                    Left err -> pure (Left err)
+                    Right page ->
+                        case listToMaybe (mapMaybe
+                            (sessionTurnPullRequestURL . snd)
+                            (reverse page.pageTurns)) of
+                            Just url -> pure (Right (Just url))
+                            Nothing -> scan start
+
 reloadFullscreenHistoryForHandle
     :: FullscreenRuntime
     -> SessionHandle
@@ -95,7 +130,7 @@ reloadFullscreenHistoryForHandle runtime handle = do
                     (UiSetNotice
                         (Just (warningNotice
                             ("Could not refresh session history: " <> err))))
-            Right page ->
+            Right page -> do
                 reloadFullscreenHistorySource
                     runtime
                     sessionId
@@ -104,3 +139,4 @@ reloadFullscreenHistoryForHandle runtime handle = do
                         (HistoryGeneration 0)
                         HistoryNewer
                         page)
+                restoreFullscreenPullRequest runtime handle.sessionPool root sessionId

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -83,7 +83,7 @@ import Agent.CLI.ProviderTransition
     , TransitionCause(AutomaticFallback) )
 import Agent.CLI.Resume ( publishResumeHistoryAfterBoundary )
 import Agent.CLI.Runtime.HistorySource
-    ( loadFullscreenHistoryPage, sessionUiPageSize )
+    ( loadFullscreenHistoryPage, sessionUiPageSize, restoreFullscreenPullRequest )
 import Agent.CLI.Runtime.Orchestration.Startup
     ( setStartupRepository )
 import Agent.CLI.Runtime.Orchestration.Tools ( AgentToolsRequest(..)
@@ -518,7 +518,7 @@ resolveInitializedTargets request workspace = do
                         sessionUiPageSize >>= \case
                             Left err ->
                                 startupDie startup err
-                            Right page ->
+                            Right page -> do
                                 setFullscreenHistorySource
                                     runtime
                                     meta.metaId
@@ -531,6 +531,11 @@ resolveInitializedTargets request workspace = do
                                         (HistoryGeneration 0)
                                         HistoryNewer
                                         page)
+                                restoreFullscreenPullRequest
+                                    runtime
+                                    (trustedPool startup.startupDatabaseStore)
+                                    request.initializedRoot
+                                    meta.metaId
     either (startupDie startup) pure resumedHistoryResult
     resumedTarget <-
         either (startupDie startup) pure resumedTargetResult

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -88,6 +88,7 @@ module Agent.CLI.TUI.App
     , clearFullscreenHistorySource
     , reloadFullscreenHistorySource
     , setFullscreenHistorySource
+    , setFullscreenPullRequestURL
     , setFullscreenSessionActions
     , fullscreenBounds
     , fullscreenVtyConfig

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -216,6 +216,11 @@ handleEvent event = do
         resolveConversationFollow
     when (isMotionTick event) refreshNativeProgressKeepalive
     handleEventInner event
+    stateAfterEvent <- get
+    when (isJust stateBeforeEvent.appPullRequestURL
+        /= isJust stateAfterEvent.appPullRequestURL) do
+        invalidateCache
+        queueConversationReflow
     when (eventMayExposeSyntax event) requestVisibleSyntaxLanguages
     state <- get
     let visible =
@@ -285,6 +290,7 @@ handleEvent event = do
         AppDictationPartial{} -> True
         AppAgentSnapshot{} -> True
         AppSetWindowTitle{} -> True
+        AppSetPullRequestURL{} -> True
         AppSyntaxHighlighterChanged -> True
         AppHistoryLiveStarted -> True
         AppConversationReflow -> True
@@ -315,6 +321,7 @@ handleEvent event = do
 
     agentStructureRequiresUnfocusedRedraw previous next =
         previous.appAgentSelected /= next.appAgentSelected
+            || previous.appPullRequestURL /= next.appPullRequestURL
             || agentChromeSignature previous.appAgentEntries
                 /= agentChromeSignature next.appAgentEntries
 
@@ -425,6 +432,10 @@ handleAppEvent = \case
         handleSetWindowTitleEvent title
     AppSyntaxHighlighterChanged ->
         handleSyntaxHighlighterChangedEvent
+    AppSetPullRequestURL generation url -> do
+        state <- get
+        when (generation == state.appHistoryWindow.historyWindowGeneration) $
+            modify' \current -> current { appPullRequestURL = url }
     AppHistoryReset page ->
         handleHistoryResetEvent page
     AppHistoryLoaded request result ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/History.hs
@@ -205,6 +205,7 @@ resetHistoryPage page state =
             either (const empty) id (applyHistoryPage remapped empty)
     in state
         { appUi = reduceUi UiConversationCleared state.appUi
+        , appPullRequestURL = Nothing
         , appHistoryWindow = window
         , appHistorySelectedBlock = Nothing
         , appHistoryLiveStart = Nothing

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -754,6 +754,8 @@ appEventLogicalBytes = \case
             (logicalTextBytes callId)
             (imagePreviewLogicalBytes preview)
     AppSyntaxHighlighterChanged -> 256
+    AppSetPullRequestURL _ url ->
+        saturatingAdd 256 (maybe 0 logicalTextBytes url)
     AppHistoryReset page ->
         saturatingAdd 256 (historyPageLogicalBytes page)
     AppHistoryLoaded _ result ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -339,6 +339,8 @@ applyUiEvent uiEvent state =
         nextState0 =
             state
                 { appUi = nextUi
+                , appPullRequestURL =
+                    Bridge.pullRequestForUiEvent uiEvent previousUi state.appPullRequestURL
                 , appAutoRecapShownThisAway =
                     case uiEvent of
                         UiRecapReady _ -> True

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -481,6 +481,7 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appSubmittedImagePreviews = Map.empty
         , appAgentSelected = initialAgent
         , appAgentEntries = initialAgents
+        , appPullRequestURL = Nothing
         , appAgentHover = Nothing
         , appMarkdownLinkHovered = False
         , appHoveredControl = Nothing

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -427,6 +427,11 @@ setFullscreenSessionActions
             , sessionAgentSelect = agentSelect
             }
 
+setFullscreenPullRequestURL :: FullscreenRuntime -> Maybe Text -> IO ()
+setFullscreenPullRequestURL runtime url = do
+    generation <- HistoryGeneration <$> readIORef runtime.runtimeHistoryGeneration
+    enqueueAppEvent runtime (AppSetPullRequestURL generation url)
+
 setFullscreenHistorySource
     :: FullscreenRuntime
     -> Text

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -10,6 +10,7 @@ module Agent.CLI.TUI.Bridge
     , pushHistory
     , reconcileAgentSelection
     , trimHistory
+    , pullRequestForUiEvent
     ) where
 
 import Agent.CLI.AgentViewport
@@ -18,9 +19,50 @@ import Agent.CLI.AgentViewport
     , lookupAgentEntry
     )
 import Agent.TUI.Model (UiEvent(..), UiState(..))
-import Agent.Loop (LoopEvent(..))
+import Agent.Loop (LoopEvent(..), TurnOutput(..))
+import Agent.CLI.RepositoryDelivery (conversationPullRequestURLs)
+import Agent.ToolDispatch (ToolCallResult(..))
+import Control.Applicative ((<|>))
+import qualified Data.Aeson as Aeson
+import Data.Aeson ((.=))
+import qualified Data.Map.Strict as Map
+import Data.Maybe (listToMaybe)
 import Data.Text (Text)
 import qualified Graphics.Vty as V
+
+-- | Use the same evidence rules as persisted conversation associations.
+-- Inspect complete outputs/messages only, never partially streamed URLs.
+pullRequestForUiEvent :: UiEvent -> UiState -> Maybe Text -> Maybe Text
+pullRequestForUiEvent event state previous =
+    case event of
+        UiConversationCleared -> Nothing
+        UiUserSubmitted text ->
+            firstURL text Nothing [] <|> previous
+        UiAssistantHistory text ->
+            firstURL "" (Just text) [] <|> previous
+        UiLoop (ToolFinished result) ->
+            case Map.lookup result.callId state.uiToolCalls of
+                Nothing -> previous
+                Just (_, call) ->
+                    firstURL "" Nothing
+                        [ Aeson.object
+                            [ "type" .= ("function_call" :: Text)
+                            , "call_id" .= call.callId
+                            , "name" .= call.name
+                            , "arguments" .= call.arguments
+                            ]
+                        , Aeson.object
+                            [ "type" .= ("function_call_output" :: Text)
+                            , "call_id" .= result.callId
+                            , "output" .= result.output
+                            ]
+                        ] <|> previous
+        UiLoop (TurnFinished output) ->
+            firstURL "" output.assistantText [] <|> previous
+        _ -> previous
+  where
+    firstURL user assistant items =
+        listToMaybe (conversationPullRequestURLs user assistant items)
 
 -- | Keep enough prompt recall for normal interactive use without retaining an
 -- unbounded copy of the persistent Haskeline history in the fullscreen state.

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
@@ -50,7 +50,7 @@ import Agent.CLI.TUI.LambdaArt ( lambdaArtWidget )
 import Agent.TUI.Accent ()
 import Agent.CLI.TUI.Types
     ( AppState(appConversationAnchor, appHoveredControl, appHistorySelectedBlock,
-               appAgentEntries, appSlashCatalog, appHistoryWindow, appUi,
+               appAgentEntries, appPullRequestURL, appSlashCatalog, appHistoryWindow, appUi,
                appAgentSelected),
       Name(QuickStartModel, CodeCopy, ConversationChunkCache,
            ConversationReserve, QuickStartWorktree, QuickStartResume,
@@ -355,7 +355,8 @@ stickyPromptLayers state =
         _ -> []
   where
     conversationWidth =
-        if length state.appAgentEntries <= 1 then 100 else 68
+        if length state.appAgentEntries <= 1 && state.appPullRequestURL == Nothing
+            then 100 else 68
 
 stickyPromptPreview :: Text -> Text
 stickyPromptPreview text =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Workspace.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Workspace.hs
@@ -51,10 +51,10 @@ import Agent.CLI.TUI.Types
     ( AgentHover(agentHoverTarget, agentHoverPaneUpperLeft,
                  agentHoverPaneWidth, agentHoverUpperLeft),
       AppState(appAgentHover, appRuntime, appMotionElapsedMillis, appUi,
-               appAgentSelected, appHistoryWindow, appAgentEntries),
+               appAgentSelected, appHistoryWindow, appAgentEntries, appPullRequestURL),
       FullscreenRuntime(runtimeMotionMode),
       Name(AgentPopover, ConversationViewportExtent,
-           ConversationViewport, AgentRow, AgentPane) )
+           ConversationViewport, AgentRow, AgentPane, MarkdownLink) )
 import Agent.CLI.Terminal ()
 import Agent.CLI.Timestamp ()
 import Agent.Loop ()
@@ -117,7 +117,7 @@ import Data.Foldable ()
 import Data.IORef ()
 import Data.List ( findIndex, intersperse, sortOn )
 import Data.List.NonEmpty ()
-import Data.Maybe ( fromMaybe )
+import Data.Maybe ( fromMaybe, isJust )
 import Data.Sequence ()
 import Data.Text ( Text )
 import Data.Time.Clock ()
@@ -139,7 +139,7 @@ import qualified Agent.CLI.TUI.Scroll as Scroll ()
 import qualified Data.Sequence as Seq ( null )
 import qualified Data.Set as Set ()
 import qualified Data.Text as Text
-    ( pack )
+    ( pack, takeWhileEnd, stripPrefix, breakOn )
 import qualified Data.Text.Encoding as TextEncoding ()
 import qualified Agent.TUI.Theme as Theme
     ( assistantAttr,
@@ -147,6 +147,7 @@ import qualified Agent.TUI.Theme as Theme
       borderActiveAttr,
       borderAttr,
       controlLinkHoverAttr,
+      controlLinkAttr,
       errorAttr,
       headingAttr,
       mutedAttr,
@@ -163,29 +164,66 @@ drawWorkspace :: AppState -> Widget Name
 drawWorkspace state =
     Widget Greedy Greedy do
         context <- getContext
+        let showAgents = length state.appAgentEntries > 1
+                && context.availHeight >= 8 + pullRequestHeight
         render $
             padTop (Pad 1) $
                 hBox $
                     [drawConversationPane state]
                         <> if not
-                            (agentPaneVisible
+                            (workspaceSidePaneVisible
                                 context.availWidth
                                 context.availHeight
-                                state.appAgentEntries)
+                                state.appAgentEntries
+                                state.appPullRequestURL)
                             then []
                             else
                                 [ hLimitPercent 40 $
                                     hLimit agentPaneWidth $
                                         padLeft (Pad 1) $
-                                            drawAgentPane
-                                                state
-                                                (agentPaneEntryLimit
-                                                    context.availHeight)
-                                                state.appAgentSelected
-                                                ((.agentHoverTarget)
-                                                    <$> state.appAgentHover)
-                                                state.appAgentEntries
+                                            vBox $
+                                                [ drawAgentPane
+                                                    state
+                                                    (agentPaneEntryLimit
+                                                        (context.availHeight - pullRequestHeight))
+                                                    state.appAgentSelected
+                                                    ((.agentHoverTarget)
+                                                        <$> state.appAgentHover)
+                                                    state.appAgentEntries
+                                                | showAgents
+                                                ]
+                                                <> [ (if showAgents
+                                                        then padTop (Pad 1)
+                                                        else id) (drawPullRequestPane url)
+                                                   | Just url <- [state.appPullRequestURL]
+                                                   ]
                                 ]
+  where
+    pullRequestHeight = if isJust state.appPullRequestURL then 5 else 0
+
+-- The PR remains accessible when the last subagent has finished.
+workspaceSidePaneVisible :: Int -> Int -> [AgentEntry] -> Maybe Text -> Bool
+workspaceSidePaneVisible width height entries pullRequest =
+    width >= agentPaneMinScreenWidth
+        && height >= agentPaneMinAvailableHeight
+        && (length entries > 1 || isJust pullRequest)
+
+drawPullRequestPane :: Text -> Widget Name
+drawPullRequestPane url =
+    withAttr Theme.borderAttr $
+        withBorderStyle unicodeRounded $
+            borderWithLabel (txt " Pull request ") $
+                padLeftRight 1 $
+                    vBox
+                        [ clickable (MarkdownLink url) $
+                            withAttr Theme.controlLinkAttr $
+                                terminalTxt ("PR #" <> Text.takeWhileEnd (/= '/') url <> " ↗")
+                        , withAttr Theme.mutedAttr $
+                            terminalTxt repository
+                        ]
+  where
+    repository = fst $ Text.breakOn "/pull/" $
+        fromMaybe url (Text.stripPrefix "https://github.com/" url)
 
 drawConversationPane :: AppState -> Widget Name
 drawConversationPane state =

--- a/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
@@ -6,6 +6,7 @@
 module Agent.CLI.TUI.SessionHistory
     ( sessionHistoryPage
     , sessionHistoryTurn
+    , sessionTurnPullRequestURL
     ) where
 
 import Agent.CLI.Session
@@ -14,6 +15,11 @@ import Agent.CLI.Session
     )
 import Agent.CLI.Session.Types (TranscriptEffect(..))
 import Agent.CLI.Render (renderToolOutputValue)
+import Agent.CLI.RepositoryDelivery (conversationPullRequestURLs)
+import qualified Data.Aeson as Aeson
+import Data.Maybe (listToMaybe)
+import Control.Applicative ((<|>))
+import qualified Data.Map.Strict as Map
 import Agent.CLI.Plan
     ( ProposedPlanSegment(..)
     , feedProposedPlanStream
@@ -69,6 +75,40 @@ import Agent.TUI.Model
 import Data.Foldable (toList)
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
+
+sessionTurnPullRequestURL :: SessionTurn -> Maybe Text.Text
+sessionTurnPullRequestURL turn =
+    firstURL "" turn.turnAssistantText []
+        <|> snd (foldl' inspectItem (Map.empty, Nothing)
+            (turn.turnItems <> turn.turnDisplayItems))
+        <|> firstURL turn.turnUserText Nothing []
+  where
+    firstURL :: Text.Text -> Maybe Text.Text -> [ResponseItem] -> Maybe Text.Text
+    firstURL user assistant items =
+        listToMaybe (conversationPullRequestURLs user assistant (map Aeson.toJSON items))
+    -- The shared detector returns a set of associations, not recency order.
+    -- Keep the newest message/output evidence, pairing each output only with
+    -- its preceding call, so an old PR in the user prompt cannot replace the
+    -- PR just created during this turn.
+    inspectItem current@(calls, latest) item =
+        case item of
+            FunctionCallItem call ->
+                (Map.insert call.callId item calls, latest)
+            CustomToolCallItem call ->
+                (Map.insert call.callId item calls, latest)
+            FunctionCallOutputItem output ->
+                inspectOutput output.callId
+            CustomToolCallOutputItem output ->
+                inspectOutput output.callId
+            MessageItem _ ->
+                (calls, firstURL "" Nothing [item] <|> latest)
+            _ -> current
+      where
+        inspectOutput callId =
+            case Map.lookup callId calls of
+                Nothing -> current
+                Just call ->
+                    (calls, firstURL "" Nothing [call, item] <|> latest)
 
 sessionHistoryPage
     :: HistoryGeneration

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -190,6 +190,7 @@ data AppEvent
     | AppDictationFinished !(Either Text Text)
     | AppAgentSnapshot !AgentTarget ![AgentEntry]
     | AppSetWindowTitle !Text
+    | AppSetPullRequestURL !HistoryGeneration !(Maybe Text)
     | AppSyntaxHighlighterChanged
     | AppHistoryReset !HistoryPage
     | AppHistoryLoaded
@@ -514,6 +515,7 @@ data AppState = AppState
     , appSubmittedImagePreviews :: !(Map.Map BlockId [TuiImagePreview])
     , appAgentSelected :: !AgentTarget
     , appAgentEntries :: ![AgentEntry]
+    , appPullRequestURL :: !(Maybe Text)
     , appAgentHover :: !(Maybe AgentHover)
     , appMarkdownLinkHovered :: !Bool
     , appHoveredControl :: !(Maybe Name)

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -27,8 +27,9 @@ import Agent.CLI.Request (requestPromptParts)
 import Agent.CLI.TUI.App
     ( commitFullscreenHistoryTurn
     , emitUiEvent
+    , setFullscreenPullRequestURL
     )
-import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn)
+import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn, sessionTurnPullRequestURL)
 import Agent.CLI.TUI.Types (HistoryCommit(..))
 import Agent.TUI.Model
     ( BlockState(..)
@@ -586,11 +587,13 @@ persistIncompleteTurn
                 appendTurnWithMetaUpdateIndexed handle turn \meta ->
                     meta { metaLastResponseId = Nothing }
             writeIORef slotRef (PersistenceActive handle')
-            forM_ env.sessionFullscreen \runtime ->
+            forM_ env.sessionFullscreen \runtime -> do
                 commitFullscreenHistoryTurn
                     runtime
                     (sessionHistoryTurn turnIndex turn)
                     HistoryCommitAppend
+                forM_ (sessionTurnPullRequestURL turn) $
+                    setFullscreenPullRequestURL runtime . Just
             evictDurableConversation env handle'
   where
     request = executed.executedRequest
@@ -914,7 +917,7 @@ persistSuccessfulTurn
             writeIORef env.sessionTitleTurnCount titleTurns
             let countedMeta = countedHandle.sessionMeta
             writeIORef slotRef (PersistenceActive countedHandle)
-            forM_ env.sessionFullscreen \runtime ->
+            forM_ env.sessionFullscreen \runtime -> do
                 commitFullscreenHistoryTurn
                     runtime
                     (sessionHistoryTurn turnIndex turn)
@@ -924,6 +927,8 @@ persistSuccessfulTurn
                         -- transcript. Keep earlier turns scrollable.
                         TranscriptReplace -> HistoryCommitAppend
                         TranscriptReset -> HistoryCommitReset)
+                forM_ (sessionTurnPullRequestURL turn) $
+                    setFullscreenPullRequestURL runtime . Just
             evictDurableConversation env countedHandle
             when
                 ( not countedMeta.metaTitleIsManual

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -194,6 +194,52 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "pull request event state" do
+        let url = "https://github.com/owner/repository/pull/42"
+            association generation =
+                FullscreenScriptApp (AppSetPullRequestURL (HistoryGeneration generation) (Just url))
+        it "accepts the active session generation and rejects a different generation" do
+            runtime <- newScriptRuntime initialUiState
+            let initialState = initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, associated) <- runFullscreenScriptWithState initialState
+                [association 0, FullscreenScriptHalt]
+            associated.appPullRequestURL `shouldBe` Just url
+            (_, unchanged) <- runFullscreenScriptWithState associated
+                [ FullscreenScriptApp (AppSetPullRequestURL (HistoryGeneration 1) Nothing)
+                , FullscreenScriptHalt
+                ]
+            unchanged.appPullRequestURL `shouldBe` Just url
+        it "clears a previous session association and rejects its delayed result" do
+            runtime <- newScriptRuntime initialUiState
+            let initialState = (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    { appPullRequestURL = Just url }
+                page = HistoryPage
+                    { historyPageGeneration = HistoryGeneration 1
+                    , historyPageDirection = HistoryNewer
+                    , historyPageTurns = Seq.empty
+                    , historyPageGenerationStart = HistoryCursor 0
+                    , historyPageTotalTurns = 0
+                    , historyPageHasOlder = False
+                    , historyPageHasNewer = False
+                    }
+            (_, cleared) <- runFullscreenScriptWithState initialState
+                [ FullscreenScriptApp (AppHistoryReset page)
+                , association 0
+                , FullscreenScriptHalt
+                ]
+            cleared.appPullRequestURL `shouldBe` Nothing
+        it "reflows a cached transcript when the pull request pane appears" do
+            let body = Text.unwords (replicate 18 "transcript")
+                bounds = (160, 24)
+            initialState <- cachedHistoryState [markerBlock (BlockId (-1)) body]
+            (_, frames, finalState) <- runFullscreenScriptDetailedAt bounds initialState
+                [association 0, FullscreenScriptHalt]
+            finalState.appPullRequestURL `shouldBe` Just url
+            frames `shouldSatisfy` (not . null)
+            let finalText = renderedPictureTextAt bounds (last frames)
+            finalText `shouldSatisfy` Text.isInfixOf "PR #42"
+            finalText `shouldBe` renderedAppText bounds finalState
+
     describe "fullscreen worker ownership" do
         it "closes input and preserves a cooperative worker result" do
             closed <- newEmptyMVar
@@ -1695,6 +1741,36 @@ spec = do
                 `shouldBe` [9]
 
     describe "Agents pane layout" do
+        it "shows the current pull request below agents and without children" do
+            runtime <- newScriptRuntime initialUiState
+            let state entries =
+                    (initialFullscreenAppState runtime [] AgentRoot entries 0)
+                        { appPullRequestURL =
+                            Just "https://github.com/owner/repository/pull/42"
+                        }
+                withAgents = renderedAppText (120, 35)
+                    (state [rootEntry, childEntry 1])
+                withoutAgents = renderedAppText (120, 35) (state [rootEntry])
+                rowOf text = length . takeWhile (not . Text.isInfixOf text) . Text.lines
+            withAgents `shouldSatisfy` Text.isInfixOf "PR #42"
+            withAgents `shouldSatisfy` Text.isInfixOf "owner/repository"
+            rowOf "PR #42" withAgents `shouldSatisfy`
+                (> rowOf "Agents" withAgents)
+            withoutAgents `shouldSatisfy` Text.isInfixOf "PR #42"
+            withoutAgents `shouldSatisfy` (not . Text.isInfixOf "Agents ·")
+
+        it "hides the pull request in narrow terminals and when absent" do
+            runtime <- newScriptRuntime initialUiState
+            let state = initialFullscreenAppState runtime [] AgentRoot [rootEntry] 0
+                withPullRequest = state
+                    { appPullRequestURL =
+                        Just "https://github.com/owner/repository/pull/42"
+                    }
+            renderedAppText (71, 35) withPullRequest `shouldSatisfy`
+                (not . Text.isInfixOf "PR #42")
+            renderedAppText (120, 35) state `shouldSatisfy`
+                (not . Text.isInfixOf "Pull request")
+
         it "hides below the responsive breakpoint and without children" do
             agentPaneVisible 71 20 [rootEntry, childEntry 1]
                 `shouldBe` False
@@ -2677,7 +2753,14 @@ runFullscreenScriptDetailed
     :: AppState
     -> [FullscreenScriptEvent]
     -> IO (ByteString.ByteString, [V.Picture], AppState)
-runFullscreenScriptDetailed initialState script = do
+runFullscreenScriptDetailed = runFullscreenScriptDetailedAt (80, 24)
+
+runFullscreenScriptDetailedAt
+    :: (Int, Int)
+    -> AppState
+    -> [FullscreenScriptEvent]
+    -> IO (ByteString.ByteString, [V.Picture], AppState)
+runFullscreenScriptDetailedAt bounds initialState script = do
     let scriptedApp = App
             { appDraw = fullscreenApp.appDraw
             , appChooseCursor = fullscreenApp.appChooseCursor
@@ -2704,7 +2787,6 @@ runFullscreenScriptDetailed initialState script = do
             }
     events <- newBChan (max 1 (length script))
     mapM_ (writeBChan events) script
-    let bounds = (80, 24)
     (_, mockOutput) <- VMock.mockTerminal bounds
     outputBytes <- newIORef ByteString.empty
     renderedFrames <- newIORef []

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -40,7 +40,7 @@ import Agent.TUI.Presentation
 import Agent.Loop (ImageAttachment(..), LoopEvent(..), emptyTurnOutput)
 import Agent.Provider (Provider(XAIProvider))
 import Agent.Subagents (SubagentId(..))
-import Agent.ToolDispatch (ToolCall(..), functionToolCall)
+import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..), ToolCallKind(..), ToolCallMode(..), functionToolCall)
 import Agent.TUI.Motion (MotionMode(..))
 import Control.Concurrent.Async (wait, withAsync)
 import Control.Concurrent.STM (atomically, readTVarIO)
@@ -57,6 +57,44 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "fullscreen TUI bridge" do
+    describe "pull request associations" do
+        let url = "https://github.com/owner/repository/pull/42"
+            previous = Just "https://github.com/owner/repository/pull/41"
+            call command = functionToolCall "create-pr" "shell_command" command
+            result = ToolCallResult "create-pr" url FunctionCallKind BlockingToolCall [] Nothing
+            completed = UiLoop (ToolFinished result)
+        it "detects the PR as soon as its creation tool completes" do
+            let state = reduceUi (UiLoop (ToolStarted (call "gh pr create --title change"))) initialUiState
+            pullRequestForUiEvent completed state previous `shouldBe` Just url
+        it "keeps a newly created PR when the final response contains no PR" do
+            let oldHistory = reduceUi
+                    (UiAssistantHistory "Created https://github.com/owner/repository/pull/41")
+                    initialUiState
+                state = reduceUi (UiLoop (ToolStarted (call "gh pr create"))) oldHistory
+                associated = pullRequestForUiEvent completed state previous
+                finished = UiLoop (TurnFinished (emptyTurnOutput "response" [] (Just "Done")))
+            pullRequestForUiEvent finished (reduceUi completed state) associated `shouldBe` Just url
+        it "does not associate raw PR search results or unmatched outputs" do
+            let state = reduceUi (UiLoop (ToolStarted (call "gh search prs"))) initialUiState
+            pullRequestForUiEvent completed state previous `shouldBe` previous
+            pullRequestForUiEvent completed initialUiState previous `shouldBe` previous
+        it "waits for complete assistant output and retains the PR on unrelated turns" do
+            pullRequestForUiEvent (UiLoop (TextDelta ("Created " <> url))) initialUiState previous
+                `shouldBe` previous
+            pullRequestForUiEvent
+                (UiLoop (TurnFinished (emptyTurnOutput "response" [] (Just ("Created " <> url)))))
+                initialUiState previous `shouldBe` Just url
+            pullRequestForUiEvent
+                (UiLoop (TurnFinished (emptyTurnOutput "response" [] (Just "Done"))))
+                initialUiState previous `shouldBe` previous
+        it "accepts explicit user PR tasks but ignores quoted references" do
+            pullRequestForUiEvent (UiUserSubmitted ("Please review " <> url)) initialUiState Nothing
+                `shouldBe` Just url
+            pullRequestForUiEvent (UiAssistantHistory ("> Created " <> url)) initialUiState previous
+                `shouldBe` previous
+        it "clears the association when the conversation is cleared" do
+            pullRequestForUiEvent UiConversationCleared initialUiState previous `shouldBe` Nothing
+
     it "follows retained output events but not draft-only events" do
         eventFollows (UiSystemMessage "copied") `shouldBe` True
         eventFollows (UiErrorMessage "failed") `shouldBe` True

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -14,7 +14,7 @@ import Agent.CLI.Session
 import Agent.CLI.TUI.History
 import Agent.Json (rawJsonFromEncoding)
 import Agent.CLI.TUI.Composer (composerScrollbackAvailable)
-import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn)
+import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn, sessionTurnPullRequestURL)
 import Agent.Responses.LoopBackend (toolResultToItem)
 import Agent.Responses.Types
 import Agent.ToolDispatch
@@ -955,6 +955,60 @@ spec = describe "bounded fullscreen history window" do
         map (.blockKind) blocks `shouldBe` [BlockUser, BlockAssistant]
         map (.blockBody) blocks
             `shouldBe` ["current prompt", "current answer"]
+
+    describe "current pull request precedence" do
+        let oldURL = "https://github.com/owner/repository/pull/41"
+            newURL = "https://github.com/owner/repository/pull/42"
+            finalURL = "https://github.com/owner/repository/pull/43"
+            creationCall = FunctionCallItem FunctionCall
+                { itemId = Nothing
+                , callId = "image-call"
+                , name = "shell_command"
+                , namespace = Nothing
+                , provider = Nothing
+                , arguments = "{\"command\":\"gh pr create\"}"
+                , encryptedFunctionArgs = Nothing
+                , status = Nothing
+                , async = Nothing
+                }
+            createdTurn = sessionTurn TranscriptAppend oldURL
+                [ assistantMessage ("Reviewed " <> oldURL)
+                , creationCall
+                , toolOutputItem [Aeson.String newURL]
+                , assistantMessage "Done"
+                ]
+        it "prefers a newly created PR over the user prompt and earlier messages" do
+            sessionTurnPullRequestURL createdTurn `shouldBe` Just newURL
+        it "prefers the final assistant association over preceding tool output" do
+            sessionTurnPullRequestURL
+                (createdTurn { turnAssistantText = Just ("Opened " <> finalURL) })
+                `shouldBe` Just finalURL
+        it "uses the latest message association when no final assistant text was stored" do
+            sessionTurnPullRequestURL
+                (createdTurn
+                    { turnDisplayItems = [assistantMessage ("Created " <> finalURL)] })
+                `shouldBe` Just finalURL
+        it "falls back to an explicit user PR when there is no later association" do
+            sessionTurnPullRequestURL
+                (sessionTurn TranscriptAppend oldURL [assistantMessage "Done"])
+                `shouldBe` Just oldURL
+
+    it "restores pull request associations from persisted messages and failed display items" do
+        let url = "https://github.com/owner/repository/pull/42"
+            completed = sessionTurn TranscriptAppend "create the PR"
+                [assistantMessage ("Created " <> url)]
+            incomplete = (sessionTurn TranscriptAppend "create the PR" [])
+                { turnError = Just "provider disconnected"
+                , turnDisplayItems = [assistantMessage ("Opened " <> url)]
+                }
+        sessionTurnPullRequestURL completed `shouldBe` Just url
+        sessionTurnPullRequestURL incomplete `shouldBe` Just url
+
+    it "does not restore a pull request from an unrelated persisted reference" do
+        sessionTurnPullRequestURL
+            (sessionTurn TranscriptAppend "inspect the code"
+                [assistantMessage "For reference: https://github.com/owner/repository/pull/42"])
+            `shouldBe` Nothing
 
     it "keeps mid-turn steering in durable history" do
         let projected =


### PR DESCRIPTION
## Summary
- Reuse existing PR detection to show a clickable current pull request below subagents.
- Restore the association from persisted session history and guard session switches against stale updates.
- Keep narrow-terminal layout and transcript reflow correct.

## Validation
- Focused GHCi layout and pull-request tests pass.
- Real fullscreen TUI fixture exercised in tmux, including narrow/wide resizing and input.
- Regenerated agent-cli Nix dependencies; git diff --check passes.