### PR TITLE
Scope CLI temporary files and conversation hydration

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/Runtime/ConversationStore.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/ConversationStore.hs
@@ -39,7 +39,7 @@ import Control.Concurrent.MVar
     , newMVar
     , readMVar
     )
-import Control.Exception.Safe (finally, mask)
+import Control.Exception.Safe (bracket)
 import Data.Text (Text)
 import Data.Word (Word64)
 
@@ -138,55 +138,56 @@ withConversationBackendState
 withConversationBackendState
         store@(ConversationStore stateVar)
         action =
-    mask \restore -> do
-        (generation, releaseHydration, snapshot) <-
-            modifyMVar stateVar \state ->
-                case state.stateTranscript of
-                    ResidentTranscript items CommittedResident ->
-                        pure
-                            ( state
-                            , ( state.stateGeneration
-                              , False
-                              , snapshotFromState state items
-                              )
-                            )
-                    ResidentTranscript items
-                            (HydratedResident checkpoint readers) ->
-                        pure
-                            ( state
+    bracket acquire release \(_, _, snapshot) ->
+        action snapshot
+  where
+    acquire =
+        modifyMVar stateVar \state ->
+            case state.stateTranscript of
+                ResidentTranscript items CommittedResident ->
+                    pure
+                        ( state
+                        , ( state.stateGeneration
+                          , False
+                          , snapshotFromState state items
+                          )
+                        )
+                ResidentTranscript items
+                        (HydratedResident checkpoint readers) ->
+                    pure
+                        ( state
+                            { stateTranscript =
+                                ResidentTranscript
+                                    items
+                                    (HydratedResident
+                                        checkpoint
+                                        (readers + 1))
+                            }
+                        , ( state.stateGeneration
+                          , True
+                          , snapshotFromState state items
+                          )
+                        )
+                ColdTranscript cold -> do
+                    items <- cold.checkpointLoad
+                    let resident =
+                            state
                                 { stateTranscript =
                                     ResidentTranscript
                                         items
-                                        (HydratedResident
-                                            checkpoint
-                                            (readers + 1))
+                                        (HydratedResident cold 1)
                                 }
-                            , ( state.stateGeneration
-                              , True
-                              , snapshotFromState state items
-                              )
-                            )
-                    ColdTranscript cold -> do
-                        items <- cold.checkpointLoad
-                        let resident =
-                                state
-                                    { stateTranscript =
-                                        ResidentTranscript
-                                            items
-                                            (HydratedResident cold 1)
-                                    }
-                        pure
-                            ( resident
-                            , ( state.stateGeneration
-                              , True
-                              , snapshotFromState state items
-                              )
-                            )
-        restore (action snapshot)
-            `finally`
-                if releaseHydration
-                    then releaseHydratedTranscript store generation
-                    else pure ()
+                    pure
+                        ( resident
+                        , ( state.stateGeneration
+                          , True
+                          , snapshotFromState state items
+                          )
+                        )
+    release (generation, releaseHydration, _) =
+        if releaseHydration
+            then releaseHydratedTranscript store generation
+            else pure ()
 
 -- | Publish a newer exact transcript and return its generation token.
 commitConversationTranscript

--- a/packages/agent-cli-runtime/test/Agent/Runtime/ConversationStoreSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/Runtime/ConversationStoreSpec.hs
@@ -10,7 +10,7 @@ import Agent.Loop
     , emptyBackendSnapshot
     )
 import Agent.Responses.Types
