### PR TITLE
Prevent dependent worker cleanup from deadlocking session shutdown

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/Runtime/SessionOwner.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/SessionOwner.hs
@@ -185,7 +185,16 @@ cancelSessionTurn owner sessionId = do
 -- cancellation/close caller. No caller interruption cancels this owned sender.
 cancelOwnedWorker :: OwnedWorker -> IO ()
 cancelOwnedWorker worker = mask \restore -> do
-    sender <- modifyMVar worker.cancelSignal \case
+    sender <- requestWorkerCancellation worker
+    restore do
+        mapM_ wait sender
+        void (waitCatch worker.workerAsync)
+
+-- Request delivery without waiting for it: a worker may defer cancellation
+-- until another worker starts cleanup. The sender remains owned by the worker.
+requestWorkerCancellation :: OwnedWorker -> IO (Maybe (Async ()))
+requestWorkerCancellation worker =
+    modifyMVar worker.cancelSignal \case
         Just sender -> pure (Just sender, Just sender)
         Nothing -> do
             poll worker.workerAsync >>= \case
@@ -194,9 +203,6 @@ cancelOwnedWorker worker = mask \restore -> do
                     sender <- asyncWithUnmask \unmask ->
                         unmask (throwTo (asyncThreadId worker.workerAsync) AsyncCancelled)
                     pure (Just sender, Just sender)
-    restore do
-        mapM_ wait sender
-        void (waitCatch worker.workerAsync)
 
 -- | All concurrent closers retain the same workers until they are joined.
 -- If a closer is interrupted, a subsequent close can still finish cleanup.
@@ -207,6 +213,11 @@ closeSessionOwner owner = mask \restore -> do
             ( current { closed = True }
             , [worker | Running worker <- Map.elems current.entries]
             )
-    restore (mapM_ cancelOwnedWorker workers)
+    -- Start every cancellation before joining any worker. Sequential
+    -- cancel-and-join can deadlock when cleanup depends on a sibling stopping.
+    senders <- traverse requestWorkerCancellation workers
+    restore do
+        mapM_ (mapM_ wait) senders
+        mapM_ (\worker -> void (waitCatch worker.workerAsync)) workers
     modifyMVar_ owner.state \current ->
         pure current { entries = Map.empty }

--- a/packages/agent-cli-runtime/test/Agent/Runtime/SessionOwnerSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/Runtime/SessionOwnerSpec.hs
@@ -4,8 +4,9 @@ import Agent.Runtime.SessionOwner
 import Control.Concurrent (yield)
 import Control.Concurrent.Async (cancel, concurrently_, withAsync, wait)
 import Control.Concurrent.MVar
-    (newEmptyMVar, putMVar, takeMVar, tryTakeMVar)
+    (newEmptyMVar, putMVar, readMVar, takeMVar, tryPutMVar, tryTakeMVar)
 import Control.Exception.Safe (finally)
+import Control.Monad (void)
 import qualified Data.Map.Strict as Map
 import System.Timeout (timeout)
 import Test.Hspec
@@ -144,6 +145,41 @@ spec = describe "runtime session owner" do
             sessionOwnerSnapshot owner `shouldReturn` (True, Map.empty)
             submitSessionTurn owner "two" silent (pure (Right ()))
                 `shouldReturn` Left OwnerClosed
+
+    it "signals all workers before joining dependent cleanup" $
+        withSessionOwner 2 \owner -> do
+            firstStarted <- newEmptyMVar
+            secondStarted <- newEmptyMVar
+            blocked <- newEmptyMVar
+            firstCleaning <- newEmptyMVar
+            secondCleaning <- newEmptyMVar
+            firstFinished <- newEmptyMVar
+            secondFinished <- newEmptyMVar
+            let run started cleaning sibling finished =
+                    (putMVar started () >> readMVar blocked >> pure (Right ()))
+                        `finally` do
+                            void (tryPutMVar cleaning ())
+                            readMVar sibling
+                            putMVar finished ()
+                -- Release both handshakes on failure so the regression fails
+                -- with a timeout rather than hanging the test owner's cleanup.
+                releaseCleanup = do
+                    void (tryPutMVar firstCleaning ())
+                    void (tryPutMVar secondCleaning ())
+            (do
+                submitSessionTurn owner "first" silent
+                    (run firstStarted firstCleaning secondCleaning firstFinished)
+                    `shouldReturn` Right ()
+                submitSessionTurn owner "second" silent
+                    (run secondStarted secondCleaning firstCleaning secondFinished)
+                    `shouldReturn` Right ()
+                within (takeMVar firstStarted)
+                within (takeMVar secondStarted)
+                within (closeSessionOwner owner)
+                tryTakeMVar firstFinished `shouldReturn` Just ()
+                tryTakeMVar secondFinished `shouldReturn` Just ()
+                sessionOwnerSnapshot owner `shouldReturn` (True, Map.empty))
+                `finally` releaseCleanup
 
     it "supports a zero-capacity owner without launching workers" $
         withSessionOwner 0 \owner ->


### PR DESCRIPTION
## Summary
- Reuse the existing SessionOwner cancellation sender to request cancellation of every owned worker before joining any sender or worker.
- Preserve exactly-once cancellation, concurrent closure, and recovery after an interrupted closer; retain handles until joins finish.
- Add a deterministic two-worker cleanup dependency regression, with failure cleanup so a regression does not hang the test suite.

## Validation
- Actual Cabal test component via GHCi: `printf ':main\n:quit\n' | nix develop -c cabal repl agent-cli-runtime:test:agent-cli-runtime-test --repl-options=-fobject-code`.
- All 10 SessionOwner examples pass, including the new regression.
- Full runtime suite: 300 examples, 289 pass; 11 SessionObservation examples fail because local macOS observation socket paths exceed the 104-byte limit. These failures are outside the changed ownership code.
- Ran the new spec against the original SessionOwner source in an isolated temporary source directory: only the new regression fails, with the expected timeout; test cleanup completes.
- Concurrency review and `git diff --check` passed.

No public API, dependency, or UI changes.