### PR TITLE
Retry upstream connection failures after partial output

### DIFF
--- a/packages/agent-openai/CHANGELOG.md
+++ b/packages/agent-openai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Classify `upstream_connection_error` as temporary provider unavailability,
+  allowing automatic retries after partial output without weakening the
+  replay guard for admitted asynchronous tool calls.
 - Retry Codex overload and service-unavailable failures after partial model
   output instead of ending the turn as `replay_unsafe`. Visible text is kept
   behind a restart boundary; hidden activity is discarded.

--- a/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ErrorSpec.hs
@@ -9,6 +9,18 @@ import Test.Hspec
 spec :: Spec
 spec = do
     describe "ApiError JSON parsing" do
+        it "classifies an upstream connection interruption as service unavailability" do
+            decodeOpenAIError "{\"error\":{\"type\":\"server_error\",\"code\":\"upstream_connection_error\",\"message\":\"ParseException \\\"not enough bytes\\\"\",\"retry_after\":2}}"
+                `shouldBe` Right
+                    (ProviderError ServiceUnavailableError
+                        "ParseException \"not enough bytes\" (code: upstream_connection_error)"
+                        (Just 2))
+
+        it "does not make an unclassified parse failure replay-safe" do
+            mkOpenAIError ApiErrorType "ParseException \"not enough bytes\"" Nothing Nothing
+                `shouldBe` ProviderError ApiErrorType
+                    "ParseException \"not enough bytes\"" Nothing
+
         it "normalizes previous_response_not_found codes to a typed error" do
             decodeOpenAIError "{\"error\":{\"type\":\"invalid_request_error\",\"code\":\"previous_response_not_found\",\"message\":\"Previous response with id 'resp_123' not found.\"}}"
                 `shouldBe` Right

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec/StateSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec/StateSpec.hs
@@ -5,10 +5,12 @@ import Agent.Error
     , ErrorType(..)
     )
 import Agent.Loop
+import Agent.OpenAI.Error (mkOpenAIError)
 import Agent.OpenAI.LoopBackend
 import Agent.Responses.Request (stripReplayedItemStatus)
 import Agent.Responses.Types
 import Agent.ToolDispatch
+import Control.Monad (forM_)
 import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.IORef
@@ -519,6 +521,47 @@ spec = do
                 , TextDelta "complete"
                 ]
 
+        it "discards hidden output before retrying upstream_connection_error" do
+            attempts <- newIORef (0 :: Int)
+            transcript <- newIORef []
+            events <- newIORef []
+            let upstreamFailure = mkOpenAIError ApiErrorType
+                    "ParseException \"not enough bytes\""
+                    (Just "upstream_connection_error")
+                    Nothing
+                send _request _previous onEvent = do
+                    modifyIORef' attempts (+ 1)
+                    attempt <- readIORef attempts
+                    if attempt == 1
+                        then do
+                            onEvent ResponseOutputItemAddedEvent
+                                { item = assistantItem "partial"
+                                , outputIndex = Just 0
+                                , sequenceNumber = Nothing
+                                }
+                            pure (Left upstreamFailure)
+                        else do
+                            onEvent (deltaEvent EventOutputTextDelta "complete")
+                            pure (Right
+                                (testResponse "resp-replayed"
+                                    [assistantItem "complete"]))
+                backend = openAiBackendWithRetryPolicy
+                    (constantDelay 0 <> limitRetries 3)
+                    send
+                    (pure baseParams)
+            result <- submitWithState transcript backend Nothing [UserMessage "one"]
+                (modifyIORef' events . (:))
+            result `shouldBe`
+                Right (emptyTurnOutput "resp-replayed" [] (Just "complete"))
+            readIORef attempts `shouldReturn` 2
+            reverse <$> readIORef events `shouldReturn`
+                [ ActivityUpdated
+                    "Codex is unavailable; retrying in 0s (attempt 1)…"
+                , ResponseAttemptDiscarded
+                , ActivityUpdated "Retrying Codex request (attempt 1)…"
+                , TextDelta "complete"
+                ]
+
         it "discards hidden model output before retrying an overload" do
             attempts <- newIORef (0 :: Int)
             transcript <- newIORef []
@@ -594,12 +637,13 @@ spec = do
                 , ActivityUpdated "Retrying Codex request (attempt 2)…"
                 ]
 
-        it "resubmits after unavailability behind a restart boundary" do
+        it "resubmits after upstream_connection_error behind a restart boundary" do
             attempts <- newIORef (0 :: Int)
             transcript <- newIORef []
             events <- newIORef []
-            let unavailable = ProviderError ServiceUnavailableError
-                    "service unavailable"
+            let upstreamFailure = mkOpenAIError ApiErrorType
+                    "ParseException \"not enough bytes\""
+                    (Just "upstream_connection_error")
                     Nothing
                 send _request _previous onEvent = do
                     modifyIORef' attempts (+ 1)
@@ -607,7 +651,7 @@ spec = do
                     if attempt == 1
                         then do
                             onEvent (deltaEvent EventOutputTextDelta "partial")
-                            pure (Left unavailable)
+                            pure (Left upstreamFailure)
                         else do
                             onEvent (deltaEvent EventOutputTextDelta "complete")
                             pure (Right
@@ -698,53 +742,61 @@ spec = do
                 , TextDelta "complete"
                 ]
 
