### PR TITLE
Display pasted terminal images during active turns

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Input/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Types.hs
@@ -22,6 +22,8 @@ data ReplLine
     | ReplMeta Text
     | ReplPasted Text
     | ReplClipboardPaste !Text !(Maybe [ImageAttachment])
+    -- | Images already captured and previewed by the active composer.
+    | ReplClipboardPasteCaptured ![ImageAttachment]
     -- | Classify a bracketed paste off the UI thread. The fields are the draft
     -- before the paste, the raw pasted payload, and the draft with that payload
     -- inserted. Image paths or clipboard images become attachments; otherwise

--- a/packages/agent-cli/src/Agent/CLI/InputBudget.hs
+++ b/packages/agent-cli/src/Agent/CLI/InputBudget.hs
@@ -84,6 +84,7 @@ logicalReplLineBytes = \case
     ReplClipboardPaste draft images ->
         logicalTextBytes draft
             `saturatingAdd` maybe 0 (foldBytes logicalImageBytes) images
+    ReplClipboardPasteCaptured images -> foldBytes logicalImageBytes images
     ReplClipboardPasteOrText draft pasted inserted ->
         logicalTextBytes draft
             `saturatingAdd` logicalTextBytes pasted

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -237,6 +237,8 @@ readChangeNotes provider interrupt color = do
             if Text.null (Text.strip text)
                 then readChangeNotes provider interrupt color
                 else pure (Text.strip text)
+        ReplClipboardPasteCaptured _ ->
+            readChangeNotes provider interrupt color
         ReplClipboardPasteOrText _ _ text ->
             if Text.null (Text.strip text)
                 then readChangeNotes provider interrupt color
@@ -292,6 +294,9 @@ askQuestion provider interrupt resolveColor question options = do
                                 then askQuestion
                                     provider interrupt resolveColor question []
                                 else pure (Just (Text.strip text))
+                        ReplClipboardPasteCaptured _ ->
+                            askQuestion
+                                provider interrupt resolveColor question []
                         ReplClipboardPasteOrText _ _ text ->
                             if Text.null (Text.strip text)
                                 then askQuestion

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -79,7 +79,7 @@ import Agent.CLI.TUI.App
     ( FullscreenRuntime
     , emitUiEvent,
       readFullscreenLineOrWithCatalog,
-      setFullscreenImagePreviews )
+      refreshFullscreenImagePreviews )
 import Agent.CLI.Terminal
     ( emitTerminalSequence,
       osc133PromptEnd,
@@ -213,7 +213,7 @@ replWithDraft env@SessionEnv
     mlineResult <- case fullscreen of
         Just runtime -> do
             syncFullscreenContext env
-            setFullscreenImagePreviews runtime pendingAttachments
+            refreshFullscreenImagePreviews runtime pendingAttachments
             let promptState =
                     buildPromptState
                         (dialectId dialect)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
@@ -44,6 +44,7 @@ import qualified Data.Text.IO as Text ( hPutStrLn, putStrLn )
 -- | Clipboard operations after the REPL input has been classified.
 data ClipboardInput
     = ClipboardPaste !Text !(Maybe [ImageAttachment])
+    | ClipboardPasteCaptured ![ImageAttachment]
     | ClipboardPasteOrText !Text !Text !Text
 
 handleClipboardInput
@@ -60,6 +61,12 @@ handleClipboardInput
             }
         continueWith
         stdoutColor = \case
+    ClipboardPasteCaptured images -> do
+        -- The composer already rendered this snapshot. Consume it in input
+        -- order without restoring an old draft or replacing newer previews.
+        _ <- queueAttachedImages
+            conversationRef previewIdRef stdoutColor (isNothing fullscreen) images
+        continueWith ""
     ClipboardPaste keptDraft clipboardPasteImages -> do
         case clipboardPasteImages of
             Just images@(_:_) -> do

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -45,7 +45,7 @@ import Agent.CLI.Input
       submissionPromptText,
       truncateDisplayText,
       ReplLine(ReplText, ReplMeta, ReplEof, ReplQuitInterrupt, ReplCycleMode,
-               ReplClipboardPaste, ReplClipboardPasteOrText, ReplChooseModel,
+               ReplClipboardPaste, ReplClipboardPasteCaptured, ReplClipboardPasteOrText, ReplChooseModel,
                ReplChooseEffort, ReplChooseAccount, ReplRemovePendingImage,
                ReplPasted) )
 import Agent.CLI.GatewayClient ( loadGatewayCredential )
