### PR TITLE
Cache gateway models for a faster model picker

### DIFF
--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -179,6 +179,7 @@ test-suite agent-cli-runtime-test
     build-depends:    agent-cli-runtime
                     , agent-core
                     , agent-json
+                    , agent-openai
                     , agent-responses
                     , agent-responses-types
                     , agent-store

--- a/packages/agent-cli-runtime/package.nix
+++ b/packages/agent-cli-runtime/package.nix
@@ -24,10 +24,10 @@ mkDerivation {
     wai warp
   ];
   testHaskellDepends = [
-    aeson agent-core agent-json agent-responses agent-responses-types
-    agent-store async base bytestring containers directory filepath
-    hspec http-client http-types QuickCheck safe-exceptions stm text
-    time unix wai warp
+    aeson agent-core agent-json agent-openai agent-responses
+    agent-responses-types agent-store async base bytestring containers
+    directory filepath hspec http-client http-types QuickCheck
+    safe-exceptions stm text time unix wai warp
   ];
   description = "Headless shared runtime for agent frontends";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Catalog.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Catalog.hs
@@ -6,6 +6,10 @@ module Agent.CLI.Gateway.Catalog
     , GatewayModelProvider(..)
     , GatewayModelAccess
     , newGatewayModelAccess
+    , newGatewayModelAccessWithStore
+    , newGatewayModelAccessWithStoreAndFetch
+    , GatewayModelFetchFailure(..)
+    , newGatewayModelAccessWithStoreAndResult
     , newGatewayModelAccessWith
     , newGatewayModelAccessWithDictation
     , newGatewayModelAccessWithUsage
@@ -14,6 +18,7 @@ module Agent.CLI.Gateway.Catalog
     , gatewayModelIds
     , fetchGatewayModels
     , fetchGatewayUsage
+    , cachedGatewayUsage
     , transcribeGatewayPcm
     ) where
 
@@ -22,15 +27,20 @@ import Agent.CLI.Gateway.Dictation (transcribeGatewayPcmWith)
 import Agent.CLI.Gateway.Usage (fetchGatewayUsageWithCredential)
 import Agent.ClientIdentity (gatewayUserAgent)
 import Agent.OpenAI.Usage (UsageSnapshot)
-import Agent.Server.Client.GatewayIdentity (GatewayCredential(..))
+import Agent.Server.Client.GatewayIdentity (GatewayCredential(..), gatewayCredentialIdentity)
+import Agent.Store.Postgres.Connection (StorePool)
+import Agent.Store.Postgres.ModelCatalogCache qualified as Store
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception.Safe (tryAny)
-import Data.Aeson ((.:))
+import Control.Monad (void)
+import Data.Aeson ((.:), (.=))
+import Data.Bifunctor (first)
 import Data.Aeson qualified as Aeson
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import Data.Char (isPrint, isSpace)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef, atomicModifyIORef')
+import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
@@ -85,6 +95,18 @@ instance Aeson.FromJSON GatewayModel where
                 then pure (GatewayModel modelId protocol provider)
                 else fail "Gateway model provider and protocol are incompatible."
 
+instance Aeson.ToJSON GatewayModel where
+    toJSON model = Aeson.object
+        [ "id" .= model.gatewayModelId
+        , "protocol" .= (case model.gatewayModelProtocol of
+            GatewayResponsesProtocol -> "responses" :: Text
+            GatewayAnthropicProtocol -> "anthropic")
+        , "provider" .= (case model.gatewayModelProvider of
+            GatewayOpenAIProvider -> "openai" :: Text
+            GatewayXAIProvider -> "xai"
+            GatewayAnthropicProvider -> "anthropic")
+        ]
+
 instance Aeson.FromJSON GatewayModelProvider where
     parseJSON =
         Aeson.withText "GatewayModelProvider" \case
@@ -112,23 +134,78 @@ instance Aeson.FromJSON GatewayModelProtocol where
 -- The constructor is deliberately hidden: callers can list models but cannot
 -- accidentally inspect or log the credential captured by its fetch action.
 data GatewayModelAccess = GatewayModelAccess
