### PR TITLE
Scope Telegram process managers, bridge directories, and media

### DIFF
--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Launch.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Launch.hs
@@ -45,7 +45,7 @@ import Control.Concurrent ()
 import Control.Concurrent.Async (race_)
 import Control.Concurrent.Chan (newChan)
 import Control.Concurrent.MVar (newMVar)
-import Control.Exception.Safe (finally)
+import Control.Exception.Safe (bracket)
 import Control.Monad (when)
 import Data.Aeson ()
 import qualified Data.ByteString.Lazy as LBS ()
@@ -146,28 +146,28 @@ runTelegramWithStore store home config token = do
     manager <- HttpTls.newTlsManager
     let client = TelegramClient token manager
     bot <- TelegramClient.getTelegramBot client
-    processManager <-
-        newSessionProcessManagerWithLifetime ScopedSessionProcesses root
-    let runtime = TelegramRuntime
-            { runtimeClient = client
-            , runtimeBot = bot
-            , runtimeRespondToAllGroupMessages =
-                config.telegramRespondToAllGroupMessages
-            , runtimeWorkerCount = config.telegramWorkerCount
-            , runtimeGatewayDirectory = gatewayDir
-            , runtimePool = trustedPool store
-            , runtimeSessionsRoot = root
-            , runtimeStatePath = statePath
-            , runtimeStateVar = stateVar
-            , runtimeWorkQueue = workQueue
-            , runtimeScheduled = scheduled
-            , runtimeProcessManager = processManager
-            , runtimeTarget = target
-            , runtimeCwd = cwd
-            , runtimeEffort = effort
-            , runtimePolicy = policy
-            }
-    Text.putStrLn "Telegram gateway started (private and group chats)."
-    race_ (pollForever runtime) (dispatchForever runtime)
-        `finally` do
-            closeSessionProcessManager processManager
+    bracket
+        (newSessionProcessManagerWithLifetime ScopedSessionProcesses root)
+        closeSessionProcessManager
+        \processManager -> do
+            let runtime = TelegramRuntime
+                    { runtimeClient = client
+                    , runtimeBot = bot
+                    , runtimeRespondToAllGroupMessages =
+                        config.telegramRespondToAllGroupMessages
+                    , runtimeWorkerCount = config.telegramWorkerCount
+                    , runtimeGatewayDirectory = gatewayDir
+                    , runtimePool = trustedPool store
+                    , runtimeSessionsRoot = root
+                    , runtimeStatePath = statePath
+                    , runtimeStateVar = stateVar
+                    , runtimeWorkQueue = workQueue
+                    , runtimeScheduled = scheduled
+                    , runtimeProcessManager = processManager
+                    , runtimeTarget = target
+                    , runtimeCwd = cwd
+                    , runtimeEffort = effort
+                    , runtimePolicy = policy
+                    }
+            Text.putStrLn "Telegram gateway started (private and group chats)."
+            race_ (pollForever runtime) (dispatchForever runtime)

--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Support.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Support.hs
@@ -8,10 +8,7 @@ module Agent.Telegram.Internal.Support
     ) where
 
 
-import Agent.CLI.ManagedTurn
-    ( ManagedTurnMedia(..)
-    , ManagedTurnRequest(..)
-    )
+import Agent.CLI.ManagedTurn (ManagedTurnMedia(..))
 import Agent.CLI.Session
     ( SessionCreate(..)
     , SessionHandle(..)
@@ -50,10 +47,9 @@ import System.Directory.OsPath (doesFileExist, removeFile)
 import System.OsPath (OsPath, unsafeEncodeUtf)
 import Agent.Telegram.Internal.Runtime.Types
 import Agent.Telegram.Internal.Text (splitTelegramText)
-cleanupManagedTurnMedia :: ManagedTurnRequest -> IO ()
-cleanupManagedTurnMedia request =
-    forM_
-        (request.managedTurnImages <> request.managedTurnFiles)
+cleanupManagedTurnMedia :: [ManagedTurnMedia] -> IO ()
+cleanupManagedTurnMedia mediaFiles =
+    forM_ mediaFiles
         \media ->
             void $ tryAny $
                 removeFile (unsafeEncodeUtf media.managedTurnMediaPath)

--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Turn.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Turn.hs
@@ -34,7 +34,7 @@ import Control.Concurrent.MVar
     )
 import Control.Exception.Safe
     ( bracket
-    , finally
+    , bracket_
     , onException
     , tryAny
     )
