### PR TITLE
Share current pull request detection across frontends

### DIFF
--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -81,6 +81,7 @@ library
                     , Agent.CLI.Models
                     , Agent.CLI.Permission.Types
                     , Agent.CLI.PrivateFileLock
+                    , Agent.CLI.Session.PullRequest
                     , Agent.CLI.Request
                     , Agent.CLI.Runtime.Options
                     , Agent.CLI.Session

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/PullRequest.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/PullRequest.hs
@@ -1,9 +1,10 @@
--- | Pure conversation pull-request association detection shared by frontends.
+-- | Conversation pull-request association detection and incremental indexing.
 module Agent.CLI.Session.PullRequest
     ( pullRequestURLs
     , conversationPullRequestURLs
     , sessionTurnPullRequestURL
     , sessionTurnPullRequestURLs
+    , advanceSessionPullRequestIndex
     ) where
 
 import Agent.CLI.Session.Types (SessionTurn(..))
@@ -18,12 +19,44 @@ import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Char (isAlphaNum)
+import Data.Int (Int64)
 import Data.List (foldl', nub)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (listToMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Text.Read (readMaybe)
+
+-- | Advance a recency-ordered cache using ascending, bounded history pages.
+-- A current cache performs no history reads. Persist each completed page so
+-- interrupted indexing resumes without repeating the completed prefix.
+advanceSessionPullRequestIndex
+    :: Monad m
+    => (Int64 -> Int64 -> m (Either Text [(Int64, [Text])]))
+    -> (Int64 -> [Text] -> m (Either Text ()))
+    -> Int64
+    -> Maybe (Int64, [Text])
+    -> m (Either Text [Text])
+advanceSessionPullRequestIndex loadPage savePage total cached =
+    case cached of
+        Just (cursor, urls) | cursor >= 0 && cursor <= total -> scan cursor urls
+        _ -> scan 0 []
+  where
+    scan cursor urls
+        | cursor >= total = pure (Right urls)
+        | otherwise = loadPage cursor total >>= \case
+            Left err -> pure (Left err)
+            Right [] -> pure (Left "incomplete PR association history")
+            Right turns
+                | map fst turns /= [cursor .. cursor + fromIntegral (length turns) - 1]
+                    || fst (last turns) >= total ->
+                    pure (Left "invalid PR association history page")
+                | otherwise -> do
+                    let next = 1 + fst (last turns)
+                        associated = nub (concatMap snd (reverse turns) <> urls)
+                    savePage next associated >>= \case
+                        Left err -> pure (Left err)
+                        Right () -> scan next associated
 
 -- Only canonical public GitHub PR identities are accepted. Never pass arbitrary
 -- conversation URLs to gh (or to a shell). Strip Markdown/query/fragment tails.

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/PullRequest.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/PullRequest.hs
@@ -1,0 +1,136 @@
+-- | Pure conversation pull-request association detection shared by frontends.
+module Agent.CLI.Session.PullRequest
+    ( pullRequestURLs
+    , conversationPullRequestURLs
+    , sessionTurnPullRequestURL
+    , sessionTurnPullRequestURLs
+    ) where
+
+import Agent.CLI.Session.Types (SessionTurn(..))
+import Agent.Responses.Types
+    ( ResponseItem(..)
+    , FunctionCall(..)
+    , FunctionCallOutput(..)
+    , CustomToolCall(..)
+    , CustomToolCallOutput(..)
+    )
+import Control.Applicative ((<|>))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Char (isAlphaNum)
+import Data.List (foldl', nub)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (listToMaybe, maybeToList)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Text.Read (readMaybe)
+
+-- Only canonical public GitHub PR identities are accepted. Never pass arbitrary
+-- conversation URLs to gh (or to a shell). Strip Markdown/query/fragment tails.
+pullRequestURLs :: Text -> [Text]
+pullRequestURLs = nub . go
+  where
+    go input = case Text.breakOn "https://github.com/" input of
+        (_, rest) | Text.null rest -> []
+        (prefix, rest) ->
+            let suffix = Text.drop 19 rest
+                token = Text.takeWhile (\c -> isAlphaNum c || c `elem` ("-._/" :: String)) suffix
+                remaining = Text.drop (Text.length token) suffix
+                validBoundary = Text.null prefix || not (isAlphaNum (Text.last prefix) || Text.last prefix `elem` ("/_-." :: String))
+                found = case Text.splitOn "/" token of
+                    owner : repo : "pull" : number : _
+                        | validBoundary, validName owner, validName repo
+                        , Just n <- readMaybe (Text.unpack number) :: Maybe Int
+                        , n > 0, Text.all (\c -> c >= '0' && c <= '9') number ->
+                            ["https://github.com/" <> Text.toCaseFold owner <> "/" <> Text.toCaseFold repo <> "/pull/" <> Text.pack (show n)]
+                    _ -> []
+            in found <> go remaining
+    validName name = not (Text.null name) && name /= "." && name /= ".."
+        && Text.all (\c -> c < '\128' && (isAlphaNum c || c `elem` ("-_." :: String))) name
+
+-- Evidence stays local to a paragraph. Quoted references/examples do not become
+-- associations. Tools must be paired with a PR operation; raw search output alone
+-- cannot attach every PR it happens to mention.
+conversationPullRequestURLs :: Text -> Maybe Text -> [Aeson.Value] -> [Text]
+conversationPullRequestURLs user assistant items = nub $
+    directUser <> concatMap evidence (maybe [] pure assistant <> [user] <> messages) <> toolURLs
+  where
+    directUser = case pullRequestURLs user of
+        [url] | Text.toCaseFold (Text.strip user) == url -> [url]
+        _ -> []
+    evidence = paragraphs . Text.splitOn "\n\n"
+    paragraphs (header : list : rest)
+        | null (pullRequestURLs header)
+        , any (`elem` ["pr", "prs", "pull"]) (Text.words (Text.map wordCharacter (Text.toCaseFold header)))
+        , any (`Text.isPrefixOf` Text.stripStart list) ["- ", "* ", "1. "] =
+            paragraph (header <> "\n" <> list) <> paragraphs rest
+    paragraphs (content : rest) = paragraph content <> paragraphs rest
+    paragraphs [] = []
+    wordCharacter c = if isAlphaNum c then c else ' '
+    paragraph content
+        | any (`Text.isInfixOf` lower) ["for reference", "example", "unrelated", "see also", "beispiel", "referenz"] = []
+        | any (`Text.isInfixOf` lower) ["created", "opened", "merged", "review", "fix", "address", "implement", "update", "check", "work on", "look at", "erstellt", "gemerg", "beheb", "prüf", "bearbeit"] =
+            pullRequestURLs (Text.unlines (filter (not . Text.isPrefixOf ">" . Text.stripStart) (Text.lines content)))
+        | otherwise = []
+      where lower = Text.toCaseFold (Text.unwords (filter (null . pullRequestURLs) (Text.words content)))
+    messages = [Text.intercalate "\n" (strings content) | Aeson.Object o <- items
+        , KeyMap.lookup "type" o == Just (Aeson.String "message")
+        , Just (Aeson.String role) <- [KeyMap.lookup "role" o], role `elem` ["user", "assistant"]
+        , Just content <- [KeyMap.lookup "content" o]]
+    calls = [callId | Aeson.Object o <- items
+        , Just (Aeson.String kind) <- [KeyMap.lookup "type" o]
+        , kind `elem` ["function_call", "custom_tool_call"]
+        , Just (Aeson.String callId) <- [KeyMap.lookup "call_id" o]
+        , let body = Text.toCaseFold (Text.intercalate " " (strings (Aeson.Object o)))
+        , any (`Text.isInfixOf` body) ["gh pr create", "gh pr checkout", "gh pr merge", "gh pr review", "create_pull_request"]]
+    toolURLs = concat [pullRequestURLs (Text.intercalate "\n" (strings output))
+        | Aeson.Object o <- items
+        , Just (Aeson.String kind) <- [KeyMap.lookup "type" o]
+        , kind `elem` ["function_call_output", "custom_tool_call_output"]
+        , Just (Aeson.String callId) <- [KeyMap.lookup "call_id" o], callId `elem` calls
+        , Just output <- [KeyMap.lookup "output" o]]
+    strings (Aeson.String value) = [value]
+    strings (Aeson.Array values) = foldMap strings values
+    strings (Aeson.Object values) = foldMap strings values
+    strings _ = []
+
+sessionTurnPullRequestURL :: SessionTurn -> Maybe Text
+sessionTurnPullRequestURL turn =
+    firstURL "" turn.turnAssistantText []
+        <|> snd (foldl' inspectItem (Map.empty, Nothing)
+            (turn.turnItems <> turn.turnDisplayItems))
+        <|> firstURL turn.turnUserText Nothing []
+  where
+    firstURL :: Text -> Maybe Text -> [ResponseItem] -> Maybe Text
+    firstURL user assistant items =
+        listToMaybe (conversationPullRequestURLs user assistant (map Aeson.toJSON items))
+    -- The shared detector returns a set of associations, not recency order.
+    -- Keep the newest message/output evidence, pairing each output only with
+    -- its preceding call, so an old PR in the user prompt cannot replace the
+    -- PR just created during this turn.
+    inspectItem current@(calls, latest) item =
+        case item of
+            FunctionCallItem call ->
+                (Map.insert call.callId item calls, latest)
+            CustomToolCallItem call ->
+                (Map.insert call.callId item calls, latest)
+            FunctionCallOutputItem output ->
+                inspectOutput output.callId
+            CustomToolCallOutputItem output ->
+                inspectOutput output.callId
+            MessageItem _ ->
+                (calls, firstURL "" Nothing [item] <|> latest)
+            _ -> current
+      where
+        inspectOutput callId =
+            case Map.lookup callId calls of
+                Nothing -> current
+                Just call ->
+                    (calls, firstURL "" Nothing [call, item] <|> latest)
+
+-- | Retain every association, ordering the current one first.
+sessionTurnPullRequestURLs :: SessionTurn -> [Text]
+sessionTurnPullRequestURLs turn = nub $
+    maybeToList (sessionTurnPullRequestURL turn)
+        <> conversationPullRequestURLs turn.turnUserText turn.turnAssistantText
+            (map Aeson.toJSON (turn.turnItems <> turn.turnDisplayItems))

--- a/packages/agent-cli-runtime/test/Spec.hs
+++ b/packages/agent-cli-runtime/test/Spec.hs
@@ -4,6 +4,8 @@ import qualified Agent.CLI.SessionActivitySpec as SessionActivitySpec
 import qualified Agent.CLI.SessionRequestSpec as SessionRequestSpec
 import qualified Agent.CLI.SessionThreadsSpec as SessionThreadsSpec
 import Agent.CLI.Session.TitlePolicy (titleRefreshIndex)
+import Agent.CLI.Session.PullRequest (advanceSessionPullRequestIndex)
+import Data.IORef
 import qualified Agent.CLI.CredentialStoreSpec as CredentialStoreSpec
 import qualified Agent.CLI.EnvironmentSpec as EnvironmentSpec
 import qualified Agent.CLI.ErrorSpec as ErrorSpec
@@ -29,6 +31,46 @@ main = hspec do
     SessionActivitySpec.spec
     SessionRequestSpec.spec
     SessionThreadsSpec.spec
+    describe "pull request cache indexing" do
+        it "persists a long history once and performs no reads for a current cache" do
+            reads <- newIORef (0 :: Int)
+            saved <- newIORef Nothing
+            let older = "https://github.com/o/repo/pull/1"
+                newer = "https://github.com/o/repo/pull/2"
+                loadPage start end = do
+                    modifyIORef' reads (+ 1)
+                    pure (Right [(index, if index == 0 then [newer, older] else [])
+                        | index <- [start .. min (end - 1) (start + 31)]])
+                savePage cursor urls = writeIORef saved (Just (cursor, urls)) >> pure (Right ())
+            advanceSessionPullRequestIndex loadPage savePage 4096 Nothing
+                `shouldReturn` Right [newer, older]
+            readIORef reads `shouldReturn` 128
+            cached <- readIORef saved
+            cached `shouldBe` Just (4096, [newer, older])
+            advanceSessionPullRequestIndex loadPage savePage 4096 cached
+                `shouldReturn` Right [newer, older]
+            readIORef reads `shouldReturn` 128
+        it "reads only appended turns and prioritizes newly associated pull requests" do
+            let older = "https://github.com/o/repo/pull/1"
+                newer = "https://github.com/o/repo/pull/2"
+                loadPage start end = do
+                    (start, end) `shouldBe` (4096, 4097)
+                    pure (Right [(4096, [newer])])
+                savePage cursor urls = do
+                    (cursor, urls) `shouldBe` (4097, [newer, older])
+                    pure (Right ())
+            advanceSessionPullRequestIndex loadPage savePage 4097 (Just (4096, [older]))
+                `shouldReturn` Right [newer, older]
+        it "does not advance the cursor when persistence fails" do
+            advanceSessionPullRequestIndex
+                (\_ _ -> pure (Right [(0, [])]))
+                (\_ _ -> pure (Left "write failed"))
+                64 Nothing `shouldReturn` Left "write failed"
+        it "rejects incomplete pages instead of marking missing history indexed" do
+            advanceSessionPullRequestIndex
+                (\_ _ -> pure (Right [(1, [])]))
+                (\_ _ -> expectationFailure "must not persist incomplete history" >> pure (Right ()))
+                2 Nothing `shouldReturn` Left "invalid PR association history page"
     describe "titleRefreshIndex" do
         it "advances only at the persisted title milestones" do
             map titleRefreshIndex [0, 1, 2, 3, 5, 6, 10]

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -305,7 +305,6 @@ library
                     , agent-cli-runtime:Agent.CLI.Session.StoreCodec as Agent.CLI.Session.StoreCodec
                     , agent-cli-runtime:Agent.CLI.SessionLock as Agent.CLI.SessionLock
     build-depends:    agent-cli-runtime >= 0.1 && < 0.2
-                    , agent-repository >= 0.1 && < 0.2
                     , agent-external-session >= 0.1 && < 0.2
                     , agent-integration-api >= 0.1 && < 0.2
                     , agent-connectivity >= 0.1 && < 0.2

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -2,7 +2,7 @@
 , agent-codex-dialect, agent-connectivity, agent-core
 , agent-external-session, agent-gemini, agent-grok-build-dialect
 , agent-integration-api, agent-json, agent-mcp, agent-openai
-, agent-openrouter, agent-process, agent-repository
+, agent-openrouter, agent-process
 , agent-responses, agent-responses-types, agent-store, agent-syntax
 , agent-tui, agent-xai, ansi-terminal, async, base
 , base64-bytestring, brick, bytestring, colour, containers, crypton
@@ -25,7 +25,7 @@ mkDerivation {
     aeson agent-claude agent-cli-runtime agent-codex-dialect
     agent-connectivity agent-core agent-external-session agent-gemini
     agent-grok-build-dialect agent-integration-api agent-json agent-mcp
-    agent-openai agent-openrouter agent-process agent-repository
+    agent-openai agent-openrouter agent-process
     agent-responses agent-responses-types agent-store agent-syntax
     agent-tui agent-xai ansi-terminal async base base64-bytestring
     brick bytestring colour containers crypton crypton-connection dbus

--- a/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Bridge.hs
@@ -20,7 +20,7 @@ import Agent.CLI.AgentViewport
     )
 import Agent.TUI.Model (UiEvent(..), UiState(..))
 import Agent.Loop (LoopEvent(..), TurnOutput(..))
-import Agent.CLI.RepositoryDelivery (conversationPullRequestURLs)
+import Agent.CLI.Session.PullRequest (conversationPullRequestURLs)
 import Agent.ToolDispatch (ToolCallResult(..))
 import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson

--- a/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
@@ -15,11 +15,7 @@ import Agent.CLI.Session
     )
 import Agent.CLI.Session.Types (TranscriptEffect(..))
 import Agent.CLI.Render (renderToolOutputValue)
-import Agent.CLI.RepositoryDelivery (conversationPullRequestURLs)
-import qualified Data.Aeson as Aeson
-import Data.Maybe (listToMaybe)
-import Control.Applicative ((<|>))
-import qualified Data.Map.Strict as Map
+import Agent.CLI.Session.PullRequest (sessionTurnPullRequestURL)
 import Agent.CLI.Plan
     ( ProposedPlanSegment(..)
     , feedProposedPlanStream
@@ -75,40 +71,6 @@ import Agent.TUI.Model
 import Data.Foldable (toList)
 import qualified Data.Sequence as Seq
 import qualified Data.Text as Text
-
-sessionTurnPullRequestURL :: SessionTurn -> Maybe Text.Text
-sessionTurnPullRequestURL turn =
-    firstURL "" turn.turnAssistantText []
-        <|> snd (foldl' inspectItem (Map.empty, Nothing)
-            (turn.turnItems <> turn.turnDisplayItems))
-        <|> firstURL turn.turnUserText Nothing []
-  where
-    firstURL :: Text.Text -> Maybe Text.Text -> [ResponseItem] -> Maybe Text.Text
-    firstURL user assistant items =
-        listToMaybe (conversationPullRequestURLs user assistant (map Aeson.toJSON items))
-    -- The shared detector returns a set of associations, not recency order.
-    -- Keep the newest message/output evidence, pairing each output only with
-    -- its preceding call, so an old PR in the user prompt cannot replace the
-    -- PR just created during this turn.
-    inspectItem current@(calls, latest) item =
-        case item of
-            FunctionCallItem call ->
-                (Map.insert call.callId item calls, latest)
-            CustomToolCallItem call ->
-                (Map.insert call.callId item calls, latest)
-            FunctionCallOutputItem output ->
-                inspectOutput output.callId
-            CustomToolCallOutputItem output ->
-                inspectOutput output.callId
-            MessageItem _ ->
-                (calls, firstURL "" Nothing [item] <|> latest)
-            _ -> current
-      where
-        inspectOutput callId =
-            case Map.lookup callId calls of
-                Nothing -> current
-                Just call ->
-                    (calls, firstURL "" Nothing [call, item] <|> latest)
 
 sessionHistoryPage
     :: HistoryGeneration

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -15,6 +15,7 @@ import Agent.CLI.TUI.History
 import Agent.Json (rawJsonFromEncoding)
 import Agent.CLI.TUI.Composer (composerScrollbackAvailable)
 import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn, sessionTurnPullRequestURL)
+import Agent.CLI.Session.PullRequest (sessionTurnPullRequestURLs)
 import Agent.Responses.LoopBackend (toolResultToItem)
 import Agent.Responses.Types
 import Agent.ToolDispatch
@@ -979,6 +980,12 @@ spec = describe "bounded fullscreen history window" do
                 ]
         it "prefers a newly created PR over the user prompt and earlier messages" do
             sessionTurnPullRequestURL createdTurn `shouldBe` Just newURL
