### PR TITLE
Extract typed ownership for background session workers

### DIFF
--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -67,6 +67,10 @@ runtime library from depending on the CLI or TUI packages.
 
 ## Bounded process-resource extraction
 
+Background session workers now use a frontend-independent typed owner; see
+[session worker ownership](session-worker-ownership.md) for admission,
+cancellation, notification ordering, and the remaining composition boundary.
+
 `agent-cli-runtime` also owns `Agent.CLI.NativeProcess` and
 `Agent.CLI.Session.Threads`. These retain the legacy shared-module namespace,
 but belong to the runtime package, not `agent-cli`. They own process allocation,

--- a/docs/session-worker-ownership.md
+++ b/docs/session-worker-ownership.md
@@ -1,0 +1,45 @@
+# In-process session worker ownership
+
+`Agent.Runtime.SessionOwner` owns background session-turn workers without
+depending on CLI, TUI, filesystem layout, providers, or transport messages.
+`Agent.CLI.Session.Threads` uses it in production and remains the compatibility
+adapter for text responses and external session/activity locks.
+
+The owner provides:
+
+- typed, nonblocking admission failures (closed, same session busy, capacity);
+- one running action per session identity;
+- an explicit active-worker limit, including workers executing cleanup;
+- immutable status snapshots and waits captured for one generation;
+- cancellation that joins that generation without cancelling a later retry;
+- close that rejects admission, suppresses completion notifications, and joins
+  tracked workers before discarding their handles.
+
+The adapter admits at most 64 active background turns per manager. There is no
+pending queue: a rejected action never starts later. Terminal outcomes remain
+available for repeated status queries and do not occupy an active slot.
+This preserves the previous outcome-retention behavior; bounded terminal
+retention is a separate policy decision.
+
+The submitted action owns its persistence and cleanup ordering. Completion
+notification runs before readiness for another turn and must be nonblocking
+and must not call back into the owner. Cancellation and close must be initiated
+outside the worker being cancelled. Cancellation remains cooperative Haskell
+thread cancellation: an action or finalizer that masks forever can delay close.
+Concurrent cancellation requests are serialized per worker so they do not
+repeatedly interrupt the same cleanup.
+
+## Remaining boundaries
+
+This is a worker-lifecycle extraction, **not** a replacement for the complete
+session engine. Foreground turn preparation, state commits, persistence
+composition, provider/tool startup, and frontend rendering still require their
+own capability boundary. Cross-process mutual exclusion continues to use the
+existing session lock. The server still depends on `agent-cli`; moving the
+native facade alone would not remove its underlying orchestration dependency.
+
+The next composition change should extract shared startup/tool construction
+from `runAgentWithRuntime`, retaining first-party dialect selection and
+capability restrictions, before switching CLI and server to that implementation.
+Moving or duplicating the current facade would hide rather than fix this
+dependency.

--- a/docs/session-worker-ownership.md
+++ b/docs/session-worker-ownership.md
@@ -26,8 +26,10 @@ notification runs before readiness for another turn and must be nonblocking
 and must not call back into the owner. Cancellation and close must be initiated
 outside the worker being cancelled. Cancellation remains cooperative Haskell
 thread cancellation: an action or finalizer that masks forever can delay close.
-Concurrent cancellation requests are serialized per worker so they do not
-repeatedly interrupt the same cleanup.
+Each generation owns one cancellation sender, shared by concurrent cancellation
+requests and close. Interrupting a cancellation caller does not interrupt signal
+delivery or cause another caller to send a second cancellation into cleanup.
+Worker handles remain tracked until their `Async` has actually terminated.
 
 ## Remaining boundaries
 

--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -56,6 +56,7 @@ library
     exposed-modules:  Agent.Runtime.Compaction
                     , Agent.Runtime.ConversationStore
                     , Agent.Runtime.SessionState
+                    , Agent.Runtime.SessionOwner
                     , Agent.CLI.NativeProcess
                     , Agent.Runtime.Request
                     , Agent.Runtime.StartupPolicy
@@ -163,6 +164,7 @@ test-suite agent-cli-runtime-test
                     , Agent.CLI.SessionActivitySpec
                     , Agent.CLI.SessionRequestSpec
                     , Agent.CLI.SessionThreadsSpec
+                    , Agent.Runtime.SessionOwnerSpec
                     , Agent.CLI.SessionSpec
                     , Agent.CLI.SessionSpec.Compatibility
                     , Agent.CLI.SessionSpec.Fixtures

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/Threads.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/Threads.hs
@@ -1,5 +1,4 @@
--- | Runtime-owned in-process session workers. The legacy namespace matches
--- the persistence and locking modules; this module has no frontend dependency.
+-- | Filesystem-lock and text compatibility adapter for runtime-owned workers.
 module Agent.CLI.Session.Threads
     ( SessionThreadManager
     , newSessionThreadManager
@@ -11,234 +10,94 @@ module Agent.CLI.Session.Threads
     ) where
 
 import Agent.CLI.Error (formatException)
