### PR TITLE
Register MCP servers after successful OAuth login

### DIFF
--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -65,6 +65,16 @@ The token record is written atomically with mode `0600` to
 configured remote servers automatically. The wire client refreshes expired
 tokens with the stored `resource` and `client_secret`.
 
+After authorization is saved, login also registers the endpoint in
+`~/.haskell-agent/config.json` if it is missing, enabled by default. The
+generated server name is derived from the URL host, with a numeric suffix
+when necessary to avoid overwriting another server. Existing server names,
+settings, and explicit disabled states are preserved. If the server is
+disabled, login prints the command needed to enable it.
+
+Start a new session to connect the
+registered server. A failed authorization does not register a server.
+
 ## Configuration
 
 Remote servers accept an optional `oauth` object. Every key is optional:

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -72,6 +72,10 @@ when necessary to avoid overwriting another server. Existing server names,
 settings, and explicit disabled states are preserved. If the server is
 disabled, login prints the command needed to enable it.
 
+Equivalent URL spellings (such as a trailing slash or host capitalization)
+reuse the configured server. Its URL is updated to the spelling used for login
+so it uses the saved credential. Query parameters remain significant.
+
 Start a new session to connect the
 registered server. A failed authorization does not register a server.
 

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -26,7 +26,7 @@ import Control.Concurrent.MVar
     , readMVar
     , tryPutMVar
     )
-import Network.URI (parseURI, uriAuthority, uriRegName, uriScheme, uriUserInfo)
+import Network.URI (parseURI, uriAuthority, uriRegName, uriScheme, uriUserInfo, uriQuery)
 import Control.Exception.Safe (bracket, bracketOnError, finally, tryAny)
 import Control.Monad (forM_, void, when)
 import Crypto.Hash (Digest, SHA256, hash)
@@ -260,10 +260,8 @@ registerAuthorizedMcpServer home serverUrl =
     modifyHarnessConfig home (\_ -> authorizedMcpServerRegistration serverUrl)
         >>= pure . fmap (\(_, _, result) -> result)
 
--- | Endpoint matching deliberately follows the exact URL key used by the
--- credential store. Resource-URI canonicalization removes query parameters
--- and therefore cannot be used to decide which configured endpoint can use
--- this credential.
+-- | Preserve the configured server when the URL spelling changes. Its URL
+-- must be updated to the exact key under which login saved the credential.
 authorizedMcpServerRegistration
     :: Text -> HarnessConfig -> Either Text (HarnessConfig, (Text, Bool))
 authorizedMcpServerRegistration serverUrl config = do
@@ -273,8 +271,12 @@ authorizedMcpServerRegistration serverUrl config = do
         || not (null (uriUserInfo authority))
         then Left "MCP server URL must be an HTTP URL without user information"
         else case [(name, server) | (name, server) <- Map.toAscList config.configMcpServers,
-                    server.mcpUrl == Just serverUrl] of
-            (name, server) : _ -> Right (config, (name, server.mcpEnabled))
+                    maybe False (sameMcpEndpoint serverUrl) server.mcpUrl] of
+            (name, server) : _ -> Right
+                ( config { configMcpServers = Map.insert name
+                    (server { mcpUrl = Just serverUrl }) config.configMcpServers }
+                , (name, server.mcpEnabled)
+                )
             [] ->
                 let hostName = Text.toLower (Text.pack (uriRegName authority))
                     baseName = Text.map sanitize hostName
@@ -327,8 +329,18 @@ lookupServerOAuthConfig serverUrl harness =
         server : _ -> server.mcpOAuth
         [] -> Nothing
   where
-    canonical = OAuth.canonicalResourceUri serverUrl
-    matches server = maybe False ((== canonical) . OAuth.canonicalResourceUri) server.mcpUrl
+    matches server = maybe False (sameMcpEndpoint serverUrl) server.mcpUrl
+
+-- | Use the resource URI's spelling normalization, but retain the complete
+-- query: different queries can identify different accounts or MCP endpoints.
+-- Invalid URLs only match exactly, never through the resource URI fallback.
+sameMcpEndpoint :: Text -> Text -> Bool
+sameMcpEndpoint left right =
+    left == right || case (parseURI (Text.unpack left), parseURI (Text.unpack right)) of
+        (Just leftUri, Just rightUri) ->
+            OAuth.canonicalResourceUri left == OAuth.canonicalResourceUri right
+                && uriQuery leftUri == uriQuery rightUri
+        _ -> False
 
 data Callback = Callback
     { callbackCode :: Maybe Text

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -13,10 +13,12 @@ module Agent.CLI.McpOAuth
     , loginMcpWith
     , logoutMcp
     , lookupServerOAuthConfig
+    , registerAuthorizedMcpServer
     ) where
 