+        it "orders native associations with the current PR first without losing the earlier PR" do
+            sessionTurnPullRequestURLs createdTurn `shouldBe` [newURL, oldURL]
+        it "deduplicates the final assistant PR while retaining all other associations" do
+            sessionTurnPullRequestURLs
+                (createdTurn { turnAssistantText = Just ("Opened " <> finalURL) })
+                `shouldBe` [finalURL, oldURL, newURL]
         it "prefers the final assistant association over preceding tool output" do
             sessionTurnPullRequestURL
                 (createdTurn { turnAssistantText = Just ("Opened " <> finalURL) })
@@ -992,6 +999,18 @@ spec = describe "bounded fullscreen history window" do
             sessionTurnPullRequestURL
                 (sessionTurn TranscriptAppend oldURL [assistantMessage "Done"])
                 `shouldBe` Just oldURL
+        it "does not use a later call to qualify an earlier unrelated output" do
+            sessionTurnPullRequestURL
+                (sessionTurn TranscriptAppend oldURL
+                    [toolOutputItem [Aeson.String newURL], creationCall])
+                `shouldBe` Just oldURL
+        it "pairs failed display output with its persisted creation call" do
+            sessionTurnPullRequestURL
+                ((sessionTurn TranscriptAppend oldURL [creationCall])
+                    { turnError = Just "provider disconnected"
+                    , turnDisplayItems = [toolOutputItem [Aeson.String newURL]]
+                    })
+                `shouldBe` Just newURL
 
     it "restores pull request associations from persisted messages and failed display items" do
         let url = "https://github.com/owner/repository/pull/42"

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/RepositoryDeliveryBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/RepositoryDeliveryBridge.hs
@@ -14,13 +14,14 @@ import Control.Exception.Safe (mask, tryAny)
 import Agent.CLI.MacOS.NativeGatewayBoundary (withNativeSessionBoundary, validateNativeSessionBoundary)
 import Agent.CLI.MacOS.SessionTransferBridge (withNativeSessionStore)
 import Agent.CLI.Session
