### PR TITLE
Add document processing utilities to sandbox image

### DIFF
--- a/nix/sandbox-rootfs.nix
+++ b/nix/sandbox-rootfs.nix
@@ -29,10 +29,17 @@ let
       sandboxNix
       openssh
       patch
+      # Document processing must work inside the guest without downloading
+      # packages or depending on utilities installed on the host.
+      python3
+      poppler-utils
+      qpdf
       procps
       ripgrep
+      unzip
       util-linux
       which
+      zip
     ];
     pathsToLink = [
       "/bin"

--- a/scripts/verify-sandbox-document-utilities.sh
+++ b/scripts/verify-sandbox-document-utilities.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run inside the sandbox, not on its host. Uses only disposable test documents.
+set -euo pipefail
+
+for utility in python3 zip unzip pdfinfo pdftotext pdftoppm qpdf jq; do
+    command -v "$utility" >/dev/null
+done
+
+directory=$(mktemp -d "${TMPDIR:?}/document-utilities.XXXXXXXX")
+trap 'rm -rf -- "$directory"' EXIT
+
+python3 - "$directory" <<'PY'
+import pathlib
+import subprocess
+import sys
+import zipfile
+
+root = pathlib.Path(sys.argv[1])
+original = b"Document processing verification\n"
+(root / "original.txt").write_bytes(original)
+subprocess.run(["zip", "-q", "source.zip", "original.txt"], cwd=root, check=True)
+with zipfile.ZipFile(root / "source.zip") as source:
+    assert source.testzip() is None
+    with zipfile.ZipFile(root / "classified.zip", "w", zipfile.ZIP_DEFLATED) as target:
+        target.writestr("Documents/original.txt", source.read("original.txt"))
+subprocess.run(["unzip", "-t", "classified.zip"], cwd=root, check=True)
+with zipfile.ZipFile(root / "classified.zip") as result:
+    assert result.namelist() == ["Documents/original.txt"]
+    assert result.read("Documents/original.txt") == original
+subprocess.run(["qpdf", "--empty", str(root / "empty.pdf")], check=True)
+subprocess.run(["qpdf", "--check", str(root / "empty.pdf")], check=True)
+PY
+
+printf '%s\n' 'Sandbox document utilities verified.'


### PR DESCRIPTION
## Summary
- Include Python 3, zip/unzip, Poppler utilities and qpdf in the guest image.
- Preserve existing network and tenant isolation settings.
- Add an in-sandbox verification script that checks command availability, ZIP restructuring with byte-preserved contents, and PDF validation.

## Motivation
A production Telegram agent created an export but could not inspect or restructure it because unzip, python and python3 were unavailable in its sandbox.

## Validation
- git diff --check
- Nix syntax parse
- bash -n scripts/verify-sandbox-document-utilities.sh
- Full image build and in-sandbox execution have not yet been run.

## Rollout
This PR alone does not update Belege production. Update its pinned runtime and effective runner configuration separately, then run the verification script inside the deployed sandbox before retrying the customer export.

Additional Python libraries, OCR and 7z support are not included.