### PR TITLE
Preserve typed history projections through turn persistence

### DIFF
--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -1,5 +1,19 @@
 # Shared session engine boundary
 
+## Typed turn persistence records
+
+`Agent.Runtime.TurnRecord` carries the engine's opaque `ModelItems` and
+`DisplayItems` projections through successful and interrupted turn persistence.
+Only `Agent.CLI.Session.TurnRecord.sessionTurnFromRecord`, a compatibility
+adapter owned by `agent-cli-runtime`, unwraps them into the existing `SessionTurn`
+storage format. Display-only activity cannot be passed as canonical history.
+The persisted schema is unchanged.
+
+This is a data boundary, not a new persistence scheduler. The CLI host still
+owns the existing timestamp/session creation, metadata append, slot publication,
+fullscreen history, eviction, and title-update ordering. Extracting that IO
+ownership remains a separate session-owner/composition step.
+
 ## Implemented: frontend-neutral turn lifecycle
 
 `agent-cli-runtime` owns the lifecycle policy in `Agent.Runtime.*`:

--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -61,6 +61,8 @@ library
                     , Agent.Runtime.StartupPolicy
                     , Agent.Runtime.TurnEngine
                     , Agent.Runtime.TurnExecution
+                    , Agent.Runtime.TurnRecord
+                    , Agent.CLI.Session.TurnRecord
                     , Agent.Runtime.TurnState
                     , Agent.CLI.AgentSessions.Process
                     , Agent.CLI.Auth
@@ -164,6 +166,7 @@ test-suite agent-cli-runtime-test
                     , Agent.CLI.SessionActivitySpec
                     , Agent.CLI.SessionObservationSpec
                     , Agent.CLI.SessionRequestSpec
+                    , Agent.CLI.TurnRecordSpec
                     , Agent.CLI.SessionThreadsSpec
                     , Agent.CLI.SessionSpec
                     , Agent.CLI.SessionSpec.Compatibility

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/TurnRecord.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/TurnRecord.hs
@@ -1,0 +1,20 @@
+-- | Compatibility adapter for the existing session storage format.
+module Agent.CLI.Session.TurnRecord (sessionTurnFromRecord) where
+
+import Agent.CLI.Session.Types (SessionTurn(..))
+import Agent.Runtime.TurnEngine (modelItems, displayItems)
+import Agent.Runtime.TurnRecord qualified as Runtime
+
+sessionTurnFromRecord :: Runtime.TurnRecord -> SessionTurn
+sessionTurnFromRecord record = SessionTurn
+    { turnAt = record.turnAt
+    , turnUserText = record.turnUserText
+    , turnAssistantText = record.turnAssistantText
+    , turnError = record.turnError
+    , turnResponseId = record.turnResponseId
+    , turnEffect = record.turnEffect
+    , turnItems = modelItems record.turnItems
+    , turnDisplayItems = displayItems record.turnDisplayItems
+    , turnUsage = record.turnUsage
+    , turnProviderTelemetry = record.turnProviderTelemetry
+    }

--- a/packages/agent-cli-runtime/src/Agent/Runtime/TurnRecord.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/TurnRecord.hs
@@ -1,0 +1,26 @@
+-- | Typed input to turn persistence. Keep canonical model history separate
+-- from display-only activity until a storage adapter encodes the record.
+module Agent.Runtime.TurnRecord
+    ( TurnRecord(..)
+    ) where
+
+import Agent.Loop (TokenUsage)
+import Agent.Runtime.TurnEngine (ModelItems, DisplayItems)
+import Agent.Store.Postgres.Session (TranscriptEffect)
+import Agent.Telemetry (TurnTelemetry)
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+
+data TurnRecord = TurnRecord
+    { turnAt :: !UTCTime
+    , turnUserText :: !Text
+    , turnAssistantText :: !(Maybe Text)
+    , turnError :: !(Maybe Text)
+    , turnResponseId :: !(Maybe Text)
+    , turnEffect :: !TranscriptEffect
+    , turnItems :: !ModelItems
+    , turnDisplayItems :: !DisplayItems
+    , turnUsage :: !(Maybe TokenUsage)
+    , turnProviderTelemetry :: ![TurnTelemetry]
+    }
+    deriving (Eq, Show)

