### PR TITLE
Separate subagent resource ownership from scoped turn execution

### DIFF
--- a/packages/agent-core/src/Agent/Subagents/Registry.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry.hs
@@ -1,7 +1,7 @@
 -- | Nestable subagent registry.
 --
 -- Shared state (agent map, status, mailboxes, admission count) lives in STM.
--- IO is only used to allocate ids, start child supervisors, and wait with timeouts.
+-- IO allocates ids and leases, runs scoped turns, and waits with timeouts.
 module Agent.Subagents.Registry
     ( SubagentRegistry
     , SubagentLease

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal/Core.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal/Core.hs
@@ -27,25 +27,22 @@ import Agent.Subagents.Types
     , SubagentSpawnEnv(..)
     , SubagentStatus(..)
     )
-import Control.Concurrent (throwTo)
 import Control.Concurrent.Async
-    ( AsyncCancelled(..), async, asyncThreadId, asyncWithUnmask
-    , poll, race, wait, waitCatch
+    ( asyncWithUnmask, concurrently_, link, race, replicateConcurrently_, wait, waitSTM, withAsync
     )
-import Control.Concurrent.MVar (modifyMVar, newMVar, withMVar)
+import Control.Concurrent.MVar (newEmptyMVar, newMVar, putMVar, readMVar, withMVar)
 import Control.Concurrent.STM
+import qualified Control.Exception as Exception
 import Control.Exception.Safe
     ( SomeException
-    , catchAny
+    , finally
     , mask
     , onException
-    , throwIO
     , tryAny
     )
 import Control.Monad (void)
-import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Trans.Resource (runResourceT)
-import Data.Acquire (allocateAcquire, withAcquire)
+import qualified Agent.ResourceScope as ResourceScope
+import Data.Acquire (withAcquire)
 import Data.IORef
 import Data.List (groupBy, sortOn)
 import Data.Map.Strict (Map)
@@ -72,7 +69,7 @@ newSubagentRegistry
     -> RunSubagent
     -> (SubagentId -> LoopEvent -> IO ())
     -> IO SubagentRegistry
-newSubagentRegistry config cwd run onEvent = do
+newSubagentRegistry config cwd run onEvent = mask \_ -> do
     agents <- newTVarIO Map.empty
     paths <- newTVarIO Map.empty
     live <- newTVarIO 0
@@ -92,8 +89,11 @@ newSubagentRegistry config cwd run onEvent = do
     runRef <- newIORef run
     onCompleteRef <- newIORef (\_ _ -> pure ())
     onSettledRef <- newIORef (\_ _ -> pure ())
-    pure SubagentRegistry
-        { registryAgents = agents
+    resources <- ResourceScope.newResourceScope
+    executor <- newEmptyMVar
+    executorStopped <- newTVarIO False
+    cleanupQueue <- newTQueueIO
+    let registry = SubagentRegistry { registryAgents = agents
         , registryPaths = paths
         , registryLiveCount = live
         , registryRootTurnSpawnCounts = rootTurnSpawnCounts
@@ -111,7 +111,20 @@ newSubagentRegistry config cwd run onEvent = do
         , registryNextRootTurnId = nextRootTurnId
         , registryAbortedRootTurns = abortedRootTurns
         , registryLifecycle = lifecycle
+        , registryResources = resources
+        , registryExecutor = executor
+        , registryExecutorStopped = executorStopped
+        , registryCleanupQueue = cleanupQueue
         }
+    -- The constructor returns before the service ends. This single root is
+    -- retained by the registry and joined by close; every executor child below
+    -- it has a lexical structured-concurrency scope.
+    worker <- asyncWithUnmask (\unmask -> unmask $
+        runRegistryExecutor registry
+            `finally` ResourceScope.closeResourceScope resources)
+        `onException` ResourceScope.closeResourceScope resources
+    putMVar executor worker
+    pure registry
 
 setSubagentRunner :: SubagentRegistry -> RunSubagent -> IO ()
 setSubagentRunner registry = writeIORef registry.registryRunRef
@@ -138,8 +151,8 @@ setSubagentOnComplete registry = writeIORef registry.registryOnCompleteRef
 
 -- | Invoked synchronously after a child publishes a final turn status,
 -- including completions routed directly to another subagent, and before the
--- child's supervisor can begin queued follow-up work. A first transition to
--- 'Closed' is reported after the supervisor has stopped; that callback runs
+-- child's executor can begin queued follow-up work. A first transition to
+-- 'Closed' is reported after execution and resource release finish; that callback runs
 -- under the registry lifecycle lock and must not call lifecycle-mutating
 -- registry operations.
 setSubagentOnSettled
@@ -157,8 +170,10 @@ beginRootTurn registry = atomically do
 
 closeSubagentRegistry :: SubagentRegistry -> IO ()
 closeSubagentRegistry registry =
-    withMVar registry.registryLifecycle \_ ->
+    withMVar registry.registryLifecycle \_ -> do
         closeSubagentRegistryLocked registry
+        atomically $ writeTVar registry.registryExecutorStopped True
+        readMVar registry.registryExecutor >>= wait
 
 closeSubagentRegistryLocked :: SubagentRegistry -> IO ()
 closeSubagentRegistryLocked registry = do
@@ -172,9 +187,12 @@ closeSubagentRegistryLocked registry = do
             (sortOn (Down . (.recordDepth)) records))
 
 -- | Shut down live children and reopen the registry for a fresh session.
+-- A terminally closed registry must be replaced, not reset.
 resetSubagentRegistry :: SubagentRegistry -> IO ()
 resetSubagentRegistry registry =
     withMVar registry.registryLifecycle \_ -> do
+        stopped <- readTVarIO registry.registryExecutorStopped
+        whenIO stopped $ ioError (userError "Cannot reset a terminally closed subagent registry.")
         closeSubagentRegistryLocked registry
         atomically do
             writeTVar registry.registryAgents Map.empty
@@ -221,7 +239,7 @@ spawnSubagentWithCwdForTurn registry rootTurnId childCwd =
     spawnSubagentWithCwdPreparedForTurn
         registry rootTurnId childCwd (\_ -> pure mempty)
 
--- | Run host preparation after admission but before the supervisor starts.
+-- | Run host preparation after admission but before turn execution starts.
 spawnSubagentWithCwdPrepared
     :: SubagentRegistry
     -> OsPath
@@ -347,7 +365,9 @@ spawnSubagentAtWithIdPreparedForTurn
         parentId requestedParentPath requestedParentDepth taskName content nickname = do
     cancelFlag <- newCancelFlag
     mailbox <- newTQueueIO
-    asyncVar <- newTVarIO Nothing
+    executionVar <- newTVarIO False
+    leaseVar <- newTVarIO Nothing
+    cleanupVar <- newTVarIO Nothing
     previousVar <- newTVarIO Nothing
     lastUpdateVar <- newTVarIO Nothing
     admitted <- withMVar registry.registryLifecycle \_ -> atomically do
@@ -423,7 +443,9 @@ spawnSubagentAtWithIdPreparedForTurn
                                                                 , recordPhase = phaseVar
                                                                 , recordCancel = cancelFlag
                                                                 , recordMailbox = mailbox
-                                                                , recordAsync = asyncVar
+                                                                , recordExecution = executionVar
+                                                                , recordLease = leaseVar
+                                                                , recordCleanup = cleanupVar
                                                                 , recordPreviousResponseId = previousVar
                                                                 , recordLastUpdate = lastUpdateVar
                                                                 , recordTaskPath = childPath
@@ -460,7 +482,7 @@ spawnSubagentAtWithIdPreparedForTurn
         started <-
             restore
                 (withMVar registry.registryLifecycle \_ ->
-                    startRecordSupervisor registry record lease)
+                    acquireRecordResources registry record lease)
                 `onException` shutdownRecord registry record
         case started of
             Left err -> do
