### PR TITLE
Scope provider image handles and Claude probe resources

### DIFF
--- a/packages/agent-claude/agent-claude.cabal
+++ b/packages/agent-claude/agent-claude.cabal
@@ -85,6 +85,7 @@ test-suite agent-claude-test
                     , agent-responses-types
                     , claude-agent-sdk-haskell
                     , aeson
+                    , async
                     , bytestring
                     , directory
                     , filepath

--- a/packages/agent-claude/package.nix
+++ b/packages/agent-claude/package.nix
@@ -16,8 +16,8 @@ mkDerivation {
   ];
   testHaskellDepends = [
     aeson agent-core agent-json agent-responses agent-responses-types
-    base bytestring claude-agent-sdk-haskell directory filepath hspec
-    safe-exceptions text unix
+    async base bytestring claude-agent-sdk-haskell directory filepath
+    hspec safe-exceptions text unix
   ];
   description = "Claude Code subscription adapter for Agent.Loop";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-claude/src/Agent/Claude/Auth.hs
+++ b/packages/agent-claude/src/Agent/Claude/Auth.hs
@@ -17,10 +17,9 @@ import Agent.Process (terminateProcessGroup)
 import qualified Agent.Json.Decode as Json
 import Control.Concurrent.Async (poll, waitBoth, withAsync)
 import Control.Exception.Safe
