### PR TITLE
Keep native mail administration local and preserve OAuth client configuration

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -616,6 +616,7 @@ test-suite agent-cli-test
                     , agent-cli-runtime
                     , agent-connectivity
                     , agent-core
+                    , agent-integration-api
                     , agent-mcp
                     , agent-json
                     , agent-codex-dialect

--- a/packages/agent-cli/benchmark/Concurrency.hs
+++ b/packages/agent-cli/benchmark/Concurrency.hs
@@ -1346,6 +1346,7 @@ fakeMcpConfig executable project delayMillis index = McpServerConfig
     , mcpServerRootsEnabled = False
     , mcpServerSamplingEnabled = False
     , mcpServerLogLevel = Nothing
+    , mcpServerExcludedTools = []
     }
 
 runFakeMcpServer :: Int -> Int -> IO ()

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -43,6 +43,7 @@ mkDerivation {
   testHaskellDepends = [
     aeson agent-claude agent-cli-runtime agent-codex-dialect
     agent-connectivity agent-core agent-gemini agent-grok-build-dialect
+    agent-integration-api
     agent-json agent-mcp agent-openai agent-openrouter agent-responses
     agent-responses-types agent-store agent-tui agent-xai ansi-terminal
     async base base64-bytestring brick bytestring colour containers

--- a/packages/agent-cli/src/Agent/CLI/IntegrationGateway.hs
+++ b/packages/agent-cli/src/Agent/CLI/IntegrationGateway.hs
@@ -4,11 +4,12 @@ module Agent.CLI.IntegrationGateway
     ( gatewayIntegrationAuthority
     , gatewayIntegrationMcpConfig
     , availableIntegrationServerName
+    , integrationEndpointServers
     ) where
 
 import Agent.CLI.GatewayClient (GatewayCredential(..))
-import Agent.Integration.API (IntegrationAuthority(..))
-import Agent.MCP (McpServerConfig(..), McpProtocolPreference(..))
+import Agent.Integration.API (IntegrationAuthority(..), IntegrationEndpoint(..))
+import Agent.MCP (McpServerConfig(..), McpProtocolPreference(..), McpToolServer)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 
@@ -34,6 +35,7 @@ gatewayIntegrationMcpConfig credential = McpServerConfig
     , mcpServerRootsEnabled = False
     , mcpServerSamplingEnabled = False
     , mcpServerLogLevel = Nothing
+    , mcpServerExcludedTools = []
     }
 
 availableIntegrationServerName :: [Text.Text] -> Text.Text
@@ -48,3 +50,25 @@ availableIntegrationServerName configuredNames =
         candidate
             | index == 1 = "integrations"
             | otherwise = "integrations-" <> Text.pack (show index)
+
+-- | Explicit overlays own the canonical namespace. Remote tools retain a
+-- separate namespace, with reserved names denied even if local tools disappear.
+-- Plain combined endpoints deliberately retain their existing remote-first names.
+integrationEndpointServers
+    :: [Text.Text] -> IntegrationEndpoint
+    -> ([McpServerConfig], [(Text.Text, McpToolServer)])
+integrationEndpointServers configured endpoint = case endpoint of
+    NoIntegrationEndpoint -> ([], [])
+    LocalIntegrationEndpoint server -> ([], [(primary, server)])
+    LocalOverlayIntegrationEndpoint _ server -> ([], [(primary, server)])
+    RemoteIntegrationEndpoint config -> ([named primary config], [])
+    CombinedIntegrationEndpoint config server ->
+        ([named primary config], [(secondary, server)])
+    CombinedOverlayIntegrationEndpoint config names server ->
+        ([named secondary config
+            { mcpServerExcludedTools = config.mcpServerExcludedTools <> names }],
+            [(primary, server)])
+  where
+    primary = availableIntegrationServerName configured
+    secondary = availableIntegrationServerName (primary : configured)
+    named name config = config { mcpServerName = name }

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -17,6 +17,7 @@ module Agent.CLI.NativeRuntime
     , newNativeProcessRuntimeWithIntegrations
     , newNativeProcessRuntimeWithOrganizationIntegrations
     , nativeProcessIntegrationSupervisor
+    , acquireNativeLocalIntegrationRuntime
     , nativeTurnOptions
     , applyNativeStartupPolicy
     , restartNativeMcpRuntime
@@ -27,6 +28,10 @@ module Agent.CLI.NativeRuntime
 import qualified Agent.CLI.NativeProcess as NativeProcess
 import Agent.Integration.API
     ( IntegrationSupervisor
+    , IntegrationRuntime(..)
+    , IntegrationAuthority(..)
+    , acquireIntegrationRuntime
+    , newIntegrationSupervisor
     , closeIntegrationSupervisor
     , newIntegrationSupervisorWithOrganizationProvider
     , resetIntegrationSupervisor
@@ -86,6 +91,7 @@ import System.OsPath (OsPath)
 data NativeProcessRuntime = NativeProcessRuntime
     { nativeProcessCore :: !NativeProcess.NativeProcessRuntime
     , nativeIntegrationSupervisor :: !IntegrationSupervisor
+    , nativeLocalIntegrationSupervisor :: !IntegrationSupervisor
     }
 
 newNativeProcessRuntime :: OsPath -> IO NativeProcessRuntime
@@ -103,15 +109,24 @@ newNativeProcessRuntimeWithOrganizationIntegrations
     -> OsPath -> IO NativeProcessRuntime
 newNativeProcessRuntimeWithOrganizationIntegrations provider organizationProvider root = mask \restore -> do
     integrationToolEnv <- restore (defaultToolEnv root)
+    localIntegrations <- restore (newIntegrationSupervisor provider integrationToolEnv)
+    -- Direct turns borrow the same local owner used by native account settings.
+    -- Changing gateway identity must retire banking, not an ongoing mail OAuth flow.
+    let borrowedLocalProvider _ =
+            fmap (fmap (\runtime -> runtime { closeIntegrationRuntime = pure () }))
+                (acquireIntegrationRuntime localIntegrations LocalIntegrationAuthority)
     integrations <-
         restore (newIntegrationSupervisorWithOrganizationProvider
-            provider organizationProvider integrationToolEnv)
+            borrowedLocalProvider organizationProvider integrationToolEnv)
+            `onException` closeIntegrationSupervisor localIntegrations
     core <- restore (NativeProcess.newNativeProcessRuntimeWithMcpHooks
         MCP.defaultMcpHostHooks
-        root) `onException` closeIntegrationSupervisor integrations
+        root) `onException` (closeIntegrationSupervisor integrations
+            `finally` closeIntegrationSupervisor localIntegrations)
     pure NativeProcessRuntime
         { nativeProcessCore = core
         , nativeIntegrationSupervisor = integrations
+        , nativeLocalIntegrationSupervisor = localIntegrations
         }
 
 closeNativeProcessRuntime :: NativeProcessRuntime -> IO ()
@@ -119,6 +134,7 @@ closeNativeProcessRuntime runtime =
     NativeProcess.closeNativeProcessRuntime runtime.nativeProcessCore
         `finally`
             closeIntegrationSupervisor runtime.nativeIntegrationSupervisor
+                `finally` closeIntegrationSupervisor runtime.nativeLocalIntegrationSupervisor
 
 restartNativeMcpRuntime :: NativeProcessRuntime -> IO ()
 restartNativeMcpRuntime runtime =