@@ -504,12 +526,12 @@ rollbackAdmissionLocked registry record = do
         releaseSlotSTM registry record
         writeTVar record.recordPhase AgentClosed
     -- Keep the record discoverable by registry shutdown if rollback is
-    -- interrupted while its supervisor is releasing resources.
-    stopRecordSupervisor record
+    -- interrupted while the service is releasing its resources.
+    releaseRecordResources registry record
     atomically do
         agents <- readTVar registry.registryAgents
         case Map.lookup record.recordId agents of
-            Just current | current.recordAsync == record.recordAsync -> do
+            Just current | current.recordExecution == record.recordExecution -> do
                 writeTVar registry.registryAgents (Map.delete record.recordId agents)
                 modifyTVar' registry.registryPaths $
                     deleteOwnedPath record.recordTaskPath record.recordId
@@ -521,16 +543,9 @@ deleteOwnedPath key expected mappings =
         Just actual | actual == expected -> Map.delete key mappings
         _ -> mappings
 
-runSupervisor :: SubagentRegistry -> SubagentRecord -> IO ()
-runSupervisor registry record = awaitWork
+runRecordTurn :: SubagentRegistry -> SubagentRecord -> SubagentWork -> IO ()
+runRecordTurn registry record initialWork = runWork initialWork
   where
-    awaitWork =
-        atomically (takeStartedWork record) >>= \case
-            Nothing -> pure ()
-            Just work -> do
-                resetCancel record.recordCancel
-                runWork work
-
     runWork work = do
         let onEvent = registry.registryOnEvent record.recordId
             env = SubagentSpawnEnv
@@ -561,13 +576,13 @@ runSupervisor registry record = awaitWork
                     writeTVar record.recordPreviousResponseId
                         (Just loopResult.finalResponseId)
             _ -> pure ()
-        atomically (nextSupervisorStep registry record) >>= \case
-            SupervisorStop -> pure ()
-            SupervisorIdle -> awaitWork
-            SupervisorMessage nextWork -> do
-                resetCancel record.recordCancel
+        atomically (nextTurnStep registry record) >>= \case
+            TurnStop -> pure ()
+            TurnIdle -> pure ()
+            TurnMessage nextWork -> do
+                resetForQueuedWork
                 runWork nextWork
-            SupervisorComplete -> do
+            TurnComplete -> do
                 notifyRoot <- atomically $
                     publishCompletionSTM registry record status
                 whenIO notifyRoot do
@@ -576,26 +591,22 @@ runSupervisor registry record = awaitWork
                             registry record.recordId work.workRootTurnId status
                     pure ()
                 notifySettled registry record.recordId status
-                atomically (finishSupervisorStep registry record status) >>= \case
-                    SupervisorStop -> pure ()
-                    SupervisorIdle -> awaitWork
-                    SupervisorMessage nextWork -> do
-                        resetCancel record.recordCancel
+                atomically (finishTurnStep registry record status) >>= \case
+                    TurnStop -> pure ()
+                    TurnIdle -> pure ()
+                    TurnMessage nextWork -> do
+                        resetForQueuedWork
                         runWork nextWork
-                    SupervisorComplete -> pure ()
+                    TurnComplete -> pure ()
 
-takeStartedWork
-    :: SubagentRecord
-    -> STM (Maybe SubagentWork)
-takeStartedWork record = do
-    readTVar record.recordPhase >>= \case
-        AgentClosed -> pure Nothing
-        AgentPending work -> do
-            writeTVar record.recordPhase (AgentRunning work.workRootTurnId)
-            pure (Just work)
-        AgentIdle{} -> retry
-        AgentRunning{} -> retry
-        AgentInterrupting{} -> retry
+    resetForQueuedWork = do
+        resetCancel record.recordCancel
+        interrupted <- atomically $
+            readTVar record.recordPhase >>= \case
+                AgentInterrupting{} -> pure True
+                AgentClosed -> pure True
+                _ -> pure False
+        whenIO interrupted (requestCancel record.recordCancel)
 
 publishCompletionSTM :: SubagentRegistry -> SubagentRecord -> SubagentStatus -> STM Bool
 publishCompletionSTM registry record status = do
@@ -606,7 +617,7 @@ publishCompletionSTM registry record status = do
     routeCompletionSTM registry record status
 
 -- | Publish a status for a turn settled administratively before its
--- supervisor starts.  This wakes untargeted waiters just like a normal
+-- execution starts. This wakes untargeted waiters just like a normal
 -- completion, but deliberately does not route a completion message to the
 -- parent (there was no model turn to report).
 publishDirectUpdateSTM
@@ -667,20 +678,20 @@ completionMessage child parent status =
         QueuedMessage
         (plainInterAgentContent (formatCompletionNotice child.recordId status))
 
-startRecordSupervisor
+acquireRecordResources
     :: SubagentRegistry
     -> SubagentRecord
     -> SubagentLease
     -> IO (Either Text ())
-startRecordSupervisor registry record lease =
-    mask \restore -> do
+acquireRecordResources registry record lease =
+    mask \_ -> do
         canStart <- atomically do
             closed <- readTVar registry.registryClosed
             phase <- readTVar record.recordPhase
             aborted <- isRootTurnAborted registry (phaseRootTurnId phase)
             agents <- readTVar registry.registryAgents
             paths <- readTVar registry.registryPaths
-            current <- readTVar record.recordAsync
+            current <- readTVar record.recordLease
             pure $
                 not closed
                     && not aborted
@@ -692,121 +703,169 @@ startRecordSupervisor registry record lease =
         if not canStart
             then do
                 releaseSubagentLease lease
-                pure (Left "Subagent closed before its supervisor started.")
+                pure (Left "Subagent closed before resource acquisition.")
             else do