-    ( SessionMeta(..), SessionTurn(..), SessionTurnPage(..), isValidSessionId
+    ( SessionMeta(..), SessionTurnPage(..), isValidSessionId
     , loadSessionHistorySnapshot, loadSessionHistoryTurnsRangeBounded )
+import Agent.CLI.Session.PullRequest (sessionTurnPullRequestURL, sessionTurnPullRequestURLs)
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Types (renderStoreError)
 import qualified Agent.Store.Postgres.Session as PRStore
-import qualified Data.Aeson as Aeson
 import qualified Data.List as PRList
+import Data.Maybe (mapMaybe)
 import System.OsPath (OsPath, decodeFS)
 import Control.Monad (when)
 import Data.Text (Text)
@@ -524,8 +525,25 @@ indexSessionPullRequests pool root sessionId =
                 let (cursor, urls) = case cached of
                         Just value@(next, _) | next <= total -> value
                         _ -> (0, [])
-                scan total cursor urls
+                scan total cursor urls >>= \case
+                    Left err -> pure (Left err)
+                    Right associated -> prioritizeLatest total associated
   where
+    -- Old caches contain all associations, but ordered prompt evidence before
+    -- newly created PRs. Re-read the latest associated turn even when the
+    -- cursor is already current, skipping unrelated turns in bounded pages.
+    prioritizeLatest _ [] = pure (Right [])
+    prioritizeLatest end urls
+        | end <= 0 = pure (Right urls)
+        | otherwise =
+            let start = max 0 (end - 32)
+            in loadSessionHistoryTurnsRangeBounded pool root sessionId start end 32 >>= \case
+                Left err -> pure (Left err)
+                Right page -> case page.pageTurns of
+                    [] -> pure (Left "incomplete PR association history")
+                    turns -> case mapMaybe (sessionTurnPullRequestURL . snd) (reverse turns) of
+                        url : _ -> pure (Right (PRList.nub (url : urls)))
+                        [] -> prioritizeLatest start urls
     scan total cursor urls
         | cursor >= total = pure (Right urls)
         | otherwise = loadSessionHistoryTurnsRangeBounded pool root sessionId cursor total 32 >>= \case
@@ -534,9 +552,7 @@ indexSessionPullRequests pool root sessionId =
                 [] -> pure (Left "incomplete PR association history")
                 turns -> do
                     let next = 1 + maximum (map fst turns)
-                        discovered = concatMap (\(_, turn) ->
-                            RepositoryDelivery.conversationPullRequestURLs turn.turnUserText turn.turnAssistantText
-                                (map Aeson.toJSON (turn.turnItems <> turn.turnDisplayItems))) (reverse turns)
+                        discovered = concatMap (sessionTurnPullRequestURLs . snd) (reverse turns)
                         associated = PRList.nub (discovered <> urls)
                     PRStore.saveSessionPullRequests pool sessionId next associated >>= \case
                         Left err -> pure (Left (renderStoreError err))

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/RepositoryDeliveryBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/RepositoryDeliveryBridge.hs
@@ -16,12 +16,10 @@ import Agent.CLI.MacOS.SessionTransferBridge (withNativeSessionStore)
 import Agent.CLI.Session
     ( SessionMeta(..), SessionTurnPage(..), isValidSessionId
     , loadSessionHistorySnapshot, loadSessionHistoryTurnsRangeBounded )
-import Agent.CLI.Session.PullRequest (sessionTurnPullRequestURL, sessionTurnPullRequestURLs)
+import Agent.CLI.Session.PullRequest (advanceSessionPullRequestIndex, sessionTurnPullRequestURLs)
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Types (renderStoreError)
 import qualified Agent.Store.Postgres.Session as PRStore
-import qualified Data.List as PRList
-import Data.Maybe (mapMaybe)
 import System.OsPath (OsPath, decodeFS)
 import Control.Monad (when)
 import Data.Text (Text)
@@ -521,39 +519,13 @@ indexSessionPullRequests pool root sessionId =
         Left err -> pure (Left err)
         Right (_, _, total) -> PRStore.loadSessionPullRequests pool sessionId >>= \case
             Left err -> pure (Left (renderStoreError err))
-            Right cached -> do
-                let (cursor, urls) = case cached of
-                        Just value@(next, _) | next <= total -> value
-                        _ -> (0, [])
-                scan total cursor urls >>= \case
-                    Left err -> pure (Left err)
-                    Right associated -> prioritizeLatest total associated
+            Right cached ->
+                advanceSessionPullRequestIndex loadPage savePage total cached
   where
-    -- Old caches contain all associations, but ordered prompt evidence before
-    -- newly created PRs. Re-read the latest associated turn even when the
-    -- cursor is already current, skipping unrelated turns in bounded pages.
-    prioritizeLatest _ [] = pure (Right [])
-    prioritizeLatest end urls
-        | end <= 0 = pure (Right urls)
-        | otherwise =
-            let start = max 0 (end - 32)
-            in loadSessionHistoryTurnsRangeBounded pool root sessionId start end 32 >>= \case
-                Left err -> pure (Left err)
-                Right page -> case page.pageTurns of
-                    [] -> pure (Left "incomplete PR association history")
-                    turns -> case mapMaybe (sessionTurnPullRequestURL . snd) (reverse turns) of
-                        url : _ -> pure (Right (PRList.nub (url : urls)))
-                        [] -> prioritizeLatest start urls
-    scan total cursor urls
-        | cursor >= total = pure (Right urls)
-        | otherwise = loadSessionHistoryTurnsRangeBounded pool root sessionId cursor total 32 >>= \case
-            Left err -> pure (Left err)
-            Right page -> case page.pageTurns of
-                [] -> pure (Left "incomplete PR association history")
-                turns -> do
-                    let next = 1 + maximum (map fst turns)
-                        discovered = concatMap (sessionTurnPullRequestURLs . snd) (reverse turns)
-                        associated = PRList.nub (discovered <> urls)
-                    PRStore.saveSessionPullRequests pool sessionId next associated >>= \case
-                        Left err -> pure (Left (renderStoreError err))
-                        Right () -> scan total next associated
+    loadPage cursor total =
+        fmap (fmap (\page -> map (\(index, turn) -> (index, sessionTurnPullRequestURLs turn)) page.pageTurns))
+            (loadSessionHistoryTurnsRangeBounded pool root sessionId cursor total 32)
+    savePage next associated =
+        PRStore.saveSessionPullRequests pool sessionId next associated >>= \case
+            Left err -> pure (Left (renderStoreError err))
+            Right () -> pure (Right ())

--- a/packages/agent-repository/agent-repository.cabal
+++ b/packages/agent-repository/agent-repository.cabal
@@ -47,7 +47,8 @@ library
     exposed-modules:  Agent.CLI.RepositoryDelivery
                     , Agent.CLI.RepositoryDelivery.ConfirmationStore
                     , Agent.CLI.RepositoryReview
-    build-depends:    aeson >= 2.0
+    build-depends:    agent-cli-runtime >= 0.1 && < 0.2
+                    , aeson >= 2.0
                     , async
                     , base >= 4.17 && < 5
                     , bytestring

--- a/packages/agent-repository/package.nix
+++ b/packages/agent-repository/package.nix
@@ -1,4 +1,4 @@
-{ mkDerivation, aeson, async, base, bytestring, containers, crypton
+{ mkDerivation, agent-cli-runtime, aeson, async, base, bytestring, containers, crypton
 , directory, filelock, filepath, hspec, lib, process
 , safe-exceptions, text, time, transformers, unix
 }:
@@ -7,7 +7,7 @@ mkDerivation {
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson async base bytestring containers crypton directory filelock
+    agent-cli-runtime aeson async base bytestring containers crypton directory filelock
     filepath process safe-exceptions text time transformers unix
   ];
   testHaskellDepends = [

--- a/packages/agent-repository/src/Agent/CLI/RepositoryDelivery.hs
+++ b/packages/agent-repository/src/Agent/CLI/RepositoryDelivery.hs
@@ -48,6 +48,7 @@ import Crypto.Hash (Digest, SHA1, SHA256, hash)
 import Data.Aeson ((.:), (.:?), (.!=))
 import qualified Data.Aeson.Types as AesonTypes
 import qualified Data.Aeson.KeyMap as KeyMap
+import Agent.CLI.Session.PullRequest (pullRequestURLs, conversationPullRequestURLs)
 import Data.List (nub)
 import Data.Maybe (fromMaybe)
 import Text.Read (readMaybe)
@@ -55,7 +56,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
-import Data.Char (isAlphaNum, isHexDigit, isSpace)
+import Data.Char (isHexDigit, isSpace)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -1770,75 +1771,6 @@ parseRepositoryPullRequest repository bytes = do
         | value `elem` ["PENDING", "EXPECTED"] = 2
         | otherwise = 0
 
-
--- Only canonical public GitHub PR identities are accepted. Never pass arbitrary
--- conversation URLs to gh (or to a shell). Strip Markdown/query/fragment tails.
-pullRequestURLs :: Text -> [Text]
-pullRequestURLs = nub . go
-  where
-    go input = case Text.breakOn "https://github.com/" input of
-        (_, rest) | Text.null rest -> []
-        (prefix, rest) ->
-            let suffix = Text.drop 19 rest
-                token = Text.takeWhile (\c -> isAlphaNum c || c `elem` ("-._/" :: String)) suffix
-                remaining = Text.drop (Text.length token) suffix
-                validBoundary = Text.null prefix || not (isAlphaNum (Text.last prefix) || Text.last prefix `elem` ("/_-." :: String))
-                found = case Text.splitOn "/" token of
-                    owner : repo : "pull" : number : _
-                        | validBoundary, validName owner, validName repo
-                        , Just n <- readMaybe (Text.unpack number) :: Maybe Int
-                        , n > 0, Text.all (\c -> c >= '0' && c <= '9') number ->
-                            ["https://github.com/" <> Text.toCaseFold owner <> "/" <> Text.toCaseFold repo <> "/pull/" <> Text.pack (show n)]
-                    _ -> []
-            in found <> go remaining
-    validName name = not (Text.null name) && name /= "." && name /= ".."
-        && Text.all (\c -> c < '\128' && (isAlphaNum c || c `elem` ("-_." :: String))) name
-
--- Evidence stays local to a paragraph. Quoted references/examples do not become
--- associations. Tools must be paired with a PR operation; raw search output alone
--- cannot attach every PR it happens to mention.
-conversationPullRequestURLs :: Text -> Maybe Text -> [Aeson.Value] -> [Text]
-conversationPullRequestURLs user assistant items = nub $
-    directUser <> concatMap evidence (maybe [] pure assistant <> [user] <> messages) <> toolURLs
-  where
-    directUser = case pullRequestURLs user of
-        [url] | Text.toCaseFold (Text.strip user) == url -> [url]
-        _ -> []
-    evidence = paragraphs . Text.splitOn "\n\n"
-    paragraphs (header : list : rest)
-        | null (pullRequestURLs header)
-        , any (`elem` ["pr", "prs", "pull"]) (Text.words (Text.map wordCharacter (Text.toCaseFold header)))
-        , any (`Text.isPrefixOf` Text.stripStart list) ["- ", "* ", "1. "] =
-            paragraph (header <> "\n" <> list) <> paragraphs rest
-    paragraphs (content : rest) = paragraph content <> paragraphs rest
-    paragraphs [] = []
-    wordCharacter c = if isAlphaNum c then c else ' '
-    paragraph content
-        | any (`Text.isInfixOf` lower) ["for reference", "example", "unrelated", "see also", "beispiel", "referenz"] = []
-        | any (`Text.isInfixOf` lower) ["created", "opened", "merged", "review", "fix", "address", "implement", "update", "check", "work on", "look at", "erstellt", "gemerg", "beheb", "prüf", "bearbeit"] =
-            pullRequestURLs (Text.unlines (filter (not . Text.isPrefixOf ">" . Text.stripStart) (Text.lines content)))
-        | otherwise = []
-      where lower = Text.toCaseFold (Text.unwords (filter (null . pullRequestURLs) (Text.words content)))
-    messages = [Text.intercalate "\n" (strings content) | Aeson.Object o <- items
-        , KeyMap.lookup "type" o == Just (Aeson.String "message")
-        , Just (Aeson.String role) <- [KeyMap.lookup "role" o], role `elem` ["user", "assistant"]
-        , Just content <- [KeyMap.lookup "content" o]]
-    calls = [callId | Aeson.Object o <- items
-        , Just (Aeson.String kind) <- [KeyMap.lookup "type" o]
-        , kind `elem` ["function_call", "custom_tool_call"]
-        , Just (Aeson.String callId) <- [KeyMap.lookup "call_id" o]
-        , let body = Text.toCaseFold (Text.intercalate " " (strings (Aeson.Object o)))
-        , any (`Text.isInfixOf` body) ["gh pr create", "gh pr checkout", "gh pr merge", "gh pr review", "create_pull_request"]]
-    toolURLs = concat [pullRequestURLs (Text.intercalate "\n" (strings output))
-        | Aeson.Object o <- items
-        , Just (Aeson.String kind) <- [KeyMap.lookup "type" o]
-        , kind `elem` ["function_call_output", "custom_tool_call_output"]
-        , Just (Aeson.String callId) <- [KeyMap.lookup "call_id" o], callId `elem` calls
-        , Just output <- [KeyMap.lookup "output" o]]
-    strings (Aeson.String value) = [value]
-    strings (Aeson.Array values) = foldMap strings values
-    strings (Aeson.Object values) = foldMap strings values
-    strings _ = []
 
 -- A conversation association is independent of checkout branch and fork origin.
 pullRequestByURL :: FilePath -> Text -> IO (Either DeliveryError RepositoryPullRequest)

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -481,6 +481,14 @@ coreMigrations =
             , "GRANT SELECT, INSERT, UPDATE, DELETE ON harness.session_pull_requests TO ha_runtime"
             ]
         }
+    , Migration
+        { migrationVersion = 115
+        , migrationName = "recency ordered conversation pull request cache"
+        , migrationStatements =
+            [ "CREATE TABLE IF NOT EXISTS harness.session_pull_request_recency (session_id uuid PRIMARY KEY REFERENCES harness.sessions(session_id) ON DELETE CASCADE, next_turn_index bigint NOT NULL CHECK (next_turn_index >= 0), urls text[] NOT NULL)"
+            , "GRANT SELECT, INSERT, UPDATE, DELETE ON harness.session_pull_request_recency TO ha_runtime"
+            ]
+        }
     ]
 
 -- | Specialize all runtime grants for a validated cluster-global role.