@@ -129,6 +145,14 @@ nativeProcessIntegrationSupervisor
     :: NativeProcessRuntime
     -> IntegrationSupervisor
 nativeProcessIntegrationSupervisor = (.nativeIntegrationSupervisor)
+
+-- | Native account administration is always device-local. It neither changes
+-- the turn's authority nor acquires/exposes local tools to organization turns.
+acquireNativeLocalIntegrationRuntime
+    :: NativeProcessRuntime -> IO (Either Text IntegrationRuntime)
+acquireNativeLocalIntegrationRuntime runtime =
+    acquireIntegrationRuntime runtime.nativeLocalIntegrationSupervisor
+        LocalIntegrationAuthority
 
 -- | Execute one typed native turn without reconstructing command-line
 -- arguments.

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs
@@ -8,7 +8,7 @@ import Agent.CLI.Config
     ( HarnessConfig(..), McpServerConfig(..)
     , mcpServersForRuntime, useProgressiveMcp )
 import Agent.CLI.FileUri (fileUri)
-import Agent.CLI.IntegrationGateway (availableIntegrationServerName)
+import Agent.CLI.IntegrationGateway (integrationEndpointServers)
 import Agent.CLI.McpElicitation (cliMcpElicitation)
 import Agent.CLI.McpOAuthStore (mcpOAuthStorePath)
 import Agent.CLI.McpStatus
@@ -27,7 +27,7 @@ import Agent.CLI.Session.Runtime.Types (StartupRuntime(..))
 import Agent.CLI.Startup.Auth (setStartupNotice, startupDie)
 import Agent.CLI.TUI.App (emitUiEvent)
 import Agent.Integration.API
-    (IntegrationRuntime(..), IntegrationEndpoint(..))
+    (IntegrationRuntime(..))
 import Agent.Loop (TurnInput(..))
 import qualified Agent.MCP as MCP
 import Agent.OsPath (unsafeToFilePath)
@@ -38,7 +38,6 @@ import Control.Exception.Safe
 import Control.Monad (forM_, unless, when)
 import Data.IORef (atomicModifyIORef', newIORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -99,6 +98,7 @@ mcpConfiguration AgentToolsRequest
             , MCP.mcpServerRootsEnabled = config.mcpRoots
             , MCP.mcpServerSamplingEnabled = config.mcpSampling
             , MCP.mcpServerLogLevel = config.mcpLogLevel
+            , MCP.mcpServerExcludedTools = []
             }
         | (label, config) <-
             mcpServersForRuntime
@@ -133,30 +133,12 @@ acquireMcpRuntime request@AgentToolsRequest
     } integrationRuntime = do
     let (configuredServers, configuredProgressive) =
             mcpConfiguration request toolStartup
-        integrationServerName =
-            availableIntegrationServerName
-                [ serverName
-                | MCP.McpServerConfig
-                    { MCP.mcpServerName = serverName
-                    } <- configuredServers
-                ]
-        remoteServers =
-            [ config { MCP.mcpServerName = integrationServerName }
-            | runtime <- maybeToList integrationRuntime
-            , config <- case integrationRuntimeEndpoint runtime of
-                RemoteIntegrationEndpoint config -> [config]
-                CombinedIntegrationEndpoint config _ -> [config]
-                _ -> []]
-        localIntegrationServerName =
-            availableIntegrationServerName
-                (map (.mcpServerName) (configuredServers <> remoteServers))
+        (remoteServers, localServers) = maybe ([], [])
+            (integrationEndpointServers (map (.mcpServerName) configuredServers)
+                . integrationRuntimeEndpoint)
+            integrationRuntime
         inMemoryServers =
-            [(integrationsMcpConfig localIntegrationServerName, server)
-            | runtime <- maybeToList integrationRuntime
-            , server <- case integrationRuntimeEndpoint runtime of
-                LocalIntegrationEndpoint server -> [server]
-                CombinedIntegrationEndpoint _ server -> [server]
-                _ -> []]
+            [(integrationsMcpConfig name, server) | (name, server) <- localServers]
         -- Include the in-memory name in the reported configuration too: callers
         -- use this list to decide whether MCP tools exist at all.
         runtimeMcpServerConfigs = configuredServers <> remoteServers
@@ -300,4 +282,5 @@ integrationsMcpConfig serverName = MCP.McpServerConfig
     , MCP.mcpServerRootsEnabled = False
     , MCP.mcpServerSamplingEnabled = False
     , MCP.mcpServerLogLevel = Nothing
+    , MCP.mcpServerExcludedTools = []
     }

--- a/packages/agent-cli/test/Agent/CLI/IntegrationGatewaySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/IntegrationGatewaySpec.hs
@@ -2,12 +2,37 @@ module Agent.CLI.IntegrationGatewaySpec (spec) where
 
 import Agent.CLI.GatewayClient (GatewayCredential(..))
 import Agent.CLI.IntegrationGateway
-    (availableIntegrationServerName, gatewayIntegrationMcpConfig)
-import Agent.MCP (McpServerConfig(..))
+    (availableIntegrationServerName, gatewayIntegrationMcpConfig, integrationEndpointServers)
+import Agent.Integration.API (IntegrationEndpoint(..))
+import Agent.MCP (McpServerConfig(..), McpToolServer(..))
 import Test.Hspec
 
 spec :: Spec
 spec = describe "generic gateway integrations" do
+    it "gives explicit device tools the canonical namespace and excludes only reserved remote names" do
+        let config = gatewayIntegrationMcpConfig
+                (GatewayCredential "https://gateway.example" "wss://gateway.example/ws" "token")
+            endpoint = McpToolServer
+                { toolServerInitialize = ioError (userError "not used by namespace test")
+                , toolServerListTools = pure (Right [])
+                , toolServerCallTool = \_ -> ioError (userError "not used by namespace test")
+                , toolServerSubscribe = \_ -> pure (pure ())
+                }
+            (remote, local) = integrationEndpointServers []
+                (CombinedOverlayIntegrationEndpoint config ["device_lookup"] endpoint)
+        map (.mcpServerName) remote `shouldBe` ["integrations-2"]
+        map (.mcpServerExcludedTools) remote `shouldBe` [["device_lookup"]]
+        map fst local `shouldBe` ["integrations"]
+        let (plainRemote, plainLocal) = integrationEndpointServers []
+                (CombinedIntegrationEndpoint config endpoint)
+        map (.mcpServerName) plainRemote `shouldBe` ["integrations"]
+        map (.mcpServerExcludedTools) plainRemote `shouldBe` [[]]
+        map fst plainLocal `shouldBe` ["integrations-2"]
+        let (collisionRemote, collisionLocal) = integrationEndpointServers ["integrations"]
+                (CombinedOverlayIntegrationEndpoint config ["device_lookup"] endpoint)
+        map (.mcpServerName) collisionRemote `shouldBe` ["integrations-3"]
+        map fst collisionLocal `shouldBe` ["integrations-2"]
+
     it "uses the aggregate endpoint and keeps credentials out of URLs and Show" do
         let config = gatewayIntegrationMcpConfig GatewayCredential
                 { gatewayBaseUrl = "https://gateway.example/"

--- a/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
@@ -11,7 +11,21 @@ import Agent.CLI.NativeRuntime
     , nativePreparedDiscovery
     , nativeTurnOptions
     , applyNativeStartupPolicy
+    , newNativeProcessRuntimeWithOrganizationIntegrations
+    , closeNativeProcessRuntime
+    , nativeProcessIntegrationSupervisor
+    , acquireNativeLocalIntegrationRuntime
+    , restartNativeMcpRuntime
     )
