### PR TITLE
Log slow session and runtime cleanup steps

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -85,6 +85,7 @@ import Agent.CLI.Status
     )
 import Agent.CLI.Terminal ( resolveColor )
 import Agent.CLI.Worktree ( isUnderWorktreeRoot, worktreeRoot )
+import Agent.ResourceScope (logSlowCleanup)
 import Agent.Tools.Types (defaultToolEnv)
 import Agent.Tools.ResourceArbiter
     ( newToolResourceArbiter, closeToolResourceArbiter )
@@ -271,13 +272,16 @@ runAgentWithRestarts options =
                         (runAgentWithRuntime
                             processRuntime foregroundRunMode options)
                         `finally`
-                            (closeToolResourceArbiter toolResourceArbiter
-                                `finally` closeSessionThreadManager sessionThreads
+                            (logSlowCleanup "tool resource arbiter"
+                                (closeToolResourceArbiter toolResourceArbiter)
+                                `finally` logSlowCleanup "session thread manager"
+                                    (closeSessionThreadManager sessionThreads)
                                 `finally`
-                                    (MCP.closeMcpSupervisor
-                                        mcpSupervisor
+                                    (logSlowCleanup "MCP supervisor"
+                                        (MCP.closeMcpSupervisor mcpSupervisor)
                                         `finally`
-                                            closeIntegrationSupervisor
-                                                integrationSupervisor)))
+                                            logSlowCleanup "integration supervisor"
+                                                (closeIntegrationSupervisor
+                                                    integrationSupervisor))))
         (pure DevQuit)
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -112,6 +112,7 @@ import Agent.Provider (Provider(OpenAIProvider))
 import Agent.ResourceScope
     ( allocateResource
     , allocateFourResourcesConcurrently
+    , logSlowCleanup
     , releaseResource
     , withResourceScope
     )
@@ -203,7 +204,7 @@ runAgentTools request = withResourceScope \resourceScope -> do
                 toolStartup
                 toolModelRuntime
                 collaborationRuntime)
-            (.scratchCleanup)
+            (logSlowCleanup "session temporary resources" . (.scratchCleanup))
     let scratchRuntime =
             acquiredScratchRuntime
                 { scratchCleanup = releaseResource scratchKey }
@@ -222,29 +223,31 @@ runAgentTools request = withResourceScope \resourceScope -> do
                         collaborationRuntime
                         scratchRuntime
                         integrationRuntime)
-                    (.runtimeCloseMcp)
+                    (logSlowCleanup "session MCP resources" . (.runtimeCloseMcp))
                     (acquireLocalToolRuntime
                         request
                         toolModelRuntime
                         toolHostHooks
                         collaborationRuntime
                         scratchRuntime)
-                    (.localCoding.codingClose)
+                    (logSlowCleanup "local coding tools" . (.localCoding.codingClose))
                     (acquireWebFetchRuntime
                         request
                         toolStartup
                         toolModelRuntime)
-                    (mapM_ closeWebFetchRuntime)
+                    (logSlowCleanup "web fetch runtime" . mapM_ closeWebFetchRuntime)
                     (acquireLspStartup
                         request
                         toolStartup
                         toolModelRuntime)
-                    (mapM_ closeLspRuntime . (.lspStartupRuntime))
+                    (logSlowCleanup "language server runtime"
+                        . mapM_ closeLspRuntime . (.lspStartupRuntime))
                 )
                 ( allocateResource
                     resourceScope
                     (acquireComputerUseRuntime toolModelRuntime)
-                    (mapM_ ComputerUse.closeComputerUseRuntime)
+                    (logSlowCleanup "computer use runtime"
+                        . mapM_ ComputerUse.closeComputerUseRuntime)
                 )
             )
             (prepareInitialContextPreload request toolModelRuntime)
@@ -772,10 +775,11 @@ assembleSessionToolsRuntime AgentToolsRequest
             writeIORef sessionPlanMode.planSessionDir (Just dir)
             writeIORef subagentStoreRoot (Just dir)
         sessionCloseAll =
-            closeAgents
+            logSlowCleanup "collaboration agents" closeAgents
                 `finally`
