### PR TITLE
Display terminal planning questions in a contextual panel

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/PromptHooks.hs
+++ b/packages/agent-cli/src/Agent/CLI/PromptHooks.hs
@@ -14,6 +14,8 @@ import Agent.CLI.Secret (sanitizeSecretPromptText)
 import Agent.CLI.TUI.App
     ( FullscreenRuntime
     , requestFullscreenChoiceWithBody
+    , requestFullscreenPlanningChoice
+    , requestFullscreenPlanningText
     , requestFullscreenSecret
     , requestFullscreenText
     , showFullscreenToolImage
@@ -89,18 +91,14 @@ fullscreenAwarePlanHooks runtimeRef hooks = PlanModeHooks
                 notifyAttention stderr InputRequested
                 case options of
                     [] ->
-                        requestFullscreenText
+                        requestFullscreenPlanningText
                             runtime
-                            "Planning question"
                             question
-                            ""
                             >>= pure . nonBlank
                     choices ->
-                        requestFullscreenChoiceWithBody
+                        requestFullscreenPlanningChoice
                             runtime
-                            "Planning question"
                             question
-                            0
                             [(choice, "") | choice <- choices]
                             >>= pure . (>>= (`atMay` choices))
     }

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -72,6 +72,8 @@ module Agent.CLI.TUI.App
     , requestFullscreenPermission
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
+    , requestFullscreenPlanningChoice
+    , requestFullscreenPlanningText
     , requestFullscreenDocument
     , requestFullscreenThemeChoice
     , requestFullscreenFilterChoice

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -1100,6 +1100,9 @@ handleOverlayMouseDown state name button =
          , state.appUi.uiPermission
          , state.appMetaConsole
          ) of
+        (Just (PendingDialog _ prompt), _, _, _)
+            | prompt.textInputMode == TextInputPlanning ->
+                handlePlanningMouseDown name button
         (Just _, _, _, _) ->
             case button of
                 V.BScrollUp ->
@@ -1115,6 +1118,9 @@ handleOverlayMouseDown state name button =
             pure ()
         (Nothing, Nothing, Nothing, Nothing) ->
             handleNormalMouseDown name button
+        (Nothing, Just (PendingDialog _ choice), _, _)
+            | choice.choicePresentation == ChoicePlanning ->
+                handlePlanningMouseDown name button
         (Nothing, Just _, _, _) ->
             handleChoiceMouseDown name button
         (Nothing, Nothing, Just _, _) ->
@@ -1172,6 +1178,26 @@ handleNormalMouseDown name button =
         (link@MarkdownLink{}, V.BLeft) ->
             Composer.handleControlMouseDown link
         _ -> handleMouseDown name button
+
+-- | Wheel events belong to the surface under the pointer. A question must
+-- not intercept scrolling intended for the explanation above it.
+handlePlanningMouseDown :: Name -> V.Button -> EventM Name AppState ()
+handlePlanningMouseDown name button =
+    case (name, button) of
+        (PlanningSubmit, V.BLeft) ->
+            Composer.handleControlMouseDown PlanningSubmit
+        (ChoiceRow index, V.BLeft) ->
+            Composer.handleControlMouseDown (ChoiceRow index)
+        (_, V.BScrollUp) -> scrollPlanningSurface (-mouseScrollLines)
+        (_, V.BScrollDown) -> scrollPlanningSurface mouseScrollLines
+        _ -> pure ()
+  where
+    scrollPlanningSurface amount = case name of
+        PlanningPanel -> vScrollBy (viewportScroll OverlayViewport) amount
+        PlanningSubmit -> vScrollBy (viewportScroll OverlayViewport) amount
+        OverlayViewport -> vScrollBy (viewportScroll OverlayViewport) amount
+        ChoiceRow _ -> vScrollBy (viewportScroll OverlayViewport) amount
+        _ -> scrollConversationBy amount
 
 handleChoiceMouseDown
     :: Name
@@ -1278,6 +1304,10 @@ handleResizeEvent = do
     state <- get
     when (state.appTerminalFocus /= TerminalUnfocused) $
         getVtyHandle >>= liftIO . V.refresh