-import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.Async (cancel, wait, withAsync)
 import Control.Concurrent.MVar
     ( newEmptyMVar
     , putMVar
@@ -41,6 +41,45 @@ spec = do
             conversationResidency store `shouldReturn` ConversationCold
             readConversationPreviousResponseId store
                 `shouldReturn` Just "response-1"
+
+        it "returns to cold state when a scoped reader is cancelled" do
+            entered <- newEmptyMVar
+            blocked <- newEmptyMVar
+            let checkpoint = TranscriptCheckpoint "turn:1" $
+                    pure [messageItem "cold"]
+            store <- newColdConversationStore Nothing checkpoint []
+
+            withAsync
+                (withConversationTranscript store \_ -> do
+                    putMVar entered ()
+                    takeMVar blocked)
+                \reader -> do
+                    takeMVar entered
+                    conversationResidency store
+                        `shouldReturn` ConversationResident
+                    cancel reader
+                    conversationResidency store
+                        `shouldReturn` ConversationCold
+
+        it "remains usable when checkpoint hydration is cancelled" do
+            entered <- newEmptyMVar
+            blocked <- newEmptyMVar
+            let checkpoint = TranscriptCheckpoint "blocked" do
+                    putMVar entered ()
+                    takeMVar blocked
+            store <- newColdConversationStore Nothing checkpoint []
+
+            withAsync
+                (withConversationTranscript store (\_ -> pure ()))
+                \reader -> do
+                    takeMVar entered
+                    cancel reader
+
+            conversationResidency store `shouldReturn` ConversationCold
+            let items = [messageItem "recovered"]
+            retargetConversationCheckpoint store
+                (TranscriptCheckpoint "replacement" (pure items))
+            withConversationTranscript store (`shouldBe` items)
 
         it "returns to cold state when a scoped reader throws" do
             let checkpoint = TranscriptCheckpoint "turn:1" $

--- a/packages/agent-cli/src/Agent/CLI/Clipboard/Linux.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard/Linux.hs
@@ -6,7 +6,7 @@ module Agent.CLI.Clipboard.Linux
 
 import Agent.CLI.Error (formatException)
 import Agent.Loop (ImageAttachment(..))
-import Control.Exception.Safe (finally, tryAny)
+import Control.Exception.Safe (bracket, finally, tryAny)
 import Control.Monad (void)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -110,35 +110,36 @@ runTextCmd cmd args = do
 runBytesCmd :: FilePath -> [String] -> IO (Either Text ByteString)
 runBytesCmd cmd args = do
     tmpDir <- getTemporaryDirectory
-    result <- tryAny do
-        (path, handle) <- openBinaryTempFile tmpDir "agent-clipboard-.bin"
-        hClose handle
-        let cleanup = void (tryAny (removeFile path))
-        (do
-            removeFile path
-            (code, _, err) <- readProcessWithExitCode "bash"
-                [ "-c"
-                , shellQuote cmd
-                    <> " "
-                    <> unwords (map shellQuote args)
-                    <> " > "
-                    <> shellQuote path
-                ]
-                ""
-            case code of
-                ExitSuccess -> do
-                    bytes <- withBinaryFile path ReadMode \input ->
-                        BS.hGet input (maxClipboardImageBytes + 1)
-                    if BS.length bytes > maxClipboardImageBytes
-                        then pure (Left
-                            "clipboard image exceeds the 20 MB limit")
-                        else if BS.null bytes
+    result <- tryAny $
+        bracket
+            (openBinaryTempFile tmpDir "agent-clipboard-.bin")
+            (\(path, handle) ->
+                hClose handle `finally` void (tryAny (removeFile path)))
+            \(path, handle) -> do
+                hClose handle
+                removeFile path
+                (code, _, err) <- readProcessWithExitCode "bash"
+                    [ "-c"
+                    , shellQuote cmd
+                        <> " "
+                        <> unwords (map shellQuote args)
+                        <> " > "
+                        <> shellQuote path
+                    ]
+                    ""
+                case code of
+                    ExitSuccess -> do
+                        bytes <- withBinaryFile path ReadMode \input ->
+                            BS.hGet input (maxClipboardImageBytes + 1)
+                        if BS.length bytes > maxClipboardImageBytes
                             then pure (Left
-                                "no image found on the clipboard")
-                            else pure (Right bytes)
-                ExitFailure _ ->
-                    pure (Left (Text.strip (Text.pack err))))
-            `finally` cleanup
+                                "clipboard image exceeds the 20 MB limit")
+                            else if BS.null bytes
+                                then pure (Left
+                                    "no image found on the clipboard")
+                                else pure (Right bytes)
+                    ExitFailure _ ->
+                        pure (Left (Text.strip (Text.pack err)))
     case result of
         Left ex -> pure (Left (formatException ex))
         Right value -> pure value

--- a/packages/agent-cli/src/Agent/CLI/Clipboard/MacOS.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard/MacOS.hs
@@ -11,7 +11,7 @@ module Agent.CLI.Clipboard.MacOS
 
 import Agent.CLI.Error (formatException)
 import Agent.Loop (ImageAttachment(..))
-import Control.Exception.Safe (finally, tryAny)
+import Control.Exception.Safe (bracket, finally, tryAny)
 import Control.Monad (void)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -102,43 +102,44 @@ readMacClipboardPaths = do
 readMacClipboardClass :: String -> IO (Either Text ByteString)
 readMacClipboardClass typeClass = do
     tmpDir <- getTemporaryDirectory
