### PR TITLE
Gate provider account failover on explicit replay safety

### DIFF
--- a/docs/provider-replay-safety.md
+++ b/docs/provider-replay-safety.md
@@ -1,0 +1,68 @@
+# Provider account failover and replay safety
+
+Account health and permission to replay an action are separate decisions.
+An authentication or quota error may justify replacing a credential, but not
+repeating a request that already streamed output or admitted an async tool.
+
+`Agent.Provider.runWithTokenProviderAttempt` consumes `ProviderAttemptFailure`,
+which carries the original `ApiError` and an explicit `ReplaySafety`:
+
+- `ReplaySafe`: account classification may authorize a replacement attempt.
+- `ReplayUnsafe`: effects/output have crossed the action's replay boundary.
+- `ReplayUnknown`: the action cannot establish that repetition is safe.
+
+Only `ReplaySafe` permits failover. Unsafe and unknown failures return the
+original error, without another credential checkout, even when a custom
+account classifier recognizes that error. Unclassified failures still do not
+rotate accounts, and the existing 64-attempt budget is unchanged.
+
+## Streaming adapters
+
+`runWithTokenProviderStreaming` latches output before delivering it to the
+consumer. A later lifecycle event cannot clear that latch. Transports must
+complete all callbacks before returning. Consumer exceptions, transport
+exceptions, and cancellation propagate without being caught or replayed.
+
+All three credentialed stateless Responses adapters use the existing
+`streamOutputObserved` predicate. It includes visible output, completed
+opaque checkpoints and completed tool items, including async tool admission.
+The xAI and OpenRouter production backends use these adapters.
+Lifecycle-only events still allow a rejected request to use another account.
+The Gemini adapter treats every Gemini stream event as output: text,
+reasoning, or a ready function call.
+
+This adapter assumes classified account failures before output represent
+request rejection. It is not an automatic proof that arbitrary remote effects
+did not happen. Actions with uncertain effects must use explicit attempt
+metadata and return `ReplayUnknown` or `ReplayUnsafe`.
+
+## Compatibility and remaining boundaries
+
+`runWithTokenProvider` and `runWithTokenProviderAfter` retain their historical
+API and replay-safe-action precondition. They delegate to the explicit attempt
+gate with `ReplaySafe`; they do not infer safety for arbitrary callbacks.
+Existing non-streaming callers and connection-acquisition wrappers are not
+silently given a different retry policy.
+
+OpenAI's specialized backend already tracks raw/visible/tool output and async
+admission, handles attempt-local display retraction, and guards its own
+transport recovery. Those policies and its legacy replay-unsafe error markers
+remain unchanged. This change does not migrate every retry layer to a new
+failure type, implement a durable external-effect journal, or promise
+exactly-once execution across crashes.
+
+## Contract tests
+
+- `agent-core/Agent.ProviderSpec`: explicit unsafe/unknown outcomes, custom
+  classifiers, safe rejection, unclassified errors, bounded retries, streaming
+  latching, consumer exceptions and cancellation.
+- `agent-responses/Agent.Responses.LoopBackendSpec`: the same pre-output and
+  post-output contract for all three checkpoint/history modes, including
+  single async admission after a provider failure.
+- `agent-gemini/Agent.Gemini.LoopBackendSpec`: safe pre-output failover and
+  no replay after each native stream-event kind.
+
+Run through the corresponding test-component `cabal repl` from `nix develop`,
+then `:main` (or a focused Hspec `--match`). Require both a successful GHCi
+module load and a nonzero test count with zero failures; GHCi's exit status
+alone does not establish either.

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -299,6 +299,7 @@ test-suite agent-core-test
                     , Agent.JsonTextSpec
                     , Agent.ProjectInstructionsSpec
                     , Agent.Provider.OptionsSpec
+                    , Agent.ProviderSpec
                     , Agent.ResourceScopeSpec
                     , Agent.RetrySpec
                     , Agent.SkillsSpec

--- a/packages/agent-core/src/Agent/Provider.hs
+++ b/packages/agent-core/src/Agent/Provider.hs
@@ -16,6 +16,10 @@ module Agent.Provider
     , getNextToken
     , runWithTokenProvider
     , runWithTokenProviderAfter
+    , ReplaySafety(..)
+    , ProviderAttemptFailure(..)
+    , runWithTokenProviderAttempt
+    , runWithTokenProviderStreaming
     , seedTokenProvider
     , accountFailureFromApiError
     , accountFailureReason