@@ -264,6 +264,9 @@ handleReplLine
     ReplClipboardPaste draft images ->
         handleClipboardInput env continueWith stdoutColor
             (ClipboardPaste draft images)
+    ReplClipboardPasteCaptured images ->
+        handleClipboardInput env continueWith stdoutColor
+            (ClipboardPasteCaptured images)
     ReplClipboardPasteOrText draft pasted pastedDraft ->
         handleClipboardInput env continueWith stdoutColor
             (ClipboardPasteOrText draft pasted pastedDraft)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -107,6 +107,7 @@ module Agent.CLI.TUI.App
     , wrapMarkdownLinkCursorVty
     , withTrackedVtyBuilder
     , setFullscreenImagePreviews
+    , refreshFullscreenImagePreviews
     , setFullscreenWindowTitle
     , showFullscreenToolImage
     , toolImageBlockId

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -410,6 +410,10 @@ handleAppEvent = \case
         handleSetModelIdsEvent modelIds
     AppSetImagePreviews prepared ->
         handleSetImagePreviewsEvent prepared
+    AppRefreshImagePreviews prepared -> do
+        state <- get
+        unless state.appComposerOwnsImagePreviews $
+            handleSetImagePreviewsEvent prepared
     AppCommitImagePreviews prepared ->
         handleCommitImagePreviewsEvent prepared
     AppToolImage callId preview ->
@@ -596,6 +600,7 @@ handleSetImagePreviewsEvent prepared = do
     modify' \current ->
         current
             { appImagePreviews = map snd prepared
+            , appComposerOwnsImagePreviews = False
             }
 
 handleCommitImagePreviewsEvent
@@ -618,7 +623,7 @@ handleCommitImagePreviewsEvent prepared = do
             retainSubmittedImagePreviewsForBlocks
                 (nub (conversationBlockIds state <> [nextBlockId]))
                 submitted
-    liftIO do
+    liftIO $ when (not state.appComposerOwnsImagePreviews) do
         writeIORef state.appRuntime.runtimeImagePreviews []
         modifyIORef'
             state.appRuntime.runtimeImagePreviewRevision
@@ -626,7 +631,10 @@ handleCommitImagePreviewsEvent prepared = do
     clearSubmittedImagePlacements state.appRuntime
     modify' \current ->
         current
