### PR TITLE
Avoid quadratic buffering of streamed Markdown blocks

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -411,6 +411,24 @@ executable eval-ghci-vs-bash
                     , time
                     , unix
 
+benchmark markdown-streaming-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark, src
+    main-is:          MarkdownStreaming.hs
+    -- Compile old/new streaming and shared rendering with identical -O2.
+    other-modules:    MarkdownStreamBaseline
+                    , Agent.CLI.Render.MarkdownStream
+                    , Agent.CLI.Markdown
+                    , Agent.CLI.Style
+    ghc-options:      -O2 -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-tui
+                    , ansi-terminal
+                    , base >= 4.17 && < 5
+                    , colour
+                    , filepath
+                    , text
+
 benchmark worktree-collection-bench
     import:           common-options
     type:             exitcode-stdio-1.0

--- a/packages/agent-cli/benchmark/MarkdownStreamBaseline.hs
+++ b/packages/agent-cli/benchmark/MarkdownStreamBaseline.hs
@@ -1,11 +1,10 @@
-module Agent.CLI.Render.MarkdownStream
+-- Frozen streaming implementation from 89102f95873de78ccf23142c847105bce9ac4777.
+-- Keep the repeated strict append/full-block scan as the comparison workload.
+module MarkdownStreamBaseline
     ( MarkdownStreamState
     , emptyMarkdownStreamState
-    , feedMarkdownStream
     , feedMarkdownStreamAtWidth
-    , flushMarkdownStream
     , flushMarkdownStreamAtWidth
-    , streamMarkdownText
     ) where
 
 import Agent.CLI.Markdown
@@ -15,11 +14,7 @@ import Agent.CLI.Markdown
     , renderMarkdownFragment
     , splitMarkdownFragment
     )
-import Agent.TUI.FencedCode
-    ( FenceMarker
-    , fenceOpener
-    , isFenceCloser
-    )
+import Agent.TUI.FencedCode (FenceMarker, fenceOpener, isFenceCloser)
 import qualified Agent.TUI.Markdown.Block as Block
 import Agent.TUI.TextWidth (splitTerminalGraphemeSuffix)
 import Data.Char (isDigit, isSpace)
@@ -38,60 +33,29 @@ data MarkdownStreamState = MarkdownStreamState
 data MarkdownStreamMode
     = StreamLineStart
     | StreamProse
-    | StreamFence !FenceMarker !BufferedBlock
-    | StreamTableCandidate !Text ![Text]
-    | StreamTable !BufferedBlock
-
--- Completed lines and fragments of the current line are kept newest-first.
--- Only new input is searched for newlines; an unfinished block is flattened
--- once, when it is rendered, rather than copied and rescanned on every delta.
-data BufferedBlock = BufferedBlock
-    { completedLines :: ![Text]
-    , lineFragments :: ![Text]
-    }
+    | StreamFence !FenceMarker
+    | StreamTableCandidate
+    | StreamTable
 
 emptyMarkdownStreamState :: MarkdownStreamState
 emptyMarkdownStreamState =
     MarkdownStreamState "" Nothing StreamLineStart "" Nothing
 
-streamMarkdownText
-    :: MarkdownStreamState
-    -> Text
-    -> (MarkdownStreamState, Text)
-streamMarkdownText = feedMarkdownStream
-
-feedMarkdownStream
-    :: MarkdownStreamState
-    -> Text
-    -> (MarkdownStreamState, Text)
-feedMarkdownStream state =
-    feedMarkdownStreamCurrent state{renderWidth = Nothing}
-
 feedMarkdownStreamAtWidth
-    :: Int
-    -> MarkdownStreamState
-    -> Text
-    -> (MarkdownStreamState, Text)
+    :: Int -> MarkdownStreamState -> Text -> (MarkdownStreamState, Text)
 feedMarkdownStreamAtWidth width state =
-    feedMarkdownStreamCurrent
-        state{renderWidth = Just (max 1 width)}
+    feedMarkdownStreamCurrent state{renderWidth = Just (max 1 width)}
 
 feedMarkdownStreamCurrent
-    :: MarkdownStreamState
-    -> Text
-    -> (MarkdownStreamState, Text)
+    :: MarkdownStreamState -> Text -> (MarkdownStreamState, Text)
 feedMarkdownStreamCurrent state input = case state.streamMode of
     StreamLineStart -> feedLineStart state input
     StreamProse -> feedProse state input
-    StreamFence marker block -> feedFence marker block state input
-    StreamTableCandidate header fragments ->
-        feedTableCandidate header fragments state input
-    StreamTable block -> feedTable block state input
+    StreamFence marker -> feedFence marker state input
+    StreamTableCandidate -> feedTableCandidate state input
+    StreamTable -> feedTable state input
 
-feedLineStart
-    :: MarkdownStreamState
-    -> Text
-    -> (MarkdownStreamState, Text)
+feedLineStart :: MarkdownStreamState -> Text -> (MarkdownStreamState, Text)
 feedLineStart state input =
     let buffered = state.blockPending <> input
     in case takeCompleteLine buffered of