+    case choiceOverlay state of
+        Just choice | choice.choicePresentation == ChoicePlanning ->
+            makeVisible (ChoiceRow choice.choiceIndex)
+        _ -> pure ()
     queueConversationReflow
 
 handleInputEvent :: V.Event -> EventM Name AppState ()

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -186,7 +186,7 @@ import Agent.CLI.TUI.App.Runtime
 import Agent.CLI.TUI.App.Mailbox
 import Agent.CLI.TUI.App.Reduce
 import Agent.CLI.TUI.App.Navigation
-    ( mouseScrollLines, historyBlock, selectedBlock )
+    ( mouseScrollLines, historyBlock, selectedBlock, scrollConversationPage )
 
 handleResumeKey :: V.Event -> EventM Name AppState ()
 handleResumeKey event = do
@@ -485,6 +485,18 @@ handleStaticChoiceKey :: V.Event -> EventM Name AppState ()
 handleStaticChoiceKey event = do
     choice <- gets choiceOverlay
     case (choice, event) of
+        (Just current, V.EvKey V.KPageUp [])
+            | current.choicePresentation == ChoicePlanning ->
+                scrollConversationPage Up
+        (Just current, V.EvKey V.KPageDown [])
+            | current.choicePresentation == ChoicePlanning ->
+                scrollConversationPage Down
+        (Just current, V.EvKey V.KUp [V.MMeta])
+            | current.choicePresentation == ChoicePlanning ->
+                scrollNotes (-1)
+        (Just current, V.EvKey V.KDown [V.MMeta])
+            | current.choicePresentation == ChoicePlanning ->
+                scrollNotes 1
         (Just current, V.EvKey V.KUp [])
             | current.choicePresentation == ChoiceDocument ->
                 scrollNotes (-1)
@@ -537,6 +549,11 @@ handleStaticChoiceKey event = do
                         <$> state.appChoice
                 }
         when previewingTheme invalidateCache
+        current <- gets choiceOverlay
+        case current of
+            Just choice | choice.choicePresentation == ChoicePlanning ->
+                makeVisible (ChoiceRow choice.choiceIndex)
+            _ -> pure ()
 
 handleFilterChoiceKey :: V.Event -> EventM Name AppState ()
 handleFilterChoiceKey event = case event of
@@ -642,11 +659,19 @@ confirmChoiceAt index = do
                             fmap (\overlay -> overlay { choiceIndex = index })
                                 <$> current.appChoice
                         }
-                resolveChoice True
+                if choice.choicePresentation == ChoicePlanning
+                    then makeVisible (ChoiceRow index)
+                    else resolveChoice True
         _ -> pure ()
 
 activateControl :: Name -> EventM Name AppState ()
 activateControl = \case
+    PlanningSubmit -> do
+        prompt <- gets textOverlay
+        case prompt of
+            Just current | current.textInputMode == TextInputPlanning ->
+                resolveTextPrompt True
+            _ -> resolveChoice True
     ComposerModel ->
         Composer.handlePromptControlClick
             applyLocalUiEventWith
@@ -695,6 +720,7 @@ activateQuickStartCommand command =
 
 isInteractiveControl :: Name -> Bool
 isInteractiveControl = \case
+    PlanningSubmit -> True
     ComposerModel -> True
     ComposerEffort -> True
     ComposerMode -> True
@@ -891,10 +917,12 @@ handleTextPromptKey event = case event of
             _ <- handleCtrlC
             when state.appUi.uiRunning (resolveTextPrompt False)
     V.EvKey V.KEnter [] -> resolveTextPrompt True
+    V.EvKey V.KUp [V.MMeta] -> scrollPromptDetails (-1)
+    V.EvKey V.KDown [V.MMeta] -> scrollPromptDetails 1
     V.EvKey V.KPageUp [] ->
-        vScrollPage (viewportScroll OverlayViewport) Up
+        scrollPromptPage Up
     V.EvKey V.KPageDown [] ->
-        vScrollPage (viewportScroll OverlayViewport) Down
+        scrollPromptPage Down
     V.EvMouseDown _ _ V.BScrollUp _ ->
         vScrollBy (viewportScroll OverlayViewport) (-mouseScrollLines)
     V.EvMouseDown _ _ V.BScrollDown _ ->