-                ready <- newEmptyTMVarIO
-                cancellation <- newMVar Nothing
-                started <- tryAny $ async $
-                    supervisorAction ready
-                case started of
+                acquired <- tryAny $ case lease of
+                    SubagentLease acquire ->
+                        ResourceScope.allocateAcquire registry.registryResources acquire
+                case acquired of
                     Left (exception :: SomeException) -> do
-                        releaseSubagentLease lease
                         pure (Left ("Failed to start subagent: " <> Text.pack (show exception)))
-                    Right supervisor -> do
-                        atomically $ writeTVar record.recordAsync $
-                            Just (OwnedSubagentSupervisor supervisor cancellation)
-                        ownership <- restore (atomically (takeTMVar ready))
-                            `onException` stopRecordSupervisor record
-                        case ownership of
-                            Left err -> do
-                                stopRecordSupervisor record
-                                pure (Left err)
-                            Right () -> pure (Right ())
-  where
-    supervisorAction ready =
-        mask \restoreSupervisor ->
-            (runResourceT do
-                case lease of
-                    SubagentLease acquire -> void (allocateAcquire acquire)
-                liftIO $ atomically $ putTMVar ready (Right ())
-                -- A closed phase stops accepting work, but only the owner's
-                -- cancellation ends this scope. Otherwise cooperative shutdown
-                -- could begin lease cleanup before that exception is delivered.
-                liftIO $ restoreSupervisor do
-                    runSupervisor registry record
-                    atomically retry)
-            `catchAny` \exception -> do
-                atomically $ void $ tryPutTMVar ready $ Left $
-                    "Failed to start subagent: " <> Text.pack (show exception)
-                throwIO exception
+                    Right (key, ()) -> do
+                        atomically do
+                            writeTVar record.recordLease (Just key)
+                            writeTVar record.recordCleanup Nothing
+                        pure (Right ())
 
 releaseSubagentLease :: SubagentLease -> IO ()
 releaseSubagentLease (SubagentLease acquire) =
     withAcquire acquire (const (pure ()))
 
-stopRecordSupervisor :: SubagentRecord -> IO ()
-stopRecordSupervisor record =
-    -- Mask only the ownership transitions. Blocking delivery and joining run
-    -- outside those transitions, with both handles retained for another closer.
-    mask \restore -> do
-        current <- readTVarIO record.recordAsync
-        mapM_ (\supervisor -> do
-            cancellation <- modifyMVar supervisor.supervisorCancellation \case
-                Just sender -> pure (Just sender, Just sender)
-                Nothing -> poll supervisor.supervisorAsync >>= \case
-                    Just _ -> pure (Nothing, Nothing)
-                    Nothing -> do
-                        -- throwTo can block. A tracked sender makes cancellation
-                        -- exactly-once even when the waiting closer is interrupted.
-                        sender <- asyncWithUnmask \unmask ->
-                            unmask $
-                                throwTo (asyncThreadId supervisor.supervisorAsync)
-                                    AsyncCancelled
-                        pure (Just sender, Just sender)
-            restore do
-                mapM_ wait cancellation
-                void (waitCatch supervisor.supervisorAsync)
-            atomically do
-                latest <- readTVar record.recordAsync
-                case latest of
-                    Just owned
-                        | owned.supervisorAsync == supervisor.supervisorAsync ->
-                            writeTVar record.recordAsync Nothing
-                    _ -> pure ()) current
+-- | Closing callers wait for service-owned cleanup. Cancelling a waiter cannot
+-- interrupt resource release, and every retry observes the same acknowledgement.
+releaseRecordResources :: SubagentRegistry -> SubagentRecord -> IO ()
+releaseRecordResources registry record = do
+    completion <- atomically $
+        readTVar record.recordCleanup >>= \case
+            Just completion -> pure completion
+            Nothing -> do
+                completion <- newEmptyTMVar
+                writeTVar record.recordCleanup (Just completion)
+                writeTQueue registry.registryCleanupQueue (record, completion)
+                pure completion
+    executor <- readMVar registry.registryExecutor
+    atomically $
+        readTMVar completion `orElse` do
+            waitSTM executor
+            throwSTM (userError "Subagent executor stopped before resource cleanup completed.")
 
-data SupervisorStep
-    = SupervisorStop
-    | SupervisorIdle
-    | SupervisorComplete
-    | SupervisorMessage !SubagentWork
+-- | Worker scopes grow only when the configured concurrency high-water mark
+-- increases. Completed turns reuse workers; idle agents own no threads.
+runRegistryExecutor :: SubagentRegistry -> IO ()
+runRegistryExecutor registry =
+    concurrently_ (growWorkers 0) (replicateConcurrently_ 8 cleanupWorker)
+  where
+    growWorkers count = do
+        grow <- atomically do
+            stopped <- readTVar registry.registryExecutorStopped
+            config <- readTVar registry.registryConfig
+            if stopped then pure False
+            else if count < config.maxConcurrent then pure True
+            else retry
+        whenIO grow $
+            withAsync turnWorker \worker -> do
+                link worker
+                growWorkers (count + 1)
 
-nextSupervisorStep
+    turnWorker = do
+        selected <- atomically do
+            stopped <- readTVar registry.registryExecutorStopped
+            if stopped then pure Nothing
+            else readTVar registry.registryAgents >>= selectPending . Map.elems
+        case selected of
+            Nothing -> pure ()
+            Just (record, work) -> do
+                -- Administrative close also covers callbacks outside the
+                -- provider's per-turn cancellation race. Its scope is joined
+                -- before the resource-release worker can proceed.
+                (do
+                    result <- race (atomically $ waitClosed record)
+                        -- Contain child outcomes, including async-classified
+                        -- exceptions, inside the child's scope. Cancellation of
+                        -- the reusable executor itself still propagates.
+                        (Exception.try (runRecordTurn registry record work))
+                    case result of
+                        Right (Left (exception :: SomeException)) ->
+                            atomically $
+                                readTVar record.recordPhase >>= \case
+                                    AgentClosed -> pure ()
+                                    _ -> do
+                                        let status = Errored (Text.pack (show exception))
+                                        publishDirectUpdateSTM registry record status
+                                        transitionToIdleSTM registry record status
+                        _ -> pure ())
+                    `finally` atomically (writeTVar record.recordExecution False)
+                turnWorker
+
+    selectPending :: [SubagentRecord] -> STM (Maybe (SubagentRecord, SubagentWork))
+    selectPending [] = retry
+    selectPending (record : remaining) = do
+        executing <- readTVar record.recordExecution
+        lease <- readTVar record.recordLease
+        phase <- readTVar record.recordPhase
+        case (executing, lease, phase) of
+            (False, Just _, AgentPending work) -> do
+                writeTVar record.recordExecution True
+                writeTVar record.recordPhase (AgentRunning work.workRootTurnId)
+                pure (Just (record, work))
+            _ -> selectPending remaining
+
+    waitClosed :: SubagentRecord -> STM ()
+    waitClosed record = readTVar record.recordPhase >>= \case
+        AgentClosed -> pure ()
+        _ -> retry
+
+    cleanupWorker = do
+        job <- atomically $
+            (Just <$> readTQueue registry.registryCleanupQueue)
+                `orElse` do
+                    stopped <- readTVar registry.registryExecutorStopped
+                    check stopped
+                    pure Nothing
+        case job of
+            Nothing -> pure ()
+            Just (record, completion) -> do
+                atomically $ readTVar record.recordExecution >>= check . not
+                key <- readTVarIO record.recordLease
+                void $ tryAny $ mapM_ ResourceScope.releaseResource key
+                atomically do
+                    writeTVar record.recordLease Nothing
+                    putTMVar completion ()
+                cleanupWorker
+
+data TurnStep
+    = TurnStop
+    | TurnIdle
+    | TurnComplete
+    | TurnMessage !SubagentWork
+
+nextTurnStep
     :: SubagentRegistry
     -> SubagentRecord
