### PR TITLE
Use typed shell task state for Grok task coordination

### DIFF
--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
@@ -13,6 +13,9 @@ module Agent.GrokBuild.Dialect.Shell
     , startBackground
     , startMonitor
     , readTaskOutput
+    , ShellTaskSnapshot(..)
+    , readTaskSnapshot
+    , formatTaskSnapshot
     , killTask
     , hasUnwaitedBackgroundOp
     ) where
@@ -396,11 +399,32 @@ insertBackgroundTask session task =
             , ()
             )
 
+-- | Keep process state separate from its presentation for task coordination.
+data ShellTaskSnapshot
+    = ShellTaskUnknown
+    | ShellTaskRunning !Text !Text
+    | ShellTaskCompleted !CommandResult
+    deriving (Eq, Show)
+
+formatTaskSnapshot :: Text -> ShellTaskSnapshot -> Text
+formatTaskSnapshot taskId = \case
+    ShellTaskUnknown -> "Unknown task_id: " <> taskId
+    ShellTaskCompleted result -> formatCommandResult result
+    ShellTaskRunning out err ->
+        let body = combineCommandOutput out err
+        in if Text.null body
+            then "still running"
+            else "still running\n" <> body
+
 readTaskOutput :: GrokSession -> Text -> Maybe Int -> IO Text
-readTaskOutput session taskId timeoutMs = do
+readTaskOutput session taskId timeoutMs =
+    formatTaskSnapshot taskId <$> readTaskSnapshot session taskId timeoutMs
+
+readTaskSnapshot :: GrokSession -> Text -> Maybe Int -> IO ShellTaskSnapshot
+readTaskSnapshot session taskId timeoutMs = do
     store <- readMVar session.grokTasks
     case Map.lookup taskId store.backgroundTasks of
-        Nothing -> pure $ "Unknown task_id: " <> taskId
+        Nothing -> pure ShellTaskUnknown
         Just task -> do
             case timeoutMs of
               Nothing -> snapshotTask session task
@@ -412,7 +436,7 @@ readTaskOutput session taskId timeoutMs = do
                     Left () -> snapshotTask session task
                     Right result -> do
                         consumeTaskCompletion session task
-                        pure (formatCommandResult result)
+                        pure (ShellTaskCompleted result)
 
 -- The watchdog is part of the spawned process tree, so it outlives the tool
 -- call without requiring an untracked Haskell thread. The outer shell waits
@@ -444,18 +468,15 @@ monitorCommand command = \case
     timeoutSeconds ms =
         Text.pack (show (fromIntegral (max 1 ms) / 1000 :: Double))
 
-snapshotTask :: GrokSession -> BackgroundTask -> IO Text
+snapshotTask :: GrokSession -> BackgroundTask -> IO ShellTaskSnapshot
 snapshotTask session task =
     tryReadMVar task.backgroundRunning.runningResult >>= \case
         Just result -> do
             consumeTaskCompletion session task
-            pure (formatCommandResult result)
+            pure (ShellTaskCompleted result)
         Nothing -> do
             (out, err) <- runningLiveOutput task.backgroundRunning
-            let body = combineCommandOutput out err
-            pure $ if Text.null body
-                then "still running"
-                else "still running\n" <> body
+            pure (ShellTaskRunning out err)
 
 killTask :: GrokSession -> Text -> IO Text
 killTask session taskId = do

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/TaskControl.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/TaskControl.hs
@@ -24,8 +24,10 @@ import Agent.GrokBuild.Dialect.Json
     )
 import Agent.GrokBuild.Dialect.Shell
     ( GrokSession
+    , ShellTaskSnapshot(..)
+    , formatTaskSnapshot
     , killTask
-    , readTaskOutput
+    , readTaskSnapshot
     )
 import Agent.GrokBuild.Dialect.Task (isSubagentIdText)
 import Agent.Tools.MultiAgents (MultiAgentContext(..))
@@ -111,8 +113,14 @@ maxTaskOutputWaitMs = 600000
 data TaskOutputEntry = TaskOutputEntry
     { taskOutputId :: !Text
     , output :: !Text
-    , terminal :: !Bool
+    , taskState :: !TaskState
     }