@@ -908,6 +936,20 @@ handleTextPromptKey event = case event of
                         <$> state.appTextPrompt
                 }
 
+  where
+    scrollPromptDetails amount = do
+        prompt <- gets textOverlay
+        case prompt of
+            Just current | current.textInputMode == TextInputPlanning ->
+                vScrollBy (viewportScroll OverlayViewport) amount
+            _ -> pure ()
+    scrollPromptPage direction = do
+        prompt <- gets textOverlay
+        case prompt of
+            Just current | current.textInputMode == TextInputPlanning ->
+                scrollConversationPage direction
+            _ -> vScrollPage (viewportScroll OverlayViewport) direction
+
 -- | Apply one text-editing key to a fullscreen prompt overlay.
 --
 -- Cursor offsets are normalized to grapheme boundaries before and after the
@@ -916,7 +958,7 @@ applyTextPromptEdit :: V.Event -> TextOverlay -> Maybe TextOverlay
 applyTextPromptEdit event prompt = case event of
     V.EvKey V.KEnter [V.MShift] ->
         Just $
-            if prompt.textInputMode == TextInputPlain
+            if prompt.textInputMode /= TextInputSecret
                 then insert "\n"
                 else prompt
     V.EvKey V.KBS [] ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -946,6 +946,25 @@ requestFullscreenPermission runtime workspace call = do
     enqueueAppEvent runtime (AppAskPermission summary reply)
     atomically (readTMVar reply)
 
+requestFullscreenPlanningText :: FullscreenRuntime -> Text -> IO (Maybe Text)
+requestFullscreenPlanningText runtime body = do
+    reply <- newEmptyTMVarIO
+    enqueueAppEvent runtime
+        (AppAskText TextInputPlanning "Planning question" body "" reply)
+    atomically (readTMVar reply)
+
+-- | Ask in the conversation layout, without obscuring the agent's explanation.
+requestFullscreenPlanningChoice
+    :: FullscreenRuntime
+    -> Text
+    -> [(Text, Text)]
+    -> IO (Maybe Int)
+requestFullscreenPlanningChoice runtime body rows = do
+    reply <- newEmptyTMVarIO
+    enqueueAppEvent runtime
+        (AppAskChoice ChoicePlanning "Planning question" body 0 rows reply)
+    atomically (readTMVar reply)
+
 requestFullscreenThemeChoice
     :: FullscreenRuntime
     -> Int

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -66,6 +66,10 @@ import Agent.CLI.TUI.Types
     ( AppState(appMetaConsole, appMotionElapsedMillis, appTerminalFocus,
                appAgentEntries, appRuntime, appImagePreviews, appUi),
       choiceOverlay, resumeOverlay, textOverlay,
+      ChoiceOverlay(choicePresentation),
+      ChoicePresentation(ChoicePlanning),
+      TextOverlay(textInputMode),
+      TextInputMode(TextInputPlanning),
       activeTheme,
       FullscreenRuntime(runtimeNativeImagePreviews, runtimeWaveTrough,
                         runtimeColor, runtimeMotionMode),
@@ -220,9 +224,13 @@ drawApp state =
             Nothing ->
                 case (textOverlay state, choiceOverlay state, state.appUi.uiPermission) of
                     (Just prompt, _, _) ->
-                        drawTextPrompt state prompt : dimmedMainLayers
+                        if prompt.textInputMode == TextInputPlanning
+                            then mainLayers
+                            else drawTextPrompt state prompt : dimmedMainLayers
                     (Nothing, Just choice, _) ->
-                        drawChoice state choice : dimmedMainLayers
+                        if choice.choicePresentation == ChoicePlanning
+                            then mainLayers
+                            else drawChoice state choice : dimmedMainLayers
                     (Nothing, Nothing, Just permission) ->
                         drawPermission state permission : dimmedMainLayers
                     (Nothing, Nothing, Nothing) ->
@@ -256,6 +264,16 @@ drawMain state =
                 , drawFollowStatus state.appUi
                 , drawLiveTodos (activeConversationUi state)
                 , drawPromptActivity state
+                , case textOverlay state of
+                    Just prompt
+                        | prompt.textInputMode == TextInputPlanning ->
+                            drawTextPrompt state prompt
+                    _ -> emptyWidget
+                , case choiceOverlay state of
+                    Just choice
+                        | choice.choicePresentation == ChoicePlanning ->
+                            drawChoice state choice
+                    _ -> emptyWidget
                 , Composer.drawComposer state
                 , drawFooter state
                 ]

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -71,14 +71,15 @@ import Agent.CLI.TUI.Types
       choiceOverlay,
       selectedChoiceIndex,
       ChoicePresentation(ChoiceOnboarding, ChoiceDialog, ChoiceDocument,
-                         ChoiceTheme),
+                         ChoiceTheme, ChoicePlanning),
       AppState(appRuntime,
                appDictation, appTextPrompt, appMetaConsole,
                appMotionElapsedMillis, appUi, appTerminalFocus),
       activeTheme,
       FullscreenRuntime(runtimeMotionMode, runtimeColor, runtimeWaveTrough),
       Name(ChoiceRow, PermissionRow, ResumeViewport,
-           ResumeSearchCursor, ResumeRow, OverlayViewport, MarkdownLink,
+           ResumeSearchCursor, ResumeRow, OverlayViewport, PlanningPanel,
+           PlanningSubmit, MarkdownLink,
            OverlayCursor, MetaConsoleCursor) )
 import Agent.CLI.Terminal ()
 import Agent.CLI.Timestamp ()