@@ -74,7 +74,12 @@ runQueuedMediaTurn runtime pending = do
     progressMessageId <- newIORef Nothing
     handle <- sessionForPrompt runtime pending.pendingMediaChat pending.pendingMediaText
     let agentPrompt = telegramAgentPrompt pending.pendingMediaText
-    attachments <- downloadTelegramMediaAttachments runtime handle pending
+    bracket
+        (downloadTelegramMediaAttachments runtime handle pending)
+        (cleanupManagedTurnMedia . map snd)
+        (runWithAttachments progressMessageId handle agentPrompt)
+  where
+   runWithAttachments progressMessageId handle agentPrompt attachments = do
     let imageAttachments =
             [ media
             | (TelegramMediaPhoto, media) <- attachments
@@ -121,12 +126,11 @@ runQueuedMediaTurn runtime pending = do
                 progressMessageId
                 (not (isAmbientGroupPrompt pending.pendingMediaText))
                 (unsafeToFilePath handle.sessionTempDir)
-    createDirectoryIfMissing True bridgeDir
-    setFileMode bridgePath 0o700
-    priorTurnIndex <-
-        latestPersistedTurnIndex runtime handle.sessionMeta.metaId
-    result <-
-        (withTelegramBridge bridgeEnv $
+    (priorTurnIndex, result) <-
+        withTurnBridgeDirectory runtime bridgeDir do
+          priorTurnIndex <-
+              latestPersistedTurnIndex runtime handle.sessionMeta.metaId
+          result <- withTelegramBridge bridgeEnv $
             launchManagedTurnBounded
                 runtime.runtimeProcessManager
                 False
@@ -135,9 +139,9 @@ runQueuedMediaTurn runtime pending = do
                 False
                 (Just (20 * 60 * 1_000_000))
                 handle
-                gatewayRequest)
-            `finally` cleanupTelegramBridge runtime bridgePath bridgeDir
-    response <- (case result of
+                gatewayRequest
+          pure (priorTurnIndex, result)
+    response <- case result of
         Left err -> fail (Text.unpack err)
         Right _ ->
             loadSessionHandle
@@ -158,9 +162,18 @@ runQueuedMediaTurn runtime pending = do
                                 _ ->
                                     fail
                                         "agent completed without recording \
-                                        \the Telegram turn")
-        `finally` cleanupManagedTurnMedia request
+                                        \the Telegram turn"
     TelegramTurnResponse response <$> readIORef progressMessageId
+
+-- Install cleanup before chmod, persisted-turn lookup, or bridge startup.
+withTurnBridgeDirectory :: TelegramRuntime -> OsPath -> IO a -> IO a
+withTurnBridgeDirectory runtime bridgeDir action =
+    bracket_
+        (createDirectoryIfMissing True bridgeDir)
+        (cleanupTelegramBridge runtime bridgePath bridgeDir)
+        (setFileMode bridgePath 0o700 >> action)
+  where
+    bridgePath = unsafeToFilePath bridgeDir
 
 checkpointVoiceTranscript
     :: TelegramRuntime
@@ -550,11 +563,10 @@ runManagedAgentTurn
                 progressMessageId
                 groupActivityEnabled
                 (unsafeToFilePath handle.sessionTempDir)
-    createDirectoryIfMissing True bridgeDir
-    setFileMode bridgePath 0o700
-    priorTurnIndex <-
-        latestPersistedTurnIndex runtime handle.sessionMeta.metaId
-    response <- (withTelegramBridge bridgeEnv $
+    (priorTurnIndex, result) <- withTurnBridgeDirectory runtime bridgeDir do
+      priorTurnIndex <-
+          latestPersistedTurnIndex runtime handle.sessionMeta.metaId
+      result <- withTelegramBridge bridgeEnv $
         launchManagedTurnBounded
             runtime.runtimeProcessManager
             False
@@ -563,9 +575,9 @@ runManagedAgentTurn
             False
             (Just (20 * 60 * 1_000_000))
             handle
-            request)
-        `finally` cleanupTelegramBridge runtime bridgePath bridgeDir
-        >>= \case
+            request
+      pure (priorTurnIndex, result)
+    response <- case result of
             Left err -> fail (Text.unpack err)
             Right _ ->
                 loadSessionHandle


### PR DESCRIPTION
## Summary
- Own process managers across startup logging and runtime use.
- Install bridge directory cleanup before setup and launch.
- Scope downloaded media across setup, launch, and response loading.

## Validation
Telegram test suite through GHCi: 73 examples, zero failures. No new public API or dependency changes.