-                    ((readIORef activeSessionLock
-                        >>= mapM_ releaseSessionLock)
+                    (logSlowCleanup "session lock"
+                        (readIORef activeSessionLock
+                            >>= mapM_ releaseSessionLock)
                         `finally`
                             (closeExtraTools
                                 `finally`
@@ -783,9 +787,10 @@ assembleSessionToolsRuntime AgentToolsRequest
                                         `finally`
                                             (coding.codingClose
                                                 `finally`
-                                                    (join
-                                                        (readIORef
-                                                            codeModeCloseRef)
+                                                    (logSlowCleanup "code mode runtime"
+                                                        (join
+                                                            (readIORef
+                                                                codeModeCloseRef))
                                                         `finally`
                                                             cleanupScratch)))))
         sessionAllTools = composeToolGroups allToolGroups

--- a/packages/agent-core/src/Agent/ResourceScope.hs
+++ b/packages/agent-core/src/Agent/ResourceScope.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NumericUnderscores #-}
+
 -- | Dynamically owned resources with explicit early release.
 --
 -- The public API stays in 'IO' so resource ownership does not force
@@ -13,6 +15,8 @@ module Agent.ResourceScope
     , allocateFourResourcesConcurrently
     , registerResource
     , releaseResource
+    , logSlowCleanup
+    , logSlowCleanupWith
     ) where
 
 import Control.Concurrent.Async (concurrently)
@@ -22,7 +26,12 @@ import Control.Concurrent.MVar
     , newMVar
     , withMVar
     )
-import Control.Exception.Safe (bracket, throwIO)
+import qualified Control.Exception as Exception
+import Control.Exception.Safe (bracket, catchAny, throwIO)
+import Control.Monad (when)
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
+import System.IO (hPutStrLn, stderr)
 import Control.Monad.Trans.Resource
     ( InternalState
     , ReleaseKey
@@ -38,6 +47,28 @@ import Control.Monad.Trans.Resource
 newtype ResourceScope = ResourceScope (MVar (Maybe InternalState))
 
 newtype ResourceKey = ResourceKey ReleaseKey
+
+-- | Report cleanup taking at least 100 ms to stderr, without requiring debug
+-- mode. Labels should describe the resource, not include commands or secrets.
+-- This observes completion (including exceptions); it does not impose a
+-- timeout or change the cleanup's thread, masking state, or ownership.
+logSlowCleanup :: String -> IO a -> IO a
+logSlowCleanup = logSlowCleanupWith getMonotonicTimeNSec (hPutStrLn stderr)
+
+-- | Injectable monotonic nanosecond clock and diagnostic sink for testing.
+logSlowCleanupWith :: IO Word64 -> (String -> IO ()) -> String -> IO a -> IO a
+logSlowCleanupWith clock report label action = do
+    started <- clock
+    -- Base finally avoids making a diagnostic write uninterruptible when
+    -- the caller was interruptible. The action retains its incoming state.
+    action `Exception.finally`
+        -- Only the diagnostic is best-effort; never swallow an action failure.
+        ((do
+            finished <- clock
+            let elapsed = (finished - started) `div` 1_000_000
+            when (elapsed >= 100) $
+                report ("[slow cleanup] " <> label <> ": " <> show elapsed <> " ms")
+        ) `catchAny` \_ -> pure ())
 
 -- | Run an action inside a lexical resource scope.
 --

--- a/packages/agent-core/test/Agent/ResourceScopeSpec.hs
+++ b/packages/agent-core/test/Agent/ResourceScopeSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NumericUnderscores #-}
+
 module Agent.ResourceScopeSpec (spec) where
 
 import Agent.ResourceScope
@@ -10,6 +12,7 @@ import Control.Concurrent.MVar
     , takeMVar
     )
 import Control.Exception.Safe (throwIO, tryAny)
+import qualified Control.Exception as Exception
 import Control.Monad (replicateM_, when)
 import Data.IORef
 import Data.List (sort)
