### PR TITLE
Fix active-turn image removal and prompt updates

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Input/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Types.hs
@@ -24,6 +24,7 @@ data ReplLine
     | ReplClipboardPaste !Text !(Maybe [ImageAttachment])
     -- | Images already captured and previewed by the active composer.
     | ReplClipboardPasteCaptured ![ImageAttachment]
+    | ReplRemoveCapturedImage !Int
     -- | Classify a bracketed paste off the UI thread. The fields are the draft
     -- before the paste, the raw pasted payload, and the draft with that payload
     -- inserted. Image paths or clipboard images become attachments; otherwise

--- a/packages/agent-cli/src/Agent/CLI/Input/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/Types.hs
@@ -24,7 +24,7 @@ data ReplLine
     | ReplClipboardPaste !Text !(Maybe [ImageAttachment])
     -- | Images already captured and previewed by the active composer.
     | ReplClipboardPasteCaptured ![ImageAttachment]
-    | ReplRemoveCapturedImage !Int
+    | ReplRemoveCapturedImage !ImageAttachment
     -- | Classify a bracketed paste off the UI thread. The fields are the draft
     -- before the paste, the raw pasted payload, and the draft with that payload
     -- inserted. Image paths or clipboard images become attachments; otherwise

--- a/packages/agent-cli/src/Agent/CLI/InputBudget.hs
+++ b/packages/agent-cli/src/Agent/CLI/InputBudget.hs
@@ -85,7 +85,7 @@ logicalReplLineBytes = \case
         logicalTextBytes draft
             `saturatingAdd` maybe 0 (foldBytes logicalImageBytes) images
     ReplClipboardPasteCaptured images -> foldBytes logicalImageBytes images
-    ReplRemoveCapturedImage _ -> 0
+    ReplRemoveCapturedImage image -> logicalImageBytes image
     ReplClipboardPasteOrText draft pasted inserted ->
         logicalTextBytes draft
             `saturatingAdd` logicalTextBytes pasted

--- a/packages/agent-cli/src/Agent/CLI/InputBudget.hs
+++ b/packages/agent-cli/src/Agent/CLI/InputBudget.hs
@@ -85,6 +85,7 @@ logicalReplLineBytes = \case
         logicalTextBytes draft
             `saturatingAdd` maybe 0 (foldBytes logicalImageBytes) images
     ReplClipboardPasteCaptured images -> foldBytes logicalImageBytes images
+    ReplRemoveCapturedImage _ -> 0
     ReplClipboardPasteOrText draft pasted inserted ->
         logicalTextBytes draft
             `saturatingAdd` logicalTextBytes pasted

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -239,6 +239,8 @@ readChangeNotes provider interrupt color = do
                 else pure (Text.strip text)
         ReplClipboardPasteCaptured _ ->
             readChangeNotes provider interrupt color
+        ReplRemoveCapturedImage _ ->
+            readChangeNotes provider interrupt color
         ReplClipboardPasteOrText _ _ text ->
             if Text.null (Text.strip text)
                 then readChangeNotes provider interrupt color
@@ -295,6 +297,9 @@ askQuestion provider interrupt resolveColor question options = do
                                     provider interrupt resolveColor question []
                                 else pure (Just (Text.strip text))
                         ReplClipboardPasteCaptured _ ->
+                            askQuestion
+                                provider interrupt resolveColor question []
+                        ReplRemoveCapturedImage _ ->
                             askQuestion
                                 provider interrupt resolveColor question []
                         ReplClipboardPasteOrText _ _ text ->

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
@@ -16,7 +16,7 @@ import Agent.CLI.Render ( resetRenderPrintedText )
 import Agent.CLI.Runtime.Types ( RunResult )
 import Agent.CLI.Session.Attachments
     ( putImagePreview, queueAttachedImages, queueClipboardImages )