-import Agent.CLI.SessionLock (sessionLockIsActive, sessionLockPath, sessionActivitySnapshot)
+import Agent.CLI.SessionLock
+    ( sessionLockIsActive, sessionLockPath, sessionActivitySnapshot )
+import Agent.Runtime.SessionOwner
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async
-    ( Async, AsyncCancelled, asyncWithUnmask, cancel, poll, waitCatch )
-import Control.Concurrent.MVar
-    ( MVar, modifyMVar, modifyMVar_, newEmptyMVar, newMVar, putMVar, readMVar, takeMVar )
-import Control.Exception.Safe (mask, tryAny, SomeException, fromException)
-import Control.Monad (void)
-import Data.Maybe (isJust)
-import Data.Map.Strict (Map)
+import Control.Exception.Safe (tryAny)
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
 
-data ManagedSessionThread
-    = ManagedSessionThreadRunning !(Async Text)
-    | ManagedSessionThreadCompleted
-    | ManagedSessionThreadFailed !Text
-
-data SessionThreadManagerState = SessionThreadManagerState
-    { threadManagerClosed :: !Bool
-    , managedThreads :: !(Map Text ManagedSessionThread)
-    }
-
 data SessionThreadManager = SessionThreadManager
     { threadManagerRoot :: !OsPath
-    , threadManagerState :: !(MVar SessionThreadManagerState)
+    , threadManagerOwner :: !SessionOwner
     }
 
+-- | Bound concurrent in-process background turns. This is an admission limit,
+-- not a queue: rejected calls never execute later without another request.
 newSessionThreadManager :: OsPath -> IO SessionThreadManager
-newSessionThreadManager root = do
-    state <- newMVar SessionThreadManagerState
-        { threadManagerClosed = False
-        , managedThreads = Map.empty
-        }
-    pure SessionThreadManager
-        { threadManagerRoot = root
-        , threadManagerState = state
-        }
+newSessionThreadManager root = SessionThreadManager root <$> newSessionOwner 64
 
--- | Start one in-process background turn. The task is registered before it is
--- allowed to execute, so shutdown can always cancel and join every live turn.
 launchSessionThread
     :: SessionThreadManager
     -> Text
     -> IO (Either Text ())
     -> IO (Either Text Text)
-launchSessionThread manager sessionId action =
-    launchSessionThreadNotifying manager sessionId (const (pure ())) action
+launchSessionThread manager sessionId =
+    launchSessionThreadNotifying manager sessionId (const (pure ()))
 
--- | Enqueue one completion notification for this particular turn. The sink
--- runs in the tracked worker while the manager lock is held, immediately
--- before publishing the terminal state. It must be nonblocking and must not
--- call back into the manager. This makes notification delivery and readiness
--- for a follow-up atomic to callers, without an unowned notification thread.
--- Rejected launches and manager shutdown do not emit completion notices.
+-- | The sink runs before terminal publication and must be nonblocking and
+-- must not call back into this manager.
 launchSessionThreadNotifying
     :: SessionThreadManager
     -> Text
     -> (Text -> IO ())
     -> IO (Either Text ())
     -> IO (Either Text Text)
-launchSessionThreadNotifying manager sessionId notify action =
-    mask \_ -> do
-        launched <- modifyMVar manager.threadManagerState \state ->
-            if state.threadManagerClosed
-                then pure (state, Left "agent session manager is closed")
-                else case Map.lookup sessionId state.managedThreads of
-                    Just (ManagedSessionThreadRunning _) ->
-                        pure
-                            ( state
-                            , Left
-                                ("session " <> sessionId
-                                    <> " is already running")
-                            )
-                    _ -> do
-                        gate <- newEmptyMVar
-                        started <- tryAny $
-                            asyncWithUnmask \unmask -> do
-                                takeMVar gate
-                                result <- tryAny (unmask action)
-                                let terminal = case result of
-                                        Left err ->
-                                            ManagedSessionThreadFailed
-                                                (formatException err)
-                                        Right (Left err) ->
-                                            ManagedSessionThreadFailed err
-                                        Right (Right ()) ->
-                                            ManagedSessionThreadCompleted
-                                let status = case terminal of
-                                        ManagedSessionThreadFailed err -> "failed (" <> err <> ")"
-                                        _ -> "completed"
-                                modifyMVar_ manager.threadManagerState \current ->
-                                    if current.threadManagerClosed
-                                        then pure current
-                                        else do
-                                            -- A notification failure must not
-                                            -- replace the child turn's outcome.
-                                            void (tryAny (notify status))
-                                            pure current
-                                                { managedThreads =
-                                                    Map.insert
-                                                        sessionId
-                                                        terminal
-                                                        current.managedThreads
-                                                }
-                                pure status
-                        case started of
-                            Left err ->
-                                pure
-                                    ( state
-                                    , Left
-                                        ("failed to start agent session: "
-                                            <> formatException err)
-                                    )
-                            Right worker -> do
-                                let running = state
-                                        { managedThreads =
-                                            Map.insert
-                                                sessionId
-                                                (ManagedSessionThreadRunning worker)
-                                                state.managedThreads
-                                        }
-                                putMVar gate ()
-                                pure
-                                    ( running
-                                    , Right ("started session " <> sessionId)
-                                    )
-        pure launched
+launchSessionThreadNotifying manager sessionId notify action = do
+    launched <- tryAny $
+        submitSessionTurn manager.threadManagerOwner sessionId
+            (notify . outcomeText)
+            -- Preserve the legacy user-facing exception formatting.
+            (tryAny action >>= pure . either (Left . formatException) id)
+    pure $ case launched of
+        Left err -> Left ("failed to start agent session: " <> formatException err)
+        Right (Left OwnerClosed) -> Left "agent session manager is closed"
+        Right (Left SessionBusy) -> Left ("session " <> sessionId <> " is already running")
+        Right (Left OwnerAtCapacity) -> Left "agent session manager is at capacity"
+        Right (Right ()) -> Right ("started session " <> sessionId)
 
 sessionThreadStatus :: SessionThreadManager -> Text -> IO Text
