### PR TITLE
Encapsulate runtime session state behind lifecycle operations

### DIFF
--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -96,12 +96,35 @@ and restoration preserves concurrently refreshed context.
 This is a mutable conversation owner, not a scheduler or an atomic transaction
 across references. Persistence and frontend composition still belong to the host.
 
+### Opaque session state
+
+`SessionState` no longer exports its constructor or mutable fields. Turn
+execution and frontend consumers use runtime operations for transcript
+residency, continuation/attachment reads, usage accumulation, last-assistant
+reads, compaction boundaries, and consumed prompt context. This keeps the
+existing ordered patch protocol in the runtime rather than duplicating it in
+frontends. Usage deltas remain individually atomic; this does not introduce
+cross-field transactions or change the exception/commit ordering above.
+
+`newSessionStateWith` remains a compatibility construction boundary: the host
+supplies conversation, generated-startup-context, usage, and compaction
+references whose lifetimes can span provider restarts. `restartSessionState`
+preserves those references while allocating fresh per-run framing and
+last-assistant state. The previous run must have stopped before it is rebuilt.
+
+The one reference-returning migration seam, `borrowConversationRef`, is limited
+to legacy attachment and model-selection helpers that still accept the host's
+conversation slot. Ordinary transcript reads and turn execution do not use it.
+Removing this seam requires migrating those helpers and their startup callers
+together; encapsulation does not yet prevent a legacy owner from replacing the
+conversation slot. Pending-state references are not otherwise exposed.
+
 These extractions provide turn execution, process resources, and conversation
-state, not a
-complete headless session owner. The dependency graph still includes
+state, not a complete headless session owner. The dependency graph still includes
 `agent-server -> agent-cli -> agent-cli-runtime`. The server still calls
 `Agent.CLI.NativeRuntime.runNativeTurn`, which lowers native requests into
-`CliOptions`; `NativeRunHooks.nativePrepareOptions` itself accepts that type.
+`CliOptions` internally. The public native hook uses `nativeStartupPolicy`
+rather than exposing those options.
 Startup, tool composition, turn preparation, terminal state in `SessionEnv`,
 normal persistence, and auxiliary rollback application remain in the CLI.
 Server sandbox option restrictions remain on the existing path.

--- a/packages/agent-cli-runtime/src/Agent/Runtime/SessionState.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/SessionState.hs
@@ -5,20 +5,45 @@
 -- with different restart lifetimes; keeping those references does not duplicate
 -- their contents or reset them when the frontend environment is rebuilt.
 module Agent.Runtime.SessionState
-    ( SessionState(..)
+    ( SessionState
     , newSessionState
     , newSessionStateWith
+    , restartSessionState
+    , borrowConversationRef
+    , readSessionTranscript
+    , withSessionTranscript
+    , readSessionPreviousResponseId
+    , readSessionAttachments
+    , currentSessionTranscriptGeneration
+    , evictSessionTranscript
+    , readSessionUsage
+    , addSessionUsage
+    , readLastAssistant
+    , clearLastAssistant
+    , readAutomaticCompaction
+    , installAutomaticCompaction
+    , clearAutomaticCompaction
+    , takeGrokContext
+    , clearGrokContext
     , commitConversationPatch
     , restoreConsumedPromptContext
     , takeStartupContext
     ) where
 
-import Agent.Loop (TokenUsage, addTokenUsage, emptyTokenUsage)
+import Agent.Loop (ImageAttachment, TokenUsage, addTokenUsage, emptyTokenUsage)
+import Agent.Responses.Types (ResponseItem)
 import Agent.Runtime.Compaction (AutomaticCompactionBoundary)
 import Agent.Runtime.ConversationStore
     ( ConversationStore
+    , TranscriptCheckpoint
+    , TranscriptGeneration
     , commitConversationTranscript
+    , currentTranscriptGeneration
+    , evictConversationTranscript
     , newConversationStore
+    , readConversationAttachments
+    , readConversationPreviousResponseId
+    , withConversationTranscript
     , writeConversationPreviousResponseId
     )
 import Agent.Runtime.TurnState
@@ -74,6 +99,80 @@ newSessionStateWith conversation startup usage compaction initialGrok = do
         , stateAutomaticCompaction = compaction
         }
 
