### PR TITLE
Scope runtime daemon descriptors and socket acquisition

### DIFF
--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -20,8 +20,8 @@ import Control.Concurrent.STM
 import Control.Exception.Safe
     ( Exception
     , IOException
+    , bracket
     , catch
-    , finally
     , onException
     , throwIO
     , tryIO
@@ -221,14 +221,10 @@ normaliseRecoveredTasks config recoveredTasks =
 
 synchronisePath :: FilePath -> IO ()
 synchronisePath path =
-    bracketFd
+    bracket
         (openFd path ReadOnly defaultFileFlags {nofollow = True, cloexec = True, directory = True})
+        closeFd
         fileSynchronise
-  where
-    bracketFd acquire use = do
-        descriptor <- acquire
-        _ <- use descriptor `onException` closeFd descriptor
-        closeFd descriptor
 
 appendEvent :: Journal -> Text -> Value -> IO EventEnvelope
 appendEvent journal eventType payload =
@@ -419,17 +415,17 @@ nextSequenceAfter sequenceNumber@(Sequence value)
 
 verifyPrivateDirectory :: FilePath -> IO ()
 verifyPrivateDirectory path =
-    tryIO (openFd path ReadOnly defaultFileFlags {nofollow = True, cloexec = True, directory = True}) >>= \case
-        Left (_ :: IOException) -> throwIO (JournalInsecurePath path)
-        Right descriptor ->
-            ( do
-                status <- getFdStatus descriptor
-                effectiveUser <- getEffectiveUserID
-                unless (isDirectory status && fileOwner status == effectiveUser) $
-                    throwIO (JournalInsecurePath path)
-                setFdMode descriptor 0o700
-            )
-                `finally` closeFd descriptor
+    bracket acquire closeFd $ \descriptor -> do
+        status <- getFdStatus descriptor
+        effectiveUser <- getEffectiveUserID
+        unless (isDirectory status && fileOwner status == effectiveUser) $
+            throwIO (JournalInsecurePath path)
+        setFdMode descriptor 0o700
+  where
+    acquire =
+        tryIO (openFd path ReadOnly defaultFileFlags {nofollow = True, cloexec = True, directory = True}) >>= \case
+            Left (_ :: IOException) -> throwIO (JournalInsecurePath path)
+            Right descriptor -> pure descriptor
 
 redactValue :: Value -> Value
 redactValue = \case
@@ -530,15 +526,17 @@ decodeLine (lineNumber, bytes) =
 
 readPrivateFile :: FilePath -> Integer -> IO (Maybe BS.ByteString)
 readPrivateFile path maximumBytes =
-    tryIO (openFd path ReadOnly defaultFileFlags {nofollow = True, cloexec = True}) >>= \case
-        Left exception
-            | isDoesNotExistError exception -> pure Nothing
-            | otherwise -> throwIO (JournalInsecurePath path)
-        Right descriptor ->
-            Just
-                <$> ( (verifyPrivateDescriptor path descriptor >> setFdMode descriptor 0o600 >> readDescriptorBounded path maximumBytes descriptor)
-                        `finally` closeFd descriptor
-                    )
+    bracket
+        (tryIO (openFd path ReadOnly defaultFileFlags {nofollow = True, cloexec = True}))
+        (either (const (pure ())) closeFd)
+        $ \case
+            Left exception
+                | isDoesNotExistError exception -> pure Nothing
+                | otherwise -> throwIO (JournalInsecurePath path)
+            Right descriptor -> do
+                verifyPrivateDescriptor path descriptor
+                setFdMode descriptor 0o600
+                Just <$> readDescriptorBounded path maximumBytes descriptor
 
 readDescriptorBounded :: FilePath -> Integer -> Fd -> IO BS.ByteString
 readDescriptorBounded path maximumBytes descriptor = do
@@ -560,9 +558,9 @@ readDescriptorBounded path maximumBytes descriptor = do
                 go total (chunk : chunks)
 
 appendEventFile :: JournalConfig -> EventEnvelope -> IO ()
-appendEventFile config event = do
-    descriptor <-
-        openFd
+appendEventFile config event =
+    bracket
+        (openFd
             (eventsPath config)
             WriteOnly
             defaultFileFlags
@@ -570,12 +568,13 @@ appendEventFile config event = do
                 , creat = Just 0o600
                 , nofollow = True
                 , cloexec = True
-                }
-    verifyPrivateDescriptor (eventsPath config) descriptor `onException` closeFd descriptor
-    setFdMode descriptor 0o600 `onException` closeFd descriptor
-    writeDescriptor descriptor (encodeLine event) `onException` closeFd descriptor
-    fileSynchronise descriptor `onException` closeFd descriptor
-    closeFd descriptor
+                })
+        closeFd
+        $ \descriptor -> do
+            verifyPrivateDescriptor (eventsPath config) descriptor
+            setFdMode descriptor 0o600
+            writeDescriptor descriptor (encodeLine event)
+            fileSynchronise descriptor
 
 verifyPrivateDescriptor :: FilePath -> Fd -> IO ()
 verifyPrivateDescriptor path descriptor = do