-import Agent.CLI.SessionState (removeImageAttachmentAt)
+import Agent.CLI.SessionState (removeImageAttachment, removeImageAttachmentAt)
 import Agent.CLI.Session.History
     ( modifyLiveAttachments )
 import Agent.CLI.SessionEnv ( SessionEnv(..) )
@@ -45,7 +45,7 @@ import qualified Data.Text.IO as Text ( hPutStrLn, putStrLn )
 data ClipboardInput
     = ClipboardPaste !Text !(Maybe [ImageAttachment])
     | ClipboardPasteCaptured ![ImageAttachment]
-    | ClipboardRemoveCaptured !Int
+    | ClipboardRemoveCaptured !ImageAttachment
     | ClipboardPasteOrText !Text !Text !Text
 
 handleClipboardInput
@@ -68,10 +68,10 @@ handleClipboardInput
         _ <- queueAttachedImages
             conversationRef previewIdRef stdoutColor (isNothing fullscreen) images
         continueWith ""
-    ClipboardRemoveCaptured index -> do
+    ClipboardRemoveCaptured image -> do
         -- Apply the composer edit in queue order without replacing its newer
         -- draft or previews when the REPL catches up.
-        _ <- modifyLiveAttachments conversationRef (removeImageAttachmentAt index)
+        _ <- modifyLiveAttachments conversationRef (removeImageAttachment image)
         continueWith ""
     ClipboardPaste keptDraft clipboardPasteImages -> do
         case clipboardPasteImages of

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Attachments.hs
@@ -45,6 +45,7 @@ import qualified Data.Text.IO as Text ( hPutStrLn, putStrLn )
 data ClipboardInput
     = ClipboardPaste !Text !(Maybe [ImageAttachment])
     | ClipboardPasteCaptured ![ImageAttachment]
+    | ClipboardRemoveCaptured !Int
     | ClipboardPasteOrText !Text !Text !Text
 
 handleClipboardInput
@@ -66,6 +67,11 @@ handleClipboardInput
         -- order without restoring an old draft or replacing newer previews.
         _ <- queueAttachedImages
             conversationRef previewIdRef stdoutColor (isNothing fullscreen) images
+        continueWith ""
+    ClipboardRemoveCaptured index -> do
+        -- Apply the composer edit in queue order without replacing its newer
+        -- draft or previews when the REPL catches up.
+        _ <- modifyLiveAttachments conversationRef (removeImageAttachmentAt index)
         continueWith ""
     ClipboardPaste keptDraft clipboardPasteImages -> do
         case clipboardPasteImages of

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -46,7 +46,7 @@ import Agent.CLI.Input
       truncateDisplayText,
       ReplLine(ReplText, ReplMeta, ReplEof, ReplQuitInterrupt, ReplCycleMode,
                ReplClipboardPaste, ReplClipboardPasteCaptured, ReplClipboardPasteOrText, ReplChooseModel,
-               ReplChooseEffort, ReplChooseAccount, ReplRemovePendingImage,
+               ReplChooseEffort, ReplChooseAccount, ReplRemovePendingImage, ReplRemoveCapturedImage,
                ReplPasted) )
 import Agent.CLI.GatewayClient ( loadGatewayCredential )
 import Agent.CLI.Login
@@ -300,6 +300,9 @@ handleReplLine
             finishTurn
             (continueWith keptDraft)
             (ReplRemoveAttachment index)
+    ReplRemoveCapturedImage index ->
+        handleClipboardInput env continueWith stdoutColor
+            (ClipboardRemoveCaptured index)
     ReplPasted pasted ->
         submit (continueWith "") True pasted
     ReplText line ->

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -300,9 +300,9 @@ handleReplLine
             finishTurn
             (continueWith keptDraft)
             (ReplRemoveAttachment index)
-    ReplRemoveCapturedImage index ->
+    ReplRemoveCapturedImage image ->
         handleClipboardInput env continueWith stdoutColor
-            (ClipboardRemoveCaptured index)
+            (ClipboardRemoveCaptured image)
     ReplPasted pasted ->
         submit (continueWith "") True pasted
     ReplText line ->