-            { appImagePreviews = []
+            { appImagePreviews =
+                if current.appComposerOwnsImagePreviews
+                    then current.appImagePreviews
+                    else []
             , appSubmittedImagePreviews = retained
             }
     queueConversationReflow

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -760,6 +760,8 @@ appEventLogicalBytes = \case
         either logicalTextBytes logicalTextBytes result
     AppSetImagePreviews previews ->
         imagePreviewPairsLogicalBytes previews
+    AppRefreshImagePreviews previews ->
+        imagePreviewPairsLogicalBytes previews
     AppCommitImagePreviews previews ->
         imagePreviewPairsLogicalBytes previews
     AppToolImage callId preview ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -481,6 +481,7 @@ initialFullscreenAppState runtime history initialAgent initialAgents initialCloc
         , appDictation = Nothing
         , appSlashCatalog = defaultSlashCatalog
         , appImagePreviews = []
+        , appComposerOwnsImagePreviews = False
         , appSubmittedImagePreviews = Map.empty
         , appAgentSelected = initialAgent
         , appAgentEntries = initialAgents

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -639,13 +639,29 @@ setFullscreenImagePreviews
     :: FullscreenRuntime
     -> [ImageAttachment]
     -> IO ()
-setFullscreenImagePreviews runtime images = do
+setFullscreenImagePreviews =
+    publishFullscreenImagePreviews AppSetImagePreviews
+
+-- | Refresh session state without overwriting a draft edited during a turn.
+refreshFullscreenImagePreviews
+    :: FullscreenRuntime
+    -> [ImageAttachment]
+    -> IO ()
+refreshFullscreenImagePreviews =
+    publishFullscreenImagePreviews AppRefreshImagePreviews
+
+publishFullscreenImagePreviews
+    :: ([(ImageAttachment, TuiImagePreview)] -> AppEvent)
+    -> FullscreenRuntime
+    -> [ImageAttachment]
+    -> IO ()
+publishFullscreenImagePreviews event runtime images = do
     previous <- readIORef runtime.runtimeImagePreviews
     prepared <-
         if map fst previous == images
             then pure previous
             else prepareFullscreenImagePreviews runtime images
-    enqueueAppEvent runtime (AppSetImagePreviews prepared)
+    enqueueAppEvent runtime (event prepared)
 
 -- | Move pending composer previews into the next submitted user message.
 commitFullscreenImagePreviews

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -1,6 +1,7 @@
 -- | Fullscreen prompt composer rendering, editing, and input buffering.
 module Agent.CLI.TUI.Composer
     ( ComposerEscapeAction(..)
+    , ComposerPasteResult(..)
     , KillDirection(..)
     , activateSlashAt
     , appendFullscreenInput
@@ -35,6 +36,7 @@ module Agent.CLI.TUI.Composer
     , isKillKey
     , newFullscreenInputBuffer
     , prepareBracketedPaste
+    , processComposerPaste
     , promoteFullscreenInput
     , queuedFullscreenInputDisplays
     , readFullscreenInputs
@@ -49,7 +51,10 @@ module Agent.CLI.TUI.Composer
     ) where
 
 import Agent.CLI.Clipboard
-    ( nonEmptyClipboardText
+    ( appendBoundedImageAttachments
+    , loadImagesFromPastedText
+    , nonEmptyClipboardText
+    , readClipboardImagesImageFirst
     , readClipboardText
     )
 import Agent.CLI.Command
@@ -64,11 +69,16 @@ import Agent.CLI.Input
     , submissionPromptText
     )
 import Agent.CLI.Interrupt (CtrlCDecision)
+import Agent.Loop (ImageAttachment)
 import qualified Agent.CLI.TUI.Bridge as Bridge
 import Agent.CLI.TUI.Composer.Buffer
 import Agent.CLI.TUI.Composer.Edit
 import Agent.CLI.TUI.Composer.Logic
 import Agent.CLI.TUI.Composer.Render
+import Agent.CLI.TUI.ImagePreview
+    ( prepareNativeTuiImagePreview
+    , prepareTuiImagePreview
+    )
 import Agent.CLI.TUI.Types
 import Agent.TUI.Model
 import Agent.TUI.TextWidth
@@ -81,7 +91,7 @@ import Control.Concurrent.STM (atomically, writeTQueue)
 import Control.Monad (void, when)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
-import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
 import Data.List (elemIndex)
 import Data.Maybe (fromMaybe)
 import qualified Data.Sequence as Seq
@@ -339,6 +349,7 @@ prepareBracketedPaste awaitingInput draft cursor pasted =
 steeringPrompt :: UiState -> Bool -> Text -> Maybe (Bool, Text)
 steeringPrompt ui pasted text
     | not ui.uiRunning = Nothing
+    | ui.uiPrompt.promptAttachments > 0 = Nothing
     | otherwise =
         case parseReplLine text of
             ReplPrompt prompt -> Just (pasted, prompt)
@@ -480,11 +491,14 @@ handleComposerKey
         V.EvKey (V.KChar 'v') modifiers
             | V.MCtrl `elem` modifiers
                 || V.MMeta `elem` modifiers -> do
-                clipboardText <- liftIO readClipboardText
-                case nonEmptyClipboardText clipboardText of
-                    Just text -> insertPastedText applyUiEvent text
-                    Nothing ->
-                        submitRaw applyUiEvent (ReplClipboardPaste ui.uiDraft Nothing)
+                if ui.uiRunning
+                    then handleActiveComposerPaste applyUiEvent Nothing
+                    else do
+                        clipboardText <- liftIO readClipboardText
+                        case nonEmptyClipboardText clipboardText of
+                            Just text -> insertPastedText applyUiEvent text
+                            Nothing ->
+                                submitRaw applyUiEvent (ReplClipboardPaste ui.uiDraft Nothing)
         V.EvKey V.KDel [] ->
             deleteAfter applyUiEvent
         V.EvKey V.KLeft modifiers
@@ -509,6 +523,8 @@ handleComposerKey
             scrollConversationPage Down
         V.EvKey (V.KChar character) [] ->
             insertText applyUiEvent (Text.singleton character)
+        V.EvPaste bytes | ui.uiRunning ->
+            handleActiveComposerPaste applyUiEvent (Just (decodePaste bytes))
         V.EvPaste bytes -> do
             let pasted = decodePaste bytes
                 (pastedDraft, pastedCursor, clipboardInput) =
@@ -532,6 +548,116 @@ handleComposerKey
     -- Only a kill directly followed by another kill accumulates into the
     -- kill buffer; any other key breaks the chain.
     modify' \current -> current { appKillChain = isKillKey event }
+
+-- | Resolve a paste independently of the REPL consumer, which cannot service
+-- clipboard actions while a provider turn is running. Terminal-supplied text
+-- is authoritative; only an explicit clipboard paste consults bitmap data.
+data ComposerPasteResult
+    = ComposerPasteText !Text
+    | ComposerPasteAttached !Text
+    | ComposerPasteFailed !Text
+    deriving (Eq, Show)
+
+processComposerPaste
+    :: Monad m
+    => m (Either Text [ImageAttachment])
+    -> (Text -> m (Maybe [ImageAttachment]))
+    -> m (Either Text Text)
+    -> ([ImageAttachment] -> m (Either Text Text))
+    -> Maybe Text
+    -> m ComposerPasteResult
+processComposerPaste readImages loadPaths readText attachImages terminalText =
+    case terminalText of
+        Just text | not (Text.null text) -> do
+            loadPaths text >>= \case
+                Just images@(_:_) -> attach images
+                _ -> pure (ComposerPasteText text)
+        _ -> do
+            imagesResult <- readImages
+            case imagesResult of
+                Right images@(_:_) -> attach images
+                _ -> do
+                    textResult <- readText
+                    pure $ case nonEmptyClipboardText textResult of
+                        Just text -> ComposerPasteText text
+                        Nothing -> ComposerPasteFailed $
+                            either id
+                                (const "no image found on the clipboard")
+                                imagesResult
+  where
+    attach images =
+        either ComposerPasteFailed ComposerPasteAttached
+            <$> attachImages images
+
+handleActiveComposerPaste
+    :: ApplyLocalUiEvent
+    -> Maybe Text
+    -> EventM Name AppState ()
+handleActiveComposerPaste applyUiEvent terminalText = do
+    result <-
+        processComposerPaste
+            (liftIO readClipboardImagesImageFirst)
+            (liftIO . loadImagesFromPastedText)
+            (liftIO readClipboardText)
+            (queueComposerImages applyUiEvent)
+            terminalText
+    case result of
+        ComposerPasteText text -> insertPastedText applyUiEvent text
+        ComposerPasteAttached message ->
+            modifyUi applyUiEvent
+                (UiSetNotice (Just (successNotice message)))
+        ComposerPasteFailed message ->
+            modifyUi applyUiEvent
+                (UiSetNotice (Just (warningNotice message)))
+
+queueComposerImages
+    :: ApplyLocalUiEvent
+    -> [ImageAttachment]
+    -> EventM Name AppState (Either Text Text)
+queueComposerImages applyUiEvent images = do
+    state <- get
+    previous <- liftIO (readIORef state.appRuntime.runtimeImagePreviews)
+    let (_, added, _, rejected) =
+            appendBoundedImageAttachments (map fst previous) images
+        prepare =
+            if state.appRuntime.runtimeNativeImagePreviews
+                then prepareNativeTuiImagePreview
+                else prepareTuiImagePreview
+    if null added
+        then pure $
+            if rejected > 0
+                then Left "image attachment limit reached"
+                else Right "image already attached"
+        else case traverse (\image -> (image,) <$> prepare image) added of
+            Left message -> pure (Left message)
+            Right prepared -> do
+                queued <- liftIO $ atomically $
+                    appendFullscreenInput state.appRuntime.runtimeInput FullscreenInput
+                        { fullscreenInputLine = ReplClipboardPasteCaptured added
+                        , fullscreenInputQueued = True
+                        , fullscreenInputDisplay = Nothing
+                        }
+                case queued of
+                    Left message -> pure (Left message)
+                    Right () -> do
+                        let pending = previous <> prepared
+                            prompt = state.appUi.uiPrompt
+                        liftIO do
+                            writeIORef state.appRuntime.runtimeImagePreviews pending
+                            modifyIORef'
+                                state.appRuntime.runtimeImagePreviewRevision
+                                (+ 1)
+                        modify' \current -> current
+                            { appImagePreviews = map snd pending
+                            , appComposerOwnsImagePreviews = True
+                            }
+                        applyUiEvent
+                            (UiSetPrompt prompt { promptAttachments = length pending })
+                            id
+                        pure $ Right $
+                            if rejected > 0
+                                then "image attached; some images exceeded the attachment limit"
+                                else "image attached — send with next message"
 
 startDictation :: ApplyLocalUiEvent -> EventM Name AppState ()
 startDictation applyUiEvent = do
@@ -691,6 +817,8 @@ sendNow applyUiEvent = do
                                     , appSlashDismissed = False
                                     , appUndo = []
                                     }