@@ -18,6 +21,57 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.ResourceScope" do
+    describe "slow cleanup diagnostics" do
+        it "keeps cleanup below 100 ms silent and preserves its result" do
+            elapsed <- newIORef 0
+            messages <- newIORef []
+            logSlowCleanupWith (readIORef elapsed) (record messages) "test resource"
+                (writeIORef elapsed 99_999_999 >> pure (42 :: Int))
+                `shouldReturn` 42
+            readIORef messages `shouldReturn` []
+
+        it "reports the resource and elapsed milliseconds at the threshold" do
+            elapsed <- newIORef 0
+            messages <- newIORef []
+            logSlowCleanupWith (readIORef elapsed) (record messages) "test resource"
+                (writeIORef elapsed 100_000_000)
+            readIORef messages `shouldReturn`
+                ["[slow cleanup] test resource: 100 ms"]
+
+        it "reports slow failures without replacing their exception" do
+            elapsed <- newIORef 0
+            messages <- newIORef []
+            let failure = userError "cleanup failed"
+            logSlowCleanupWith (readIORef elapsed) (record messages) "test resource"
+                (writeIORef elapsed 250_000_000 >> throwIO failure)
+                `shouldThrow` (== failure)
+            readIORef messages `shouldReturn`
+                ["[slow cleanup] test resource: 250 ms"]
+
+        it "ignores diagnostic failures without hiding cleanup failures" do
+            elapsed <- newIORef 0
+            let report _ = throwIO (userError "diagnostic failed")
+                failure = userError "cleanup failed"
+            logSlowCleanupWith (readIORef elapsed) report "test resource"
+                (writeIORef elapsed 250_000_000 >> throwIO failure)
+                `shouldThrow` (== failure)
+
+        it "preserves asynchronous exceptions" do
+            elapsed <- newIORef 0
+            messages <- newIORef []
+            logSlowCleanupWith (readIORef elapsed) (record messages) "test resource"
+                (writeIORef elapsed 250_000_000
+                    >> Exception.throwIO Exception.UserInterrupt)
+                `shouldThrow` (== Exception.UserInterrupt)
+            length <$> readIORef messages `shouldReturn` 1
+
+        it "preserves the cleanup masking state" do
+            let observe = logSlowCleanupWith (pure 0) (const (pure ())) "test resource"
+                    Exception.getMaskingState
+            observe `shouldReturn` Exception.Unmasked
+            Exception.mask_ observe `shouldReturn` Exception.MaskedInterruptible
+            Exception.uninterruptibleMask_ observe `shouldReturn` Exception.MaskedUninterruptible
+
     it "releases resources in reverse acquisition order" do
         released <- newIORef ([] :: [Int])
         scope <- newResourceScope
@@ -197,7 +251,7 @@ spec = describe "Agent.ResourceScope" do
             Right () -> pure ()
         (sort <$> readIORef releases) `shouldReturn` [1, 2, 3]
 
-record :: IORef [Int] -> Int -> IO ()
+record :: IORef [a] -> a -> IO ()
 record ref value =
     atomicModifyIORef' ref \values -> (values <> [value], ())
 


### PR DESCRIPTION
## Summary
- Log named session and runtime cleanup steps taking at least 100 ms to stderr, without requiring debug mode.
- Include the component and elapsed milliseconds; keep fast cleanup silent.
- Preserve cleanup ordering, ownership, masking state, and action exceptions. Diagnostics run after completion, not as a watchdog.

This adds visibility into slow Ctrl+C shutdown; it does not claim to reduce shutdown latency.

## Validation
- 17 ResourceScope examples pass in GHCi, including six deterministic diagnostic tests.
- Full CLI/core multi-package GHCi load passes: 536 modules loaded.
- `git diff --check` passes.

Commands:
```sh
nix develop -c ghci -ignore-dot-ghci -XHaskell2010 -XBlockArguments -XLambdaCase -XOverloadedStrings -ipackages/agent-core/src -ipackages/agent-core/test packages/agent-core/test/Agent/ResourceScopeSpec.hs -e 'Test.Hspec.hspec Agent.ResourceScopeSpec.spec'
printf ':quit\n' | nix develop -c cabal repl --offline agent-cli:lib:agent-cli agent-core:lib:agent-core
```

- Live tmux startup smoke was blocked before the prompt: `could not allocate a unique session temp directory`.

## CI result
- For commit `a43e74fc4e332fb5f2502e3c70aa47b999fba6a3`, seven check groups passed. Extracted package tests reached the 60-minute timeout while `agent-repository` tests were still making progress; the aggregate Nix flake check consequently failed (`MATRIX_RESULT: cancelled`).
- Last completed repository example: `joins a successful commit hook descendant that retains Git output`. Investigating the repository suite runtime is a separate follow-up; no timeout increase or rerun was performed.
- Run: https://github.com/digitallyinduced/haskell-agent/actions/runs/34284467817