--- a/packages/agent-store/src/Agent/Store/Postgres/Session/PullRequests.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Session/PullRequests.hs
@@ -12,6 +12,9 @@ import Agent.Store.Postgres.Connection (StorePool, withSession)
 import Agent.Store.Postgres.Hasql (mkStatement)
 import Agent.Store.Types (StoreError)
 
+-- The recency cache is separate from the legacy association cache. Its
+-- presence records that history was indexed using current ordering semantics;
+-- older running clients cannot overwrite it with prompt-first ordering.
 loadSessionPullRequests :: StorePool -> Text -> IO (Either StoreError (Maybe (Int64, [Text])))
 loadSessionPullRequests pool key = withSession pool (Session.statement key loadStatement)
 
@@ -20,14 +23,14 @@ saveSessionPullRequests pool key cursor urls = withSession pool (Session.stateme
 
 loadStatement :: Statement Text (Maybe (Int64, [Text]))
 loadStatement = mkStatement
-    "SELECT p.next_turn_index, p.urls FROM harness.session_pull_requests p JOIN harness.sessions s USING (session_id) WHERE s.session_key = $1 AND s.deleted_at IS NULL"
+    "SELECT p.next_turn_index, p.urls FROM harness.session_pull_request_recency p JOIN harness.sessions s USING (session_id) WHERE s.session_key = $1 AND s.deleted_at IS NULL"
     (E.param (E.nonNullable E.text))
     (D.rowMaybe ((,) <$> D.column (D.nonNullable D.int8)
         <*> D.column (D.nonNullable (D.listArray (D.nonNullable D.text))))) True
 
 saveStatement :: Statement (Text, Int64, [Text]) ()
 saveStatement = mkStatement
-    "INSERT INTO harness.session_pull_requests (session_id, next_turn_index, urls) SELECT session_id, $2, $3 FROM harness.sessions WHERE session_key = $1 AND deleted_at IS NULL ON CONFLICT (session_id) DO UPDATE SET next_turn_index = EXCLUDED.next_turn_index, urls = EXCLUDED.urls WHERE harness.session_pull_requests.next_turn_index <= EXCLUDED.next_turn_index"
+    "INSERT INTO harness.session_pull_request_recency (session_id, next_turn_index, urls) SELECT session_id, $2, $3 FROM harness.sessions WHERE session_key = $1 AND deleted_at IS NULL ON CONFLICT (session_id) DO UPDATE SET next_turn_index = EXCLUDED.next_turn_index, urls = EXCLUDED.urls WHERE harness.session_pull_request_recency.next_turn_index <= EXCLUDED.next_turn_index"
     (((\(a,_,_) -> a) >$< E.param (E.nonNullable E.text))
     <> ((\(_,b,_) -> b) >$< E.param (E.nonNullable E.int8))
     <> ((\(_,_,c) -> c) >$< E.param (E.nonNullable (E.foldableArray (E.nonNullable E.text)))))

--- a/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/SessionSpec.hs
@@ -21,8 +21,20 @@ import Agent.Store.Postgres
     , trustedPool
     )
 import Agent.Store.Postgres.Managed (stopManagedPostgres)