-    { gatewayModelFetch :: !(IO (Either Text [GatewayModel]))
+    { gatewayModelFetch :: !(IO (Either GatewayModelFetchFailure [GatewayModel]))
     , gatewayUsageFetch :: !(Text -> IO (Either Text UsageSnapshot))
+    , gatewayUsageCache :: !(IORef (Map.Map Text UsageSnapshot))
     , gatewayModelCache :: !(IORef (Maybe [GatewayModel]))
     , gatewayModelRefreshLock :: !(MVar ())
+    , gatewayModelPersist :: !(Maybe [GatewayModel] -> IO ())
     , gatewayDictation
         :: !(((BS.ByteString -> IO ()) -> IO ())
             -> (Text -> IO ())
             -> IO (Either Text Text))
     }
 
+data GatewayModelFetchFailure
+    = GatewayModelAuthorizationRejected !Text
+    | GatewayModelRefreshFailed !Text
+    deriving (Eq, Show)
+
+gatewayModelFailureMessage :: GatewayModelFetchFailure -> Text
+gatewayModelFailureMessage = \case
+    GatewayModelAuthorizationRejected message -> message
+    GatewayModelRefreshFailed message -> message
+
 -- | Construct a cached model-list handle for a validated gateway credential.
 newGatewayModelAccess :: GatewayCredential -> IO GatewayModelAccess
 newGatewayModelAccess credential =
     newGatewayModelAccessWithActions
-        (fetchGatewayModels credential)
+        (fetchGatewayModelsResult credential)
         (fetchGatewayUsageWithCredential credential)
         (transcribeGatewayPcmWith credential)
+
+-- | Hydrate presentation data without contacting the gateway. The exact
+-- credential identity prevents cache reuse across accounts or organizations,
+-- including when a bearer is replaced at the same endpoint.
+newGatewayModelAccessWithStore :: StorePool -> GatewayCredential -> IO GatewayModelAccess
+newGatewayModelAccessWithStore pool credential =
+    newGatewayModelAccess credential >>= attachGatewayModelStore pool credential
+
+-- | Injectable persistent catalog transport. A fresh handle is always created:
+-- an existing credential-bound handle cannot be rebound to another cache key.
+newGatewayModelAccessWithStoreAndFetch
+    :: StorePool
+    -> GatewayCredential
+    -> IO (Either Text [GatewayModel])
+    -> IO GatewayModelAccess
+newGatewayModelAccessWithStoreAndFetch pool credential fetch =
+    newGatewayModelAccessWith fetch >>= attachGatewayModelStore pool credential
+
+-- | Trusted typed transport injection for authorization-invalidation tests.
+newGatewayModelAccessWithStoreAndResult
+    :: StorePool
+    -> GatewayCredential
+    -> IO (Either GatewayModelFetchFailure [GatewayModel])
+    -> IO GatewayModelAccess
+newGatewayModelAccessWithStoreAndResult pool credential fetch =
+    newGatewayModelAccessWithActions fetch unavailableGatewayUsage unavailableGatewayDictation
+        >>= attachGatewayModelStore pool credential
+
+attachGatewayModelStore :: StorePool -> GatewayCredential -> GatewayModelAccess -> IO GatewayModelAccess
+attachGatewayModelStore pool credential access = do
+    let identity = gatewayCredentialIdentity credential
+    stored <- tryAny (Store.loadModelCatalogCache pool identity)
+    let models = case stored of
+            Right (Right (Just payload)) ->
+                normalizeGatewayModels <$> Aeson.decodeStrict' (TextEncoding.encodeUtf8 payload)
+            _ -> Nothing
+        persist value = void $ tryAny $ case value of
+            Nothing -> Store.deleteModelCatalogCache pool identity
+            Just catalog ->
+                Store.upsertModelCatalogCache pool identity
+                    (TextEncoding.decodeUtf8 (LBS.toStrict (Aeson.encode catalog)))
+    writeIORef access.gatewayModelCache models
+    pure access { gatewayModelPersist = persist }
 
 -- | Injectable constructor used by tests and alternative trusted transports.
 -- The resulting value remains opaque, so the fetch action cannot be read back
@@ -150,7 +227,7 @@ newGatewayModelAccessWithUsage
     -> IO GatewayModelAccess
 newGatewayModelAccessWithUsage fetch usage =
     newGatewayModelAccessWithActions
-        fetch
+        (first GatewayModelRefreshFailed <$> fetch)
         usage
         unavailableGatewayDictation
 
@@ -165,12 +242,12 @@ newGatewayModelAccessWithDictation
     -> IO GatewayModelAccess
 newGatewayModelAccessWithDictation fetch dictation =
     newGatewayModelAccessWithActions
-        fetch
+        (first GatewayModelRefreshFailed <$> fetch)
         unavailableGatewayUsage
         dictation
 
 newGatewayModelAccessWithActions
-    :: IO (Either Text [GatewayModel])
+    :: IO (Either GatewayModelFetchFailure [GatewayModel])
     -> (Text -> IO (Either Text UsageSnapshot))
     -> (((BS.ByteString -> IO ()) -> IO ())
         -> (Text -> IO ())
@@ -178,12 +255,15 @@ newGatewayModelAccessWithActions
     -> IO GatewayModelAccess
 newGatewayModelAccessWithActions fetch usage dictation = do
     cache <- newIORef Nothing
+    usageCache <- newIORef Map.empty
     refreshLock <- newMVar ()
     pure GatewayModelAccess
         { gatewayModelFetch = fetch
         , gatewayUsageFetch = usage
+        , gatewayUsageCache = usageCache
         , gatewayModelCache = cache
         , gatewayModelRefreshLock = refreshLock
+        , gatewayModelPersist = \_ -> pure ()
         , gatewayDictation = dictation
         }
 
@@ -214,7 +294,18 @@ fetchGatewayUsage access model
         tryAny (access.gatewayUsageFetch model) >>= \case
             Left _ ->
                 pure (Left "Could not refresh organization gateway usage.")
-            Right result -> pure result
+            Right result -> do
+                case result of
+                    Left _ -> pure ()
+                    Right snapshot ->
+                        atomicModifyIORef' access.gatewayUsageCache \cached ->
+                            (Map.insert model snapshot cached, ())
+                pure result
+
+-- | Last successful presentation snapshot for this exact connection and alias.
+cachedGatewayUsage :: GatewayModelAccess -> Text -> IO (Maybe UsageSnapshot)
+cachedGatewayUsage access model =
+    Map.lookup model <$> readIORef access.gatewayUsageCache
 
 -- | Record PCM through the opaque, gateway-bound dictation action.
 transcribeGatewayPcm
@@ -226,9 +317,8 @@ transcribeGatewayPcm access = access.gatewayDictation
 
 -- | Refresh the gateway's authorized model aliases.
 --
--- A failed refresh deliberately clears the previous value.  Continuing to
--- show a stale authorization list would let an organization revocation look
--- like an available model.
+-- Cached lists are presentation data, never authorization. Transient failures
+-- retain the last successful list; explicit authentication rejection clears it.
 refreshGatewayModels
     :: GatewayModelAccess
     -> IO (Either Text [GatewayModel])
@@ -237,20 +327,25 @@ refreshGatewayModels
             { gatewayModelFetch
             , gatewayModelCache
             , gatewayModelRefreshLock
+            , gatewayModelPersist
             } =
     withMVar gatewayModelRefreshLock \_ ->
         tryAny gatewayModelFetch >>= \case
-            Left _ -> do
-                writeIORef gatewayModelCache Nothing
+            Left _ ->
                 pure (Left "Could not refresh organization gateway models.")
             Right result ->
                 case result of
                     Left err -> do
-                        writeIORef gatewayModelCache Nothing
-                        pure (Left err)
+                        case err of
+                            GatewayModelAuthorizationRejected _ -> do
+                                writeIORef gatewayModelCache Nothing
+                                gatewayModelPersist Nothing
+                            GatewayModelRefreshFailed _ -> pure ()
+                        pure (Left (gatewayModelFailureMessage err))
                     Right models -> do
                         let normalized = normalizeGatewayModels models
                         writeIORef gatewayModelCache (Just normalized)
+                        gatewayModelPersist (Just normalized)
                         pure (Right normalized)
 
 -- | Read the most recent successful gateway refresh without issuing I/O.
@@ -264,8 +359,14 @@ cachedGatewayModels GatewayModelAccess { gatewayModelCache } =
 -- contain external content, while request headers contain the bearer token.
 fetchGatewayModels :: GatewayCredential -> IO (Either Text [GatewayModel])
 fetchGatewayModels credential =
+    first gatewayModelFailureMessage <$> fetchGatewayModelsResult credential
+
+fetchGatewayModelsResult
+    :: GatewayCredential
+    -> IO (Either GatewayModelFetchFailure [GatewayModel])
+fetchGatewayModelsResult credential =
     case validateGatewayCredential credential of
-        Left _ -> pure (Left "Gateway credential is invalid.")
+        Left _ -> pure (Left (GatewayModelAuthorizationRejected "Gateway credential is invalid."))
         Right () -> do
             response <- tryAny do
                 userAgent <- gatewayUserAgent
@@ -297,7 +398,7 @@ fetchGatewayModels credential =
                     manager
             pure case response of
                 Left _ ->
-                    Left "Could not reach the gateway models endpoint."
+                    Left (GatewayModelRefreshFailed "Could not reach the gateway models endpoint.")
                 Right value
                     | statusIsSuccessful (HTTP.responseStatus value) ->
                         case
@@ -306,15 +407,15 @@ fetchGatewayModels credential =
                                 :: Either String GatewayModelCatalogResponse
                             of
                             Left _ ->
-                                Left
-                                    "Gateway returned an unreadable models response."
-                            Right catalog
-                                | null catalog.gatewayModelCatalogData ->
-                                    Left "Gateway returned an empty model catalog."
-                                | otherwise ->
-                                    Right catalog.gatewayModelCatalogData
+                                Left (GatewayModelRefreshFailed
+                                    "Gateway returned an unreadable models response.")
+                            Right catalog -> Right catalog.gatewayModelCatalogData
                     | otherwise ->
-                        Left $
+                        let code = statusCode (HTTP.responseStatus value)
+                            failure = if code == 401 || code == 403
+                                then GatewayModelAuthorizationRejected
+                                else GatewayModelRefreshFailed
+                        in Left $ failure $
                             "Gateway models returned HTTP "
                                 <> Text.pack
                                     (show

--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -53,7 +53,12 @@ module Agent.CLI.GatewayClient
     , loadGatewayCredentialAt
     , fetchGatewayModels
     , fetchGatewayUsage
+    , cachedGatewayUsage
     , newGatewayModelAccess
+    , newGatewayModelAccessWithStore
+    , newGatewayModelAccessWithStoreAndFetch
+    , GatewayModelFetchFailure(..)
+    , newGatewayModelAccessWithStoreAndResult
     , newGatewayModelAccessWith
     , newGatewayModelAccessWithDictation
     , newGatewayModelAccessWithUsage

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
@@ -4,7 +4,6 @@ import Agent.CLI.GatewayClient
 import Agent.CLI.SessionSpec.Fixtures (withTempStore)
 import Agent.Store.Postgres (trustedPool)
 import Agent.Store.Postgres.ModelCatalogCache qualified as ModelStore
-import Agent.Server.Client.GatewayIdentity (gatewayCredentialIdentity)
 import Agent.ClientIdentity (gatewayUserAgent)
 import Agent.OpenAI.Usage (UsageSnapshot(..))
 import Agent.CLI.PrivateFileLock (withPrivateFileLock)

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
@@ -1,7 +1,12 @@
 module Agent.CLI.GatewayClientSpec (spec) where
 
 import Agent.CLI.GatewayClient
+import Agent.CLI.SessionSpec.Fixtures (withTempStore)
+import Agent.Store.Postgres (trustedPool)
+import Agent.Store.Postgres.ModelCatalogCache qualified as ModelStore
+import Agent.Server.Client.GatewayIdentity (gatewayCredentialIdentity)
 import Agent.ClientIdentity (gatewayUserAgent)
+import Agent.OpenAI.Usage (UsageSnapshot(..))
 import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Agent.Json.Decode qualified as Hermes
 import Control.Concurrent
@@ -178,7 +183,7 @@ spec = describe "gateway device authorization" do
             "{\"data\":[{\"id\":\"company-model\",\"protocol\":\"responses\",\"provider\":\"anthropic\"}]}"
             `shouldSatisfy` isLeft
 
-    it "clears cached gateway models when refresh fails" do
+    it "retains cached gateway models when refresh fails" do
         results <- newIORef
             [ Right
                 [ GatewayModel " gpt-5.6-sol " GatewayResponsesProtocol GatewayOpenAIProvider
@@ -207,7 +212,63 @@ spec = describe "gateway device authorization" do
                     ]
         refreshGatewayModels access
             `shouldReturn` Left "gateway unavailable"
-        cachedGatewayModels access `shouldReturn` Nothing
+        cachedGatewayModels access `shouldReturn` Just
+            [ GatewayModel "gpt-5.6-sol" GatewayResponsesProtocol GatewayOpenAIProvider
+            , GatewayModel "sonnet" GatewayAnthropicProtocol GatewayAnthropicProvider
+            ]
+
+    it "round-trips persisted model provider and protocol identities" do
+        let models =
+                [ GatewayModel "openai-model" GatewayResponsesProtocol GatewayOpenAIProvider
+                , GatewayModel "xai-model" GatewayResponsesProtocol GatewayXAIProvider
+                , GatewayModel "anthropic-model" GatewayAnthropicProtocol GatewayAnthropicProvider
+                ]
+        Aeson.decode (Aeson.encode models) `shouldBe` Just models
+
+    it "persists gateway catalogs across handles and isolates replacement credentials" $
+        withTempStore \store _ -> do
+            let pool = trustedPool store
+                credential = GatewayCredential "https://gateway" "wss://gateway/v1/responses" "first"
+                models = [GatewayModel "company-model" GatewayResponsesProtocol GatewayOpenAIProvider]
+                newAccess = newGatewayModelAccessWithStoreAndFetch pool credential
+            access <- newAccess (pure (Right models))
+            cachedGatewayModels access `shouldReturn` Nothing
+            refreshGatewayModels access `shouldReturn` Right models
+            restored <- newGatewayModelAccessWithStore pool credential
+            cachedGatewayModels restored `shouldReturn` Just models
+            unavailable <- newAccess (pure (Left "gateway unavailable"))
+            refreshGatewayModels unavailable `shouldReturn` Left "gateway unavailable"
+            retained <- newGatewayModelAccessWithStore pool credential
+            cachedGatewayModels retained `shouldReturn` Just models
+            textFailure <- newAccess (pure (Left "Gateway models returned HTTP 403"))
+            refreshGatewayModels textFailure `shouldReturn` Left "Gateway models returned HTTP 403"
+            cachedGatewayModels textFailure `shouldReturn` Just models
+            replacement <- newGatewayModelAccessWithStore pool
+                credential { gatewayAccessToken = "second" }
+            cachedGatewayModels replacement `shouldReturn` Nothing
+            otherGateway <- newGatewayModelAccessWithStore pool
+                credential { gatewayBaseUrl = "https://other-gateway" }
+            cachedGatewayModels otherGateway `shouldReturn` Nothing
+            empty <- newAccess (pure (Right []))
+            refreshGatewayModels empty `shouldReturn` Right []
+            emptyRestored <- newGatewayModelAccessWithStore pool credential
+            cachedGatewayModels emptyRestored `shouldReturn` Just []
+            denied <- newGatewayModelAccessWithStoreAndResult pool credential
+                (pure (Left (GatewayModelAuthorizationRejected "Gateway models returned HTTP 403")))
+            refreshGatewayModels denied `shouldReturn` Left "Gateway models returned HTTP 403"
+            cachedGatewayModels denied `shouldReturn` Nothing
+            deniedRestored <- newGatewayModelAccessWithStore pool credential
+            cachedGatewayModels deniedRestored `shouldReturn` Nothing
+
+    it "ignores corrupt persisted model catalogs without contacting the gateway" $
+        withTempStore \store _ -> do
+            let pool = trustedPool store
+                credential = GatewayCredential "https://gateway" "wss://gateway/v1/responses" "first"
+            ModelStore.upsertModelCatalogCache pool
+                (gatewayCredentialIdentity credential) "not json"
+                `shouldReturn` Right ()
+            access <- newGatewayModelAccessWithStore pool credential
+            cachedGatewayModels access `shouldReturn` Nothing
 
     it "passes the exact public alias to the gateway usage transport" do
         aliases <- newIORef ([] :: [Text.Text])
@@ -231,6 +292,20 @@ spec = describe "gateway device authorization" do
         fetchGatewayUsage access "company-model"
             `shouldReturn`
                 Left "Could not refresh organization gateway usage."
+
+    it "retains successful usage snapshots per alias after transient failures" do
+        let snapshot = UsageSnapshot "organization" Nothing []
+        results <- newIORef [Right snapshot, Left "unavailable"]
+        access <- newGatewayModelAccessWithUsage (pure (Right [])) \_ ->
+            atomicModifyIORef' results \case
+                result : remaining -> (remaining, result)
+                [] -> ([], Left "unexpected refresh")
+        cachedGatewayUsage access "company-model" `shouldReturn` Nothing
+        fetchGatewayUsage access "company-model" `shouldReturn` Right snapshot
+        cachedGatewayUsage access "company-model" `shouldReturn` Just snapshot
+        cachedGatewayUsage access "other-model" `shouldReturn` Nothing
+        fetchGatewayUsage access "company-model" `shouldReturn` Left "unavailable"
+        cachedGatewayUsage access "company-model" `shouldReturn` Just snapshot
 
     it "keeps gateway dictation behind the opaque model access" do
         events <- newIORef ([] :: [Text.Text])
@@ -261,7 +336,7 @@ spec = describe "gateway device authorization" do
                 , "text:gateway transcript"
                 ]
 
-    it "clears cached gateway models when a fetch throws" do
+    it "retains cached gateway models when a fetch throws" do
         calls <- newIORef (0 :: Int)
         access <-
             newGatewayModelAccessWith do
@@ -284,7 +359,8 @@ spec = describe "gateway device authorization" do
         refreshGatewayModels access
             `shouldReturn`
                 Left "Could not refresh organization gateway models."
-        cachedGatewayModels access `shouldReturn` Nothing
+        cachedGatewayModels access `shouldReturn` Just
+            [GatewayModel "company-model" GatewayResponsesProtocol GatewayOpenAIProvider]
 
     it "does not expose a gateway bearer in model-list validation errors" do
         let credential =

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec/Fixtures.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionSpec/Fixtures.hs
@@ -25,6 +25,8 @@ import Agent.Responses.Types
 import Agent.Telemetry (TurnTelemetry(..))
 import Agent.Store.Postgres
     ( Store
+    , ManagedPostgresConfig(..)
+    , ManagedPostgresPaths(..)
     , closeStore
     , defaultManagedPostgresConfig
     , openStore
@@ -214,7 +216,13 @@ withTempStore action = do
                 stateDirectory = basePath FilePath.</> ".haskell-agent"
                 sessionsDirectory =
                     stateDirectory FilePath.</> "sessions"
-                config = defaultManagedPostgresConfig stateDirectory ""
+                initialConfig = defaultManagedPostgresConfig stateDirectory ""
+                -- Keep the socket close to the temporary root: macOS limits
+                -- Unix socket paths even when the data directory is valid.
+                config = initialConfig
+                    { postgresPaths = initialConfig.postgresPaths
+                        { postgresSocketDirectory = basePath FilePath.</> "s" }
+                    }
             Directory.createDirectoryIfMissing True sessionsDirectory
             bracket
                 (openStore config >>= either

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -120,7 +120,6 @@ library
                     , Agent.CLI.Render.MarkdownStream
                     , Agent.CLI.Render.Status
                     , Agent.CLI.Session.Attachments
-                    , Agent.CLI.Session.Choices
                     , Agent.CLI.Session.Interaction
                     , Agent.CLI.Session.Lifecycle
                     , Agent.CLI.Session.Retry
@@ -158,6 +157,7 @@ library
                     , Agent.CLI.TUI.Render.Workspace
                     , Paths_agent_cli
     exposed-modules:  Agent.CLI
+                    , Agent.CLI.Session.Choices
                     , Agent.CLI.TUI.Keyboard
                     , Agent.CLI.IntegrationGateway
                     , Agent.CLI.ActiveAccount
@@ -734,3 +734,22 @@ benchmark transcript-scrolling-bench
                     , deepseq
                     , text
                     , vty >= 6.4 && < 7
+
+benchmark model-picker-latency-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          ModelPickerLatency.hs
+    ghc-options:      -O2 -threaded -rtsopts
+    build-depends:    agent-cli
+                    , agent-cli-runtime
+                    , agent-core
+                    , agent-openai
+                    , agent-tui
+                    , async
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , containers
+                    , safe-exceptions
+                    , stm
+                    , text

--- a/packages/agent-cli/benchmark/ModelPickerLatency.hs
+++ b/packages/agent-cli/benchmark/ModelPickerLatency.hs
@@ -1,0 +1,278 @@
+-- | Time to first usable rows and, separately, completed refresh publication.
+-- The baseline preserves the removed model-refresh + bounded usage barrier.
+-- Both workloads use the production picker to construct and publish rows.
+module Main (main) where
+
+import Agent.CLI.AgentViewport (AgentTarget(..))
+import Agent.CLI.GatewayClient
+    ( GatewayModel(..)
+    , GatewayModelAccess
+    , GatewayModelProtocol(..)
+    , GatewayModelProvider(..)
+    , cachedGatewayModels
+    , fetchGatewayUsage
+    , newGatewayModelAccessWithUsage
+    , refreshGatewayModels
+    )
+import Agent.CLI.GatewayModels
+    ( modelOptionsForGatewayModels, selectGatewayModelOption, withGatewayModelsForStartup )
+import Agent.CLI.Models (ModelOption(..))
+import Agent.CLI.Interrupt (CtrlCDecision(..))
+import Agent.CLI.ModelConfig
+    ( ModelCatalog
+    , decodeModelConfig
+    , organizationGatewayConnectionId
+    , packagedModelCatalogPath
+    )
+import Agent.CLI.Session.Choices (modelChoiceWithEffort)
+import Agent.CLI.TUI.App (newFullscreenInputBuffer, newFullscreenRuntime)
+import Agent.CLI.TUI.Types
+import Agent.CLI.Usage (formatModelUsageSummary)
+import Agent.Concurrent (mapConcurrentlyBounded)
+import Agent.Dialect (DialectId(..))
+import Agent.OpenAI.Usage (UsageSnapshot(..), UsageLimit(..), UsageWindow(..))
+import Agent.Provider (Provider(..))
+import Agent.ReasoningEffort (ReasoningEffort(..))
+import Agent.TUI.Model (initialUiState)
+import Agent.TUI.Motion (MotionMode(..))
+import Control.Concurrent (threadDelay, yield)
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent.STM
+    ( atomically, putTMVar, readTVar, retry )
+import Control.Exception (evaluate)
+import Control.Monad (forM, unless, void, when)
+import Data.ByteString.Lazy qualified as LBS
+import Data.Foldable (toList)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.List (sort)
+import Data.Text qualified as Text
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import System.Timeout (timeout)
+import Text.Printf (printf)
+import Text.Read (readMaybe)
+
+data Sample = Sample
+    { elapsedMilliseconds :: !Double
+    , cpuMilliseconds :: !Double
+    }
+
+data PickerSample = PickerSample
+    { firstList :: !Sample
+    , completedRefresh :: !Sample
+    }
+
+main :: IO ()
+main = do
+    getArgs >>= \case
+        [workload, modelsArgument, delayArgument, samplesArgument] -> do
+            unless (workload `elem`
+                ["blocking-baseline", "cached-first",
+                 "startup-baseline", "startup-cached", "startup-cold"]) usage
+            modelCount <- positive modelsArgument
+            delayMilliseconds <- positive delayArgument
+            sampleCount <- positive samplesArgument
+            catalogPath <- packagedModelCatalogPath
+            catalog <- LBS.readFile catalogPath >>=
+                either (die . Text.unpack) pure . decodeModelConfig "packaged catalog"
+            results <- forM [1 .. sampleCount] \_ -> do
+                -- Models and the successful in-memory cache are constructed
+                -- outside the interval, as they are before opening /model.
+                let models =
+                        [ GatewayModel
+                            ("benchmark-model-" <> Text.pack (show index))
+                            GatewayResponsesProtocol GatewayOpenAIProvider
+                        | index <- [1 .. modelCount]
+                        ]
+                void (evaluate (sum (map (Text.length . (.gatewayModelId)) models)))
+                if "startup-" `Text.isPrefixOf` Text.pack workload
+                    then startupSample catalog workload models delayMilliseconds
+                    else pickerSample catalog workload models modelCount delayMilliseconds
+            printf "%s models=%d delay-ms=%d samples=%d first-list-ms=%.3f first-list-cpu-ms=%.3f complete-ms=%.3f complete-cpu-ms=%.3f\n"
+                workload modelCount delayMilliseconds sampleCount
+                (median (map (.firstList.elapsedMilliseconds) results))
+                (median (map (.firstList.cpuMilliseconds) results))
+                (median (map (.completedRefresh.elapsedMilliseconds) results))
+                (median (map (.completedRefresh.cpuMilliseconds) results))
+        _ -> usage
+
+-- The production startup selector and scope, excluding unrelated startup work
+-- and PostgreSQL hydration. A transport signal avoids polling during network
+-- latency; only the short cache-publication handoff uses cooperative yielding.
+startupSample :: ModelCatalog -> String -> [GatewayModel] -> Int -> IO PickerSample
+startupSample catalog workload models delayMilliseconds = do
+    unless (length models >= 2) (die "Startup workloads require at least two models")
+    delayed <- newIORef False
+    transported <- newEmptyMVar
+    let refreshed = reverse models
+        select available = selectGatewayModelOption
+            (modelOptionsForGatewayModels catalog available)
+            (Just "benchmark-model-1") Nothing []
+    access <- newGatewayModelAccessWithUsage
+        (readIORef delayed >>= \case
+            False -> pure (Right models)
+            True -> do
+                threadDelay (delayMilliseconds * 1000)
+                putMVar transported ()
+                pure (Right refreshed))
+        (const (pure (Left "Usage is outside startup catalog selection")))
+    unless (workload == "startup-cold") $
+        void (refreshGatewayModels access >>= either (die . Text.unpack) pure)
+    writeIORef delayed True
+    performGC
+    started <- startMeasurement
+    let continue result = do
+            selected <- either (die . Text.unpack) pure result
+            void (evaluate (length (show selected.modelTarget)))
+            firstList <- finishMeasurement started
+            takeMVar transported
+            let awaitPublication = cachedGatewayModels access >>= \case
+                    Just latest | latest == refreshed ->
+                        void (evaluate (sum (map (Text.length . (.gatewayModelId)) latest)))
+                    _ -> yield >> awaitPublication
+            awaitPublication
+            completedRefresh <- finishMeasurement started
+            pure PickerSample { firstList, completedRefresh }
+    timeout 10000000
+        (if workload == "startup-baseline"
+            then refreshGatewayModels access >>= continue . (>>= select)
+            else withGatewayModelsForStartup access select continue)
+        >>= maybe (die "Startup catalog did not finish within ten seconds") pure
+
+pickerSample :: ModelCatalog -> String -> [GatewayModel] -> Int -> Int -> IO PickerSample
+pickerSample catalog workload models modelCount delayMilliseconds = do
+    delayEnabled <- newIORef False
+    transportEnabled <- newIORef True
+    let transportDelay = do
+            enabled <- readIORef transportEnabled
+            unless enabled (atomically retry)
+            readIORef delayEnabled >>= \delayed ->
+                when delayed (threadDelay (delayMilliseconds * 1000))
+    access <- newGatewayModelAccessWithUsage
+        (transportDelay >> pure (Right models))
+        (\_ -> transportDelay >> pure (Right usageSnapshot))
+    refreshGatewayModels access >>= either (die . Text.unpack) (const (pure ()))
+    writeIORef delayEnabled True
+    runtime <- newBenchmarkRuntime
+    performGC
+    started <- startMeasurement
+    timeout 10000000 (do
+        when (workload == "blocking-baseline") $
+            blockingBaseline access >> writeIORef transportEnabled False
+        observeFirstList catalog access runtime modelCount started
+            (workload == "cached-first"))
+        >>= maybe (die "Picker did not finish within ten seconds") pure
+
+-- Equivalent to the removed barrier: model refresh followed by at most four
+-- usage requests concurrently, with a two-second timeout for the whole group.
+-- Every request incurs the configured transport latency.
+blockingBaseline :: GatewayModelAccess -> IO ()
+blockingBaseline access = do
+    models <- refreshGatewayModels access >>= either (die . Text.unpack) pure
+    void $ timeout 2000000 $
+        mapConcurrentlyBounded 4
+            (\model -> fetchGatewayUsage access model.gatewayModelId >>= \case
+                Left _ -> pure ()
+                Right snapshot -> void (evaluate
+                    (maybe 0 Text.length (formatModelUsageSummary snapshot))))
+            models
+
+observeFirstList
+    :: ModelCatalog -> GatewayModelAccess -> FullscreenRuntime -> Int
+    -> (Word64, Integer) -> Bool -> IO PickerSample
+observeFirstList catalog access runtime expectedCount started awaitRefresh =
+    withAsync
+        (modelChoiceWithEffort catalog (Just access) (Just runtime) False
+            organizationGatewayConnectionId OpenAIProvider "benchmark-model-1"
+            CodexDialect EffortHigh)
+        \worker -> do
+            (rows, reply) <- atomically do
+                let AppEventMailbox mailbox = runtime.runtimeMailbox
+                events <- (.mailboxPendingEvents) <$> readTVar mailbox
+                case
+                    [ (rows, reply)
+                    | PendingEvent (AppAskDynamicAdjustableFilterChoice _ _ _ rows reply) <- toList events
+                    , not (null rows)
+                    ]
+                    of
+                        first : _ -> pure first
+                        [] -> retry
+            unless (length rows == expectedCount) $
+                die "Picker did not publish the requested catalog size"
+            void (evaluate (rowChecksum rows))
+            firstList <- finishMeasurement started
+            completedRefresh <- if not awaitRefresh
+                then pure firstList
+                else do
+                    updates <- atomically do
+                        let AppEventMailbox mailbox = runtime.runtimeMailbox
+                        events <- (.mailboxPendingEvents) <$> readTVar mailbox
+                        let updates =
+                                [ rows
+                                | PendingEvent (AppUpdateDynamicAdjustableFilterChoice target _ rows) <- toList events
+                                , target == reply
+                                ]
+                        if length updates >= 2
+                            && any (all (\(_, _, detail, _, _) ->
+                                "\nUsage: " `Text.isInfixOf` detail)) updates
+                            then pure updates
+                            else retry
+                    void (evaluate (sum (map rowChecksum updates)))
+                    finishMeasurement started
+            atomically (putTMVar reply Nothing)
+            void (wait worker)
+            pure PickerSample{firstList, completedRefresh}
+
+rowChecksum :: [(Text.Text, Text.Text, Text.Text, [Text.Text], Int)] -> Int
+rowChecksum rows = sum
+    [ Text.length key + Text.length label + Text.length detail
+        + sum (map Text.length adjustments) + initial
+    | (key, label, detail, adjustments, initial) <- rows
+    ]
+
+usageSnapshot :: UsageSnapshot
+usageSnapshot = UsageSnapshot
+    "benchmark"
+    (Just (UsageLimit True False
+        (Just (UsageWindow 25 18000 9000 2000000000)) Nothing))
+    []
+
+newBenchmarkRuntime :: IO FullscreenRuntime
+newBenchmarkRuntime = do
+    input <- newFullscreenInputBuffer
+    newFullscreenRuntime input
+        (pure ()) (const (pure ())) (pure WarnExit)
+        (const (pure True)) (const (pure ())) (const (pure ()))
+        (pure (AgentRoot, [])) (const (pure ())) (pure ())
+        (const (pure ())) MotionFull False initialUiState
+
+startMeasurement :: IO (Word64, Integer)
+startMeasurement = do
+    beforeElapsed <- getMonotonicTimeNSec
+    beforeCpu <- getCPUTime
+    pure (beforeElapsed, beforeCpu)
+
+finishMeasurement :: (Word64, Integer) -> IO Sample
+finishMeasurement (beforeElapsed, beforeCpu) = do
+    afterCpu <- getCPUTime
+    afterElapsed <- getMonotonicTimeNSec
+    pure Sample
+        { elapsedMilliseconds = fromIntegral (afterElapsed - beforeElapsed) / 1e6
+        , cpuMilliseconds = fromIntegral (afterCpu - beforeCpu) / 1e9
+        }
+
+median :: [Double] -> Double
+median samples = sort samples !! (length samples `div` 2)
+
+positive :: String -> IO Int
+positive input = case readMaybe input of
+    Just value | value > 0 -> pure value
+    _ -> usage
+
+usage :: IO a
+usage = die "model-picker-latency-bench (blocking-baseline|cached-first|startup-baseline|startup-cached|startup-cold) MODEL_COUNT DELAY_MS SAMPLES"

--- a/packages/agent-cli/benchmark/ModelPickerLatency.md
+++ b/packages/agent-cli/benchmark/ModelPickerLatency.md
@@ -1,0 +1,144 @@
+# Model picker latency
+
+Startup catalog selection is measured separately below; neither measurement
+represents complete process launch time.
+
+This benchmark exercises the production `modelChoiceWithEffort` path with a
+successful cached gateway catalog and controlled transport latency. It observes
+the first nonempty picker event and forces every row label, detail, and effort
+indicator. It separately measures complete catalog/usage refresh publication,
+then dismisses the picker and joins its workers outside the measured interval.
+
+`blocking-baseline` retains the removed synchronous model refresh and usage
+barrier: four concurrent usage requests, with a two-second timeout for the
+entire group. It then uses the same production picker for equivalent row
+construction and publication. The baseline forces every formatted usage
+summary and the production picker reads those snapshots from its usage cache.
+The background transports of that final shared picker invocation are blocked,
+avoiding a second baseline refresh.
+
+`cached-first` invokes the production picker without that barrier. Model and
+usage transports have exactly the same injected latency as the baseline.
+Catalog construction, cache seeding, runtime construction, and a garbage
+collection occur before each measured sample.
+
+The first-list metric stops before waiting for refresh completion. The
+complete-refresh metric includes catalog publication and all model usage
+annotations, forcing every intermediate update. It does not measure terminal
+drawing or PostgreSQL startup/hydration. This is a latency benchmark, not an
+allocation-reduction claim. Workloads must finish all usage requests within the
+production two-second deadline; the documented dimensions satisfy that bound.
+
+Build and run from the repository root:
+
+```sh
+nix develop -c cabal build --offline agent-cli:bench:model-picker-latency-bench
+bin=$(nix develop -c cabal list-bin agent-cli:bench:model-picker-latency-bench)
+for models in 4 16 64; do
+    for workload in blocking-baseline cached-first; do
+        nix develop -c "$bin" "$workload" "$models" 100 7
+    done
+done
+for repetition in 1 2; do
+    for workload in blocking-baseline cached-first; do
+        nix develop -c "$bin" "$workload" 16 250 7
+    done
+done
+```
+
+The component uses `-O2 -threaded -rtsopts` and reports median elapsed and CPU
+milliseconds. Production modules retain their repository build settings,
+including module-local optimization overrides.
+
+## Initial measurement and rejected update strategy
+
+Measured on 2026-09-08, macOS arm64, GHC 9.10.3, Cabal library profile `-O1`,
+benchmark component `-O2 -threaded -rtsopts`, default single RTS capability.
+Seven samples per row, medians in milliseconds:
+
+| Models | Transport delay | Workload | First list | First-list CPU | Complete refresh | Complete CPU |
+|---:|---:|---|---:|---:|---:|---:|
+| 4 | 100 | Blocking baseline | 202.398 | 0.679 | 202.398 | 0.679 |
+| 4 | 100 | Cached, per-model updates | 0.138 | 0.117 | 102.011 | 0.701 |
+| 16 | 100 | Blocking baseline | 505.261 | 0.893 | 505.261 | 0.893 |
+| 16 | 100 | Cached, per-model updates | 0.147 | 0.149 | 405.503 | 3.567 |
+| 64 | 100 | Blocking baseline | 1719.035 | 3.090 | 1719.035 | 3.090 |
+| 64 | 100 | Cached, per-model updates | 0.351 | 0.356 | 1642.506 | 61.489 |
+| 16 | 250 | Blocking baseline | 1254.995 | 1.362 | 1254.995 | 1.362 |
+| 16 | 250 | Cached, per-model updates | 0.113 | 0.114 | 1005.824 | 3.941 |
+| 16 | 250 | Blocking baseline, repeat | 1253.697 | 1.427 | 1253.697 | 1.427 |
+| 16 | 250 | Cached, per-model updates, repeat | 0.110 | 0.113 | 1005.774 | 3.854 |
+
+Cached-first presentation removed the network barrier, but publishing a complete
+row snapshot for every usage response increased total CPU sharply with catalog
+size. That per-model publication strategy was removed: usage results are now
+published in a batch without delaying the initial model list.
+
+## Batched usage publication
+
+The same commands, build settings, machine, sample counts, and workload
+dimensions were repeated after replacing per-model publication with a single
+usage batch. The completion observer now requires the catalog update and a
+complete usage update rather than one update per model.
+
+| Models | Transport delay | Workload | First list | First-list CPU | Complete refresh | Complete CPU |
+|---:|---:|---|---:|---:|---:|---:|
+| 4 | 100 | Blocking baseline | 201.579 | 0.409 | 201.579 | 0.409 |
+| 4 | 100 | Cached, batched updates | 0.061 | 0.057 | 101.273 | 0.388 |
+| 16 | 100 | Blocking baseline | 504.714 | 0.894 | 504.714 | 0.894 |
+| 16 | 100 | Cached, batched updates | 0.141 | 0.143 | 404.302 | 1.149 |
+| 64 | 100 | Blocking baseline | 1715.990 | 3.013 | 1715.990 | 3.013 |
+| 64 | 100 | Cached, batched updates | 0.296 | 0.299 | 1615.436 | 3.949 |
+| 16 | 250 | Blocking baseline | 1255.469 | 1.457 | 1255.469 | 1.457 |
+| 16 | 250 | Cached, batched updates | 0.140 | 0.136 | 1004.046 | 1.468 |
+| 16 | 250 | Blocking baseline, repeat | 1254.833 | 1.388 | 1254.833 | 1.388 |
+| 16 | 250 | Cached, batched updates, repeat | 0.132 | 0.137 | 1003.928 | 1.683 |
+
+The representative 16-model, 250-ms transport workload publishes usable models
+in 0.14 ms rather than 1.26 seconds. Complete refresh also finishes earlier,
+because catalog and usage requests overlap. The two representative repetitions
+agree closely on elapsed time.
+
+This does not claim lower total CPU. Publishing the initial cached view and two
+updated views has measurable overhead compared with publishing one final view:
+at 64 models, complete CPU is 3.95 ms versus 3.01 ms. Batching removes the
+rejected quadratic publication behavior (61.49 ms at 64 models); the remaining
+cost is the additional bounded number of snapshots required for live refresh.
+No network requests were removed or deferred beyond the complete-refresh
+measurement.
+
+## Startup catalog selection
+
+The `startup-baseline` workload reproduces synchronous catalog refresh followed
+by the production gateway model-option selection. `startup-cached` invokes
+`withGatewayModelsForStartup` with a seeded cache, using the same production
+selector. `startup-cold` invokes that helper without a cache. Every workload
+selects the same explicit alias and forces the complete selected model target.
+The reported `first-list` columns mean **selected startup target readiness** for
+these workloads, not picker publication or terminal readiness.
+
+The refreshed catalog reverses its original order so the benchmark can detect
+actual cache publication. After target readiness, the observer waits for a
+transport-completion signal, then cooperatively yields until the changed cache
+is visible, forces every catalog identifier, and records complete elapsed/CPU
+time. It does not poll during the injected network wait. The background worker
+is cancelled and joined outside the timed interval when its scope closes.
+Catalog construction, successful cache seeding, and GC occur before timing;
+PostgreSQL hydration, authentication, repository discovery, and terminal setup
+are excluded. This measures removal of the catalog network barrier, not a
+reduction in complete-refresh work, allocation, or total CLI startup duration.
+
+Use the optimized build and executable lookup above, then:
+
+```sh
+for models in 4 16 64; do
+    for workload in startup-baseline startup-cached startup-cold; do
+        nix develop -c "$bin" "$workload" "$models" 100 7
+    done
+done
+for repetition in 1 2; do
+    for workload in startup-baseline startup-cached startup-cold; do
+        nix develop -c "$bin" "$workload" 16 250 7
+    done
+done
+```

--- a/packages/agent-cli/benchmark/ModelPickerLatency.md
+++ b/packages/agent-cli/benchmark/ModelPickerLatency.md
@@ -142,3 +142,31 @@ for repetition in 1 2; do
     done
 done
 ```
+
+Measured on 2026-09-08 with the same macOS arm64/GHC 9.10.3 settings
+above; seven samples, medians in milliseconds:
+
+| Models | Delay | Workload | Target ready | Ready CPU | Complete refresh | Complete CPU |
+|---:|---:|---|---:|---:|---:|---:|
+| 4 | 100 | Startup baseline | 101.059 | 0.135 | 101.061 | 0.139 |
+| 4 | 100 | Startup cached | 0.032 | 0.038 | 101.072 | 0.159 |
+| 4 | 100 | Startup cold | 101.053 | 0.142 | 101.054 | 0.146 |
+| 16 | 100 | Startup baseline | 101.062 | 0.123 | 101.064 | 0.128 |
+| 16 | 100 | Startup cached | 0.031 | 0.039 | 101.083 | 0.164 |
+| 16 | 100 | Startup cold | 100.648 | 0.140 | 100.649 | 0.144 |
+| 64 | 100 | Startup baseline | 101.089 | 0.149 | 101.092 | 0.153 |
+| 64 | 100 | Startup cached | 0.030 | 0.035 | 101.083 | 0.161 |
+| 64 | 100 | Startup cold | 101.088 | 0.150 | 101.091 | 0.155 |
+| 16 | 250 | Startup baseline | 251.061 | 0.247 | 251.063 | 0.253 |
+| 16 | 250 | Startup cached | 0.046 | 0.056 | 250.796 | 0.289 |
+| 16 | 250 | Startup cold | 251.071 | 0.220 | 251.073 | 0.225 |
+| 16 | 250 | Startup baseline, repeat | 250.788 | 0.230 | 250.790 | 0.234 |
+| 16 | 250 | Startup cached, repeat | 0.047 | 0.057 | 251.089 | 0.270 |
+| 16 | 250 | Startup cold, repeat | 251.064 | 0.235 | 251.066 | 0.238 |
+
+Warm startup removes the injected catalog wait from target selection:
+approximately 251 ms becomes 0.046 ms in the representative case, with a
+consistent repeat. Complete refresh remains approximately 251 ms, as expected;
+the work still occurs within the runtime-owned background scope. The modest
+CPU overhead of that scope does not grow sharply across the tested catalog
+sizes. Cold startup retains the baseline network wait.

--- a/packages/agent-cli/benchmark/ModelPickerLatency.md
+++ b/packages/agent-cli/benchmark/ModelPickerLatency.md
@@ -28,6 +28,9 @@ annotations, forcing every intermediate update. It does not measure terminal
 drawing or PostgreSQL startup/hydration. This is a latency benchmark, not an
 allocation-reduction claim. Workloads must finish all usage requests within the
 production two-second deadline; the documented dimensions satisfy that bound.
+Confirming a row performs an additional authoritative catalog lookup before
+committing its routing. That confirmation cost is outside these presentation
+measurements; the benchmark dismisses the picker instead.
 
 Build and run from the repository root:
 
@@ -109,24 +112,30 @@ measurement.
 
 ## Startup catalog selection
 
+Startup must refresh the authoritative catalog before initializing the provider
+runtime, even when a persisted catalog contains the requested alias. An alias
+can change provider or protocol between launches, and updating the display cache
+does not rebuild the initialized runtime's routing. Cached-first presentation
+therefore applies to the picker, not startup routing.
+
 The `startup-baseline` workload reproduces synchronous catalog refresh followed
 by the production gateway model-option selection. `startup-cached` invokes
 `withGatewayModelsForStartup` with a seeded cache, using the same production
-selector. `startup-cold` invokes that helper without a cache. Every workload
+selector and an authoritative synchronous refresh. `startup-cold` invokes that
+helper without a cache. Every workload
 selects the same explicit alias and forces the complete selected model target.
 The reported `first-list` columns mean **selected startup target readiness** for
 these workloads, not picker publication or terminal readiness.
 
 The refreshed catalog reverses its original order so the benchmark can detect
-actual cache publication. After target readiness, the observer waits for a
-transport-completion signal, then cooperatively yields until the changed cache
-is visible, forces every catalog identifier, and records complete elapsed/CPU
-time. It does not poll during the injected network wait. The background worker
-is cancelled and joined outside the timed interval when its scope closes.
+actual cache publication. After target readiness, the observer consumes the
+transport-completion signal, verifies the changed cache is visible, forces every
+catalog identifier, and records complete elapsed/CPU time. Refresh and cache
+publication now complete before target selection in all three workloads.
 Catalog construction, successful cache seeding, and GC occur before timing;
 PostgreSQL hydration, authentication, repository discovery, and terminal setup
-are excluded. This measures removal of the catalog network barrier, not a
-reduction in complete-refresh work, allocation, or total CLI startup duration.
+are excluded. These workloads compare the authoritative routing boundary with
+and without a populated cache; they do not demonstrate a startup speedup.
 
 Use the optimized build and executable lookup above, then:
 
@@ -143,30 +152,7 @@ for repetition in 1 2; do
 done
 ```
 
-Measured on 2026-09-08 with the same macOS arm64/GHC 9.10.3 settings
-above; seven samples, medians in milliseconds:
-
-| Models | Delay | Workload | Target ready | Ready CPU | Complete refresh | Complete CPU |
-|---:|---:|---|---:|---:|---:|---:|
-| 4 | 100 | Startup baseline | 101.059 | 0.135 | 101.061 | 0.139 |
-| 4 | 100 | Startup cached | 0.032 | 0.038 | 101.072 | 0.159 |
-| 4 | 100 | Startup cold | 101.053 | 0.142 | 101.054 | 0.146 |
-| 16 | 100 | Startup baseline | 101.062 | 0.123 | 101.064 | 0.128 |
-| 16 | 100 | Startup cached | 0.031 | 0.039 | 101.083 | 0.164 |
-| 16 | 100 | Startup cold | 100.648 | 0.140 | 100.649 | 0.144 |
-| 64 | 100 | Startup baseline | 101.089 | 0.149 | 101.092 | 0.153 |
-| 64 | 100 | Startup cached | 0.030 | 0.035 | 101.083 | 0.161 |
-| 64 | 100 | Startup cold | 101.088 | 0.150 | 101.091 | 0.155 |
-| 16 | 250 | Startup baseline | 251.061 | 0.247 | 251.063 | 0.253 |
-| 16 | 250 | Startup cached | 0.046 | 0.056 | 250.796 | 0.289 |
-| 16 | 250 | Startup cold | 251.071 | 0.220 | 251.073 | 0.225 |
-| 16 | 250 | Startup baseline, repeat | 250.788 | 0.230 | 250.790 | 0.234 |
-| 16 | 250 | Startup cached, repeat | 0.047 | 0.057 | 251.089 | 0.270 |
-| 16 | 250 | Startup cold, repeat | 251.064 | 0.235 | 251.066 | 0.238 |
-
-Warm startup removes the injected catalog wait from target selection:
-approximately 251 ms becomes 0.046 ms in the representative case, with a
-consistent repeat. Complete refresh remains approximately 251 ms, as expected;
-the work still occurs within the runtime-owned background scope. The modest
-CPU overhead of that scope does not grow sharply across the tested catalog
-sizes. Cold startup retains the baseline network wait.
+The previous cached-startup measurements were removed because they measured an
+unsafe implementation that committed potentially stale routing. No replacement
+startup measurements are reported here. Both warm and cold startup retain the
+catalog network wait; the picker measurements above remain applicable.

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -43,20 +43,19 @@ mkDerivation {
   testHaskellDepends = [
     aeson agent-claude agent-cli-runtime agent-codex-dialect
     agent-connectivity agent-core agent-gemini agent-grok-build-dialect
-    agent-integration-api
-    agent-json agent-mcp agent-openai agent-openrouter agent-responses
-    agent-responses-types agent-store agent-tui agent-xai ansi-terminal
-    async base base64-bytestring brick bytestring colour containers
-    dbus directory filelock filepath haskeline hspec http-client
-    http-types JuicyPixels network network-uri process QuickCheck
-    safe-exceptions stm temporary text time transformers unix vty
-    vty-unix wai warp
+    agent-integration-api agent-json agent-mcp agent-openai
+    agent-openrouter agent-responses agent-responses-types agent-store
+    agent-tui agent-xai ansi-terminal async base base64-bytestring
+    brick bytestring colour containers dbus directory filelock filepath
+    haskeline hspec http-client http-types JuicyPixels network
+    network-uri process QuickCheck safe-exceptions stm temporary text
+    time transformers unix vty vty-unix wai warp
   ];
   benchmarkHaskellDepends = [
-    aeson agent-core agent-json agent-mcp agent-responses
-    agent-responses-types agent-store agent-tui async base brick
-    bytestring containers deepseq directory filepath JuicyPixels
-    process safe-exceptions stm text time unix vty
+    aeson agent-cli-runtime agent-core agent-json agent-mcp
+    agent-openai agent-responses agent-responses-types agent-store
+    agent-tui async base brick bytestring containers deepseq directory
+    filepath JuicyPixels process safe-exceptions stm text time unix vty
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
@@ -1,20 +1,23 @@
--- | Load the authoritative model options exposed by a connected organization
--- gateway for native clients that do not own a long-running CLI session.
+-- | Resolve organization-gateway model options for long-running CLI sessions
+-- and native clients that require an authoritative one-shot catalog.
 module Agent.CLI.GatewayModels
     ( loadGatewayModelOptionsAt
     , loadGatewayModelOptionsWithCredentialAt
     , modelOptionsForGatewayModels
     , modelOptionsForGatewayState
     , selectGatewayModelOption
+    , withGatewayModelsForStartup
     ) where
 
 import Agent.CLI.GatewayClient
     ( GatewayCredential
+    , GatewayModelAccess
     , GatewayModel(..)
     , GatewayModelProvider(..)
     , loadGatewayCredentialAt
     , newGatewayModelAccess
     , refreshGatewayModels
+    , cachedGatewayModels
     )
 import Agent.CLI.ModelConfig
     ( ModelCatalog
@@ -29,13 +32,33 @@ import Agent.CLI.Models
     )
 import Agent.Provider
     ( Provider (ClaudeCodeProvider, OpenAIProvider, XAIProvider) )
+import Control.Concurrent.Async (withAsync)
+import Control.Monad (void)
 import Data.List (find, nubBy)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import System.OsPath (OsPath)
 
--- | Select from the authoritative gateway catalog before authentication.
+-- | Start from a credential-scoped cached catalog when it satisfies selection.
+-- Cache misses, including a newly requested alias absent from the snapshot,
+-- retain authoritative synchronous selection. The warm refresh belongs to the
+-- continuation's lifetime and is cancelled and joined when that runtime exits.
+-- Cached metadata does not grant access: the gateway authorizes every request.
+withGatewayModelsForStartup
+    :: GatewayModelAccess
+    -> ([GatewayModel] -> Either Text selection)
+    -> (Either Text selection -> IO result)
+    -> IO result
+withGatewayModelsForStartup access select continue =
+    cachedGatewayModels access >>= \case
+        Just models | Right selected <- select models ->
+            withAsync (void (refreshGatewayModels access)) \_ ->
+                continue (Right selected)
+        _ ->
+            refreshGatewayModels access >>= continue . (>>= select)
+
+-- | Select from a credential-scoped gateway catalog before authentication.
 -- Saved targets supply an alias preference, never provider identity: older
 -- gateway sessions recorded Grok aliases as OpenAI targets.
 selectGatewayModelOption

--- a/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
@@ -17,7 +17,6 @@ import Agent.CLI.GatewayClient
     , loadGatewayCredentialAt
     , newGatewayModelAccess
     , refreshGatewayModels
-    , cachedGatewayModels
     )
 import Agent.CLI.ModelConfig
     ( ModelCatalog
@@ -32,31 +31,23 @@ import Agent.CLI.Models
     )
 import Agent.Provider
     ( Provider (ClaudeCodeProvider, OpenAIProvider, XAIProvider) )
-import Control.Concurrent.Async (withAsync)
-import Control.Monad (void)
 import Data.List (find, nubBy)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import System.OsPath (OsPath)
 
--- | Start from a credential-scoped cached catalog when it satisfies selection.
--- Cache misses, including a newly requested alias absent from the snapshot,
--- retain authoritative synchronous selection. The warm refresh belongs to the
--- continuation's lifetime and is cancelled and joined when that runtime exits.
--- Cached metadata does not grant access: the gateway authorizes every request.
+-- | Resolve authoritative routing before initializing the provider runtime.
+-- Cached catalogs are suitable for immediate picker presentation, but an alias
+-- may have changed provider or dialect since the snapshot was persisted.
+-- Refreshing only the cache after initialization cannot rebuild that runtime.
 withGatewayModelsForStartup
     :: GatewayModelAccess
     -> ([GatewayModel] -> Either Text selection)
     -> (Either Text selection -> IO result)
     -> IO result
 withGatewayModelsForStartup access select continue =
-    cachedGatewayModels access >>= \case
-        Just models | Right selected <- select models ->
-            withAsync (void (refreshGatewayModels access)) \_ ->
-                continue (Right selected)
-        _ ->
-            refreshGatewayModels access >>= continue . (>>= select)
+    refreshGatewayModels access >>= continue . (>>= select)
 
 -- | Select from a credential-scoped gateway catalog before authentication.
 -- Saved targets supply an alias preference, never provider identity: older

--- a/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
@@ -8,6 +8,8 @@ module Agent.CLI.ModelPicker
     , pickModelState
     , pickModelStateWithEffort
     , pickModelStateWithEffortAndUsage
+    , pickModelStateWithUpdates
+    , refreshModelPickerState
     , formatCatalogListing
     , initialModelPickerState
     , applyModelPickerEvent
@@ -46,9 +48,12 @@ import Agent.ReasoningEffort
     , reasoningEffortText
     )
 import Agent.TUI.TextWidth (displayTerminalText)
-import Control.Monad (join)
+import Control.Monad (join, unless)
+import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.STM (atomically, newEmptyTMVarIO, takeTMVar, tryTakeTMVar, putTMVar)
 import Data.Char (isPrint)
-import Data.List (elemIndex)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.List (elemIndex, findIndex)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -210,6 +215,77 @@ pickModelStateWithEffortAndUsage color currentEffort usage models = do
                     (\key -> applyModelPickerEvent (toEvent key))
                     state0
             pure (join result)
+
+-- | A private, conflated update channel belongs to this invocation only.
+-- Network workers never draw directly or race the terminal's input decoder.
+pickModelStateWithUpdates
+    :: Bool
+    -> ReasoningEffort
+    -> Text
+    -> Map.Map Text Text
+    -> PickerState
+    -> ((PickerState -> Map.Map Text Text -> Text -> IO ()) -> IO ())
+    -> IO (Maybe ModelPickerSelection)
+pickModelStateWithUpdates color currentEffort notice usage models refresh = do
+    isTty <- hIsTerminalDevice stdin
+    if not isTty
+        then do
+            -- A non-interactive listing cannot redraw after it is printed.
+            -- Resolve the refresh first rather than printing a cold empty cache.
+            latest <- newIORef (models, usage, notice)
+            refresh \nextModels nextUsage nextNotice ->
+                writeIORef latest (nextModels, nextUsage, nextNotice)
+            (nextModels, nextUsage, nextNotice) <- readIORef latest
+            unless (Text.null nextNotice) $
+                Text.hPutStrLn stderr (displayPickerText nextNotice)
+            pickModelStateWithEffortAndUsage color currentEffort nextUsage nextModels
+        else do
+            updates <- newEmptyTMVarIO
+            let initial =
+                    ((initialModelPickerState currentEffort models)
+                        { modelPickerUsage = usage }, notice)
+                publish nextModels nextUsage nextNotice = atomically do
+                    _ <- tryTakeTMVar updates
+                    putTMVar updates (nextModels, nextUsage, nextNotice)
+                render (state, message) =
+                    renderModelPickerFrame color state
+                        <> "\n" <> roleMuted color (displayPickerText message)
+                step key (state, message) =
+                    fmap (, message) (applyModelPickerEvent (toEvent key) state)
+                apply (nextModels, nextUsage, nextNotice) (state, _) =
+                    (refreshModelPickerState currentEffort nextModels nextUsage state, nextNotice)
+            result <- withAsync (refresh publish) \_ ->
+                Picker.runOverlayWithDecoderAndUpdates
+                    decodeModelPickerKey render step
+                    (atomically (takeTMVar updates)) apply initial
+            pure (result >>= fst)
+
+-- | Preserve the filter, focused model identity, and each model's effort when
+-- a catalog or usage refresh replaces the displayed options.
+refreshModelPickerState
+    :: ReasoningEffort
+    -> PickerState
+    -> Map.Map Text Text
+    -> ModelPickerState
+    -> ModelPickerState
+refreshModelPickerState currentEffort models usage previous =
+    let oldModels = previous.modelPickerModels
+        filtered = models { pickerFilter = oldModels.pickerFilter }
+        focused = selectedOption oldModels >>= \selected ->
+            findIndex ((== selected.modelTarget) . (.modelTarget)) (visibleOptions filtered)
+        nextModels = filtered
+            { pickerIndex = fromMaybe
+                (max 0 (min (max 0 (length (visibleOptions filtered) - 1)) oldModels.pickerIndex))
+                focused
+            }
+        initial = initialModelPickerState currentEffort nextModels
+    in initial
+        { modelPickerEfforts =
+            Map.intersection
+                (Map.union previous.modelPickerEfforts initial.modelPickerEfforts)
+                initial.modelPickerEfforts
+        , modelPickerUsage = usage
+        }
 
 -- | Seed each row with the active effort for the current model and the target
 -- provider's normalized default for every other model.

--- a/packages/agent-cli/src/Agent/CLI/Picker.hs
+++ b/packages/agent-cli/src/Agent/CLI/Picker.hs
@@ -10,6 +10,7 @@ module Agent.CLI.Picker
     , runOverlay
     , runOverlayWithDecoder
     , runOverlayWithUpdates
+    , runOverlayWithDecoderAndUpdates
     , withRawTty
     ) where
 
@@ -216,8 +217,19 @@ runOverlayWithUpdates
     -> state
     -> IO (Maybe (result, state))
 runOverlayWithUpdates render step awaitUpdate applyUpdate =
+    runOverlayWithDecoderAndUpdates decodePickerKey render step awaitUpdate applyUpdate
+
+runOverlayWithDecoderAndUpdates
+    :: (String -> Maybe PickerKey)
+    -> (state -> Text)
+    -> (PickerKey -> state -> Either result state)
+    -> IO update
+    -> (update -> state -> state)
+    -> state
+    -> IO (Maybe (result, state))
+runOverlayWithDecoderAndUpdates decode render step awaitUpdate applyUpdate =
     runOverlayInternal
-        decodePickerKey
+        decode
         render
         step
         (Just (awaitUpdate, applyUpdate))

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -40,10 +40,12 @@ import Agent.CLI.GatewayClient
     , GatewayModelAccess
     , gatewayCredentialIdentity
     , newGatewayModelAccess
+    , newGatewayModelAccessWithStore
     , refreshGatewayModels
     )
 import Agent.CLI.GatewayModels
-    ( modelOptionsForGatewayModels, selectGatewayModelOption )
+    ( modelOptionsForGatewayModels, selectGatewayModelOption
+    , withGatewayModelsForStartup )
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , catalogConnection,
@@ -424,11 +426,12 @@ prepareInitializedWorkspace request = do
         , initializedSkills
         }
 
-resolveInitializedTargets
+withInitializedTargets
     :: InitializedRequest
     -> InitializedWorkspace
-    -> IO InitializedTargets
-resolveInitializedTargets request workspace = do
+    -> (InitializedTargets -> IO result)
+    -> IO result
+withInitializedTargets request workspace continue = do
     let startup = request.initializedStartup
         options = request.initializedOptions
         transition = request.initializedTransition
@@ -541,70 +544,73 @@ resolveInitializedTargets request workspace = do
         either (startupDie startup) pure resumedTargetResult
     projectTarget <-
         either (startupDie startup) pure projectTargetResult
-    (gatewayModelAccess, gatewayTarget) <- case connectedGateway of
-        Nothing -> pure (Nothing, Nothing)
-        Just credential -> do
-            access <- newGatewayModelAccess credential
-            models <- refreshGatewayModels access
-                >>= either (startupDie startup) pure
-            selected <- either (startupDie startup) pure $
-                selectGatewayModelOption
-                    (modelOptionsForGatewayModels catalog models)
-                    options.optModel
-                    (if isJust transition then Nothing else options.optProvider)
-                    (catMaybes
-                        [ transitionTarget, configuredOptionTarget
-                        , resumedTarget, projectTarget
-                        ])
-            pure (Just access, Just selected.modelTarget)
-    let targetHint =
-            gatewayTarget <|>
-            transitionTarget
-                <|> configuredOptionTarget
-                <|> resumedTarget
-                <|> if isNothing options.optModel
-                    then projectTarget
-                    else Nothing
-        requestedProvider
-            | Just target <- gatewayTarget = Just target.targetProvider
-            | otherwise =
-                (.targetProvider) <$> targetHint
-                    <|> options.optProvider
-                    <|> ((.metaProvider) . fst <$> resumed)
+    let withGatewayTarget continueGateway = case connectedGateway of
+            Nothing -> continueGateway (Nothing, Nothing)
+            Just credential -> do
+                access <- newGatewayModelAccessWithStore
+                    (trustedPool startup.startupDatabaseStore)
+                    credential
+                let select models =
+                        selectGatewayModelOption
+                            (modelOptionsForGatewayModels catalog models)
+                            options.optModel
+                            (if isJust transition then Nothing else options.optProvider)
+                            (catMaybes
+                                [ transitionTarget, configuredOptionTarget
+                                , resumedTarget, projectTarget
+                                ])
+                withGatewayModelsForStartup access select \result -> do
+                    selected <- either (startupDie startup) pure result
+                    continueGateway (Just access, Just selected.modelTarget)
+    withGatewayTarget \(gatewayModelAccess, gatewayTarget) -> do
+        let targetHint =
+                gatewayTarget <|>
+                transitionTarget
+                    <|> configuredOptionTarget
+                    <|> resumedTarget
                     <|> if isNothing options.optModel
-                        then projectModelProvider projectSettings
+                        then projectTarget
                         else Nothing
-        targetConnection =
-            targetHint >>= catalogConnection catalog . (.targetConnectionId)
-        customResponses
-            | isJust connectedGateway = Nothing
-            | otherwise =
-                targetConnection >>= \connection ->
-                    case connection.connectionKind of
-                        CustomResponsesConnection responses -> Just
-                            (connection.connectionId, responses)
-                        BuiltinConnection _ -> Nothing
-                        OrganizationGatewayConnection -> Nothing
-        checkStartupUsageInBackground =
-            isNothing connectedGateway
-                && isJust fullscreen
-                && isNothing transition
-                && isNothing resumed
-                && isNothing options.optProvider
-                && isNothing options.optModel
-    pure InitializedTargets
-        { initializedGatewayIdentity = connectedGatewayIdentity
-        , initializedGatewayModelAccess = gatewayModelAccess
-        , initializedTransitionTarget = transitionTarget
-        , initializedConfiguredTarget = configuredOptionTarget
-        , initializedResumedTarget = resumedTarget
-        , initializedProjectTarget = projectTarget
-        , initializedTargetHint = targetHint
-        , initializedRequestedProvider = requestedProvider
-        , initializedCustomResponses = customResponses
-        , initializedCheckStartupUsageInBackground =
-            checkStartupUsageInBackground
-        }
+            requestedProvider
+                | Just target <- gatewayTarget = Just target.targetProvider
+                | otherwise =
+                    (.targetProvider) <$> targetHint
+                        <|> options.optProvider
+                        <|> ((.metaProvider) . fst <$> resumed)
+                        <|> if isNothing options.optModel
+                            then projectModelProvider projectSettings
+                            else Nothing
+            targetConnection =
+                targetHint >>= catalogConnection catalog . (.targetConnectionId)
+            customResponses
+                | isJust connectedGateway = Nothing
+                | otherwise =
+                    targetConnection >>= \connection ->
+                        case connection.connectionKind of
+                            CustomResponsesConnection responses -> Just
+                                (connection.connectionId, responses)
+                            BuiltinConnection _ -> Nothing
+                            OrganizationGatewayConnection -> Nothing
+            checkStartupUsageInBackground =
+                isNothing connectedGateway
+                    && isJust fullscreen
+                    && isNothing transition
+                    && isNothing resumed
+                    && isNothing options.optProvider
+                    && isNothing options.optModel
+        continue InitializedTargets
+            { initializedGatewayIdentity = connectedGatewayIdentity
+            , initializedGatewayModelAccess = gatewayModelAccess
+            , initializedTransitionTarget = transitionTarget
+            , initializedConfiguredTarget = configuredOptionTarget
+            , initializedResumedTarget = resumedTarget
+            , initializedProjectTarget = projectTarget
+            , initializedTargetHint = targetHint
+            , initializedRequestedProvider = requestedProvider
+            , initializedCustomResponses = customResponses
+            , initializedCheckStartupUsageInBackground =
+                checkStartupUsageInBackground
+            }
 
 loadInitializedAuth
     :: InitializedRequest
@@ -1140,7 +1146,15 @@ newInitializedHttpRuntime auth refs activeHttpAuth =
 runInitialized :: InitializedRequest -> IO RunResult
 runInitialized request = do
     workspace <- prepareInitializedWorkspace request
-    targets <- resolveInitializedTargets request workspace
+    withInitializedTargets request workspace $
+        runInitializedWithTargets request workspace
+
+runInitializedWithTargets
+    :: InitializedRequest
+    -> InitializedWorkspace
+    -> InitializedTargets
+    -> IO RunResult
+runInitializedWithTargets request workspace targets = do
     routedAuth <- loadInitializedAuth request targets
     initializedAuth <-
         selectInitializedStartupAccount

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -11,6 +11,8 @@ module Agent.CLI.Session.Choices
 import Agent.CLI.Error (formatApiErrorInlineAt)
 import Agent.CLI.GatewayClient
     ( GatewayModelAccess
+    , cachedGatewayModels
+    , cachedGatewayUsage
     , fetchGatewayUsage
     , refreshGatewayModels
     )
@@ -25,6 +27,7 @@ import Agent.CLI.ModelPicker
     , initialModelEffort
     , modelEffortOptions
     , pickModelStateWithEffortAndUsage
+    , pickModelStateWithUpdates
     , renderEffortIndicator
     )
 import Agent.CLI.Models
@@ -48,6 +51,7 @@ import Agent.CLI.Terminal (resolveColor)
 import Agent.CLI.TUI.App
     ( FullscreenRuntime
     , requestFullscreenAdjustableFilterChoice
+    , requestFullscreenDynamicAdjustableFilterChoice
     , requestFullscreenChoice
     )
 import Agent.CLI.Options (defaultEffortFor)
@@ -74,9 +78,13 @@ import Agent.Provider
     , TokenProvider
     , getNextToken
     )