+
+data TaskState = TaskMissing | TaskActive | TaskFinished
+    deriving (Eq)
+
+terminal :: TaskOutputEntry -> Bool
+terminal entry = entry.taskState == TaskFinished
 
 runOneTaskOutput
     :: GrokSession
@@ -134,20 +142,21 @@ runOneTaskOutput session multi timeout taskId = case multi of
         pure TaskOutputEntry
             { taskOutputId = taskId
             , output = formatAgentWait taskId timedOut (Just status)
-            , terminal = isFinalStatus status
+            , taskState = case status of
+                NotFound -> TaskMissing
+                _ | isFinalStatus status -> TaskFinished
+                  | otherwise -> TaskActive
             }
     _ -> do
-        text <- stripAnsi <$> readTaskOutput session taskId timeout
+        snapshot <- readTaskSnapshot session taskId timeout
         pure TaskOutputEntry
             { taskOutputId = taskId
-            , output = text
-            , terminal = terminalCommandOutput text
+            , output = stripAnsi (formatTaskSnapshot taskId snapshot)
+            , taskState = case snapshot of
+                ShellTaskUnknown -> TaskMissing
+                ShellTaskRunning _ _ -> TaskActive
+                ShellTaskCompleted _ -> TaskFinished
             }
-
-terminalCommandOutput :: Text -> Bool
-terminalCommandOutput text =
-    "exit:" `Text.isPrefixOf` text
-        || "killed " `Text.isPrefixOf` text
 
 formatMultiTaskOutput :: Bool -> [TaskOutputEntry] -> Text
 formatMultiTaskOutput waits entries =
@@ -156,7 +165,7 @@ formatMultiTaskOutput waits entries =
         | entry <- entries
         ]
         <> "\n\n"
-        <> Text.pack (show (length (filter (.terminal) entries)))
+        <> Text.pack (show (length (filter terminal entries)))
         <> "/"
         <> Text.pack (show (length entries))
         <> " tasks completed ("
@@ -245,16 +254,20 @@ runWaitTasks session multi args
         entries <- mapConcurrently
             (runOneTaskOutput session multi Nothing)
             taskIds
-        let completed = length (filter (.terminal) entries)
+        let completed = length (filter terminal entries)
             satisfied = case args.waitMode of
                 WaitAny -> completed > 0
                 WaitAll -> completed == length entries
         now <- getCurrentTime
         let elapsedMs =
                 floor (realToFrac (diffUTCTime now started) * (1000 :: Double))
-        if satisfied || elapsedMs >= timeoutMs
-            then pure $ Right $ formatWaitResult args.waitMode completed entries
-            else threadDelay 50000 >> waitLoop taskIds started
+        case filter (\entry -> entry.taskState == TaskMissing) entries of
+            missing@(_ : _) ->
+                pure (Left (Text.intercalate "\n" (map (.output) missing)))
+            [] ->
+                if satisfied || elapsedMs >= timeoutMs
+                    then pure $ Right $ formatWaitResult args.waitMode completed entries
+                    else threadDelay 50000 >> waitLoop taskIds started
 
 validateTaskIds :: [Text] -> Either Text [Text]
 validateTaskIds taskIds