--- a/packages/agent-cli/src/Agent/CLI/SessionState.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionState.hs
@@ -3,6 +3,7 @@ module Agent.CLI.SessionState
     ( SessionState(..)
     , newSessionState
     , removeImageAttachmentAt
+    , removeImageAttachment
     ) where
 
 import Agent.CLI.Session.ConversationStore (newConversationStore)
@@ -38,7 +39,18 @@ newSessionState = do
         , sessionPreviewId = previewId
         }
 
--- | Remove one pending attachment by its stable zero-based composer index.
+-- | Remove the captured image, independent of any difference between the
+-- composer index and session attachments retained by earlier slash commands.
+removeImageAttachment
+    :: ImageAttachment
+    -> [ImageAttachment]
+    -> ([ImageAttachment], Bool)
+removeImageAttachment image pending =
+    case break (== image) pending of
+        (before, _ : after) -> (before <> after, True)
+        _ -> (pending, False)
+
+-- | Remove one pending attachment by its zero-based composer index.
 removeImageAttachmentAt
     :: Int
     -> [ImageAttachment]

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -688,9 +688,7 @@ activateControl = \case
             applyLocalUiEventWith
             ReplChooseAccount
     ComposerImageRemove index ->
-        Composer.handlePromptControlClick
-            applyLocalUiEventWith
-            (\draft -> ReplRemovePendingImage draft index)
+        Composer.handleImageRemoveClick applyLocalUiEventWith index
     QuickStartWorktree ->
         activateQuickStartCommand "/worktree"
     QuickStartResume ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -229,12 +229,14 @@ handleImageRemoveClick applyUiEvent index = do
     if state.appComposerOwnsImagePreviews && not overlayOpen
         then do
             previous <- liftIO (readIORef state.appRuntime.runtimeImagePreviews)
-            if index < 0 || index >= length previous
+            if index < 0
                 then pure ()
-                else do
+                else case splitAt index previous of
+                  (_, []) -> pure ()
+                  (before, (image, _) : after) -> do
                     queued <- liftIO $ atomically $
                         appendFullscreenInput state.appRuntime.runtimeInput FullscreenInput
-                            { fullscreenInputLine = ReplRemoveCapturedImage index
+                            { fullscreenInputLine = ReplRemoveCapturedImage image
                             , fullscreenInputQueued = True
                             , fullscreenInputDisplay = Nothing
                             }
@@ -242,7 +244,7 @@ handleImageRemoveClick applyUiEvent index = do
                         Left message ->
                             applyUiEvent (UiSetNotice (Just (warningNotice message))) id
                         Right () -> do
-                            let pending = take index previous <> drop (index + 1) previous
+                            let pending = before <> after
                             liftIO do
                                 writeIORef state.appRuntime.runtimeImagePreviews pending
                                 modifyIORef' state.appRuntime.runtimeImagePreviewRevision (+ 1)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -31,6 +31,7 @@ module Agent.CLI.TUI.Composer
     , handleControlMouseUp
     , handleEffortControlClick
     , handlePromptControlClick
+    , handleImageRemoveClick
     , immediateBtwQuestion
     , immediateReplCommand
     , isKillKey
@@ -210,6 +211,51 @@ handlePromptControlClick applyUiEvent choice = do
                         (warningNotice
                             "Prompt settings can be changed when input is ready.")))
                 id
