### PR TITLE
Publish Darwin CLI cache when native-bridge checks fail

### DIFF
--- a/.github/workflows/publish-binary-cache.yml
+++ b/.github/workflows/publish-binary-cache.yml
@@ -206,6 +206,8 @@ jobs:
 
           if (( ${#extra_targets[@]} > 0 )); then
             extra_out_paths_file="$RUNNER_TEMP/haskell-agent-cache-extra-out-paths"
+            extra_realised_file="$RUNNER_TEMP/haskell-agent-cache-extra-realised"
+            : > "$extra_realised_file"
             set +e
             nix_build_roots \
               "$extra_out_paths_file" \
@@ -214,7 +216,44 @@ jobs:
             extra_status=$?
             set -e
             if [[ -s "$extra_out_paths_file" ]]; then
-              cat "$extra_out_paths_file" >> "$root_out_paths_file"
+              cat "$extra_out_paths_file" >> "$extra_realised_file"
+            fi
+            # `nix build --keep-going --print-out-paths` does not print
+            # after a failing Installable::build, even for realised
+            # extras. Collect those outputs from the extra derivations.
+            mapfile -t extra_drvs < <(
+              "$nix_bin" path-info \
+                --derivation \
+                "${extra_targets[@]}"
+            )
+            nix_store_bin="$(command -v nix-store || true)"
+            if (( ${#extra_drvs[@]} > 0 )) && [[ -n "$nix_store_bin" ]]; then
+              extra_all_outputs_file="$RUNNER_TEMP/haskell-agent-cache-extra-outputs"
+              extra_invalid_file="$RUNNER_TEMP/haskell-agent-cache-extra-invalid"
+              "$nix_store_bin" \
+                --query \
+                --outputs \
+                "${extra_drvs[@]}" |
+                sort -u > "$extra_all_outputs_file"
+              if [[ -s "$extra_all_outputs_file" ]]; then
+                mapfile -t extra_outputs < "$extra_all_outputs_file"
+                set +e
+                "$nix_store_bin" \
+                  --check-validity \
+                  --print-invalid \
+                  "${extra_outputs[@]}" \
+                  > "$extra_invalid_file"
+                set -e
+                sort -u "$extra_invalid_file" -o "$extra_invalid_file"
+                comm -23 \
+                  "$extra_all_outputs_file" \
+                  "$extra_invalid_file" \
+                  >> "$extra_realised_file"
+              fi
+            fi
+            if [[ -s "$extra_realised_file" ]]; then
+              cat "$extra_realised_file" >> "$root_out_paths_file"
+              sort -u "$root_out_paths_file" -o "$root_out_paths_file"
             fi
             if [[ "$extra_status" -ne 0 ]]; then
               printf 'CACHE_EXTRA_FAILED=1\n' >> "$GITHUB_ENV"

--- a/.github/workflows/publish-binary-cache.yml
+++ b/.github/workflows/publish-binary-cache.yml
@@ -127,18 +127,19 @@ jobs:
             exit 1
           fi
 
-          build_targets=(
-            # `nix profile add` installs packages.default, while `nix run`
-            # executes apps.default, backed by packages.agent-cli. They are
-            # different outputs on Linux, so publish both closures.
+          # `nix profile add` installs packages.default, while `nix run`
+          # executes apps.default, backed by packages.agent-cli. They are
+          # different outputs on Linux, so publish both closures.
+          release_targets=(
             .#default
             .#agent-cli
           )
+          extra_targets=()
           if [[ "$SYSTEM" == x86_64-linux ]]; then
             # Seed the public cache with the same roots used by the secretless
             # PR matrix. Source filtering lets a PR reuse every unchanged
             # package test while rebuilding only its affected graph.
-            build_targets+=(
+            extra_targets+=(
               .#checks.x86_64-linux.agent-cli
               .#checks.x86_64-linux.agent-external-session
               .#checks.x86_64-linux.agent-repository
@@ -156,38 +157,68 @@ jobs:
           if [[ "$SYSTEM" == aarch64-darwin ]]; then
             # The native bridge is now its own Cabal package rather than an
             # agent-cli component, so build its checked and wrapped outputs
-            # explicitly on the native runner.
-            build_targets+=(
+            # explicitly on the native runner. Keep these off the release
+            # `nix build` so a check failure cannot skip publishing agent-cli.
+            extra_targets+=(
               .#checks.aarch64-darwin.agent-native-bridge
               .#agent-native-bridge
             )
           fi
-
-          build_args=(
-            build
-            "${build_targets[@]}"
-            --no-link
-            --print-out-paths
-            --max-jobs 1
-            --cores "$BUILD_CORES"
+          build_targets=(
+            "${release_targets[@]}"
+            "${extra_targets[@]}"
           )
-          if [[ "$TRUSTED_REBUILD" == true ]]; then
-            # Never restore the Darwin output from the cache previously populated
-            # by the affected Mac. Dependencies still come from cache.nixos.org.
-            build_args+=(
-              --option accept-flake-config false
-              --option substituters https://cache.nixos.org/
-              --option extra-substituters ""
+
+          nix_build_roots() {
+            local out_file="$1"
+            shift
+            local args=(
+              build
+              "$@"
+              --no-link
+              --print-out-paths
+              --max-jobs 1
+              --cores "$BUILD_CORES"
             )
-          else
-            build_args+=(--accept-flake-config)
-          fi
+            if [[ "$TRUSTED_REBUILD" == true ]]; then
+              # Never restore the Darwin output from the cache previously
+              # populated by the affected Mac. Dependencies still come from
+              # cache.nixos.org.
+              args+=(
+                --option accept-flake-config false
+                --option substituters https://cache.nixos.org/
+                --option extra-substituters ""
+              )
+            else
+              args+=(--accept-flake-config)
+            fi
+            "$nix_bin" "${args[@]}" > "$out_file"
+          }
+
+          printf 'CACHE_EXTRA_FAILED=0\n' >> "$GITHUB_ENV"
 
           root_out_paths_file="$RUNNER_TEMP/haskell-agent-cache-root-out-paths"
-          "$nix_bin" "${build_args[@]}" > "$root_out_paths_file"
+          nix_build_roots "$root_out_paths_file" "${release_targets[@]}"
           if [[ ! -s "$root_out_paths_file" ]]; then
             echo "::error title=Missing build outputs::Nix did not report any store paths"
             exit 1
+          fi
+
+          if (( ${#extra_targets[@]} > 0 )); then
+            extra_out_paths_file="$RUNNER_TEMP/haskell-agent-cache-extra-out-paths"
+            set +e
+            nix_build_roots \
+              "$extra_out_paths_file" \
+              --keep-going \
+              "${extra_targets[@]}"
+            extra_status=$?
+            set -e
+            if [[ -s "$extra_out_paths_file" ]]; then
+              cat "$extra_out_paths_file" >> "$root_out_paths_file"
+            fi
+            if [[ "$extra_status" -ne 0 ]]; then
+              printf 'CACHE_EXTRA_FAILED=1\n' >> "$GITHUB_ENV"
+            fi
           fi
 
           # Keep this assertion next to the CI targets so a future app/package
@@ -305,3 +336,8 @@ jobs:
           "$nix_bin" run "$ATTIC_PACKAGE" -- \
             push --jobs 4 --stdin di:public \
             < "$RUNNER_TEMP/haskell-agent-cache-out-paths"
+
+          if [[ "${CACHE_EXTRA_FAILED:-0}" == 1 ]]; then
+            echo "::error title=Optional cache roots failed::Published the release closures; remaining check or native-bridge roots did not all build"
+            exit 1
+          fi

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineLifecycle.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineLifecycle.hs
@@ -8,7 +8,10 @@ import Agent.CLI.MacOS.BundledIntegrations
 import Agent.CLI.MacOS.ComputerBridge (ComputerHost)
 import Agent.CLI.MacOS.ConnectionBridge (sendConnectionResult)
 import Agent.CLI.MacOS.EngineEvents (EventCallback)
-import Agent.CLI.MacOS.EngineCallbacks (invokeIntegrationResultCallback)
+import Agent.CLI.MacOS.EngineCallbacks
+    ( invokeIntegrationResultCallback
+    , invokeTaskSnapshotCallback
+    )
 import Agent.CLI.MacOS.EngineMailbox
 import Agent.CLI.MacOS.EngineState
 import Agent.CLI.MacOS.EngineStore (closeEngineStore)
@@ -35,7 +38,7 @@ import Data.Map.Strict qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Set qualified as Set
 import Data.Text (Text)
-import Foreign.Ptr (FunPtr, Ptr, nullPtr)
+import Foreign.Ptr (FunPtr, Ptr, castPtr, nullPtr)
 import System.OsPath (OsPath)
 
 workerLifecycle
@@ -116,6 +119,15 @@ cancelPendingCallbacks commands = do
                 (Left "Engine stopped before connection operation completed.")
         EngineIntegrationAdminCall _ _ callback context ->
             sendIntegrationStopped callback context
+        EngineTaskSnapshot callback context ->
+            void $ tryAny $
+                withText "engine stopped before task snapshot completed"
+                    \errorPointer errorLength ->
+                        invokeTaskSnapshotCallback
+                            callback context
+                            (-1)
+                            nullPtr 0 nullPtr 0 0
+                            (castPtr errorPointer) errorLength
         _ -> pure ()
   where
     sendIntegrationStopped callback context =

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeSupervisor.hs
@@ -663,49 +663,61 @@ supervisorLoop
                 , "state" Aeson..= state
                 ]
 
-    sendTaskSnapshot snapshotCallback snapshotContext supervisor =
-        withGatewayCredentialLease $
-            loadNativeGatewayIdentity >>= \case
-                Left err ->
-                    withTextBytes err \errorPointer errorLength ->
-                        invokeTaskSnapshotCallback
-                            snapshotCallback
-                            snapshotContext
-                            (-1)
-                            nullPtr 0 nullPtr 0 0
-                            errorPointer errorLength
-                Right gatewayIdentity -> do
-                    forM_ supervisor.supervisorPending \pending ->
-                        when
-                            (nativeTurnRouteMatchesBoundary
-                                pending.pendingTurnGatewayIdentity
-                                gatewayIdentity) $
+    sendTaskSnapshot snapshotCallback snapshotContext supervisor = do
+        delivered <- tryAny $
+            withGatewayCredentialLease $
+                loadNativeGatewayIdentity >>= \case
+                    Left err ->
+                        sendSnapshotFailure snapshotCallback snapshotContext err
+                    Right gatewayIdentity -> do
+                        forM_ supervisor.supervisorPending \pending ->
+                            when
+                                (nativeTurnRouteMatchesBoundary
+                                    pending.pendingTurnGatewayIdentity
+                                    gatewayIdentity) $
+                                    sendSnapshotItem
+                                        snapshotCallback
+                                        snapshotContext
+                                        pending.pendingTurnStart.turnStartId
+                                        pending.pendingTurnStart.turnStartSessionId
+                                        0
+                        forM_
+                            (filter
+                                (\running ->
+                                    let control = running.runningTurnControl
+                                    in nativeTurnRouteMatchesBoundary
+                                        control.turnControlGatewayIdentity
+                                        gatewayIdentity)
+                                (Map.elems supervisor.supervisorRunning))
+                            \running -> do
+                                sessionId <- readTVarIO
+                                    running.runningTurnControl.turnControlSessionId
                                 sendSnapshotItem
                                     snapshotCallback
                                     snapshotContext
-                                    pending.pendingTurnStart.turnStartId
-                                    pending.pendingTurnStart.turnStartSessionId
-                                    0
-                    forM_
-                        (filter
-                            (\running ->
-                                let control = running.runningTurnControl
-                                in nativeTurnRouteMatchesBoundary
-                                    control.turnControlGatewayIdentity
-                                    gatewayIdentity)
-                            (Map.elems supervisor.supervisorRunning))
-                        \running -> do
-                            sessionId <- readTVarIO
-                                running.runningTurnControl.turnControlSessionId
-                            sendSnapshotItem
-                                snapshotCallback
-                                snapshotContext
-                                running.runningTurnControl.turnControlId
-                                sessionId
-                                1
-                    invokeTaskSnapshotCallback
-                        snapshotCallback snapshotContext
-                        1 nullPtr 0 nullPtr 0 0 nullPtr 0
+                                    running.runningTurnControl.turnControlId
+                                    sessionId
+                                    1
+                        invokeTaskSnapshotCallback
+                            snapshotCallback snapshotContext
+                            1 nullPtr 0 nullPtr 0 0 nullPtr 0
+        case delivered of
+            Right () -> pure ()
+            Left exception ->
+                void $ tryAny $
+                    sendSnapshotFailure
+                        snapshotCallback
+                        snapshotContext
+                        (Text.pack (show exception))
+
+    sendSnapshotFailure snapshotCallback snapshotContext err =
+        withTextBytes err \errorPointer errorLength ->
+            invokeTaskSnapshotCallback
+                snapshotCallback
+                snapshotContext
+                (-1)
+                nullPtr 0 nullPtr 0 0
+                errorPointer errorLength
 
     sendSnapshotItem snapshotCallback snapshotContext taskId sessionId state =
         withTextBytes taskId \taskPointer taskLength ->

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -26,13 +26,21 @@ import Control.Concurrent.STM
     , readTMVar
     , readTVarIO
     )
-import Control.Exception.Safe (finally, tryAny)
+import Control.Exception.Safe (bracket, finally, tryAny)
 import Data.Either (isRight)
 import Data.IORef (newIORef)
 import qualified Data.Aeson as Aeson
 import qualified Data.Map.Strict as Map
 import Foreign.C.Types (CInt(..))
 import Foreign.StablePtr (castStablePtrToPtr, newStablePtr)
+import System.Directory
+    ( createDirectory
+    , getTemporaryDirectory
+    , removeFile
+    , removePathForcibly
+    )
+import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.IO (hClose, openTempFile)
 import Test.Hspec
     ( Spec
     , describe
@@ -101,7 +109,7 @@ spec = describe "native bridge FFI" do
 
     it "controls and snapshots native tasks through the exported bridge" do
 #ifdef darwin_HOST_OS
-        taskSupervisorAbiSmoke `shouldReturn` 0
+        withIsolatedHome $ taskSupervisorAbiSmoke `shouldReturn` 0
 #else
         pendingWith "the native bridge smoke test only links on macOS"
 #endif
@@ -214,6 +222,27 @@ spec = describe "native bridge FFI" do
 #endif
 
 #ifdef darwin_HOST_OS
+withIsolatedHome :: IO a -> IO a
+withIsolatedHome action =
+    bracket create removePathForcibly \home ->
+        bracket
+            (do
+                old <- lookupEnv "HOME"
+                setEnv "HOME" home
+                pure old)
+            (\case
+                Just old -> setEnv "HOME" old
+                Nothing -> unsetEnv "HOME")
+            (\_ -> action)
+  where
+    create = do
+        temporary <- getTemporaryDirectory
+        (path, handle) <- openTempFile temporary "agent-native-bridge-home"
+        hClose handle
+        removeFile path
+        createDirectory path
+        pure path
+
 repositoryCheckDestroyReentrancySmoke :: IO Bool
 repositoryCheckDestroyReentrancySmoke = do
     gate <- newEmptyMVar


### PR DESCRIPTION
## Summary

macOS `nix profile upgrade` / flake updates were rebuilding `agent-cli` from source because the Darwin binary-cache job never reached Attic.

The publisher built `. #default`, `.#agent-cli`, and `.#checks.aarch64-darwin.agent-native-bridge` in one `nix build`. The native-bridge task-snapshot smoke test failed (`ha_engine_list_tasks` returned 16: no terminal callback), so the whole job failed before the push step. Linux still published (`fail-fast: false`). Darwin `agent-cli` did not.

## Changes

- Build and collect the Darwin/Linux **release** closures first, then extra check/native-bridge roots with `--keep-going`.
- Push whatever was realised, then fail the job if extras failed. A native-bridge test failure can no longer skip publishing `agent-cli`.
- Deliver a task-snapshot error callback if listing tasks throws, and drain pending snapshots on engine destroy instead of dropping them.
- Isolate `HOME` for the task-supervisor FFI smoke test so leftover runner credentials cannot abort the snapshot.

## Test plan

- [x] `agent-native-bridge-test --match "/native bridge FFI/"` — 12 examples, 0 failures
- [ ] PR Linux tests
- [ ] After merge, confirm `Publish aarch64-darwin` uploads `packages.agent-cli` even if the native-bridge check is red
- [ ] `nix profile upgrade --refresh --accept-flake-config haskell-agent` on Darwin substitutes instead of rebuilding