-sessionThreadStatus manager sessionId =
-    modifyMVar manager.threadManagerState \state ->
-        case Map.lookup sessionId state.managedThreads of
-            Nothing -> do
-                locked <- lockIsActive
-                pure (state, if locked then "running" else "idle")
-            Just (ManagedSessionThreadRunning worker) ->
-                poll worker >>= \case
-                    Nothing -> pure (state, "running")
-                    Just (Right status) ->
-                        settle state
-                            (if status == "completed"
-                                then ManagedSessionThreadCompleted
-                                else ManagedSessionThreadFailed status)
-                            status
-                    Just (Left err) ->
-                        let message = "failed (" <> formatException err <> ")"
-                        in settle state
-                            (ManagedSessionThreadFailed message)
-                            message
-            Just ManagedSessionThreadCompleted ->
-                terminalStatus state "completed"
-            Just (ManagedSessionThreadFailed err) ->
-                terminalStatus state ("failed (" <> err <> ")")
-  where
-    lockIsActive =
-        sessionLockIsActive
-            (sessionLockPath
-                (manager.threadManagerRoot
-                    </> unsafeEncodeUtf (Text.unpack sessionId)))
-    -- Persist the terminal outcome instead of deleting it, so repeated status
-    -- polls stay observable. The background worker itself records the same
-    -- terminal constructor on exit (launchSessionThread); deleting it here
-    -- destroyed that record, making a failed session report "idle" on the
-    -- second poll (and never report its failure at all when a poll landed
-    -- while the session lock was still held). A still-active lock only masks
-    -- the outcome as "running" for this poll; the retained record surfaces the
-    -- real status once the lock clears.
-    settle state record terminal = do
-        locked <- lockIsActive
-        pure
-            ( state
-                { managedThreads =
-                    Map.insert sessionId record state.managedThreads
-                }
-            , if locked then "running" else terminal
-            )
-    terminalStatus state terminal = do
-        locked <- lockIsActive
-        pure (state, if locked then "running" else terminal)
+sessionThreadStatus manager sessionId = do
+    (_, snapshot) <- sessionOwnerSnapshot manager.threadManagerOwner
+    locked <- sessionLockIsActive (sessionLockPath (sessionDirectory manager sessionId))
+    pure $ if locked
+        then "running"
+        else case Map.lookup sessionId snapshot of
+            Nothing -> "idle"
+            Just SessionRunning -> "running"
+            Just (SessionFinished outcome) -> outcomeText outcome
 
--- | Waiting on the captured Async (not repeated map lookups) prevents a quick
--- resume from moving the waiter onto a different run. The waiter never owns or
--- cancels the target. External interactive sessions use the turn activity lock,
--- not the lifetime lock, which remains held while the prompt is idle.
+-- | The owner captures this generation, so a later retry cannot move a waiter
+-- onto a different run. External sessions retain the activity-lock fallback.
 prepareSessionThreadWait :: SessionThreadManager -> Text -> IO (IO Text)
 prepareSessionThreadWait manager sessionId = do
-    state <- readMVar manager.threadManagerState
-    case Map.lookup sessionId state.managedThreads of
-        Just (ManagedSessionThreadRunning worker) ->
-            pure $ either waitExceptionStatus id <$> waitCatch worker
+    captured <- prepareSessionWait manager.threadManagerOwner sessionId
+    case captured of
+        Just (SessionRunning, wait) -> pure (outcomeText <$> wait)
         _ -> do
             (generation, active) <- sessionActivitySnapshot sessionDir
             if active
                 then pure (waitExternal generation)
-                else pure $ pure $ case Map.lookup sessionId state.managedThreads of
-                    Just ManagedSessionThreadCompleted -> "completed"
-                    Just (ManagedSessionThreadFailed err) -> "failed (" <> err <> ")"
-                    _ -> "idle"
+                else pure $ maybe (pure "idle") (fmap outcomeText . snd) captured
   where
-    sessionDir = manager.threadManagerRoot </> unsafeEncodeUtf (Text.unpack sessionId)
+    sessionDir = sessionDirectory manager sessionId
     waitExternal generation = do
         (current, active) <- sessionActivitySnapshot sessionDir
         if active && (generation == current || generation == Nothing)
             then threadDelay 100000 >> waitExternal current
             else pure "idle"
 
