### PR TITLE
Fix enhanced terminal keyboard decoding and word navigation

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -366,7 +366,7 @@ library
                     , vector
                     , vty >= 6.4 && < 7
                     , vty-crossplatform >= 0.4 && < 0.5
-                    , vty-unix >= 0.4 && < 0.5
+                    , vty-unix >= 0.2 && < 0.5
                     , terminfo
                     , wai
                     , warp
@@ -662,7 +662,7 @@ test-suite agent-cli-test
                     , transformers
                     , unix
                     , vty >= 6.4 && < 7
-                    , vty-unix >= 0.4 && < 0.5
+                    , vty-unix >= 0.2 && < 0.5
                     , wai
                     , warp
 benchmark image-preview-latency-bench

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -158,6 +158,7 @@ library
                     , Agent.CLI.TUI.Render.Workspace
                     , Paths_agent_cli
     exposed-modules:  Agent.CLI
+                    , Agent.CLI.TUI.Keyboard
                     , Agent.CLI.IntegrationGateway
                     , Agent.CLI.ActiveAccount
                     , Agent.CLI.AccountPicker
@@ -366,6 +367,8 @@ library
                     , vector
                     , vty >= 6.4 && < 7
                     , vty-crossplatform >= 0.4 && < 0.5
+                    , vty-unix >= 0.4 && < 0.5
+                    , terminfo
                     , wai
                     , warp
     if os(darwin)
@@ -660,6 +663,7 @@ test-suite agent-cli-test
                     , transformers
                     , unix
                     , vty >= 6.4 && < 7
+                    , vty-unix >= 0.4 && < 0.5
                     , wai
                     , warp
 benchmark image-preview-latency-bench

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -10,9 +10,9 @@
 , filepath, haskeline, hasql-pool, hspec, http-client
 , http-client-tls, http-types, JuicyPixels, lib, memory, mtl
 , network, network-uri, optparse-applicative, process, QuickCheck