--- a/packages/agent-cli-runtime/test/Agent/CLI/TurnRecordSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/TurnRecordSpec.hs
@@ -1,0 +1,91 @@
+module Agent.CLI.TurnRecordSpec (spec) where
+
+import Agent.CLI.Session.TurnRecord (sessionTurnFromRecord)
+import Agent.CLI.SessionSpec.Fixtures (sampleTurnTelemetry)
+import Agent.CLI.Session.Types (SessionTurn(..), TranscriptEffect(..), sessionTurnDecoder)
+import Agent.Error (ApiError(..))
+import Agent.Loop hiding (TurnCompleted)
+import Agent.Responses.LoopBackend (turnInputsToItems)
+import Agent.Runtime.TurnEngine
+import Agent.Runtime.TurnRecord qualified as Record
+import Agent.Runtime.TurnState (PreparedTurn(..))
+import Agent.Json.Decode qualified as Hermes
+import Data.Aeson (encode)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Time.Clock (UTCTime(..))
+import Test.Hspec
+
+spec :: Spec
+spec = describe "typed turn persistence adapter" do
+    it "preserves successful canonical history and all legacy metadata" do
+        let result = LoopResult "response" (Just "answer") 1 (TokenUsage 10 4 1)
+            final = finish baseExecution
+                { executionState = turnInputsToItems [UserMessage "canonical"]
+                , executionProgress = ResponseCommitted
+                , executionResult = Right result
+                }
+            record = (recordFor final)
+                { Record.turnAssistantText = Just "answer"
+                , Record.turnResponseId = Just "response"
+                , Record.turnUsage = Just result.tokenUsage
+                , Record.turnEffect = TranscriptReplace
+                }
+            stored = sessionTurnFromRecord record
+        stored `shouldBe` SessionTurn
+            { turnAt = record.turnAt
+            , turnUserText = "prompt"
+            , turnAssistantText = Just "answer"
+            , turnError = Nothing
+            , turnResponseId = Just "response"
+            , turnEffect = TranscriptReplace
+            , turnItems = turnInputsToItems [UserMessage "canonical"]
+            , turnDisplayItems = []
+            , turnUsage = Just result.tokenUsage
+            , turnProviderTelemetry = [sampleTurnTelemetry]
+            }
+        Hermes.decodeEither sessionTurnDecoder (LBS.toStrict (encode stored))
+            `shouldBe` Right stored
+
+    it "keeps interrupted visible output out of persisted model history" do
+        let final = finish baseExecution
+                { executionUncommittedDisplayEvents =
+                    [TextDelta "partial visible answer", ResponseAttemptFailed]
+                , executionResult = Left (LoopCancelled [])
+                }
+            stored = sessionTurnFromRecord
+                (recordFor final) { Record.turnError = Just "cancelled" }
+        stored.turnItems `shouldBe` turnInputsToItems [UserMessage "prompt"]
+        stored.turnDisplayItems `shouldBe` displayItems final.finalizedDisplayItems
+        stored.turnDisplayItems `shouldSatisfy` (not . null)
+        stored.turnError `shouldBe` Just "cancelled"
+        Hermes.decodeEither sessionTurnDecoder (LBS.toStrict (encode stored))
+            `shouldBe` Right stored
+
+recordFor :: FinalizedTurn -> Record.TurnRecord
+recordFor final = Record.TurnRecord
+    { turnAt = UTCTime (toEnum 60000) 0
+    , turnUserText = "prompt"
+    , turnAssistantText = Nothing
+    , turnError = Nothing
+    , turnResponseId = Nothing
+    , turnEffect = TranscriptAppend
+    , turnItems = final.finalizedModelItems
+    , turnDisplayItems = final.finalizedDisplayItems
+    , turnUsage = Nothing
+    , turnProviderTelemetry = [sampleTurnTelemetry]
+    }
+
+finish :: LoopExecution -> FinalizedTurn
+finish = finalizeTurn (TurnPolicy (const False) id) Nothing Nothing
+    (PreparedTurn [] Nothing Nothing [UserMessage "prompt"])
+
+baseExecution :: LoopExecution
+baseExecution = LoopExecution
+    { executionState = []
+    , executionPendingInputs = [UserMessage "prompt"]
+    , executionProgress = NoResponseCommitted
+    , executionUncommittedAssistantText = Nothing
+    , executionUncommittedDisplayEvents = []
+    , executionProviderTelemetry = []
+    , executionResult = Left (LoopTransport (ConnectionError "offline"))
+    }

--- a/packages/agent-cli-runtime/test/Spec.hs
+++ b/packages/agent-cli-runtime/test/Spec.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import qualified Agent.CLI.SessionActivitySpec as SessionActivitySpec
 import qualified Agent.CLI.SessionObservationSpec as SessionObservationSpec
 import qualified Agent.CLI.SessionRequestSpec as SessionRequestSpec
+import qualified Agent.CLI.TurnRecordSpec as TurnRecordSpec
 import qualified Agent.CLI.SessionThreadsSpec as SessionThreadsSpec
 import Agent.CLI.Session.TitlePolicy (titleRefreshIndex)
 import Agent.CLI.Session.PullRequest (advanceSessionPullRequestIndex)
@@ -32,6 +33,7 @@ main = hspec do
     SessionActivitySpec.spec
     SessionObservationSpec.spec
     SessionRequestSpec.spec
