### PR TITLE
Add inline terminal chart rendering and history restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,15 @@ WezTerm, and iTerm2 draw the bitmap natively, other terminals get a
 true-colour text approximation. The image is shown to the user only; it is
 not added to the model context.
 
+### Inline charts
+
+In interactive terminal sessions, `render_chart` displays static line, bar,
+area, and scatter charts from the same validated chart documents used by the
+macOS app. Ghostty and Kitty display PNGs directly; other terminals retain a
+readable text summary. No plotting program or browser is required.
+Fullscreen conversation history recreates cached previews from saved chart
+documents. Hover and zoom are not supported in the terminal.
+
 ## Ideas and direction
 
 Why an independent harness matters, why code and Haskell are useful

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -679,6 +679,22 @@ benchmark image-preview-latency-bench
                     , bytestring
                     , JuicyPixels
 
+benchmark history-chart-restoration-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          HistoryChartRestoration.hs
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-cli
+                    , agent-core
+                    , agent-tui
+                    , async
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , containers
+                    , stm
+                    , text
+
 benchmark clipboard-latency-bench
     import:           common-options
     type:             exitcode-stdio-1.0

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -201,6 +201,7 @@ library
                     , Agent.CLI.ExternalProgram
                     , Agent.CLI.FileUri
                     , Agent.CLI.ImagePreview
+                    , Agent.CLI.ChartImage
                     , Agent.CLI.GatewayModels
                     , Agent.CLI.GitDiff
                     , Agent.CLI.Input
@@ -552,6 +553,7 @@ test-suite agent-cli-test
                     , Agent.CLI.IntegrationGatewaySpec
                     , Agent.CLI.GitDiffSpec
                     , Agent.CLI.ImagePreviewSpec
+                    , Agent.CLI.ChartImageSpec
                     , Agent.CLI.InputSpec
                     , Agent.CLI.InterruptSpec
                     , Agent.CLI.LoginSpec

