### PR TITLE
Fix gateway sign-in link activation over SSH

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/AgentSessions/Process.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/AgentSessions/Process.hs
@@ -10,6 +10,7 @@ module Agent.CLI.AgentSessions.Process
     , newSessionProcessManagerWithLifetime
     , sessionProcessStatus
     , signalManagedSessionReady
+    , waitForManagedSessionReadyWith
     ) where
 
 import Agent.CLI.Error (formatException)
@@ -499,24 +500,44 @@ signalManagedSessionReady result =
             Left err -> "error\n" <> err
 
 waitForManagedSessionReady :: ProcessHandle -> FilePath -> IO (Either Text ())
-waitForManagedSessionReady process path = go
+waitForManagedSessionReady process path =
+    waitForManagedSessionReadyWith
+        (either (const Nothing) Just <$> try @_ @SomeException (TextIO.readFile path))
+        (getProcessExitCode process)
+
+-- | Poll readiness with explicit observations so publication/exit interleavings
+-- can be tested without relying on process scheduling.
+waitForManagedSessionReadyWith
+    :: IO (Maybe Text)
+    -> IO (Maybe ExitCode)
+    -> IO (Either Text ())
+waitForManagedSessionReadyWith readContents readExitCode = go
   where
     go = do
-        contents <- try @_ @SomeException (TextIO.readFile path)
-        case contents of
-            Right "ready\n" -> pure (Right ())
-            Right text
-                | Just err <- Text.stripPrefix "error\n" text ->
-                    pure (Left err)
-            _ ->
-                getProcessExitCode process >>= \case
+        result <- readinessResult <$> readContents
+        case result of
+            Just ready -> pure ready
+            Nothing ->
+                readExitCode >>= \case
                     Nothing -> threadDelay 10000 >> go
-                    Just ExitSuccess ->
-                        pure (Left "agent session exited before acquiring its lock")
-                    Just (ExitFailure code) ->
-                        pure $ Left
-                            ("agent session exited before acquiring its lock (exit code "
-                                <> Text.pack (show code) <> ")")
+                    Just exitCode -> do
+                        -- The child may publish and exit after the first read.
+                        -- Once exit is observed, its final marker is stable.
+                        finalResult <- readinessResult <$> readContents
+                        pure $ case finalResult of
+                            Just ready -> ready
+                            Nothing -> Left (earlyExitMessage exitCode)
+
+    readinessResult (Just "ready\n") = Just (Right ())
+    readinessResult (Just text)
+        | Just err <- Text.stripPrefix "error\n" text = Just (Left err)
+    readinessResult _ = Nothing
+
+    earlyExitMessage ExitSuccess =
+        "agent session exited before acquiring its lock"
+    earlyExitMessage (ExitFailure code) =
+        "agent session exited before acquiring its lock (exit code "
+            <> Text.pack (show code) <> ")"
 
 removePrivateFile :: FilePath -> IO ()
 removePrivateFile path = do

--- a/packages/agent-cli-runtime/test/Agent/CLI/ManagedTurnSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ManagedTurnSpec.hs
@@ -1,5 +1,6 @@
 module Agent.CLI.ManagedTurnSpec (spec) where
 
