### PR TITLE
Collect stale merged worktrees with verified clean recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,34 +293,40 @@ child session.
 
 ### Worktree recovery and cleanup
 
-New managed worktrees are enrolled in snapshot-backed cleanup. After seven
-days of inactivity, an inactive, unprotected checkout may be collected even
-when it contains uncommitted work. Before removal, recovery refs preserve its
-commits, staged changes, working-tree changes, and non-ignored untracked files.
-Conversation history is not deleted; resuming a collected session restores
-its checkout. Recovery snapshots do not automatically expire.
+Managed worktrees are collected only when **clean, incorporated into another
+branch, and inactive for at least 24 hours** (configurable to a longer interval).
+Dirty checkouts and unmerged work never expire merely because they are old.
+Inactivity means saved-session idle time, not commit age or time since merge.
+Ownership, active-session, protection and safety checks still apply.
 
-A checkout whose exact `HEAD` is already an ancestor of the repository's
-default branch is eligible after **24 hours of inactivity**, rather than the
-normal configured interval. This means idle time, not 24 hours since merge;
-commit author/committer timestamps are not activity or merge clocks. Additional
-commits not incorporated into the default branch disqualify this fast path.
-Dirty checkouts still require the same verified recovery snapshot, and all
-ownership, active-session, protection and safety checks still apply.
+Local proof uses exact commit ancestry into another surviving local or
+remote-tracking branch, excluding the checkout's own branch and upstream.
+An equal-tip copy alone is insufficient, except for the resolved default branch
+(`origin/HEAD`, or local `main`/`master` when it is unavailable).
+For squash/rebase merges, authenticated GitHub API evidence must identify a
+merged PR with the checkout's exact HEAD. Its merge commit must exist locally
+and be reachable from the target branch, with exact final content and modes
+preserved for every branch-changed path. Missing or ambiguous evidence retains
+the checkout. GC does not fetch; cached refs may miss recent merges.
 
-Maintenance resolves the selected remote's existing local symbolic
-`refs/remotes/<remote>/HEAD`, using the branch's configured remote, then
-`upstream`, `origin`, or a sole remaining remote. It does not fetch, guess
-`master`/`main`, or use the currently checked-out branch as the default.
-Missing default-branch evidence keeps the normal interval. Locally cached refs
-can be stale: this proves incorporation into the available ref, not the current
-server state, and may miss recent merges. Squash/rebase merges without exact
-ancestry proof also keep the normal interval; matching commit messages or trees
-are not merge evidence.
+Clean recovery reuses existing Git trees rather than launching a hashing
+process for every file. Recovery refs also preserve checkout reflog commits,
+`REBASE_HEAD` commits, and `AUTO_MERGE` trees. Active merge/rebase operations
+still prevent collection.
+Conversation history and historical recovery snapshots are retained, and
+resuming a collected session restores its checkout.
 
-**Ignored untracked files are not backed up.** This includes ignored `.env`
-files, build output, and local databases. Move important ignored data outside
-the checkout or protect the worktree before relying on it.
+**Recognized, explicitly ignored build/cache directories are disposable and
+are not restored** (for example `node_modules`, `dist-newstyle`, and `.venv`).
+An ignored `result` symlink directly into the Nix store is also disposable.
+Known ignored agent settings (`.haskell-agent/settings.json`) and generated
+OpenAI provider files (`packages/agent-openai/data/models.json` and `prompt.md`)
+are permitted only when byte-identical regular copies remain in the primary
+checkout; these duplicate copies are not restored. Additional files under
+`.haskell-agent` or differing contents prevent collection.
+Other ignored data, including `.env` files and local databases, prevents
+collection. Protect a checkout if its build/cache directories contain
+irreplaceable data.
 
 Existing agent worktrees are automatically adopted only when their managed-root
 location, reciprocal linked-Git metadata, and saved-session provenance verify
@@ -346,7 +352,10 @@ overhead and filesystem/APFS sharing, not guaranteed net reclaimed disk space.
 Adoption reads the existing session database
 without starting it, migrating it, or importing old sessions. Manual `enroll`
 remains available for a checkout whose provenance cannot be established and
-starts its inactivity clock now. `gc` runs a bounded collection pass.
+starts its inactivity clock now. Manual `gc` examines every candidate and prints
+progress, with a per-checkout deadline. Background maintenance retains its
+short pass budget and rotates its starting point. Not-examined worktrees and
+failed operations are reported separately from retained worktrees.
 Active leases, explicit protection, unsupported Git state, incomplete snapshots,
 or detected concurrent edits prevent deletion. Restoration refuses to overwrite
 an existing directory and never resets a branch that moved after collection.

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -288,6 +288,9 @@ library
                     , Agent.CLI.Worktree.ReadOnlyLock
                     , Agent.CLI.Worktree.Provenance
                     , Agent.CLI.Worktree.Snapshot
+                    , Agent.CLI.Worktree.Clean
+                    , Agent.CLI.Worktree.Ignored
+                    , Agent.CLI.Worktree.Incorporation
     reexported-modules:
                       agent-external-session:Agent.CLI.ExternalSession as Agent.CLI.ExternalSession
                     , agent-cli-runtime:Agent.CLI.Auth as Agent.CLI.Auth
@@ -405,6 +408,22 @@ executable eval-ghci-vs-bash
                     , safe-exceptions
                     , text >= 2.0 && < 2.2
                     , time
+                    , unix
+
+benchmark worktree-collection-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          WorktreeCollection.hs
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-cli
+                    , base
+                    , bytestring
+                    , directory
+                    , filepath
+                    , safe-exceptions
+                    , text
+                    , process
                     , unix
 
 benchmark subagent-retention-bench
@@ -612,6 +631,9 @@ test-suite agent-cli-test
                     , Agent.CLI.UsageSpec
                     , Agent.CLI.WebLspSpec
                     , Agent.CLI.WorktreeSpec
+                    , Agent.CLI.WorktreeCleanSpec
+                    , Agent.CLI.WorktreeIgnoredSpec
+                    , Agent.CLI.WorktreeIncorporationSpec
                     , Agent.CLI.WorktreeAdminSpec
                     , Agent.CLI.Worktree.SnapshotSpec
                     , Agent.CLI.Worktree.ProvenanceSpec

--- a/packages/agent-cli/benchmark/WorktreeCollection.hs
+++ b/packages/agent-cli/benchmark/WorktreeCollection.hs
@@ -1,0 +1,177 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- Compare the replaced snapshot path with clean-object recovery, including
+-- their production verification counts. Fixture construction is not measured.
+-- Both paths preserve the same clean linked checkout and leave it present.
+-- Session/lease discovery, incorporation proof, size estimation and deletion
+-- are excluded: this benchmark measures recovery preparation, not total GC.
+module Main (main) where
+
+import qualified Agent.CLI.Worktree.Clean as Clean
+import qualified Agent.CLI.Worktree.Snapshot as Snapshot
+import Control.Exception (evaluate)
+import Control.Exception.Safe (bracket)
+import Control.Monad (forM, forM_, unless)
+import qualified Data.ByteString.Char8 as BS
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.CPUTime (getCPUTime)
+import qualified System.Directory as Directory
+import System.Environment (getArgs, getEnvironment, getEnv)
+import System.Exit (ExitCode(..), die)
+import System.FilePath ((</>))
+import System.IO (BufferMode(..), hSetBuffering, stdout)
+import System.Mem (performGC)
+import System.OsPath (OsPath, unsafeEncodeUtf)
+import System.Posix.Temp (mkdtemp)
+import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
+import Text.Printf (printf)
+import Text.Read (readMaybe)
+
+data Sample = Sample
+    { elapsedMillis :: !Double
+    , cpuMillis :: !Double
+    , allocatedBytes :: !Integer
+    , resultChecksum :: !Int
+    }
+
+main :: IO ()
+main = do
+    hSetBuffering stdout LineBuffering
+    enabled <- getRTSStatsEnabled
+    unless enabled $ die "RTS statistics required: +RTS -T"
+    arguments <- getArgs
+    (counts, samples, selection) <- case arguments of
+        [] -> pure ([100, 1000, 3000], 3, "both")
+        [files, repetitions] -> do
+            count <- positive files
+            sampleCount <- positive repetitions
+            pure ([count], sampleCount, "both")
+        [implementation, files, repetitions] | implementation `elem` ["old-snapshot", "new-clean"] -> do
+            count <- positive files
+            sampleCount <- positive repetitions
+            pure ([count], sampleCount, implementation)
+        _ -> die "usage: worktree-collection-bench [[old-snapshot|new-clean] FILES SAMPLES] +RTS -T"
+    putStrLn "implementation,files,bytes_per_file,samples,median_elapsed_ms,median_parent_cpu_ms,median_parent_allocated_bytes,checksum"
+    forM_ counts $ \count -> withFixture count $ \checkout -> do
+      if selection /= "both" then do
+        measurements <- forM [1 .. samples] $ \_ ->
+            measure (if selection == "old-snapshot" then oldRecovery checkout else newRecovery checkout)
+        printMedian selection count measurements
+      else do
+        -- Alternate order to avoid attributing a systematic warm-cache or
+        -- thermal-order advantage to either implementation.
+        pairs <- forM [1 .. samples] $ \sampleNumber ->
+            if odd sampleNumber then do
+                baseline <- measure (oldRecovery checkout)
+                replacement <- measure (newRecovery checkout)
+                pure (baseline, replacement)
+            else do
+                replacement <- measure (newRecovery checkout)
+                baseline <- measure (oldRecovery checkout)
+                pure (baseline, replacement)
+        printMedian "old-snapshot" count (map fst pairs)
+        printMedian "new-clean" count (map snd pairs)
+  where
+    positive value = case readMaybe value of
+        Just number | number > 0 -> pure number
+        _ -> die "FILES and SAMPLES must be positive integers"
+
+oldRecovery :: OsPath -> IO Snapshot.WorktreeSnapshot
+oldRecovery path = do
+    require =<< Snapshot.checkSnapshotSupported path
+    snapshot <- require =<< Snapshot.createSnapshot path
+    require =<< Snapshot.verifySnapshotUnchanged path snapshot
+    pure snapshot
+
+newRecovery :: OsPath -> IO Snapshot.WorktreeSnapshot
+newRecovery path = do
+    clean <- require =<< Clean.inspectCleanCheckout path
+    require =<< Clean.verifyCleanCheckout path clean
+    snapshot <- require =<< Clean.preserveCleanCheckout path clean
+    require =<< Clean.verifyCleanCheckout path clean
+    require =<< Clean.verifyCleanCheckout path clean
+    pure snapshot
+
+require :: Either Text a -> IO a
+require = either (fail . Text.unpack) pure
+
+measure :: IO Snapshot.WorktreeSnapshot -> IO Sample
+measure action = do
+    performGC
+    beforeStatistics <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeElapsed <- getMonotonicTimeNSec
+    snapshot <- action
+    checksum <- evaluate $ sum $ map Text.length
+        [ snapshot.snapshotHead, snapshot.snapshotIndexTree
+        , snapshot.snapshotWorkTree, snapshot.snapshotRef, snapshot.snapshotBranch ]
+    afterElapsed <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    -- Account for the last partial nursery; this GC is outside elapsed/CPU time.
+    performGC
+    afterStatistics <- getRTSStats
+    pure Sample
+        { elapsedMillis = fromIntegral (afterElapsed - beforeElapsed) / 1e6
+        , cpuMillis = fromIntegral (afterCpu - beforeCpu) / 1e9
+        , allocatedBytes = toInteger afterStatistics.allocated_bytes
+            - toInteger beforeStatistics.allocated_bytes
+        , resultChecksum = checksum
+        }
+
+printMedian :: String -> Int -> [Sample] -> IO ()
+printMedian implementation files samples =
+    printf "%s,%d,1024,%d,%.3f,%.3f,%d,%d\n"
+        implementation files (length samples)
+        (median (map (.elapsedMillis) samples))
+        (median (map (.cpuMillis) samples))
+        (median (map (.allocatedBytes) samples))
+        (sum (map (.resultChecksum) samples))
+  where
+    median values = sort values !! (length values `div` 2)
+
+withFixture :: Int -> (OsPath -> IO a) -> IO a
+withFixture count action = do
+    temporaryRoot <- getEnv "TMPDIR"
+    bracket (mkdtemp (temporaryRoot </> "worktree-collection-benchmark-"))
+        Directory.removePathForcibly $ \root -> do
+            let repository = root </> "repository"
+                checkout = root </> "checkout"
+            Directory.createDirectory repository
+            git repository ["init", "-q", "-b", "main"]
+            git repository ["config", "user.name", "Collection Benchmark"]
+            git repository ["config", "user.email", "collection-benchmark@example.invalid"]
+            git repository ["config", "core.autocrlf", "false"]
+            git repository ["config", "core.attributesFile", "/dev/null"]
+            git repository ["config", "core.excludesFile", "/dev/null"]
+            git repository ["config", "commit.gpgsign", "false"]
+            git repository ["config", "gc.auto", "0"]
+            forM_ [1 .. count] $ \number ->
+                BS.writeFile (repository </> ("source-" <> show number <> ".txt"))
+                    (BS.pack (take 1024 (cycle ("file " <> show number <> "\n"))))
+            git repository ["add", "."]
+            git repository ["commit", "-q", "-m", "Baseline source files"]
+            git repository ["worktree", "add", "-q", "-b", "merged-feature", checkout]
+            BS.writeFile (checkout </> "source-1.txt") (BS.replicate 1024 'm')
+            git checkout ["commit", "-q", "-a", "-m", "Feature change"]
+            git repository ["merge", "--no-ff", "-q", "-m", "Merge feature", "merged-feature"]
+            action (unsafeEncodeUtf checkout)
+
+git :: FilePath -> [String] -> IO ()
+git directory arguments = do
+    environment <- getEnvironment
+    let overrides =
+            [ ("GIT_CONFIG_NOSYSTEM", "1"), ("GIT_CONFIG_GLOBAL", "/dev/null")
+            , ("GIT_TERMINAL_PROMPT", "0")
+            ]
+    (code, _, diagnostic) <- readCreateProcessWithExitCode
+        (proc "git" ("-C" : directory : arguments))
+            { env = Just (overrides <> filter (\(name, _) ->
+                name `notElem` map fst overrides) environment) } ""
+    unless (code == ExitSuccess) $ fail diagnostic