+                        when state.appComposerOwnsImagePreviews $
+                            clearComposerImagePreviews applyUiEvent
                         liftIO state.appRuntime.runtimeCancel
                         vScrollToEnd
                             (viewportScroll ConversationViewport)
@@ -738,7 +866,19 @@ enqueueInput applyUiEvent state replLine display clearDraft = do
             case event of
                 Nothing -> modify' update
                 Just uiEvent -> applyUiEvent uiEvent update
+            when (clearDraft && state.appComposerOwnsImagePreviews) $
+                clearComposerImagePreviews applyUiEvent
             pure True
+
+clearComposerImagePreviews :: ApplyLocalUiEvent -> EventM Name AppState ()
+clearComposerImagePreviews applyUiEvent = do
+    state <- get
+    liftIO do
+        writeIORef state.appRuntime.runtimeImagePreviews []
+        modifyIORef' state.appRuntime.runtimeImagePreviewRevision (+ 1)
+    let prompt = state.appUi.uiPrompt
+    modify' \current -> current { appImagePreviews = [] }
+    applyUiEvent (UiSetPrompt prompt { promptAttachments = 0 }) id
 
 cancelOrClear :: ApplyLocalUiEvent -> EventM Name AppState ()
 cancelOrClear applyUiEvent = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Buffer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Buffer.hs