--- a/packages/agent-cli/benchmark/HistoryChartRestoration.hs
+++ b/packages/agent-cli/benchmark/HistoryChartRestoration.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE BlockArguments, DuplicateRecordFields, LambdaCase, NoFieldSelectors #-}
+{-# LANGUAGE OverloadedRecordDot, OverloadedStrings, RecordWildCards #-}
+module Main (main) where
+
+import Agent.CLI.AgentViewport (AgentTarget(..))
+import Agent.CLI.ChartImage (chartResultImage)
+import Agent.CLI.Interrupt (CtrlCDecision(..))
+import Agent.CLI.TUI.App
+import Agent.CLI.TUI.History
+import Agent.CLI.TUI.ImagePreview
+import Agent.CLI.TUI.Types
+import Agent.Loop (ImageAttachment(..))
+import Agent.Tools.RenderChart (renderChartResult)
+import Agent.TUI.Model
+import Agent.TUI.Motion (MotionMode(..))
+import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.STM (atomically, readTVar, retry)
+import Control.Exception (evaluate)
+import Control.Monad (forM, unless)
+import qualified Data.ByteString as BS
+import Data.Foldable (toList)
+import Data.List (sort)
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence as Seq
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Sample = Sample
+    { elapsedMilliseconds :: !Double
+    , cpuMilliseconds :: !Double
+    , allocatedBytes :: !Integer
+    }
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    unless enabled (die "Run with +RTS -T")
+    getArgs >>= \case
+        [workload, chartsArgument, pointsArgument, samplesArgument] -> do
+            charts <- positive chartsArgument
+            points <- positive pointsArgument
+            samples <- positive samplesArgument
+            unless (charts <= 64 && points <= 2000)
+                (die "At most 64 charts and 2000 points per chart")
+            results <- forM [1 .. samples] \sampleIndex -> do
+                page <- makePage sampleIndex charts points
+                runtime <- newBenchmarkRuntime
+                let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+                _ <- evaluate initial
+                -- Complete all input construction before the measured interval.
+                _ <- evaluate (sum
+                    [ Text.length envelope
+                    | turn <- toList page.historyPageTurns
+                    , envelope <- Map.elems turn.historyTurnCharts
+                    ])
+                measure case workload of
+                    "synchronous" -> do
+                        let restored = synchronousRestoration (resetHistoryPage page initial)
+                        unless (Map.size restored.appSubmittedImagePreviews == charts)
+                            (die "Baseline did not retain every requested chart")
+                        evaluate (previewChecksum restored)
+                    "event" -> do
+                        let reset = resetHistoryPage page initial
+                        queueHistoryChartPreviews reset
+                        requests <- atomically (readTVar runtime.runtimeHistoryChartRequests)
+                        unless (length requests == charts)
+                            (die "Event did not queue every requested chart")
+                        evaluate (length requests + Map.size reset.appSubmittedImagePreviews)
+                    "worker-total" -> do
+                        let reset = resetHistoryPage page initial
+                        queueHistoryChartPreviews reset
+                        withAsync (runHistoryChartWorker runtime) \_ -> do
+                            events <- atomically do
+                                let AppEventMailbox mailbox = runtime.runtimeMailbox
+                                pending <- readTVar mailbox
+                                let prepared =
+                                        [ (generation, blockId, preview)
+                                        | PendingEvent (AppHistoryChartPrepared generation blockId preview)
+                                            <- toList pending.mailboxPendingEvents
+                                        ]
+                                if length prepared == charts then pure prepared else retry
+                            let restored = foldl'
+                                    (\state (generation, blockId, preview) ->
+                                        applyHistoryChartPreview generation blockId preview state)
+                                    reset events
+                            unless (Map.size restored.appSubmittedImagePreviews == charts)
+                                (die "Worker did not retain every requested chart")
+                            evaluate (previewChecksum restored)
+                    _ -> die "Workloads: synchronous, event, worker-total"
+            printf "%s,%d,%d,%d,%.3f,%.3f,%d\n" workload charts points samples
+                (median (map (.elapsedMilliseconds) results))
+                (median (map (.cpuMilliseconds) results))
+                (median (map (.allocatedBytes) results))
+        _ -> die "Usage: history-chart-restoration WORKLOAD CHARTS POINTS SAMPLES +RTS -T"
+  where
+    positive text = case reads text of
+        [(number, "")] | number > 0 -> pure number
+        _ -> die ("Invalid positive integer: " <> text)
+
+-- Frozen synchronous chart-restoration algorithm from 98ae13c. Both variants
+-- use the same current reset/remapping, rasterizer, PNG encoder and cache limits.
+-- The tested pages contain only charts and fit the normal history/cache budgets.
+synchronousRestoration :: AppState -> AppState
+synchronousRestoration state =
+    state { appSubmittedImagePreviews =
+        retainSubmittedImagePreviewsForBlocks blockIds restored }
+  where
+    blockIds = [block.blockId
+        | turn <- toList state.appHistoryWindow.historyWindowTurns
+        , block <- toList turn.historyTurnBlocks]
+    candidates = reverse
+        [ (block.blockId, envelope)
+        | turn <- toList state.appHistoryWindow.historyWindowTurns
+        , block <- toList turn.historyTurnBlocks
+        , Just envelope <- [Map.lookup block.blockId turn.historyTurnCharts]
+        ]
+    restored = foldl' restore state.appSubmittedImagePreviews
+        (take submittedImagePreviewCountBudget candidates)
+    restore previews (blockId, envelope)
+        | Map.member blockId previews = previews
+        | otherwise = case chartResultImage envelope >>= prepareNativeTuiImagePreview of
+            Left _ -> previews
+            Right preview -> Map.insert blockId [preview] previews
+
+previewChecksum :: AppState -> Int
+previewChecksum state = sum
+    [ BS.foldl' (\checksum byte -> checksum * 33 + fromIntegral byte) 5381
+        preview.previewKittyAttachment.imageBytes
+    | previews <- Map.elems state.appSubmittedImagePreviews
+    , preview <- previews
+    ]
+
+measure :: IO Int -> IO Sample
+measure action = do
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    checksum <- action
+    _ <- evaluate checksum
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    -- Collect afterwards for accurate sub-allocation-area byte accounting;
+    -- this collection is excluded from the reported execution interval.
+    performGC
+    afterStats <- getRTSStats
+    pure Sample
+        { elapsedMilliseconds = fromIntegral (afterElapsed - beforeElapsed) / 1e6
+        , cpuMilliseconds = fromIntegral (afterCpu - beforeCpu) / 1e9
+        , allocatedBytes = fromIntegral (afterStats.allocated_bytes - beforeStats.allocated_bytes)
+        }
+
+median :: Ord a => [a] -> a
+median values = sort values !! (length values `div` 2)
+
+makePage :: Int -> Int -> Int -> IO HistoryPage
+makePage sampleIndex charts points = do
+    turns <- forM [0 .. charts - 1] \chartIndex -> do
+        let title = "Chart " <> Text.pack (show sampleIndex <> "-" <> show chartIndex)
+            input = "{\"version\":1,\"kind\":\"line\",\"title\":\"" <> title
+                <> "\",\"x_axis\":{\"type\":\"number\"},\"y_axis\":{},\"series\":[{\"name\":\"Requests\",\"points\":["
+                <> Text.intercalate ","
+                    [ "{\"x\":" <> Text.pack (show index) <> ",\"y\":"
+                        <> Text.pack (show ((index * 13 + chartIndex + sampleIndex) `mod` 101)) <> "}"
+                    | index <- [1 .. points] ]
+                <> "]}]}"
+        envelope <- either (fail . Text.unpack) pure (renderChartResult input)
+        let block = UiBlock
+                { blockId = BlockId 1, blockKind = BlockTool, blockTitle = "Chart"
+                , blockBody = title, blockTimestamp = "", blockDetail = ""
+                , blockState = BlockComplete, blockExpanded = False
+                , blockCallId = Nothing, blockInspectionGroupable = False
+                }
+        pure (HistoryTurn (HistoryCursor (fromIntegral chartIndex)) (Seq.singleton block)
+            (Map.singleton (BlockId 1) envelope))
+    pure (HistoryPage (HistoryGeneration 0) HistoryNewer (Seq.fromList turns)
+        (HistoryCursor 0) (fromIntegral charts) False False)
+
+newBenchmarkRuntime :: IO FullscreenRuntime
+newBenchmarkRuntime = do
+    input <- newFullscreenInputBuffer
+    newFullscreenRuntime input (pure ()) (const (pure ())) (pure WarnExit)
+        (const (pure True)) (const (pure ())) (const (pure ()))
+        (pure (AgentRoot, [])) (const (pure ())) (pure ())
+        (const (pure ())) MotionFull True initialUiState

--- a/packages/agent-cli/benchmark/HistoryChartRestoration.md
+++ b/packages/agent-cli/benchmark/HistoryChartRestoration.md
@@ -1,0 +1,63 @@
+# History chart restoration benchmark
+
+This benchmark separates history event-handler latency from total chart work.
+It uses distinct 2,000-point numeric line charts, native previews (Ghostty), and
+empty preview caches. Input construction and runtime setup precede measurement.
+Every requested chart must be queued/retained; a checksum forces every PNG byte.
+
+* `synchronous`: current history reset/remapping plus the removed synchronous
+  restore loop from `98ae13c`, using the same rasterizer and cache budgets.
+* `event`: production reset, select, and enqueue, without starting the worker.
+* `worker-total`: production reset/enqueue, scoped worker, mailbox delivery, and
+  application of every prepared preview. Results are collected before applying
+  them, rather than interleaved with terminal drawing.
+
+The last boundary includes all rendering work, not just work shifted off the
+event thread. Database reads, Brick reflow, Kitty transmission, terminal drawing,
+and competing UI events are excluded. This measures responsiveness, not a
+claim of increased rendering throughput.
+
+## Reproduction
+
+```sh
+nix develop --command cabal build agent-cli:bench:history-chart-restoration-bench --offline
+nix develop --command sh -c '
+  bench=$(cabal list-bin agent-cli:bench:history-chart-restoration-bench)
+  for charts in 1 8 64; do
+    for workload in synchronous event worker-total; do
+      "$bench" "$workload" "$charts" 2000 3 +RTS -N1 -T
+    done
+  done
+'
+```
+
+The benchmark executable uses `-O2`; libraries use normal project optimization,
+including the existing explicit `-O0` on the App/History orchestration modules.
+Do not use GHCi timings. Output columns are workload, charts, points, samples,
+median wall milliseconds, median process CPU milliseconds, and median allocated
+bytes. GC occurs before and after samples for complete nursery accounting; the
+final GC is excluded from wall/CPU timing. Allocation is cumulative, not peak
+memory residency.
+
+## Recorded results
+
+Apple M3 Max, macOS 26.6.1, GHC 9.10.3, `+RTS -N1 -T`, three fresh samples per
+row. The executable was directly compiled with `ghc -O2 -threaded -rtsopts`
+against the current Cabal-registered libraries, using the same source and
+dependencies as the stanza above.
+
+| Charts | Boundary | Wall ms | CPU ms | Allocated bytes |
+|---:|---|---:|---:|---:|
+| 1 | synchronous | 98.463 | 95.127 | 394094376 |
+| 1 | event | 0.011 | 0.012 | 6152 |
+| 1 | worker-total | 105.661 | 103.667 | 405426480 |
+| 8 | synchronous | 877.255 | 845.732 | 3152698184 |
+| 8 | event | 0.067 | 0.057 | 29808 |
+| 8 | worker-total | 870.913 | 850.913 | 3243203784 |
+| 64 | synchronous | 6826.110 | 6593.407 | 25222768168 |
+| 64 | event | 0.184 | 0.184 | 260800 |
+| 64 | worker-total | 6593.216 | 6561.716 | 25952134336 |
+
+Reset/enqueue no longer blocks on seconds of rasterization. Total work remains
+similar, with about 2.9% more allocation at 64 charts. Small timing differences
+between total-work rows should not be interpreted as a throughput improvement.

--- a/packages/agent-cli/benchmark/HistoryEviction.hs
+++ b/packages/agent-cli/benchmark/HistoryEviction.hs
@@ -164,6 +164,7 @@ makeTurn :: Int -> Int -> Int -> HistoryTurn
 makeTurn salt size ident =
     HistoryTurn
         { historyTurnCursor = HistoryCursor (fromIntegral ident)
+        , historyTurnCharts = Map.empty
         , historyTurnBlocks = Seq.fromList
             [ UiBlock
                 { blockId = BlockId (ident * 4 + offset)

--- a/packages/agent-cli/benchmark/TranscriptScrolling.hs
+++ b/packages/agent-cli/benchmark/TranscriptScrolling.hs
@@ -293,6 +293,7 @@ benchmarkState blockCount bodyLines = do
             Seq.fromList
                 [ HistoryTurn
                     { historyTurnCursor = HistoryCursor (fromIntegral cursor)
+                    , historyTurnCharts = Map.empty
                     , historyTurnBlocks = Seq.fromList turnBlocks
                     }
                 | (cursor, turnBlocks) <-

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -2,17 +2,17 @@
 , agent-codex-dialect, agent-connectivity, agent-core
 , agent-external-session, agent-gemini, agent-grok-build-dialect
 , agent-integration-api, agent-json, agent-mcp, agent-openai
-, agent-openrouter, agent-process
-, agent-responses, agent-responses-types, agent-store, agent-syntax
-, agent-tui, agent-xai, ansi-terminal, async, base
-, base64-bytestring, brick, bytestring, colour, containers, crypton
-, crypton-connection, dbus, deepseq, directory, entropy, filelock
-, filepath, haskeline, hasql-pool, hspec, http-client
-, http-client-tls, http-types, JuicyPixels, lib, memory, mtl
-, network, network-uri, optparse-applicative, process, QuickCheck
-, retry, safe-exceptions, scientific, stm, tagsoup, temporary
-, terminfo, text, time, tls, transformers, unix, vector, vty
-, vty-crossplatform, vty-unix, wai, warp
+, agent-openrouter, agent-process, agent-responses
+, agent-responses-types, agent-store, agent-syntax, agent-tui
+, agent-xai, ansi-terminal, async, base, base64-bytestring, brick
+, bytestring, colour, containers, crypton, crypton-connection, dbus
+, deepseq, directory, entropy, filelock, filepath, haskeline
+, hasql-pool, hspec, http-client, http-client-tls, http-types
+, JuicyPixels, lib, memory, mtl, network, network-uri
+, optparse-applicative, process, QuickCheck, retry, safe-exceptions
+, scientific, stm, tagsoup, temporary, terminfo, text, time, tls
+, transformers, unix, vector, vty, vty-crossplatform, vty-unix, wai
+, warp
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -25,15 +25,15 @@ mkDerivation {
     aeson agent-claude agent-cli-runtime agent-codex-dialect
     agent-connectivity agent-core agent-external-session agent-gemini
     agent-grok-build-dialect agent-integration-api agent-json agent-mcp
-    agent-openai agent-openrouter agent-process
-    agent-responses agent-responses-types agent-store agent-syntax
-    agent-tui agent-xai ansi-terminal async base base64-bytestring
-    brick bytestring colour containers crypton crypton-connection dbus
-    directory entropy filelock filepath haskeline hasql-pool
-    http-client http-client-tls http-types JuicyPixels memory mtl
-    network network-uri optparse-applicative process retry
-    safe-exceptions scientific stm tagsoup terminfo text time tls
-    transformers unix vector vty vty-crossplatform vty-unix wai warp
+    agent-openai agent-openrouter agent-process agent-responses
+    agent-responses-types agent-store agent-syntax agent-tui agent-xai
+    ansi-terminal async base base64-bytestring brick bytestring colour
+    containers crypton crypton-connection dbus directory entropy
+    filelock filepath haskeline hasql-pool http-client http-client-tls
+    http-types JuicyPixels memory mtl network network-uri
+    optparse-applicative process retry safe-exceptions scientific stm
+    tagsoup terminfo text time tls transformers unix vector vty
+    vty-crossplatform vty-unix wai warp
   ];
   executableHaskellDepends = [
     aeson agent-cli-runtime agent-responses agent-responses-types

--- a/packages/agent-cli/src/Agent/CLI/ChartImage.hs
+++ b/packages/agent-cli/src/Agent/CLI/ChartImage.hs
@@ -8,7 +8,7 @@ module Agent.CLI.ChartImage
     ) where
 
 import Agent.Loop (ImageAttachment(..))
-import Agent.Tools.RenderChart (chartResultDocument, renderChartTool)
+import Agent.Tools.RenderChart (chartResultDocument, chartResultFallback, renderChartTool)
 import Agent.Tools.ShowImage (ImageDisplayHooks(..), ImageDisplayRequest(..))
 import Agent.Tools.Types (AppTool(..))
 import Agent.ToolDispatch (ToolCall(..), ToolHandlerResult(..), wrapToolHandler)
@@ -89,12 +89,6 @@ chartResultImage output = do
         , imageBytes = LBS.toStrict (encodePng (drawChart chart))
         }
 
--- | Plain-text presentation for terminals without graphics. Text is also
--- retained outside the image so Unicode labels are accessible: the embedded
--- bitmap lettering deliberately covers ASCII only.
-chartResultFallback :: Text -> Maybe Text
-chartResultFallback output = either (const Nothing) (Just . describeChart) (parseResult output)
-
 parseResult :: Text -> Either Text Chart
 parseResult output = do
     document <- maybe (Left "Invalid chart presentation document.") Right
@@ -138,26 +132,6 @@ axisDescription :: Axis -> Text
 axisDescription axis =
     safeText axis.label
         <> if Text.null axis.unit then "" else " (" <> safeText axis.unit <> ")"
-
-describeChart :: Chart -> Text
-describeChart chart = Text.intercalate "\n" $
-    filter (not . Text.null)
-        [ safeText chart.title <> " [" <> chart.kind <> " chart]"
-        , safeText chart.subtitle
-        , "X: " <> axisDescription chart.xAxis <> "; Y: " <> axisDescription chart.yAxis
-        , let categories = nub [safeText text | series <- chart.series, (Category text, _) <- series.points]
-          in if null categories then "" else
-              "Categories: " <> Text.intercalate ", " (take 8 categories)
-                  <> if length categories > 8 then " (first 8 shown)" else ""
-        ]
-        <> map describeSeries chart.series
-  where
-    describeSeries series =
-        safeText series.name <> ": "
-            <> Text.pack (show (length series.points))
-            <> (if length series.points == 1 then " point; range " else " points; range ")
-            <> numberText (minimum (map snd series.points)) <> " to "
-            <> numberText (maximum (map snd series.points))
 
 imageWidth, imageHeight, plotLeft, plotRight, plotTop, plotBottom :: Int
 imageWidth = 960

--- a/packages/agent-cli/src/Agent/CLI/ChartImage.hs
+++ b/packages/agent-cli/src/Agent/CLI/ChartImage.hs
@@ -1,0 +1,422 @@
+-- | Bounded, process-free rasterization of the shared chart presentation
+-- protocol. The original document remains authoritative; images are disposable
+-- view data and never become model context.
+module Agent.CLI.ChartImage
+    ( chartResultImage
+    , chartResultFallback
+    , terminalChartTool
+    ) where
+
+import Agent.Loop (ImageAttachment(..))
+import Agent.Tools.RenderChart (chartResultDocument, renderChartTool)
+import Agent.Tools.ShowImage (ImageDisplayHooks(..), ImageDisplayRequest(..))
+import Agent.Tools.Types (AppTool(..))
+import Agent.ToolDispatch (ToolCall(..), ToolHandlerResult(..), wrapToolHandler)
+import Codec.Picture (Image, PixelRGB8(..), encodePng)
+import Codec.Picture.Types (MutableImage, createMutableImage, freezeImage, writePixel)
+import Control.Monad (forM_, when)
+import Control.Monad.ST (ST, runST)
+import Data.Aeson (Value, eitherDecodeStrict', withObject, (.:), (.:?), (.!=))
+import Data.Aeson.Types (Parser, parseEither)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Char (isControl, toUpper)
+import qualified Data.IntMap.Strict as IntMap
+import Data.List (nub)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Data.Time (UTCTime, defaultTimeLocale, formatTime, parseTimeM)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import Numeric (showGFloat)
+
+data Chart = Chart
+    { kind :: !Text
+    , title :: !Text
+    , subtitle :: !Text
+    , xAxis :: !Axis
+    , yAxis :: !Axis
+    , series :: ![Series]
+    }
+
+-- | Keep the durable chart document unchanged; only the host sees the PNG.
+terminalChartTool :: ImageDisplayHooks -> AppTool
+terminalChartTool hooks =
+    renderChartTool
+        { appToolDescription =
+            Text.replace "interactive native chart" "static chart"
+                renderChartTool.appToolDescription
+        , appToolHandler =
+            wrapToolHandler
+                (\call execute -> execute >>= \case
+                    Left err -> pure (Left err)
+                    Right result ->
+                        case chartResultImage result.resultText of
+                            Left err -> pure (Left err)
+                            Right image -> do
+                                displayed <- hooks.showImage ImageDisplayRequest
+                                    { displayCallId = call.callId
+                                    , displayPath = "render_chart"
+                                    , displayCaption = chartResultFallback result.resultText
+                                    , displayImage = image
+                                    }
+                                pure (result <$ displayed))
+                renderChartTool.appToolHandler
+        }
+
+data Axis = Axis
+    { axisType :: !Text
+    , label :: !Text
+    , unit :: !Text
+    }
+
+data Series = Series
+    { name :: !Text
+    , points :: ![(Coordinate, Double)]
+    }
+
+data Coordinate = Category !Text | Number !Double | Timestamp !UTCTime
+    deriving (Eq, Ord)
+
+-- | Accept only the complete validated tool-result envelope, not arbitrary
+-- JSON that merely happens to contain a chart-shaped field.
+chartResultImage :: Text -> Either Text ImageAttachment
+chartResultImage output = do
+    chart <- parseResult output
+    pure ImageAttachment
+        { imageMime = "image/png"
+        , imageBytes = LBS.toStrict (encodePng (drawChart chart))
+        }
+
+-- | Plain-text presentation for terminals without graphics. Text is also
+-- retained outside the image so Unicode labels are accessible: the embedded
+-- bitmap lettering deliberately covers ASCII only.
+chartResultFallback :: Text -> Maybe Text
+chartResultFallback output = either (const Nothing) (Just . describeChart) (parseResult output)
+
+parseResult :: Text -> Either Text Chart
+parseResult output = do
+    document <- maybe (Left "Invalid chart presentation document.") Right
+        (chartResultDocument output)
+    value <- either (Left . Text.pack) Right (eitherDecodeStrict' (Text.encodeUtf8 document))
+    either (Left . Text.pack) Right (parseEither parseChart value)
+
+parseChart :: Value -> Parser Chart
+parseChart = withObject "chart" \fields -> do
+    kind <- fields .: "kind"
+    title <- fields .: "title"
+    subtitle <- fields .:? "subtitle" .!= ""
+    xAxis <- fields .: "x_axis" >>= parseAxis
+    yAxis <- fields .: "y_axis" >>= parseAxis
+    series <- fields .: "series" >>= traverse (parseSeries xAxis.axisType)
+    pure Chart{..}
+  where
+    parseAxis = withObject "axis" \fields ->
+        Axis <$> (fields .:? "type" .!= "number")
+            <*> (fields .:? "label" .!= "")
+            <*> (fields .:? "unit" .!= "")
+    parseSeries axisType = withObject "series" \fields -> do
+        name <- fields .: "name"
+        points <- fields .: "points" >>= traverse (parsePoint axisType)
+        pure Series{..}
+    parsePoint axisType = withObject "point" \fields -> do
+        coordinate <- case axisType of
+            "category" -> Category <$> fields .: "x"
+            "timestamp" -> do
+                text <- fields .: "x"
+                Timestamp <$> parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" text
+            _ -> Number <$> fields .: "x"
+        ordinate <- fields .: "y"
+        pure (coordinate, ordinate)
+
+safeText :: Text -> Text
+safeText = Text.unwords . Text.words . Text.map \character ->
+    if isControl character then ' ' else character
+
+axisDescription :: Axis -> Text
+axisDescription axis =
+    safeText axis.label
+        <> if Text.null axis.unit then "" else " (" <> safeText axis.unit <> ")"
+
+describeChart :: Chart -> Text
+describeChart chart = Text.intercalate "\n" $
+    filter (not . Text.null)
+        [ safeText chart.title <> " [" <> chart.kind <> " chart]"
+        , safeText chart.subtitle
+        , "X: " <> axisDescription chart.xAxis <> "; Y: " <> axisDescription chart.yAxis
+        , let categories = nub [safeText text | series <- chart.series, (Category text, _) <- series.points]
+          in if null categories then "" else
+              "Categories: " <> Text.intercalate ", " (take 8 categories)
+                  <> if length categories > 8 then " (first 8 shown)" else ""
+        ]
+        <> map describeSeries chart.series
+  where
+    describeSeries series =
+        safeText series.name <> ": "
+            <> Text.pack (show (length series.points))
+            <> (if length series.points == 1 then " point; range " else " points; range ")
+            <> numberText (minimum (map snd series.points)) <> " to "
+            <> numberText (maximum (map snd series.points))
+
+imageWidth, imageHeight, plotLeft, plotRight, plotTop, plotBottom :: Int
+imageWidth = 960
+imageHeight = 600
+plotLeft = 150
+plotRight = 918
+plotTop = 112
+plotBottom = 434
+
+background, foreground, muted, grid :: PixelRGB8
+background = PixelRGB8 19 27 38
+foreground = PixelRGB8 232 237 243
+muted = PixelRGB8 165 180 195
+grid = PixelRGB8 49 64 79
+
+seriesColors :: [PixelRGB8]
+seriesColors =
+    [ PixelRGB8 81 174 245, PixelRGB8 245 174 71
+    , PixelRGB8 87 207 162, PixelRGB8 231 116 146
+    , PixelRGB8 179 153 247, PixelRGB8 95 210 220
+    , PixelRGB8 226 214 102, PixelRGB8 203 164 132
+    ]
+
+-- Rational domain arithmetic prevents overflow for finite extremes and
+-- preserves narrow ranges (including subnormals). Conversion to floating
+-- point happens only after normalization into [0,1].
+data Scale = Scale !Rational !Rational
+
+makeScale :: Bool -> [Rational] -> Scale
+makeScale includeZero values =
+    let bounds = if includeZero then 0 : values else values
+    in Scale (minimum bounds) (maximum bounds)
+
+fractionAt :: Scale -> Rational -> Double
+fractionAt (Scale lower upper) value
+    | lower == upper = 0.5
+    | otherwise = fromRational ((value - lower) / (upper - lower))
+
+valueAt :: Scale -> Rational -> Rational
+valueAt (Scale lower upper) fraction =
+    lower * (1 - fraction) + upper * fraction
+
+drawChart :: Chart -> Image PixelRGB8
+drawChart chart = runST do
+    image <- createMutableImage imageWidth imageHeight background
+    labelText image foreground 3 24 20 50 chart.title
+    labelText image muted 2 24 54 75 chart.subtitle
+    labelText image muted 2 plotLeft 84 64 (axisDescription chart.yAxis)
+    forM_ yTickFractions \fraction -> do
+        let position = plotBottom - round (fromIntegral (plotBottom - plotTop) * fraction)
+        line image grid 1 (plotLeft, position) (plotRight, position)
+        labelText image muted 2 8 (position - 6) 11
+            (numberText (fromRational (valueAt yScale fraction)))
+    forM_ xTicks \(position, text) -> do
+        line image grid 1 (position, plotTop) (position, plotBottom)
+        labelText image muted 2 (max 8 (min (imageWidth - 145) (position - 45)))
+            (plotBottom + 16) 12 text
+    line image muted 1 (plotLeft, plotTop) (plotLeft, plotBottom)
+    line image muted 1 (plotLeft, plotBottom) (plotRight, plotBottom)
+    forM_ (zip3 [0 ..] seriesColors chart.series) \(seriesIndex, color, series) -> do
+        let positions = [(xPosition x, yPosition y) | (x, y) <- series.points]
+        case chart.kind of
+            "bar" -> forM_ positions \(x, y) -> do
+                let totalWidth = max 1 (min 64 (barSpacing * 3 `div` 4))
+                    width = max 1 (totalWidth `div` length chart.series)
+                    left = x - totalWidth `div` 2 + seriesIndex * width
+                rectangle image color left (min y zeroY)
+                    (left + width - 1) (max y zeroY)
+            "scatter" -> pure ()
+            _ -> do
+                when (chart.kind == "area") $
+                    fillArea image (areaColor color) zeroY positions
+                forM_ (zip positions (drop 1 positions)) \(start, end) ->
+                    line image color 2 start end
+        when (chart.kind /= "bar") $
+            forM_ positions \(x, y) ->
+                rectangle image color (x - 2) (y - 2) (x + 2) (y + 2)
+        let legendX = 24 + (seriesIndex `mod` 4) * 234
+            legendY = 520 + (seriesIndex `div` 4) * 32
+        rectangle image color legendX legendY (legendX + 13) (legendY + 13)
+        labelText image foreground 2 (legendX + 22) legendY 16 series.name
+    labelText image muted 2 plotLeft 477 64 (axisDescription chart.xAxis)
+    freezeImage image
+  where
+    coordinates = nub [x | series <- chart.series, (x, _) <- series.points]
+    coordinateIndices = Map.fromList (zip coordinates [0 :: Int ..])
+    coordinateValue = \case
+        Number value -> toRational value
+        Timestamp value -> toRational (utcTimeToPOSIXSeconds value)
+        category -> fromIntegral (Map.findWithDefault 0 category coordinateIndices)
+    rawXScale = makeScale False (map coordinateValue coordinates)
+    xScale = case rawXScale of
+        Scale lower upper
+            | chart.xAxis.axisType == "category" || chart.kind == "bar" ->
+                let padding = if lower == upper then 1 / 2 else (upper - lower) / 20
+                in Scale (lower - padding) (upper + padding)
+        _ -> rawXScale
+    yScale = makeScale (chart.kind `elem` ["bar", "area"])
+        [toRational y | series <- chart.series, (_, y) <- series.points]
+    yTickFractions = case yScale of
+        Scale lower upper | lower == upper -> [1 / 2]
+        _ -> [0, 1 / 4, 1 / 2, 3 / 4, 1]
+    xPosition coordinate =
+        plotLeft + round (fromIntegral (plotRight - plotLeft) * fractionAt xScale (coordinateValue coordinate))
+    yPosition :: Double -> Int
+    yPosition value =
+        plotBottom - round (fromIntegral (plotBottom - plotTop) * fractionAt yScale (toRational value))
+    zeroY = max plotTop (min plotBottom (yPosition 0))
+    coordinatePositions = Map.keys (Map.fromList [(xPosition x, ()) | x <- coordinates])
+    barSpacing = minimum (64 : zipWith (-) (drop 1 coordinatePositions) coordinatePositions)
+    xTicks
+        | chart.xAxis.axisType == "category" || chart.xAxis.axisType == "timestamp" =
+            [(xPosition coordinate, tickText coordinate) | coordinate <- sampleLabels coordinates]
+        | otherwise =
+            [ (plotLeft + round (fromIntegral (plotRight - plotLeft) * fractionAt xScale value)
+              , numberText (fromRational value))
+            | index <- [0 .. 4 :: Int]
+            , let value = valueAt rawXScale (fromIntegral index / 4)
+            ]
+    tickText (Timestamp value) =
+        let Scale lower upper = rawXScale
+            format
+                | upper - lower < 60 = "%H:%M:%S%Q"
+                | upper - lower < 86400 = "%H:%M:%S"
+                | otherwise = "%m-%d %H:%M"
+        in Text.pack (formatTime defaultTimeLocale format value)
+    tickText coordinate = coordinateText coordinate
+
+sampleLabels :: [a] -> [a]
+sampleLabels values
+    | length values <= 5 = values
+    | otherwise = [values !! (index * (length values - 1) `div` 4) | index <- [0 .. 4]]
+
+coordinateText :: Coordinate -> Text
+coordinateText = \case
+    Category text -> text
+    Number value -> numberText value
+    Timestamp value -> Text.pack (formatTime defaultTimeLocale "%m-%d %H:%M" value)
+
+numberText :: Double -> Text
+numberText value
+    | value == 0 = "0"
+    | otherwise = Text.pack (showGFloat (Just 3) value "")
+
+areaColor :: PixelRGB8 -> PixelRGB8
+areaColor (PixelRGB8 red green blue) =
+    PixelRGB8 (red `div` 3 + 13) (green `div` 3 + 18) (blue `div` 3 + 25)
+
+rectangle :: MutableImage s PixelRGB8 -> PixelRGB8 -> Int -> Int -> Int -> Int -> ST s ()
+rectangle image color left top right bottom =
+    forM_ [max 0 top .. min (imageHeight - 1) bottom] \y ->
+        forM_ [max 0 left .. min (imageWidth - 1) right] \x ->
+            writePixel image x y color
+
+line :: MutableImage s PixelRGB8 -> PixelRGB8 -> Int -> (Int, Int) -> (Int, Int) -> ST s ()
+line image color thickness (startX, startY) (endX, endY) =
+    forM_ [0 .. steps] \index -> do
+        let fraction = fromIntegral index / fromIntegral (max 1 steps) :: Double
+            x = startX + round (fromIntegral (endX - startX) * fraction)
+            y = startY + round (fromIntegral (endY - startY) * fraction)
+        rectangle image color x y (x + thickness - 1) (y + thickness - 1)
+  where
+    steps = max (abs (endX - startX)) (abs (endY - startY))
+
+-- | Every segment's vertical interval contains the same baseline, so their
+-- union is exactly their minimum/maximum extent. Resolve that union before
+-- touching the bitmap: even categorical paths that repeatedly cross the
+-- canvas paint each pixel at most once per series.
+fillArea :: MutableImage s PixelRGB8 -> PixelRGB8 -> Int -> [(Int, Int)] -> ST s ()
+fillArea image color baseline positions =
+    forM_ (IntMap.toList extents) \(x, (top, bottom)) ->
+        rectangle image color x top x bottom
+  where
+    extents = foldl' addSegment IntMap.empty (zip positions (drop 1 positions))
+    addSegment accumulated ((startX, startY), (endX, endY)) =
+        foldl' addColumn accumulated [min startX endX .. max startX endX]
+      where
+        addColumn columns x =
+            let fraction = if startX == endX then 0 else
+                    fromIntegral (x - startX) / fromIntegral (endX - startX) :: Double
+                y = startY + round (fromIntegral (endY - startY) * fraction)
+            in IntMap.insertWith mergeExtents x (min y baseline, max y baseline) columns
+    mergeExtents (firstTop, firstBottom) (secondTop, secondBottom) =
+        (min firstTop secondTop, max firstBottom secondBottom)
+
+-- | Small built-in specification lettering avoids font discovery, filesystem
+-- reads and platform-specific graphics libraries. Unsupported glyphs are
+-- visibly marked rather than silently omitted; original labels accompany the
+-- image in the text presentation.
+labelText :: MutableImage s PixelRGB8 -> PixelRGB8 -> Int -> Int -> Int -> Int -> Text -> ST s ()
+labelText image color scale left top maximumCharacters text =
+    forM_ (zip [0 ..] (Text.unpack clipped)) \(index, character) ->
+        forM_ (zip [0 ..] (glyph (toUpper character))) \(row, columns) ->
+            forM_ (zip [0 ..] columns) \(column, pixel) ->
+                when (pixel == '#') $
+                    rectangle image color
+                        (left + index * 6 * scale + column * scale)
+                        (top + row * scale)
+                        (left + index * 6 * scale + column * scale + scale - 1)
+                        (top + row * scale + scale - 1)
+  where
+    cleaned = safeText text
+    clipped
+        | Text.length cleaned <= maximumCharacters = cleaned
+        | otherwise = Text.take (max 0 (maximumCharacters - 3)) cleaned <> "..."
+
+glyph :: Char -> [String]
+glyph character = fromMaybe ["#####","#...#","...#.","..#..",".....","..#..","....."] $
+    Map.lookup character lettering
+
+lettering :: Map.Map Char [String]
+lettering = Map.fromList
+    [ (' ', [".....",".....",".....",".....",".....",".....","....."])
+    , ('A', [".###.","#...#","#...#","#####","#...#","#...#","#...#"])
+    , ('B', ["####.","#...#","#...#","####.","#...#","#...#","####."])
+    , ('C', [".####","#....","#....","#....","#....","#....",".####"])
+    , ('D', ["####.","#...#","#...#","#...#","#...#","#...#","####."])
+    , ('E', ["#####","#....","#....","####.","#....","#....","#####"])
+    , ('F', ["#####","#....","#....","####.","#....","#....","#...."])
+    , ('G', [".####","#....","#....","#.###","#...#","#...#",".###."])
+    , ('H', ["#...#","#...#","#...#","#####","#...#","#...#","#...#"])
+    , ('I', ["#####","..#..","..#..","..#..","..#..","..#..","#####"])
+    , ('J', ["..###","...#.","...#.","...#.","...#.","#..#.",".##.."])
+    , ('K', ["#...#","#..#.","#.#..","##...","#.#..","#..#.","#...#"])
+    , ('L', ["#....","#....","#....","#....","#....","#....","#####"])
+    , ('M', ["#...#","##.##","#.#.#","#.#.#","#...#","#...#","#...#"])
+    , ('N', ["#...#","##..#","##..#","#.#.#","#..##","#..##","#...#"])
+    , ('O', [".###.","#...#","#...#","#...#","#...#","#...#",".###."])
+    , ('P', ["####.","#...#","#...#","####.","#....","#....","#...."])
+    , ('Q', [".###.","#...#","#...#","#...#","#.#.#","#..#.",".##.#"])
+    , ('R', ["####.","#...#","#...#","####.","#.#..","#..#.","#...#"])
+    , ('S', [".####","#....","#....",".###.","....#","....#","####."])
+    , ('T', ["#####","..#..","..#..","..#..","..#..","..#..","..#.."])
+    , ('U', ["#...#","#...#","#...#","#...#","#...#","#...#",".###."])
+    , ('V', ["#...#","#...#","#...#","#...#","#...#",".#.#.","..#.."])
+    , ('W', ["#...#","#...#","#...#","#.#.#","#.#.#","##.##","#...#"])
+    , ('X', ["#...#","#...#",".#.#.","..#..",".#.#.","#...#","#...#"])
+    , ('Y', ["#...#","#...#",".#.#.","..#..","..#..","..#..","..#.."])
+    , ('Z', ["#####","....#","...#.","..#..",".#...","#....","#####"])
+    , ('0', [".###.","#...#","#..##","#.#.#","##..#","#...#",".###."])
+    , ('1', ["..#..",".##..","..#..","..#..","..#..","..#..",".###."])
+    , ('2', [".###.","#...#","....#","...#.","..#..",".#...","#####"])
+    , ('3', ["####.","....#","....#",".###.","....#","....#","####."])
+    , ('4', ["...#.","..##.",".#.#.","#..#.","#####","...#.","...#."])
+    , ('5', ["#####","#....","#....","####.","....#","....#","####."])
+    , ('6', [".###.","#....","#....","####.","#...#","#...#",".###."])
+    , ('7', ["#####","....#","...#.","..#..",".#...",".#...",".#..."])
+    , ('8', [".###.","#...#","#...#",".###.","#...#","#...#",".###."])
+    , ('9', [".###.","#...#","#...#",".####","....#","....#",".###."])
+    , ('.', [".....",".....",".....",".....",".....","..#..","..#.."])
+    , (',', [".....",".....",".....",".....","..#..","..#..",".#..."])
+    , ('-', [".....",".....",".....","#####",".....",".....","....."])
+    , ('+', [".....","..#..","..#..","#####","..#..","..#..","....."])
+    , ('/', ["....#","....#","...#.","..#..",".#...","#....","#...."])
+    , (':', [".....","..#..","..#..",".....","..#..","..#..","....."])
+    , ('(', ["...#.","..#..",".#...",".#...",".#...","..#..","...#."])
+    , (')', [".#...","..#..","...#.","...#.","...#.","..#..",".#..."])
+    , ('%', ["##..#","##..#","...#.","..#..",".#...","#..##","#..##"])
+    , ('_', [".....",".....",".....",".....",".....",".....","#####"])
+    , ('=', [".....",".....","#####",".....","#####",".....","....."])
+    , ('$', ["..#..",".####","#.#..",".###.","..#.#","####.","..#.."])
+    ]

--- a/packages/agent-cli/src/Agent/CLI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/ImagePreview.hs
@@ -19,6 +19,7 @@ module Agent.CLI.ImagePreview
     , previewRowsFor
     , previewColumnsFor
     , renderImagePreview
+    , routeChartPresentation
     ) where
 
 import Agent.Loop (ImageAttachment(..))
@@ -32,8 +33,19 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
+import qualified Data.Text.IO as TextIO
 import System.Environment (lookupEnv)
 import System.IO (Handle, hIsTerminalDevice)
+
+-- | Keep one-shot results and redirected stdout free of presentation output.
+-- The diagnostic stream still receives the complete text fallback. Inspect the
+-- output handle, not stdin: a redirected command can retain terminal input.
+routeChartPresentation :: Bool -> Handle -> Handle -> Maybe Text -> IO () -> IO ()
+routeChartPresentation oneShot output diagnostics caption preview = do
+    interactive <- if oneShot then pure False else hIsTerminalDevice output
+    let destination = if interactive then output else diagnostics
+    mapM_ (TextIO.hPutStrLn destination) caption
+    if interactive then preview else pure ()
 
 -- | How (if at all) this terminal can draw inline images.
 data ImagePreviewProtocol

--- a/packages/agent-cli/src/Agent/CLI/Prompt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Prompt.hs
@@ -352,6 +352,13 @@ secretInputGuidance available
 -- | Point the model at inline image display when the host can present one.
 imageDisplayGuidance :: Set Text -> Text
 imageDisplayGuidance available
+    | "render_chart" `Set.member` available =
+        Text.unlines
+            [ "Chart display:"
+            , "- Use render_chart for line, bar, area, and scatter charts from actual data. Supply clear labels and units."
+            , "- The host displays charts in the conversation, with a text fallback where graphics are unavailable. Do not promise hover or zoom."
+            , imageDisplayGuidance (Set.delete "render_chart" available)
+            ]
     | "show_image" `Set.notMember` available = ""
     | otherwise =
         Text.unlines

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -701,6 +701,10 @@ assembleSessionToolsRuntime AgentToolsRequest
                 learnedSkillToolsEnv
         nativeToolGroups =
             maybe [] (.nativeToolGroups) startup.startupNativeHooks
+        terminalChartTools =
+            case (startup.startupNativeHooks, imageHooks) of
+                (Nothing, Just hooks) -> [terminalChartTool hooks]
+                _ -> []
         computerTools =
             maybe [] (pure . ComputerUse.computerUseRuntimeTool)
                 computerUseRuntime
@@ -732,6 +736,7 @@ assembleSessionToolsRuntime AgentToolsRequest
             , HostToolGroup sessionDatabaseTools
             , HostToolGroup sessionLearnedSkillTools
             , HostToolGroup externalSessionAppTools
+            , HostToolGroup terminalChartTools
             ]
                 <> nativeToolGroups
                 <> [ HostToolGroup imageGenerationTools

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/HostHooks.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/HostHooks.hs
@@ -2,9 +2,11 @@
 module Agent.CLI.Runtime.Orchestration.Tools.HostHooks
     ( ToolHostHooks(..)
     , buildToolHostHooks
+    , terminalChartTool
     ) where
 
 import Agent.CLI.Options (isOneShot)
+import Agent.CLI.ChartImage (terminalChartTool)
 import Agent.CLI.Plan (cliPlanHooks)
 import Agent.CLI.PromptHooks
     ( fullscreenAwareImageHooks, fullscreenAwarePlanHooks, fullscreenAwareSecretHooks )
@@ -12,13 +14,14 @@ import Agent.CLI.Runtime.Orchestration.Tools.Model
 import Agent.CLI.Runtime.Orchestration.Tools.Request
 import Agent.CLI.Runtime.Orchestration.Types (NativeRunCapabilities(..), NativeRunHooks(..))
 import Agent.CLI.Secret (promptSecretLine)
-import Agent.CLI.Session.Attachments (putImagePreview)
+import Agent.CLI.Session.Attachments (putImagePreview, putChartPreview)
 import Agent.CLI.Session.Runtime.Types (StartupRuntime(..))
 import Agent.CLI.SessionState (SessionState(..))
 import Agent.CLI.Terminal (resolveColor)
 import Agent.Tools.PlanMode (PlanModeHooks(..), PlanDecision(..))
 import Agent.Tools.Secret (SecretPrompt(..), SecretPromptHooks(..))
 import Agent.Tools.ShowImage (ImageDisplayHooks(..), ImageDisplayRequest(..))
+import qualified Data.Text.IO as TextIO
 
 data ToolHostHooks = ToolHostHooks
     { toolPlanHooks :: PlanModeHooks
@@ -73,7 +76,10 @@ buildToolHostHooks AgentToolsRequest
     -- same graphics path as pasted attachments.
     baseImageHooks = ImageDisplayHooks \request -> do
         color <- resolveColor stderrHandle
-        putImagePreview
+        case (request.displayPath, request.displayCaption) of
+            ("render_chart", Just caption) -> TextIO.putStrLn caption
+            _ -> pure ()
+        (if request.displayPath == "render_chart" then putChartPreview else putImagePreview)
             startup.startupSessionState.sessionPreviewId
             color
             [request.displayImage]

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/HostHooks.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/HostHooks.hs
@@ -7,6 +7,7 @@ module Agent.CLI.Runtime.Orchestration.Tools.HostHooks
 
 import Agent.CLI.Options (isOneShot)
 import Agent.CLI.ChartImage (terminalChartTool)
+import Agent.CLI.ImagePreview (routeChartPresentation)
 import Agent.CLI.Plan (cliPlanHooks)
 import Agent.CLI.PromptHooks
     ( fullscreenAwareImageHooks, fullscreenAwarePlanHooks, fullscreenAwareSecretHooks )
@@ -21,7 +22,7 @@ import Agent.CLI.Terminal (resolveColor)
 import Agent.Tools.PlanMode (PlanModeHooks(..), PlanDecision(..))
 import Agent.Tools.Secret (SecretPrompt(..), SecretPromptHooks(..))
 import Agent.Tools.ShowImage (ImageDisplayHooks(..), ImageDisplayRequest(..))
-import qualified Data.Text.IO as TextIO
+import System.IO (stdout)
 
 data ToolHostHooks = ToolHostHooks
     { toolPlanHooks :: PlanModeHooks
@@ -76,13 +77,17 @@ buildToolHostHooks AgentToolsRequest
     -- same graphics path as pasted attachments.
     baseImageHooks = ImageDisplayHooks \request -> do
         color <- resolveColor stderrHandle
-        case (request.displayPath, request.displayCaption) of
-            ("render_chart", Just caption) -> TextIO.putStrLn caption
-            _ -> pure ()
-        (if request.displayPath == "render_chart" then putChartPreview else putImagePreview)
-            startup.startupSessionState.sessionPreviewId
-            color
-            [request.displayImage]
+        if request.displayPath == "render_chart"
+            then routeChartPresentation (isOneShot options) stdout stderrHandle
+                request.displayCaption
+                (putChartPreview
+                    startup.startupSessionState.sessionPreviewId
+                    color
+                    [request.displayImage])
+            else putImagePreview
+                startup.startupSessionState.sessionPreviewId
+                color
+                [request.displayImage]
         pure (Right ())
     toolImageHooks
         | not nativeCapabilities.nativeHostExtensions || not isTty =

--- a/packages/agent-cli/src/Agent/CLI/Session/Attachments.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Attachments.hs
@@ -1,6 +1,7 @@
 -- | Queue and preview image attachments for an interactive session.
 module Agent.CLI.Session.Attachments
     ( putImagePreview
+    , putChartPreview
     , queueAttachedImages
     , queueClipboardImages
     ) where
@@ -134,13 +135,21 @@ queueClipboardImages
         Left err -> pure (Left err)
 
 putImagePreview :: IORef Int -> Bool -> [ImageAttachment] -> IO ()
-putImagePreview previewIdRef color images = do
+putImagePreview = putSizedImagePreview False
+
+putChartPreview :: IORef Int -> Bool -> [ImageAttachment] -> IO ()
+putChartPreview = putSizedImagePreview True
+
+putSizedImagePreview :: Bool -> IORef Int -> Bool -> [ImageAttachment] -> IO ()
+putSizedImagePreview chart previewIdRef color images = do
     protocol <- detectImagePreviewProtocol stdout
     inTmux <- isJust <$> lookupEnv "TMUX"
     size <- getTerminalSize
     let (termRows, termCols) = fromMaybe (24, 80) size
-        columns = previewColumnsFor termCols
-        rows = previewRowsFor termRows
+        columns = if chart then max 1 (min 72 (termCols - 2)) else previewColumnsFor termCols
+        -- The chart is 8:5; Kitty derives width from rows. Allow roughly
+        -- two pixels of cell height per pixel of cell width on narrow panes.
+        rows = if chart then max 1 (minimum [24, termRows - 4, columns * 5 `div` 16]) else previewRowsFor termRows
     startId <- atomicModifyIORef' previewIdRef \n ->
         (n + max 1 (length images), n)
     case renderImagePreview

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -87,6 +87,9 @@ module Agent.CLI.TUI.App
     , resetHistoryPage
     , applyLoadedHistoryPage
     , remapHistoryPage
+    , queueHistoryChartPreviews
+    , runHistoryChartWorker
+    , applyHistoryChartPreview
     , beginFullscreenLiveHistory
     , clearFullscreenHistorySource
     , reloadFullscreenHistorySource

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -84,6 +84,9 @@ module Agent.CLI.TUI.App
     , withFullscreenWorker
     , commitFullscreenImagePreviews
     , commitFullscreenHistoryTurn
+    , resetHistoryPage
+    , applyLoadedHistoryPage
+    , remapHistoryPage
     , beginFullscreenLiveHistory
     , clearFullscreenHistorySource
     , reloadFullscreenHistorySource

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -438,6 +438,10 @@ handleAppEvent = \case
             modify' \current -> current { appPullRequestURL = url }
     AppHistoryReset page ->
         handleHistoryResetEvent page
+    AppHistoryChartPrepared generation blockId preview -> do
+        modify' (applyHistoryChartPreview generation blockId preview)
+        invalidateCache
+        queueConversationReflow
     AppHistoryLoaded request result ->
         handleHistoryLoadedEvent request result
     AppHistoryLiveStarted ->
@@ -707,6 +711,7 @@ handleHistoryResetEvent page = do
     state <- get
     clearSubmittedImagePlacements state.appRuntime
     modify' (resetHistoryPage page)
+    get >>= liftIO . queueHistoryChartPreviews
     invalidateCache
     resolveConversationFollow
     queueConversationReflow
@@ -738,6 +743,7 @@ handleHistoryLoadedEvent request result = do
                     do
                         clearSubmittedImagePlacements state.appRuntime
                         modify' (applyLoadedHistoryPage page)
+                        get >>= liftIO . queueHistoryChartPreviews
             invalidateCache
             case anchorBlock of
                 Nothing -> pure ()
@@ -776,6 +782,7 @@ handleHistoryCommittedEvent generation turn commit = do
         modify'
             (commitLiveHistoryTurn turn commit
                 . setHistoryGeneration generation)
+        get >>= liftIO . queueHistoryChartPreviews
         invalidateCache
         resolveConversationFollow
         queueConversationReflow

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/History.hs
@@ -3,6 +3,7 @@
 module Agent.CLI.TUI.App.History where
 
 import Agent.CLI.Clipboard ( formatImageSize )
+import Agent.CLI.ChartImage (chartResultImage)
 import Agent.CLI.Dictation ( DictationControl(..)
     , DictationResult(..)
     , dictateWith
@@ -99,6 +100,7 @@ import Agent.CLI.TUI.ImagePreview ( NativePreviewPlacement(..)
     , TuiImagePreview(..)
     , nativePreviewPlacements
     , prepareTuiImagePreview
+    , prepareNativeTuiImagePreview
     , previewCountForWidth
     , previewCellSize
     , renderTuiImagePreview
@@ -203,17 +205,18 @@ resetHistoryPage page state =
             remapHistoryPage state.appNextHistoryBlockId page
         window =
             either (const empty) id (applyHistoryPage remapped empty)
-    in state
-        { appUi = reduceUi UiConversationCleared state.appUi
-        , appPullRequestURL = Nothing
-        , appHistoryWindow = window
-        , appHistorySelectedBlock = Nothing
-        , appHistoryLiveStart = Nothing
-        , appNextHistoryBlockId = nextBlockId
-        , appCompletionFlashes = Map.empty
-        , appConversationAnchor = Nothing
-        , appSubmittedImagePreviews = Map.empty
-        }
+        nextState = state
+            { appUi = reduceUi UiConversationCleared state.appUi
+            , appPullRequestURL = Nothing
+            , appHistoryWindow = window
+            , appHistorySelectedBlock = Nothing
+            , appHistoryLiveStart = Nothing
+            , appNextHistoryBlockId = nextBlockId
+            , appCompletionFlashes = Map.empty
+            , appConversationAnchor = Nothing
+            , appSubmittedImagePreviews = Map.empty
+            }
+    in restoreHistoryChartPreviews nextState
 
 setHistoryGeneration :: HistoryGeneration -> AppState -> AppState
 setHistoryGeneration generation state =
@@ -258,7 +261,7 @@ applyLoadedHistoryPage page state =
                     , appHistorySelectedBlock = selected
                     , appNextHistoryBlockId = nextBlockId
                     }
-            in nextState
+            in restoreHistoryChartPreviews nextState
                 { appSubmittedImagePreviews =
                     retainSubmittedImagePreviews nextState
                         nextState.appSubmittedImagePreviews
@@ -300,7 +303,11 @@ commitLiveHistoryTurn durableTurn commit state =
                 state.appNextHistoryBlockId
                 (precedingBlocks <> durableTurn.historyTurnBlocks)
         remappedTurn =
-            durableTurn { historyTurnBlocks = remappedBlocks }
+            durableTurn
+                { historyTurnBlocks = remappedBlocks
+                , historyTurnCharts =
+                    remapHistoryCharts blockIdRemap durableTurn.historyTurnCharts
+                }
         baseWindow =
             case commit of
                 HistoryCommitReset ->
@@ -351,7 +358,7 @@ commitLiveHistoryTurn durableTurn commit state =
                             (toList ui.uiBlocks))
                     state.appCompletionFlashes
             }
-    in nextState
+    in restoreHistoryChartPreviews nextState
         { appSubmittedImagePreviews =
             retainSubmittedImagePreviews nextState remappedPreviews
         }
@@ -394,15 +401,51 @@ remapHistoryPage nextId page =
         (remaining, turns) =
             foldl'
                 (\(current, accumulated) turn ->
-                    let (next, blocks, _) =
+                    let (next, blocks, identifiers) =
                             remapHistoryBlocks
                                 current
                                 turn.historyTurnBlocks
                     in (next, accumulated |> turn
-                        { historyTurnBlocks = blocks }))
+                        { historyTurnBlocks = blocks
+                        , historyTurnCharts =
+                            remapHistoryCharts identifiers turn.historyTurnCharts
+                        }))
                 (nextId, Seq.empty)
                 page.historyPageTurns
     in (remaining, page { historyPageTurns = turns })
+
+remapHistoryCharts :: Map.Map BlockId BlockId -> Map.Map BlockId Text -> Map.Map BlockId Text
+remapHistoryCharts identifiers charts =
+    Map.fromList
+        [ (newId, envelope)
+        | (oldId, envelope) <- Map.toList charts
+        , Just newId <- [Map.lookup oldId identifiers]
+        ]
+
+-- | Materialize only a bounded tail of chart previews after history changes.
+-- Existing previews are reused; neither resize nor transcript redraw rasterizes.
+restoreHistoryChartPreviews :: AppState -> AppState
+restoreHistoryChartPreviews state =
+    state { appSubmittedImagePreviews =
+        retainSubmittedImagePreviews state restored }
+  where
+    candidates = reverse
+        [ (block.blockId, envelope)
+        | turn <- toList state.appHistoryWindow.historyWindowTurns
+        , block <- toList turn.historyTurnBlocks
+        , Just envelope <- [Map.lookup block.blockId turn.historyTurnCharts]
+        ]
+    restored = foldl' restore state.appSubmittedImagePreviews
+        (take submittedImagePreviewCountBudget candidates)
+    restore previews (blockId, envelope)
+        | Map.member blockId previews = previews
+        | otherwise =
+            case chartResultImage envelope >>= preparePreview of
+                Left _ -> previews
+                Right preview -> Map.insert blockId [preview] previews
+    preparePreview
+        | state.appRuntime.runtimeNativeImagePreviews = prepareNativeTuiImagePreview
+        | otherwise = prepareTuiImagePreview
 
 remapHistoryBlocks
     :: Int

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/History.hs
@@ -134,7 +134,7 @@ import Brick.Widgets.Border (borderWithLabel)
 import qualified Brick.Widgets.Border as Border
 import Brick.Widgets.Border.Style (unicodeRounded)
 import Brick.Widgets.Center (center, centerLayer, hCenter)
-import Codec.Picture (pixelAt)
+import Codec.Picture (pixelAt, imageData)
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
@@ -144,7 +144,7 @@ import Agent.CLI.Recap ( autoRecapAwayThreshold , autoRecapIdleThreshold , autoR
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
 import Control.Exception.Safe (finally, mask, onException, throwIO, tryAny)
-import Control.Exception (AsyncException(UserInterrupt))
+import Control.Exception (AsyncException(UserInterrupt), evaluate)
 import Data.Char (isControl, isSpace)
 import qualified Data.ByteString as BS
 import Data.Foldable (toList)
@@ -216,7 +216,7 @@ resetHistoryPage page state =
             , appConversationAnchor = Nothing
             , appSubmittedImagePreviews = Map.empty
             }
-    in restoreHistoryChartPreviews nextState
+    in nextState
 
 setHistoryGeneration :: HistoryGeneration -> AppState -> AppState
 setHistoryGeneration generation state =
@@ -261,7 +261,7 @@ applyLoadedHistoryPage page state =
                     , appHistorySelectedBlock = selected
                     , appNextHistoryBlockId = nextBlockId
                     }
-            in restoreHistoryChartPreviews nextState
+            in nextState
                 { appSubmittedImagePreviews =
                     retainSubmittedImagePreviews nextState
                         nextState.appSubmittedImagePreviews
@@ -358,7 +358,7 @@ commitLiveHistoryTurn durableTurn commit state =
                             (toList ui.uiBlocks))
                     state.appCompletionFlashes
             }
-    in restoreHistoryChartPreviews nextState
+    in nextState
         { appSubmittedImagePreviews =
             retainSubmittedImagePreviews nextState remappedPreviews
         }
@@ -422,12 +422,19 @@ remapHistoryCharts identifiers charts =
         , Just newId <- [Map.lookup oldId identifiers]
         ]
 
--- | Materialize only a bounded tail of chart previews after history changes.
--- Existing previews are reused; neither resize nor transcript redraw rasterizes.
-restoreHistoryChartPreviews :: AppState -> AppState
-restoreHistoryChartPreviews state =
-    state { appSubmittedImagePreviews =
-        retainSubmittedImagePreviews state restored }
+-- | Only select envelopes on the event thread. The replaceable request list
+-- prevents obsolete paging requests from accumulating while a chart is prepared.
+queueHistoryChartPreviews :: AppState -> IO ()
+queueHistoryChartPreviews state =
+    atomically $ writeTVar state.appRuntime.runtimeHistoryChartRequests
+        [ (state.appHistoryWindow.historyWindowGeneration, blockId, envelope)
+        | (blockId, envelope) <- historyChartPreviewCandidates state
+        , Map.notMember blockId state.appSubmittedImagePreviews
+        ]
+
+historyChartPreviewCandidates :: AppState -> [(BlockId, Text)]
+historyChartPreviewCandidates state =
+    take submittedImagePreviewCountBudget candidates
   where
     candidates = reverse
         [ (block.blockId, envelope)
@@ -435,17 +442,53 @@ restoreHistoryChartPreviews state =
         , block <- toList turn.historyTurnBlocks
         , Just envelope <- [Map.lookup block.blockId turn.historyTurnCharts]
         ]
-    restored = foldl' restore state.appSubmittedImagePreviews
-        (take submittedImagePreviewCountBudget candidates)
-    restore previews (blockId, envelope)
-        | Map.member blockId previews = previews
-        | otherwise =
-            case chartResultImage envelope >>= preparePreview of
-                Left _ -> previews
-                Right preview -> Map.insert blockId [preview] previews
+
+-- | Scoped by the fullscreen runtime. Publish individual, fully prepared
+-- previews so input remains responsive and later pages can replace pending work.
+runHistoryChartWorker :: FullscreenRuntime -> IO ()
+runHistoryChartWorker runtime = forever do
+    (generation, blockId, envelope) <- atomically do
+        requests <- readTVar runtime.runtimeHistoryChartRequests
+        case requests of
+            [] -> retry
+            request : remaining -> do
+                writeTVar runtime.runtimeHistoryChartRequests remaining
+                pure request
+    current <- HistoryGeneration <$> readIORef runtime.runtimeHistoryGeneration
+    when (generation == current) do
+        result <- tryAny (prepareHistoryChartPreview runtime.runtimeNativeImagePreviews envelope)
+        case result of
+            Right (Right preview) ->
+                enqueueAppEvent runtime
+                    (AppHistoryChartPrepared generation blockId preview)
+            _ -> pure ()
+
+prepareHistoryChartPreview :: Bool -> Text -> IO (Either Text TuiImagePreview)
+prepareHistoryChartPreview native envelope =
+    case chartResultImage envelope >>= preparePreview of
+        Left err -> pure (Left err)
+        Right preview -> do
+            -- Force encoded bytes and the fallback sample on this worker.
+            -- Merely evaluating the Either would leave image work for Brick.
+            _ <- evaluate (BS.length preview.previewKittyAttachment.imageBytes)
+            unless native $ void $ evaluate (imageData preview.previewSample)
+            pure (Right preview)
+  where
     preparePreview
-        | state.appRuntime.runtimeNativeImagePreviews = prepareNativeTuiImagePreview
+        | native = prepareNativeTuiImagePreview
         | otherwise = prepareTuiImagePreview
+
+applyHistoryChartPreview
+    :: HistoryGeneration -> BlockId -> TuiImagePreview -> AppState -> AppState
+applyHistoryChartPreview generation blockId preview state
+    | generation /= state.appHistoryWindow.historyWindowGeneration = state
+    | blockId `notElem` map fst (historyChartPreviewCandidates state) = state
+    | otherwise = state
+        { appSubmittedImagePreviews =
+            retainSubmittedImagePreviews state $
+                Map.insertWith (\_ existing -> existing)
+                    blockId [preview] state.appSubmittedImagePreviews
+        }
 
 remapHistoryBlocks
     :: Int

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -927,7 +927,8 @@ historyTurnLogicalBytes turn =
         foldl'
             (\size block ->
                 saturatingAdd size (uiBlockLogicalBytes block))
-            0
+            (foldl' (\size envelope -> saturatingAdd size (logicalTextBytes envelope))
+                0 turn.historyTurnCharts)
             turn.historyTurnBlocks
 
 historyPageLogicalBytes :: HistoryPage -> Int

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -758,6 +758,8 @@ appEventLogicalBytes = \case
         saturatingAdd 256 (maybe 0 logicalTextBytes url)
     AppHistoryReset page ->
         saturatingAdd 256 (historyPageLogicalBytes page)
+    AppHistoryChartPrepared _ _ preview ->
+        saturatingAdd 256 (imagePreviewLogicalBytes preview)
     AppHistoryLoaded _ result ->
         saturatingAdd 256 $
             either logicalTextBytes historyPageLogicalBytes result

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -541,6 +541,7 @@ eventMayExposeSyntax = \case
         any uiEventMayExposeSyntax uiEvents
     AppEvent AppSyntaxHighlighterChanged -> True
     AppEvent (AppHistoryReset _) -> True
+    AppEvent (AppHistoryChartPrepared _ _ _) -> True
     AppEvent (AppHistoryLoaded _ _) -> True
     AppEvent (AppHistoryCommitted _ _ _) -> True
     AppEvent AppHistoryLiveStarted -> True

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -141,6 +141,7 @@ import Codec.Picture (pixelAt)
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async
     ( Async
+    , concurrently_
     , poll
     , wait
     , waitCatch
@@ -286,7 +287,7 @@ runFullscreen runtime workerAction = do
                 withAsync (eventPump runtime) \_eventPump ->
                     withAsync (recapTicker runtime) \_recapTicker ->
                         withAsync
-                            historyLoader
+                            (concurrently_ historyLoader (runHistoryChartWorker runtime))
                             \_historyLoader ->
                             withAsync
                                 dictationWorker

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -302,6 +302,7 @@ newFullscreenRuntimeWithSyntaxLoaderAndTheme
         motionSchedule <- newTVarIO (MotionNone, 1000000, 0)
         motionTickQueued <- newTVarIO False
         historyRequests <- newTQueueIO
+        historyChartRequests <- newTVarIO []
         syntaxRequests <- newTQueueIO
         syntaxHighlighter <-
             newIORef (SyntaxHighlighterUnloaded 0)
@@ -384,6 +385,7 @@ newFullscreenRuntimeWithSyntaxLoaderAndTheme
             , runtimeInitial = initial
             , runtimeSessionActions = sessionActions
             , runtimeHistoryRequests = historyRequests
+            , runtimeHistoryChartRequests = historyChartRequests
             , runtimeHistorySource = historySource
             , runtimeHistoryGeneration = historyGeneration
             , runtimeDictationJobs = dictationJobs

--- a/packages/agent-cli/src/Agent/CLI/TUI/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/History.hs
@@ -68,6 +68,8 @@ data HistoryDirection
 data HistoryTurn = HistoryTurn
     { historyTurnCursor :: !HistoryCursor
     , historyTurnBlocks :: !(Seq UiBlock)
+    , historyTurnCharts :: !(Map BlockId Text.Text)
+      -- ^ Validated complete chart envelopes, independent of bounded text previews.
     }
     deriving (Eq, Show)
 
@@ -460,11 +462,12 @@ withinBudget window =
         && historyWindowLoadedBytes window <= window.historyWindowMaxBytes
 
 historyTurnBytes :: HistoryTurn -> Int
-historyTurnBytes =
-    sum
+historyTurnBytes turn =
+    sum (map ((2 *) . Text.length) (Map.elems turn.historyTurnCharts))
+    + (sum
         . fmap historyBlockBytes
         . toList
-        . (.historyTurnBlocks)
+        $ turn.historyTurnBlocks)
 
 historyBlockBytes :: UiBlock -> Int
 historyBlockBytes block =

--- a/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
@@ -13,6 +13,8 @@ import Agent.CLI.Session
     ( SessionTurn(..)
     , SessionTurnPage(..)
     )
+import Agent.Tools.RenderChart (chartResultDocument, renderChartToolName)
+import qualified Data.Map.Strict as Map
 import Agent.CLI.Session.Types (TranscriptEffect(..))
 import Agent.CLI.Render (renderToolOutputValue)
 import Agent.CLI.Session.PullRequest (sessionTurnPullRequestURL)
@@ -98,9 +100,37 @@ sessionHistoryTurn cursor turn =
     HistoryTurn
         { historyTurnCursor =
             HistoryCursor (fromIntegral cursor)
-        , historyTurnBlocks =
-            (projectTurn turn).uiBlocks
+        , historyTurnBlocks = blocks
+        , historyTurnCharts = Map.fromList
+            [ (block.blockId, envelope)
+            | block <- toList blocks
+            , Just callId <- [block.blockCallId]
+            , Just envelope <- [Map.lookup callId charts]
+            ]
         }
+  where
+    blocks = (projectTurn turn).uiBlocks
+    charts = snd (foldl' collect (Map.empty, Map.empty)
+        (turn.turnItems <> turn.turnDisplayItems))
+    collect (calls, results) = \case
+        FunctionCallItem call ->
+            (Map.insert call.callId call.name calls, results)
+        CustomToolCallItem call ->
+            (Map.insert call.callId call.name calls, results)
+        FunctionCallOutputItem output ->
+            finish calls results output.callId (renderToolOutputValue output.output)
+        CustomToolCallOutputItem output ->
+            finish calls results output.callId (renderToolOutputValue output.output)
+        _ -> (calls, results)
+    finish calls results callId envelope =
+        ( Map.delete callId calls
+        , case Map.lookup callId calls of
+            Just name
+                | name == renderChartToolName
+                , Just _ <- chartResultDocument envelope ->
+                    Map.insert callId envelope results
+            _ -> Map.delete callId results
+        )
 
 projectTurn :: SessionTurn -> UiState
 projectTurn turn =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -193,6 +193,7 @@ data AppEvent
     | AppSetPullRequestURL !HistoryGeneration !(Maybe Text)
     | AppSyntaxHighlighterChanged
     | AppHistoryReset !HistoryPage
+    | AppHistoryChartPrepared !HistoryGeneration !BlockId !TuiImagePreview
     | AppHistoryLoaded
         !HistoryRequest
         !(Either Text HistoryPage)
@@ -425,6 +426,7 @@ data FullscreenRuntime = FullscreenRuntime
     , runtimeInitial :: !UiState
     , runtimeSessionActions :: !(IORef FullscreenSessionActions)
     , runtimeHistoryRequests :: !(TQueue HistoryRequest)
+    , runtimeHistoryChartRequests :: !(TVar [(HistoryGeneration, BlockId, Text)])
     , runtimeHistorySource :: !(IORef (Maybe FullscreenHistorySource))
     , runtimeHistoryGeneration :: !(IORef Int64)
     , runtimeDictationJobs :: !(TQueue DictationJob)

--- a/packages/agent-cli/test/Agent/CLI/ChartImageSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ChartImageSpec.hs
@@ -1,0 +1,140 @@
+module Agent.CLI.ChartImageSpec (spec) where
+
+import Agent.CLI.ChartImage
+import Agent.Loop (ImageAttachment(..))
+import Agent.Tools.RenderChart (renderChartResult)
+import Codec.Picture (convertRGB8, decodePng, imageHeight, imageWidth, pixelAt, PixelRGB8(..))
+import Control.Monad (forM_)
+import Data.Aeson (ToJSON, Value, encode, object, (.=))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Either (isLeft)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "chart presentation images" do
+    forM_ ["line", "bar", "area", "scatter"] \kind ->
+        it ("renders a bounded PNG for " <> Text.unpack kind) do
+            image <- renderedImage (document kind "number"
+                [point (1 :: Double) 3, point (2 :: Double) 7, point (3 :: Double) 4])
+            image.imageMime `shouldBe` "image/png"
+            BS.take 8 image.imageBytes `shouldBe` "\137PNG\r\n\SUB\n"
+            BS.length image.imageBytes `shouldSatisfy` (< 256 * 1024)
+            case decodePng image.imageBytes of
+                Left err -> expectationFailure err
+                Right bitmap -> do
+                    let pixels = convertRGB8 bitmap
+                    (imageWidth pixels, imageHeight pixels) `shouldBe` (960, 600)
+                    -- Plot geometry and labels both differ from the canvas.
+                    pixelAt pixels 150 112 `shouldNotBe` PixelRGB8 19 27 38
+
+    it "renders categorical coordinates and millisecond timestamps" do
+        forM_
+            [ document "bar" "category"
+                [point ("North" :: Text) 12, point ("South" :: Text) (-4)]
+            , document "line" "timestamp"
+                [ point ("2026-09-08T12:00:00.001Z" :: Text) 1
+                , point ("2026-09-08T12:00:00.002Z" :: Text) 2
+                ]
+            ] \input -> do
+                image <- renderedImage input
+                BS.length image.imageBytes `shouldSatisfy` (> 1000)
+
+    it "normalizes finite extremes, subnormals and constant domains without overflow" do
+        forM_
+            [ [point (-1e308 :: Double) (-1e308), point (1e308 :: Double) 1e308]
+            , [point (1 :: Double) 1e308]
+            , [point (1 :: Double) 0, point (2 :: Double) 0]
+            , [point (0 :: Double) 0, point (5e-324 :: Double) 5e-324]
+            ] \points ->
+                forM_ ["line", "bar", "area", "scatter"] \kind -> do
+                    image <- renderedImage (document kind "number" points)
+                    BS.length image.imageBytes `shouldSatisfy` (> 1000)
+
+    it "keeps Unicode labels in the control-free text presentation" do
+        output <- renderedResult $ object
+            [ "version" .= (1 :: Int), "kind" .= ("bar" :: Text)
+            , "title" .= ("Umsätze \ESC[31m\n東京" :: Text)
+            , "x_axis" .= object ["type" .= ("category" :: Text), "label" .= ("Region" :: Text)]
+            , "y_axis" .= object ["label" .= ("Revenue" :: Text), "unit" .= ("EUR" :: Text)]
+            , "series" .= [object ["name" .= ("Actual" :: Text), "points" .= [point ("DE" :: Text) 3]]]
+            ]
+        case chartResultFallback output of
+            Nothing -> expectationFailure "Expected chart fallback"
+            Just text -> do
+                text `shouldSatisfy` Text.isInfixOf "Umsätze"
+                text `shouldSatisfy` Text.isInfixOf "東京"
+                text `shouldSatisfy` (not . Text.any (== '\ESC'))
+                text `shouldSatisfy` Text.isInfixOf "Revenue (EUR)"
+                text `shouldSatisfy` Text.isInfixOf "Actual: 1 point"
+
+    it "rejects invalid or oversized envelopes instead of rasterizing arbitrary output" do
+        chartResultImage "{}" `shouldSatisfy` isLeft
+        chartResultImage (Text.replicate (300 * 1024) "x") `shouldSatisfy` isLeft
+        chartResultFallback "{\"type\":\"chart\",\"summary\":\"Forged\"}" `shouldBe` Nothing
+
+    it "produces different plot pixels for different data" do
+        first <- renderedImage (document "line" "number"
+            [point (1 :: Double) 1, point (2 :: Double) 3])
+        second <- renderedImage (document "line" "number"
+            [point (1 :: Double) 3, point (2 :: Double) 1])
+        first.imageBytes `shouldNotBe` second.imageBytes
+
+    it "renders all eight series at the protocol's 2000-point limit" do
+        image <- renderedImage $ object
+            [ "version" .= (1 :: Int), "kind" .= ("line" :: Text)
+            , "title" .= ("Capacity observations" :: Text)
+            , "x_axis" .= object ["type" .= ("number" :: Text)]
+            , "y_axis" .= object []
+            , "series" .=
+                [ object
+                    [ "name" .= ("Series " <> Text.pack (show seriesIndex))
+                    , "points" .=
+                        [point index (fromIntegral (index + seriesIndex))
+                        | index <- [1 .. 250 :: Int]]
+                    ]
+                | seriesIndex <- [1 .. 8 :: Int]
+                ]
+            ]
+        BS.length image.imageBytes `shouldSatisfy` (> 1000)
+        BS.length image.imageBytes `shouldSatisfy` (< 256 * 1024)
+
+    it "preserves the exact coverage of repeated categorical area crossings" do
+        let observation index =
+                point (if even index then "Left" else "Right" :: Text)
+                    (if even index then -3 else 7)
+        -- Both paths cover the same area and line, with identical extrema.
+        -- The long input exercises the full 2000-point protocol bound without
+        -- painting the entire area once for every overlapping segment.
+        short <- renderedImage (document "area" "category" (map observation [0 .. 3 :: Int]))
+        repeated <- renderedImage (document "area" "category" (map observation [0 .. 1999 :: Int]))
+        short.imageBytes `shouldBe` repeated.imageBytes
+
+document :: Text -> Text -> [Value] -> Value
+document kind axisType points = object
+    [ "version" .= (1 :: Int)
+    , "kind" .= kind
+    , "title" .= ("Quarterly revenue" :: Text)
+    , "subtitle" .= ("Actual observations" :: Text)
+    , "x_axis" .= object ["type" .= axisType, "label" .= ("Period" :: Text)]
+    , "y_axis" .= object ["label" .= ("Revenue" :: Text), "unit" .= ("USD" :: Text)]
+    , "series" .= [object ["name" .= ("Actual" :: Text), "points" .= points]]
+    ]
+
+point :: ToJSON coordinate => coordinate -> Double -> Value
+point x y = object ["x" .= x, "y" .= y]
+
+renderedResult :: Value -> IO Text
+renderedResult value = case renderChartResult (Text.decodeUtf8 (LBS.toStrict (encode value))) of
+    Left err -> expectationFailure (Text.unpack err) >> fail "Chart fixture was invalid"
+    Right output -> pure output
+
+renderedImage :: Value -> IO ImageAttachment
+renderedImage value = do
+    output <- renderedResult value
+    case chartResultImage output of
+        Left err -> expectationFailure (Text.unpack err) >> fail "Chart rendering failed"
+        Right image -> pure image

--- a/packages/agent-cli/test/Agent/CLI/ImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ImagePreviewSpec.hs
@@ -2,6 +2,8 @@ module Agent.CLI.ImagePreviewSpec (spec) where
 
 import Agent.CLI.ImagePreview
 import Agent.Loop (ImageAttachment(..))
+import Control.Exception.Safe (bracket)
+import Control.Monad (forM_)
 import Codec.Picture
     ( PixelYCbCr8(..)
     , encodeJpegAtQuality
@@ -10,10 +12,32 @@ import Codec.Picture
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as Text
+import qualified Data.Text.IO as TextIO
+import System.Directory (getTemporaryDirectory, removeFile)
+import System.IO (Handle, SeekMode(..), hClose, hFileSize, hSeek, openTempFile)
 import Test.Hspec
+
+withCaptureHandle :: (Handle -> IO a) -> IO a
+withCaptureHandle action = do
+    directory <- getTemporaryDirectory
+    bracket (openTempFile directory "chart-output")
+        (\(path, handle) -> hClose handle >> removeFile path)
+        (action . snd)
 
 spec :: Spec
 spec = do
+    describe "chart output routing" do
+        forM_ [False, True] \oneShot ->
+            it ("keeps redirected stdout clean with one-shot mode " <> show oneShot) do
+                withCaptureHandle \output ->
+                    withCaptureHandle \diagnostics -> do
+                        routeChartPresentation oneShot output diagnostics
+                            (Just "Revenue: 東京")
+                            (expectationFailure "Unexpected bitmap output")
+                        hFileSize output `shouldReturn` 0
+                        hSeek diagnostics AbsoluteSeek 0
+                        TextIO.hGetLine diagnostics `shouldReturn` "Revenue: 東京"
+
     describe "parseImagePreviewProtocol" do
         it "detects Kitty, Ghostty, and WezTerm" do
             parseImagePreviewProtocol (Just "xterm-kitty") Nothing (Just "1") Nothing

--- a/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PromptSpec.hs
@@ -52,6 +52,16 @@ systemPromptForToolsWithHostedSearch includeHostedSearch dialect =
 
 spec :: Spec
 spec = describe "systemPrompt" do
+    it "adds chart guidance only when render_chart is registered, independently of show_image" do
+        let prompt tools = systemPromptForTools codexDialect tools
+                (fromFilePath "/workspace") Nothing (fromGregorian 2026 9 8) False
+            withCharts = prompt ["render_chart"]
+        withCharts `shouldSatisfy` Text.isInfixOf "Use render_chart"
+        withCharts `shouldSatisfy` Text.isInfixOf "Do not promise hover or zoom"
+        withCharts `shouldNotSatisfy` Text.isInfixOf "Use show_image"
+        prompt ["show_image"] `shouldNotSatisfy` Text.isInfixOf "Chart display:"
+        prompt ["render_chart", "show_image"] `shouldSatisfy` Text.isInfixOf "Use show_image"
+
     it "keeps ownership guidance after bundled catalog instructions" do
         catalog <- loadBundledModelsOrThrow
         catalog.models `shouldSatisfy` (not . null)

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -76,6 +76,9 @@ import Agent.CLI.TUI.App
 import Agent.CLI.WindowTitle (oscWindowTitleBytes)
 import Agent.CLI.TUI.Types
     ( AppEvent(..)
+    , AppEventMailbox(..)
+    , AppEventMailboxState(..)
+    , PendingAppEvent(..)
     , AppState(..)
     , ChoiceOverlay(..)
     , ChoicePresentation(..)
@@ -160,13 +163,14 @@ import Agent.TUI.Presentation
     )
 import Agent.TUI.Motion
 import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, threadDelay)
-import Control.Concurrent.Async (waitCatch)
+import Control.Concurrent.Async (waitCatch, withAsync)
 import Control.Exception.Safe (bracket, bracket_)
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import Control.Exception (AsyncException(UserInterrupt))
 import qualified Control.Exception as Exception
 import Control.Concurrent.STM
     ( atomically
+    , readTVar
     , newEmptyTMVarIO
     , newTChanIO
     , retry
@@ -204,7 +208,7 @@ import Agent.Tools.RenderChart (renderChartResult)
 spec :: Spec
 spec = do
     describe "durable chart previews" do
-        it "restores previews on history reset and page load and clears them on replacement" do
+        it "queues history charts without rasterizing on reset or page load" do
             runtime <- newScriptRuntime initialUiState
             envelope <- either (fail . Text.unpack) pure (renderChartResult
                 "{\"version\":1,\"kind\":\"bar\",\"title\":\"Requests\",\"x_axis\":{\"type\":\"category\",\"label\":\"Region\"},\"y_axis\":{\"label\":\"Count\"},\"series\":[{\"name\":\"Requests\",\"points\":[{\"x\":\"EU\",\"y\":4}]}]}")
@@ -219,9 +223,60 @@ spec = do
                 reset = History.resetHistoryPage (page [durable 0]) initial
                 loaded = History.applyLoadedHistoryPage (page [durable 1]) reset
                 cleared = History.resetHistoryPage (page []) loaded
-            Map.size reset.appSubmittedImagePreviews `shouldBe` 1
-            Map.size loaded.appSubmittedImagePreviews `shouldBe` 2
+            Map.null reset.appSubmittedImagePreviews `shouldBe` True
+            Map.null loaded.appSubmittedImagePreviews `shouldBe` True
+            History.queueHistoryChartPreviews reset
+            first <- atomically (readTVar runtime.runtimeHistoryChartRequests)
+            length first `shouldBe` 1
+            History.queueHistoryChartPreviews loaded
+            second <- atomically (readTVar runtime.runtimeHistoryChartRequests)
+            length second `shouldBe` 2
+            let chartHeavy = History.resetHistoryPage
+                    (page (map durable [0 .. 69])) initial
+            History.queueHistoryChartPreviews chartHeavy
+            bounded <- atomically (readTVar runtime.runtimeHistoryChartRequests)
+            length bounded `shouldBe` 64
+            History.queueHistoryChartPreviews cleared
+            atomically (readTVar runtime.runtimeHistoryChartRequests) `shouldReturn` []
             Map.null cleared.appSubmittedImagePreviews `shouldBe` True
+        it "publishes prepared charts on a scoped worker and rejects stale results" do
+            runtime <- newScriptRuntime initialUiState
+            envelope <- either (fail . Text.unpack) pure (renderChartResult
+                "{\"version\":1,\"kind\":\"bar\",\"title\":\"Requests\",\"x_axis\":{\"type\":\"category\"},\"y_axis\":{},\"series\":[{\"name\":\"Requests\",\"points\":[{\"x\":\"EU\",\"y\":4}]}]}")
+            let durable = HistoryTurn (HistoryCursor 0)
+                    (Seq.singleton (markerBlock (BlockId 1) "Requests"))
+                    (Map.singleton (BlockId 1) envelope)
+                page = HistoryPage (HistoryGeneration 0) HistoryNewer
+                    (Seq.singleton durable) (HistoryCursor 0) 1 False False
+                initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, reset) <- runFullscreenScriptWithState initial
+                [FullscreenScriptApp (AppHistoryReset page), FullscreenScriptHalt]
+            result <- withAsync (History.runHistoryChartWorker runtime) \_ ->
+                timeout 10_000_000 $ atomically do
+                    let AppEventMailbox mailbox = runtime.runtimeMailbox
+                    pending <- readTVar mailbox
+                    case
+                        [ (generation, blockId, preview)
+                        | PendingEvent (AppHistoryChartPrepared generation blockId preview) <-
+                            toList pending.mailboxPendingEvents
+                        ] of
+                        prepared : _ -> pure prepared
+                        _ -> retry
+            case result of
+                Nothing -> expectationFailure "History chart worker did not publish a preview"
+                Just (generation, blockId, preview) -> do
+                    preview.previewSourceWidth `shouldBe` 960
+                    preview.previewSourceHeight `shouldBe` 600
+                    let restored = History.applyHistoryChartPreview generation blockId preview reset
+                        stale = History.applyHistoryChartPreview (HistoryGeneration 99) blockId preview reset
+                        removed = History.resetHistoryPage
+                            (page { historyPageTurns = Seq.empty }) reset
+                        rejected = History.applyHistoryChartPreview generation blockId preview removed
+                    Map.size restored.appSubmittedImagePreviews `shouldBe` 1
+                    History.queueHistoryChartPreviews restored
+                    atomically (readTVar runtime.runtimeHistoryChartRequests) `shouldReturn` []
+                    Map.null stale.appSubmittedImagePreviews `shouldBe` True
+                    Map.null rejected.appSubmittedImagePreviews `shouldBe` True
     describe "pull request event state" do
         let url = "https://github.com/owner/repository/pull/42"
             association generation =

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -198,9 +198,30 @@ import Graphics.Vty.Span (SpanOp(..))
 import qualified Agent.CLI.TUI.Composer as Composer
 import System.Timeout (timeout)
 import Test.Hspec
+import qualified Agent.CLI.TUI.App as History
+import Agent.Tools.RenderChart (renderChartResult)
 
 spec :: Spec
 spec = do
+    describe "durable chart previews" do
+        it "restores previews on history reset and page load and clears them on replacement" do
+            runtime <- newScriptRuntime initialUiState
+            envelope <- either (fail . Text.unpack) pure (renderChartResult
+                "{\"version\":1,\"kind\":\"bar\",\"title\":\"Requests\",\"x_axis\":{\"type\":\"category\",\"label\":\"Region\"},\"y_axis\":{\"label\":\"Count\"},\"series\":[{\"name\":\"Requests\",\"points\":[{\"x\":\"EU\",\"y\":4}]}]}")
+            let durable cursor = HistoryTurn
+                    { historyTurnCursor = HistoryCursor cursor
+                    , historyTurnBlocks = Seq.singleton (markerBlock (BlockId 1) "Requests")
+                    , historyTurnCharts = Map.singleton (BlockId 1) envelope
+                    }
+                page turns = HistoryPage (HistoryGeneration 1) HistoryNewer
+                    (Seq.fromList turns) (HistoryCursor 0) 2 False False
+                initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+                reset = History.resetHistoryPage (page [durable 0]) initial
+                loaded = History.applyLoadedHistoryPage (page [durable 1]) reset
+                cleared = History.resetHistoryPage (page []) loaded
+            Map.size reset.appSubmittedImagePreviews `shouldBe` 1
+            Map.size loaded.appSubmittedImagePreviews `shouldBe` 2
+            Map.null cleared.appSubmittedImagePreviews `shouldBe` True
     describe "pull request event state" do
         let url = "https://github.com/owner/repository/pull/42"
             association generation =
@@ -2432,6 +2453,7 @@ replacementAfterHistoryReplacement scenario = do
             }
         durableTurn = HistoryTurn
             { historyTurnCursor = HistoryCursor 0
+            , historyTurnCharts = Map.empty
             , historyTurnBlocks = Seq.singleton durableBlock
             }
         initialState =
@@ -2485,6 +2507,7 @@ replacementPreservesFollow follow = do
         (initialUiState { uiFollow = follow })
     let durableTurn = HistoryTurn
             { historyTurnCursor = HistoryCursor 0
+            , historyTurnCharts = Map.empty
             , historyTurnBlocks =
                 Seq.singleton
                     (markerBlock
@@ -2517,6 +2540,7 @@ startupMessagesPrecedeFirstCommittedTurn = do
                 reduceUi (UiUserSubmitted "first prompt") initialUiState
         durableTurn = HistoryTurn
             { historyTurnCursor = HistoryCursor 0
+            , historyTurnCharts = Map.empty
             , historyTurnBlocks = durableUi.uiBlocks
             }
         initialState =
@@ -2549,6 +2573,7 @@ interTurnMessagesPrecedeNextCommittedTurn = do
                         reduceUi (UiUserSubmitted prompt) initialUiState
             in HistoryTurn
                 { historyTurnCursor = HistoryCursor cursor
+                , historyTurnCharts = Map.empty
                 , historyTurnBlocks = durableUi.uiBlocks
                 }
         commit cursor prompt response =
@@ -2584,6 +2609,7 @@ resetDoesNotRetainPriorSystemMessages = do
                 reduceUi (UiUserSubmitted "new prompt") initialUiState
         durableTurn = HistoryTurn
             { historyTurnCursor = HistoryCursor 0
+            , historyTurnCharts = Map.empty
             , historyTurnBlocks = durableUi.uiBlocks
             }
         initialState =
@@ -2621,6 +2647,7 @@ committedPreviewKeys = do
                 }
         durableTurn = HistoryTurn
             { historyTurnCursor = HistoryCursor 0
+            , historyTurnCharts = Map.empty
             , historyTurnBlocks =
                 Seq.singleton (markerBlock (BlockId 0) "question")
             }
@@ -2727,6 +2754,7 @@ historyTestTurn :: Int -> BlockId -> HistoryTurn
 historyTestTurn cursor blockId =
     HistoryTurn
         { historyTurnCursor = HistoryCursor (fromIntegral cursor)
+        , historyTurnCharts = Map.empty
         , historyTurnBlocks =
             Seq.singleton
                 (markerBlock blockId ("turn " <> Text.pack (show cursor)))
@@ -2813,6 +2841,7 @@ unfocusedHistoryResetIsVisible = do
         cursor = HistoryCursor 0
         durableTurn = HistoryTurn
             { historyTurnCursor = cursor
+            , historyTurnCharts = Map.empty
             , historyTurnBlocks =
                 Seq.singleton
                     (markerBlock
@@ -3131,6 +3160,7 @@ cachedHistoryState blocks = do
     let ui = reduceUi (UiFocusChanged FocusScrollback) initialUiState
         turn = HistoryTurn
             { historyTurnCursor = HistoryCursor 0
+            , historyTurnCharts = Map.empty
             , historyTurnBlocks = Seq.fromList blocks
             }
         window =

--- a/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIHistorySpec.hs
@@ -15,6 +15,8 @@ import Agent.CLI.TUI.History
 import Agent.Json (rawJsonFromEncoding)
 import Agent.CLI.TUI.Composer (composerScrollbackAvailable)
 import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn, sessionTurnPullRequestURL)
+import Agent.CLI.TUI.App (remapHistoryPage)
+import Agent.Tools.RenderChart (renderChartResult)
 import Agent.CLI.Session.PullRequest (sessionTurnPullRequestURLs)
 import Agent.Responses.LoopBackend (toolResultToItem)
 import Agent.Responses.Types
@@ -46,6 +48,41 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "bounded fullscreen history window" do
+    it "retains complete validated chart results separately from display summaries" do
+        let projected = sessionHistoryTurn (0 :: Int)
+                (sessionTurn TranscriptAppend "" (chartItems "render_chart" chartEnvelope))
+        Map.elems projected.historyTurnCharts `shouldBe` [chartEnvelope]
+        let chartBlocks =
+                [ block.blockId
+                | block <- toList projected.historyTurnBlocks
+                , block.blockCallId == Just "chart-call"
+                ]
+        Map.keys projected.historyTurnCharts `shouldBe` chartBlocks
+
+    it "rejects chart envelopes from other tools and malformed chart results" do
+        let project name output = (sessionHistoryTurn (0 :: Int)
+                (sessionTurn TranscriptAppend "" (chartItems name output))).historyTurnCharts
+        project "shell_command" chartEnvelope `shouldBe` Map.empty
+        project "render_chart" "{}" `shouldBe` Map.empty
+
+    it "remaps chart documents with their history blocks and accounts for document bytes" do
+        let projected = sessionHistoryTurn (0 :: Int)
+                (sessionTurn TranscriptAppend "" (chartItems "render_chart" chartEnvelope))
+            page = HistoryPage (HistoryGeneration 1) HistoryNewer
+                (Seq.singleton projected) (HistoryCursor 0) 1 False False
+            (_, remapped) = remapHistoryPage (-1) page
+            window = emptyHistoryWindow (HistoryGeneration 1) 10 100 1000000
+        restored <- case toList remapped.historyPageTurns of
+            [value] -> pure value
+            _ -> expectationFailure "expected one remapped history turn" >> fail "missing history turn"
+        Map.elems restored.historyTurnCharts `shouldBe` [chartEnvelope]
+        Map.keys restored.historyTurnCharts `shouldSatisfy`
+            all (`elem` map (.blockId) (toList restored.historyTurnBlocks))
+        let withChart = appendHistoryTurn restored window
+            withoutChart = appendHistoryTurn (restored { historyTurnCharts = Map.empty }) window
+        historyWindowLoadedBytes withChart - historyWindowLoadedBytes withoutChart
+            `shouldBe` 2 * Text.length chartEnvelope
+
     it "projects history in order, coalescing within turns but not across turn boundaries" do
         let regular = Seq.fromList [block identifier | identifier <- [1 .. 31]]
             readBlock = inspectionBlock 32 "Read a.hs"
@@ -54,11 +91,12 @@ spec = describe "bounded fullscreen history window" do
             fetchedBlock = inspectionBlock 35 "Fetched docs"
             turns =
                 Seq.fromList
-                    [ HistoryTurn (HistoryCursor 1) (regular Seq.|> readBlock)
-                    , HistoryTurn (HistoryCursor 2) (Seq.singleton listedBlock)
+                    [ HistoryTurn (HistoryCursor 1) (regular Seq.|> readBlock) Map.empty
+                    , HistoryTurn (HistoryCursor 2) (Seq.singleton listedBlock) Map.empty
                     , HistoryTurn
                         (HistoryCursor 3)
                         (Seq.fromList [searchedBlock, fetchedBlock])
+                        Map.empty
                     ]
             window =
                 setHistoryWindowTurns turns $
@@ -122,6 +160,7 @@ spec = describe "bounded fullscreen history window" do
                         [ inspectionBlock 70 "Searched first"
                         , inspectionBlock 71 "Searched second"
                         ])
+                    Map.empty
             original =
                 setHistoryWindowTurns (Seq.singleton historyTurn) $
                     emptyHistoryWindow
@@ -1135,12 +1174,33 @@ turn :: Int64 -> Int -> HistoryTurn
 turn cursor blocks =
     HistoryTurn
         { historyTurnCursor = HistoryCursor cursor
+        , historyTurnCharts = Map.empty
         , historyTurnBlocks =
             Seq.fromList
                 [ block (fromIntegral cursor * 10 + index)
                 | index <- [0 .. blocks - 1]
                 ]
         }
+
+chartEnvelope :: Text.Text
+chartEnvelope =
+    either (error . Text.unpack) id (renderChartResult
+        "{\"version\":1,\"kind\":\"line\",\"title\":\"Requests\",\"x_axis\":{\"type\":\"number\",\"label\":\"Time\"},\"y_axis\":{\"label\":\"Count\"},\"series\":[{\"name\":\"Requests\",\"points\":[{\"x\":1,\"y\":2},{\"x\":2,\"y\":4}]}]}")
+
+chartItems :: Text.Text -> Text.Text -> [ResponseItem]
+chartItems name envelope =
+    [ FunctionCallItem FunctionCall
+        { itemId = Nothing, callId = "chart-call", name
+        , namespace = Nothing, provider = Nothing, arguments = "{}"
+        , encryptedFunctionArgs = Nothing, status = Just ItemCompleted, async = Nothing
+        }
+    , FunctionCallOutputItem FunctionCallOutput
+        { localOutcome = Nothing, itemId = Nothing, callId = "chart-call"
+        , name = Nothing, namespace = Nothing, provider = Nothing
+        , output = rawJsonFromEncoding (Aeson.toEncoding envelope)
+        , status = Just ItemCompleted, async = Nothing
+        }
+    ]
 
 block :: Int -> UiBlock
 block identifier =

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.ToolsSpec (spec) where
 
 import Agent.CLI.Tools
+import Agent.CLI.ChartImage (terminalChartTool)
 import Agent.CLI.ComputerUse (computerUseTool)
 import Agent.CLI.CodeModeRuntime
     ( CodeModeProjectionStrategy(..)
@@ -10,12 +11,14 @@ import Agent.CLI.CodeModeRuntime
     , projectCodeModeTools
     , projectCodeModeToolsFor
     )
+import Agent.Tools.RenderChart (renderChartResult)
+import Agent.Tools.ShowImage (ImageDisplayHooks(..), ImageDisplayRequest(..))
 import Agent.Dialect
     ( claudeCodeDialect
     , codexDialect
     , grokBuildDialect
     )
-import Agent.Loop (LoopError(..))
+import Agent.Loop (LoopError(..), ImageAttachment(..))
 import Agent.Json (RawJson, rawJsonBytes, rawJsonFromEncoding)
 import Agent.Json.Decode qualified as Hermes
 import Agent.Responses.Types
@@ -29,6 +32,10 @@ import Agent.ToolDispatch
     ( ToolCall(..)
     , ToolCallKind(..)
     , ToolCallResult(..)
+    , ToolDispatchConfig(..)
+    , ToolDispatchOutcome(..)
+    , dispatchToolHandlerDetailed
+    , functionToolCall
     , noArgsTool
     )
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
@@ -54,6 +61,8 @@ import Agent.Tools.Types
 import Control.Exception.Safe (bracket)
 import Control.Monad (join)
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import Data.IORef (newIORef, readIORef, modifyIORef')
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Info (os)
@@ -62,6 +71,50 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "schemasFromAppTools" do
+    describe "terminalChartTool" do
+        let input = "{\"version\":1,\"kind\":\"line\",\"title\":\"Revenue\",\"x_axis\":{\"type\":\"number\"},\"y_axis\":{},\"series\":[{\"name\":\"Sales\",\"points\":[{\"x\":1,\"y\":2},{\"x\":2,\"y\":3}]}]}"
+            config = ToolDispatchConfig
+                { toolDispatchUnknownTool = id
+                , toolDispatchFormatResult = either id id
+                , toolDispatchFormatException = \_ exception -> Text.pack (show exception)
+                , toolDispatchOnException = \_ _ -> pure ()
+                , toolDispatchOnOutput = \_ _ -> pure ()
+                , toolDispatchFinalizeOutput = \_ -> pure
+                }
+            invoke hooks arguments =
+                dispatchToolHandlerDetailed config
+                    (Just (terminalChartTool hooks).appToolHandler)
+                    (functionToolCall "chart-call" "render_chart" arguments)
+        it "displays a PNG for the original call while preserving the durable document" do
+            requests <- newIORef []
+            result <- invoke (ImageDisplayHooks \request -> do
+                modifyIORef' requests (request :)
+                pure (Right ())) input
+            result.toolDispatchSucceeded `shouldBe` True
+            Right result.toolDispatchResult.output `shouldBe` renderChartResult input
+            result.toolDispatchResult.toolResultImages `shouldBe` []
+            readIORef requests >>= \case
+                [request] -> do
+                    request.displayCallId `shouldBe` "chart-call"
+                    request.displayImage.imageMime `shouldBe` "image/png"
+                    BS.take 8 request.displayImage.imageBytes
+                        `shouldBe` BS.pack [137, 80, 78, 71, 13, 10, 26, 10]
+                    request.displayCaption `shouldSatisfy`
+                        maybe False (Text.isInfixOf "Revenue")
+                _ -> expectationFailure "expected exactly one chart display"
+        it "rejects invalid chart input before calling the display hook" do
+            calls <- newIORef (0 :: Int)
+            result <- invoke (ImageDisplayHooks \_ -> do
+                modifyIORef' calls (+ 1)
+                pure (Right ())) "{}"
+            result.toolDispatchSucceeded `shouldBe` False
+            readIORef calls `shouldReturn` 0
+        it "propagates display failures without attaching image bytes to the result" do
+            result <- invoke (ImageDisplayHooks \_ -> pure (Left "display unavailable")) input
+            result.toolDispatchSucceeded `shouldBe` False
+            result.toolDispatchResult.output `shouldBe` "display unavailable"
+            result.toolDispatchResult.toolResultImages `shouldBe` []
+
     it "emits async only when both the model and tool opt in" do
         let capable = withAsyncToolCalls jsonTool
             project modelCapability tool =

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -57,6 +57,7 @@ import qualified Agent.CLI.GatewayModelsSpec as GatewayModelsSpec
 import qualified Agent.CLI.IntegrationGatewaySpec as IntegrationGatewaySpec
 import qualified Agent.CLI.GitDiffSpec as GitDiffSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
+import qualified Agent.CLI.ChartImageSpec as ChartImageSpec
 import qualified Agent.CLI.InputSpec as InputSpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
 import qualified Agent.CLI.LoginSpec as LoginSpec
@@ -192,6 +193,7 @@ specs = do
     IntegrationGatewaySpec.spec
     GitDiffSpec.spec
     ImagePreviewSpec.spec
+    ChartImageSpec.spec
     InputSpec.spec
     InterruptSpec.spec
     LoginSpec.spec

--- a/packages/agent-core/src/Agent/Tools/RenderChart.hs
+++ b/packages/agent-core/src/Agent/Tools/RenderChart.hs
@@ -5,24 +5,28 @@ module Agent.Tools.RenderChart
     , renderChartResult
     , chartResultDocument
     , chartResultSummary
+    , chartResultFallback
     ) where
 
 import Agent.ToolDispatch (textTool)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.Tools.Types (AppTool, ToolExecutionPolicy(..), jsonTool)
 import Control.Monad (unless, when)
-import Data.Aeson (Value(..), Object, eitherDecodeStrict', encode, object, (.=), (.:), (.:?))
+import Data.Aeson (Value(..), Object, eitherDecodeStrict', encode, object, (.=), (.:), (.:?), (.!=))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.Types (Parser, parseEither, parseMaybe, withObject)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
+import Data.Char (isControl)
+import Data.List (nub)
 import Data.Scientific (toRealFloat)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import Data.Time (UTCTime, defaultTimeLocale, parseTimeM)
+import Numeric (showGFloat)
 
 renderChartToolName :: Text
 renderChartToolName = "render_chart"
@@ -92,6 +96,53 @@ chartResultDocument = fmap (encodeText . fst) . parseChartResult
 
 chartResultSummary :: Text -> Maybe Text
 chartResultSummary = fmap snd . parseChartResult
+
+-- | Accessible plain-text presentation shared by terminal views. Derive every
+-- label from the validated document, never from stored summary prose. Preserve
+-- Unicode even when a client's bitmap font cannot display it.
+chartResultFallback :: Text -> Maybe Text
+chartResultFallback input = do
+    (document, _) <- parseChartResult input
+    parseMaybe describeChart document
+  where
+    describeChart = withObject "chart" \fields -> do
+        title <- fields .: "title"
+        kind <- fields .: "kind"
+        subtitle <- fields .:? "subtitle" .!= ""
+        xAxis <- fields .: "x_axis"
+        yAxis <- fields .: "y_axis"
+        xDescription <- describeAxis xAxis
+        yDescription <- describeAxis yAxis
+        axisType <- withObject "axis" (.: "type") xAxis
+        series <- fields .: "series" >>= traverse (describeSeries axisType)
+        let categories = nub (concatMap fst series)
+        pure (Text.intercalate "\n" $
+            filter (not . Text.null)
+                [ safeLabel title <> " [" <> kind <> " chart]"
+                , safeLabel subtitle
+                , "X: " <> xDescription <> "; Y: " <> yDescription
+                , if null categories then "" else
+                    "Categories: " <> Text.intercalate ", " categories
+                ] <> map snd series)
+    describeAxis = withObject "axis" \fields -> do
+        label <- fields .:? "label" .!= ""
+        unit <- fields .:? "unit" .!= ""
+        pure (safeLabel label <> if Text.null unit then "" else " (" <> safeLabel unit <> ")")
+    describeSeries axisType = withObject "series" \fields -> do
+        name <- fields .: "name"
+        points <- fields .: "points" :: Parser [Value]
+        categories <- if axisType == ("category" :: Text)
+            then traverse (withObject "point" (fmap safeLabel . (.: "x"))) points
+            else pure []
+        ordinates <- traverse (withObject "point" (\point -> point .: "y" >>= finiteNumber)) points
+        pure (categories, safeLabel name <> ": " <> Text.pack (show (length points))
+            <> (if length points == 1 then " point; range " else " points; range ")
+            <> numberText (minimum ordinates) <> " to " <> numberText (maximum ordinates))
+    safeLabel = Text.unwords . Text.words . Text.map \character ->
+        if isControl character then ' ' else character
+    numberText value
+        | value == 0 = "0"
+        | otherwise = Text.pack (showGFloat (Just 3) value "")
 
 parseChartResult :: Text -> Maybe (Value, Text)
 parseChartResult input = do

--- a/packages/agent-core/test/Agent/Tools/RenderChartSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/RenderChartSpec.hs
@@ -33,6 +33,28 @@ spec = describe "Agent.Tools.RenderChart" do
             renderChartResult (document kind "number" [point (Number 1) (-4)])
                 `shouldSatisfy` isRight) ["line", "bar", "area", "scatter"]
 
+    it "keeps every Unicode category in the accessible chart fallback" do
+        let labels = ["地域" <> Text.pack (show index) | index <- [1 :: Int .. 12]]
+            input = document "bar" "category" [point (String label) 2 | label <- labels]
+        case renderChartResult input >>= maybe (Left "Missing fallback") Right . chartResultFallback of
+            Left err -> expectationFailure (Text.unpack err)
+            Right fallback ->
+                mapM_ (\label -> fallback `shouldSatisfy` Text.isInfixOf label) labels
+
+    it "rejects invalid chart envelopes instead of trusting stored fallback text" do
+        chartResultFallback "{\"type\":\"chart\",\"summary\":\"Forged\"}" `shouldBe` Nothing
+        chartResultFallback "Error: invalid chart" `shouldBe` Nothing
+
+    it "removes terminal controls from every chart fallback label" do
+        let input = "{\"version\":1,\"kind\":\"bar\",\"title\":\"売上\",\"subtitle\":\"地域\\u0007別\",\"x_axis\":{\"type\":\"category\",\"label\":\"都\\u001b市\",\"unit\":\"区\\u009b域\"},\"y_axis\":{\"label\":\"収\\u000d益\",\"unit\":\"円\\u0008\"},\"series\":[{\"name\":\"実\\u0000績\",\"points\":[{\"x\":\"東\\u001b京\",\"y\":2}]}]}"
+        case renderChartResult input >>= maybe (Left "Missing fallback") Right . chartResultFallback of
+            Left err -> expectationFailure (Text.unpack err)
+            Right fallback -> do
+                mapM_ (\label -> fallback `shouldSatisfy` Text.isInfixOf label)
+                    ["地域 別", "都 市", "区 域", "収 益", "円", "実 績", "東 京"]
+                mapM_ (\control -> fallback `shouldNotSatisfy` Text.isInfixOf control)
+                    ["\ESC", "\NUL", "\BEL", "\r", "\BS", "\x9b"]
+
     it "rejects unsupported versions, kinds and fields" do
         let input = document "bar" "number" [point (Number 1) 2]
         renderChartResult (Text.replace "\"version\":1" "\"version\":2" input) `shouldSatisfy` isLeft

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -53,7 +53,7 @@ import Agent.JsonText
 import qualified Agent.Json.Decode as Hermes
 import Agent.OsPath (fromText, relativeDisplayPath)
 import Agent.TUI.TextWidth (displayTerminalText)
-import Agent.Tools.RenderChart (chartResultSummary)
+import Agent.Tools.RenderChart (chartResultFallback)
 import Agent.ToolDispatch
     ( ToolCall(..)
     , canonicalToolName
@@ -590,7 +590,7 @@ searchReplaceLineStart output =
 formatToolOutput :: ToolCall -> Text -> Text
 formatToolOutput call output = case canonicalToolName call.name of
     "render_chart" ->
-        displayTerminalText (fromMaybe output (chartResultSummary output))
+        displayTerminalText (fromMaybe output (chartResultFallback output))
     "computer" -> "Screenshot captured"
     "exec" -> completedExecOutput output
     "mcp_call" -> formatMcpOutput output

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -53,6 +53,7 @@ import Agent.JsonText
 import qualified Agent.Json.Decode as Hermes
 import Agent.OsPath (fromText, relativeDisplayPath)
 import Agent.TUI.TextWidth (displayTerminalText)
+import Agent.Tools.RenderChart (chartResultSummary)
 import Agent.ToolDispatch
     ( ToolCall(..)
     , canonicalToolName
@@ -588,6 +589,8 @@ searchReplaceLineStart output =
 
 formatToolOutput :: ToolCall -> Text -> Text
 formatToolOutput call output = case canonicalToolName call.name of
+    "render_chart" ->
+        displayTerminalText (fromMaybe output (chartResultSummary output))
     "computer" -> "Screenshot captured"
     "exec" -> completedExecOutput output
     "mcp_call" -> formatMcpOutput output

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -22,6 +22,17 @@ spec = describe "tool presentation" do
                 presented `shouldNotSatisfy` Text.isInfixOf "\"points\""
                 presented `shouldNotSatisfy` Text.isInfixOf "\ESC"
 
+    it "retains Unicode chart axis, unit, category and series labels in fullscreen text" do
+        let call = functionToolCall "chart" "render_chart" "{}"
+            input = "{\"version\":1,\"kind\":\"bar\",\"title\":\"売上\",\"subtitle\":\"地域別\",\"x_axis\":{\"type\":\"category\",\"label\":\"都市\"},\"y_axis\":{\"label\":\"収益\",\"unit\":\"円\"},\"series\":[{\"name\":\"実績\",\"points\":[{\"x\":\"東京\",\"y\":2},{\"x\":\"大阪\",\"y\":3}]}]}"
+        case renderChartResult input of
+            Left err -> expectationFailure (Text.unpack err)
+            Right output -> do
+                let presented = formatToolOutput call output
+                mapM_ (\label -> presented `shouldSatisfy` Text.isInfixOf label)
+                    ["売上", "地域別", "都市", "収益", "円", "実績", "東京", "大阪"]
+                presented `shouldNotSatisfy` Text.isInfixOf "\"points\""
+
     it "separates only real filesystem paths from tool actions" do
         let readFile =
                 functionToolCall

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -1,6 +1,7 @@
 module Agent.TUI.PresentationSpec (spec) where
 
 import Agent.TUI.Presentation
+import Agent.Tools.RenderChart (renderChartResult)
 import Agent.ToolDispatch
     ( customToolCall
     , functionToolCall
@@ -10,6 +11,17 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "tool presentation" do
+    it "summarizes chart results without leaking the document or terminal controls" do
+        let call = functionToolCall "chart" "render_chart" "{}"
+            input = "{\"version\":1,\"kind\":\"line\",\"title\":\"Revenue\\u001b[2J\",\"x_axis\":{\"type\":\"number\"},\"y_axis\":{},\"series\":[{\"name\":\"Sales\",\"points\":[{\"x\":1,\"y\":2}]}]}"
+        case renderChartResult input of
+            Left err -> expectationFailure (Text.unpack err)
+            Right output -> do
+                let presented = formatToolOutput call output
+                presented `shouldSatisfy` Text.isInfixOf "Revenue"
+                presented `shouldNotSatisfy` Text.isInfixOf "\"points\""
+                presented `shouldNotSatisfy` Text.isInfixOf "\ESC"
+
     it "separates only real filesystem paths from tool actions" do
         let readFile =
                 functionToolCall


### PR DESCRIPTION
## Summary
- Add `render_chart` to the terminal agent with static line, bar, area, and scatter charts.
- Render bounded PNG previews through the existing image transport, including Ghostty's Kitty graphics support.
- Restore durable history charts on a scoped background worker with bounded, replaceable requests and stale-result rejection.
- Keep one-shot and redirected stdout free of chart presentation; send text fallback to stderr instead.
- Share a validated, control-character-safe Unicode fallback between inline and fullscreen views, preserving titles, subtitles, axes, units, series, and categories.

## Validation
- Focused CLI integration: chart 20/20, terminalChartTool 3/3, image 47/47, bounded history 76/76.
- Core chart tests 16/16; TUI presentation tests 32/32.
- Regression coverage for output routing, asynchronous history preparation, queue bounds/replacement, stale results, and Unicode/control-character handling.
- TTY routing smoke: interactive presentation goes to stdout; one-shot presentation goes to stderr even with terminal stdout.
- Fresh `Agent.CLI.run` tmux smoke through Cabal GHCi: startup, `/help`, cursor editing, resize from 110×35 to 72×24, and clean exit all passed without a provider submission.
- History benchmark covers 1, 8, and 64 distinct 2,000-point charts, measuring both event-thread and total-work boundaries. At 64 charts, reset/enqueue takes 0.184 ms versus 6,826 ms synchronously; total rendering work remains similar. Methodology and results are in `packages/agent-cli/benchmark/HistoryChartRestoration.md`.

## Scope and limitations
- Static charts, not interactive macOS chart controls.
- Bitmap text uses the existing limited font; the accompanying text preserves Unicode labels.
- Kitty payload construction and PNG decoding were verified; actual Ghostty pixel output and a provider-driven end-to-end chart turn were not verified.