-    ( displayException
+    ( bracket
+    , displayException
     , finally
-    , mask
-    , onException
     , tryAny
     )
 import Control.Monad (void)
@@ -36,6 +35,7 @@ import System.Environment (lookupEnv)
 import System.Exit (ExitCode(..))
 import System.Process
     ( CreateProcess(..)
+    , ProcessHandle
     , StdStream(CreatePipe)
     , createProcess
     , getPid
@@ -110,64 +110,52 @@ runAuthStatusProbe
     -> [(String, String)]
     -> IO (ExitCode, String, String)
 runAuthStatusProbe executablePath cleanEnvironment =
-    mask \restore -> do
-        let spec =
-                (proc executablePath ["auth", "status", "--json"])
-                    { env = Just cleanEnvironment
-                    -- Claude Code inspects an inherited TTY even for this
-                    -- non-interactive status command. Give it a closed pipe
-                    -- instead of the full-screen UI's raw-mode terminal.
-                    , std_in = CreatePipe
-                    , std_out = CreatePipe
-                    , std_err = CreatePipe
-                    , close_fds = True
-                    , create_group = True
-                    , new_session = True
-                    }
-        (mIn, mOut, mErr, processHandle) <- createProcess spec
+    withAuthStatusProcess spec \(mIn, mOut, mErr, processHandle) -> do
         mapM_ hCloseQuiet mIn
         case (mOut, mErr) of
             (Just out, Just err) -> do
                 mapM_ setupHandle [out, err]
-                let stop = do
-                        group <- getPid processHandle
-                        terminateProcessGroup group processHandle
-                    awaitProbe =
-                        withAsync (safeDrain out) \outReader ->
-                            withAsync (safeDrain err) \errReader -> do
-                                result <- restore
-                                    (timeout authProbeTimeoutMicros
-                                        (waitForProcess processHandle))
-                                    `onException` stop
-                                case result of
-                                    Nothing -> do
-                                        stop
-                                        pure
-                                            ( ExitFailure 124
-                                            , ""
-                                            , "authentication probe timed out"
-                                            )
-                                    Just code -> do
-                                        streams <- restore $
-                                            timeout readerDrainTimeoutMicros
-                                                (waitBoth outReader errReader)
-                                        (stdoutText, stderrText) <-
-                                            case streams of
-                                                Just completed ->
-                                                    pure completed
-                                                Nothing ->
-                                                    (,)
-                                                        <$> completedOutput outReader
-                                                        <*> completedOutput errReader
-                                        pure (code, stdoutText, stderrText)
-                awaitProbe `finally` mapM_ hCloseQuiet [out, err]
+                withAsync (safeDrain out) \outReader ->
+                    withAsync (safeDrain err) \errReader -> do
+                        result <- timeout authProbeTimeoutMicros
+                            (waitForProcess processHandle)
+                        case result of
+                            Nothing -> do
+                                stopAuthStatusProcess processHandle
+                                pure
+                                    ( ExitFailure 124
+                                    , ""
+                                    , "authentication probe timed out"
+                                    )
+                            Just code -> do
+                                streams <- timeout readerDrainTimeoutMicros
+                                    (waitBoth outReader errReader)
+                                (stdoutText, stderrText) <-
+                                    case streams of
+                                        Just completed ->
+                                            pure completed
+                                        Nothing ->
+                                            (,)
+                                                <$> completedOutput outReader
+                                                <*> completedOutput errReader
+                                pure (code, stdoutText, stderrText)
             _ -> do
-                mapM_ (maybe (pure ()) hCloseQuiet) [mOut, mErr]
-                group <- getPid processHandle
-                terminateProcessGroup group processHandle
+                stopAuthStatusProcess processHandle
                 pure (ExitFailure 1, "", "Claude Code did not provide output pipes")
   where
-    hCloseQuiet = void . tryAny . hClose
+    spec =
+        (proc executablePath ["auth", "status", "--json"])
+            { env = Just cleanEnvironment
+            -- Claude Code inspects an inherited TTY even for this
+            -- non-interactive status command. Give it a closed pipe
+            -- instead of the full-screen UI's raw-mode terminal.
+            , std_in = CreatePipe
+            , std_out = CreatePipe
+            , std_err = CreatePipe
+            , close_fds = True
+            , create_group = True
+            , new_session = True
+            }
     safeDrain handle =
         either (const "") id <$> tryAny (drainCapped handle)
     completedOutput reader =
@@ -177,6 +165,28 @@ runAuthStatusProbe executablePath cleanEnvironment =
     setupHandle handle = do
         hSetBinaryMode handle True
         hSetBuffering handle NoBuffering
+
+-- | Own the process and all pipes from creation, including while setting modes
+-- and starting readers. Release stops a still-running process before closing
+-- its pipes; a process already reaped by the caller needs no further stopping.
+withAuthStatusProcess
+    :: CreateProcess
+    -> ((Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle) -> IO a)
+    -> IO a
+withAuthStatusProcess spec =
+    bracket (createProcess spec) release
+  where
+    release (input, output, err, processHandle) =
+        stopAuthStatusProcess processHandle
+            `finally` mapM_ hCloseQuiet (catMaybes [input, output, err])
+
+stopAuthStatusProcess :: ProcessHandle -> IO ()
+stopAuthStatusProcess processHandle = do
+    group <- getPid processHandle
+    terminateProcessGroup group processHandle
+
+hCloseQuiet :: Handle -> IO ()
+hCloseQuiet = void . tryAny . hClose
 
 authProbeTimeoutMicros :: Int
 authProbeTimeoutMicros = 5 * 1_000_000

--- a/packages/agent-claude/test/Agent/Claude/AuthSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/AuthSpec.hs
@@ -4,12 +4,16 @@ module Agent.Claude.AuthSpec (spec) where
 
 import Agent.Claude.Auth
 import Agent.Claude.Transport
-import Control.Exception.Safe (bracket, finally, onException)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (cancel, withAsync)
+import Control.Exception.Safe (bracket, finally, onException, tryAny)
 import Control.Monad (void)
 import qualified Data.ByteString.Char8 as ByteString
+import Data.Either (isLeft)
 import qualified Data.Text as Text
 import System.Directory
     ( createDirectory
+    , doesFileExist
     , getTemporaryDirectory
     , removeDirectoryRecursive
     , removeFile
@@ -31,6 +35,7 @@ import System.Posix.IO
     , dupTo
     , stdInput
     )
+import System.Posix.Signals (nullSignal, signalProcess)
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -92,6 +97,33 @@ spec = do
                         }
 
     describe "loadClaudeCodeAuth" do
+        it "stops the auth subprocess when its scope is cancelled" $
+            withScratchDirectory "agent-claude-auth-cancel" \root -> do
+                let executable = root </> "fake-claude"
+                    pidFile = root </> "pid"
+                    waitForPid = do
+                        exists <- doesFileExist pidFile
+                        contents <- if exists then ByteString.readFile pidFile else pure ""
+                        case reads (ByteString.unpack contents) of
+                            [(pid, _)] -> pure pid
+                            _ -> threadDelay 10_000 >> waitForPid
+                writeFile executable $
+                    "#!/bin/sh\necho $$ > " <> show pidFile <> "\nexec sleep 30\n"
+                setFileMode executable $
+                    ownerReadMode
+                        `unionFileModes` ownerWriteMode
+                        `unionFileModes` ownerExecuteMode
+                withEnvironmentVariables
+                    [("CLAUDE_CODE_EXECUTABLE", Just executable)]
+                    $ withAsync loadClaudeCodeAuth \probe -> do
+                        pid <- timeout 2_000_000 waitForPid
+                        case pid of
+                            Nothing -> expectationFailure "auth subprocess did not start"
+                            Just processId -> do
+                                cancel probe
+                                alive <- tryAny (signalProcess nullSignal processId)
+                                alive `shouldSatisfy` isLeft
+
         it "does not inherit caller stdin for the auth subprocess" $
             withScratchDirectory "agent-claude-auth-stdin" \root -> do
                 let executable = root </> "fake-claude"

--- a/packages/agent-openai/src/Agent/OpenAI/ImageGeneration.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/ImageGeneration.hs
@@ -57,8 +57,8 @@ import Agent.Tools.Types
     )
 import Control.Applicative ((<|>))
 import Control.Exception.Safe
