### PR TITLE
Fix 15-second delay opening idle session event streams

### DIFF
--- a/packages/agent-server/agent-server.cabal
+++ b/packages/agent-server/agent-server.cabal
@@ -149,6 +149,7 @@ test-suite agent-server-test
                     , directory
                     , filepath
                     , hspec >= 2.11 && < 2.12
+                    , http-client
                     , http-types
                     , safe-exceptions
                     , stm
@@ -158,3 +159,4 @@ test-suite agent-server-test
                     , unix
                     , wai
                     , wai-extra
+                    , warp

--- a/packages/agent-server/package.nix
+++ b/packages/agent-server/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, agent-cli, agent-cli-runtime, agent-core
 , agent-store, async, base, base64-bytestring, bytestring
-, containers, crypton, directory, filepath, hspec, http-types, lib
+, containers, crypton, directory, filepath, hspec, http-client, http-types, lib
 , memory, optparse-applicative, process, safe-exceptions, stm
 , temporary, text, time, unix, uuid-types, wai, wai-extra, warp
 }:
@@ -20,8 +20,8 @@ mkDerivation {
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
     aeson agent-cli-runtime agent-core async base base64-bytestring
-    bytestring containers crypton directory filepath hspec http-types
-    safe-exceptions stm temporary text time unix wai wai-extra
+    bytestring containers crypton directory filepath hspec http-client http-types
+    safe-exceptions stm temporary text time unix wai wai-extra warp
   ];
   description = "Local HTTP API for managing haskell-agent sessions";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-server/src/Agent/Server/Application.hs
+++ b/packages/agent-server/src/Agent/Server/Application.hs
@@ -1195,8 +1195,8 @@ emitInitialEvents backend boundary subscription write flush = do
             else pure True
     if not resetOk
         then pure False
-        else
-            foldM
+        else do
+            replayOk <- foldM
                 (\continue event ->
                     if not continue
                         then pure False
@@ -1211,6 +1211,17 @@ emitInitialEvents backend boundary subscription write flush = do
                                     flush)
                 True
                 subscription.subscriptionReplay
+            if replayOk
+                -- A quiet subscription must flush its response before waiting
+                -- for live events or the first 15-second keepalive. A comment
+                -- opens the transport without changing the replay cursor.
+                then emitUnderBoundary
+                    backend
+                    boundary
+                    (byteString ": connected\n\n")
+                    write
+                    flush
+                else pure False
 
 eventLoop
     :: Backend

--- a/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
@@ -4,6 +4,8 @@ import Agent.Server.Application (
     ApplicationConfig (..),
     newApplication,
  )
+import Network.HTTP.Client qualified as HTTP
+import Network.Wai.Handler.Warp qualified as Warp
 import Agent.Server.Auth
 import Agent.Server.Backend (Backend (..), SessionMutationLease (..))
 import Agent.Server.Supervisor
@@ -69,6 +71,30 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "agent-server WAI application" do
+    it "flushes an idle event stream before the first heartbeat" do
+        withApplication immediateRunner \application ->
+            Warp.testWithApplication (pure application) \port ->
+                bracket
+                    (HTTP.newManager HTTP.defaultManagerSettings)
+                    HTTP.closeManager
+                    \manager -> do
+                        initialRequest <-
+                            HTTP.parseRequest
+                                ("http://127.0.0.1:" <> show port <> "/v1/events")
+                        let request = initialRequest
+                                { HTTP.requestHeaders = validHeaders
+                                , HTTP.proxy = Nothing
+                                }
+                        -- Include response headers in the deadline: waiting only
+                        -- for the body would miss delayed stream establishment.
+                        result <- timeout (2 * 1000 * 1000) $
+                            HTTP.withResponse request manager \response -> do
+                                HTTP.responseStatus response `shouldBe` status200
+                                lookup "Content-Type" (HTTP.responseHeaders response)
+                                    `shouldBe` Just "text/event-stream"
+                                HTTP.brReadSome (HTTP.responseBody response) 13
+                        result `shouldBe` Just ": connected\n\n"
+
     it "decodes image-only turn requests" do
         let decode body = eitherDecode body :: Either String CreateTurnRequest
         request <-


### PR DESCRIPTION
## Summary
- Flush an initial SSE comment after reset/replay processing so an idle `/v1/events` connection opens immediately instead of waiting for its 15-second heartbeat.
- Preserve authorization checks, replay ordering, event identifiers, and subscription cleanup.
- Add a real Warp/HTTP regression test with a two-second deadline covering both response headers and the initial comment; declare its test dependencies in Cabal and Nix.

## Cause
Clients that establish the event subscription before fetching their session snapshot were blocked waiting for response headers on quiet streams. The existing empty-replay path performed no write or flush before entering the heartbeat loop.

## Validation
- Server package tests passed in CI on b5426dbba64e7da9497955cb9839a5f422630a3b, including the new regression test.
- Local GHCi validation was blocked by missing Nix GHC interface files while building agent-cli dependencies, before reaching the server tests.
- git diff --check passed.

## Rollout
Deploy the updated agent-server after merge. This PR does not deploy or change platform configuration.