-waitExceptionStatus :: SomeException -> Text
-waitExceptionStatus err
-    | isJust (fromException err :: Maybe AsyncCancelled) = "cancelled"
-    | otherwise = "failed (" <> formatException err <> ")"
+sessionDirectory :: SessionThreadManager -> Text -> OsPath
+sessionDirectory manager sessionId =
+    manager.threadManagerRoot </> unsafeEncodeUtf (Text.unpack sessionId)
+
+outcomeText :: SessionOutcome -> Text
+outcomeText SessionCompleted = "completed"
+outcomeText (SessionFailed err) = "failed (" <> err <> ")"
+outcomeText SessionCancelled = "cancelled"
 
 closeSessionThreadManager :: SessionThreadManager -> IO ()
-closeSessionThreadManager manager = do
-    workers <- modifyMVar manager.threadManagerState \state ->
-        let running =
-                [ worker
-                | ManagedSessionThreadRunning worker <-
-                    Map.elems state.managedThreads
-                ]
-        in pure
-            ( state
-                { threadManagerClosed = True
-                , managedThreads = Map.empty
-                }
-            , running
-            )
-    mapM_ cancel workers
-    mapM_ (void . waitCatch) workers
+closeSessionThreadManager = closeSessionOwner . (.threadManagerOwner)

--- a/packages/agent-cli-runtime/src/Agent/Runtime/SessionOwner.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/SessionOwner.hs
@@ -1,0 +1,190 @@
+-- | Frontend-independent ownership of in-process session turns.
+--
+-- Admission is nonblocking: one worker per session and a bounded number of
+-- workers per owner. The action includes persistence and cleanup; its slot is
+-- not reusable until that action and the completion notification have ended.
+module Agent.Runtime.SessionOwner
+    ( SessionOwner
+    , AdmissionFailure(..)
+    , SessionOutcome(..)
+    , SessionStatus(..)
+    , newSessionOwner
+    , withSessionOwner
+    , submitSessionTurn
+    , sessionOwnerSnapshot
+    , prepareSessionWait
+    , cancelSessionTurn
+    , closeSessionOwner
+    ) where
+
+import Control.Concurrent.Async
+    ( Async, AsyncCancelled, asyncWithUnmask, cancel, poll, waitCatch )
+import Control.Concurrent.MVar
+    ( MVar, modifyMVar, modifyMVar_, newEmptyMVar, newMVar
+    , putMVar, readMVar, takeMVar, withMVar
+    )
+import Control.Exception.Safe
+    ( SomeException, bracket, displayException, fromException, mask, tryAny )
+-- Cancellation is an outcome here, not an exception to discard. Catch all
+-- exceptions only at the owned worker's terminal publication boundary.
+import qualified Control.Exception as Exception
+import Control.Monad (void)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (isJust)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Numeric.Natural (Natural)
+
+data AdmissionFailure = OwnerClosed | SessionBusy | OwnerAtCapacity
+    deriving (Eq, Show)
+
+data SessionOutcome = SessionCompleted | SessionFailed !Text | SessionCancelled
+    deriving (Eq, Show)
+
+data SessionStatus = SessionRunning | SessionFinished !SessionOutcome
+    deriving (Eq, Show)
+
+data Entry
+    = Running !OwnedWorker
+    | Finished !SessionOutcome
+
+data OwnedWorker = OwnedWorker
+    { workerAsync :: !(Async SessionOutcome)
+    , cancelGate :: !(MVar ())
+    }
+
+data OwnerState = OwnerState
+    { closed :: !Bool
+    , entries :: !(Map Text Entry)
+    }
+
+data SessionOwner = SessionOwner
+    { capacity :: !Natural
+    , state :: !(MVar OwnerState)
+    }
+
+newSessionOwner :: Natural -> IO SessionOwner
+newSessionOwner capacity =
+    SessionOwner capacity <$> newMVar (OwnerState False Map.empty)
+
+withSessionOwner :: Natural -> (SessionOwner -> IO a) -> IO a
+withSessionOwner capacity = bracket (newSessionOwner capacity) closeSessionOwner
+
+-- | The notification is part of terminal publication. It must be nonblocking
+-- and must not call back into this owner. Notification failures cannot replace
+-- the action's outcome. Closing suppresses notifications, as in the legacy
+-- background-session adapter.
+submitSessionTurn
+    :: SessionOwner
+    -> Text
+    -> (SessionOutcome -> IO ())
+    -> IO (Either Text ())
+    -> IO (Either AdmissionFailure ())
+submitSessionTurn owner sessionId notify action = mask \_ ->
+    modifyMVar owner.state \previous -> do
+        current <- settleState previous
+        if current.closed
+            then pure (current, Left OwnerClosed)
+            else case Map.lookup sessionId current.entries of
+                Just (Running _) -> pure (current, Left SessionBusy)
+                _
+                    | fromIntegral (length [() | Running _ <- Map.elems current.entries])
+                        >= owner.capacity ->
+                        pure (current, Left OwnerAtCapacity)
+                    | otherwise -> do
+                        gate <- newEmptyMVar
+                        -- This worker outlives submission, but is registered
+                        -- before execution and retained until close joins it.
+                        cancelGate <- newMVar ()
+                        workerAsync <- asyncWithUnmask \unmask -> do
+                            takeMVar gate
+                            result <- Exception.try (unmask action)
+                            let outcome = either exceptionOutcome
+                                    (either SessionFailed (const SessionCompleted))
+                                    result
+                            modifyMVar_ owner.state \latest ->
+                                if latest.closed
+                                    then pure latest
+                                    else do
+                                        void (tryAny (notify outcome))
+                                        pure latest
+                                            { entries = Map.insert sessionId
+                                                (Finished outcome) latest.entries
+                                            }
+                            pure outcome
+                        let worker = OwnedWorker { workerAsync, cancelGate }
+                        putMVar gate ()
+                        pure
+                            ( current { entries = Map.insert sessionId
+                                (Running worker) current.entries }
+                            , Right ()
+                            )
+
+exceptionOutcome :: SomeException -> SessionOutcome
+exceptionOutcome err
+    | isJust (fromException err :: Maybe AsyncCancelled) = SessionCancelled
+    | otherwise = SessionFailed (Text.pack (displayException err))
+
+sessionOwnerSnapshot :: SessionOwner -> IO (Bool, Map Text SessionStatus)
+sessionOwnerSnapshot owner =
+    modifyMVar owner.state \previous -> do
+        current <- settleState previous
+        pure (current, (current.closed, Map.map status current.entries))
+  where
+    status (Running _) = SessionRunning
+    status (Finished outcome) = SessionFinished outcome
+
+-- | Capture this generation, never accidentally wait for a later retry.
+prepareSessionWait
+    :: SessionOwner -> Text -> IO (Maybe (SessionStatus, IO SessionOutcome))
+prepareSessionWait owner sessionId = do
+    current <- readMVar owner.state
+    pure $ case Map.lookup sessionId current.entries of
+        Nothing -> Nothing
+        Just (Finished outcome) -> Just (SessionFinished outcome, pure outcome)
+        Just (Running worker) ->
+            Just (SessionRunning, either exceptionOutcome id <$> waitCatch worker.workerAsync)
+
+-- A second asynchronous exception can interrupt terminal publication while
+-- acquiring the lock. Recover that outcome from the owned Async rather than
+-- retaining a permanently busy slot.
+settleState :: OwnerState -> IO OwnerState
+settleState current
+    | current.closed = pure current
+    | otherwise = do
+        settled <- traverse settle current.entries
+        pure current { entries = settled }
+  where
+    settle entry@(Finished _) = pure entry
+    settle entry@(Running worker) =
+        poll worker.workerAsync >>= \case
+            Nothing -> pure entry
+            Just outcome -> pure (Finished (either exceptionOutcome id outcome))
+
+-- | Cancel and join only the generation captured by this call.
+cancelSessionTurn :: SessionOwner -> Text -> IO Bool
+cancelSessionTurn owner sessionId = do
+    current <- readMVar owner.state
+    case Map.lookup sessionId current.entries of
+        Just (Running worker) -> cancelOwnedWorker worker >> pure True
+        _ -> pure False
+
+-- Concurrent cancellation and close must not inject a second cancellation
+-- into the first cancellation's interruptible cleanup.
+cancelOwnedWorker :: OwnedWorker -> IO ()
+cancelOwnedWorker worker =
+    withMVar worker.cancelGate \_ -> cancel worker.workerAsync
+
+-- | All concurrent closers retain the same workers until they are joined.
+-- If a closer is interrupted, a subsequent close can still finish cleanup.
+closeSessionOwner :: SessionOwner -> IO ()
+closeSessionOwner owner = mask \restore -> do
+    workers <- modifyMVar owner.state \current ->
+        pure
+            ( current { closed = True }
+            , [worker | Running worker <- Map.elems current.entries]
+            )
+    restore (mapM_ cancelOwnedWorker workers)
+    modifyMVar_ owner.state \current ->
+        pure current { entries = Map.empty }