@@ -136,6 +136,7 @@ isPromptPrelude :: FullscreenInput -> Bool
 isPromptPrelude input =
     case input.fullscreenInputLine of
         ReplClipboardPaste _ _ -> True
+        ReplClipboardPasteCaptured _ -> True
         ReplClipboardPasteOrText _ _ _ -> True
         _ -> False
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Logic.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Logic.hs
@@ -25,7 +25,7 @@ import Agent.CLI.Command
     )
 import Agent.CLI.Input (ReplLine(..))
 import Agent.CLI.TUI.Types (AppState(..))
-import Agent.TUI.Model (UiEvent(..), UiState(..))
+import Agent.TUI.Model (PromptState(..), UiEvent(..), UiState(..))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Graphics.Vty as V
@@ -96,6 +96,14 @@ applyComposerUiEvent uiEvent state =
             if isDraft then Nothing else state.appHistoryIndex
         , appHistoryDraft =
             if isDraft then draftText else state.appHistoryDraft
+        , appUi =
+            case uiEvent of
+                UiSetPrompt _ | state.appComposerOwnsImagePreviews ->
+                    let ui = state.appUi
+                        prompt = ui.uiPrompt
+                    in ui { uiPrompt =
+                        prompt { promptAttachments = length state.appImagePreviews } }
+                _ -> state.appUi
         }
   where
     isDraft = case uiEvent of

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -197,6 +197,7 @@ data AppEvent
     | AppSetTheme !ThemeKind
       -- ^ Apply a theme to the retained fullscreen UI.
     | AppSetImagePreviews ![(ImageAttachment, TuiImagePreview)]
+    | AppRefreshImagePreviews ![(ImageAttachment, TuiImagePreview)]
     | AppCommitImagePreviews ![(ImageAttachment, TuiImagePreview)]
     | AppToolImage !Text !TuiImagePreview
       -- ^ An image the agent displayed through @show_image@, keyed by the
