### PR TITLE
Establish scoped session resource ownership with Acquire

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -97,6 +97,7 @@ library
                     , Agent.CLI.Runtime.Orchestration.Session
                     , Agent.CLI.Runtime.Orchestration.Startup
                     , Agent.CLI.Runtime.Orchestration.Tools
+                    , Agent.CLI.Runtime.Orchestration.Tools.Resources
                     , Agent.CLI.Runtime.Orchestration.Tools.Request
                     , Agent.CLI.Runtime.Orchestration.Tools.Model
                     , Agent.CLI.Runtime.Orchestration.Tools.Collaboration
@@ -356,6 +357,7 @@ library
                     , process >= 1.6.26
                     , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions
+                    , resourcet
                     , scientific
                     , stm
                     , tagsoup
@@ -596,6 +598,7 @@ test-suite agent-cli-test
                     , Agent.CLI.TranscriptExportSpec
                     , Agent.CLI.SessionHistorySpec
                     , Agent.CLI.SessionStateSpec
+                    , Agent.CLI.SessionResourcesSpec
                     , Agent.CLI.SessionTitleSpec
                     , Agent.CLI.SkillsSpec
                     , Agent.CLI.SubagentStoreSpec
@@ -659,6 +662,7 @@ test-suite agent-cli-test
                     , process
                     , QuickCheck >= 2.14 && < 2.16
                     , safe-exceptions
+                    , resourcet
                     , stm
                     , text
                     , time

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -97,7 +97,6 @@ library
                     , Agent.CLI.Runtime.Orchestration.Session
                     , Agent.CLI.Runtime.Orchestration.Startup
                     , Agent.CLI.Runtime.Orchestration.Tools
-                    , Agent.CLI.Runtime.Orchestration.Tools.Resources
                     , Agent.CLI.Runtime.Orchestration.Tools.Request
                     , Agent.CLI.Runtime.Orchestration.Tools.Model
                     , Agent.CLI.Runtime.Orchestration.Tools.Collaboration
@@ -247,6 +246,7 @@ library
                     , Agent.CLI.Runtime.MetaConsole
                     , Agent.CLI.Runtime.Orchestration.Providers
                     , Agent.CLI.Runtime.Orchestration.Providers.Types
+                    , Agent.CLI.Runtime.Orchestration.Tools.Resources
                     , Agent.CLI.Resume
                     , Agent.CLI.Session.ConversationStore
                     , Agent.CLI.Session.History

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -9,10 +9,10 @@
 , deepseq, directory, entropy, filelock, filepath, haskeline
 , hasql-pool, hspec, http-client, http-client-tls, http-types
 , JuicyPixels, lib, memory, mtl, network, network-uri