+import Control.Concurrent.Async (concurrently_)
+import Control.Concurrent.MVar (modifyMVar_, newMVar)
+import Control.Monad (unless, void)
+import Data.IORef (atomicModifyIORef', modifyIORef', newIORef, readIORef)
 import Data.List (elemIndex)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, maybeToList)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -130,52 +138,149 @@ modelChoiceWithEffort
         provider
         current
         currentDialect
-        currentEffort = do
-    scopedPicker >>= \case
-        Left err -> pure (Left err)
-        Right (title, picker, usage) ->
-            Right <$> presentPicker title picker usage
+        currentEffort =
+    case gatewayAccess of
+        Just access -> chooseGateway access
+        Nothing -> do
+            discovered <- discoverModelOptions connectionId provider
+            picker <-
+                initialPickerStateResolvedWith
+                    catalog discovered connectionId provider current currentDialect
+            Right <$> presentPicker "Models" picker Map.empty
   where
-    scopedPicker =
-        case gatewayAccess of
-            Just access ->
-                refreshGatewayModels access >>= \case
-                    Left err -> pure (Left err)
-                    Right [] ->
-                        pure
-                            (Left
-                                "The organization gateway does not offer any models.")
-                    Right models -> do
-                        let gatewayConnectionId =
-                                organizationGatewayConnectionId
-                            options =
-                                modelOptionsForGatewayModels catalog models
-                        picker <-
-                            initialPickerStateForOptions
-                                "organization gateway"
-                                options
-                                gatewayConnectionId
-                                provider
-                                current
-                                currentDialect
-                        usage <- loadGatewayModelUsage access options
-                        pure
-                            (Right
-                                ( "Models · organization gateway"
-                                , picker
-                                , usage
-                                ))
+    gatewayTitle = "Models · organization gateway"
+    emptyGatewayMessage = "The organization gateway does not offer any models."
+
+    gatewayPicker models =
+        initialPickerStateForOptions
+            "organization gateway"
+            (modelOptionsForGatewayModels catalog models)
+            organizationGatewayConnectionId provider current currentDialect
+
+    chooseGateway access = do
+        cached <- cachedGatewayModels access
+        case fullscreen of
             Nothing -> do