-    -> STM SupervisorStep
-nextSupervisorStep registry record = do
-    supervisorStep registry record (pure SupervisorComplete)
+    -> STM TurnStep
+nextTurnStep registry record = do
+    turnStep registry record (pure TurnComplete)
 
-finishSupervisorStep
+finishTurnStep
     :: SubagentRegistry
     -> SubagentRecord
     -> SubagentStatus
-    -> STM SupervisorStep
-finishSupervisorStep registry record status = do
-    supervisorStep registry record do
+    -> STM TurnStep
+finishTurnStep registry record status = do
+    turnStep registry record do
         transitionToIdleSTM registry record status
-        pure SupervisorIdle
+        pure TurnIdle
 
-supervisorStep
+turnStep
     :: SubagentRegistry
     -> SubagentRecord
-    -> STM SupervisorStep
-    -> STM SupervisorStep
-supervisorStep registry record onIdle =
+    -> STM TurnStep
+    -> STM TurnStep
+turnStep registry record onIdle =
     readTVar record.recordPhase >>= \case
-        AgentClosed -> release SupervisorStop
+        AgentClosed -> release TurnStop
         AgentInterrupting{} -> do
             transitionToIdleSTM registry record Interrupted
-            pure SupervisorIdle
+            pure TurnIdle
         AgentRunning{} ->
             tryReadTQueue record.recordMailbox >>= \case
                 Nothing -> onIdle
                 Just work -> do
                     writeTVar record.recordPhase
                         (AgentRunning work.workRootTurnId)
-                    pure (SupervisorMessage work)
+                    pure (TurnMessage work)
         AgentPending{} -> retry
-        AgentIdle{} -> pure SupervisorIdle
+        AgentIdle{} -> pure TurnIdle
   where
     release step = do
         releaseSlotSTM registry record
@@ -919,7 +978,7 @@ shutdownRecord registry record = do
         pure $ case phase of
             AgentClosed -> False
             _ -> True
-    stopRecordSupervisor record
+    releaseRecordResources registry record
     whenIO transitioned $
         notifySettled registry record.recordId Closed
 

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal/Core.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal/Core.hs
@@ -27,8 +27,12 @@ import Agent.Subagents.Types
     , SubagentSpawnEnv(..)
     , SubagentStatus(..)
     )
-import Control.Concurrent.Async (Async, async, cancel, race, waitCatch)
-import Control.Concurrent.MVar (newMVar, withMVar)
+import Control.Concurrent (throwTo)
+import Control.Concurrent.Async
+    ( AsyncCancelled(..), async, asyncThreadId, asyncWithUnmask
+    , poll, race, wait, waitCatch
+    )
+import Control.Concurrent.MVar (modifyMVar, newMVar, withMVar)
 import Control.Concurrent.STM
 import Control.Exception.Safe
     ( SomeException
@@ -490,14 +494,26 @@ taskNameForAgentId agentId =
     "a" <> Text.filter (/= '-') agentId.unSubagentId
 
 rollbackAdmission :: SubagentRegistry -> SubagentRecord -> IO ()
-rollbackAdmission registry record = do
+rollbackAdmission registry record =
+    withMVar registry.registryLifecycle \_ ->
+        rollbackAdmissionLocked registry record
+
+rollbackAdmissionLocked :: SubagentRegistry -> SubagentRecord -> IO ()
+rollbackAdmissionLocked registry record = do
     atomically do
-        modifyTVar' registry.registryAgents (Map.delete record.recordId)
-        modifyTVar' registry.registryPaths $
-            deleteOwnedPath record.recordTaskPath record.recordId
         releaseSlotSTM registry record
         writeTVar record.recordPhase AgentClosed
+    -- Keep the record discoverable by registry shutdown if rollback is
+    -- interrupted while its supervisor is releasing resources.
     stopRecordSupervisor record
+    atomically do
+        agents <- readTVar registry.registryAgents
+        case Map.lookup record.recordId agents of
+            Just current | current.recordAsync == record.recordAsync -> do
+                writeTVar registry.registryAgents (Map.delete record.recordId agents)
+                modifyTVar' registry.registryPaths $
+                    deleteOwnedPath record.recordTaskPath record.recordId
+            _ -> pure ()
 
 deleteOwnedPath :: TaskPath -> SubagentId -> Map TaskPath SubagentId -> Map TaskPath SubagentId
 deleteOwnedPath key expected mappings =
@@ -679,6 +695,7 @@ startRecordSupervisor registry record lease =
                 pure (Left "Subagent closed before its supervisor started.")
             else do
                 ready <- newEmptyTMVarIO
+                cancellation <- newMVar Nothing
                 started <- tryAny $ async $
                     supervisorAction ready
                 case started of
@@ -686,7 +703,8 @@ startRecordSupervisor registry record lease =
                         releaseSubagentLease lease
                         pure (Left ("Failed to start subagent: " <> Text.pack (show exception)))
                     Right supervisor -> do
-                        atomically $ writeTVar record.recordAsync (Just supervisor)
+                        atomically $ writeTVar record.recordAsync $
+                            Just (OwnedSubagentSupervisor supervisor cancellation)
                         ownership <- restore (atomically (takeTMVar ready))
                             `onException` stopRecordSupervisor record
                         case ownership of
@@ -701,7 +719,12 @@ startRecordSupervisor registry record lease =
                 case lease of
                     SubagentLease acquire -> void (allocateAcquire acquire)
                 liftIO $ atomically $ putTMVar ready (Right ())
-                liftIO $ restoreSupervisor (runSupervisor registry record))
+                -- A closed phase stops accepting work, but only the owner's
+                -- cancellation ends this scope. Otherwise cooperative shutdown
+                -- could begin lease cleanup before that exception is delivered.
+                liftIO $ restoreSupervisor do
+                    runSupervisor registry record
+                    atomically retry)
             `catchAny` \exception -> do
                 atomically $ void $ tryPutTMVar ready $ Left $
                     "Failed to start subagent: " <> Text.pack (show exception)
