### PR TITLE
Add capability-gated native chart rendering

### DIFF
--- a/docs/native-charts.md
+++ b/docs/native-charts.md
@@ -1,0 +1,75 @@
+# Native chart document protocol, version 1
+
+`render_chart` presents data in a capable frontend. It does not run Swift,
+read files, fetch URLs, or export files. The macOS application offers native
+interaction and user-initiated PNG export. Tool availability must be enabled
+explicitly by the frontend; the operating system alone is not authorization.
+
+Native hosts opt in with `ha_engine_set_chart_rendering_enabled(engine, 1)`.
+New engines default to disabled; changes affect subsequently started turns,
+not an already running turn. The ordinary CLI does not register this tool.
+
+## Example tool arguments
+
+```json
+{
+  "version": 1,
+  "kind": "line",
+  "title": "Monthly revenue",
+  "subtitle": "Actual booked revenue, excluding tax",
+  "x_axis": {"type": "timestamp", "label": "Month"},
+  "y_axis": {"type": "number", "label": "Revenue", "unit": "EUR"},
+  "series": [
+    {
+      "name": "Subscriptions",
+      "points": [
+        {"x": "2026-07-01T00:00:00Z", "y": 12000},
+        {"x": "2026-08-01T00:00:00Z", "y": 14500},
+        {"x": "2026-09-01T00:00:00Z", "y": 13900}
+      ]
+    }
+  ]
+}
+```
+
+Use `line` or `area` for trends, `bar` for comparisons, and `scatter` for
+relationships. Give axes meaningful labels and units. Category x values are
+strings; numeric x values are JSON numbers; timestamp x values are UTC strings
+of the form `YYYY-MM-DDTHH:mm:ss[.fraction]Z`, with 1–3 fractional digits
+when present (millisecond precision).
+Years range from 0001 through 9999; leap seconds are not supported.
+All y values are finite JSON numbers. Numeric and timestamp x coordinates in
+each line/area series must be strictly increasing and unique. Aggregate timestamps
+more precise than milliseconds before rendering. Category order
+is input order. No null/missing observations are supported: do not invent
+replacements, and disclose omitted data or aggregation in the subtitle.
+
+There must be 1–8 uniquely named nonempty series and no more than 2,000 total
+points. The UTF-8 argument document is limited to 256 KiB. Every text field is
+limited to 200 Unicode scalar values. Titles, series names and category values
+must not be blank. Optional subtitle, label, unit, and numeric y-axis type may
+be omitted or null. Unknown object fields and unsupported versions are errors.
+
+## Persistent result
+
+The successful tool result is:
+
+```json
+{"type":"chart","chart":{"version":1,"...":"..."},"summary":"Rendered Monthly revenue — line chart; 1 series, 3 points."}
+```
+
+The `chart` field contains the complete validated argument document. This
+versioned envelope is durable tool output, not an executable request or a
+native-language boundary convenience. Native projections extract a distinct
+complete chart attachment before truncating diagnostic output previews.
+They must never reconstruct a chart from tool arguments or truncated output.
+The summary provides a readable fallback for unsupported consumers. Failed,
+malformed, and unknown-version results do not become charts.
+
+HAEV v1 tool-finish frames set flag bit 3 and append the complete chart
+document as a third UTF-8 field after call ID and readable output. The field
+is independently bounded and never preview-truncated. Native session history
+projects the same document as `chart`; load-around consumers read the durable
+result envelope from full response items. Both paths associate results with
+the originating `render_chart` call ID, not with similarly shaped output
+from unrelated tools.

--- a/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionAdmin.hs
@@ -11,6 +11,7 @@ module Agent.CLI.SessionAdmin
     , sessionSummaryJSON
     , sessionSummaryWithStatusJSON
     , sessionToolEvent
+    , sessionToolEventWithChartCalls
     ) where
 
 import Agent.CLI.Database.Storage
@@ -56,6 +57,7 @@ import Agent.CLI.SessionLock
     )
 import Agent.Json (RawJson, rawJsonBytes)
 import Agent.OsPath (unsafeToFilePath)
+import Agent.Tools.RenderChart (chartResultDocument, chartResultSummary)
 import Agent.Provider (providerSlug)
 import Agent.Responses.LoopBackend (responseItemToToolCall)
 import Agent.Responses.Types
@@ -317,10 +319,19 @@ indexedSessionTurnJSON (index, turn) =
 
 sessionToolEvents :: SessionTurn -> [Aeson.Value]
 sessionToolEvents turn =
-    mapMaybe sessionToolEvent turn.turnItems
+    mapMaybe (sessionToolEventWithChartCalls chartCalls) turn.turnItems
+  where
+    chartCalls = Set.fromList
+        [ call.callId
+        | FunctionCallItem call <- turn.turnItems
+        , call.name == "render_chart"
+        ]
 
 sessionToolEvent :: ResponseItem -> Maybe Aeson.Value