-                discovered <- discoverModelOptions connectionId provider
-                picker <-
-                    initialPickerStateResolvedWith
-                        catalog
-                        discovered
-                        connectionId
-                        provider
-                        current
-                        currentDialect
-                pure (Right ("Models", picker, Map.empty))
+                picker <- gatewayPicker (fromMaybe [] cached)
+                usage <- cachedGatewayModelUsage access picker.pickerAll
+                let notice = case cached of
+                        Nothing -> "Loading models…"
+                        Just [] -> emptyGatewayMessage
+                        Just _ -> ""
+                state <- newMVar (picker, usage, notice)
+                let refresh publish = do
+                        let update transform = modifyMVar_ state \previous -> do
+                                let next@(models, values, message) = transform previous
+                                publish models values message
+                                pure next
+                            updateUsage values = update \(models, previous, message) ->
+                                (models, Map.union values previous, message)
+                            refreshCatalog = refreshGatewayModels access >>= \case
+                                Left err -> do
+                                    retained <- cachedGatewayModels access
+                                    case retained of
+                                        Nothing -> do
+                                            empty <- gatewayPicker []
+                                            update \_ -> (empty, Map.empty, err)
+                                        Just _ -> update \(models, values, _) ->
+                                            (models, values, err <> " Showing cached models.")
+                                Right models -> do
+                                    refreshed <- gatewayPicker models
+                                    let added = filter
+                                            (\option -> all
+                                                ((/= option.modelTarget) . (.modelTarget))
+                                                picker.pickerAll)
+                                            refreshed.pickerAll
+                                    update \(_, values, _) ->
+                                        (refreshed, values,
+                                            if null refreshed.pickerAll then emptyGatewayMessage else "")
+                                    refreshGatewayModelUsage access added updateUsage
+                        concurrently_ refreshCatalog
+                            (refreshGatewayModelUsage access picker.pickerAll updateUsage)
+                Right <$> pickModelStateWithUpdates
+                    color currentEffort notice usage picker refresh
+            Just runtime -> do
+                initialPicker <- gatewayPicker (fromMaybe [] cached)
+                initialUsage <- cachedGatewayModelUsage access initialPicker.pickerAll
+                let initialBody = case cached of
+                        Nothing -> "Loading models…"
+                        Just [] -> emptyGatewayMessage
+                        Just _ -> ""
+                    optionEntries picker =
+                        Map.fromList
+                            [(modelOptionKey option, option) | option <- picker.pickerAll]
+                -- Retain every displayed identity until the reply is consumed:
+                -- selection may already be queued when a refresh removes a row.
+                registry <- newIORef (optionEntries initialPicker)
+                state <- newMVar (initialPicker, initialUsage, initialBody)
+                let refresh publish = do
+                        let update transform =
+                                modifyMVar_ state \previous -> do
+                                    let next@(picker, usage, body) = transform previous
+                                    modifyIORef' registry (Map.union (optionEntries picker))
+                                    publish body (dynamicRows picker usage)
+                                    pure next
+                            updateUsage usage =
+                                update \(picker, previousUsage, body) ->
+                                    (picker, Map.union usage previousUsage, body)
+                            refreshCatalog =
+                                refreshGatewayModels access >>= \case
+                                    Left err -> do
+                                        retained <- cachedGatewayModels access
+                                        case retained of
+                                            Nothing -> do
+                                                emptyPicker <- gatewayPicker []
+                                                update \_ -> (emptyPicker, Map.empty, err)
+                                            Just _ ->
+                                                update \(picker, usage, _) ->
+                                                    (picker, usage, err <> " Showing cached models.")
+                                    Right models -> do
+                                        picker <- gatewayPicker models
+                                        let body = if null picker.pickerAll
+                                                then emptyGatewayMessage else ""
+                                            initialKeys = optionEntries initialPicker
+                                            added =
+                                                filter
+                                                    (\option -> Map.notMember (modelOptionKey option) initialKeys)
+                                                    picker.pickerAll
+                                        update \(_, usage, _) -> (picker, usage, body)
+                                        refreshGatewayModelUsage access added updateUsage
+                        concurrently_
+                            refreshCatalog
+                            (refreshGatewayModelUsage access initialPicker.pickerAll updateUsage)
+                selected <-
+                    requestFullscreenDynamicAdjustableFilterChoice
+                        runtime gatewayTitle initialBody initialPicker.pickerIndex
+                        (dynamicRows initialPicker initialUsage)
+                        refresh
+                options <- readIORef registry
+                pure $ Right do
+                    (key, effortIndex) <- selected
+                    option <- Map.lookup key options
+                    effort <- atMay effortIndex (modelEffortOptions option)
+                    pure ModelPickerSelection
+                        { modelPickerOption = option
+                        , modelPickerEffort = effort
+                        }
+
+    dynamicRows picker usage =
+        [ (modelOptionKey option, label, detail, efforts, initialIndex)
+        | option <- picker.pickerAll
+        , let (label, detail, efforts, initialIndex) = row picker usage option
+        ]
+
+    row picker usage option =
+        let efforts = modelEffortOptions option
+            initial = initialModelEffort picker currentEffort option
+            initialIndex = fromMaybe 0 (elemIndex initial efforts)
+            usageText = Map.lookup option.modelTarget.targetModelId usage
+            withUsage separator text =
+                text <> maybe "" (separator <>) usageText
+        in ( withUsage "  " (modelRowLabel picker option)
+           , withUsage "\nUsage: " (modelDetail picker option)
+           , map (renderEffortIndicator option) efforts
+           , initialIndex
+           )
 
     presentPicker title picker usage =
         case fullscreen of