--- a/packages/agent-cli-runtime/src/Agent/Runtime/SessionOwner.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/SessionOwner.hs
@@ -18,10 +18,11 @@ module Agent.Runtime.SessionOwner
     ) where
 
 import Control.Concurrent.Async
-    ( Async, AsyncCancelled, asyncWithUnmask, cancel, poll, waitCatch )
+    ( Async, AsyncCancelled(..), asyncThreadId, asyncWithUnmask, poll, wait, waitCatch )
+import Control.Concurrent (throwTo)
 import Control.Concurrent.MVar
     ( MVar, modifyMVar, modifyMVar_, newEmptyMVar, newMVar
-    , putMVar, readMVar, takeMVar, withMVar
+    , putMVar, readMVar, takeMVar
     )
 import Control.Exception.Safe
     ( SomeException, bracket, displayException, fromException, mask, tryAny )
@@ -51,7 +52,7 @@ data Entry
 
 data OwnedWorker = OwnedWorker
     { workerAsync :: !(Async SessionOutcome)
-    , cancelGate :: !(MVar ())
+    , cancelSignal :: !(MVar (Maybe (Async ())))
     }
 
 data OwnerState = OwnerState
@@ -96,7 +97,7 @@ submitSessionTurn owner sessionId notify action = mask \_ ->
                         gate <- newEmptyMVar
                         -- This worker outlives submission, but is registered
                         -- before execution and retained until close joins it.