@@ -526,6 +527,9 @@ data AppState = AppState
     , appDictation :: !(Maybe DictationSession)
     , appSlashCatalog :: !SlashCatalog
     , appImagePreviews :: ![TuiImagePreview]
+    -- | Active-turn pastes are previewed and cleared by the composer rather
+    -- than by delayed REPL attachment/commit events.
+    , appComposerOwnsImagePreviews :: !Bool
       -- | Previews attached to conversation blocks: images the user
       -- submitted with a prompt and images the agent displayed from a tool
       -- call. Native placements are synchronized from this map after each

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -149,6 +149,7 @@ import Brick
     , vLimit
     )
 import Brick.BChan (newBChan, writeBChan)
+import Codec.Picture (PixelRGB8(..), generateImage, writePng)
 import qualified Brick.Types as B
 import Agent.Subagents (SubagentId(..))
 import Agent.ToolDispatch
@@ -204,12 +205,83 @@ import Graphics.Vty.PictureToSpans (displayOpsForPic)
 import Graphics.Vty.Span (SpanOp(..))
 import qualified Agent.CLI.TUI.Composer as Composer
 import System.Timeout (timeout)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
 import qualified Agent.CLI.TUI.App as History
 import Agent.Tools.RenderChart (renderChartResult)
 
 spec :: Spec
 spec = do
+    describe "active-turn image paste" do
+        it "shows a bracketed image paste before the REPL consumes it and survives delayed refreshes" $
+            withPastedImageFixtures \path _ -> do
+                let running = reduceUi (UiSetDraft "unfinished draft" 4) $
+                        reduceUi (UiLoop TurnStarted) initialUiState
+                runtime <- newScriptRuntime running
+                let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+                (_, pasted) <- runFullscreenScriptWithState initial
+                    [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack path)))
+                    , FullscreenScriptHalt
+                    ]
+                length pasted.appImagePreviews `shouldBe` 1
+                pasted.appUi.uiPrompt.promptAttachments `shouldBe` 1
+                pasted.appUi.uiDraft `shouldBe` "unfinished draft"
+                pasted.appUi.uiCursor `shouldBe` 4
+                prepared <- readIORef runtime.runtimeImagePreviews
+                map snd prepared == pasted.appImagePreviews `shouldBe` True
+                -- No REPL consumer is started: the captured image remains queued.
+                queued <- atomically (Composer.readFullscreenInputs runtime.runtimeInput)
+                map (.fullscreenInputLine) (toList queued)
+                    `shouldBe` [ReplClipboardPasteCaptured (map fst prepared)]
+                map (.fullscreenInputQueued) (toList queued) `shouldBe` [True]
+                forM_
+                    [ AppRefreshImagePreviews []
+                    , AppCommitImagePreviews []
+                    , AppUi (UiSetPrompt running.uiPrompt)
+                    ] \event -> do
+                        (_, refreshed) <- runFullscreenScriptWithState pasted
+                            [FullscreenScriptApp event, FullscreenScriptHalt]
+                        refreshed.appImagePreviews == pasted.appImagePreviews
+                            `shouldBe` True
+                        refreshed.appUi.uiPrompt.promptAttachments `shouldBe` 1
+                        refreshed.appUi.uiDraft `shouldBe` "unfinished draft"
+                        refreshed.appUi.uiCursor `shouldBe` 4
+
+        it "leaves existing previews and the draft untouched when the input queue is full" $
+            withPastedImageFixtures \firstPath secondPath -> do
+                let running = reduceUi (UiSetDraft "unfinished draft" 4) $
+                        reduceUi (UiLoop TurnStarted) initialUiState
+                runtime <- newScriptRuntime running
+                (_, pasted) <- runFullscreenScriptWithState
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack firstPath)))
+                    , FullscreenScriptHalt
+                    ]
+                length pasted.appImagePreviews `shouldBe` 1
+                before <- readIORef runtime.runtimeImagePreviews
+                revision <- readIORef runtime.runtimeImagePreviewRevision
+                replicateM_ (Composer.fullscreenInputCountLimit - 1) do
+                    atomically (Composer.appendFullscreenInput runtime.runtimeInput
+                        (FullscreenInput ReplEof True Nothing))
+                        `shouldReturn` Right ()
+                (_, rejected) <- runFullscreenScriptWithState pasted
+                    [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack secondPath)))
+                    , FullscreenScriptHalt
+                    ]
+                rejected.appImagePreviews == pasted.appImagePreviews `shouldBe` True
+                rejected.appUi.uiPrompt.promptAttachments `shouldBe` 1
+                rejected.appUi.uiDraft `shouldBe` "unfinished draft"
+                rejected.appUi.uiCursor `shouldBe` 4
+                after <- readIORef runtime.runtimeImagePreviews
+                after == before `shouldBe` True
+                readIORef runtime.runtimeImagePreviewRevision `shouldReturn` revision
+                (.noticeText) <$> rejected.appUi.uiNotice
+                    `shouldBe` Just
+                        "Prompt queue is full; wait for a queued prompt to be consumed."
+                queued <- atomically (Composer.readFullscreenInputs runtime.runtimeInput)
+                Seq.length queued `shouldBe` Composer.fullscreenInputCountLimit
+
     describe "dynamic model choice" do
         it "preserves filter, selected identity, and effort across reordered rows" do
             runtime <- newScriptRuntime initialUiState