@@ -187,28 +292,11 @@ modelChoiceWithEffort
                     picker
             Just runtime -> do
                 let options = picker.pickerAll
-                    row option =
-                        let efforts = modelEffortOptions option
-                            initial =
-                                initialModelEffort picker currentEffort option
-                            initialIndex =
-                                fromMaybe 0 (elemIndex initial efforts)
-                            usageText =
-                                Map.lookup
-                                    option.modelTarget.targetModelId
-                                    usage
-                            withUsage separator text =
-                                text <> maybe "" (separator <>) usageText
-                        in ( withUsage "  " (modelRowLabel picker option)
-                           , withUsage "\nUsage: " (modelDetail picker option)
-                           , map (renderEffortIndicator option) efforts
-                           , initialIndex
-                           )
                 requestFullscreenAdjustableFilterChoice
                     runtime
                     title
                     picker.pickerIndex
-                    (map row options)
+                    (map (row picker usage) options)
                     >>= \case
                         Just (modelIndex, effortIndex)
                             | Just option <- atMay modelIndex options
@@ -220,26 +308,43 @@ modelChoiceWithEffort
                                         }
                         _ -> pure Nothing
 
-loadGatewayModelUsage
+modelOptionKey :: ModelOption -> Text
+modelOptionKey option =
+    Text.pack (show option.modelTarget)
+
+cachedGatewayModelUsage :: GatewayModelAccess -> [ModelOption] -> IO (Map.Map Text Text)
+cachedGatewayModelUsage access options =
+    Map.fromList . catMaybes <$> traverse load options
+  where
+    load option = do
+        let modelId = option.modelTarget.targetModelId
+        snapshot <- cachedGatewayUsage access modelId
+        pure ((modelId,) <$> (snapshot >>= formatModelUsageSummary))
+
+-- | Publish one usage update per bounded group, independently of the catalog.
+-- Retain completed results on timeout without rebuilding every row for every
+-- response (which would make presentation work quadratic in catalog size).
+refreshGatewayModelUsage
     :: GatewayModelAccess
     -> [ModelOption]
-    -> IO (Map.Map Text Text)
-loadGatewayModelUsage access options = do
-    loaded <-
-        timeout 2000000 $
-            Map.fromList . concat
-                <$> mapConcurrentlyBounded 4 loadUsage options
-    pure (fromMaybe Map.empty loaded)
+    -> (Map.Map Text Text -> IO ())
+    -> IO ()
+refreshGatewayModelUsage access options publish = do
+    completed <- newIORef Map.empty
+    void $ timeout 2000000 $ mapConcurrentlyBounded 4 (loadUsage completed) options
+    usage <- readIORef completed
+    unless (Map.null usage) (publish usage)
   where
-    loadUsage option = do
+    loadUsage completed option = do
         let modelId = option.modelTarget.targetModelId
         fetchGatewayUsage access modelId >>= \case
-            Left _ -> pure []
+            Left _ -> pure ()
             Right snapshot ->
-                pure
-                    [ (modelId, summary)
-                    | summary <- maybeToList (formatModelUsageSummary snapshot)
-                    ]
+                case formatModelUsageSummary snapshot of
+                    Nothing -> pure ()
+                    Just summary ->
+                        atomicModifyIORef' completed \usage ->
+                            (Map.insert modelId summary usage, ())
 
 discoverModelOptions :: Text -> Provider -> IO [ModelOption]
 discoverModelOptions connectionId provider

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -16,7 +16,10 @@ import Agent.CLI.GatewayClient
     , fetchGatewayUsage
     , refreshGatewayModels
     )
-import Agent.CLI.GatewayModels (modelOptionsForGatewayModels)
+import Agent.CLI.GatewayModels
+    ( modelOptionsForGatewayModels
+    , selectGatewayModelOption
+    )
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , builtinConnectionId
@@ -140,7 +143,22 @@ modelChoiceWithEffort
         currentDialect
         currentEffort =
     case gatewayAccess of
