### PR TITLE
Share explicit filesystem tool claims across in-process agent loops

### DIFF
--- a/docs/tool-resource-arbitration.md
+++ b/docs/tool-resource-arbitration.md
@@ -1,0 +1,92 @@
+# Shared tool-resource arbitration
+
+`Agent.Tools.ResourceArbiter` is a cooperative, in-process service. The CLI
+process and native process runtime each own one authority. Session tool
+environments borrow it, including in-process background sessions; subagents
+inherit it rather than allocating an independent authority. Separate runtime
+handles and OS processes do not coordinate with one another.
+
+## Implemented boundary
+
+`withSharedToolResourceClaims` opts a handler into shared arbitration while
+retaining its existing turn-local claims. Production consumers are `read_file`,
+`list_dir`, `grep`, local image readers, and the Codex-dialect `apply_patch`
+implementation. Their existing resolvers produce canonical allowed paths.
+An entire claim set is acquired together; overlapping reads may run together,
+and unrelated worktrees remain independent.
+
+The arbiter preserves admission order between conflicting claims without
+blocking unrelated claims behind them. Active claims plus waiting requests are
+bounded (1,024 per production authority); capacity exhaustion fails the tool
+visibly instead of retaining an unbounded waiter. Claim admission and removal
+are exception-safe. Cancellation removes a waiting request or releases the
+running handler's lease. Model-asynchronous tool calls hold the lease until the
+actual handler completes, not merely until the provider continues its response.
+
+Loop approval and initial filesystem-root resolution happen before acquiring resources.
+Closing an authority wakes blocked requests and rejects further admission,
+but does not revoke running leases. Existing scoped worker owners remain
+responsible for cancellation and joining before releasing their other resources.
+The arbiter itself allocates no worker threads.
+
+No tool schemas, provider dialects, approval rules, or sandbox permissions are
+changed. Handler wrapping preserves canonical argument decoding, progress
+events, rich results, and asynchronous exception propagation.
+
+## Deliberate limits and next steps
+
+This is not a claim that all tool effects are serialized:
+
+- Managed shell commands, `write_stdin`, and GHCi can return while underlying
+  processes remain alive. They are **not** opted into handler-scoped leases.
+  Their supervisors need an explicit lease transfer/completion contract before
+  they can participate safely. Shell writes can therefore still race these
+  filesystem tools.
+- Desktop input, Git/worktree operations, MCP tools, sandbox replacements, and
+  other handlers need appropriately scoped explicit claims and lifetime tests
+  before adoption.
+- `TurnSequential`/`ToolExclusive` retain their original turn-local meaning.
+  Promoting these defaults to a global lock would deadlock a parent waiting for
+  a child whose tool needs the same lock. Collaboration control operations do
+  not claim arbitrary execution resources.
+- Claims are advisory within the participating authority, not an OS security
+  boundary. External editors, other processes, hard-link aliases, and filesystem
+  mutations outside participating handlers are not fenced. Existing handler
+  path authorization remains authoritative and is not bypassed by a lease.
+- For isolated execution hosts, resources must refer to the actual host/path
+  identity rather than a coincidentally equal path inside two sandboxes.
+  The current opt-in wrappers are host tool implementations; replacement
+  sandbox tools are not implicitly enrolled.
+
+The next expansion should attach leases to managed-process ownership, including
+yield, completion, cancellation, retained pipe descendants, and process shutdown.
+Do not broaden the opt-in merely because a tool has turn-local resource claims.
+
+## Validation
+
+`Agent.Tools.ResourceArbiterSpec` covers two real loops sharing an authority,
+blocking and model-asynchronous handler lifetime, cancellation while waiting,
+read sharing, independent worktrees, cancellation of held leases, conflicting
+request fairness, capacity rejection, close, and independent authorities.
+The existing filesystem and dialect suites cover the opted-in handlers.
+
+Development checks use GHCi:
+
+```sh
+cabal repl agent-core:lib:agent-core \
+  agent-codex-dialect:lib:agent-codex-dialect \
+  agent-cli-runtime:lib:agent-cli-runtime agent-cli:lib:agent-cli
+cabal repl agent-core:test:agent-core-test
+# :main --match "shared tool resource arbiter"
+# :main --match grepTool
+# hspec (ReadFileSpec.spec >> ListDirSpec.spec >> ShowImageSpec.spec >> ViewImageSpec.spec)
+cabal repl agent-codex-dialect:test:agent-codex-dialect-test
+# :main
+cabal repl agent-cli-runtime:test:agent-cli-runtime-test
+# :main --match "shared native process resources"
+```
+
+The production load checks all four changed libraries together. Run test
+components separately: GHC 9.10 multi-unit GHCi does not support `:main`.
+Fresh worktrees need the development shell's pinned upstream data-file setup
+(`nix develop`) before loading the provider libraries.

--- a/docs/tool-resource-arbitration.md
+++ b/docs/tool-resource-arbitration.md
@@ -11,7 +11,11 @@ handles and OS processes do not coordinate with one another.
 `withSharedToolResourceClaims` opts a handler into shared arbitration while
 retaining its existing turn-local claims. Production consumers are `read_file`,
 `list_dir`, `grep`, local image readers, and the Codex-dialect `apply_patch`
-implementation. Their existing resolvers produce canonical allowed paths.
+implementation. Their existing resolvers produce absolute allowed paths:
+existing paths are canonicalized, while missing suffixes remain lexical beneath
+a canonical existing ancestor. Root and child relative paths use their own
+canonical workspace cwd; private temporary-path aliases resolve to the owning
+session's actual temporary directory.
 An entire claim set is acquired together; overlapping reads may run together,
 and unrelated worktrees remain independent.
 
@@ -53,6 +57,8 @@ This is not a claim that all tool effects are serialized:
   boundary. External editors, other processes, hard-link aliases, and filesystem
   mutations outside participating handlers are not fenced. Existing handler
   path authorization remains authoritative and is not bypassed by a lease.
+  Missing-path lexical aliases and path topology changes between claim resolution
+  and handler execution are not a physical-identity exclusion guarantee either.
 - For isolated execution hosts, resources must refer to the actual host/path
   identity rather than a coincidentally equal path inside two sandboxes.
   The current opt-in wrappers are host tool implementations; replacement