@@ -102,53 +66,32 @@ feedLineStart state input =
                 (state{blockPending = buffered}, "")
             | otherwise ->
                 feedProse
-                    state
-                        { streamMode = StreamProse
-                        , blockPending = ""
-                        }
+                    state{streamMode = StreamProse, blockPending = ""}
                     buffered
 
 classifyCompleteLine
-    :: MarkdownStreamState
-    -> Text
-    -> Text
-    -> (MarkdownStreamState, Text)
+    :: MarkdownStreamState -> Text -> Text -> (MarkdownStreamState, Text)
 classifyCompleteLine state line rest
     | Just (marker, _) <- fenceOpener (dropLineEnding line) =
         feedMarkdownStreamCurrent
-            state
-                { streamMode = StreamFence marker (BufferedBlock [line] [])
-                , blockPending = ""
-                }
+            state{streamMode = StreamFence marker, blockPending = line}
             rest
     | isPossibleTableHeader line =
         feedMarkdownStreamCurrent
-            state
-                { streamMode = StreamTableCandidate line []
-                , blockPending = ""
-                }
+            state{streamMode = StreamTableCandidate, blockPending = line}
             rest
     | lineIsBlock line =
         let (nextState, output) =
                 feedMarkdownStreamCurrent
-                    state
-                        { streamMode = StreamLineStart
-                        , blockPending = ""
-                        }
+                    state{streamMode = StreamLineStart, blockPending = ""}
                     rest
         in (nextState, renderBuffered state line <> output)
     | otherwise =
         feedProse
-            state
-                { streamMode = StreamProse
-                , blockPending = ""
-                }
+            state{streamMode = StreamProse, blockPending = ""}
             (line <> rest)
 
-feedProse
-    :: MarkdownStreamState
-    -> Text
-    -> (MarkdownStreamState, Text)
+feedProse :: MarkdownStreamState -> Text -> (MarkdownStreamState, Text)
 feedProse state input =
     case Text.breakOn "\n" input of
         (linePart, rest)
@@ -158,8 +101,7 @@ feedProse state input =
                         { markdownReady = parsedReady
                         , markdownPending = parsedPending
                         , markdownPrevChar = parsedContext
-                        } =
-                        splitMarkdownFragment state.context source
+                        } = splitMarkdownFragment state.context source
                     (stablePrefix, graphemePending) =
                         splitTerminalGraphemeSuffix parsedReady
                     MarkdownFragmentSplit
@@ -174,13 +116,9 @@ feedProse state input =
                                 , markdownPrevChar = parsedContext
                                 }
                         | otherwise =
-                            splitMarkdownFragment
-                                state.context
-                                stablePrefix
+                            splitMarkdownFragment state.context stablePrefix
                     pending' =