-        Just access -> chooseGateway access
+        Just access -> chooseGateway access >>= \case
+            Right (Just selection) ->
+                -- Cached rows are presentation hints, not routing authority.
+                -- Validate only after confirmation so opening and cancelling
+                -- remain immediate, even while catalog requests are blocked.
+                refreshGatewayModels access >>= \case
+                    Left err -> pure (Left err)
+                    Right models ->
+                        pure $ do
+                            option <- selectGatewayModelOption
+                                (modelOptionsForGatewayModels catalog models)
+                                (Just selection.modelPickerOption.modelTarget.targetModelId)
+                                Nothing
+                                []
+                            Right (Just selection { modelPickerOption = option })
+            result -> pure result
         Nothing -> do
             discovered <- discoverModelOptions connectionId provider
             picker <-

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -76,6 +76,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenThemeChoice
     , requestFullscreenFilterChoice
     , requestFullscreenAdjustableFilterChoice
+    , requestFullscreenDynamicAdjustableFilterChoice
     , requestFullscreenOnboarding
     , requestFullscreenResume
     , requestFullscreenSecret

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -468,6 +468,32 @@ handleAppEvent = \case
         handleAskFilterChoiceEvent title initial rows reply
     AppAskAdjustableFilterChoice title initial rows reply ->
         handleAskAdjustableFilterChoiceEvent title initial rows reply
+    AppCloseDynamicAdjustableFilterChoice reply ->
+        modify' \state -> case state.appChoice of
+            Just pending
+                | Just dynamic <- pending.dialogOverlay.choiceDynamic
+                , dynamic.dynamicChoiceReply == reply ->
+                    state { appChoice = Nothing }
+            _ -> state
+    AppAskDynamicAdjustableFilterChoice title body initial rows reply -> do
+        state <- get
+        liftIO (state.appRuntime.runtimeNativeProgress False)
+        modify' \current -> current
+            { appChoice = Just $ dynamicChoiceDialog reply $
+                newDynamicChoice title body initial rows reply
+            , appAgentHover = Nothing
+            }
+        vScrollToBeginning (viewportScroll OverlayViewport)
+    AppUpdateDynamicAdjustableFilterChoice reply body rows ->
+        modify' \current -> current
+            { appChoice = case current.appChoice of
+                Just pending
+                    | Just dynamic <- pending.dialogOverlay.choiceDynamic
+                    , dynamic.dynamicChoiceReply == reply ->
+                        Just $ dynamicChoiceDialog reply $
+                            refreshDynamicChoice body rows pending.dialogOverlay
+                other -> other
+            }
     AppAskResume browser loadEntry deleteEntry searchEntries reply ->
         handleAskResumeEvent
             browser
@@ -911,6 +937,7 @@ handleAskChoiceEvent presentation title body initial rows reply = do
                 , choiceAdjustments = Nothing
                 , choiceAdjustmentIndices = []
                 , choiceCloseOnTurnEnd = False
+                , choiceDynamic = Nothing
                 }
             , appAgentHover = Nothing
             }
@@ -941,6 +968,7 @@ handleAskFilterChoiceEvent title initial rows reply = do
                 , choiceAdjustments = Nothing
                 , choiceAdjustmentIndices = []
                 , choiceCloseOnTurnEnd = False
+                , choiceDynamic = Nothing
                 }
             , appAgentHover = Nothing
             }
@@ -987,10 +1015,24 @@ handleAskAdjustableFilterChoiceEvent title initial adjustableRows reply = do
                 , choiceAdjustments = Just adjustments
                 , choiceAdjustmentIndices = adjustmentIndices
                 , choiceCloseOnTurnEnd = False
+                , choiceDynamic = Nothing
                 }
             , appAgentHover = Nothing
             }
     vScrollToBeginning (viewportScroll OverlayViewport)
+
+dynamicChoiceDialog
+    :: TMVar (Maybe (Text, Int))
+    -> ChoiceOverlay
+    -> PendingDialog (Maybe ChoiceSelection -> IO ()) ChoiceOverlay
+dynamicChoiceDialog reply choice =
+    PendingDialog
+        (\selected -> atomically $ putTMVar reply do
+            selection <- selected
+            dynamic <- choice.choiceDynamic
+            key <- lookup selection.choiceSelectionIndex (zip [0 ..] dynamic.dynamicChoiceKeys)
+            pure (key, fromMaybe 0 selection.choiceSelectionAdjustment))
+        choice
 
 handleAskResumeEvent
     :: ResumeBrowser

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -676,6 +676,14 @@ uiEventLogicalBytes = \case
     UiTurnEnded _ -> 128
     UiTurnRestarted -> 128
 
+dynamicChoiceLogicalBytes :: [Text] -> [(Text, Text, Text, [Text], Int)] -> Int
+dynamicChoiceLogicalBytes headings rows =
+    saturatingAdd 256 $ foldl'
+        (\size (key, label, detail, values, _) ->
+            saturatingAdd size (logicalTextsBytes (key : label : detail : values)))
+        (logicalTextsBytes headings)
+        rows
+
 appEventLogicalBytes :: AppEvent -> Int
 appEventLogicalBytes = \case
     AppUi event -> uiEventLogicalBytes event
@@ -707,6 +715,11 @@ appEventLogicalBytes = \case
                     0
                     rows
                 )
+    AppAskDynamicAdjustableFilterChoice title body _ rows _ ->
+        dynamicChoiceLogicalBytes [title, body] rows
+    AppUpdateDynamicAdjustableFilterChoice _ body rows ->
+        dynamicChoiceLogicalBytes [body] rows
+    AppCloseDynamicAdjustableFilterChoice _ -> 256
     AppAskText _ title body draft _ ->
         saturatingAdd 256 (logicalTextsBytes [title, body, draft])
     AppAskResume browser _ _ _ _ ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -406,6 +406,7 @@ openCommandPalette = do
                 , choiceAdjustments = Nothing
                 , choiceAdjustmentIndices = []
                 , choiceCloseOnTurnEnd = False
+                , choiceDynamic = Nothing
                 }
             , appAgentHover = Nothing
             }

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -946,6 +946,28 @@ requestFullscreenPermission runtime workspace call = do
     enqueueAppEvent runtime (AppAskPermission summary reply)
     atomically (readTMVar reply)
 
+-- | Updates belong to this reply token, never to whichever dialog happens to
+-- be open later. The refresh worker is cancelled and joined when it closes.
+requestFullscreenDynamicAdjustableFilterChoice
+    :: FullscreenRuntime
+    -> Text
+    -> Text
+    -> Int
+    -> [(Text, Text, Text, [Text], Int)]
+    -> ((Text -> [(Text, Text, Text, [Text], Int)] -> IO ()) -> IO ())
+    -> IO (Maybe (Text, Int))
+requestFullscreenDynamicAdjustableFilterChoice runtime title body initial rows refresh = do
+    reply <- newEmptyTMVarIO
+    let publish notice values =
+            enqueueAppEvent runtime
+                (AppUpdateDynamicAdjustableFilterChoice reply notice values)
+        close = enqueueAppEvent runtime (AppCloseDynamicAdjustableFilterChoice reply)
+    (do
+        enqueueAppEvent runtime
+            (AppAskDynamicAdjustableFilterChoice title body initial rows reply)
+        withAsync (refresh publish) \_ -> atomically (readTMVar reply))
+        `finally` close
+
 requestFullscreenThemeChoice
     :: FullscreenRuntime
     -> Int

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -242,6 +242,7 @@ handleEffortControlClick applyUiEvent = do
                             , choiceAdjustments = Nothing
                             , choiceAdjustmentIndices = []
                             , choiceCloseOnTurnEnd = True
+                            , choiceDynamic = Nothing
                             }
                         }
                 vScrollToBeginning (viewportScroll OverlayViewport)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -9,6 +9,9 @@ module Agent.CLI.TUI.Types
     , DictationSession(..)
     , ChoicePresentation(..)
     , ChoiceOverlay(..)
+    , DynamicChoice(..)
+    , newDynamicChoice
+    , refreshDynamicChoice
     , ChoiceSelection(..)
     , CommandPaletteAction(..)
     , CommandPaletteEntry(..)
@@ -80,6 +83,7 @@ import Data.IORef (IORef)
 import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import Data.Sequence (Seq)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -158,6 +162,16 @@ data AppEvent
         !Int
         ![(Text, Text, [Text], Int)]
         !(TMVar (Maybe (Int, Int)))
+    | AppAskDynamicAdjustableFilterChoice
+        !Text !Text !Int
+        ![(Text, Text, Text, [Text], Int)]
+        !(TMVar (Maybe (Text, Int)))
+    | AppUpdateDynamicAdjustableFilterChoice
+        !(TMVar (Maybe (Text, Int)))
+        !Text
+        ![(Text, Text, Text, [Text], Int)]
+    | AppCloseDynamicAdjustableFilterChoice
+        !(TMVar (Maybe (Text, Int)))
     | AppAskText
         !TextInputMode
         !Text
@@ -577,8 +591,73 @@ data ChoiceOverlay = ChoiceOverlay
     , choiceAdjustments :: !(Maybe [[Text]])
     , choiceAdjustmentIndices :: ![Int]
     , choiceCloseOnTurnEnd :: !Bool
+    , choiceDynamic :: !(Maybe DynamicChoice)
     }
     deriving (Eq, Show)
+
+data DynamicChoice = DynamicChoice
+    { dynamicChoiceReply :: !(TMVar (Maybe (Text, Int)))
+    , dynamicChoiceKeys :: ![Text]
+    }
+    deriving (Eq)
+
+instance Show DynamicChoice where
+    show choice = "DynamicChoice " <> show choice.dynamicChoiceKeys
+
+newDynamicChoice
+    :: Text -> Text -> Int -> [(Text, Text, Text, [Text], Int)]
+    -> TMVar (Maybe (Text, Int)) -> ChoiceOverlay
+newDynamicChoice title body initial rows reply = ChoiceOverlay
+    { choicePresentation = ChoiceDialog
+    , choiceTitle = title
+    , choiceBody = body
+    , choiceIndex = max 0 (min (max 0 (length rows - 1)) initial)
+    , choiceRows = [(label, detail) | (_, label, detail, _, _) <- rows]
+    , choiceSearch = True
+    , choiceQuery = ""
+    , choiceAdjustments = Just [values | (_, _, _, values, _) <- rows]
+    , choiceAdjustmentIndices =
+        [max 0 (min (max 0 (length values - 1)) index) | (_, _, _, values, index) <- rows]
+    , choiceCloseOnTurnEnd = False
+    , choiceDynamic = Just (DynamicChoice reply [key | (key, _, _, _, _) <- rows])
+    }
+
+-- | Keep focus by model identity and adjustment by value, not by row index.
+-- Removed focused rows fall back to the nearest remaining visible position.
+refreshDynamicChoice
+    :: Text -> [(Text, Text, Text, [Text], Int)] -> ChoiceOverlay -> ChoiceOverlay
+refreshDynamicChoice body rows previous =
+    case previous.choiceDynamic of
+        Nothing -> previous
+        Just dynamic ->
+            let oldKeys = dynamic.dynamicChoiceKeys
+                at index values = lookup index (zip [0 ..] values)
+                focused = selectedChoiceIndex previous >>= (`at` oldKeys)
+                oldValues = Map.fromList
+                    [ (key, value)
+                    | (key, values, index) <- zip3 oldKeys
+                        (fromMaybe [] previous.choiceAdjustments)
+                        previous.choiceAdjustmentIndices
+                    , Just value <- [at index values]
+                    ]
+                retainedRows =
+                    [ (key, label, detail, values,
+                        fromMaybe initial do
+                            value <- Map.lookup key oldValues
+                            lookup value (zip values [0 ..]))
+                    | (key, label, detail, values, initial) <- rows
+                    ]
+                next = (newDynamicChoice previous.choiceTitle body 0 retainedRows
+                    dynamic.dynamicChoiceReply) { choiceQuery = previous.choiceQuery }
+                visible = choiceVisibleRows next
+                newKeys = Map.fromList (zip [0 :: Int ..] [key | (key, _, _, _, _) <- rows])
+                visibleKeys =
+                    [(key, position)
+                    | (position, (source, _)) <- zip [0 ..] visible
+                    , Just key <- [Map.lookup source newKeys]
+                    ]
+                fallback = min previous.choiceIndex (max 0 (length visible - 1))
+            in next { choiceIndex = fromMaybe fallback (focused >>= (`lookup` visibleKeys)) }
 
 data ChoiceSelection = ChoiceSelection
     { choiceSelectionIndex :: !Int

--- a/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
@@ -5,20 +5,339 @@ import Agent.CLI.GatewayClient
     ( GatewayModel(..)
     , GatewayModelProtocol(..)
     , GatewayModelProvider(..)
+    , GatewayModelAccess
+    , newGatewayModelAccessWithUsage
+    , newGatewayModelAccessWith
+    , cachedGatewayModels
+    , refreshGatewayModels
+    , fetchGatewayUsage
     )
+import Agent.CLI.AgentViewport (AgentTarget(AgentRoot))
+import Agent.CLI.Interrupt (CtrlCDecision(WarnExit))
 import Agent.CLI.ModelConfig
-import Agent.CLI.Models (ModelOption(..), ModelTarget(..))
+import Agent.CLI.ModelPicker
+    ( ModelPickerSelection(..), ModelPickerState(..), initialModelPickerState
+    , refreshModelPickerState, applyModelPickerEvent )
+import Agent.CLI.Models
+    ( ModelOption(..), ModelTarget(..), PickerState(..), PickerEvent(..)
+    , initialPickerStateForOptions, selectedOption )
+import Agent.CLI.Session.Choices (modelChoiceWithEffort)
+import Agent.CLI.TUI.App (newFullscreenInputBuffer, newFullscreenRuntime)
+import Agent.CLI.TUI.Types
+    ( AppEvent(..)
+    , AppEventMailbox(..)
+    , AppEventMailboxState(..)
+    , FullscreenRuntime(..)
+    , PendingAppEvent(..)
+    )
+import Agent.TUI.Model (initialUiState)
+import Agent.TUI.Motion (MotionMode(MotionFull))
 import Agent.Dialect (DialectId(..))
+import Agent.OpenAI.Usage (UsageSnapshot(..), UsageLimit(..), UsageWindow(..))
 import Agent.Provider (Provider(ClaudeCodeProvider, GeminiProvider, OpenAIProvider, XAIProvider))
+import Agent.ReasoningEffort (ReasoningEffort(EffortHigh))
+import Control.Concurrent.Async (withAsync, wait)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar, tryTakeMVar)
+import Control.Concurrent.STM (atomically, putTMVar, readTVar, retry)
+import Control.Exception.Safe (finally)
 import Data.Aeson qualified as Aeson
 import Data.Aeson ((.=))
 import Data.Either (isLeft)
+import Data.Foldable (toList)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as Text
+import System.Timeout (timeout)
 import Test.Hspec
+
+newPickerRuntime :: IO FullscreenRuntime
+newPickerRuntime = do
+    input <- newFullscreenInputBuffer
+    newFullscreenRuntime
+        input
+        (pure ())
+        (const (pure ()))
+        (pure WarnExit)
+        (const (pure True))
+        (const (pure ()))
+        (const (pure ()))
+        (pure (AgentRoot, []))
+        (const (pure ()))
+        (pure ())
+        (const (pure ()))
+        MotionFull
+        False
+        initialUiState
+
+openGatewayPicker
+    :: FullscreenRuntime
+    -> GatewayModelAccess
+    -> IO (Either Text (Maybe ModelPickerSelection))
+openGatewayPicker runtime access =
+    modelChoiceWithEffort
+        testCatalog (Just access) (Just runtime) False
+        organizationGatewayConnectionId OpenAIProvider "company-a"
+        CodexDialect EffortHigh
+
+awaitPickerAction :: IO a -> IO a
+awaitPickerAction action =
+    timeout 1_000_000 action >>= maybe
+        (fail "Model picker operation did not complete while network requests were blocked")
+        pure
+
+awaitPickerEvent :: FullscreenRuntime -> (AppEvent -> Maybe a) -> IO a
+awaitPickerEvent runtime project =
+    awaitPickerAction $ atomically do
+        let AppEventMailbox mailbox = runtime.runtimeMailbox
+        pending <- readTVar mailbox
+        case
+            [ value
+            | PendingEvent event <- toList pending.mailboxPendingEvents
+            , Just value <- [project event]
+            ] of
+            value : _ -> pure value
+            [] -> retry
+
+pickerModel :: Text -> GatewayModel
+pickerModel model = GatewayModel model GatewayResponsesProtocol GatewayOpenAIProvider
+
+pickerUsage :: UsageSnapshot
+pickerUsage = UsageSnapshot
+    { planType = "plus"
+    , rateLimit = Just UsageLimit
+        { allowed = True
+        , limitReached = False
+        , primaryWindow = Just UsageWindow
+            { usedPercent = 25
+            , limitWindowSeconds = 18000
+            , resetAfterSeconds = 9000
+            , resetAt = 1783880000
+            }
+        , secondaryWindow = Nothing
+        }
+    , additionalRateLimits = []
+    }
 
 spec :: Spec
 spec = describe "Agent.CLI.GatewayModels" do