+-- | Rebuild the per-run state without copying or resetting references owned by
+-- the surrounding session. The caller must have stopped the previous run.
+restartSessionState :: SessionState -> Maybe Text -> IO SessionState
+restartSessionState state =
+    newSessionStateWith state.stateConversation state.stateStartupContext
+        state.stateUsage state.stateAutomaticCompaction
+
+-- | Migration seam for legacy attachment/model-selection APIs that still
+-- accept the host-owned conversation slot. Do not use this to replace the slot
+-- during a running turn. New consumers should use runtime operations instead.
+-- This is deliberately the only reference exposed by the session state.
+borrowConversationRef :: SessionState -> IORef ConversationStore
+borrowConversationRef state = state.stateConversation
+
+readSessionTranscript :: SessionState -> IO [ResponseItem]
+readSessionTranscript state = withSessionTranscript state pure
+
+withSessionTranscript :: SessionState -> ([ResponseItem] -> IO a) -> IO a
+withSessionTranscript state action =
+    readIORef state.stateConversation >>= \store ->
+        withConversationTranscript store action
+
+readSessionPreviousResponseId :: SessionState -> IO (Maybe Text)
+readSessionPreviousResponseId state =
+    readIORef state.stateConversation >>= readConversationPreviousResponseId
+
+readSessionAttachments :: SessionState -> IO [ImageAttachment]
+readSessionAttachments state =
+    readIORef state.stateConversation >>= readConversationAttachments
+
+currentSessionTranscriptGeneration :: SessionState -> IO TranscriptGeneration
+currentSessionTranscriptGeneration state =
+    readIORef state.stateConversation >>= currentTranscriptGeneration
+
+evictSessionTranscript
+    :: SessionState -> TranscriptGeneration -> TranscriptCheckpoint -> IO Bool
+evictSessionTranscript state generation checkpoint =
+    readIORef state.stateConversation >>= \store ->
+        evictConversationTranscript store generation checkpoint
+
+readSessionUsage :: SessionState -> IO TokenUsage
+readSessionUsage state = readIORef state.stateUsage
+
+addSessionUsage :: SessionState -> TokenUsage -> IO ()
+addSessionUsage state delta =
+    atomicModifyIORef' state.stateUsage \current ->
+        (addTokenUsage current delta, ())
+
+readLastAssistant :: SessionState -> IO (Maybe Text)
+readLastAssistant state = readIORef state.stateLastAssistant
+
+clearLastAssistant :: SessionState -> IO ()
+clearLastAssistant state = writeIORef state.stateLastAssistant Nothing
+
+readAutomaticCompaction :: SessionState -> IO (Maybe AutomaticCompactionBoundary)
+readAutomaticCompaction state = readIORef state.stateAutomaticCompaction
+
+installAutomaticCompaction :: SessionState -> AutomaticCompactionBoundary -> IO ()
+installAutomaticCompaction state boundary =
+    writeIORef state.stateAutomaticCompaction (Just boundary)
+
+clearAutomaticCompaction :: SessionState -> IO ()
+clearAutomaticCompaction state = writeIORef state.stateAutomaticCompaction Nothing
+
+-- | Consume a prepared first-turn prefix once. Loading a fallback remains a
+-- host operation, outside mutation of the session state.
+takeGrokContext :: SessionState -> IO (Maybe Text)
+takeGrokContext state =
+    atomicModifyIORef' state.stateGrokFirstTurnContext \pending ->
+        (Nothing, pending)
+
+clearGrokContext :: SessionState -> IO ()
+clearGrokContext state = writeIORef state.stateGrokFirstTurnContext Nothing
+
 takeStartupContext :: SessionState -> IO (Maybe Text)
 takeStartupContext state =
     atomicModifyIORef' state.stateStartupContext \pending ->
@@ -121,8 +220,7 @@ commitConversationPatch state patch = do
         (case patch.patchGrokFirstTurnContext of
             KeepGrokContext -> Nothing
             RestoreGrokContext consumed -> Just consumed)
-    atomicModifyIORef' state.stateUsage \current ->
-        (addTokenUsage current patch.patchUsageDelta, ())
+    addSessionUsage state patch.patchUsageDelta
     case patch.patchLastAssistant of
         KeepField -> pure ()
         SetField value -> writeIORef state.stateLastAssistant value

--- a/packages/agent-cli-runtime/test/Agent/Runtime/ConversationSessionSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/Runtime/ConversationSessionSpec.hs
@@ -12,6 +12,8 @@ import Agent.Runtime.TurnEngine qualified as Engine
 import Agent.Runtime.TurnExecution qualified as Execution
 import Agent.Runtime.TurnState
 import Agent.Tools.Types (mkToolRegistry)
+import Control.Concurrent.Async (concurrently_)
+import Control.Monad (replicateM_)
 import Data.IORef
 import Data.Text qualified as Text
 import Test.Hspec
@@ -27,8 +29,8 @@ spec = describe "runtime conversation state" do
             }
         readTranscript first `shouldReturn` history
         readTranscript second `shouldReturn` []
-        readIORef second.stateLastAssistant `shouldReturn` Nothing
-        readIORef second.stateUsage `shouldReturn` emptyTokenUsage
+        Session.readLastAssistant second `shouldReturn` Nothing
+        Session.readSessionUsage second `shouldReturn` emptyTokenUsage
 
     it "borrows durable references while resetting only per-host context" do
         original <- Session.newSessionState
@@ -37,24 +39,21 @@ spec = describe "runtime conversation state" do
             , patchUsageDelta = TokenUsage 10 4 1
             , patchLastAssistant = SetField (Just "old answer")
             }
-        writeIORef original.stateStartupContext (Just "pending")
-        rebuilt <- Session.newSessionStateWith
-            original.stateConversation original.stateStartupContext
-            original.stateUsage original.stateAutomaticCompaction
-            (Just "new framing")
+        Session.restoreConsumedPromptContext original (Just "pending") Nothing
+        rebuilt <- Session.restartSessionState original (Just "new framing")
         readTranscript rebuilt `shouldReturn` history
-        readIORef rebuilt.stateUsage `shouldReturn` TokenUsage 10 4 1
+        Session.readSessionUsage rebuilt `shouldReturn` TokenUsage 10 4 1
         Session.takeStartupContext rebuilt `shouldReturn` Just "pending"
-        readIORef original.stateStartupContext `shouldReturn` Nothing
-        readIORef rebuilt.stateLastAssistant `shouldReturn` Nothing
-        readIORef original.stateLastAssistant `shouldReturn` Just "old answer"
-        readIORef rebuilt.stateGrokFirstTurnContext `shouldReturn` Just "new framing"
+        Session.takeStartupContext original `shouldReturn` Nothing
+        Session.readLastAssistant rebuilt `shouldReturn` Nothing
+        Session.readLastAssistant original `shouldReturn` Just "old answer"
+        Session.takeGrokContext rebuilt `shouldReturn` Just "new framing"
 
     it "preserves transcript-write continuation invalidation and adds newer usage" do
         state <- Session.newSessionState
