### PR TITLE
Scope code-mode hosts and observation admissions

### DIFF
--- a/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
@@ -20,6 +20,7 @@ module Agent.Tools.CodeMode.Host
     , newCodeModeHost
     , terminateCodeCell
     , waitCodeCell
+    , withCodeModeHost
     ) where
 
 import Agent.Tools.CodeMode.Protocol
@@ -92,8 +93,10 @@ import Control.Concurrent.STM
     )
 import Control.Exception.Safe
     ( SomeException
+    , bracket
+    , bracketOnError
     , displayException
-    , finally
+    , mask_
     , onException
     , try
     )
@@ -129,19 +132,34 @@ import System.Process
     , waitForProcess
     )
 newCodeModeHost :: CodeModeConfig -> IO CodeModeHost
-newCodeModeHost config = do
-    host <- CodeModeHost config
-        <$> newMVar Map.empty
-        <*> newIORef 0
-        <*> newMVar Map.empty
-        <*> newMVar (WorkerPool [] Nothing False)
-    if config.workerPoolSize > 0
-        then spawnIdleWorker config >>= \case
-            Right worker -> modifyMVar_ host.hostWorkerPool \pool ->
-                pure pool { poolIdle = [worker] }
-            Left _ -> pure ()
-        else pure ()
-    pure host
+newCodeModeHost config =
+    bracketOnError
+        (CodeModeHost config
+            <$> newMVar Map.empty
+            <*> newIORef 0
+            <*> newMVar Map.empty
+            <*> newMVar (WorkerPool [] Nothing False))
+        closeCodeModeHost
+        \host -> do
+            if config.workerPoolSize > 0
+                -- Complete the ownership handoff before leaving the worker's
+                -- rollback scope, so cancellation cannot close it both here
+                -- and through the host's newly populated pool.
+                then mask_ $ bracketOnError
+                    (spawnIdleWorker config)
+                    (either (const (pure ())) stopIdleWorker)
+                    \case
+                        Right worker -> modifyMVar_ host.hostWorkerPool \pool ->
+                            pure pool { poolIdle = [worker] }
+                        Left _ -> pure ()
+                else pure ()
+            pure host
+
+-- | Keep a host, its cells, and its retained workers within an action's
+-- lifetime. Use 'newCodeModeHost' only when transferring ownership to a
+-- longer-lived resource manager.
+withCodeModeHost :: CodeModeConfig -> (CodeModeHost -> IO a) -> IO a
+withCodeModeHost config = bracket (newCodeModeHost config) closeCodeModeHost
 
 closeCodeModeHost :: CodeModeHost -> IO ()
 closeCodeModeHost host = do
@@ -266,32 +284,33 @@ terminateCodeCell host identifier =
     lookupCell host identifier >>= \case
         Nothing -> pure $ Left $ CodeModeUnknownCell identifier
         Just cell ->
-            beginTermination cell >>= \case
+            bracket (beginTermination cell) (releaseTermination cell) \case
                 Left err -> pure (Left err)
-                Right () ->
-                    (do
-                        observed <- atomically $ tryReadTMVar cell.cellResult
-                        case observed of
-                            Just result -> do
-                                releaseCell host cell
-                                pure $ fmap (cellOutcomeResult identifier) result
-                            Nothing -> do
-                                beforeStop <- atomically $
-                                    (,) <$> drainTQueue cell.cellYields
-                                        <*> drainTQueue cell.cellContent
-                                stopCell cell
-                                afterStop <- atomically $
-                                    (,) <$> drainTQueue cell.cellYields
-                                        <*> drainTQueue cell.cellContent
-                                pure $ Right CodeModeTerminated
-                                    { cellId = identifier
-                                    , cellValue = combineCellOutput
-                                        (fst beforeStop <> fst afterStop)
-                                        (snd beforeStop <> snd afterStop)
-                                    })
-                    `finally` do
-                        markCellClosed cell
-                        void $ takeCell host identifier
+                Right () -> do
+                    observed <- atomically $ tryReadTMVar cell.cellResult
+                    case observed of
+                        Just result -> do
+                            releaseCell host cell
+                            pure $ fmap (cellOutcomeResult identifier) result
+                        Nothing -> do
+                            beforeStop <- atomically $
+                                (,) <$> drainTQueue cell.cellYields
+                                    <*> drainTQueue cell.cellContent
+                            stopCell cell
+                            afterStop <- atomically $
+                                (,) <$> drainTQueue cell.cellYields
+                                    <*> drainTQueue cell.cellContent
+                            pure $ Right CodeModeTerminated
+                                { cellId = identifier
+                                , cellValue = combineCellOutput
+                                    (fst beforeStop <> fst afterStop)
+                                    (snd beforeStop <> snd afterStop)
+                                }
+  where
+    releaseTermination _ (Left _) = pure ()
+    releaseTermination cell (Right ()) = do
+        markCellClosed cell
+        void $ takeCell host identifier
 
 startCell
     :: CodeModeHost