+    describe "cached gateway startup" do
+        it "enters the runtime before warm refresh completes and joins it on exit" do
+            let models = [pickerModel "company-a"]
+            fetch <- newIORef (pure (Right models))
+            started <- newEmptyMVar
+            stopped <- newEmptyMVar
+            gate <- newEmptyMVar
+            access <- newGatewayModelAccessWith (readIORef fetch >>= id)
+            refreshGatewayModels access `shouldReturn` Right models
+            writeIORef fetch $
+                (putMVar started () >> takeMVar gate)
+                    `finally` putMVar stopped ()
+            awaitPickerAction $
+                withGatewayModelsForStartup access Right \selected -> do
+                    selected `shouldBe` Right models
+                    takeMVar started
+                    tryTakeMVar stopped `shouldReturn` Nothing
+            tryTakeMVar stopped `shouldReturn` Just ()
+
+        it "waits for the first authoritative catalog on a cold start" do
+            let models = [pickerModel "company-a"]
+            started <- newEmptyMVar
+            entered <- newEmptyMVar
+            gate <- newEmptyMVar
+            access <- newGatewayModelAccessWith (putMVar started () >> takeMVar gate)
+            withAsync
+                (withGatewayModelsForStartup access Right \selected ->
+                    putMVar entered selected >> pure selected) \worker -> do
+                    awaitPickerAction (takeMVar started)
+                    tryTakeMVar entered `shouldReturn` Nothing
+                    putMVar gate (Right models)
+                    awaitPickerAction (wait worker) `shouldReturn` Right models
+                    takeMVar entered `shouldReturn` Right models
+
+        it "refreshes before rejecting an explicit alias absent from the cache" do
+            let original = [pickerModel "company-a"]
+                updated = original <> [pickerModel "company-new"]
+                select models =
+                    fmap (.modelTarget.targetModelId) $
+                        selectGatewayModelOption
+                            (modelOptionsForGatewayModels testCatalog models)
+                            (Just "company-new") Nothing []
+            fetch <- newIORef (pure (Right original))
+            access <- newGatewayModelAccessWith (readIORef fetch >>= id)
+            refreshGatewayModels access `shouldReturn` Right original
+            writeIORef fetch (pure (Right updated))
+            withGatewayModelsForStartup access select pure
+                `shouldReturn` Right "company-new"
+            cachedGatewayModels access `shouldReturn` Just updated
+
+        it "refreshes an empty cache before deciding that no models are available" do
+            let updated = [pickerModel "company-a"]
+                select models =
+                    fmap (.modelTarget.targetModelId) $
+                        selectGatewayModelOption
+                            (modelOptionsForGatewayModels testCatalog models)
+                            Nothing Nothing []
+            fetch <- newIORef (pure (Right []))
+            access <- newGatewayModelAccessWith (readIORef fetch >>= id)
+            refreshGatewayModels access `shouldReturn` Right []
+            writeIORef fetch (pure (Right updated))
+            withGatewayModelsForStartup access select pure
+                `shouldReturn` Right "company-a"
+
+        it "reports cold-start transport failure without selecting a model" do
+            access <- newGatewayModelAccessWith (pure (Left "gateway unavailable"))
+            withGatewayModelsForStartup access Right pure
+                `shouldReturn` Left "gateway unavailable"
+            cachedGatewayModels access `shouldReturn` Nothing
+
+        it "keeps the warm selection and cache when background transport fails" do
+            let models = [pickerModel "company-a"]
+            fetch <- newIORef (pure (Right models))
+            started <- newEmptyMVar
+            access <- newGatewayModelAccessWith (readIORef fetch >>= id)
+            refreshGatewayModels access `shouldReturn` Right models
+            writeIORef fetch (putMVar started () >> pure (Left "gateway unavailable"))
+            awaitPickerAction
+                (withGatewayModelsForStartup access Right \selected ->
+                    takeMVar started >> pure selected)
+                `shouldReturn` Right models
+            cachedGatewayModels access `shouldReturn` Just models
+
+    describe "cached model picker" do
+        it "preserves minimal-picker filter, focus, and effort during a catalog update" do
+            let options = modelOptionsForGatewayModels testCatalog
+                    [pickerModel "company-a", pickerModel "company-b"]
+            models <- initialPickerStateForOptions "organization gateway" options
+                organizationGatewayConnectionId OpenAIProvider "company-a" CodexDialect
+            let original = initialModelPickerState EffortHigh
+                    models { pickerFilter = "company", pickerIndex = 1 }
+                adjusted = either (error . show) id (applyModelPickerEvent PickerRight original)
+                updated = refreshModelPickerState EffortHigh
+                    models { pickerAll = reverse models.pickerAll }
+                    (Map.singleton "company-b" "5h 75% left") adjusted
+            updated.modelPickerModels.pickerFilter `shouldBe` "company"
+            fmap (.modelTarget.targetModelId) (selectedOption updated.modelPickerModels)
+                `shouldBe` Just "company-b"
+            updated.modelPickerEfforts `shouldBe` adjusted.modelPickerEfforts
+            updated.modelPickerUsage `shouldBe` Map.singleton "company-b" "5h 75% left"
+
+        it "includes cached usage in the first rows without awaiting usage refresh" do
+            runtime <- newPickerRuntime
+            usageFetch <- newIORef (pure (Right pickerUsage))
+            gate <- newEmptyMVar
+            access <- newGatewayModelAccessWithUsage
+                (pure (Right [pickerModel "company-a"]))
+                (\_ -> readIORef usageFetch >>= id)
+            refreshGatewayModels access `shouldReturn` Right [pickerModel "company-a"]
+            _ <- fetchGatewayUsage access "company-a"
+            writeIORef usageFetch (takeMVar gate)
+            withAsync (openGatewayPicker runtime access) \worker -> do
+                (rows, reply) <- awaitPickerEvent runtime \case
+                    AppAskDynamicAdjustableFilterChoice _ _ _ rows reply -> Just (rows, reply)
+                    _ -> Nothing
+                [label | (_, label, _, _, _) <- rows]
+                    `shouldBe` ["company-a ✓  5h 75% left"]
+                atomically (putTMVar reply Nothing)
+                awaitPickerAction (wait worker) `shouldReturn` Right Nothing
+
+        it "opens cached rows while both network requests are blocked and joins them on cancel" do
+            runtime <- newPickerRuntime
+            fetch <- newIORef (pure (Right [pickerModel "company-a"]))
+            modelStarted <- newEmptyMVar
+            modelStopped <- newEmptyMVar
+            usageStarted <- newEmptyMVar
+            usageStopped <- newEmptyMVar
+            modelGate <- newEmptyMVar
+            usageGate <- newEmptyMVar
+            access <- newGatewayModelAccessWithUsage
+                (readIORef fetch >>= id)
+                (\_ ->
+                    (putMVar usageStarted () >> takeMVar usageGate)
+                        `finally` putMVar usageStopped ())
+            refreshGatewayModels access `shouldReturn` Right [pickerModel "company-a"]
+            writeIORef fetch $
+                (putMVar modelStarted () >> takeMVar modelGate)
+                    `finally` putMVar modelStopped ()
+            withAsync (openGatewayPicker runtime access) \worker -> do
+                (body, rows, reply) <- awaitPickerEvent runtime \case
+                    AppAskDynamicAdjustableFilterChoice _ body _ rows reply ->
+                        Just (body, rows, reply)
+                    _ -> Nothing
+                body `shouldBe` ""
+                [label | (_, label, _, _, _) <- rows] `shouldBe` ["company-a ✓"]
+                awaitPickerAction (takeMVar modelStarted)
+                awaitPickerAction (takeMVar usageStarted)
+                atomically (putTMVar reply Nothing)
+                awaitPickerAction (wait worker) `shouldReturn` Right Nothing
+                awaitPickerAction (takeMVar modelStopped)
+                awaitPickerAction (takeMVar usageStopped)
+
+        it "opens a cancellable loading picker before the first catalog request completes" do
+            runtime <- newPickerRuntime
+            gate <- newEmptyMVar
+            access <- newGatewayModelAccessWithUsage (takeMVar gate)
+                (const (pure (Left "usage unavailable")))
+            withAsync (openGatewayPicker runtime access) \worker -> do
+                (body, rows, reply) <- awaitPickerEvent runtime \case
+                    AppAskDynamicAdjustableFilterChoice _ body _ rows reply ->
+                        Just (body, rows, reply)
+                    _ -> Nothing
+                body `shouldBe` "Loading models…"
+                rows `shouldBe` []
+                atomically (putTMVar reply Nothing)
+                awaitPickerAction (wait worker) `shouldReturn` Right Nothing
+
+        it "publishes refreshed model rows without waiting for their usage" do
+            runtime <- newPickerRuntime
+            gate <- newEmptyMVar
+            usageGate <- newEmptyMVar
+            access <- newGatewayModelAccessWithUsage (takeMVar gate)
+                (const (takeMVar usageGate))
+            withAsync (openGatewayPicker runtime access) \worker -> do
+                reply <- awaitPickerEvent runtime \case
+                    AppAskDynamicAdjustableFilterChoice _ _ _ _ reply -> Just reply
+                    _ -> Nothing
+                putMVar gate (Right [pickerModel "company-new"])
+                rows <- awaitPickerEvent runtime \case
+                    AppUpdateDynamicAdjustableFilterChoice _ _ rows
+                        | not (null rows) -> Just rows
+                    _ -> Nothing
+                [label | (_, label, _, _, _) <- rows] `shouldBe` ["company-new"]
+                case rows of
+                    (key, _, _, _, effort) : _ -> do
+                        atomically (putTMVar reply (Just (key, effort)))
+                        selected <- awaitPickerAction (wait worker)
+                        fmap (fmap (.modelPickerOption.modelTarget.targetModelId)) selected
+                            `shouldBe` Right (Just "company-new")
+                    _ -> expectationFailure "Expected refreshed model row"
+
+        it "publishes usage in one group while the model catalog refresh is blocked" do
+            runtime <- newPickerRuntime
+            let models = [pickerModel "company-a", pickerModel "company-b"]
+            fetch <- newIORef (pure (Right models))
+            modelGate <- newEmptyMVar
+            usageGate <- newEmptyMVar
+            access <- newGatewayModelAccessWithUsage
+                (readIORef fetch >>= id) (const (takeMVar usageGate))
+            refreshGatewayModels access `shouldReturn` Right models
+            writeIORef fetch (takeMVar modelGate)
+            withAsync (openGatewayPicker runtime access) \worker -> do
+                reply <- awaitPickerEvent runtime \case
+                    AppAskDynamicAdjustableFilterChoice _ _ _ _ reply -> Just reply
+                    _ -> Nothing
+                putMVar usageGate (Right pickerUsage)
+                putMVar usageGate (Right pickerUsage)
+                rows <- awaitPickerEvent runtime \case
+                    AppUpdateDynamicAdjustableFilterChoice _ _ rows
+                        | any (\(_, label, _, _, _) -> "75% left" `Text.isInfixOf` label) rows ->
+                            Just rows
+                    _ -> Nothing
+                [label | (_, label, _, _, _) <- rows]
+                    `shouldBe` ["company-a ✓  5h 75% left", "company-b  5h 75% left"]
+                atomically (putTMVar reply Nothing)
+                awaitPickerAction (wait worker) `shouldReturn` Right Nothing
+
     it "uses only the aliases advertised by the connected gateway" do
         let options =
                 modelOptionsForGatewayState

--- a/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GatewayModelsSpec.hs
@@ -102,6 +102,34 @@ awaitPickerEvent runtime project =
 pickerModel :: Text -> GatewayModel
 pickerModel model = GatewayModel model GatewayResponsesProtocol GatewayOpenAIProvider
 