@@ -711,23 +734,35 @@ releaseSubagentLease :: SubagentLease -> IO ()
 releaseSubagentLease (SubagentLease acquire) =
     withAcquire acquire (const (pure ()))
 
-stopAsync :: Async () -> IO ()
-stopAsync supervisor = do
-    cancel supervisor
-    _ <- waitCatch supervisor
-    pure ()
-
-takeRecordSupervisor :: SubagentRecord -> IO (Maybe (Async ()))
-takeRecordSupervisor record =
-    atomically do
-        current <- readTVar record.recordAsync
-        writeTVar record.recordAsync Nothing
-        pure current
-
 stopRecordSupervisor :: SubagentRecord -> IO ()
-stopRecordSupervisor record = do
-    supervisor <- takeRecordSupervisor record
-    mapM_ stopAsync supervisor
+stopRecordSupervisor record =
+    -- Mask only the ownership transitions. Blocking delivery and joining run
+    -- outside those transitions, with both handles retained for another closer.
+    mask \restore -> do
+        current <- readTVarIO record.recordAsync
+        mapM_ (\supervisor -> do
+            cancellation <- modifyMVar supervisor.supervisorCancellation \case
+                Just sender -> pure (Just sender, Just sender)
+                Nothing -> poll supervisor.supervisorAsync >>= \case
+                    Just _ -> pure (Nothing, Nothing)
+                    Nothing -> do
+                        -- throwTo can block. A tracked sender makes cancellation
+                        -- exactly-once even when the waiting closer is interrupted.
+                        sender <- asyncWithUnmask \unmask ->
+                            unmask $
+                                throwTo (asyncThreadId supervisor.supervisorAsync)
+                                    AsyncCancelled
+                        pure (Just sender, Just sender)
+            restore do
+                mapM_ wait cancellation
+                void (waitCatch supervisor.supervisorAsync)
+            atomically do
+                latest <- readTVar record.recordAsync
+                case latest of
+                    Just owned
+                        | owned.supervisorAsync == supervisor.supervisorAsync ->
+                            writeTVar record.recordAsync Nothing
+                    _ -> pure ()) current
 
 data SupervisorStep
     = SupervisorStop

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal/Operations.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal/Operations.hs
@@ -330,8 +330,8 @@ filterMSTM predicate = fmap reverse . go []
 
 -- | Re-admit a previously persisted agent that is not currently in the
 -- in-memory map (e.g. after close, or across a process restart within the
--- same session directory). Starts an idle supervisor; callers follow with
--- 'sendInput'. Does not consume a concurrency slot until the next turn.
+-- same session directory). Restores idle state; callers follow with
+-- 'sendInput'. Does not occupy an execution worker until the next turn.
 restoreSubagent
     :: SubagentRegistry
     -> SubagentId
@@ -484,7 +484,7 @@ restoreSubagentResolvedWithCwd
                         atomically $
                             writeTVar record.recordPhase
                                 (AgentIdle normalizedStatus Nothing)
-                        startRecordSupervisor registry record mempty
+                        acquireRecordResources registry record mempty
                     else pure (Right ())
                 case restarted of
                     Left err -> do
@@ -496,7 +496,9 @@ restoreSubagentResolvedWithCwd
         cancelFlag <- newCancelFlag
         mailbox <- newTQueueIO
         phaseVar <- newTVarIO normalizedPhase
-        asyncVar <- newTVarIO Nothing
+        executionVar <- newTVarIO False
+        leaseVar <- newTVarIO Nothing
+        cleanupVar <- newTVarIO Nothing
         previousVar <- newTVarIO previous
         lastUpdateVar <- newTVarIO Nothing
         restored <- atomically do
@@ -524,7 +526,9 @@ restoreSubagentResolvedWithCwd
                                             , recordPhase = phaseVar
                                             , recordCancel = cancelFlag
                                             , recordMailbox = mailbox
-                                            , recordAsync = asyncVar
+                                            , recordExecution = executionVar
+                                            , recordLease = leaseVar
+                                            , recordCleanup = cleanupVar
                                             , recordPreviousResponseId = previousVar
                                             , recordLastUpdate = lastUpdateVar
                                             , recordTaskPath = resolvedPath
@@ -544,7 +548,7 @@ restoreSubagentResolvedWithCwd
                         writeTVar record.recordPhase
                             (AgentIdle normalizedStatus Nothing)
                     _ -> pure ()
-                startRecordSupervisor registry record mempty >>= \case
+                acquireRecordResources registry record mempty >>= \case
                     Left err -> do
                         rollbackAdmissionLocked registry record
                         pure (Left err)

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal/Operations.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal/Operations.hs
@@ -546,7 +546,7 @@ restoreSubagentResolvedWithCwd
                     _ -> pure ()
                 startRecordSupervisor registry record mempty >>= \case
                     Left err -> do
-                        rollbackAdmission registry record
+                        rollbackAdmissionLocked registry record
                         pure (Left err)
                     Right () -> pure (Right agentId)
 

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal/Operations.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal/Operations.hs
@@ -30,7 +30,7 @@ import Control.Concurrent.Async (race)
 import Control.Concurrent.MVar (withMVar)
 import Control.Concurrent.STM
 import Control.Exception.Safe (finally)
-import Control.Monad (void)
+import Control.Monad (void, when)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -472,6 +472,10 @@ restoreSubagentResolvedWithCwd
             Pending -> pure (Left "cannot restore a pending subagent")
             NotFound -> pure (Left "cannot restore a missing subagent record")
             _ -> do
+                -- An interrupted close can leave service-owned cleanup running.
+                -- Keep the record closed until that cleanup has been joined.
+                when (status == Closed) $
+                    releaseRecordResources registry record
                 resetCancel record.recordCancel
                 atomically do
                     releaseSlotSTM registry record

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal/Types.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal/Types.hs
@@ -30,12 +30,20 @@ data SubagentRecord = SubagentRecord
     , recordPhase :: !(TVar SubagentPhase)
     , recordCancel :: !CancelFlag
     , recordMailbox :: !(TQueue SubagentWork)
-    , recordAsync :: !(TVar (Maybe (Async ())))
+    , recordAsync :: !(TVar (Maybe OwnedSubagentSupervisor))
       -- | Last successful response id for conversation continuity.
     , recordPreviousResponseId :: !(TVar (Maybe Text))
     , recordLastUpdate :: !(TVar (Maybe (Int, SubagentStatus)))
     , recordTaskPath :: !TaskPath
     , recordCwd :: !OsPath