@@ -606,8 +605,8 @@ atomicWrite config destination bytes = do
         cleanup = removeFile temporary `catch` \(_ :: IOException) -> pure ()
     verifyTemporaryPath temporary
     (do
-            descriptor <-
-                openFd
+            bracket
+                (openFd
                     temporary
                     WriteOnly
                     defaultFileFlags
@@ -615,11 +614,12 @@ atomicWrite config destination bytes = do
                         , exclusive = True
                         , nofollow = True
                         , cloexec = True
-                        }
-            setFdMode descriptor 0o600 `onException` closeFd descriptor
-            writeDescriptor descriptor bytes `onException` closeFd descriptor
-            fileSynchronise descriptor `onException` closeFd descriptor
-            closeFd descriptor
+                        })
+                closeFd
+                $ \descriptor -> do
+                    setFdMode descriptor 0o600
+                    writeDescriptor descriptor bytes
+                    fileSynchronise descriptor
             renameFile temporary destination
             synchronisePath config.directory
         )

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Socket.hs
@@ -7,7 +7,7 @@ module Agent.Runtime.Daemon.Socket
     , verifyPeerOwner
     ) where
 
-import Control.Exception.Safe (IOException, bracket, catch, finally, onException, throwString, tryIO)
+import Control.Exception.Safe (IOException, bracket, bracketOnError, catch, throwString, tryIO)
 import Control.Monad (unless, when)
 import Network.Socket
 import System.Directory hiding (isSymbolicLink)
@@ -54,10 +54,10 @@ withUnixListener config action = do
         Just value -> pure value
 
 acceptOwnedPeer :: Socket -> IO Socket
-acceptOwnedPeer listener = do
-    (peer, _) <- accept listener
-    verifyPeerOwner peer `onException` close peer
-    pure peer
+acceptOwnedPeer listener =
+    bracketOnError (accept listener) (close . fst) $ \(peer, _) -> do
+        verifyPeerOwner peer
+        pure peer
 
 verifyPeerOwner :: Socket -> IO ()
 verifyPeerOwner peer = do
@@ -81,48 +81,43 @@ prepareSocketDirectory :: SocketConfig -> IO ()
 prepareSocketDirectory config = do
     let directory = takeDirectory config.path
     createDirectoryIfMissing True directory
-    descriptor <-
-        openFd
+    bracket
+        (openFd
             directory
             ReadOnly
-            defaultFileFlags {nofollow = True, cloexec = True, directory = True}
-    (do
+            defaultFileFlags {nofollow = True, cloexec = True, directory = True})
+        closeFd
+        $ \descriptor -> do
             status <- getFdStatus descriptor
             effectiveUser <- getEffectiveUserID
             unless (isDirectory status && fileOwner status == effectiveUser) $
                 throwString ("runtime socket directory is not a user-owned directory: " <> directory)
             setFdMode descriptor 0o700
-        )
-        `finally` closeFd descriptor
 
 prepareLockFile :: FilePath -> IO ()