+
+-- | Edit locally owned attachments immediately, but apply the corresponding
+-- session mutation in input order after any earlier queued messages.
+handleImageRemoveClick
+    :: ApplyLocalUiEvent
+    -> Int
+    -> EventM Name AppState ()
+handleImageRemoveClick applyUiEvent index = do
+    state <- get
+    let ui = state.appUi
+        overlayOpen =
+            maybe False (const True) state.appTextPrompt
+                || maybe False (const True) state.appChoice
+                || maybe False (const True) state.appMetaConsole
+                || maybe False (const True) ui.uiPermission
+    if state.appComposerOwnsImagePreviews && not overlayOpen
+        then do
+            previous <- liftIO (readIORef state.appRuntime.runtimeImagePreviews)
+            if index < 0 || index >= length previous
+                then pure ()
+                else do
+                    queued <- liftIO $ atomically $
+                        appendFullscreenInput state.appRuntime.runtimeInput FullscreenInput
+                            { fullscreenInputLine = ReplRemoveCapturedImage index
+                            , fullscreenInputQueued = True
+                            , fullscreenInputDisplay = Nothing
+                            }
+                    case queued of
+                        Left message ->
+                            applyUiEvent (UiSetNotice (Just (warningNotice message))) id
+                        Right () -> do
+                            let pending = take index previous <> drop (index + 1) previous
+                            liftIO do
+                                writeIORef state.appRuntime.runtimeImagePreviews pending
+                                modifyIORef' state.appRuntime.runtimeImagePreviewRevision (+ 1)
+                            modify' \current -> current
+                                { appImagePreviews = map snd pending }
+                            applyUiEvent
+                                (UiSetPrompt ui.uiPrompt { promptAttachments = length pending })
+                                id
+                            applyUiEvent
+                                (UiSetNotice (Just (successNotice "attachment removed")))
+                                id
+        else handlePromptControlClick applyUiEvent
+            (\draft -> ReplRemovePendingImage draft index)
 
 handleEffortControlClick
     :: ApplyLocalUiEvent

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Buffer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Buffer.hs
@@ -137,6 +137,7 @@ isPromptPrelude input =
     case input.fullscreenInputLine of
         ReplClipboardPaste _ _ -> True
         ReplClipboardPasteCaptured _ -> True
+        ReplRemoveCapturedImage _ -> True
         ReplClipboardPasteOrText _ _ _ -> True
         _ -> False
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Logic.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Logic.hs
@@ -98,9 +98,8 @@ applyComposerUiEvent uiEvent state =
             if isDraft then draftText else state.appHistoryDraft
         , appUi =
             case uiEvent of
-                UiSetPrompt _ | state.appComposerOwnsImagePreviews ->
+                UiSetPrompt prompt | state.appComposerOwnsImagePreviews ->
                     let ui = state.appUi
-                        prompt = ui.uiPrompt
                     in ui { uiPrompt =
                         prompt { promptAttachments = length state.appImagePreviews } }
                 _ -> state.appUi

--- a/packages/agent-cli/test/Agent/CLI/SessionStateSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionStateSpec.hs
@@ -40,6 +40,21 @@ spec =
             removeImageAttachmentAt 2 pending
                 `shouldBe` (pending, False)
 
+        it "removes a captured image without removing earlier retained session images" do
+            state <- newSessionState
+            let retained = ImageAttachment "image/png" "retained-by-help"
+                captured = ImageAttachment "image/png" "new-composer-image"
+            -- An earlier slash command can leave session images pending even
+            -- though its submission cleared the composer's local previews.
+            modifyLiveAttachments state.sessionConversation
+                (\_ -> ([retained, captured], ()))
+            modifyLiveAttachments state.sessionConversation
+                (removeImageAttachment captured) `shouldReturn` True
+            readLiveAttachments state.sessionConversation `shouldReturn` [retained]
+            modifyLiveAttachments state.sessionConversation
+                (removeImageAttachment captured) `shouldReturn` False
+            readLiveAttachments state.sessionConversation `shouldReturn` [retained]
+
         it "starts a new user session with empty composer state" do
             state <- newSessionState
             readIORef state.sessionDraft `shouldReturn` ""

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -3524,7 +3524,13 @@ withPastedImageFixtures action =
             secondPath = directory </> "second.png"
         writePng firstPath (generateImage (\_ _ -> PixelRGB8 255 0 0) 4 3)
         writePng secondPath (generateImage (\_ _ -> PixelRGB8 0 255 0) 4 3)