+    }
+
+-- | The cancellation request remains owned alongside the supervisor until both
+-- have completed. An interrupted closer can therefore resume the same shutdown
+-- without delivering another exception into resource cleanup.
+data OwnedSubagentSupervisor = OwnedSubagentSupervisor
+    { supervisorAsync :: !(Async ())
+    , supervisorCancellation :: !(MVar (Maybe (Async ())))
     }
 
 data SubagentWork = SubagentWork

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal/Types.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal/Types.hs
@@ -3,6 +3,7 @@ module Agent.Subagents.Registry.Internal.Types where
 import Agent.Cancel (CancelFlag)
 import Agent.InterAgentMessage (InterAgentMessage)
 import Agent.Loop (LoopEvent)
+import Agent.ResourceScope (ResourceKey, ResourceScope)
 import Agent.Subagents.TaskPath (TaskPath)
 import Agent.Subagents.Types
     ( RootTurnId
@@ -13,7 +14,7 @@ import Agent.Subagents.Types
     )
 import Control.Concurrent.Async (Async)
 import Control.Concurrent.MVar (MVar)
-import Control.Concurrent.STM (TQueue, TVar)
+import Control.Concurrent.STM (TMVar, TQueue, TVar)
 import Data.Acquire (Acquire, mkAcquire)
 import Data.IORef (IORef)
 import Data.Map.Strict (Map)
@@ -30,20 +31,14 @@ data SubagentRecord = SubagentRecord
     , recordPhase :: !(TVar SubagentPhase)
     , recordCancel :: !CancelFlag
     , recordMailbox :: !(TQueue SubagentWork)
-    , recordAsync :: !(TVar (Maybe OwnedSubagentSupervisor))
+    , recordExecution :: !(TVar Bool)
+    , recordLease :: !(TVar (Maybe ResourceKey))
+    , recordCleanup :: !(TVar (Maybe (TMVar ())))
       -- | Last successful response id for conversation continuity.
     , recordPreviousResponseId :: !(TVar (Maybe Text))
     , recordLastUpdate :: !(TVar (Maybe (Int, SubagentStatus)))
     , recordTaskPath :: !TaskPath
     , recordCwd :: !OsPath
-    }
-
--- | The cancellation request remains owned alongside the supervisor until both
--- have completed. An interrupted closer can therefore resume the same shutdown
--- without delivering another exception into resource cleanup.
-data OwnedSubagentSupervisor = OwnedSubagentSupervisor
-    { supervisorAsync :: !(Async ())
-    , supervisorCancellation :: !(MVar (Maybe (Async ())))
     }
 
 data SubagentWork = SubagentWork
@@ -87,9 +82,9 @@ phaseHoldsSlot = \case
     AgentIdle{} -> False
     AgentClosed -> False
 
--- | Resources acquired while preparing an agent and transferred to its
--- supervisor. They remain alive across turns and are released in reverse order
--- when the supervisor exits.
+-- | Resources acquired while preparing an agent and transferred to the
+-- registry resource scope. They remain alive across turns and are released in
+-- reverse order after the agent's final execution scope ends.
 newtype SubagentLease = SubagentLease (Acquire ())
 
 instance Semigroup SubagentLease where
@@ -122,4 +117,8 @@ data SubagentRegistry = SubagentRegistry
     , registryNextRootTurnId :: !(TVar Word64)
     , registryAbortedRootTurns :: !(TVar (Set RootTurnId))
     , registryLifecycle :: !(MVar ())
+    , registryResources :: !ResourceScope
+    , registryExecutor :: !(MVar (Async ()))
+    , registryExecutorStopped :: !(TVar Bool)
+    , registryCleanupQueue :: !(TQueue (SubagentRecord, TMVar ()))
     }

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -27,9 +27,9 @@ import System.Timeout (timeout)
 import Test.Hspec
 
 -- The release gate makes the interruption occur during owned resource cleanup,
--- rather than relying on the supervisor's scheduling or normal completion.
-interruptedSupervisorShutdown :: Bool -> IO ()
-interruptedSupervisorShutdown resetAfterInterruption = do
+-- rather than relying on worker scheduling or normal completion.
+interruptedResourceCleanup :: Bool -> IO ()
+interruptedResourceCleanup resetAfterInterruption = do
     cleanupStarted <- newEmptyMVar
     cleanupRelease <- newEmptyMVar
     cleanupFinished <- newEmptyMVar
@@ -152,7 +152,7 @@ spec = describe "Agent.Subagents" do
         timedOut `shouldBe` False
         Map.lookup agentId statuses `shouldBe` Just (Completed (Just "done:hello"))
 
-    it "does not launch a prepared supervisor after registry shutdown" do
+    it "does not launch a prepared turn after registry shutdown" do
         entered <- newEmptyMVar
         release <- newEmptyMVar
         ran <- newIORef False
@@ -165,10 +165,10 @@ spec = describe "Agent.Subagents" do
         closeSubagentRegistry registry
         putMVar release ()
         Async.wait spawning `shouldReturn`
-            Left "Subagent closed before its supervisor started."
+            Left "Subagent closed before resource acquisition."
         readIORef ran `shouldReturn` False
 
-    it "releases a prepared lease when the supervisor cannot start" do
+    it "releases a prepared lease when resource acquisition is rejected" do
         entered <- newEmptyMVar
         release <- newEmptyMVar
         releases <- newIORef (0 :: Int)
@@ -186,7 +186,7 @@ spec = describe "Agent.Subagents" do
         closeSubagentRegistry registry
         putMVar release ()
         Async.wait spawning `shouldReturn`
-            Left "Subagent closed before its supervisor started."
+            Left "Subagent closed before resource acquisition."
         readIORef releases `shouldReturn` 1
         readIORef ran `shouldReturn` False
 
@@ -223,7 +223,7 @@ spec = describe "Agent.Subagents" do
         closeSubagent registry agentId `shouldReturn` Right Pending
         putMVar release ()
         Async.wait spawning `shouldReturn`
-            Left "Subagent closed before its supervisor started."
+            Left "Subagent closed before resource acquisition."
 
         Right _ <- spawnSubagent registry Nothing 0 "replacement" Nothing
         extra <- spawnSubagent registry Nothing 0 "extra" Nothing
@@ -255,7 +255,7 @@ spec = describe "Agent.Subagents" do
         getStatus registry agentId `shouldReturn` Interrupted
         putMVar release ()
         Async.wait spawning `shouldReturn`
-            Left "Subagent closed before its supervisor started."
+            Left "Subagent closed before resource acquisition."
         readIORef leaseReleases `shouldReturn` 1
         getStatus registry agentId `shouldReturn` NotFound
         closeSubagentRegistry registry
@@ -861,11 +861,117 @@ spec = describe "Agent.Subagents" do
         closeSubagentRegistry registry
         readIORef released `shouldReturn` True
 
-    it "retains supervisor ownership after an interrupted close" do
-        interruptedSupervisorShutdown False
+    it "retains resource cleanup ownership after an interrupted close" do
+        interruptedResourceCleanup False
 