-, optparse-applicative, process, QuickCheck, retry, safe-exceptions
-, scientific, stm, tagsoup, temporary, terminfo, text, time, tls
-, transformers, unix, vector, vty, vty-crossplatform, vty-unix, wai
-, warp
+, optparse-applicative, process, QuickCheck, resourcet, retry
+, safe-exceptions, scientific, stm, tagsoup, temporary, terminfo
+, text, time, tls, transformers, unix, vector, vty
+, vty-crossplatform, vty-unix, wai, warp
 }:
 mkDerivation {
   pname = "agent-cli";
@@ -31,9 +31,9 @@ mkDerivation {
     containers crypton crypton-connection dbus directory entropy
     filelock filepath haskeline hasql-pool http-client http-client-tls
     http-types JuicyPixels memory mtl network network-uri
-    optparse-applicative process retry safe-exceptions scientific stm
-    tagsoup terminfo text time tls transformers unix vector vty
-    vty-crossplatform vty-unix wai warp
+    optparse-applicative process resourcet retry safe-exceptions
+    scientific stm tagsoup terminfo text time tls transformers unix
+    vector vty vty-crossplatform vty-unix wai warp
   ];
   executableHaskellDepends = [
     aeson agent-cli-runtime agent-responses agent-responses-types
@@ -48,8 +48,8 @@ mkDerivation {
     agent-tui agent-xai ansi-terminal async base base64-bytestring
     brick bytestring colour containers dbus directory filelock filepath
     haskeline hspec http-client http-types JuicyPixels network
-    network-uri process QuickCheck safe-exceptions stm temporary text
-    time transformers unix vty vty-unix wai warp
+    network-uri process QuickCheck resourcet safe-exceptions stm
+    temporary text time transformers unix vty vty-unix wai warp
   ];
   benchmarkHaskellDepends = [
     aeson agent-cli-runtime agent-core agent-json agent-mcp

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -220,6 +220,7 @@ import Agent.OpenRouter.Options (ClientOptions)
 import Agent.Provider
     (Credential(..), Provider(..), TokenProvider,
      tokenProviderBillingMode)
+import Agent.ResourceScope (ResourceScope, allocateAcquire)
 import Agent.Responses.GenericClient (GenericClientOptions)
 import Agent.Responses.Types
     (ResponseItem, ResponseCreateParams(model))
@@ -244,6 +245,7 @@ import Control.Concurrent.Async ( waitSTM, withAsync )
 import Control.Concurrent.STM ( STM, retry )
 import Control.Exception.Safe ( mask_, finally )
 import Control.Monad ( forM_, void, when )
+import Data.Acquire (mkAcquire)
 import Data.Functor ( (<&>) )
 import Data.IORef
     ( IORef,
@@ -264,7 +266,7 @@ import System.OsPath (OsPath)
 import qualified Agent.MCP as MCP
 import qualified Data.Text.IO as Text ( hPutStr )
 
-data AgentSessionRequest closeResult windowTitleResult = AgentSessionRequest
+data AgentSessionRequest windowTitleResult = AgentSessionRequest
     { loaded :: LoadedAuth
     , connectedGateway :: Maybe GatewayCredential
     , learnAboutUserRequested :: Bool
@@ -280,8 +282,7 @@ data AgentSessionRequest closeResult windowTitleResult = AgentSessionRequest
     , checkStartupUsageInBackground :: Bool
     , claimCurrentSession :: SessionHandle -> IO ()
     , claudeBypassEnabled :: Bool
-    , closeAll :: IO closeResult
-    , codeModeCloseRef :: IORef (IO ())
+    , codeModeResourceScope :: ResourceScope
     , coding :: CodingTools
     , createSubagentWorktree
         :: OsPath -> IO (Either Text SubagentWorktree)
@@ -399,18 +400,17 @@ data SessionLiveRuntime = SessionLiveRuntime
     }
 
 runAgentSession
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> IO RunResult
-runAgentSession request@AgentSessionRequest{closeAll} =
-    flip finally closeAll do
-        validateSessionMcpTools request
-        codeRuntime <- prepareSessionCodeRuntime request
-        promptRuntime <- prepareSessionPromptRuntime request codeRuntime
-        liveRuntime <- prepareSessionLiveRuntime request promptRuntime
-        launchPreparedSession request promptRuntime liveRuntime
+runAgentSession request = do
+    validateSessionMcpTools request
+    codeRuntime <- prepareSessionCodeRuntime request
+    promptRuntime <- prepareSessionPromptRuntime request codeRuntime
+    liveRuntime <- prepareSessionLiveRuntime request promptRuntime
+    launchPreparedSession request promptRuntime liveRuntime
 
 validateSessionMcpTools
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> IO ()
 validateSessionMcpTools AgentSessionRequest
     { coding
@@ -439,7 +439,7 @@ validateSessionMcpTools AgentSessionRequest
             Nothing -> pure ()
 
 prepareSessionCodeRuntime
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> IO SessionCodeRuntime
 prepareSessionCodeRuntime AgentSessionRequest
     { loaded
@@ -453,7 +453,7 @@ prepareSessionCodeRuntime AgentSessionRequest
     , startup
     , options
     , tools
-    , codeModeCloseRef
+    , codeModeResourceScope
     , allTools
     , effortText
     , workspace = WorkspaceContext{cwd}
@@ -501,15 +501,20 @@ prepareSessionCodeRuntime AgentSessionRequest
             | otherwise =
                 "image generation code mode unavailable; \
                 \disabling image generation: "
+    -- Attach cleanup during acquisition, before warnings or subsequent startup
+    -- work can throw. The enclosing session owns this scope.
+    (_, initializedCodeMode) <-
+        allocateAcquire codeModeResourceScope $
+            mkAcquire initializeCodeMode \case
+                Left _ -> pure ()
+                Right runtime -> mapM_ (.codeModeClose) runtime
     (sessionCodeModeRuntime, suppressDirectImageGeneration) <-
-        initializeCodeMode >>= \case
+        case initializedCodeMode of
             Left err -> do
                 reportStartupWarning startup
                     (codeModeFallbackWarning <> err)
                 pure (Nothing, True)
             Right runtime -> pure (runtime, False)
-    writeIORef codeModeCloseRef
-        (maybe (pure ()) (.codeModeClose) sessionCodeModeRuntime)
     sessionReservedId <- reservedSessionId persist
     let providerTools =
             filterStartupUnavailableTools
@@ -582,7 +587,7 @@ prepareSessionCodeRuntime AgentSessionRequest
     pure SessionCodeRuntime{..}
 
 prepareSessionPromptRuntime
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> SessionCodeRuntime
     -> IO SessionPromptRuntime
 prepareSessionPromptRuntime AgentSessionRequest
@@ -660,7 +665,7 @@ isClaudeBridgeTool tool =
             _ -> False
 
 sessionCatalogContextWindowForParams
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> (Text -> Text)
     -> ResponseCreateParams
     -> Maybe Int
@@ -676,7 +681,7 @@ sessionCatalogContextWindowForParams AgentSessionRequest
         (mapTransportModel currentModel)
 
 sessionCurrentModelContextWindow
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> SessionPromptRuntime
     -> (Text -> Text)
     -> IO (Maybe Int)
@@ -689,7 +694,7 @@ sessionCurrentModelContextWindow request promptRuntime mapTransportModel = do
             currentParams
 
 sessionContextWindowForParams
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> (Text -> Text)
     -> Int
     -> ResponseCreateParams
@@ -702,7 +707,7 @@ sessionContextWindowForParams request mapTransportModel fallback params =
             params)
 
 buildSessionSubagentRuntime
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> SessionPromptRuntime
     -> SubagentRuntime
 buildSessionSubagentRuntime AgentSessionRequest
@@ -765,7 +770,7 @@ buildSessionSubagentRuntime AgentSessionRequest
         }
 
 prepareSessionLiveRuntime
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> SessionPromptRuntime
     -> IO SessionLiveRuntime
 prepareSessionLiveRuntime request@AgentSessionRequest
@@ -806,7 +811,7 @@ prepareSessionLiveRuntime request@AgentSessionRequest
     pure SessionLiveRuntime{..}
 
 sessionWindowTitle
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> Text
 sessionWindowTitle AgentSessionRequest
     { resumed
@@ -824,7 +829,7 @@ sessionWindowTitle AgentSessionRequest
                 promptRequest
 
 loadSessionStartupContext
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> SessionPromptRuntime
     -> IO (IORef (Maybe Text))
 loadSessionStartupContext AgentSessionRequest
@@ -876,7 +881,7 @@ loadSessionStartupContext AgentSessionRequest
         | otherwise = promptRuntime.sessionInitialPrevious
 
 evictResumedConversation
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> IORef LiveConversation
     -> IO ()
 evictResumedConversation AgentSessionRequest
@@ -898,7 +903,7 @@ evictResumedConversation AgentSessionRequest
         when evicted performMajorGC
 
 recordSessionCompactionUsage
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> IORef TokenUsage
     -> TokenUsage
     -> IO ()
@@ -918,7 +923,7 @@ recordSessionCompactionUsage AgentSessionRequest
             modifyIORef' usageRef (`addTokenUsage` usage)
 
 claimPersistedSession
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> IO ()
 claimPersistedSession AgentSessionRequest
     { persist
@@ -935,7 +940,7 @@ claimPersistedSession AgentSessionRequest
         PersistenceDisabled -> pure ()
 
 buildProviderSessionRequest
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> SessionPromptRuntime
     -> SessionLiveRuntime
     -> Maybe (STM ApiError)
@@ -1064,7 +1069,7 @@ buildProviderSessionRequest
             }
 
 withSessionStartupAvailability
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> Bool
     -> (Maybe (STM ApiError) -> IO result)
     -> IO result
@@ -1088,7 +1093,7 @@ withSessionStartupAvailability AgentSessionRequest
         | otherwise = action Nothing
 
 runSessionWithInterruptHandling
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> String
     -> IO RunResult
     -> IO RunResult
@@ -1104,7 +1109,7 @@ runSessionWithInterruptHandling AgentSessionRequest
                 withResumeHintOnQuit fullscreen progName persist action
 
 launchPreparedSession
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> SessionPromptRuntime
     -> SessionLiveRuntime
     -> IO RunResult
@@ -1142,7 +1147,7 @@ runSession = SessionRunner.runSession sessionRunnerContinuation
 -- | The session owns composition and presentation. Provider runtimes only
 -- supply transport capabilities, scoped around this continuation.
 launchProvider
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> SessionPromptRuntime
     -> SessionLiveRuntime
     -> Bool
@@ -1204,7 +1209,7 @@ launchProvider request promptRuntime liveRuntime shouldProbeAtStartup startupUna
         _ -> withProviderRuntime config host use
 
 prepareProviderConfig
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> SessionPromptRuntime
     -> NativeRunCapabilities
     -> IO ProviderConfig
@@ -1282,7 +1287,7 @@ prepareProviderConfig request promptRuntime nativeCapabilities = case request.pr
             }
 
 installProviderSubagents
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> SessionLiveRuntime
     -> ProviderSubagents
     -> IO ()
@@ -1359,7 +1364,7 @@ installProviderSubagents request liveRuntime capabilities =
                         "This provider requires a separate child session; it cannot run as an in-process gateway subagent."))
 
 handleOpenAiStartupResult
-    :: AgentSessionRequest closeResult windowTitleResult
+    :: AgentSessionRequest windowTitleResult
     -> NativeRunCapabilities
     -> Bool
     -> Either CodexAuthFailed RunResult

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -110,11 +110,12 @@ import Agent.OpenAI.ImageGeneration
     )
 import Agent.Provider (Provider(OpenAIProvider))
 import Agent.ResourceScope
-    ( allocateResource
-    , allocateFourResourcesConcurrently
-    , releaseResource
-    , withResourceScope
+    ( ResourceScope
+    , allocateAcquire
+    , registerResource
     )
+import Agent.CLI.Runtime.Orchestration.Tools.Resources
+    ( SessionResourceScopes(..), withSessionResourceScopes )
 import Agent.Skills
     ( SkillCatalog(..)
     , SkillInvocation
@@ -132,12 +133,13 @@ import Agent.Tools.Types
     , ToolEnv(..)
     , appToolsFromGroups
     )
-import Control.Concurrent.Async ( concurrently, concurrently_ )
+import Control.Concurrent.Async ( concurrently )
 import Control.Exception.Safe
-    ( SomeException, bracketOnError, finally, mask_, throwIO, try )
-import Control.Monad ( forM_, join, when, void )
+    ( SomeException, mask_, throwIO, try )
+import Control.Monad ( forM_, when, void )
+import Data.Acquire (Acquire, mkAcquire)
 import Data.IORef
-    (IORef, newIORef, readIORef, writeIORef)
+    (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
 import Data.Maybe (isJust)
 import Data.Unique (newUnique, hashUnique)
 import System.Info (os)
@@ -159,7 +161,6 @@ data CodingRuntime = CodingRuntime
     { runtimeCoding :: CodingTools
     , runtimeExtraTools :: [AppTool]
     , runtimeComputerUse :: Maybe ComputerUse.ComputerUseRuntime
-    , runtimeCloseExtraTools :: IO ()
     }
 
 data SessionControlRuntime = SessionControlRuntime
@@ -167,7 +168,6 @@ data SessionControlRuntime = SessionControlRuntime
     , controlBashEnabledRef :: IORef Bool
     , controlSkillsRef :: IORef SkillCatalog
     , controlSkillInvocationsRef :: IORef [SkillInvocation]
-    , controlCodeModeCloseRef :: IORef (IO ())
     , controlClaimCurrentSession :: SessionHandle -> IO ()
     , controlSessionTools :: [AppTool]
     }
@@ -181,99 +181,88 @@ data SessionToolsRuntime = SessionToolsRuntime
     , sessionGatewayTools :: [AppTool]
     , sessionPlanMode :: PlanModeEnv
     , sessionNoteDirectory :: OsPath -> IO ()
-    , sessionCloseAll :: IO ()
     , sessionResumedPlanPending :: Bool
     }
 
 runAgentTools
     :: AgentToolsRequest windowTitleResult
     -> IO RunResult
-runAgentTools request = withResourceScope \resourceScope -> do
+runAgentTools request = withSessionResourceScopes \resources -> do
     toolStartup <- loadToolStartup request
     let toolModelRuntime = resolveToolModel request toolStartup
         toolHostHooks =
             buildToolHostHooks request toolStartup toolModelRuntime
-    collaborationRuntime <-
-        newCollaborationRuntime request toolStartup toolModelRuntime
-    (scratchKey, acquiredScratchRuntime) <-
-        allocateResource
-            resourceScope
+    (_, collaborationRuntime) <-
+        allocateAcquire resources.activityResources
+            (acquireCollaborationRuntime request toolStartup toolModelRuntime)
+    -- The current lock changes on conversation reset. Drain the slot only
+    -- after session activities stop; the preparation owner still protects
+    -- the original resume lock before this boundary is established.
+    _ <- registerResource resources.sessionLockResources do
+        current <- atomicModifyIORef'
+            collaborationRuntime.collaborationActiveSessionLock
+            (\value -> (Nothing, value))
+        mapM_ releaseSessionLock current
+    (_, scratchRuntime) <-
+        allocateAcquire resources.scratchResources $
+        mkAcquire
             (prepareScratchRuntime
                 request
                 toolStartup
                 toolModelRuntime
                 collaborationRuntime)
             (.scratchCleanup)
-    let scratchRuntime =
-            acquiredScratchRuntime
-                { scratchCleanup = releaseResource scratchKey }
     integrationRuntime <- acquireSessionIntegrationRuntime request
-    ( (acquiredResources, (computerUseKey, runtimeComputerUse))
+    ( ((((_, mcpRuntime), (_, localToolRuntime)),
+          ((_, webFetchRuntime), (_, lspStartup))),
+         (_, runtimeComputerUse))
       , (initialContext, initialContextPreload)
       ) <-
         concurrently
             ( concurrently
-                ( allocateFourResourcesConcurrently
-                    resourceScope
-                    (acquireMcpRuntime
-                        request
-                        toolStartup
-                        toolModelRuntime
-                        collaborationRuntime
-                        scratchRuntime
-                        integrationRuntime)
-                    (.runtimeCloseMcp)
-                    (acquireLocalToolRuntime
-                        request
-                        toolModelRuntime
-                        toolHostHooks
-                        collaborationRuntime
-                        scratchRuntime)
-                    (.localCoding.codingClose)
-                    (acquireWebFetchRuntime
-                        request
-                        toolStartup
-                        toolModelRuntime)
-                    (mapM_ closeWebFetchRuntime)
-                    (acquireLspStartup
-                        request
-                        toolStartup
-                        toolModelRuntime)
-                    (mapM_ closeLspRuntime . (.lspStartupRuntime))
+                ( concurrently
+                    ( concurrently
+                        ( allocateAcquire resources.mcpResources $
+                            mkAcquire
+                                (acquireMcpRuntime
+                                    request toolStartup toolModelRuntime
+                                    collaborationRuntime scratchRuntime
+                                    integrationRuntime)
+                                (.runtimeCloseMcp)
+                        )
+                        ( allocateAcquire resources.codingResources
+                            (acquireLocalToolRuntime
+                                request toolModelRuntime toolHostHooks
+                                collaborationRuntime scratchRuntime)
+                        )
+                    )
+                    ( concurrently
+                        ( allocateAcquire resources.webFetchResources $
+                            mkAcquire
+                                (acquireWebFetchRuntime
+                                    request toolStartup toolModelRuntime)
+                                (mapM_ closeWebFetchRuntime)
+                        )
+                        ( allocateAcquire resources.lspResources $
+                            mkAcquire
+                                (acquireLspStartup
+                                    request toolStartup toolModelRuntime)
+                                (mapM_ closeLspRuntime . (.lspStartupRuntime))
+                        )
+                    )
                 )
-                ( allocateResource
-                    resourceScope
-                    (acquireComputerUseRuntime toolModelRuntime)
-                    (mapM_ ComputerUse.closeComputerUseRuntime)
+                ( allocateAcquire resources.computerUseResources $
+                    mkAcquire
+                        (acquireComputerUseRuntime toolModelRuntime)
+                        (mapM_ ComputerUse.closeComputerUseRuntime)
                 )
             )
             (prepareInitialContextPreload request toolModelRuntime)
-    let ( (mcpKey, acquiredMcpRuntime)
-          , (localToolKey, acquiredLocalToolRuntime)
-          , (webFetchKey, webFetchRuntime)
-          , (lspKey, lspStartup)
-          ) = acquiredResources
-        mcpRuntime =
-            acquiredMcpRuntime
-                { runtimeCloseMcp =
-                    releaseResource mcpKey
-                }
-        localToolRuntime =
-            acquiredLocalToolRuntime
-                { localCoding =
-                    acquiredLocalToolRuntime.localCoding
-                        { codingClose = releaseResource localToolKey }
-                }
-        lspRuntime = lspStartup.lspStartupRuntime
+    let lspRuntime = lspStartup.lspStartupRuntime
         runtimeCoding = localToolRuntime.localCoding
         runtimeExtraTools =
             maybe [] (pure . webFetchRuntimeTool) webFetchRuntime
                 <> maybe [] (pure . lspRuntimeTool) lspRuntime
-        runtimeCloseExtraTools =
-            releaseResource computerUseKey
-                `finally` concurrently_
-                    (releaseResource lspKey)
-                    (releaseResource webFetchKey)
         codingRuntime = CodingRuntime{..}
     mapM_
         (reportStartupWarning request.startup)
@@ -306,6 +295,7 @@ runAgentTools request = withResourceScope \resourceScope -> do
             codingRuntime
             sessionControlRuntime
     launchAgentToolsSession
+        resources.codeModeResources
         request
         toolStartup
         toolModelRuntime
@@ -341,7 +331,7 @@ acquireLocalToolRuntime
     -> ToolHostHooks
     -> CollaborationRuntime
     -> ScratchRuntime
-    -> IO LocalToolRuntime
+    -> Acquire LocalToolRuntime
 acquireLocalToolRuntime AgentToolsRequest
     { startup
     , baseToolEnv
@@ -367,7 +357,7 @@ acquireLocalToolRuntime AgentToolsRequest
                     baseToolEnv
                         { toolCwd = context.nativeDiscoveryProjectRoot }
                 Nothing -> baseToolEnv
-    bracketOnError
+    localCoding <- mkAcquire
         (codingToolsForWithTypes
             dialect
             codingToolEnv
@@ -378,9 +368,8 @@ acquireLocalToolRuntime AgentToolsRequest
             multiCtx
             agentTypesRef)
         (.codingClose)
-        \localCoding -> do
-            let localInitialSkills = initialSkills
-            pure LocalToolRuntime{..}
+    let localInitialSkills = initialSkills
+    pure LocalToolRuntime{..}
 
 acquireWebFetchRuntime
     :: AgentToolsRequest windowTitleResult
@@ -527,7 +516,6 @@ newSessionControlRuntime AgentToolsRequest
     controlBashEnabledRef <- newIORef options.optBash
     controlSkillsRef <- newIORef initialSkills
     controlSkillInvocationsRef <- newIORef []
-    controlCodeModeCloseRef <- newIORef (pure ())
     let controlClaimCurrentSession handle = mask_ do
             let desired = sessionLockPath handle.sessionDir
             readIORef activeSessionLock >>= \case
@@ -638,27 +626,21 @@ assembleSessionToolsRuntime AgentToolsRequest
     } CollaborationRuntime
     { collaborationPersistSlotRef = persistSlotRef
     , collaborationSubagentStoreRoot = subagentStoreRoot
-    , collaborationActiveSessionLock = activeSessionLock
-    , collaborationCloseAgents = closeAgents
     } ScratchRuntime
     { scratchPromptRequest = promptRequest
     , scratchImageGenerationHistory = imageGenerationHistory
     , scratchExternalSessionTools = externalSessionAppTools
     , scratchSessionTmp = sessionTmp
-    , scratchCleanup = cleanupScratch
     } McpRuntime
     { runtimeMcpServerConfigs = mcpServerConfigs
     , runtimeProgressiveMcp = progressiveMcp
     , runtimeMcpFleet = mcpFleet
-    , runtimeCloseMcp = closeMcp
     } CodingRuntime
     { runtimeCoding = coding
     , runtimeExtraTools = extraTools
     , runtimeComputerUse = computerUseRuntime
-    , runtimeCloseExtraTools = closeExtraTools
     } SessionControlRuntime
     { controlSkillInvocationsRef = skillInvocationsRef
-    , controlCodeModeCloseRef = codeModeCloseRef
     , controlSessionTools = persistedSessionTools
     } = do
     let artifactDirectory = Just (unsafeToFilePath sessionTmp)
@@ -771,29 +753,13 @@ assembleSessionToolsRuntime AgentToolsRequest
         sessionNoteDirectory dir = do
             writeIORef sessionPlanMode.planSessionDir (Just dir)
             writeIORef subagentStoreRoot (Just dir)
-        sessionCloseAll =
-            closeAgents
-                `finally`
-                    ((readIORef activeSessionLock
-                        >>= mapM_ releaseSessionLock)
-                        `finally`
-                            (closeExtraTools
-                                `finally`
-                                    (closeMcp
-                                        `finally`
-                                            (coding.codingClose
-                                                `finally`
-                                                    (join
-                                                        (readIORef
-                                                            codeModeCloseRef)
-                                                        `finally`
-                                                            cleanupScratch)))))
         sessionAllTools = composeToolGroups allToolGroups
         sessionTools = composeToolGroups activeToolGroups
     pure SessionToolsRuntime{..}
 
 launchAgentToolsSession
-    :: AgentToolsRequest windowTitleResult
+    :: ResourceScope
+    -> AgentToolsRequest windowTitleResult
     -> ToolStartup
     -> ToolModelRuntime
     -> ToolHostHooks
@@ -806,7 +772,7 @@ launchAgentToolsSession
     -> SessionControlRuntime
     -> SessionToolsRuntime
     -> IO RunResult
-launchAgentToolsSession AgentToolsRequest{..} ToolStartup
+launchAgentToolsSession codeModeResourceScope AgentToolsRequest{..} ToolStartup
     { toolOpenRouterOptions = openRouterOptions
     } ToolModelRuntime
     { toolProvider = provider
@@ -853,7 +819,6 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
     , controlBashEnabledRef = bashEnabledRef
     , controlSkillsRef = skillsRef
     , controlSkillInvocationsRef = skillInvocationsRef
-    , controlCodeModeCloseRef = codeModeCloseRef
     , controlClaimCurrentSession = claimCurrentSession
     , controlSessionTools = agentSessionAppTools
     } SessionToolsRuntime
@@ -865,7 +830,6 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
     , sessionGatewayTools = gatewayTools
     , sessionPlanMode = planMode
     , sessionNoteDirectory = noteSessionDir
-    , sessionCloseAll = closeAll
     , sessionResumedPlanPending = resumedPlanPending
     } = do
     when resumedPlanPending (activatePlanMode planMode)
@@ -894,8 +858,7 @@ launchAgentToolsSession AgentToolsRequest{..} ToolStartup
         , checkStartupUsageInBackground
         , claimCurrentSession
         , claudeBypassEnabled
-        , closeAll
-        , codeModeCloseRef
+        , codeModeResourceScope
         , coding
         , createSubagentWorktree
         , customGenericOptions

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -134,7 +134,7 @@ import Agent.Tools.Types
     , ToolEnv(..)
     , appToolsFromGroups
     )
-import Control.Concurrent.Async ( concurrently )
+import Control.Concurrent.Async ( Concurrently(..), concurrently )
 import Control.Exception.Safe
     ( SomeException, mask_, throwIO, try )
 import Control.Monad ( forM_, when, void )
@@ -156,6 +156,15 @@ import qualified Data.Text as Text (unpack, pack)
 data LocalToolRuntime = LocalToolRuntime
     { localCoding :: CodingTools
     , localInitialSkills :: SkillCatalog
+    }
+
+data StartupResources = StartupResources
+    { startupMcp :: McpRuntime
+    , startupLocalTools :: LocalToolRuntime
+    , startupWebFetch :: Maybe WebFetchRuntime
+    , startupLsp :: LspStartup
+    , startupComputerUse :: Maybe ComputerUse.ComputerUseRuntime
+    , startupInitialContext :: (SessionInitialContext, InitialContextPreload)
     }
 
 data CodingRuntime = CodingRuntime
@@ -214,52 +223,49 @@ runAgentTools request = withSessionResourceScopes \resources -> do
                 collaborationRuntime)
             (logSlowCleanup "session temporary resources" . (.scratchCleanup))
     integrationRuntime <- acquireSessionIntegrationRuntime request
-    ( ((((_, mcpRuntime), (_, localToolRuntime)),
-          ((_, webFetchRuntime), (_, lspStartup))),
-         (_, runtimeComputerUse))
-      , (initialContext, initialContextPreload)
-      ) <-
-        concurrently
-            ( concurrently
-                ( concurrently
-                    ( concurrently
-                        ( allocateAcquire resources.mcpResources $
-                            mkAcquire
-                                (acquireMcpRuntime
-                                    request toolStartup toolModelRuntime
-                                    collaborationRuntime scratchRuntime
-                                    integrationRuntime)
-                                (logSlowCleanup "session MCP resources" . (.runtimeCloseMcp))
-                        )
-                        ( allocateAcquire resources.codingResources
-                            (acquireLocalToolRuntime
-                                request toolModelRuntime toolHostHooks
-                                collaborationRuntime scratchRuntime)
-                        )
-                    )
-                    ( concurrently
-                        ( allocateAcquire resources.webFetchResources $
-                            mkAcquire
-                                (acquireWebFetchRuntime
-                                    request toolStartup toolModelRuntime)
-                                (logSlowCleanup "web fetch runtime" . mapM_ closeWebFetchRuntime)
-                        )
-                        ( allocateAcquire resources.lspResources $
-                            mkAcquire
-                                (acquireLspStartup
-                                    request toolStartup toolModelRuntime)
-                                (logSlowCleanup "language server runtime" . mapM_ closeLspRuntime . (.lspStartupRuntime))
-                        )
-                    )
-                )
-                ( allocateAcquire resources.computerUseResources $
-                    mkAcquire
-                        (acquireComputerUseRuntime toolModelRuntime)
-                        (logSlowCleanup "computer use runtime" . mapM_ ComputerUse.closeComputerUseRuntime)
-                )
-            )
-            (prepareInitialContextPreload request toolModelRuntime)
-    let lspRuntime = lspStartup.lspStartupRuntime
+    let acquireOwnedMcp =
+            snd <$> allocateAcquire resources.mcpResources
+                (mkAcquire
+                    (acquireMcpRuntime
+                        request toolStartup toolModelRuntime
+                        collaborationRuntime scratchRuntime integrationRuntime)
+                    (logSlowCleanup "session MCP resources" . (.runtimeCloseMcp)))
+        acquireOwnedCoding =
+            snd <$> allocateAcquire resources.codingResources
+                (acquireLocalToolRuntime
+                    request toolModelRuntime toolHostHooks
+                    collaborationRuntime scratchRuntime)
+        acquireOwnedWebFetch =
+            snd <$> allocateAcquire resources.webFetchResources
+                (mkAcquire
+                    (acquireWebFetchRuntime request toolStartup toolModelRuntime)
+                    (logSlowCleanup "web fetch runtime" . mapM_ closeWebFetchRuntime))
+        acquireOwnedLsp =
+            snd <$> allocateAcquire resources.lspResources
+                (mkAcquire
+                    (acquireLspStartup request toolStartup toolModelRuntime)
+                    (logSlowCleanup "language server runtime" . mapM_ closeLspRuntime . (.lspStartupRuntime)))
+        acquireOwnedComputerUse =
+            snd <$> allocateAcquire resources.computerUseResources
+                (mkAcquire
+                    (acquireComputerUseRuntime toolModelRuntime)
+                    (logSlowCleanup "computer use runtime" . mapM_ ComputerUse.closeComputerUseRuntime))
+    -- Startup is concurrent; resource scopes determine shutdown order.
+    startupResources <- runConcurrently $
+        StartupResources
+            <$> Concurrently acquireOwnedMcp
+            <*> Concurrently acquireOwnedCoding
+            <*> Concurrently acquireOwnedWebFetch
+            <*> Concurrently acquireOwnedLsp
+            <*> Concurrently acquireOwnedComputerUse
+            <*> Concurrently (prepareInitialContextPreload request toolModelRuntime)
+    let mcpRuntime = startupResources.startupMcp
+        localToolRuntime = startupResources.startupLocalTools
+        webFetchRuntime = startupResources.startupWebFetch
+        lspStartup = startupResources.startupLsp
+        runtimeComputerUse = startupResources.startupComputerUse
+        (initialContext, initialContextPreload) = startupResources.startupInitialContext
+        lspRuntime = lspStartup.lspStartupRuntime
         runtimeCoding = localToolRuntime.localCoding
         runtimeExtraTools =
             maybe [] (pure . webFetchRuntimeTool) webFetchRuntime

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Collaboration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Collaboration.hs
@@ -1,8 +1,8 @@
--- | Root collaboration setup and callbacks. Registry ownership remains with
--- the session's existing close action.
+-- | Root collaboration setup and callbacks. Acquisition owns the registry
+-- before later initialization, and releases it even when persistence fails.
 module Agent.CLI.Runtime.Orchestration.Tools.Collaboration
     ( CollaborationRuntime(..)
-    , newCollaborationRuntime
+    , acquireCollaborationRuntime
     , installCollaborationCallbacks
     ) where
 
@@ -41,6 +41,9 @@ import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.Tools.MultiAgents
     ( CollaborationModelTarget(..), MultiAgentContext(..), SubagentWorktree(..) )
 import Control.Applicative ((<|>))
+import Control.Exception.Safe (finally)
+import Control.Monad.IO.Class (liftIO)
+import Data.Acquire (Acquire, mkAcquire)
 import Data.IORef (IORef, newIORef, readIORef)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -71,15 +74,14 @@ data CollaborationRuntime = CollaborationRuntime
     , collaborationCreateWorktree
         :: OsPath -> IO (Either Text SubagentWorktree)
     , collaborationContext :: Maybe MultiAgentContext
-    , collaborationCloseAgents :: IO ()
     }
 