+import Agent.Integration.API
+import Agent.Json (rawJsonFromEncoding)
+import qualified Data.Aeson as Aeson
+import Data.IORef
+import Data.Text (Text)
+import Control.Exception.Safe (bracket)
+import System.IO.Temp (withSystemTempDirectory)
+import Agent.CLI.GatewayClient (GatewayCredential(..))
+import Agent.CLI.IntegrationGateway (gatewayIntegrationMcpConfig)
 import Agent.CLI.Options
     ( CliOptions(..)
     , ScreenMode(..)
@@ -29,6 +43,74 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "nativeTurnOptions" do
+    it "keeps local account administration separate from organization connections" $
+        withSystemTempDirectory "native-local-admin" \root -> do
+            localStarts <- newIORef (0 :: Int)
+            localCloses <- newIORef (0 :: Int)
+            organizationStarts <- newIORef (0 :: Int)
+            organizationCloses <- newIORef (0 :: Int)
+            let payload = rawJsonFromEncoding (Aeson.toEncoding ([] :: [Aeson.Value]))
+                provider :: IORef Int -> IORef Int -> Text -> IntegrationProvider
+                provider starts closes label _ = do
+                    modifyIORef' starts (+ 1)
+                    pure (Right IntegrationRuntime
+                        { integrationRuntimeEndpoint = NoIntegrationEndpoint
+                        , integrationRuntimeAdminDefinitions = payload
+                        , callIntegrationRuntimeAdmin = \_ _ ->
+                            pure (Left (IntegrationUnavailable label))
+                        , integrationRuntimeConnections = Nothing
+                        , closeIntegrationRuntime = modifyIORef' closes (+ 1)
+                        })
+                localProvider env = do
+                    runtime <- provider localStarts localCloses "local mail" env
+                        >>= shouldReturnRight
+                    operations <- newIORef ([] :: [Text])
+                    pure (Right runtime
+                        { callIntegrationRuntimeAdmin = \name _ -> do
+                            modifyIORef' operations (<> [name])
+                            Right . rawJsonFromEncoding . Aeson.toEncoding
+                                <$> readIORef operations
+                        })
+                operationResult names = Right
+                    (rawJsonFromEncoding (Aeson.toEncoding (names :: [Text])))
+                organizationProvider _ = provider organizationStarts organizationCloses "banking"
+                config = gatewayIntegrationMcpConfig GatewayCredential
+                    { gatewayBaseUrl = "https://gateway.example"
+                    , gatewayWebSocketUrl = "wss://gateway.example/ws"
+                    , gatewayAccessToken = "fixture-token"
+                    }
+            bracket
+                (newNativeProcessRuntimeWithOrganizationIntegrations localProvider
+                    (Just organizationProvider) (unsafeEncodeUtf root))
+                closeNativeProcessRuntime \process -> do
+                    let supervisor = nativeProcessIntegrationSupervisor process
+                        acquire authority = acquireIntegrationRuntime supervisor authority
+                            >>= shouldReturnRight
+                    bank <- acquire (OrganizationIntegrationAuthority config)
+                    readIORef localStarts `shouldReturn` 0
+                    mail <- acquireNativeLocalIntegrationRuntime process >>= shouldReturnRight
+                    callIntegrationRuntimeAdmin mail "email.oauth.start" payload
+                        `shouldReturn` operationResult ["email.oauth.start"]
+                    callIntegrationRuntimeAdmin bank "email.oauth.start" payload
+                        `shouldReturn` Left (IntegrationUnavailable "banking")
+                    readIORef organizationCloses `shouldReturn` 0
+                    _ <- acquire LocalIntegrationAuthority
+                    readIORef localStarts `shouldReturn` 1
+                    readIORef organizationCloses `shouldReturn` 1
+                    _ <- acquire (OrganizationIntegrationAuthority config)
+                    readIORef localCloses `shouldReturn` 0
+                    restartNativeMcpRuntime process
+                    resumedMail <- acquireNativeLocalIntegrationRuntime process >>= shouldReturnRight
+                    callIntegrationRuntimeAdmin resumedMail "email.oauth.poll" payload
+                        `shouldReturn` operationResult ["email.oauth.start", "email.oauth.poll"]
+                    callIntegrationRuntimeAdmin resumedMail "email.oauth.cancel" payload
+                        `shouldReturn` operationResult
+                            ["email.oauth.start", "email.oauth.poll", "email.oauth.cancel"]
+                    readIORef localStarts `shouldReturn` 1
+                    readIORef localCloses `shouldReturn` 0
+            readIORef localCloses `shouldReturn` 1
+            readIORef organizationCloses `shouldReturn` 2
+
     it "preserves legacy host startup options exactly" do
         applyNativeStartupPolicy hostNativeStartupPolicy
             (unsafeEncodeUtf "/admitted") conflictingOptions

--- a/packages/agent-integration-api/src/Agent/Integration/API.hs
+++ b/packages/agent-integration-api/src/Agent/Integration/API.hs
@@ -41,6 +41,10 @@ data IntegrationEndpoint
     | LocalIntegrationEndpoint !McpToolServer
     | RemoteIntegrationEndpoint !McpServerConfig
     | CombinedIntegrationEndpoint !McpServerConfig !McpToolServer
+    -- | Explicit distribution ownership of exact tools, never a fallback.
+    -- Reserved names stay local even when currently unavailable.
+    | LocalOverlayIntegrationEndpoint ![Text] !McpToolServer
+    | CombinedOverlayIntegrationEndpoint !McpServerConfig ![Text] !McpToolServer
 
 data IntegrationRuntime = IntegrationRuntime
     { integrationRuntimeEndpoint :: !IntegrationEndpoint
@@ -145,6 +149,8 @@ acquireIntegrationRuntime supervisor authority =
                                 { integrationRuntimeEndpoint = RemoteIntegrationEndpoint config })
                             LocalIntegrationEndpoint server -> pure (Right runtime
                                 { integrationRuntimeEndpoint = CombinedIntegrationEndpoint config server })
+                            LocalOverlayIntegrationEndpoint names server -> pure (Right runtime
+                                { integrationRuntimeEndpoint = CombinedOverlayIntegrationEndpoint config names server })
                             _ -> do
                                 closeIntegrationRuntime runtime
                                 pure (Left "Organization-local providers must not supply remote endpoints.")

--- a/packages/agent-integration-api/test/Spec.hs
+++ b/packages/agent-integration-api/test/Spec.hs
@@ -14,6 +14,26 @@ import Test.Hspec
 main :: IO ()
 main = hspec do
     describe "provider-neutral integration ownership" do
+        it "retains explicit exact device ownership without acquiring the ordinary provider" $
+            withEnvironment \env -> do
+                let provider _ toolEnv = fmap (fmap (\runtime -> runtime
+                        { integrationRuntimeEndpoint =
+                            LocalOverlayIntegrationEndpoint ["device_lookup"] testServer }))
+                        (emptyIntegrationProvider toolEnv)
+                bracket
+                    (newIntegrationSupervisorWithOrganizationProvider
+                        (\_ -> expectationFailure "ordinary provider invoked" >> emptyIntegrationProvider env)
+                        (Just provider) env)
+                    closeIntegrationSupervisor \supervisor -> do
+                        acquired <- acquireIntegrationRuntime supervisor
+                            (OrganizationIntegrationAuthority remoteConfig)
+                        case acquired of
+                            Right runtime -> case integrationRuntimeEndpoint runtime of
+                                CombinedOverlayIntegrationEndpoint config names _ -> do
+                                    config `shouldBe` remoteConfig
+                                    names `shouldBe` ["device_lookup"]
+                                _ -> expectationFailure "expected explicit device overlay"
+                            Left _ -> expectationFailure "overlay unavailable"
         it "never acquires a local provider for an organization authority" $
             withEnvironment \env ->
                 bracket
@@ -214,4 +234,5 @@ remoteConfig = McpServerConfig
     , mcpServerRootsEnabled = False
     , mcpServerSamplingEnabled = False
     , mcpServerLogLevel = Nothing
+    , mcpServerExcludedTools = []
     }