-        action firstPath secondPath
+        -- Submitting a draft persists REPL history; keep it inside the fixture.
+        bracket
+            (lookupEnv "HOME")
+            (\previous -> maybe (unsetEnv "HOME") (setEnv "HOME") previous)
+            \_ -> do
+                setEnv "HOME" directory
+                action firstPath secondPath
 
 newScriptRuntime :: UiState -> IO FullscreenRuntime
 newScriptRuntime ui = do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -369,9 +369,47 @@ spec = do
                 map (.fullscreenInputLine) (toList queued)
                     `shouldBe` map (.fullscreenInputLine) (toList earlierQueue)
                         <> map (ReplClipboardPasteCaptured . pure . fst) before
-                        <> [ ReplRemoveCapturedImage 0
-                           , ReplText "next draft"
-                           ]
+                        <> map (ReplRemoveCapturedImage . fst) (take 1 before)
+                        <> [ReplText "next draft"]
+
+        it "captures the selected image identity after an earlier slash command submission" $
+            withPastedImageFixtures \firstPath secondPath -> do
+                let running = reduceUi (UiLoop TurnStarted) initialUiState
+                runtime <- newScriptRuntime running
+                (_, firstPaste) <- runFullscreenScriptWithState
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack firstPath)))
+                    , FullscreenScriptHalt
+                    ]
+                earlierImages <- map fst <$> readIORef runtime.runtimeImagePreviews
+                (_, commandQueued) <- runFullscreenScriptWithState
+                    firstPaste
+                        { appSlashDismissed = True
+                        , appUi = reduceUi (UiSetDraft "/help" 5) firstPaste.appUi
+                        }
+                    [ FullscreenScriptVty (V.EvKey V.KEnter [])
+                    , FullscreenScriptHalt
+                    ]
+                null commandQueued.appImagePreviews `shouldBe` True
+                (_, secondPaste) <- runFullscreenScriptWithState commandQueued
+                    [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack secondPath)))
+                    , FullscreenScriptHalt
+                    ]
+                selectedImages <- map fst <$> readIORef runtime.runtimeImagePreviews
+                selectedImages `shouldNotBe` earlierImages
+                (_, removed) <- runFullscreenScriptWithState secondPaste
+                    [ FullscreenScriptMouseDown (ComposerImageRemove 0) V.BLeft (B.Location (0, 0))
+                    , FullscreenScriptMouseUp (ComposerImageRemove 0) (B.Location (0, 0))
+                    , FullscreenScriptHalt
+                    ]
+                null removed.appImagePreviews `shouldBe` True
+                queued <- atomically (Composer.readFullscreenInputs runtime.runtimeInput)
+                map (.fullscreenInputLine) (toList queued)
+                    `shouldBe`
+                        [ ReplClipboardPasteCaptured earlierImages
+                        , ReplText "/help"
+                        , ReplClipboardPasteCaptured selectedImages
+                        ] <> map ReplRemoveCapturedImage selectedImages
 
         it "retains an active-turn image when its removal cannot be queued" $
             withPastedImageFixtures \path _ -> do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -135,7 +135,7 @@ import Agent.CLI.Terminal
     , kittyKeyboardPop
     , remoteLinkInstructions
     )