-newCollaborationRuntime
+acquireCollaborationRuntime
     :: AgentToolsRequest windowTitleResult
     -> ToolStartup
     -> ToolModelRuntime
-    -> IO CollaborationRuntime
-newCollaborationRuntime AgentToolsRequest
+    -> Acquire CollaborationRuntime
+acquireCollaborationRuntime AgentToolsRequest
     { resumeLock
     , options
     , projectSettings
@@ -107,27 +109,41 @@ newCollaborationRuntime AgentToolsRequest
     -- Keep inferred startup, resume, and delegated-agent targets session-local.
     -- Live top-level model/provider switches persist their selection in
     -- Agent.CLI.Provider.Switch instead.
-    collaborationActiveSessionLock <- newIORef resumeLock
-    collaborationPersistSlotRef <- newIORef PersistenceDisabled
+    collaborationActiveSessionLock <- liftIO $ newIORef resumeLock
+    collaborationPersistSlotRef <- liftIO $ newIORef PersistenceDisabled
     -- Per-subagent transcripts / previous ids, shared across send_input / task.
-    collaborationSubagentSessions <- newIORef Map.empty
-    collaborationSubagentStoreRoot <- newIORef Nothing
+    collaborationSubagentSessions <- liftIO $ newIORef Map.empty
+    collaborationSubagentStoreRoot <- liftIO $ newIORef Nothing
     collaborationSubagentForkSource <-
-        newIORef (Nothing :: Maybe (IO [ResponseItem]))
-    collaborationPendingNotices <- newPendingInputs
+        liftIO $ newIORef (Nothing :: Maybe (IO [ResponseItem]))
+    collaborationPendingNotices <- liftIO newPendingInputs
+    collaborationAgentTypes <- liftIO $ newIORef Map.empty
     let maxConcurrentAgents =
             fromMaybe defaultMaxConcurrent $
                 options.optMaxConcurrentAgents
                     <|> projectSettings.settingsMaxConcurrentAgents
                     <|> harnessConfig.configMaxConcurrentAgents
-    collaborationRegistry <- newSubagentRegistry
-        defaultSubagentConfig { maxConcurrent = maxConcurrentAgents }
-        cwd
-        (\_ _ _ _ -> pure $ Left LoopNoResponseId)
-        (\_ _ -> pure ())
-    collaborationRootTurnRef <- newIORef (Nothing :: Maybe RootTurnId)
-    collaborationAgentTypes <- newIORef Map.empty
-    collaborationOpenAiChild <-
+        finalizeRegistry registry =
+            -- Persistence needs the interrupted agents' final state, but a
+            -- failed snapshot must never leave their supervisors alive while
+            -- the session releases dependent tool resources.
+            (do
+                interruptActiveSubagents registry
+                flushAllSubagentSnapshots
+                    collaborationSubagentStoreRoot
+                    registry
+                    collaborationSubagentSessions
+                    collaborationAgentTypes)
+                `finally` closeSubagentRegistry registry
+    collaborationRegistry <- mkAcquire
+        (newSubagentRegistry
+            defaultSubagentConfig { maxConcurrent = maxConcurrentAgents }
+            cwd
+            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+            (\_ _ -> pure ()))
+        finalizeRegistry
+    collaborationRootTurnRef <- liftIO $ newIORef (Nothing :: Maybe RootTurnId)
+    collaborationOpenAiChild <- liftIO $
         if not nativeCapabilities.nativeCollaboration
             || isJust gatewayAllowedChildModels
             then pure Nothing
@@ -250,17 +266,6 @@ newCollaborationRuntime AgentToolsRequest
                 , multiChildModelAllowed =
                     collaborationChildModelAllowed
                 }