-        store <- readIORef state.stateConversation
+        store <- readIORef (Session.borrowConversationRef state)
         writeConversationPreviousResponseId store (Just "old")
-        writeIORef state.stateUsage (TokenUsage 20 8 2)
+        Session.addSessionUsage state (TokenUsage 20 8 2)
         Session.commitConversationPatch state keepPatch
             { patchPreviousResponseId = SetField (Just "new")
             , patchTranscript = SetField history
@@ -63,21 +62,27 @@ spec = describe "runtime conversation state" do
             }
         readConversationPreviousResponseId store `shouldReturn` Nothing
         readTranscript state `shouldReturn` history
-        readIORef state.stateUsage `shouldReturn` TokenUsage 30 12 3
-        readIORef state.stateLastAssistant `shouldReturn` Just "answer"
+        Session.readSessionUsage state `shouldReturn` TokenUsage 30 12 3
+        Session.readLastAssistant state `shouldReturn` Just "answer"
 
     it "consumes startup once and restores without losing refreshed context" do
-        state <- Session.newSessionState
-        writeIORef state.stateStartupContext (Just "original startup")
+        conversation <- newIORef =<< newConversationStore Nothing [] []
+        startup <- newIORef (Just "original startup")
+        usage <- newIORef emptyTokenUsage
+        compaction <- newIORef Nothing
+        state <- Session.newSessionStateWith
+            conversation startup usage compaction Nothing
         Session.takeStartupContext state `shouldReturn` Just "original startup"
         Session.takeStartupContext state `shouldReturn` Nothing
-        writeIORef state.stateStartupContext (Just "refreshed skills")
-        writeIORef state.stateGrokFirstTurnContext (Just "new framing")
+        -- The host retains ownership of generated startup context while the
+        -- runtime owns how consumed context is restored.
+        writeIORef startup (Just "refreshed skills")
+        Session.restoreConsumedPromptContext state Nothing (Just "new framing")
         Session.restoreConsumedPromptContext state
             (Just "original startup") (Just "old framing")
-        readIORef state.stateStartupContext `shouldReturn`
+        Session.takeStartupContext state `shouldReturn`
             restoreStartupContext "original startup" (Just "refreshed skills")
-        readIORef state.stateGrokFirstTurnContext `shouldReturn` Just "new framing"
+        Session.takeGrokContext state `shouldReturn` Just "new framing"
 
     it "restores missing context through the shared patch operation" do
         state <- Session.newSessionState
@@ -85,8 +90,36 @@ spec = describe "runtime conversation state" do
             { patchStartupContext = RestoreStartup "startup"
             , patchGrokFirstTurnContext = RestoreGrokContext "framing"
             }
-        readIORef state.stateStartupContext `shouldReturn` Just "startup"
-        readIORef state.stateGrokFirstTurnContext `shouldReturn` Just "framing"
+        Session.takeStartupContext state `shouldReturn` Just "startup"
+        Session.takeGrokContext state `shouldReturn` Just "framing"
+
+    it "adds concurrent usage deltas without exposing the usage reference" do
+        state <- Session.newSessionState
+        let add = replicateM_ 1000 (Session.addSessionUsage state (TokenUsage 1 2 3))
+        concurrently_ add add
+        Session.readSessionUsage state `shouldReturn` TokenUsage 2000 4000 6000
+
+    it "retains compaction across a host rebuild and clears it explicitly" do
+        original <- Session.newSessionState
+        let boundary = AutomaticCompactionBoundary history [UserMessage "continue"]
+        Session.installAutomaticCompaction original boundary
+        rebuilt <- Session.restartSessionState original Nothing
+        Session.readAutomaticCompaction rebuilt `shouldReturn` Just boundary
+        Session.clearAutomaticCompaction rebuilt
+        Session.readAutomaticCompaction original `shouldReturn` Nothing
+
+    it "clears per-run answer and framing without resetting the transcript" do
+        state <- Session.newSessionState
+        Session.commitConversationPatch state keepPatch
+            { patchTranscript = SetField history
+            , patchLastAssistant = SetField (Just "answer")
+            , patchGrokFirstTurnContext = RestoreGrokContext "framing"
+            }
+        Session.clearLastAssistant state
+        Session.clearGrokContext state
+        Session.readLastAssistant state `shouldReturn` Nothing
+        Session.takeGrokContext state `shouldReturn` Nothing
+        readTranscript state `shouldReturn` history
 
     it "commits failed-loop model inputs without committing partial display text" do
         state <- Session.newSessionState
@@ -103,7 +136,7 @@ spec = describe "runtime conversation state" do
         Engine.displayItems final.finalizedDisplayItems
             `shouldSatisfy` (not . null)
         readTranscript state `shouldReturn` (history <> inputOnlyTurnItems prepared)
-        readIORef state.stateLastAssistant `shouldReturn` Nothing
+        Session.readLastAssistant state `shouldReturn` Nothing
 
     it "applies exceptional rollback against the installed compaction boundary" do
         state <- Session.newSessionState