+    TurnRecordSpec.spec
     SessionThreadsSpec.spec
     describe "pull request cache indexing" do
         it "persists a long history once and performs no reads for a current cache" do

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -56,7 +56,6 @@ import Agent.CLI.Session
     ( SessionHandle(..)
     , SessionMeta(..)
     , SessionPromptSnapshot(..)
-    , SessionTurn(..)
     , SessionTurnPage(..)
     , TranscriptEffect(..)
     , Persistence(..)
@@ -73,6 +72,8 @@ import Agent.CLI.Session
     )
 import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import qualified Agent.CLI.Session.Observation as Observation
+import Agent.CLI.Session.TurnRecord (sessionTurnFromRecord)
+import Agent.Runtime.TurnRecord qualified as Record
 import Agent.CLI.SessionEnv
     ( PreparedWorkspaceEnvironment(..)
     , SessionEnv(..)
@@ -633,10 +634,7 @@ persistIncompleteTurn
             writeIORef env.sessionPlanMode.planSessionDir
                 (Just handle.sessionDir)
             writeIORef env.sessionStoreRoot (Just handle.sessionDir)
-            let displayItems =
-                    Engine.displayItems
-                        executed.executedFinalization.finalizedDisplayItems
-                turn = SessionTurn
+            let turn = sessionTurnFromRecord Record.TurnRecord
                     { turnAt = now
                     , turnUserText = request.busyPromptText
                     , turnAssistantText =
@@ -646,8 +644,9 @@ persistIncompleteTurn
                     , turnError = Just errorText
                     , turnResponseId = (.responseId) <$> maybeTurn
                     , turnEffect = TranscriptAppend
-                    , turnItems = Engine.modelItems retainedItems
-                    , turnDisplayItems = displayItems
+                    , turnItems = retainedItems
+                    , turnDisplayItems =
+                        executed.executedFinalization.finalizedDisplayItems
                     , turnUsage = (.tokenUsage) <$> maybeTurn
                     , turnProviderTelemetry =
                         executed.executedLoop.executionProviderTelemetry
@@ -896,7 +895,7 @@ finishSuccessfulTurn executed loopResult = do
         handleProposedPlan env.sessionPlanMode loopResult.finalText
     printUnrenderedAssistant env assistantText
     let newItems =
-            Engine.modelItems executed.executedFinalization.finalizedModelItems
+            executed.executedFinalization.finalizedModelItems
         effect =
             if turnReplacesTranscript
                 executed.executedCommittedTurn.preparedBeforeItems
@@ -954,7 +953,7 @@ persistSuccessfulTurn
     :: ExecutedBusyTurn
     -> LoopResult
     -> Maybe Text
-    -> [ResponseItem]
+    -> Engine.ModelItems
     -> TranscriptEffect
     -> IO ()
 persistSuccessfulTurn
@@ -967,7 +966,7 @@ persistSuccessfulTurn
             writeIORef env.sessionPlanMode.planSessionDir
                 (Just handle.sessionDir)
             writeIORef env.sessionStoreRoot (Just handle.sessionDir)
-            let turn = SessionTurn
+            let turn = sessionTurnFromRecord Record.TurnRecord
                     { turnAt = now
                     , turnUserText = request.busyPromptText
                     , turnAssistantText = assistantText
@@ -975,7 +974,8 @@ persistSuccessfulTurn
                     , turnResponseId = Just loopResult.finalResponseId
                     , turnEffect = effect
                     , turnItems = newItems
-                    , turnDisplayItems = []
+                    , turnDisplayItems =
+                        executed.executedFinalization.finalizedDisplayItems
                     , turnUsage = Just loopResult.tokenUsage
                     , turnProviderTelemetry =
                         executed.executedLoop.executionProviderTelemetry


### PR DESCRIPTION
## Summary

- Carry opaque `ModelItems` and `DisplayItems` through successful and interrupted turn persistence using `Agent.Runtime.TurnRecord`.
- Centralize conversion to the existing session format in a runtime-package compatibility adapter, so display-only activity cannot be substituted for canonical history.
- Keep the persisted schema and timestamp/session creation, metadata append, slot publication, fullscreen history, eviction, and title-update ordering unchanged.

This is a focused persistence **data boundary**, not a new persistence scheduler or complete session-owner extraction. Storage IO ownership remains with the current host.

## Validation

- GHCi runtime library + tests: successful module load.
- Focused GHCi tests: 2 examples, 0 failures, including successful schema/metadata roundtrip and cancellation display/model separation.
- Combined CLI/runtime GHCi typecheck.
- `scripts/check-package-boundaries.sh` and `git diff --check`.
- Regenerated `agent-cli-runtime/package.nix` with `cabal2nix`; no generated diff.
