### PR TITLE
Use foldM to apply patch chunks sequentially

### DIFF
--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/ApplyPatch.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/ApplyPatch.hs
@@ -18,7 +18,7 @@ import Agent.Tools.IO
     , writeTextFile
     )
 import Agent.Tools.Types (ToolEnv(..))
-import Control.Monad (unless)
+import Control.Monad (foldM, unless)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
     ( ExceptT(..)
@@ -324,10 +324,7 @@ resolvePath env path =
 
 applyChunks :: [UpdateChunk] -> [Text] -> Either Text (Seq Text)
 applyChunks chunks start =
-    foldl applyOne (Right (Seq.fromList start)) chunks
-  where
-    applyOne (Left err) _ = Left err
-    applyOne (Right lines_) chunk = applyChunk chunk lines_
+    foldM (flip applyChunk) (Seq.fromList start) chunks
 
 applyChunk :: UpdateChunk -> Seq Text -> Either Text (Seq Text)
 applyChunk chunk fileLines =

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -556,6 +556,46 @@ spec = describe "Codex dialect" do
                 Left _ -> False
             Text.readFile path `shouldReturn` "after\n"
 
+    it "applies update chunks in order within one hunk" do
+        withTempDir \dir -> do
+            let path = dir </> "chunks.txt"
+            Text.writeFile path "before\n"
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            result <- applyPatch env $
+                "*** Begin Patch\n\
+                \*** Update File: chunks.txt\n\
+                \@@\n\
+                \-before\n\
+                \+middle\n\
+                \@@\n\
+                \-middle\n\
+                \+after\n\
+                \*** End Patch"
+            result `shouldSatisfy` \case
+                Right _ -> True
+                Left _ -> False
+            Text.readFile path `shouldReturn` "after\n"
+
+    it "does not commit earlier chunks when a later chunk fails" do
+        withTempDir \dir -> do
+            let path = dir </> "chunks.txt"
+            Text.writeFile path "before\n"
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            result <- applyPatch env $
+                "*** Begin Patch\n\
+                \*** Update File: chunks.txt\n\
+                \@@\n\
+                \-before\n\
+                \+middle\n\
+                \@@\n\
+                \-missing\n\
+                \+after\n\
+                \*** End Patch"
+            result `shouldSatisfy` \case
+                Left message -> "Failed to find expected lines" `Text.isInfixOf` message
+                Right _ -> False
+            Text.readFile path `shouldReturn` "before\n"
+
     it "waits instead of hot-polling an empty write_stdin call" do
         withTempDir \dir -> do
             env <- defaultToolEnv (unsafeEncodeUtf dir)


### PR DESCRIPTION
## Summary
Replace the hand-written Either fold with foldM. Add tests for sequential chunks and unchanged files when a later chunk fails. Idiomatic refactor, not a performance claim.

Independent PR; no dependency on the other review fixes.

## Validation
Codex dialect suite: 29 examples, 0 failures.

Tests ran via single test-component cabal repl in nix develop, with all five review fixes present. Verified successful GHCi load and test summaries. git diff --check passes.