### PR TITLE
Bracket MCP stdio startup ownership transfers

### DIFF
--- a/packages/agent-mcp/src/Agent/MCP/Client/Internal/Core.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Client/Internal/Core.hs
@@ -70,7 +70,7 @@ import Agent.ToolDispatch ()
 import Agent.Tools.IO ( terminateProcessGroup )
 import Agent.Tools.Types ()
 import Control.Concurrent ()
-import Control.Concurrent.Async ( asyncWithUnmask )
+import Control.Concurrent.Async ( asyncWithUnmask, cancel )
 import Control.Concurrent.MVar ( newMVar )
 import Control.Concurrent.STM
     ( atomically,
@@ -84,7 +84,7 @@ import Control.Concurrent.STM
       tryPutTMVar,
       TMVar )
 import Control.Exception.Safe
-    ( finally, onException, tryAny, MonadMask(mask) )
+    ( bracketOnError, finally, onException, tryAny, MonadMask(mask) )
 import Control.Monad ( void )
 import Control.Monad.Trans.Class ()
 import Control.Monad.Trans.Except ()
@@ -176,8 +176,9 @@ startMcpClientWith hooks eraHint config = case config.mcpServerUrl of
                     , std_err = CreatePipe
                     , create_group = True
                     }
-        created <- createProcess processSpec
-        case created of
+        -- Keep startup masked through the handoff to the long-lived client.
+        -- Every intermediate owner has rollback before the next setup step.
+        bracketOnError (createProcess processSpec) rollbackProcess \case
             (Just input, Just output, Just errOutput, processHandle) -> do
                 groupId <- getPid processHandle
                 hSetBinaryMode input True
@@ -200,21 +201,28 @@ startMcpClientWith hooks eraHint config = case config.mcpServerUrl of
                 client <-
                     newClientRecord hooks eraHint config
                         (McpClientStdio transport)
-                stderrReader <- asyncWithUnmask \unmask ->
-                    unmask (stderrLoop errOutput transport.stdioStderr)
-                        `finally` void (tryAny (hClose errOutput))
-                writeIORef transport.stdioStderrReader (Just stderrReader)
-                reader <- asyncWithUnmask \unmask ->
-                    unmask (readerLoop client output)
-                        `finally` void (tryAny (hClose output))
-                writeIORef transport.stdioReader (Just reader)
-                pure client
-            _ -> do
-                let (_, _, _, processHandle) = created
-                groupId <- getPid processHandle
-                terminateProcessGroup groupId processHandle
-                closeOptionalHandles created
+                bracketOnError
+                    (asyncWithUnmask \unmask ->
+                        unmask (stderrLoop errOutput transport.stdioStderr)
+                            `finally` void (tryAny (hClose errOutput)))
+                    cancel
+                    \stderrReader -> do
+                        writeIORef transport.stdioStderrReader (Just stderrReader)
+                        bracketOnError
+                            (asyncWithUnmask \unmask ->
+                                unmask (readerLoop client output)
+                                    `finally` void (tryAny (hClose output)))
+                            cancel
+                            \reader -> do
+                                writeIORef transport.stdioReader (Just reader)
+                                pure client
+            _ ->
                 ioError (userError "MCP server did not provide all stdio pipes")
+  where
+    rollbackProcess created@(_, _, _, processHandle) =
+        (getPid processHandle >>= \groupId ->
+            terminateProcessGroup groupId processHandle)
+            `finally` closeOptionalHandles created
 
 startMcpHttpClient
     :: McpHostHooks

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -105,8 +105,9 @@ import Control.Concurrent
     , threadDelay
     , tryPutMVar
     )
-import Control.Concurrent.Async (async, cancel, wait, waitCatch, withAsync)
+import Control.Concurrent.Async (async, cancel, poll, wait, waitCatch, withAsync)
 import Control.Monad (void)
+import Data.Maybe (isNothing)
 import Data.Aeson (object, (.=))
 import qualified Data.Aeson
 import qualified Data.ByteString as BS
@@ -370,15 +371,27 @@ spec = describe "Agent.MCP" do
                     \client -> case client.clientTransport of
                         McpClientStdio transport -> do
                             readIORef transport.stdioReader >>= \case
-                                Just _ -> pure ()
+                                Just reader ->
+                                    poll reader >>= (`shouldSatisfy` isNothing)
                                 Nothing ->
                                     expectationFailure
                                         "stdio response reader was not started"
                             readIORef transport.stdioStderrReader >>= \case
-                                Just _ -> pure ()
+                                Just reader ->
+                                    poll reader >>= (`shouldSatisfy` isNothing)
                                 Nothing ->
                                     expectationFailure
                                         "stdio stderr reader was not started"
+                            -- Startup transfers the live readers to the
+                            -- client; closing that owner must still join both.
+                            closeMcpClient client
+                            readers <- sequence
+                                [ readIORef transport.stdioReader
+                                , readIORef transport.stdioStderrReader
+                                ]
+                            timeout 2000000
+                                (mapM_ (mapM_ (void . waitCatch)) readers)
+                                `shouldReturn` Just ()
                         _ ->
                             expectationFailure "expected a stdio transport"
 


### PR DESCRIPTION
## Summary
- Roll back subprocess and pipe acquisition when setup fails.
- Cancel partially started readers on failed ownership transfer.
- Preserve successful long-lived clients and existing shutdown policy.

## Validation
MCP test suite via GHCi: 154 examples, zero failures. Strengthened successful reader handoff and shutdown regression. No deterministic setup-failure injection seam added.