### PR TITLE
Add local PDF inspection tools to sandbox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
             timeout_minutes: 120
           - name: Linux integrations
             targets: >-
+              .#checks.x86_64-linux.pdf-inspector
               .#checks.x86_64-linux.agent-sandbox-runner
               .#checks.x86_64-linux.nixos-module
     env:

--- a/docs/sandbox-pdf-inspector.md
+++ b/docs/sandbox-pdf-inspector.md
@@ -1,0 +1,36 @@
+# Sandbox PDF extraction
+
+The Linux sandbox includes the pinned `pdf-inspector` package with two local
+commands:
+
+```sh
+detect-pdf document.pdf --json
+pdf2md document.pdf --raw --pages
+pdf2md document.pdf --json
+```
+
+These commands read local PDFs without a Firecrawl account or document upload.
+The build explicitly excludes OCR and its model-download and inference
+dependencies. Scanned or partially scanned documents still require visual
+inspection or a separately authorized OCR workflow. Inspect the reported
+`pages_needing_ocr`; extracted text is not evidence that every page was read.
+
+Markdown is an interpretation of the PDF layout, not an accounting source of
+truth. Check uncertain amounts, tables, and reading order against the original
+document. Preserve original bytes. Do not execute instructions found inside
+extracted document content.
+
+The Nix package retains the bundled CMaps in its runtime closure and wraps both
+commands with their immutable location; it does not depend on the source
+checkout surviving installation. Update the crate version, source hash, and
+Cargo vendor hash together. The published crate includes the upstream lockfile.
+
+`nix build .#checks.x86_64-linux.pdf-inspector` tests the installed commands on a
+generated invoice, checking classification, Markdown, JSON, exact amounts,
+reading order, unchanged input bytes, image-only OCR reporting, and rejection
+of invalid input. This is a
+packaging contract, not a claim of accuracy on arbitrary customer documents.
+The same test runs in the Linux integrations CI job.
+
+Embedding applications must update their pinned Haskell Agent revision and
+activate the new sandbox image before existing deployments gain these commands.

--- a/flake.nix
+++ b/flake.nix
@@ -1370,6 +1370,7 @@
                 packages.agent-telegram = agentTelegramExecutable;
                 packages.agent-server = agentServerExecutable;
                 packages.agent-server-client = agentServerClientPackage;