--- a/packages/agent-mail/agent-mail.cabal
+++ b/packages/agent-mail/agent-mail.cabal
@@ -73,5 +73,6 @@ test-suite agent-mail-test
         , aeson
         , base
         , hspec >= 2.11 && < 2.12
+        , http-types
         , text
         , time

--- a/packages/agent-mail/package.nix
+++ b/packages/agent-mail/package.nix
@@ -12,7 +12,7 @@ mkDerivation {
     crypton-connection http-client http-client-tls http-types network
     safe-exceptions tagsoup text time tls
   ];
-  testHaskellDepends = [ aeson base hspec text time ];
+  testHaskellDepends = [ aeson base hspec http-types text time ];
   description = "Low-level email types and provider transports";
   license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/agent-mail/src/Agent/Mail/OAuth.hs
+++ b/packages/agent-mail/src/Agent/Mail/OAuth.hs
@@ -14,6 +14,7 @@ module Agent.Mail.OAuth
     , exchangeMailOAuthCode
     , refreshMailOAuthToken
     , resolveMailOAuthMailbox
+    , decodeMailOAuthMailboxResponse
     ) where
 
 import Agent.Mail.Types (MailProvider(..))
@@ -315,6 +316,7 @@ resolveMailOAuthMailbox manager provider accessToken =
         GmailProvider ->
             getJson
                 manager
+                provider
                 accessToken
                 "https://gmail.googleapis.com/gmail/v1/users/me/profile"
                 >>= \case
@@ -338,11 +340,13 @@ resolveMailOAuthMailbox manager provider accessToken =
             identity <-
                 getJson
                     manager
+                    provider
                     accessToken
                     "https://graph.microsoft.com/v1.0/me?$select=mail,userPrincipalName,displayName"
             mailboxProbe <-
                 getJson
                     manager
+                    provider
                     accessToken
                     "https://graph.microsoft.com/v1.0/me/messages?$top=1&$select=id"
             pure do
@@ -378,10 +382,11 @@ resolveMailOAuthMailbox manager provider accessToken =
 
 getJson
     :: Manager
+    -> MailProvider
     -> Text
     -> Text
     -> IO (Either Text Aeson.Value)
-getJson manager accessToken rawUrl = do
+getJson manager provider accessToken rawUrl = do
     parsed <- tryAny (parseRequest (Text.unpack rawUrl))
     case parsed of
         Left _ -> pure (Left oauthUnavailable)
@@ -408,15 +413,44 @@ getJson manager accessToken rawUrl = do
                         pure (response.responseStatus, body)
             pure case attempted of
                 Left _ -> Left oauthUnavailable