+import Agent.Store.Postgres.Connection (withSession)
+import Agent.Store.Postgres.Config (ManagedPostgresConfig(..), ManagedPostgresPaths(..))
+import qualified Hasql.Session as Hasql
 import Agent.Store.Postgres.Session
 import Agent.Store.SessionItem
+
+-- Session temp roots can be long; leave room for PostgreSQL's socket filename.
+sessionTestPostgresConfig :: FilePath -> ManagedPostgresConfig
+sessionTestPostgresConfig stateDirectory =
+    let config = defaultManagedPostgresConfig stateDirectory ""
+    in config
+        { postgresPaths = config.postgresPaths
+            { postgresSocketDirectory = stateDirectory <> "/socket" }
+        }
 
 spec :: Spec
 spec = describe "PostgreSQL session schema" do
@@ -92,7 +104,7 @@ spec = describe "PostgreSQL session schema" do
     it "round-trips response items, tool calls, and outputs through relational rows" $
         withSystemTempDirectory "ha" \stateDirectory -> do
             let
-                config = defaultManagedPostgresConfig stateDirectory ""
+                config = sessionTestPostgresConfig stateDirectory
                 cleanup = do
                     _ <- stopManagedPostgres config
                     pure ()
@@ -273,9 +285,19 @@ spec = describe "PostgreSQL session schema" do
                                             })
                             createSession pool metadata
                                 `shouldReturn` Right True