@@ -116,14 +149,14 @@ spec = describe "runtime conversation state" do
                     { readBackendState = do
                         Session.commitConversationPatch state keepPatch
                             { patchTranscript = SetField summary }
-                        writeIORef state.stateAutomaticCompaction (Just boundary)
+                        Session.installAutomaticCompaction state boundary
                         ioError (userError "interrupted")
                     }
                 }
         execute state config `shouldThrow` anyIOException
         readTranscript state `shouldReturn` summary
-        readIORef state.stateStartupContext `shouldReturn` Nothing
-        readIORef state.stateGrokFirstTurnContext `shouldReturn` Nothing
+        Session.takeStartupContext state `shouldReturn` Nothing
+        Session.takeGrokContext state `shouldReturn` Nothing
 
 keepPatch :: ConversationPatch
 keepPatch = ConversationPatch
@@ -143,20 +176,19 @@ prepared = PreparedTurn history (Just "startup") (Just "framing")
     [UserMessage "fix it"]
 
 readTranscript :: Session.SessionState -> IO [ResponseItem]
-readTranscript state = readIORef state.stateConversation >>= \store ->
-    withConversationTranscript store pure
+readTranscript = Session.readSessionTranscript
 
 execute :: Session.SessionState -> LoopConfig -> IO Execution.ExecutedTurn
 execute state config = Execution.executePreparedTurn
     (Execution.PreparedExecution config Nothing prepared)
-    (readIORef state.stateAutomaticCompaction)
+    (Session.readAutomaticCompaction state)
     (Session.commitConversationPatch state . (.exceptionalPatch))
 
 configFor :: Session.SessionState -> Backend -> IO LoopConfig
 configFor state backend = do
     cancel <- newCancelFlag
     tools <- either (fail . Text.unpack) pure (mkToolRegistry [])
-    let readStore = readIORef state.stateConversation
+    let readStore = readIORef (Session.borrowConversationRef state)
     pure LoopConfig
         { loopBackend = backend
         , loopBackendState = BackendStateStore

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Recap.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Recap.hs
@@ -32,7 +32,6 @@ import Agent.CLI.Session
     , setSessionRecap
     , setSessionTurnSummary
     )
-import Agent.CLI.Session.History (readLiveTranscript)
 import Agent.CLI.SessionEnv (SessionEnv(..))
 import Agent.Runtime.SessionState qualified as RuntimeState
 import Agent.CLI.Style (roleMuted)
@@ -50,7 +49,7 @@ runSessionRecap registerCancel env kind = do
     let fullscreen = env.sessionFullscreen
         stdoutHandle = env.sessionRender.renderStdout
     params <- readSessionRequestParams env.sessionParams
-    transcript <- readLiveTranscript env.sessionState.stateConversation
+    transcript <- RuntimeState.readSessionTranscript env.sessionState
     let snapshot = sideCallSnapshot params transcript
     color <- resolveColor stdoutHandle
     let mainTurns = mainTurnCount transcript
@@ -171,7 +170,7 @@ recapFailed env message = do
 runSessionTurnSummary :: SessionEnv -> IO ()
 runSessionTurnSummary env = do
     params <- readSessionRequestParams env.sessionParams
-    transcript <- readLiveTranscript env.sessionState.stateConversation
+    transcript <- RuntimeState.readSessionTranscript env.sessionState
     let snapshot = sideCallSnapshot params transcript
     result <-
         runTurnSummaryWithCancel

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -58,7 +58,6 @@ import Agent.CLI.Runtime.Types
     ( PendingTurnPresentation
     , RunResult(RunSwitchProvider)
     )