-import Agent.CLI.Config (HarnessConfig(..), McpOAuthConfig(..), McpServerConfig(..), loadHarnessConfig)
+import Agent.CLI.Config (HarnessConfig(..), McpOAuthConfig(..), McpServerConfig(..), loadHarnessConfig, modifyHarnessConfig)
 import Agent.CLI.McpOAuthStore (loadMcpOAuthRecord, mcpOAuthStorePath, saveMcpOAuthRecord)
+import Agent.MCP (McpProtocolPreference(..))
 import qualified Agent.MCP.OAuth as OAuth
 import Control.Concurrent.MVar
     ( newEmptyMVar
@@ -24,9 +26,11 @@ import Control.Concurrent.MVar
     , readMVar
     , tryPutMVar
     )
+import Network.URI (parseURI, uriAuthority, uriRegName, uriScheme, uriUserInfo)
 import Control.Exception.Safe (bracket, bracketOnError, finally, tryAny)
 import Control.Monad (forM_, void, when)
 import Crypto.Hash (Digest, SHA256, hash)
+import Data.Char (isAsciiLower, isDigit)
 import qualified Data.ByteArray as BA
 import qualified Data.ByteString.Base64.URL as Base64
 import qualified Data.Map.Strict as Map
@@ -56,6 +60,7 @@ import qualified Network.Wai.Handler.Warp as Warp
 import qualified System.Directory.OsPath as Dir
 import qualified System.Entropy
 import System.Exit (ExitCode(..))
+import System.OsPath (OsPath)
 import System.Process (rawSystem)
 import System.Timeout (timeout)
 
@@ -236,7 +241,76 @@ loginMcpWith options serverUrl = do
                     when (Text.null tokenFile.tokenRefreshToken) $
                         putStrLn "Warning: MCP provider returned no refresh token; reauthorization may be required."
                     saveMcpOAuthRecord serverUrl tokenFile extra
-                        >>= either failText (const (putStrLn "MCP authorization saved."))
+                        >>= either failText pure
+                    putStrLn "MCP authorization saved."
+                    registerAuthorizedMcpServer home serverUrl >>= \case
+                        Left err -> failText
+                            ("MCP authorization was saved, but server registration failed: " <> err)
+                        Right (name, enabled) -> do
+                            putStrLn ("MCP server configured: " <> Text.unpack name)
+                            if enabled
+                                then putStrLn "Start a new session to connect this server."
+                                else putStrLn ("This server remains disabled. Enable it with: agent-cli mcp enable "
+                                    <> Text.unpack (shellQuote name))
+
+-- | Register only after the token record has been persisted successfully.
+-- Re-read under the configuration lock so browser-time edits are preserved.
+registerAuthorizedMcpServer :: OsPath -> Text -> IO (Either Text (Text, Bool))
+registerAuthorizedMcpServer home serverUrl =
+    modifyHarnessConfig home (\_ -> authorizedMcpServerRegistration serverUrl)
+        >>= pure . fmap (\(_, _, result) -> result)
+
+-- | Endpoint matching deliberately follows the exact URL key used by the
+-- credential store. Resource-URI canonicalization removes query parameters
+-- and therefore cannot be used to decide which configured endpoint can use
+-- this credential.
+authorizedMcpServerRegistration
+    :: Text -> HarnessConfig -> Either Text (HarnessConfig, (Text, Bool))
+authorizedMcpServerRegistration serverUrl config = do
+    uri <- maybe (Left "MCP server URL is invalid") Right (parseURI (Text.unpack serverUrl))
+    authority <- maybe (Left "MCP server URL requires a host") Right (uriAuthority uri)
+    if uriScheme uri `notElem` ["https:", "http:"] || null (uriRegName authority)
+        || not (null (uriUserInfo authority))
+        then Left "MCP server URL must be an HTTP URL without user information"
+        else case [(name, server) | (name, server) <- Map.toAscList config.configMcpServers,
+                    server.mcpUrl == Just serverUrl] of
+            (name, server) : _ -> Right (config, (name, server.mcpEnabled))
+            [] ->
+                let hostName = Text.toLower (Text.pack (uriRegName authority))
+                    baseName = Text.map sanitize hostName
+                    name = availableName baseName 1
+                    server = McpServerConfig
+                        { mcpEnabled = True
+                        , mcpUrl = Just serverUrl
+                        , mcpCommand = ""
+                        , mcpArgs = []
+                        , mcpCwd = Nothing
+                        , mcpEnv = Map.empty
+                        , mcpStartupTimeoutSeconds = 30
+                        , mcpRequestTimeoutSeconds = 60
+                        , mcpOAuth = Nothing
+                        , mcpProtocol = McpProtocolAuto
+                        , mcpRoots = False
+                        , mcpSampling = False
+                        , mcpLogLevel = Nothing
+                        }
+                in Right
+                    ( config { configMcpServers = Map.insert name server config.configMcpServers }
+                    , (name, True)
+                    )
+  where
+    sanitize character
+        | isAsciiLower character || isDigit character || character == '-' = character
+        | otherwise = '-'
+    availableName baseName (suffix :: Int) =
+        let candidate = if suffix == 1 then baseName else baseName <> "-" <> Text.pack (show suffix)
+        in if Map.member candidate config.configMcpServers
+            then availableName baseName (suffix + 1)
+            else candidate
+
+-- Server names can be user-selected, so quote the suggested shell command.
+shellQuote :: Text -> Text
+shellQuote value = "'" <> Text.replace "'" "'\\''" value <> "'"
 
 logoutMcp :: Text -> IO ()
 logoutMcp server = do