-        collaborationCloseAgents =
-            case collaborationContext of
-                Just ctx -> do
-                    interruptActiveSubagents ctx.multiRegistry
-                    flushAllSubagentSnapshots
-                        collaborationSubagentStoreRoot
-                        ctx.multiRegistry
-                        collaborationSubagentSessions
-                        collaborationAgentTypes
-                    closeSubagentRegistry ctx.multiRegistry
-                Nothing -> pure ()
     pure CollaborationRuntime{..}
 
 installCollaborationCallbacks

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Resources.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Resources.hs
@@ -1,0 +1,49 @@
+-- | Ownership for one invocation of the tool/session runtime, including
+-- conversation resets. Process-owned services and independent sessions do
+-- not belong here.
+module Agent.CLI.Runtime.Orchestration.Tools.Resources
+    ( SessionResourceScopes(..)
+    , withSessionResourceScopes
+    ) where
+
+import Agent.ResourceScope
+    ( ResourceScope, closeResourceScopeChecked, newResourceScope )
+import Data.Acquire (Acquire, mkAcquire)
+import qualified Data.Acquire as Acquire
+
+data SessionResourceScopes = SessionResourceScopes
+    { scratchResources :: ResourceScope
+    , codingResources :: ResourceScope
+    , mcpResources :: ResourceScope
+    , webFetchResources :: ResourceScope
+    , lspResources :: ResourceScope
+    , computerUseResources :: ResourceScope
+    , sessionLockResources :: ResourceScope
+    , codeModeResources :: ResourceScope
+    , activityResources :: ResourceScope
+    }
+
+-- | Establish ownership before starting concurrent acquisitions. Their
+-- completion order cannot change dependency teardown order.
+--
+-- Acquire unwinds in reverse: join session activities, stop the code-mode
+-- dispatcher, release the session lock, close tools, then remove scratch
+-- storage. Each domain uses the existing resourcet finalizer machinery;
+-- there is no separate cleanup registry or worker supervisor here.
+withSessionResourceScopes :: (SessionResourceScopes -> IO a) -> IO a
+withSessionResourceScopes = Acquire.with acquireSessionResourceScopes
+
+acquireSessionResourceScopes :: Acquire SessionResourceScopes
+acquireSessionResourceScopes = do
+    scratchResources <- acquireScope
+    codingResources <- acquireScope
+    mcpResources <- acquireScope
+    webFetchResources <- acquireScope
+    lspResources <- acquireScope
+    computerUseResources <- acquireScope
+    sessionLockResources <- acquireScope
+    codeModeResources <- acquireScope
+    activityResources <- acquireScope
+    pure SessionResourceScopes{..}
+  where
+    acquireScope = mkAcquire newResourceScope closeResourceScopeChecked