--- a/packages/agent-cli/benchmark/WorktreeCollection.md
+++ b/packages/agent-cli/benchmark/WorktreeCollection.md
@@ -1,0 +1,111 @@
+# Worktree recovery preparation benchmark
+
+`WorktreeCollection.hs` compares the old full-snapshot collection path against
+clean-checkout recovery using existing Git objects. It keeps the old path as a
+baseline. Each fixture is a linked checkout with a committed feature merged into
+its primary checkout, containing the requested number of 1,024-byte tracked
+files.
+
+The measured old path runs snapshot preflight, snapshot creation (which captures
+the checkout twice), and final snapshot verification (a third capture). The new
+path runs the five clean inspections used by collection, including the inspection
+inside recovery preservation. Both paths prepare recovery without removing the
+fixture. Fixture construction and destruction are outside measurement.
+
+This is **not an end-to-end GC benchmark**: saved-session discovery, leases,
+incorporation proofs, directory size estimation, and checkout removal are not
+measured. Git subprocess time is included in elapsed time. CPU and allocation
+columns cover the Haskell parent only, not Git subprocess CPU or allocation.
+
+Each sample forces a checksum of the returned recovery descriptor. GC runs before
+each sample and after the elapsed/CPU interval so the allocation count includes
+the last partial nursery. Sample order alternates between implementations; each
+column reports its median.
+
+## Build
+
+From the repository root, compile the narrow dependency graph with optimization
+inside the repository development shell:
+
+```sh
+export BENCHMARK_OUTPUT="$TMPDIR/worktree-collection-build"
+mkdir -p "$BENCHMARK_OUTPUT"
+nix develop -c ghc \
+  -O2 -threaded -rtsopts \
+  -XGHC2021 -XBlockArguments -XOverloadedStrings \
+  -XOverloadedRecordDot -XNoFieldSelectors -XLambdaCase \
+  -ipackages/agent-cli/src -ipackages/agent-core/src \
+  -outputdir "$BENCHMARK_OUTPUT" \
+  packages/agent-cli/benchmark/WorktreeCollection.hs \
+  -o "$BENCHMARK_OUTPUT/worktree-collection-bench"
+```
+
+## Run
+
+Use a controlled environment for both implementations. A development shell's
+large build environment otherwise becomes part of every `getEnvironment` and
+subprocess invocation, disproportionately inflating allocation in the old
+one-process-per-file implementation. The Git executable still comes from Nix.
+
+```sh
+nix develop -c sh -c '
+  env -i \
+    PATH="$(dirname "$(command -v git)"):/usr/bin:/bin" \
+    TMPDIR="$TMPDIR" HOME="$HOME" LANG=en_US.UTF-8 \
+    "$BENCHMARK_OUTPUT/worktree-collection-bench" +RTS -T
+'
+```
+
+With no positional arguments, the benchmark runs 100, 1,000, and 3,000 files with
+three samples each. Pass `FILES SAMPLES` before `+RTS` for a particular case.
+Repeat at least one case in a separate invocation to check stability.
+
+## Recorded results (2026-09-08)
+
+Apple Silicon macOS, GHC 9.10.3, `-O2 -threaded -rtsopts`, one RTS capability,
+`+RTS -T`, controlled environment as above. All rows are medians of three
+samples. Allocated bytes and CPU are **parent-process measurements**.
+
+| Files | Implementation | Elapsed ms | Parent CPU ms | Parent allocated bytes |
+| ---: | --- | ---: | ---: | ---: |
+| 100 | Old snapshot | 9,668.189 | 688.825 | 241,265,440 |
+| 100 | New clean | 608.060 | 40.928 | 44,661,584 |
+| 1,000 | Old snapshot | 98,508.686 | 6,700.591 | 2,301,874,480 |
+| 1,000 | New clean | 940.249 | 94.700 | 282,592,184 |
+| 3,000 | New clean | 1,696.219 | 206.774 | 823,954,736 |
+| 100, repeat | Old snapshot | 10,004.516 | 668.768 | 241,266,072 |
+| 100, repeat | New clean | 636.439 | 42.366 | 44,498,808 |
+| 1,000, repeat | New clean | 949.621 | 95.615 | 282,632,936 |
+| 100, final FETCH_HEAD support | Old snapshot | 10,276.352 | 687.667 | 241,266,840 |
+| 100, final FETCH_HEAD support | New clean | 632.616 | 43.874 | 44,630,040 |
+
+The initial mixed matrix completed the 100- and 1,000-file baselines before its
+tool session became unavailable during the 3,000-file case. No 3,000-file old-path
+result is claimed. After final safety checks were added to the clean
+implementation, it was recompiled and measured separately using:
+
+```text
+new-clean 100 3
+new-clean 1000 3
+new-clean 3000 3
+new-clean 1000 3
+```
+
+The final 100-file repetition used the mixed `100 3` invocation with alternating
+order and the final implementation. It confirms approximately 15.7× lower
+recovery-preparation elapsed time and 81.6% less parent allocation. At 1,000
+files, the completed baseline versus final clean measurement is approximately
+105× faster with 87.7% less parent allocation. These are not whole-GC speedups.
+The final 1,000-file clean repetitions differ by about 1% in elapsed time.
+
+After adding optional `FETCH_HEAD` preservation and extracting ignored-directory
+validation, the final implementation was rebuilt and the alternating `100 3`
+case repeated once more. It measured 10.276 seconds versus 0.633 seconds (16.2×),
+with 81.5% less parent allocation. That fixture has no `FETCH_HEAD`, so it covers
+the added absence check rather than the cost of preserving populated fetch
+metadata.
+
+The remaining clean implementation still allocates proportionally to tracked
+file count because its safety checks enumerate the index and attributes several
+times. Large repository histories, ignored-directory size estimation, and
+checkout removal remain separate performance boundaries not assessed here.

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -2,17 +2,17 @@
 , agent-codex-dialect, agent-connectivity, agent-core
 , agent-external-session, agent-gemini, agent-grok-build-dialect
 , agent-integration-api, agent-json, agent-mcp, agent-openai
-, agent-openrouter, agent-process
-, agent-responses, agent-responses-types, agent-store, agent-syntax
-, agent-tui, agent-xai, ansi-terminal, async, base
-, base64-bytestring, brick, bytestring, colour, containers, crypton
-, crypton-connection, dbus, deepseq, directory, entropy, filelock
-, filepath, haskeline, hasql-pool, hspec, http-client
-, http-client-tls, http-types, JuicyPixels, lib, memory, mtl
-, network, network-uri, optparse-applicative, process, QuickCheck
-, retry, safe-exceptions, scientific, stm, tagsoup, temporary
-, terminfo, text, time, tls, transformers, unix, vector, vty
-, vty-crossplatform, vty-unix, wai, warp
+, agent-openrouter, agent-process, agent-responses
+, agent-responses-types, agent-store, agent-syntax, agent-tui
+, agent-xai, ansi-terminal, async, base, base64-bytestring, brick
+, bytestring, colour, containers, crypton, crypton-connection, dbus
+, deepseq, directory, entropy, filelock, filepath, haskeline
+, hasql-pool, hspec, http-client, http-client-tls, http-types
+, JuicyPixels, lib, memory, mtl, network, network-uri
+, optparse-applicative, process, QuickCheck, retry, safe-exceptions
+, scientific, stm, tagsoup, temporary, terminfo, text, time, tls
+, transformers, unix, vector, vty, vty-crossplatform, vty-unix, wai
+, warp
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -25,15 +25,15 @@ mkDerivation {
     aeson agent-claude agent-cli-runtime agent-codex-dialect
     agent-connectivity agent-core agent-external-session agent-gemini
     agent-grok-build-dialect agent-integration-api agent-json agent-mcp
-    agent-openai agent-openrouter agent-process
-    agent-responses agent-responses-types agent-store agent-syntax
-    agent-tui agent-xai ansi-terminal async base base64-bytestring
-    brick bytestring colour containers crypton crypton-connection dbus
-    directory entropy filelock filepath haskeline hasql-pool
-    http-client http-client-tls http-types JuicyPixels memory mtl
-    network network-uri optparse-applicative process retry
-    safe-exceptions scientific stm tagsoup terminfo text time tls
-    transformers unix vector vty vty-crossplatform vty-unix wai warp
+    agent-openai agent-openrouter agent-process agent-responses
+    agent-responses-types agent-store agent-syntax agent-tui agent-xai
+    ansi-terminal async base base64-bytestring brick bytestring colour
+    containers crypton crypton-connection dbus directory entropy
+    filelock filepath haskeline hasql-pool http-client http-client-tls
+    http-types JuicyPixels memory mtl network network-uri
+    optparse-applicative process retry safe-exceptions scientific stm
+    tagsoup terminfo text time tls transformers unix vector vty
+    vty-crossplatform vty-unix wai warp
   ];
   executableHaskellDepends = [
     aeson agent-cli-runtime agent-responses agent-responses-types

--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -397,7 +397,7 @@ defaultHarnessConfig = HarnessConfig
         }
     , configWorktree = WorktreeConfig
         { worktreeFetchLatestUpstream = True
-        , worktreeInactiveDays = 7
+        , worktreeInactiveDays = 1
         }
     , configMaxConcurrentAgents = Nothing
     }
@@ -524,7 +524,7 @@ worktreeConfigDecoder =
     Hermes.object $
         WorktreeConfig
             <$> defaultKey True "fetchLatestUpstream" Hermes.bool
-            <*> defaultKey 7 "inactivityDays" Hermes.int
+            <*> defaultKey 1 "inactivityDays" Hermes.int
 
 harnessConfigDecoder :: Hermes.Decoder HarnessConfig
 harnessConfigDecoder =

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -351,8 +351,8 @@ worktreeParser = Worktree <$> Options.hsubparser
                     (Options.long "dry-run" <> Options.help "Simulate adoption and report eligibility, reasons and estimated bytes without writing or collecting")
                 <*> Options.optional (Options.option (positiveIntReader "--inactivity-days")
                     (Options.long "inactivity-days" <> Options.metavar "DAYS"
-                        <> Options.help "Override normal inactivity expiry (default 7 days; incorporated HEADs expire after 24h idle)")))
-            (Options.progDesc "Adopt verified agent worktrees, then snapshot and collect inactive checkouts; ignored files are NOT recovered"))
+                        <> Options.help "Minimum inactivity for merged, clean checkouts (default 1 day; unmerged work never expires)")))
+            (Options.progDesc "Collect stale, clean worktrees whose work is incorporated into another branch or verified merged PR"))
     <> pathCommand "enroll" WorktreeEnroll "Explicitly enroll an existing checkout in automatic collection"
     <> pathCommand "restore" WorktreeRestore "Restore a collected checkout without overwriting existing paths"
     <> pathCommand "protect" WorktreeProtect "Protect an enrolled checkout from collection"

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -9,6 +9,7 @@ module Agent.CLI.Worktree
     , cleanupStaleWorktrees
     , gcWorktrees
     , gcWorktreesWithActivity
+    , gcWorktreesManuallyWithActivity
     , worktreeInactive
     , enrollWorktree
     , protectWorktree
@@ -33,6 +34,8 @@ import Agent.OsPath (unsafeToFilePath)
 import Agent.CLI.Worktree.Registry
 import Agent.CLI.Worktree.ReadOnlyLock (withExistingReadOnlyLock)
 import qualified Agent.CLI.Worktree.Snapshot as Snapshot
+import qualified Agent.CLI.Worktree.Clean as Clean
+import Agent.CLI.Worktree.Incorporation (inspectIncorporation)
 import Control.Applicative ((<|>))
 import Control.Exception.Safe
     ( SomeException
@@ -44,7 +47,7 @@ import Control.Exception.Safe
     , catchIO
     )
 import Control.Monad (foldM, void, when, unless)