--- a/packages/agent-cli/test/Agent/CLI/McpCatalogSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpCatalogSpec.hs
@@ -2,15 +2,17 @@ module Agent.CLI.McpCatalogSpec (spec) where
 
 import Agent.CLI.Config
     ( HarnessConfig(..)
+    , McpOAuthConfig(..)
     , McpServerConfig(..)
     , defaultHarnessConfig
     , loadHarnessConfig
     , saveHarnessConfig
     )
 import Agent.CLI.McpCatalog
-import Agent.CLI.McpOAuth (registerAuthorizedMcpServer)
+import Agent.CLI.McpOAuth (lookupServerOAuthConfig, registerAuthorizedMcpServer)
 import Agent.MCP (McpProtocolPreference(..))
 import Control.Exception.Safe (bracket)
+import Control.Monad (forM_)
 import qualified Data.Aeson as Aeson
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
@@ -49,6 +51,42 @@ spec = describe "Agent.CLI.McpCatalog" do
                 registerAuthorizedMcpServer home "https://example.test/mcp"
                     `shouldReturn` Right ("billing", False)
                 loadHarnessConfig home `shouldReturn` Right configured
+
+        forM_ [False, True] \enabled ->
+            it ("reuses equivalent URL spellings with enabled = " <> show enabled) $
+                withTempDir \home -> do
+                    let oauth = McpOAuthConfig (Just "billing-client") Nothing Nothing ["billing"]
+                        server = remoteServer
+                            { mcpUrl = Just "https://EXAMPLE.test/mcp/?account=first"
+                            , mcpEnabled = enabled
+                            , mcpRequestTimeoutSeconds = 123
+                            , mcpOAuth = Just oauth
+                            }
+                        configured = catalogConfig
+                            { configMcpServers = Map.singleton "billing" server }
+                        loginUrl = "https://example.test/mcp?account=first"
+                    lookupServerOAuthConfig loginUrl configured `shouldBe` Just oauth
+                    saveHarnessConfig home configured `shouldReturn` Right ()
+                    registerAuthorizedMcpServer home loginUrl
+                        `shouldReturn` Right ("billing", enabled)
+                    registerAuthorizedMcpServer home loginUrl
+                        `shouldReturn` Right ("billing", enabled)
+                    loadHarnessConfig home `shouldReturn` Right configured
+                        { configMcpServers = Map.singleton "billing" server
+                            { mcpUrl = Just loginUrl } }
+
+        it "does not reuse OAuth settings from a different endpoint query" do
+            let oauth = McpOAuthConfig (Just "first-client") Nothing Nothing ["first"]
+                configured = catalogConfig
+                    { configMcpServers = Map.singleton "billing" remoteServer
+                        { mcpUrl = Just "https://example.test/mcp?account=first"
+                        , mcpOAuth = Just oauth
+                        }
+                    }
+            lookupServerOAuthConfig "https://example.test/mcp?account=second" configured
+                `shouldBe` Nothing
+            lookupServerOAuthConfig "https://example.test/mcp" configured
+                `shouldBe` Nothing
 
         it "allocates a stable unused name without overwriting other endpoints" $
             withTempDir \home -> do

--- a/packages/agent-cli/test/Agent/CLI/McpCatalogSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpCatalogSpec.hs
@@ -8,6 +8,7 @@ import Agent.CLI.Config
     , saveHarnessConfig
     )
 import Agent.CLI.McpCatalog
+import Agent.CLI.McpOAuth (registerAuthorizedMcpServer)
 import Agent.MCP (McpProtocolPreference(..))
 import Control.Exception.Safe (bracket)
 import qualified Data.Aeson as Aeson