@@ -279,7 +292,7 @@ formatWaitResult mode completed entries =
     Text.intercalate "\n"
         [ entry.taskOutputId
             <> ": "
-            <> if entry.terminal then "completed" else "running"
+            <> if terminal entry then "completed" else "running"
         | entry <- entries
         ]
         <> "\n\n"

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -3,9 +3,11 @@ module Agent.GrokBuild.DialectSpec (spec) where
 import Agent.GrokBuild.Dialect.Shell
     ( GrokSession(..)
     , PersistentShell(..)
+    , ShellTaskSnapshot(..)
     , closeGrokSession
     , newGrokSession
     , readTaskOutput
+    , readTaskSnapshot
     , resetGrokSessionTemp
     , runForegroundStreaming
     , startBackground
@@ -19,7 +21,7 @@ import Agent.GrokBuild.Dialect.Runtime
     ( GrokCodingTools(..)
     , newGrokCodingTools
     )
-import Agent.GrokBuild.Dialect.TaskControl (validateTaskIds)
+import Agent.GrokBuild.Dialect.TaskControl (validateTaskIds, waitTasksTool)
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
 import Agent.OsPath (unsafeToFilePath)
 import Agent.ToolDispatch
@@ -72,10 +74,74 @@ import System.IO.Error (isPermissionError)
 import System.OsPath (unsafeEncodeUtf)
 import System.Posix.Files (fileMode, getFileStatus)
 import System.Process (readProcessWithExitCode)
+import qualified System.Timeout as Timeout
 import Test.Hspec
 
 spec :: Spec
 spec = describe "Grok Build dialect" do
+    it "rejects unknown tasks immediately in either wait mode" do
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            bracket (newGrokSession env) closeGrokSession \session -> do
+                readTaskSnapshot session "missing" Nothing
+                    `shouldReturn` ShellTaskUnknown
+                let tool = waitTasksTool session Nothing
+                mapM_ (\mode -> do
+                    result <- Timeout.timeout 1000000 $
+                        dispatchToolCall testDispatchConfig [tool.appToolHandler]
+                            (functionToolCall "wait" "wait_tasks"
+                                ("{\"task_ids\":[\"missing\"],\"mode\":\""
+                                    <> mode <> "\"}"))
+                    case result of
+                        Nothing -> expectationFailure "unknown task waited for timeout"
+                        Just response -> do
+                            response.output `shouldSatisfy`
+                                Text.isInfixOf "Unknown task_id: missing"
+                            response.output `shouldNotSatisfy`
+                                Text.isInfixOf "running")
+                    ["wait_any", "wait_all"]
+
+    it "keeps completed command status independent of its output" do
+        requireProcessSandbox
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            bracket (newGrokSession env) closeGrokSession \session -> do
+                started <- startBackground session
+                    "printf 'still running\\nUnknown task_id: t1\\n'; exit 7"
+                started `shouldSatisfy`
+                    either (const False) (Text.isInfixOf "task_id: t1")
+                readTaskSnapshot session "t1" (Just 5000) >>= \case
+                    ShellTaskCompleted result -> do
+                        result.commandExitCode `shouldBe` Just 7
+                        result.commandStdout `shouldSatisfy`
+                            Text.isPrefixOf "still running"
+                    snapshot -> expectationFailure ("unexpected snapshot: " <> show snapshot)
+                let tool = waitTasksTool session Nothing
+                response <- dispatchToolCall testDispatchConfig [tool.appToolHandler]
+                    (functionToolCall "wait" "wait_tasks"
+                        "{\"task_ids\":[\"t1\"],\"mode\":\"wait_all\",\"timeout_ms\":1}")
+                response.output `shouldSatisfy` Text.isInfixOf "t1: completed"
+                response.output `shouldSatisfy` Text.isInfixOf "1/1"
+
+    it "keeps live commands active even when they print completion markers" do
+        requireProcessSandbox
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            bracket (newGrokSession env) closeGrokSession \session -> do
+                started <- startBackground session
+                    "printf 'exit: 0\\nkilled t1\\n'; sleep 30"
+                started `shouldSatisfy`
+                    either (const False) (Text.isInfixOf "task_id: t1")
+                readTaskSnapshot session "t1" Nothing >>= \case
+                    ShellTaskRunning _ _ -> pure ()
+                    snapshot -> expectationFailure ("unexpected snapshot: " <> show snapshot)
+                let tool = waitTasksTool session Nothing
+                response <- dispatchToolCall testDispatchConfig [tool.appToolHandler]
+                    (functionToolCall "wait" "wait_tasks"
+                        "{\"task_ids\":[\"t1\"],\"mode\":\"wait_any\",\"timeout_ms\":1}")
+                response.output `shouldSatisfy` Text.isInfixOf "t1: running"
+                response.output `shouldSatisfy` Text.isInfixOf "0/1"
+
     it "normalizes and validates task id lists consistently" do
         validateTaskIds [" task-1 ", "", "task-1", "task-2"]
             `shouldBe` Right ["task-1", "task-2"]


### PR DESCRIPTION
## Summary
Separate lifecycle state from rendered output. Fail unknown task waits immediately. Preserve output rendering and polling cadence. Add three regression tests for missing tasks and misleading output.

Independent PR; no dependency on the other review fixes.

## Validation
Grok Build dialect suite: 63 examples, 0 failures.

Tests ran via single test-component cabal repl in nix develop, with all five review fixes present. Verified successful GHCi load and test summaries. git diff --check passes.