+import Agent.CLI.AgentSessions.Process (waitForManagedSessionReadyWith)
 import Agent.CLI.ManagedTurn
     ( ManagedTurnMedia(..)
     , ManagedTurnRequest(..)
@@ -27,10 +28,44 @@ import System.Directory
 import System.FilePath ((</>))
 import Control.Exception.Safe (finally)
 import Data.Unique (newUnique, hashUnique)
+import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
+import System.Exit (ExitCode(..))
 import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.CLI.ManagedTurn" do
+    describe "managed session readiness" do
+        let observeExit finalContents exitCode = do
+                contents <- newIORef Nothing
+                reads <- newIORef (0 :: Int)
+                result <- waitForManagedSessionReadyWith
+                    (modifyIORef' reads (+ 1) >> readIORef contents)
+                    (writeIORef contents finalContents >> pure (Just exitCode))
+                readIORef reads `shouldReturn` 2
+                pure result
+
+        it "accepts readiness published between the initial read and process exit" do
+            observeExit (Just "ready\n") ExitSuccess `shouldReturn` Right ()
+
+        it "preserves an error published between the initial read and process exit" do
+            observeExit (Just "error\ncould not acquire lock") (ExitFailure 1)
+                `shouldReturn` Left "could not acquire lock"
+
+        it "does not mistake a successful exit without readiness for readiness" do
+            observeExit Nothing ExitSuccess
+                `shouldReturn` Left "agent session exited before acquiring its lock"
+
+        it "reports the exit code when the final marker is incomplete" do
+            observeExit (Just "rea") (ExitFailure 7)
+                `shouldReturn`
+                    Left "agent session exited before acquiring its lock (exit code 7)"
+
+        it "returns published readiness without requiring the child to exit" do
+            waitForManagedSessionReadyWith
+                (pure (Just "ready\n"))
+                (expectationFailure "unexpected exit observation" >> pure Nothing)
+                `shouldReturn` Right ()
+
     it "loads --prompt-file as plain text" $
         withManagedTempDir \dir -> do
             let pathFile = dir </> "prompt.txt"

--- a/packages/agent-cli/src/Agent/CLI/Login.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login.hs
@@ -16,6 +16,7 @@ module Agent.CLI.Login
     , applyLoginKey
     , connectProviderAccount
     , advanceDevicePollSchedule
+    , deviceAuthorizationBody
     , devicePollReadiness
     , discoverLoginAccounts
     , discoverSelectableLoginAccounts
@@ -53,6 +54,7 @@ import Agent.CLI.Login.Internal.Device
     ( DevicePollReadiness(..)
     , DevicePollSchedule
     , advanceDevicePollSchedule
+    , deviceAuthorizationBody
     , devicePollReadiness
     , initialDevicePollSchedule
     )

--- a/packages/agent-cli/src/Agent/CLI/Login/Internal/Device.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login/Internal/Device.hs
@@ -108,6 +108,9 @@ deviceAuthorizationBody
 deviceAuthorizationBody provider url userCode notice =
     Text.intercalate "\n\n" $
         [ "1. [Open the " <> provider <> " sign-in page](" <> url <> ")."
+        , "Or copy this URL into your browser: "
+            <> Text.replace ":" "\\:"
+                (Text.replace "&" "\\&" (markdownText (Text.length url) url))
         , "2. Enter this one-time code:"
         , "`" <> markdownText 100 userCode <> "`"
         , "3. Return here and choose **Check authorization**."

--- a/packages/agent-cli/src/Agent/CLI/Login/Internal/Gateway.hs
+++ b/packages/agent-cli/src/Agent/CLI/Login/Internal/Gateway.hs
@@ -5,7 +5,7 @@ module Agent.CLI.Login.Internal.Gateway
     , selectGatewayLoginFlow
     ) where
 
-import Agent.CLI.Environment (lookupNonEmpty)
+import Agent.CLI.Terminal (isSshSession, remoteLinkInstructions)
 import Agent.CLI.Error (formatException)
 import Agent.CLI.GatewayClient
     ( GatewayAuthorization(..)
@@ -52,7 +52,6 @@ import Control.Concurrent.MVar
     )
 import Control.Exception.Safe (onException, tryAny)
 import Control.Monad (unless)
-import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -77,13 +76,11 @@ selectGatewayLoginFlow operatingSystem remoteSession
 
 currentGatewayLoginFlow :: IO GatewayLoginFlow
 currentGatewayLoginFlow = do
-    sshConnection <- lookupNonEmpty "SSH_CONNECTION"
-    sshClient <- lookupNonEmpty "SSH_CLIENT"
-    sshTty <- lookupNonEmpty "SSH_TTY"
+    remoteSession <- isSshSession
     pure $
         selectGatewayLoginFlow
             SystemInfo.os
-            (any isJust [sshConnection, sshClient, sshTty])
+            remoteSession
 
 connectFullscreenGateway :: FullscreenRuntime -> IO (Maybe LoginNotice)
 connectFullscreenGateway runtime = do
@@ -215,6 +212,7 @@ connectFullscreenGatewayDevice
     :: FullscreenRuntime
     -> IO (Maybe LoginNotice)
 connectFullscreenGatewayDevice runtime = do
+    remoteSession <- isSshSession
     requestedAt <- getCurrentTime
     requested <-
         withLoginProgress runtime
@@ -229,8 +227,10 @@ connectFullscreenGatewayDevice runtime = do
             let device =
                     authorization.authorizationDevice
                 notice =
-                    Just
-                        "Open the verification link in a browser on your local computer."
+                    Just $
+                        if remoteSession
+                            then remoteLinkInstructions
+                            else "Open the verification link in a browser on your local computer."
             awaitAuthorization
                 authorization
                 (initialDevicePollSchedule

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -1172,6 +1172,8 @@ handleChoiceMouseDown
     -> EventM Name AppState ()
 handleChoiceMouseDown name button =
     case (name, button) of
+        (link@MarkdownLink{}, V.BLeft) ->
+            Composer.handleControlMouseDown link
         (ChoiceRow index, V.BLeft) ->
             Composer.handleControlMouseDown (ChoiceRow index)
         (ChoiceRow _, V.BScrollUp) ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -61,6 +61,8 @@ import Agent.CLI.WindowTitle (oscWindowTitleBytes)
 import Agent.CLI.Status (formatTokenUsage)
 import Agent.CLI.Timestamp (currentShortMessageTimestamp)
 import Agent.CLI.Terminal ( TerminalCapabilities(..)
+    , isSshSession
+    , remoteLinkInstructions
     , detectTerminalCapabilities
     , kittyAltCsiBodies
     , kittyCtrlCsiBodies
@@ -719,24 +721,48 @@ isQuickStartControl = \case
 
 openMarkdownLink :: Text -> EventM Name AppState ()
 openMarkdownLink url = do
-    opened <- liftIO (openExternalUrl url)
-    unless opened $ do
-        copyAction <- gets (.appRuntime.runtimeCopy)
-        copied <- liftIO (copyAction url)
-        modify' $
-            applyUiEvent
-                (UiSetNotice
-                    (Just (warningNotice
-                        (if copied
-                            then "Could not open that link; URL copied."
-                            else "Could not open that link."))))
+    remoteSession <- liftIO isSshSession
+    if remoteSession
+        then setLinkNotice remoteLinkInstructions
+        else do
+            opened <- liftIO (openExternalUrl url)
+            unless opened $ do
+                copyAction <- gets (.appRuntime.runtimeCopy)
+                copied <- liftIO (copyAction url)
+                setLinkNotice $
+                    if copied
+                        then "Could not open that link; URL copied."
+                        else "Could not open that link."
+
+-- Keep feedback inside a choice dialog: the conversation notice underneath
+-- the modal can be obscured by the sign-in page.
+setLinkNotice :: Text -> EventM Name AppState ()
+setLinkNotice message = modify' \state ->
+    let updated = applyUiEvent (UiSetNotice (Just (warningNotice message))) state
+    in updated
+        { appChoice = fmap
+            (\dialog ->
+                let overlay = dialog.dialogOverlay
+                in dialog
+                    { dialogOverlay = overlay
+                        { choiceBody =
+                            if message `Text.isInfixOf` overlay.choiceBody
+                                then overlay.choiceBody
+                                else overlay.choiceBody <> "\n\n" <> message
+                        }
+                    })
+            updated.appChoice
+        }
 
 openExternalUrl :: Text -> IO Bool
-openExternalUrl url =
-    case externalUrlCommand url of
-        Nothing -> pure False
-        Just command ->
-            launchExternalUrlCommand command
+openExternalUrl url = do
+    remoteSession <- isSshSession
+    if remoteSession
+        then pure False
+        else case externalUrlCommand url of
+            Nothing -> pure False
+            Just command ->
+                launchExternalUrlCommand command
 
 -- | Start the platform URL opener without waiting for it to exit. Browser
 -- launchers may remain attached for the lifetime of the browser, and waiting

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -723,7 +723,15 @@ openMarkdownLink :: Text -> EventM Name AppState ()
 openMarkdownLink url = do
     remoteSession <- liftIO isSshSession
     if remoteSession
-        then setLinkNotice remoteLinkInstructions
+        then do
+            copyAction <- gets (.appRuntime.runtimeCopy)
+            copied <- liftIO (copyAction url)
+            setLinkNotice $
+                remoteLinkInstructions <> "\n\n"
+                    <> (if copied
+                    then "URL copied. "
+                    else "Could not copy the URL. ")
+                    <> "Open this URL in your local browser: " <> url
         else do
             opened <- liftIO (openExternalUrl url)
             unless opened $ do
@@ -739,6 +747,13 @@ openMarkdownLink url = do
 setLinkNotice :: Text -> EventM Name AppState ()
 setLinkNotice message = modify' \state ->
     let updated = applyUiEvent (UiSetNotice (Just (warningNotice message))) state
+        markdownMessage = Text.concatMap escape message
+        escape character
+            -- Escape the scheme separator too: otherwise the URL recognizer
+            -- consumes subsequent Markdown escapes as literal URL characters.
+            | character `elem` ("\\`*_[]<>!#&:" :: String) =
+                "\\" <> Text.singleton character
+            | otherwise = Text.singleton character
     in updated
         { appChoice = fmap
             (\dialog ->
@@ -746,9 +761,9 @@ setLinkNotice message = modify' \state ->
                 in dialog
                     { dialogOverlay = overlay
                         { choiceBody =
-                            if message `Text.isInfixOf` overlay.choiceBody
+                            if markdownMessage `Text.isInfixOf` overlay.choiceBody
                                 then overlay.choiceBody
-                                else overlay.choiceBody <> "\n\n" <> message
+                                else overlay.choiceBody <> "\n\n" <> markdownMessage
                         }
                     })
             updated.appChoice

--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -4,6 +4,8 @@ module Agent.CLI.Terminal
     , TerminalCapabilities(..)
     , rawAttrs
     , detectTerminalCapabilities
+    , isSshSession
+    , remoteLinkInstructions
     , formatTerminalCapabilities
     , resolveColor
     , osc7WorkingDirectory
@@ -40,6 +42,7 @@ module Agent.CLI.Terminal
     ) where
 
 import Agent.CLI.FileUri (fileUri)
+import Agent.CLI.Environment (lookupNonEmpty)
 import Control.Exception.Safe (bracket_)
 import qualified Data.ByteString.Base64 as Base64
 import Data.Char (ord, toLower, toUpper)
@@ -132,6 +135,17 @@ detectTerminalCapabilities handle = do
         , terminalKittyKeyboard =
             not tmux && oneOf [TerminalGhostty, TerminalKitty, TerminalWezTerm]
         }
+
+-- | SSH identifies the process host, not the computer displaying its terminal.
+-- A browser launched on this host cannot open a window on the SSH client.
+isSshSession :: IO Bool
+isSshSession =
+    any isJust <$> traverse lookupNonEmpty
+        ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"]
+
+remoteLinkInstructions :: Text
+remoteLinkInstructions =
+    "Over SSH, use your terminal's Open Link action (usually Cmd-click on macOS or Ctrl-click on Linux/Windows) to open this URL on your local computer."
 
 formatTerminalCapabilities :: TerminalCapabilities -> Text
 formatTerminalCapabilities capabilities =

--- a/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LoginSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Login
 import Agent.CLI.CredentialStore (ManagedAuthKind(..))
 import Agent.CLI.Picker (PickerKey(..))
 import Agent.Provider (Provider(..))
+import Agent.TUI.Markdown (inlinePlainText, parseInline)
 import Data.Either (isLeft)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
@@ -13,6 +14,15 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "deviceAuthorizationBody" do
+        it "exposes the complete verification URL without requiring hyperlink support" do
+            let url = "https://example.com/connect?user_code=a_b&next=[label](target)&copy;"
+                    <> Text.replicate 400 "a"
+                body = deviceAuthorizationBody "gateway" url "TEST-CODE" Nothing
+                fallback = filter (Text.isPrefixOf "Or copy") (Text.lines body)
+            fmap (inlinePlainText . parseInline) fallback
+                `shouldBe` ["Or copy this URL into your browser: " <> url]
+
     describe "applyLoginKey" do
         it "moves and wraps the selected credential" do
             let state = initialLoginState [openai, grok]

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1538,7 +1538,9 @@ spec = do
             readIORef events `shouldReturn` [Left reset, Right ()]
 
     describe "fullscreen choice links" do
-        it "shows SSH link feedback once after repeated clicks without resolving the choice" do
+        forM_ [(copied, inDialog) | copied <- [False, True], inDialog <- [False, True]] \(copied, inDialog) ->
+          it ("preserves an SSH URL after repeated clicks (copy=" <> show copied
+                <> ", dialog=" <> show inDialog <> ")") do
             bracket
                 (lookupEnv "SSH_CONNECTION")
                 (\previous -> maybe (unsetEnv "SSH_CONNECTION")
@@ -1547,11 +1549,21 @@ spec = do
                     setEnv "SSH_CONNECTION" "192.0.2.1 1000 192.0.2.2 22"
                     runtime <- newScriptRuntime initialUiState
                     replies <- newIORef (0 :: Int)
-                    let name = MarkdownLink "https://example.com/connect"
+                    copiedUrls <- newIORef []
+                    let url = "https://e.test/?a_b=[label](target)&x=1"
+                        escapedUrl = "https://e.test/?a\\_b=\\[label\\](target)\\&x=1"
+                        name = MarkdownLink url
                         body = "[Sign in](https://example.com/connect)"
+                        notice = remoteLinkInstructions <> "\n\n"
+                            <> (if copied then "URL copied. " else "Could not copy the URL. ")
+                            <> "Open this URL in your local browser: " <> url
+                        runtimeWithCopy = runtime
+                            { runtimeCopy = \value ->
+                                modifyIORef' copiedUrls (<> [value]) >> pure copied
+                            }
                         initialState =
-                            (initialFullscreenAppState runtime [] AgentRoot [] 0)
-                                { appChoice = Just $
+                            (initialFullscreenAppState runtimeWithCopy [] AgentRoot [] 0)
+                                { appChoice = if not inDialog then Nothing else Just $
                                     PendingDialog
                                         (const (modifyIORef' replies (+ 1)))
                                         (choiceOverlay False) { choiceBody = body }
@@ -1564,7 +1576,13 @@ spec = do
                         runFullscreenScriptWithState initialState
                             (click <> click <> [FullscreenScriptHalt])
                     fmap (.dialogOverlay.choiceBody) finalState.appChoice
-                        `shouldBe` Just (body <> "\n\n" <> remoteLinkInstructions)
+                        `shouldBe` (if inDialog
+                            then Just (body <> "\n\n"
+                                <> Text.replace ":" "\\:" (Text.replace url escapedUrl notice))
+                            else Nothing)
+                    fmap (.noticeText) finalState.appUi.uiNotice `shouldBe` Just notice
+                    renderedAppText (120, 40) finalState `shouldSatisfy` Text.isInfixOf url
+                    readIORef copiedUrls `shouldReturn` [url, url]
                     finalState.appPressedControl `shouldBe` Nothing
                     readIORef replies `shouldReturn` 0
 

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -128,6 +128,7 @@ import Agent.CLI.Terminal
     , TerminalKind(..)
     , kittyKeyboardDisambiguatePush
     , kittyKeyboardPop
+    , remoteLinkInstructions
     )
 import Agent.Loop (ImageAttachment(..), LoopEvent(..), emptyTurnOutput)
 import Brick
@@ -160,7 +161,8 @@ import Agent.TUI.Presentation
 import Agent.TUI.Motion
 import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Concurrent.Async (waitCatch)
-import Control.Exception.Safe (bracket_)
+import Control.Exception.Safe (bracket, bracket_)
+import System.Environment (lookupEnv, setEnv, unsetEnv)
 import Control.Exception (AsyncException(UserInterrupt))
 import qualified Control.Exception as Exception
 import Control.Concurrent.STM
@@ -180,7 +182,7 @@ import Data.IORef
     , readIORef
     , writeIORef
     )
-import Data.Maybe (isNothing)
+import Data.Maybe (isJust, isNothing)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 import qualified Data.Set as Set
@@ -1535,6 +1537,72 @@ spec = do
             V.shutdown wrapped
             readIORef events `shouldReturn` [Left reset, Right ()]
 
+    describe "fullscreen choice links" do
+        it "shows SSH link feedback once after repeated clicks without resolving the choice" do
+            bracket
+                (lookupEnv "SSH_CONNECTION")
+                (\previous -> maybe (unsetEnv "SSH_CONNECTION")
+                    (setEnv "SSH_CONNECTION") previous)
+                \_ -> do
+                    setEnv "SSH_CONNECTION" "192.0.2.1 1000 192.0.2.2 22"
+                    runtime <- newScriptRuntime initialUiState
+                    replies <- newIORef (0 :: Int)
+                    let name = MarkdownLink "https://example.com/connect"
+                        body = "[Sign in](https://example.com/connect)"
+                        initialState =
+                            (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                                { appChoice = Just $
+                                    PendingDialog
+                                        (const (modifyIORef' replies (+ 1)))
+                                        (choiceOverlay False) { choiceBody = body }
+                                }
+                        click =
+                            [ FullscreenScriptMouseDown name V.BLeft (B.Location (0, 0))
+                            , FullscreenScriptMouseRelease name V.BLeft (B.Location (0, 0))
+                            ]
+                    (_, finalState) <-
+                        runFullscreenScriptWithState initialState
+                            (click <> click <> [FullscreenScriptHalt])
+                    fmap (.dialogOverlay.choiceBody) finalState.appChoice
+                        `shouldBe` Just (body <> "\n\n" <> remoteLinkInstructions)
+                    finalState.appPressedControl `shouldBe` Nothing
+                    readIORef replies `shouldReturn` 0
+
+        it "records a link press without resolving the choice" do
+            runtime <- newScriptRuntime initialUiState
+            replies <- newIORef (0 :: Int)
+            let name = MarkdownLink "https://example.com/connect"
+                initialState =
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                        { appChoice = Just $
+                            PendingDialog
+                                (const (modifyIORef' replies (+ 1)))
+                                (choiceOverlay False)
+                        }
+            (_, pressed) <-
+                runFullscreenScriptWithState initialState
+                    [ FullscreenScriptMouseDown name V.BLeft (B.Location (0, 0))
+                    , FullscreenScriptHalt
+                    ]
+            pressed.appPressedControl `shouldBe` Just name
+            isJust pressed.appChoice `shouldBe` True
+            readIORef replies `shouldReturn` 0
+
+        it "does not record a right-button link press" do
+            runtime <- newScriptRuntime initialUiState
+            let name = MarkdownLink "https://example.com/connect"
+                initialState =
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                        { appChoice = Just $
+                            PendingDialog (const (pure ())) (choiceOverlay False)
+                        }
+            (_, pressed) <-
+                runFullscreenScriptWithState initialState
+                    [ FullscreenScriptMouseDown name V.BRight (B.Location (0, 0))
+                    , FullscreenScriptHalt
+                    ]
+            pressed.appPressedControl `shouldBe` Nothing
+
     describe "fullscreen transcript hover" do
         it "tracks pointer motion without selecting the transcript row" do
             runtime <- newScriptRuntime initialUiState
@@ -2278,6 +2346,8 @@ spec = do
 data FullscreenScriptEvent
     = FullscreenScriptApp !AppEvent
     | FullscreenScriptVty !V.Event
+    | FullscreenScriptMouseDown !Name !V.Button !B.Location
+    | FullscreenScriptMouseRelease !Name !V.Button !B.Location
     | FullscreenScriptMouseUp !Name !B.Location
     | FullscreenScriptHalt
 
@@ -2878,6 +2948,12 @@ runFullscreenScriptDetailedAt bounds initialState script = do
                     fullscreenApp.appHandleEvent (AppEvent event)
                 AppEvent (FullscreenScriptVty event) ->
                     fullscreenApp.appHandleEvent (VtyEvent event)
+                AppEvent (FullscreenScriptMouseDown name button location) ->
+                    fullscreenApp.appHandleEvent
+                        (MouseDown name button [] location)
+                AppEvent (FullscreenScriptMouseRelease name button location) ->
+                    fullscreenApp.appHandleEvent
+                        (MouseUp name (Just button) location)
                 AppEvent (FullscreenScriptMouseUp name location) ->
                     fullscreenApp.appHandleEvent
                         (MouseUp name Nothing location)

--- a/packages/agent-cli/test/Agent/CLI/TerminalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TerminalSpec.hs
@@ -1,11 +1,30 @@
 module Agent.CLI.TerminalSpec (spec) where
 
 import Agent.CLI.Terminal
+import Control.Exception.Safe (bracket)
+import Control.Monad (forM_)
 import qualified Data.Text as Text
+import System.Environment (lookupEnv, setEnv, unsetEnv)
 import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "SSH session detection" do
+        it "does not classify a local terminal as SSH" do
+            withSshEnvironment Nothing $
+                isSshSession `shouldReturn` False
+
+        it "recognizes each SSH environment marker independently" do
+            forM_ ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"] \name ->
+                withSshEnvironment (Just (name, "connection")) $
+                    isSshSession `shouldReturn` True
+
+        it "ignores empty SSH markers" do
+            withSshEnvironment Nothing do
+                forM_ ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"] \name ->
+                    setEnv name ""
+                isSshSession `shouldReturn` False
+
     describe "terminal protocol encoders" do
         it "reports an escaped working directory" do
             osc7WorkingDirectory "/tmp/a b"
@@ -63,3 +82,17 @@ spec = do
         it "drops an incomplete trailing CSI sequence" do
             stripAnsi "ready\ESC[38;5"
                 `shouldBe` "ready"
+
+withSshEnvironment :: Maybe (String, String) -> IO a -> IO a
+withSshEnvironment marker action =
+    bracket
+        (traverse (\name -> (name,) <$> lookupEnv name) names)
+        (mapM_ restore)
+        \_ -> do
+            mapM_ unsetEnv names
+            forM_ marker (uncurry setEnv)
+            action
+  where
+    names = ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"]
+    restore (name, Nothing) = unsetEnv name
+    restore (name, Just value) = setEnv name value


### PR DESCRIPTION
## Summary
- Route link mouse-down events through the fullscreen choice dialog so clicks reach the link handler.
- Reuse SSH session detection and avoid launching a browser on the remote host.
- Show local-terminal Open Link instructions, attempt the clipboard fallback on SSH clicks, and display the full URL whether copying succeeds or fails.
- Show an untruncated URL in device sign-in dialogs before any click, independently of terminal hyperlink support.
- Preserve literal URL characters through Markdown rendering and avoid duplicate click feedback.
- Fix the managed-child readiness race exposed by CI: reread the final marker after observing child exit instead of rejecting a fast successful child.

Over SSH, opening the local browser uses the terminal Open Link action (typically Cmd-click or Ctrl-click), or copying the visible URL into the browser.

## Validation
- GHCi: `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`.
- Original change: 43 focused examples passed.
- Review update: 28 focused examples passed, including clipboard success/failure, dialog/transcript links, repeated clicks, and full literal URL rendering.
- Live production fullscreen dialog fixture exercised in tmux at 80 and 120 columns with SSH detection enabled: visible URL, copy failure feedback, repeated clicks, and Esc cancellation.
- `git diff --check` passed.
- Readiness fix: 9 runtime examples passed in GHCi, including 5 deterministic readiness/exit regression cases. Local managed-session integration tests were blocked by the macOS PostgreSQL socket-path limit; Linux CI validates those tests.
- Actual local-browser launch and clipboard delivery through an SSH client terminal were not tested end to end.