@@ -30,6 +34,8 @@ import Agent.Error
     , credentialExhaustionReasonFromApiError
     )
 import Control.Applicative ((<|>))
+import Control.Monad (when)
+import Data.Bifunctor (first)
 import qualified Agent.Json.Decode as Json
 import qualified Data.Aeson as Aeson
 import Data.IORef
@@ -185,6 +191,10 @@ seedTokenProvider provider credential = do
                         Just firstCredential -> pure (Right firstCredential)
                         Nothing -> getNextToken provider Nothing
 
+-- | Compatibility entry point for actions whose account failures are known
+-- to be replay-safe. Streaming actions should use
+-- 'runWithTokenProviderStreaming'; actions with uncertain effects should
+-- return explicit metadata through 'runWithTokenProviderAttempt'.
 runWithTokenProvider
     :: TokenProvider
     -> (Credential -> IO (Either ApiError a))
@@ -203,6 +213,36 @@ runWithTokenProviderAfter
     -> (Credential -> IO (Either ApiError a))
     -> IO (Either ApiError a)
 runWithTokenProviderAfter provider initialFailure action =
+    runWithTokenProviderAttemptAfter provider initialFailure \credential ->
+        first (ProviderAttemptFailure ReplaySafe) <$> action credential
+
+-- | Whether repeating a failed action is safe, independently of whether its
+-- error suggests that another credential could succeed. Unknown is deliberately
+-- distinct from a known pre-effect failure and never permits account failover.
+data ReplaySafety = ReplaySafe | ReplayUnsafe | ReplayUnknown
+    deriving (Eq, Show)
+
+data ProviderAttemptFailure = ProviderAttemptFailure
+    { attemptReplaySafety :: !ReplaySafety
+    , attemptError :: !ApiError
+    } deriving (Eq, Show)
+
+-- | Account classification cannot override the action's replay boundary.
+-- Preserve the original error when replay is unsafe or unknown; do not rewrite
+-- its provider type merely to prevent the classifier from recognizing it.
+runWithTokenProviderAttempt
+    :: TokenProvider
+    -> (Credential -> IO (Either ProviderAttemptFailure a))
+    -> IO (Either ApiError a)
+runWithTokenProviderAttempt provider =
+    runWithTokenProviderAttemptAfter provider Nothing
+
+runWithTokenProviderAttemptAfter
+    :: TokenProvider
+    -> Maybe FailedCredential
+    -> (Credential -> IO (Either ProviderAttemptFailure a))
+    -> IO (Either ApiError a)
+runWithTokenProviderAttemptAfter provider initialFailure action =
     go maxProviderFailoverAttempts initialFailure
   where
     go attemptsLeft failed
@@ -211,8 +251,9 @@ runWithTokenProviderAfter provider initialFailure action =
         | otherwise = getNextToken provider failed >>= \case
             Left err -> pure (Left err)
             Right credential -> action credential >>= \case
-                Left err
-                    | Just failure <-
+                Left ProviderAttemptFailure{attemptReplaySafety, attemptError = err}
+                    | attemptReplaySafety == ReplaySafe
+                    , Just failure <-
                         provider.runClassifyAccountFailure credential err ->
                         go (attemptsLeft - 1) $ Just FailedCredential
                             { credential
@@ -220,7 +261,36 @@ runWithTokenProviderAfter provider initialFailure action =
                             , failureReason =
                                 accountFailureReason err failure
                             }
-                result -> pure result
+                Left failedAttempt -> pure (Left failedAttempt.attemptError)
+                Right result -> pure (Right result)
+
+-- | Credential failover for a streaming action. The transport identifies
+-- events that cross its replay boundary (including non-visible output and
+-- async tool admission), and must finish all event callbacks before returning.
+-- Latch the boundary /before/ invoking the consumer, which may start effects.
+--
+-- Absence of output is not proof that arbitrary external work is replay-safe:
+-- this adapter is for transports whose classified account errors before output
+-- represent a rejected request. Other actions must supply explicit failure
+-- metadata. Exceptions, including cancellation and consumer failures, propagate
+-- unchanged and are never caught or replayed here.
+runWithTokenProviderStreaming
+    :: TokenProvider
+    -> (event -> Bool)
+    -> (Credential -> (event -> IO ()) -> IO (Either ApiError a))
+    -> (event -> IO ())
+    -> IO (Either ApiError a)
+runWithTokenProviderStreaming provider outputObserved send onEvent =
+    runWithTokenProviderAttempt provider \credential -> do
+        emitted <- newIORef False
+        result <- send credential \event -> do
+            when (outputObserved event) (atomicWriteIORef emitted True)
+            onEvent event
+        observed <- readIORef emitted
+        pure $ first
+            (ProviderAttemptFailure
+                (if observed then ReplayUnsafe else ReplaySafe))
+            result
 
 maxProviderFailoverAttempts :: Int
 maxProviderFailoverAttempts = 64