@@ -128,6 +129,7 @@ import Brick
       AttrName,
       Location(Location),
       Context(availHeight, availWidth),
+      Result(image),
       Size(Fixed, Greedy),
       VScrollBarOrientation(OnRight),
       ViewportType(Vertical),
@@ -202,7 +204,7 @@ import qualified Agent.TUI.Theme as Theme
       waveTroughForTheme )
 import qualified Agent.CLI.TUI.Transcript as Transcript ()
 import qualified Graphics.Vty as V
-    ( char )
+    ( char, imageHeight )
 import qualified Graphics.Vty.CrossPlatform as Vty ()
 
 
@@ -530,6 +532,7 @@ drawChoice appState choice
     | choice.choiceSearch = drawFilterChoice appState choice
     | otherwise = case choice.choicePresentation of
         ChoiceDialog -> drawDialogChoice appState choice
+        ChoicePlanning -> drawPlanningChoice appState choice
         ChoiceDocument -> drawDialogChoice appState choice
         ChoiceOnboarding -> drawOnboardingChoice appState choice
         ChoiceTheme -> drawDialogChoice appState choice
@@ -759,6 +762,76 @@ listAt index values
         value : _ -> Just value
         [] -> Nothing
 
+-- | Planning questions occupy their own retained section instead of obscuring
+-- the transcript. Measure only plain text here (no named extents or cursors),
+-- so short questions shrink to their contents while long questions remain
+-- independently scrollable within half the available terminal height.
+drawPlanningChoice :: AppState -> ChoiceOverlay -> Widget Name
+drawPlanningChoice appState choice =
+    Widget Greedy Fixed do
+        context <- getContext
+        let contentWidth = max 1 (context.availWidth - 5)
+            optionWidth = max 1 (contentWidth - 2)
+            prompt = terminalTxtWrap choice.choiceBody
+            rowBody (label, detail) =
+                terminalTxtWrap $
+                    label <> if Text.null detail then "" else "\n" <> detail
+            rows = choiceVisibleRows choice
+            compactFooter = context.availWidth < 60
+            footer =
+                vBox
+                    [ hBox
+                        [ clickable PlanningSubmit $
+                            withAttr Theme.strongAttr $
+                                txt (if compactFooter then "[Submit]" else "[Submit answer]")
+                        , terminalTxt $
+                            if compactFooter
+                                then " Enter · ↑/↓ choose · Esc"
+                                else "  Enter submit · ↑/↓ choose · Esc cancel"
+                        ]
+                    , terminalTxt "PgUp/PgDn history · Alt+↑/↓ details"
+                    ]
+        promptMeasurement <- render (hLimit contentWidth prompt)
+        rowMeasurements <- traverse
+            (\(_, row) -> render (hLimit optionWidth (rowBody row)))
+            rows
+        let naturalHeight =
+                V.imageHeight promptMeasurement.image + 1
+                    + sum (map (V.imageHeight . (.image)) rowMeasurements)
+            panelHeight = min
+                (max 1 (context.availHeight `div` 2))
+                (naturalHeight + 4)
+            contentHeight = max 1 (panelHeight - 4)
+            optionRow (index, row) =
+                let content = hBox
+                        [ txt (if choice.choiceIndex == index then "› " else "  ")
+                        , rowBody row
+                        ]
+                    styled
+                        | choice.choiceIndex == index =
+                            withAttr Theme.selectedAttr content
+                        | otherwise = content
+                in clickable (ChoiceRow index) styled
+        render $
+            vLimit panelHeight $
+                clickable PlanningPanel $
+                    overrideAttr Border.borderAttr Theme.borderActiveAttr $
+                        withBorderStyle unicodeRounded $
+                            borderWithLabel
+                                (waitingOverlayLabel appState choice.choiceTitle) $
+                                padLeftRight 1 $
+                                    vBox
+                                        [ vLimit contentHeight $
+                                            withVScrollBarRenderer conversationScrollbarRenderer $
+                                                withVScrollBars OnRight $
+                                                    viewport OverlayViewport Vertical $
+                                                        vBox
+                                                            [ padBottom (Pad 1) prompt
+                                                            , vBox (map optionRow rows)
+                                                            ]
+                                        , withAttr Theme.footerAttr footer
+                                        ]
+
 drawDialogChoice :: AppState -> ChoiceOverlay -> Widget Name
 drawDialogChoice appState choice =
     centerLayer $