-                        cancelGate <- newMVar ()
+                        cancelSignal <- newMVar Nothing
                         workerAsync <- asyncWithUnmask \unmask -> do
                             takeMVar gate
                             result <- Exception.try (unmask action)
@@ -109,11 +110,8 @@ submitSessionTurn owner sessionId notify action = mask \_ ->
                                     else do
                                         void (tryAny (notify outcome))
                                         pure latest
-                                            { entries = Map.insert sessionId
-                                                (Finished outcome) latest.entries
-                                            }
                             pure outcome
-                        let worker = OwnedWorker { workerAsync, cancelGate }
+                        let worker = OwnedWorker { workerAsync, cancelSignal }
                         putMVar gate ()
                         pure
                             ( current { entries = Map.insert sessionId
@@ -138,17 +136,20 @@ sessionOwnerSnapshot owner =
 -- | Capture this generation, never accidentally wait for a later retry.
 prepareSessionWait
     :: SessionOwner -> Text -> IO (Maybe (SessionStatus, IO SessionOutcome))
-prepareSessionWait owner sessionId = do
-    current <- readMVar owner.state
-    pure $ case Map.lookup sessionId current.entries of
+prepareSessionWait owner sessionId =
+    modifyMVar owner.state \previous -> do
+        current <- settleState previous
+        pure (current, capture current)
+  where
+    capture current = case Map.lookup sessionId current.entries of
         Nothing -> Nothing
         Just (Finished outcome) -> Just (SessionFinished outcome, pure outcome)
         Just (Running worker) ->
             Just (SessionRunning, either exceptionOutcome id <$> waitCatch worker.workerAsync)
 
--- A second asynchronous exception can interrupt terminal publication while
--- acquiring the lock. Recover that outcome from the owned Async rather than
--- retaining a permanently busy slot.
+-- Retain the worker handle until the Async has actually terminated, not merely
+-- until its action and notification have returned. Close therefore joins every
+-- live worker, including one leaving its final publication boundary.
 settleState :: OwnerState -> IO OwnerState
 settleState current
     | current.closed = pure current
@@ -160,7 +161,14 @@ settleState current
     settle entry@(Running worker) =
         poll worker.workerAsync >>= \case
             Nothing -> pure entry
-            Just outcome -> pure (Finished (either exceptionOutcome id outcome))
+            Just outcome -> do
+                sender <- readMVar worker.cancelSignal
+                senderFinished <- case sender of
+                    Nothing -> pure True
+                    Just signal -> isJust <$> poll signal
+                pure $ if senderFinished
+                    then Finished (either exceptionOutcome id outcome)
+                    else entry
 
 -- | Cancel and join only the generation captured by this call.
 cancelSessionTurn :: SessionOwner -> Text -> IO Bool
@@ -170,11 +178,25 @@ cancelSessionTurn owner sessionId = do
         Just (Running worker) -> cancelOwnedWorker worker >> pure True
         _ -> pure False
 
--- Concurrent cancellation and close must not inject a second cancellation
--- into the first cancellation's interruptible cleanup.
+-- Signal exactly once, independently of the cancelling caller's lifetime.
+-- throwTo itself is interruptible before delivery, so a Boolean "sent" flag in
+-- the caller is insufficient: interrupted delivery could lose cancellation.
+-- The single sender is tracked alongside its target and joined by every
+-- cancellation/close caller. No caller interruption cancels this owned sender.
 cancelOwnedWorker :: OwnedWorker -> IO ()
-cancelOwnedWorker worker =
-    withMVar worker.cancelGate \_ -> cancel worker.workerAsync
+cancelOwnedWorker worker = mask \restore -> do
+    sender <- modifyMVar worker.cancelSignal \case
+        Just sender -> pure (Just sender, Just sender)
+        Nothing -> do
+            poll worker.workerAsync >>= \case
+                Just _ -> pure (Nothing, Nothing)
+                Nothing -> do
+                    sender <- asyncWithUnmask \unmask ->
+                        unmask (throwTo (asyncThreadId worker.workerAsync) AsyncCancelled)
+                    pure (Just sender, Just sender)
+    restore do
+        mapM_ wait sender
+        void (waitCatch worker.workerAsync)
 
 -- | All concurrent closers retain the same workers until they are joined.
 -- If a closer is interrupted, a subsequent close can still finish cleanup.

--- a/packages/agent-cli-runtime/test/Agent/Runtime/SessionOwnerSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/Runtime/SessionOwnerSpec.hs
@@ -1,7 +1,8 @@
 module Agent.Runtime.SessionOwnerSpec (spec) where
 
 import Agent.Runtime.SessionOwner
-import Control.Concurrent.Async (concurrently_, withAsync, wait)
+import Control.Concurrent (yield)
+import Control.Concurrent.Async (cancel, concurrently_, withAsync, wait)
 import Control.Concurrent.MVar
     (newEmptyMVar, putMVar, takeMVar, tryTakeMVar)
 import Control.Exception.Safe (finally)
@@ -102,6 +103,32 @@ spec = describe "runtime session owner" do
                     wait closer
             tryTakeMVar cleaned `shouldReturn` Just ()
 
+    it "does not resend cancellation after the cancelling caller is interrupted" $
+        withSessionOwner 1 \owner -> do
+            started <- newEmptyMVar
+            release <- newEmptyMVar
+            cleaning <- newEmptyMVar
+            finishCleanup <- newEmptyMVar
+            cleaned <- newEmptyMVar
+            submitSessionTurn owner "one" silent
+                ((putMVar started () >> takeMVar release >> pure (Right ()))
+                    `finally` (putMVar cleaning () >> takeMVar finishCleanup >> putMVar cleaned ()))
+                `shouldReturn` Right ()
+            within (takeMVar started)
+            withAsync (cancelSessionTurn owner "one") \canceller -> do
+                within (takeMVar cleaning)
+                cancel canceller
+            withAsync (closeSessionOwner owner) \closer -> do
+                -- The owner marks itself closed before joining cleanup.
+                -- Wait for that admission barrier without timing assumptions.
+                (do
+                    within (awaitClosed owner)
+                    -- Bound the observer, not the closer's cleanup.
+                    timeout 10000 (wait closer) `shouldReturn` Nothing)
+                    `finally` putMVar finishCleanup ()
+                wait closer
+            tryTakeMVar cleaned `shouldReturn` Just ()
+
     it "concurrent closes join all workers and reject future admission" $
         withSessionOwner 1 \owner -> do
             started <- newEmptyMVar
@@ -128,3 +155,8 @@ spec = describe "runtime session owner" do
 within :: IO a -> IO a
 within action =
     timeout 5000000 action >>= maybe (fail "session owner handshake timed out") pure
+
+awaitClosed :: SessionOwner -> IO ()
+awaitClosed owner = do
+    (closed, _) <- sessionOwnerSnapshot owner
+    if closed then pure () else yield >> awaitClosed owner

--- a/packages/agent-cli-runtime/test/Agent/Runtime/SessionOwnerSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/Runtime/SessionOwnerSpec.hs
@@ -1,0 +1,130 @@
+module Agent.Runtime.SessionOwnerSpec (spec) where
+
+import Agent.Runtime.SessionOwner
+import Control.Concurrent.Async (concurrently_, withAsync, wait)
+import Control.Concurrent.MVar
+    (newEmptyMVar, putMVar, takeMVar, tryTakeMVar)
+import Control.Exception.Safe (finally)
+import qualified Data.Map.Strict as Map
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "runtime session owner" do
+    it "rejects duplicate and excess work without queuing or executing it" $
+        withSessionOwner 1 \owner -> do
+            started <- newEmptyMVar
+            release <- newEmptyMVar
+            rejected <- newEmptyMVar
+            submitSessionTurn owner "one" silent
+                (putMVar started () >> takeMVar release >> pure (Right ()))
+                `shouldReturn` Right ()
+            within (takeMVar started)
+            submitSessionTurn owner "one" silent
+                (putMVar rejected () >> pure (Right ()))
+                `shouldReturn` Left SessionBusy
+            submitSessionTurn owner "two" silent
+                (putMVar rejected () >> pure (Right ()))
+                `shouldReturn` Left OwnerAtCapacity
+            Just (_, wait) <- prepareSessionWait owner "one"
+            putMVar release ()
+            within wait `shouldReturn` SessionCompleted
+            tryTakeMVar rejected `shouldReturn` Nothing
+            submitSessionTurn owner "two" silent (pure (Right ()))
+                `shouldReturn` Right ()
+
+    it "captures the exact generation across a quick retry" $
+        withSessionOwner 1 \owner -> do
+            release <- newEmptyMVar
+            submitSessionTurn owner "one" silent
+                (takeMVar release >> pure (Left "first"))
+                `shouldReturn` Right ()
+            Just (_, firstWait) <- prepareSessionWait owner "one"
+            putMVar release ()
+            within firstWait `shouldReturn` SessionFailed "first"
+            secondRelease <- newEmptyMVar
+            submitSessionTurn owner "one" silent
+                (takeMVar secondRelease >> pure (Right ()))
+                `shouldReturn` Right ()
+            within firstWait `shouldReturn` SessionFailed "first"
+            cancelSessionTurn owner "one" `shouldReturn` True
+
+    it "joins cancellation cleanup before allowing another generation" $
+        withSessionOwner 1 \owner -> do
+            started <- newEmptyMVar
+            release <- newEmptyMVar
+            finished <- newEmptyMVar
+            submitSessionTurn owner "one" silent
+                ((putMVar started () >> takeMVar release >> pure (Right ()))
+                    `finally` putMVar finished ())
+                `shouldReturn` Right ()
+            within (takeMVar started)
+            cancelSessionTurn owner "one" `shouldReturn` True
+            tryTakeMVar finished `shouldReturn` Just ()
+            sessionOwnerSnapshot owner `shouldReturn`
+                (False, Map.singleton "one" (SessionFinished SessionCancelled))
+            submitSessionTurn owner "one" silent (pure (Right ()))
+                `shouldReturn` Right ()
+
+    it "publishes completion before a captured waiter returns" $
+        withSessionOwner 1 \owner -> do
+            notified <- newEmptyMVar
+            submitSessionTurn owner "one" (putMVar notified) (pure (Left "provider"))
+                `shouldReturn` Right ()
+            Just (_, wait) <- prepareSessionWait owner "one"
+            within wait `shouldReturn` SessionFailed "provider"
+            tryTakeMVar notified `shouldReturn` Just (SessionFailed "provider")
+
+    it "does not replace the outcome when a notification fails" $
+        withSessionOwner 1 \owner -> do
+            submitSessionTurn owner "one" (const (fail "notification")) (pure (Right ()))
+                `shouldReturn` Right ()
+            Just (_, captured) <- prepareSessionWait owner "one"
+            within captured `shouldReturn` SessionCompleted
+
+    it "does not inject repeated cancellation into cleanup" $
+        withSessionOwner 1 \owner -> do
+            started <- newEmptyMVar
+            release <- newEmptyMVar
+            cleaning <- newEmptyMVar
+            finishCleanup <- newEmptyMVar
+            cleaned <- newEmptyMVar
+            submitSessionTurn owner "one" silent
+                ((putMVar started () >> takeMVar release >> pure (Right ()))
+                    `finally` (putMVar cleaning () >> takeMVar finishCleanup >> putMVar cleaned ()))
+                `shouldReturn` Right ()
+            within (takeMVar started)
+            withAsync (cancelSessionTurn owner "one") \canceller -> do
+                within (takeMVar cleaning)
+                withAsync (closeSessionOwner owner) \closer -> do
+                    putMVar finishCleanup ()
+                    wait canceller `shouldReturn` True
+                    wait closer
+            tryTakeMVar cleaned `shouldReturn` Just ()
+
+    it "concurrent closes join all workers and reject future admission" $
+        withSessionOwner 1 \owner -> do
+            started <- newEmptyMVar
+            release <- newEmptyMVar
+            finished <- newEmptyMVar
+            submitSessionTurn owner "one" silent
+                ((putMVar started () >> takeMVar release >> pure (Right ()))
+                    `finally` putMVar finished ())
+                `shouldReturn` Right ()
+            within (takeMVar started)
+            concurrently_ (closeSessionOwner owner) (closeSessionOwner owner)
+            tryTakeMVar finished `shouldReturn` Just ()
+            sessionOwnerSnapshot owner `shouldReturn` (True, Map.empty)
+            submitSessionTurn owner "two" silent (pure (Right ()))
+                `shouldReturn` Left OwnerClosed
+
+    it "supports a zero-capacity owner without launching workers" $
+        withSessionOwner 0 \owner ->
+            submitSessionTurn owner "one" silent (pure (Right ()))
+                `shouldReturn` Left OwnerAtCapacity
+  where
+    silent _ = pure ()
+
+within :: IO a -> IO a
+within action =
+    timeout 5000000 action >>= maybe (fail "session owner handshake timed out") pure

--- a/packages/agent-cli-runtime/test/Spec.hs
+++ b/packages/agent-cli-runtime/test/Spec.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import qualified Agent.CLI.SessionActivitySpec as SessionActivitySpec
 import qualified Agent.CLI.SessionRequestSpec as SessionRequestSpec
 import qualified Agent.CLI.SessionThreadsSpec as SessionThreadsSpec
+import qualified Agent.Runtime.SessionOwnerSpec as SessionOwnerSpec
 import Agent.CLI.Session.TitlePolicy (titleRefreshIndex)
 import Agent.CLI.Session.PullRequest (advanceSessionPullRequestIndex)
 import Data.IORef
@@ -31,6 +32,7 @@ main = hspec do
     SessionActivitySpec.spec
     SessionRequestSpec.spec
     SessionThreadsSpec.spec
+    SessionOwnerSpec.spec
     describe "pull request cache indexing" do
         it "persists a long history once and performs no reads for a current cache" do
             reads <- newIORef (0 :: Int)


### PR DESCRIPTION
## Summary

- Extract frontend-independent `Agent.Runtime.SessionOwner` and use it in the existing background-session thread manager.
- Provide typed nonblocking admission, per-session serialization, generation-scoped waits, snapshots, and cancel/join. Bound active background turns to 64 per manager; rejected actions are not queued.
- Track one cancellation sender per generation so an interrupted cancellation caller cannot lose delivery or cause another cancellation to interrupt worker cleanup. Retain handles until worker and sender have actually terminated.
- Keep external filesystem/activity locks and legacy text responses in the adapter.

## Scope

This is background worker ownership, not the complete foreground session engine. Shared startup/tool composition and removal of the server's CLI dependency remain follow-ups. Terminal outcome retention and cooperative cancellation behavior are unchanged policies.

## Validation

- Nix GHCi 9.10.3 with package extensions and runtime/core/json source paths: **14 modules loaded**, no compiler diagnostics.
- Nine owner lifecycle tests repeated 25 times plus five existing adapter tests: **230 examples, 0 failures**.
- Covers duplicate/capacity rejection without queued work, generation-safe retry waits, cancellation cleanup, notification failure isolation, concurrent closes, and interrupted cancellation followed by close.
- `scripts/check-package-boundaries.sh` and `git diff --check` pass.
- Regenerated runtime `package.nix` with `cabal2nix`; unchanged output.