@@ -22,6 +23,73 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.CLI.McpCatalog" do
+    describe "authorized MCP server registration" do
+        it "persists a newly authorized endpoint enabled and visible in the catalog" $
+            withTempDir \home -> do
+                registerAuthorizedMcpServer home "https://mcp.stripe.com/"
+                    `shouldReturn` Right ("mcp-stripe-com", True)
+                config <- loadHarnessConfig home >>= either (fail . Text.unpack) pure
+                Map.lookup "mcp-stripe-com" config.configMcpServers
+                    `shouldBe` Just remoteServer { mcpUrl = Just "https://mcp.stripe.com/" }
+                entries <- listMcpCatalog home >>= either (fail . show) pure
+                map (.mcpCatalogName) entries `shouldBe` ["mcp-stripe-com"]
+
+        it "preserves configured names, settings, and disabled state on repeated login" $
+            withTempDir \home -> do
+                let configured = catalogConfig
+                        { configMcpServers = Map.singleton "billing" remoteServer
+                            { mcpEnabled = False
+                            , mcpRequestTimeoutSeconds = 123
+                            , mcpEnv = Map.singleton "EXAMPLE" "preserved"
+                            }
+                        }
+                saveHarnessConfig home configured `shouldReturn` Right ()
+                registerAuthorizedMcpServer home "https://example.test/mcp"
+                    `shouldReturn` Right ("billing", False)
+                registerAuthorizedMcpServer home "https://example.test/mcp"
+                    `shouldReturn` Right ("billing", False)
+                loadHarnessConfig home `shouldReturn` Right configured
+
+        it "allocates a stable unused name without overwriting other endpoints" $
+            withTempDir \home -> do
+                let configured = catalogConfig
+                        { configMcpServers = Map.fromList
+                            [ ("example-test", remoteServer { mcpUrl = Just "https://other.test/" })
+                            , ("example-test-2", remoteServer { mcpUrl = Just "https://other.test/second" })
+                            ]
+                        }
+                saveHarnessConfig home configured `shouldReturn` Right ()
+                registerAuthorizedMcpServer home "https://example.test/mcp"
+                    `shouldReturn` Right ("example-test-3", True)
+                registerAuthorizedMcpServer home "https://example.test/mcp"
+                    `shouldReturn` Right ("example-test-3", True)
+                updated <- loadHarnessConfig home >>= either (fail . Text.unpack) pure
+                Map.delete "example-test-3" updated.configMcpServers
+                    `shouldBe` configured.configMcpServers
+
+        it "does not collapse distinct endpoint queries into one credential key" $
+            withTempDir \home -> do
+                registerAuthorizedMcpServer home "https://example.test/mcp?account=first"
+                    `shouldReturn` Right ("example-test", True)
+                registerAuthorizedMcpServer home "https://example.test/mcp?account=second"
+                    `shouldReturn` Right ("example-test-2", True)
+
+        it "preserves unrelated configuration when adding a server" $
+            withTempDir \home -> do
+                saveHarnessConfig home catalogConfig `shouldReturn` Right ()
+                registerAuthorizedMcpServer home "https://mcp.stripe.com/"
+                    `shouldReturn` Right ("mcp-stripe-com", True)
+                updated <- loadHarnessConfig home >>= either (fail . Text.unpack) pure
+                updated { configMcpServers = Map.delete "mcp-stripe-com" updated.configMcpServers }
+                    `shouldBe` catalogConfig
+
+        it "rejects invalid endpoints without changing configuration" $
+            withTempDir \home -> do
+                saveHarnessConfig home catalogConfig `shouldReturn` Right ()
+                result <- registerAuthorizedMcpServer home "file:///etc/example"
+                result `shouldSatisfy` either (const True) (const False)
+                loadHarnessConfig home `shouldReturn` Right catalogConfig
+
     it "lists configured servers without exposing environment values" $
         withTempDir \home -> do
             saveHarnessConfig home catalogConfig `shouldReturn` Right ()


### PR DESCRIPTION
## Summary
- Fix successful `agent-cli mcp login URL` saving credentials without registering the endpoint, leaving its tools unavailable in subsequent sessions.
- Register missing HTTP endpoints after credentials are saved, using a locked configuration update and collision-safe host-derived names.
- Preserve existing names, settings, and explicit disabled states; provide connection or enable instructions.
- Reuse equivalent URL spellings, preserving disabled state and pointing configuration at the saved credential key while keeping query parameters distinct.
- Document the behavior and add nine registration and endpoint-matching regression tests.

## Validation
- Nix/GHCi: `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`, then `:main --match Agent.CLI.Mcp` — 19 examples, 0 failures.
- `git diff --check` passed.
- Live provider OAuth was not repeated; tests use isolated temporary configuration directories.