-import Data.IORef (newIORef, readIORef, modifyIORef')
+import Data.IORef (newIORef, readIORef, modifyIORef', writeIORef)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
     ( ExceptT(..)
@@ -54,7 +57,7 @@ import Control.Monad.Trans.Except
     )
 import qualified Data.ByteString as ByteString
 import Data.Char (isHexDigit)
-import Data.List (isPrefixOf)
+import Data.List (isPrefixOf, sort)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (listToMaybe)
@@ -66,6 +69,7 @@ import Data.Time.Clock (UTCTime(..), getCurrentTime, nominalDiffTimeToSeconds, d
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format (defaultTimeLocale, formatTime, parseTimeM)
 import Numeric (showHex)
+import GHC.Clock (getMonotonicTimeNSec)
 import System.IO.Error (isDoesNotExistError)
 import System.Directory.OsPath
     ( createDirectoryIfMissing
@@ -118,6 +122,8 @@ data WorktreeCleanupReport = WorktreeCleanupReport
     , cleanupFailures :: ![(OsPath, Text)]
     , cleanupEligible :: ![(OsPath, Integer)]
     , cleanupRetained :: ![(OsPath, Text)]
+    , cleanupNotExamined :: ![(OsPath, Text)]
+    , cleanupEvidence :: ![(OsPath, Text)]
     }
     deriving (Eq, Show)
 
@@ -127,10 +133,12 @@ instance Semigroup WorktreeCleanupReport where
         , cleanupFailures = left.cleanupFailures <> right.cleanupFailures
         , cleanupEligible = left.cleanupEligible <> right.cleanupEligible
         , cleanupRetained = left.cleanupRetained <> right.cleanupRetained
+        , cleanupNotExamined = left.cleanupNotExamined <> right.cleanupNotExamined
+        , cleanupEvidence = left.cleanupEvidence <> right.cleanupEvidence
         }
 
 instance Monoid WorktreeCleanupReport where
-    mempty = WorktreeCleanupReport [] [] [] []
+    mempty = WorktreeCleanupReport [] [] [] [] [] []
 
 data WorktreeLease = WorktreeLease FileLock.FileLock (Maybe (OsPath, OsPath))
 
@@ -423,9 +431,10 @@ catchingWorktree action = tryAny action >>= \case
     Left err -> pure (Left (exceptionText err))
     Right result -> pure result
 
--- | Snapshot-backed GC. Actual passes are bounded to eight eligible checkouts
--- and sixty seconds; each snapshot/removal has a thirty-second deadline.
--- Dry runs do not create snapshots, registry entries, or recovery refs.
+-- | Merged-only GC. Background passes are bounded to eight eligible checkouts
+-- and sixty seconds; each assessment/removal has a thirty-second deadline.
+-- Dirty or unproven work is retained regardless of age. Dry runs do not create
+-- registry entries or recovery refs.
 -- This compatibility entry point has no legacy provenance; production callers
 -- supply the saved-session reader through 'gcWorktreesWithActivity'.
 gcWorktrees :: OsPath -> Int -> Bool -> [OsPath] -> IO WorktreeCleanupReport
@@ -437,17 +446,41 @@ gcWorktrees root = gcWorktreesWithActivity (pure (Right Map.empty)) root
 gcWorktreesWithActivity
     :: IO (Either Text (Map OsPath (Either Text UTCTime)))
     -> OsPath -> Int -> Bool -> [OsPath] -> IO WorktreeCleanupReport
-gcWorktreesWithActivity loadActivity root days dryRun protected = do
+gcWorktreesWithActivity loadActivity root days dryRun protected =
+    collectWorktrees False (const (pure ())) loadActivity root days dryRun protected
+
+-- | Explicit administration visits every discovered candidate, independently
+-- of the background pass budget. Each candidate still has a deadline.
+gcWorktreesManuallyWithActivity
+    :: IO (Either Text (Map OsPath (Either Text UTCTime)))
+    -> OsPath -> Int -> Bool -> [OsPath] -> (OsPath -> IO ())
+    -> IO WorktreeCleanupReport
+gcWorktreesManuallyWithActivity loadActivity root days dryRun protected progress =
+    collectWorktrees True progress loadActivity root days dryRun protected
+
+collectWorktrees
+    :: Bool -> (OsPath -> IO ())
+    -> IO (Either Text (Map OsPath (Either Text UTCTime)))
+    -> OsPath -> Int -> Bool -> [OsPath] -> IO WorktreeCleanupReport
+collectWorktrees manual progress loadActivity root days dryRun protected = do
     exists <- doesDirectoryExist root
     if not exists then pure mempty else do
         result <- tryAny do
             linked <- pathIsSymbolicLink root
             when linked (ioError (userError "symlinked managed worktree root"))
-            started <- getCurrentTime
+            started <- getMonotonicTimeNSec
             discovered <- timeout (30 * 1000000) (discoverManagedPaths root)
-            candidates <- maybe
+            paths <- maybe
                 (ioError (userError "worktree discovery deadline exceeded; no checkouts collected"))
                 pure discovered
+            -- Do not repeatedly spend the background budget on the same first
+            -- few slow candidates. Manual passes use stable display ordering.
+            candidates <- if manual || dryRun || null paths then pure (sort paths) else do
+                entropy <- getEntropy 8
+                let offset = fromIntegral
+                        (ByteString.foldl' (\value byte -> value * 256 + toInteger byte) 0 entropy
+                            `mod` toInteger (length paths))
+                pure (drop offset paths <> take offset paths)
             activity <- timeout (30 * 1000000) loadActivity
             attempts <- newIORef (0 :: Int)
             foldM (visit started attempts (maybe (Left "session activity discovery deadline exceeded") id activity))
@@ -457,10 +490,15 @@ gcWorktreesWithActivity loadActivity root days dryRun protected = do
     retained path reason = mempty { cleanupRetained = [(path, reason)] }
     visit started attempts activity report path = do
         now <- getCurrentTime
+        clock <- getMonotonicTimeNSec
         attempted <- readIORef attempts
-        let exhausted = not dryRun &&
-                (attempted >= 8 || diffUTCTime now started >= 60)
-        if exhausted then pure (report <> retained path "pass budget exhausted") else do
+        let exhausted = not manual && not dryRun &&
+                (attempted >= 8 || clock - started >= 60 * 1000000000)
+        if exhausted then pure (report <> mempty
+            { cleanupNotExamined = [(path, "background pass budget exhausted")] }) else do
+            progress path
+            assessed <- newIORef mempty
+            removing <- newIORef False
             result <- timeout (30 * 1000000) $ catchingWorktree $
                 checkoutLock path $ runExceptT do
                     when (any (isUnderWorktreeRoot path . normalise) protected)
@@ -474,62 +512,69 @@ gcWorktreesWithActivity loadActivity root days dryRun protected = do
                             throwE ("state: " <> record.recordState)
                         _ -> pure ()
                     record <- resolveRecord path activity existing
-                    isRecent <- lift (recent path now record)
+                    let isRecent = recent now record
                     if isRecent then pure (retained path "recent activity") else do
-                        lift $ modifyIORef' attempts (+ 1)
                         common <- inspectManagedIdentity root path
                         unless (unsafeToFilePath common == record.recordCommonDir)
                             (throwE "enrolled repository identity changed")
                         ExceptT $ repositoryLock common $ runExceptT do
-                            ExceptT $ Snapshot.checkSnapshotSupported path
-                            if dryRun then do
-                                bytes <- lift (estimateCheckoutBytes path)
-                                pure mempty { cleanupEligible = [(path, bytes)] }
-                            else do
+                            clean <- ExceptT $ Clean.inspectCleanCheckout path
+                            evidence <- ExceptT $ inspectIncorporation path
+                            bytes <- lift (estimateCheckoutBytes path)
+                            lift $ writeIORef assessed mempty
+                                { cleanupEligible = [(path, bytes)]
+                                , cleanupEvidence = [(path, evidence)]
+                                }
+                            if dryRun then pure mempty else do
+                                lift $ modifyIORef' attempts (+ 1)
                                 latest <- lift loadActivity
                                 refreshed <- resolveRecord path latest existing
                                 recheckedAt <- lift getCurrentTime
-                                recheckedRecent <- lift (recent path recheckedAt refreshed)
-                                when recheckedRecent
+                                when (recent recheckedAt refreshed)
                                     (throwE "recent activity")
                                 unless (refreshed.recordCommonDir == record.recordCommonDir)
                                     (throwE "repository identity changed during adoption")
-                                snapshot <- ExceptT $ Snapshot.createSnapshot path
+                                ExceptT $ Clean.verifyCleanCheckout path clean
+                                snapshot <- ExceptT $ Clean.preserveCleanCheckout path clean
                                 finalActivity <- lift loadActivity
                                 finalRecord <- resolveRecord path finalActivity existing
                                 finalAt <- lift getCurrentTime
-                                finalRecent <- lift (recent path finalAt finalRecord)
-                                when finalRecent
+                                when (recent finalAt finalRecord)
                                     (throwE "recent activity")
                                 finalCommon <- inspectManagedIdentity root path
                                 unless (finalCommon == common && finalRecord.recordCommonDir == record.recordCommonDir)
-                                    (throwE "repository identity changed during snapshot")
+                                    (throwE "repository identity changed during preservation")
+                                void $ ExceptT $ inspectIncorporation path
+                                ExceptT $ Clean.verifyCleanCheckout path clean
                                 -- Adoption is persisted with the original saved
                                 -- activity, never an artificial 'now' timestamp.
                                 let saved = finalRecord { recordSnapshot = Just snapshot, recordState = "collecting" }
                                 ExceptT $ writeRecord root path saved
                                 removalAt <- lift getCurrentTime
-                                removalRecent <- lift (recent path removalAt finalRecord)
-                                when removalRecent do
+                                when (recent removalAt finalRecord) do
                                     ExceptT $ writeRecord root path saved { recordState = "present" }
-                                    throwE "recent activity or default-branch ancestry changed before removal"
-                                verified <- lift $ Snapshot.verifySnapshotUnchanged path snapshot
+                                    throwE "recent activity before removal"
+                                verified <- lift $ Clean.verifyCleanCheckout path clean
                                 case verified of
                                     Right () -> pure ()
                                     Left err -> do
                                         ExceptT $ writeRecord root path saved { recordState = "present" }
                                         throwE err
-                                void $ ExceptT $ git common ["worktree", "remove", "--force", unsafeToFilePath path]
+                                lift $ writeIORef removing True
+                                -- Let Git perform its own final dirty check.
+                                -- Clean recovery never authorizes forced removal.
+                                void $ ExceptT $ git common ["worktree", "remove", "--", unsafeToFilePath path]
                                 ExceptT $ writeRecord root path saved { recordState = "collected" }
                                 pure mempty { cleanupRemoved = [path] }
-            pure $ report <> case result of
-                Nothing -> retained path "maintenance deadline exceeded; recovery record retained"
+            eligibility <- readIORef assessed
+            removalStarted <- readIORef removing
+            pure $ report <> eligibility <> case result of
+                Nothing -> mempty { cleanupFailures =
+                    [(path, "maintenance deadline exceeded; checkout/recovery state requires reassessment")] }
+                Just (Left err) | removalStarted -> mempty { cleanupFailures = [(path, err)] }
                 Just (Left err) -> retained path err
                 Just (Right one) -> one
-    recent path now record
-        | worktreeInactive days False now record.recordLastActivity = pure False
-        | not (worktreeInactive days True now record.recordLastActivity) = pure True
-        | otherwise = not <$> headInDefaultBranch path
+    recent now record = not (worktreeInactive days True now record.recordLastActivity)
     checkoutLock path
         | dryRun = withReadOnlyLock (worktreeLeasePath root path)
         | otherwise = withExclusiveManaged root path
@@ -560,40 +605,11 @@ gcWorktreesWithActivity loadActivity root days dryRun protected = do
                     , recordSnapshot = Nothing
                     }
 
--- | Inactivity, not commit age or time since merge. Exact ancestry proof permits
--- the one-day fast path; uncertainty keeps the configured normal threshold.
+-- | Inactivity is necessary but never sufficient: unproven work never expires.
+-- At least 24 hours are required, even for callers passing an invalid threshold.
 worktreeInactive :: Int -> Bool -> UTCTime -> UTCTime -> Bool
 worktreeInactive days incorporated now lastActivity =
-    diffUTCTime now lastActivity >= fromIntegral threshold * 86400
-  where
-    threshold = if incorporated then min 1 (max 0 days) else max 0 days
-
--- | Resolve only an existing remote-default symbolic ref, never infer the
--- default from a familiar branch name or from the current checkout. No fetch,
--- network request or ref mutation is performed by maintenance. Stale/missing
--- tracking refs can miss merges; squash/rebase equivalence is not ancestry.
--- This proof is recomputed after snapshotting so newer commits cannot inherit
--- an older HEAD's eligibility. Final snapshot verification also checks HEAD.
-headInDefaultBranch :: OsPath -> IO Bool
-headInDefaultBranch path = do
-    result <- runExceptT do
-        graftPath <- Text.strip <$> ExceptT
-            (git path ["rev-parse", "--path-format=absolute", "--git-path", "info/grafts"])
-        grafts <- lift $ Directory.doesPathExist (Text.unpack graftPath)
-        when grafts (throwE "grafted history is not merge evidence")
-        remote <- selectUpstreamRemote path >>= maybe (throwE "no default remote") pure
-        let prefix = "refs/remotes/" <> remote <> "/"
-        target <- Text.strip <$> ExceptT
-            (git path ["symbolic-ref", "--quiet", Text.unpack (prefix <> "HEAD")])
-        unless (prefix `Text.isPrefixOf` target && target /= prefix <> "HEAD")
-            (throwE "default branch is outside the selected remote")
-        base <- Text.strip <$> ExceptT
-            (git path ["--no-replace-objects", "rev-parse", "--verify", Text.unpack (target <> "^{commit}")])
-        headCommit <- Text.strip <$> ExceptT
-            (git path ["--no-replace-objects", "rev-parse", "--verify", "HEAD^{commit}"])
-        void $ ExceptT
-            (git path ["--no-replace-objects", "merge-base", "--is-ancestor", Text.unpack headCommit, Text.unpack base])
-    pure $ either (const False) (const True) result
+    incorporated && diffUTCTime now lastActivity >= fromIntegral (max 1 days) * 86400
 
 discoverManagedPaths :: OsPath -> IO [OsPath]
 discoverManagedPaths root = do
@@ -624,7 +640,7 @@ estimateCheckoutBytes path = walk (unsafeToFilePath path)
                 sum <$> mapM (walk . (file FilePath.</>)) children
             else Directory.getFileSize file
 
--- | Bounded snapshot-backed cleanup. The second argument is inactivity days.
+-- | Bounded merged-only cleanup. The second argument is minimum inactivity days.
 cleanupStaleWorktrees
     :: OsPath
     -> Int

--- a/packages/agent-cli/src/Agent/CLI/Worktree/Clean.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree/Clean.hs
@@ -1,0 +1,255 @@
+-- | A conservative, read-only clean-checkout proof and recovery using existing
+-- Git objects. The caller holds the checkout lease and repository lock through
+-- inspection, preservation, final verification, and removal.
+module Agent.CLI.Worktree.Clean
+    ( CleanCheckout
+    , inspectCleanCheckout
+    , preserveCleanCheckout
+    , verifyCleanCheckout
+    ) where
+
+import Agent.CLI.Worktree.Snapshot (WorktreeSnapshot(..))
+import Agent.CLI.Worktree.Ignored (checkIgnoredPath)
+import Agent.OsPath (unsafeToFilePath)
+import Control.Exception.Safe (bracket, displayException, tryAny)
+import Control.Monad (forM_, unless, void, when)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B8
+import Data.List (isPrefixOf, nub)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Numeric (showHex)
+import qualified System.Directory as Directory
+import System.Environment (getEnvironment)
+import System.Entropy (getEntropy)
+import System.Exit (ExitCode(..))
+import System.FilePath ((</>), takeFileName)
+import System.OsPath (OsPath)
+import System.IO.Error (isDoesNotExistError, tryIOError)
+import qualified System.Posix.Files as Posix
+import System.Posix.Temp (mkdtemp)
+import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
+
+data CleanCheckout = CleanCheckout
+    { cleanHead :: !String
+    , cleanTree :: !String
+    , cleanBranch :: !String
+    , cleanIndex :: !BS.ByteString
+    , cleanReflog :: !BS.ByteString
+    , cleanOriginalHead :: !BS.ByteString
+    , cleanCommitMessage :: !BS.ByteString
+    , cleanFetchHead :: !BS.ByteString
+    , cleanAutoMerge :: !BS.ByteString
+    , cleanRebaseHead :: !BS.ByteString
+    } deriving (Eq, Show)
+
+inspectCleanCheckout :: OsPath -> IO (Either Text CleanCheckout)
+inspectCleanCheckout = result . inspect . unsafeToFilePath
+
+verifyCleanCheckout :: OsPath -> CleanCheckout -> IO (Either Text ())
+verifyCleanCheckout path expected = result $ do
+    actual <- inspect (unsafeToFilePath path)
+    unless (actual == expected) $
+        fail "checkout or private Git history changed during collection"
+
+-- | Retain the legacy snapshot shape, but reuse the existing HEAD tree.
+-- Reflog-only commits get permanent refs before checkout removal.
+preserveCleanCheckout :: OsPath -> CleanCheckout -> IO (Either Text WorktreeSnapshot)
+preserveCleanCheckout path expected = result $ do
+    let repository = unsafeToFilePath path
+    actual <- inspect repository
+    unless (actual == expected) $ fail "checkout changed before recovery preservation"
+    identifier <- concatMap (\byte -> let digits = showHex byte "" in
+        replicate (2 - length digits) '0' <> digits) . BS.unpack <$> getEntropy 16
+    fetchedObjects <- parseFetchedObjects expected.cleanFetchHead
+    autoMerge <- validatePseudoReference repository "AUTO_MERGE" "tree" expected.cleanAutoMerge
+    rebaseHead <- validatePseudoReference repository "REBASE_HEAD" "commit" expected.cleanRebaseHead
+    let reference = "refs/haskell-agent/snapshots/" <> identifier
+        history = nub $ filter (not . all (== '0')) $
+            concatMap (take 2 . words . B8.unpack) (B8.lines expected.cleanReflog)
+            <> words (B8.unpack expected.cleanOriginalHead)
+            <> fetchedObjects
+            <> rebaseHead
+    forM_ history $ \object -> do
+        unless (validObject object) $ fail "invalid private Git history object"
+        void $ git repository ["cat-file", "-e", object <> "^{commit}"] ""
+        void $ git repository ["update-ref",
+            "refs/haskell-agent/reclaimed/" <> identifier <> "/" <> object, object, ""] ""
+    forM_ autoMerge $ \object ->
+        void $ git repository ["update-ref",
+            "refs/haskell-agent/reclaimed/" <> identifier <> "/auto-merge", object, ""] ""
+    forM_ [("commit-message", expected.cleanCommitMessage), ("fetched-heads", expected.cleanFetchHead)] $
+        \(name, bytes) -> unless (BS.null bytes) $ do
+            contents <- either (fail . show) (pure . Text.unpack) $ Text.decodeUtf8' bytes
+            object <- stripped repository ["hash-object", "-w", "--no-filters", "--stdin"] contents
+            void $ git repository ["update-ref",
+                "refs/haskell-agent/reclaimed/" <> identifier <> "/" <> name, object, ""] ""
+    indexCommit <- stripped repository ["commit-tree", expected.cleanTree,
+        "-p", expected.cleanHead] "haskell-agent clean recovery index\n"
+    commit <- stripped repository ["commit-tree", expected.cleanTree,
+        "-p", expected.cleanHead, "-p", indexCommit] "haskell-agent clean recovery working files\n"
+    void $ git repository ["update-ref", reference, commit, ""] ""
+    void $ git repository ["cat-file", "-e", reference <> "^{commit}"] ""
+    -- Unlike a full capture, no working-file blobs are written here. Prove that
+    -- recovery's existing object closure is present before authorizing removal.
+    void $ git repository (["rev-list", "--objects", "--missing=error", reference] <> history <> autoMerge) ""
+    pure WorktreeSnapshot
+        { snapshotHead = Text.pack expected.cleanHead
+        , snapshotIndexTree = Text.pack expected.cleanTree
+        , snapshotWorkTree = Text.pack expected.cleanTree
+        , snapshotRef = Text.pack reference
+        , snapshotBranch = Text.pack expected.cleanBranch
+        }
+
+inspect :: FilePath -> IO CleanCheckout
+inspect repository = do
+    administration <- stripped repository ["rev-parse", "--absolute-git-dir"] ""
+    entries <- Directory.listDirectory administration
+    let unsupported = filter (`notElem` ["HEAD", "index", "commondir", "gitdir", "logs",
+            "ORIG_HEAD", "COMMIT_EDITMSG", "FETCH_HEAD", "AUTO_MERGE", "REBASE_HEAD", "refs"]) entries
+    unless (null unsupported) $
+        fail ("unsupported private Git state: " <> show unsupported)
+    forM_ entries $ \entry -> do
+        status <- Posix.getSymbolicLinkStatus (administration </> entry)
+        when (Posix.isSymbolicLink status) $ fail ("symlinked private Git state: " <> entry)
+    when ("refs" `elem` entries) $ do
+        privateReferences <- Directory.listDirectory (administration </> "refs")
+        unless (null privateReferences) $ fail ("unsupported private Git references: " <> show privateReferences)
+    logsExist <- Directory.doesDirectoryExist (administration </> "logs")
+    when logsExist $ do
+        logs <- Directory.listDirectory (administration </> "logs")
+        unless (all (== "HEAD") logs) $ fail ("unsupported private Git reflogs: " <> show (filter (/= "HEAD") logs))
+    flags <- git repository ["ls-files", "-v", "-z"] ""
+    unless (all ((== "H ") . take 2) (nul flags)) $
+        fail "unsupported Git index: assume-unchanged or sparse checkout"
+    stages <- git repository ["ls-files", "--stage", "-z"] ""
+    forM_ (nul stages) $ \entry ->
+        case words (takeWhile (/= '\t') entry) of
+            [mode, _, "0"] | mode `elem` ["100644", "100755", "120000"] -> pure ()
+            _ -> fail "unsupported Git index: conflict or submodule"
+    symlinks <- stripped repository ["config", "--default=true", "--get", "core.symlinks"] ""
+    unless (symlinks `elem` ["true", "yes", "on", "1"]) $
+        fail "disabled symbolic links prevent exact clean recovery"
+    names <- git repository ["ls-files", "-z"] ""
+    attributes <- git repository ["check-attr", "-z", "--stdin",
+        "filter", "working-tree-encoding", "text", "eol", "ident"] names
+    checkAttributes (nul attributes)
+    status <- git repository ["status", "--porcelain=v1", "-z",
+        "--untracked-files=all", "--ignored=matching", "--ignore-submodules=none"] ""
+    forM_ (nul status) $ \entry ->
+        if take 3 entry == "!! " then checkIgnoredPath (git repository) repository (drop 3 entry)
+        else fail "unique staged, unstaged, or untracked files"
+    headObject <- stripped repository ["rev-parse", "--verify", "HEAD^{commit}"] ""
+    treeObject <- stripped repository ["rev-parse", "--verify", "HEAD^{tree}"] ""
+    -- Never trust stat-cache hits made with autocrlf or other historical
+    -- settings. A fresh private index forces Git to compare actual working
+    -- bytes with the existing tree in one process, without live-index writes.
+    temporary <- Directory.getTemporaryDirectory
+    bracket (mkdtemp (temporary </> "worktree-clean-inspection-"))
+        Directory.removePathForcibly $ \scratch -> do
+            let privateGit = gitWithEnvironment [("GIT_INDEX_FILE", scratch </> "index")] repository
+            void $ privateGit ["read-tree", treeObject] ""
+            void $ privateGit ["update-index", "--really-refresh"] ""
+            void $ privateGit ["diff-files", "--quiet", "--no-ext-diff", "--no-textconv"] ""
+    branch <- stripped repository ["rev-parse", "--symbolic-full-name", "HEAD"] ""
+    index <- BS.readFile (administration </> "index")
+    history <- readOptional (administration </> "logs" </> "HEAD")
+    original <- readOptional (administration </> "ORIG_HEAD")
+    message <- readOptional (administration </> "COMMIT_EDITMSG")
+    fetched <- readOptional (administration </> "FETCH_HEAD")
+    void $ parseFetchedObjects fetched
+    autoMerge <- readOptional (administration </> "AUTO_MERGE")
+    rebaseHead <- readOptional (administration </> "REBASE_HEAD")
+    void $ validatePseudoReference repository "AUTO_MERGE" "tree" autoMerge
+    void $ validatePseudoReference repository "REBASE_HEAD" "commit" rebaseHead
+    pure (CleanCheckout headObject treeObject branch index history original message fetched autoMerge rebaseHead)
+  where
+    checkAttributes [] = pure ()
+    checkAttributes (_ : _ : value : rest)
+        | value `elem` ["unspecified", "unset"] = checkAttributes rest
+        | otherwise = fail "working-file attributes prevent exact clean recovery"
+    checkAttributes _ = fail "malformed Git attribute response"
+
+readOptional :: FilePath -> IO BS.ByteString
+readOptional path = do
+    status <- tryIOError (Posix.getSymbolicLinkStatus path)
+    case status of
+        Left failure | isDoesNotExistError failure -> pure BS.empty
+        Left failure -> ioError failure
+        Right metadata -> do
+            unless (Posix.isRegularFile metadata) $
+                fail ("unsupported private Git history file: " <> takeFileName path)
+            BS.readFile path
+
+validObject :: String -> Bool
+validObject object = length object `elem` [40, 64] &&
+    all (`elem` ("0123456789abcdef" :: String)) object
+
+-- Only inactive, direct pseudorefs are supported. Active operation markers
+-- (MERGE_HEAD, rebase-merge, rebase-apply, sequencer, etc.) remain rejected.
+-- Retain the exact bytes in the proof so changes invalidate removal.
+validatePseudoReference :: FilePath -> String -> String -> BS.ByteString -> IO [String]
+validatePseudoReference repository name expectedType bytes
+    | BS.null bytes = pure []
+    | otherwise = case B8.lines bytes of
+        [line] | validObject (B8.unpack line) -> do
+            let object = B8.unpack line
+            actualType <- stripped repository ["cat-file", "-t", object] ""
+            unless (actualType == expectedType) $
+                fail ("unsupported " <> name <> " object type: " <> actualType)
+            pure [object]
+        _ -> fail ("unsupported " <> name <> " contents")
+
+parseFetchedObjects :: BS.ByteString -> IO [String]
+parseFetchedObjects = mapM parseEntry . B8.lines
+  where
+    parseEntry entry = case B8.split '\t' entry of
+        object : disposition : descriptionFields
+            | validObject (B8.unpack object)
+            , disposition `elem` ["", "not-for-merge"]
+            , not (null descriptionFields) -> pure (B8.unpack object)
+        _ -> fail "unsupported FETCH_HEAD contents"
+
+nul :: String -> [String]
+nul [] = []
+nul value = case break (== '\0') value of
+    (entry, []) -> [entry]
+    (entry, _ : rest) -> entry : nul rest
+
+stripped :: FilePath -> [String] -> String -> IO String
+stripped repository arguments input =
+    Text.unpack . Text.strip . Text.pack <$> git repository arguments input
+
+git :: FilePath -> [String] -> String -> IO String
+git = gitWithEnvironment []
+
+gitWithEnvironment :: [(String, String)] -> FilePath -> [String] -> String -> IO String
+gitWithEnvironment supplied repository arguments input = do
+    environment <- getEnvironment
+    let overrides = supplied <>
+            [ ("GIT_OPTIONAL_LOCKS", "0"), ("GIT_NO_REPLACE_OBJECTS", "1")
+            , ("GIT_NO_LAZY_FETCH", "1")
+            , ("GIT_TERMINAL_PROMPT", "0")
+            , ("GIT_AUTHOR_NAME", "Agent worktree recovery")
+            , ("GIT_AUTHOR_EMAIL", "worktree-recovery@localhost")
+            , ("GIT_COMMITTER_NAME", "Agent worktree recovery")
+            , ("GIT_COMMITTER_EMAIL", "worktree-recovery@localhost")
+            ]
+        settings = ["--no-optional-locks", "-c", "core.fsmonitor=false",
+            "-c", "core.untrackedCache=false", "-c", "core.ignorestat=false",
+            "-c", "core.autocrlf=false", "-c", "core.safecrlf=false",
+            "-c", "core.sparseCheckout=false", "-c", "core.sparseCheckoutCone=false",
+            "-c", "core.filemode=true", "-c", "core.hooksPath=/dev/null",
+            "-c", "commit.gpgsign=false", "-c", "core.fsync=committed,reference"]
+    (code, output, errors) <- readCreateProcessWithExitCode
+        (proc "git" (settings <> arguments))
+            { cwd = Just repository
+            , env = Just (overrides <> filter (not . isPrefixOf "GIT_" . fst) environment)
+            } input
+    unless (code == ExitSuccess) $
+        fail ("Git clean-checkout check failed: " <> take 500 errors)
+    pure output
+
+result :: IO a -> IO (Either Text a)
+result action = either (Left . Text.pack . displayException) Right <$> tryAny action

--- a/packages/agent-cli/src/Agent/CLI/Worktree/Clean.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree/Clean.hs
@@ -123,6 +123,11 @@ inspect repository = do
     flags <- git repository ["ls-files", "-v", "-z"] ""
     unless (all ((== "H ") . take 2) (nul flags)) $
         fail "unsupported Git index: assume-unchanged or sparse checkout"
+    -- Tree-based recovery cannot reconstruct saved conflict stages, even when
+    -- the resolved index contains only stage-zero entries and status is clean.
+    resolveUndo <- git repository ["ls-files", "--resolve-undo", "-z"] ""
+    unless (null resolveUndo) $
+        fail "unsupported Git index: resolve-undo records"
     stages <- git repository ["ls-files", "--stage", "-z"] ""
     forM_ (nul stages) $ \entry ->
         case words (takeWhile (/= '\t') entry) of

--- a/packages/agent-cli/src/Agent/CLI/Worktree/Ignored.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree/Ignored.hs
@@ -1,0 +1,108 @@
+-- | Narrow exceptions for disposable or independently retained ignored paths.
+-- Never treat an arbitrary ignored directory as disposable user data.
+module Agent.CLI.Worktree.Ignored (checkIgnoredPath) where
+
+import Control.Monad (unless)
+import qualified Data.ByteString as BS
+import Data.List (isPrefixOf)
+import qualified System.Directory as Directory
+import System.FilePath ((</>), dropTrailingPathSeparator, takeFileName, takeDirectory, splitDirectories)
+import qualified System.Posix.Files as Posix
+
+checkIgnoredPath :: ([String] -> String -> IO String) -> FilePath -> FilePath -> IO ()
+checkIgnoredPath git repository name = do
+    let relative = dropTrailingPathSeparator name
+        components = splitDirectories relative
+        reject reason = fail (reason <> ": " <> show name)
+    unless (not (null components) && all (`notElem` ["", ".", "..", "/"]) components) $
+        reject "unsafe ignored path"
+    evidence <- git ["check-ignore", "-v", "-z", "--stdin"] (name <> "\0")
+    case nul evidence of
+        [source, _, _, _] ->
+            unless (takeFileName source == ".gitignore" &&
+                not ("/" `isPrefixOf` source) &&
+                not (".." `elem` splitDirectories source)) $
+                reject "ignored path is not excluded by repository ignore rules"
+        _ -> reject "cannot verify ignored path rule"
+    if not (null name) && last name == '/' &&
+        takeFileName relative `elem`
+            ["dist-newstyle", "node_modules", ".venv", "venv", "target",
+             ".direnv", "__pycache__", ".pytest_cache", ".mypy_cache",
+             ".ruff_cache", ".next", ".nuxt", ".stack-work"]
+      then requireDirectories repository components
+      else case relative of
+        ".haskell-agent" -> do
+            requireDirectories repository components
+            entries <- Directory.listDirectory (repository </> relative)
+            unless (entries == ["settings.json"]) $
+                reject "ignored agent directory contains additional state"
+            checkDuplicate git repository ".haskell-agent/settings.json"
+        ".haskell-agent/settings.json" -> checkDuplicate git repository relative
+        "packages/agent-openai/data/models.json" -> checkDuplicate git repository relative
+        "packages/agent-openai/data/prompt.md" -> checkDuplicate git repository relative
+        "result" -> do
+            status <- Posix.getSymbolicLinkStatus (repository </> relative)
+            unless (Posix.isSymbolicLink status) $
+                reject "ignored result is not a Nix store symlink"
+            target <- Posix.readSymbolicLink (repository </> relative)
+            unless (takeDirectory target == "/nix/store" && validStoreName (takeFileName target)) $
+                reject "ignored result does not point directly into the Nix store"
+        _ -> reject "ignored files are not a recognized build/cache directory"
+
+-- Exact duplicates are already retained in the repository's primary checkout.
+-- Both copies and every intervening directory must be ordinary filesystem nodes.
+checkDuplicate :: ([String] -> String -> IO String) -> FilePath -> FilePath -> IO ()
+checkDuplicate git repository relative = do
+    common <- trim <$> git ["rev-parse", "--path-format=absolute", "--git-common-dir"] ""
+    let primary = takeDirectory common
+    unless (takeFileName common == ".git") $
+        fail ("cannot locate primary checkout for ignored file: " <> show relative)
+    primaryCanonical <- Directory.canonicalizePath primary
+    repositoryCanonical <- Directory.canonicalizePath repository
+    unless (primaryCanonical /= repositoryCanonical) $
+        fail ("ignored file has no independent primary checkout copy: " <> show relative)
+    first <- readRegular repository relative
+    second <- readRegular primary relative
+    unless (first == second) $
+        fail ("ignored file differs from primary checkout: " <> show relative)
+
+readRegular :: FilePath -> FilePath -> IO BS.ByteString
+readRegular root relative = do
+    requireDirectories root (splitDirectories (takeDirectory relative))
+    status <- Posix.getSymbolicLinkStatus (root </> relative)
+    unless (Posix.isRegularFile status) $
+        fail ("ignored duplicate is not a regular file: " <> show relative)
+    unless (Posix.fileSize status <= 8 * 1024 * 1024) $
+        fail ("ignored duplicate exceeds inspection size limit: " <> show relative)
+    BS.readFile (root </> relative)
+
+requireDirectories :: FilePath -> [FilePath] -> IO ()
+requireDirectories root components = do
+    status <- Posix.getSymbolicLinkStatus root
+    unless (Posix.isDirectory status) $
+        fail "ignored path root is not an ordinary directory"
+    go root components
+  where
+    go _ [] = pure ()
+    go parent (component : rest) = do
+        let path = parent </> component
+        status <- Posix.getSymbolicLinkStatus path
+        unless (Posix.isDirectory status) $
+            fail ("ignored path has a non-directory or symlinked parent: " <> show component)
+        go path rest
+
+validStoreName :: String -> Bool
+validStoreName name = case splitAt 32 name of
+    (digest, '-' : suffix) ->
+        length digest == 32 && not (null suffix) &&
+        all (`elem` ("0123456789abcdfghijklmnpqrsvwxyz" :: String)) digest
+    _ -> False
+
+trim :: String -> String
+trim = reverse . dropWhile (`elem` ['\r', '\n']) . reverse
+
+nul :: String -> [String]
+nul [] = []
+nul value = case break (== '\0') value of
+    (entry, []) -> [entry]
+    (entry, _ : rest) -> entry : nul rest

--- a/packages/agent-cli/src/Agent/CLI/Worktree/Incorporation.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree/Incorporation.hs
@@ -1,0 +1,219 @@
+-- | Read-only, fail-closed evidence that another branch incorporated HEAD.
+-- Merely publishing the current branch is not incorporation. GitHub's merged
+-- flag is likewise insufficient without an exact head and local content proof.
+module Agent.CLI.Worktree.Incorporation
+    ( inspectIncorporation
+    , inspectIncorporationWith
+    , MergedPullRequest(..)
+    ) where
+
+import Agent.OsPath (unsafeToFilePath)
+import Control.Exception.Safe (tryAny, displayException)
+import Control.Monad (unless)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except (ExceptT(..), runExceptT, throwE)
+import Data.Aeson (FromJSON(..), eitherDecodeStrict', withObject, (.:), (.:?))
+import Data.Aeson.Types (Parser)
+import Data.Char (isAscii, isAlphaNum, isHexDigit)
+import Data.List (isPrefixOf)
+import Data.Maybe (catMaybes)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import System.Directory (doesPathExist)
+import System.Environment (getEnvironment)
+import System.Exit (ExitCode(..))
+import System.OsPath (OsPath)
+import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
+import System.Timeout (timeout)
+
+data MergedPullRequest = MergedPullRequest
+    { pullRequestHead :: !Text
+    , pullRequestMerge :: !Text
+    , pullRequestBase :: !Text
+    } deriving (Eq, Show)
+
+newtype PullRequestResponse = PullRequestResponse (Maybe MergedPullRequest)
+
+instance FromJSON PullRequestResponse where
+    parseJSON = withObject "pull request" $ \object -> do
+        mergedAt <- object .:? "merged_at" :: Parser (Maybe Text)
+        mergeCommit <- object .:? "merge_commit_sha"
+        headObject <- object .: "head"
+        baseObject <- object .: "base"
+        headCommit <- headObject .: "sha"
+        baseBranch <- baseObject .: "ref"
+        pure $ PullRequestResponse $
+            case (mergedAt, mergeCommit) of
+                (Just _, Just mergeOid) ->
+                    Just (MergedPullRequest headCommit mergeOid baseBranch)
+                _ -> Nothing
+
+inspectIncorporation :: OsPath -> IO (Either Text Text)
+inspectIncorporation path = inspectIncorporationWith (loadMergedPullRequests path) path
+
+-- | The injected reader is used only after local ancestry fails. Production
+-- uses the authenticated GitHub API; tests provide authoritative fixtures.
+inspectIncorporationWith
+    :: (Text -> IO (Either Text [MergedPullRequest]))
+    -> OsPath -> IO (Either Text Text)
+inspectIncorporationWith loadPullRequests path = do
+    result <- tryAny $ runExceptT do
+        shallow <- git ["rev-parse", "--is-shallow-repository"]
+        unless (shallow == "false") (throwE "shallow history cannot prove incorporation")
+        graftPath <- git ["rev-parse", "--path-format=absolute", "--git-path", "info/grafts"]
+        grafts <- lift $ doesPathExist (Text.unpack graftPath)
+        unless (not grafts) (throwE "Git grafts cannot prove incorporation")
+        headCommit <- git ["rev-parse", "--verify", "HEAD^{commit}"]
+        current <- optionalGit ["symbolic-ref", "-q", "HEAD"]
+        upstream <- optionalGit ["rev-parse", "--symbolic-full-name", "@{upstream}"]
+        defaultRemote <- optionalGit ["symbolic-ref", "-q", "refs/remotes/origin/HEAD"]
+        references <- Text.lines <$> git
+            ["for-each-ref", "--format=%(refname) %(objectname) %(symref)",
+             "refs/heads/", "refs/remotes/"]
+        let currentName = current >>= Text.stripPrefix "refs/heads/"
+            eligible reference =
+                Just reference /= current && Just reference /= upstream
+                && not (maybe False (\name ->
+                    "refs/remotes/" `Text.isPrefixOf` reference
+                    && Text.intercalate "/" (drop 3 (Text.splitOn "/" reference)) == name)
+                    currentName)
+            defaultReference reference =
+                Just reference == defaultRemote
+                || Just ("refs/remotes/origin/" <>
+                    Text.drop (Text.length "refs/heads/") reference) == defaultRemote
+                || (defaultRemote == Nothing && reference `elem` ["refs/heads/main", "refs/heads/master"])
+            candidates =
+                [ (reference, objectId)
+                | line <- references
+                , [reference, objectId] <- [Text.words line]
+                , eligible reference
+                , objectId /= headCommit || defaultReference reference
+                ]
+        containing <- Set.fromList . Text.lines <$> git
+            ["for-each-ref", "--format=%(refname)", "--contains=" <> Text.unpack headCommit,
+             "refs/heads/", "refs/remotes/"]
+        case [reference | (reference, _) <- candidates, Set.member reference containing] of
+            reference : _ -> pure ("incorporated into " <> reference)
+            [] -> do
+                requests <- ExceptT (loadPullRequests headCommit)
+                proof <- firstProof requests $ \request -> do
+                    if request.pullRequestHead /= headCommit
+                        || not (validOid request.pullRequestMerge)
+                        || not (validBranch request.pullRequestBase)
+                        then pure Nothing
+                        else do
+                            let targets = filter (\(reference, _) ->
+                                    reference == "refs/heads/" <> request.pullRequestBase
+                                    || reference == "refs/remotes/origin/" <> request.pullRequestBase)
+                                    candidates
+                            firstProof targets $ \(reference, target) -> do
+                                contained <- isAncestor request.pullRequestMerge target
+                                if not contained then pure Nothing else do
+                                    -- Every path changed by the branch must have
+                                    -- its exact final blob, mode or deletion at
+                                    -- the merge commit. Other target changes are
+                                    -- irrelevant. Comparing tree objects avoids
+                                    -- filters, patch equivalence and rehashing.
+                                    commonBases <- Text.lines <$> git
+                                        ["merge-base", "--all", Text.unpack headCommit,
+                                         Text.unpack request.pullRequestMerge]
+                                    matches <- case commonBases of
+                                        [base] -> do
+                                            changed <- changedPaths base headCommit
+                                            different <- changedPaths headCommit request.pullRequestMerge
+                                            pure (Set.disjoint changed different)
+                                        _ -> pure False
+                                    pure $ if matches
+                                        then Just ("merged pull request incorporated into " <> reference)
+                                        else Nothing
+                maybe (throwE "work is not proven incorporated into another branch") pure proof
+    pure $ either (Left . Text.pack . displayException) id result
+  where
+    git arguments = ExceptT $ command path "git" (gitArguments arguments)
+    optionalGit arguments = lift $
+        either (const Nothing) Just <$> command path "git" (gitArguments arguments)
+    changedPaths older newer = do
+        (code, output, _) <- lift $ runCommand path "git" $
+            gitArguments ["diff", "--name-only", "-z", "--no-renames",
+                "--no-ext-diff", "--no-textconv", "--ignore-submodules=none",
+                Text.unpack older, Text.unpack newer, "--"]
+        unless (code == ExitSuccess) (throwE "Git merge content could not be verified")
+        -- Do not strip whitespace: it can be part of a filename. Invalid
+        -- output encoding raises an exception and retains the checkout.
+        pure $ Set.fromList $ filter (not . Text.null) $
+            Text.splitOn "\0" (Text.pack output)
+    isAncestor older newer = do
+        (code, _, _) <- lift $ runCommand path "git"
+            (gitArguments ["merge-base", "--is-ancestor", Text.unpack older, Text.unpack newer])
+        case code of
+            ExitSuccess -> pure True
+            ExitFailure 1 -> pure False
+            _ -> throwE "Git ancestry could not be verified"
+
+firstProof :: [a] -> (a -> ExceptT Text IO (Maybe b)) -> ExceptT Text IO (Maybe b)
+firstProof [] _ = pure Nothing
+firstProof (candidate : remaining) inspect = inspect candidate >>= \case
+    Just proof -> pure (Just proof)
+    Nothing -> firstProof remaining inspect
+
+validOid :: Text -> Bool
+validOid value = Text.length value `elem` [40, 64] && Text.all isHexDigit value
+
+validBranch :: Text -> Bool
+validBranch value = not (Text.null value)
+    && Text.all (\character -> isAscii character
+        && (isAlphaNum character || character `elem` ("/._-" :: String))) value
+    && not (".." `Text.isInfixOf` value)
+
+loadMergedPullRequests :: OsPath -> Text -> IO (Either Text [MergedPullRequest])
+loadMergedPullRequests path headCommit = runExceptT do
+    remote <- ExceptT $ command path "git" (gitArguments ["remote", "get-url", "origin"])
+    repository <- maybe (throwE "no supported GitHub origin; incorporation unproven") pure $
+        githubRepository remote
+    response <- lift $ timeout (10 * 1000000) $ command path "gh"
+        ["api", "--hostname", "github.com",
+         "repos/" <> Text.unpack repository <> "/commits/" <> Text.unpack headCommit <> "/pulls?per_page=100"]
+    body <- ExceptT $ pure $ maybe (Left "GitHub merge verification deadline exceeded") id response
+    case eitherDecodeStrict' (Text.encodeUtf8 body) of
+        Left _ -> throwE "GitHub merge verification returned invalid data"
+        Right requests -> pure $ catMaybes [request | PullRequestResponse request <- requests]
+
+githubRepository :: Text -> Maybe Text
+githubRepository remote = do
+    repository <- firstJust
+        [Text.stripPrefix prefix remote
+        | prefix <- ["https://github.com/", "git@github.com:", "ssh://git@github.com/"]]
+    let withoutSuffix = maybe repository id (Text.stripSuffix ".git" repository)
+        parts = Text.splitOn "/" withoutSuffix
+    if length parts == 2 && all (\part -> not (Text.null part)
+        && part /= "." && part /= ".."
+        && Text.all (\character -> isAscii character &&
+            (isAlphaNum character || character `elem` ("._-" :: String))) part) parts
+        then Just withoutSuffix else Nothing
+  where
+    firstJust [] = Nothing
+    firstJust (Just value : _) = Just value
+    firstJust (Nothing : values) = firstJust values
+
+gitArguments :: [String] -> [String]
+gitArguments arguments = ["--no-replace-objects", "--no-optional-locks",
+    "-c", "core.fsmonitor=false", "-c", "core.hooksPath=/dev/null"] <> arguments
+
+command :: OsPath -> String -> [String] -> IO (Either Text Text)
+command path executable arguments = do
+    (code, output, _) <- runCommand path executable arguments
+    pure $ case code of
+        ExitSuccess -> Right (Text.strip (Text.pack output))
+        _ -> Left (Text.pack executable <> " could not verify incorporation")
+
+runCommand :: OsPath -> String -> [String] -> IO (ExitCode, String, String)
+runCommand path executable arguments = do
+    environment <- getEnvironment
+    readCreateProcessWithExitCode
+        (proc executable arguments)
+            { cwd = Just (unsafeToFilePath path)
+            , env = Just $ [("GIT_TERMINAL_PROMPT", "0"), ("GIT_NO_LAZY_FETCH", "1")] <>
+                filter (\(name, _) -> not ("GIT_" `isPrefixOf` name)) environment
+            } ""

--- a/packages/agent-cli/src/Agent/CLI/WorktreeAdmin.hs
+++ b/packages/agent-cli/src/Agent/CLI/WorktreeAdmin.hs
@@ -4,12 +4,11 @@ module Agent.CLI.WorktreeAdmin (runWorktreeAdmin, renderWorktreeCleanupReport) w
 
 import Agent.CLI.Config (HarnessConfig(..), WorktreeConfig(..), loadHarnessConfig)
 import Agent.CLI.Options (WorktreeCommand(..))
-import Agent.CLI.SessionAdmin (managedPostgresConfigForHome)
 import Agent.CLI.Worktree.Provenance (WorktreeActivity, loadWorktreeActivity)
 import Agent.CLI.Worktree
     ( WorktreeCleanupReport(..)
     , enrollWorktree
-    , gcWorktreesWithActivity
+    , gcWorktreesManuallyWithActivity
     , isUnderWorktreeRoot
     , protectWorktree
     , restoreManagedWorktree
@@ -17,6 +16,7 @@ import Agent.CLI.Worktree
     )
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Store.Postgres.Connection (closeStorePool, defaultPoolConfig, openStorePool)
+import Agent.Store.Postgres (managedPostgresConfigFromEnv)
 import Control.Exception.Safe (bracket, tryAny)
 import Control.Monad (unless)
 import Data.Maybe (fromMaybe)
@@ -26,7 +26,7 @@ import qualified Data.Text.IO as Text
 import System.Directory.OsPath (getCurrentDirectory, getHomeDirectory, makeAbsolute)
 import System.Exit (exitFailure)
 import System.IO (stderr)
-import System.OsPath (OsPath)
+import System.OsPath (OsPath, decodeFS, unsafeEncodeUtf, (</>))
 
 runWorktreeAdmin :: WorktreeCommand -> IO ()
 runWorktreeAdmin command = do
@@ -43,7 +43,13 @@ runWorktreeAdmin command = do
             config <- loadHarnessConfig home >>= either failCommand pure
             cwd <- getCurrentDirectory
             let days = fromMaybe config.configWorktree.worktreeInactiveDays overrideDays
-            report <- gcWorktreesWithActivity (readExistingActivity home root) root days dryRun [cwd]
+            Text.hPutStrLn stderr $
+                (if dryRun then "Inspecting" else "Collecting")
+                <> " stale, merged, clean worktrees; unique work is retained."
+            report <- gcWorktreesManuallyWithActivity
+                (readExistingActivity home root) root days dryRun [cwd]
+                (\path -> Text.hPutStrLn stderr
+                    ("examining\t" <> Text.pack (show (unsafeToFilePath path))))
             Text.putStr (renderWorktreeCleanupReport dryRun days report)
             unless (null report.cleanupFailures) exitFailure
         WorktreeEnroll path ->
@@ -64,7 +70,8 @@ failCommand message = Text.hPutStrLn stderr ("worktree: " <> message) >> exitFai
 readExistingActivity :: OsPath -> OsPath -> IO (Either Text WorktreeActivity)
 readExistingActivity home root = do
     result <- tryAny do
-        config <- managedPostgresConfigForHome home
+        stateDirectory <- decodeFS (home </> unsafeEncodeUtf ".haskell-agent")
+        config <- managedPostgresConfigFromEnv stateDirectory
         bracket (openStorePool config defaultPoolConfig)
             (either (const (pure ())) closeStorePool)
             (either (const (pure unavailable)) (\pool -> loadWorktreeActivity pool root))
@@ -75,23 +82,28 @@ readExistingActivity home root = do
 renderWorktreeCleanupReport :: Bool -> Int -> WorktreeCleanupReport -> Text
 renderWorktreeCleanupReport dryRun days report = Text.unlines $
     [ (if dryRun then "Dry run" else "Collection pass")
-        <> " — inactivity expiry: " <> tshow days <> " days"
-    , "HEAD incorporated into the resolved default branch: 24 hours of inactivity."
-    , "Ignored untracked files are NOT backed up or restored."
+        <> " — minimum inactivity: " <> tshow (max 1 days) <> " days"
+    , "Only clean checkouts incorporated into another branch or a verified merged PR are collected."
+    , "Dirty, unmerged, protected and uncertain worktrees never expire solely because of age."
+    , "Only recognized, explicitly ignored build/cache directories may be discarded; they are NOT restored."
     , if dryRun then "Automatic adoption is simulated; no registry or snapshot is written."
         else "Verified existing agent worktrees are adopted using saved-session activity."
     ]
     <> [ "eligible\t" <> pathText path <> "\testimated bytes: " <> tshow bytes
+            <> maybe "" ("\t" <>) (lookup path report.cleanupEvidence)
        | (path, bytes) <- report.cleanupEligible ]
     <> [ "retained\t" <> pathText path <> "\t" <> reason
        | (path, reason) <- report.cleanupRetained ]
     <> [ "collected\t" <> pathText path | path <- report.cleanupRemoved ]
     <> [ "failed\t" <> pathText path <> "\t" <> reason
        | (path, reason) <- report.cleanupFailures ]
+    <> [ "not examined\t" <> pathText path <> "\t" <> reason
+       | (path, reason) <- report.cleanupNotExamined ]
     <> [ tshow (length report.cleanupEligible) <> " eligible, "
         <> tshow (length report.cleanupRemoved) <> " collected, "
         <> tshow (length report.cleanupRetained) <> " retained, "
-        <> tshow (length report.cleanupFailures) <> " failed."
+        <> tshow (length report.cleanupFailures) <> " failed, "
+        <> tshow (length report.cleanupNotExamined) <> " not examined."
        , "Eligible checkout gross apparent bytes: " <> tshow (sum (map snd report.cleanupEligible))
            <> " (excludes snapshot overhead and APFS sharing; not guaranteed net disk savings)."
        ]

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -279,7 +279,7 @@ spec = describe "Agent.CLI.Config" do
             fmap (.configWorktree) result
                 `shouldBe` Right WorktreeConfig
                     { worktreeFetchLatestUpstream = True
-                    , worktreeInactiveDays = 7
+                    , worktreeInactiveDays = 1
                     }
 
     it "loads the managed worktree fetch opt-out" $
@@ -290,7 +290,7 @@ spec = describe "Agent.CLI.Config" do
             fmap (.configWorktree) result
                 `shouldBe` Right WorktreeConfig
                     { worktreeFetchLatestUpstream = False
-                    , worktreeInactiveDays = 7
+                    , worktreeInactiveDays = 1
                     }
 
     it "loads configurable worktree inactivity expiry" $

--- a/packages/agent-cli/test/Agent/CLI/WorktreeAdminSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeAdminSpec.hs
@@ -8,31 +8,38 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "worktree cleanup report" do
-    it "shows eligibility, estimates, retained reasons, failures and the ignored-file warning" do
-        let report = WorktreeCleanupReport
+    it "shows eligibility, estimates, evidence, retained reasons, failures and unexamined candidates" do
+        let report = mempty
                 { cleanupRemoved = []
                 , cleanupFailures = [(unsafeEncodeUtf "/broken", "snapshot verification failed")]
                 , cleanupEligible = [(unsafeEncodeUtf "/ready", 1234)]
                 , cleanupRetained = [(unsafeEncodeUtf "/legacy", "unknown saved-session activity")]
+                , cleanupNotExamined = [(unsafeEncodeUtf "/pending", "pass budget exhausted")]
+                , cleanupEvidence = [(unsafeEncodeUtf "/ready", "refs/heads/release")]
                 }
             rendered = renderWorktreeCleanupReport True 14 report
         mapM_ (\part -> rendered `shouldSatisfy` Text.isInfixOf part)
             [ "Dry run"
-            , "14 days"
-            , "HEAD incorporated into the resolved default branch: 24 hours of inactivity."
+            , "minimum inactivity: 14 days"
+            , "never expire solely because of age"
+            , "explicitly ignored build/cache directories"
             , "estimated bytes: 1234"
             , "unknown saved-session activity"
-            , "Automatic adoption is simulated; no registry or snapshot is written."
             , "Eligible checkout gross apparent bytes: 1234"
             , "snapshot verification failed"
-            , "Ignored untracked files are NOT backed up or restored."
-            , "1 eligible, 0 collected, 1 retained, 1 failed."
+            , "refs/heads/release"
+            , "pass budget exhausted"
+            , "1 eligible"
+            , "0 collected"
+            , "1 retained"
+            , "1 failed"
+            , "1 not examined"
             ]
     it "escapes newlines in filenames" do
         let report = mempty { cleanupRetained = [(unsafeEncodeUtf "/line\nbreak", "protected")] }
             rendered = renderWorktreeCleanupReport True 7 report
         rendered `shouldSatisfy` Text.isInfixOf "/line\\nbreak"
-        length (Text.lines rendered) `shouldBe` 7
+        rendered `shouldSatisfy` (not . Text.isInfixOf "/line\nbreak")
     it "sums only eligible estimates and does not describe estimates as recovered space" do
         let report = mempty
                 { cleanupEligible = [(unsafeEncodeUtf "/one", 1234), (unsafeEncodeUtf "/two", 4321)]
@@ -41,4 +48,4 @@ spec = describe "worktree cleanup report" do
             rendered = renderWorktreeCleanupReport True 7 report
         rendered `shouldSatisfy` Text.isInfixOf "Eligible checkout gross apparent bytes: 5555"
         rendered `shouldSatisfy` Text.isInfixOf "not guaranteed net disk savings"
-        rendered `shouldSatisfy` Text.isInfixOf "2 eligible, 0 collected, 1 retained, 0 failed."
+        rendered `shouldSatisfy` Text.isInfixOf "2 eligible, 0 collected, 1 retained, 0 failed"

--- a/packages/agent-cli/test/Agent/CLI/WorktreeCleanSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeCleanSpec.hs
@@ -70,6 +70,31 @@ spec = describe "clean worktree recovery" $ do
             void $ git checkout ["commit", "-m", "Remove text conversion"]
             void $ git checkout ["update-index", "--assume-unchanged", "source.txt"]
             inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+    it "retains clean committed resolutions with resolve-undo records without changing the index" $
+        withCheckout $ \repository checkout -> do
+            writeFile (repository </> "source.txt") "primary change\n"
+            void $ git repository ["commit", "-am", "Change primary branch"]
+            writeFile (checkout </> "source.txt") "checkout change\n"
+            void $ git checkout ["commit", "-am", "Change checkout"]
+            (code, _, _) <- readCreateProcessWithExitCode
+                (proc "git" ["merge", "main"]) { cwd = Just checkout } ""
+            code `shouldBe` ExitFailure 1
+            writeFile (checkout </> "source.txt") "resolved change\n"
+            void $ git checkout ["add", "source.txt"]
+            void $ git checkout ["commit", "-m", "Resolve conflict"]
+            git checkout ["status", "--porcelain"] `shouldReturn` ""
+            git checkout ["ls-files", "--unmerged"] `shouldReturn` ""
+            records <- git checkout ["ls-files", "--resolve-undo"]
+            records `shouldSatisfy` (not . null)
+            administration <- git checkout ["rev-parse", "--absolute-git-dir"]
+            index <- BS.readFile (administration </> "index")
+            outcome <- inspectCleanCheckout (unsafeEncodeUtf checkout)
+            outcome `shouldSatisfy` either (Text.isInfixOf "resolve-undo records") (const False)
+            BS.readFile (administration </> "index") `shouldReturn` index
+            git checkout ["ls-files", "--resolve-undo"] `shouldReturn` records
+            git repository ["for-each-ref", "refs/haskell-agent"] `shouldReturn` ""
+            void $ git checkout ["update-index", "--clear-resolve-undo"]
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isRight
     it "retains private Git operation state" $
         withCheckout $ \_ checkout -> do
             administration <- git checkout ["rev-parse", "--absolute-git-dir"]

--- a/packages/agent-cli/test/Agent/CLI/WorktreeCleanSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeCleanSpec.hs
@@ -1,0 +1,213 @@
+module Agent.CLI.WorktreeCleanSpec (spec) where
+
+import Agent.CLI.Worktree.Clean
+import qualified Agent.CLI.Worktree.Snapshot as Snapshot
+import Control.Exception.Safe (bracket)
+import Control.Monad (void)
+import qualified Data.ByteString as BS
+import Data.Either (isLeft, isRight)
+import Data.List (isInfixOf)
+import qualified Data.Text as Text
+import qualified System.Directory as Directory
+import System.Exit (ExitCode(..))
+import System.FilePath ((</>))
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Temp (mkdtemp)
+import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "clean worktree recovery" $ do
+    it "inspects without changing the live index or creating recovery refs" $
+        withCheckout $ \repository checkout -> do
+            administration <- git checkout ["rev-parse", "--absolute-git-dir"]
+            before <- BS.readFile (administration </> "index")
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isRight
+            BS.readFile (administration </> "index") `shouldReturn` before
+            git repository ["for-each-ref", "refs/haskell-agent"] `shouldReturn` ""
+    it "retains unstaged, staged, and untracked work" $
+        withCheckout $ \_ checkout -> do
+            writeFile (checkout </> "source.txt") "changed\n"
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+            void $ git checkout ["add", "source.txt"]
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+            void $ git checkout ["reset", "--hard", "HEAD"]
+            writeFile (checkout </> "notes.txt") "private work\n"
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+    it "accepts unchanged LF bytes under autocrlf=input but retains converted CRLF bytes" $
+        withCheckout $ \_ checkout -> do
+            void $ git checkout ["config", "core.autocrlf", "input"]
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isRight
+            writeFile (checkout </> "source.txt") "original\r\n"
+            -- Populate the normal index's stat cache under conversion settings.
+            void $ git checkout ["add", "source.txt"]
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+    it "retains ignored private files but permits repository-ignored output directories" $
+        withCheckout $ \_ checkout -> do
+            writeFile (checkout </> ".gitignore") "dist-newstyle/\n.env\n"
+            void $ git checkout ["add", ".gitignore"]
+            void $ git checkout ["commit", "-m", "Specify ignored paths"]
+            Directory.createDirectory (checkout </> "dist-newstyle")
+            writeFile (checkout </> "dist-newstyle" </> "output") "cache"
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isRight
+            writeFile (checkout </> ".env") "private configuration"
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+    it "does not treat global ignore rules as repository authorization" $
+        withCheckout $ \repository checkout -> do
+            let exclusions = repository </> "global-excludes"
+            writeFile exclusions "dist-newstyle/\n"
+            void $ git checkout ["config", "core.excludesFile", exclusions]
+            Directory.createDirectory (checkout </> "dist-newstyle")
+            writeFile (checkout </> "dist-newstyle" </> "output") "private"
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+    it "retains byte transformations and assume-unchanged files" $
+        withCheckout $ \_ checkout -> do
+            writeFile (checkout </> ".gitattributes") "source.txt text\n"
+            void $ git checkout ["add", ".gitattributes"]
+            void $ git checkout ["commit", "-m", "Specify text conversion"]
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+            void $ git checkout ["rm", ".gitattributes"]
+            void $ git checkout ["commit", "-m", "Remove text conversion"]
+            void $ git checkout ["update-index", "--assume-unchanged", "source.txt"]
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+    it "retains private Git operation state" $
+        withCheckout $ \_ checkout -> do
+            administration <- git checkout ["rev-parse", "--absolute-git-dir"]
+            writeFile (administration </> "MERGE_HEAD") "unfinished"
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+    it "detects edits after the initial proof" $
+        withCheckout $ \_ checkout -> do
+            proof <- inspectCleanCheckout (unsafeEncodeUtf checkout) >>= requireRight
+            writeFile (checkout </> "source.txt") "changed after inspection"
+            verifyCleanCheckout (unsafeEncodeUtf checkout) proof `shouldReturnSatisfy` isLeft
+    it "does not authorize recovery when an existing blob object is missing" $
+        withCheckout $ \repository checkout -> do
+            proof <- inspectCleanCheckout (unsafeEncodeUtf checkout) >>= requireRight
+            object <- git checkout ["rev-parse", "HEAD:source.txt"]
+            Directory.removeFile (repository </> ".git" </> "objects" </>
+                take 2 object </> drop 2 object)
+            preserveCleanCheckout (unsafeEncodeUtf checkout) proof `shouldReturnSatisfy` isLeft
+    it "retains worktree-private references" $
+        withCheckout $ \_ checkout -> do
+            void $ git checkout ["update-ref", "refs/worktree/private", "HEAD"]
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+    it "preserves FETCH_HEAD objects and metadata before collection" $
+        withCheckout $ \repository checkout -> do
+            void $ git checkout ["fetch", repository, "main"]
+            administration <- git checkout ["rev-parse", "--absolute-git-dir"]
+            fetched <- readFile (administration </> "FETCH_HEAD")
+            proof <- inspectCleanCheckout (unsafeEncodeUtf checkout) >>= requireRight
+            snapshot <- preserveCleanCheckout (unsafeEncodeUtf checkout) proof >>= requireRight
+            let identifier = last (Text.splitOn "/" snapshot.snapshotRef)
+                reference = "refs/haskell-agent/reclaimed/" <> Text.unpack identifier <> "/fetched-heads"
+            git repository ["cat-file", "blob", reference] `shouldReturn`
+                Text.unpack (Text.strip (Text.pack fetched))
+    it "retains malformed FETCH_HEAD contents" $
+        withCheckout $ \_ checkout -> do
+            administration <- git checkout ["rev-parse", "--absolute-git-dir"]
+            writeFile (administration </> "FETCH_HEAD") "unknown fetched state\n"
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+    it "preserves inactive AUTO_MERGE trees and REBASE_HEAD commits" $
+        withCheckout $ \repository checkout -> do
+            administration <- git checkout ["rev-parse", "--absolute-git-dir"]
+            original <- git checkout ["rev-parse", "HEAD"]
+            writeFile (checkout </> "source.txt") "abandoned resolution\n"
+            void $ git checkout ["commit", "-am", "Temporary resolution"]
+            tree <- git checkout ["rev-parse", "HEAD^{tree}"]
+            commit <- git checkout ["rev-parse", "HEAD"]
+            void $ git checkout ["reset", "--hard", original]
+            writeFile (administration </> "AUTO_MERGE") (tree <> "\n")
+            writeFile (administration </> "REBASE_HEAD") (commit <> "\n")
+            proof <- inspectCleanCheckout (unsafeEncodeUtf checkout) >>= requireRight
+            snapshot <- preserveCleanCheckout (unsafeEncodeUtf checkout) proof >>= requireRight
+            let identifier = Text.unpack (last (Text.splitOn "/" snapshot.snapshotRef))
+                prefix = "refs/haskell-agent/reclaimed/" <> identifier <> "/"
+            git repository ["rev-parse", prefix <> "auto-merge"] `shouldReturn` tree
+            git repository ["rev-parse", prefix <> commit] `shouldReturn` commit
+            git repository ["show", prefix <> "auto-merge:source.txt"] `shouldReturn` "abandoned resolution"
+            verifyCleanCheckout (unsafeEncodeUtf checkout) proof `shouldReturn` Right ()
+            writeFile (administration </> "REBASE_HEAD") (original <> "\n")
+            verifyCleanCheckout (unsafeEncodeUtf checkout) proof `shouldReturnSatisfy` isLeft
+    it "retains active rebase state even with valid inactive pseudorefs" $
+        withCheckout $ \_ checkout -> do
+            administration <- git checkout ["rev-parse", "--absolute-git-dir"]
+            commit <- git checkout ["rev-parse", "HEAD"]
+            writeFile (administration </> "REBASE_HEAD") (commit <> "\n")
+            Directory.createDirectory (administration </> "rebase-merge")
+            outcome <- inspectCleanCheckout (unsafeEncodeUtf checkout)
+            outcome `shouldSatisfy` either (Text.isInfixOf "rebase-merge") (const False)
+    it "retains malformed and incorrectly typed inactive pseudorefs" $
+        withCheckout $ \_ checkout -> do
+            administration <- git checkout ["rev-parse", "--absolute-git-dir"]
+            commit <- git checkout ["rev-parse", "HEAD"]
+            writeFile (administration </> "AUTO_MERGE") (commit <> "\n")
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+            Directory.removeFile (administration </> "AUTO_MERGE")
+            writeFile (administration </> "REBASE_HEAD") "ref: refs/heads/main\n"
+            inspectCleanCheckout (unsafeEncodeUtf checkout) `shouldReturnSatisfy` isLeft
+    it "rechecks AUTO_MERGE changes before recovery preservation" $
+        withCheckout $ \_ checkout -> do
+            administration <- git checkout ["rev-parse", "--absolute-git-dir"]
+            tree <- git checkout ["rev-parse", "HEAD^{tree}"]
+            writeFile (administration </> "AUTO_MERGE") (tree <> "\n")
+            proof <- inspectCleanCheckout (unsafeEncodeUtf checkout) >>= requireRight
+            Directory.removeFile (administration </> "AUTO_MERGE")
+            preserveCleanCheckout (unsafeEncodeUtf checkout) proof `shouldReturnSatisfy` isLeft
+    it "creates legacy-compatible recovery using existing tree objects" $
+        withCheckout $ \repository checkout -> do
+            proof <- inspectCleanCheckout (unsafeEncodeUtf checkout) >>= requireRight
+            snapshot <- preserveCleanCheckout (unsafeEncodeUtf checkout) proof >>= requireRight
+            Snapshot.verifySnapshotUnchanged (unsafeEncodeUtf checkout) snapshot `shouldReturn` Right ()
+            let restored = repository </> "restored"
+            Snapshot.restoreSnapshot (unsafeEncodeUtf repository) (unsafeEncodeUtf restored) snapshot
+                `shouldReturn` Right ()
+            readFile (restored </> "source.txt") `shouldReturn` "original\n"
+    it "preserves commits referenced only by the checkout reflog" $
+        withCheckout $ \repository checkout -> do
+            original <- git checkout ["rev-parse", "HEAD"]
+            writeFile (checkout </> "source.txt") "temporary commit\n"
+            void $ git checkout ["commit", "-am", "Create recoverable commit"]
+            abandoned <- git checkout ["rev-parse", "HEAD"]
+            void $ git checkout ["reset", "--hard", original]
+            proof <- inspectCleanCheckout (unsafeEncodeUtf checkout) >>= requireRight
+            void $ preserveCleanCheckout (unsafeEncodeUtf checkout) proof >>= requireRight
+            references <- git repository ["for-each-ref", "--format=%(objectname)",
+                "refs/haskell-agent/reclaimed"]
+            references `shouldSatisfy` isInfixOf abandoned
+
+shouldReturnSatisfy :: Show a => IO a -> (a -> Bool) -> Expectation
+shouldReturnSatisfy action predicate = action >>= (`shouldSatisfy` predicate)
+
+requireRight :: Show error => Either error a -> IO a
+requireRight = either (fail . show) pure
+
+withCheckout :: (FilePath -> FilePath -> IO a) -> IO a
+withCheckout action = do
+    temporary <- Directory.getTemporaryDirectory
+    bracket (mkdtemp (temporary </> "worktree-clean-spec-"))
+        Directory.removePathForcibly $ \directory -> do
+            let repository = directory </> "repository"
+                checkout = directory </> "checkout"
+            Directory.createDirectory repository
+            void $ git repository ["init", "-b", "main"]
+            void $ git repository ["config", "user.name", "Worktree test"]
+            void $ git repository ["config", "user.email", "worktree-test@localhost"]
+            void $ git repository ["config", "commit.gpgsign", "false"]
+            void $ git repository ["config", "core.autocrlf", "false"]
+            void $ git repository ["config", "core.attributesFile", "/dev/null"]
+            void $ git repository ["config", "core.excludesFile", "/dev/null"]
+            writeFile (repository </> "source.txt") "original\n"
+            void $ git repository ["add", "source.txt"]
+            void $ git repository ["commit", "-m", "Initial commit"]
+            void $ git repository ["worktree", "add", "--detach", checkout]
+            action repository checkout
+
+git :: FilePath -> [String] -> IO String
+git directory arguments = do
+    (code, output, errors) <- readCreateProcessWithExitCode
+        (proc "git" arguments) { cwd = Just directory } ""
+    unlessSuccess code errors
+    pure (Text.unpack (Text.strip (Text.pack output)))
+  where
+    unlessSuccess ExitSuccess _ = pure ()
+    unlessSuccess _ errors = fail errors

--- a/packages/agent-cli/test/Agent/CLI/WorktreeIgnoredSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeIgnoredSpec.hs
@@ -1,0 +1,93 @@
+module Agent.CLI.WorktreeIgnoredSpec (spec) where
+
+import Agent.CLI.Worktree.Ignored (checkIgnoredPath)
+import Control.Monad (forM_)
+import qualified System.Directory as Directory
+import System.FilePath ((</>), takeDirectory)
+import System.IO.Temp (withSystemTempDirectory)
+import qualified System.Posix.Files as Posix
+import Test.Hspec
+
+spec :: Spec
+spec = describe "ignored worktree paths" $ do
+    it "accepts only an exact primary-checkout settings duplicate" $
+        fixture $ \primary checkout check -> do
+            copies primary checkout ".haskell-agent/settings.json" "{}"
+            check ".haskell-agent/" `shouldReturn` ()
+            writeFile (checkout </> ".haskell-agent/settings.json") "{\"model\":\"other\"}"
+            check ".haskell-agent/" `shouldThrow` anyIOException
+    it "retains additional agent-directory state" $
+        fixture $ \primary checkout check -> do
+            copies primary checkout ".haskell-agent/settings.json" "{}"
+            writeFile (checkout </> ".haskell-agent/notes") "unique"
+            check ".haskell-agent/" `shouldThrow` anyIOException
+    it "retains settings when the primary copy is absent" $
+        fixture $ \_ checkout check -> do
+            Directory.createDirectory (checkout </> ".haskell-agent")
+            writeFile (checkout </> ".haskell-agent/settings.json") "{}"
+            check ".haskell-agent/" `shouldThrow` anyIOException
+    it "accepts duplicate generated provider data but retains differences" $
+        fixture $ \primary checkout check -> do
+            forM_ ["models.json", "prompt.md"] $ \name -> do
+                let relative = "packages/agent-openai/data/" <> name
+                copies primary checkout relative "data"
+                check relative `shouldReturn` ()
+                writeFile (checkout </> relative) "unique"
+                check relative `shouldThrow` anyIOException
+    it "rejects symlinked duplicate files" $
+        fixture $ \primary checkout check -> do
+            copies primary checkout ".haskell-agent/settings.json" "{}"
+            Directory.removeFile (checkout </> ".haskell-agent/settings.json")
+            Posix.createSymbolicLink (primary </> ".haskell-agent/settings.json")
+                (checkout </> ".haskell-agent/settings.json")
+            check ".haskell-agent/" `shouldThrow` anyIOException
+    it "rejects symlinked parent directories" $
+        fixture $ \primary checkout check -> do
+            copies primary primary ".haskell-agent/settings.json" "{}"
+            Posix.createSymbolicLink (primary </> ".haskell-agent") (checkout </> ".haskell-agent")
+            check ".haskell-agent/" `shouldThrow` anyIOException
+    it "accepts a Nix result symlink but rejects other targets and regular files" $
+        fixture $ \_ checkout check -> do
+            let path = checkout </> "result"
+            Posix.createSymbolicLink ("/nix/store/" <> replicate 32 'a' <> "-output") path
+            check "result" `shouldReturn` ()
+            Directory.removeFile path
+            Posix.createSymbolicLink "../valuable" path
+            check "result" `shouldThrow` anyIOException
+            Directory.removeFile path
+            writeFile path "unique"
+            check "result" `shouldThrow` anyIOException
+    it "retains unknown ignored files and release artifacts" $
+        fixture $ \_ _ check -> do
+            check ".env" `shouldThrow` anyIOException
+            check "release-output/" `shouldThrow` anyIOException
+    it "retains existing recognized cache-directory behavior" $
+        fixture $ \_ checkout check -> do
+            Directory.createDirectory (checkout </> "dist-newstyle")
+            check "dist-newstyle/" `shouldReturn` ()
+    it "rejects global ignore evidence even for recognized paths" $
+        fixture $ \primary checkout _ -> do
+            Directory.createDirectory (checkout </> "dist-newstyle")
+            checkIgnoredPath (response primary "/global/excludes") checkout "dist-newstyle/"
+                `shouldThrow` anyIOException
+
+fixture :: (FilePath -> FilePath -> (FilePath -> IO ()) -> IO ()) -> IO ()
+fixture action = withSystemTempDirectory "worktree-ignored-spec-" $ \root -> do
+    let primary = root </> "primary"
+        checkout = root </> "checkout"
+    Directory.createDirectory primary
+    Directory.createDirectory checkout
+    Directory.createDirectory (primary </> ".git")
+    action primary checkout (checkIgnoredPath (response primary ".gitignore") checkout)
+
+response :: FilePath -> FilePath -> [String] -> String -> IO String
+response primary source arguments input
+    | take 1 arguments == ["check-ignore"] = pure (source <> "\0" <> "1\0*\0" <> input)
+    | take 1 arguments == ["rev-parse"] = pure (primary </> ".git" <> "\n")
+    | otherwise = fail "unexpected Git command"
+
+copies :: FilePath -> FilePath -> FilePath -> String -> IO ()
+copies primary checkout relative contents =
+    forM_ [primary, checkout] $ \root -> do
+        Directory.createDirectoryIfMissing True (takeDirectory (root </> relative))
+        writeFile (root </> relative) contents

--- a/packages/agent-cli/test/Agent/CLI/WorktreeIncorporationSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeIncorporationSpec.hs
@@ -1,0 +1,190 @@
+module Agent.CLI.WorktreeIncorporationSpec (spec) where
+
+import Agent.CLI.Worktree.Incorporation
+import Control.Exception.Safe (bracket)
+import Control.Monad (void)
+import Data.Either (isLeft)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.Directory (getTemporaryDirectory, removePathForcibly)
+import System.Exit (ExitCode(..))
+import System.FilePath ((</>))
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Files (setFileMode)
+import System.Posix.Temp (mkdtemp)
+import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "worktree incorporation" do
+    it "accepts incorporation into a non-default branch" $ withRepository $ \repository -> do
+        feature repository
+        void $ git repository ["checkout", "-b", "integration"]
+        commit repository "integration" "integration"
+        void $ git repository ["checkout", "feature"]
+        inspect repository [] `shouldReturn` Right "incorporated into refs/heads/integration"
+
+    it "retains a branch published only to its own remote tracking reference" $
+        withRepository $ \repository -> do
+            feature repository
+            headCommit <- git repository ["rev-parse", "HEAD"]
+            void $ git repository ["update-ref", "refs/remotes/origin/feature", Text.unpack headCommit]
+            inspect repository [] >>= (`shouldSatisfy` isLeft)
+
+    it "retains an unmerged detached head with an identical feature reference" $
+        withRepository $ \repository -> do
+            feature repository
+            void $ git repository ["checkout", "--detach"]
+            inspect repository [] >>= (`shouldSatisfy` isLeft)
+
+    it "accepts a detached checkout at the default branch tip" $
+        withRepository $ \repository -> do
+            void $ git repository ["checkout", "--detach"]
+            inspect repository [] `shouldReturn` Right "incorporated into refs/heads/main"
+
+    it "does not treat recovery refs as incorporation" $ withRepository $ \repository -> do
+        feature repository
+        headCommit <- git repository ["rev-parse", "HEAD"]
+        void $ git repository ["update-ref", "refs/haskell-agent/reclaimed/test", Text.unpack headCommit]
+        inspect repository [] >>= (`shouldSatisfy` isLeft)
+
+    it "accepts an exact merged squash PR with matching resulting content" $
+        withRepository $ \repository -> do
+            request <- squash repository
+            inspect repository [request]
+                `shouldReturn` Right "merged pull request incorporated into refs/heads/main"
+
+    it "retains post-PR commits even when a PR was merged" $ withRepository $ \repository -> do
+        request <- squash repository
+        commit repository "subsequent" "subsequent"
+        inspect repository [request] >>= (`shouldSatisfy` isLeft)
+
+    it "accepts squash integration alongside unrelated target changes" $
+        withRepository $ \repository -> do
+            feature repository
+            headCommit <- git repository ["rev-parse", "HEAD"]
+            void $ git repository ["checkout", "main"]
+            commit repository "unrelated" "unrelated"
+            void $ git repository ["merge", "--squash", "feature"]
+            void $ git repository ["commit", "-m", "Squash integration"]
+            mergeCommit <- git repository ["rev-parse", "HEAD"]
+            void $ git repository ["checkout", "feature"]
+            inspect repository [MergedPullRequest headCommit mergeCommit "main"]
+                `shouldReturn` Right "merged pull request incorporated into refs/heads/main"
+
+    it "accepts verified rebase integration" $ withRepository $ \repository -> do
+        feature repository
+        headCommit <- git repository ["rev-parse", "HEAD"]
+        void $ git repository ["checkout", "main"]
+        commit repository "unrelated" "unrelated"
+        void $ git repository ["cherry-pick", Text.unpack headCommit]
+        mergeCommit <- git repository ["rev-parse", "HEAD"]
+        void $ git repository ["checkout", "feature"]
+        inspect repository [MergedPullRequest headCommit mergeCommit "main"]
+            `shouldReturn` Right "merged pull request incorporated into refs/heads/main"
+
+    it "preserves whitespace and pathspec characters in content checks" $
+        withRepository $ \repository -> do
+            feature repository
+            commit repository " \n[work]* " "unique content"
+            headCommit <- git repository ["rev-parse", "HEAD"]
+            void $ git repository ["checkout", "main"]
+            void $ git repository ["merge", "--squash", "feature"]
+            writeFile (repository </> " \n[work]* ") "omitted content"
+            void $ git repository ["add", "--all"]
+            void $ git repository ["commit", "-m", "Incomplete integration"]
+            mergeCommit <- git repository ["rev-parse", "HEAD"]
+            void $ git repository ["checkout", "feature"]
+            inspect repository [MergedPullRequest headCommit mergeCommit "main"]
+                >>= (`shouldSatisfy` isLeft)
+
+    it "does not confuse matching content with a matching executable mode" $
+        withRepository $ \repository -> do
+            feature repository
+            setFileMode (repository </> "feature") 0o755
+            void $ git repository ["add", "feature"]
+            void $ git repository ["commit", "-m", "Executable mode"]
+            headCommit <- git repository ["rev-parse", "HEAD"]
+            void $ git repository ["checkout", "main"]
+            void $ git repository ["merge", "--squash", "feature"]
+            setFileMode (repository </> "feature") 0o644
+            void $ git repository ["add", "feature"]
+            void $ git repository ["commit", "-m", "Missing executable mode"]
+            mergeCommit <- git repository ["rev-parse", "HEAD"]
+            void $ git repository ["checkout", "feature"]
+            inspect repository [MergedPullRequest headCommit mergeCommit "main"]
+                >>= (`shouldSatisfy` isLeft)
+
+    it "retains a merged PR whose resulting content omits work" $ withRepository $ \repository -> do
+        feature repository
+        headCommit <- git repository ["rev-parse", "HEAD"]
+        void $ git repository ["checkout", "main"]
+        commit repository "other" "other"
+        mergeCommit <- git repository ["rev-parse", "HEAD"]
+        void $ git repository ["checkout", "feature"]
+        inspect repository [MergedPullRequest headCommit mergeCommit "main"]
+            >>= (`shouldSatisfy` isLeft)
+
+    it "retains a PR merge commit no surviving target branch contains" $
+        withRepository $ \repository -> do
+            request <- squash repository
+            void $ git repository ["branch", "-f", "main", "main^"]
+            inspect repository [request] >>= (`shouldSatisfy` isLeft)
+
+    it "does not let replacement objects manufacture ancestry" $
+        withRepository $ \repository -> do
+            feature repository
+            headCommit <- git repository ["rev-parse", "HEAD"]
+            void $ git repository ["checkout", "main"]
+            commit repository "other" "other"
+            mainCommit <- git repository ["rev-parse", "HEAD"]
+            void $ git repository ["replace", Text.unpack headCommit, Text.unpack mainCommit]
+            void $ git repository ["checkout", "feature"]
+            inspect repository [] >>= (`shouldSatisfy` isLeft)
+
+inspect :: FilePath -> [MergedPullRequest] -> IO (Either Text Text)
+inspect repository requests =
+    inspectIncorporationWith (const (pure (Right requests))) (unsafeEncodeUtf repository)
+
+feature :: FilePath -> IO ()
+feature repository = do
+    void $ git repository ["checkout", "-b", "feature"]
+    commit repository "feature" "feature"
+
+squash :: FilePath -> IO MergedPullRequest
+squash repository = do
+    feature repository
+    headCommit <- git repository ["rev-parse", "HEAD"]
+    void $ git repository ["checkout", "main"]
+    void $ git repository ["merge", "--squash", "feature"]
+    void $ git repository ["commit", "-m", "Squash integration"]
+    mergeCommit <- git repository ["rev-parse", "HEAD"]
+    void $ git repository ["checkout", "feature"]
+    pure (MergedPullRequest headCommit mergeCommit "main")
+
+withRepository :: (FilePath -> IO a) -> IO a
+withRepository action = do
+    temporary <- getTemporaryDirectory
+    bracket (mkdtemp (temporary </> "worktree-incorporation-")) removePathForcibly $ \repository -> do
+        void $ git repository ["init", "-b", "main"]
+        void $ git repository ["config", "user.name", "Worktree Test"]
+        void $ git repository ["config", "user.email", "worktree@example.invalid"]
+        void $ git repository ["config", "commit.gpgsign", "false"]
+        void $ git repository ["config", "core.filemode", "true"]
+        commit repository "initial" "initial"
+        action repository
+
+commit :: FilePath -> FilePath -> String -> IO ()
+commit repository name content = do
+    writeFile (repository </> name) content
+    void $ git repository ["add", "--", name]
+    void $ git repository ["commit", "-m", name]
+
+git :: FilePath -> [String] -> IO Text
+git repository arguments = do
+    (code, output, errors) <- readCreateProcessWithExitCode
+        (proc "git" ("-c" : "core.hooksPath=/dev/null" : arguments))
+            { cwd = Just repository } ""
+    case code of
+        ExitSuccess -> pure (Text.strip (Text.pack output))
+        _ -> fail errors

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.WorktreeSpec (spec) where
 import Agent.CLI.Config
 import Agent.CLI.Worktree
 import Agent.CLI.Worktree.Registry
+import qualified Agent.CLI.Worktree.Snapshot as Snapshot
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception.Safe (bracket)
 import Control.Monad (void)
@@ -436,24 +437,26 @@ spec = describe "Agent.CLI.Worktree" do
     describe "merged worktree inactivity" do
         it "uses the exact inclusive 24-hour inactivity boundary for incorporated HEADs" do
             now <- getCurrentTime
-            worktreeInactive 7 True now (addUTCTime (-86400 + 0.001) now) `shouldBe` False
-            worktreeInactive 7 True now (addUTCTime (-86400) now) `shouldBe` True
-            worktreeInactive 7 True now (addUTCTime (-86400 - 0.001) now) `shouldBe` True
-            worktreeInactive 7 True now (addUTCTime 1 now) `shouldBe` False
+            worktreeInactive 1 True now (addUTCTime (-86400 + 0.001) now) `shouldBe` False
+            worktreeInactive 1 True now (addUTCTime (-86400) now) `shouldBe` True
+            worktreeInactive 1 True now (addUTCTime (-86400 - 0.001) now) `shouldBe` True
+            worktreeInactive 1 True now (addUTCTime 1 now) `shouldBe` False
+            worktreeInactive 0 True now (addUTCTime (-3600) now) `shouldBe` False
 
-        it "uses configured inactivity for unproven HEADs without a commit-date clock" do
+        it "never expires unproven HEADs and honors longer configured inactivity" do
             now <- getCurrentTime
             worktreeInactive 7 False now (addUTCTime (-86400) now) `shouldBe` False
             worktreeInactive 7 False now (addUTCTime (-7 * 86400 + 0.001) now) `shouldBe` False
-            worktreeInactive 7 False now (addUTCTime (-7 * 86400) now) `shouldBe` True
+            worktreeInactive 7 False now (addUTCTime (-30 * 86400) now) `shouldBe` False
             worktreeInactive 14 False now (addUTCTime (-8 * 86400) now) `shouldBe` False
-            worktreeInactive 14 True now (addUTCTime (-86400) now) `shouldBe` True
+            worktreeInactive 14 True now (addUTCTime (-86400) now) `shouldBe` False
+            worktreeInactive 14 True now (addUTCTime (-14 * 86400) now) `shouldBe` True
 
         mapM_ (\branch ->
             it ("recognizes a normal merge into the resolved " <> branch <> " default branch") $
                 withMergedWorktree branch \_ root path -> do
                     activity <- savedActivityDaysAgo path 2
-                    report <- gcWorktreesWithActivity activity root 7 True []
+                    report <- gcWorktreesWithActivity activity root 1 True []
                     map fst report.cleanupEligible `shouldBe` [path]
                     report.cleanupRetained `shouldBe` []
                     readRecord root path `shouldReturn` Right Nothing
@@ -463,41 +466,41 @@ spec = describe "Agent.CLI.Worktree" do
             withMergedWorktree "main" \_ root path -> do
                 now <- getCurrentTime
                 let activity = pure (Right (Map.singleton path (Right (addUTCTime (-23 * 3600) now))))
-                report <- gcWorktreesWithActivity activity root 7 True []
+                report <- gcWorktreesWithActivity activity root 1 True []
                 report.cleanupEligible `shouldBe` []
-                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+                map fst report.cleanupRetained `shouldBe` [path]
 
-        it "new commits after the merged head disqualify the short expiry" $
+        it "new commits after the merged head prevent collection" $
             withMergedWorktree "main" \_ root path -> do
                 _ <- git path ["commit", "--allow-empty", "-m", "after merge"]
                 activity <- savedActivityDaysAgo path 2
-                report <- gcWorktreesWithActivity activity root 7 True []
+                report <- gcWorktreesWithActivity activity root 1 True []
                 report.cleanupEligible `shouldBe` []
-                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+                map fst report.cleanupRetained `shouldBe` [path]
 
-        it "an absent default-branch target keeps the normal expiry" $
+        it "accepts incorporation into a surviving local branch without a remote target" $
             withMergedWorktree "main" \repo root path -> do
                 _ <- git repo ["update-ref", "-d", "refs/remotes/origin/main"]
                 activity <- savedActivityDaysAgo path 2
-                report <- gcWorktreesWithActivity activity root 7 True []
-                report.cleanupEligible `shouldBe` []
-                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+                report <- gcWorktreesWithActivity activity root 1 True []
+                map fst report.cleanupEligible `shouldBe` [path]
+                report.cleanupRetained `shouldBe` []
 
-        it "does not guess a default branch from local branch names" $
+        it "accepts incorporation into another branch without a default-branch symbolic ref" $
             withMergedWorktree "master" \repo root path -> do
                 _ <- git repo ["symbolic-ref", "--delete", "refs/remotes/origin/HEAD"]
                 activity <- savedActivityDaysAgo path 2
-                report <- gcWorktreesWithActivity activity root 7 True []
-                report.cleanupEligible `shouldBe` []
-                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+                report <- gcWorktreesWithActivity activity root 1 True []
+                map fst report.cleanupEligible `shouldBe` [path]
+                report.cleanupRetained `shouldBe` []
 
-        it "keeps the normal expiry when legacy grafts make ancestry uncertain" $
+        it "retains work when legacy grafts make ancestry uncertain" $
             withMergedWorktree "main" \repo root path -> do
                 writeFile (toFilePath (repo </> fromFilePath ".git/info/grafts")) ""
                 activity <- savedActivityDaysAgo path 2
-                report <- gcWorktreesWithActivity activity root 7 True []
+                report <- gcWorktreesWithActivity activity root 1 True []
                 report.cleanupEligible `shouldBe` []
-                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+                map fst report.cleanupRetained `shouldBe` [path]
 
         it "does not mistake squash-equivalent content for an incorporated HEAD" $
             withTempGitRepo \repo ->
@@ -512,14 +515,15 @@ spec = describe "Agent.CLI.Worktree" do
                 _ <- git repo ["commit", "-m", "squashed feature"]
                 configureDefaultRef repo "main"
                 activity <- savedActivityDaysAgo path 2
-                report <- gcWorktreesWithActivity activity root 7 True []
+                report <- gcWorktreesWithActivity activity root 1 True []
                 report.cleanupEligible `shouldBe` []
-                report.cleanupRetained `shouldBe` [(path, "recent activity")]
+                map fst report.cleanupRetained `shouldBe` [path]
                 oldActivity <- savedActivityDaysAgo path 8
                 oldReport <- gcWorktreesWithActivity oldActivity root 7 True []
-                map fst oldReport.cleanupEligible `shouldBe` [path]
+                oldReport.cleanupEligible `shouldBe` []
+                map fst oldReport.cleanupRetained `shouldBe` [path]
 
-        it "snapshots dirty merged checkouts before collecting at two days" $
+        it "retains dirty merged checkouts instead of snapshotting them" $
             withMergedWorktree "main" \_ root path -> do
                 let file name = toFilePath (path </> fromFilePath name)
                 writeFile (file "README") "staged\n"
@@ -530,20 +534,20 @@ spec = describe "Agent.CLI.Worktree" do
                 writeFile (file "cache") "discarded\n"
                 headBefore <- git path ["rev-parse", "HEAD"]
                 activity <- savedActivityDaysAgo path 2
-                report <- gcWorktreesWithActivity activity root 7 False []
-                report.cleanupRemoved `shouldBe` [path]
-                restoreManagedWorktree root path `shouldReturn` Right ()
+                report <- gcWorktreesWithActivity activity root 1 False []
+                report.cleanupRemoved `shouldBe` []
+                map fst report.cleanupRetained `shouldBe` [path]
                 git path ["rev-parse", "HEAD"] `shouldReturn` headBefore
                 git path ["show", ":README"] `shouldReturn` "staged"
                 readFile (file "README") `shouldReturn` "unstaged\n"
                 readFile (file "notes") `shouldReturn` "untracked\n"
-                Directory.doesFileExist (file "cache") `shouldReturn` False
+                Directory.doesFileExist (file "cache") `shouldReturn` True
 
         it "keeps active merged checkouts even after 24 hours" $
             withMergedWorktree "main" \_ root path -> do
                 activity <- savedActivityDaysAgo path 2
                 bracket (acquireWorktreeLease root path) releaseLease $ \_ -> do
-                    report <- gcWorktreesWithActivity activity root 7 True []
+                    report <- gcWorktreesWithActivity activity root 1 True []
                     report.cleanupEligible `shouldBe` []
                     map snd report.cleanupRetained `shouldSatisfy` any (Text.isInfixOf "existing lock is busy")
                 doesDirectoryExist path `shouldReturn` True
@@ -557,7 +561,7 @@ spec = describe "Agent.CLI.Worktree" do
                     `shouldReturn` Right ()
                 protectWorktree root path True `shouldReturn` Right ()
                 activity <- savedActivityDaysAgo path 2
-                report <- gcWorktreesWithActivity activity root 7 False []
+                report <- gcWorktreesWithActivity activity root 1 False []
                 report.cleanupRemoved `shouldBe` []
                 report.cleanupRetained `shouldBe` [(path, "protected")]
 
@@ -573,13 +577,28 @@ spec = describe "Agent.CLI.Worktree" do
                                 then void (git path ["commit", "--allow-empty", "-m", "concurrent new commit"])
                                 else pure ()
                             saved
-                    report <- gcWorktreesWithActivity activity root 7 False []
+                    report <- gcWorktreesWithActivity activity root 1 False []
                     report.cleanupRemoved `shouldBe` []
-                    report.cleanupRetained `shouldBe` [(path, "recent activity")]
+                    map fst report.cleanupRetained `shouldBe` [path]
                     doesDirectoryExist path `shouldReturn` True
             ) [2, 3]
 
-    describe "snapshot-backed worktree GC" do
+        it "retains files that appear after recovery preservation" $
+            withMergedWorktree "main" \_ root path -> do
+                saved <- savedActivityDaysAgo path 2
+                reads <- newIORef (0 :: Int)
+                let file = toFilePath (path </> fromFilePath "concurrent-notes")
+                    activity = do
+                        modifyIORef' reads (+1)
+                        count <- readIORef reads
+                        if count == 3 then writeFile file "preserve concurrent work\n" else pure ()
+                        saved
+                report <- gcWorktreesWithActivity activity root 1 False []
+                report.cleanupRemoved `shouldBe` []
+                map fst report.cleanupRetained `shouldBe` [path]
+                readFile file `shouldReturn` "preserve concurrent work\n"
+
+    describe "merged-only worktree GC and legacy recovery" do
         it "simulates verified legacy adoption without registry or lock writes" $
             withTempGitRepo \repo ->
             withTempDir "agent-home-" \home -> do
@@ -587,8 +606,7 @@ spec = describe "Agent.CLI.Worktree" do
                 path <- addManagedWorktree repo root "2026-08-20-00000001"
                 now <- getCurrentTime
                 let activity = pure (Right (Map.singleton path (Right (addUTCTime (-8 * 86400) now))))
-                writeFile (toFilePath (path </> fromFilePath ".gitignore")) "cache\n"
-                writeFile (toFilePath (path </> fromFilePath "cache")) (replicate 10000 'x')
+                addIgnoredBuildDirectory repo path
                 before <- git repo ["show-ref"]
                 report <- gcWorktreesWithActivity activity root 7 True []
                 report.cleanupRetained `shouldBe` []
@@ -601,7 +619,7 @@ spec = describe "Agent.CLI.Worktree" do
                 doesFileExist (repo </> fromFilePath ".git/haskell-agent-worktree.lock") `shouldReturn` False
                 git repo ["show-ref"] `shouldReturn` before
 
-        it "adopts and collects legacy dirty work with its original activity and restores it" $
+        it "retains legacy dirty work without adopting or modifying it" $
             withTempGitRepo \repo ->
             withTempDir "agent-home-" \home -> do
                 let root = worktreeRoot home
@@ -617,17 +635,13 @@ spec = describe "Agent.CLI.Worktree" do
                 writeFile (file ".gitignore") "cache\n"
                 writeFile (file "cache") "excluded\n"
                 report <- gcWorktreesWithActivity activity root 7 False []
-                report.cleanupRemoved `shouldBe` [path]
-                readRecord root path >>= \case
-                    Right (Just record) -> do
-                        record.recordLastActivity `shouldBe` old
-                        record.recordState `shouldBe` "collected"
-                    other -> expectationFailure (show other)
-                restoreManagedWorktree root path `shouldReturn` Right ()
+                report.cleanupRemoved `shouldBe` []
+                map fst report.cleanupRetained `shouldBe` [path]
+                readRecord root path `shouldReturn` Right Nothing
                 git path ["show", ":README"] `shouldReturn` "staged"
                 readFile (file "README") `shouldReturn` "unstaged\n"
                 readFile (file "notes") `shouldReturn` "untracked\n"
-                Directory.doesFileExist (file "cache") `shouldReturn` False
+                Directory.doesFileExist (file "cache") `shouldReturn` True
 
         it "retains legacy unknown activity and recent session activity without adoption" $
             withTempGitRepo \repo ->
@@ -716,7 +730,7 @@ spec = describe "Agent.CLI.Worktree" do
                 restoreManagedWorktree root path `shouldReturn` Right ()
                 doesDirectoryExist path `shouldReturn` True
 
-        it "bounds eligible attempts even when every candidate fails preflight" $
+        it "bounds background eligible attempts even when activity revalidation fails" $
             withTempGitRepo \repo ->
             withTempDir "agent-home-" \home -> do
                 let root = worktreeRoot home
@@ -724,12 +738,50 @@ spec = describe "Agent.CLI.Worktree" do
                     path <- addManagedWorktree repo root ("2026-08-20-0000000" <> show n)
                     enrollWorktree root path `shouldReturn` Right ()
                     ageRecord root path
-                    _ <- git path ["update-index", "--assume-unchanged", "README"]
                     pure path) [1 :: Int .. 9]
-                report <- gcWorktrees root 7 False []
+                reads <- newIORef (0 :: Int)
+                let activity = do
+                        count <- readIORef reads
+                        modifyIORef' reads (+1)
+                        pure (if count == 0 then Right Map.empty else Left "activity unavailable")
+                report <- gcWorktreesWithActivity activity root 7 False []
                 report.cleanupRemoved `shouldBe` []
-                length (filter ((== "pass budget exhausted") . snd) report.cleanupRetained) `shouldBe` 1
+                length report.cleanupNotExamined `shouldBe` 1
                 mapM_ (\path -> doesDirectoryExist path `shouldReturn` True) paths
+
+        it "manual collection examines every candidate and reports progress beyond eight attempts" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                paths <- mapM (\number -> do
+                    path <- addManagedWorktree repo root ("2026-08-20-0000000" <> show number)
+                    enrollWorktree root path `shouldReturn` Right ()
+                    ageRecord root path
+                    pure path) [1 :: Int .. 9]
+                progress <- newIORef []
+                report <- gcWorktreesManuallyWithActivity
+                    (pure (Right Map.empty)) root 7 False []
+                    (\path -> modifyIORef' progress (path :))
+                report.cleanupRemoved `shouldMatchList` paths
+                report.cleanupNotExamined `shouldBe` []
+                report.cleanupFailures `shouldBe` []
+                readIORef progress >>= (`shouldMatchList` paths)
+
+        it "retains unique committed work even after the former seven-day expiry" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                writeFile (toFilePath (path </> fromFilePath "unique")) "unmerged work\n"
+                _ <- git path ["add", "unique"]
+                _ <- git path ["commit", "-m", "Unmerged work"]
+                activity <- savedActivityDaysAgo path 30
+                report <- gcWorktreesWithActivity activity root 7 False []
+                report.cleanupRemoved `shouldBe` []
+                report.cleanupEligible `shouldBe` []
+                map fst report.cleanupRetained `shouldBe` [path]
+                readFile (toFilePath (path </> fromFilePath "unique"))
+                    `shouldReturn` "unmerged work\n"
 
         it "enrollment starts a fresh inactivity window" $
             withTempGitRepo \repo ->
@@ -770,13 +822,26 @@ spec = describe "Agent.CLI.Worktree" do
                 report <- gcWorktrees root 7 False []
                 report.cleanupRetained `shouldBe` [(path, "recent activity")]
 
+        it "collects merged clean checkouts containing only recognized ignored build output" $
+            withTempGitRepo \repo ->
+            withTempDir "agent-home-" \home -> do
+                let root = worktreeRoot home
+                path <- addManagedWorktree repo root "2026-08-20-00000001"
+                addIgnoredBuildDirectory repo path
+                enrollWorktree root path `shouldReturn` Right ()
+                ageRecord root path
+                report <- gcWorktrees root 7 False []
+                report.cleanupFailures `shouldBe` []
+                report.cleanupRetained `shouldBe` []
+                report.cleanupRemoved `shouldBe` [path]
+                doesDirectoryExist path `shouldReturn` False
+
         it "dry runs preserve refs, registry, index, and checkout while estimating ignored bytes" $
             withTempGitRepo \repo ->
             withTempDir "agent-home-" \home -> do
                 let root = worktreeRoot home
                 path <- addManagedWorktree repo root "2026-08-20-00000001"
-                writeFile (toFilePath (path </> fromFilePath ".gitignore")) "cache\n"
-                writeFile (toFilePath (path </> fromFilePath "cache")) (replicate 10000 'x')
+                addIgnoredBuildDirectory repo path
                 enrollWorktree root path `shouldReturn` Right ()
                 ageRecord root path
                 before <- readRecord root path
@@ -790,7 +855,7 @@ spec = describe "Agent.CLI.Worktree" do
                 git path ["status", "--porcelain"] `shouldReturn` status
                 doesDirectoryExist path `shouldReturn` True
 
-        it "collects dirty unique work and restores staged, unstaged and untracked files, not ignored data" $
+        it "restores a legacy snapshot with staged, unstaged and untracked files, not ignored data" $
             withTempGitRepo \repo ->
             withTempDir "agent-home-" \home -> do
                 let root = worktreeRoot home
@@ -809,9 +874,12 @@ spec = describe "Agent.CLI.Worktree" do
                 status <- git path ["status", "--porcelain", "--untracked-files=all"]
                 enrollWorktree root path `shouldReturn` Right ()
                 ageRecord root path
-                report <- gcWorktrees root 7 False []
-                report.cleanupRetained `shouldBe` []
-                report.cleanupRemoved `shouldBe` [path]
+                snapshot <- Snapshot.createSnapshot path >>= either
+                    (fail . Text.unpack) pure
+                modifyRecord root path (Right . fmap (\record ->
+                    record { recordSnapshot = Just snapshot, recordState = "collected" }))
+                    `shouldReturn` Right ()
+                _ <- git repo ["worktree", "remove", "--force", toFilePath path]
                 doesDirectoryExist path `shouldReturn` False
                 let originalBranch = toFilePath (takeFileName path)
                 _ <- git repo ["branch", "-f", originalBranch, "HEAD"]
@@ -957,6 +1025,16 @@ ageRecord root path = do
     modifyRecord root path (Right . fmap (\record ->
         record { recordLastActivity = addUTCTime (-8 * 86400) now }))
         `shouldReturn` Right ()
+
+addIgnoredBuildDirectory :: OsPath -> OsPath -> IO ()
+addIgnoredBuildDirectory repo path = do
+    writeFile (toFilePath (path </> fromFilePath ".gitignore")) "dist-newstyle/\n"
+    _ <- git path ["add", ".gitignore"]
+    _ <- git path ["commit", "-m", "Exclude generated build directory"]
+    _ <- git repo ["merge", "--ff-only", toFilePath (takeFileName path)]
+    let directory = path </> fromFilePath "dist-newstyle"
+    createDirectoryIfMissing True directory
+    writeFile (toFilePath (directory </> fromFilePath "output")) (replicate 10000 'x')
 
 releaseLease :: Either Text (Maybe WorktreeLease) -> IO ()
 releaseLease (Right (Just lease)) = releaseWorktreeLease lease

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -115,6 +115,9 @@ import qualified Agent.CLI.TUIMeasuredViewportSpec as TUIMeasuredViewportSpec
 import qualified Agent.CLI.UsageSpec as UsageSpec
 import qualified Agent.CLI.WebLspSpec as WebLspSpec
 import qualified Agent.CLI.WorktreeSpec as WorktreeSpec
+import qualified Agent.CLI.WorktreeCleanSpec as WorktreeCleanSpec
+import qualified Agent.CLI.WorktreeIgnoredSpec as WorktreeIgnoredSpec
+import qualified Agent.CLI.WorktreeIncorporationSpec as WorktreeIncorporationSpec
 import qualified Agent.CLI.WorktreeAdminSpec as WorktreeAdminSpec
 import qualified Agent.CLI.Worktree.SnapshotSpec as SnapshotSpec
 import qualified Agent.CLI.Worktree.ProvenanceSpec as ProvenanceSpec
@@ -250,6 +253,9 @@ specs = do
     UsageSpec.spec
     WebLspSpec.spec
     WorktreeSpec.spec
+    WorktreeCleanSpec.spec
+    WorktreeIgnoredSpec.spec
+    WorktreeIncorporationSpec.spec
     WorktreeAdminSpec.spec
     ProvenanceSpec.spec
     SnapshotSpec.spec


### PR DESCRIPTION
## Summary
- Collect only stale, verified-clean worktrees whose HEAD is incorporated into another branch or a verified merged PR; default minimum inactivity is one day. Dirty or unique work no longer expires solely by age.
- Let explicit GC inspect every candidate with progress reporting; retain bounded background maintenance and distinguish unexamined candidates from retained ones.
- Prepare recovery from existing Git objects instead of repeatedly snapshotting clean files. Preserve supported private history, including inactive AUTO_MERGE and REBASE_HEAD records, and revalidate before non-forced removal.
- Permit narrowly verified duplicate ignored files and Nix result links; report the precise path for unsupported metadata or ignored content. Differing local settings remain protected.

## Validation
- 148 focused Hspec examples passed across Worktree (64), Clean (18), Ignored (10), Incorporation (14), Config (39), and WorktreeAdmin (3), using GHCi inside the Nix development environment. Latest integrated Worktree/Clean run: 82 examples, zero failures.
- `cabal2nix .` regeneration matches `packages/agent-cli/package.nix`; `git diff --check` passes.
- Read-only live pass: 197 examined in 26.498 seconds; 11 eligible, 186 retained, zero failed or unexamined. No user worktrees deleted.
- Remaining retention: 63 recent, 43 dirty, 41 differing settings, 17 missing provenance, 13 busy/unsafe locks, and 9 other safety exclusions. Ignored local-settings backup is not implemented by this change.

## Performance
Retained benchmark and reproduction commands: `packages/agent-cli/benchmark/WorktreeCollection.md` and `.hs`.

Apple Silicon macOS, GHC 9.10.3, optimized `-O2 -threaded -rtsopts` build inside `nix develop`, `+RTS -T`, controlled environment, median of three samples. Fixtures use committed 1,024-byte files; setup is excluded and results are forced.

| Workload | Old elapsed | New elapsed | Old parent CPU | New parent CPU | Old parent allocation | New parent allocation |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 100 files, final repetition | 10,276.352 ms | 632.616 ms | 687.667 ms | 43.874 ms | 241,266,840 B | 44,630,040 B |
| 1,000 files | 98,508.686 ms | 940.249 ms | 6,700.591 ms | 94.700 ms | 2,301,874,480 B | 282,592,184 B |

The final 100-file repetition shows 16.2x faster **recovery preparation**, not whole-GC throughput, and 81.5% less parent allocation. The 1,000-file new-path repetition was 949.621 ms. A 3,000-file new-path measurement is recorded, but the interrupted old-path measurement is not claimed. The final metadata/ignored-path changes were remeasured at 100 files; see the document for measurement chronology and boundaries. Git subprocess CPU/allocation, discovery, incorporation checks, directory-size estimation, and actual removal are outside the corresponding parent/stage measurements.
