### PR TITLE
Preserve exact server approval requests or fail closed

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -211,6 +211,13 @@ curl -X POST \
   -d '{"input":"Inspect this project and run its focused tests."}'
 ```
 
+Human requests retain their complete prompt and options, including plaintext
+tool arguments and plans (encrypted arguments remain redacted). Requests
+exceeding 64 KiB of encoded JSON or 100 options
+are rejected rather than truncated: approving a preview must not authorize
+an unseen suffix. Tool/plan approval adapters fail closed when such a request
+cannot be published.
+
 Watch lifecycle, streaming, tool, and approval events:
 
 ```console

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -1409,13 +1409,13 @@ requestToolApproval control call =
         { humanRequestSpecKind = ToolApprovalRequest
         , humanRequestSpecPrompt =
             "Allow mutating tool "
-                <> fst (boundedPublicText call.name)
+                <> call.name
                 <> " (call "
-                <> fst (boundedPublicText call.callId)
+                <> call.callId
                 <> ")?\nArguments: "
                 <> if call.argumentsEncrypted
                     then "<encrypted>"
-                    else fst (boundedPublicText call.arguments)
+                    else call.arguments
         , humanRequestSpecOptions =
             [ "allow_once"
             , "allow_tool"
@@ -1467,8 +1467,7 @@ planHooks control = PlanModeHooks
     , planDecideExit = \planBody ->
         control.turnControlRequestInput HumanRequestSpec
             { humanRequestSpecKind = PlanExitRequest
-            , humanRequestSpecPrompt =
-                fst (boundedPublicText planBody)
+            , humanRequestSpecPrompt = planBody
             , humanRequestSpecOptions =
                 ["approve", "request_changes", "cancel"]
             } >>= \case

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -1605,17 +1605,9 @@ requestTurnInput supervisor turnId spec requestSpec =
         now <- getCurrentTime
         requestId <- RequestId <$> newUUIDv7Text
         reply <- atomically newEmptyTMVar
-        let boundedRequestSpec = HumanRequestSpec
-                { humanRequestSpecKind =
-                    requestSpec.humanRequestSpecKind
-                , humanRequestSpecPrompt =
-                    boundedSupervisorText
-                        requestSpec.humanRequestSpecPrompt
-                , humanRequestSpecOptions =
-                    map boundedSupervisorText
-                        (take 100 requestSpec.humanRequestSpecOptions)
-                }
-            request = HumanRequest
+        -- Approval text is authorization data, not a log preview. Never
+        -- truncate it: the omitted suffix can change what is being approved.
+        let request = HumanRequest
                 { humanRequestId = requestId
                 , humanRequestTurnId = turnId
                 , humanRequestSessionId =
@@ -1623,15 +1615,17 @@ requestTurnInput supervisor turnId spec requestSpec =
                 , humanRequestBoundary =
                     spec.turnSpecBoundary
                 , humanRequestKind =
-                    boundedRequestSpec.humanRequestSpecKind
+                    requestSpec.humanRequestSpecKind
                 , humanRequestPrompt =
-                    boundedRequestSpec.humanRequestSpecPrompt
+                    requestSpec.humanRequestSpecPrompt
                 , humanRequestOptions =
-                    boundedRequestSpec.humanRequestSpecOptions
+                    requestSpec.humanRequestSpecOptions
                 , humanRequestCreatedAt = now
                 }
-        if LazyByteString.length (encode request)
-            > maximumHumanRequestBytes
+        if length (take 101 requestSpec.humanRequestSpecOptions) > 100
+            || LazyByteString.length
+                (LazyByteString.take (maximumHumanRequestBytes + 1) (encode request))
+                > maximumHumanRequestBytes
             then
                 pure
                     ( Left

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -694,6 +694,78 @@ spec = describe "turn supervisor" do
                         , humanResponseValue = Just "add tests"
                         }
 
+    it "requires fresh approval for a repeated identical request" do
+        resolved <- newEmptyMVar
+        let runner control _ = do
+                forM_ [1 :: Int, 2] \_ -> do
+                    answer <- control.turnControlRequestInput HumanRequestSpec
+                        { humanRequestSpecKind = ToolApprovalRequest
+                        , humanRequestSpecPrompt = "Run the same tool call?"
+                        , humanRequestSpecOptions = ["allow_once", "deny"]
+                        }
+                    putMVar resolved answer
+                pure (Right testOutput)
+            response = HumanResponse "allow_once" Nothing
+        withSupervisor runner \supervisor -> do
+            void (submitTurn supervisor (turnSpec "session-a"))
+            first <- awaitRequest supervisor
+            resolveHumanRequest supervisor localAccessBoundary
+                first.humanRequestId response `shouldReturn` Right first
+            takeWithin resolved `shouldReturn` Right response
+            second <- awaitRequest supervisor
+            second.humanRequestId `shouldNotBe` first.humanRequestId
+            resolveHumanRequest supervisor localAccessBoundary
+                first.humanRequestId response
+                `shouldReturn` Left HumanRequestResolutionNotFound
+            resolveHumanRequest supervisor localAccessBoundary
+                second.humanRequestId response `shouldReturn` Right second
+            takeWithin resolved `shouldReturn` Right response
+
+    it "retains exact approval text and options beyond the log preview limit" do
+        resolved <- newEmptyMVar
+        let prompt = Text.replicate 17000 "x" <> "; also remove the backup"
+            option = Text.replicate 17000 "y" <> "-deny"
+            runner control _ = do
+                answer <- control.turnControlRequestInput HumanRequestSpec
+                    { humanRequestSpecKind = ToolApprovalRequest
+                    , humanRequestSpecPrompt = prompt
+                    , humanRequestSpecOptions = [option]
+                    }
+                putMVar resolved answer
+                pure (Right testOutput)
+        withSupervisor runner \supervisor -> do
+            void (submitTurn supervisor (turnSpec "session-a"))
+            request <- awaitRequest supervisor
+            request.humanRequestPrompt `shouldBe` prompt
+            request.humanRequestOptions `shouldBe` [option]
+            let response = HumanResponse option Nothing
+            resolveHumanRequest supervisor localAccessBoundary
+                request.humanRequestId response
+                `shouldReturn` Right request
+            takeWithin resolved `shouldReturn` Right response
+
+    forM_
+        [ ("oversized prompt", Text.replicate (64 * 1024) "x", ["allow"])
+        , ("UTF-8 oversized prompt", Text.replicate 22000 "界", ["allow"])
+        , ("excess options", "Choose", replicate 101 "allow")
+        ] \(label, prompt, options) ->
+            it ("rejects rather than truncates " <> label) do
+                result <- newEmptyMVar
+                let runner control _ = do
+                        answer <- control.turnControlRequestInput HumanRequestSpec
+                            { humanRequestSpecKind = ToolApprovalRequest
+                            , humanRequestSpecPrompt = prompt
+                            , humanRequestSpecOptions = options
+                            }
+                        putMVar result answer
+                        pure (Right testOutput)
+                withSupervisor runner \supervisor -> do
+                    void (submitTurn supervisor (turnSpec "session-a"))
+                    takeWithin result
+                        `shouldReturn` Left "human request exceeds the public size limit"
+                    listHumanRequests supervisor localAccessBoundary Nothing
+                        `shouldReturn` Right []
+
     it "rejects human input too large for the public transport" do
         result <- newEmptyMVar
         let runner control _ = do


### PR DESCRIPTION
## Summary
- Preserve full human-request prompts and options instead of truncating authorization text to log-preview limits.
- Keep plaintext tool arguments and plan bodies intact through the server adapter. Reject requests exceeding 64 KiB encoded JSON or 100 options before persistence/publication; existing adapters fail closed.
- Preserve encrypted-argument redaction and existing one-shot request IDs, turn ownership, access boundaries, and durable cross-instance resolution.

## Validation
- Nix multi-package GHCi: **Ok, 649 modules loaded**.
- SupervisorSpec: **30 examples, 0 failures**, including five new cases covering repeated identical requests requiring fresh approval, exact long prompts/options, oversized ASCII/UTF-8 prompts, and excess options.
- Package-boundary check and git diff check pass.

## Scope
This is a focused safety prerequisite from the agent architecture review, not a new approval protocol. Shared runtime pending-request extraction and structured daemon/subprocess approval bridging remain separate work. No CLI TTY behavior or daemon process-isolation changes.