@@ -3274,6 +3346,15 @@ unfocusedStreamingRefreshesOnMotionTick = do
             ]
     rendered <- runFullscreenScript initialState script
     pure $ encoded marker `ByteString.isInfixOf` rendered
+
+withPastedImageFixtures :: (FilePath -> FilePath -> IO a) -> IO a
+withPastedImageFixtures action =
+    withSystemTempDirectory "agent-tui-image-paste" \directory -> do
+        let firstPath = directory </> "first.png"
+            secondPath = directory </> "second.png"
+        writePng firstPath (generateImage (\_ _ -> PixelRGB8 255 0 0) 4 3)
+        writePng secondPath (generateImage (\_ _ -> PixelRGB8 0 255 0) 4 3)
+        action firstPath secondPath
 
 newScriptRuntime :: UiState -> IO FullscreenRuntime
 newScriptRuntime ui = do

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -25,8 +25,10 @@ import Agent.CLI.Input
     )
 import Agent.CLI.TUI.Composer
 import Agent.CLI.TUI.Types
+import Agent.Loop (ImageAttachment(..))
 import Agent.TUI.Model
     ( NoticeKind(..)
+    , PromptState(..)
     , UiNotice(..)
     , UiState(..)
     , initialUiState
@@ -126,6 +128,17 @@ spec = describe "fullscreen composer" do
             "WHERE listings.agent_id = $1"
             `shouldBe` Just (True, "WHERE listings.agent_id = $1")
         steeringPrompt initialUiState True "not running"
+            `shouldBe` Nothing
+
+    it "keeps prompts with images out of text-only steering" do
+        let prompt = initialUiState.uiPrompt
+        steeringPrompt
+            initialUiState
+                { uiRunning = True
+                , uiPrompt = prompt { promptAttachments = 1 }
+                }
+            False
+            "describe the image"
             `shouldBe` Nothing
 
     it "dismisses slash completion or preserves the draft while idle" do
@@ -275,6 +288,74 @@ spec = describe "fullscreen composer" do
                 , 4
                 , Just (ReplClipboardPaste "next message" Nothing)
                 )