-    it "waits for retained supervisor cleanup before resetting the registry" do
-        interruptedSupervisorShutdown True
+    it "waits for retained resource cleanup before resetting the registry" do
+        interruptedResourceCleanup True
+
+    it "rejects reset after terminal registry closure" do
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath ".")
+            (\_ _ _ _ -> pure (completedResult "done"))
+            (\_ _ -> pure ())
+        closeSubagentRegistry registry
+        resetSubagentRegistry registry `shouldThrow` anyIOException
+        result <- spawnSubagent registry Nothing 0 "task" Nothing
+        result `shouldSatisfy` either (const True) (const False)
+        closeSubagentRegistry registry
+
+    it "starts sibling resource finalizers concurrently during registry close" do
+        started <- newTVarIO (0 :: Int)
+        release <- newEmptyMVar
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath ".")
+            (\_ _ _ _ -> pure (completedResult "done"))
+            (\_ _ -> pure ())
+        let unblock = void $ tryPutMVar release ()
+            prepare _ = pure $ subagentLease do
+                atomically $ modifyTVar' started (+ 1)
+                readMVar release
+        (do
+            Right _ <- spawnSubagentWithCwdPrepared registry (fromFilePath ".")
+                prepare Nothing 0 "first" Nothing
+            Right _ <- spawnSubagentWithCwdPrepared registry (fromFilePath ".")
+                prepare Nothing 0 "second" Nothing
+            Async.withAsync (closeSubagentRegistry registry) \closer -> do
+                (timeout 5000000 (atomically $ readTVar started >>= check . (== 2))
+                    `shouldReturn` Just ())
+                    `finally` unblock
+                Async.wait closer)
+            `finally` (unblock >> closeSubagentRegistry registry)
+
+    it "starts additional turns after increasing the concurrency limit" do
+        started <- newTQueueIO
+        registry <- newSubagentRegistry
+            (defaultSubagentConfig { maxConcurrent = 1 })
+            (fromFilePath ".")
+            (\_ _ prompt _ -> do
+                atomically $ writeTQueue started (messagePayload prompt)
+                atomically retry)
+            (\_ _ -> pure ())
+        (do
+            Right _ <- spawnSubagent registry Nothing 0 "first" Nothing
+            timeout 5000000 (atomically $ readTQueue started)
+                `shouldReturn` Just "first"
+            setMaxConcurrent registry 2
+            Right _ <- spawnSubagent registry Nothing 0 "second" Nothing
+            timeout 5000000 (atomically $ readTQueue started)
+                `shouldReturn` Just "second"
+            ) `finally` closeSubagentRegistry registry
+
+    it "joins turn cleanup before releasing the agent lease" do
+        started <- newEmptyMVar
+        turnCleanupStarted <- newEmptyMVar
+        turnCleanupRelease <- newEmptyMVar
+        leaseReleased <- newEmptyMVar
+        registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath ".")
+            (\_ _ _ _ ->
+                (putMVar started () >> atomically retry)
+                    `finally` do
+                        putMVar turnCleanupStarted ()
+                        readMVar turnCleanupRelease)
+            (\_ _ -> pure ())
+        let releaseGate = void $ tryPutMVar turnCleanupRelease ()
+        (do
+            Right agentId <- spawnSubagentWithCwdPrepared registry (fromFilePath ".")
+                (\_ -> pure $ subagentLease (putMVar leaseReleased ()))
+                Nothing 0 "blocked" Nothing
+            timeout 5000000 (readMVar started) `shouldReturn` Just ()
+            Async.withAsync (closeSubagent registry agentId) \closer ->
+                (do
+                    timeout 5000000 (readMVar turnCleanupStarted)
+                        `shouldReturn` Just ()
+                    tryReadMVar leaseReleased `shouldReturn` Nothing
+                    timeout 5000000 (Async.cancel closer) `shouldReturn` Just ()
+                    tryReadMVar leaseReleased `shouldReturn` Nothing
+                    releaseGate
+                    _ <- closeSubagent registry agentId
+                    timeout 5000000 (readMVar leaseReleased) `shouldReturn` Just ()
+                    ) `finally` releaseGate
+            ) `finally` (releaseGate >> closeSubagentRegistry registry)
+
+    it "releases an idle agent while every turn worker is occupied" do
+        started <- newEmptyMVar
+        released <- newEmptyMVar
+        registry <- newSubagentRegistry
+            (defaultSubagentConfig { maxConcurrent = 1 })
+            (fromFilePath ".")
+            (\_ _ prompt _ ->
+                if messagePayload prompt == "blocked"
+                    then putMVar started () >> atomically retry
+                    else pure (completedResult (messagePayload prompt)))
+            (\_ _ -> pure ())
+        (do
+            Right idleAgent <- spawnSubagentWithCwdPrepared registry (fromFilePath ".")
+                (\_ -> pure $ subagentLease (putMVar released ()))
+                Nothing 0 "completed" Nothing
+            (_, timedOut) <- waitSubagents registry [idleAgent] 5000
+            timedOut `shouldBe` False
+            Right _ <- spawnSubagent registry Nothing 0 "blocked" Nothing
+            timeout 5000000 (readMVar started) `shouldReturn` Just ()
+            result <- timeout 5000000 (closeSubagent registry idleAgent)
+            result `shouldSatisfy` maybe False (const True)
+            timeout 5000000 (readMVar released) `shouldReturn` Just ()
+            ) `finally` closeSubagentRegistry registry
 
     it "releases composed subagent leases in reverse acquisition order" do
         released <- newIORef ([] :: [Int])

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -73,6 +73,51 @@ interruptedResourceCleanup resetAfterInterruption = do
             ) `finally` releaseGate
         ) `finally` (releaseGate >> closeSubagentRegistry registry)
 
+interruptedRestoreCleanup :: Bool -> IO ()
+interruptedRestoreCleanup interruptRestore = do
+    cleanupStarted <- newEmptyMVar
+    cleanupRelease <- newEmptyMVar
+    workerStarted <- newEmptyMVar
+    restoreStarted <- newEmptyMVar
+    releases <- newIORef (0 :: Int)
+    registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath ".")
+        (\_ _ _ _ -> putMVar workerStarted () >> atomically retry)
+        (\_ _ -> pure ())
+    let releaseGate = void (tryPutMVar cleanupRelease ())
+        cleanup = do
+            atomicModifyIORef' releases \n -> (n + 1, ())
+            putMVar cleanupStarted ()
+            readMVar cleanupRelease
+    (do
+        Right agentId <- spawnSubagentWithCwdPrepared registry (fromFilePath ".")
+            (\_ -> pure (subagentLease cleanup))
+            Nothing 0 "owned" Nothing
+        timeout 5000000 (readMVar workerStarted) `shouldReturn` Just ()
+        Async.withAsync (closeSubagent registry agentId) \closer ->
+            (do
+                timeout 5000000 (readMVar cleanupStarted) `shouldReturn` Just ()
+                timeout 5000000 (Async.cancel closer) `shouldReturn` Just ()
+                let restore = restoreSubagent registry agentId Nothing 1 Nothing Nothing
+                Async.withAsync (putMVar restoreStarted () >> restore) \restorer ->
+                    (do
+                        timeout 5000000 (readMVar restoreStarted) `shouldReturn` Just ()
+                        timeout 100000 (Async.wait restorer) `shouldReturn` Nothing
+                        getStatus registry agentId `shouldReturn` Closed
+                        if interruptRestore
+                            then do
+                                timeout 5000000 (Async.cancel restorer) `shouldReturn` Just ()
+                                getStatus registry agentId `shouldReturn` Closed
+                                releaseGate
+                                timeout 5000000 restore `shouldReturn` Just (Right agentId)
+                            else do
+                                releaseGate
+                                timeout 5000000 (Async.wait restorer) `shouldReturn` Just (Right agentId)
+                        getStatus registry agentId `shouldReturn` Completed Nothing
+                        readIORef releases `shouldReturn` 1
+                    ) `finally` releaseGate
+            ) `finally` releaseGate
+        ) `finally` (releaseGate >> closeSubagentRegistry registry)
+
 messagePayload :: InterAgentMessage -> Text
 messagePayload message = case message.messageContent of
     PlainInterAgentContent text -> text