-    result <- tryAny do
-        (path, handle) <- openBinaryTempFile tmpDir "agent-clipboard-.bin"
-        hClose handle
-        let cleanup = void (tryAny (removeFile path))
-        (do
-            removeFile path
-            let script =
-                    unlines
-                        [ "try"
-                        , "  set clipData to the clipboard as " <> typeClass
-                        , "  set outFile to open for access POSIX file "
-                            <> appleString path
-                            <> " with write permission"
-                        , "  set eof of outFile to 0"
-                        , "  write clipData to outFile"
-                        , "  close access outFile"
-                        , "  return \"ok\""
-                        , "on error errMsg"
-                        , "  try"
-                        , "    close access POSIX file " <> appleString path
-                        , "  end try"
-                        , "  error errMsg"
-                        , "end try"
-                        ]
-            (code, _out, err) <-
-                readProcessWithExitCode "osascript" ["-e", script] ""
-            case code of
-                ExitSuccess -> do
-                    bytes <- withBinaryFile path ReadMode \input ->
-                        BS.hGet input (maxClipboardImageBytes + 1)
-                    if BS.length bytes > maxClipboardImageBytes
-                        then pure (Left
-                            "clipboard image exceeds the 20 MB limit")
-                        else pure (Right bytes)
-                ExitFailure _ ->
-                    pure (Left (clipboardErrorMessage typeClass err)))
-            `finally` cleanup
+    result <- tryAny $
+        bracket
+            (openBinaryTempFile tmpDir "agent-clipboard-.bin")
+            (\(path, handle) ->
+                hClose handle `finally` void (tryAny (removeFile path)))
+            \(path, handle) -> do
+                hClose handle
+                removeFile path
+                let script =
+                        unlines
+                            [ "try"
+                            , "  set clipData to the clipboard as " <> typeClass
+                            , "  set outFile to open for access POSIX file "
+                                <> appleString path
+                                <> " with write permission"
+                            , "  set eof of outFile to 0"
+                            , "  write clipData to outFile"
+                            , "  close access outFile"
+                            , "  return \"ok\""
+                            , "on error errMsg"
+                            , "  try"
+                            , "    close access POSIX file " <> appleString path
+                            , "  end try"
+                            , "  error errMsg"
+                            , "end try"
+                            ]
+                (code, _out, err) <-
+                    readProcessWithExitCode "osascript" ["-e", script] ""
+                case code of
+                    ExitSuccess -> do
+                        bytes <- withBinaryFile path ReadMode \input ->
+                            BS.hGet input (maxClipboardImageBytes + 1)
+                        if BS.length bytes > maxClipboardImageBytes
+                            then pure (Left
+                                "clipboard image exceeds the 20 MB limit")
+                            else pure (Right bytes)
+                    ExitFailure _ ->
+                        pure (Left (clipboardErrorMessage typeClass err))
     case result of
         Left ex -> pure (Left (formatException ex))
         Right value -> pure value

--- a/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
+++ b/packages/agent-cli/src/Agent/CLI/ComputerUse.hs
@@ -99,7 +99,7 @@ import Control.Concurrent
     , threadDelay
     , withMVar
     )
-import Control.Exception.Safe (finally, mask, onException, tryAny)
+import Control.Exception.Safe (bracket, finally, mask, onException, tryAny)
 import Control.Monad (foldM)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
@@ -1204,34 +1204,35 @@ screenshotMainDisplayWith encoding (width, height) = do
                 ScreenshotJpeg ->
                     (".jpg", "jpg", "image/jpeg",
                         ["-s", "formatOptions", "80"])