+                            -- Simulate an older client before and after the
+                            -- recency cache is built. Its cursor and ordering
+                            -- must never be accepted as current-format data.
+                            withSession pool (Hasql.script
+                                "INSERT INTO harness.session_pull_requests (session_id, next_turn_index, urls) SELECT session_id, 5, ARRAY['https://github.com/o/app/pull/1'] FROM harness.sessions WHERE session_key = 'session-1'")
+                                `shouldReturn` Right ()
                             loadSessionPullRequests pool "session-1" `shouldReturn` Right Nothing
                             let prURLs = ["https://github.com/o/app/pull/1", "https://github.com/o/runtime/pull/2"]
                             saveSessionPullRequests pool "session-1" 5 prURLs `shouldReturn` Right ()
+                            loadSessionPullRequests pool "session-1" `shouldReturn` Right (Just (5, prURLs))
+                            withSession pool (Hasql.script
+                                "UPDATE harness.session_pull_requests SET next_turn_index = 6, urls = ARRAY[]::text[] WHERE session_id = (SELECT session_id FROM harness.sessions WHERE session_key = 'session-1')")
+                                `shouldReturn` Right ()
                             loadSessionPullRequests pool "session-1" `shouldReturn` Right (Just (5, prURLs))
                             saveSessionPullRequests pool "session-1" 3 [] `shouldReturn` Right ()
                             loadSessionPullRequests pool "session-1" `shouldReturn` Right (Just (5, prURLs))