+confirmCachedGatewayModel
+    :: Either Text [GatewayModel]
+    -> IO (Either Text (Maybe ModelPickerSelection))
+confirmCachedGatewayModel authoritative = do
+    runtime <- newPickerRuntime
+    let models = [pickerModel "company-a"]
+    fetch <- newIORef (pure (Right models))
+    started <- newEmptyMVar
+    gate <- newEmptyMVar
+    access <- newGatewayModelAccessWithUsage
+        (readIORef fetch >>= id)
+        (const (pure (Left "usage unavailable")))
+    refreshGatewayModels access `shouldReturn` Right models
+    writeIORef fetch (putMVar started () >> takeMVar gate)
+    withAsync (openGatewayPicker runtime access) \worker -> do
+        (rows, reply) <- awaitPickerEvent runtime \case
+            AppAskDynamicAdjustableFilterChoice _ _ _ rows reply -> Just (rows, reply)
+            _ -> Nothing
+        awaitPickerAction (takeMVar started)
+        -- The displayed selection is stale; the picker worker will cancel its
+        -- blocked presentation refresh before fetching at confirmation.
+        writeIORef fetch (pure authoritative)
+        case rows of
+            (key, _, _, _, effort) : _ -> do
+                atomically (putTMVar reply (Just (key, effort)))
+                awaitPickerAction (wait worker)
+            _ -> fail "Expected a cached model row"
+
 pickerUsage :: UsageSnapshot
 pickerUsage = UsageSnapshot
     { planType = "plus"
@@ -121,24 +149,48 @@ pickerUsage = UsageSnapshot
 
 spec :: Spec
 spec = describe "Agent.CLI.GatewayModels" do
-    describe "cached gateway startup" do
-        it "enters the runtime before warm refresh completes and joins it on exit" do
+    describe "authoritative gateway startup" do
+        it "waits for warm refresh and routes a reassigned alias with its current provider and dialect" do
             let models = [pickerModel "company-a"]
+                updated = [GatewayModel "company-a" GatewayAnthropicProtocol GatewayAnthropicProvider]
+                select available =
+                    fmap (\option -> (option.modelTarget.targetProvider, option.modelTarget.targetDialect)) $
+                        selectGatewayModelOption
+                            (modelOptionsForGatewayModels testCatalog available)
+                            (Just "company-a") Nothing []
             fetch <- newIORef (pure (Right models))
             started <- newEmptyMVar
-            stopped <- newEmptyMVar
+            entered <- newEmptyMVar
             gate <- newEmptyMVar
             access <- newGatewayModelAccessWith (readIORef fetch >>= id)
             refreshGatewayModels access `shouldReturn` Right models
-            writeIORef fetch $
-                (putMVar started () >> takeMVar gate)
-                    `finally` putMVar stopped ()
-            awaitPickerAction $
-                withGatewayModelsForStartup access Right \selected -> do
-                    selected `shouldBe` Right models
-                    takeMVar started
-                    tryTakeMVar stopped `shouldReturn` Nothing
-            tryTakeMVar stopped `shouldReturn` Just ()
+            select models `shouldBe` Right (OpenAIProvider, CodexDialect)
+            writeIORef fetch (putMVar started () >> takeMVar gate)
+            withAsync
+                (withGatewayModelsForStartup access select \selected ->
+                    putMVar entered selected >> pure selected) \worker -> do
+                    awaitPickerAction (takeMVar started)
+                    tryTakeMVar entered `shouldReturn` Nothing
+                    putMVar gate (Right updated)
+                    awaitPickerAction (wait worker)
+                        `shouldReturn` Right (ClaudeCodeProvider, ClaudeCodeDialect)
+                    takeMVar entered `shouldReturn` Right (ClaudeCodeProvider, ClaudeCodeDialect)
+            cachedGatewayModels access `shouldReturn` Just updated
+
+        it "rejects an explicit alias removed from the authoritative catalog" do
+            let models = [pickerModel "company-a"]
+                select available =
+                    fmap (.modelTarget.targetModelId) $
+                        selectGatewayModelOption
+                            (modelOptionsForGatewayModels testCatalog available)
+                            (Just "company-a") Nothing []
+            fetch <- newIORef (pure (Right models))
+            access <- newGatewayModelAccessWith (readIORef fetch >>= id)
+            refreshGatewayModels access `shouldReturn` Right models
+            writeIORef fetch (pure (Right []))
+            withGatewayModelsForStartup access select pure
+                `shouldReturn` Left "Model company-a is not offered by the organization gateway."
+            cachedGatewayModels access `shouldReturn` Just []
 
         it "waits for the first authoritative catalog on a cold start" do
             let models = [pickerModel "company-a"]
@@ -191,20 +243,37 @@ spec = describe "Agent.CLI.GatewayModels" do
                 `shouldReturn` Left "gateway unavailable"
             cachedGatewayModels access `shouldReturn` Nothing
 
-        it "keeps the warm selection and cache when background transport fails" do
+        it "reports warm-start transport failure without selecting stale routing and retains the display cache" do
             let models = [pickerModel "company-a"]
             fetch <- newIORef (pure (Right models))
-            started <- newEmptyMVar
             access <- newGatewayModelAccessWith (readIORef fetch >>= id)
             refreshGatewayModels access `shouldReturn` Right models
-            writeIORef fetch (putMVar started () >> pure (Left "gateway unavailable"))
-            awaitPickerAction
-                (withGatewayModelsForStartup access Right \selected ->
-                    takeMVar started >> pure selected)
-                `shouldReturn` Right models
+            writeIORef fetch (pure (Left "gateway unavailable"))
+            withGatewayModelsForStartup access Right pure
+                `shouldReturn` Left "gateway unavailable"
             cachedGatewayModels access `shouldReturn` Just models
 
     describe "cached model picker" do
+        it "validates a confirmed cached alias and preserves effort when its provider and dialect changed" do
+            selected <- confirmCachedGatewayModel
+                (Right [GatewayModel "company-a" GatewayAnthropicProtocol GatewayAnthropicProvider])
+            fmap (fmap (\selection ->
+                ( selection.modelPickerOption.modelTarget.targetProvider
+                , selection.modelPickerOption.modelTarget.targetDialect
+                , selection.modelPickerEffort
+                ))) selected
+                `shouldBe` Right (Just (ClaudeCodeProvider, ClaudeCodeDialect, EffortHigh))
+
+        it "rejects confirmation of a cached alias removed from the gateway" do
+            selected <- confirmCachedGatewayModel (Right [])
+            fmap (fmap (.modelPickerOption.modelTarget.targetModelId)) selected
+                `shouldBe` Left "Model company-a is not offered by the organization gateway."
+
+        it "returns no stale selection when confirmation refresh fails" do
+            selected <- confirmCachedGatewayModel (Left "gateway unavailable")
+            fmap (fmap (.modelPickerOption.modelTarget.targetModelId)) selected
+                `shouldBe` Left "gateway unavailable"
+
         it "preserves minimal-picker filter, focus, and effort during a catalog update" do
             let options = modelOptionsForGatewayModels testCatalog
                     [pickerModel "company-a", pickerModel "company-b"]
@@ -307,6 +376,7 @@ spec = describe "Agent.CLI.GatewayModels" do
                 case rows of
                     (key, _, _, _, effort) : _ -> do
                         atomically (putTMVar reply (Just (key, effort)))
+                        putMVar gate (Right [pickerModel "company-new"])
                         selected <- awaitPickerAction (wait worker)
                         fmap (fmap (.modelPickerOption.modelTarget.targetModelId)) selected
                             `shouldBe` Right (Just "company-new")

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -81,6 +81,8 @@ import Agent.CLI.TUI.Types
     , PendingAppEvent(..)
     , AppState(..)
     , ChoiceOverlay(..)
+    , newDynamicChoice
+    , refreshDynamicChoice
     , ChoicePresentation(..)
     , ChoiceSelection(..)
     , CommandPaletteAction(..)
@@ -171,6 +173,7 @@ import qualified Control.Exception as Exception
 import Control.Concurrent.STM
     ( atomically
     , readTVar
+    , readTMVar
     , newEmptyTMVarIO
     , newTChanIO
     , retry
@@ -207,6 +210,50 @@ import Agent.Tools.RenderChart (renderChartResult)
 
 spec :: Spec
 spec = do
+    describe "dynamic model choice" do
+        it "preserves filter, selected identity, and effort across reordered rows" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+                row key = (key, key, "", ["low", "high"], 0)
+            (_, updated) <- runFullscreenScriptWithState initial
+                [ FullscreenScriptApp
+                    (AppAskDynamicAdjustableFilterChoice "Models" "" 0
+                        [row "alpha", row "beta"] reply)
+                , FullscreenScriptVty (V.EvKey (V.KChar 'b') [])
+                , FullscreenScriptVty (V.EvKey V.KRight [])
+                , FullscreenScriptApp
+                    (AppUpdateDynamicAdjustableFilterChoice reply ""
+                        [row "beta", row "alpha"])
+                , FullscreenScriptHalt
+                ]
+            case updated.appChoice of
+                Nothing -> expectationFailure "Model choice unexpectedly closed"
+                Just pending -> do
+                    pending.dialogOverlay.choiceQuery `shouldBe` "b"
+                    pending.dialogOverlay.choiceIndex `shouldBe` 0
+                    pending.dialogOverlay.choiceAdjustmentIndices `shouldBe` [1, 0]
+            _ <- runFullscreenScriptWithState updated
+                [FullscreenScriptVty (V.EvKey V.KEnter []), FullscreenScriptHalt]
+            atomically (readTMVar reply) `shouldReturn` Just ("beta", 1)
+
+        it "ignores updates and closure from an earlier picker" do
+            runtime <- newScriptRuntime initialUiState
+            previous <- newEmptyTMVarIO
+            current <- newEmptyTMVarIO
+            let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+                rows = [("current", "Current", "", ["high"], 0)]
+            (_, updated) <- runFullscreenScriptWithState initial
+                [ FullscreenScriptApp
+                    (AppAskDynamicAdjustableFilterChoice "Models" "" 0 rows current)
+                , FullscreenScriptApp
+                    (AppUpdateDynamicAdjustableFilterChoice previous "stale" [])
+                , FullscreenScriptApp (AppCloseDynamicAdjustableFilterChoice previous)
+                , FullscreenScriptHalt
+                ]
+            fmap (.dialogOverlay.choiceRows) updated.appChoice
+                `shouldBe` Just [("Current", "")]
+
     describe "durable chart previews" do
         it "queues history charts without rasterizing on reset or page load" do
             runtime <- newScriptRuntime initialUiState
@@ -1328,6 +1375,44 @@ spec = do
                         }
             adjustChoiceValue 1 adjusted
                 `shouldBe` adjusted
+
+    describe "dynamic model choice rows" do
+        it "preserves filter, focused identity and effort through reordering" do
+            reply <- newEmptyTMVarIO
+            let row key = (key, key, "", ["low", "high"], 0)
+                original = (newDynamicChoice "Models" "" 1
+                    [row "model-a", row "model-b"] reply)
+                    { choiceQuery = "model"
+                    , choiceAdjustmentIndices = [0, 1]
+                    }
+                updated = refreshDynamicChoice "Updated"
+                    [row "model-b", row "model-c", row "model-a"] original
+            updated.choiceQuery `shouldBe` "model"
+            updated.choiceBody `shouldBe` "Updated"
+            selectedChoice updated `shouldBe` Just (ChoiceSelection 0 (Just 1))
+        it "preserves effort by value when available values are reordered" do
+            reply <- newEmptyTMVarIO
+            let original = newDynamicChoice "Models" "" 0
+                    [("a", "a", "", ["low", "high"], 1)] reply
+                updated = refreshDynamicChoice ""
+                    [("a", "a", "", ["high", "low"], 1)] original
+            selectedChoice updated `shouldBe` Just (ChoiceSelection 0 (Just 0))
+        it "keeps an empty loading picker searchable until rows arrive" do
+            reply <- newEmptyTMVarIO
+            let loading = (newDynamicChoice "Models" "Loading…" 0 [] reply)
+                    { choiceQuery = "wanted" }
+                updated = refreshDynamicChoice ""
+                    [("a", "other", "", ["low"], 0), ("b", "wanted", "", ["high"], 0)]
+                    loading
+            selectedChoice loading `shouldBe` Nothing
+            selectedChoice updated `shouldBe` Just (ChoiceSelection 1 (Just 0))
+        it "clamps focus when its model disappears and accepts empty catalogs" do
+            reply <- newEmptyTMVarIO
+            let row key = (key, key, "", ["low"], 0)
+                original = newDynamicChoice "Models" "" 1 [row "a", row "b"] reply
+                updated = refreshDynamicChoice "" [row "a"] original
+            selectedChoice updated `shouldBe` Just (ChoiceSelection 0 (Just 0))
+            selectedChoice (refreshDynamicChoice "No models" [] updated) `shouldBe` Nothing
 
     describe "prompt target refresh" do
         it "preserves the live draft and cursor across a provider restart" do
@@ -3332,6 +3417,7 @@ choiceOverlay closeOnTurnEnd = ChoiceOverlay
     , choiceAdjustments = Nothing
     , choiceAdjustmentIndices = []
     , choiceCloseOnTurnEnd = closeOnTurnEnd
+    , choiceDynamic = Nothing
     }
 
 keyboardEventsForReads :: [IO ByteString.ByteString] -> IO [V.Event]

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -675,6 +675,7 @@ applyAction action harness =
                                 , choiceAdjustments = Nothing
                                 , choiceAdjustmentIndices = []
                                 , choiceCloseOnTurnEnd = False
+                                , choiceDynamic = Nothing
                                 }
                         , appTextPrompt = Nothing
                         }

--- a/packages/agent-store/agent-store.cabal
+++ b/packages/agent-store/agent-store.cabal
@@ -52,6 +52,7 @@ library
                     , Agent.Store.Postgres.Skill
                     , Agent.Store.Postgres.Tenant
                     , Agent.Store.Postgres.UsageCache
+                    , Agent.Store.Postgres.ModelCatalogCache
     other-modules:    Agent.Store.Postgres.Session.PullRequests
                     , Agent.Store.Custom.QueryResult
                     , Agent.Store.Postgres.Custom.Sql

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -30,6 +30,7 @@ import qualified Hasql.Transaction as Transaction
 import qualified Hasql.Transaction.Sessions as Transactions
 
 import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Postgres.ModelCatalogCache (modelCatalogCacheSchemaStatements)
 
 import Agent.Store.Postgres.Connection
 import Agent.Store.Postgres.Scope (customSchemaStatements)
@@ -488,6 +489,11 @@ coreMigrations =
             [ "CREATE TABLE IF NOT EXISTS harness.session_pull_request_recency (session_id uuid PRIMARY KEY REFERENCES harness.sessions(session_id) ON DELETE CASCADE, next_turn_index bigint NOT NULL CHECK (next_turn_index >= 0), urls text[] NOT NULL)"
             , "GRANT SELECT, INSERT, UPDATE, DELETE ON harness.session_pull_request_recency TO ha_runtime"
             ]
+        }
+    , Migration
+        { migrationVersion = 116
+        , migrationName = "persistent gateway model catalog cache"
+        , migrationStatements = modelCatalogCacheSchemaStatements
         }
     ]
 

--- a/packages/agent-store/src/Agent/Store/Postgres/ModelCatalogCache.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/ModelCatalogCache.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Presentation-only model catalogs keyed by a non-secret connection identity.
+module Agent.Store.Postgres.ModelCatalogCache
+    ( modelCatalogCacheSchemaStatements
+    , loadModelCatalogCache
+    , upsertModelCatalogCache
+    , deleteModelCatalogCache
+    ) where
+
+import Agent.Store.Postgres.Connection (StorePool, withSession)
+import Agent.Store.Postgres.Hasql (mkStatement)
+import Agent.Store.Types (StoreError)
+import Data.ByteString (ByteString)
+import Data.Functor.Contravariant ((>$<))
+import Data.Text (Text)
+import qualified Hasql.Decoders as Decoders
+import qualified Hasql.Encoders as Encoders
+import qualified Hasql.Session as Session
+
+modelCatalogCacheSchemaStatements :: [ByteString]
+modelCatalogCacheSchemaStatements =
+    [ "CREATE TABLE IF NOT EXISTS harness.model_catalog_cache (\
+      \ connection_identity text PRIMARY KEY,\
+      \ payload_text text NOT NULL,\
+      \ fetched_at timestamptz NOT NULL DEFAULT clock_timestamp())"
+    , "GRANT SELECT, INSERT, UPDATE, DELETE ON harness.model_catalog_cache TO ha_runtime"
+    ]
+
+loadModelCatalogCache :: StorePool -> Text -> IO (Either StoreError (Maybe Text))
+loadModelCatalogCache pool identity =
+    withSession pool (Session.statement identity (mkStatement
+        "SELECT payload_text FROM harness.model_catalog_cache WHERE connection_identity = $1"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        (Decoders.rowMaybe (Decoders.column (Decoders.nonNullable Decoders.text)))
+        True))
+
+upsertModelCatalogCache :: StorePool -> Text -> Text -> IO (Either StoreError ())
+upsertModelCatalogCache pool identity payload =
+    withSession pool (Session.statement (identity, payload) (mkStatement
+        "INSERT INTO harness.model_catalog_cache (connection_identity, payload_text)\
+        \ VALUES ($1, $2) ON CONFLICT (connection_identity) DO UPDATE SET\
+        \ payload_text = EXCLUDED.payload_text, fetched_at = clock_timestamp()"
+        ((fst >$< Encoders.param (Encoders.nonNullable Encoders.text))
+            <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.text)))
+        Decoders.noResult
+        True))
+
+deleteModelCatalogCache :: StorePool -> Text -> IO (Either StoreError ())
+deleteModelCatalogCache pool identity =
+    withSession pool (Session.statement identity (mkStatement
+        "DELETE FROM harness.model_catalog_cache WHERE connection_identity = $1"
+        (Encoders.param (Encoders.nonNullable Encoders.text))
+        Decoders.noResult
+        True))

--- a/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ManagedSpec.hs
@@ -31,6 +31,7 @@ import Agent.Store.Postgres.Connection
     , withStorePool
     , withSession
     )
+import qualified Agent.Store.Postgres.ModelCatalogCache as ModelCatalogCache
 import Agent.Store.Postgres.Config (postgresSocketPath)
 import Agent.Store.Postgres.Managed
     ( ensureManagedPostgres
@@ -132,6 +133,21 @@ spec =
                         "openai"
                         "account-1"
                         `shouldReturn` Right (Just usageEntry)
+                    let pool = trustedPool store
+                    ModelCatalogCache.upsertModelCatalogCache pool "connection-first" "[\"first\"]"
+                        `shouldReturn` Right ()
+                    ModelCatalogCache.loadModelCatalogCache pool "connection-first"
+                        `shouldReturn` Right (Just "[\"first\"]")
+                    ModelCatalogCache.loadModelCatalogCache pool "connection-second"
+                        `shouldReturn` Right Nothing
+                    ModelCatalogCache.upsertModelCatalogCache pool "connection-first" "[]"
+                        `shouldReturn` Right ()
+                    ModelCatalogCache.loadModelCatalogCache pool "connection-first"
+                        `shouldReturn` Right (Just "[]")
+                    ModelCatalogCache.deleteModelCatalogCache pool "connection-first"
+                        `shouldReturn` Right ()
+                    ModelCatalogCache.loadModelCatalogCache pool "connection-first"
+                        `shouldReturn` Right Nothing
                     ) >>= \case
                         Left err ->
                             expectationFailure


### PR DESCRIPTION
## Problem

Opening `/model` waited for the gateway catalog and usage requests before showing any rows.

## Changes

- Persist the last successful gateway catalog in PostgreSQL, scoped to the exact opaque credential identity.
- Show cached models immediately in fullscreen and minimal pickers, then refresh catalog and usage in scoped background tasks without losing filter, focus, or effort selection.
- Validate the confirmed picker alias against the authoritative catalog before applying its provider/dialect, preserving the chosen effort. Cancellation never waits for this validation.
- Keep startup routing authoritative: refresh before initializing the provider runtime, even with a populated cache. An alias can change provider or dialect between launches; a background cache update cannot rebuild an already initialized runtime.
- Keep last-known-good models on transient failures; clear cached catalogs on HTTP 401/403. Cached metadata never bypasses gateway request authorization.
- Add persistence, startup, cancellation, and dynamic-picker regression tests and a reproducible latency benchmark.

## Validation

- Gateway model/startup tests: 30 examples, 0 failures.
- Gateway client/persistence tests: 49 examples, 0 failures.
- TUI app tests: 179 examples, 0 failures (209 combined with gateway model/startup tests after merging current master).
- Real PostgreSQL cache CRUD and runtime persistence/invalidation assertions passed.
- Live tmux CLI: open `/model`, filter, adjust effort, select, and return to the prompt.
- Optimized picker benchmark, 16 models with 250 ms transport latency: first usable list **1,255 ms → 0.14 ms**. This measures row publication, not terminal drawing. Complete-refresh CPU is reported separately in `packages/agent-cli/benchmark/ModelPickerLatency.md`; no claim of reduced total CPU.

The delayed fullscreen smoke verified Escape clearing the filter, not the subsequent dialog cancellation. Cancellation is covered by the focused tests and earlier isolated picker smoke.
