### PR TITLE
Scope temporary external-session SQLite resources

### DIFF
--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/SQLite.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/SQLite.hs
@@ -68,13 +68,10 @@ withTemporaryDatabase
     -> String
     -> (Database -> IO value)
     -> IO value
-withTemporaryDatabase scratch prefix action = do
-    (path, handle) <- openBinaryTempFile scratch prefix
-    hClose handle
-    setFileMode path (ownerReadMode `unionFileModes` ownerWriteMode)
-    let cleanup = mapM_ removeQuietly
-            [path, path <> "-journal", path <> "-wal", path <> "-shm"]
-    flip finally cleanup $
+withTemporaryDatabase scratch prefix action =
+    bracket (openBinaryTempFile scratch prefix) cleanup \(path, handle) -> do
+        hClose handle
+        setFileMode path (ownerReadMode `unionFileModes` ownerWriteMode)
         bracket
             (SQLite.open2
                 (Text.pack path)
@@ -88,6 +85,13 @@ withTemporaryDatabase scratch prefix action = do
                 SQLite.exec database "PRAGMA journal_mode = OFF"
                 SQLite.exec database "PRAGMA synchronous = OFF"
                 action database
+  where
+    -- Own the file from creation, including failures while closing the initial
+    -- handle, setting permissions, or opening SQLite. Close SQLite before
+    -- removing its files; hClose is harmless if the initial handle is closed.
+    cleanup (path, handle) =
+        hClose handle `finally` mapM_ removeQuietly
+            [path, path <> "-journal", path <> "-wal", path <> "-shm"]
 
 removeQuietly :: FilePath -> IO ()
 removeQuietly path =

--- a/packages/agent-external-session/test/Agent/CLI/ExternalSessionSpec.hs
+++ b/packages/agent-external-session/test/Agent/CLI/ExternalSessionSpec.hs
@@ -7,7 +7,7 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(ParallelSafe)
     , defaultToolEnv
     )
-import Control.Exception.Safe (bracket)
+import Control.Exception.Safe (bracket, finally)
 import Control.Monad (forM_)
 import Data.Aeson (Value, encode, object, (.=))
 import Data.Aeson.Types (Pair)
@@ -23,6 +23,7 @@ import System.Directory
     , createDirectoryIfMissing
     , createFileLink
     , getTemporaryDirectory
+    , listDirectory
     , removeFile
     , removePathForcibly
     )
@@ -733,6 +734,7 @@ withFixture action =
                 , externalNow = fail "externalNow was unexpectedly evaluated"
                 }
         action Fixture{root, cwd, env}
+            `finally` (listDirectory scratch `shouldReturn` [])
 
 latest
     :: ExternalSessionEnv


### PR DESCRIPTION
## Summary
- Bracket temporary database files immediately on creation, covering close, chmod, and SQLite-open failures.
- Preserve nested SQLite close-before-unlink ordering and sidecar cleanup.
- Assert scratch directories are empty after every external-session fixture.

## Validation
`nix develop -c cabal repl agent-external-session:test:agent-external-session-test` with `:main`: modules loaded; 14 examples, 0 failures.

Part of the scoped `with…` resource-handling audit. Long-lived ownership is unchanged.