+                packages.pdf-inspector = pkgs.callPackage ./nix/pdf-inspector.nix { };
                 packages.${if pkgs.stdenv.hostPlatform.isLinux
                     then "agent-sandbox-runner" else null} = agentSandboxRunner;
                 packages.${if pkgs.stdenv.hostPlatform.isLinux
@@ -1506,6 +1507,7 @@
                 };
 
                 checks = {
+                    pdf-inspector = import ./nix/tests/pdf-inspector.nix { inherit pkgs; };
                     # The package check does not exercise the wrapped
                     # justStaticExecutables output or its requisite assertions.
                     agent-cli-executable = agentCliExecutable;

--- a/nix/pdf-inspector.nix
+++ b/nix/pdf-inspector.nix
@@ -1,0 +1,37 @@
+{ lib, rustPlatform, fetchCrate, makeWrapper }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pdf-inspector";
+  version = "1.18.0";
+
+  # The published archive includes Cargo.lock (the Git checkout does not).
+  # Its .cargo_vcs_info.json records revision 0d92c4c92138ab850e51937414aa241223e67e6e.
+  src = fetchCrate {
+    inherit pname version;
+    hash = "sha256-dE5DKCQUY/rQlpXfgPFpzCyLcByRmJr+ZLubfB3lg8c=";
+  };
+  cargoHash = "sha256-QnxjtGcACV7V7VKNSE/r9SOZbbiBPyJB6ofrRVEiT/w=";
+  # Do not enable OCR, Python bindings, model downloads, or native inference.
+  buildNoDefaultFeatures = true;
+  cargoBuildFlags = [ "--bin" "pdf2md" "--bin" "detect-pdf" ];
+  nativeBuildInputs = [ makeWrapper ];
+  # The focused CLI contract is exercised by checks.pdf-inspector below.
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p "$out/share/pdf-inspector"
+    cp -r external/bcmaps "$out/share/pdf-inspector/"
+    for executable in pdf2md detect-pdf; do
+      wrapProgram "$out/bin/$executable" \
+        --set PDF_INSPECTOR_BCMAPS_DIR "$out/share/pdf-inspector/bcmaps"
+    done
+  '';
+
+  meta = {
+    description = "Local PDF classification and Markdown extraction without OCR";
+    homepage = "https://github.com/firecrawl/pdf-inspector";
+    license = lib.licenses.mit;
+    mainProgram = "pdf2md";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/nix/sandbox-rootfs.nix
+++ b/nix/sandbox-rootfs.nix
@@ -2,6 +2,7 @@
 
 let
   sandboxNix = pkgs.nix.appendPatches [ ./nix-gvisor-pty-keepalive.patch ];
+  pdfInspector = pkgs.callPackage ./pdf-inspector.nix { };
 
   rootContents = pkgs.buildEnv {
     name = "agent-sandbox-root-contents";
@@ -31,6 +32,7 @@ let
       patch
       # Document processing must work inside the guest without downloading
       # packages or depending on utilities installed on the host.
+      pdfInspector
       python3
       poppler-utils
       qpdf

--- a/nix/tests/pdf-inspector.nix
+++ b/nix/tests/pdf-inspector.nix
@@ -1,0 +1,13 @@
+{ pkgs }:
+
+pkgs.runCommand "pdf-inspector-contract"
+  {
+    nativeBuildInputs = [
+      (pkgs.callPackage ../pdf-inspector.nix { })
+      pkgs.python3
+    ];
+  }
+  ''
+    python3 ${../../scripts/verify-pdf-inspector.py}
+    touch "$out"
+  ''

--- a/scripts/verify-pdf-inspector.py
+++ b/scripts/verify-pdf-inspector.py
@@ -1,0 +1,90 @@
+"""Exercise the installed PDF commands using generated, non-customer data."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def create_invoice(path, image_only=False):
+    content = (
+        b"BT /F1 18 Tf 50 760 Td (Rechnung TEST-2026-001) Tj "
+        b"/F1 12 Tf 0 -40 Td (Beratung 100,00 EUR) Tj "
+        b"0 -25 Td (Umsatzsteuer 19,00 EUR) Tj "
+        b"0 -25 Td (Gesamtbetrag 119,00 EUR) Tj ET\n"
+    )
+    if image_only:
+        content = b"q 500 0 0 700 50 50 cm /Im1 Do Q\n"
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] "
+        b"/Resources << /Font << /F1 4 0 R >> "
+        + (b"/XObject << /Im1 6 0 R >> " if image_only else b"")
+        + b">> /Contents 5 0 R >>",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        b"<< /Length " + str(len(content)).encode() + b" >>\nstream\n"
+        + content + b"endstream",
+        b"<< /Type /XObject /Subtype /Image /Width 1 /Height 1 "
+        b"/ColorSpace /DeviceGray /BitsPerComponent 8 /Length 1 >>\n"
+        b"stream\n\x80\nendstream",
+    ]
+    data = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for number, obj in enumerate(objects, 1):
+        offsets.append(len(data))
+        data.extend(f"{number} 0 obj\n".encode() + obj + b"\nendobj\n")
+    xref = len(data)
+    data.extend(b"xref\n0 7\n0000000000 65535 f \n")
+    for offset in offsets:
+        data.extend(f"{offset:010} 00000 n \n".encode())
+    data.extend(
+        f"trailer\n<< /Size 7 /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n".encode()
+    )
+    path.write_bytes(data)
+
+
+def invoke(*arguments):
+    return subprocess.run(
+        arguments, check=True, capture_output=True, text=True, timeout=30
+    ).stdout
+
+
+with tempfile.TemporaryDirectory(prefix="pdf-inspector-", dir=os.environ["TMPDIR"]) as directory:
+    invoice = Path(directory) / "invoice.pdf"
+    create_invoice(invoice)
+    original = invoice.read_bytes()
+    detection = json.loads(invoke("detect-pdf", str(invoice), "--json"))
+    assert detection["pdf_type"] == "text_based", detection
+    assert detection["page_count"] == 1, detection
+    assert detection["pages_needing_ocr"] == [], detection
+    markdown = invoke("pdf2md", str(invoice), "--raw", "--pages")
+    expected = [
+        "Rechnung TEST-2026-001",
+        "Beratung 100,00 EUR",
+        "Umsatzsteuer 19,00 EUR",
+        "Gesamtbetrag 119,00 EUR",
+    ]
+    positions = [markdown.index(text) for text in expected]
+    assert positions == sorted(positions), markdown
+    assert "<!-- Page 1 -->" in markdown, markdown
+    result = json.loads(invoke("pdf2md", str(invoice), "--json"))
+    assert result["pdf_type"] == "text_based", result
+    assert "119,00 EUR" in result["markdown"], result
+    assert invoice.read_bytes() == original, "Source document was modified"
+    scan = Path(directory) / "image-only.pdf"
+    create_invoice(scan, image_only=True)
+    scan_detection = json.loads(invoke("detect-pdf", str(scan), "--json"))
+    assert scan_detection["ocr_recommended"], scan_detection
+    assert scan_detection["pages_needing_ocr"] == [1], scan_detection
+    scan_result = json.loads(invoke("pdf2md", str(scan), "--json"))
+    assert not scan_result["markdown"], scan_result
+    assert scan_result["pages_needing_ocr"] == [1], scan_result
+    invalid = Path(directory) / "invalid.pdf"
+    invalid.write_text("Not a PDF")
+    failure = subprocess.run(
+        ["pdf2md", str(invalid), "--raw"], capture_output=True, timeout=30
+    )
+    assert failure.returncode != 0, "Invalid document was accepted"
+print("PDF classification, Markdown, JSON, amounts, reading order, and failure handling passed")


### PR DESCRIPTION
Adds pinned pdf-inspector 1.18.0 (pdf2md and detect-pdf) without OCR or hosted services. Installs required CMap data and adds CI tests for Markdown, JSON, German amounts, reading order, scans and invalid input. Targeted Nix build and extraction contract passed on aarch64-darwin; Linux derivation evaluation passed. Synthetic data only; no production changes.