### PR TITLE
Extend Telegram turn timeout to twelve hours

### DIFF
--- a/packages/agent-telegram/src/Agent/Telegram/Internal/Turn.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Internal/Turn.hs
@@ -61,6 +61,11 @@ import System.Posix.Files (setFileMode)
 import Agent.Telegram.Internal.Runtime.Types
 import Agent.Telegram.Internal.Allowlist
 import Agent.Telegram.Internal.Support
+
+-- Allow substantial development tasks while still bounding each turn.
+telegramTurnTimeoutMicros :: Int
+telegramTurnTimeoutMicros = 12 * 60 * 60 * 1_000_000
+
 data TelegramTurnResponse = TelegramTurnResponse
     { telegramTurnText :: !Text
     , telegramTurnProgressMessageId :: !(Maybe Integer)
@@ -137,7 +142,7 @@ runQueuedMediaTurn runtime pending = do
                 runtime.runtimePolicy
                 True
                 False
-                (Just (20 * 60 * 1_000_000))
+                (Just telegramTurnTimeoutMicros)
                 handle
                 gatewayRequest
           pure (priorTurnIndex, result)
@@ -573,7 +578,7 @@ runManagedAgentTurn
             runtime.runtimePolicy
             True
             False
-            (Just (20 * 60 * 1_000_000))
+            (Just telegramTurnTimeoutMicros)
             handle
             request
       pure (priorTurnIndex, result)


### PR DESCRIPTION
## Summary
- Extend the overall Telegram turn deadline from 20 minutes to 12 hours.
- Share one timeout constant between text and media turns.
- Preserve existing timeout cleanup and retry behavior; individual tool and network timeouts are unchanged.

## Motivation
A production development task was terminated at the 20-minute deadline and automatically retried, leaving a second progress message. Substantial tasks need a longer execution window while retaining an eventual deadline.

## Validation
- git diff --check passed.
- Local GHCi validation was attempted through nix develop but blocked by a missing Hermes source dependency checkout.
- CI must pass before merge.

No production deployment or restart is included.