--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -187,6 +187,7 @@ test-suite agent-cli-runtime-test
                     , http-types
                     , QuickCheck
                     , safe-exceptions
+                    , stm
                     , text
                     , time
                     , unix

--- a/packages/agent-cli-runtime/package.nix
+++ b/packages/agent-cli-runtime/package.nix
@@ -26,8 +26,8 @@ mkDerivation {
   testHaskellDepends = [
     aeson agent-core agent-json agent-responses agent-responses-types
     agent-store async base bytestring containers directory filepath
-    hspec http-client http-types QuickCheck safe-exceptions text time
-    unix wai warp
+    hspec http-client http-types QuickCheck safe-exceptions stm text
+    time unix wai warp
   ];
   description = "Headless shared runtime for agent frontends";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli-runtime/src/Agent/CLI/NativeProcess.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/NativeProcess.hs
@@ -4,6 +4,7 @@ module Agent.CLI.NativeProcess
     ( NativeProcessRuntime
         ( nativeMcpSupervisor
         , nativeSessionThreads
+        , nativeToolResourceArbiter
         , nativeNetworkRecovery
         , nativeStartCleanup
         , nativeMcpElicitation
@@ -18,6 +19,8 @@ module Agent.CLI.NativeProcess
 
 import Agent.CLI.Session.Threads
     ( SessionThreadManager, closeSessionThreadManager, newSessionThreadManager )
+import Agent.Tools.ResourceArbiter
+    ( ToolResourceArbiter, newToolResourceArbiter, closeToolResourceArbiter )
 import Agent.Connectivity.NetworkPath
     ( NetworkRecoveryMonitor
     , closeNetworkRecoveryMonitor
@@ -37,6 +40,7 @@ import System.OsPath (OsPath)
 data NativeProcessRuntime = NativeProcessRuntime
     { nativeMcpSupervisor :: !MCP.McpSupervisor
     , nativeSessionThreads :: !SessionThreadManager
+    , nativeToolResourceArbiter :: !ToolResourceArbiter
     , nativeNetworkRecovery :: !NetworkRecoveryMonitor
     , nativeStartCleanup :: !(IO () -> IO ())
     , nativeMcpElicitation
@@ -60,6 +64,7 @@ newNativeProcessRuntime = newNativeProcessRuntimeWithMcpHooks MCP.defaultMcpHost
 newNativeProcessRuntimeWithMcpHooks
     :: MCP.McpHostHooks -> OsPath -> IO NativeProcessRuntime
 newNativeProcessRuntimeWithMcpHooks hostHooks root = mask \restore -> do
+    arbiter <- newToolResourceArbiter 1024
     elicitationRef <- newIORef Nothing
     rootsRef <- newIORef Nothing
     samplingRef <- newIORef Nothing
@@ -99,6 +104,7 @@ newNativeProcessRuntimeWithMcpHooks hostHooks root = mask \restore -> do
     pure NativeProcessRuntime
         { nativeMcpSupervisor = mcpSupervisor
         , nativeSessionThreads = sessionThreads
+        , nativeToolResourceArbiter = arbiter
         , nativeNetworkRecovery = networkMonitor
         , nativeStartCleanup = startCleanup
         , nativeMcpElicitation = elicitationRef
@@ -109,7 +115,8 @@ newNativeProcessRuntimeWithMcpHooks hostHooks root = mask \restore -> do
 
 closeNativeProcessRuntime :: NativeProcessRuntime -> IO ()
 closeNativeProcessRuntime runtime =
-    closeSessionThreadManager runtime.nativeSessionThreads
+    closeToolResourceArbiter runtime.nativeToolResourceArbiter
+        `finally` closeSessionThreadManager runtime.nativeSessionThreads
         `finally`
             (MCP.closeMcpSupervisor runtime.nativeMcpSupervisor
                 `finally`

--- a/packages/agent-cli-runtime/test/Agent/CLI/NativeProcessSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/NativeProcessSpec.hs
@@ -2,9 +2,14 @@ module Agent.CLI.NativeProcessSpec (spec) where
 
 import Agent.CLI.Session.Threads (launchSessionThread)
 import Agent.CLI.NativeProcess
+import Agent.Tools.ResourceArbiter
+    ( ToolResourceArbiterError(..), withToolResources, toolResourceArbiterCounts )
+import Agent.Tools.Scheduling
+    ( ToolAccess(..), ToolResource(..), ToolResourceClaim(..) )
+import Control.Concurrent.STM (atomically)
 import Control.Concurrent.MVar
     ( newEmptyMVar, putMVar, takeMVar, tryTakeMVar )
-import Control.Exception.Safe (bracket, finally)
+import Control.Exception.Safe (bracket, finally, try)
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import System.OsPath (unsafeEncodeUtf)
 import System.Timeout (timeout)
@@ -48,6 +53,23 @@ spec = describe "shared native process resources" do
 
     it "closes an unused cleanup worker without requiring a cleanup request" do
         withinDeadline (withRuntime (const (pure ())))
+
+    it "joins resource-owning session workers and closes their shared authority" do
+        started <- newEmptyMVar
+        blocked <- newEmptyMVar
+        arbiter <- withinDeadline $ withRuntime \runtime -> do
+            let arbiter = runtime.nativeToolResourceArbiter
+                claim = ToolResourceClaim ToolWrite (ToolNamedResource "test")
+            launchSessionThread runtime.nativeSessionThreads "resource-owner"
+                (withToolResources arbiter [claim] $
+                    putMVar started () >> takeMVar blocked >> pure (Right ()))
+                `shouldReturn` Right "started session resource-owner"
+            takeMVar started
+            atomically (toolResourceArbiterCounts arbiter) `shouldReturn` (0, 1)
+            pure arbiter
+        atomically (toolResourceArbiterCounts arbiter) `shouldReturn` (0, 0)
+        try (withToolResources arbiter [] (pure ()))
+            `shouldReturn` Left ToolResourceArbiterClosed
 
 -- Bounds interruptible test handshakes; this is not a hard deadline for
 -- masked resource cleanup.

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -228,6 +228,8 @@ runNativeOptions runtime output cwd hooks options =
                 runtime.nativeIntegrationSupervisor
             , processSessionThreads =
                 runtime.nativeProcessCore.nativeSessionThreads
+            , processToolResourceArbiter =
+                runtime.nativeProcessCore.nativeToolResourceArbiter
             , processStartCleanup =
                 runtime.nativeProcessCore.nativeStartCleanup
             , processMcpElicitation =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -86,6 +86,8 @@ import Agent.CLI.Status
 import Agent.CLI.Terminal ( resolveColor )
 import Agent.CLI.Worktree ( isUnderWorktreeRoot, worktreeRoot )
 import Agent.Tools.Types (defaultToolEnv)
+import Agent.Tools.ResourceArbiter
+    ( newToolResourceArbiter, closeToolResourceArbiter )
 import Control.Concurrent.Async ( withAsync )
 import Control.Concurrent.MVar ( newEmptyMVar, putMVar, takeMVar )
 import Control.Exception.Safe ( finally, mask_, onException )
@@ -221,6 +223,7 @@ runAgentWithRestarts options =
                 elicitationRef <- newIORef Nothing
                 rootsRef <- newIORef Nothing
                 samplingRef <- newIORef Nothing
+                toolResourceArbiter <- newToolResourceArbiter 1024
                 cleanupStarted <- newIORef False
                 cleanupRequest <- newEmptyMVar
                 -- Cleanup is intentionally process-scoped rather than
@@ -257,6 +260,7 @@ runAgentWithRestarts options =
                             , processIntegrationSupervisor =
                                 integrationSupervisor
                             , processSessionThreads = sessionThreads
+                            , processToolResourceArbiter = toolResourceArbiter
                             , processStartCleanup = startCleanup
                             , processMcpElicitation = elicitationRef
                             , processMcpRoots = rootsRef
@@ -267,7 +271,8 @@ runAgentWithRestarts options =
                         (runAgentWithRuntime
                             processRuntime foregroundRunMode options)
                         `finally`
-                            (closeSessionThreadManager sessionThreads
+                            (closeToolResourceArbiter toolResourceArbiter
+                                `finally` closeSessionThreadManager sessionThreads
                                 `finally`
                                     (MCP.closeMcpSupervisor
                                         mcpSupervisor

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -64,7 +64,7 @@ import Agent.CLI.Runtime.Orchestration.Restart
 import Agent.CLI.Runtime.Orchestration.Startup
     ( clearNativeProgress, setNativeProgress )
 import Agent.CLI.Runtime.Orchestration.Types
-    ( AgentProcessRuntime(processNetworkRecovery)
+    ( AgentProcessRuntime(processNetworkRecovery, processToolResourceArbiter)
     , AgentRunMode
         ( runInBackground
         , runStdout
@@ -156,7 +156,7 @@ import Agent.TUI.Model
       UiState(uiQueuedInputs) )
 import Agent.TUI.Motion ( nativeProgressAnimationEnabled )
 import Agent.TUI.Theme ( ThemeKind )
-import Agent.Tools.Types ( defaultToolEnv, ToolEnv(toolCancel) )
+import Agent.Tools.Types ( defaultToolEnv, ToolEnv(toolCancel, toolResourceArbiter) )
 import Control.Applicative ( (<|>) )
 import Control.Concurrent.MVar
     ( MVar, newEmptyMVar, newMVar, readMVar, tryPutMVar )
@@ -1135,7 +1135,11 @@ runPreparedAgentIteration
         interface.iterationTerminal
         runMode.runStdout
         terminalCwd
-    toolEnv <- defaultToolEnv cwd
+    freshToolEnv <- defaultToolEnv cwd
+    let toolEnv = freshToolEnv
+            { toolResourceArbiter =
+                request.iterationProcessRuntime.processToolResourceArbiter
+            }
     interface.iterationInstallToolRuntime toolEnv
     let startup =
             interface.iterationBuildStartupRuntime

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -178,7 +178,7 @@ import Agent.CLI.Subagents.Runtime
                       subagentOptions, subagentNetworkRecovery,
                       subagentGhciEnabled, subagentBashEnabled,
                       subagentPolicy, subagentPlanHooks, subagentSkillRoots,
-                      subagentAllowedRoots, subagentRootAccessRequest,
+                      subagentAllowedRoots, subagentToolResourceArbiter, subagentRootAccessRequest,
                       subagentParams, subagentMcpTools, subagentRegistry,
                       subagentSessions, subagentStoreRoot, subagentTypes,
                       subagentLegacyTarget, subagentConnection, subagentMapModel,
@@ -237,7 +237,7 @@ import Agent.ToolDispatch (canonicalToolName, ToolDispatchConfig(..))
 import Agent.Tools.Types
     ( AppTool(..)
     , ToolSchema(..)
-    , ToolEnv(toolAllowedRoots, toolRootAccessRequest, toolSkillRoots, toolSessionTmp)
+    , ToolEnv(toolAllowedRoots, toolRootAccessRequest, toolSkillRoots, toolSessionTmp, toolResourceArbiter)
     )
 import Control.Applicative ( (<|>) )
 import Control.Concurrent.Async ( waitSTM, withAsync )
@@ -737,6 +737,7 @@ buildSessionSubagentRuntime AgentSessionRequest
         , subagentPlanHooks = planHooks
         , subagentSkillRoots = toolEnv.toolSkillRoots
         , subagentAllowedRoots = toolEnv.toolAllowedRoots
+        , subagentToolResourceArbiter = toolEnv.toolResourceArbiter
         , subagentRootAccessRequest = toolEnv.toolRootAccessRequest
         , subagentParams = promptRuntime.sessionParamsRef
         , subagentMcpTools = mcpTools

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -36,6 +36,7 @@ import System.IO ( Handle, stderr, stdout )
 import System.OsPath ( OsPath )
 
 import qualified Agent.MCP as MCP
+import Agent.Tools.ResourceArbiter (ToolResourceArbiter)
 
 data ActiveHttpAuth = ActiveHttpAuth
     { activeHttpGeneration :: !Int
@@ -48,6 +49,7 @@ data AgentProcessRuntime = AgentProcessRuntime
     { processMcpSupervisor :: !MCP.McpSupervisor
     , processIntegrationSupervisor :: !IntegrationSupervisor
     , processSessionThreads :: !SessionThreadManager
+    , processToolResourceArbiter :: !ToolResourceArbiter
     -- | Starts the process-scoped stale-resource cleanup exactly once. Its
     -- owner joins it when the process runtime closes.
     , processStartCleanup :: !(IO () -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -1223,6 +1223,7 @@ prepareChild
         freshEnv <- defaultToolEnv env.subCwd
         pure freshEnv
             { toolAllowedRoots = runtime.subagentAllowedRoots
+            , toolResourceArbiter = runtime.subagentToolResourceArbiter
             , toolRootAccessRequest = runtime.subagentRootAccessRequest
             }
     skillRoots <- readIORef runtime.subagentSkillRoots

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime/Types.hs
@@ -26,6 +26,7 @@ import Agent.Tools.MultiAgents
     )
 import Agent.Tools.PlanMode (PlanModeHooks)
 import Agent.Tools.Types (AppTool, ToolEnv)
+import Agent.Tools.ResourceArbiter (ToolResourceArbiter)
 import Agent.Dialect (DialectId)
 import Control.Concurrent.MVar (MVar)
 import Data.IORef (IORef)
@@ -66,6 +67,7 @@ data SubagentRuntime = SubagentRuntime
     , subagentPlanHooks :: !PlanModeHooks
     , subagentSkillRoots :: !(IORef [OsPath])
     , subagentAllowedRoots :: !(IORef [OsPath])
+    , subagentToolResourceArbiter :: !ToolResourceArbiter
     , subagentRootAccessRequest :: !(IORef (Maybe (OsPath -> IO Bool)))
     , subagentSessionTmp :: !(IORef (Maybe OsPath))
     , subagentMcpTools :: ![AppTool]

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -85,6 +85,7 @@ import Agent.Tools.Types
     , jsonTool
     , rawJsonAppToolWithExecution
     , withToolResourceClaims
+    , withSharedToolResourceClaims
     )
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -398,7 +399,7 @@ applyPatchArgsDecoder = Json.withType \case
 
 applyPatchTool :: ToolEnv -> AppTool
 applyPatchTool env =
-    withToolResourceClaims (applyPatchResourceClaims env) $
+    withSharedToolResourceClaims env (applyPatchResourceClaims env) $
     freeformApplyPatchAppToolWithExecution
         "apply_patch" applyPatchDescription AlwaysPrompt TurnSequential
         (textTool "apply_patch" (applyPatch env))

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -94,6 +94,7 @@ library
                     , Agent.Tools.TaskPlan
                     , Agent.Tools.Secret
                     , Agent.Tools.Scheduling
+                    , Agent.Tools.ResourceArbiter
                     , Agent.Tools.ShowImage
                     , Agent.Tools.ShellReadOnly
                     , Agent.Tools.Types
@@ -322,6 +323,7 @@ test-suite agent-core-test
                     , Agent.Tools.ShowImageSpec
                     , Agent.Tools.ViewImageSpec
                     , Agent.Tools.RenderChartSpec
+                    , Agent.Tools.ResourceArbiterSpec
                     , Agent.ToolDSLSpec
                     , Agent.Transport.WebSocketSpec
                     , Paths_agent_core

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -44,6 +44,7 @@ module Agent.ToolDispatch
     , dispatchToolHandler
     , dispatchToolHandlerDetailed
     , handlerName
+    , wrapToolHandler
     , toolArgumentsValue
     , decodeToolArguments
     ) where
@@ -327,6 +328,20 @@ data ToolHandler = ToolHandler
         -> Text
         -> IO (Either Text ToolHandlerResult)
     }
+
+-- | Wrap actual handler execution without losing canonical argument decoding,
+-- streaming updates, rich results, or the original provider call.
+wrapToolHandler
+    :: (ToolCall
+        -> IO (Either Text ToolHandlerResult)
+        -> IO (Either Text ToolHandlerResult))
+    -> ToolHandler
+    -> ToolHandler
+wrapToolHandler wrap handler =
+    handler
+        { toolHandlerRun = \emit call input ->
+            wrap call (handler.toolHandlerRun emit call input)
+        }
 
 typedTool :: Text -> Decoder args -> (args -> IO (Either Text Text)) -> ToolHandler
 typedTool name decoder run =

--- a/packages/agent-core/src/Agent/Tools/FileSystem/Grep.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/Grep.hs
@@ -28,7 +28,7 @@ import Agent.Tools.Types
     , ToolEnv(..)
     , ToolExecutionPolicy(..)
     , jsonTool
-    , withToolResourceClaims
+    , withSharedToolResourceClaims
     )
 import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
@@ -103,7 +103,7 @@ grepArgsDecoder = objectArgs \object -> do
             <*> (fromMaybe False <$> optBool object "multiline")
 
 grepTool :: ToolEnv -> AppTool
-grepTool env = withToolResourceClaims (grepClaims env) $
+grepTool env = withSharedToolResourceClaims env (grepClaims env) $
     jsonTool "grep" grepDescription
     [ PropertySchema "pattern" PropertyString True $ Just
         "The regular expression pattern to search for in file contents (rg --regexp)"

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ListDir.hs
@@ -33,7 +33,7 @@ import Agent.Tools.Types
     , ToolEnv(..)
     , ToolExecutionPolicy(..)
     , jsonTool
-    , withToolResourceClaims
+    , withSharedToolResourceClaims
     )
 import Data.List (sortOn)
 import qualified Data.Map.Strict as Map
@@ -49,7 +49,7 @@ listDirArgsDecoder :: Decoder ListDirArgs
 listDirArgsDecoder = objectArgs \object -> ListDirArgs <$> reqText object "target_directory"
 
 listDirTool :: ToolEnv -> AppTool
-listDirTool env = withToolResourceClaims (listDirClaims env) $
+listDirTool env = withSharedToolResourceClaims env (listDirClaims env) $
     jsonTool "list_dir" listDirDescription
     [ PropertySchema "target_directory" PropertyString True $ Just
         "Path to a directory within an allowed filesystem root. Relative paths use the workspace root; absolute paths may resolve within the workspace or session temp directory."

--- a/packages/agent-core/src/Agent/Tools/FileSystem/ReadFile.hs
+++ b/packages/agent-core/src/Agent/Tools/FileSystem/ReadFile.hs
@@ -28,7 +28,7 @@ import Agent.Tools.Types
     , ToolEnv
     , ToolExecutionPolicy(..)
     , jsonTool
-    , withToolResourceClaims
+    , withSharedToolResourceClaims
     )
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -59,7 +59,7 @@ readFileArgsDecoder = objectArgs \object -> ReadFileArgs
         <*> optText object "format"
 
 readFileTool :: ToolEnv -> AppTool
-readFileTool env = withToolResourceClaims (readFileClaims env) $
+readFileTool env = withSharedToolResourceClaims env (readFileClaims env) $
     jsonTool "read_file" readFileDescription
     [ PropertySchema "target_file" PropertyString True $ Just
         "The path of the file to read. Relative paths use the workspace; absolute paths may resolve within the workspace or session temp directory."

--- a/packages/agent-core/src/Agent/Tools/ResourceArbiter.hs
+++ b/packages/agent-core/src/Agent/Tools/ResourceArbiter.hs
@@ -1,0 +1,118 @@
+-- | Cooperative resource ownership shared by tool workers in one runtime.
+-- This is not a filesystem sandbox or a cross-process lock service.
+module Agent.Tools.ResourceArbiter
+    ( ToolResourceArbiter
+    , ToolResourceArbiterError(..)
+    , newToolResourceArbiter
+    , withToolResources
+    , closeToolResourceArbiter
+    , waitToolResourceArbiter
+    , toolResourceArbiterCounts
+    ) where
+
+import Agent.Tools.Scheduling
+    ( ToolResourceClaim, ToolSchedulingPlan(..), schedulingPlansConflict )
+import Control.Concurrent.STM
+    ( STM, TVar, atomically, check, modifyTVar', newTVarIO, readTVar
+    , throwSTM, writeTVar
+    )
+import Control.Exception.Safe (Exception, bracket)
+import Control.Monad (when)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+
+data ToolResourceArbiter = ToolResourceArbiter
+    { state :: !(TVar ArbiterState)
+    , capacity :: !Int
+    }
+
+data ArbiterState = ArbiterState
+    { closed :: !Bool
+    , nextTicket :: !Integer
+    , claims :: !(Map Integer Claim)
+    }
+
+data Claim = Claim
+    { resources :: ![ToolResourceClaim]
+    , running :: !Bool
+    }
+
+data ToolResourceArbiterError
+    = ToolResourceArbiterClosed
+    | ToolResourceArbiterFull
+    deriving (Eq, Show)
+
+instance Exception ToolResourceArbiterError
+
+-- | Bound both active claims and waiters. Full admission fails immediately,
+-- rather than leaving unbounded requests waiting outside a bounded queue.
+newToolResourceArbiter :: Int -> IO ToolResourceArbiter
+newToolResourceArbiter capacity
+    | capacity <= 0 = ioError (userError "resource arbiter capacity must be positive")
+    | otherwise =
+        ToolResourceArbiter <$> newTVarIO (ArbiterState False 0 Map.empty)
+            <*> pure capacity
+
+-- | Acquire the complete claim set atomically. Conflicting requests retain
+-- admission order, but unrelated work may pass a blocked request. Cancellation
+-- removes either a waiter or an active lease. The action must encompass the
+-- actual worker lifetime, including joining any structured children.
+--
+-- Do not call recursively while holding conflicting resources. In particular,
+-- collaboration wait/spawn handlers must not acquire a global exclusive lease.
+withToolResources :: ToolResourceArbiter -> [ToolResourceClaim] -> IO a -> IO a
+withToolResources arbiter resources action =
+    bracket
+        (atomically (admit arbiter resources))
+        (\ticket -> atomically $
+            modifyTVar' arbiter.state \current ->
+                current { claims = Map.delete ticket current.claims })
+        \ticket -> do
+            atomically (acquire arbiter ticket resources)
+            action
+
+admit :: ToolResourceArbiter -> [ToolResourceClaim] -> STM Integer
+admit arbiter resources = do
+    current <- readTVar arbiter.state
+    when current.closed (throwSTM ToolResourceArbiterClosed)
+    when (Map.size current.claims >= arbiter.capacity)
+        (throwSTM ToolResourceArbiterFull)
+    let ticket = current.nextTicket
+    writeTVar arbiter.state current
+        { nextTicket = ticket + 1
+        , claims = Map.insert ticket (Claim resources False) current.claims
+        }
+    pure ticket
+
+acquire :: ToolResourceArbiter -> Integer -> [ToolResourceClaim] -> STM ()
+acquire arbiter ticket resources = do
+    current <- readTVar arbiter.state
+    when current.closed (throwSTM ToolResourceArbiterClosed)
+    check $ not $ Map.foldrWithKey
+        (\other claim conflict ->
+            conflict || (other /= ticket && (claim.running || other < ticket)
+                && schedulingPlansConflict
+                    (ToolResourceClaims resources)
+                    (ToolResourceClaims claim.resources)))
+        False current.claims
+    writeTVar arbiter.state current
+        { claims = Map.adjust (\claim -> claim { running = True })
+            ticket current.claims
+        }
+
+-- | Reject new work and wake blocked admissions. Does not revoke resources
+-- from running work: the owning runtime must cancel/join its workers.
+closeToolResourceArbiter :: ToolResourceArbiter -> IO ()
+closeToolResourceArbiter arbiter =
+    atomically $ modifyTVar' arbiter.state \current -> current { closed = True }
+
+waitToolResourceArbiter :: ToolResourceArbiter -> IO ()
+waitToolResourceArbiter arbiter =
+    atomically $ readTVar arbiter.state >>= check . Map.null . (.claims)
+
+-- | Consistent diagnostic snapshot: (waiting, running).
+toolResourceArbiterCounts :: ToolResourceArbiter -> STM (Int, Int)
+toolResourceArbiterCounts arbiter = do
+    current <- readTVar arbiter.state
+    let active = Map.size (Map.filter (.running) current.claims)
+    pure (Map.size current.claims - active, active)

--- a/packages/agent-core/src/Agent/Tools/ShowImage.hs
+++ b/packages/agent-core/src/Agent/Tools/ShowImage.hs
@@ -35,7 +35,7 @@ import Agent.Tools.Types
     , ToolEnv
     , ToolExecutionPolicy(..)
     , jsonTool
-    , withToolResourceClaims
+    , withSharedToolResourceClaims
     )
 import Control.Exception.Safe (tryIO)
 import qualified Data.ByteString as BS
@@ -84,7 +84,7 @@ showImageArgsDecoder = objectArgs \object ->
 
 showImageTool :: ToolEnv -> ImageDisplayHooks -> AppTool
 showImageTool env hooks =
-    withToolResourceClaims (showImageClaims env) $
+    withSharedToolResourceClaims env (showImageClaims env) $
         jsonTool showImageToolName showImageDescription
             [ PropertySchema "path" PropertyString True $ Just
                 "Path of the image file to display. Relative paths use the workspace; absolute paths may resolve within the workspace or session temp directory. PNG, JPEG, GIF, BMP, and TIFF are supported."

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -29,6 +29,7 @@ module Agent.Tools.Types
     , freeformGrammarAppToolWithExecution
     , withToolHumanInputWait
     , withToolResourceClaims
+    , withSharedToolResourceClaims
     , withAsyncToolCalls
     , appToolSupportsAsync
     , mkToolRegistry
@@ -62,7 +63,10 @@ import Agent.ToolDispatch
     , dispatchToolHandler
     , dispatchToolHandlerDetailed
     , handlerName
+    , wrapToolHandler
     )
+import Agent.Tools.ResourceArbiter
+    ( ToolResourceArbiter, newToolResourceArbiter, withToolResources )
 import Agent.Tools.Scheduling
     ( ToolAccess(..)
     , ToolResource(..)
@@ -213,6 +217,7 @@ noBackgroundTaskHooks = BackgroundTaskHooks
 
 data ToolEnv = ToolEnv
     { toolCwd :: !OsPath
+    , toolResourceArbiter :: !ToolResourceArbiter
     , toolAllowedRoots :: !(IORef [OsPath])
       -- | Additional non-session filesystem roots. The current
       -- 'toolSessionTmp' is always allowed implicitly and receives absolute
@@ -244,6 +249,7 @@ data ToolEnv = ToolEnv
 
 defaultToolEnv :: OsPath -> IO ToolEnv
 defaultToolEnv cwd = do
+    arbiter <- newToolResourceArbiter 1024
     cancel <- newCancelFlag
     allowedRoots <- newIORef []
     rootAccessRequest <- newIORef Nothing
@@ -253,6 +259,7 @@ defaultToolEnv cwd = do
     backgroundTaskHooks <- newIORef noBackgroundTaskHooks
     pure ToolEnv
         { toolCwd = dropTrailingPathSeparator cwd
+        , toolResourceArbiter = arbiter
         , toolAllowedRoots = allowedRoots
         , toolRootAccessRequest = rootAccessRequest
         , toolHumanInputWaitHooks = humanInputWaitHooks
@@ -389,6 +396,24 @@ withToolResourceClaims
     -> AppTool
 withToolResourceClaims resolver tool =
     tool { appToolResourceClaims = Just resolver }
+
+-- | Opt a handler whose complete effects are scoped to its return into shared
+-- arbitration as well as turn-local ordering. Resolve before taking a lease,
+-- so claim resolution does not hold execution resources. Resolution
+-- failure denies dispatch rather than running with incomplete claims.
+--
+-- Never use this for a handler that yields a live process/session handle.
+-- Those need resource leases owned by the process supervisor itself.
+withSharedToolResourceClaims
+    :: ToolEnv -> ToolResourceResolver -> AppTool -> AppTool
+withSharedToolResourceClaims env resolver tool =
+    (withToolResourceClaims resolver tool)
+        { appToolHandler = wrapToolHandler
+            (\call action -> resolver call >>= \case
+                Left err -> pure (Left err)
+                Right claims -> withToolResources env.toolResourceArbiter claims action)
+            tool.appToolHandler
+        }
 
 -- | Explicitly opt a tool into provider-requested asynchronous execution.
 withAsyncToolCalls :: AppTool -> AppTool

--- a/packages/agent-core/src/Agent/Tools/ViewImage.hs
+++ b/packages/agent-core/src/Agent/Tools/ViewImage.hs
@@ -30,7 +30,7 @@ import Agent.Tools.Types
     , ToolEnv
     , ToolExecutionPolicy(..)
     , jsonTool
-    , withToolResourceClaims
+    , withSharedToolResourceClaims
     )
 import Codec.Picture (decodeGifImages, decodeImage)
 import Control.Exception.Safe (tryIO)
@@ -65,7 +65,7 @@ viewImageArgsDecoder = objectArgs \object ->
 
 viewImageTool :: ToolEnv -> AppTool
 viewImageTool env =
-    withToolResourceClaims (viewImageClaims env) $
+    withSharedToolResourceClaims env (viewImageClaims env) $
         jsonTool viewImageToolName viewImageDescription
             [ PropertySchema "path" PropertyString True $ Just
                 "Local filesystem path to an image file."

--- a/packages/agent-core/test/Agent/Tools/ResourceArbiterSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/ResourceArbiterSpec.hs
@@ -1,0 +1,191 @@
+module Agent.Tools.ResourceArbiterSpec (spec) where
+
+import Agent.Tools.ResourceArbiter
+import Agent.Tools.Scheduling
+import Agent.Cancel (requestCancel)
+import Agent.Loop
+import Agent.Loop.Fixtures
+    ( testConfig, registryFromTools, noArgsAppTool, appendStateMarker )
+import Agent.ToolDispatch (functionToolCall, withToolCallMode, ToolCallMode(..))
+import Agent.Tools.Types
+    ( ToolEnv(..), defaultToolEnv, withSharedToolResourceClaims, withAsyncToolCalls )
+import Control.Concurrent.Async (cancel, wait, withAsync)
+import Control.Concurrent.STM
+    ( atomically, check, newEmptyTMVarIO, putTMVar, readTMVar )
+import Control.Exception.Safe (try)
+import Data.Either (isRight)
+import Data.IORef (atomicModifyIORef', newIORef)
+import System.OsPath (unsafeEncodeUtf)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "shared tool resource arbiter" do
+    mapM_ (\mode ->
+        it ("coordinates separate loops, including " <> show mode <> " worker lifetime") do
+            env <- defaultToolEnv (unsafeEncodeUtf "/workspace")
+            release <- newEmptyTMVarIO
+            started <- newEmptyTMVarIO
+            first <- configWithClaim env mode $
+                atomically (putTMVar started ()) >> atomically (readTMVar release)
+            second <- configWithClaim env BlockingToolCall (pure ())
+            withAsync (runLoopInputs first Nothing [UserMessage "first"]) \worker -> do
+                atomically (readTMVar started)
+                withAsync (runLoopInputs second Nothing [UserMessage "second"]) \waiting -> do
+                    awaitCounts env.toolResourceArbiter (1, 1)
+                    atomically (putTMVar release ())
+                    timeout 1000000 (wait waiting) >>= (`shouldSatisfy` maybe False isRight)
+                timeout 1000000 (wait worker) >>= (`shouldSatisfy` maybe False isRight)
+            atomically (toolResourceArbiterCounts env.toolResourceArbiter)
+                `shouldReturn` (0, 0))
+        [BlockingToolCall, AsyncToolCall]
+
+    it "cancels a loop waiting for another loop's resources without running its handler" do
+        env <- defaultToolEnv (unsafeEncodeUtf "/workspace")
+        second <- configWithClaim env BlockingToolCall
+            (expectationFailure "cancelled handler executed")
+        withHeld env.toolResourceArbiter [writeA] do
+            withAsync (runLoopInputs second Nothing [UserMessage "cancel"]) \waiting -> do
+                awaitCounts env.toolResourceArbiter (1, 1)
+                requestCancel second.loopCancel
+                timeout 1000000 (wait waiting) >>= (`shouldSatisfy` maybe False (const True))
+                atomically (toolResourceArbiterCounts env.toolResourceArbiter)
+                    `shouldReturn` (0, 1)
+
+    it "allows shared reads and unrelated worktrees" do
+        arbiter <- newToolResourceArbiter 8
+        withHeld arbiter [readA] do
+            timeout 1000000 (withToolResources arbiter [readA] (pure ()))
+                `shouldReturn` Just ()
+            timeout 1000000 (withToolResources arbiter [writeB] (pure ()))
+                `shouldReturn` Just ()
+        atomically (toolResourceArbiterCounts arbiter) `shouldReturn` (0, 0)
+
+    it "blocks a writer until the reader completes" do
+        arbiter <- newToolResourceArbiter 8
+        started <- newEmptyTMVarIO
+        release <- newEmptyTMVarIO
+        withAsync
+            (withToolResources arbiter [readA] $
+                atomically (putTMVar started ()) >> atomically (readTMVar release))
+            \reader -> do
+                atomically (readTMVar started)
+                withAsync (withToolResources arbiter [writeA] (pure ())) \writer -> do
+                    awaitCounts arbiter (1, 1)
+                    atomically (putTMVar release ())
+                    timeout 1000000 (wait writer) `shouldReturn` Just ()
+                wait reader
+
+    it "removes cancelled waiters and keeps all-or-nothing acquisition" do
+        arbiter <- newToolResourceArbiter 8
+        withHeld arbiter [writeA] do
+            withAsync (withToolResources arbiter [writeA, writeB] (pure ())) \worker -> do
+                awaitCounts arbiter (1, 1)
+                -- B has not been acquired while waiting for A.
+                -- A later nonconflicting read of C can also bypass this waiter.
+                timeout 1000000 (withToolResources arbiter [writeC] (pure ()))
+                    `shouldReturn` Just ()
+                cancel worker
+            atomically (toolResourceArbiterCounts arbiter) `shouldReturn` (0, 1)
+            timeout 1000000 (withToolResources arbiter [writeB] (pure ()))
+                `shouldReturn` Just ()
+
+    it "releases leases when a running worker is cancelled" do
+        arbiter <- newToolResourceArbiter 8
+        started <- newEmptyTMVarIO
+        blocked <- newEmptyTMVarIO
+        withAsync
+            (withToolResources arbiter [writeA] $
+                atomically (putTMVar started ()) >> atomically (readTMVar blocked))
+            \worker -> do
+                atomically (readTMVar started)
+                cancel worker
+        timeout 1000000 (withToolResources arbiter [writeA] (pure ()))
+            `shouldReturn` Just ()
+        atomically (toolResourceArbiterCounts arbiter) `shouldReturn` (0, 0)
+
+    it "does not let later readers starve an admitted writer" do
+        arbiter <- newToolResourceArbiter 8
+        releaseWriter <- newEmptyTMVarIO
+        withHeld arbiter [readA] do
+            withAsync
+                (withToolResources arbiter [writeA] $
+                    atomically (readTMVar releaseWriter))
+                \writer -> do
+                    awaitCounts arbiter (1, 1)
+                    withAsync (withToolResources arbiter [readA] (pure ())) \reader -> do
+                        awaitCounts arbiter (2, 1)
+                        cancel writer
+                        timeout 1000000 (wait reader) `shouldReturn` Just ()
+
+    it "rejects full admission without retaining another waiter" do
+        arbiter <- newToolResourceArbiter 1
+        withHeld arbiter [writeA] do
+            try (withToolResources arbiter [writeA] (pure ()))
+                `shouldReturn` Left ToolResourceArbiterFull
+            atomically (toolResourceArbiterCounts arbiter) `shouldReturn` (0, 1)
+
+    it "close wakes waiters but does not revoke active resources" do
+        arbiter <- newToolResourceArbiter 8
+        withHeld arbiter [writeA] do
+            withAsync
+                (try (withToolResources arbiter [writeA] (pure ())))
+                \worker -> do
+                    awaitCounts arbiter (1, 1)
+                    closeToolResourceArbiter arbiter
+                    timeout 1000000 (wait worker)
+                        `shouldReturn` Just (Left ToolResourceArbiterClosed)
+            atomically (toolResourceArbiterCounts arbiter) `shouldReturn` (0, 1)
+            try (withToolResources arbiter [] (pure ()))
+                `shouldReturn` Left ToolResourceArbiterClosed
+        timeout 1000000 (waitToolResourceArbiter arbiter) `shouldReturn` Just ()
+
+    it "does not coordinate independent authorities" do
+        first <- newToolResourceArbiter 8
+        second <- newToolResourceArbiter 8
+        withHeld first [writeA] $
+            timeout 1000000 (withToolResources second [writeA] (pure ()))
+                `shouldReturn` Just ()
+
+readA, writeA, writeB, writeC :: ToolResourceClaim
+readA = ToolResourceClaim ToolRead (ToolPath (unsafeEncodeUtf "/workspace/a/file"))
+writeA = ToolResourceClaim ToolWrite (ToolPathTree (unsafeEncodeUtf "/workspace/a"))
+writeB = ToolResourceClaim ToolWrite (ToolPathTree (unsafeEncodeUtf "/workspace/b"))
+writeC = ToolResourceClaim ToolWrite (ToolPathTree (unsafeEncodeUtf "/workspace/c"))
+
+awaitCounts :: ToolResourceArbiter -> (Int, Int) -> IO ()
+awaitCounts arbiter expected =
+    timeout 1000000
+        (atomically $ toolResourceArbiterCounts arbiter >>= check . (== expected))
+        `shouldReturn` Just ()
+
+withHeld :: ToolResourceArbiter -> [ToolResourceClaim] -> IO a -> IO a
+withHeld arbiter claims action = do
+    started <- newEmptyTMVarIO
+    release <- newEmptyTMVarIO
+    withAsync
+        (withToolResources arbiter claims $
+            atomically (putTMVar started ()) >> atomically (readTMVar release))
+        \_worker -> atomically (readTMVar started) >> action
+
+configWithClaim :: ToolEnv -> ToolCallMode -> IO () -> IO LoopConfig
+configWithClaim env mode action = do
+    first <- newIORef True
+    let call = withToolCallMode mode (functionToolCall "call" "resource" "{}")
+        backend = backendWithCallbacks \snapshot _previous _inputs callbacks -> do
+            initial <- atomicModifyIORef' first (\value -> (False, value))
+            if initial && mode == AsyncToolCall
+                then callbacks.onAsyncToolCall call
+                else pure ()
+            pure $ Right BackendResult
+                { backendOutput = emptyTurnOutput
+                    (if initial then "tools" else "done")
+                    (if initial then [call] else [])
+                    (if initial then Nothing else Just "done")
+                , backendState = appendStateMarker snapshot
+                }
+        tool = withAsyncToolCalls $
+            withSharedToolResourceClaims env (\_ -> pure (Right [writeA])) $
+                noArgsAppTool "resource" (action >> pure (Right "done"))
+    config <- testConfig backend
+    pure config { loopTools = registryFromTools [tool] }

--- a/packages/agent-core/test/Agent/Tools/ResourceArbiterSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/ResourceArbiterSpec.hs
@@ -118,6 +118,16 @@ spec = describe "shared tool resource arbiter" do
                         cancel writer
                         timeout 1000000 (wait reader) `shouldReturn` Just ()
 
+    it "releases the lease after a synchronous handler exception or error result" do
+        arbiter <- newToolResourceArbiter 8
+        withToolResources arbiter [writeA] (ioError (userError "handler failed"))
+            `shouldThrow` anyIOException
+        withToolResources arbiter [writeA] (pure (Left "handler failed" :: Either String ()))
+            `shouldReturn` Left "handler failed"
+        timeout 1000000 (withToolResources arbiter [writeA] (pure ()))
+            `shouldReturn` Just ()
+        atomically (toolResourceArbiterCounts arbiter) `shouldReturn` (0, 0)
+
     it "rejects full admission without retaining another waiter" do
         arbiter <- newToolResourceArbiter 1
         withHeld arbiter [writeA] do

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -39,6 +39,7 @@ import qualified Agent.Tools.SecretSpec as SecretSpec
 import qualified Agent.Tools.ShowImageSpec as ShowImageSpec
 import qualified Agent.Tools.ViewImageSpec as ViewImageSpec
 import qualified Agent.Tools.RenderChartSpec as RenderChartSpec
+import qualified Agent.Tools.ResourceArbiterSpec as ResourceArbiterSpec
 import qualified Agent.Transport.WebSocketSpec as WebSocketSpec
 import Test.Hspec (hspec)
 
@@ -80,6 +81,7 @@ main = hspec do
     ShowImageSpec.spec
     ViewImageSpec.spec
     RenderChartSpec.spec
+    ResourceArbiterSpec.spec
     CodeModeHostSpec.spec
     CodeModeProtocolSpec.spec
     DangerousSpec.spec


### PR DESCRIPTION
## Scope
Introduce a bounded, cancellation-safe in-process resource arbiter shared by root, background-session, and subagent tool environments in one runtime authority. Reuse existing scheduling claims for synchronous filesystem/image tools and Codex apply_patch; retain turn-local scheduling and existing dialect, approval, and sandbox behavior.

This is the first filesystem-only slice, not universal resource exclusion. Managed shell/write_stdin/GHCi leases, desktop/Git/MCP claims, and sandbox replacements remain deferred. Separate authorities/processes do not coordinate. Claims are advisory; unclaimed shell writes, external changes, and path topology/alias races are not fenced. See docs/tool-resource-arbitration.md.

## Validation
- Four-library GHCi integration load: 530 modules
- Resource arbiter: 12 examples, including two actual loops, async worker lifetime, cancellation, fairness, capacity, close, and exception/error release
- Filesystem/image regressions: 55 examples
- Entire Codex dialect suite: 27 examples
- Native process ownership/shutdown: 4 examples
- All 98 examples passed; package boundaries and diff checks passed
- cabal2nix regenerated for changed package metadata
- No UI/tmux smoke; no UI changes

Independent read-only review found no blocking correctness regressions. No merge requested.