-                Right (status, body)
-                    | not (statusIsSuccessful status) ->
-                        Left invalidMailboxIdentity
-                    | otherwise -> do
-                        bytes <- body
-                        either
-                            (const (Left invalidMailboxIdentity))
-                            Right
-                            (Aeson.eitherDecodeStrict' bytes)
+                Right (status, body) ->
+                    body >>= decodeMailOAuthMailboxResponse provider status
+
+-- | Decode a bounded mailbox response without exposing provider messages,
+-- request identifiers, or credential material in diagnostics.
+decodeMailOAuthMailboxResponse
+    :: MailProvider
+    -> Status
+    -> BS.ByteString
+    -> Either Text Aeson.Value
+decodeMailOAuthMailboxResponse provider status bytes
+    | statusIsSuccessful status =
+        either (const (Left invalidMailboxIdentity)) Right decoded
+    | provider /= MicrosoftProvider = Left invalidMailboxIdentity
+    | statusCode status == 429 =
+        Left "Microsoft is limiting mailbox requests. Please wait and try connecting again."
+    | statusCode status >= 500 =
+        Left "Microsoft mailbox services are temporarily unavailable. Please try again later."
+    | statusCode status == 401 =
+        Left "Microsoft rejected the mailbox authorization. Please reconnect and select the intended account."
+    | graphCode `elem`
+        [ Just "MailboxNotEnabledForRESTAPI"
+        , Just "MailboxNotSupportedForRESTAPI"
+        , Just "ErrorMailboxNotEnabledForRESTAPI"
+        ] =
+        Left "The selected Microsoft account does not have a supported Outlook mailbox. Select another account, or ask your Microsoft 365 administrator to enable its mailbox."
+    | statusCode status == 403 =
+        Left "Microsoft denied access to this mailbox. Reconnect and grant the requested mail permissions; for a work account, ask your administrator to check consent and access policies."
+    | otherwise =
+        Left "Microsoft could not verify this mailbox. Check that the selected account can open mail in Outlook on the web, then try connecting again."
+  where
+    decoded = Aeson.eitherDecodeStrict' bytes
+    graphCode :: Maybe Text
+    graphCode = either (const Nothing)
+        (parseMaybe (Aeson.withObject "Graph error" \value -> do
+            detail <- value .: "error"
+            Aeson.withObject "Graph error detail" (.: "code") detail))
+        decoded
 
 authorizationEndpoint :: MailProvider -> Text
 authorizationEndpoint = \case
@@ -436,7 +470,7 @@ tokenEndpoint = \case
 providerExtras :: MailProvider -> Text
 providerExtras GmailProvider =
     "&access_type=offline&prompt=consent"
-providerExtras MicrosoftProvider = ""
+providerExtras MicrosoftProvider = "&prompt=select_account"
 providerExtras ImapProvider = ""
 
 readOAuthBody

--- a/packages/agent-mail/src/Agent/Mail/SecretCodec.hs
+++ b/packages/agent-mail/src/Agent/Mail/SecretCodec.hs
@@ -30,6 +30,7 @@ mailSecretStorageValue = \case
         , mailOAuthRefreshToken
         , mailOAuthExpiresAt
         , mailOAuthScopes
+        , mailOAuthClientSecret
         } ->
             object
                 [ "id" .= mailSecretAccountId
@@ -38,6 +39,7 @@ mailSecretStorageValue = \case
                 , "refresh_token" .= mailOAuthRefreshToken
                 , "expires_at" .= mailOAuthExpiresAt
                 , "scopes" .= mailOAuthScopes
+                , "client_secret" .= mailOAuthClientSecret
                 ]
     MailImapSecret
         { mailSecretAccountId
@@ -60,6 +62,7 @@ parseMailSecretStorageValue = withObject "MailSecret" \value -> do
                 <*> value .:? "refresh_token"
                 <*> value .:? "expires_at"
                 <*> value .:? "scopes" .!= []
+                <*> value .:? "client_secret"
         "imap_password" ->
             MailImapSecret
                 <$> value .: "id"

--- a/packages/agent-mail/src/Agent/Mail/Types.hs
+++ b/packages/agent-mail/src/Agent/Mail/Types.hs
@@ -272,6 +272,8 @@ data MailSecret
         , mailOAuthRefreshToken :: !(Maybe Text)
         , mailOAuthExpiresAt :: !(Maybe UTCTime)
         , mailOAuthScopes :: ![Text]
+        -- | Optional installed-client parameter retained for token refresh.
+        , mailOAuthClientSecret :: !(Maybe Text)
         }
     | MailImapSecret
         { mailSecretAccountId :: !Text

--- a/packages/agent-mail/test/Spec.hs
+++ b/packages/agent-mail/test/Spec.hs
@@ -6,6 +6,7 @@ import Agent.Mail.OAuth
 import Agent.Mail.SecretCodec
 import Agent.Mail.Transport
 import Agent.Mail.Types
+import qualified Agent.Mail.Types as MailTypes
 import Data.Aeson (Result(..), Value(..), object, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -99,6 +100,32 @@ main = hspec do
                 `shouldContain` ["Mail.Send"]
 
     describe "explicit secret storage codec" do
+        it "round trips the installed OAuth client parameter without exposing it in Show" do
+            let secret = (validOAuthCredential "account-1").mailCredentialSecret
+                    { MailTypes.mailOAuthClientSecret = Just "synthetic-desktop-parameter" }
+            AesonTypes.parseEither
+                parseMailSecretStorageValue
+                (mailSecretStorageValue secret)
+                `shouldBe` Right secret
+            show secret `shouldNotContain` "synthetic-desktop-parameter"
+            show secret `shouldNotContain` "access-token"
+            show secret `shouldNotContain` "refresh-token"
+
+        it "reads existing OAuth credentials without a client parameter" do
+            let secret = (validOAuthCredential "account-1").mailCredentialSecret
+                legacy = case mailSecretStorageValue secret of
+                    Object value -> Object (KeyMap.delete "client_secret" value)
+                    value -> value
+            AesonTypes.parseEither parseMailSecretStorageValue legacy
+                `shouldBe` Right secret
+
+        it "round trips OAuth credentials with no installed client parameter" do
+            let secret = (validOAuthCredential "account-1").mailCredentialSecret
+            AesonTypes.parseEither
+                parseMailSecretStorageValue
+                (mailSecretStorageValue secret)
+                `shouldBe` Right secret
+
         it "round trips only through the opt-in codec and redacts Show" do
             let secret = MailImapSecret
                     { mailSecretAccountId = "account-1"
@@ -479,6 +506,7 @@ validOAuthCredential accountId = MailCredential
         , mailOAuthExpiresAt = Nothing
         , mailOAuthScopes =
             ["https://www.googleapis.com/auth/gmail.readonly"]
+        , mailOAuthClientSecret = Nothing
         }
     }
 

--- a/packages/agent-mail/test/Spec.hs
+++ b/packages/agent-mail/test/Spec.hs
@@ -16,6 +16,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time (UTCTime(..), fromGregorian)
+import Network.HTTP.Types (mkStatus)
 import Test.Hspec
 
 main :: IO ()
@@ -89,6 +90,19 @@ main = hspec do
                     Success _ -> False
 
     describe "OAuth PKCE" do
+        it "requests Microsoft account selection without changing Google consent or PKCE" do
+            let url provider = mailOAuthAuthorizationUrl
+                    (MailOAuthClient provider "client" Nothing "http://localhost:54321")
+                    "state" "verifier"
+            url MicrosoftProvider `shouldSatisfy`
+                either (const False) (\value ->
+                    "prompt=select_account" `Text.isInfixOf` value
+                    && "code_challenge_method=S256" `Text.isInfixOf` value)
+            url GmailProvider `shouldSatisfy`
+                either (const False) (\value ->
+                    "prompt=consent" `Text.isInfixOf` value
+                    && not ("select_account" `Text.isInfixOf` value))
+
         it "matches the RFC 7636 S256 example" do
             mailOAuthPkceChallenge
                 "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
@@ -98,6 +112,34 @@ main = hspec do
         it "requests the Microsoft permission needed to send approved drafts" do
             Text.words (mailOAuthScopes MicrosoftProvider)
                 `shouldContain` ["Mail.Send"]
+
+    describe "Microsoft mailbox response diagnostics" do
+        let decode status = decodeMailOAuthMailboxResponse MicrosoftProvider
+                (mkStatus status "")
+            diagnosticContains expected result =
+                result `shouldSatisfy` either (Text.isInfixOf expected) (const False)
+        it "decodes successful profile responses" do
+            decode 200 "{\"mail\":\"person@example.com\"}" `shouldBe`
+                Right (object ["mail" .= ("person@example.com" :: Text)])
+        it "identifies unsupported mailboxes without exposing provider details" do
+            let result = decode 404 "{\"error\":{\"code\":\"MailboxNotEnabledForRESTAPI\",\"message\":\"private-provider-detail\"}}"
+            diagnosticContains "does not have a supported Outlook mailbox" result
+            show result `shouldNotContain` "private-provider-detail"
+        it "distinguishes authorization and permission failures" do
+            diagnosticContains "rejected the mailbox authorization" (decode 401 "{}")
+            diagnosticContains "consent and access policies" (decode 403 "{}")
+        it "distinguishes throttling and service failures even with non-JSON bodies" do
+            diagnosticContains "limiting mailbox requests" (decode 429 "private-body")
+            diagnosticContains "temporarily unavailable" (decode 503 "private-body")
+        it "does not expose unknown provider errors or malformed successful responses" do
+            let result = decode 400 "{\"error\":{\"code\":\"Unknown\",\"message\":\"private-detail\"}}"
+            diagnosticContains "could not verify this mailbox" result
+            show result `shouldNotContain` "private-detail"
+            decode 200 "private-invalid-json" `shouldSatisfy` either
+                (not . Text.isInfixOf "private-invalid-json") (const False)
+        it "preserves Gmail diagnostics" do
+            decodeMailOAuthMailboxResponse GmailProvider (mkStatus 403 "") "{}"
+                `shouldBe` Left "Mail provider did not return a usable mailbox identity."
 
     describe "explicit secret storage codec" do
         it "round trips the installed OAuth client parameter without exposing it in Show" do

--- a/packages/agent-mcp/benchmark/McpStartup.hs
+++ b/packages/agent-mcp/benchmark/McpStartup.hs
@@ -190,6 +190,7 @@ fakeConfig script delayMillis index = McpServerConfig
     , mcpServerRootsEnabled = False
     , mcpServerSamplingEnabled = False
     , mcpServerLogLevel = Nothing
+    , mcpServerExcludedTools = []
     }
 
 withFakeServer :: (FilePath -> IO a) -> IO a

--- a/packages/agent-mcp/src/Agent/MCP/Client/Internal/Operations.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Client/Internal/Operations.hs
@@ -47,7 +47,7 @@ import Agent.MCP.Types
       McpError(..),
       McpServerCapabilities(capabilitySkills),
       McpServerInfo(serverInfoCapabilities),