@@ -941,7 +1014,10 @@ waitingOverlayLabel state label =
         ]
 
 drawTextPrompt :: AppState -> TextOverlay -> Widget Name
-drawTextPrompt state prompt =
+drawTextPrompt state prompt
+    | prompt.textInputMode == TextInputPlanning =
+        drawPlanningText state prompt
+    | otherwise =
     centerLayer $
         hLimitPercent 82 $
             vLimitPercent 78 $
@@ -965,6 +1041,55 @@ drawTextPrompt state prompt =
                                                 padLeftRight 1 $
                                                     renderTextDraft prompt
                                     ]
+
+drawPlanningText :: AppState -> TextOverlay -> Widget Name
+drawPlanningText state prompt =
+    Widget Greedy Fixed do
+        context <- getContext
+        let contentWidth = max 1 (context.availWidth - 5)
+            maximumHeight = max 1 (context.availHeight `div` 2)
+            draftLimit = max 1 (min 3 ((maximumHeight - 6) `div` 2))
+            (draftRows, _) = Composer.wrapDraftWindow
+                draftLimit
+                (max 1 (contentWidth - 3))
+                prompt.textDraft
+                prompt.textCursor
+            draftHeight = min draftLimit (length draftRows)
+            body = terminalTxtWrap prompt.textBody
+            compactFooter = context.availWidth < 60
+        bodyMeasurement <- render (hLimit contentWidth body)
+        let bodyHeight = max 1 $
+                min (V.imageHeight bodyMeasurement.image)
+                    (maximumHeight - 6 - draftHeight)
+        render $
+            vLimit maximumHeight $
+                clickable PlanningPanel $
+                    overrideAttr Border.borderAttr Theme.borderActiveAttr $
+                        withBorderStyle unicodeRounded $
+                            borderWithLabel
+                                (waitingOverlayLabel state prompt.textTitle) $
+                                padLeftRight 1 $
+                                    vBox
+                                        [ vLimit bodyHeight $
+                                            withVScrollBarRenderer conversationScrollbarRenderer $
+                                                withVScrollBars OnRight $
+                                                    viewport OverlayViewport Vertical body
+                                        , borderWithLabel (txt " Answer ") $
+                                            padLeftRight 1 $
+                                                vLimit draftLimit (renderTextDraft prompt)
+                                        , hBox
+                                            [ clickable PlanningSubmit $
+                                                withAttr Theme.strongAttr $
+                                                    txt (if compactFooter then "[Submit]" else "[Submit answer]")
+                                            , withAttr Theme.footerAttr $
+                                                terminalTxt $
+                                                    if compactFooter
+                                                        then " Enter · Esc cancel"
+                                                        else "  Enter submit · Esc cancel"
+                                            ]
+                                        , withAttr Theme.footerAttr $
+                                            terminalTxt "PgUp/PgDn history · Alt+↑/↓ details"
+                                        ]
 
 drawMetaConsole :: AppState -> MetaConsoleOverlay -> Widget Name
 drawMetaConsole state overlay =