+
+    it "attaches clipboard images immediately without reading clipboard text" do
+        let image = ImageAttachment "image/png" "clipboard image"
+        attached <- newIORef []
+        result <- processComposerPaste
+            (pure (Right [image]))
+            (\_ -> expectationFailure "unexpected path read" >> pure Nothing)
+            (expectationFailure "unexpected text read" >> pure (Right ""))
+            (\images -> do
+                modifyIORef' attached (<> images)
+                pure (Right "attached"))
+            Nothing
+        result `shouldBe` ComposerPasteAttached "attached"
+        readIORef attached `shouldReturn` [image]
+
+    it "resolves an empty bracketed image paste without deferring to input" do
+        let image = ImageAttachment "image/png" "clipboard image"
+        processComposerPaste
+            (pure (Right [image]))
+            (const (pure Nothing))
+            (pure (Right ""))
+            (const (pure (Right "attached")))
+            (Just "")
+            `shouldReturn` ComposerPasteAttached "attached"
+
+    it "loads terminal image paths without consulting a different clipboard image" do
+        let image = ImageAttachment "image/png" "file image"
+        attached <- newIORef []
+        result <- processComposerPaste
+            (expectationFailure "unexpected clipboard read" >> pure (Right []))
+            (\path -> do
+                path `shouldBe` "/images/example.png"
+                pure (Just [image]))
+            (pure (Right ""))
+            (\images -> do
+                modifyIORef' attached (<> images)
+                pure (Right "attached"))
+            (Just "/images/example.png")
+        result `shouldBe` ComposerPasteAttached "attached"
+        readIORef attached `shouldReturn` [image]
+
+    it "preserves terminal text without reading potentially stale clipboard data" do
+        processComposerPaste
+            (expectationFailure "unexpected clipboard read" >> pure (Right []))
+            (const (pure Nothing))
+            (expectationFailure "unexpected clipboard text read" >> pure (Right ""))
+            (\_ -> expectationFailure "unexpected image attachment" >> pure (Right ""))
+            (Just " plain\ntext ")
+            `shouldReturn` ComposerPasteText " plain\ntext "
+
+    it "falls back to clipboard text when no clipboard image exists" do
+        processComposerPaste
+            (pure (Left "no image"))
+            (const (pure Nothing))
+            (pure (Right "copied text"))
+            (const (pure (Right "attached")))
+            Nothing
+            `shouldReturn` ComposerPasteText "copied text"
+
+    it "reports image attachment failures rather than inserting image paths" do
+        let image = ImageAttachment "image/png" "file image"
+        processComposerPaste
+            (pure (Right []))
+            (const (pure (Just [image])))
+            (pure (Right ""))
+            (const (pure (Left "attachment limit reached")))
+            (Just "/images/example.png")
+            `shouldReturn` ComposerPasteFailed "attachment limit reached"
 
     it "inserts dictation at the cursor with word-safe spacing" do
         insertDictation "please now" 6 "fix this"
@@ -485,6 +566,38 @@ spec = describe "fullscreen composer" do
                     "before/path.png"
                 , ReplText "urgent"
                 , ReplText "queued"
+                ]
+
+    it "retains captured images after older queued prompts" do
+        let image = ImageAttachment "image/png" "captured image"
+        buffer <- newFullscreenInputBuffer
+        atomically do
+            appendFullscreenInput buffer (input (ReplText "older prompt"))
+            appendFullscreenInput buffer
+                (input (ReplClipboardPasteCaptured [image]))
+            appendFullscreenInput buffer (input (ReplText "image prompt"))
+        queued <- atomically (readFullscreenInputs buffer)
+        map (.fullscreenInputLine) (toList queued)
+            `shouldBe`
+                [ ReplText "older prompt"
+                , ReplClipboardPasteCaptured [image]
+                , ReplText "image prompt"
+                ]
+
+    it "promotes captured image preludes with their draft rather than older prompts" do
+        let image = ImageAttachment "image/png" "captured image"
+        buffer <- newFullscreenInputBuffer
+        atomically do
+            appendFullscreenInput buffer (input (ReplText "older prompt"))
+            appendFullscreenInput buffer
+                (input (ReplClipboardPasteCaptured [image]))
+            promoteFullscreenInput buffer (input (ReplText "image prompt"))
+        queued <- atomically (readFullscreenInputs buffer)
+        map (.fullscreenInputLine) (toList queued)
+            `shouldBe`
+                [ ReplClipboardPasteCaptured [image]
+                , ReplText "image prompt"
+                , ReplText "older prompt"
                 ]
 
     it "only exposes displays for queued prompts" do


### PR DESCRIPTION
## Summary
- Resolve image pastes in the terminal composer immediately instead of waiting for the active agent turn to finish.
- Preserve the draft and cursor, capture image bytes in queue order, and prevent delayed turn updates from clearing the next draft’s attachments.
- Add regression coverage for image/text paste handling, queue ordering, attachment display, and queue-capacity rejection.

## Validation
- Loaded the updated CLI library and focused test modules in GHCi inside `nix develop`.
- All 239 composer and terminal UI examples passed (58 composer, 181 UI).
- Exercised the fullscreen terminal in tmux with a deliberately blocked worker: an image preview appeared while Thinking remained active, the draft stayed intact, and Enter queued the message and cleared the composer preview.
- `git diff --check` passed.