-      McpServerConfig(mcpServerName),
+      McpServerConfig(mcpServerName, mcpServerExcludedTools),
       renderMcpError,
       mcpSkillEntryDecoder,
       mcpResourceContentDecoder,
@@ -156,6 +156,7 @@ discoverMcpTools client = do
         annotated =
             [ (tool.discoveredName, annotateHeaderParams isHttp tool)
             | tool <- tools
+            , tool.discoveredName `notElem` client.clientConfig.mcpServerExcludedTools
             ]
         accepted = [tool | (_, Right tool) <- annotated]
         warnings =
@@ -648,6 +649,9 @@ callDiscoveredToolWith
     -> RawJson
     -> Maybe (McpProgress -> IO ())
     -> IO (Either Text Text)
+callDiscoveredToolWith _ client tool _ _
+    | tool.discoveredName `elem` client.clientConfig.mcpServerExcludedTools =
+        pure (Left "This tool is owned by another integration endpoint.")
 callDiscoveredToolWith artifactDirectory client tool arguments _
     | McpClientInMemory server _ <- client.clientTransport = do
         state <- readTVarIO client.clientLifecycle

--- a/packages/agent-mcp/src/Agent/MCP/Types.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Types.hs
@@ -211,6 +211,9 @@ data McpServerConfig = McpServerConfig
     , mcpServerRootsEnabled :: !Bool
     , mcpServerSamplingEnabled :: !Bool
     , mcpServerLogLevel :: !(Maybe McpLogLevel)
+    -- | Host-owned exact tool exclusions, applied to discovery and dispatch.
+    -- They remain part of configuration identity across reconnects.
+    , mcpServerExcludedTools :: ![Text]
     } deriving (Eq)
 
 instance Show McpServerConfig where
@@ -235,6 +238,7 @@ instance Show McpServerConfig where
             <> show config.mcpServerSamplingEnabled
             <> ", mcpServerLogLevel = "
             <> show config.mcpServerLogLevel
+            <> ", mcpServerExcludedTools = " <> show config.mcpServerExcludedTools
             <> " }"
 
 -- | Host-provided integration points shared by every server in a fleet.

--- a/packages/agent-mcp/test/Agent/MCP/InProcessSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCP/InProcessSpec.hs
@@ -60,6 +60,39 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "in-process MCP server" do
+    it "reserves exact tools at discovery and dispatch without blocking other tools" do
+        adapter <- testServer (const (pure (Right True))) [echoTool]
+        let base = inProcessMcpToolServer adapter
+        Right [reserved] <- base.toolServerListTools
+        calls <- newIORef []
+        let ordinary = reserved { discoveredName = "ordinary" }
+            endpoint = base
+                { toolServerListTools = pure (Right [reserved, ordinary])
+                , toolServerCallTool = \request -> do
+                    modifyIORef' calls (<> [request.callToolName])
+                    pure (Right (McpCallToolResult False ["remote"] Nothing))
+                }
+            config = memoryConfig { mcpServerExcludedTools = ["echo"] }
+            arguments = rawJsonFromEncoding (toEncoding (object []))
+        bracket (startInMemoryMcpClient defaultMcpHostHooks config endpoint)
+            closeMcpClient \client -> do
+                ready <- ensureMcpClientReady client
+                fmap (map (.discoveredName) . fst) ready `shouldBe` Right ["ordinary"]
+                callDiscoveredTool client reserved arguments `shouldReturn`
+                    Left "This tool is owned by another integration endpoint."
+                callDiscoveredTool client ordinary arguments `shouldReturn` Right "remote"
+                readIORef calls `shouldReturn` ["ordinary"]
+        -- A replacement client retains the same host exclusion policy.
+        bracket (startInMemoryMcpClient defaultMcpHostHooks config endpoint)
+            closeMcpClient \client -> do
+                ready <- ensureMcpClientReady client
+                fmap (map (.discoveredName) . fst) ready `shouldBe` Right ["ordinary"]
+        -- No opt-in preserves the complete catalog.
+        bracket (startInMemoryMcpClient defaultMcpHostHooks memoryConfig endpoint)
+            closeMcpClient \client -> do
+                ready <- ensureMcpClientReady client
+                fmap (map (.discoveredName) . fst) ready `shouldBe` Right ["echo", "ordinary"]
+
     it "connects a typed endpoint without launching the configured command" do
         adapter <- testServer (const (pure (Right True))) [echoTool]
         let endpoint = inProcessMcpToolServer adapter
@@ -410,6 +443,7 @@ memoryConfig = McpServerConfig
     , mcpServerRootsEnabled = False
     , mcpServerSamplingEnabled = False
     , mcpServerLogLevel = Nothing
+    , mcpServerExcludedTools = []
     }
 
 echoTool :: AppTool

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -230,6 +230,7 @@ spec = describe "Agent.MCP" do
                 , mcpServerRootsEnabled = False
                 , mcpServerSamplingEnabled = False
                 , mcpServerLogLevel = Nothing
+                , mcpServerExcludedTools = []
                 }
         rendered `shouldContain` "API_TOKEN"
         rendered `shouldContain` "<redacted>"
@@ -593,6 +594,7 @@ spec = describe "Agent.MCP" do
                     , mcpServerRootsEnabled = True
                     , mcpServerSamplingEnabled = True
                     , mcpServerLogLevel = Nothing
+                    , mcpServerExcludedTools = []
                     }
                 ]
             bracket (pure fleet) closeMcpFleet \_ -> do
@@ -1149,6 +1151,7 @@ spec = describe "Agent.MCP" do
                     { mcpServerArgs = [log]
                     , mcpServerProtocol = McpProtocolLegacy
                     , mcpServerLogLevel = Just McpLogWarning
+                    , mcpServerExcludedTools = []
                     }
             fleet <- startMcpFleetWithProgressHooks hooks (const (pure ())) [config]
             bracket (pure fleet) closeMcpFleet \_ -> do
@@ -1186,6 +1189,7 @@ spec = describe "Agent.MCP" do
                     , mcpServerRootsEnabled = False
                     , mcpServerSamplingEnabled = False
                     , mcpServerLogLevel = Nothing
+                    , mcpServerExcludedTools = []
                     }
             fleet <- startMcpFleetWithProgressHooks hooks (const (pure ())) [config]
             bracket (pure fleet) closeMcpFleet \_ -> do
@@ -2027,6 +2031,7 @@ concurrentConfig script barrier name = McpServerConfig
     , mcpServerRootsEnabled = True
     , mcpServerSamplingEnabled = True
     , mcpServerLogLevel = Nothing
+    , mcpServerExcludedTools = []
     }
 
 data WorkerLifecycleOperation
@@ -2079,6 +2084,7 @@ baseConfig name command = McpServerConfig
     , mcpServerRootsEnabled = True
     , mcpServerSamplingEnabled = True
     , mcpServerLogLevel = Nothing
+    , mcpServerExcludedTools = []
     }
 
 withConcurrentFakeServer :: (FilePath -> FilePath -> IO a) -> IO a

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineLifecycle.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineLifecycle.hs
@@ -17,6 +17,7 @@ import Agent.CLI.MacOS.McpAdminBridge (invokeMcpResultCallback)
 import Agent.CLI.MacOS.NativeSupervisor
     ( newIntegrationWorkerRegistry
     , shutdownIntegrationWorkers
+    , shutdownOrganizationIntegrationWorkers
     , shutdownRunningTurns
     , supervisorLoop
     )
