### PR TITLE
Preserve transcript follow when planning panels open

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -915,6 +915,8 @@ handleAskChoiceEvent presentation title body initial rows reply = do
             , appAgentHover = Nothing
             }
     vScrollToBeginning (viewportScroll OverlayViewport)
+    -- The inline panel reduces the transcript viewport on the next render.
+    when (presentation == ChoicePlanning) resolveConversationFollow
 
 handleAskFilterChoiceEvent
     :: Text
@@ -1047,6 +1049,7 @@ handleAskTextEvent mode title body initial reply = do
             , appAgentHover = Nothing
             }
     vScrollToBeginning (viewportScroll OverlayViewport)
+    when (mode == TextInputPlanning) resolveConversationFollow
 
 handleSuspendEvent
     :: IO a

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -733,6 +733,53 @@ spec = do
             rendered `shouldSatisfy` Text.isInfixOf marker
 
     describe "planning question panel" do
+        forM_ [False, True] \textPrompt ->
+            describe (if textPrompt then "custom answer" else "choice") do
+                forM_ [False, True] \following ->
+                    it (if following
+                        then "keeps the transcript tail visible when opening"
+                        else "preserves a manually scrolled transcript when opening") do
+                        let marker = "LATESTEXPLANATION"
+                            transcript = Text.unlines
+                                ([ "Earlier explanation row " <> Text.pack (show index)
+                                 | index <- [1 .. 100 :: Int]
+                                 ] <> [marker])
+                            ui = reduceUi (UiAssistantHistory transcript) initialUiState
+                            bounds = (80, 24)
+                        runtime <- newScriptRuntime ui
+                        choiceReply <- newEmptyTMVarIO
+                        textReply <- newEmptyTMVarIO
+                        let initial = (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                                { appUi = ui }
+                            prompt = if textPrompt
+                                then AppAskText TextInputPlanning "Planning question"
+                                    "Describe the preferred approach." "" textReply
+                                else AppAskChoice ChoicePlanning "Planning question"
+                                    "Choose the preferred approach." 0
+                                    [("First approach", ""), ("Second approach", "")] choiceReply
+                            scroll = if following then [] else
+                                [FullscreenScriptMouseDown ConversationViewport
+                                    V.BScrollUp (B.Location (0, 0))]
+                        (_, frames, finalState) <- runFullscreenScriptDetailedAt bounds initial
+                            (scroll <> [FullscreenScriptApp prompt, FullscreenScriptHalt])
+                        let rendered = map (renderedPictureTextAt bounds) frames
+                        rendered `shouldSatisfy` (not . null)
+                        take 1 rendered `shouldSatisfy` all (Text.isInfixOf marker)
+                        last rendered `shouldSatisfy` Text.isInfixOf "Planning question"
+                        finalState.appUi.uiFollow `shouldBe` following
+                        if following
+                            then last rendered `shouldSatisfy` Text.isInfixOf marker
+                            else do
+                                last rendered `shouldSatisfy` (not . Text.isInfixOf marker)
+                                let transcriptRows =
+                                        filter (Text.isInfixOf "Earlier explanation row")
+                                            . Text.lines
+                                    before = transcriptRows (rendered !! 1)
+                                    after = transcriptRows (last rendered)
+                                before `shouldSatisfy` (not . null)
+                                after `shouldSatisfy` (not . null)
+                                take 1 after `shouldBe` take 1 before
+
         it "keeps the explanation visible and wraps complete option descriptions" do
             let explanation = "EXPLANATIONVISIBLE"
                 marker = "DESCRIPTIONEND"


### PR DESCRIPTION
## Summary
- Address the scroll-follow feedback on #1166: opening either planning panel keeps the latest explanation visible.
- Preserve the current position when the user has manually scrolled up.
- Add four frame-based regressions covering choice/custom-answer panels with follow enabled and disabled.

## Validation
- GHCi: 177 TUIAppSpec examples passed.
- Baseline verification: both new follow-tail tests fail without the fix; both manual-scroll tests pass.
- Live production fullscreen runtime in tmux at 80x24: latest explanation remains visible after delayed choice and text panel insertion; submission and cancellation work.
- git diff --check passed.

Feedback: https://github.com/digitallyinduced/haskell-agent/pull/1166#discussion_r3962299921