@@ -863,6 +908,12 @@ spec = describe "Agent.Subagents" do
 
     it "retains resource cleanup ownership after an interrupted close" do
         interruptedResourceCleanup False
+
+    it "joins retained cleanup before restoring an interrupted close" do
+        interruptedRestoreCleanup False
+
+    it "keeps a restore interrupted during retained cleanup closed and retryable" do
+        interruptedRestoreCleanup True
 
     it "waits for retained resource cleanup before resetting the registry" do
         interruptedResourceCleanup True

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -16,7 +16,7 @@ import qualified Control.Concurrent.Async as Async
 import Control.Concurrent.MVar
 import Control.Concurrent.STM
 import Control.Exception.Safe (finally)
-import Control.Monad (unless)
+import Control.Monad (unless, void)
 import Data.IORef
 import Data.Maybe (fromMaybe)
 import qualified Data.Map.Strict as Map
@@ -25,6 +25,53 @@ import qualified Data.Text as Text
 import qualified Data.Text.Read as TextRead
 import System.Timeout (timeout)
 import Test.Hspec
+
+-- The release gate makes the interruption occur during owned resource cleanup,
+-- rather than relying on the supervisor's scheduling or normal completion.
+interruptedSupervisorShutdown :: Bool -> IO ()
+interruptedSupervisorShutdown resetAfterInterruption = do
+    cleanupStarted <- newEmptyMVar
+    cleanupRelease <- newEmptyMVar
+    cleanupFinished <- newEmptyMVar
+    workerStarted <- newEmptyMVar
+    retryStarted <- newEmptyMVar
+    releases <- newIORef (0 :: Int)
+    registry <- newSubagentRegistry defaultSubagentConfig (fromFilePath ".")
+        (\_ _ _ _ -> putMVar workerStarted () >> atomically retry)
+        (\_ _ -> pure ())
+    let releaseGate = void (tryPutMVar cleanupRelease ())
+        cleanup = do
+            atomicModifyIORef' releases \n -> (n + 1, ())
+            putMVar cleanupStarted ()
+            readMVar cleanupRelease
+            putMVar cleanupFinished ()
+    (do
+        Right agentId <- spawnSubagentWithCwdPrepared registry (fromFilePath ".")
+            (\_ -> pure (subagentLease cleanup))
+            Nothing 0 "owned" Nothing
+        timeout 5000000 (readMVar workerStarted) `shouldReturn` Just ()
+        Async.withAsync (closeSubagent registry agentId) \closer ->
+            (do
+                timeout 5000000 (readMVar cleanupStarted) `shouldReturn` Just ()
+                timeout 5000000 (Async.cancel closer) `shouldReturn` Just ()
+                let retryShutdown =
+                        if resetAfterInterruption
+                            then resetSubagentRegistry registry
+                            else void (closeSubagent registry agentId)
+                Async.withAsync (putMVar retryStarted () >> retryShutdown) \retryCloser ->
+                    (do
+                        timeout 5000000 (readMVar retryStarted) `shouldReturn` Just ()
+                        -- Waiting times out without cancelling the closer.
+                        timeout 100000 (Async.wait retryCloser) `shouldReturn` Nothing
+                        readIORef releases `shouldReturn` 1
+                        releaseGate
+                        timeout 5000000 (Async.wait retryCloser) `shouldReturn` Just ()
+                        timeout 5000000 (readMVar cleanupFinished) `shouldReturn` Just ()
+                        getStatus registry agentId `shouldReturn`
+                            (if resetAfterInterruption then NotFound else Closed)
+                    ) `finally` releaseGate
+            ) `finally` releaseGate
+        ) `finally` (releaseGate >> closeSubagentRegistry registry)
 
 messagePayload :: InterAgentMessage -> Text
 messagePayload message = case message.messageContent of
@@ -813,6 +860,12 @@ spec = describe "Agent.Subagents" do
             Nothing 0 "first" Nothing
         closeSubagentRegistry registry
         readIORef released `shouldReturn` True
+
+    it "retains supervisor ownership after an interrupted close" do
+        interruptedSupervisorShutdown False
+
+    it "waits for retained supervisor cleanup before resetting the registry" do
+        interruptedSupervisorShutdown True
 
     it "releases composed subagent leases in reverse acquisition order" do
         released <- newIORef ([] :: [Int])


### PR DESCRIPTION
## Summary
- Replace persistent per-agent supervisors and cancellation handles with shared, lexically scoped turn workers.
- Retain conversation state independently of execution. Idle agents own leases, not threads.
- Transfer prepared leases to the registry resource scope; join active execution before releasing resources.
- Keep cleanup service-owned so interrupted close callers can safely retry. Preserve deepest-first shutdown and bounded concurrent sibling finalization.
- Retain one explicit registry executor handle at the constructor/close boundary; scope its children with structured concurrency.
- Reject reset after terminal registry closure rather than reopen a stopped executor.

## Validation
- Full agent-core suite through `nix develop -c cabal repl agent-core:test:agent-core-test`, running `:main`: **685 examples, 0 failures, 8 pending**.
- Restore-after-interrupted-close regressions verify that restore joins retained cleanup and remains safely retryable if interrupted.
- Added regressions for concurrency-limit increases, idle-agent cleanup while turn workers are occupied, joining turn cleanup before lease release, sibling finalization, and terminal reset.
- Existing interrupted close/reset, follow-up turn, preparation rollback, and nested resource-order tests pass.
- `git diff --check` passed; ownership review completed.

## Scope
This is a lifecycle and ownership redesign, not a fully immutable agent-loop rewrite. STM remains for shared coordination. No runtime performance claim is made.