-import Agent.Loop (ImageAttachment(..), LoopEvent(..), emptyTurnOutput)
+import Agent.Loop (ImageAttachment(..), LoopEvent(..), TokenUsage(..), emptyTurnOutput)
 import Brick
     ( App(..)
     , BrickEvent(..)
@@ -248,6 +248,47 @@ spec = do
                         refreshed.appUi.uiDraft `shouldBe` "unfinished draft"
                         refreshed.appUi.uiCursor `shouldBe` 4
 
+        it "refreshes every other prompt field while preserving locally owned attachment counts" $
+            withPastedImageFixtures \path _ -> do
+                let running = reduceUi (UiSetDraft "unfinished draft" 4) $
+                        reduceUi (UiLoop TurnStarted) initialUiState
+                    incoming = running.uiPrompt
+                        { promptModel = "updated-model"
+                        , promptEffort = "high"
+                        , promptEffortOptions = ["low", "high"]
+                        , promptMode = "plan"
+                        , promptAccount = "updated-account"
+                        , promptAccountSelectable = True
+                        , promptUsage = TokenUsage 120 30 20
+                        , promptLimitStatus = Just (PromptLimitStatus "75% remaining" False)
+                        , promptAttachments = 7
+                        }
+                runtime <- newScriptRuntime running
+                (_, pasted) <- runFullscreenScriptWithState
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack path)))
+                    , FullscreenScriptApp (AppUi (UiSetPrompt incoming))
+                    , FullscreenScriptHalt
+                    ]
+                pasted.appUi.uiPrompt
+                    `shouldBe` incoming { promptAttachments = 1 }
+                pasted.appUi.uiDraft `shouldBe` "unfinished draft"
+                pasted.appUi.uiCursor `shouldBe` 4
+                let later = incoming
+                        { promptModel = "subsequent-model"
+                        , promptMode = "ask"
+                        , promptUsage = TokenUsage 240 60 40
+                        }
+                (_, submitted) <- runFullscreenScriptWithState pasted
+                    [ FullscreenScriptVty (V.EvKey V.KEnter [])
+                    , FullscreenScriptApp (AppUi (UiSetPrompt later))
+                    , FullscreenScriptHalt
+                    ]
+                submitted.appComposerOwnsImagePreviews `shouldBe` True
+                null submitted.appImagePreviews `shouldBe` True
+                submitted.appUi.uiPrompt
+                    `shouldBe` later { promptAttachments = 0 }
+
         it "leaves existing previews and the draft untouched when the input queue is full" $
             withPastedImageFixtures \firstPath secondPath -> do
                 let running = reduceUi (UiSetDraft "unfinished draft" 4) $
@@ -281,6 +322,88 @@ spec = do
                         "Prompt queue is full; wait for a queued prompt to be consumed."
                 queued <- atomically (Composer.readFullscreenInputs runtime.runtimeInput)
                 Seq.length queued `shouldBe` Composer.fullscreenInputCountLimit
