### PR TITLE
Add typed native integration connection management

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Credentials.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Credentials.hs
@@ -15,6 +15,8 @@ module Agent.CLI.Gateway.Credentials
     , removeGatewayCredential
     , removeGatewayCredentialWith
     , validateGatewayCredential
+    , registerGatewayCredentialInvalidator
+    , registerGatewayCredentialInvalidatorAt
     ) where
 
 import Agent.CLI.Gateway.Origin
@@ -33,6 +35,7 @@ import Agent.OpenAI.WebSocketClient (validateGatewayWebSocketUrl)
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Server.Client.GatewayIdentity (GatewayCredential(..))
 import Control.Concurrent (ThreadId, myThreadId)
+import Control.Concurrent.MVar (MVar, newMVar, modifyMVar_, withMVar)
 import Control.Concurrent.STM
     ( TVar
     , atomically
@@ -47,10 +50,38 @@ import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy qualified as LBS
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Map.Strict qualified as Map
+import Data.Unique (Unique, newUnique)
 import System.Directory.OsPath qualified as Directory
 import System.IO.Unsafe (unsafePerformIO)
 import System.OsPath (OsPath, takeDirectory, unsafeEncodeUtf, (</>))
 import System.Posix.Files (setFileMode)
+
+-- Owners register before accepting credential-scoped work and unregister
+-- before closing. Mutation holds the writer lease, so callbacks must not
+-- acquire a credential lease (nor join finalizers that acquire one).
+{-# NOINLINE gatewayCredentialInvalidators #-}
+gatewayCredentialInvalidators :: MVar (Map.Map Unique (OsPath, IO ()))
+gatewayCredentialInvalidators = unsafePerformIO (newMVar Map.empty)
+
+registerGatewayCredentialInvalidator :: IO () -> IO (IO ())
+registerGatewayCredentialInvalidator action = do
+    home <- Directory.getHomeDirectory
+    registerGatewayCredentialInvalidatorAt home action
+
+registerGatewayCredentialInvalidatorAt :: OsPath -> IO () -> IO (IO ())
+registerGatewayCredentialInvalidatorAt home action = do
+    key <- newUnique
+    modifyMVar_ gatewayCredentialInvalidators
+        (pure . Map.insert key (home, action))
+    pure $ modifyMVar_ gatewayCredentialInvalidators
+        (pure . Map.delete key)
+
+invalidateGatewayCredentialOwnersAt :: OsPath -> IO ()
+invalidateGatewayCredentialOwnersAt home =
+    withMVar gatewayCredentialInvalidators \owners ->
+        foldr finally (pure ())
+            [action | (ownerHome, action) <- Map.elems owners, ownerHome == home]
 
 gatewayCredentialDecoder :: Hermes.Decoder GatewayCredential
 gatewayCredentialDecoder =
@@ -309,6 +340,7 @@ saveGatewayCredentialAtWith home credential afterSave =
         Right () -> do
             result <- tryAny $
                 withGatewayCredentialLockAt home do
+                    invalidateGatewayCredentialOwnersAt home
                     let path = gatewayCredentialPath home
                         directory = takeDirectory path
                     Directory.createDirectoryIfMissing True directory
@@ -385,6 +417,7 @@ removeGatewayCredentialWith afterRemove = do
     result <- tryAny do
         home <- Directory.getHomeDirectory
         withGatewayCredentialLockAt home do
+            invalidateGatewayCredentialOwnersAt home
             let path = gatewayCredentialPath home
             exists <- Directory.doesFileExist path
             when exists (Directory.removeFile path)

--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -35,6 +35,8 @@ module Agent.CLI.GatewayClient
     , saveGatewayCredential
     , removeGatewayCredential
     , removeGatewayCredentialWith
+    , registerGatewayCredentialInvalidator
+    , registerGatewayCredentialInvalidatorAt
     , openGatewayAuthorizationPage
     , connectGateway
     , disconnectGateway

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
@@ -19,7 +19,7 @@ import Data.Bits ((.&.))
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import Data.Either (isLeft)
-import Data.IORef (atomicModifyIORef', newIORef)
+import Data.IORef (atomicModifyIORef', newIORef, modifyIORef', readIORef)
 import Data.Maybe (isNothing)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as TextEncoding
@@ -56,6 +56,42 @@ decodeGatewayModels bytes =
 
 spec :: Spec
 spec = describe "gateway device authorization" do
+    it "invalidates idle credential owners before replacement and logout complete" $
+        withTempHome \home ->
+            withHomeEnvironment home do
+                let credential = GatewayCredential
+                        "https://gateway" "wss://gateway/v1/responses" "first"
+                    replacement = credential {gatewayAccessToken = "second"}
+                saveGatewayCredentialAt home credential `shouldReturn` Right ()
+                observed <- newIORef []
+                bracket
+                    (registerGatewayCredentialInvalidatorAt home do
+                        current <- loadGatewayCredentialAt home
+                        modifyIORef' observed (<> [current]))
+                    id \unregister -> do
+                        saveGatewayCredentialAt home replacement `shouldReturn` Right ()
+                        removeGatewayCredentialWith (readIORef observed)
+                            `shouldReturn` Right
+                                [Right (Just credential), Right (Just replacement)]
+                        unregister
+                        saveGatewayCredentialAt home credential `shouldReturn` Right ()
+                        readIORef observed `shouldReturn`
+                            [Right (Just credential), Right (Just replacement)]
+
+    it "fails credential replacement closed when an owner cannot retire" $
+        withTempHome \home -> do
+            let credential = GatewayCredential
+                    "https://gateway" "wss://gateway/v1/responses" "first"
+                replacement = credential {gatewayAccessToken = "second"}
+            saveGatewayCredentialAt home credential `shouldReturn` Right ()
+            bracket
+                (registerGatewayCredentialInvalidatorAt home
+                    (throwString "owner cleanup failed"))
+                id \_ -> do
+                    saveGatewayCredentialAt home replacement
+                        >>= (`shouldSatisfy` isLeft)
+                    loadGatewayCredentialAt home `shouldReturn` Right (Just credential)
+
     it "sends the versioned User-Agent when discovering gateway models" do
         received <- newEmptyMVar
         expected <- gatewayUserAgent

--- a/packages/agent-cli/src/Agent/CLI/IntegrationGateway.hs
+++ b/packages/agent-cli/src/Agent/CLI/IntegrationGateway.hs
@@ -1,4 +1,5 @@
--- | The public CLI knows only the authenticated aggregate MCP endpoint.
+-- | Provider-neutral authenticated gateway authority. Organization-local
+-- extensions require a separate explicit distribution opt-in.
 module Agent.CLI.IntegrationGateway
     ( gatewayIntegrationAuthority
     , gatewayIntegrationMcpConfig

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -15,6 +15,7 @@ module Agent.CLI.NativeRuntime
     , closeNativeProcessRuntime
     , newNativeProcessRuntime
     , newNativeProcessRuntimeWithIntegrations
+    , newNativeProcessRuntimeWithOrganizationIntegrations
     , nativeProcessIntegrationSupervisor
     , nativeTurnOptions
     , applyNativeStartupPolicy
@@ -27,8 +28,10 @@ import qualified Agent.CLI.NativeProcess as NativeProcess
 import Agent.Integration.API
     ( IntegrationSupervisor
     , closeIntegrationSupervisor
-    , newIntegrationSupervisor
+    , newIntegrationSupervisorWithOrganizationProvider
+    , resetIntegrationSupervisor
     , IntegrationProvider
+    , OrganizationIntegrationProvider
     , emptyIntegrationProvider
     )
 import Agent.Runtime.StartupPolicy
@@ -90,10 +93,19 @@ newNativeProcessRuntime = newNativeProcessRuntimeWithIntegrations emptyIntegrati
 
 newNativeProcessRuntimeWithIntegrations
     :: IntegrationProvider -> OsPath -> IO NativeProcessRuntime
-newNativeProcessRuntimeWithIntegrations provider root = mask \restore -> do
+newNativeProcessRuntimeWithIntegrations provider =
+    newNativeProcessRuntimeWithOrganizationIntegrations provider Nothing
+
+-- | Organization-local execution is a separate distribution opt-in; supplying
+-- an ordinary local provider alone never enables it for gateway users.
+newNativeProcessRuntimeWithOrganizationIntegrations
+    :: IntegrationProvider -> Maybe OrganizationIntegrationProvider
+    -> OsPath -> IO NativeProcessRuntime
+newNativeProcessRuntimeWithOrganizationIntegrations provider organizationProvider root = mask \restore -> do
     integrationToolEnv <- restore (defaultToolEnv root)
     integrations <-
-        restore (newIntegrationSupervisor provider integrationToolEnv)
+        restore (newIntegrationSupervisorWithOrganizationProvider
+            provider organizationProvider integrationToolEnv)
     core <- restore (NativeProcess.newNativeProcessRuntimeWithMcpHooks
         MCP.defaultMcpHostHooks
         root) `onException` closeIntegrationSupervisor integrations
@@ -109,8 +121,9 @@ closeNativeProcessRuntime runtime =
             closeIntegrationSupervisor runtime.nativeIntegrationSupervisor
 
 restartNativeMcpRuntime :: NativeProcessRuntime -> IO ()
-restartNativeMcpRuntime =
-    NativeProcess.restartNativeMcpRuntime . (.nativeProcessCore)
+restartNativeMcpRuntime runtime =
+    NativeProcess.restartNativeMcpRuntime runtime.nativeProcessCore
+        `finally` resetIntegrationSupervisor runtime.nativeIntegrationSupervisor
 
 nativeProcessIntegrationSupervisor
     :: NativeProcessRuntime

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs
@@ -143,11 +143,20 @@ acquireMcpRuntime request@AgentToolsRequest
         remoteServers =
             [ config { MCP.mcpServerName = integrationServerName }
             | runtime <- maybeToList integrationRuntime
-            , RemoteIntegrationEndpoint config <- [integrationRuntimeEndpoint runtime]]
+            , config <- case integrationRuntimeEndpoint runtime of
+                RemoteIntegrationEndpoint config -> [config]
+                CombinedIntegrationEndpoint config _ -> [config]
+                _ -> []]
+        localIntegrationServerName =
+            availableIntegrationServerName
+                (map (.mcpServerName) (configuredServers <> remoteServers))
         inMemoryServers =
-            [(integrationsMcpConfig integrationServerName, server)
+            [(integrationsMcpConfig localIntegrationServerName, server)
             | runtime <- maybeToList integrationRuntime
-            , LocalIntegrationEndpoint server <- [integrationRuntimeEndpoint runtime]]
+            , server <- case integrationRuntimeEndpoint runtime of
+                LocalIntegrationEndpoint server -> [server]
+                CombinedIntegrationEndpoint _ server -> [server]
+                _ -> []]
         -- Include the in-memory name in the reported configuration too: callers
         -- use this list to decide whether MCP tools exist at all.
         runtimeMcpServerConfigs = configuredServers <> remoteServers

--- a/packages/agent-integration-api/agent-integration-api.cabal
+++ b/packages/agent-integration-api/agent-integration-api.cabal
@@ -19,8 +19,9 @@ library
     import: options
     hs-source-dirs: src
     exposed-modules: Agent.Integration.API
+                     Agent.Integration.Connection
     build-depends: base >= 4.17 && < 5, agent-core, agent-json, agent-mcp,
-                   aeson, text
+                   aeson, bytestring, safe-exceptions, text
 
 test-suite agent-integration-api-test
     import: options

--- a/packages/agent-integration-api/package.nix
+++ b/packages/agent-integration-api/package.nix
@@ -1,15 +1,18 @@
 { mkDerivation, aeson, agent-core, agent-json, agent-mcp, async
-, base, filepath, hspec, lib, safe-exceptions, temporary, text
+, base, bytestring, filepath, hspec, lib, safe-exceptions
+, temporary, text
 }:
 mkDerivation {
   pname = "agent-integration-api";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson agent-core agent-json agent-mcp base text
+    aeson agent-core agent-json agent-mcp base bytestring
+    safe-exceptions text
   ];
   testHaskellDepends = [
-    agent-core agent-mcp async base filepath hspec safe-exceptions temporary
+    agent-core agent-mcp async base filepath hspec safe-exceptions
+    temporary
   ];
   description = "Provider-neutral integration embedding API";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-integration-api/src/Agent/Integration/API.hs
+++ b/packages/agent-integration-api/src/Agent/Integration/API.hs
@@ -5,19 +5,25 @@ module Agent.Integration.API
     , IntegrationEndpoint(..)
     , IntegrationRuntime(..)
     , IntegrationProvider
+    , OrganizationIntegrationProvider
     , IntegrationAuthority(..)
     , IntegrationSupervisor
     , emptyIntegrationProvider
     , newIntegrationSupervisor
+    , newIntegrationSupervisorWithOrganizationProvider
+    , resetIntegrationSupervisor
     , acquireIntegrationRuntime
     , closeIntegrationSupervisor
     ) where
 
 import Agent.Json (RawJson, rawJsonFromEncoding)
+import Agent.Integration.Connection (IntegrationConnections)
 import Agent.MCP (McpServerConfig, McpToolServer)
 import Agent.Tools.Types (ToolEnv)
-import Control.Concurrent.MVar (MVar, modifyMVar, newMVar)
+import Control.Concurrent.MVar (MVar, withMVar, newMVar)
+import Control.Exception.Safe (mask, onException)
 import qualified Data.Aeson as Aeson
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Text (Text)
 
 data IntegrationError
@@ -28,31 +34,45 @@ data IntegrationError
 
 -- | The provider transfers ownership of its runtime to the supervisor.
 -- Cleanup must unsubscribe its MCP host and cancel/join its owned workers.
+-- Returned callbacks must reject use after cleanup. Hosts retain the gateway
+-- lease for the complete operation, not merely for acquisition.
 data IntegrationEndpoint
     = NoIntegrationEndpoint
     | LocalIntegrationEndpoint !McpToolServer
     | RemoteIntegrationEndpoint !McpServerConfig
+    | CombinedIntegrationEndpoint !McpServerConfig !McpToolServer
 
 data IntegrationRuntime = IntegrationRuntime
     { integrationRuntimeEndpoint :: !IntegrationEndpoint
     , integrationRuntimeAdminDefinitions :: !RawJson
     , callIntegrationRuntimeAdmin
         :: !(Text -> RawJson -> IO (Either IntegrationError RawJson))
+    , integrationRuntimeConnections :: !(Maybe IntegrationConnections)
     , closeIntegrationRuntime :: !(IO ())
     }
 
 type IntegrationProvider = ToolEnv -> IO (Either Text IntegrationRuntime)
+
+-- | Explicit distribution opt-in, separate from the ordinary local provider.
+-- The factory must capture this exact authenticated gateway configuration;
+-- it must never resolve credentials from mutable process-global state.
+-- It may supply only integrations authorized for organization-local execution.
+type OrganizationIntegrationProvider = McpServerConfig -> IntegrationProvider
 
 data IntegrationAuthority
     = LocalIntegrationAuthority
     | OrganizationIntegrationAuthority !McpServerConfig
     deriving (Eq, Show)
 
-data SupervisorState = Open !(Maybe IntegrationRuntime) | Closed
+data SupervisorState
+    = Open !(Maybe (IntegrationAuthority, IntegrationRuntime))
+    | Closed
 
 data IntegrationSupervisor = IntegrationSupervisor
-    { supervisorState :: !(MVar SupervisorState)
+    { supervisorLock :: !(MVar ())
+    , supervisorState :: !(IORef SupervisorState)
     , supervisorProvider :: !IntegrationProvider
+    , supervisorOrganizationProvider :: !(Maybe OrganizationIntegrationProvider)
     , supervisorToolEnv :: !ToolEnv
     }
 
@@ -69,40 +89,95 @@ emptyRuntime = IntegrationRuntime
         pure (Left (IntegrationUnavailable
             "Local integrations are not available in this distribution."))
     , closeIntegrationRuntime = pure ()
+    , integrationRuntimeConnections = Nothing
     }
 
 newIntegrationSupervisor :: IntegrationProvider -> ToolEnv -> IO IntegrationSupervisor
-newIntegrationSupervisor supervisorProvider supervisorToolEnv = do
-    supervisorState <- newMVar (Open Nothing)
+newIntegrationSupervisor provider =
+    newIntegrationSupervisorWithOrganizationProvider provider Nothing
+
+newIntegrationSupervisorWithOrganizationProvider
+    :: IntegrationProvider -> Maybe OrganizationIntegrationProvider
+    -> ToolEnv -> IO IntegrationSupervisor
+newIntegrationSupervisorWithOrganizationProvider
+    supervisorProvider supervisorOrganizationProvider supervisorToolEnv = do
+    supervisorLock <- newMVar ()
+    supervisorState <- newIORef (Open Nothing)
     pure IntegrationSupervisor{..}
 
--- | Organization acquisition never evaluates the local provider, even when
--- the remote endpoint is unavailable. The ordinary MCP supervisor owns that
--- connection and its credential-scoped identity.
+-- | Organization acquisition never evaluates the ordinary local provider.
+-- Identity includes the entire configuration (including authentication), not
+-- just the URL. Retire the previous owner before constructing its replacement.
+-- The caller must hold its authenticated gateway lease while using the runtime.
 acquireIntegrationRuntime
     :: IntegrationSupervisor -> IntegrationAuthority
     -> IO (Either Text IntegrationRuntime)
 acquireIntegrationRuntime supervisor authority =
-    modifyMVar supervisor.supervisorState \case
-        Closed -> pure (Closed, Left "The integration runtime is already closed.")
-        state@(Open local) -> case authority of
-            OrganizationIntegrationAuthority config ->
-                pure (state, Right emptyRuntime
-                    { integrationRuntimeEndpoint = RemoteIntegrationEndpoint config
-                    , callIntegrationRuntimeAdmin = \_ _ ->
-                        pure (Left (IntegrationUnavailable
-                            "Manage organization integrations through the gateway."))
-                    })
-            LocalIntegrationAuthority -> case local of
-                Just runtime -> pure (state, Right runtime)
-                Nothing ->
-                    supervisor.supervisorProvider supervisor.supervisorToolEnv >>= \case
-                        Left err -> pure (state, Left err)
-                        Right runtime -> pure (Open (Just runtime), Right runtime)
+    withMVar supervisor.supervisorLock \_ -> mask \restore ->
+        readIORef supervisor.supervisorState >>= \case
+            Closed -> pure (Left "The integration runtime is already closed.")
+            Open (Just (previous, runtime)) | previous == authority ->
+                pure (Right runtime)
+            Open previous -> do
+                -- Never resurrect a retired runtime if cleanup or acquisition
+                -- throws, including asynchronous cancellation.
+                writeIORef supervisor.supervisorState (Open Nothing)
+                closePrevious previous
+                    `onException` writeIORef supervisor.supervisorState Closed
+                restore acquire >>= \case
+                    Left err -> pure (Left err)
+                    Right runtime -> do
+                        writeIORef supervisor.supervisorState
+                            (Open (Just (authority, runtime)))
+                        pure (Right runtime)
+  where
+    acquire = case authority of
+        LocalIntegrationAuthority ->
+            supervisor.supervisorProvider supervisor.supervisorToolEnv
+        OrganizationIntegrationAuthority config ->
+            case supervisor.supervisorOrganizationProvider of
+                Nothing -> pure (Right (remoteRuntime config))
+                Just provider ->
+                    provider config supervisor.supervisorToolEnv >>= \case
+                        Left err -> pure (Left err)
+                        Right runtime -> case integrationRuntimeEndpoint runtime of
+                            NoIntegrationEndpoint -> pure (Right runtime
+                                { integrationRuntimeEndpoint = RemoteIntegrationEndpoint config })
+                            LocalIntegrationEndpoint server -> pure (Right runtime
+                                { integrationRuntimeEndpoint = CombinedIntegrationEndpoint config server })
+                            _ -> do
+                                closeIntegrationRuntime runtime
+                                pure (Left "Organization-local providers must not supply remote endpoints.")
+
+remoteRuntime :: McpServerConfig -> IntegrationRuntime
+remoteRuntime config = emptyRuntime
+    { integrationRuntimeEndpoint = RemoteIntegrationEndpoint config
+    , callIntegrationRuntimeAdmin = \_ _ ->
+        pure (Left (IntegrationUnavailable
+            "Manage organization integrations through the gateway."))
+    }
+
+closePrevious :: Maybe (IntegrationAuthority, IntegrationRuntime) -> IO ()
+closePrevious = maybe (pure ()) (closeIntegrationRuntime . snd)
+
+-- | Invalidate owned work immediately on logout/credential replacement,
+-- without acquiring any replacement provider. The host must first stop/join
+-- callers using the old gateway lease and retire its MCP fleet.
+resetIntegrationSupervisor :: IntegrationSupervisor -> IO ()
+resetIntegrationSupervisor supervisor =
+    withMVar supervisor.supervisorLock \_ -> mask \_ ->
+        readIORef supervisor.supervisorState >>= \case
+            Closed -> pure ()
+            Open previous -> do
+                writeIORef supervisor.supervisorState (Open Nothing)
+                closePrevious previous
+                    `onException` writeIORef supervisor.supervisorState Closed
 
 closeIntegrationSupervisor :: IntegrationSupervisor -> IO ()
-closeIntegrationSupervisor supervisor = do
-    previous <- modifyMVar supervisor.supervisorState \state -> pure (Closed, state)
-    case previous of
-        Closed -> pure ()
-        Open local -> maybe (pure ()) closeIntegrationRuntime local
+closeIntegrationSupervisor supervisor =
+    withMVar supervisor.supervisorLock \_ -> mask \_ -> do
+        previous <- readIORef supervisor.supervisorState
+        writeIORef supervisor.supervisorState Closed
+        case previous of
+            Closed -> pure ()
+            Open runtime -> closePrevious runtime

--- a/packages/agent-integration-api/src/Agent/Integration/Connection.hs
+++ b/packages/agent-integration-api/src/Agent/Integration/Connection.hs
@@ -1,0 +1,79 @@
+-- | Native connection management. No credentials or authorization challenges
+-- enter the conversational tool protocol. A distribution owns the state
+-- machine; the host renders these typed, non-executable descriptions.
+module Agent.Integration.Connection where
+
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+
+data ConnectionPhase
+    = ConnectionCatalog
+    | ConnectionSearch
+    | ConnectionCredentials
+    | ConnectionChallenge
+    | ConnectionRedirect
+    | ConnectionSelection
+    | ConnectionConnected
+    | ConnectionWaiting
+    deriving (Eq, Show, Enum, Bounded)
+
+data ConnectionFieldKind = ConnectionTextField | ConnectionSecretField
+    deriving (Eq, Show, Enum, Bounded)
+
+data ConnectionField = ConnectionField
+    { connectionFieldId :: !Text
+    , connectionFieldLabel :: !Text
+    , connectionFieldKind :: !ConnectionFieldKind
+    , connectionFieldRequired :: !Bool
+    } deriving (Eq, Show)
+
+data ConnectionItem = ConnectionItem
+    { connectionItemId :: !Text
+    , connectionItemTitle :: !Text
+    , connectionItemDetail :: !Text
+    , connectionItemSelected :: !Bool
+    } deriving (Eq, Show)
+
+data ConnectionSnapshot = ConnectionSnapshot
+    { connectionPhase :: !ConnectionPhase
+    , connectionSessionId :: !Text
+    , connectionTitle :: !Text
+    , connectionMessage :: !Text
+    , connectionRedirectUrl :: !Text
+    , connectionPollAfterMilliseconds :: !Int
+    , connectionFields :: ![ConnectionField]
+    , connectionItems :: ![ConnectionItem]
+    } deriving (Eq, Show)
+
+-- Deliberately no Show instance: answers may contain PINs or TANs.
+data ConnectionAnswer = ConnectionAnswer
+    { connectionAnswerId :: !Text
+    , connectionAnswerValue :: !Text
+    }
+
+-- Deliberately no Show instance: commands can contain secret answers.
+data ConnectionCommand
+    = ListConnections
+    | SearchConnections !Text !Text
+    | BeginConnection !Text !Text
+    | SubmitConnection !Text ![ConnectionAnswer]
+    | PollConnection !Text
+    | CancelConnection !Text
+    | DisconnectConnection !Text
+
+-- | Key bytes are supplied by the native secure store, not the chat or a
+-- configuration file. The provider must validate its required key length.
+type ConnectionSecretStore = Text -> IO (Either Text ByteString)
+
+-- | Every operation is bound to the runtime's captured authority. Providers
+-- must reject stale sessions and cancel/join outstanding work when closed.
+-- The supplied secure-store function is borrowed for this invocation only.
+-- Cache validated key bytes if needed by subsequent tool calls, never the
+-- function itself: its native callback context expires at completion.
+-- Cancellation must be callable concurrently with an in-flight operation.
+newtype IntegrationConnections = IntegrationConnections
+    { runConnectionCommand
+        :: ConnectionSecretStore
+        -> ConnectionCommand
+        -> IO (Either Text ConnectionSnapshot)
+    }

--- a/packages/agent-integration-api/test/Spec.hs
+++ b/packages/agent-integration-api/test/Spec.hs
@@ -1,11 +1,12 @@
 module Main (main) where
 
 import Agent.Integration.API
-import Agent.MCP (McpServerConfig(..), McpProtocolPreference(..))
+import Agent.MCP (McpServerConfig(..), McpProtocolPreference(..), McpToolServer(..))
 import Agent.Tools.Types (ToolEnv, defaultToolEnv)
 import Control.Concurrent.Async (mapConcurrently_)
 import Control.Exception.Safe (bracket)
 import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.Either (isLeft)
 import System.IO.Temp (withSystemTempDirectory)
 import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
@@ -27,6 +28,116 @@ main = hspec do
                             Right runtime -> case integrationRuntimeEndpoint runtime of
                                 RemoteIntegrationEndpoint config -> config `shouldBe` remoteConfig
                                 _ -> expectationFailure "wrong endpoint authority"
+        it "combines only the explicitly supplied organization-local provider" $
+            withEnvironment \env -> do
+                starts <- newIORef []
+                let provider config toolEnv = do
+                        modifyIORef' starts (<> [config])
+                        fmap (fmap (\runtime -> runtime
+                            { integrationRuntimeEndpoint = LocalIntegrationEndpoint testServer }))
+                            (emptyIntegrationProvider toolEnv)
+                bracket
+                    (newIntegrationSupervisorWithOrganizationProvider
+                        (\_ -> expectationFailure "ordinary local provider invoked" >> emptyIntegrationProvider env)
+                        (Just provider) env)
+                    closeIntegrationSupervisor \supervisor -> do
+                        mapConcurrently_
+                            (\_ -> acquireIntegrationRuntime supervisor
+                                (OrganizationIntegrationAuthority remoteConfig))
+                            [1 .. 20 :: Int]
+                        readIORef starts `shouldReturn` [remoteConfig]
+                        acquired <- acquireIntegrationRuntime supervisor
+                            (OrganizationIntegrationAuthority remoteConfig)
+                        case acquired of
+                            Right runtime -> case integrationRuntimeEndpoint runtime of
+                                CombinedIntegrationEndpoint config server -> do
+                                    config `shouldBe` remoteConfig
+                                    fmap (either (const False) null) server.toolServerListTools
+                                        `shouldReturn` True
+                                _ -> expectationFailure "expected remote and authorized local endpoint"
+                            Left _ -> expectationFailure "organization provider unavailable"
+        it "retires each exact credential identity before replacement and on logout" $
+            withEnvironment \env -> do
+                events <- newIORef []
+                let provider config toolEnv = do
+                        modifyIORef' events (<> [("start", config)])
+                        fmap (fmap (\runtime -> runtime
+                            { closeIntegrationRuntime =
+                                modifyIORef' events (<> [("close", config)]) }))
+                            (emptyIntegrationProvider toolEnv)
+                    rotated = remoteConfig
+                        { mcpServerEnv = [("MCP_ACCESS_TOKEN", "different-test-token")] }
+                    switched = rotated
+                        { mcpServerUrl = Just "https://other.invalid/mcp/integrations" }
+                bracket
+                    (newIntegrationSupervisorWithOrganizationProvider
+                        emptyIntegrationProvider (Just provider) env)
+                    closeIntegrationSupervisor \supervisor -> do
+                        let acquire config = acquireIntegrationRuntime supervisor
+                                (OrganizationIntegrationAuthority config)
+                        _ <- acquire remoteConfig
+                        _ <- acquire rotated
+                        _ <- acquire switched
+                        resetIntegrationSupervisor supervisor
+                        resetIntegrationSupervisor supervisor
+                        readIORef events `shouldReturn`
+                            [ ("start", remoteConfig), ("close", remoteConfig)
+                            , ("start", rotated), ("close", rotated)
+                            , ("start", switched), ("close", switched)
+                            ]
+                        _ <- acquire switched
+                        _ <- acquireIntegrationRuntime supervisor LocalIntegrationAuthority
+                        readIORef events `shouldReturn`
+                            [ ("start", remoteConfig), ("close", remoteConfig)
+                            , ("start", rotated), ("close", rotated)
+                            , ("start", switched), ("close", switched)
+                            , ("start", switched), ("close", switched)
+                            ]
+        it "fails closed without invoking the ordinary local provider on organization failure" $
+            withEnvironment \env ->
+                bracket
+                    (newIntegrationSupervisorWithOrganizationProvider
+                        (\_ -> expectationFailure "ordinary local fallback invoked" >> emptyIntegrationProvider env)
+                        (Just (\_ _ -> pure (Left "organization integration unavailable"))) env)
+                    closeIntegrationSupervisor \supervisor ->
+                        acquireIntegrationRuntime supervisor
+                            (OrganizationIntegrationAuthority remoteConfig)
+                            `shouldReturnSatisfy` isLeft
+        it "rejects a provider-supplied remote endpoint and closes it" $
+            withEnvironment \env -> do
+                closes <- newIORef (0 :: Int)
+                let provider _ toolEnv = fmap (fmap (\runtime -> runtime
+                        { integrationRuntimeEndpoint = RemoteIntegrationEndpoint remoteConfig
+                        , closeIntegrationRuntime = modifyIORef' closes (+ 1) }))
+                        (emptyIntegrationProvider toolEnv)
+                bracket
+                    (newIntegrationSupervisorWithOrganizationProvider
+                        emptyIntegrationProvider (Just provider) env)
+                    closeIntegrationSupervisor \supervisor -> do
+                        acquireIntegrationRuntime supervisor
+                            (OrganizationIntegrationAuthority remoteConfig)
+                            `shouldReturnSatisfy` isLeft
+                        readIORef closes `shouldReturn` 1
+        it "never revives the previous identity when switching cleanup throws" $
+            withEnvironment \env -> do
+                starts <- newIORef (0 :: Int)
+                let provider _ toolEnv = do
+                        modifyIORef' starts (+ 1)
+                        fmap (fmap (\runtime -> runtime
+                            { closeIntegrationRuntime = ioError (userError "cleanup failed") }))
+                            (emptyIntegrationProvider toolEnv)
+                supervisor <- newIntegrationSupervisorWithOrganizationProvider
+                    emptyIntegrationProvider (Just provider) env
+                _ <- acquireIntegrationRuntime supervisor
+                    (OrganizationIntegrationAuthority remoteConfig)
+                acquireIntegrationRuntime supervisor LocalIntegrationAuthority
+                    `shouldThrow` anyIOException
+                acquireIntegrationRuntime supervisor
+                    (OrganizationIntegrationAuthority remoteConfig)
+                    `shouldReturnSatisfy` isLeft
+                closeIntegrationSupervisor supervisor
+                readIORef starts `shouldReturn` 1
+
         it "closes idempotently even when provider cleanup fails" $
             withEnvironment \env -> do
                 let provider toolEnv = emptyIntegrationProvider toolEnv >>= \case
@@ -72,6 +183,18 @@ main = hspec do
                             Right runtime -> case integrationRuntimeEndpoint runtime of
                                 RemoteIntegrationEndpoint config -> config `shouldBe` remoteConfig
                                 _ -> expectationFailure "wrong endpoint authority"
+
+shouldReturnSatisfy :: IO a -> (a -> Bool) -> Expectation
+shouldReturnSatisfy action predicate = action >>= \value ->
+    predicate value `shouldBe` True
+
+testServer :: McpToolServer
+testServer = McpToolServer
+    { toolServerInitialize = ioError (userError "not used by ownership test")
+    , toolServerListTools = pure (Right [])
+    , toolServerCallTool = \_ -> ioError (userError "not used by ownership test")
+    , toolServerSubscribe = \_ -> pure (pure ())
+    }
 
 withEnvironment :: (ToolEnv -> IO a) -> IO a
 withEnvironment action = withSystemTempDirectory "integration-api-test" \root ->

--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -74,6 +74,7 @@ foreign-library haskell-agent-bridge
                    , Agent.CLI.MacOS.EngineState
                    , Agent.CLI.MacOS.EngineStore
                    , Agent.CLI.MacOS.EngineSubmission
+                   , Agent.CLI.MacOS.ConnectionBridge
                    , Agent.CLI.MacOS.InteractionState
                    , Agent.CLI.MacOS.NativeInteraction
                    , Agent.CLI.MacOS.NativeRequestHandler
@@ -197,6 +198,7 @@ test-suite agent-native-bridge-test
                      , Agent.CLI.MacOS.EngineState
                      , Agent.CLI.MacOS.EngineStore
                      , Agent.CLI.MacOS.EngineSubmission
+                     , Agent.CLI.MacOS.ConnectionBridge
                      , Agent.CLI.MacOS.InteractionState
                      , Agent.CLI.MacOS.NativeInteraction
                      , Agent.CLI.MacOS.NativeRequestHandler

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/BundledIntegrations.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/BundledIntegrations.hs
@@ -1,9 +1,14 @@
 -- | Distribution composition root. The public bridge has no bundled provider.
 -- Private distributions replace this module at build time and link their
 -- provider in the same GHC package set; no runtime plugin loading is involved.
-module Agent.CLI.MacOS.BundledIntegrations (bundledIntegrationProvider) where
+module Agent.CLI.MacOS.BundledIntegrations
+    (bundledIntegrationProvider, bundledOrganizationIntegrationProvider) where
 
-import Agent.Integration.API (IntegrationProvider, emptyIntegrationProvider)
+import Agent.Integration.API
+    (IntegrationProvider, OrganizationIntegrationProvider, emptyIntegrationProvider)
 
 bundledIntegrationProvider :: IntegrationProvider
 bundledIntegrationProvider = emptyIntegrationProvider
+
+bundledOrganizationIntegrationProvider :: Maybe OrganizationIntegrationProvider
+bundledOrganizationIntegrationProvider = Nothing

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ConnectionBridge.hsc
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ConnectionBridge.hsc
@@ -1,0 +1,114 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module Agent.CLI.MacOS.ConnectionBridge
+    ( ConnectionCallback, ConnectionSecretCallback
+    , sendConnectionResult, connectionSecretStore, decodeConnectionAnswers
+    , withSnapshot
+    ) where
+
+#include "HaskellAgentBridge.h"
+
+import Agent.Integration.Connection
+import Agent.CLI.MacOS.Marshalling (withText, decodeUtf8Input)
+import Data.Bifunctor (first)
+import Control.Exception.Safe (finally)
+import Control.Monad (forM)
+import qualified Data.ByteString as BS
+import Data.Text (Text)
+import Data.Word (Word8, Word32)
+import Foreign
+import Foreign.C.Types
+
+type ConnectionCallback =
+    Ptr () -> CInt -> Ptr () -> Ptr Word8 -> CSize -> IO ()
+type ConnectionSecretCallback =
+    Ptr () -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> IO CInt
+foreign import ccall "dynamic" invokeConnectionCallback
+    :: FunPtr ConnectionCallback -> ConnectionCallback
+foreign import ccall "dynamic" invokeSecretCallback
+    :: FunPtr ConnectionSecretCallback -> ConnectionSecretCallback
+
+connectionSecretStore :: FunPtr ConnectionSecretCallback -> Ptr () -> ConnectionSecretStore
+connectionSecretStore callback context scope
+    | callback == nullFunPtr = pure (Left "A native secure store is required.")
+    | otherwise = withTextBytes scope \bytes len ->
+        allocaBytes 32 \out -> flip finally (fillBytes out 0 32) do
+            fillBytes out 0 32
+            status <- invokeSecretCallback callback context bytes len out 32
+            if status /= 0
+                then pure (Left "The native secure store is unavailable.")
+                else Right <$> BS.packCStringLen (castPtr out, 32)
+
+decodeConnectionAnswers :: Ptr () -> CSize -> IO (Either Text [ConnectionAnswer])
+decodeConnectionAnswers pointer count
+    | count > 64 || (count > 0 && pointer == nullPtr) =
+        pure (Left "Invalid connection answers.")
+    | otherwise = fmap sequence $ forM [0 .. fromIntegral count - 1] \index -> do
+        let row = pointer `plusPtr` (index * #{size ha_connection_answer})
+        identifier <- readSlice (row `plusPtr` #{offset ha_connection_answer, identifier})
+        value <- readSlice (row `plusPtr` #{offset ha_connection_answer, value})
+        pure (ConnectionAnswer <$> identifier <*> value)
+  where
+    readSlice row = do
+        bytes <- #{peek ha_utf8_slice, bytes} row
+        len <- #{peek ha_utf8_slice, length} row :: IO CSize
+        if len > 16384 || (len > 0 && bytes == nullPtr)
+            then pure (Left "Invalid connection answer.")
+            else if len == 0 then pure (Right "")
+            else first (const "Invalid UTF-8 connection answer.") <$> decodeUtf8Input bytes (fromIntegral len)
+
+withTextBytes :: Text -> (Ptr Word8 -> CSize -> IO a) -> IO a
+withTextBytes text action = withText text \bytes len -> action (castPtr bytes) len
+
+sendConnectionResult :: FunPtr ConnectionCallback -> Ptr ()
+    -> Either Text ConnectionSnapshot -> IO ()
+sendConnectionResult callback context = \case
+    Left err -> withTextBytes err \bytes len ->
+        invokeConnectionCallback callback context (-1) nullPtr bytes len
+    Right snapshot -> withSnapshot snapshot \pointer ->
+        invokeConnectionCallback callback context 0 pointer nullPtr 0
+
+withSlice :: Ptr a -> Text -> IO b -> IO b
+withSlice pointer value action = withTextBytes value \bytes len -> do
+    #{poke ha_utf8_slice, bytes} pointer bytes
+    #{poke ha_utf8_slice, length} pointer len
+    action
+
+withRows :: Int -> [a] -> (Ptr () -> a -> IO b -> IO b) -> (Ptr () -> CSize -> IO b) -> IO b
+withRows stride rows write action =
+    allocaBytes (max 1 (stride * length rows)) \pointer ->
+        let go _ [] = action pointer (fromIntegral (length rows))
+            go index (row:rest) = write (pointer `plusPtr` (stride * index)) row (go (index + 1) rest)
+        in go 0 rows
+
+withField :: Ptr () -> ConnectionField -> IO a -> IO a
+withField pointer field action =
+    withSlice (pointer `plusPtr` #{offset ha_connection_field, identifier}) field.connectionFieldId $
+    withSlice (pointer `plusPtr` #{offset ha_connection_field, label}) field.connectionFieldLabel $ do
+        #{poke ha_connection_field, kind} pointer (fromIntegral (fromEnum field.connectionFieldKind) :: CInt)
+        #{poke ha_connection_field, required} pointer (if field.connectionFieldRequired then 1 else 0 :: CInt)
+        action
+
+withItem :: Ptr () -> ConnectionItem -> IO a -> IO a
+withItem pointer item action =
+    withSlice (pointer `plusPtr` #{offset ha_connection_item, identifier}) item.connectionItemId $
+    withSlice (pointer `plusPtr` #{offset ha_connection_item, title}) item.connectionItemTitle $
+    withSlice (pointer `plusPtr` #{offset ha_connection_item, detail}) item.connectionItemDetail $ do
+        #{poke ha_connection_item, selected} pointer (if item.connectionItemSelected then 1 else 0 :: CInt)
+        action
+
+withSnapshot :: ConnectionSnapshot -> (Ptr () -> IO a) -> IO a
+withSnapshot snapshot action = allocaBytes #{size ha_connection_snapshot} \pointer ->
+    withSlice (pointer `plusPtr` #{offset ha_connection_snapshot, session_id}) snapshot.connectionSessionId $
+    withSlice (pointer `plusPtr` #{offset ha_connection_snapshot, title}) snapshot.connectionTitle $
+    withSlice (pointer `plusPtr` #{offset ha_connection_snapshot, message}) snapshot.connectionMessage $
+    withSlice (pointer `plusPtr` #{offset ha_connection_snapshot, redirect_url}) snapshot.connectionRedirectUrl $
+    withRows #{size ha_connection_field} snapshot.connectionFields withField \fields fieldCount ->
+    withRows #{size ha_connection_item} snapshot.connectionItems withItem \items itemCount -> do
+        #{poke ha_connection_snapshot, phase} pointer (fromIntegral (fromEnum snapshot.connectionPhase) :: CInt)
+        #{poke ha_connection_snapshot, poll_after_milliseconds} pointer
+            (fromIntegral (max 0 (min 300000 snapshot.connectionPollAfterMilliseconds)) :: Word32)
+        #{poke ha_connection_snapshot, fields} pointer fields
+        #{poke ha_connection_snapshot, field_count} pointer fieldCount
+        #{poke ha_connection_snapshot, items} pointer items
+        #{poke ha_connection_snapshot, item_count} pointer itemCount
+        action pointer

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineLifecycle.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineLifecycle.hs
@@ -2,8 +2,11 @@
 module Agent.CLI.MacOS.EngineLifecycle (workerLifecycle) where
 
 import Agent.CLI.MacOS.BrowserBridge (BrowserHost)
-import Agent.CLI.MacOS.BundledIntegrations (bundledIntegrationProvider)
+import Agent.CLI.GatewayClient (registerGatewayCredentialInvalidator)
+import Agent.CLI.MacOS.BundledIntegrations
+    (bundledIntegrationProvider, bundledOrganizationIntegrationProvider)
 import Agent.CLI.MacOS.ComputerBridge (ComputerHost)
+import Agent.CLI.MacOS.ConnectionBridge (sendConnectionResult)
 import Agent.CLI.MacOS.EngineEvents (EventCallback)
 import Agent.CLI.MacOS.EngineCallbacks (invokeIntegrationResultCallback)
 import Agent.CLI.MacOS.EngineMailbox
@@ -24,7 +27,7 @@ import Agent.Loop (ImageAttachment)
 import Agent.Store.Postgres (ManagedPostgresConfig)
 import Control.Concurrent.MVar (newMVar)
 import Control.Concurrent.STM
-import Control.Exception.Safe (finally, tryAny)
+import Control.Exception.Safe (bracket, finally, tryAny, onException)
 import Control.Monad (forM_, void)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -51,16 +54,22 @@ workerLifecycle
         stagedTurnOptions interactions =
     (do
         store <- newMVar Nothing
-        processRuntime <- newNativeProcessRuntimeWithIntegrations
-            bundledIntegrationProvider root
+        processRuntime <- newNativeProcessRuntimeWithOrganizationIntegrations
+            bundledIntegrationProvider bundledOrganizationIntegrationProvider root
         workerRegistry <- newTVarIO Map.empty
         integrationWorkers <- newIntegrationWorkerRegistry
-        let cleanup =
+        let closeResources =
                 shutdownRunningTurns workerRegistry
                     `finally` shutdownIntegrationWorkers integrationWorkers
                     `finally` closeNativeProcessRuntime processRuntime
                     `finally` closeEngineStore store
-        supervisorLoop
+        bracket
+            (registerGatewayCredentialInvalidator
+                (shutdownIntegrationWorkers integrationWorkers
+                    `finally` restartNativeMcpRuntime processRuntime)
+                `onException` closeResources)
+            (\unregister -> unregister `finally` closeResources)
+            \_ -> supervisorLoop
             callback
             context
             config
@@ -81,7 +90,7 @@ workerLifecycle
                 , supervisorRunning = Map.empty
                 , supervisorKnownTaskIds = Set.empty
                 }
-            `finally` cleanup)
+            )
         `finally`
             (atomically $
                 cancelPendingInteractions interactions.interactionPending)
@@ -99,6 +108,9 @@ cancelPendingCallbacks commands = do
                     invokeMcpResultCallback callback context (-1) expected
         EngineIntegrationAdminList callback context ->
             sendIntegrationStopped callback context
+        EngineConnectionCommand _ _ _ _ callback context ->
+            void $ tryAny $ sendConnectionResult callback context
+                (Left "Engine stopped before connection operation completed.")
         EngineIntegrationAdminCall _ _ callback context ->
             sendIntegrationStopped callback context
         _ -> pure ()

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineState.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineState.hs
@@ -7,6 +7,8 @@ module Agent.CLI.MacOS.EngineState
 
 import Agent.CLI.MacOS.BrowserBridge (BrowserHost)
 import Agent.CLI.MacOS.ComputerBridge (ComputerHost)
+import Agent.CLI.MacOS.ConnectionBridge (ConnectionCallback, ConnectionSecretCallback)
+import Agent.Integration.Connection (ConnectionCommand)
 import Agent.CLI.MacOS.EngineCallbacks
     ( IntegrationResultCallback
     , SearchCallback
@@ -35,6 +37,10 @@ data EngineCommand
     | EngineMcpRestart !Word64 !Text !(FunPtr McpResultCallback) !(Ptr ())
     | EngineIntegrationAdminList
         !(FunPtr IntegrationResultCallback) !(Ptr ())
+    | EngineConnectionCommand
+        !(Maybe Text) !ConnectionCommand
+        !(FunPtr ConnectionSecretCallback) !(Ptr ())
+        !(FunPtr ConnectionCallback) !(Ptr ())
     | EngineIntegrationAdminCall
         !Text !RawJson !(FunPtr IntegrationResultCallback) !(Ptr ())
     | EngineCancelTask !Text

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineSubmission.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineSubmission.hs
@@ -12,6 +12,9 @@ import Agent.CLI.MacOS.EngineCallbacks
     , TaskSnapshotCallback
     )
 import Agent.CLI.MacOS.EngineMailbox (acceptEngineCommand)
+import Agent.CLI.MacOS.ConnectionBridge
+import Agent.CLI.MacOS.NativeGatewayBoundary (loadNativeGatewayIdentity)
+import Agent.Integration.Connection
 import Agent.CLI.MacOS.EngineState (Engine(..), EngineCommand(..), SessionMutation(..))
 import Agent.CLI.MacOS.Marshalling
     ( anyNonEmptyNull
@@ -67,6 +70,87 @@ foreign export ccall ha_engine_mcp_server_restart
 
 foreign export ccall ha_engine_integration_admin_list
     :: Ptr () -> FunPtr IntegrationResultCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_engine_connections_list
+    :: Ptr () -> FunPtr ConnectionSecretCallback -> Ptr () -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+foreign export ccall ha_engine_connections_search
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr ConnectionSecretCallback -> Ptr () -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+foreign export ccall ha_engine_connection_begin
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr ConnectionSecretCallback -> Ptr () -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+foreign export ccall ha_engine_connection_submit
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> FunPtr ConnectionSecretCallback -> Ptr () -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+foreign export ccall ha_engine_connection_poll
+    :: Ptr () -> Ptr Word8 -> CSize
+    -> FunPtr ConnectionSecretCallback -> Ptr () -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+foreign export ccall ha_engine_connection_cancel
+    :: Ptr () -> Ptr Word8 -> CSize
+    -> FunPtr ConnectionSecretCallback -> Ptr () -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+foreign export ccall ha_engine_connection_disconnect
+    :: Ptr () -> Ptr Word8 -> CSize
+    -> FunPtr ConnectionSecretCallback -> Ptr () -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+
+ha_engine_connections_list
+    :: Ptr () -> FunPtr ConnectionSecretCallback -> Ptr ()
+    -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+ha_engine_connections_list pointer = submitConnectionCommand pointer (pure (Right ListConnections))
+ha_engine_connections_search, ha_engine_connection_begin
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr ConnectionSecretCallback -> Ptr ()
+    -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+ha_engine_connections_search pointer a al b bl =
+    submitConnectionCommand pointer do
+        provider <- connectionText a al
+        query <- connectionText b bl
+        pure (SearchConnections <$> provider <*> query)
+ha_engine_connection_begin pointer a al b bl =
+    submitConnectionCommand pointer do
+        provider <- connectionText a al
+        identifier <- connectionText b bl
+        pure (BeginConnection <$> provider <*> identifier)
+ha_engine_connection_submit
+    :: Ptr () -> Ptr Word8 -> CSize -> Ptr () -> CSize
+    -> FunPtr ConnectionSecretCallback -> Ptr ()
+    -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+ha_engine_connection_submit pointer session len answers count =
+    submitConnectionCommand pointer do
+        decodedSession <- connectionText session len
+        decodedAnswers <- decodeConnectionAnswers answers count
+        pure (SubmitConnection <$> decodedSession <*> decodedAnswers)
+ha_engine_connection_poll, ha_engine_connection_cancel, ha_engine_connection_disconnect
+    :: Ptr () -> Ptr Word8 -> CSize
+    -> FunPtr ConnectionSecretCallback -> Ptr ()
+    -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+ha_engine_connection_poll pointer session len =
+    submitConnectionCommand pointer (fmap PollConnection <$> connectionText session len)
+ha_engine_connection_cancel pointer session len =
+    submitConnectionCommand pointer (fmap CancelConnection <$> connectionText session len)
+ha_engine_connection_disconnect pointer identifier len =
+    submitConnectionCommand pointer (fmap DisconnectConnection <$> connectionText identifier len)
+
+connectionText :: Ptr Word8 -> CSize -> IO (Either Text.Text Text.Text)
+connectionText bytes len
+    | len > 16384 || (len > 0 && bytes == nullPtr) = pure (Left "Invalid connection input.")
+    | len == 0 = pure (Right "")
+    | otherwise = either (const (Left "Invalid connection input.")) Right
+        <$> decodeUtf8Input bytes (fromIntegral len)
+
+submitConnectionCommand :: Ptr () -> IO (Either Text.Text ConnectionCommand)
+    -> FunPtr ConnectionSecretCallback -> Ptr () -> FunPtr ConnectionCallback -> Ptr () -> IO CInt
+submitConnectionCommand pointer decode secret secretContext callback context
+    | pointer == nullPtr = pure 1
+    | callback == nullFunPtr = pure 2
+    | otherwise = do
+        outcome <- tryAny do
+            decode >>= \case
+                Left _ -> pure 2
+                Right command -> loadNativeGatewayIdentity >>= \case
+                    Left _ -> pure 3
+                    Right identity -> enqueueIntegrationCommand pointer
+                        (EngineConnectionCommand identity command secret secretContext callback context)
+        pure (either (const 3) id outcome)
 
 foreign export ccall ha_engine_integration_admin_call
     :: Ptr () -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
@@ -180,7 +264,12 @@ integrationABISynchronousValidationSmoke = do
     callStatus <-
         ha_engine_integration_admin_call
             nullPtr nullPtr 0 nullPtr 0 nullFunPtr nullPtr
-    pure (listStatus == 1 && callStatus == 1)
+    connectionList <- ha_engine_connections_list nullPtr nullFunPtr nullPtr nullFunPtr nullPtr
+    connectionSubmit <- ha_engine_connection_submit
+        nullPtr nullPtr 0 nullPtr 0 nullFunPtr nullPtr nullFunPtr nullPtr
+    invalidAnswers <- decodeConnectionAnswers nullPtr 65
+    pure (listStatus == 1 && callStatus == 1 && connectionList == 1 &&
+        connectionSubmit == 1 && either (const True) (const False) invalidAnswers)
 
 maximumIntegrationAdminNameBytes, maximumIntegrationAdminArgumentsBytes :: Word64
 maximumIntegrationAdminNameBytes = 256

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
@@ -3,6 +3,7 @@
 module Agent.CLI.MacOS.NativeSupervisor
     ( IntegrationWorkerRegistry
     , launchIntegrationWorkerWith
+    , completeBoundaryChecked
     , newIntegrationWorkerRegistry
     , shutdownIntegrationWorkers
     , supervisorLoop
@@ -18,6 +19,8 @@ import Agent.CLI.MacOS.EngineCallbacks
     , invokeIntegrationResultCallback
     , invokeTaskSnapshotCallback
     )
+import Agent.Integration.Connection (IntegrationConnections(..), ConnectionCommand(..))
+import Agent.CLI.MacOS.ConnectionBridge (sendConnectionResult, connectionSecretStore)
 import Agent.CLI.MacOS.EngineEvents
 import Agent.CLI.MacOS.EngineMailbox
     ( EngineMailbox, acceptEngineCommand, readEngineCommand )
@@ -53,6 +56,7 @@ import Agent.Integration.API
     , acquireIntegrationRuntime
     , callIntegrationRuntimeAdmin
     , integrationRuntimeAdminDefinitions
+    , integrationRuntimeConnections
     )
 import Agent.Json (RawJson, rawJsonBytes)
 import Agent.Loop (ImageAttachment, emptyTokenUsage)
@@ -62,6 +66,7 @@ import Control.Concurrent.Async (Async, asyncWithUnmask, cancel, waitCatch)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, takeMVar, putMVar)
 import Control.Concurrent.STM
 import Control.Exception.Safe (bracket, finally, mask, tryAny)
+import qualified Control.Exception as Exception
 import Control.Monad (filterM, foldM, forM_, void, when)
 import Data.Aeson ((.:?))
 import qualified Data.Aeson as Aeson
@@ -188,6 +193,34 @@ supervisorLoop
                     withText "cannot restart MCP while tasks are active" $
                         invokeMcpResultCallback resultCallback resultContext
                             (-1) expected
+            go supervisor
+        EngineConnectionCommand expected command secret secretContext resultCallback resultContext -> do
+            launchIntegrationWorkerWith integrationWorkers
+                (\case
+                    -- Cancellation is joined while the credential writer
+                    -- lease is held. A data-free failure must not try to
+                    -- reacquire that lease in its terminal finalizer.
+                    Left _ -> sendConnectionResult resultCallback resultContext
+                        (Left "Connection operation failed or was cancelled.")
+                    outcome@(Right _) -> completeBoundaryChecked
+                        (emitForNativeGatewayBoundary expected)
+                        (sendConnectionResult resultCallback resultContext outcome)
+                        (sendConnectionResult resultCallback resultContext
+                            (Left "Gateway identity changed; reopen the connection dialog."))) $
+                (case command of
+                    CancelConnection _ -> id
+                    _ -> withGatewayCredentialTurnLease) $
+                withNativeGatewayCredentialBoundary \credential identity ->
+                    if identity /= expected
+                        then pure (Left "Gateway identity changed; reopen the connection dialog.")
+                        else acquireIntegrationRuntime
+                            (nativeProcessIntegrationSupervisor processRuntime)
+                            (gatewayIntegrationAuthority credential) >>= \case
+                                Left err -> pure (Left err)
+                                Right runtime -> case integrationRuntimeConnections runtime of
+                                    Nothing -> pure (Left "Connection management is unavailable for this account.")
+                                    Just connections -> runConnectionCommand connections
+                                        (connectionSecretStore secret secretContext) command
             go supervisor
         EngineIntegrationAdminList resultCallback resultContext -> do
             launchIntegrationWorker
@@ -703,10 +736,31 @@ launchIntegrationWorker registry callback context action =
             (sendIntegrationResult callback context))
         action
 
+-- | Waiting for the output lease is interruptible, but ownership of the host
+-- callback is claimed only inside that lease. Cancellation while waiting must
+-- still release the host context with one data-free terminal callback.
+completeBoundaryChecked
+    :: (IO () -> IO (Either Text ()))
+    -> IO ()
+    -> IO ()
+    -> IO ()
+completeBoundaryChecked boundary success failure = mask \_ -> do
+    delivered <- newTVarIO False
+    let once callback = do
+            claimed <- atomically do
+                previous <- readTVar delivered
+                writeTVar delivered True
+                pure (not previous)
+            when claimed callback
+    (boundary (once success) >>= \case
+        Left _ -> once failure
+        Right () -> pure ())
+        `Exception.onException` once failure
+
 launchIntegrationWorkerWith
     :: IntegrationWorkerRegistry
-    -> (Either Text RawJson -> IO ())
-    -> IO (Either Text RawJson)
+    -> (Either Text a -> IO ())
+    -> IO (Either Text a)
     -> IO ()
 launchIntegrationWorkerWith registry complete action =
     mask \_ -> do

--- a/packages/agent-native-bridge/include/HaskellAgentBridge.h
+++ b/packages/agent-native-bridge/include/HaskellAgentBridge.h
@@ -446,6 +446,96 @@ typedef struct ha_mcp_env_entry {
     ha_utf8_slice value;
 } ha_mcp_env_entry;
 
+typedef struct ha_connection_answer {
+    ha_utf8_slice identifier;
+    ha_utf8_slice value;
+} ha_connection_answer;
+
+typedef struct ha_connection_field {
+    ha_utf8_slice identifier;
+    ha_utf8_slice label;
+    int32_t kind; /* 0 text, 1 secret (never echoed) */
+    int32_t required;
+} ha_connection_field;
+
+typedef struct ha_connection_item {
+    ha_utf8_slice identifier;
+    ha_utf8_slice title;
+    ha_utf8_slice detail;
+    int32_t selected;
+} ha_connection_item;
+
+typedef struct ha_connection_snapshot {
+    /* 0 catalog, 1 search, 2 credentials, 3 challenge, 4 redirect,
+     * 5 selection, 6 connected, 7 waiting */
+    int32_t phase;
+    ha_utf8_slice session_id;
+    ha_utf8_slice title;
+    ha_utf8_slice message;
+    ha_utf8_slice redirect_url;
+    uint32_t poll_after_milliseconds;
+    const ha_connection_field *fields;
+    size_t field_count;
+    const ha_connection_item *items;
+    size_t item_count;
+} ha_connection_snapshot;
+
+/*
+ * Exactly one completion for an accepted request, on a runtime worker (not
+ * the main thread). All output memory is borrowed for the callback only.
+ * Copy before returning; never free it. status 0 has snapshot, -1 has error.
+ * Input strings/answers are synchronously copied, limited to 16 KiB each,
+ * 64 answers; secrets are never sent through the conversational protocol.
+ * Return 0 accepted, 1 null engine, 2 invalid input, 3 engine closed.
+ * Caller retains both callback contexts through terminal completion.
+ * Engine destruction cancels accepted requests and joins their workers;
+ * all accepted terminal callbacks have returned before destruction returns.
+ * Do not synchronously destroy the engine or mutate gateway credentials from
+ * a callback. Dispatch host UI work asynchronously.
+ */
+typedef void (*ha_connection_callback)(
+    void *context, int32_t status, const ha_connection_snapshot *snapshot,
+    const uint8_t *error, size_t error_length);
+
+/* A secure-store callback writes exactly 32 key bytes on success (return 0).
+ * Called on a worker; scope is an opaque identity-scoped key identifier.
+ * No key is returned in snapshots. Output buffer is borrowed for this call.
+ * No callback/context is retained after the terminal connection callback. */
+typedef int32_t (*ha_connection_secret_callback)(
+    void *context, const uint8_t *scope, size_t scope_length,
+    uint8_t *key_out, size_t key_capacity);
+
+int32_t ha_engine_connections_list(
+    void *engine, ha_connection_secret_callback secret, void *secret_context,
+    ha_connection_callback callback, void *context);
+int32_t ha_engine_connections_search(
+    void *engine, const uint8_t *provider, size_t provider_length,
+    const uint8_t *query, size_t query_length,
+    ha_connection_secret_callback secret, void *secret_context,
+    ha_connection_callback callback, void *context);
+int32_t ha_engine_connection_begin(
+    void *engine, const uint8_t *provider, size_t provider_length,
+    const uint8_t *identifier, size_t identifier_length,
+    ha_connection_secret_callback secret, void *secret_context,
+    ha_connection_callback callback, void *context);
+int32_t ha_engine_connection_submit(
+    void *engine, const uint8_t *session, size_t session_length,
+    const ha_connection_answer *answers, size_t answer_count,
+    ha_connection_secret_callback secret, void *secret_context,
+    ha_connection_callback callback, void *context);
+int32_t ha_engine_connection_poll(
+    void *engine, const uint8_t *session, size_t session_length,
+    ha_connection_secret_callback secret, void *secret_context,
+    ha_connection_callback callback, void *context);
+int32_t ha_engine_connection_cancel(
+    void *engine, const uint8_t *session, size_t session_length,
+    ha_connection_secret_callback secret, void *secret_context,
+    ha_connection_callback callback, void *context);
+int32_t ha_engine_connection_disconnect(
+    void *engine, const uint8_t *identifier, size_t identifier_length,
+    ha_connection_secret_callback secret, void *secret_context,
+    ha_connection_callback callback, void *context);
+
 /*
  * MCP catalog reads expose redacted typed rows. Environment values are never
  * returned: field callbacks use kind 0 for an argument and kind 1 for an

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeHeaderSpec.hs
@@ -2,7 +2,14 @@
 
 module Agent.CLI.MacOS.BridgeHeaderSpec (spec) where
 
-import Foreign.C.Types (CInt(..))
+import Foreign.C.Types (CInt(..), CSize(..))
+import Foreign.Ptr (Ptr, FunPtr, nullFunPtr, nullPtr, freeHaskellFunPtr)
+import Foreign.Marshal.Utils (fillBytes)
+import Control.Exception.Safe (bracket)
+import qualified Data.ByteString as BS
+import Agent.CLI.MacOS.ConnectionBridge
+    (withSnapshot, ConnectionSecretCallback, connectionSecretStore)
+import Agent.Integration.Connection
 import Test.Hspec (Spec, describe, it, shouldReturn)
 
 foreign import ccall "ha_image_attachment_abi_smoke"
@@ -29,9 +36,40 @@ foreign import ccall "ha_data_browser_abi_smoke"
 foreign import ccall "ha_integration_abi_smoke"
     integrationAbiSmoke :: IO CInt
 
+foreign import ccall "ha_connection_abi_check_snapshot"
+    connectionSnapshotAbiCheck :: Ptr () -> IO CInt
+
+foreign import ccall "wrapper" makeSecretCallback
+    :: ConnectionSecretCallback -> IO (FunPtr ConnectionSecretCallback)
+
 spec :: Spec
 spec = do
+    describe "native connection secure store" do
+        it "fails closed when the native secure store is absent" do
+            connectionSecretStore nullFunPtr nullPtr "scope"
+                `shouldReturn` Left "A native secure store is required."
+        it "copies exactly the host key before releasing callback storage" do
+            bracket
+                (makeSecretCallback \_ _ _ pointer capacity ->
+                    if capacity /= 32 then pure 1
+                    else fillBytes pointer 42 32 >> pure 0)
+                freeHaskellFunPtr \callback ->
+                    connectionSecretStore callback nullPtr "scope"
+                        `shouldReturn` Right (BS.replicate 32 42)
+        it "never returns partial key bytes after a secure-store failure" do
+            bracket
+                (makeSecretCallback \_ _ _ pointer _ ->
+                    fillBytes pointer 42 16 >> pure 1)
+                freeHaskellFunPtr \callback ->
+                    connectionSecretStore callback nullPtr "scope"
+                        `shouldReturn` Left "The native secure store is unavailable."
     describe "native bridge struct ABI" do
+        it "marshals connection fields and items in the layout consumed by C" do
+            let snapshot = ConnectionSnapshot ConnectionChallenge "session"
+                    "Authorization" "Enter the code" "" 2500
+                    [ConnectionField "tan" "Code" ConnectionSecretField True]
+                    [ConnectionItem "account" "Bank" "••1234" True]
+            withSnapshot snapshot connectionSnapshotAbiCheck `shouldReturn` 0
         it "preserves the documented image struct layout and ordered buffers" do
             imageAttachmentAbiSmoke `shouldReturn` 0
         it "preserves typed gateway callbacks and synchronous validation" do

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeSpec.hs
@@ -12,6 +12,7 @@ import Agent.CLI.MacOS.Bridge
     )
 import Agent.CLI.MacOS.NativeSupervisor
     ( launchIntegrationWorkerWith
+    , completeBoundaryChecked
     , newIntegrationWorkerRegistry
     , shutdownIntegrationWorkers
     )
@@ -53,6 +54,33 @@ spec = do
 integrationWorkerSpec :: Spec
 integrationWorkerSpec =
     describe "native integration worker supervision" do
+        it "completes once when cancelled while waiting for the output boundary" do
+            registry <- newIntegrationWorkerRegistry
+            waiting <- newEmptyMVar
+            blocked <- newEmptyMVar
+            callbacks <- newIORef ([] :: [String])
+            let record value = atomicModifyIORef' callbacks \values ->
+                    (values <> [value], ())
+            launchIntegrationWorkerWith registry
+                (\_ -> completeBoundaryChecked
+                    (\_ -> putMVar waiting () >> takeMVar blocked)
+                    (record "success")
+                    (record "cancelled"))
+                (pure (Right ()))
+            takeMVar waiting
+            timeout 1000000 (shutdownIntegrationWorkers registry)
+                `shouldReturn` Just ()
+            readIORef callbacks `shouldReturn` ["cancelled"]
+
+        it "does not retry a callback after boundary delivery has begun" do
+            callbacks <- newIORef ([] :: [String])
+            let record value = modifyIORef' callbacks (<> [value])
+            completeBoundaryChecked
+                (\emit -> emit >> pure (Left "changed"))
+                (record "success")
+                (record "cancelled")
+            readIORef callbacks `shouldReturn` ["success"]
+
         it "keeps the mailbox launch nonblocking and completes once on shutdown" do
             registry <- newIntegrationWorkerRegistry
             started <- newEmptyMVar

--- a/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeIntegrationSmoke.c
+++ b/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeIntegrationSmoke.c
@@ -1,6 +1,20 @@
 #include "HaskellAgentBridge.h"
 
 #include <stddef.h>
+#include <string.h>
+
+int ha_connection_abi_check_snapshot(const ha_connection_snapshot *snapshot) {
+    if (!snapshot || snapshot->phase != 3 || snapshot->field_count != 1 ||
+            snapshot->item_count != 1 || snapshot->poll_after_milliseconds != 2500) return 1;
+    if (snapshot->session_id.length != 7 ||
+            memcmp(snapshot->session_id.bytes, "session", 7) != 0) return 2;
+    if (snapshot->fields[0].kind != 1 || snapshot->fields[0].required != 1 ||
+            snapshot->fields[0].identifier.length != 3 ||
+            memcmp(snapshot->fields[0].identifier.bytes, "tan", 3) != 0) return 3;
+    if (snapshot->items[0].selected != 1 || snapshot->items[0].title.length != 4 ||
+            memcmp(snapshot->items[0].title.bytes, "Bank", 4) != 0) return 4;
+    return 0;
+}
 
 static void integration_result_callback(
         void *context, int32_t status,
@@ -32,5 +46,35 @@ int ha_integration_abi_smoke(void) {
     if (callback == NULL) {
         return 3;
     }
+    int32_t (*connections_list)(
+        void *, ha_connection_secret_callback, void *, ha_connection_callback, void *) =
+        ha_engine_connections_list;
+    int32_t (*connections_search)(
+        void *, const uint8_t *, size_t, const uint8_t *, size_t,
+        ha_connection_secret_callback, void *, ha_connection_callback, void *) =
+        ha_engine_connections_search;
+    int32_t (*connection_begin)(
+        void *, const uint8_t *, size_t, const uint8_t *, size_t,
+        ha_connection_secret_callback, void *, ha_connection_callback, void *) =
+        ha_engine_connection_begin;
+    int32_t (*connection_submit)(
+        void *, const uint8_t *, size_t, const ha_connection_answer *, size_t,
+        ha_connection_secret_callback, void *, ha_connection_callback, void *) =
+        ha_engine_connection_submit;
+    int32_t (*connection_poll)(
+        void *, const uint8_t *, size_t,
+        ha_connection_secret_callback, void *, ha_connection_callback, void *) =
+        ha_engine_connection_poll;
+    int32_t (*connection_cancel)(
+        void *, const uint8_t *, size_t,
+        ha_connection_secret_callback, void *, ha_connection_callback, void *) =
+        ha_engine_connection_cancel;
+    int32_t (*connection_disconnect)(
+        void *, const uint8_t *, size_t,
+        ha_connection_secret_callback, void *, ha_connection_callback, void *) =
+        ha_engine_connection_disconnect;
+    if (!connections_list || !connections_search || !connection_begin ||
+            !connection_submit || !connection_poll || !connection_cancel ||
+            !connection_disconnect) return 4;
     return 0;
 }


### PR DESCRIPTION
## Summary
- Add provider-neutral connection lifecycle types and seven typed native C ABI operations.
- Invalidate integration runtimes when organization gateway credentials change; preserve cancellation and callback ownership.
- Keep provider implementations outside the public runtime.

## Validation
- Native bridge suite: 123 examples passed.
- Integration API: 9 tests passed; gateway client: 45 tests passed.
- Matching application bundle validation remains outstanding; draft until coordinated validation completes.