--- a/packages/agent-core/test/Agent/ProviderSpec.hs
+++ b/packages/agent-core/test/Agent/ProviderSpec.hs
@@ -1,0 +1,127 @@
+module Agent.ProviderSpec (spec) where
+
+import Agent.Error (ApiError(..))
+import Agent.Provider
+import Control.Concurrent.Async (cancel, waitCatch, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Exception.Safe (throwIO)
+import Control.Monad (forM_)
+import Data.Either (isLeft)
+import Data.IORef
+import Data.Text (Text)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "explicit provider attempt replay safety" do
+        forM_ [ReplayUnsafe, ReplayUnknown] \safety ->
+            it ("does not let account classification override " <> show safety) do
+                (provider, acquisitions) <- countingProvider
+                let broadClassifier = withAccountFailureClassifier
+                        (\_ _ -> Just AccountAuthenticationRejected) provider
+                    err = ConnectionError "effect outcome uncertain"
+                result <- runWithTokenProviderAttempt broadClassifier \_ ->
+                    pure (Left (ProviderAttemptFailure safety err)
+                        :: Either ProviderAttemptFailure ())
+                result `shouldBe` Left err
+                readIORef acquisitions `shouldReturn` 1
+
+        it "reacquires only for a replay-safe classified failure" do
+            (provider, acquisitions) <- countingProvider
+            attempts <- newIORef (0 :: Int)
+            result <- runWithTokenProviderAttempt provider \_ -> do
+                attempt <- atomicModifyIORef' attempts (\n -> (n + 1, n))
+                pure $ if attempt == 0
+                    then Left (ProviderAttemptFailure ReplaySafe rejected)
+                    else Right "done"
+            result `shouldBe` Right ("done" :: Text)
+            readIORef acquisitions `shouldReturn` 2
+
+        it "does not retry an unclassified error even when replay is safe" do
+            (provider, acquisitions) <- countingProvider
+            let err = ConnectionError "offline"
+            result <- runWithTokenProviderAttempt provider \_ ->
+                pure (Left (ProviderAttemptFailure ReplaySafe err)
+                    :: Either ProviderAttemptFailure ())
+            result `shouldBe` Left err
+            readIORef acquisitions `shouldReturn` 1
+
+        it "preserves the bounded account failover budget" do
+            (provider, acquisitions) <- countingProvider
+            result <- runWithTokenProviderAttempt provider \_ ->
+                pure (Left (ProviderAttemptFailure ReplaySafe rejected)
+                    :: Either ProviderAttemptFailure ())
+            result `shouldBe`
+                Left (ConnectionError "token provider failover budget exhausted")
+            readIORef acquisitions `shouldReturn` 64
+
+    describe "streaming provider replay boundary" do
+        it "allows pre-output rejection and ignores lifecycle-only events" do
+            (provider, acquisitions) <- countingProvider
+            attempts <- newIORef (0 :: Int)
+            events <- newIORef []
+            let send _ emit = do
+                    attempt <- atomicModifyIORef' attempts (\n -> (n + 1, n))
+                    emit False
+                    if attempt == 0
+                        then pure (Left rejected)
+                        else emit True >> pure (Right ())
+            result <- runWithTokenProviderStreaming provider id send
+                (\event -> modifyIORef' events (<> [event]))
+            result `shouldBe` Right ()
+            readIORef acquisitions `shouldReturn` 2
+            readIORef events `shouldReturn` [False, False, True]
+
+        it "does not replay after output, even if later events are lifecycle-only" do
+            (provider, acquisitions) <- countingProvider
+            effects <- newIORef (0 :: Int)
+            let send _ emit = do
+                    emit True
+                    emit False
+                    pure (Left rejected :: Either ApiError ())
+            result <- runWithTokenProviderStreaming provider id send
+                (\event -> if event then modifyIORef' effects (+ 1) else pure ())
+            result `shouldBe` Left rejected
+            readIORef acquisitions `shouldReturn` 1
+            readIORef effects `shouldReturn` 1
+
+        it "propagates consumer exceptions without retry" do
+            (provider, acquisitions) <- countingProvider
+            let send _ emit = emit True >> pure (Right ())
+            runWithTokenProviderStreaming provider id send
+                (\_ -> throwIO (userError "consumer failed"))
+                `shouldThrow` anyIOException
+            readIORef acquisitions `shouldReturn` 1
+
+        it "propagates cancellation without credential reacquisition" do
+            (provider, acquisitions) <- countingProvider
+            entered <- newEmptyMVar
+            blocked <- newEmptyMVar
+            let send _ emit = emit True >> pure (Right ())
+                consume _ = putMVar entered () >> takeMVar blocked
+            outcome <- timeout 1000000 $
+                withAsync
+                    (runWithTokenProviderStreaming provider id send consume)
+                    \worker -> do
+                        takeMVar entered
+                        cancel worker
+                        isLeft <$> waitCatch worker
+            outcome `shouldBe` Just True
+            readIORef acquisitions `shouldReturn` 1
+
+rejected :: ApiError
+rejected = HttpError 401 "rejected"
+
+countingProvider :: IO (TokenProvider, IORef Int)
+countingProvider = do
+    acquisitions <- newIORef 0
+    let provider = tokenProvider SubscriptionBilled \_ -> do
+            modifyIORef' acquisitions (+ 1)
+            pure (Right Credential
+                { accessToken = "test"
+                , accountId = "test"
+                , leaseId = Nothing
+                , provider = OpenAIProvider
+                })
+    pure (provider, acquisitions)

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -13,6 +13,7 @@ import qualified Agent.LoopSpec as LoopSpec
 import qualified Agent.OsPathSpec as OsPathSpec
 import qualified Agent.ProjectInstructionsSpec as ProjectInstructionsSpec
 import qualified Agent.Provider.OptionsSpec as ProviderOptionsSpec
+import qualified Agent.ProviderSpec as ProviderSpec
 import qualified Agent.ResourceScopeSpec as ResourceScopeSpec
 import qualified Agent.RetrySpec as RetrySpec
 import qualified Agent.SkillsSpec as SkillsSpec
@@ -57,6 +58,7 @@ main = hspec do
     OsPathSpec.spec
     ProjectInstructionsSpec.spec
     ProviderOptionsSpec.spec
+    ProviderSpec.spec
     ResourceScopeSpec.spec
     RetrySpec.spec
     SkillsSpec.spec

--- a/packages/agent-gemini/agent-gemini.cabal
+++ b/packages/agent-gemini/agent-gemini.cabal
@@ -85,6 +85,7 @@ test-suite agent-gemini-test
                     , Agent.Gemini.ClientSpec
                     , Agent.Gemini.CredentialSpec
                     , Agent.Gemini.ErrorSpec
+                    , Agent.Gemini.LoopBackendSpec
                     , Agent.Gemini.RequestSpec
                     , Agent.Gemini.ResponseSpec
                     , Agent.Gemini.StreamSpec

--- a/packages/agent-gemini/src/Agent/Gemini/LoopBackend.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/LoopBackend.hs
@@ -17,7 +17,7 @@ import Agent.Loop
 import Agent.Provider
     ( Credential
     , TokenProvider
-    , runWithTokenProvider
+    , runWithTokenProviderStreaming
     )
 import Agent.Responses.LoopBackend
     ( responseItemToToolCall
@@ -68,8 +68,9 @@ tokenProviderStatelessGeminiBackend
     -> Backend
 tokenProviderStatelessGeminiBackend provider send =
     statelessGeminiBackend \params onEvent ->
-        runWithTokenProvider provider \credential ->
-            send credential params onEvent
+        -- Every Gemini stream event is text, reasoning, or a ready tool call.
+        runWithTokenProviderStreaming provider (const True)
+            (\credential -> send credential params) onEvent
 
 geminiStreamEventToLoopEvent
     :: GeminiStreamEvent

--- a/packages/agent-gemini/test/Agent/Gemini/LoopBackendSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/LoopBackendSpec.hs
@@ -1,0 +1,66 @@
+module Agent.Gemini.LoopBackendSpec (spec) where
+
+import Agent.Error (ApiError(..))
+import Agent.Gemini.LoopBackend (tokenProviderStatelessGeminiBackend)
+import Agent.Gemini.Response (GeminiStreamEvent(..))
+import Agent.Loop (Backend(..), TurnInput(..), emptyBackendSnapshot)
+import Agent.Provider
+import Agent.Responses.Types (FunctionCall(..), defaultResponseCreateParams)
+import Control.Monad (forM_)
+import Data.IORef
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Gemini account replay boundary" do
+    it "retains account failover before output" do
+        attempts <- newIORef (0 :: Int)
+        let send _ _ _ = do
+                attempt <- atomicModifyIORef' attempts (\n -> (n + 1, n))
+                pure $ Left $ if attempt == 0
+                    then HttpError 401 "rejected"
+                    else ConnectionError "stop after failover"
+            backend = tokenProviderStatelessGeminiBackend provider send
+                (pure defaultResponseCreateParams)
+        result <- backend.submitTurn emptyBackendSnapshot Nothing
+            [UserMessage "hello"] (const (pure ()))
+        result `shouldBe` Left (ConnectionError "stop after failover")
+        readIORef attempts `shouldReturn` 2
+
+    forM_
+        [ GeminiTextDelta "partial"
+        , GeminiReasoningDelta "thinking"
+        , GeminiFunctionCallReady FunctionCall
+            { itemId = Nothing
+            , callId = "call"
+            , name = "shell_command"
+            , namespace = Nothing
+            , provider = Nothing
+            , arguments = "{}"
+            , encryptedFunctionArgs = Nothing
+            , status = Nothing
+            , async = Nothing
+            }
+        ] \event -> it ("does not replay after " <> show event) do
+        attempts <- newIORef (0 :: Int)
+        events <- newIORef []
+        let rejected = HttpError 429 "limited after output"
+            send _ _ emit = do
+                modifyIORef' attempts (+ 1)
+                emit event
+                pure (Left rejected)
+            backend = tokenProviderStatelessGeminiBackend provider send
+                (pure defaultResponseCreateParams)
+        result <- backend.submitTurn emptyBackendSnapshot Nothing
+            [UserMessage "hello"] (\value -> modifyIORef' events (<> [value]))
+        result `shouldBe` Left rejected
+        readIORef attempts `shouldReturn` 1
+        length <$> readIORef events `shouldReturn` 1
+
+provider :: TokenProvider
+provider = tokenProvider SubscriptionBilled $
+    const (pure (Right Credential
+        { accessToken = "test"
+        , accountId = "test"
+        , leaseId = Nothing
+        , provider = GeminiProvider
+        }))

--- a/packages/agent-gemini/test/Spec.hs
+++ b/packages/agent-gemini/test/Spec.hs
@@ -5,6 +5,7 @@ import qualified Agent.Gemini.AuthSpec as AuthSpec
 import qualified Agent.Gemini.ClientSpec as ClientSpec
 import qualified Agent.Gemini.CredentialSpec as CredentialSpec
 import qualified Agent.Gemini.ErrorSpec as ErrorSpec
+import qualified Agent.Gemini.LoopBackendSpec as LoopBackendSpec
 import qualified Agent.Gemini.RequestSpec as RequestSpec
 import qualified Agent.Gemini.ResponseSpec as ResponseSpec
 import qualified Agent.Gemini.StreamSpec as StreamSpec
@@ -15,6 +16,7 @@ main = hspec do
     ClientSpec.spec
     CredentialSpec.spec
     ErrorSpec.spec
+    LoopBackendSpec.spec
     RequestSpec.spec
     ResponseSpec.spec
     StreamSpec.spec

--- a/packages/agent-openai/README.md
+++ b/packages/agent-openai/README.md
@@ -92,6 +92,12 @@ classifies only account-scoped failures, reports the rejected credential, and
 reruns the supplied operation with the provider's replacement. Generic network
 or server failures do not poison account health.
 
+That compatibility API requires replay-safe actions. Streaming adapters use
+`runWithTokenProviderStreaming`, and actions with uncertain effects can return
+explicit `ProviderAttemptFailure` metadata through
+`runWithTokenProviderAttempt`. Account classification cannot override an unsafe
+or unknown replay decision. See [the replay contract](../../docs/provider-replay-safety.md).
+
 For replay-safe WebSocket operations, `withCodexWsRetrying` applies that same
 loop to both handshake and in-band 401/403/usage-limit failures. Its callback
 can be executed again from the beginning, so callers must keep externally

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend.hs
@@ -45,7 +45,7 @@ import Agent.Loop
 import Agent.Provider
     ( Credential
     , TokenProvider
-    , runWithTokenProvider
+    , runWithTokenProviderStreaming
     )
 import Agent.Responses.LoopBackend.Input
 import Agent.Responses.LoopBackend.Output
@@ -201,8 +201,8 @@ tokenProviderStatelessResponsesBackend
     -> Backend
 tokenProviderStatelessResponsesBackend provider send =
     statelessResponsesBackend \params onEvent ->
-        runWithTokenProvider provider \credential ->
-            send credential params onEvent
+        runWithTokenProviderStreaming provider streamOutputObserved
+            (\credential -> send credential params) onEvent
 
 -- | Credentialed counterpart to
 -- 'statelessResponsesBackendPreservingCheckpointHistory'.
@@ -218,8 +218,8 @@ tokenProviderStatelessResponsesBackendPreservingCheckpointHistory
         provider
         send =
     statelessResponsesBackendPreservingCheckpointHistory \params onEvent ->
-        runWithTokenProvider provider \credential ->
-            send credential params onEvent
+        runWithTokenProviderStreaming provider streamOutputObserved
+            (\credential -> send credential params) onEvent
 
 -- | Credentialed counterpart to
 -- 'statelessResponsesBackendPreservingHistory'.
@@ -233,5 +233,5 @@ tokenProviderStatelessResponsesBackendPreservingHistory
     -> Backend
 tokenProviderStatelessResponsesBackendPreservingHistory provider send =
     statelessResponsesBackendPreservingHistory \params onEvent ->
-        runWithTokenProvider provider \credential ->
-            send credential params onEvent
+        runWithTokenProviderStreaming provider streamOutputObserved
+            (\credential -> send credential params) onEvent

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -34,6 +34,8 @@ import Agent.Responses.LoopBackend
     , statelessResponsesBackend
     , statelessResponsesBackendWithRawReasoning
     , tokenProviderStatelessResponsesBackend
+    , tokenProviderStatelessResponsesBackendPreservingCheckpointHistory
+    , tokenProviderStatelessResponsesBackendPreservingHistory
     , turnInputsToItems
     , responseItemToToolCall
     , toolResultToItem
@@ -78,6 +80,7 @@ import Agent.Responses.Types.Items (responseItemDecoder)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
+import Control.Monad (forM_)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import System.Timeout (timeout)
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -106,7 +109,98 @@ spec :: Spec
 spec = do
     wireAsyncSpec
     backendSpec
+    accountReplaySpec
     streamProjectionSpec
+
+accountReplaySpec :: Spec
+accountReplaySpec = describe "stateless Responses account replay boundary" $
+    forM_
+        [ ("default", tokenProviderStatelessResponsesBackend)
+        , ("preserving checkpoints",
+            tokenProviderStatelessResponsesBackendPreservingCheckpointHistory)
+        , ("preserving history",
+            tokenProviderStatelessResponsesBackendPreservingHistory)
+        ] \(label, makeBackend) -> describe label do
+        it "still fails over after a lifecycle-only pre-output rejection" do
+            attempts <- newIORef (0 :: Int)
+            let provider = tokenProvider SubscriptionBilled
+                    (const (pure (Right (credential "test"))))
+                send _ _ emit = do
+                    attempt <- atomicModifyIORef' attempts (\n -> (n + 1, n))
+                    emit (ResponseCreatedEvent (responseWithOutput []) Nothing)
+                    pure $ if attempt == 0
+                        then Left (HttpError 401 "rejected")
+                        else Right (responseWithOutput [])
+                backend = makeBackend provider send
+                    (pure defaultResponseCreateParams)
+            result <- backend.submitTurn emptyBackendSnapshot Nothing
+                [UserMessage "hello"] (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef attempts `shouldReturn` 2
+
+        forM_ replayBoundaryEvents \(eventLabel, event, expectedAsync) ->
+            it ("does not replay an account error after " <> eventLabel) do
+                attempts <- newIORef (0 :: Int)
+                admissions <- newIORef (0 :: Int)
+                events <- newIORef []
+                let rejected = HttpError 429 "limited after output"
+                    provider = tokenProvider SubscriptionBilled
+                        (const (pure (Right (credential "test"))))
+                    send _ _ emit = do
+                        modifyIORef' attempts (+ 1)
+                        emit event
+                        pure (Left rejected)
+                    backend = makeBackend provider send
+                        (pure defaultResponseCreateParams)
+                result <- backend.submitTurnWithCallbacks
+                    emptyBackendSnapshot Nothing [UserMessage "hello"]
+                    BackendCallbacks
+                        { onLoopEvent = \value -> modifyIORef' events (<> [value])
+                        , onRecoveryCheckpoint = const (pure ())
+                        , onAsyncToolCall = \_ -> modifyIORef' admissions (+ 1)
+                        }
+                result `shouldBe` Left rejected
+                readIORef attempts `shouldReturn` 1
+                readIORef admissions `shouldReturn` expectedAsync
+                if eventLabel == "visible text"
+                    then readIORef events `shouldReturn` [TextDelta "partial"]
+                    else pure ()
+
+replayBoundaryEvents :: [(String, ResponseStreamEvent, Int)]
+replayBoundaryEvents =
+    [ ("visible text", OtherResponseStreamEvent
+        { otherEventType = EventOutputTextDelta
+        , sequenceNumber = Nothing
+        , eventDelta = Just "partial"
+        , streamItemId = Nothing
+        , streamOutputIndex = Nothing
+        , summaryIndex = Nothing
+        , turnState = Nothing
+        }, 0)
+    , ("an opaque checkpoint", ResponseOutputItemDoneEvent
+        { item = CompactionItemValue CompactionItem
+            { itemId = Just "checkpoint"
+            , encryptedContent = Just "opaque"
+            }
+        , outputIndex = Nothing
+        , sequenceNumber = Nothing
+        }, 0)
+    , ("async tool admission", ResponseOutputItemDoneEvent
+        { item = FunctionCallItem FunctionCall
+            { itemId = Just "effect-item"
+            , callId = "effect-call"
+            , name = "shell_command"
+            , namespace = Nothing
+            , provider = Nothing
+            , arguments = "{\"command\":\"effect\"}"
+            , encryptedFunctionArgs = Nothing
+            , status = Just ItemCompleted
+            , async = Just True
+            }
+        , outputIndex = Just 0
+        , sequenceNumber = Just 1
+        }, 1)
+    ]
 
 wireAsyncSpec :: Spec
 wireAsyncSpec = describe "Responses async wire fields" do


### PR DESCRIPTION
## Summary

- Separate account-error classification from explicit replay eligibility (`ReplaySafe`, `ReplayUnsafe`, `ReplayUnknown`); preserve the existing bounded failover budget.
- Latch streamed output before invoking consumers, then prevent account failover after text, opaque checkpoints, or async tool admission. Adopt this in all three stateless Responses token-provider adapters (including xAI/OpenRouter) and Gemini's native backend.
- Preserve lifecycle-only pre-output rejection retries and propagate consumer exceptions/cancellation without credential reacquisition.
- Document the contract and retain source-compatible helpers for callers that already establish replay safety.

This is a bounded account-failover improvement, not a replacement for every provider transport/recovery policy or an exactly-once effect guarantee. OpenAI's specialized recovery remains unchanged. Pre-output retry relies on the provider's account classifier identifying a rejected request; absence of output does not prove arbitrary remote effects did not occur.

## Validation

All scripted GHCi logs checked for successful module loading, absence of errors, and nonzero examples where executing tests:

- `cabal repl --offline agent-core:test:agent-core-test`, `:main --match "provider"`: 24 examples, 0 failures.
- `cabal repl --offline agent-responses:test:agent-responses-test`, `:main`: 140 examples, 0 failures.
- `cabal repl --offline agent-gemini:test:agent-gemini-test`, `:main`: 59 examples, 0 failures.
- Combined GHCi load of agent-core, agent-responses, agent-gemini, agent-openai, agent-xai, and agent-openrouter libraries: 155 modules loaded.
- 25 new contract/regression cases across core and production adapters.
- `scripts/check-package-boundaries.sh` and `git diff --check` pass; regenerated cabal2nix outputs unchanged.

No agent binary rebuild.