@@ -66,7 +67,7 @@ workerLifecycle
                     `finally` closeEngineStore store
         bracket
             (registerGatewayCredentialInvalidator
-                (shutdownIntegrationWorkers integrationWorkers
+                (shutdownOrganizationIntegrationWorkers integrationWorkers
                     `finally` restartNativeMcpRuntime processRuntime)
                 `onException` closeResources)
             (\unregister -> unregister `finally` closeResources)

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
@@ -3,11 +3,14 @@
 module Agent.CLI.MacOS.NativeSupervisor
     ( IntegrationWorkerRegistry
     , launchIntegrationWorkerWith
+    , launchLocalIntegrationWorkerWith
     , completeBoundaryChecked
     , newIntegrationWorkerRegistry
     , shutdownIntegrationWorkers
+    , shutdownOrganizationIntegrationWorkers
     , supervisorLoop
     , shutdownRunningTurns
+    , runIntegrationAdmin
     ) where
 
 import Agent.CLI.MacOS.AgentSnapshot (activeAgentSnapshot)
@@ -47,6 +50,7 @@ import Agent.CLI.McpAdmin
 import Agent.CLI.NativeRuntime
     ( NativeProcessRuntime
     , nativeProcessIntegrationSupervisor
+    , acquireNativeLocalIntegrationRuntime
     , restartNativeMcpRuntime
     )
 import Agent.CLI.IntegrationGateway (gatewayIntegrationAuthority)
@@ -96,6 +100,7 @@ import System.OsPath (OsPath)
 data IntegrationWorkerRegistry = IntegrationWorkerRegistry
     { integrationWorkerNextId :: !(TVar Word64)
     , integrationWorkers :: !(TVar (Map Word64 (Async ())))
+    , localIntegrationWorkers :: !(TVar (Map Word64 (Async ())))
     }
 
 newIntegrationWorkerRegistry :: IO IntegrationWorkerRegistry
@@ -103,12 +108,24 @@ newIntegrationWorkerRegistry =
     IntegrationWorkerRegistry
         <$> newTVarIO 0
         <*> newTVarIO Map.empty
+        <*> newTVarIO Map.empty
 
 shutdownIntegrationWorkers :: IntegrationWorkerRegistry -> IO ()
-shutdownIntegrationWorkers registry = do
+shutdownIntegrationWorkers registry =
+    shutdownOrganizationIntegrationWorkers registry
+        `finally` shutdownWorkerMap registry.localIntegrationWorkers
+
+-- | Credential replacement retires organization callbacks, never device-local
+-- account administration. Both domains are still joined at engine shutdown.
+shutdownOrganizationIntegrationWorkers :: IntegrationWorkerRegistry -> IO ()
+shutdownOrganizationIntegrationWorkers registry =
+    shutdownWorkerMap registry.integrationWorkers
+
+shutdownWorkerMap :: TVar (Map Word64 (Async ())) -> IO ()
+shutdownWorkerMap workerMap = do
     workers <- atomically do
-        current <- readTVar registry.integrationWorkers
-        writeTVar registry.integrationWorkers Map.empty
+        current <- readTVar workerMap
+        writeTVar workerMap Map.empty
         pure (Map.elems current)
     mapM_ cancel workers
     mapM_ waitCatch workers
@@ -707,21 +724,16 @@ shutdownRunningTurns workerRegistry = do
     mapM_ (cancel . (.runningTurnWorker)) running
     mapM_ (waitCatch . (.runningTurnWorker)) running
 
--- | Keep the gateway credential lease while selecting and using the runtime.
--- A connected gateway is authoritative, matching turn startup; a direct
--- engine uses local integrations.
+-- | Account settings administer this Mac's local integrations even while a
+-- gateway is connected. Organization connections use EngineConnectionCommand.
 runIntegrationAdmin
     :: NativeProcessRuntime
     -> (IntegrationRuntime -> IO (Either Text RawJson))
     -> IO (Either Text RawJson)
 runIntegrationAdmin processRuntime action =
-    withNativeGatewayCredentialBoundary \credential _ -> do
-        let authority = gatewayIntegrationAuthority credential
-        acquireIntegrationRuntime
-            (nativeProcessIntegrationSupervisor processRuntime)
-            authority >>= \case
-                Left err -> pure (Left err)
-                Right runtime -> action runtime
+    acquireNativeLocalIntegrationRuntime processRuntime >>= \case
+        Left err -> pure (Left err)
+        Right runtime -> action runtime
 
 -- | A command is accepted only after the worker is registered. The gate keeps
 -- cancellation from racing registration. Normal completion and the shutdown
@@ -733,7 +745,7 @@ launchIntegrationWorker
     -> IO (Either Text RawJson)
     -> IO ()
 launchIntegrationWorker registry callback context action =
-    launchIntegrationWorkerWith
+    launchLocalIntegrationWorkerWith
         registry
         (either
             (sendIntegrationFailure callback context)
@@ -766,7 +778,24 @@ launchIntegrationWorkerWith
     -> (Either Text a -> IO ())
     -> IO (Either Text a)
     -> IO ()
-launchIntegrationWorkerWith registry complete action =
+launchIntegrationWorkerWith registry =
+    launchIntegrationWorkerIn registry registry.integrationWorkers
+
+launchLocalIntegrationWorkerWith
+    :: IntegrationWorkerRegistry
+    -> (Either Text a -> IO ())
+    -> IO (Either Text a)
+    -> IO ()
+launchLocalIntegrationWorkerWith registry =
+    launchIntegrationWorkerIn registry registry.localIntegrationWorkers
+
+launchIntegrationWorkerIn
+    :: IntegrationWorkerRegistry
+    -> TVar (Map Word64 (Async ()))
+    -> (Either Text a -> IO ())
+    -> IO (Either Text a)
+    -> IO ()
+launchIntegrationWorkerIn registry workerMap complete action =
     mask \_ -> do
         completionClaimed <- newTVarIO False
         let finish outcome = do
@@ -797,10 +826,10 @@ launchIntegrationWorkerWith registry complete action =
                             "engine stopped before integration operation completed")
                     atomically
                         (modifyTVar'
-                            registry.integrationWorkers
+                            workerMap
                             (Map.delete workerId))
         atomically $
-            modifyTVar' registry.integrationWorkers
+            modifyTVar' workerMap
                 (Map.insert workerId worker)
         putMVar gate ()
 

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/AccountConnectionSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/AccountConnectionSpec.hs
@@ -1,11 +1,57 @@
 module Agent.CLI.MacOS.AccountConnectionSpec (spec) where
 
 import Agent.CLI.MacOS.AccountConnection
+import Agent.CLI.MacOS.NativeSupervisor (runIntegrationAdmin)
+import Agent.CLI.NativeRuntime
+import Agent.CLI.GatewayClient (GatewayCredential(..))
+import Agent.CLI.IntegrationGateway (gatewayIntegrationMcpConfig)
+import Agent.Integration.API
+import Agent.Json (rawJsonFromEncoding)
+import qualified Data.Aeson as Aeson
+import Data.IORef
+import Control.Exception.Safe (bracket)
+import System.Directory (getTemporaryDirectory)
+import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
 
 -- Invalid requests are rejected before provider I/O or credential mutation.
 spec :: Spec
 spec = describe "native account connection validation" do
+    it "dispatches email administration locally without retiring organization connections" do
+        root <- getTemporaryDirectory
+        bankCloses <- newIORef (0 :: Int)
+        let payload = rawJsonFromEncoding (Aeson.toEncoding ([] :: [Aeson.Value]))
+            bankPayload = rawJsonFromEncoding (Aeson.toEncoding ("bank" :: String))
+            provider response close _ = pure (Right IntegrationRuntime
+                { integrationRuntimeEndpoint = NoIntegrationEndpoint
+                , integrationRuntimeAdminDefinitions = response
+                , callIntegrationRuntimeAdmin = \_ _ -> pure (Right response)
+                , integrationRuntimeConnections = Nothing
+                , closeIntegrationRuntime = close
+                })
+            config = gatewayIntegrationMcpConfig GatewayCredential
+                { gatewayBaseUrl = "https://gateway.example"
+                , gatewayWebSocketUrl = "wss://gateway.example/ws"
+                , gatewayAccessToken = "fixture-token"
+                }
+        bracket
+            (newNativeProcessRuntimeWithOrganizationIntegrations
+                (provider payload (pure ()))
+                (Just (\_ -> provider bankPayload (modifyIORef' bankCloses (+ 1))))
+                (unsafeEncodeUtf root))
+            closeNativeProcessRuntime \process -> do
+                bank <- acquireIntegrationRuntime
+                    (nativeProcessIntegrationSupervisor process)
+                    (OrganizationIntegrationAuthority config)
+                case bank of
+                    Left err -> expectationFailure (show err)
+                    Right _ -> pure ()
+                runIntegrationAdmin process
+                    (\runtime -> pure (Right (integrationRuntimeAdminDefinitions runtime)))
+                    `shouldReturn` Right payload
+                readIORef bankCloses `shouldReturn` 0
+        readIORef bankCloses `shouldReturn` 1
+
     it "rejects unsupported OAuth providers" do
         startAccountOAuth (AccountProviderRequest "unsupported")
             `shouldReturn`

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeSpec.hs
@@ -12,9 +12,16 @@ import Agent.CLI.MacOS.Bridge
     )
 import Agent.CLI.MacOS.NativeSupervisor
     ( launchIntegrationWorkerWith
+    , launchLocalIntegrationWorkerWith
     , completeBoundaryChecked
     , newIntegrationWorkerRegistry
     , shutdownIntegrationWorkers
+    , shutdownOrganizationIntegrationWorkers
+    )
+import Agent.CLI.GatewayClient
+    ( GatewayCredential(..)
+    , registerGatewayCredentialInvalidatorAt
+    , saveGatewayCredentialAt
     )
 import Agent.CLI.NativeRuntime (StartupFailure(..))
 import Control.Concurrent
@@ -23,11 +30,13 @@ import Control.Concurrent
     , putMVar
     , takeMVar
     , threadDelay
+    , tryReadMVar
     , withMVar
     )
 import Control.Concurrent.Async (poll, wait, withAsync)
 import Control.Exception.Safe
-    ( bracket_
+    ( bracket
+    , bracket_
     , displayException
     , throwString
     , toException
@@ -37,6 +46,11 @@ import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Data.IORef
     ( atomicModifyIORef', modifyIORef', newIORef, readIORef, writeIORef )
 import Data.Maybe (isNothing)
+import Data.Either (isLeft)
+import System.Directory
+    ( createDirectory, getTemporaryDirectory, removeFile, removePathForcibly )
+import System.IO (hClose, openTempFile)
+import System.OsPath (unsafeEncodeUtf)
 import System.Timeout (timeout)
 import Test.Hspec
 
@@ -54,6 +68,62 @@ spec = do
 integrationWorkerSpec :: Spec
 integrationWorkerSpec =
     describe "native integration worker supervision" do
+        it "preserves local OAuth work through a real credential invalidation and joins it on shutdown" do
+            temporaryRoot <- getTemporaryDirectory
+            let acquireHome = do
+                    (path, handle) <- openTempFile temporaryRoot "native-mail-workers"
+                    hClose handle
+                    removeFile path
+                    createDirectory path
+                    pure path
+            bracket acquireHome removePathForcibly \path ->
+                bracket newIntegrationWorkerRegistry shutdownIntegrationWorkers \registry -> do
+                    let home = unsafeEncodeUtf path
+                        credential = GatewayCredential
+                            "https://gateway.example" "wss://gateway.example/ws" "first"
+                    saveGatewayCredentialAt home credential `shouldReturn` Right ()
+                    bracket
+                        (registerGatewayCredentialInvalidatorAt home
+                            (shutdownOrganizationIntegrationWorkers registry))
+                        id \_ -> do
+                            localStarted <- newEmptyMVar
+                            organizationStarted <- newEmptyMVar
+                            resumePoll <- newEmptyMVar
+                            organizationBlock <- newEmptyMVar
+                            localResult <- newEmptyMVar
+                            organizationResult <- newEmptyMVar
+                            launchLocalIntegrationWorkerWith registry (putMVar localResult) do
+                                putMVar localStarted ()
+                                takeMVar resumePoll
+                                pure (Right ())
+                            launchIntegrationWorkerWith registry (putMVar organizationResult) do
+                                putMVar organizationStarted ()
+                                takeMVar organizationBlock
+                                pure (Right ())
+                            takeMVar localStarted
+                            takeMVar organizationStarted
+                            timeout 1000000 (saveGatewayCredentialAt home
+                                credential {gatewayAccessToken = "second"})
+                                `shouldReturn` Just (Right ())
+                            takeMVar organizationResult >>= (`shouldSatisfy` isLeft)
+                            tryReadMVar localResult `shouldReturn` Nothing
+                            putMVar resumePoll ()
+                            timeout 1000000 (takeMVar localResult)
+                                `shouldReturn` Just (Right ())
+                            -- A second pending local operation must still be
+                            -- cancelled/joined when the engine itself closes.
+                            shutdownStarted <- newEmptyMVar
+                            shutdownBlock <- newEmptyMVar
+                            shutdownResult <- newEmptyMVar
+                            launchLocalIntegrationWorkerWith registry (putMVar shutdownResult) do
+                                putMVar shutdownStarted ()
+                                takeMVar shutdownBlock
+                                pure (Right ())
+                            takeMVar shutdownStarted
+                            timeout 1000000 (shutdownIntegrationWorkers registry)
+                                `shouldReturn` Just ()
+                            takeMVar shutdownResult >>= (`shouldSatisfy` isLeft)
+
         it "completes once when cancelled while waiting for the output boundary" do
             registry <- newIntegrationWorkerRegistry
             waiting <- newEmptyMVar


### PR DESCRIPTION
## Summary
- Route native mail administration through a local integration supervisor independently of gateway connectivity.
- Preserve local OAuth worker ownership across gateway transitions.
- Add backward-compatible optional OAuth client credential persistence, with redacted display.

## Validation
- Mail codec: 28 examples passed.
- CLI routing: 60 examples passed; bridge routing: 23 examples passed.
- Combined macOS host suite: 1,043 reported, five skipped, zero failures.
- Full runtime Nix tests retain a pre-existing BridgeFFISpec taskSupervisorAbiSmoke failure also reproduced on the pristine base; no tests disabled.
- Live Google reconnection retest pending.