@@ -405,6 +424,8 @@ spawnIdleWorker config =
                                 , processHandle
                                 ) -> do
                             mapM_ configurePipe [input, output, stderr]
+                                `onException` stopIncompleteProcess
+                                    input output stderr processHandle
                             writer <- newMVar ()
                             stderrReader <- asyncWithUnmask
                                 (\unmask -> unmask (readAll stderr))
@@ -748,11 +769,19 @@ observeCell
     -> Int
     -> IO (Either CodeModeError CodeModeResult)
 observeCell host cell yieldMs =
-    beginObservation cell >>= \case
+    withCellObservation cell (waitForCell host cell yieldMs)
+
+withCellObservation
+    :: Cell
+    -> IO (Either CodeModeError a)
+    -> IO (Either CodeModeError a)
+withCellObservation cell action =
+    bracket (beginObservation cell) release \case
         Left err -> pure (Left err)
-        Right () ->
-            waitForCell host cell yieldMs
-                `finally` endObservation cell
+        Right () -> action
+  where
+    release (Left _) = pure ()
+    release (Right ()) = endObservation cell
 
 beginObservation :: Cell -> IO (Either CodeModeError ())
 beginObservation cell =

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
@@ -56,6 +56,7 @@ import Agent.Tools.CodeMode.Host
     , newCodeModeHost
     , terminateCodeCell
     , waitCodeCell
+    , withCodeModeHost
     )
 import Agent.Tools.CodeMode.Protocol (CodeModeToolMetadata(..))
 import Agent.Tools.Types
@@ -68,7 +69,6 @@ import Agent.Tools.Types
     , withAsyncToolCalls
     )
 import Control.Applicative ((<|>))
-import Control.Exception.Safe (finally)
 import Control.Monad (foldM)
 import Data.Aeson (Value(..), encode)
 import qualified Data.Aeson as Aeson
@@ -187,14 +187,12 @@ newCodeModeToolSet mode detailVisibility workerPath invoke specs =
 
 probeCodeModeConfig :: CodeModeConfig -> IO (Either Text ())
 probeCodeModeConfig config = do
-    host <- newCodeModeHost config
-    result <-
+    result <- withCodeModeHost config \host ->
         execCodeCellWithTools
             host
             ""
             []
             config.startupTimeoutMs
-        `finally` closeCodeModeHost host
     pure $ case result of
         Right CodeModeFinished{} -> Right ()
         Right unexpected ->

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -33,8 +33,8 @@ import Control.Concurrent
     , threadDelay
     , tryPutMVar
     )
-import Control.Concurrent.Async (async, cancel, wait, withAsync)
-import Control.Exception.Safe (bracket, finally, uninterruptibleMask_)
+import Control.Concurrent.Async (cancel, wait, withAsync)
+import Control.Exception.Safe (bracket, finally, throwIO, uninterruptibleMask_)
 import Control.Monad (void)
 import Data.Aeson (Value(..))
 import qualified Data.Aeson as Aeson
@@ -55,6 +55,24 @@ spec = describe "code-mode Bun host" do
                 "data/code-mode/worker.mjs"
                 (\_ _ -> pure $ Left "no tools")
         config.workerPoolSize `shouldBe` 2
+
+    describe "withCodeModeHost" do
+        it "closes running cells before returning the action result" do
+            checkScopedHostCleanup \run ->
+                run (pure (42 :: Int)) `shouldReturn` 42
+
+        it "closes running cells when the action throws" do
+            checkScopedHostCleanup \run ->
+                run (throwIO (userError "host action failed") :: IO ())
+                    `shouldThrow` anyIOException
+
+        it "closes running cells when the action is cancelled" do
+            checkScopedHostCleanup \run -> do
+                entered <- newEmptyMVar
+                blocked <- newEmptyMVar
+                withAsync (run (putMVar entered () >> takeMVar blocked)) \running -> do
+                    timeout 5000000 (readMVar entered) `shouldReturn` Just ()
+                    cancel running
 
     it "resolves the bundled worker independently of the current directory" do
         worker <- bundledCodeModeWorkerPath
@@ -114,13 +132,12 @@ spec = describe "code-mode Bun host" do
             config = defaultCodeModeConfig
                 "data/code-mode/worker.mjs"
                 handler