-    ( bracketOnError
-    , finally
+    ( bracket
+    , bracketOnError
     , tryAny
     )
 import Control.Monad (unless)
@@ -588,19 +588,24 @@ saveGeneratedImage env fileName bytes = do
                     then pure $ Left
                         "generated image destination already exists"
                     else do
-                        handle <- bracketOnError
-                            (openFd
-                                (unsafeToFilePath destination)
-                                WriteOnly
-                                defaultFileFlags
-                                    { creat = Just 0o600
-                                    , exclusive = True
-                                    , nofollow = True
-                                    , cloexec = True
-                                    })
-                            closeFd
-                            fdToHandle
-                        BS.hPut handle bytes `finally` hClose handle
+                        -- Keep descriptor-to-handle ownership transfer inside
+                        -- acquisition, so cancellation cannot strand the handle
+                        -- before its cleanup is installed.
+                        bracket
+                            (bracketOnError
+                                (openFd
+                                    (unsafeToFilePath destination)
+                                    WriteOnly
+                                    defaultFileFlags
+                                        { creat = Just 0o600
+                                        , exclusive = True
+                                        , nofollow = True
+                                        , cloexec = True
+                                        })
+                                closeFd
+                                fdToHandle)
+                            hClose
+                            (\handle -> BS.hPut handle bytes)
                         pure (Right ())
 
 displayGeneratedImage

--- a/packages/agent-openai/test/Agent/OpenAI/ImageGenerationSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ImageGenerationSpec.hs
@@ -54,6 +54,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
+import System.Directory (createDirectory)
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
@@ -129,6 +130,32 @@ spec = describe "image generation tool" do
                 , "quality" .= ("auto" :: Text)
                 , "size" .= ("auto" :: Text)
                 ]