-        it "does not replay an overload after admitting a completed async tool call" do
-            attempts <- newIORef (0 :: Int)
-            admitted <- newIORef []
-            let overload = ProviderError OverloadedError "busy" Nothing
-                asyncCall =
-                    FunctionCallItem FunctionCall
-                        { itemId = Nothing
-                        , callId = "fc-async"
-                        , name = "shell"
-                        , namespace = Nothing
-                        , provider = Nothing
-                        , arguments = "{}"
-                        , encryptedFunctionArgs = Nothing
-                        , status = Just ItemCompleted
-                        , async = Just True
-                        }
-                send _request _previous onEvent = do
-                    modifyIORef' attempts (+ 1)
-                    onEvent ResponseOutputItemDoneEvent
-                        { item = asyncCall
-                        , outputIndex = Just 0
-                        , sequenceNumber = Nothing
-                        }
-                    pure (Left overload)
-                backend = openAiBackendWithRetryPolicy
-                    (constantDelay 0 <> limitRetries 3)
-                    send
-                    (pure baseParams)
-            result <- backend.submitTurnWithCallbacks
-                emptyBackendSnapshot
-                Nothing
-                [UserMessage "one"]
-                BackendCallbacks
-                    { onLoopEvent = const (pure ())
-                    , onRecoveryCheckpoint = const (pure ())
-                    , onAsyncToolCall =
-                        \call -> modifyIORef' admitted (call.callId :)
-                    }
-            result `shouldBe` Left (ProviderError
-                (UnknownErrorType "replay_unsafe")
-                ( "provider failed after asynchronous tool call; "
-                    <> "refusing to replay: "
-                    <> Text.pack (show overload)
-                )
-                Nothing)
-            readIORef attempts `shouldReturn` 1
-            readIORef admitted `shouldReturn` ["fc-async"]
+        it "does not replay transient failures after admitting an async tool call" do
+            let upstreamFailure = mkOpenAIError ApiErrorType
+                    "ParseException \"not enough bytes\""
+                    (Just "upstream_connection_error")
+                    Nothing
+            forM_
+                [ ProviderError OverloadedError "busy" Nothing
+                , upstreamFailure
+                ]
+                \transientFailure -> do
+                    attempts <- newIORef (0 :: Int)
+                    admitted <- newIORef []
+                    let asyncCall =
+                            FunctionCallItem FunctionCall
+                                { itemId = Nothing
+                                , callId = "fc-async"
+                                , name = "shell"
+                                , namespace = Nothing
+                                , provider = Nothing
+                                , arguments = "{}"
+                                , encryptedFunctionArgs = Nothing
+                                , status = Just ItemCompleted
+                                , async = Just True
+                                }
+                        send _request _previous onEvent = do
+                            modifyIORef' attempts (+ 1)
+                            onEvent ResponseOutputItemDoneEvent
+                                { item = asyncCall
+                                , outputIndex = Just 0
+                                , sequenceNumber = Nothing
+                                }
+                            pure (Left transientFailure)
+                        backend = openAiBackendWithRetryPolicy
+                            (constantDelay 0 <> limitRetries 3)
+                            send
+                            (pure baseParams)
+                    result <- backend.submitTurnWithCallbacks
+                        emptyBackendSnapshot
+                        Nothing
+                        [UserMessage "one"]
+                        BackendCallbacks
+                            { onLoopEvent = const (pure ())
+                            , onRecoveryCheckpoint = const (pure ())
+                            , onAsyncToolCall =
+                                \call -> modifyIORef' admitted (call.callId :)
+                            }
+                    result `shouldBe` Left (ProviderError
+                        (UnknownErrorType "replay_unsafe")
+                        ( "provider failed after asynchronous tool call; "
+                            <> "refusing to replay: "
+                            <> Text.pack (show transientFailure)
+                        )
+                        Nothing)
+                    readIORef attempts `shouldReturn` 1
+                    readIORef admitted `shouldReturn` ["fc-async"]
 
         it "does not replay after admitting a completed async tool call" do
             attempts <- newIORef (0 :: Int)

--- a/packages/agent-responses/src/Agent/Responses/Error.hs
+++ b/packages/agent-responses/src/Agent/Responses/Error.hs
@@ -70,6 +70,11 @@ classifyErrorType errorType message code
     | normalizedCode == Just "usage_not_included" = UsageNotIncluded
     | normalizedCode `elem` map Just ["server_is_overloaded", "slow_down"] = OverloadedError
     | normalizedCode == Just "service_unavailable_error" = ServiceUnavailableError
+    -- The provider's upstream connection failed, not our client transport.
+    -- Preserve the provider envelope and retry delay, but allow the existing
+    -- interrupted-response retry path instead of treating this as a generic
+    -- API failure after output.
+    | normalizedCode == Just "upstream_connection_error" = ServiceUnavailableError
     | normalizedCode == Just "websocket_connection_limit_reached" =
         WebSocketConnectionLimitReached
     | normalizedCode == Just "cyber_policy" = CyberPolicyError


### PR DESCRIPTION
## Summary

- Normalize the structured `upstream_connection_error` code to `ServiceUnavailableError`, preserving the provider message and retry delay.
- Reuse the existing partial-response retry path rather than terminating with `replay_unsafe` after hidden model output.
- Preserve the replay guard after admitted asynchronous tool calls; generic parse/API failures remain unchanged.

## Validation

54 focused Hspec examples passed in GHCi under `nix develop`, covering error decoding, visible-output restart, hidden-output discard, and the async-tool replay guard for both overload and upstream connection failures.

```sh
nix develop -c cabal repl agent-openai:test:agent-openai-test agent-responses:lib:agent-responses --offline
```

```haskell
import qualified Agent.OpenAI.ErrorSpec
import qualified Agent.OpenAI.LoopBackendSpec.StateSpec
import Test.Hspec
hspec (Agent.OpenAI.ErrorSpec.spec >> Agent.OpenAI.LoopBackendSpec.StateSpec.spec)
```

`git diff --check` passed. No CLI rendering or interaction changes.
