### PR TITLE
Use cached Git default branch during worktree startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,17 @@ The server is queried only when that reference is missing or invalid, or when
 fetching the cached branch reports that it no longer exists. Successful
 discovery and fetching refresh the local reference; unrelated fetch failures
 are not retried. If the server changes its default but retains the old branch,
-refresh explicitly with `git remote set-head origin --auto` (substitute the
-selected remote name).
+fetch the new default branch into its remote-tracking reference before
+refreshing the cache. For a new default named `main` on `origin`:
+
+```sh
+git fetch origin refs/heads/main:refs/remotes/origin/main &&
+git remote set-head origin --auto
+```
+
+Substitute the selected remote and its new default branch name.
+`set-head --auto` requires the new remote-tracking reference to exist; the
+agent's isolated fetches do not create it.
 
 ### Organization gateway model routing
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,15 @@ remote is selected from the current branch's configured remote, then
 fetch failure aborts worktree creation rather than falling back to a stale
 commit.
 
+Default-branch discovery first uses Git's local
+`refs/remotes/<remote>/HEAD` symbolic reference, shared across linked worktrees.
+The server is queried only when that reference is missing or invalid, or when
+fetching the cached branch reports that it no longer exists. Successful
+discovery and fetching refresh the local reference; unrelated fetch failures
+are not retried. If the server changes its default but retains the old branch,
+refresh explicitly with `git remote set-head origin --auto` (substitute the
+selected remote name).
+
 ### Organization gateway model routing
 
 Connected organization gateways must include `provider` and `protocol` for every

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -848,7 +848,8 @@ fetchLatestUpstream report repo = do
 -- Git shares this symbolic reference across linked worktrees. Its target need
 -- not exist locally: our isolated fetch deliberately leaves tracking refs alone.
 -- A default-branch change that retains the old branch requires an explicit
--- `git remote set-head <remote> --auto` to refresh this cache.
+-- fetch into the new remote-tracking ref before
+-- `git remote set-head <remote> --auto` (see README).
 cachedRemoteDefaultBranch :: OsPath -> Text -> IO (Maybe Text)
 cachedRemoteDefaultBranch repo remote = do
     let prefix = "refs/remotes/" <> remote <> "/"

--- a/packages/agent-cli/src/Agent/CLI/Worktree.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree.hs
@@ -81,6 +81,7 @@ import qualified System.Directory as Directory
 import qualified System.FilePath as FilePath
 import System.Timeout (timeout)
 import System.Exit (ExitCode(..))