--- a/packages/agent-cli/test/Agent/CLI/SessionResourcesSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionResourcesSpec.hs
@@ -1,0 +1,161 @@
+module Agent.CLI.SessionResourcesSpec (spec) where
+
+import Agent.CLI.Runtime.Orchestration.Tools.Resources
+import Agent.ResourceScope
+    ( ResourceScope, allocateAcquire, registerResource, releaseResource )
+import Control.Concurrent.Async (cancel, concurrently_, race, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Exception.Safe (finally, throwIO, tryAny)
+import Control.Monad (forM_, void)
+import Data.Acquire (mkAcquire)
+import Data.Either (isLeft)
+import Data.IORef
+    ( IORef, atomicModifyIORef', newIORef, readIORef, writeIORef )
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "session resource ownership" do
+    it "tears down domains in dependency order rather than registration order" do
+        released <- newIORef []
+        withSessionResourceScopes \scopes -> do
+            -- Deliberately register in shutdown order. A single shared scope
+            -- would reverse this order and release scratch storage first.
+            forM_ (shutdownDomains scopes) \(name, scope) ->
+                retain scope released name
+        readIORef released `shouldReturn` shutdownNames
+
+    it "preserves dependency teardown for either concurrent completion order" do
+        forM_ [False, True] \mcpCompletesFirst -> do
+            completed <- newIORef []
+            released <- newIORef []
+            firstCompleted <- newEmptyMVar
+            secondStarted <- newEmptyMVar
+            result <- timeout 2000000 $
+                withSessionResourceScopes \scopes -> do
+                    let (firstName, firstScope, secondName, secondScope)
+                            | mcpCompletesFirst =
+                                ("mcp", scopes.mcpResources,
+                                 "coding", scopes.codingResources)
+                            | otherwise =
+                                ("coding", scopes.codingResources,
+                                 "mcp", scopes.mcpResources)
+                    concurrently_
+                        (do
+                            -- Both acquisitions have begun before either
+                            -- completes; this also detects serialized startup.
+                            void $ allocateAcquire firstScope $
+                                mkAcquire
+                                    (takeMVar secondStarted)
+                                    (const (record released firstName))
+                            record completed firstName
+                            putMVar firstCompleted ())
+                        (do
+                            void $ allocateAcquire secondScope $
+                                mkAcquire
+                                    (putMVar secondStarted ()
+                                        >> takeMVar firstCompleted)
+                                    (const (record released secondName))
+                            record completed secondName)
+                    readIORef completed
+                        `shouldReturn` [firstName, secondName]
+            result `shouldBe` Just ()
+            readIORef released `shouldReturn` ["mcp", "coding"]
+
+    it "releases completed startup resources when another acquisition is cancelled" do
+        released <- newIORef []
+        acquisitionStarted <- newEmptyMVar
+        blocked <- newEmptyMVar
+        result <- timeout 2000000 $
+            race
+                (withSessionResourceScopes \scopes -> do
+                    retain scopes.scratchResources released "scratch"
+                    retain scopes.codingResources released "coding"
+                    void $ allocateAcquire scopes.mcpResources $
+                        mkAcquire
+                            (putMVar acquisitionStarted ()
+                                >> takeMVar blocked :: IO ())
+                            (const (record released "mcp")))
+                (takeMVar acquisitionStarted)
+        result `shouldBe` Just (Right ())
+        readIORef released `shouldReturn` ["coding", "scratch"]
+
+    it "continues other domain finalizers before reporting a cleanup exception" do
+        released <- newIORef []
+        result <- tryAny $
+            withSessionResourceScopes \scopes -> do
+                retain scopes.scratchResources released "scratch"
+                retain scopes.codingResources released "coding"
+                void $ allocateAcquire scopes.mcpResources $
+                    mkAcquire (pure ()) \() -> do
+                        record released "mcp"
+                        throwIO (userError "MCP cleanup failed")
+                retain scopes.activityResources released "activities"
+        readIORef released
+            `shouldReturn` ["activities", "mcp", "coding", "scratch"]
+        result `shouldSatisfy` isLeft
+
+    it "does not repeat an early domain-resource release at session exit" do
+        released <- newIORef []
+        withSessionResourceScopes \scopes -> do
+            (key, _) <- allocateAcquire scopes.codeModeResources $
+                mkAcquire (pure ()) (const (record released "code mode"))
+            releaseResource key
+            releaseResource key
+        readIORef released `shouldReturn` ["code mode"]
+
+    it "joins an owned activity before closing its tool resources" do
+        activityStarted <- newEmptyMVar
+        blocked <- newEmptyMVar
+        activityFinished <- newIORef False
+        observedAtToolClose <- newIORef False
+        released <- newIORef []
+        let activity =
+                (putMVar activityStarted () >> takeMVar blocked :: IO ())
+                    `finally` do
+                        record released "activity"
+                        writeIORef activityFinished True
+        result <- timeout 2000000 $
+            withAsync activity \worker ->
+                withSessionResourceScopes \scopes -> do
+                    takeMVar activityStarted
+                    void $ allocateAcquire scopes.codingResources $
+                        mkAcquire (pure ()) \() -> do
+                            readIORef activityFinished
+                                >>= writeIORef observedAtToolClose
+                            record released "coding"
+                    -- The worker is lexically protected by withAsync even
+                    -- if setup fails; session closure is its normal owner.
+                    void $ registerResource scopes.activityResources
+                        (cancel worker)
+        result `shouldBe` Just ()
+        readIORef observedAtToolClose `shouldReturn` True
+        readIORef released `shouldReturn` ["activity", "coding"]
+
+shutdownDomains :: SessionResourceScopes -> [(String, ResourceScope)]
+shutdownDomains scopes =
+    [ ("activities", scopes.activityResources)
+    , ("code mode", scopes.codeModeResources)
+    , ("session lock", scopes.sessionLockResources)
+    , ("computer use", scopes.computerUseResources)
+    , ("LSP", scopes.lspResources)
+    , ("web fetch", scopes.webFetchResources)
+    , ("mcp", scopes.mcpResources)
+    , ("coding", scopes.codingResources)
+    , ("scratch", scopes.scratchResources)
+    ]
+
+shutdownNames :: [String]
+shutdownNames =
+    [ "activities", "code mode", "session lock", "computer use", "LSP"
+    , "web fetch", "mcp", "coding", "scratch"
+    ]
+
+retain :: ResourceScope -> IORef [String] -> String -> IO ()
+retain scope released name =
+    void $ allocateAcquire scope $
+        mkAcquire (pure ()) (const (record released name))
+
+record :: IORef [a] -> a -> IO ()
+record values value =
+    atomicModifyIORef' values \previous -> (previous <> [value], ())

--- a/packages/agent-cli/test/Agent/CLI/SessionResourcesSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionResourcesSpec.hs
@@ -3,7 +3,7 @@ module Agent.CLI.SessionResourcesSpec (spec) where
 import Agent.CLI.Runtime.Orchestration.Tools.Resources
 import Agent.ResourceScope
     ( ResourceScope, allocateAcquire, registerResource, releaseResource )
-import Control.Concurrent.Async (cancel, concurrently_, race, withAsync)
+import Control.Concurrent.Async (Concurrently(..), cancel, race, withAsync)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Exception.Safe (finally, throwIO, tryAny)
 import Control.Monad (forM_, void)
@@ -40,8 +40,8 @@ spec = describe "session resource ownership" do
                             | otherwise =
                                 ("coding", scopes.codingResources,
                                  "mcp", scopes.mcpResources)
-                    concurrently_
-                        (do
+                    runConcurrently $
+                        Concurrently (do
                             -- Both acquisitions have begun before either
                             -- completes; this also detects serialized startup.
                             void $ allocateAcquire firstScope $
@@ -50,7 +50,7 @@ spec = describe "session resource ownership" do
                                     (const (record released firstName))
                             record completed firstName
                             putMVar firstCompleted ())
-                        (do
+                        *> Concurrently (do
                             void $ allocateAcquire secondScope $
                                 mkAcquire
                                     (putMVar secondStarted ()
@@ -61,6 +61,31 @@ spec = describe "session resource ownership" do
                         `shouldReturn` [firstName, secondName]
             result `shouldBe` Just ()
             readIORef released `shouldReturn` ["mcp", "coding"]
+
+    it "joins cancelled applicative acquisitions before releasing owned resources" do
+        released <- newIORef []
+        codingAcquired <- newEmptyMVar
+        mcpStarted <- newEmptyMVar
+        blocked <- newEmptyMVar
+        result <- timeout 2000000 $ tryAny $
+            withSessionResourceScopes \scopes ->
+                runConcurrently $
+                    (,,)
+                        <$> Concurrently (do
+                            retain scopes.codingResources released "coding"
+                            putMVar codingAcquired ())
+                        <*> Concurrently
+                            (void $ allocateAcquire scopes.mcpResources $
+                                mkAcquire
+                                    ((putMVar mcpStarted () >> takeMVar blocked :: IO ())
+                                        `finally` record released "acquisition stopped")
+                                    (const (record released "mcp")))
+                        <*> Concurrently (do
+                            takeMVar codingAcquired
+                            takeMVar mcpStarted
+                            throwIO (userError "initial context failed") :: IO ())
+        result `shouldSatisfy` maybe False isLeft
+        readIORef released `shouldReturn` ["acquisition stopped", "coding"]
 
     it "releases completed startup resources when another acquisition is cancelled" do
         released <- newIORef []

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -93,6 +93,7 @@ import qualified Agent.CLI.ReviewSpec as ReviewSpec
 import qualified Agent.CLI.SecretSpec as SecretSpec
 import qualified Agent.CLI.SessionHistorySpec as SessionHistorySpec
 import qualified Agent.CLI.SessionStateSpec as SessionStateSpec
+import qualified Agent.CLI.SessionResourcesSpec as SessionResourcesSpec
 import qualified Agent.CLI.SessionTitleSpec as SessionTitleSpec
 import qualified Agent.CLI.SkillsSpec as SkillsSpec
 import qualified Agent.CLI.SubagentStoreSpec as SubagentStoreSpec
@@ -236,6 +237,7 @@ specs = do
     TerminalSpec.spec
     TextLayoutSpec.spec
     SessionStateSpec.spec
+    SessionResourcesSpec.spec
     SessionTitleSpec.spec
     SkillsSpec.spec
     SubagentStoreSpec.spec

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -345,6 +345,7 @@ test-suite agent-core-test
                     , process
                     , QuickCheck >= 2.14 && < 2.16
                     , retry >= 0.9.3.1 && < 0.10
+                    , resourcet
                     , safe-exceptions
                     , stm
                     , text

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -21,8 +21,8 @@ mkDerivation {
   testHaskellDepends = [
     aeson agent-json agent-responses-types async base base64-bytestring
     bytestring containers crypton-connection directory filepath hspec
-    JuicyPixels process QuickCheck retry safe-exceptions stm text time
-    tls unix websockets yaml zlib
+    JuicyPixels process QuickCheck resourcet retry safe-exceptions stm
+    text time tls unix websockets yaml zlib
   ];
   benchmarkHaskellDepends = [
     aeson agent-json agent-responses-types async base bytestring

--- a/packages/agent-core/src/Agent/ResourceScope.hs
+++ b/packages/agent-core/src/Agent/ResourceScope.hs
@@ -8,6 +8,8 @@ module Agent.ResourceScope
     , withResourceScope
     , newResourceScope
     , closeResourceScope
+    , closeResourceScopeChecked
+    , allocateAcquire
     , allocateResource
     , allocateResourcesConcurrently
     , allocateFourResourcesConcurrently
@@ -23,6 +25,11 @@ import Control.Concurrent.MVar
     , withMVar
     )
 import Control.Exception.Safe (bracket, throwIO)
+-- safe-exceptions makes bracket release uninterruptible.  State cleanup must
+-- retain interruptible masking so blocking finalizers can be cancelled.
+import qualified Control.Exception as Exception (bracket)
+import Data.Acquire (Acquire)
+import qualified Data.Acquire as Acquire
 import Control.Monad.Trans.Resource
     ( InternalState
     , ReleaseKey
@@ -34,6 +41,9 @@ import Control.Monad.Trans.Resource
     , release
     , runInternalState
     )
+-- resourcet exposes checked cleanup of an existing state only in this module.
+-- Keep that dependency at the resource-ownership boundary.
+import Control.Monad.Trans.Resource.Internal (stateCleanupChecked)
 
 newtype ResourceScope = ResourceScope (MVar (Maybe InternalState))
 
@@ -51,11 +61,38 @@ newResourceScope = do
     state <- createInternalState
     ResourceScope <$> newMVar (Just state)
 
+-- | Close all remaining resources using resourcet's best-effort cleanup:
+-- finalizer exceptions are suppressed after all finalizers are attempted.
+-- Use 'closeResourceScopeChecked' or 'releaseResource' when the caller needs
+-- cleanup failure reporting.
 closeResourceScope :: ResourceScope -> IO ()
-closeResourceScope (ResourceScope stateVar) = do
-    state <- modifyMVar stateVar \current ->
-        pure (Nothing, current)
-    mapM_ closeInternalState state
+closeResourceScope = closeResourceScopeWith closeInternalState
+
+-- | Close all remaining resources and report cleanup failures after every
+-- finalizer has been attempted.  Subsequent closure calls are no-ops, including
+-- when this call reports a resourcet @ResourceCleanupException@.
+closeResourceScopeChecked :: ResourceScope -> IO ()
+closeResourceScopeChecked = closeResourceScopeWith (stateCleanupChecked Nothing)
+
+closeResourceScopeWith :: (InternalState -> IO ()) -> ResourceScope -> IO ()
+closeResourceScopeWith cleanup (ResourceScope stateVar) =
+    -- Detachment transfers ownership from the scope to this bracket.  Its
+    -- release action cannot be skipped by cancellation between those steps.
+    Exception.bracket
+        (modifyMVar stateVar \current -> pure (Nothing, current))
+        (mapM_ cleanup)
+        (const (pure ()))
+
+-- | Acquire a resource together with its composed release action.
+--
+-- Intermediate acquisitions are released if composition fails before the
+-- complete value can be registered.  The returned key releases the complete
+-- composition once, in reverse dependency order.
+allocateAcquire :: ResourceScope -> Acquire a -> IO (ResourceKey, a)
+allocateAcquire scope acquisition =
+    withOpenScope scope \state -> do
+        (key, value) <- runInScope state (Acquire.allocateAcquire acquisition)
+        pure (ResourceKey key, value)
 
 allocateResource
     :: ResourceScope

--- a/packages/agent-core/test/Agent/ResourceScopeSpec.hs
+++ b/packages/agent-core/test/Agent/ResourceScopeSpec.hs
@@ -10,7 +10,13 @@ import Control.Concurrent.MVar
     , takeMVar
     )
 import Control.Exception.Safe (throwIO, tryAny)
-import Control.Monad (replicateM_, when)
+import qualified Control.Exception as Exception
+    ( MaskingState(MaskedInterruptible)
+    , getMaskingState
+    )
+import Control.Monad (replicateM_, void, when)
+import Control.Monad.Trans.Resource (ResourceCleanupException(..))
+import Data.Acquire (mkAcquire)
 import Data.IORef
 import Data.List (sort)
 import System.Timeout (timeout)
@@ -18,6 +24,126 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.ResourceScope" do
+    it "releases composed acquisitions in reverse dependency order" do
+        released <- newIORef []
+        withResourceScope \scope -> do
+            (_, values) <- allocateAcquire scope do
+                first <- mkAcquire (pure (1 :: Int)) (record released)
+                second <- mkAcquire (pure (first + 1)) (record released)
+                pure (first, second)
+            values `shouldBe` (1, 2)
+        readIORef released `shouldReturn` [2, 1]
+
+    it "reports checked closure failures after attempting every finalizer" do
+        released <- newIORef []
+        scope <- newResourceScope
+        _ <- registerResource scope (record released 1)
+        _ <- registerResource scope do
+            record released 2
+            throwIO (userError "second release failed")
+        _ <- registerResource scope do
+            record released 3
+            throwIO (userError "third release failed")
+        closeResourceScopeChecked scope `shouldThrow`
+            (\exception -> length (rceOtherCleanupExceptions exception) == 1)
+        readIORef released `shouldReturn` [3, 2, 1]
+        closeResourceScopeChecked scope
+        closeResourceScope scope
+        readIORef released `shouldReturn` [3, 2, 1]
+
+    it "does not make scope finalizers uninterruptible" do
+        mapM_ (\close -> do
+            maskingState <- newIORef Nothing
+            scope <- newResourceScope
+            _ <- registerResource scope $
+                Exception.getMaskingState >>= writeIORef maskingState . Just
+            close scope
+            readIORef maskingState `shouldReturn` Just Exception.MaskedInterruptible)
+            [closeResourceScope, closeResourceScopeChecked]
+
+    it "does not repeat early release during checked closure" do
+        released <- newIORef []
+        scope <- newResourceScope
+        (key, _) <- allocateAcquire scope $
+            mkAcquire (pure (1 :: Int)) (record released)
+        releaseResource key
+        closeResourceScopeChecked scope
+        readIORef released `shouldReturn` [1]
+
+    it "rejects acquisition after checked closure without running its constructor" do
+        scope <- newResourceScope
+        acquired <- newIORef False
+        closeResourceScopeChecked scope
+        outcome <- tryAny $ void $ allocateAcquire scope $
+            mkAcquire (writeIORef acquired True) (const (pure ()))
+        outcome `shouldSatisfy` isLeft
+        readIORef acquired `shouldReturn` False
+
+    it "rolls back partial composition before returning an acquisition failure" do
+        released <- newIORef []
+        withResourceScope \scope -> do
+            result <- tryAny $ void $ allocateAcquire scope do
+                _ <- mkAcquire (pure (1 :: Int)) (record released)
+                mkAcquire
+                    (throwIO (userError "dependent acquisition failed") :: IO ())
+                    (const (record released 2))
+            result `shouldSatisfy` isLeft
+            readIORef released `shouldReturn` [1]
+        readIORef released `shouldReturn` [1]
+
+    it "releases a composed acquisition once after early release" do
+        released <- newIORef []
+        withResourceScope \scope -> do
+            (key, _) <- allocateAcquire scope do
+                _ <- mkAcquire (pure (1 :: Int)) (record released)
+                mkAcquire (pure (2 :: Int)) (record released)
+            releaseResource key
+            releaseResource key
+            readIORef released `shouldReturn` [2, 1]
+        readIORef released `shouldReturn` [2, 1]
+
+    it "attempts every composed finalizer before reporting an early release exception" do
+        released <- newIORef []
+        result <- tryAny $ withResourceScope \scope -> do
+            (key, _) <- allocateAcquire scope do
+                _ <- mkAcquire (pure (1 :: Int)) (record released)
+                _ <- mkAcquire (pure (2 :: Int)) \value -> do
+                    record released value
+                    throwIO (userError "dependent release failed")
+                mkAcquire (pure (3 :: Int)) (record released)
+            releaseResource key
+        result `shouldSatisfy` isLeft
+        readIORef released `shouldReturn` [3, 2, 1]
+
+    it "attempts every composed finalizer during best-effort scope closure" do
+        released <- newIORef []
+        withResourceScope \scope -> do
+            _ <- allocateAcquire scope do
+                _ <- mkAcquire (pure (1 :: Int)) (record released)
+                mkAcquire (pure (2 :: Int)) \value -> do
+                    record released value
+                    throwIO (userError "dependent release failed")
+            pure ()
+        readIORef released `shouldReturn` [2, 1]
+
+    it "rolls back completed composition when dependent acquisition is cancelled" do
+        released <- newIORef []
+        dependentStarted <- newEmptyMVar
+        blocked <- newEmptyMVar
+        withResourceScope \scope -> do
+            outcome <- race
+                (allocateAcquire scope do
+                    _ <- mkAcquire (pure (1 :: Int)) (record released)
+                    mkAcquire
+                        (putMVar dependentStarted () >> takeMVar blocked :: IO ())
+                        (const (record released 2)))
+                (takeMVar dependentStarted)
+            case outcome of
+                Left _ -> expectationFailure "blocked acquisition unexpectedly completed"
+                Right () -> pure ()
+            readIORef released `shouldReturn` [1]
+        readIORef released `shouldReturn` [1]
+
     it "releases resources in reverse acquisition order" do
         released <- newIORef ([] :: [Int])
         scope <- newResourceScope


### PR DESCRIPTION
## Summary
- Compose resource acquisition with `Acquire` and retain explicit session ownership scopes instead of introducing a pervasive `ResourceT` stack.
- Preserve parallel startup while defining dependency-ordered shutdown: join session activities and close code-mode before closing their tools.
- Protect partial startup and cancellation cleanup, register collaboration ownership immediately, and close the supervisor even when snapshot persistence fails.
- Add checked scope closure that attempts remaining finalizers before reporting cleanup failures; preserve the existing silent closure API.
- Compose independent startup actions with the `Concurrently` applicative and a named `StartupResources` record instead of nested tuples.

## Validation
- CLI/core multi-package Cabal GHCi check after the applicative refactor: 540 modules loaded successfully.
- Seven session resource ownership examples passed, including cancellation and joining of applicative acquisitions before resource release.
- CLI Cabal test component loaded successfully (102 modules), and all seven ownership examples passed using `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`.
- Tests cover both concurrent acquisition completion orders, partial-startup cancellation, early release, cleanup failures, and joining activities before tool closure.
- `git diff --check` passed; both modified package.nix expressions regenerated with cabal2nix.

## Validation limitation
CI identified a hidden-module declaration preventing the CLI test component from importing the resource ownership module. The Cabal declaration has been corrected and component-level validation passed.

The full local CLI suite ran 2,173 examples with 35 PostgreSQL socket-directory length errors and one pending example. The session temp path exceeds the database socket limit; this local run is not claimed as a full-suite pass.

The live tmux lifecycle check was attempted but stopped before the UI with `could not allocate a unique session temp directory`. Interactive reset/exit/cancellation checks remain unverified. This change does not alter CLI rendering or keybindings.