-prepareLockFile path = do
-    descriptor <-
-        openFd path ReadWrite defaultFileFlags {creat = Just 0o600, nofollow = True, cloexec = True}
-    (do
+prepareLockFile path =
+    bracket
+        (openFd path ReadWrite defaultFileFlags {creat = Just 0o600, nofollow = True, cloexec = True})
+        closeFd
+        $ \descriptor -> do
             status <- getFdStatus descriptor
             effectiveUser <- getEffectiveUserID
             unless (isRegularFile status && fileOwner status == effectiveUser) $
                 throwString ("runtime lock is not a user-owned regular file: " <> path)
             setFdMode descriptor 0o600
-        )
-        `finally` closeFd descriptor
 
 openListener :: SocketConfig -> IO Listener
 openListener config = do
     removeStaleSocket config.path
-    listener <- socket AF_UNIX Stream defaultProtocol
-    (do
-            bind listener (SockAddrUnix config.path)
-            setFileMode config.path 0o600
-            listen listener config.backlog
-            status <- getSymbolicLinkStatus config.path
-            pure Listener
-                { listenerSocket = listener
-                , identity = identityOf status
-                }
-        )
-        `onException` close listener
+    bracketOnError (socket AF_UNIX Stream defaultProtocol) close $ \listener -> do
+        bind listener (SockAddrUnix config.path)
+        setFileMode config.path 0o600
+        listen listener config.backlog
+        status <- getSymbolicLinkStatus config.path
+        pure Listener
+            { listenerSocket = listener
+            , identity = identityOf status
+            }
 
 closeListener :: SocketConfig -> Listener -> IO ()
 closeListener config listener = do

--- a/packages/agent-runtime-daemon/test/Spec.hs
+++ b/packages/agent-runtime-daemon/test/Spec.hs
@@ -15,13 +15,15 @@ import Control.Concurrent.STM
     , takeTMVar
     , writeTQueue
     )
-import Control.Exception.Safe (bracket, finally, isAsyncException, uninterruptibleMask_)
+import Control.Exception.Safe (bracket, finally, isAsyncException, tryIO, uninterruptibleMask_)
+import Control.Monad (when)
 import Data.Aeson (Result (..), Value (..), encode, fromJSON, object, toJSON, (.=))
 import Data.Bits ((.&.))
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
+import Data.List (isPrefixOf)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -30,7 +32,9 @@ import Network.Socket
 import qualified Network.Socket.ByteString as Socket
 import System.Directory
     ( createDirectory
+    , doesDirectoryExist
     , doesFileExist
+    , listDirectory
     , removeFile
     , renamePath
     )
@@ -40,6 +44,7 @@ import System.Posix.Files
     ( createSymbolicLink
     , fileMode
     , getFileStatus
+    , readSymbolicLink
     , setFileMode
     )
 import System.Timeout (timeout)
@@ -88,6 +93,30 @@ main = hspec $ do
             negotiateVersion [ProtocolVersion 99] `shouldBe` Nothing
 
     describe "durable journal" $ do