-, retry, safe-exceptions, scientific, stm, tagsoup, temporary, text
-, time, tls, transformers, unix, vector, vty, vty-crossplatform
-, wai, warp
+, retry, safe-exceptions, scientific, stm, tagsoup, temporary
+, terminfo, text, time, tls, transformers, unix, vector, vty
+, vty-crossplatform, vty-unix, wai, warp
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -32,8 +32,8 @@ mkDerivation {
     directory entropy filelock filepath haskeline hasql-pool
     http-client http-client-tls http-types JuicyPixels memory mtl
     network network-uri optparse-applicative process retry
-    safe-exceptions scientific stm tagsoup text time tls transformers
-    unix vector vty vty-crossplatform wai warp
+    safe-exceptions scientific stm tagsoup terminfo text time tls
+    transformers unix vector vty vty-crossplatform vty-unix wai warp
   ];
   executableHaskellDepends = [
     aeson agent-cli-runtime agent-responses agent-responses-types
@@ -48,8 +48,8 @@ mkDerivation {
     async base base64-bytestring brick bytestring colour containers
     dbus directory filelock filepath haskeline hspec http-client
     http-types JuicyPixels network network-uri process QuickCheck
-    safe-exceptions stm temporary text time transformers unix vty wai
-    warp
+    safe-exceptions stm temporary text time transformers unix vty
+    vty-unix wai warp
   ];
   benchmarkHaskellDepends = [
     aeson agent-core agent-json agent-mcp agent-responses

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -493,6 +493,8 @@ readEscapeKey = do
                 '\r' -> pure (EditorChar '\n')
                 '\DEL' -> pure EditorKillWord
                 '\BS' -> pure EditorKillWord
+                'b' -> pure EditorWordLeft
+                'f' -> pure EditorWordRight
                 _ -> pure EditorIgnore
 
 readCsiKey :: IO EditorKey
@@ -504,6 +506,7 @@ readCsiKey =
             | isShiftTabCsiBody body -> pure EditorCycleMode
             | isClipboardPasteCsiBody body -> readClipboardEditorKey
             | Just key <- decodeKittyEditorKey body -> pure key
+            | Just key <- decodeModifiedArrowKey body -> pure key
             | otherwise -> case body of
                 "A" -> pure EditorUp
                 "B" -> pure EditorDown

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -491,6 +491,8 @@ readEscapeKey = do
                                 _ -> EditorIgnore
                 '\n' -> pure (EditorChar '\n')
                 '\r' -> pure (EditorChar '\n')
+                '\DEL' -> pure EditorKillWord
+                '\BS' -> pure EditorKillWord
                 _ -> pure EditorIgnore
 
 readCsiKey :: IO EditorKey

--- a/packages/agent-cli/src/Agent/CLI/Input/Editor.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Editor.hs
@@ -133,6 +133,25 @@ reduceEditorKey entries state key =
             , editorSelected = 0
             , editorSlashDismissed = False
             }
+        EditorWordLeft -> redraw state
+            { editorCursor =
+                Text.length
+                    (Text.dropWhileEnd (not . isSpace)
+                        (Text.dropWhileEnd isSpace
+                            (Text.take state.editorCursor state.editorText)))
+            , editorSelected = 0
+            , editorSlashDismissed = False
+            }
+        EditorWordRight -> redraw state
+            { editorCursor =
+                Text.length state.editorText
+                    - Text.length
+                        (Text.dropWhile (not . isSpace)
+                            (Text.dropWhile isSpace
+                                (Text.drop state.editorCursor state.editorText)))
+            , editorSelected = 0
+            , editorSlashDismissed = False
+            }
         EditorHome -> redraw state
             { editorCursor = 0
             , editorSelected = 0

--- a/packages/agent-cli/src/Agent/CLI/Input/KeyDecoder.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/KeyDecoder.hs
@@ -5,10 +5,12 @@ module Agent.CLI.Input.KeyDecoder
     , kittySuper
     , kittyRelease
     , hasModifier
+    , withoutKittyLockModifiers
     , parseKittyKey
     , parseKittyKeyFields
     , decodeKittyEditorKey
     , decodeKittyControl
+    , decodeModifiedArrowKey
     , isClipboardPasteKey
     , isClipboardPasteCsiBody
     , isShiftEnterCsiBody
@@ -21,7 +23,8 @@ module Agent.CLI.Input.KeyDecoder
 
 import Agent.CLI.Input.Types (EditorKey(..), KittyKey(..))
 import Agent.CLI.Terminal (shiftEnterCsiBodies, shiftTabCsiBodies)
-import Data.Bits ((.&.))
+import Control.Monad (guard)
+import Data.Bits ((.&.), complement)
 import Data.Char (ord)
 import Data.Maybe (fromMaybe)
 
@@ -34,6 +37,10 @@ kittyRelease = 3
 
 hasModifier :: Int -> Int -> Bool
 hasModifier modifier modifiers = modifiers .&. modifier /= 0
+
+-- Caps Lock and Num Lock describe terminal state, not shortcut modifiers.
+withoutKittyLockModifiers :: Int -> Int
+withoutKittyLockModifiers modifiers = modifiers .&. complement 192
 
 isClipboardPasteKey :: Char -> Bool
 isClipboardPasteKey = (== '\SYN')
@@ -49,10 +56,21 @@ isClipboardPasteCsiBody body =
         _ -> False
 
 isShiftEnterCsiBody :: String -> Bool
-isShiftEnterCsiBody body = body `elem` shiftEnterCsiBodies
+isShiftEnterCsiBody body =
+    body `elem` shiftEnterCsiBodies || isKittyShiftKey 13 body
 
 isShiftTabCsiBody :: String -> Bool
-isShiftTabCsiBody body = body `elem` shiftTabCsiBodies
+isShiftTabCsiBody body =
+    body `elem` shiftTabCsiBodies || isKittyShiftKey 9 body
+
+isKittyShiftKey :: Int -> String -> Bool
+isKittyShiftKey codepoint body =
+    case parseKittyKey body of
+        Just key ->
+            key.kittyCodepoint == codepoint
+                && withoutKittyLockModifiers key.kittyModifiers == kittyShift
+                && key.kittyEvent /= kittyRelease
+        Nothing -> False
 
 parseKittyKey :: String -> Maybe KittyKey
 parseKittyKey body = do
@@ -64,15 +82,28 @@ parseKittyKeyFields raw = do
     let fields = splitFields ';' raw
         modifierField = fromMaybe "1" (listAt 1 fields)
         modifierParts = splitFields ':' modifierField
+    guard (length fields <= 3 && length modifierParts <= 2)
     codeField <- listAt 0 fields
-    codepoint <- readDecimal (takeWhile (/= ':') codeField)
-    encodedModifiers <- listAt 0 modifierParts >>= readDecimal
-    event <- maybe (Just 1) readDecimal (listAt 1 modifierParts)
+    let codeParts = splitFields ':' codeField
+    guard (length codeParts <= 3)
+    codepoint <- listAt 0 codeParts >>= readCodepoint
+    mapM_ (\part -> if null part then Just () else () <$ readCodepoint part) (drop 1 codeParts)
+    encodedModifiers <- listAt 0 modifierParts >>= readDefaultOne
+    event <- maybe (Just 1) readDefaultOne (listAt 1 modifierParts)
+    guard (encodedModifiers >= 1 && encodedModifiers <= 256 && event >= 1 && event <= 3)
+    mapM_ (mapM_ readCodepoint . splitFields ':') (listAt 2 fields)
     pure KittyKey
         { kittyCodepoint = codepoint
-        , kittyModifiers = max 0 (encodedModifiers - 1)
+        , kittyModifiers = encodedModifiers - 1
         , kittyEvent = event
         }
+  where
+    readDefaultOne "" = Just 1
+    readDefaultOne value = readDecimal value
+    readCodepoint value = do
+        codepoint <- readDecimal value
+        guard (codepoint <= 0x10ffff && not (codepoint >= 0xd800 && codepoint <= 0xdfff))
+        pure codepoint
 
 decodeKittyEditorKey :: String -> Maybe EditorKey
 decodeKittyEditorKey body
@@ -84,9 +115,13 @@ decodeKittyEditorKey body
             else Just (decodeKittyControl kittyModifiers kittyCodepoint)
 
 decodeKittyControl :: Int -> Int -> EditorKey
-decodeKittyControl modifiers codepoint
+decodeKittyControl rawModifiers codepoint
+    | codepoint == 13 && modifiers == kittyShift = EditorChar '\n'
     | codepoint == 9 && hasModifier kittyShift modifiers = EditorCycleMode
-    | codepoint == 127 && hasModifier kittyAlt modifiers = EditorKillWord
+    | hasModifier kittyAlt modifiers && codepoint == ord 'b' = EditorWordLeft
+    | hasModifier kittyAlt modifiers && codepoint == ord 'f' = EditorWordRight
+    | codepoint == 127
+        && any (`hasModifier` modifiers) [kittyAlt, kittyCtrl, kittySuper] = EditorKillWord
     | codepoint == 127 && modifiers == 0 = EditorBackspace
     | hasModifier kittyCtrl modifiers = case codepoint of
         97 -> EditorHome
@@ -106,6 +141,21 @@ decodeKittyControl modifiers codepoint
         _ -> EditorIgnore
     | codepoint == 27 = EditorEscape
     | otherwise = EditorIgnore
+  where
+    modifiers = withoutKittyLockModifiers rawModifiers
+
+-- Modified arrows use CSI 1;modifier C/D, including Kitty event suffixes.
+decodeModifiedArrowKey :: String -> Maybe EditorKey
+decodeModifiedArrowKey body = do
+    (direction, raw) <- case reverse body of
+        'C' : rest -> Just (EditorWordRight, reverse rest)
+        'D' : rest -> Just (EditorWordLeft, reverse rest)
+        _ -> Nothing
+    KittyKey{kittyCodepoint, kittyModifiers, kittyEvent} <- parseKittyKeyFields raw
+    if kittyCodepoint == 1
+        && any (`hasModifier` kittyModifiers) [kittyAlt, kittyCtrl]
+        then Just (if kittyEvent == kittyRelease then EditorIgnore else direction)
+        else Nothing
 
 splitFields :: Eq a => a -> [a] -> [[a]]
 splitFields separator = go
@@ -131,7 +181,8 @@ stripFinal suffix xs =
         _ -> Nothing
 
 readDecimal :: String -> Maybe Int
-readDecimal input =
-    case reads input of
-        [(value, "")] -> Just value
+readDecimal input = do
+    guard (not (null input) && all (\character -> character >= '0' && character <= '9') input)
+    case reads input :: [(Integer, String)] of
+        [(value, "")] | value <= toInteger (maxBound :: Int) -> Just (fromInteger value)
         _ -> Nothing

--- a/packages/agent-cli/src/Agent/CLI/Input/KeyDecoder.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/KeyDecoder.hs
@@ -25,8 +25,9 @@ import Data.Bits ((.&.))
 import Data.Char (ord)
 import Data.Maybe (fromMaybe)
 
-kittyShift, kittyCtrl, kittySuper, kittyRelease :: Int
+kittyShift, kittyAlt, kittyCtrl, kittySuper, kittyRelease :: Int
 kittyShift = 1
+kittyAlt = 2
 kittyCtrl = 4
 kittySuper = 8
 kittyRelease = 3
@@ -85,6 +86,8 @@ decodeKittyEditorKey body
 decodeKittyControl :: Int -> Int -> EditorKey
 decodeKittyControl modifiers codepoint
     | codepoint == 9 && hasModifier kittyShift modifiers = EditorCycleMode
+    | codepoint == 127 && hasModifier kittyAlt modifiers = EditorKillWord
+    | codepoint == 127 && modifiers == 0 = EditorBackspace
     | hasModifier kittyCtrl modifiers = case codepoint of
         97 -> EditorHome
         98 -> EditorLeft

--- a/packages/agent-cli/src/Agent/CLI/Input/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Types.hs
@@ -70,6 +70,8 @@ data EditorKey
     | EditorDelete
     | EditorLeft
     | EditorRight
+    | EditorWordLeft
+    | EditorWordRight
     | EditorHome
     | EditorEnd
     | EditorUp

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -2,6 +2,8 @@
 {-# OPTIONS_GHC -O0 -Wno-unused-imports #-}
 module Agent.CLI.TUI.App.Run where
 
+import Agent.CLI.TUI.Keyboard (mkKeyboardVty)
+
 import Agent.CLI.Clipboard ( formatImageSize )
 import Agent.CLI.Dictation ( DictationControl(..)
     , DictationResult(..)
@@ -217,7 +219,7 @@ runFullscreen runtime workerAction = do
     initialClock <- getMonotonicTimeNSec
     terminal <- detectTerminalCapabilities stdout
     let makeVty = do
-            vty <- Vty.mkVty fullscreenVtyConfig
+            vty <- mkKeyboardVty fullscreenVtyConfig
             let setupVty = do
                     let output = V.outputIface vty
                     -- Without this mode terminals paste image clipboard

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -850,6 +850,16 @@ fullscreenVtyConfig =
               )
             | body <- shiftTabCsiBodies
             ]
+            -- Backspace is not a printable character: register its modified
+            -- CSI-u encodings explicitly rather than leaking their payload.
+            <> [ (Nothing, "\ESC[" <> body, V.EvKey V.KBS [modifier])
+               | (encode, modifier) <-
+                    [ (kittyAltCsiBodies, V.MAlt)
+                    , (kittyCtrlCsiBodies, V.MCtrl)
+                    , (kittySuperCsiBodies, V.MMeta)
+                    ]
+               , body <- encode '\DEL'
+               ]
             <> [ ( Nothing
                  , "\ESC[" <> body
                  , V.EvKey (V.KChar character) [V.MCtrl]

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -822,9 +822,9 @@ readFullscreenLineOrWithCatalog
                         Nothing -> UiSetAwaitingInput False
             pure (Right input.fullscreenInputLine)
 
--- | Fullscreen Vty configuration, including enhanced-keyboard encodings that
--- are not present in the default terminfo input table. Without these entries,
--- Vty emits the payload of modified-key sequences as printable characters.
+-- | Fullscreen Vty configuration, including legacy terminal overrides.
+-- 'Agent.CLI.TUI.Keyboard' decodes CSI-u before this compatibility table,
+-- so enhanced keys are not limited to the characters and modifiers below.
 fullscreenVtyConfig :: V.VtyUserConfig
 fullscreenVtyConfig =
     V.defaultConfig
@@ -867,12 +867,8 @@ fullscreenVtyConfig =
                | character <- ['a'..'z']
                , body <- kittyCtrlCsiBodies character
                ]
-            -- The Kitty disambiguation mode reports every Command-modified
-            -- printable key as CSI-u, not only shortcuts we handle. Vty
-            -- otherwise emits an unknown sequence's body as literal text
-            -- (for example Cmd+ß appeared as "[223;9u"). Decode the
-            -- characters available on ASCII and Latin-1 keyboard layouts;
-            -- Composer will act on supported shortcuts and ignore the rest.
+            -- Compatibility mappings for callers using stock Vty. The live
+            -- fullscreen input decoder handles all Unicode scalar values.
             <> [ ( Nothing
                  , "\ESC[" <> body
                  , V.EvKey (V.KChar character) [V.MMeta]

--- a/packages/agent-cli/src/Agent/CLI/TUI/Keyboard.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Keyboard.hs
@@ -1,0 +1,223 @@
+-- | Byte-level enhanced keyboard support. Parse CSI-u before Vty's finite
+-- terminfo table: an unlisted Unicode key must never become printable CSI text.
+module Agent.CLI.TUI.Keyboard
+    ( mkKeyboardVty
+    , classifyKeyboard
+    , decodeKeyboardBody
+    , runKeyboardInput
+    ) where
+
+import Agent.CLI.Input.KeyDecoder
+    (parseKittyKey, withoutKittyLockModifiers, splitFields, listAt, readDecimal)
+import Agent.CLI.Input.Types (KittyKey(..))
+import Control.Concurrent (threadWaitRead)
+import qualified Control.Concurrent.Async as Async
+import Control.Concurrent.STM
+import Control.Exception.Safe (mask, onException, finally, throwIO)
+import Control.Monad (unless, when, void)
+import Data.Bits (testBit, (.&.))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
+import Data.Char (chr, toUpper)
+import Foreign (allocaBytes, castPtr)
+import qualified Graphics.Vty as V
+import Graphics.Vty.Input (Input(..), InternalEvent(..))
+import Graphics.Vty.Platform.Unix.Input (attributeControl)
+import Graphics.Vty.Platform.Unix.Input.Classify (classify)
+import Graphics.Vty.Platform.Unix.Input.Classify.Types
+import Graphics.Vty.Platform.Unix.Input.Terminfo (classifyMapForTerm)
+import Graphics.Vty.Platform.Unix.Output (buildOutput)
+import Graphics.Vty.Platform.Unix.Settings
+import qualified System.Console.Terminfo as Terminfo
+import System.Posix.IO (fdReadBuf)
+import System.Posix.Signals.Exts
+import System.Posix.Terminal
+import System.Posix.Types (Fd)
+import System.Timeout (timeout)
+
+-- An internal no-op, filtered before reaching Brick. Vty has no key-release
+-- event, and unsupported functional keys must not be inserted as PUA text.
+ignoredKey :: V.Event
+ignoredKey = V.EvKey (V.KFun 0) []
+
+decodeKeyboardBody :: String -> Maybe V.Event
+decodeKeyboardBody body = do
+    KittyKey{kittyCodepoint, kittyModifiers, kittyEvent} <- parseKittyKey body
+    let modifiers = withoutKittyLockModifiers kittyModifiers
+        shiftedCode = listAt 0 (splitFields ';' body)
+            >>= listAt 1 . splitFields ':'
+            >>= readDecimal
+        vtyModifiers =
+            [modifier | (bit, modifier) <-
+                [(0, V.MShift), (1, V.MAlt), (2, V.MCtrl), (3, V.MMeta)]
+            , testBit modifiers bit]
+        character = chr kittyCodepoint
+        key = case kittyCodepoint of
+            9 | testBit modifiers 0 -> V.KBackTab
+            9 -> V.KChar '\t'
+            13 -> V.KEnter
+            27 -> V.KEsc
+            127 -> V.KBS
+            45 | testBit modifiers 2
+                && (testBit modifiers 0 || shiftedCode == Just 95) -> V.KChar '_'
+            _ -> V.KChar $
+                if modifiers == 1
+                    then maybe (toUpper character) chr shiftedCode
+                    else character
+        eventModifiers = case key of
+            V.KEsc -> []
+            V.KBackTab -> []
+            V.KChar '_' | modifiers `elem` [4, 5] -> [V.MCtrl]
+            V.KChar _ | modifiers == 1 && kittyCodepoint >= 32 -> []
+            _ -> vtyModifiers
+    pure $
+        if kittyEvent `notElem` [1, 2]
+            || (key /= V.KEsc && modifiers .&. 48 /= 0)
+            || kittyCodepoint < 0 || kittyCodepoint > 0x10ffff
+            || kittyCodepoint >= 0xd800 && kittyCodepoint <= 0xdfff
+            || kittyCodepoint >= 57344 && kittyCodepoint <= 63743
+        then ignoredKey
+        else V.EvKey key eventModifiers
+
+-- | Nothing delegates to the regular Vty parser (mouse, paste, legacy keys).
+-- Prefix retains fragmented CSI-u packets until their final byte arrives.
+classifyKeyboard :: BS.ByteString -> Maybe KClass
+classifyKeyboard bytes
+    | not ("\ESC[" `BS.isPrefixOf` bytes) = Nothing
+    | otherwise =
+        let (parameters, rest) = BS8.span (\c -> c >= '0' && c <= '9' || c == ';' || c == ':')
+                (BS.drop 2 bytes)
+        in case BS8.uncons rest of
+            Nothing | not (BS.null parameters) -> Just Prefix
+            Just ('u', remaining) ->
+                Just (Valid
+                    (maybe ignoredKey id (decodeKeyboardBody (BS8.unpack parameters <> "u")))
+                    remaining)
+            _ -> Nothing
+
+-- | Own the input worker through Vty's shutdown lifecycle, including suspended
+-- and rebuilt Brick sessions. All other terminal behavior remains Vty's.
+mkKeyboardVty :: V.VtyUserConfig -> IO V.Vty
+mkKeyboardVty config = mask \restore -> do
+    settings <- defaultSettings
+    when (V.configAllowCustomUnicodeWidthTables config /= Just False) $
+        V.installCustomWidthTable (V.configDebugLog config)
+            (Just (settingTermName settings)) (V.configTermWidthMaps config)
+    input <- buildKeyboardInput config settings
+    output <- restore (buildOutput config settings)
+        `onException` shutdownInput input
+    restore (V.mkVtyFromPair input output) `onException`
+        (shutdownInput input `finally`
+            (V.releaseDisplay output `finally` V.releaseTerminal output))
+
+buildKeyboardInput :: V.VtyUserConfig -> UnixSettings -> IO Input
+buildKeyboardInput config settings = mask \restore -> do
+    let fd = settingInputFd settings
+        name = settingTermName settings
+    terminal <- Terminfo.setupTerm name
+    let table = classifyMapForTerm name terminal <>
+            [(bytes, event) | (term, bytes, event) <- V.configInputMap config
+                , term == Nothing || term == Just name]
+    (setRaw, restoreTerminal) <- attributeControl fd
+    let configure = do
+            setRaw
+            attrs <- getTerminalAttributes fd
+            setTerminalAttributes fd (withMinInput (withTime attrs 0) 1) Immediately
+    configure `onException` restoreTerminal
+    channel <- newTChanIO
+    -- The handle is retained below and cancelled/joined by shutdownInput.
+    worker <- Async.async (restore (keyboardLoop fd table channel))
+        `onException` restoreTerminal
+    let stop = Async.cancel worker `finally` restoreTerminal
+        resume = Catch (configure >> atomically (writeTChan channel ResumeAfterInterrupt))
+    oldResize <- installHandler windowChange resume Nothing `onException` stop
+    oldContinue <- installHandler continueProcess resume Nothing
+        `onException` (void (installHandler windowChange oldResize Nothing) `finally` stop)
+    Async.link worker
+    pure Input
+        { eventChannel = channel
+        , shutdownInput =
+            stop `finally` do
+                void (installHandler windowChange oldResize Nothing)
+                void (installHandler continueProcess oldContinue Nothing)
+        , restoreInputState = restoreTerminal
+        , inputLogMsg = const (pure ())
+        }
+
+keyboardLoop :: Fd -> V.ClassifyMap -> TChan InternalEvent -> IO ()
+keyboardLoop fd table channel =
+    runKeyboardInput table readBytes
+        (\event -> atomically (writeTChan channel (InputEvent event)))
+  where
+    readBytes = do
+        threadWaitRead fd
+        allocaBytes 4096 \buffer -> do
+            count <- fdReadBuf fd buffer 4096
+            BS.packCStringLen (castPtr buffer, fromIntegral count)
+
+-- | The production byte loop with injectable transport, so packet boundaries,
+-- timeout handling and paste isolation are exercised without a fake decoder.
+-- An empty read denotes EOF and is propagated to the owner of the input worker.
+runKeyboardInput :: V.ClassifyMap -> IO BS.ByteString -> (V.Event -> IO ()) -> IO ()
+runKeyboardInput table readTransport emit = readMore ClassifierStart BS.empty
+  where
+    standard = classify table
+    readBytes = do
+        bytes <- readTransport
+        if BS.null bytes
+            then throwIO (userError "Terminal input closed")
+            else pure bytes
+    readMore state buffered = do
+        bytes <- readBytes
+        process state (buffered <> bytes)
+    process state bytes
+        | BS.null bytes = readMore state BS.empty
+        | otherwise =
+            case classifyInput state bytes of
+                Valid event remaining -> do
+                    unless (event == ignoredKey) (emit event)
+                    process ClassifierStart remaining
+                Prefix | BS.length bytes > 1024 && "\ESC[" `BS.isPrefixOf` bytes ->
+                    discardCsi (BS.drop 2 bytes)
+                Prefix -> do
+                    continuation <- timeout 100000 readBytes
+                    case continuation of
+                        Just more | not (BS.null more) -> process state (bytes <> more)
+                        _ -> do
+                            when (bytes == "\ESC") $
+                                emit (V.EvKey V.KEsc [])
+                            readMore ClassifierStart BS.empty
+                Chunk -> readPaste [] (BS.drop 6 bytes)
+                Invalid -> readMore ClassifierStart BS.empty
+    classifyInput ClassifierStart bytes =
+        if bytes == "\ESC" || bytes == "\ESC["
+            || ("\ESC[<" `BS.isPrefixOf` bytes
+                && not (BS8.any (\c -> c == 'M' || c == 'm') bytes))
+            || ("\ESC[M" `BS.isPrefixOf` bytes && BS.length bytes < 6)
+            then Prefix
+            else maybe (standard ClassifierStart bytes) id (classifyKeyboard bytes)
+    classifyInput state bytes = standard state bytes
+    -- Keep only the possible delimiter suffix between reads. Paste contents
+    -- never enter the keyboard decoder, even if they contain literal CSI-u.
+    readPaste chunks bytes =
+        let (content, ending) = BS.breakSubstring "\ESC[201~" bytes
+        in if not (BS.null ending)
+            then do
+                emit (V.EvPaste (BS.concat (reverse (content : chunks))))
+                process ClassifierStart (BS.drop 6 ending)
+            else do
+                let keep = min 5 (BS.length bytes)
+                    (complete, suffix) = BS.splitAt (BS.length bytes - keep) bytes
+                more <- readBytes
+                readPaste (complete : chunks) (suffix <> more)
+    -- Drop an oversized parameter run without retaining it or leaking the
+    -- remaining payload as text. Resume normally after its final byte.
+    discardCsi bytes =
+        let rest = BS8.dropWhile (\c -> c >= '0' && c <= '9' || c == ';' || c == ':') bytes
+        in case BS8.uncons rest of
+            Just (final, remaining) | final >= '@' && final <= '~' ->
+                process ClassifierStart remaining
+            Just _ -> process ClassifierStart rest
+            Nothing -> do
+                next <- timeout 100000 readBytes
+                maybe (readMore ClassifierStart BS.empty) discardCsi next

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -235,6 +235,19 @@ spec = do
             decodeKittyEditorKey "114;5:3u" `shouldBe` Just EditorIgnore
             decodeKittyEditorKey "117;5u" `shouldBe` Just EditorKillStart
 
+    describe "Option+Backspace" do
+        it "decodes Kitty press and repeat events as previous-word deletion" do
+            mapM_
+                (\body -> decodeKittyEditorKey body `shouldBe` Just EditorKillWord)
+                ["127;3u", "127;3:1u", "127;3:2u"]
+
+        it "ignores Kitty release events" do
+            decodeKittyEditorKey "127;3:3u" `shouldBe` Just EditorIgnore
+
+        it "preserves unmodified Kitty Backspace as single-character deletion" do
+            decodeKittyEditorKey "127u" `shouldBe` Just EditorBackspace
+            decodeKittyEditorKey "127;1u" `shouldBe` Just EditorBackspace
+
     describe "Shift+Enter" do
         it "recognizes xterm modifyOtherKeys and Kitty CSI-u encodings" do
             isShiftEnterCsiBody "27;2;13~" `shouldBe` True

--- a/packages/agent-cli/test/Agent/CLI/InputSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputSpec.hs
@@ -26,10 +26,11 @@ import Agent.CLI.Input.Editor
     , initialEditorState
     , reduceEditorKey
     )
-import Agent.CLI.Input.KeyDecoder (decodeKittyEditorKey)
+import Agent.CLI.Input.KeyDecoder (decodeKittyEditorKey, decodeModifiedArrowKey, parseKittyKey, readDecimal)
 import Agent.CLI.Input.Types
     ( EditorKey(..)
     , EditorState(..)
+    , KittyKey(..)
     , ReplLine(..)
     )
 import Data.Char (isControl)
@@ -235,6 +236,24 @@ spec = do
             decodeKittyEditorKey "114;5:3u" `shouldBe` Just EditorIgnore
             decodeKittyEditorKey "117;5u" `shouldBe` Just EditorKillStart
 
+    describe "Kitty key parsing" do
+        it "rejects signed, whitespace-padded, and overflowing decimal fields" do
+            mapM_ (\value -> readDecimal value `shouldBe` Nothing)
+                ["-1", "+1", " 1", "1 ", "", "18446744073709551617"]
+
+        it "rejects invalid modifiers, event types, codepoints, and extra fields" do
+            mapM_ (\body -> fmap (\key -> (key.kittyCodepoint, key.kittyModifiers, key.kittyEvent)) (parseKittyKey body) `shouldBe` Nothing)
+                [ "127;0u", "127;-1u", "127;257u"
+                , "127;3:0u", "127;3:4u", "127;3:1:1u"
+                , "-1;3u", "1114112;3u", "55296;3u"
+                , "127:bad;3u", "127;3;bad u", "127;3;1;2u"
+                ]
+
+        it "accepts optional alternate keycodes and default modifier fields" do
+            let fields body = fmap (\key -> (key.kittyCodepoint, key.kittyModifiers, key.kittyEvent)) (parseKittyKey body)
+            fields "127::127;3u" `shouldBe` fields "127;3u"
+            fields "127;:1u" `shouldBe` fields "127u"
+
     describe "Option+Backspace" do
         it "decodes Kitty press and repeat events as previous-word deletion" do
             mapM_
@@ -248,11 +267,63 @@ spec = do
             decodeKittyEditorKey "127u" `shouldBe` Just EditorBackspace
             decodeKittyEditorKey "127;1u" `shouldBe` Just EditorBackspace
 
+        it "decodes Ctrl and Command Backspace with either lock bit set" do
+            mapM_
+                (\modifier ->
+                    decodeKittyEditorKey ("127;" <> show modifier <> "u")
+                        `shouldBe` Just EditorKillWord)
+                [5, 9, 67, 69, 73, 131, 133, 137, 195, 197, 201 :: Int]
+            mapM_
+                (\modifier ->
+                    decodeKittyEditorKey ("127;" <> show modifier <> "u")
+                        `shouldBe` Just EditorBackspace)
+                [65, 129, 193 :: Int]
+            decodeKittyEditorKey "127;5:3u" `shouldBe` Just EditorIgnore
+
+    describe "modified arrow keys" do
+        it "decodes Option and Ctrl arrows including repeat and lock modifiers" do
+            mapM_
+                (\modifier -> mapM_
+                    (\event -> do
+                        decodeModifiedArrowKey ("1;" <> show modifier <> event <> "D")
+                            `shouldBe` Just EditorWordLeft
+                        decodeModifiedArrowKey ("1;" <> show modifier <> event <> "C")
+                            `shouldBe` Just EditorWordRight)
+                    ["", ":1", ":2"])
+                [3, 5, 67, 69, 131, 133, 195, 197 :: Int]
+
+        it "ignores releases and leaves ordinary arrows to the legacy decoder" do
+            decodeModifiedArrowKey "1;3:3D" `shouldBe` Just EditorIgnore
+            decodeModifiedArrowKey "1;5:3C" `shouldBe` Just EditorIgnore
+            decodeModifiedArrowKey "D" `shouldBe` Nothing
+            decodeModifiedArrowKey "1;1C" `shouldBe` Nothing
+            decodeModifiedArrowKey "1;3A" `shouldBe` Nothing
+
+        it "also decodes Kitty Option+b/f word navigation" do
+            decodeKittyEditorKey "98;3u" `shouldBe` Just EditorWordLeft
+            decodeKittyEditorKey "102;67u" `shouldBe` Just EditorWordRight
+
+        it "moves over words and whitespace without changing the text" do
+            let initial = initialEditorState defaultSlashCatalog False "alpha  beta"
+                left = (reduceEditorKey [] initial EditorWordLeft).editorStepState
+                start = (reduceEditorKey [] left EditorWordLeft).editorStepState
+                right = (reduceEditorKey [] start EditorWordRight).editorStepState
+                end = (reduceEditorKey [] right EditorWordRight).editorStepState
+            left.editorCursor `shouldBe` 7
+            start.editorCursor `shouldBe` 0
+            right.editorCursor `shouldBe` 5
+            end.editorCursor `shouldBe` 11
+            end.editorText `shouldBe` initial.editorText
+            (reduceEditorKey [] start EditorWordLeft).editorStepState.editorCursor `shouldBe` 0
+            (reduceEditorKey [] end EditorWordRight).editorStepState.editorCursor `shouldBe` 11
+
     describe "Shift+Enter" do
         it "recognizes xterm modifyOtherKeys and Kitty CSI-u encodings" do
             isShiftEnterCsiBody "27;2;13~" `shouldBe` True
             isShiftEnterCsiBody "13;2u" `shouldBe` True
             isShiftEnterCsiBody "13u" `shouldBe` False
+            isShiftEnterCsiBody "13;66:2u" `shouldBe` True
+            isShiftEnterCsiBody "13;194:3u" `shouldBe` False
 
     describe "Shift+Tab" do
         it "recognizes xterm modifyOtherKeys and Kitty CSI-u encodings" do
@@ -261,6 +332,8 @@ spec = do
             isShiftTabCsiBody "9;2:1u" `shouldBe` True
             isShiftTabCsiBody "9u" `shouldBe` False
             isShiftTabCsiBody "13;2u" `shouldBe` False
+            isShiftTabCsiBody "9;130:2u" `shouldBe` True
+            isShiftTabCsiBody "9;194:3u" `shouldBe` False
 
         it "decodes Kitty press events as mode cycle and ignores releases" do
             decodeKittyEditorKey "9;2u" `shouldBe` Just EditorCycleMode
@@ -471,6 +544,8 @@ genPureEditorKey =
         , EditorChar '\x0301'
         , EditorChar '🙂'
         , EditorBackspace
+        , EditorWordLeft
+        , EditorWordRight
         , EditorDelete
         , EditorLeft
         , EditorRight

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1,5 +1,9 @@
 module Agent.CLI.TUIAppSpec (spec) where
 
+import Agent.CLI.TUI.Keyboard (decodeKeyboardBody, classifyKeyboard, runKeyboardInput)
+import Control.Monad (forM_, when)
+import Graphics.Vty.Platform.Unix.Input.Classify.Types (KClass(..))
+
 import Agent.CLI.TUIAppSpec.AgentFixtures
 import qualified Agent.CLI.TUIAppSpec.Motion as Motion
 import Agent.CLI.AgentViewport
@@ -154,7 +158,7 @@ import Agent.TUI.Presentation
     , TodoDisplayStatus(..)
     )
 import Agent.TUI.Motion
-import Control.Concurrent (newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Concurrent.Async (waitCatch)
 import Control.Exception.Safe (bracket_)
 import Control.Exception (AsyncException(UserInterrupt))
@@ -170,7 +174,8 @@ import Control.Monad (replicateM_, void)
 import qualified Data.ByteString as ByteString
 import Data.Foldable (find, toList)
 import Data.IORef
-    ( modifyIORef'
+    ( atomicModifyIORef'
+    , modifyIORef'
     , newIORef
     , readIORef
     , writeIORef
@@ -1262,6 +1267,97 @@ spec = do
             after.uiCursor `shouldBe` 7
             after.uiPrompt.promptModel `shouldBe` "gpt-5.6-sol"
             after.uiPrompt.promptAccount `shouldBe` "OpenAI account"
+
+    describe "enhanced fullscreen keyboard decoding" do
+        it "preserves every existing CSI-u input-map binding" do
+            let normalizeAlt event = case event of
+                    V.EvKey key modifiers ->
+                        V.EvKey key [if modifier == V.MAlt then V.MMeta else modifier | modifier <- modifiers]
+                    _ -> event
+            forM_ (V.configInputMap fullscreenVtyConfig) \(_, bytes, expected) ->
+                when (take 2 bytes == "\ESC[" && last bytes == 'u') $
+                    fmap normalizeAlt (decodeKeyboardBody (drop 2 bytes))
+                        `shouldBe` Just (normalizeAlt expected)
+        it "inserts shifted letters and punctuation as text" do
+            decodeKeyboardBody "97:65;2u"
+                `shouldBe` Just (V.EvKey (V.KChar 'A') [])
+            decodeKeyboardBody "49:33;2u"
+                `shouldBe` Just (V.EvKey (V.KChar '!') [])
+            decodeKeyboardBody "13;2u"
+                `shouldBe` Just (V.EvKey V.KEnter [V.MShift])
+
+        it "preserves cancel behavior for modified Escape" do
+            decodeKeyboardBody "27;3u"
+                `shouldBe` Just (V.EvKey V.KEsc [])
+
+        it "decodes Command+Shift without discarding either modifier" do
+            decodeKeyboardBody "118;10u"
+                `shouldBe` Just (V.EvKey (V.KChar 'v') [V.MShift, V.MMeta])
+
+        it "preserves alternate-key Ctrl+underscore encodings" do
+            decodeKeyboardBody "45:95;5u"
+                `shouldBe` Just (V.EvKey (V.KChar '_') [V.MCtrl])
+
+        it "ignores lock-state bits for shortcuts and Backspace" do
+            forM_ [0, 64, 128, 192 :: Int] \locks -> do
+                decodeKeyboardBody ("118;" <> show (9 + locks) <> "u")
+                    `shouldBe` Just (V.EvKey (V.KChar 'v') [V.MMeta])
+                decodeKeyboardBody ("127;" <> show (3 + locks) <> "u")
+                    `shouldBe` Just (V.EvKey V.KBS [V.MAlt])
+
+        it "decodes Unicode beyond Latin-1 and preserves trailing input" do
+            classifyKeyboard "\ESC[955;9ux"
+                `shouldBe` Just (Valid (V.EvKey (V.KChar 'λ') [V.MMeta]) "x")
+            decodeKeyboardBody "128512;9u"
+                `shouldBe` Just (V.EvKey (V.KChar '😀') [V.MMeta])
+
+        it "retains fragmented CSI-u packets without interpreting ordinary text" do
+            classifyKeyboard "\ESC[955;9" `shouldBe` Just Prefix
+            classifyKeyboard "[955;9u" `shouldBe` Nothing
+            classifyKeyboard "\ESC[A" `shouldBe` Nothing
+            classifyKeyboard "\ESC[200~text\ESC[201~" `shouldBe` Nothing
+            classifyKeyboard "\ESC[<0;1;1M" `shouldBe` Nothing
+
+        it "decodes repeat events and consumes release and invalid Unicode events" do
+            decodeKeyboardBody "127:127:127;3:2u"
+                `shouldBe` Just (V.EvKey V.KBS [V.MAlt])
+            decodeKeyboardBody "127;3:3u"
+                `shouldBe` Just (V.EvKey (V.KFun 0) [])
+            forM_ ["\ESC[1114112;9u", "\ESC[55296;9u"] \bytes ->
+                classifyKeyboard bytes
+                    `shouldBe` Just (Valid (V.EvKey (V.KFun 0) []) "")
+
+        it "decodes every transport split of enhanced keys, arrows, mouse and focus" do
+            forM_
+                [ ("\ESC[955;9u", V.EvKey (V.KChar 'λ') [V.MMeta])
+                , ("\ESC[127;67u", V.EvKey V.KBS [V.MAlt])
+                , ("\ESC[A", V.EvKey V.KUp [])
+                , ("\ESC[<0;1;1M", V.EvMouseDown 0 0 V.BLeft [])
+                , ("\ESC[I", V.EvGainedFocus)
+                ] \(bytes, expected) ->
+                    forM_ [1 .. ByteString.length bytes - 1] \offset -> do
+                        let (prefix, suffix) = ByteString.splitAt offset bytes
+                        keyboardEventsForReads [pure prefix, pure (suffix <> "x")]
+                            `shouldReturn` [expected, V.EvKey (V.KChar 'x') []]
+
+        it "keeps paste contents literal across every transport split" do
+            let content = "literal \ESC[955;9u"
+                bytes = "\ESC[200~" <> content <> "\ESC[201~"
+            forM_ [1 .. ByteString.length bytes - 1] \offset -> do
+                let (prefix, suffix) = ByteString.splitAt offset bytes
+                keyboardEventsForReads [pure prefix, pure (suffix <> "x")]
+                    `shouldReturn` [V.EvPaste content, V.EvKey (V.KChar 'x') []]
+
+        it "times out Escape and incomplete CSI without swallowing the next key" do
+            keyboardEventsForReads [pure "\ESC", threadDelay 200000 >> pure "unused", pure "x"]
+                `shouldReturn` [V.EvKey V.KEsc [], V.EvKey (V.KChar 'x') []]
+            keyboardEventsForReads [pure "\ESC[955;", threadDelay 200000 >> pure "unused", pure "x"]
+                `shouldReturn` [V.EvKey (V.KChar 'x') []]
+
+        it "discards oversized fragmented CSI parameters but preserves subsequent text" do
+            keyboardEventsForReads
+                [pure ("\ESC[" <> ByteString.replicate 1100 49), pure "111;9ux"]
+                `shouldReturn` [V.EvKey (V.KChar 'x') []]
 
     describe "fullscreenVtyConfig" do
         it "maps modified Backspace CSI-u sequences to word deletion keys" do
@@ -3058,6 +3154,23 @@ choiceOverlay closeOnTurnEnd = ChoiceOverlay
     , choiceAdjustmentIndices = []
     , choiceCloseOnTurnEnd = closeOnTurnEnd
     }
+
+keyboardEventsForReads :: [IO ByteString.ByteString] -> IO [V.Event]
+keyboardEventsForReads reads = do
+    pending <- newIORef reads
+    events <- newIORef []
+    let readNext = do
+            action <- atomicModifyIORef' pending \remaining ->
+                case remaining of
+                    [] -> ([], pure ByteString.empty)
+                    next : rest -> (rest, next)
+            action
+        table =
+            [("\ESC", V.EvKey V.KEsc []), ("\ESC[A", V.EvKey V.KUp [])]
+                <> [([character], V.EvKey (V.KChar character) []) | character <- [' '..'~']]
+    runKeyboardInput table readNext (\event -> modifyIORef' events (event :))
+        `shouldThrow` anyIOException
+    reverse <$> readIORef events
 
 textOverlay :: Text -> Int -> TextOverlay
 textOverlay draft cursor = TextOverlay

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1264,6 +1264,19 @@ spec = do
             after.uiPrompt.promptAccount `shouldBe` "OpenAI account"
 
     describe "fullscreenVtyConfig" do
+        it "maps modified Backspace CSI-u sequences to word deletion keys" do
+            let mappings = V.configInputMap fullscreenVtyConfig
+            mapM_
+                (\(encodedModifier, modifier) ->
+                    mapM_
+                        (\body -> mappings `shouldContain`
+                            [(Nothing, "\ESC[" <> body, V.EvKey V.KBS [modifier])])
+                        [ code <> ";" <> encodedModifier <> event <> "u"
+                        | code <- ["127", "127:127:127"]
+                        , event <- ["", ":1"]
+                        ])
+                [("3", V.MAlt), ("5", V.MCtrl), ("9", V.MMeta)]
+
         it "maps the Kitty-encoded Esc key so its payload cannot leak" do
             let mappings = V.configInputMap fullscreenVtyConfig
             mapM_


### PR DESCRIPTION
## Summary
- Fix Option/Ctrl/Command-Backspace escape text leaking into the composer.
- Decode CSI-u before Vty's legacy classifier, removing finite Unicode/modifier mapping gaps and ignoring Caps/Num Lock state for shortcuts.
- Support Option/Ctrl word arrows and Option+b/f in the raw editor.
- Preserve shifted punctuation, Escape, repeat/release behavior, fragmented key sequences, and literal bracketed paste.
- Add parser, reducer, transport-boundary, and legacy-mapping compatibility regressions.

## Validation
- Revalidated against Nix's vty 6.4 and vty-unix 0.2.0.0: 14 enhanced-keyboard examples and all 48 InputSpec examples passed, including 1,000 generated editor transitions.
- GHCi object-code tests: enhanced fullscreen decoding (13 examples), Kitty (21), Backspace (6), and modified arrows/reducer (4), zero failures. Filters overlap.
- Live fullscreen tmux check using current library sources: lock-state Option-Backspace, Command combinations without payload leakage, shifted punctuation, and split Option-Backspace sequences.
- Live raw-editor tmux check: Option-Left/Right navigation and Ctrl-Backspace returned the expected `alpha ` draft. Fullscreen modified Escape and ordinary arrows also passed.
- Literal bracketed paste is covered by transport tests; visual text-paste verification was obstructed by the existing clipboard-image fallback.
- `git diff --check` passed.

## Scope
Ordinary UTF-8 input still delegates to upstream Vty; a possible pre-existing split-UTF-8 issue was identified during review but is not fixed or claimed as validated here.

## CI
Corrected the vty-unix lower bound to accept Nix's compatible 0.2.0.0 version. Merged current master to incorporate the upstream package-boundary fix; the boundary script now passes. Exact-head CI run: https://github.com/digitallyinduced/haskell-agent/actions/runs/34206324259.