-import Agent.CLI.Session.History ( readLiveAttachments )
 import Agent.CLI.Session.Interaction
     ( buildPromptState
     , syncFullscreenContext
@@ -160,10 +159,7 @@ repl env = replWithDraft env ""
 replWithDraft :: SessionEnv -> Text -> IO RunResult
 replWithDraft env@SessionEnv
     { sessionRender = render
-    , sessionState = RuntimeState.SessionState
-        { stateConversation = conversationRef
-        , stateUsage = usageRef
-        }
+    , sessionState = sessionState
     , sessionProvider = provider
     , sessionModelCatalog = catalog
     , sessionGatewayModels = gatewayModelsRef
@@ -210,9 +206,9 @@ replWithDraft env@SessionEnv
     let planActive = planState == PlanActive
         planPending = planState == PlanPending
     policy <- readIORef policyRef
-    pendingAttachments <- readLiveAttachments conversationRef
+    pendingAttachments <- RuntimeState.readSessionAttachments sessionState
     let idleMode = replModeFromState planState policy
-    usage <- readIORef usageRef
+    usage <- RuntimeState.readSessionUsage sessionState
     account <- (.activeAccountLabel) <$> readActiveAccount accountRef
     mlineResult <- case fullscreen of
         Just runtime -> do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
@@ -18,7 +18,7 @@ import Agent.CLI.Session.Attachments
     ( putImagePreview, queueAttachedImages, queueClipboardImages )
 import Agent.CLI.SessionState (removeImageAttachmentAt)
 import Agent.CLI.Session.History
-    ( modifyLiveAttachments, readLiveAttachments )
+    ( modifyLiveAttachments )
 import Agent.CLI.SessionEnv ( SessionEnv(..) )
 import Agent.Runtime.SessionState qualified as RuntimeState
 import Agent.CLI.Style ( glyphOk, glyphSession, roleError, roleMuted )
@@ -54,8 +54,7 @@ handleClipboardInput
     -> IO RunResult
 handleClipboardInput
         SessionEnv
-            { sessionState = RuntimeState.SessionState
-                { stateConversation = conversationRef }
+            { sessionState = sessionState
             , sessionPreviewId = previewIdRef
             , sessionFullscreen = fullscreen
             }
@@ -120,12 +119,13 @@ handleClipboardInput
                 fullscreenEvent (UiSetNotice Nothing)
                 continueWith pastedDraft
   where
+    conversationRef = RuntimeState.borrowConversationRef sessionState
     fullscreenEvent event = case fullscreen of
         Nothing -> pure ()
         Just runtime -> emitUiEvent runtime event
     syncFullscreenImagePreviews =
         forM_ fullscreen \runtime ->
-            readLiveAttachments conversationRef
+            RuntimeState.readSessionAttachments sessionState
                 >>= setFullscreenImagePreviews runtime
     displayInfo message minimalAction = case fullscreen of
         Nothing -> minimalAction
@@ -143,8 +143,7 @@ handleAttachmentAction
 handleAttachmentAction
         env@SessionEnv
             { sessionRender = render
-            , sessionState = RuntimeState.SessionState
-                { stateConversation = conversationRef }
+            , sessionState = sessionState
             , sessionPreviewId = previewIdRef
             , sessionFullscreen = fullscreen
             }
@@ -208,7 +207,7 @@ handleAttachmentAction
                                     (glyphOk <> message))
                         continue
     ReplShowAttachments -> do
-        pending <- readLiveAttachments conversationRef
+        pending <- RuntimeState.readSessionAttachments sessionState
         color <- resolveColor stdout
         let message =
                 if null pending
@@ -250,12 +249,13 @@ handleAttachmentAction
                 (roleMuted color (glyphOk <> message))
         continue
   where
+    conversationRef = RuntimeState.borrowConversationRef sessionState
     fullscreenEvent event = case fullscreen of
         Nothing -> pure ()
         Just runtime -> emitUiEvent runtime event
     syncFullscreenImagePreviews =
         forM_ fullscreen \runtime ->
-            readLiveAttachments conversationRef
+            RuntimeState.readSessionAttachments sessionState
                 >>= setFullscreenImagePreviews runtime
     displayInfo message minimalAction = case fullscreen of
         Nothing -> minimalAction

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -121,7 +121,7 @@ import Agent.CLI.Session.Attachments ( queueAttachedImages )
 import Agent.CLI.Session.Choices
     ( accountUsageText, showAccountUsage )
 import Agent.CLI.Session.History
-    ( modifyLiveAttachments, readLiveAttachments, readLiveTranscript )
+    ( modifyLiveAttachments )
 import Agent.CLI.Session.Interaction ( runBtwQuestion )
 import Agent.CLI.Session.Selection
     ( currentSessionId, pickAgentChoice )
@@ -333,15 +333,13 @@ submitReplLine handlerContext finishTurn retryPendingTurn slashCatalog skillInvo
         , handlerStdoutColor = stdoutColor
         } = handlerContext
     SessionEnv
-        { sessionState = RuntimeState.SessionState
-            { stateConversation = conversationRef }
-        , sessionPersist = persist
+        { sessionPersist = persist
         , sessionFullscreen = fullscreen
         } = env
     submitLine
             slashCatalog skillInvocations
             continue color pasted line = do
-        attachmentCount <- length <$> readLiveAttachments conversationRef
+        attachmentCount <- length <$> RuntimeState.readSessionAttachments env.sessionState
         case submissionPromptText attachmentCount line of
             Nothing -> continue
             Just promptLine -> do
@@ -742,7 +740,7 @@ showQueuedPrompts handlerContext next = do
 showContextReport :: ReplHandlerContext -> IO RunResult -> IO RunResult
 showContextReport handlerContext next = do
         currentParams <- readSessionRequestParams env.sessionParams
-        history <- readLiveTranscript conversationRef
+        history <- RuntimeState.readSessionTranscript env.sessionState
         occupancy <- readIORef contextOccupancyRef
         contextWindow <- currentContextWindow
         activeTools <- env.sessionActiveToolNames
@@ -759,7 +757,6 @@ showContextReport handlerContext next = do
         next
   where
     env = handlerContext.handlerSessionEnv
-    conversationRef = env.sessionState.stateConversation
     contextOccupancyRef = env.sessionContextOccupancy
     currentContextWindow = env.sessionContextWindow
     displayInfo = displayReplInfo handlerContext
@@ -993,7 +990,7 @@ submitSkillInvocation handlerContext finishTurn invocations next color line invo
                         finishTurn False result
   where
     env = handlerContext.handlerSessionEnv
-    conversationRef = env.sessionState.stateConversation
+    conversationRef = RuntimeState.borrowConversationRef env.sessionState
     fullscreen = env.sessionFullscreen
     render = env.sessionRender
     fullscreenEvent = emitReplEvent env
@@ -1041,7 +1038,7 @@ submitExpandedPrompt handlerContext finishTurn pasted next color original expand
                 finishTurn False result
   where
     env = handlerContext.handlerSessionEnv
-    conversationRef = env.sessionState.stateConversation
+    conversationRef = RuntimeState.borrowConversationRef env.sessionState
     fullscreen = env.sessionFullscreen
     render = env.sessionRender
     fullscreenEvent = emitReplEvent env
@@ -1065,7 +1062,7 @@ submitPrompt handlerContext finishTurn pasted next color text = do
                 (isNothing fullscreen)
                 images
             forM_ fullscreen \runtime ->
-                readLiveAttachments conversationRef
+                RuntimeState.readSessionAttachments env.sessionState
                     >>= setFullscreenImagePreviews runtime
             displayReplInfo handlerContext message $
                 Text.putStrLn
@@ -1095,7 +1092,7 @@ submitPrompt handlerContext finishTurn pasted next color text = do
                         finishTurn False result
   where
     env = handlerContext.handlerSessionEnv
-    conversationRef = env.sessionState.stateConversation
+    conversationRef = RuntimeState.borrowConversationRef env.sessionState
     fullscreen = env.sessionFullscreen
 
 showWorkingTreeDiff :: ReplHandlerContext -> IO RunResult -> Bool -> IO RunResult

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Selection.hs
@@ -301,8 +301,7 @@ handleSelection
 handleSelection
         env@SessionEnv
             { sessionRender = render
-            , sessionState = RuntimeState.SessionState
-                { stateConversation = conversationRef }
+            , sessionState = sessionState
             , sessionProvider = provider
             , sessionConnection = connectionId
             , sessionDialect = dialect
@@ -382,7 +381,7 @@ handleSelection
                             choice.modelTarget.targetModelId
                             choice.modelTarget.targetWireModelId
                             choice.modelTarget.targetDialect
-                            paramsRef render conversationRef persist
+                            paramsRef render (RuntimeState.borrowConversationRef sessionState) persist
                         env.sessionRefreshRequestParams
                         displayInfo message $
                             Text.putStrLn
@@ -470,8 +469,7 @@ chooseModel env@SessionEnv
     , sessionParams = paramsRef
     , sessionWorkspace = WorkspaceContext{home, projectRoot}
     , sessionRender = render
-    , sessionState = RuntimeState.SessionState
-        { stateConversation = conversationRef }
+    , sessionState = sessionState
     , sessionPersist = persist
     } next = do
     color <- resolveColor stderr
@@ -517,7 +515,7 @@ chooseModel env@SessionEnv
                     choice.modelTarget.targetModelId
                     choice.modelTarget.targetWireModelId
                     choice.modelTarget.targetDialect
-                    paramsRef render conversationRef persist
+                    paramsRef render (RuntimeState.borrowConversationRef sessionState) persist
                 env.sessionRefreshRequestParams
                 setSessionEffort env selectedEffort
                 selectionInfo env message $

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Session.hs
@@ -719,7 +719,7 @@ handleShowSessionInfoAction runtime = do
     let env = runtime.actionEnv
     color <- resolveColor stdout
     params <- readSessionRequestParams env.sessionParams
-    usage <- readIORef env.sessionState.stateUsage
+    usage <- RuntimeState.readSessionUsage env.sessionState
     shellMode <- env.sessionShellMode
     (persistenceState, sessionId, sessionTitle) <-
         case env.sessionPersist of

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Transcript.hs
@@ -248,14 +248,11 @@ copyResponse context request =
 loadAssistantResponses
     :: SessionEnv
     -> IO (Either Text [Text])
-loadAssistantResponses env@SessionEnv
-        { sessionState = RuntimeState.SessionState
-            { stateLastAssistant = lastAssistantRef }
-        } =
+loadAssistantResponses env =
     loadPersistedTranscript env >>= \case
         Left err -> pure (Left err)
         Right persisted -> do
-            latest <- readIORef lastAssistantRef
+            latest <- RuntimeState.readLastAssistant env.sessionState
             let responses =
                     maybe
                         []
@@ -319,7 +316,7 @@ copyCodeBlock
     -> IO ()
 copyCodeBlock context index = do
     answer <-
-        readIORef context.handlerSessionEnv.sessionState.stateLastAssistant
+        RuntimeState.readLastAssistant context.handlerSessionEnv.sessionState
     let label = "code block " <> Text.pack (show index)
     copyCommand
         context
@@ -330,7 +327,7 @@ copyCodeBlock context index = do
 copyDiffBlock :: ReplHandlerContext -> IO ()
 copyDiffBlock context = do
     answer <-
-        readIORef context.handlerSessionEnv.sessionState.stateLastAssistant
+        RuntimeState.readLastAssistant context.handlerSessionEnv.sessionState
     copyCommand
         context
         "diff block"

--- a/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Interaction.hs
@@ -53,10 +53,6 @@ import Agent.CLI.Session
     )
 import Agent.CLI.SessionEnv (SessionEnv(..))
 import Agent.Runtime.SessionState qualified as RuntimeState
-import Agent.CLI.Session.History
-    ( readLiveAttachments
-    , readLiveTranscript
-    )
 import Agent.CLI.Style (roleError)
 import Agent.CLI.Status (formatFooterAccount)
 import Agent.CLI.Terminal (resolveColor)
@@ -99,8 +95,8 @@ syncFullscreenPrompt env = do
         params <- readSessionRequestParams env.sessionParams
         policy <- readIORef env.sessionPolicy
         account <- (.activeAccountLabel) <$> readActiveAccount env.sessionAccount
-        usage <- readIORef env.sessionState.stateUsage
-        attachments <- readLiveAttachments env.sessionState.stateConversation
+        usage <- RuntimeState.readSessionUsage env.sessionState
+        attachments <- RuntimeState.readSessionAttachments env.sessionState
         emitUiEvent runtime $ UiSetPrompt $
             buildPromptState
                 (dialectId env.sessionDialect)
@@ -119,7 +115,7 @@ syncFullscreenContext env =
     forM_ env.sessionFullscreen \runtime -> do
         occupancy <- readIORef env.sessionContextOccupancy
         params <- readSessionRequestParams env.sessionParams
-        history <- readLiveTranscript env.sessionState.stateConversation
+        history <- RuntimeState.readSessionTranscript env.sessionState
         contextWindow <- env.sessionContextWindow
         emitUiEvent runtime $
             UiSetContextUsage
@@ -198,7 +194,7 @@ runBtwQuestion registerCancel env question = do
         stderrHandle = env.sessionRender.renderStderr
     color <- resolveColor stdoutHandle
     params <- readSessionRequestParams env.sessionParams
-    transcript <- readLiveTranscript env.sessionState.stateConversation
+    transcript <- RuntimeState.readSessionTranscript env.sessionState
     let snapshot = sideCallSnapshot params transcript
     forM_ fullscreen \runtime ->
         emitUiEvent runtime

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -360,7 +360,7 @@ data SessionControlRuntime = SessionControlRuntime
     , controlRenderStateRef :: !(IORef RenderState)
     , controlAllowedToolsRef :: !(IORef (Set.Set Text.Text))
     , controlComputerUseEnabledRef :: !(IORef Bool)
-    , controlLastAssistantRef :: !(IORef (Maybe Text.Text))
+    , controlReadLastAssistant :: !(IO (Maybe Text.Text))
     , controlUnavailableProvidersRef :: !(IORef (Set.Set Provider))
     , controlStartupUnavailableRef :: !(IORef (Maybe (STM ApiError)))
     , controlRestartEffortRef :: !(IORef (Maybe Text.Text))
@@ -403,7 +403,6 @@ newSessionControlRuntime host SessionRequest{..} = do
                 (lookupAppTool
                     computerToolName
                     (sessionDirectTools refreshTools codeModeRuntime))
-    let lastAssistantRef = host.hostSessionState.stateLastAssistant
     unavailableProvidersRef <- newIORef unavailableProviders
     startupUnavailableRef <- newIORef startupUnavailable
     restartEffortRef <- newIORef Nothing
@@ -491,7 +490,7 @@ newSessionControlRuntime host SessionRequest{..} = do
         , controlRenderStateRef = renderStateRef
         , controlAllowedToolsRef = allowedToolsRef
         , controlComputerUseEnabledRef = computerUseEnabledRef
-        , controlLastAssistantRef = lastAssistantRef
+        , controlReadLastAssistant = RuntimeState.readLastAssistant host.hostSessionState
         , controlUnavailableProvidersRef = unavailableProvidersRef
         , controlStartupUnavailableRef = startupUnavailableRef
         , controlRestartEffortRef = restartEffortRef
@@ -528,7 +527,6 @@ buildSkillContextRuntime
     stderrHandle = host.hostStderrHandle
     loadsHostWorkspaceContext = host.hostLoadsWorkspaceContext
     renderStateRef = controls.controlRenderStateRef
-    lastAssistantRef = controls.controlLastAssistantRef
     steeringInputs = controls.controlSteeringInputs
     agentViewportRuntime = controls.controlAgentViewportRuntime
     installSkills context queueContext skills = do
@@ -607,9 +605,9 @@ buildSkillContextRuntime
         writeIORef usageRef emptyTokenUsage
         writeIORef contextOccupancyRef Nothing
         modifyIORef' renderStateRef clearRenderTokenRate
-        writeIORef lastAssistantRef Nothing
+        RuntimeState.clearLastAssistant host.hostSessionState
         writeIORef subagentSessions Map.empty
-        writeIORef host.hostSessionState.stateGrokFirstTurnContext Nothing
+        RuntimeState.clearGrokContext host.hostSessionState
         resetAgentViewport agentViewportRuntime
         case multiCtx of
             Just ctx -> resetSubagentRegistry ctx.multiRegistry
@@ -1676,13 +1674,13 @@ installSessionActions
                     ReplCopy request
                         | request.copyResponseIndex == 1
                         , Nothing <- request.copyDestination ->
-                        readIORef controls.controlLastAssistantRef
+                        controls.controlReadLastAssistant
                             >>= copyImmediate
                                 "last response"
                                 "no assistant response to copy"
                     ReplCopyCode index -> do
                         answer <-
-                            readIORef controls.controlLastAssistantRef
+                            controls.controlReadLastAssistant
                         let label =
                                 "code block " <> Text.pack (show index)
                         copyImmediate
@@ -1691,7 +1689,7 @@ installSessionActions
                             (answer >>= fencedCodeBlock index)
                     ReplCopyDiff -> do
                         answer <-
-                            readIORef controls.controlLastAssistantRef
+                            controls.controlReadLastAssistant
                         copyImmediate
                             "diff block"
                             "no diff block was found"

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -76,11 +76,7 @@ import Agent.CLI.SessionEnv
     , SessionEnv(..)
     )
 import Agent.CLI.Session.History