-        host <- newCodeModeHost config
-        result <- execCodeCell
-            host
-            "text(await tools.math.double({ value: 21 }));"
-            ["math.double"]
-            3000
-        closeCodeModeHost host
+        result <- withCodeModeHost config \host ->
+            execCodeCell
+                host
+                "text(await tools.math.double({ value: 21 }));"
+                ["math.double"]
+                3000
         result `shouldBe`
             Right CodeModeFinished
                 { cellId = "1"
@@ -184,7 +201,7 @@ spec = describe "code-mode Bun host" do
             config = defaultCodeModeConfig
                 "data/code-mode/worker.mjs"
                 handler
-        bracket (newCodeModeHost config) closeCodeModeHost \host ->
+        withCodeModeHost config \host ->
             (do
                 started <- execCodeCell
                     host
@@ -241,26 +258,34 @@ spec = describe "code-mode Bun host" do
                 }
         closeCodeModeHost host
 
-    it "rejects a second observer without racing cell output queues" do
+    it "rejects competing observers and releases observation on cancellation" do
         let config = defaultCodeModeConfig
                 "data/code-mode/worker.mjs"
                 (\_ _ -> pure $ Left "no tools")
-        host <- newCodeModeHost config
-        started <- execCodeCell
-            host
-            "await new Promise(() => {});"
-            []
-            1
-        started `shouldSatisfy` \case
-            Right CodeModeRunning { cellId = "1" } -> True
-            _ -> False
-        first <- async (waitCodeCell host "1" 200)
-        threadDelay 20000
-        waitCodeCell host "1" 200 `shouldReturn`
-            Left (CodeModeBusyObserver "1")
-        _ <- wait first
-        _ <- terminateCodeCell host "1"
-        closeCodeModeHost host
+        withCodeModeHost config \host -> do
+            let running = Right CodeModeRunning
+                    { cellId = "1", cellOutput = emptyContent }
+                awaitObserver =
+                    waitCodeCell host "1" 1 >>= \case
+                        Left (CodeModeBusyObserver "1") -> pure ()
+                        Right CodeModeRunning{} -> threadDelay 1000 >> awaitObserver
+                        unexpected -> expectationFailure $
+                            "unexpected observer state: " <> show unexpected
+                observe =
+                    waitCodeCell host "1" 60000 >>= \case
+                        Left (CodeModeBusyObserver "1") -> threadDelay 1000 >> observe
+                        result -> pure result
+            execCodeCell host "await new Promise(() => {});" [] 1
+                `shouldReturn` running
+            withAsync observe \first -> do
+                timeout 5000000 awaitObserver `shouldReturn` Just ()
+                terminateCodeCell host "1" `shouldReturn`
+                    Left (CodeModeBusyObserver "1")
+                cancel first
+            waitCodeCell host "1" 1 `shouldReturn` running
+            terminateCodeCell host "1" `shouldReturn`
+                Right CodeModeTerminated
+                    { cellId = "1", cellValue = emptyContent }
 
     it "returns queued explicit yields when a cell is terminated" do
         let config = defaultCodeModeConfig
@@ -298,7 +323,7 @@ spec = describe "code-mode Bun host" do
             config = defaultCodeModeConfig
                 "data/code-mode/worker.mjs"
                 handler
-        bracket (newCodeModeHost config) closeCodeModeHost \host -> do
+        withCodeModeHost config \host -> do
             started <- execCodeCell
                 host
                 "await tools.gate({}); store(\"completion-marker\", true); text(\"done\");"
@@ -382,7 +407,7 @@ spec = describe "code-mode Bun host" do
                 (defaultCodeModeConfig "data/code-mode/worker.mjs" handler)
                     { notifyHandler = putMVar notification
                     }
-        bracket (newCodeModeHost config) closeCodeModeHost \host -> do
+        withCodeModeHost config \host -> do
             started <- execCodeCell
                 host
                 "await tools.gate({}); text(\"late\"); notify(\"late-content-observed\"); await new Promise(() => {});"
@@ -902,6 +927,30 @@ newtype DoubleArgs = DoubleArgs { value :: Int }
 doubleArgsDecoder :: Json.Decoder DoubleArgs
 doubleArgsDecoder = objectArgsExact ["value"] \object_ ->
         DoubleArgs <$> reqInt object_ "value"
+
+-- Each runner chooses how to leave the host scope. The nested tool is still
+-- running after exec yields, so its finalizer proves host teardown joined it.
+checkScopedHostCleanup :: ((IO value -> IO value) -> IO ()) -> IO ()
+checkScopedHostCleanup exercise = do
+    started <- newEmptyMVar
+    stopped <- newEmptyMVar
+    blocked <- newEmptyMVar
+    worker <- codeModeWorkerPath
+    let handler _ _ =
+            (putMVar started () >> takeMVar blocked >> pure (Right Null))
+                `finally` putMVar stopped ()
+        config = defaultCodeModeConfig worker handler
+        run action = withCodeModeHost config \host -> do
+            result <- execCodeCell host "await tools.slow({});" ["slow"] 1
+            result `shouldBe`
+                Right CodeModeRunning
+                    { cellId = "1"
+                    , cellOutput = emptyContent
+                    }
+            timeout 5000000 (readMVar started) `shouldReturn` Just ()
+            action
+    exercise run
+    timeout 5000000 (readMVar stopped) `shouldReturn` Just ()
 
 emptyObjectDecoder :: Json.Decoder ()
 emptyObjectDecoder = Json.object (pure ())


### PR DESCRIPTION
## Summary
- Add withCodeModeHost and use it in probes and representative tests.
- Protect partial host/worker acquisition and mask ownership publication.
- Scope observation and termination admissions with bracket.

## Validation
GHCi loaded library and tests successfully; 35 examples, zero failures, repeated five times. Includes exception and cancellation cleanup regressions.