+
+    it "leaves an existing destination unchanged and still returns the generated image" do
+        withSystemTempDirectory "agent-imagegen-existing" \cwd -> do
+            let destination = cwd </> "generated_images" </> "call-existing.png"
+            createDirectory (cwd </> "generated_images")
+            BS.writeFile destination "original"
+            recorded <- newIORef []
+            withImageServer recorded generatedPng \baseUrl -> do
+                env <- defaultToolEnv (fromText (Text.pack cwd))
+                history <- newImageGenerationHistory
+                let tool = imageGenerationToolAt baseUrl openAiProvider env history Nothing
+                result <- dispatchToolCall
+                    defaultLoopDispatch
+                    (appToolHandlers [tool])
+                    (functionToolCall
+                        "call-existing"
+                        "image_gen.imagegen"
+                        "{\"prompt\":\"paint a moonlit lake\"}")
+                BS.readFile destination `shouldReturn` "original"
+                result.output `shouldSatisfy` (not . Text.isInfixOf "Generated images are saved")
+                toolCallResultImages result `shouldBe`
+                    [ ToolResultImage
+                        { imageUrl = pngDataUrl generatedPng
+                        , imageDetail = Just "high"
+                        }
+                    ]
 
     it "edits the requested number of recent images in chronological order" do
         withSystemTempDirectory "agent-imagegen-edit" \cwd -> do

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Capabilities.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Capabilities.hs
@@ -21,7 +21,9 @@ import Agent.Process (terminateProcessGroup)
 import Control.Concurrent.Async (withAsync, waitCatch)
 import Control.Exception.Safe
     ( SomeException
+    , bracket
     , catchAny
+    , finally
     , mask
     , onException
     , tryAny
@@ -230,7 +232,9 @@ capabilityCache = unsafePerformIO (newIORef Map.empty)
 runProbe :: FilePath -> FilePath -> [String] -> IO (Either Text (ExitCode, Text, Text))
 runProbe executable cwd args =
     mask \restore -> do
-        created <- tryAny $ createProcess
+        -- Own the process and pipes even before reader setup finishes. Readers
+        -- may finish by cancellation or a read error, not just EOF or the cap.
+        bracket (tryAny $ createProcess
             (proc executable args)
                 { cwd = Just cwd
                 -- Claude Code inspects inherited terminals even for
@@ -243,8 +247,7 @@ runProbe executable cwd args =
                 , close_fds = True
                 , create_group = True
                 , new_session = True
-                }
-        case created of
+                }) releaseCreated \case
             Left exception -> pure (Left (Text.pack (show (exception :: SomeException))))
             Right (Just input, Just output, Just error, processHandle) -> do
                 voidClose input
@@ -296,6 +299,11 @@ runProbe executable cwd args =
                 terminateProcessGroup Nothing processHandle
                 pure (Left "Claude Code probe returned incomplete output handles.")
   where
+    releaseCreated (Left _) = pure ()
+    releaseCreated (Right (input, output, error, processHandle)) =
+        (getPid processHandle >>= \groupId ->
+            terminateProcessGroup groupId processHandle)
+            `finally` mapM_ (maybe (pure ()) voidClose) [input, output, error]
     probeTimeoutMicros = 3_000_000
     waitBounded stream reader = do
         result <- timeout 1_000_000 (waitCatch reader)
@@ -325,13 +333,13 @@ readBounded handle = do
     go acc = do
         chunk <- ByteString.hGetSome handle 8192
         if ByteString.null chunk
-            then do
-                voidClose handle
-                pure (decode acc)
+            then pure (decode acc)
             else
                 let next = ByteString.take limit (acc <> chunk)
                 in if ByteString.length next >= limit
                     then do
+                        -- Deliberately stop the producer at the output cap;
+                        -- ordinary cleanup belongs to the probe's bracket.
                         voidClose handle
                         pure (decode next)
                     else go next


### PR DESCRIPTION
## Summary
- Own image destination handles from acquisition through write completion.
- Bracket Claude authentication and SDK probe processes and pipes, including setup failures and cancellation.
- Preserve probe deadlines and successful output handling; regenerate package.nix for async test dependency.

## Validation
Focused GHCi suites loaded and passed: Claude auth 9 examples, OpenAI image generation 4, SDK capabilities 7; zero failures. Includes auth cancellation and image destination regressions.