+        it "closes recovery descriptors when a snapshot exceeds its limit" $
+            withSystemTempDirectory "daemon-read-cleanup" $ \directory -> do
+                BS.writeFile (directory </> "snapshot.json") "{}"
+                let config =
+                        (defaultJournalConfig directory) {maximumSnapshotBytes = 1}
+                openJournal config `shouldThrow` \case
+                    JournalFileTooLarge _ 2 1 -> True
+                    _ -> False
+                assertNoOpenDescriptorsWithin directory
+
+        it "closes journal descriptors and removes the temporary snapshot after a failed rename" $
+            withSystemTempDirectory "daemon-write-cleanup" $ \directory -> do
+                let config = (defaultJournalConfig directory) {maximumEvents = 0}
+                journal <- openJournal config
+                -- The snapshot write and fsync succeed, but a directory cannot
+                -- be replaced by the temporary regular file.
+                createDirectory (directory </> "snapshot.json")
+                appendEvent journal "first" Null `shouldThrow` anyException
+                doesFileExist (directory </> "snapshot.json.tmp") `shouldReturn` False
+                assertNoOpenDescriptorsWithin directory
+                appendEvent journal "second" Null `shouldThrow` \case
+                    JournalPoisoned _ -> True
+                    _ -> False
+
         it "keeps sequence numbers monotonic and replays after a cursor" $
             withSystemTempDirectory "daemon-journal" $ \directory -> do
                 journal <- openJournal (defaultJournalConfig directory)
@@ -506,6 +535,28 @@ main = hspec $ do
                         _ -> False
 
     describe "secure Unix socket" $ do
+        it "releases the listener and setup descriptors when its callback is cancelled" $
+            withSystemTempDirectory "ds" $ \directory -> do
+                let config = SocketConfig {path = directory </> "s", backlog = 1}
+                entered <- newEmptyTMVarIO
+                blocked <- newEmptyTMVarIO :: IO (TMVar ())
+                withAsync
+                    (withUnixListener config $ \_ -> do
+                        atomically (putTMVar entered ())
+                        atomically (takeTMVar blocked))
+                    $ \worker -> do
+                        timeout 1_000_000 (atomically (takeTMVar entered))
+                            `shouldReturn` Just ()
+                        cancel worker
+                        waitCatch worker >>= (`shouldSatisfy` \case
+                            Left exception -> isAsyncException exception
+                            Right () -> False)
+                doesFileExist config.path `shouldReturn` False
+                assertNoOpenDescriptorsWithin directory
+                -- Cancellation releases the file lock as well as the socket.
+                withUnixListener config (const (pure ()))
+                assertNoOpenDescriptorsWithin directory
+
         it "uses private modes and authenticates the same-user peer" $
             withTempDirectory "/tmp" "daemon-socket" $ \directory -> do
                 let path = directory </> "private" </> "daemon.sock"
@@ -1383,3 +1434,18 @@ waitForStatus journal taskId status =
         case Map.lookup taskId saved.tasks of
             Just task | task.status == status -> pure ()
             _ -> threadDelay 10_000 >> loop
+
+-- Linux CI can inspect descriptors for these particular fixtures without
+-- relying on a process-wide descriptor count (other test threads may open
+-- unrelated files). Other platforms still exercise the failure semantics.
+assertNoOpenDescriptorsWithin :: FilePath -> Expectation
+assertNoOpenDescriptorsWithin directory = do
+    let descriptors = "/proc/self/fd"
+    available <- doesDirectoryExist descriptors
+    when available $ do
+        entries <- listDirectory descriptors
+        targets <- traverse (tryIO . readSymbolicLink . (descriptors </>)) entries
+        [ target
+            | Right target <- targets
+            , target == directory || (directory <> "/") `isPrefixOf` target
+            ] `shouldBe` []


### PR DESCRIPTION
## Summary
- Replace manual journal and secure socket FD cleanup with Safe.bracket.
- Use bracketOnError for socket ownership transfer.
- Preserve permissions, close-before-rename, fsync ordering, and poisoned-journal behavior.
- Add descriptor cleanup, failed rename, and listener cancellation regressions.

## Validation
Daemon test suite via cabal repl/GHCi: 44 examples, 0 failures.

## Scope
Part of the with-resource audit. TaskAdapter.runProcessTask remains a separate process-lifecycle follow-up: its PID capture, group termination, and post-exit drain policy need dedicated ownership-transfer testing.