@@ -1062,6 +1187,7 @@ maskedSecretText value =
 textOverlayDisplayText :: TextOverlay -> Text
 textOverlayDisplayText prompt = case prompt.textInputMode of
     TextInputPlain -> prompt.textDraft
+    TextInputPlanning -> prompt.textDraft
     TextInputSecret -> maskedSecretText prompt.textDraft
 
 -- | Secret prompts are deliberately single-line. Plain overlays preserve
@@ -1069,6 +1195,7 @@ textOverlayDisplayText prompt = case prompt.textInputMode of
 normalizeTextOverlayInsertion :: TextInputMode -> Text -> Text
 normalizeTextOverlayInsertion = \case
     TextInputPlain -> id
+    TextInputPlanning -> id
     TextInputSecret -> Text.takeWhile \character ->
         character /= '\n' && character /= '\r'
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -94,6 +94,8 @@ data Name
     | ConversationReserve
     | ConversationImage !BlockId !Int
     | OverlayViewport
+    | PlanningPanel
+    | PlanningSubmit
     | ConversationBlock !AgentTarget !BlockId
     | ConversationChunkCache
         !AgentTarget
@@ -559,6 +561,7 @@ data AgentHover = AgentHover
 
 data ChoicePresentation
     = ChoiceDialog
+    | ChoicePlanning
     | ChoiceDocument
     | ChoiceOnboarding
     | ChoiceTheme
@@ -658,5 +661,6 @@ data MetaConsoleOverlay = MetaConsoleOverlay
 
 data TextInputMode
     = TextInputPlain
+    | TextInputPlanning
     | TextInputSecret
     deriving (Eq, Show)

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -732,6 +732,210 @@ spec = do
                     RowEnd width -> Text.replicate width " "
             rendered `shouldSatisfy` Text.isInfixOf marker
 