-sessionToolEvent = \case
+sessionToolEvent = sessionToolEventWithChartCalls Set.empty
+
+sessionToolEventWithChartCalls :: Set.Set Text -> ResponseItem -> Maybe Aeson.Value
+sessionToolEventWithChartCalls chartCalls = \case
     item@(FunctionCallItem call)
         | ( call.name == computerFunctionName
                 && call.namespace `elem` [Nothing, Just "functions"]
@@ -355,6 +366,7 @@ sessionToolEvent = \case
     FunctionCallOutputItem result ->
         Just
             (toolFinishedJSON
+                (Set.member result.callId chartCalls)
                 result.callId
                 (if containsInputImage result.output
                     then "Screenshot captured"
@@ -363,6 +375,7 @@ sessionToolEvent = \case
     CustomToolCallOutputItem result ->
         Just
             (toolFinishedJSON
+                False
                 result.callId
                 (renderToolValue result.output)
                 (fromMaybe False result.async))
@@ -379,6 +392,7 @@ sessionToolEvent = \case
     ComputerCallOutputItem result ->
         Just
             (toolFinishedJSON
+                False
                 result.computerOutputCallId
                 "Screenshot captured"
                 False)
@@ -410,16 +424,19 @@ toolStartedJSON callId name arguments isAsync =
         , "truncated" Aeson..= truncated
         ]
 
-toolFinishedJSON :: Text -> Text -> Bool -> Aeson.Value
-toolFinishedJSON callId output isAsync =
-    let (visible, truncated) = boundedSessionToolText output
+toolFinishedJSON :: Bool -> Text -> Text -> Bool -> Aeson.Value
+toolFinishedJSON isChartCall callId output isAsync =
+    let (visible, truncated) = boundedSessionToolText
+            (if isChartCall then fromMaybe output (chartResultSummary output) else output)
+        chart = (if isChartCall then chartResultDocument output else Nothing)
+            >>= Aeson.decodeStrict' . TextEncoding.encodeUtf8
     in Aeson.object
-        [ "type" Aeson..= ("tool_finished" :: Text)
+        ([ "type" Aeson..= ("tool_finished" :: Text)
         , "callId" Aeson..= callId
         , "output" Aeson..= visible
         , "async" Aeson..= isAsync
         , "truncated" Aeson..= truncated
-        ]
+        ] <> maybe [] (\document -> ["chart" Aeson..= (document :: Aeson.Value)]) chart)
 
 renderToolValue :: RawJson -> Text
 renderToolValue raw =

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -98,6 +98,7 @@ library
                     , Agent.Tools.ShellReadOnly
                     , Agent.Tools.Types
                     , Agent.Tools.ViewImage
+                    , Agent.Tools.RenderChart
                     , Agent.Transport.WebSocket
     other-modules:    Agent.Image.Normalize
                     , Agent.Loop.Backend
@@ -320,6 +321,7 @@ test-suite agent-core-test
                     , Agent.Tools.SecretSpec
                     , Agent.Tools.ShowImageSpec
                     , Agent.Tools.ViewImageSpec
+                    , Agent.Tools.RenderChartSpec
                     , Agent.ToolDSLSpec
                     , Agent.Transport.WebSocketSpec
                     , Paths_agent_core

--- a/packages/agent-core/src/Agent/Tools/OutputArtifact.hs
+++ b/packages/agent-core/src/Agent/Tools/OutputArtifact.hs
@@ -25,6 +25,7 @@ import Agent.OsPath (unsafeToFilePath)
 import Agent.ToolArgs (objectArgs, optBool, optInt, reqText)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (ToolCall(..), typedTool, typedToolWithCall)
+import Agent.Tools.RenderChart (chartResultDocument)
 import Agent.Tools.Types
     ( AppTool
     , ToolEnv(..)
@@ -457,6 +458,10 @@ artifactLinePreviewBytes = 32 * 1024
 -- | Replace an oversized provider-facing result with a compact artifact marker.
 finalizeToolOutput :: ToolEnv -> ToolCall -> Text -> IO Text
 finalizeToolOutput env call output
+    -- Chart documents are already independently bounded and must remain in
+    -- durable response items, not in session-temporary output artifacts.
+    | call.name == "render_chart", Just _ <- chartResultDocument output =
+        pure output
     | BS.length encoded <= max 0 env.toolOutputInlineCap = pure output
     | otherwise =
         writeOutputArtifactDetailed env encoded >>= \case

--- a/packages/agent-core/src/Agent/Tools/RenderChart.hs
+++ b/packages/agent-core/src/Agent/Tools/RenderChart.hs
@@ -1,0 +1,235 @@
+-- | Validated, versioned presentation documents. No chart input is executed.
+module Agent.Tools.RenderChart
+    ( renderChartTool
+    , renderChartToolName
+    , renderChartResult
+    , chartResultDocument
+    , chartResultSummary
+    ) where
+
+import Agent.ToolDispatch (textTool)
+import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
+import Agent.Tools.Types (AppTool, ToolExecutionPolicy(..), jsonTool)
+import Control.Monad (unless, when)
+import Data.Aeson (Value(..), Object, eitherDecodeStrict', encode, object, (.=), (.:), (.:?))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Aeson.Types (Parser, parseEither, parseMaybe, withObject)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Scientific (toRealFloat)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Time (UTCTime, defaultTimeLocale, parseTimeM)
+
+renderChartToolName :: Text
+renderChartToolName = "render_chart"
+
+renderChartTool :: AppTool
+renderChartTool =
+    jsonTool renderChartToolName description properties True ParallelSafe
+        (textTool renderChartToolName (pure . renderChartResult))
+  where
+    description =
+        "Present an interactive native chart in the conversation. Use line/area for trends, \
+        \bar for comparisons, scatter for relationships. Supply actual data, clear axis \
+        \labels and units; never invent missing values. This tool does not execute Swift. \
+        \Use version 1; at most 8 series, 2000 total points, 256 KiB JSON, and 200 characters \
+        \per text field. Numeric/time x values in each line/area series must be strictly \
+        \increasing. Timestamps are UTC YYYY-MM-DDTHH:mm:ss[.fraction]Z with at most \
+        \3 fractional digits (milliseconds). Aggregate large \
+        \datasets first and describe the aggregation in subtitle. Missing values are \
+        \not supported: omit missing observations and disclose gaps in subtitle."
+    properties =
+        [ PropertySchema "version" PropertyInteger True (Just "Document version; must be 1.")
+        , PropertySchema "kind" (PropertyEnum ["line", "bar", "area", "scatter"]) True Nothing
+        , PropertySchema "title" PropertyString True (Just "Nonempty descriptive chart title.")
+        , PropertySchema "subtitle" PropertyString False Nothing
+        , PropertySchema "x_axis" (PropertyObject
+            (PropertySchema "type" (PropertyEnum ["category", "number", "timestamp"]) True Nothing : axisLabels))
+            True Nothing
+        , PropertySchema "y_axis" (PropertyObject
+            (PropertySchema "type" (PropertyEnum ["number"]) False Nothing : axisLabels))
+            True (Just "Numeric y-axis; type may be omitted.")
+        , PropertySchema "series" (PropertyArray (PropertyObject
+            [ PropertySchema "name" PropertyString True (Just "Unique nonempty series name.")
+            , PropertySchema "points" (PropertyArray (PropertyObject
+                [ PropertySchema "x" (PropertyRaw (object
+                    [ "anyOf" .=
+                        [ object ["type" .= ("string" :: Text)]
+                        , object ["type" .= ("number" :: Text)]
+                        ]
+                    ])) True (Just "Category string, finite number, or UTC timestamp, matching x_axis.type.")
+                , PropertySchema "y" PropertyNumber True (Just "Finite numeric value.")
+                ])) True Nothing
+            ])) True Nothing
+        ]
+    axisLabels =
+        [ PropertySchema "label" PropertyString False Nothing
+        , PropertySchema "unit" PropertyString False Nothing
+        ]
+
+maximumDocumentBytes :: Int
+maximumDocumentBytes = 256 * 1024
+
+-- | The result itself is the authoritative persisted protocol document. Native
+-- projections extract its chart before any display-preview truncation.
+renderChartResult :: Text -> Either Text Text
+renderChartResult input = do
+    let bytes = TextEncoding.encodeUtf8 input
+    when (BS.length bytes > maximumDocumentBytes) $
+        Left "render_chart: document exceeds 256 KiB; aggregate the data first."
+    value <- either (Left . Text.pack) Right (eitherDecodeStrict' bytes)
+    summary <- either (Left . ("render_chart: " <>) . Text.pack) Right
+        (parseEither validateDocument value)
+    pure (encodeText (object
+        [ "type" .= ("chart" :: Text), "chart" .= value, "summary" .= summary ]))
+
+chartResultDocument :: Text -> Maybe Text
+chartResultDocument = fmap (encodeText . fst) . parseChartResult
+
+chartResultSummary :: Text -> Maybe Text
+chartResultSummary = fmap snd . parseChartResult
+
+parseChartResult :: Text -> Maybe (Value, Text)
+parseChartResult input = do
+    -- Envelope text adds only a bounded generated summary to the document.
+    let bytes = TextEncoding.encodeUtf8 input
+    unless (BS.length bytes <= maximumDocumentBytes + 4096) Nothing
+    value <- either (const Nothing) Just (eitherDecodeStrict' bytes)
+    parseMaybe (withObject "chart result" \fields -> do
+        exactFields ["type", "chart", "summary"] fields
+        resultType <- fields .: "type"
+        unless (resultType == ("chart" :: Text)) (fail "Not a chart result")
+        chart <- fields .: "chart"
+        summary <- validateDocument chart
+        -- Recompute the fallback from validated data, not untrusted stored prose.
+        pure (chart, summary)) value
+
+encodeText :: Value -> Text
+encodeText = TextEncoding.decodeUtf8 . LBS.toStrict . encode
+
+validateDocument :: Value -> Parser Text
+validateDocument value = do
+    unless (LBS.length (encode value) <= fromIntegral maximumDocumentBytes) $
+        fail "Document exceeds 256 KiB"
+    withObject "chart document" (\fields -> do
+        exactFields ["version", "kind", "title", "subtitle", "x_axis", "y_axis", "series"] fields
+        version <- fields .: "version" :: Parser Int
+        unless (version == 1) (fail "Unsupported chart version; use version 1")
+        kind <- fields .: "kind"
+        unless (kind `elem` (["line", "bar", "area", "scatter"] :: [Text])) $
+            fail "kind must be line, bar, area, or scatter"
+        title <- requiredText fields "title"
+        optionalText fields "subtitle"
+        xAxis <- fields .: "x_axis" >>= validateAxis False
+        _ <- fields .: "y_axis" >>= validateAxis True
+        series <- fields .: "series" :: Parser [Value]
+        unless (not (null series) && length series <= 8) $
+            fail "Supply between 1 and 8 series"
+        seriesInfo <- traverse (validateSeries kind xAxis) series
+        let names = map fst seriesInfo
+            pointCount = sum (map snd seriesInfo)
+        unless (Set.size (Set.fromList names) == length names) $
+            fail "Series names must be unique"
+        unless (pointCount <= 2000) (fail "At most 2000 total points; aggregate the data first")
+        pure ("Rendered " <> title <> " — " <> kind <> " chart; "
+            <> Text.pack (show (length series)) <> " series, "
+            <> Text.pack (show pointCount)
+            <> (if pointCount == 1 then " point." else " points."))
+        ) value
+
+validateAxis :: Bool -> Value -> Parser Text
+validateAxis numericOnly = withObject "axis" \fields -> do
+    exactFields ["type", "label", "unit"] fields
+    axisType <- if numericOnly
+        then maybe "number" id <$> fields .:? "type"
+        else fields .: "type"
+    unless (axisType `elem` if numericOnly then ["number"] else ["category", "number", "timestamp"]) $
+        fail "Axis type is unsupported; y_axis must be numeric"
+    optionalText fields "label"
+    optionalText fields "unit"
+    pure axisType
+
+data ChartCoordinate = NumericCoordinate Double | TimestampCoordinate UTCTime | CategoryCoordinate Text
+    deriving (Eq, Ord)
+
+validateSeries :: Text -> Text -> Value -> Parser (Text, Int)
+validateSeries kind axisType = withObject "series" \fields -> do
+    exactFields ["name", "points"] fields
+    name <- requiredText fields "name"
+    points <- fields .: "points" :: Parser [Value]
+    unless (not (null points) && length points <= 2000) $
+        fail "Each series must contain between 1 and 2000 points"
+    coordinates <- traverse (validatePoint axisType) points
+    when (kind `elem` ["line", "area"] && axisType /= "category") $
+        unless (and (zipWith coordinateIncreasing coordinates (drop 1 coordinates))) $
+            fail "Line/area x values must be strictly increasing"
+    pure (name, length points)
+
+coordinateIncreasing :: ChartCoordinate -> ChartCoordinate -> Bool
+coordinateIncreasing left right = left < right
+
+validatePoint :: Text -> Value -> Parser ChartCoordinate
+validatePoint axisType = withObject "point" \fields -> do
+    exactFields ["x", "y"] fields
+    _ <- fields .: "y" >>= finiteNumber
+    case axisType of
+        "number" -> NumericCoordinate <$> (fields .: "x" >>= finiteNumber)
+        "timestamp" -> do
+            text <- requiredText fields "x"
+            maybe (fail "Timestamp must be a valid UTC YYYY-MM-DDTHH:mm:ss[.fraction]Z")
+                (pure . TimestampCoordinate) (parseTimestamp text)
+        _ -> CategoryCoordinate <$> requiredText fields "x"
+
+finiteNumber :: Value -> Parser Double
+finiteNumber (Number number) =
+    let value = toRealFloat number
+    in if isInfinite value || isNaN value
+        then fail "Chart numbers must be finite"
+        else pure value
+finiteNumber _ = fail "Expected a finite number"
+
+parseTimestamp :: Text -> Maybe UTCTime
+parseTimestamp text = do
+    let source = Text.unpack text
+        fixed = take 19 source
+        suffix = drop 19 source
+        digits = [character | (index, character) <- zip [0 :: Int ..] fixed,
+            index `notElem` [4, 7, 10, 13, 16]]
+        asciiDigit character = character >= '0' && character <= '9'
+        fractional = case suffix of
+            "Z" -> True
+            '.' : rest -> let fraction = takeWhile asciiDigit rest
+                in not (null fraction) && length fraction <= 3
+                    && drop (length fraction) rest == "Z"
+            _ -> False
+    unless (length fixed == 19 && all asciiDigit digits && fractional
+        && take 4 fixed /= "0000"
+        && [fixed !! index | index <- [4, 7, 10, 13, 16]] == "--T::"
+        && take 2 (drop 17 fixed) < "60") Nothing
+    parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" source
+
+requiredText :: Object -> Key.Key -> Parser Text
+requiredText fields key = do
+    text <- fields .: key
+    validateText text
+    unless (not (Text.null (Text.strip text))) $
+        fail (Text.unpack (Key.toText key) <> " must not be blank")
+    pure text
+
+optionalText :: Object -> Key.Key -> Parser ()
+optionalText fields key = do
+    text <- fields .:? key
+    maybe (pure ()) validateText text
+
+validateText :: Text -> Parser ()
+validateText text = unless (Text.length text <= 200) $
+    fail "Text fields must not exceed 200 Unicode scalar values"
+
+exactFields :: [Key.Key] -> Object -> Parser ()
+exactFields allowed fields =
+    unless (all (`elem` allowed) (KeyMap.keys fields)) $
+        fail "Unknown chart field"

--- a/packages/agent-core/test/Agent/Tools/OutputArtifactSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/OutputArtifactSpec.hs
@@ -40,6 +40,19 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.Tools.OutputArtifact" do
+    it "retains validated chart documents instead of replacing them with temporary artifacts" do
+        withTempEnv \env -> do
+            let output = "{\"type\":\"chart\",\"summary\":\"Measurements\",\
+                    \\"chart\":{\"version\":1,\"kind\":\"bar\",\"title\":\"Measurements\",\
+                    \\"x_axis\":{\"type\":\"category\"},\"y_axis\":{},\
+                    \\"series\":[{\"name\":\"Count\",\"points\":[{\"x\":\"A\",\"y\":1}]}]}}"
+                boundedEnv = env { toolOutputInlineCap = 1 }
+            finalizeToolOutput boundedEnv (functionToolCall "chart" "render_chart" "{}") output
+                `shouldReturn` output
+            finalized <- finalizeToolOutput boundedEnv
+                (functionToolCall "ordinary" "read_file" "{}") output
+            finalized `shouldNotBe` output
+
     it "stores and reads an opaque handle" do
         withTempEnv \env -> do
             writeOutputArtifact env "hello" >>= \case

--- a/packages/agent-core/test/Agent/Tools/RenderChartSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/RenderChartSpec.hs
@@ -1,0 +1,123 @@
+module Agent.Tools.RenderChartSpec (spec) where
+
+import Agent.Tools.RenderChart
+import Agent.Tools.Types (AppTool(..), ApprovalRule(..), ToolExecutionPolicy(..))
+import Data.Aeson (Value(..), encode, object, (.=))
+import qualified Data.ByteString.Lazy as LBS
+import Data.Either (isLeft, isRight)
+import qualified Data.Text as Text
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TextEncoding
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.Tools.RenderChart" do
+    it "is a read-only parallel-safe presentation tool" do
+        renderChartTool.appToolName `shouldBe` "render_chart"
+        renderChartTool.appToolExecution `shouldBe` ParallelSafe
+        case renderChartTool.appToolApproval of
+            AlwaysReadOnly -> pure ()
+            _ -> expectationFailure "Expected read-only approval"
+
+    it "retains the complete versioned document in its result" do
+        let input = document "bar" "category" [point (String "April") 12]
+        case renderChartResult input of
+            Left err -> expectationFailure (Text.unpack err)
+            Right output -> do
+                chartResultDocument output `shouldBe` Just input
+                chartResultSummary output `shouldBe`
+                    Just "Rendered Revenue — bar chart; 1 series, 1 point."
+
+    it "accepts every chart kind, negative numbers and single points" do
+        mapM_ (\kind ->
+            renderChartResult (document kind "number" [point (Number 1) (-4)])
+                `shouldSatisfy` isRight) ["line", "bar", "area", "scatter"]
+
+    it "rejects unsupported versions, kinds and fields" do
+        let input = document "bar" "number" [point (Number 1) 2]
+        renderChartResult (Text.replace "\"version\":1" "\"version\":2" input) `shouldSatisfy` isLeft
+        renderChartResult (Text.replace "\"kind\":\"bar\"" "\"kind\":\"pie\"" input) `shouldSatisfy` isLeft
+        renderChartResult (Text.replace "\"y\":2" "\"y\":2,\"source\":\"code\"" input) `shouldSatisfy` isLeft
+
+    it "requires finite numbers and consistent x types" do
+        renderChartResult (document "bar" "number" [point (String "one") 2]) `shouldSatisfy` isLeft
+        renderChartResult (Text.replace "\"y\":2" "\"y\":1e999" $
+            document "bar" "number" [point (Number 1) 2]) `shouldSatisfy` isLeft
+        renderChartResult (Text.replace "\"y\":2" "\"y\":null" $
+            document "bar" "number" [point (Number 1) 2]) `shouldSatisfy` isLeft
+
+    it "requires numeric and timestamp line/area observations to be increasing" do
+        let points = [point (Number 2) 1, point (Number 1) 2]
+        mapM_ (\kind -> renderChartResult (document kind "number" points) `shouldSatisfy` isLeft)
+            ["line", "area"]
+        renderChartResult (document "scatter" "number" points) `shouldSatisfy` isRight
+        renderChartResult (document "line" "number" [point (Number 1) 1, point (Number 1) 2])
+            `shouldSatisfy` isLeft
+
+    it "rejects timestamps more precise than milliseconds for every kind" do
+        let points = map (\timestamp -> point (String timestamp) 2)
+                ["2026-09-07T12:30:00.000000001Z", "2026-09-07T12:30:00.000000002Z"]
+        mapM_ (\kind -> renderChartResult (document kind "timestamp" points) `shouldSatisfy` isLeft)
+            ["line", "area", "bar", "scatter"]
+
+    it "validates timestamp syntax and calendar values" do
+        mapM_ (\timestamp -> renderChartResult
+            (document "line" "timestamp" [point (String timestamp) 2]) `shouldSatisfy` isRight)
+            ["2024-02-29T12:30:00Z", "2026-09-07T12:30:00.123Z"]
+        mapM_ (\timestamp -> renderChartResult
+            (document "line" "timestamp" [point (String timestamp) 2]) `shouldSatisfy` isLeft)
+            [ "2025-02-29T12:30:00Z", "2026-09-07", "2026-09-07T12:30:00+02:00"
+            , "2026-09-07T12:30:60Z", "0000-01-01T00:00:00Z", "2026-09-07T12:30:00.Z"
+            , "2026-09-07T12:30:00.1234Z"
+            ]
+
+    it "bounds points, text and serialized input" do
+        renderChartResult (document "bar" "number" []) `shouldSatisfy` isLeft
+        renderChartResult (document "bar" "number" (replicate 2001 (point (Number 1) 2)))
+            `shouldSatisfy` isLeft
+        renderChartResult (Text.replace "Revenue" (Text.replicate 201 "x")
+            (document "bar" "number" [point (Number 1) 2])) `shouldSatisfy` isLeft
+        renderChartResult (Text.replicate (256 * 1024 + 1) " ") `shouldSatisfy` isLeft
+
+    it "does not interpret failed, truncated or unknown results as charts" do
+        chartResultDocument "Error: invalid chart" `shouldBe` Nothing
+        chartResultDocument "{\"type\":\"chart\",\"chart\":" `shouldBe` Nothing
+        chartResultDocument "{\"type\":\"image\",\"chart\":{}}" `shouldBe` Nothing
+
+    it "keeps error-related chart titles distinct from tool failures" do
+        let input = Text.replace "Revenue" "Error: request rates"
+                (document "bar" "number" [point (Number 1) 2])
+        (renderChartResult input >>= maybe (Left "Missing summary") Right . chartResultSummary)
+            `shouldBe` Right "Rendered Error: request rates — bar chart; 1 series, 1 point."
+
+    it "requires unique series names and bounds the series count" do
+        let series (name :: Text) = object ["name" .= name, "points" .= [point (Number 1) 2]]
+            input values = encodeText (object
+                [ "version" .= (1 :: Int), "kind" .= ("bar" :: Text), "title" .= ("Revenue" :: Text)
+                , "x_axis" .= object ["type" .= ("number" :: Text)]
+                , "y_axis" .= object [], "series" .= values
+                ])
+        renderChartResult (input [series ("Sales" :: Text), series "Sales"]) `shouldSatisfy` isLeft
+        renderChartResult (input [series (Text.pack (show index)) | index <- [1 :: Int .. 9]])
+            `shouldSatisfy` isLeft
+
+    it "accepts nullable optional metadata and counts Unicode scalars" do
+        let input = document "bar" "number" [point (Number 1) 2]
+        renderChartResult (Text.replace "\"title\":\"Revenue\""
+            "\"title\":\"Revenue\",\"subtitle\":null" input) `shouldSatisfy` isRight
+        renderChartResult (Text.replace "Revenue" (Text.replicate 200 "😀") input) `shouldSatisfy` isRight
+        renderChartResult (Text.replace "Revenue" (Text.replicate 201 "😀") input) `shouldSatisfy` isLeft
+
+document :: Text -> Text -> [Value] -> Text
+document kind axisType points = encodeText (object
+    [ "version" .= (1 :: Int), "kind" .= kind, "title" .= ("Revenue" :: Text)
+    , "x_axis" .= object ["type" .= axisType]
+    , "y_axis" .= object ["label" .= ("Revenue" :: Text), "unit" .= ("EUR" :: Text)]
+    , "series" .= [object ["name" .= ("Sales" :: Text), "points" .= points]]
+    ])
+
+point :: Value -> Double -> Value
+point coordinate value = object ["x" .= coordinate, "y" .= value]
+
+encodeText :: Value -> Text
+encodeText = TextEncoding.decodeUtf8 . LBS.toStrict . encode

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -38,6 +38,7 @@ import qualified Agent.Tools.TaskPlanSpec as TaskPlanSpec
 import qualified Agent.Tools.SecretSpec as SecretSpec
 import qualified Agent.Tools.ShowImageSpec as ShowImageSpec
 import qualified Agent.Tools.ViewImageSpec as ViewImageSpec
+import qualified Agent.Tools.RenderChartSpec as RenderChartSpec
 import qualified Agent.Transport.WebSocketSpec as WebSocketSpec
 import Test.Hspec (hspec)
 
@@ -78,6 +79,7 @@ main = hspec do
     SecretSpec.spec
     ShowImageSpec.spec
     ViewImageSpec.spec
+    RenderChartSpec.spec
     CodeModeHostSpec.spec
     CodeModeProtocolSpec.spec
     DangerousSpec.spec

--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -157,6 +157,7 @@ test-suite agent-native-bridge-test
                     , Agent.CLI.ResourceAdminSpec
     build-depends:    agent-native-bridge
                     , agent-cli
+                    , agent-responses-types
                     , agent-integration-api
                     , agent-core
                     , agent-json
@@ -233,7 +234,6 @@ test-suite agent-native-bridge-test
                      , agent-cli-runtime
                      , agent-openai
                      , agent-openrouter
-                     , agent-responses-types
                      , agent-xai
                      , filelock
                      , JuicyPixels

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineHandle.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineHandle.hs
@@ -41,6 +41,7 @@ ha_engine_create callback context
             stagedImages <- newTVarIO Map.empty
             browser <- BrowserHost <$> newMVar Nothing
             computer <- newComputerHost
+            chartRenderingEnabled <- newTVarIO False
             stagedTurnOptions <- newTVarIO Map.empty
             interactionTarget <- newTVarIO Nothing
             interactionLock <- newMVar ()
@@ -64,6 +65,7 @@ ha_engine_create callback context
                             stagedImages
                             browser
                             computer
+                            chartRenderingEnabled
                             stagedTurnOptions
                             interactions)
                 let engine = Engine
@@ -72,6 +74,7 @@ ha_engine_create callback context
                         , engineStagedImages = stagedImages
                         , engineBrowser = browser
                         , engineComputer = computer
+                        , engineChartRenderingEnabled = chartRenderingEnabled
                         , engineStagedTurnOptions = stagedTurnOptions
                         , engineInteractions = interactions
                         }

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineHostRegistration.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineHostRegistration.hs
@@ -33,12 +33,27 @@ foreign export ccall ha_engine_set_browser_callback
 foreign export ccall ha_engine_set_computer_callback
     :: Ptr () -> FunPtr ComputerCallback -> Ptr () -> IO CInt
 
+foreign export ccall ha_engine_set_chart_rendering_enabled
+    :: Ptr () -> CInt -> IO CInt
+
 foreign export ccall ha_engine_set_interaction_callback
     :: Ptr () -> FunPtr InteractionCallback -> Ptr () -> IO CInt
 
 foreign export ccall ha_engine_resolve_interaction
     :: Ptr () -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize
     -> CInt -> Ptr Word8 -> CSize -> IO CInt
+
+ha_engine_set_chart_rendering_enabled :: Ptr () -> CInt -> IO CInt
+ha_engine_set_chart_rendering_enabled pointer enabled
+    | pointer == nullPtr = pure 1
+    | enabled /= 0 && enabled /= 1 = pure 2
+    | otherwise = do
+        updated <- tryAny do
+            engine <- deRefStablePtr
+                (castPtrToStablePtr pointer :: StablePtr Engine)
+            atomically $
+                writeTVar engine.engineChartRenderingEnabled (enabled == 1)
+        pure $ either (const 3) (const 0) updated
 
 ha_engine_set_browser_callback
     :: Ptr () -> FunPtr BrowserCallback -> FunPtr BrowserCancelCallback -> Ptr () -> IO CInt

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineLifecycle.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineLifecycle.hs
@@ -43,11 +43,12 @@ workerLifecycle
     -> TVar (Map Text [ImageAttachment])
     -> BrowserHost
     -> ComputerHost
+    -> TVar Bool
     -> TVar (Map Text NativeTurnOptions)
     -> InteractionRuntime
     -> IO ()
 workerLifecycle
-        callback context config root commands stagedImages browser computer
+        callback context config root commands stagedImages browser computer chartRenderingEnabled
         stagedTurnOptions interactions =
     (do
         store <- newMVar Nothing
@@ -72,6 +73,7 @@ workerLifecycle
             stagedImages
             browser
             computer
+            chartRenderingEnabled
             stagedTurnOptions
             interactions
             workerRegistry

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineState.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineState.hs
@@ -55,6 +55,7 @@ data Engine = Engine
     , engineStagedImages :: !(TVar (Map Text [ImageAttachment]))
     , engineBrowser :: !BrowserHost
     , engineComputer :: !ComputerHost
+    , engineChartRenderingEnabled :: !(TVar Bool)
     , engineStagedTurnOptions :: !(TVar (Map Text NativeTurnOptions))
     , engineInteractions :: !InteractionRuntime
     }

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeLoopEvent.hs
@@ -2,17 +2,20 @@
 
 module Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
+    , encodeNativeLoopEventWithChartCalls
     , encodeNativeUsageEvent
     ) where
 
 import Agent.CLI.Render (summarizeToolCall)
 import Agent.Loop (LoopEvent(..), TokenUsage(..), TurnOutput(..))
+import Agent.Tools.RenderChart (chartResultDocument, chartResultSummary)
 import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallMode(..)
     , toolCallMode
     , toolCallResultMode
     , ToolCallResult(..)
+    , ToolOutcome(..)
     , isComputerToolCallKind
     )
 import qualified Data.Aeson as Aeson
@@ -22,6 +25,8 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
+import Data.Maybe (fromMaybe, isJust)
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Word (Word16, Word8)
@@ -37,7 +42,10 @@ import Data.Word (Word16, Word8)
 -- already supplies the complete frame length, so no outer payload length is
 -- needed.
 encodeNativeLoopEvent :: Text -> LoopEvent -> Maybe BS.ByteString
-encodeNativeLoopEvent turnId event =
+encodeNativeLoopEvent = encodeNativeLoopEventWithChartCalls Set.empty
+
+encodeNativeLoopEventWithChartCalls :: Set.Set Text -> Text -> LoopEvent -> Maybe BS.ByteString
+encodeNativeLoopEventWithChartCalls chartCalls turnId event =
     case event of
         ReasoningDelta text -> textEvent 1 turnId text
         TextDelta text -> textEvent 2 turnId text
@@ -54,14 +62,24 @@ encodeNativeLoopEvent turnId event =
             eventOutput
                 | isComputerToolCallKind result.callKind =
                     redactComputerScreenshot result.output
+                | isJust chart =
+                    fromMaybe result.output (chartResultSummary result.output)
                 | otherwise = result.output
+            chart
+                | Set.member result.callId chartCalls
+                    && maybe True (== ToolSucceeded) result.toolResultOutcome =
+                    chartResultDocument result.output
+                | otherwise = Nothing
             (output, truncated) = boundedEventText eventOutput
             flags =
                 (if truncated then 2 else 0)
                     + (if toolCallResultMode result == AsyncToolCall
                         then 4
                         else 0)
-            finishedFields = [Just result.callId, Just output]
+                    + (if isJust chart then 8 else 0)
+            finishedFields =
+                [Just result.callId, Just output]
+                    <> [chart | isJust chart]
         TurnFinished output ->
             encodeNativeUsageEvent
                 False

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
@@ -58,6 +58,7 @@ import Agent.Json (RawJson, rawJsonBytes)
 import Agent.Loop (ImageAttachment, emptyTokenUsage)
 import Agent.Runtime.Daemon.TaskScheduler (TaskIdentity(..), selectRunnableTasks)
 import Agent.Store.Postgres (ManagedPostgresConfig, Store)
+import Agent.Tools.RenderChart (renderChartTool)
 import Control.Concurrent.Async (Async, asyncWithUnmask, cancel, waitCatch)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, takeMVar, putMVar)
 import Control.Concurrent.STM
@@ -119,6 +120,7 @@ supervisorLoop
     -> TVar (Map Text [ImageAttachment])
     -> BrowserHost
     -> ComputerHost
+    -> TVar Bool
     -> TVar (Map Text NativeTurnOptions)
     -> InteractionRuntime
     -> TVar (Map Text RunningTurn)
@@ -126,7 +128,7 @@ supervisorLoop
     -> IO ()
 supervisorLoop
         callback context config store root processRuntime commands
-        integrationWorkers stagedImages browser computer
+        integrationWorkers stagedImages browser computer chartRenderingEnabled
         stagedTurnOptions interactions workerRegistry =
     go
   where
@@ -470,6 +472,8 @@ supervisorLoop
             start.turnStartSessionId
             interactions
         nativeBrowserTools <- browserToolsWhenEnabled browser start.turnStartId
+        chartsEnabled <- readTVarIO chartRenderingEnabled
+        let nativePresentationTools = [renderChartTool | chartsEnabled]
         worker <- launchTrackedWorker start.turnStartId $
             bracket
                 (if start.turnStartComputerUse
@@ -519,7 +523,7 @@ supervisorLoop
                                                 commands
                                                 processRuntime
                                                 control
-                                                nativeBrowserTools
+                                                (nativeBrowserTools <> nativePresentationTools)
                                                 nativeComputerTool
                                                 start
                                                 pending.pendingTurnImages

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
@@ -12,7 +12,7 @@ import Agent.CLI.MacOS.EngineState (EngineCommand(..))
 import Agent.CLI.MacOS.InteractionState (InteractionRuntime)
 import Agent.CLI.MacOS.NativeInteraction
     ( nativePlanModeHooks, requestApproval, requestRootAccessFromClient )
-import Agent.CLI.MacOS.NativeLoopEvent (encodeNativeLoopEvent)
+import Agent.CLI.MacOS.NativeLoopEvent (encodeNativeLoopEventWithChartCalls)
 import Agent.CLI.MacOS.NativeRequest (TurnStart(..))
 import Agent.CLI.MacOS.TurnEvents (nativeLoopEvent)
 import Agent.CLI.MacOS.TurnInputs
@@ -28,14 +28,16 @@ import Agent.CLI.NativeRuntime
 import Agent.Loop
     ( ImageAttachment, LoopEvent(..), TurnOutput(..), emptyTokenUsage )
 import Agent.Runtime.StartupPolicy (hostNativeStartupPolicy)
+import Agent.ToolDispatch (ToolCall(..))
 import Agent.Tools.Types (AppTool(..), AppToolGroup(..), appToolsFromGroups)
 import Control.Concurrent.STM (atomically, writeTVar)
 import Control.Exception.Safe (SomeException, fromException, tryAny)
 import Control.Monad (forM_, void)
 import qualified Data.Aeson as Aeson
-import Data.IORef (newIORef, readIORef, writeIORef, modifyIORef')
+import Data.IORef (newIORef, readIORef, writeIORef, modifyIORef', atomicModifyIORef')
 import Data.Text (Text)
 import qualified Data.Text as Text
+import qualified Data.Set as Set
 import Foreign.Ptr (FunPtr, Ptr)
 import System.IO (IOMode(WriteMode), withFile)
 import System.OsPath (unsafeEncodeUtf)
@@ -71,21 +73,26 @@ runNativeTurn
     -> InteractionRuntime
     -> IO TurnOutcome
 runNativeTurn
-        callback context commands processRuntime control nativeBrowserTools
+        callback context commands processRuntime control nativeHostTools
         nativeComputerSession start images turnOptions interactions = do
     sessionIdRef <- newIORef start.turnStartSessionId
     completedRef <- newIORef False
     usageRef <- newIORef emptyTokenUsage
+    chartCallsRef <- newIORef Set.empty
     let hooks = NativeRunHooks
             { nativeOnLoopEvent = \event -> do
                 case event of
+                    ToolStarted call | call.name == "render_chart" ->
+                        atomicModifyIORef' chartCallsRef \calls ->
+                            (Set.insert call.callId calls, ())
                     TurnFinished output -> do
                         writeIORef completedRef True
                         modifyIORef' usageRef (<> output.tokenUsage)
                     ModelContextReset ->
                         forM_ nativeComputerSession \(_, reset, _) -> reset
                     _ -> pure ()
-                case encodeNativeLoopEvent control.turnControlId event of
+                chartCalls <- readIORef chartCallsRef
+                case encodeNativeLoopEventWithChartCalls chartCalls control.turnControlId event of
                     Just bytes -> sendBinaryEvent callback context bytes
                     Nothing ->
                         forM_ (nativeLoopEvent control.turnControlId event)
@@ -114,7 +121,7 @@ runNativeTurn
                 requestApproval callback context control
             , nativeRequestRootAccess =
                 requestRootAccessFromClient callback context control
-            , nativeToolGroups = [HostToolGroup nativeBrowserTools]
+            , nativeToolGroups = [HostToolGroup nativeHostTools]
             , nativeComposeTools =
                 composeNativeTools
                     ((\(tool, _, _) -> tool) <$> nativeComputerSession)

--- a/packages/agent-native-bridge/include/HaskellAgentBridge.h
+++ b/packages/agent-native-bridge/include/HaskellAgentBridge.h
@@ -26,7 +26,10 @@ typedef void (*ha_event_callback)(
      * the card identified by call ID. Its flags use bit 0 for encrypted
      * arguments, bit 1 for truncation, and bit 2 for an asynchronous call;
      * tool-finish uses bit 1 for truncation and bit 2 for an asynchronous
-     * result. Consumers must ignore unknown flag bits for forward
+     * result. Tool-finish bit 3 indicates an additional third field after
+     * call ID and output: a complete versioned chart document (UTF-8 JSON,
+     * at most 256 KiB). The output field is its readable summary. The chart
+     * field is never truncated. Consumers must ignore unknown flag bits for forward
      * compatibility.
      * Turn IDs are stable task IDs for the lifetime of an engine. Events for
      * one task are delivered in order, but callbacks for different tasks may
@@ -328,6 +331,19 @@ typedef int32_t (*ha_computer_callback)(
     uint64_t *output_session_token,
     int32_t *output_image_format
 );
+
+/*
+ * Enables native chart presentation for subsequently starting turns. Disabled
+ * by default; only hosts that implement the versioned chart document should
+ * enable this capability. This does not depend on the operating system and
+ * does not change already running turns.
+ *
+ * Synchronous and thread-safe while the engine is alive. No buffers or
+ * callbacks are retained. The host must serialize engine destruction against
+ * this call. enabled is exactly 0 or 1.
+ * Status: 0 success, 1 null engine, 2 invalid enabled value, 3 runtime failure.
+ */
+int32_t ha_engine_set_chart_rendering_enabled(void *engine, int32_t enabled);
 
 /*
  * Installs native computer control for future turns. A turn replaces the

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/NativeLoopEventSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/NativeLoopEventSpec.hs
@@ -2,9 +2,14 @@ module Agent.CLI.MacOS.NativeLoopEventSpec (spec) where
 
 import Agent.CLI.MacOS.NativeLoopEvent
     ( encodeNativeLoopEvent
+    , encodeNativeLoopEventWithChartCalls
     , encodeNativeUsageEvent
     )
 import Agent.CLI.MacOS.NativeInteraction (boundedApprovalArguments)
+import Agent.CLI.SessionAdmin (sessionToolEvent, sessionToolEventWithChartCalls)
+import qualified Agent.Responses.Types as Responses
+import Agent.Json (rawJsonFromEncoding)
+import Agent.Tools.RenderChart (chartResultDocument, chartResultSummary)
 import Agent.Loop
     ( LoopEvent(..)
     , TokenUsage(..)
@@ -16,9 +21,15 @@ import Agent.ToolDispatch
     , ToolCallKind(..)
     , ToolCallMode(..)
     , ToolCallResult(..)
+    , ToolOutcome(..)
     , withToolCallMode
     )
 import qualified Data.ByteString as BS
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as LBS
+import Data.Maybe (fromJust)
+import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Word (Word8, Word32)
@@ -26,6 +37,62 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "native loop event binary encoding" do
+    it "transports the complete chart independently of the bounded output preview" do
+        let result = ToolCallResult
+                { callId = "chart-call"
+                , output = chartEnvelope
+                , callKind = FunctionCallKind
+                , toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
+                }
+        Text.length chartEnvelope `shouldSatisfy` (> 8192)
+        let document = fromJust (chartResultDocument chartEnvelope)
+            summary = fromJust (chartResultSummary chartEnvelope)
+        encodeNativeLoopEventWithChartCalls (Set.singleton "chart-call") "turn" (ToolFinished result)
+            `shouldBe` Just (frame 5 8
+                ["turn", "chart-call", Text.unpack summary, Text.unpack document])
+        fmap (BS.take 8) (encodeNativeLoopEvent "turn" (ToolFinished result))
+            `shouldBe` Just (header 5 2)
+
+    it "projects the same complete chart from durable response items on reload" do
+        let item = Responses.FunctionCallOutputItem Responses.FunctionCallOutput
+                { Responses.itemId = Nothing
+                , Responses.callId = "chart-call"
+                , Responses.name = Nothing
+                , Responses.namespace = Nothing
+                , Responses.provider = Nothing
+                , Responses.output = rawJsonFromEncoding (Aeson.toEncoding chartEnvelope)
+                , Responses.status = Nothing
+                , Responses.async = Nothing
+                , Responses.localOutcome = Nothing
+                }
+        case sessionToolEventWithChartCalls (Set.singleton "chart-call") item of
+                    Just (Aeson.Object event) -> do
+                        KeyMap.lookup "chart" event
+                            `shouldBe` (chartResultDocument chartEnvelope
+                                >>= Aeson.decodeStrict' . TextEncoding.encodeUtf8)
+                        KeyMap.lookup "output" event
+                            `shouldBe` (Aeson.String <$> chartResultSummary chartEnvelope)
+                        KeyMap.lookup "truncated" event `shouldBe` Just (Aeson.Bool False)
+                        case sessionToolEvent item of
+                            Just (Aeson.Object ordinary) ->
+                                KeyMap.lookup "chart" ordinary `shouldBe` Nothing
+                            _ -> expectationFailure "ordinary output event missing"
+                    _ -> expectationFailure "chart history event missing"
+
+    it "does not attach a chart to a failed tool result" do
+        let result = ToolCallResult
+                { callId = "chart-call"
+                , output = chartEnvelope
+                , callKind = FunctionCallKind
+                , toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Just ToolFailed
+                }
+        fmap (BS.take 8) (encodeNativeLoopEventWithChartCalls (Set.singleton "chart-call") "turn" (ToolFinished result))
+            `shouldBe` Just (header 5 2)
+
     it "encodes text deltas with a versioned HAEV frame" do
         encodeNativeLoopEvent "turn" (TextDelta "hé")
             `shouldBe` Just (frame 2 0 ["turn", "hé"])
@@ -201,6 +268,29 @@ spec = describe "native loop event binary encoding" do
 
     it "does not encode turn-start lifecycle events as native loop frames" do
         encodeNativeLoopEvent "turn" TurnStarted `shouldBe` Nothing
+
+chartEnvelope :: Text.Text
+chartEnvelope = TextEncoding.decodeUtf8 . LBS.toStrict . Aeson.encode $
+    Aeson.object
+        [ "type" Aeson..= ("chart" :: Text.Text)
+        , "summary" Aeson..= ("Measurements: 1 series, 1000 points." :: Text.Text)
+        , "chart" Aeson..= Aeson.object
+            [ "version" Aeson..= (1 :: Int)
+            , "kind" Aeson..= ("line" :: Text.Text)
+            , "title" Aeson..= ("Measurements" :: Text.Text)
+            , "x_axis" Aeson..= Aeson.object ["type" Aeson..= ("number" :: Text.Text)]
+            , "y_axis" Aeson..= Aeson.object []
+            , "series" Aeson..=
+                [ Aeson.object
+                    [ "name" Aeson..= ("Observations" :: Text.Text)
+                    , "points" Aeson..=
+                        [ Aeson.object ["x" Aeson..= index, "y" Aeson..= index]
+                        | index <- [1 .. 1000 :: Int]
+                        ]
+                    ]
+                ]
+            ]
+        ]
 
 frame :: Word8 -> Word8 -> [String] -> BS.ByteString
 frame kind flags fields =

--- a/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeTaskSmoke.c
+++ b/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeTaskSmoke.c
@@ -59,6 +59,15 @@ int ha_task_supervisor_abi_smoke(void) {
         ha_runtime_exit();
         return 11;
     }
+    if (ha_engine_set_chart_rendering_enabled(NULL, 1) != 1
+            || ha_engine_set_chart_rendering_enabled(engine, -1) != 2
+            || ha_engine_set_chart_rendering_enabled(engine, 2) != 2
+            || ha_engine_set_chart_rendering_enabled(engine, 1) != 0
+            || ha_engine_set_chart_rendering_enabled(engine, 0) != 0) {
+        ha_engine_destroy(engine);
+        ha_runtime_exit();
+        return 17;
+    }
     if (ha_engine_set_task_limit(engine, 0) != 2
             || ha_engine_set_task_limit(engine, 33) != 2
             || ha_engine_set_task_limit(engine, 2) != 0) {


### PR DESCRIPTION
## Summary
- Add a validated, versioned `render_chart` tool for line, bar, area and scatter charts.
- Keep chart rendering disabled by default and expose a narrow typed native capability setter.
- Preserve complete chart attachments through native events, output storage and session history, with tool-call identity gating.

## Validation
- Core chart tests: 27 examples, 0 failures.
- Native runtime tests: 120 examples, 0 failures.
- Coordinated downstream build with the published runtime revision passed.

## Compatibility
CLI tool availability remains unchanged unless the embedding client explicitly enables chart rendering.