-    ( currentLiveTranscriptGeneration
-    , durableTranscriptCheckpoint
-    , evictLiveTranscript
-    , readLivePreviousResponseId
-    , withLiveTranscript
+    ( durableTranscriptCheckpoint
     )
 import Agent.CLI.SessionTitle
     ( SessionTitleResult(..)
@@ -125,7 +121,6 @@ import Agent.Loop
     , LoopResult(..)
     , TurnInput(..)
     , TurnOutput(..)
-    , addTokenUsage
     , turnInputImages
     )
 import Agent.Provider (Provider(..))
@@ -204,17 +199,17 @@ runOneTurnWithContext includeTurnContext env promptText inputs = do
     -- Automatic compaction is scoped to one enclosing user turn. A committed
     -- boundary from an earlier attempt is already represented by the live and
     -- durable transcripts and must not affect this turn's suffix calculation.
-    writeIORef env.sessionState.stateAutomaticCompaction Nothing
+    RuntimeState.clearAutomaticCompaction env.sessionState
     bracket_
         env.sessionBeginWindowTitleBusy
         env.sessionEndWindowTitleBusy
         (bracket_
             env.sessionBeginTurnActivity
             env.sessionEndTurnActivity
-            (withLiveTranscript env.sessionState.stateConversation \beforeItems ->
+            (RuntimeState.withSessionTranscript env.sessionState \beforeItems ->
                 runOneTurnBusy
                     includeTurnContext env beforeItems promptText inputs))
-        `finally` writeIORef env.sessionState.stateAutomaticCompaction Nothing
+        `finally` RuntimeState.clearAutomaticCompaction env.sessionState
 
 timestampConversationBounds
     :: Persistence
@@ -295,11 +290,10 @@ prepareBusyTurn request = do
     let env = request.busyEnv
         planMode = env.sessionPlanMode
         taskPlan = env.sessionTaskPlan
-        grokFirstTurnContext = env.sessionState.stateGrokFirstTurnContext
     applyPendingSessionTitles env
     initialPlanState <- readIORef planMode.planStateRef
     when (initialPlanState == PlanPending) (activatePlanMode planMode)
-    prev <- readLivePreviousResponseId env.sessionState.stateConversation
+    prev <- RuntimeState.readSessionPreviousResponseId env.sessionState
     when request.busyIncludeTurnContext $
         env.sessionRecordImageGenerationInputs
             (concatMap turnInputImages request.busyInputs)
@@ -357,12 +351,13 @@ prepareBusyTurn request = do
                         null request.busyBeforeItems && prev == Nothing
                 if firstTurn
                     then do
-                        prefix <-
-                            takeGrokFirstTurnContext
-                                grokFirstTurnContext
+                        pending <- RuntimeState.takeGrokContext env.sessionState
+                        prefix <- maybe
                                 (loadGrokFirstTurnPrefix
                                     env.sessionPreparedWorkspaceEnvironment
                                     env.sessionWorkspace.cwd)
+                                pure
+                                pending
                         pure (UserMessage prefix : framed, Just prefix)
                     else pure (framed, Nothing)
             else pure (stampedInputs, Nothing)
@@ -485,7 +480,7 @@ executeBusyTurn request preparation = do
                     preparation.preparedPreviousResponseId
                 , executionPreparedTurn = prepared
                 }
-            (readIORef env.sessionState.stateAutomaticCompaction)
+            (RuntimeState.readAutomaticCompaction env.sessionState)
             (rollbackExceptionalTurn request preparation rootTurnId)
     let execution = executed.executedLoop
         automaticCompaction = executed.executedCompaction
@@ -779,8 +774,7 @@ finishGeneralFailureTurn executed err = do
             LoopIncomplete turn -> Just turn
             _ -> Nothing
     forM_ maybeIncompleteTurn \turn ->
-        atomicModifyIORef' env.sessionState.stateUsage \current ->
-            (addTokenUsage current turn.tokenUsage, ())
+        RuntimeState.addSessionUsage env.sessionState turn.tokenUsage
     -- Retain the same items in the live and durable transcripts. Response id,
     -- usage, and the incomplete reason remain available in turn metadata.
     persistIncompleteTurn
@@ -955,7 +949,7 @@ persistSuccessfulTurn
 evictDurableConversation :: SessionEnv -> SessionHandle -> IO ()
 evictDurableConversation env handle = do
     generation <-
-        currentLiveTranscriptGeneration env.sessionState.stateConversation
+        RuntimeState.currentSessionTranscriptGeneration env.sessionState
     let sessionId = handle.sessionMeta.metaId
         checkpoint =
             durableTranscriptCheckpoint
@@ -963,8 +957,7 @@ evictDurableConversation env handle = do
                 (sessionsRoot env.sessionWorkspace.home)
                 sessionId
     evicted <-
-        evictLiveTranscript
-            env.sessionState.stateConversation generation checkpoint
+        RuntimeState.evictSessionTranscript env.sessionState generation checkpoint
     when evicted performMajorGC
 
 -- | Wrap the last actual user payload in the Grok Build request envelope.


### PR DESCRIPTION
## Summary
- Hide SessionState constructors and mutable fields; route turn execution and frontend consumers through runtime operations.
- Preserve long-lived conversation/startup/usage/compaction across host restarts while resetting per-run framing and assistant state.
- Document the explicit legacy conversation borrowing seam and remaining host ownership. This does not yet remove the server → CLI dependency or introduce cross-field transactions.

## Validation
- GHCi CLI + runtime: 292 modules loaded successfully.
- Runtime conversation state suite: 10 examples, 0 failures (including concurrent usage and restart lifetime regressions).
- Broader local runtime suite: 262 examples, 23 fixture failures, all reporting `PostgreSQL socket directory is too long` under the mandated session temporary directory. The targeted state suite passes; CI runs the broader package tests in its own environment.
- Package boundary and whitespace checks pass.
- Live GHCi/tmux smoke: startup, prompt, successful no-tool model turn (`ARCHITECTURE_SMOKE_OK`), and return to input prompt.

Part of the incremental agent architecture improvements; independently reviewable.