+    describe "planning question panel" do
+        it "keeps the explanation visible and wraps complete option descriptions" do
+            let explanation = "EXPLANATIONVISIBLE"
+                marker = "DESCRIPTIONEND"
+                ui = reduceUi (UiAssistantHistory explanation) initialUiState
+                size = (60, 36)
+            runtime <- newScriptRuntime ui
+            let initial = (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    { appUi = ui }
+                panel = (choiceOverlay False)
+                    { choicePresentation = ChoicePlanning
+                    , choiceTitle = "Planning question"
+                    , choiceBody = "Which candidate should be selected?"
+                    , choiceRows =
+                        [(Text.replicate 18 "complete " <> marker, "")]
+                    }
+                state = initial
+                    { appChoice = Just (PendingDialog (const (pure ())) panel) }
+                rendered = renderedAppText size state
+            length (drawApp state) `shouldBe` length (drawApp initial)
+            rendered `shouldSatisfy` Text.isInfixOf explanation
+            rendered `shouldSatisfy` Text.isInfixOf marker
+            rendered `shouldSatisfy` Text.isInfixOf "Planning question"
+
+        it "moves the focused option without submitting until Enter" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+                key value = FullscreenScriptVty (V.EvKey value [])
+            (_, focused) <- runFullscreenScriptWithState initial
+                [ FullscreenScriptApp
+                    (AppAskChoice ChoicePlanning "Planning question" "Choose" 0
+                        [("first", ""), ("second", "")] reply)
+                , key V.KDown
+                , FullscreenScriptHalt
+                ]
+            fmap ((.choiceIndex) . (.dialogOverlay)) focused.appChoice
+                `shouldBe` Just 1
+            atomically (tryReadTMVar reply) `shouldReturn` Nothing
+            (_, submitted) <- runFullscreenScriptWithState focused
+                [key V.KEnter, FullscreenScriptHalt]
+            atomically (tryReadTMVar reply) `shouldReturn` Just (Just 1)
+            isNothing submitted.appChoice `shouldBe` True
+
+        it "focuses clicked options without submitting them" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+                location = B.Location (0, 0)
+            (_, focused) <- runFullscreenScriptWithState initial
+                [ FullscreenScriptApp
+                    (AppAskChoice ChoicePlanning "Planning question" "Choose" 0
+                        [("first", ""), ("second", "")] reply)
+                , FullscreenScriptMouseDown (ChoiceRow 1) V.BLeft location
+                , FullscreenScriptMouseRelease (ChoiceRow 1) V.BLeft location
+                , FullscreenScriptHalt
+                ]
+            fmap ((.choiceIndex) . (.dialogOverlay)) focused.appChoice
+                `shouldBe` Just 1
+            atomically (tryReadTMVar reply) `shouldReturn` Nothing
+
+        it "submits the focused option with the explicit submit button" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            (_, submitted) <- runFullscreenScriptWithState
+                (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                [ FullscreenScriptApp
+                    (AppAskChoice ChoicePlanning "Planning question" "Choose" 1
+                        [("first", ""), ("second", "")] reply)
+                , FullscreenScriptMouseDown PlanningSubmit V.BLeft (B.Location (0, 0))
+                , FullscreenScriptMouseRelease PlanningSubmit V.BLeft (B.Location (0, 0))
+                , FullscreenScriptHalt
+                ]
+            atomically (tryReadTMVar reply) `shouldReturn` Just (Just 1)
+            isNothing submitted.appChoice `shouldBe` True
+
+        it "scrolls the conversation only when the mouse is outside the question panel" do
+            let ui = reduceUi
+                    (UiAssistantHistory (Text.unlines (replicate 100 "Earlier explanation.")))
+                    initialUiState
+            runtime <- newScriptRuntime ui
+            reply <- newEmptyTMVarIO
+            let initial = (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    { appUi = ui }
+            (_, panelScrolled) <- runFullscreenScriptWithState initial
+                [ FullscreenScriptApp
+                    (AppAskChoice ChoicePlanning "Planning question" "Choose" 0
+                        [("first", "")] reply)
+                , FullscreenScriptMouseDown (ChoiceRow 0) V.BScrollUp (B.Location (0, 0))
+                , FullscreenScriptHalt
+                ]
+            panelScrolled.appUi.uiFollow `shouldBe` True
+            (_, conversationScrolled) <- runFullscreenScriptWithState panelScrolled
+                [ FullscreenScriptMouseDown ConversationViewport V.BScrollUp (B.Location (0, 0))
+                , FullscreenScriptHalt
+                ]
+            conversationScrolled.appUi.uiFollow `shouldBe` False
+            atomically (tryReadTMVar reply) `shouldReturn` Nothing
+
+        it "pages the conversation without changing or submitting the answer" do
+            let ui = reduceUi
+                    (UiAssistantHistory
+                        (Text.unlines (replicate 100 "Earlier explanation.")))
+                    initialUiState
+            runtime <- newScriptRuntime ui
+            reply <- newEmptyTMVarIO
+            let initial = (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    { appUi = ui }
+            (_, scrolled) <- runFullscreenScriptWithState initial
+                [ FullscreenScriptApp
+                    (AppAskChoice ChoicePlanning "Planning question" "Choose" 0
+                        [("first", ""), ("second", "")] reply)
+                , FullscreenScriptVty (V.EvKey V.KPageUp [])
+                , FullscreenScriptHalt
+                ]
+            scrolled.appUi.uiFollow `shouldBe` False
+            fmap ((.choiceIndex) . (.dialogOverlay)) scrolled.appChoice
+                `shouldBe` Just 0
+            atomically (tryReadTMVar reply) `shouldReturn` Nothing
+
+        it "scrolls through an oversized option without losing its focus" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+                option = Text.unlines
+                    (replicate 30 "Detailed explanation." <> ["OPTIONTAIL"])
+            (_, frames, scrolled) <- runFullscreenScriptDetailed initial
+                ([ FullscreenScriptApp
+                    (AppAskChoice ChoicePlanning "Planning question" "Choose" 0
+                        [(option, "")] reply)
+                 ] <> replicate 40
+                    (FullscreenScriptVty (V.EvKey V.KDown [V.MMeta]))
+                   <> [FullscreenScriptHalt])
+            map renderedPictureText frames
+                `shouldSatisfy` any (Text.isInfixOf "OPTIONTAIL")
+            fmap ((.choiceIndex) . (.dialogOverlay)) scrolled.appChoice
+                `shouldBe` Just 0
+            atomically (tryReadTMVar reply) `shouldReturn` Nothing
+
+        it "keeps custom answers inline with the explanation" do
+            let explanation = "CUSTOMCONTEXT"
+                ui = reduceUi (UiAssistantHistory explanation) initialUiState
+                size = (80, 30)
+            runtime <- newScriptRuntime ui
+            let initial = (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    { appUi = ui }
+                overlay = (textOverlay "My answer" 9)
+                    { textInputMode = TextInputPlanning
+                    , textTitle = "Planning question"
+                    , textBody = "What should happen next?"
+                    }
+                state = initial
+                    { appTextPrompt =
+                        Just (PendingDialog (const (pure ())) overlay) }
+                rendered = renderedAppText size state
+            length (drawApp state) `shouldBe` length (drawApp initial)
+            rendered `shouldSatisfy` Text.isInfixOf explanation
+            rendered `shouldSatisfy` Text.isInfixOf "My answer"
+
+        it "edits and submits custom planning answers" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            (_, submitted) <- runFullscreenScriptWithState
+                (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                [ FullscreenScriptApp
+                    (AppAskText TextInputPlanning "Planning question"
+                        "What should happen next?" "My answer" reply)
+                , FullscreenScriptVty (V.EvKey (V.KChar '!') [])
+                , FullscreenScriptVty (V.EvKey V.KEnter [])
+                , FullscreenScriptHalt
+                ]
+            atomically (tryReadTMVar reply)
+                `shouldReturn` Just (Just "My answer!")
+            isNothing submitted.appTextPrompt `shouldBe` True
+
+        it "submits custom planning answers with the explicit submit button" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            (_, submitted) <- runFullscreenScriptWithState
+                (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                [ FullscreenScriptApp
+                    (AppAskText TextInputPlanning "Planning question"
+                        "What should happen next?" "My answer" reply)
+                , FullscreenScriptMouseDown PlanningSubmit V.BLeft (B.Location (0, 0))
+                , FullscreenScriptMouseRelease PlanningSubmit V.BLeft (B.Location (0, 0))
+                , FullscreenScriptHalt
+                ]
+            atomically (tryReadTMVar reply) `shouldReturn` Just (Just "My answer")
+            isNothing submitted.appTextPrompt `shouldBe` True
+
+        it "cancels the pending question with Escape" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            (_, cancelled) <- runFullscreenScriptWithState
+                (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                [ FullscreenScriptApp
+                    (AppAskChoice ChoicePlanning "Planning question" "Choose" 0
+                        [("first", "")] reply)
+                , FullscreenScriptVty (V.EvKey V.KEsc [])
+                , FullscreenScriptHalt
+                ]
+            atomically (tryReadTMVar reply) `shouldReturn` Just Nothing
+            isNothing cancelled.appChoice `shouldBe` True
+
     describe "pending dialogs" do
         it "keeps each reply through edits and resolves simultaneous dialogs in priority order" do
             runtime <- newScriptRuntime initialUiState


### PR DESCRIPTION
## Summary
- Display planning questions above the composer without obscuring the conversation.
- Wrap complete options and allow independent question and conversation scrolling.
- Separate option selection from explicit submission, with inline custom answers.
- Preserve selected-option visibility when resizing and use compact controls in narrow terminals.

## Validation
- 173 TUIAppSpec examples passed in GHCi, including 11 planning-panel regressions.
- Exercised the production fullscreen runtime in tmux at 100, 80, and 40 columns: long descriptions, selection, submission, conversation scrolling, custom answers, oversized details, cancellation, and resizing.
- git diff --check passed.