-        (path, handle) <- openBinaryTempFile temporaryDirectory
-            ("agent-computer-use-" <> suffix)
-        hClose handle
-        let cleanup = removeFile path
-        flip finally cleanup do
-            capture <- readProcessWithExitCode
-                "/usr/sbin/screencapture"
-                ["-x", "-m", "-C", "-t", format, path]
-                ""
-            case capture of
-                (ExitFailure _, _, stderr) ->
-                    pure (Left (commandError "screencapture" stderr))
-                (ExitSuccess, _, _) -> do
-                    resized <- readProcessWithExitCode
-                        "/usr/bin/sips"
-                        ([ "-z", show height, show width ]
-                            <> formatOptions
-                            <> [path])
-                        ""
-                    case resized of
-                        (ExitFailure _, _, stderr) ->
-                            pure (Left (commandError "screenshot resize" stderr))
-                        (ExitSuccess, _, _) -> do
-                            bytes <- BS.readFile path
-                            pure $ if BS.null bytes
-                                then Left
-                                    "Screen capture returned an empty image. Grant Screen Recording permission to the terminal or agent app."
-                                else Right (ImageAttachment mime bytes)
+        bracket
+            (openBinaryTempFile temporaryDirectory
+                ("agent-computer-use-" <> suffix))
+            (\(path, handle) -> hClose handle `finally` removeFile path)
+            \(path, handle) -> do
+                hClose handle
+                capture <- readProcessWithExitCode
+                    "/usr/sbin/screencapture"
+                    ["-x", "-m", "-C", "-t", format, path]
+                    ""
+                case capture of
+                    (ExitFailure _, _, stderr) ->
+                        pure (Left (commandError "screencapture" stderr))
+                    (ExitSuccess, _, _) -> do
+                        resized <- readProcessWithExitCode
+                            "/usr/bin/sips"
+                            ([ "-z", show height, show width ]
+                                <> formatOptions
+                                <> [path])
+                            ""
+                        case resized of
+                            (ExitFailure _, _, stderr) ->
+                                pure (Left (commandError "screenshot resize" stderr))
+                            (ExitSuccess, _, _) -> do
+                                bytes <- BS.readFile path
+                                pure $ if BS.null bytes
+                                    then Left
+                                        "Screen capture returned an empty image. Grant Screen Recording permission to the terminal or agent app."
+                                    else Right (ImageAttachment mime bytes)
     pure $ either (Left . Text.pack . show) id attempted
 
 mainDisplayLogicalSize :: IO (Either Text (Int, Int))

--- a/packages/agent-cli/src/Agent/CLI/ExternalProgram.hs
+++ b/packages/agent-cli/src/Agent/CLI/ExternalProgram.hs
@@ -15,7 +15,8 @@ module Agent.CLI.ExternalProgram
     ) where
 
 import Control.Exception.Safe
-    ( catchAny
+    ( bracket
+    , catchAny
     , finally
     , onException
     , tryAny
@@ -167,12 +168,14 @@ withTemporaryTextFile
     -> IO a
 withTemporaryTextFile prefix contents action = do
     temporaryDirectory <- getTemporaryDirectory
-    bracketTemp temporaryDirectory
+    bracket
+        (openTempFile temporaryDirectory prefix)
+        (\(path, handle) -> hClose handle `finally` removeQuietly path)
+        \(path, handle) -> do
+            hClose handle
+            Text.writeFile path contents
+            action path
   where
-    bracketTemp temporaryDirectory = do
-        (path, handle) <- openTempFile temporaryDirectory prefix
-        (hClose handle >> Text.writeFile path contents >> action path)
-            `finally` removeQuietly path
     removeQuietly path =
         removeFile path `catchAny` const (pure ())
 

--- a/packages/agent-cli/test/Agent/CLI/ExternalProgramSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ExternalProgramSpec.hs
@@ -1,6 +1,9 @@
 module Agent.CLI.ExternalProgramSpec (spec) where
 
 import Agent.CLI.ExternalProgram
+import Control.Concurrent.Async (cancel, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Exception.Safe (throwString)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import qualified Data.Text.IO as Text
 import System.Directory (doesFileExist)
@@ -70,3 +73,24 @@ spec = describe "Agent.CLI.ExternalProgram" do
                 doesFileExist path `shouldReturn` True
             path <- readIORef pathRef
             doesFileExist path `shouldReturn` False
+
+        it "removes the temporary file when the action throws" do
+            pathRef <- newIORef ""
+            withTemporaryTextFile "agent-cleanup-" "draft" (\path -> do
+                writeIORef pathRef path
+                throwString "action failed")
+                `shouldThrow` anyException
+            path <- readIORef pathRef
+            doesFileExist path `shouldReturn` False
+
+        it "removes the temporary file when the action is cancelled" do
+            entered <- newEmptyMVar
+            blocked <- newEmptyMVar
+            withAsync
+                (withTemporaryTextFile "agent-cleanup-" "draft" \path -> do
+                    putMVar entered path
+                    takeMVar blocked)
+                \worker -> do
+                    path <- takeMVar entered
+                    cancel worker
+                    doesFileExist path `shouldReturn` False


### PR DESCRIPTION
## Summary
- Bracket temporary files used by external programs, clipboard backends, and screenshots.
- Scope conversation hydration admissions using bracket.
- Add exception and cancellation cleanup regressions.

## Validation
CLI GHCi: 238 modules loaded. External program tests: 9/0; conversation store: 16/0; clipboard: 14 examples, zero failures, two macOS-only pending on Linux.