+
+        it "removes the selected active-turn image immediately without changing earlier queued messages" $
+            withPastedImageFixtures \firstPath secondPath -> do
+                let running = reduceUi (UiSetDraft "queued message" 4) $
+                        reduceUi (UiLoop TurnStarted) initialUiState
+                runtime <- newScriptRuntime running
+                (_, earlier) <- runFullscreenScriptWithState
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack firstPath)))
+                    , FullscreenScriptVty (V.EvKey V.KEnter [])
+                    , FullscreenScriptHalt
+                    ]
+                earlierQueue <- atomically (Composer.readFullscreenInputs runtime.runtimeInput)
+                (_, pasted) <- runFullscreenScriptWithState earlier
+                    [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack secondPath)))
+                    , FullscreenScriptVty (V.EvPaste (encoded (Text.pack firstPath)))
+                    , FullscreenScriptApp (AppUi (UiSetDraft "next draft" 3))
+                    , FullscreenScriptHalt
+                    ]
+                before <- readIORef runtime.runtimeImagePreviews
+                length before `shouldBe` 2
+                revision <- readIORef runtime.runtimeImagePreviewRevision
+                (_, removed) <- runFullscreenScriptWithState pasted
+                    [ FullscreenScriptMouseDown (ComposerImageRemove 0) V.BLeft (B.Location (0, 0))
+                    , FullscreenScriptMouseUp (ComposerImageRemove 0) (B.Location (0, 0))
+                    , FullscreenScriptHalt
+                    ]
+                removed.appImagePreviews == map snd (drop 1 before) `shouldBe` True
+                removed.appUi.uiPrompt.promptAttachments `shouldBe` 1
+                removed.appUi.uiDraft `shouldBe` "next draft"
+                removed.appUi.uiCursor `shouldBe` 3
+                removed.appUi.uiRunning `shouldBe` True
+                removed.appUi.uiAwaitingInput `shouldBe` False
+                (.noticeText) <$> removed.appUi.uiNotice
+                    `shouldBe` Just "attachment removed"
+                after <- readIORef runtime.runtimeImagePreviews
+                after == drop 1 before `shouldBe` True
+                readIORef runtime.runtimeImagePreviewRevision `shouldReturn` (revision + 1)
+                (_, submitted) <- runFullscreenScriptWithState removed
+                    [ FullscreenScriptVty (V.EvKey V.KEnter [])
+                    , FullscreenScriptHalt
+                    ]
+                null submitted.appImagePreviews `shouldBe` True
+                queued <- atomically (Composer.readFullscreenInputs runtime.runtimeInput)
+                map (.fullscreenInputLine) (toList queued)
+                    `shouldBe` map (.fullscreenInputLine) (toList earlierQueue)
+                        <> map (ReplClipboardPasteCaptured . pure . fst) before
+                        <> [ ReplRemoveCapturedImage 0
+                           , ReplText "next draft"
+                           ]
+
+        it "retains an active-turn image when its removal cannot be queued" $
+            withPastedImageFixtures \path _ -> do
+                let running = reduceUi (UiSetDraft "unfinished draft" 4) $
+                        reduceUi (UiLoop TurnStarted) initialUiState
+                runtime <- newScriptRuntime running
+                (_, pasted) <- runFullscreenScriptWithState
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack path)))
+                    , FullscreenScriptHalt
+                    ]
+                before <- readIORef runtime.runtimeImagePreviews
+                revision <- readIORef runtime.runtimeImagePreviewRevision
+                replicateM_ (Composer.fullscreenInputCountLimit - 1) do
+                    atomically (Composer.appendFullscreenInput runtime.runtimeInput
+                        (FullscreenInput ReplEof True Nothing))
+                        `shouldReturn` Right ()
+                (_, rejected) <- runFullscreenScriptWithState pasted
+                    [ FullscreenScriptMouseDown (ComposerImageRemove 0) V.BLeft (B.Location (0, 0))
+                    , FullscreenScriptMouseUp (ComposerImageRemove 0) (B.Location (0, 0))
+                    , FullscreenScriptHalt
+                    ]
+                rejected.appImagePreviews == pasted.appImagePreviews `shouldBe` True
+                rejected.appUi.uiPrompt.promptAttachments `shouldBe` 1
+                rejected.appUi.uiDraft `shouldBe` "unfinished draft"
+                rejected.appUi.uiCursor `shouldBe` 4
+                after <- readIORef runtime.runtimeImagePreviews
+                after == before `shouldBe` True
+                readIORef runtime.runtimeImagePreviewRevision `shouldReturn` revision
+                (.noticeText) <$> rejected.appUi.uiNotice
+                    `shouldBe` Just
+                        "Prompt queue is full; wait for a queued prompt to be consumed."
 
     describe "dynamic model choice" do
         it "preserves filter, selected identity, and effort across reordered rows" do


### PR DESCRIPTION
## Summary
- Address both review findings from the already-merged #1170.
- Preserve only the locally owned attachment count when applying prompt updates; model, effort, mode, account, usage, and limit status continue refreshing.
- Allow removing images pasted during active turns immediately, preserving the draft and applying the removal in input queue order without changing earlier queued messages.
- Keep attachments unchanged if the removal cannot be queued.
- Match queued removals to the captured image rather than a preview index, including when `/help` leaves earlier attachments pending.

## Validation
- Focused TUI composer, app, and session-state regression tests in the Nix development shell: 251 examples, 0 failures.
- Live tmux smoke test with a blocked active worker: paste an image, click its remove control, and verify the preview/count disappear immediately while the draft remains intact and the agent is still thinking.
- `git diff --check`.