+import System.Environment (getEnvironment)
 import qualified System.FileLock as FileLock
 import System.OsPath
     ( OsPath
@@ -796,7 +797,7 @@ withGitWorktreeLockAt commonDir action =
         FileLock.Exclusive
         (const action)
 
--- | Fetch and return the commit at the selected remote's advertised default
+-- | Fetch and return the commit at the selected remote's cached default
 -- branch, or use the local @HEAD@ when the repository has no remotes. The
 -- current branch's configured remote wins, followed by conventional @upstream@
 -- and @origin@ names, then a sole remaining remote.
@@ -808,15 +809,56 @@ fetchLatestUpstream report repo = do
     selectUpstreamRemote repo >>= \case
         Nothing -> pure Nothing
         Just remote -> do
-            lift (report (WorktreeCheckingRemote remote))
-            remoteHead <- remoteDefaultBranch repo remote
-            lift (report (WorktreeFetchingRemote remote remoteHead))
-            localRef <- lift freshFetchRef
-            commit <-
-                ExceptT $
-                    runExceptT (fetchIntoRef repo remote remoteHead localRef)
-                        `finally` cleanupFetchRef repo localRef
+            cached <- lift (cachedRemoteDefaultBranch repo remote)
+            commit <- case cached of
+                Nothing -> discoverAndFetch remote
+                Just remoteHead -> do
+                    result <- lift (runExceptT (fetchBranch remote remoteHead))
+                    case result of
+                        Right commit -> pure commit
+                        Left err
+                            | any (== "fatal: couldn't find remote ref " <> remoteHead)
+                                (map Text.strip (Text.lines err))
+                                || (": fatal: couldn't find remote ref " <> remoteHead)
+                                    `Text.isSuffixOf` Text.strip err ->
+                                discoverAndFetch remote
+                            | otherwise -> throwE err
             pure (Just commit)
+  where
+    fetchBranch remote remoteHead = do
+        lift (report (WorktreeFetchingRemote remote remoteHead))
+        localRef <- lift freshFetchRef
+        ExceptT $
+            runExceptT (fetchIntoRef repo remote remoteHead localRef)
+                `finally` cleanupFetchRef repo localRef
+    discoverAndFetch remote = do
+        lift (report (WorktreeCheckingRemote remote))
+        remoteHead <- remoteDefaultBranch repo remote
+        commit <- fetchBranch remote remoteHead
+        -- Cache only successful discoveries. Cache contention must not fail
+        -- worktree creation; the next invocation can discover again.
+        lift $ unless (remoteHead == "refs/heads/HEAD") $ void $ tryAny $ git repo
+            [ "symbolic-ref"
+            , Text.unpack ("refs/remotes/" <> remote <> "/HEAD")
+            , Text.unpack ("refs/remotes/" <> remote <> "/"
+                <> Text.drop (Text.length "refs/heads/") remoteHead)
+            ]
+        pure commit
+
+-- Git shares this symbolic reference across linked worktrees. Its target need
+-- not exist locally: our isolated fetch deliberately leaves tracking refs alone.
+-- A default-branch change that retains the old branch requires an explicit
+-- `git remote set-head <remote> --auto` to refresh this cache.
+cachedRemoteDefaultBranch :: OsPath -> Text -> IO (Maybe Text)
+cachedRemoteDefaultBranch repo remote = do
+    let prefix = "refs/remotes/" <> remote <> "/"
+    result <- git repo ["symbolic-ref", "--quiet", "--no-recurse", Text.unpack (prefix <> "HEAD")]
+    pure $ case result of
+        Right output
+            | Just branch <- Text.stripPrefix prefix (Text.strip output)
+            , not (Text.null branch)
+            , branch /= "HEAD" -> Just ("refs/heads/" <> branch)
+        _ -> Nothing
 
 fetchIntoRef :: OsPath -> Text -> Text -> Text -> ExceptT Text IO Text
 fetchIntoRef repo remote remoteHead localRef = do
@@ -940,9 +982,16 @@ quote value = "'" <> value <> "'"
 
 git :: OsPath -> [String] -> IO (Either Text Text)
 git dir args = do
+    -- Only fetch diagnostics are parsed for missing-ref recovery.
+    environment <- if listToMaybe args == Just "fetch"
+        then Just . (("LC_ALL", "C") :) . filter ((/= "LC_ALL") . fst) <$> getEnvironment
+        else pure Nothing
     (code, out, err) <-
         readCreateProcessWithExitCode
-            (proc "git" args) { cwd = Just (unsafeToFilePath dir) }
+            (proc "git" args)
+                { cwd = Just (unsafeToFilePath dir)
+                , env = environment
+                }
             ""
     case code of
         ExitSuccess -> pure (Right (Text.pack out))

--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -125,6 +125,8 @@ spec = describe "Agent.CLI.Worktree" do
         it "fetches and branches from the remote's latest default commit by default" $
             withTempRemoteRepo \repo updater ->
             withTempDir "agent-home-" \home -> do
+                _ <- git repo
+                    ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/master"]
                 stale <- git repo ["rev-parse", "refs/remotes/origin/master"]
                 latest <- git updater ["rev-parse", "HEAD"]
                 stale `shouldNotBe` latest
@@ -150,16 +152,111 @@ spec = describe "Agent.CLI.Worktree" do
                 progress <- readIORef progressRef
                 progress `shouldBe`
                     [ WorktreeInspectingRepository
-                    , WorktreeCheckingRemote "origin"
                     , WorktreeFetchingRemote "origin" "refs/heads/master"
                     , WorktreeCreating
                     ]
                 map worktreeProgressMessage progress `shouldBe`
                     [ "Inspecting Git repository…"
-                    , "Checking Git remote origin…"
                     , "Fetching latest from origin/master…"
                     , "Creating worktree…"
                     ]
+
+        it "discovers a missing default-branch reference and reuses it on the next creation" $
+            withTempRemoteRepo \repo updater ->
+            withTempDir "agent-home-" \home -> do
+                latest <- git updater ["rev-parse", "HEAD"]
+                progressRef <- newIORef []
+                let report progress = modifyIORef' progressRef (<> [progress])
+                first <- expectRight
+                    =<< createManagedWorktreeWithProgress report home repo
+                git first ["rev-parse", "HEAD"] `shouldReturn` latest
+                git repo ["symbolic-ref", "refs/remotes/origin/HEAD"]
+                    `shouldReturn` "refs/remotes/origin/master"
+                readIORef progressRef `shouldReturn`
+                    [ WorktreeInspectingRepository
+                    , WorktreeCheckingRemote "origin"
+                    , WorktreeFetchingRemote "origin" "refs/heads/master"
+                    , WorktreeCreating
+                    ]
+                modifyIORef' progressRef (const [])
+                second <- expectRight
+                    =<< createManagedWorktreeWithProgress report home repo
+                git second ["rev-parse", "HEAD"] `shouldReturn` latest
+                readIORef progressRef `shouldReturn`
+                    [ WorktreeInspectingRepository
+                    , WorktreeFetchingRemote "origin" "refs/heads/master"
+                    , WorktreeCreating
+                    ]
+                temporaryFetchRefs repo `shouldReturn` ""
+
+        it "rediscovers the default branch when the cached branch was deleted" $
+            withTempRemoteRepo \repo updater ->
+            withTempDir "agent-home-" \home -> do
+                _ <- git repo
+                    ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/master"]
+                remotePath <- fromFilePath <$> git repo ["remote", "get-url", "origin"]
+                _ <- git updater ["push", "origin", "HEAD:refs/heads/main"]
+                _ <- git remotePath ["symbolic-ref", "HEAD", "refs/heads/main"]
+                _ <- git updater ["push", "origin", "--delete", "master"]
+                latest <- git updater ["rev-parse", "HEAD"]
+                progressRef <- newIORef []
+                path <- expectRight =<< createManagedWorktreeWithProgress
+                    (\progress -> modifyIORef' progressRef (<> [progress]))
+                    home repo
+                git path ["rev-parse", "HEAD"] `shouldReturn` latest
+                git repo ["symbolic-ref", "refs/remotes/origin/HEAD"]
+                    `shouldReturn` "refs/remotes/origin/main"
+                readIORef progressRef `shouldReturn`
+                    [ WorktreeInspectingRepository
+                    , WorktreeFetchingRemote "origin" "refs/heads/master"
+                    , WorktreeCheckingRemote "origin"
+                    , WorktreeFetchingRemote "origin" "refs/heads/main"
+                    , WorktreeCreating
+                    ]
+                temporaryFetchRefs repo `shouldReturn` ""
+
+        it "rejects a cached default-branch reference pointing outside the selected remote" $
+            withTempRemoteRepo \repo updater ->
+            withTempDir "agent-home-" \home -> do
+                _ <- git repo
+                    ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/other/master"]
+                latest <- git updater ["rev-parse", "HEAD"]
+                progressRef <- newIORef []
+                path <- expectRight =<< createManagedWorktreeWithProgress
+                    (\progress -> modifyIORef' progressRef (<> [progress]))
+                    home repo
+                git path ["rev-parse", "HEAD"] `shouldReturn` latest
+                git repo ["symbolic-ref", "refs/remotes/origin/HEAD"]
+                    `shouldReturn` "refs/remotes/origin/master"
+                readIORef progressRef `shouldReturn`
+                    [ WorktreeInspectingRepository
+                    , WorktreeCheckingRemote "origin"
+                    , WorktreeFetchingRemote "origin" "refs/heads/master"
+                    , WorktreeCreating
+                    ]
+
+        it "does not rediscover the cached default branch after an unrelated fetch failure" $
+            withTempRemoteRepo \repo _ ->
+            withTempDir "agent-home-" \home -> do
+                _ <- git repo
+                    ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/master"]
+                _ <- git repo
+                    ["remote", "set-url", "origin", toFilePath (repo </> fromFilePath "missing.git")]
+                progressRef <- newIORef []
+                result <- createManagedWorktreeWithProgress
+                    (\progress -> modifyIORef' progressRef (<> [progress]))
+                    home repo
+                result `shouldSatisfy` \case
+                    Left err -> "failed to fetch" `Text.isInfixOf` err
+                    Right _ -> False
+                readIORef progressRef `shouldReturn`
+                    [ WorktreeInspectingRepository
+                    , WorktreeFetchingRemote "origin" "refs/heads/master"
+                    ]
+                git repo ["symbolic-ref", "refs/remotes/origin/HEAD"]
+                    `shouldReturn` "refs/remotes/origin/master"
+                temporaryFetchRefs repo `shouldReturn` ""
+                doesDirectoryExist (worktreeRoot home) `shouldReturn` False
 
         it "uses local HEAD when latest-upstream fetching is disabled" $
             withTempRemoteRepo \repo updater ->

--- a/scripts/benchmark-default-branch.py
+++ b/scripts/benchmark-default-branch.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Compare remote discovery with a populated Git default-branch cache.
+
+Run: nix develop -c python3 scripts/benchmark-default-branch.py
+Uses the compiled Git executable, not interpreted Haskell timings. Measures
+only discovery subprocess latency, not fetching or total agent startup.
+Requires a populated, current refs/remotes/<remote>/HEAD; does not modify it.
+"""
+
+import argparse
+import statistics
+import subprocess
+import time
+
+
+def measure(command):
+    started = time.perf_counter()
+    result = subprocess.run(command, check=True, capture_output=True, timeout=30)
+    elapsed = (time.perf_counter() - started) * 1000
+    return elapsed, result.stdout.decode().strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", default=".")
+    parser.add_argument("--remote", default="origin")
+    parser.add_argument("--samples", type=int, default=7)
+    parser.add_argument("--repetitions", type=int, default=2)
+    arguments = parser.parse_args()
+    if arguments.samples < 1 or arguments.repetitions < 1:
+        parser.error("sample and repetition counts must be positive")
+    prefix = ["git", "-C", arguments.repository]
+    commands = {
+        "remote-discovery": prefix + ["ls-remote", "--symref", arguments.remote, "HEAD"],
+        "local-reference": prefix + [
+            "symbolic-ref", "--quiet", "--no-recurse",
+            f"refs/remotes/{arguments.remote}/HEAD",
+        ],
+    }
+    print(subprocess.check_output(["git", "--version"], text=True).strip())
+    for repetition in range(arguments.repetitions):
+        samples = {name: [] for name in commands}
+        for sample in range(arguments.samples):
+            outputs = {}
+            # Alternate order to reduce systematic ordering bias.
+            for name in list(commands)[::1 if sample % 2 == 0 else -1]:
+                elapsed, outputs[name] = measure(commands[name])
+                samples[name].append(elapsed)
+            advertised = [
+                line.split()[1] for line in outputs["remote-discovery"].splitlines()
+                if line.startswith("ref: ") and line.endswith("\tHEAD")
+            ]
+            cached = outputs["local-reference"].removeprefix(
+                f"refs/remotes/{arguments.remote}/"
+            )
+            if advertised != [f"refs/heads/{cached}"]:
+                raise RuntimeError("cached and advertised default branches differ")
+        for name, values in samples.items():
+            print(
+                f"pass {repetition + 1}: {name}: "
+                f"median {statistics.median(values):.2f} ms "
+                f"({arguments.samples} samples)",
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Use Git's local `refs/remotes/<remote>/HEAD` for worktree startup instead of contacting the server to rediscover its default branch every time.
- Discover and cache when missing/invalid; rediscover once if the cached branch was deleted. Other fetch errors are returned without retry.
- Continue fetching the latest commit with isolated temporary refs. No PostgreSQL cache or new dependencies.
- Document fetching the new default into its remote-tracking reference before running `git remote set-head origin --auto` when the server retains the old branch.

## Validation
- `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`, then `:main --match "createWorktree"`: **15 examples, 0 failures**.
- Covers cache reuse, missing cache, deleted default branch, invalid cross-remote cache, unrelated fetch failure, and existing concurrent fetch behavior.
- Live tmux/GHCi startup with a local remote and `GIT_TRACE`: cached symbolic-ref lookup, fetch, and worktree creation succeeded without `ls-remote`. Later session initialization hit an unrelated sandbox restriction creating its session temp directory; full prompt startup was not verified.
- `git diff --check` passed.

## Performance
Run `nix develop -c python3 scripts/benchmark-default-branch.py`.
macOS, Nix-provided compiled Git 2.55.0 (unchanged package build settings); Python only drives subprocesses, not GHCi timing. Seven samples per method, repeated twice, alternating measurement order.

| Workload | Old remote discovery medians (ms) | New local lookup medians (ms) |
| --- | --- | --- |
| This repository's GitHub SSH origin | 1753.67 / 1692.84 | 8.84 / 9.14 |
| Local transport, main + 10 branch refs | 21.27 / 22.83 | 7.64 / 8.29 |
| Local transport, main + 1000 branch refs | 42.59 / 40.41 | 7.82 / 7.51 |

This measures default-branch discovery only, not fetch or total startup. Both repeated remote runs show roughly 1.7 seconds of discovery replaced by a ~9 ms local lookup.

Synthetic workloads used an empty main commit, a local origin pointing to the repository itself, a populated origin/HEAD symbolic ref, and 10/1000 additional loose branch refs pointing to that commit; the same script ran with `--repository <fixture>`.

