### PR TITLE
Close the Gemini OAuth socket when setup fails

### DIFF
--- a/packages/agent-gemini/src/Agent/Gemini/Auth.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Auth.hs
@@ -38,6 +38,7 @@ import Control.Exception.Safe
     ( IOException
     , SomeException
     , bracket
+    , bracketOnError
     , finally
     , fromException
     , tryAny
@@ -471,13 +472,16 @@ authenticateGoogleAccount oauthOptions codeAssistOptions presentUrl =
 --------------------------------------------------------------------------------
 
 openLoopbackSocket :: IO Net.Socket
-openLoopbackSocket = do
-    socket <- Net.socket Net.AF_INET Net.Stream Net.defaultProtocol
-    Net.setSocketOption socket Net.ReuseAddr 1
-    Net.bind socket
-        (Net.SockAddrInet 0 (Net.tupleToHostAddress (127, 0, 0, 1)))
-    Net.listen socket 1
-    pure socket
+openLoopbackSocket =
+    bracketOnError
+        (Net.socket Net.AF_INET Net.Stream Net.defaultProtocol)
+        Net.close
+        \socket -> do
+            Net.setSocketOption socket Net.ReuseAddr 1
+            Net.bind socket
+                (Net.SockAddrInet 0 (Net.tupleToHostAddress (127, 0, 0, 1)))
+            Net.listen socket 1
+            pure socket
 
 loopbackRedirectUri :: Net.Socket -> IO Text
 loopbackRedirectUri socket = Net.getSocketName socket >>= \case


### PR DESCRIPTION
## Summary
Protect configuration, binding and listening with bracketOnError from Control.Exception.Safe. The existing outer bracket retains ownership after successful acquisition.

Independent PR; no dependency on the other review fixes.

## Validation
Gemini suite including loopback OAuth tests: 59 examples, 0 failures.

Tests ran via single test-component cabal repl in nix develop, with all five review fixes present. Verified successful GHCi load and test summaries. git diff --check passes.