@@ -948,7 +970,7 @@ spec = describe "PostgreSQL session schema" do
     it "keeps compaction as a model checkpoint while paging visual history across it" $
         withSystemTempDirectory "ha" \stateDirectory -> do
             let
-                config = defaultManagedPostgresConfig stateDirectory ""
+                config = sessionTestPostgresConfig stateDirectory
                 cleanup = do
                     _ <- stopManagedPostgres config
                     pure ()
@@ -1106,7 +1128,7 @@ spec = describe "PostgreSQL session schema" do
     it "clips visual history at an explicit reset, not at compaction" $
         withSystemTempDirectory "ha" \stateDirectory -> do
             let
-                config = defaultManagedPostgresConfig stateDirectory ""
+                config = sessionTestPostgresConfig stateDirectory
                 cleanup = do
                     _ <- stopManagedPostgres config
                     pure ()

--- a/scripts/check-package-boundaries.sh
+++ b/scripts/check-package-boundaries.sh
@@ -49,9 +49,10 @@ if rg --line-number '^import[[:space:]]+(qualified[[:space:]]+)?Agent\.(CLI|TUI)
   fail "frontend types leaked into the session lifecycle kernel"
 fi
 
-# Process resources retain legacy module names, but their implementations must
-# stay in the shared package. CLI facades may import them, not redefine them.
-for module_path in Agent/CLI/NativeProcess.hs Agent/CLI/Session/Threads.hs; do
+# Shared resources and session policy retain legacy module names, but their
+# implementations must stay in the runtime. CLI facades may import them,
+# not redefine them.
+for module_path in Agent/CLI/NativeProcess.hs Agent/CLI/Session/Threads.hs Agent/CLI/Session/PullRequest.hs; do
   [[ -f "$runtime/src/$module_path" ]] || fail "missing shared resource: $module_path"
   [[ ! -e "$cli/src/$module_path" ]] || fail "resource implementation returned to CLI: $module_path"
 done
@@ -110,7 +111,7 @@ if rg --line-number '\bagent-cli\b' \
   fail "agent-external-session must remain independent of agent-cli"
 fi
 
-if rg --line-number '\bagent-cli\b' \
+if rg --line-number '\bagent-cli([[:space:],><=]|$)' \
   "$repository/agent-repository.cabal"; then
   fail "agent-repository must remain independent of agent-cli"
 fi


### PR DESCRIPTION
## Summary
- Fix the package-boundary failure from #1128 by sharing PR detection through agent-cli-runtime.
- Reuse current-PR ordering in the native bridge, preserving tool-call pairing.
- Persist a separate recency-ordered cache so existing histories are indexed once and older clients cannot overwrite the new ordering.
- Read only appended turns after indexing; persist bounded page progress and reject incomplete history.

## Validation
- Four cache-indexing regression tests pass, including a 4096-turn history with no additional history reads at the current cursor.
- Six PostgreSQL session tests pass, including legacy-writer isolation and monotonic cursors.
- Native bridge FFI loads successfully in GHCi.
- Package-boundary check and git diff --check pass.