-                        reparsedPending
-                            <> graphemePending
-                            <> parsedPending
+                        reparsedPending <> graphemePending <> parsedPending
                 in ( state
                         { pending = pending'
                         , context = nextContext
@@ -193,8 +131,7 @@ feedProse state input =
                     MarkdownFragmentSplit
                         { markdownReady = ready
                         , markdownPending = pending'
-                        } =
-                        splitMarkdownFragment state.context source
+                        } = splitMarkdownFragment state.context source
                     rendered =
                         renderMarkdownFragment True state.context
                             (ready <> pending')
@@ -210,103 +147,85 @@ feedProse state input =
                 in (nextState, rendered <> following)
 
 feedFence
-    :: FenceMarker
-    -> BufferedBlock
-    -> MarkdownStreamState
-    -> Text
-    -> (MarkdownStreamState, Text)
-feedFence marker block state input =
-    case takeBufferedLine block.lineFragments input of
-        Left fragments ->
-            ( state
-                { streamMode =
-                    StreamFence marker block{lineFragments = fragments}
-                }
-            , ""
-            )
-        Right (line, rest)
-            | isFenceCloser marker (dropLineEnding line) ->
-                let source = Text.concat (reverse (line : block.completedLines))
-                    reset =
-                        state
-                            { streamMode = StreamLineStart
-                            , pending = ""
-                            , context = Nothing
-                            }
-                    (nextState, following) =
-                        feedMarkdownStreamCurrent reset rest
-                in (nextState, renderBuffered state source <> following)
-            | otherwise ->
-                feedFence marker
-                    (BufferedBlock (line : block.completedLines) [])
-                    state rest
+    :: FenceMarker -> MarkdownStreamState -> Text -> (MarkdownStreamState, Text)
+feedFence marker state input =
+    let buffered = state.blockPending <> input
+        (lines_, partial) = completeLines buffered
+        (beforeCloser, closingAndAfter) =
+            break (isFenceCloser marker . dropLineEnding) (drop 1 lines_)
+    in case closingAndAfter of
+        [] -> (state{blockPending = buffered}, "")
+        closing : after ->
+            let block = Text.concat (take 1 lines_ <> beforeCloser <> [closing])
+                rest = Text.concat after <> partial
+                reset =
+                    state
+                        { streamMode = StreamLineStart
+                        , blockPending = ""
+                        , pending = ""
+                        , context = Nothing
+                        }
+                (nextState, following) =
+                    feedMarkdownStreamCurrent reset rest
+            in (nextState, renderBuffered state block <> following)
 
 feedTableCandidate
-    :: Text
-    -> [Text]
-    -> MarkdownStreamState
-    -> Text
-    -> (MarkdownStreamState, Text)
-feedTableCandidate header fragments state input =
-    case takeBufferedLine fragments input of
-        Right (separator, rest)
+    :: MarkdownStreamState -> Text -> (MarkdownStreamState, Text)
+feedTableCandidate state input =
+    let buffered = state.blockPending <> input
+        (lines_, partial) = completeLines buffered
+    in case lines_ of
+        header : separator : after
             | isTableStart header separator ->
-                feedTable (BufferedBlock [separator, header] []) state rest
+                feedMarkdownStreamCurrent
+                    state
+                        { streamMode = StreamTable
+                        , blockPending = header <> separator
+                        }
+                    (Text.concat after <> partial)
             | otherwise ->
                 let reset =
-                        state
-                            { streamMode = StreamLineStart
-                            }
+                        state{streamMode = StreamLineStart, blockPending = ""}
                     (nextState, following) =
-                        feedMarkdownStreamCurrent reset (separator <> rest)
+                        feedMarkdownStreamCurrent reset
+                            (separator <> Text.concat after <> partial)
                 in (nextState, renderBuffered state header <> following)
-        Left remaining ->
-            (state{streamMode = StreamTableCandidate header remaining}, "")
+        _ -> (state{blockPending = buffered}, "")
 
-feedTable
-    :: BufferedBlock
-    -> MarkdownStreamState
-    -> Text
-    -> (MarkdownStreamState, Text)
-feedTable block state input =
-    case takeBufferedLine block.lineFragments input of
-        Left fragments ->
-            (state{streamMode = StreamTable block{lineFragments = fragments}}, "")
-        Right (line, rest)
-            | isPossibleTableHeader line ->
-                feedTable (BufferedBlock (line : block.completedLines) [])
-                    state rest
-            | otherwise ->
-                let table = Text.concat (reverse block.completedLines)
-                    reset = state{streamMode = StreamLineStart}
-                    (nextState, following) =
-                        feedMarkdownStreamCurrent reset (line <> rest)
-                in (nextState, renderBuffered state table <> following)
-
-flushMarkdownStream :: MarkdownStreamState -> Text
-flushMarkdownStream = flushMarkdownStreamCurrent
+feedTable :: MarkdownStreamState -> Text -> (MarkdownStreamState, Text)
+feedTable state input =
+    let buffered = state.blockPending <> input
+        (lines_, partial) = completeLines buffered
+        (tableLines, after) =
+            case lines_ of
+                header : separator : rows ->
+                    let (body, following) =
+                            span isPossibleTableHeader rows
+                    in (header : separator : body, following)
+                _ -> (lines_, [])
+    in case after of
+        [] -> (state{blockPending = buffered}, "")
+        line : rest ->
+            let table = Text.concat tableLines
+                reset =
+                    state{streamMode = StreamLineStart, blockPending = ""}
+                (nextState, following) =
+                    feedMarkdownStreamCurrent reset
+                        (line <> Text.concat rest <> partial)
+            in (nextState, renderBuffered state table <> following)
 
 flushMarkdownStreamAtWidth :: Int -> MarkdownStreamState -> Text
 flushMarkdownStreamAtWidth width state =
-    flushMarkdownStreamCurrent
-        state{renderWidth = Just (max 1 width)}
+    flushMarkdownStreamCurrent state{renderWidth = Just (max 1 width)}
 
 flushMarkdownStreamCurrent :: MarkdownStreamState -> Text
 flushMarkdownStreamCurrent state = case state.streamMode of
     StreamProse ->
         renderMarkdownFragment True state.context state.pending
-    StreamLineStart ->
-        renderBuffered state state.blockPending
-    StreamFence _ block ->
-        renderBuffered state (bufferedBlockText block)
-    StreamTableCandidate header fragments ->
-        renderBuffered state (Text.concat (header : reverse fragments))
-    StreamTable block ->
-        renderBuffered state (bufferedBlockText block)
-
-bufferedBlockText :: BufferedBlock -> Text
-bufferedBlockText block =
-    Text.concat (reverse block.completedLines <> reverse block.lineFragments)
+    StreamLineStart -> renderBuffered state state.blockPending
+    StreamFence _ -> renderBuffered state state.blockPending
+    StreamTableCandidate -> renderBuffered state state.blockPending
+    StreamTable -> renderBuffered state state.blockPending
 
 renderBuffered :: MarkdownStreamState -> Text -> Text
 renderBuffered state =
@@ -320,19 +239,13 @@ takeCompleteLine text =
         (_, rest) | Text.null rest -> Nothing
         (line, rest) -> Just (line <> "\n", Text.drop 1 rest)
 
--- The Left result retains a partial line without joining or rescanning its
--- earlier fragments. A Right result includes the newline, as takeCompleteLine
--- does, and leaves the remainder of this delta untouched.
-takeBufferedLine :: [Text] -> Text -> Either [Text] (Text, Text)
-takeBufferedLine fragments input =
-    case Text.breakOn "\n" input of
-        (_, rest) | Text.null rest ->
-            Left (if Text.null input then fragments else input : fragments)
-        (line, rest) ->
-            Right
-                ( Text.concat (reverse ("\n" : line : fragments))
-                , Text.drop 1 rest
-                )
+completeLines :: Text -> ([Text], Text)
+completeLines = go []
+  where
+    go reversed remaining =
+        case takeCompleteLine remaining of
+            Nothing -> (reverse reversed, remaining)
+            Just (line, rest) -> go (line : reversed) rest
 
 dropLineEnding :: Text -> Text
 dropLineEnding = Text.dropWhileEnd (== '\n')
@@ -380,10 +293,6 @@ lineNeedsLookahead line =
             isPossibleTableHeader line
                 || plausibleTableHeaderPrefix stripped
 
--- Before the first pipe, a table header is indistinguishable from prose.
--- Retain a single word and whitespace-terminated token prefixes so the next
--- chunk can supply a delimiter without imposing casing or script assumptions.
--- Once a second word is complete, ordinary prose can stream immediately.
 plausibleTableHeaderPrefix :: Text -> Bool
 plausibleTableHeaderPrefix stripped =
     length (Text.words stripped) <= 1

--- a/packages/agent-cli/benchmark/MarkdownStreaming.hs
+++ b/packages/agent-cli/benchmark/MarkdownStreaming.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE BangPatterns #-}
+
+-- End-to-end streaming: feed every delta, render completed blocks, flush the
+-- final pending block, and consume every output character (including ANSI).
+module Main (main) where
+
+import qualified Agent.CLI.Render.MarkdownStream as New
+import qualified MarkdownStreamBaseline as Old
+-- safe-exceptions does not export evaluate.
+import Control.Exception (evaluate)
+import Control.Monad (forM, unless)
+import Data.Char (ord)
+import Data.IORef (newIORef, readIORef)
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Renderer = forall state. Renderer
+    !state
+    (state -> Text -> (state, Text))
+    (state -> Text)
+
+oldRenderer, newRenderer :: Renderer
+oldRenderer = Renderer Old.emptyMarkdownStreamState
+    (Old.feedMarkdownStreamAtWidth 100) (Old.flushMarkdownStreamAtWidth 100)
+newRenderer = Renderer New.emptyMarkdownStreamState
+    (New.feedMarkdownStreamAtWidth 100) (New.flushMarkdownStreamAtWidth 100)
+
+data Sample = Sample !Double !Double !Double
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    unless enabled (die "run with +RTS -T")
+    getArgs >>= \case
+        [mode, scenario, countArg, chunkArg, sampleArg] -> do
+            renderer <- case mode of
+                "old" -> pure oldRenderer
+                "new" -> pure newRenderer
+                _ -> die "mode must be old or new"
+            unless (scenario `elem`
+                ["prose", "fence", "open-fence", "table", "open-table", "longline", "mixed"])
+                (die "unknown scenario")
+            count <- positive countArg
+            chunkSize <- positive chunkArg
+            samples <- positive sampleArg
+            let checkInput = chunks chunkSize (workload scenario count 0)
+            unless (outputs oldRenderer checkInput == outputs newRenderer checkInput)
+                (die "old/new output differs (including per-delta emission timing)")
+            results <- forM [1 .. samples] \sample ->
+                measure renderer (chunks chunkSize (workload scenario count sample))
+            printf "%s,%s,%d,%d,%d,%.6f,%.6f,%.0f\n"
+                mode scenario count chunkSize samples
+                (median [wall | Sample wall _ _ <- results])
+                (median [cpu | Sample _ cpu _ <- results])
+                (median [allocated | Sample _ _ allocated <- results])
+        _ -> die "usage: markdown-streaming-bench old|new prose|fence|open-fence|table|open-table|longline|mixed COUNT CHUNK_CHARS SAMPLES"
+  where
+    positive raw = case reads raw of
+        [(n, "")] | n > 0 -> pure n
+        _ -> die ("expected positive integer: " <> raw)
+    median values = sort values !! (length values `div` 2)
+
+measure :: Renderer -> [Text] -> IO Sample
+measure renderer input = do
+    -- Force the chunk list and payload before measurement. Reading an IORef
+    -- inside the timed interval prevents sharing a previously evaluated run.
+    _ <- evaluate (foldl' (\n text -> n + checksum text) 0 input)
+    ref <- newIORef input
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    freshInput <- readIORef ref
+    !result <- evaluate (run renderer freshInput)
+    afterWall <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    -- Account for the unfinished nursery, outside elapsed/CPU timing.
+    performGC
+    afterStats <- getRTSStats
+    _ <- evaluate result
+    pure (Sample
+        (fromIntegral (afterWall - beforeWall) / 1e6)
+        (fromIntegral (afterCpu - beforeCpu) / 1e9)
+        (fromIntegral (afterStats.allocated_bytes - beforeStats.allocated_bytes)))
+
+{-# NOINLINE run #-}
+run :: Renderer -> [Text] -> Int
+run (Renderer initial feed flush) = go initial 0
+  where
+    go !state !total [] = total + checksum (flush state)
+    go !state !total (delta : rest) =
+        let (next, output) = feed state delta
+        in go next (total + checksum output) rest
+
+outputs :: Renderer -> [Text] -> [Text]
+outputs (Renderer initial feed flush) = go initial
+  where
+    go state [] = [flush state]
+    go state (delta : rest) =
+        let (next, output) = feed state delta
+        in output : go next rest
+
+checksum :: Text -> Int
+checksum = Text.foldl' (\n character -> n * 33 + ord character) 5381
+
+chunks :: Int -> Text -> [Text]
+chunks size text
+    | Text.null text = []
+    | otherwise =
+        let (prefix, suffix) = Text.splitAt size text
+        in prefix : chunks size suffix
+
+-- COUNT is the number of body rows, except longline (number of 16-character
+-- units) and mixed (number of small prose/fence/table groups). ASCII fixtures
+-- make CHUNK_CHARS equal bytes. Sample-specific text defeats cross-run sharing.
+workload :: String -> Int -> Int -> Text
+workload scenario count sample =
+    let prose = "Here is **streamed Markdown**, with `inline code` and a [link](https://example.com).\n"
+        code = "    result = transform(value) # retain the generated code\n"
+        header = "| Name | Value |\n| --- | --- |\n"
+        row = "| **item** | `some value` |\n"
+        suffix = "\nSample " <> Text.pack (show sample) <> ".\n"
+    in case scenario of
+        "prose" -> Text.replicate count prose <> suffix
+        "fence" -> "```python\n" <> Text.replicate count code <> "```\n" <> suffix
+        "open-fence" -> "```python\n" <> Text.replicate count code
+            <> "# " <> Text.pack (show sample)
+        "table" -> header <> Text.replicate count row <> suffix
+        "open-table" -> header <> Text.replicate count row
+            <> "| last | " <> Text.pack (show sample) <> " |"
+        "longline" -> "```\n" <> Text.replicate count "abcdefghijklmnop"
+            <> Text.pack (show sample) <> "\n```\n"
+        "mixed" -> Text.replicate count
+            (prose <> "```\n" <> Text.replicate 5 code <> "```\n"
+                <> header <> Text.replicate 5 row <> "\n") <> suffix
+        _ -> error "validated scenario"

--- a/packages/agent-cli/benchmark/MarkdownStreaming.md
+++ b/packages/agent-cli/benchmark/MarkdownStreaming.md
@@ -1,0 +1,180 @@
+# Streaming Markdown benchmark
+
+The retained `MarkdownStreamBaseline.hs` implements the strict append and
+full-buffer rescan behavior from
+`89102f95873de78ccf23142c847105bce9ac4777`. The benchmark compares it with the
+production `Agent.CLI.Render.MarkdownStream`, compiling both and their shared
+ANSI Markdown renderer with `-O2` in the same component.
+
+## Reproduce
+
+From the repository root:
+
+```sh
+nix develop
+cabal build --offline agent-cli:bench:markdown-streaming-bench
+bin=$(cabal list-bin agent-cli:bench:markdown-streaming-bench)
+
+for count in 100 500 1000 2000; do
+  for scenario in fence table longline prose; do
+    for mode in old new; do
+      "$bin" "$mode" "$scenario" "$count" 16 7 +RTS -T
+    done
+  done
+done
+
+for chunk in 1 16 64 256 65536; do
+  for scenario in fence table mixed; do
+    for mode in old new; do
+      "$bin" "$mode" "$scenario" 100 "$chunk" 7 +RTS -T
+    done
+  done
+done
+
+# Repeat representative cases in the opposite old/new order. Include blocks
+# that must be rendered during final flush, not during a feed operation.
+for scenario in fence table open-fence open-table prose mixed; do
+  for mode in new old; do
+    "$bin" "$mode" "$scenario" 1000 16 7 +RTS -T
+  done
+done
+```
+
+Arguments are implementation, scenario, body count, chunk characters, and
+sample count. CSV columns are those five arguments followed by median wall
+milliseconds, CPU milliseconds, and allocated bytes per complete stream.
+
+Fixtures are ASCII, so chunk characters equal UTF-8 bytes. Fences contain
+58-byte generated-code lines; tables contain two columns, inline formatting,
+and 28-byte body rows (including newlines); prose contains emphasis, inline code,
+and a link.
+`longline` measures one fenced line containing COUNT 16-character units.
+`mixed` measures COUNT groups, each containing one prose line, a five-line
+fence, and a five-row table. Width is 100 terminal cells.
+
+All input text and the chunk list are forced before timing. Every feed output
+and the final flush output are consumed by a character checksum. The benchmark
+therefore includes final concatenation, Markdown parsing, table layout, and
+ANSI generation; it does not merely move that work outside measurement.
+An IORef read and sample-specific inputs prevent sharing a previously evaluated
+result. Each sample starts after a GC. Allocation is read after another GC,
+outside the timing interval, to include the unfinished nursery. Exact output
+equality is checked before measurement, **including output for each delta**,
+so deferring output to a later feed cannot masquerade as an improvement.
+
+These are scrollback renderer CPU/allocation measurements, not model throughput
+or terminal I/O timings. The optimization does not change fullscreen rendering.
+
+## Results (2026-09-09)
+
+Intel Core i9-9900K, x86_64 Linux, GHC 9.10.3, inside `nix develop`.
+The benchmark component and its local modules use `-O2`; the unchanged
+`agent-tui` dependency uses Cabal's `-O1` default. Single-capability,
+non-threaded RTS with `+RTS -T`, default allocation area. Seven samples per
+entry. MB below means decimal allocated bytes / 1,000,000.
+
+At 16-byte deltas, including final rendering:
+
+| Workload | Count | Wall ms old → new | CPU ms old → new | Allocated MB old → new |
+|---|---:|---:|---:|---:|
+| Fence | 100 | 3.325 → 0.938 | 3.311 → 0.942 | 17.619 → 5.546 |
+| Fence | 500 | 65.344 → 4.899 | 65.253 → 4.889 | 329.343 → 27.556 |
+| Fence | 1,000 | 268.066 → 11.646 | 267.170 → 11.365 | 1,261.867 → 55.063 |
+| Fence | 2,000 | 1,056.379 → 24.288 | 1,054.181 → 24.238 | 4,937.944 → 110.087 |
+| Table | 100 | 6.033 → 1.945 | 6.021 → 1.940 | 45.492 → 11.685 |
+| Table | 500 | 112.830 → 9.812 | 112.671 → 9.795 | 910.850 → 57.922 |
+| Table | 1,000 | 448.619 → 20.337 | 447.802 → 20.302 | 3,531.322 → 115.718 |
+| Table | 2,000 | 1,855.535 → 42.312 | 1,852.606 → 42.236 | 13,901.517 → 231.311 |
+| Long fenced line | 500 | 3.401 → 1.088 | 3.395 → 1.086 | 9.226 → 7.114 |
+| Long fenced line | 1,000 | 12.165 → 2.367 | 12.142 → 2.364 | 22.434 → 14.210 |
+| Long fenced line | 2,000 | 41.191 → 5.062 | 41.111 → 5.050 | 60.850 → 28.402 |
+| Prose | 500 | 18.074 → 18.135 | 18.036 → 18.090 | 104.228 → 104.227 |
+| Prose | 1,000 | 35.559 → 35.469 | 35.476 → 35.373 | 208.445 → 208.444 |
+| Prose | 2,000 | 72.130 → 73.051 | 71.941 → 72.866 | 416.853 → 416.853 |
+| Mixed groups | 100 | 24.487 → 22.903 | 24.422 → 22.826 | 128.694 → 117.998 |
+| Mixed groups | 1,000 | 234.472 → 214.943 | 233.875 → 214.113 | 1,286.778 → 1,179.851 |
+| Open fence (flush) | 1,000 | 258.230 → 11.211 | 257.870 → 11.190 | 1,261.541 → 54.908 |
+| Open table (flush) | 1,000 | 448.060 → 20.298 | 447.455 → 20.267 | 3,534.875 → 115.448 |
+
+The 1,000-row fence reduces CPU by 23.5× and allocation by 95.6%; the table
+reduces CPU by 22.1× and allocation by 96.7%. Doubling from 1,000 to 2,000
+rows approximately quadruples baseline work/allocation but doubles the new
+implementation. Ordinary prose is unchanged (timing varies by about 1%).
+Small-block mixed output benefits more modestly: about 8% less CPU/allocation.
+
+Repeating the 1,000-row cases with reversed process order produced fence CPU
+261.196 → 11.301 ms and table CPU 448.681 → 20.270 ms; allocation was identical
+to the first run. Prose repeated at 35.470 → 35.712 ms with unchanged allocation.
+
+Chunk-size boundary checks, COUNT=100:
+
+| Workload | Delta bytes | Wall ms old → new | CPU ms old → new | Allocated MB old → new |
+|---|---:|---:|---:|---:|
+| Fence | 1 | 44.224 → 1.345 | 43.913 → 1.324 | 200.527 → 7.618 |
+| Fence | 64 | 1.466 → 0.973 | 1.461 → 0.972 | 8.441 → 5.442 |
+| Fence | 256 | 1.053 → 0.890 | 1.051 → 0.883 | 6.158 → 5.411 |
+| Table | 1 | 68.124 → 2.091 | 68.013 → 2.086 | 556.350 → 12.649 |
+| Table | 64 | 3.048 → 1.948 | 3.045 → 1.943 | 20.236 → 11.636 |
+| Table | 256 | 2.177 → 1.849 | 2.169 → 1.844 | 13.928 → 11.624 |
+| Table | 65,536 | 1.979 → 1.871 | 1.977 → 1.865 | 11.671 → 11.620 |
+| Mixed groups | 1 | 55.765 → 28.131 | 55.605 → 28.067 | 330.377 → 163.040 |
+| Mixed groups | 64 | 21.911 → 20.933 | 21.818 → 20.868 | 118.268 → 115.244 |
+| Mixed groups | 256 | 20.996 → 20.545 | 20.939 → 20.496 | 115.356 → 113.814 |
+| Mixed groups | 65,536 | 51.116 → 27.645 | 50.977 → 27.527 | 273.537 → 150.205 |
+
+Large deltas containing many small blocks also benefit because finishing a
+fence/table no longer splits and concatenates all following blocks merely to
+recover the unconsumed remainder.
+
+### Single-shot fence boundary
+
+A complete fence arriving in one delta has no repeated-scan cost to remove.
+The initial 100-row / 65,536-byte-delta run was 0.879 → 0.919 ms CPU
+(5.410 → 5.403 MB), so this boundary was repeated with 31 samples per process,
+three independent runs, at both 100 and 1,000 rows:
+
+```sh
+for count in 100 1000; do
+  for repeat in 1 2 3; do
+    for mode in new old; do
+      "$bin" "$mode" fence "$count" 65536 31 +RTS -T
+    done
+  done
+done
+```
+
+| Count | Repeat | Wall ms old → new | CPU ms old → new | Allocated MB old → new |
+|---:|---:|---:|---:|---:|
+| 100 | 1 | 0.885 → 0.899 | 0.883 → 0.898 | 5.411 → 5.404 |
+| 100 | 2 | 0.882 → 0.895 | 0.880 → 0.893 | 5.411 → 5.404 |
+| 100 | 3 | 0.873 → 0.869 | 0.871 → 0.868 | 5.411 → 5.404 |
+| 1,000 | 1 | 11.556 → 11.553 | 11.537 → 11.534 | 53.746 → 53.686 |
+| 1,000 | 2 | 11.710 → 11.595 | 11.689 → 11.570 | 53.746 → 53.686 |
+| 1,000 | 3 | 11.501 → 11.626 | 11.478 → 11.605 | 53.746 → 53.686 |
+
+No speedup is claimed for this boundary: timings overlap and allocation is
+effectively unchanged. The substantial gains require a block to span multiple
+deltas, or a delta to contain multiple blocks.
+
+### Tiny blocks
+
+One- and five-row blocks were also checked at 16- and 256-byte deltas with
+101 samples per process (same command, COUNT=1 or 5, CHUNK_CHARS=16 or 256,
+SAMPLES=101). Allocation decreases in every case; larger deltas leave timings
+approximately neutral at these sizes.
+
+| Workload | Rows | Delta bytes | Wall ms old → new | CPU ms old → new | Allocated bytes old → new |
+|---|---:|---:|---:|---:|---:|
+| Fence | 1 | 16 | 0.0224 → 0.0216 | 0.0228 → 0.0220 | 97,352 → 95,200 |
+| Fence | 1 | 256 | 0.0210 → 0.0207 | 0.0213 → 0.0211 | 94,120 → 92,520 |
+| Fence | 5 | 16 | 0.0585 → 0.0525 | 0.0588 → 0.0529 | 342,712 → 314,000 |
+| Fence | 5 | 256 | 0.0518 → 0.0517 | 0.0522 → 0.0521 | 312,440 → 307,720 |
+| Table | 1 | 16 | 0.0620 → 0.0616 | 0.0625 → 0.0621 | 246,200 → 243,216 |
+| Table | 1 | 256 | 0.0608 → 0.0595 | 0.0613 → 0.0600 | 244,680 → 241,288 |
+| Table | 5 | 16 | 0.1447 → 0.1376 | 0.1452 → 0.1381 | 778,952 → 705,584 |
+| Table | 5 | 256 | 0.1372 → 0.1362 | 0.1377 → 0.1366 | 706,376 → 701,080 |
+
+Repeating the five-row / 256-byte cases in reverse order produced fence CPU
+0.0531 → 0.0514 ms and table CPU 0.1343 → 0.1364 ms, with identical allocation
+to the first run. These sub-millisecond differences should not be interpreted
+as a reliable speedup or regression.

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -54,8 +54,9 @@ mkDerivation {
   benchmarkHaskellDepends = [
     aeson agent-cli-runtime agent-core agent-json agent-mcp
     agent-openai agent-responses agent-responses-types agent-store
-    agent-tui async base brick bytestring containers deepseq directory
-    filepath JuicyPixels process safe-exceptions stm text time unix vty
+    agent-tui ansi-terminal async base brick bytestring colour
+    containers deepseq directory filepath JuicyPixels process
+    safe-exceptions stm text time unix vty
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -42,6 +42,7 @@ import Control.Concurrent.MVar (newEmptyMVar, newMVar, putMVar, takeMVar)
 import Control.Exception (finally)
 import Control.Monad (forM_)
 import Data.IORef (newIORef, readIORef)
+import Data.List (mapAccumL)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -186,6 +187,49 @@ spec = do
             output `shouldSatisfy` Text.isInfixOf "Control Center"
             output `shouldSatisfy` Text.isInfixOf "─"
             output `shouldSatisfy` (not . Text.isInfixOf "|")
+
+        it "renders buffered blocks identically across every two-chunk split" do
+            let sources =
+                    [ "```haskell\nmain = pure ()\n```\n# After\n"
+                    , "````\n```\n~~~\n```` not a closer\n\nλ界\n`````\n# After\n"
+                    , "  ~~~text\r\none\r\n\r\ntwo\r\n  ~~~~\r\n# After\n"
+                    , "| name | value |\n| --- | ---: |\n| λ | **bold** |\n# After\n"
+                    , "Name | Value\n--- | ---\na | `x`\nb | y\n# After\n"
+                    , "| not | a table |\n# Heading\n```text\nbody\n```\n"
+                    ]
+                renderChunks feed chunks =
+                    Text.concat (snd (mapAccumL (flip feed) emptyRenderState chunks))
+            forM_ [streamMarkdown, streamMarkdownAtWidth 24] \feed ->
+                forM_ sources \source -> do
+                    let expected = renderChunks feed [source]
+                    forM_ [0 .. Text.length source] \offset -> do
+                        let (before, after) = Text.splitAt offset source
+                        renderChunks feed [before, "", after, ""]
+                            `shouldBe` expected
+                    renderChunks feed (map Text.singleton (Text.unpack source))
+                        `shouldBe` expected
+
+        it "holds a split fence closer until its complete line arrives" do
+            let chunks = ["```text\n", "body\n", "``", "", "`", " "]
+                (state, outputs) =
+                    mapAccumL (flip streamMarkdown) emptyRenderState chunks
+                (_, closed) = streamMarkdown "\n# After\n" state
+                (_, expected) =
+                    streamMarkdown (Text.concat chunks <> "\n# After\n")
+                        emptyRenderState
+            outputs `shouldSatisfy` all Text.null
+            closed `shouldBe` expected
+
+        it "retains many fragments of a long code line in order" do
+            let source =
+                    "```text\n"
+                        <> Text.replicate 512 "xλ界 "
+                        <> "\n```\n"
+                (_, outputs) =
+                    mapAccumL (flip streamMarkdown) emptyRenderState
+                        (Text.chunksOf 7 source)
+                (_, expected) = streamMarkdown source emptyRenderState
+            Text.concat outputs `shouldBe` expected
 
         it "constrains streamed tables to the terminal width" do
             let input =
@@ -985,6 +1029,23 @@ spec = do
                 body `shouldSatisfy` Text.isInfixOf "bold"
                 body `shouldSatisfy` (not . Text.isInfixOf "```")
                 body `shouldSatisfy` (not . Text.isInfixOf "**bold**")
+
+        it "flushes chunked incomplete blocks without dropping or reordering text" do
+            let sources =
+                    [ "```text\nfirst\n\nlast λ界"
+                    , "```text\nbody\n``"
+                    , "| name | value |\n| --- | --- |\n| first | one |\n| last | λ界"
+                    , "| name | value |\n| --"
+                    ]
+            forM_ sources \source ->
+                withRenderConfig False True \config handle path -> do
+                    mapM_ (renderEvent config . TextDelta)
+                        ("" : concatMap (\chunk -> [chunk, ""]) (Text.chunksOf 2 source))
+                    renderEvent config (TurnFinished (emptyTurnOutput "r1" [] Nothing))
+                    hClose handle
+                    actual <- stripTerminalControls <$> Text.readFile path
+                    actual `shouldBe`
+                        stripTerminalControls (renderAssistantText True source)
 
         it "flushes pre-tool assistant prose before tool lines" do
             withRenderConfig False True \config handle path -> do


### PR DESCRIPTION
## Summary

Avoid quadratic copying and rescanning while streaming fenced code blocks and Markdown tables in the scrollback CLI renderer.

- Retain completed lines and partial-line chunks instead of repeatedly appending to one strict `Text`.
- Inspect only newly received input; assemble the block once when rendering or flushing.
- Preserve output and emission timing, including split delimiters, Unicode, and incomplete blocks at EOF.
- Add regression tests and a reproducible optimized benchmark with the old implementation retained as a baseline.

Fullscreen rendering and plain-prose buffering are unchanged.

## Performance

GHC 9.10.3, optimized renderer, median of 7 samples, 1,000 lines/rows delivered in 16-character chunks:

| Workload | CPU before → after | Allocations before → after |
| --- | --- | --- |
| Fenced code | 267.170 → 11.365 ms (23.5× faster) | 1,261.867 → 55.063 MB (95.6% less) |
| Table | 447.802 → 20.302 ms (22.1× faster) | 3,531.322 → 115.718 MB (96.7% less) |

Mixed prose/small-block workloads improve CPU and allocations by about 8%. Prose and single-shot rendering remain effectively unchanged. These are renderer benchmarks, not end-to-end response latency.

Full methodology, scaling/chunk-size results, and reproduction commands: [MarkdownStreaming.md](packages/agent-cli/benchmark/MarkdownStreaming.md).

## Validation

- RenderSpec in GHCi: 78 examples, 0 failures.
- Additional old/new differential checks: 3,348 comparisons passed, including per-delta output and EOF flushing at widths 24 and 80.
- Production modules loaded successfully in GHCi.
- Live CLI smoke test in tmux with real streaming output: heading, bold, inline code, fenced code, and table render correctly.
- Optimized old/new benchmark checks output equality before measurement.
- Regenerated `package.nix` after adding the Cabal benchmark component.
