### PR TITLE
feat: keep MCP server add and OAuth in the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,12 +513,14 @@ not replace that approval requirement; consult the linked documents for
 current terms. See [`packages/agent-claude/README.md`](packages/agent-claude/README.md)
 for details.
 
-### Local MCP servers
+### MCP servers
 
-Use `/mcp` to manage local stdio MCP servers, or configure them in
-`~/.haskell-agent/config.json`. `agent-cli mcp list`, `enable`, and `disable`
-toggle that catalog from the command line. See the [MCP guide](docs/mcp.md) for the
-configuration schema, startup strategies, and tool exposure rules.
+Use `/mcp` to add, authorize, enable, or remove MCP servers from the session
+UI, or configure them in `~/.haskell-agent/config.json`. Paste a remote
+`https://…` URL or a local stdio command; HTTP servers that need OAuth can be
+authorized with `i`. `agent-cli mcp list`, `add`, `enable`, and `disable`
+manage the same catalog from the command line. See the [MCP guide](docs/mcp.md)
+for the configuration schema, startup strategies, and tool exposure rules.
 
 ### Meta Console
 

--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -15,6 +15,9 @@ agent-cli mcp login https://example.com/mcp --scope files:write
 agent-cli mcp logout https://example.com/mcp
 ```
 
+In an interactive session, `/mcp` can add the HTTP server and then authorize
+it with `i` without leaving the UI.
+
 `--scope` (repeatable) requests additional scopes for step-up authorization;
 they are unioned with the scopes already granted for the same issuer. A `403`
 with `insufficient_scope` during a session names the missing scope in its

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -31,21 +31,24 @@ Manage configured servers from the command line without starting a session:
 ```
 agent-cli mcp list
 agent-cli mcp list --json
+agent-cli mcp add sentry --transport http https://mcp.sentry.dev/mcp
+agent-cli mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem /path
 agent-cli mcp enable github
 agent-cli mcp disable github
 ```
 
 `list` prints every server in `~/.haskell-agent/config.json`, marking disabled
-ones and never showing environment values. `enable` / `disable` persist
-`enabled` on that named entry; they are idempotent and exit 1 when the name
-is not configured. The next session (or `/mcp` `r` in a running one) picks up
-the change.
+ones and never showing environment values. `add` writes a local stdio command
+or a remote HTTP URL. `enable` / `disable` persist `enabled` on that named
+entry; they are idempotent and exit 1 when the name is not configured. The
+next session (or `/mcp` `r` in a running one) picks up the change.
 
-In an interactive session, `/mcp` opens the server manager. Use the arrow
-keys or `j`/`k` to navigate, Enter to inspect tools, `a` to add a server,
-Space to enable or disable it, `x` to remove it, and `r` to restart the MCP
-runtime. Saved changes restart the runtime while preserving the session.
-Environment variable values are never displayed.
+In an interactive session, `/mcp` opens the server manager in the UI. Use the
+arrow keys or `j`/`k` to navigate, Enter to inspect tools, `a` to add a
+remote URL or local command, `i` to authorize an HTTP server with OAuth,
+Space to enable or disable it, `x` then `y` to remove it, and `r` to restart
+the MCP runtime. Saved changes restart the runtime while preserving the
+session. Environment variable values are never displayed.
 
 `mcpInitStrategy` accepts `auto`, `progressive`, or `blocking`. `auto` starts
 servers progressively for interactive sessions so the prompt is immediately

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -188,6 +188,7 @@ library
                     , Agent.CLI.ComputerUse.Linux.X11
                     , Agent.CLI.ComputerUse.Accessibility
                     , Agent.CLI.Config
+                    , Agent.CLI.McpAdd
                     , Agent.CLI.McpCatalog
                     , Agent.CLI.McpOAuthStore
                     , Agent.CLI.McpOAuth
@@ -223,6 +224,7 @@ library
                     , Agent.CLI.McpElicitation
                     , Agent.CLI.McpSampling
                     , Agent.CLI.McpManager
+                    , Agent.CLI.McpManager.Fullscreen
                     , Agent.CLI.NativeAgents
                     , Agent.CLI.Notification
                     , Agent.CLI.NativeRuntime

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -58,7 +58,7 @@ slashCommands =
     , cmd "terminal" ["ghostty"] "/terminal" "Show detected terminal capabilities" False
     , cmd "changelog" [] "/changelog" "Show Haskell Agent release notes" False
     , cmd "agents" ["a"] "/agents [limit [N]]" "Browse agents, or show/set the concurrent subagent cap" True
-    , cmd "mcp" ["mcps"] "/mcp [prompt <server> <name> [key=value…]]" "Manage MCP servers or run a server prompt" False
+    , cmd "mcp" ["mcps"] "/mcp [prompt <server> <name> [key=value…]]" "Manage MCP servers, add a URL or command, or run a server prompt" False
     , grokToolCmd "scheduler_create" "loop" [] "/loop [interval] <prompt>" "Run a prompt on a recurring interval" True
     , grokToolCmd "update_goal" "goal" [] "/goal <objective> [--budget N] | status | pause | resume | clear" "Set, manage, or check an autonomous goal" True
     , grokToolCmd "workflow" "workflow" [] "/workflow runs | <name> [input]" "Launch a named workflow or list workflow runs" True

--- a/packages/agent-cli/src/Agent/CLI/McpAdd.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpAdd.hs
@@ -1,0 +1,201 @@
+-- | Parse an MCP add target (remote URL or local stdio command) and build
+-- the catalog entry. Used by the TUI add form and @agent-cli mcp add@.
+module Agent.CLI.McpAdd
+    ( McpAddTarget(..)
+    , McpTransportOption(..)
+    , defaultMcpServerConfig
+    , isHttpMcpUrl
+    , mcpServerForTarget
+    , parseMcpAddName
+    , parseMcpCommand
+    , parseMcpTarget
+    , parseMcpTargetWithTransport
+    , suggestMcpName
+    , suggestMcpNameFromUrl
+    , suggestMcpTargetName
+    ) where
+
+import Agent.CLI.Config (McpServerConfig(..))
+import Agent.CLI.ExternalProgram (parseProgramWords)
+import Agent.MCP (McpProtocolPreference(..))
+import Control.Applicative ((<|>))
+import Data.Char (isAlphaNum, isAscii, toLower)
+import Data.List (find)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.FilePath (dropExtension, takeFileName)
+
+data McpAddTarget
+    = McpAddHttpUrl !Text
+    | McpAddStdioCommand !Text ![Text]
+    deriving (Eq, Show)
+
+data McpTransportOption
+    = McpTransportStdio
+    | McpTransportHttp
+    deriving (Eq, Show)
+
+defaultMcpServerConfig :: McpServerConfig
+defaultMcpServerConfig =
+    McpServerConfig
+        { mcpEnabled = True
+        , mcpUrl = Nothing
+        , mcpCommand = ""
+        , mcpArgs = []
+        , mcpCwd = Nothing
+        , mcpEnv = Map.empty
+        , mcpStartupTimeoutSeconds = 30
+        , mcpRequestTimeoutSeconds = 60
+        , mcpOAuth = Nothing
+        , mcpProtocol = McpProtocolAuto
+        , mcpRoots = False
+        , mcpSampling = False
+        , mcpLogLevel = Nothing
+        }
+
+mcpServerForTarget :: McpAddTarget -> McpServerConfig
+mcpServerForTarget = \case
+    McpAddHttpUrl url ->
+        defaultMcpServerConfig { mcpUrl = Just url }
+    McpAddStdioCommand command arguments ->
+        defaultMcpServerConfig
+            { mcpCommand = command
+            , mcpArgs = arguments
+            }
+
+isHttpMcpUrl :: Text -> Bool
+isHttpMcpUrl input =
+    let stripped = Text.strip input
+        lower = Text.toLower stripped
+    in "https://" `Text.isPrefixOf` lower
+        || "http://" `Text.isPrefixOf` lower
+
+parseMcpTarget :: Text -> Either Text McpAddTarget
+parseMcpTarget = parseMcpTargetWithTransport Nothing
+
+parseMcpTargetWithTransport
+    :: Maybe McpTransportOption
+    -> Text
+    -> Either Text McpAddTarget
+parseMcpTargetWithTransport transport input =
+    let stripped = Text.strip input
+    in if Text.null stripped
+        then Left "MCP URL or command must not be empty"
+        else case transport of
+            Just McpTransportHttp ->
+                if isHttpMcpUrl stripped
+                    then Right (McpAddHttpUrl stripped)
+                    else Left "HTTP MCP servers require an http(s) URL"
+            Just McpTransportStdio
+                | isHttpMcpUrl stripped ->
+                    Left "stdio MCP servers require a local command, not a URL"
+                | otherwise -> stdioTarget stripped
+            Nothing
+                | isHttpMcpUrl stripped -> Right (McpAddHttpUrl stripped)
+                | otherwise -> stdioTarget stripped
+  where
+    stdioTarget raw = do
+        (command, arguments) <- parseMcpCommand raw
+        pure (McpAddStdioCommand command arguments)
+
+parseMcpCommand :: Text -> Either Text (Text, [Text])
+parseMcpCommand input = do
+    arguments <- case parseProgramWords input of
+        Left "program specification ends with an incomplete escape" ->
+            Left "MCP command ends with an incomplete escape"
+        Left "program specification contains an unterminated quote" ->
+            Left "MCP command contains an unterminated quote"
+        Left err -> Left ("MCP command " <> err)
+        Right values -> Right values
+    case arguments of
+        command : rest
+            | not (Text.null (Text.strip command)) ->
+                Right (command, rest)
+        _ -> Left "MCP command must not be empty"
+
+parseMcpAddName :: Text -> Either Text Text
+parseMcpAddName input =
+    let trimmed = Text.strip input
+    in if Text.null trimmed
+        then Left "MCP server name must not be empty"
+        else if Text.all allowed trimmed
+            then Right trimmed
+            else Left
+                "MCP server names may only contain letters, numbers, hyphens, and underscores"
+  where
+    allowed char = isAscii char && (isAlphaNum char || char `elem` ['-', '_'])
+
+suggestMcpTargetName :: McpAddTarget -> Text
+suggestMcpTargetName = \case
+    McpAddHttpUrl url -> suggestMcpNameFromUrl url
+    McpAddStdioCommand command arguments -> suggestMcpName command arguments
+
+suggestMcpNameFromUrl :: Text -> Text
+suggestMcpNameFromUrl url =
+    fromMaybe "mcp-server" (find usable candidates)
+  where
+    stripped = Text.strip url
+    withoutScheme =
+        fromMaybe stripped
+            (stripSchemePrefix "https://" stripped
+                <|> stripSchemePrefix "http://" stripped)
+    host =
+        Text.takeWhile (/= ':')
+            (Text.takeWhile (\char -> char /= '/' && char /= '?') withoutScheme)
+    labels = filter (not . Text.null) (Text.splitOn "." host)
+    withoutMcp = case labels of
+        first : rest
+            | Text.toLower first == "mcp" -> rest
+        _ -> labels
+    candidates = map normalizeCandidate (withoutMcp <> labels <> ["mcp-server"])
+
+stripSchemePrefix :: Text -> Text -> Maybe Text
+stripSchemePrefix prefix value =
+    let (head_, rest) = Text.splitAt (Text.length prefix) value
+    in if Text.toLower head_ == prefix then Just rest else Nothing
+
+suggestMcpName :: Text -> [Text] -> Text
+suggestMcpName command arguments =
+    fromMaybe "mcp-server" (find usable candidates)
+  where
+    candidates = map normalizeCandidate $
+        case Text.toLower (baseName command) of
+            "nix" ->
+                dropLauncherOptions ["run"] arguments
+                    <> [command]
+            "npx" ->
+                dropLauncherOptions [] arguments
+                    <> [command]
+            "node" ->
+                dropLauncherOptions [] arguments
+                    <> [command]
+            _ -> command : arguments
+    dropLauncherOptions subcommands =
+        dropWhile
+            (\value ->
+                "-" `Text.isPrefixOf` value
+                    || Text.toLower value `elem` subcommands)
+
+normalizeCandidate :: Text -> Text
+normalizeCandidate =
+    Text.map normalizeChar
+        . Text.pack . dropExtension . Text.unpack . baseName
+
+baseName :: Text -> Text
+baseName = Text.pack . takeFileName . Text.unpack
+
+normalizeChar :: Char -> Char
+normalizeChar char
+    | isAlphaNum char || char `elem` ['-', '_'] = toLower char
+    | otherwise = '-'
+
+usable :: Text -> Bool
+usable candidate =
+    not (Text.null candidate)
+        && candidate `notElem` reserved
+        && not ("-" `Text.isPrefixOf` candidate)
+        && Text.all (\char -> isAlphaNum char || char `elem` ['-', '_']) candidate
+  where
+    reserved = ["run", "exec", "npx", "node", "nix", "mcp", "www", "com"]

--- a/packages/agent-cli/src/Agent/CLI/McpCatalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpCatalog.hs
@@ -4,6 +4,7 @@ module Agent.CLI.McpCatalog
     ( McpCatalogChange(..)
     , McpCatalogEntry(..)
     , McpCatalogError(..)
+    , addMcpCatalogServer
     , formatMcpCatalogChange
     , formatMcpCatalogHuman
     , formatMcpCatalogJSON
@@ -20,6 +21,14 @@ import Agent.CLI.Config
     , loadHarnessConfig
     , modifyHarnessConfig
     )
+import Agent.CLI.McpAdd
+    ( McpAddTarget(..)
+    , McpTransportOption(..)
+    , isHttpMcpUrl
+    , mcpServerForTarget
+    , parseMcpAddName
+    , parseMcpTargetWithTransport
+    )
 import Agent.CLI.McpOAuth
     ( LoginOptions(..)
     , defaultLoginOptions
@@ -27,7 +36,9 @@ import Agent.CLI.McpOAuth
     , logoutMcp
     )
 import Agent.CLI.Options
-    ( McpCommand(..)
+    ( McpAddCommand(..)
+    , McpAddTransport(..)
+    , McpCommand(..)
     , SessionOutputFormat(..)
     )
 import Data.Aeson ((.=))
@@ -73,6 +84,7 @@ runMcpCommand = \case
     McpList outputFormat -> runMcpList outputFormat
     McpEnable name -> runMcpSetEnabled True name
     McpDisable name -> runMcpSetEnabled False name
+    McpAdd command -> runMcpAdd command
 
 runMcpList :: SessionOutputFormat -> IO ()
 runMcpList outputFormat = do
@@ -90,6 +102,74 @@ runMcpSetEnabled enabled name = do
     setMcpCatalogEnabled home name enabled >>= \case
         Left err -> die (Text.unpack (catalogErrorText err))
         Right change -> Text.putStrLn (formatMcpCatalogChange enabled change)
+
+runMcpAdd :: McpAddCommand -> IO ()
+runMcpAdd command = do
+    home <- getHomeDirectory
+    addMcpCatalogServer home command >>= \case
+        Left err -> die (Text.unpack (catalogErrorText err))
+        Right entry ->
+            Text.putStrLn
+                ("Added MCP server " <> entry.mcpCatalogName
+                    <> " (" <> mcpCatalogTransport entry <> ")")
+
+addMcpCatalogServer
+    :: OsPath
+    -> McpAddCommand
+    -> IO (Either McpCatalogError McpCatalogEntry)
+addMcpCatalogServer home command =
+    case parseAddCommand command of
+        Left err -> pure (Left (McpCatalogInvalid err))
+        Right (name, target) ->
+            modifyHarnessConfig home (\_ config -> insertServer config name target)
+                >>= \case
+                    Left err
+                        | Just existing <- Text.stripPrefix alreadyExistsPrefix err ->
+                            pure (Left (McpCatalogInvalid
+                                ("MCP server " <> existing <> " already exists")))
+                        | otherwise ->
+                            pure (Left (McpCatalogInvalid err))
+                    Right (_, _, entry) -> pure (Right entry)
+  where
+    insertServer config name target
+        | Map.member name config.configMcpServers =
+            Left (alreadyExistsPrefix <> name)
+        | otherwise =
+            let server = mcpServerForTarget target
+                next =
+                    config
+                        { configMcpServers =
+                            Map.insert name server config.configMcpServers
+                        }
+            in Right (next, catalogEntry name server)
+
+parseAddCommand :: McpAddCommand -> Either Text (Text, McpAddTarget)
+parseAddCommand command = do
+    name <- parseMcpAddName command.mcpAddName
+    target <- case command.mcpAddTransport of
+        Just McpAddTransportHttp ->
+            if not (null command.mcpAddArgs)
+                then Left "HTTP MCP servers do not take command arguments"
+                else parseMcpTargetWithTransport
+                    (Just McpTransportHttp)
+                    command.mcpAddTarget
+        Just McpAddTransportStdio ->
+            if isHttpMcpUrl command.mcpAddTarget
+                then Left "stdio MCP servers require a local command, not a URL"
+                else Right
+                    (McpAddStdioCommand command.mcpAddTarget command.mcpAddArgs)
+        Nothing
+            | isHttpMcpUrl command.mcpAddTarget ->
+                if not (null command.mcpAddArgs)
+                    then Left "HTTP MCP servers do not take command arguments"
+                    else Right (McpAddHttpUrl (Text.strip command.mcpAddTarget))
+            | otherwise ->
+                Right
+                    (McpAddStdioCommand command.mcpAddTarget command.mcpAddArgs)
+    pure (name, target)
+
+alreadyExistsPrefix :: Text
+alreadyExistsPrefix = "already-exists:"
 
 listMcpCatalog :: OsPath -> IO (Either McpCatalogError [McpCatalogEntry])
 listMcpCatalog home =

--- a/packages/agent-cli/src/Agent/CLI/McpManager.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpManager.hs
@@ -1,14 +1,22 @@
--- | Interactive management of local stdio MCP servers.
+-- | Interactive management of local stdio and remote HTTP MCP servers.
 module Agent.CLI.McpManager
-    ( McpEntry(..)
+    ( McpAddField(..)
+    , McpAddForm(..)
+    , McpEntry(..)
     , McpEntryStatus(..)
     , McpManagerAction(..)
     , McpManagerState(..)
     , applyMcpManagerKey
+    , authorizedMcpUrls
+    , decodeMcpManagerKey
+    , emptyMcpAddForm
     , initialMcpManagerState
+    , mcpEntryTransport
     , parseMcpCommand
     , renderMcpManagerFrame
+    , resolveMcpAddForm
     , runMcpManager
+    , submitMcpAddForm
     , suggestMcpName
     ) where
 
@@ -18,11 +26,23 @@ import Agent.CLI.Config
     , loadHarnessConfigSnapshot
     , modifyHarnessConfig
     )
-import Agent.CLI.ExternalProgram (parseProgramWords)
-import Agent.CLI.Input (readApprovalLine)
+import Agent.CLI.McpAdd
+    ( mcpServerForTarget
+    , parseMcpAddName
+    , parseMcpCommand
+    , parseMcpTarget
+    , suggestMcpName
+    , suggestMcpTargetName
+    )
+import Agent.CLI.McpOAuth
+    ( defaultLoginOptions
+    , loginMcpWithResult
+    )
+import Agent.CLI.McpOAuthStore (mcpOAuthStorePath)
 import Agent.CLI.Picker
     ( PickerKey(..)
-    , runOverlay
+    , decodePickerKey
+    , runOverlayWithDecoder
     )
 import Agent.CLI.Style
     ( roleError
@@ -33,21 +53,19 @@ import Agent.CLI.Style
     )
 import Agent.MCP (McpToolRegistration(..))
 import Agent.Tools.Types (AppTool(..))
-import Agent.MCP (McpProtocolPreference(..))
-import Data.Char (isAlphaNum, toLower)
+import Data.Char (isAlphaNum, isPrint)
 import Data.List (find)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (isJust)
 import qualified Data.Set as Set
 import Data.Set (Set)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-import System.FilePath (dropExtension, takeFileName)
+import System.Directory.OsPath (doesFileExist)
 import System.IO
     ( hFlush
     , hIsTerminalDevice
-    , isEOF
     , stderr
     , stdin
     )
@@ -56,6 +74,7 @@ import System.OsPath (OsPath)
 data McpEntryStatus
     = McpDisabled
     | McpPendingRestart
+    | McpNeedsAuth
     | McpReady !Int
     | McpUnavailable !Text
     deriving (Eq, Show)
@@ -69,21 +88,48 @@ data McpEntry = McpEntry
     }
     deriving (Eq, Show)
 
+data McpAddField
+    = McpAddTargetField
+    | McpAddNameField
+    deriving (Eq, Show)
+
+data McpAddForm = McpAddForm
+    { mcpAddTarget :: !Text
+    , mcpAddTargetCursor :: !Int
+    , mcpAddName :: !Text
+    , mcpAddNameCursor :: !Int
+    , mcpAddFocus :: !McpAddField
+    }
+    deriving (Eq, Show)
+
+emptyMcpAddForm :: McpAddForm
+emptyMcpAddForm =
+    McpAddForm
+        { mcpAddTarget = ""
+        , mcpAddTargetCursor = 0
+        , mcpAddName = ""
+        , mcpAddNameCursor = 0
+        , mcpAddFocus = McpAddTargetField
+        }
+
 data McpManagerState = McpManagerState
     { mcpManagerEntries :: ![McpEntry]
     , mcpManagerIndex :: !Int
     , mcpManagerExpanded :: !(Maybe Text)
     , mcpManagerRestartPending :: !Bool
     , mcpManagerNotice :: !(Maybe (Bool, Text))
+    , mcpManagerAddForm :: !(Maybe McpAddForm)
+    , mcpManagerConfirmRemove :: !(Maybe Text)
     }
     deriving (Eq, Show)
 
 data McpManagerAction
     = McpManagerClose
     | McpManagerRestart
-    | McpManagerAdd
+    | McpManagerSubmitAdd !Text !McpServerConfig
     | McpManagerToggle !Text
     | McpManagerRemove !Text
+    | McpManagerAuth !Text
     deriving (Eq, Show)
 
 initialMcpManagerState
@@ -91,9 +137,10 @@ initialMcpManagerState
     -> [McpToolRegistration]
     -> [Text]
     -> Set Text
+    -> Set Text
     -> Maybe (Bool, Text)
     -> McpManagerState
-initialMcpManagerState config registrations warnings pending notice =
+initialMcpManagerState config registrations warnings pending authorized notice =
     McpManagerState
         { mcpManagerEntries =
             [ entryFor label server
@@ -103,6 +150,8 @@ initialMcpManagerState config registrations warnings pending notice =
         , mcpManagerExpanded = Nothing
         , mcpManagerRestartPending = not (Set.null pending)
         , mcpManagerNotice = notice
+        , mcpManagerAddForm = Nothing
+        , mcpManagerConfirmRemove = Nothing
         }
   where
     toolsByServer =
@@ -124,6 +173,7 @@ initialMcpManagerState config registrations warnings pending notice =
             status
                 | not server.mcpEnabled = McpDisabled
                 | label `Set.member` pending = McpPendingRestart
+                | needsAuthorization server failed = McpNeedsAuth
                 | Just warning <- failed =
                     McpUnavailable (failureSummary warning)
                 | otherwise = McpReady (length tools)
@@ -134,13 +184,52 @@ initialMcpManagerState config registrations warnings pending notice =
             , mcpEntryTools = tools
             , mcpEntryWarnings = entryWarnings
             }
+    needsAuthorization server failed = case server.mcpUrl of
+        Nothing -> False
+        Just url ->
+            maybe False isAuthFailure failed
+                || (Set.notMember url authorized && isJust failed)
+
+authorizedMcpUrls :: OsPath -> HarnessConfig -> IO (Set Text)
+authorizedMcpUrls home config =
+    Set.fromList <$> foldMap hasToken (Map.elems config.configMcpServers)
+  where
+    hasToken server = case server.mcpUrl of
+        Nothing -> pure []
+        Just url -> do
+            exists <- doesFileExist (mcpOAuthStorePath home url)
+            pure (if exists then [url] else [])
+
+decodeMcpManagerKey :: String -> Maybe PickerKey
+decodeMcpManagerKey = \case
+    "q" -> Just (PickerKeyChar 'q')
+    "Q" -> Just (PickerKeyChar 'Q')
+    "j" -> Just (PickerKeyChar 'j')
+    "J" -> Just (PickerKeyChar 'J')
+    "k" -> Just (PickerKeyChar 'k')
+    "K" -> Just (PickerKeyChar 'K')
+    raw -> decodePickerKey raw
 
 applyMcpManagerKey
     :: PickerKey
     -> McpManagerState
     -> Either McpManagerAction McpManagerState
-applyMcpManagerKey key state = case key of
+applyMcpManagerKey key state =
+    case state.mcpManagerAddForm of
+        Just form -> applyAddFormKey key state form
+        Nothing ->
+            case state.mcpManagerConfirmRemove of
+                Just name -> applyConfirmRemoveKey key state name
+                Nothing -> applyBrowseKey key state
+
+applyBrowseKey
+    :: PickerKey
+    -> McpManagerState
+    -> Either McpManagerAction McpManagerState
+applyBrowseKey key state = case key of
     PickerKeyCancel -> Left McpManagerClose
+    PickerKeyChar 'q' -> Left McpManagerClose
+    PickerKeyChar 'Q' -> Left McpManagerClose
     PickerKeyConfirm ->
         case selectedEntry state of
             Nothing -> Right state
@@ -150,39 +239,136 @@ applyMcpManagerKey key state = case key of
                         if state.mcpManagerExpanded == Just entry.mcpEntryName
                             then Nothing
                             else Just entry.mcpEntryName
+                    , mcpManagerNotice = Nothing
                     }
     PickerKeyChar 'r' -> Left McpManagerRestart
     PickerKeyChar 'R' -> Left McpManagerRestart
-    PickerKeyChar 'a' -> Left McpManagerAdd
-    PickerKeyChar 'A' -> Left McpManagerAdd
+    PickerKeyChar 'a' -> openAddForm
+    PickerKeyChar 'A' -> openAddForm
     PickerKeyChar ' ' -> selectedAction McpManagerToggle
     PickerKeyChar 'e' -> selectedAction McpManagerToggle
     PickerKeyChar 'E' -> selectedAction McpManagerToggle
-    PickerKeyChar 'x' -> selectedAction McpManagerRemove
-    PickerKeyChar 'X' -> selectedAction McpManagerRemove
+    PickerKeyChar 'x' -> confirmSelected
+    PickerKeyChar 'X' -> confirmSelected
+    PickerKeyChar 'i' -> selectedAction McpManagerAuth
+    PickerKeyChar 'I' -> selectedAction McpManagerAuth
     PickerKeyUp -> Right (moveSelection (-1) state)
+    PickerKeyChar 'k' -> Right (moveSelection (-1) state)
+    PickerKeyChar 'K' -> Right (moveSelection (-1) state)
     PickerKeyDown -> Right (moveSelection 1 state)
+    PickerKeyChar 'j' -> Right (moveSelection 1 state)
+    PickerKeyChar 'J' -> Right (moveSelection 1 state)
     _ -> Right state
   where
+    openAddForm =
+        Right state
+            { mcpManagerAddForm = Just emptyMcpAddForm
+            , mcpManagerConfirmRemove = Nothing
+            , mcpManagerNotice = Nothing
+            }
+    confirmSelected =
+        maybe (Right state)
+            (\entry ->
+                Right state
+                    { mcpManagerConfirmRemove = Just entry.mcpEntryName
+                    , mcpManagerNotice = Nothing
+                    })
+            (selectedEntry state)
     selectedAction constructor =
         maybe (Right state) (Left . constructor . (.mcpEntryName))
             (selectedEntry state)
 
+applyConfirmRemoveKey
+    :: PickerKey
+    -> McpManagerState
+    -> Text
+    -> Either McpManagerAction McpManagerState
+applyConfirmRemoveKey key state name = case key of
+    PickerKeyChar 'y' -> Left (McpManagerRemove name)
+    _ ->
+        Right state
+            { mcpManagerConfirmRemove = Nothing
+            , mcpManagerNotice = Nothing
+            }
+
+applyAddFormKey
+    :: PickerKey
+    -> McpManagerState
+    -> McpAddForm
+    -> Either McpManagerAction McpManagerState
+applyAddFormKey key state form = case key of
+    PickerKeyCancel ->
+        Right state
+            { mcpManagerAddForm = Nothing
+            , mcpManagerNotice = Nothing
+            }
+    PickerKeyTab -> Right (setForm (switchAddField 1 form))
+    PickerKeyBackTab -> Right (setForm (switchAddField (-1) form))
+    PickerKeyUp -> Right (setForm (form { mcpAddFocus = McpAddTargetField }))
+    PickerKeyDown -> Right (setForm (form { mcpAddFocus = McpAddNameField }))
+    PickerKeyLeft -> Right (setForm (moveAddCursor (-1) form))
+    PickerKeyRight -> Right (setForm (moveAddCursor 1 form))
+    PickerKeyBackspace -> Right (setForm (deleteAddChar form))
+    PickerKeyConfirm ->
+        case submitMcpAddForm existingNames form of
+            Left err ->
+                Right state
+                    { mcpManagerAddForm = Just form
+                    , mcpManagerNotice = Just (False, err)
+                    }
+            Right (label, server) -> Left (McpManagerSubmitAdd label server)
+    PickerKeyChar char
+        | isPrint char -> Right (setForm (insertAddChar char form))
+        | otherwise -> Right state
+  where
+    existingNames = Set.fromList (map (.mcpEntryName) state.mcpManagerEntries)
+    setForm next =
+        state
+            { mcpManagerAddForm = Just next
+            , mcpManagerNotice = Nothing
+            }
+
+submitMcpAddForm
+    :: Set Text
+    -> McpAddForm
+    -> Either Text (Text, McpServerConfig)
+submitMcpAddForm existing form = do
+    (label, server) <- resolveMcpAddForm form
+    if Set.member label existing
+        then Left ("MCP server " <> quote label <> " already exists")
+        else Right (label, server)
+
+resolveMcpAddForm :: McpAddForm -> Either Text (Text, McpServerConfig)
+resolveMcpAddForm form = do
+    target <- parseMcpTarget form.mcpAddTarget
+    let suggested = suggestMcpTargetName target
+    label <-
+        if Text.null (Text.strip form.mcpAddName)
+            then parseMcpAddName suggested
+            else parseMcpAddName form.mcpAddName
+    pure (label, mcpServerForTarget target)
+
 renderMcpManagerFrame :: Bool -> McpManagerState -> Text
 renderMcpManagerFrame color state =
+    case state.mcpManagerAddForm of
+        Just form -> renderAddForm color state form
+        Nothing -> renderBrowseFrame color state
+
+renderBrowseFrame :: Bool -> McpManagerState -> Text
+renderBrowseFrame color state =
     Text.intercalate "\n" $
         [ rolePrompt color "MCP servers"
             <> roleMuted color
-                (" · " <> Text.pack (show (length state.mcpManagerEntries))
-                    <> " local")
+                (" · " <> Text.pack (show (length state.mcpManagerEntries)))
             <> if state.mcpManagerRestartPending
                 then roleWarn color " · restart pending"
                 else ""
         ]
             <> maybe [] renderNotice state.mcpManagerNotice
+            <> maybe [] (renderRemoveConfirm color) state.mcpManagerConfirmRemove
             <> body
             <> [ roleMuted color
-                    "↑↓/jk or scroll · enter details · a add · space enable/disable · x remove"
+                    "↑↓/jk · enter details · a add · i auth · space enable/disable · x remove"
                , roleMuted color
                     "r restart/refresh · esc/q close"
                ]
@@ -191,13 +377,74 @@ renderMcpManagerFrame color state =
         [ (if success then roleSuccess else roleError) color message ]
     body = case state.mcpManagerEntries of
         [] ->
-            [ roleWarn color "No local MCP servers configured."
+            [ roleWarn color "No MCP servers configured."
             , roleMuted color
-                "Press a to add a stdio server."
+                "Press a to add a remote URL or a local stdio command."
             ]
         entries ->
             concat $
                 zipWith (renderEntry color state) [0 ..] entries
+
+renderRemoveConfirm :: Bool -> Text -> [Text]
+renderRemoveConfirm color name =
+    [ roleWarn color
+        ("Remove " <> quote name <> "? Press y to confirm, any other key to cancel")
+    ]
+
+renderAddForm :: Bool -> McpManagerState -> McpAddForm -> Text
+renderAddForm color state form =
+    Text.intercalate "\n" $
+        [ rolePrompt color "Add MCP server"
+        , roleMuted color
+            "Paste a remote http(s) URL or a local stdio command."
+        ]
+            <> maybe [] renderNotice state.mcpManagerNotice
+            <> [ ""
+               , fieldLabel McpAddTargetField "URL / Command"
+               , fieldBox McpAddTargetField form.mcpAddTarget form.mcpAddTargetCursor Nothing
+               , ""
+               , fieldLabel McpAddNameField "Name"
+               , fieldBox McpAddNameField form.mcpAddName form.mcpAddNameCursor
+                    (Just namePlaceholder)
+               , ""
+               , roleMuted color
+                    "Enter submit  |  Tab/Shift+Tab field  |  Esc cancel"
+               ]
+  where
+    renderNotice (success, message) =
+        [ (if success then roleSuccess else roleError) color message ]
+    focused = form.mcpAddFocus
+    namePlaceholder
+        | isHttpTarget form.mcpAddTarget = "Auto generated by URL"
+        | Text.null (Text.strip form.mcpAddTarget) = "Auto generated"
+        | otherwise = "Auto generated by command"
+    fieldLabel field title =
+        (if focused == field then rolePrompt else roleMuted) color title
+    fieldBox field value cursor placeholder =
+        let shown
+                | Text.null value
+                , Just hint <- placeholder =
+                    if focused == field
+                        then rolePrompt color "▍" <> roleMuted color hint
+                        else roleMuted color hint
+                | otherwise =
+                    insertCursor color (focused == field) value cursor
+        in (if focused == field then rolePrompt else roleMuted) color "❯ "
+            <> shown
+
+isHttpTarget :: Text -> Bool
+isHttpTarget input =
+    let lower = Text.toLower (Text.strip input)
+    in "https://" `Text.isPrefixOf` lower
+        || "http://" `Text.isPrefixOf` lower
+
+insertCursor :: Bool -> Bool -> Text -> Int -> Text
+insertCursor color focused value cursor
+    | not focused = value
+    | otherwise =
+        let bounded = max 0 (min (Text.length value) cursor)
+            (before, after) = Text.splitAt bounded value
+        in before <> rolePrompt color "▍" <> after
 
 runMcpManager
     :: Bool
@@ -212,45 +459,44 @@ runMcpManager color home registrations warnings = do
             pure False
         Right (revision, config) -> do
             tty <- hIsTerminalDevice stdin
+            authorized <- authorizedMcpUrls home config
             if not tty
                 then do
                     Text.hPutStrLn stderr $
                         renderMcpManagerFrame color
                             (initialMcpManagerState
-                                config registrations warnings Set.empty Nothing)
+                                config registrations warnings Set.empty
+                                authorized Nothing)
                     hFlush stderr
                     pure False
-                else loop revision config Set.empty False Nothing
+                else loop revision config Set.empty False authorized Nothing
   where
-    loop revision config pending changed notice = do
+    loop revision config pending changed authorized notice = do
         let state =
                 initialMcpManagerState
-                    config registrations warnings pending notice
-        runOverlay (renderMcpManagerFrame color) applyMcpManagerKey state
+                    config registrations warnings pending authorized notice
+        runOverlayWithDecoder
+            decodeMcpManagerKey
+            (renderMcpManagerFrame color)
+            applyMcpManagerKey
+            state
             >>= \case
                 Nothing -> pure changed
                 Just McpManagerClose -> pure changed
                 Just McpManagerRestart -> pure True
-                Just McpManagerAdd ->
-                    promptNewServer config >>= \case
-                        Left err ->
-                            loop revision config pending changed
-                                (Just (False, err))
-                        Right Nothing ->
-                            loop revision config pending changed Nothing
-                        Right (Just (label, server)) ->
-                            persist
-                                (config
-                                    { configMcpServers =
-                                        Map.insert label server
-                                            config.configMcpServers
-                                    })
-                                (Set.insert label pending)
-                                ("Added " <> label)
+                Just (McpManagerSubmitAdd label server) ->
+                    persist
+                        (config
+                            { configMcpServers =
+                                Map.insert label server
+                                    config.configMcpServers
+                            })
+                        (Set.insert label pending)
+                        ("Added " <> label)
                 Just (McpManagerToggle label) ->
                     case Map.lookup label config.configMcpServers of
                         Nothing ->
-                            loop revision config pending changed
+                            loop revision config pending changed authorized
                                 (Just (False, "MCP server no longer exists"))
                         Just server ->
                             let enabled = not server.mcpEnabled
@@ -266,20 +512,40 @@ runMcpManager color home registrations warnings = do
                                         then " enabled"
                                         else " disabled"
                             in persist updated (Set.insert label pending) message
-                Just (McpManagerRemove label) -> do
-                    confirmed <-
-                        confirm
-                            ("Remove MCP server " <> quote label <> "? [y/N] ")
-                    if not confirmed
-                        then loop revision config pending changed Nothing
-                        else
-                            persist
-                                (config
-                                    { configMcpServers =
-                                        Map.delete label config.configMcpServers
-                                    })
-                                (Set.insert label pending)
-                                ("Removed " <> label)
+                Just (McpManagerRemove label) ->
+                    persist
+                        (config
+                            { configMcpServers =
+                                Map.delete label config.configMcpServers
+                            })
+                        (Set.insert label pending)
+                        ("Removed " <> label)
+                Just (McpManagerAuth label) ->
+                    case Map.lookup label config.configMcpServers of
+                        Nothing ->
+                            loop revision config pending changed authorized
+                                (Just (False, "MCP server no longer exists"))
+                        Just server -> case server.mcpUrl of
+                            Nothing ->
+                                loop revision config pending changed authorized
+                                    (Just
+                                        ( False
+                                        , label
+                                            <> " is a local stdio server; OAuth is only used for HTTP servers"
+                                        ))
+                            Just url ->
+                                loginMcpWithResult defaultLoginOptions url >>= \case
+                                    Left err ->
+                                        loop revision config pending changed authorized
+                                            (Just (False, err))
+                                    Right message -> do
+                                        nextAuthorized <-
+                                            authorizedMcpUrls home config
+                                        loop revision config
+                                            (Set.insert label pending)
+                                            True
+                                            nextAuthorized
+                                            (Just (True, message))
       where
         persist updated pending' message =
             modifyHarnessConfig home
@@ -289,102 +555,19 @@ runMcpManager color home registrations warnings = do
                             "MCP configuration changed; reopen /mcp and retry"
                         else Right (updated, ())) >>= \case
                 Left err ->
-                    loop revision config pending changed (Just (False, err))
-                Right (nextRevision, _, ()) ->
+                    loop revision config pending changed authorized
+                        (Just (False, err))
+                Right (nextRevision, _, ()) -> do
+                    nextAuthorized <- authorizedMcpUrls home updated
                     loop nextRevision updated pending' True
+                        nextAuthorized
                         (Just (True, message))
 
-promptNewServer
-    :: HarnessConfig
-    -> IO (Either Text (Maybe (Text, McpServerConfig)))
-promptNewServer config =
-    promptLine "Command: " >>= \case
-        Nothing -> pure (Right Nothing)
-        Just raw
-            | Text.null (Text.strip raw) -> pure (Right Nothing)
-            | otherwise -> case parseMcpCommand raw of
-                Left err -> pure (Left err)
-                Right (command, arguments) -> do
-                    let suggested = suggestMcpName command arguments
-                    promptLine ("Name [" <> suggested <> "]: ") >>= \case
-                        Nothing -> pure (Right Nothing)
-                        Just rawName ->
-                            let label =
-                                    if Text.null (Text.strip rawName)
-                                        then suggested
-                                        else Text.strip rawName
-                            in if Map.member label config.configMcpServers
-                                then pure
-                                    (Left
-                                        ("MCP server " <> quote label
-                                            <> " already exists"))
-                                else pure . Right . Just $
-                                    ( label
-                                    , McpServerConfig
-                                        { mcpEnabled = True
-                                        , mcpUrl = Nothing
-                                        , mcpCommand = command
-                                        , mcpArgs = arguments
-                                        , mcpCwd = Nothing
-                                        , mcpEnv = Map.empty
-                                        , mcpStartupTimeoutSeconds = 30
-                                        , mcpRequestTimeoutSeconds = 60
-                                        , mcpOAuth = Nothing
-                                        , mcpProtocol = McpProtocolAuto
-                                        , mcpRoots = False
-                                        , mcpSampling = False
-                                        , mcpLogLevel = Nothing
-                                        }
-                                    )
-
-parseMcpCommand :: Text -> Either Text (Text, [Text])
-parseMcpCommand input = do
-    arguments <- case parseProgramWords input of
-        Left "program specification ends with an incomplete escape" ->
-            Left "MCP command ends with an incomplete escape"
-        Left "program specification contains an unterminated quote" ->
-            Left "MCP command contains an unterminated quote"
-        Left err -> Left ("MCP command " <> err)
-        Right values -> Right values
-    case arguments of
-        command : rest
-            | not (Text.null (Text.strip command)) ->
-                Right (command, rest)
-        _ -> Left "MCP command must not be empty"
-
-suggestMcpName :: Text -> [Text] -> Text
-suggestMcpName command arguments =
-    fromMaybe "mcp-server" (find usable candidates)
-  where
-    candidates = map normalizeCandidate $
-        case Text.toLower (baseName command) of
-            "nix" ->
-                dropLauncherOptions ["run"] arguments
-                    <> [command]
-            "npx" ->
-                dropLauncherOptions [] arguments
-                    <> [command]
-            "node" ->
-                dropLauncherOptions [] arguments
-                    <> [command]
-            _ -> command : arguments
-    dropLauncherOptions subcommands =
-        dropWhile
-            (\value ->
-                "-" `Text.isPrefixOf` value
-                    || Text.toLower value `elem` subcommands)
-    normalizeCandidate =
-        Text.map normalizeChar
-            . Text.pack . dropExtension . Text.unpack . baseName
-    baseName =
-        Text.pack . takeFileName . Text.unpack
-    normalizeChar char
-        | isAlphaNum char || char `elem` ['-', '_', '.'] = toLower char
-        | otherwise = '-'
-    usable candidate =
-        not (Text.null candidate)
-            && candidate `notElem` ["run", "exec", "npx", "node", "nix"]
-            && not ("-" `Text.isPrefixOf` candidate)
+mcpEntryTransport :: McpEntry -> Text
+mcpEntryTransport entry =
+    case entry.mcpEntryConfig.mcpUrl of
+        Just _ -> "http"
+        Nothing -> "stdio"
 
 renderEntry :: Bool -> McpManagerState -> Int -> McpEntry -> [Text]
 renderEntry color state index entry =
@@ -394,6 +577,7 @@ renderEntry color state index entry =
         <> entry.mcpEntryName
         <> " "
         <> renderStatus color entry.mcpEntryStatus
+        <> roleMuted color (" · " <> mcpEntryTransport entry)
     ]
         <> if state.mcpManagerExpanded == Just entry.mcpEntryName
             then renderDetails color entry
@@ -412,6 +596,7 @@ renderStatus :: Bool -> McpEntryStatus -> Text
 renderStatus color = \case
     McpDisabled -> roleMuted color "[disabled]"
     McpPendingRestart -> roleWarn color "[restart pending]"
+    McpNeedsAuth -> roleWarn color "[needs auth]"
     McpReady count ->
         roleSuccess color "[ready]"
             <> roleMuted color
@@ -422,7 +607,7 @@ renderStatus color = \case
 
 renderDetails :: Bool -> McpEntry -> [Text]
 renderDetails color entry =
-    [ roleMuted color ("    command: " <> renderCommand server)
+    [ roleMuted color ("    " <> targetLabel <> ": " <> targetValue)
     ]
         <> maybe []
             (\cwd -> [roleMuted color ("    cwd: " <> cwd)])
@@ -443,6 +628,9 @@ renderDetails color entry =
         <> warningLines
   where
     server = entry.mcpEntryConfig
+    (targetLabel, targetValue) = case server.mcpUrl of
+        Just url -> ("url", url)
+        Nothing -> ("command", renderCommand server)
     envNames = Map.keys server.mcpEnv
     toolLines = case entry.mcpEntryTools of
         [] -> [roleMuted color "    tools: none exposed"]
@@ -497,6 +685,17 @@ warningSummary warning =
         then warning
         else "skipped " <> Text.strip (Text.drop (Text.length marker) suffix)
 
+isAuthFailure :: Text -> Bool
+isAuthFailure warning =
+    let lower = Text.toLower warning
+    in any (`Text.isInfixOf` lower)
+        [ "oauth"
+        , "unauthorized"
+        , "401"
+        , "403"
+        , "www-authenticate"
+        ]
+
 selectedEntry :: McpManagerState -> Maybe McpEntry
 selectedEntry state =
     case drop state.mcpManagerIndex state.mcpManagerEntries of
@@ -514,19 +713,63 @@ moveSelection delta state
   where
     count = length state.mcpManagerEntries
 
-promptLine :: Text -> IO (Maybe Text)
-promptLine prompt = do
-    Text.hPutStr stderr prompt
-    hFlush stderr
-    eof <- isEOF
-    if eof then pure Nothing else Just <$> Text.getLine
+switchAddField :: Int -> McpAddForm -> McpAddForm
+switchAddField delta form =
+    form
+        { mcpAddFocus =
+            if (fieldIndex form.mcpAddFocus + delta) `mod` 2 == 0
+                then McpAddTargetField
+                else McpAddNameField
+        }
+  where
+    fieldIndex = \case
+        McpAddTargetField -> 0
+        McpAddNameField -> 1
 
-confirm :: Text -> IO Bool
-confirm prompt =
-    readApprovalLine prompt >>= \case
-        Just answer ->
-            pure (Text.toLower (Text.strip answer) `elem` ["y", "yes"])
-        Nothing -> pure False
+moveAddCursor :: Int -> McpAddForm -> McpAddForm
+moveAddCursor delta form =
+    case form.mcpAddFocus of
+        McpAddTargetField ->
+            form { mcpAddTargetCursor = bound form.mcpAddTarget form.mcpAddTargetCursor }
+        McpAddNameField ->
+            form { mcpAddNameCursor = bound form.mcpAddName form.mcpAddNameCursor }
+  where
+    bound value cursor =
+        max 0 (min (Text.length value) (cursor + delta))
+
+insertAddChar :: Char -> McpAddForm -> McpAddForm
+insertAddChar char form =
+    case form.mcpAddFocus of
+        McpAddTargetField ->
+            let (next, cursor) = insertAt form.mcpAddTargetCursor char form.mcpAddTarget
+            in form { mcpAddTarget = next, mcpAddTargetCursor = cursor }
+        McpAddNameField ->
+            let (next, cursor) = insertAt form.mcpAddNameCursor char form.mcpAddName
+            in form { mcpAddName = next, mcpAddNameCursor = cursor }
+
+deleteAddChar :: McpAddForm -> McpAddForm
+deleteAddChar form =
+    case form.mcpAddFocus of
+        McpAddTargetField ->
+            let (next, cursor) = deleteAt form.mcpAddTargetCursor form.mcpAddTarget
+            in form { mcpAddTarget = next, mcpAddTargetCursor = cursor }
+        McpAddNameField ->
+            let (next, cursor) = deleteAt form.mcpAddNameCursor form.mcpAddName
+            in form { mcpAddName = next, mcpAddNameCursor = cursor }
+
+insertAt :: Int -> Char -> Text -> (Text, Int)
+insertAt cursor char value =
+    let bounded = max 0 (min (Text.length value) cursor)
+        (before, after) = Text.splitAt bounded value
+    in (before <> Text.singleton char <> after, bounded + 1)
+
+deleteAt :: Int -> Text -> (Text, Int)
+deleteAt cursor value
+    | cursor <= 0 = (value, 0)
+    | otherwise =
+        let bounded = min (Text.length value) cursor
+            (before, after) = Text.splitAt bounded value
+        in (Text.dropEnd 1 before <> after, bounded - 1)
 
 firstLine :: Text -> Text
 firstLine = Text.strip . Text.takeWhile (/= '\n')

--- a/packages/agent-cli/src/Agent/CLI/McpManager/Fullscreen.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpManager/Fullscreen.hs
@@ -1,0 +1,539 @@
+-- | Fullscreen Brick MCP manager. Every prompt stays in the alternate
+-- screen, matching Grok Build's @/mcps@ modal: add a URL or command, inspect
+-- tools, toggle, remove, and run HTTP OAuth from the same UI.
+module Agent.CLI.McpManager.Fullscreen
+    ( McpDashboardAction(..)
+    , McpNotice(..)
+    , McpServerMenuAction(..)
+    , mcpDashboardBody
+    , mcpDashboardEntries
+    , mcpServerMenuBody
+    , mcpServerMenuEntries
+    , runFullscreenMcpManager
+    ) where
+
+import Agent.CLI.Config
+    ( HarnessConfig(..)
+    , McpServerConfig(..)
+    , loadHarnessConfigSnapshot
+    , modifyHarnessConfig
+    )
+import Agent.CLI.McpAdd
+    ( mcpServerForTarget
+    , parseMcpAddName
+    , parseMcpTarget
+    , suggestMcpTargetName
+    )
+import Agent.CLI.McpManager
+    ( McpEntry(..)
+    , McpEntryStatus(..)
+    , McpManagerState(..)
+    , authorizedMcpUrls
+    , initialMcpManagerState
+    , mcpEntryTransport
+    )
+import Agent.CLI.McpOAuth
+    ( defaultLoginOptions
+    , loginMcpWithResult
+    )
+import Agent.CLI.TUI.App
+    ( FullscreenRuntime
+    , emitUiEvent
+    , requestFullscreenChoiceWithBody
+    , requestFullscreenText
+    )
+import Agent.MCP (McpToolRegistration)
+import Agent.TUI.Model (UiEvent(UiSetNotice), progressNotice)
+import Control.Exception.Safe (bracket_)
+import Data.Char (isControl)
+import Data.Maybe (catMaybes)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Data.Set (Set)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Word (Word64)
+import System.OsPath (OsPath)
+
+data McpDashboardAction
+    = McpDashboardAdd
+    | McpDashboardRestart
+    | McpDashboardOpen !Int
+    deriving (Eq, Show)
+
+data McpServerMenuAction
+    = McpServerToggle
+    | McpServerAuth
+    | McpServerRemove
+    | McpServerBack
+    deriving (Eq, Show)
+
+data McpNotice = McpNotice !Bool !Text
+
+data ManagerSnapshot = ManagerSnapshot
+    { snapshotConfig :: !HarnessConfig
+    , snapshotPending :: !(Set Text)
+    , snapshotChanged :: !Bool
+    , snapshotAuthorized :: !(Set Text)
+    }
+
+runFullscreenMcpManager
+    :: FullscreenRuntime
+    -> OsPath
+    -> [McpToolRegistration]
+    -> [Text]
+    -> IO Bool
+runFullscreenMcpManager runtime home registrations warnings =
+    loadHarnessConfigSnapshot home >>= \case
+        Left err -> do
+            _ <-
+                requestFullscreenChoiceWithBody
+                    runtime
+                    "MCP servers"
+                    err
+                    0
+                    [("Close", "Return to the session")]
+            pure False
+        Right (revision, config) -> do
+            authorized <- authorizedMcpUrls home config
+            dashboard
+                Nothing
+                revision
+                ManagerSnapshot
+                    { snapshotConfig = config
+                    , snapshotPending = Set.empty
+                    , snapshotChanged = False
+                    , snapshotAuthorized = authorized
+                    }
+  where
+    dashboard notice revision snapshot = do
+        let state = managerState snapshot notice
+            entries = mcpDashboardEntries state
+        choice <-
+            requestFullscreenChoiceWithBody
+                runtime
+                "MCP servers"
+                (mcpDashboardBody notice state)
+                0
+                (map snd entries)
+        case choice >>= (`atIndex` entries) of
+            Nothing -> pure snapshot.snapshotChanged
+            Just (McpDashboardAdd, _) ->
+                addServer notice revision snapshot
+                    >>= continueDashboard
+            Just (McpDashboardRestart, _) ->
+                pure True
+            Just (McpDashboardOpen index, _) ->
+                case atIndex index state.mcpManagerEntries of
+                    Nothing -> dashboard notice revision snapshot
+                    Just entry -> serverMenu notice revision snapshot entry
+
+    continueDashboard (nextNotice, nextRevision, nextSnapshot) =
+        dashboard nextNotice nextRevision nextSnapshot
+
+    addServer notice revision snapshot = do
+        targetText <-
+            requestFullscreenText
+                runtime
+                "Add MCP server"
+                ( Text.unlines
+                    [ "Paste a remote **http(s)** URL or a local stdio command."
+                    , "Examples: `https://mcp.sentry.dev/mcp` or `npx -y @modelcontextprotocol/server-filesystem /path`."
+                    ]
+                )
+                ""
+        case targetText of
+            Nothing -> pure (notice, revision, snapshot)
+            Just raw -> case parseMcpTarget raw of
+                Left err ->
+                    addServer (Just (McpNotice False err)) revision snapshot
+                Right target -> do
+                    let suggested = suggestMcpTargetName target
+                    nameText <-
+                        requestFullscreenText
+                            runtime
+                            "Name"
+                            ("Leave empty to use **"
+                                <> markdownText 80 suggested
+                                <> "**.")
+                            suggested
+                    case nameText of
+                        Nothing -> pure (notice, revision, snapshot)
+                        Just rawName ->
+                            case parseMcpAddName
+                                (if Text.null (Text.strip rawName)
+                                    then suggested
+                                    else rawName) of
+                                Left err ->
+                                    addServer
+                                        (Just (McpNotice False err))
+                                        revision
+                                        snapshot
+                                Right label
+                                    | Map.member label
+                                        snapshot.snapshotConfig.configMcpServers ->
+                                        addServer
+                                            (Just
+                                                (McpNotice False
+                                                    ("MCP server '"
+                                                        <> label
+                                                        <> "' already exists")))
+                                            revision
+                                            snapshot
+                                    | otherwise ->
+                                        persist
+                                            revision
+                                            snapshot
+                                            (snapshot.snapshotConfig
+                                                { configMcpServers =
+                                                    Map.insert label
+                                                        (mcpServerForTarget target)
+                                                        snapshot.snapshotConfig.configMcpServers
+                                                })
+                                            (Set.insert label snapshot.snapshotPending)
+                                            ("Added " <> label)
+                                            >>= \case
+                                                Left err ->
+                                                    pure
+                                                        ( Just (McpNotice False err)
+                                                        , revision
+                                                        , snapshot
+                                                        )
+                                                Right next ->
+                                                    pure
+                                                        ( Just (McpNotice True next.message)
+                                                        , next.persistedRevision
+                                                        , next.persistedSnapshot
+                                                        )
+
+    serverMenu notice revision snapshot entry = do
+        let actions = mcpServerMenuEntries entry
+        choice <-
+            requestFullscreenChoiceWithBody
+                runtime
+                entry.mcpEntryName
+                (mcpServerMenuBody notice entry)
+                0
+                (map snd actions)
+        case choice >>= (`atIndex` actions) of
+            Nothing -> dashboard notice revision snapshot
+            Just (McpServerBack, _) -> dashboard notice revision snapshot
+            Just (McpServerToggle, _) ->
+                let enabled = not entry.mcpEntryConfig.mcpEnabled
+                    updated =
+                        snapshot.snapshotConfig
+                            { configMcpServers =
+                                Map.insert entry.mcpEntryName
+                                    (entry.mcpEntryConfig { mcpEnabled = enabled })
+                                    snapshot.snapshotConfig.configMcpServers
+                            }
+                    message =
+                        entry.mcpEntryName
+                            <> if enabled then " enabled" else " disabled"
+                in persist revision snapshot updated
+                    (Set.insert entry.mcpEntryName snapshot.snapshotPending)
+                    message
+                    >>= afterPersist revision snapshot
+            Just (McpServerRemove, _) -> do
+                confirmed <- confirmRemove entry.mcpEntryName
+                if not confirmed
+                    then serverMenu notice revision snapshot entry
+                    else
+                        persist
+                            revision
+                            snapshot
+                            (snapshot.snapshotConfig
+                                { configMcpServers =
+                                    Map.delete entry.mcpEntryName
+                                        snapshot.snapshotConfig.configMcpServers
+                                })
+                            (Set.insert entry.mcpEntryName snapshot.snapshotPending)
+                            ("Removed " <> entry.mcpEntryName)
+                            >>= afterPersist revision snapshot
+            Just (McpServerAuth, _) ->
+                case entry.mcpEntryConfig.mcpUrl of
+                    Nothing ->
+                        serverMenu
+                            (Just
+                                (McpNotice False
+                                    (entry.mcpEntryName
+                                        <> " is a local stdio server; OAuth is only used for HTTP servers")))
+                            revision
+                            snapshot
+                            entry
+                    Just url ->
+                        withLoginProgress
+                            runtime
+                            ("Authorizing " <> entry.mcpEntryName <> "…")
+                            (loginMcpWithResult defaultLoginOptions url)
+                            >>= \case
+                                Left err ->
+                                    serverMenu
+                                        (Just (McpNotice False err))
+                                        revision
+                                        snapshot
+                                        entry
+                                Right message -> do
+                                    nextAuthorized <-
+                                        authorizedMcpUrls home snapshot.snapshotConfig
+                                    dashboard
+                                        (Just (McpNotice True message))
+                                        revision
+                                        snapshot
+                                            { snapshotPending =
+                                                Set.insert entry.mcpEntryName
+                                                    snapshot.snapshotPending
+                                            , snapshotChanged = True
+                                            , snapshotAuthorized = nextAuthorized
+                                            }
+
+    afterPersist revision snapshot = \case
+        Left err -> dashboard (Just (McpNotice False err)) revision snapshot
+        Right next ->
+            dashboard
+                (Just (McpNotice True next.message))
+                next.persistedRevision
+                next.persistedSnapshot
+
+    persist revision snapshot updated pending message =
+        persistSnapshot home revision snapshot updated pending message
+
+    confirmRemove name = do
+        choice <-
+            requestFullscreenChoiceWithBody
+                runtime
+                "Remove MCP server?"
+                ("Remove **" <> markdownText 100 name
+                    <> "** from ~/.haskell-agent/config.json?\n\n"
+                    <> "The next MCP restart drops this server from the session.")
+                1
+                [ ("Remove", "Delete the saved server")
+                , ("Keep server", "Return without changing anything")
+                ]
+        pure (choice == Just 0)
+
+    managerState snapshot notice =
+        initialMcpManagerState
+            snapshot.snapshotConfig
+            registrations
+            warnings
+            snapshot.snapshotPending
+            snapshot.snapshotAuthorized
+            (noticeText notice)
+
+data PersistedUpdate = PersistedUpdate
+    { persistedRevision :: !Word64
+    , persistedSnapshot :: !ManagerSnapshot
+    , message :: !Text
+    }
+
+persistSnapshot
+    :: OsPath
+    -> Word64
+    -> ManagerSnapshot
+    -> HarnessConfig
+    -> Set Text
+    -> Text
+    -> IO (Either Text PersistedUpdate)
+persistSnapshot home revision snapshot updated pending message =
+    modifyHarnessConfig home
+        (\current _ ->
+            if current /= revision
+                then Left "MCP configuration changed; reopen /mcp and retry"
+                else Right (updated, ())) >>= \case
+        Left err -> pure (Left err)
+        Right (nextRevision, _, ()) -> do
+            nextAuthorized <- authorizedMcpUrls home updated
+            pure $ Right PersistedUpdate
+                { persistedRevision = nextRevision
+                , persistedSnapshot =
+                    snapshot
+                        { snapshotConfig = updated
+                        , snapshotPending = pending
+                        , snapshotChanged = True
+                        , snapshotAuthorized = nextAuthorized
+                        }
+                , message = message
+                }
+
+mcpDashboardEntries
+    :: McpManagerState
+    -> [(McpDashboardAction, (Text, Text))]
+mcpDashboardEntries state =
+    [ ( McpDashboardAdd
+      , ( "＋ Add MCP server"
+        , "Paste a remote URL or a local stdio command"
+        )
+      )
+    ]
+        <> [ ( McpDashboardRestart
+             , ( "↻ Restart MCP runtime"
+               , "Apply pending configuration changes"
+               )
+             )
+           | state.mcpManagerRestartPending
+           ]
+        <> zipWith
+            (\index entry -> (McpDashboardOpen index, dashboardRow entry))
+            [0 ..]
+            state.mcpManagerEntries
+
+dashboardRow :: McpEntry -> (Text, Text)
+dashboardRow entry =
+    ( health <> entry.mcpEntryName
+    , Text.intercalate " · " $
+        [ statusLabel entry.mcpEntryStatus
+        , mcpEntryTransport entry
+        ]
+            <> case entry.mcpEntryConfig.mcpUrl of
+                Just url -> [truncateText 48 url]
+                Nothing -> [truncateText 48 entry.mcpEntryConfig.mcpCommand]
+    )
+  where
+    health =
+        if entry.mcpEntryConfig.mcpEnabled then "● " else "○ "
+
+mcpDashboardBody :: Maybe McpNotice -> McpManagerState -> Text
+mcpDashboardBody notice state =
+    Text.intercalate "\n\n" $
+        [ "Add, enable, authorize, or remove MCP servers without leaving the fullscreen UI."
+        , "**"
+            <> Text.pack (show (length state.mcpManagerEntries))
+            <> " servers**"
+            <> if state.mcpManagerRestartPending
+                then " · restart pending"
+                else ""
+        ]
+            <> maybe [] (pure . formatNotice) notice
+            <> [ if null state.mcpManagerEntries
+                    then "No MCP servers are configured. Add a remote URL or a local command to get started."
+                    else "Select a server for tools, OAuth, enable/disable, or remove."
+               ]
+
+mcpServerMenuEntries :: McpEntry -> [(McpServerMenuAction, (Text, Text))]
+mcpServerMenuEntries entry =
+    catMaybes
+        [ Just
+            ( McpServerToggle
+            , if entry.mcpEntryConfig.mcpEnabled
+                then ("Disable", "Keep the server configured but skip it on the next restart")
+                else ("Enable", "Include this server on the next MCP restart")
+            )
+        , case entry.mcpEntryConfig.mcpUrl of
+            Nothing -> Nothing
+            Just _ ->
+                Just
+                    ( McpServerAuth
+                    , ( "Authenticate"
+                      , "Open the browser OAuth flow for this HTTP server"
+                      )
+                    )
+        , Just
+            ( McpServerRemove
+            , ("Remove", "Delete this server from ~/.haskell-agent/config.json")
+            )
+        , Just
+            ( McpServerBack
+            , ("Back", "Return to the MCP server list")
+            )
+        ]
+
+mcpServerMenuBody :: Maybe McpNotice -> McpEntry -> Text
+mcpServerMenuBody notice entry =
+    Text.intercalate "\n\n" $
+        [ "**" <> markdownText 80 entry.mcpEntryName <> "** · "
+            <> statusLabel entry.mcpEntryStatus
+            <> " · "
+            <> mcpEntryTransport entry
+        , case entry.mcpEntryConfig.mcpUrl of
+            Just url -> "URL: `" <> url <> "`"
+            Nothing ->
+                "Command: `"
+                    <> Text.unwords
+                        (entry.mcpEntryConfig.mcpCommand
+                            : entry.mcpEntryConfig.mcpArgs)
+                    <> "`"
+        ]
+            <> maybe [] (pure . formatNotice) notice
+            <> toolSection
+            <> warningSection
+  where
+    toolSection = case entry.mcpEntryTools of
+        [] -> ["Tools: none exposed yet."]
+        tools ->
+            ("Tools (" <> Text.pack (show (length tools)) <> "):")
+                : [ "- **" <> markdownText 60 name <> "**"
+                        <> if Text.null description
+                            then ""
+                            else " — " <> markdownText 88 description
+                  | (name, description) <- take 24 tools
+                  ]
+                <> [ "… " <> Text.pack (show (length tools - 24)) <> " more"
+                   | length tools > 24
+                   ]
+    warningSection =
+        [ "Warning: " <> markdownText 120 (warningSummary warning)
+        | warning <- entry.mcpEntryWarnings
+        , not (" failed to start:" `Text.isInfixOf` warning)
+        ]
+
+statusLabel :: McpEntryStatus -> Text
+statusLabel = \case
+    McpDisabled -> "disabled"
+    McpPendingRestart -> "restart pending"
+    McpNeedsAuth -> "needs auth"
+    McpReady count ->
+        "ready · " <> Text.pack (show count)
+            <> if count == 1 then " tool" else " tools"
+    McpUnavailable reason -> "unavailable · " <> truncateText 72 reason
+
+formatNotice :: McpNotice -> Text
+formatNotice (McpNotice success message)
+    | success = message
+    | otherwise = "**" <> markdownText 160 message <> "**"
+
+noticeText :: Maybe McpNotice -> Maybe (Bool, Text)
+noticeText = fmap \(McpNotice success message) -> (success, message)
+
+warningSummary :: Text -> Text
+warningSummary warning =
+    let marker = " skipped "
+        (_, suffix) = Text.breakOn marker warning
+    in if Text.null suffix
+        then warning
+        else "skipped " <> Text.strip (Text.drop (Text.length marker) suffix)
+
+atIndex :: Int -> [a] -> Maybe a
+atIndex index values
+    | index < 0 = Nothing
+    | otherwise = case drop index values of
+        value : _ -> Just value
+        [] -> Nothing
+
+truncateText :: Int -> Text -> Text
+truncateText limit value
+    | Text.length value <= limit = value
+    | otherwise = Text.take (max 0 (limit - 1)) value <> "…"
+
+withLoginProgress :: FullscreenRuntime -> Text -> IO a -> IO a
+withLoginProgress runtime message =
+    bracket_
+        (emitUiEvent runtime
+            (UiSetNotice (Just (progressNotice message))))
+        (emitUiEvent runtime (UiSetNotice Nothing))
+
+markdownText :: Int -> Text -> Text
+markdownText limit =
+    Text.concatMap escape . displayText limit
+  where
+    escape character
+        | character `elem` ("\\`*_[]<>" :: String) =
+            "\\" <> Text.singleton character
+        | otherwise = Text.singleton character
+
+displayText :: Int -> Text -> Text
+displayText limit value =
+    let stripped = Text.filter (not . isControl) value
+    in if Text.length stripped <= limit
+        then stripped
+        else Text.take (max 0 (limit - 1)) stripped <> "…"

--- a/packages/agent-cli/src/Agent/CLI/McpManager/Fullscreen.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpManager/Fullscreen.hs
@@ -5,6 +5,7 @@ module Agent.CLI.McpManager.Fullscreen
     ( McpDashboardAction(..)
     , McpNotice(..)
     , McpServerMenuAction(..)
+    , mcpAuthorizationBody
     , mcpDashboardBody
     , mcpDashboardEntries
     , mcpServerMenuBody
@@ -32,9 +33,12 @@ import Agent.CLI.McpManager
     , initialMcpManagerState
     , mcpEntryTransport
     )
+import Agent.CLI.Login.Internal.Browser (openBrowser)
 import Agent.CLI.McpOAuth
-    ( defaultLoginOptions
-    , loginMcpWithResult
+    ( McpLoginHost(..)
+    , defaultLoginOptions
+    , loginMcpWithHost
+    , mcpOAuthCallbackTimeoutMicros
     )
 import Agent.CLI.TUI.App
     ( FullscreenRuntime
@@ -45,6 +49,7 @@ import Agent.CLI.TUI.App
 import Agent.MCP (McpToolRegistration)
 import Agent.TUI.Model (UiEvent(UiSetNotice), progressNotice)
 import Control.Exception.Safe (bracket_)
+import System.Timeout (timeout)
 import Data.Char (isControl)
 import Data.Maybe (catMaybes)
 import qualified Data.Map.Strict as Map
@@ -262,10 +267,10 @@ runFullscreenMcpManager runtime home registrations warnings =
                             snapshot
                             entry
                     Just url ->
-                        withLoginProgress
-                            runtime
-                            ("Authorizing " <> entry.mcpEntryName <> "…")
-                            (loginMcpWithResult defaultLoginOptions url)
+                        loginMcpWithHost
+                            (fullscreenMcpLoginHost runtime)
+                            defaultLoginOptions
+                            url
                             >>= \case
                                 Left err ->
                                     serverMenu
@@ -514,6 +519,52 @@ truncateText :: Int -> Text -> Text
 truncateText limit value
     | Text.length value <= limit = value
     | otherwise = Text.take (max 0 (limit - 1)) value <> "…"
+
+fullscreenMcpLoginHost :: FullscreenRuntime -> McpLoginHost
+fullscreenMcpLoginHost runtime =
+    McpLoginHost
+        { mcpLoginSay =
+            \message ->
+                emitUiEvent runtime
+                    (UiSetNotice (Just (progressNotice message)))
+        , mcpLoginPresentAuthorization =
+            presentMcpAuthorizationFullscreen runtime
+        , mcpLoginAwaitCallback = \wait ->
+            withLoginProgress runtime "Waiting for MCP authorization…" $
+                timeout mcpOAuthCallbackTimeoutMicros wait
+        }
+
+presentMcpAuthorizationFullscreen
+    :: FullscreenRuntime
+    -> Text
+    -> IO (Either Text ())
+presentMcpAuthorizationFullscreen runtime url = do
+    opened <- openBrowser url
+    choice <-
+        requestFullscreenChoiceWithBody
+            runtime
+            "Authorize MCP server"
+            (mcpAuthorizationBody opened url)
+            0
+            [ ( "Continue"
+              , "Finish browser authorization and continue"
+              )
+            , ("Cancel", "Stop without saving credentials")
+            ]
+    pure $ case choice of
+        Just 0 -> Right ()
+        _ -> Left "MCP authorization was cancelled."
+
+mcpAuthorizationBody :: Bool -> Text -> Text
+mcpAuthorizationBody opened url =
+    Text.intercalate "\n\n"
+        [ "[Open the authorization page](" <> url <> ")."
+        , if opened
+            then
+                "A browser window was opened automatically. Complete the sign-in, then return here."
+            else
+                "The browser could not be opened automatically. Use the link above, then return here."
+        ]
 
 withLoginProgress :: FullscreenRuntime -> Text -> IO a -> IO a
 withLoginProgress runtime message =

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -11,12 +11,14 @@ module Agent.CLI.McpOAuth
     , defaultLoginOptions
     , loginMcp
     , loginMcpWith
+    , loginMcpWithResult
     , logoutMcp
     , lookupServerOAuthConfig
     , registerAuthorizedMcpServer
     ) where
 
 import Agent.CLI.Config (HarnessConfig(..), McpOAuthConfig(..), McpServerConfig(..), loadHarnessConfig, modifyHarnessConfig)
+import Agent.CLI.Error (formatException)
 import Agent.CLI.McpOAuthStore (loadMcpOAuthRecord, mcpOAuthStorePath, saveMcpOAuthRecord)
 import Agent.MCP (McpProtocolPreference(..))
 import qualified Agent.MCP.OAuth as OAuth
@@ -76,6 +78,14 @@ defaultLoginOptions = LoginOptions { loginAdditionalScopes = [] }
 
 loginMcp :: Text -> IO ()
 loginMcp = loginMcpWith defaultLoginOptions
+
+-- | Same flow as 'loginMcpWith', returning the success message instead of
+-- throwing. Used by the TUI so authorization can stay inside the overlay.
+loginMcpWithResult :: LoginOptions -> Text -> IO (Either Text Text)
+loginMcpWithResult options serverUrl =
+    tryAny (loginMcpWith options serverUrl) >>= \case
+        Left err -> pure (Left (formatException err))
+        Right () -> pure (Right "MCP authorization saved.")
 
 -- | The @client_id@ chosen for this login and how it was obtained.
 data ResolvedClient = ResolvedClient

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -8,17 +8,22 @@
 -- RFC 9207 issuer validation of the authorization response.
 module Agent.CLI.McpOAuth
     ( LoginOptions(..)
+    , McpLoginHost(..)
     , defaultLoginOptions
+    , defaultMcpLoginHost
     , loginMcp
     , loginMcpWith
+    , loginMcpWithHost
     , loginMcpWithResult
     , logoutMcp
     , lookupServerOAuthConfig
+    , mcpOAuthCallbackTimeoutMicros
     , registerAuthorizedMcpServer
     ) where
 
 import Agent.CLI.Config (HarnessConfig(..), McpOAuthConfig(..), McpServerConfig(..), loadHarnessConfig, modifyHarnessConfig)
 import Agent.CLI.Error (formatException)
+import Agent.CLI.Login.Internal.Browser (openBrowser)
 import Agent.CLI.McpOAuthStore (loadMcpOAuthRecord, mcpOAuthStorePath, saveMcpOAuthRecord)
 import Agent.MCP (McpProtocolPreference(..))
 import qualified Agent.MCP.OAuth as OAuth
@@ -30,7 +35,7 @@ import Control.Concurrent.MVar
     )
 import Network.URI (parseURI, uriAuthority, uriRegName, uriScheme, uriUserInfo, uriQuery)
 import Control.Exception.Safe (bracket, bracketOnError, finally, tryAny)
-import Control.Monad (forM_, void, when)
+import Control.Monad (forM_, unless, void, when)
 import Crypto.Hash (Digest, SHA256, hash)
 import Data.Char (isAsciiLower, isDigit)
 import qualified Data.ByteArray as BA
@@ -61,9 +66,7 @@ import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
 import qualified System.Directory.OsPath as Dir
 import qualified System.Entropy
-import System.Exit (ExitCode(..))
 import System.OsPath (OsPath)
-import System.Process (rawSystem)
 import System.Timeout (timeout)
 
 data LoginOptions = LoginOptions
@@ -76,16 +79,61 @@ data LoginOptions = LoginOptions
 defaultLoginOptions :: LoginOptions
 defaultLoginOptions = LoginOptions { loginAdditionalScopes = [] }
 
+data Callback = Callback
+    { callbackCode :: Maybe Text
+    , callbackState :: Maybe Text
+    , callbackIss :: Maybe Text
+    , callbackError :: Maybe Text
+    , callbackErrorDescription :: Maybe Text
+    }
+
+-- | Host-owned presentation for MCP OAuth. The CLI prints to stdout; the
+-- fullscreen manager shows notices and the authorization URL in overlays.
+data McpLoginHost = McpLoginHost
+    { mcpLoginSay :: !(Text -> IO ())
+    , mcpLoginPresentAuthorization :: !(Text -> IO (Either Text ()))
+    , mcpLoginAwaitCallback :: !(IO Callback -> IO (Maybe Callback))
+    }
+
+mcpOAuthCallbackTimeoutMicros :: Int
+mcpOAuthCallbackTimeoutMicros = 5 * 60 * 1_000_000
+
+defaultMcpLoginHost :: McpLoginHost
+defaultMcpLoginHost =
+    McpLoginHost
+        { mcpLoginSay = putStrLn . Text.unpack
+        , mcpLoginPresentAuthorization = \url -> do
+            opened <- openBrowser url
+            unless opened $
+                putStrLn
+                    "Could not launch a browser automatically; open the URL above."
+            pure (Right ())
+        , mcpLoginAwaitCallback =
+            timeout mcpOAuthCallbackTimeoutMicros
+        }
+
 loginMcp :: Text -> IO ()
 loginMcp = loginMcpWith defaultLoginOptions
+
+loginMcpWith :: LoginOptions -> Text -> IO ()
+loginMcpWith options serverUrl =
+    loginMcpWithHost defaultMcpLoginHost options serverUrl
+        >>= either failText (const (pure ()))
 
 -- | Same flow as 'loginMcpWith', returning the success message instead of
 -- throwing. Used by the TUI so authorization can stay inside the overlay.
 loginMcpWithResult :: LoginOptions -> Text -> IO (Either Text Text)
-loginMcpWithResult options serverUrl =
-    tryAny (loginMcpWith options serverUrl) >>= \case
+loginMcpWithResult = loginMcpWithHost defaultMcpLoginHost
+
+loginMcpWithHost
+    :: McpLoginHost
+    -> LoginOptions
+    -> Text
+    -> IO (Either Text Text)
+loginMcpWithHost host options serverUrl =
+    tryAny (loginMcpWithHostThrow host options serverUrl) >>= \case
         Left err -> pure (Left (formatException err))
-        Right () -> pure (Right "MCP authorization saved.")
+        Right message -> pure (Right message)
 
 -- | The @client_id@ chosen for this login and how it was obtained.
 data ResolvedClient = ResolvedClient
@@ -95,8 +143,12 @@ data ResolvedClient = ResolvedClient
     , resolvedMetadataUrl :: Maybe Text
     }
 
-loginMcpWith :: LoginOptions -> Text -> IO ()
-loginMcpWith options serverUrl = do
+loginMcpWithHostThrow
+    :: McpLoginHost
+    -> LoginOptions
+    -> Text
+    -> IO Text
+loginMcpWithHostThrow host options serverUrl = do
     home <- Dir.getHomeDirectory
     harness <- loadHarnessConfig home >>= either failText pure
     let oauthConfig = lookupServerOAuthConfig serverUrl harness
@@ -104,18 +156,22 @@ loginMcpWith options serverUrl = do
     manager <- newTlsManager
     challenge <- OAuth.probeAuthorizationChallenge manager serverUrl >>= \case
         Left err -> do
-            putStrLn ("Warning: " <> Text.unpack err <> "; falling back to well-known discovery.")
+            host.mcpLoginSay
+                ("Warning: " <> err <> "; falling back to well-known discovery.")
             pure Nothing
         Right probe -> do
             when (probe.probeStatus /= 401 && probe.probeStatus /= 403) $
-                putStrLn ("Note: the MCP server answered the unauthenticated probe with HTTP "
-                    <> show probe.probeStatus <> "; continuing with discovery.")
+                host.mcpLoginSay
+                    ("Note: the MCP server answered the unauthenticated probe with HTTP "
+                        <> Text.pack (show probe.probeStatus)
+                        <> "; continuing with discovery.")
             pure probe.probeChallenge
     resource <- OAuth.discoverProtectedResourceMetadata manager serverUrl
         (challenge >>= (.challengeResourceMetadata)) >>= either failText pure
     stored <- loadMcpOAuthRecord serverUrl >>= \case
         Left err -> do
-            putStrLn ("Warning: ignoring unreadable MCP OAuth record: " <> Text.unpack err)
+            host.mcpLoginSay
+                ("Warning: ignoring unreadable MCP OAuth record: " <> err)
             pure Nothing
         Right record -> pure record
     let storedIssuer = stored >>= (.extraIssuer) . snd
@@ -130,8 +186,9 @@ loginMcpWith options serverUrl = do
         sameIssuer = storedIssuer == Just recordedIssuer
         previous = if sameIssuer then stored else Nothing
     when (isJust stored && not sameIssuer) $
-        putStrLn ("Note: the authorization server changed to " <> Text.unpack recordedIssuer
-            <> "; the previous client registration and granted scopes will not be reused.")
+        host.mcpLoginSay
+            ("Note: the authorization server changed to " <> recordedIssuer
+                <> "; the previous client registration and granted scopes will not be reused.")
     let preferredPort = previous >>= (.extraRedirectUri) . snd >>= OAuth.loopbackRedirectPort
     bracket (openCallbackSocket preferredPort) close $ \listener -> do
         port <- callbackPort listener
@@ -162,7 +219,8 @@ loginMcpWith options serverUrl = do
         plan <- either failText pure (OAuth.selectClientRegistration registrationOptions metadata)
         client <- case plan of
             OAuth.UsePreRegisteredClient pre -> do
-                putStrLn "Using the pre-registered OAuth client from ~/.haskell-agent/config.json."
+                host.mcpLoginSay
+                    "Using the pre-registered OAuth client from ~/.haskell-agent/config.json."
                 pure ResolvedClient
                     { resolvedClientId = pre.preRegisteredClientId
                     , resolvedClientSecret = pre.preRegisteredClientSecret
@@ -170,7 +228,8 @@ loginMcpWith options serverUrl = do
                     , resolvedMetadataUrl = Nothing
                     }
             OAuth.UseClientIdMetadataDocument url -> do
-                putStrLn ("Using the Client ID Metadata Document " <> Text.unpack url <> " as client_id.")
+                host.mcpLoginSay
+                    ("Using the Client ID Metadata Document " <> url <> " as client_id.")
                 pure ResolvedClient
                     { resolvedClientId = url
                     , resolvedClientSecret = Nothing
@@ -178,7 +237,8 @@ loginMcpWith options serverUrl = do
                     , resolvedMetadataUrl = Just url
                     }
             OAuth.ReuseDynamicRegistration clientId -> do
-                putStrLn "Reusing the dynamic client registration from the previous login."
+                host.mcpLoginSay
+                    "Reusing the dynamic client registration from the previous login."
                 pure ResolvedClient
                     { resolvedClientId = clientId
                     , resolvedClientSecret = Nothing
@@ -209,10 +269,11 @@ loginMcpWith options serverUrl = do
                 <> "&code_challenge_method=S256&state=" <> encode state
                 <> (if Text.null scopeText then "" else "&scope=" <> encode scopeText)
                 <> "&resource=" <> encode resourceUri
-        putStrLn ("Opening browser for MCP authorization: " <> Text.unpack authUrl)
-        _ <- openBrowser authUrl
-        callback <- timeout (5 * 60 * 1000000) (receiveCallback listener)
-            >>= maybe (failText "Timed out waiting for MCP OAuth callback") pure
+        host.mcpLoginSay ("Opening browser for MCP authorization: " <> authUrl)
+        host.mcpLoginPresentAuthorization authUrl >>= either failText (const (pure ()))
+        callback <-
+            host.mcpLoginAwaitCallback (receiveCallback listener)
+                >>= maybe (failText "Timed out waiting for MCP OAuth callback") pure
         -- RFC 9207: validate the issuer before acting on any other parameter,
         -- including error responses.
         either failText pure $ OAuth.validateAuthorizationResponseIssuer
@@ -249,19 +310,27 @@ loginMcpWith options serverUrl = do
                             , extraRedirectUri = Just redirect
                             }
                     when (Text.null tokenFile.tokenRefreshToken) $
-                        putStrLn "Warning: MCP provider returned no refresh token; reauthorization may be required."
+                        host.mcpLoginSay
+                            "Warning: MCP provider returned no refresh token; reauthorization may be required."
                     saveMcpOAuthRecord serverUrl tokenFile extra
                         >>= either failText pure
-                    putStrLn "MCP authorization saved."
                     registerAuthorizedMcpServer home serverUrl >>= \case
                         Left err -> failText
                             ("MCP authorization was saved, but server registration failed: " <> err)
                         Right (name, enabled) -> do
-                            putStrLn ("MCP server configured: " <> Text.unpack name)
-                            if enabled
-                                then putStrLn "Start a new session to connect this server."
-                                else putStrLn ("This server remains disabled. Enable it with: agent-cli mcp enable "
-                                    <> Text.unpack (shellQuote name))
+                            let followUp =
+                                    if enabled
+                                        then "Start a new session to connect this server."
+                                        else
+                                            "This server remains disabled. Enable it with: agent-cli mcp enable "
+                                                <> shellQuote name
+                                message =
+                                    "MCP authorization saved. MCP server configured: "
+                                        <> name
+                                        <> ". "
+                                        <> followUp
+                            host.mcpLoginSay message
+                            pure message
 
 -- | Register only after the token record has been persisted successfully.
 -- Re-read under the configuration lock so browser-time edits are preserved.
@@ -352,14 +421,6 @@ sameMcpEndpoint left right =
                 && uriQuery leftUri == uriQuery rightUri
         _ -> False
 
-data Callback = Callback
-    { callbackCode :: Maybe Text
-    , callbackState :: Maybe Text
-    , callbackIss :: Maybe Text
-    , callbackError :: Maybe Text
-    , callbackErrorDescription :: Maybe Text
-    }
-
 -- | Listen on the loopback interface, preferring the port used by the
 -- previous login so a stored dynamic registration's redirect URI can be
 -- reproduced exactly.
@@ -443,15 +504,6 @@ randomUrlBytes n = do
 
 encode :: Text -> Text
 encode = Encoding.decodeUtf8 . urlEncode True . Encoding.encodeUtf8
-
-openBrowser :: Text -> IO Bool
-openBrowser url = do
-    result <- tryAny (rawSystem "open" [Text.unpack url])
-    case result of
-        Right ExitSuccess -> pure True
-        _ -> do
-            result' <- tryAny (rawSystem "xdg-open" [Text.unpack url])
-            pure (case result' of Right ExitSuccess -> True; _ -> False)
 
 failText :: Text -> IO a
 failText = ioError . userError . Text.unpack

--- a/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
@@ -98,6 +98,8 @@ toEvent = \case
     PickerKeyConfirm -> PickerConfirm
     PickerKeyCancel -> PickerCancel
     PickerKeyBackspace -> PickerBackspace
+    PickerKeyTab -> PickerType '\t'
+    PickerKeyBackTab -> PickerType '\t'
     PickerKeyChar c -> PickerType c
 
 -- | Open the picker when stdin is a TTY; otherwise print the catalog.

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -5,6 +5,8 @@ module Agent.CLI.Options
     , CliOptions(..)
     , Command(..)
     , GatewayCommand(..)
+    , McpAddCommand(..)
+    , McpAddTransport(..)
     , McpCommand(..)
     , ScreenMode(..)
     , SessionOutputFormat(..)
@@ -42,6 +44,7 @@ import Agent.CLI.Runtime.Options
     , defaultEffortFor
     )
 import Agent.TUI.Motion (MotionMode(..))
+import Data.Char (toLower)
 import Data.Foldable (asum)
 import Data.Int (Int64)
 import qualified Data.List as List
@@ -90,6 +93,20 @@ data McpCommand
     | McpList SessionOutputFormat
     | McpEnable Text
     | McpDisable Text
+    | McpAdd McpAddCommand
+    deriving (Eq, Show)
+
+data McpAddTransport
+    = McpAddTransportStdio
+    | McpAddTransportHttp
+    deriving (Eq, Show)
+
+data McpAddCommand = McpAddCommand
+    { mcpAddName :: !Text
+    , mcpAddTransport :: !(Maybe McpAddTransport)
+    , mcpAddTarget :: !Text
+    , mcpAddArgs :: ![Text]
+    }
     deriving (Eq, Show)
 
 -- | Administrative commands for the harness-managed PostgreSQL server.
@@ -455,6 +472,10 @@ mcpParser = Mcp <$> Options.hsubparser
         (Options.info
             (McpDisable <$> mcpNameArgument)
             (Options.progDesc "Disable a configured MCP server"))
+    <> Options.command "add"
+        (Options.info mcpAddParser
+            (Options.progDesc
+                "Add a local stdio or remote HTTP MCP server"))
     <> Options.command "login"
         (Options.info
             (McpLogin
@@ -475,6 +496,36 @@ mcpParser = Mcp <$> Options.hsubparser
 mcpNameArgument :: Options.Parser Text
 mcpNameArgument =
     Text.pack <$> Options.argument Options.str (Options.metavar "NAME")
+
+mcpAddParser :: Options.Parser McpCommand
+mcpAddParser =
+    McpAdd <$>
+        ( McpAddCommand
+            <$> mcpNameArgument
+            <*> Options.optional
+                (Options.option mcpAddTransportReader
+                    ( Options.long "transport"
+                        <> Options.short 't'
+                        <> Options.metavar "TRANSPORT"
+                        <> Options.help
+                            "stdio (local process) or http (remote URL). Defaults to http when COMMAND_OR_URL is an http(s) URL"
+                    ))
+            <*> (Text.pack
+                <$> Options.argument Options.str
+                    (Options.metavar "COMMAND_OR_URL"))
+            <*> Options.many
+                (Text.pack
+                    <$> Options.argument Options.str
+                        (Options.metavar "ARGS"))
+        )
+
+mcpAddTransportReader :: Options.ReadM McpAddTransport
+mcpAddTransportReader =
+    Options.eitherReader \raw ->
+        case map toLower raw of
+            "stdio" -> Right McpAddTransportStdio
+            "http" -> Right McpAddTransportHttp
+            _ -> Left "TRANSPORT must be stdio or http"
 
 type OptionUpdate = CliOptions -> CliOptions
 
@@ -732,6 +783,7 @@ usage = unlines
     , "       agent-cli sessions [list]"
     , "       agent-cli sessions show <session-id>"
     , "       agent-cli mcp list [--json]"
+    , "       agent-cli mcp add [--transport stdio|http] <name> <command-or-url> [args...]"
     , "       agent-cli mcp enable <name>"
     , "       agent-cli mcp disable <name>"
     , "       agent-cli mcp login <url> [--scope SCOPE]..."

--- a/packages/agent-cli/src/Agent/CLI/Permission.hs
+++ b/packages/agent-cli/src/Agent/CLI/Permission.hs
@@ -127,6 +127,8 @@ applyApprovalPolicyKey key state = case key of
         "f" -> Left (ApprovalPolicySelected ApproveAll)
         _ -> Right state
     PickerKeyBackspace -> Right state
+    PickerKeyTab -> Right state
+    PickerKeyBackTab -> Right state
   where
     move delta current =
         current
@@ -187,6 +189,8 @@ applyPermissionKey key state = case key of
             "n" -> Left PermissionDeny
             _ -> Right state
     PickerKeyBackspace -> Right state
+    PickerKeyTab -> Right state
+    PickerKeyBackTab -> Right state
   where
     n = length permissionLabels
     move delta i = (i + delta) `mod` n

--- a/packages/agent-cli/src/Agent/CLI/Picker.hs
+++ b/packages/agent-cli/src/Agent/CLI/Picker.hs
@@ -65,6 +65,8 @@ data PickerKey
     | PickerKeyConfirm
     | PickerKeyCancel
     | PickerKeyBackspace
+    | PickerKeyTab
+    | PickerKeyBackTab
     | PickerKeyChar Char
     deriving (Eq, Show)
 
@@ -81,6 +83,8 @@ decodePickerKey = \case
         | kittyEvent sequence_ == Just kittyRelease -> Nothing
     "\n" -> Just PickerKeyConfirm
     "\r" -> Just PickerKeyConfirm
+    "\t" -> Just PickerKeyTab
+    "\ESC[Z" -> Just PickerKeyBackTab
     "\ESC" -> Just PickerKeyCancel
     "q" -> Just PickerKeyCancel
     "Q" -> Just PickerKeyCancel
@@ -181,6 +185,7 @@ codepointKey = \case
     13 -> Just PickerKeyConfirm
     27 -> Just PickerKeyCancel
     8 -> Just PickerKeyBackspace
+    9 -> Just PickerKeyTab
     127 -> Just PickerKeyBackspace
     n
         | n >= 0

--- a/packages/agent-cli/src/Agent/CLI/Plan.hs
+++ b/packages/agent-cli/src/Agent/CLI/Plan.hs
@@ -128,6 +128,8 @@ applyPlanEnterKey key state@(PlanEnterState reason index) = case key of
         Just PlanCancel -> Left PlanStayNormal
         _ -> Right state
     PickerKeyBackspace -> Right state
+    PickerKeyTab -> Right state
+    PickerKeyBackTab -> Right state
 
 renderPlanEnterFrame :: Bool -> PlanEnterState -> Text
 renderPlanEnterFrame color (PlanEnterState reason index) =
@@ -193,6 +195,8 @@ applyPlanExitKey key state@(PlanExitState index) = case key of
     PickerKeyChar c ->
         maybe (Right state) Left (planDecisionForKey c)
     PickerKeyBackspace -> Right state
+    PickerKeyTab -> Right state
+    PickerKeyBackTab -> Right state
 
 renderPlanExitFrame :: Bool -> PlanExitState -> Text
 renderPlanExitFrame color (PlanExitState index) =

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -642,6 +642,8 @@ applyResumeKey key state = case key of
                 , resumeIndex = 0
                 }
         | otherwise -> Right state
+    PickerKeyTab -> Right state
+    PickerKeyBackTab -> Right state
 
 move :: Int -> ResumeState -> ResumeState
 move delta state =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -54,6 +54,7 @@ import Agent.CLI.Login
     , runLoginManager
     )
 import Agent.CLI.McpManager ( runMcpManager )
+import Agent.CLI.McpManager.Fullscreen ( runFullscreenMcpManager )
 import Agent.CLI.Options
     ( ApprovalPolicy(..), gatewayRoutingChanged )
 import Agent.CLI.Permission ( approvalPolicyOptions )
@@ -577,9 +578,15 @@ chooseAgent env next =
 
 manageMcpServers :: ReplHandlerContext -> IO RunResult -> IO RunResult
 manageMcpServers handlerContext next = do
-        color <- resolveColor stderr
-        restart <-
-            legacy $
+        restart <- case fullscreen of
+            Just runtime ->
+                runFullscreenMcpManager
+                    runtime
+                    env.sessionWorkspace.home
+                    env.sessionMcpRegistrations
+                    env.sessionMcpWarnings
+            Nothing -> do
+                color <- resolveColor stderr
                 runMcpManager
                     color
                     env.sessionWorkspace.home
@@ -592,7 +599,6 @@ manageMcpServers handlerContext next = do
     env = handlerContext.handlerSessionEnv
     fullscreen = env.sessionFullscreen
     persist = env.sessionPersist
-    legacy = withReplSuspended handlerContext
 
 -- | Submit an expanded prompt with the original command retained for display.
 type ExpandedTurn = IO RunResult -> Bool -> Text -> Text -> IO RunResult

--- a/packages/agent-cli/test/Agent/CLI/McpCatalogSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpCatalogSpec.hs
@@ -10,6 +10,7 @@ import Agent.CLI.Config
     )
 import Agent.CLI.McpCatalog
 import Agent.CLI.McpOAuth (lookupServerOAuthConfig, registerAuthorizedMcpServer)
+import Agent.CLI.Options (McpAddCommand(..), McpAddTransport(..))
 import Agent.MCP (McpProtocolPreference(..))
 import Control.Exception.Safe (bracket)
 import Control.Monad (forM_)
@@ -206,6 +207,49 @@ spec = describe "Agent.CLI.McpCatalog" do
                 , mcpCatalogEntry = docsEntry False
                 }
                 `shouldBe` "MCP server docs is already disabled"
+
+    it "adds remote HTTP and local stdio servers" $
+        withTempDir \home -> do
+            saveHarnessConfig home catalogConfig `shouldReturn` Right ()
+            addMcpCatalogServer home
+                McpAddCommand
+                    { mcpAddName = "sentry"
+                    , mcpAddTransport = Just McpAddTransportHttp
+                    , mcpAddTarget = "https://mcp.sentry.dev/mcp"
+                    , mcpAddArgs = []
+                    }
+                `shouldReturn` Right
+                    remoteEntry
+                        { mcpCatalogName = "sentry"
+                        , mcpCatalogUrl = Just "https://mcp.sentry.dev/mcp"
+                        }
+            addMcpCatalogServer home
+                McpAddCommand
+                    { mcpAddName = "files"
+                    , mcpAddTransport = Nothing
+                    , mcpAddTarget = "npx"
+                    , mcpAddArgs = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+                    }
+                `shouldReturn` Right
+                    McpCatalogEntry
+                        { mcpCatalogName = "files"
+                        , mcpCatalogEnabled = True
+                        , mcpCatalogUrl = Nothing
+                        , mcpCatalogCommand = "npx"
+                        , mcpCatalogArgs =
+                            ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+                        , mcpCatalogCwd = Nothing
+                        , mcpCatalogEnvKeys = []
+                        }
+            addMcpCatalogServer home
+                McpAddCommand
+                    { mcpAddName = "docs"
+                    , mcpAddTransport = Nothing
+                    , mcpAddTarget = "other"
+                    , mcpAddArgs = []
+                    }
+                `shouldReturn` Left
+                    (McpCatalogInvalid "MCP server docs already exists")
 
     it "rejects unknown and empty names without rewriting config" $
         withTempDir \home -> do

--- a/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
@@ -1,9 +1,10 @@
 module Agent.CLI.McpManagerSpec (spec) where
 
 import Agent.CLI.Config
+import Agent.CLI.McpAdd
 import Agent.CLI.McpManager
+import Agent.CLI.McpManager.Fullscreen
 import Agent.CLI.Picker (PickerKey(..))
-import Agent.MCP (McpProtocolPreference(..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
@@ -46,9 +47,34 @@ spec = describe "Agent.CLI.McpManager" do
             suggestMcpName "/usr/local/bin/my-server" []
                 `shouldBe` "my-server"
 
+        it "treats http(s) URLs as remote servers and suggests a host name" do
+            parseMcpTarget "https://mcp.sentry.dev/mcp"
+                `shouldBe` Right (McpAddHttpUrl "https://mcp.sentry.dev/mcp")
+            suggestMcpNameFromUrl "https://mcp.sentry.dev/mcp"
+                `shouldBe` "sentry"
+            suggestMcpNameFromUrl "https://mcp.linear.app/mcp"
+                `shouldBe` "linear"
+            parseMcpTarget "npx -y @modelcontextprotocol/server-filesystem /tmp"
+                `shouldBe`
+                    Right
+                        ( McpAddStdioCommand
+                            "npx"
+                            ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+                        )
+
+        it "rejects empty names and names with punctuation" do
+            parseMcpAddName "  "
+                `shouldBe` Left "MCP server name must not be empty"
+            parseMcpAddName "cool server"
+                `shouldBe`
+                    Left
+                        "MCP server names may only contain letters, numbers, hyphens, and underscores"
+            parseMcpAddName "sentry" `shouldBe` Right "sentry"
+
     describe "navigation and actions" do
         let alpha = server True "alpha-command"
             beta = server False "beta-command"
+            remote = httpServer "https://mcp.example.test/mcp"
             state =
                 initialMcpManagerState
                     defaultHarnessConfig
@@ -56,14 +82,16 @@ spec = describe "Agent.CLI.McpManager" do
                             Map.fromList
                                 [ ("alpha", alpha)
                                 , ("beta", beta)
+                                , ("remote", remote)
                                 ]
                         }
                     []
                     []
                     Set.empty
+                    Set.empty
                     Nothing
 
-        it "moves, expands, toggles, removes, adds, and refreshes" do
+        it "moves, expands, toggles, removes, adds, authorizes, and refreshes" do
             applyMcpManagerKey PickerKeyDown state
                 `shouldSatisfy` \case
                     Right moved -> moved.mcpManagerIndex == 1
@@ -76,13 +104,58 @@ spec = describe "Agent.CLI.McpManager" do
             applyMcpManagerKey (PickerKeyChar ' ') state
                 `shouldBe` Left (McpManagerToggle "alpha")
             applyMcpManagerKey (PickerKeyChar 'x') state
-                `shouldBe` Left (McpManagerRemove "alpha")
+                `shouldSatisfy` \case
+                    Right confirming ->
+                        confirming.mcpManagerConfirmRemove == Just "alpha"
+                    Left _ -> False
             applyMcpManagerKey (PickerKeyChar 'a') state
-                `shouldBe` Left McpManagerAdd
+                `shouldSatisfy` \case
+                    Right adding -> adding.mcpManagerAddForm == Just emptyMcpAddForm
+                    Left _ -> False
+            applyMcpManagerKey (PickerKeyChar 'i') state
+                `shouldBe` Left (McpManagerAuth "alpha")
             applyMcpManagerKey (PickerKeyChar 'r') state
                 `shouldBe` Left McpManagerRestart
 
-        it "renders status, command details, and hidden environment values" do
+        it "confirms removal only on lowercase y" do
+            let confirming =
+                    state { mcpManagerConfirmRemove = Just "alpha" }
+            applyMcpManagerKey (PickerKeyChar 'y') confirming
+                `shouldBe` Left (McpManagerRemove "alpha")
+            applyMcpManagerKey (PickerKeyChar 'n') confirming
+                `shouldSatisfy` \case
+                    Right cancelled ->
+                        cancelled.mcpManagerConfirmRemove == Nothing
+                    Left _ -> False
+
+        it "submits an HTTP server from the in-overlay add form" do
+            let typed =
+                    typeAddForm
+                        "https://mcp.sentry.dev/mcp"
+                        (fromRightState
+                            (applyMcpManagerKey (PickerKeyChar 'a') state))
+            applyMcpManagerKey PickerKeyConfirm typed
+                `shouldBe`
+                    Left
+                        (McpManagerSubmitAdd "sentry"
+                            (httpServer "https://mcp.sentry.dev/mcp"))
+
+        it "tabs to the name field and uses an explicit label" do
+            let opened =
+                    fromRightState
+                        (applyMcpManagerKey (PickerKeyChar 'a') state)
+                withUrl = typeAddForm "https://mcp.sentry.dev/mcp" opened
+                named =
+                    typeAddForm "custom"
+                        (fromRightState
+                            (applyMcpManagerKey PickerKeyTab withUrl))
+            applyMcpManagerKey PickerKeyConfirm named
+                `shouldBe`
+                    Left
+                        (McpManagerSubmitAdd "custom"
+                            (httpServer "https://mcp.sentry.dev/mcp"))
+
+        it "renders status, command details, remote URLs, and hidden environment values" do
             let configured = alpha
                     { mcpArgs = ["arg with spaces"]
                     , mcpEnv = Map.singleton "TOKEN" "do-not-render"
@@ -91,10 +164,15 @@ spec = describe "Agent.CLI.McpManager" do
                     (initialMcpManagerState
                         defaultHarnessConfig
                             { configMcpServers =
-                                Map.singleton "alpha" configured
+                                Map.fromList
+                                    [ ("alpha", configured)
+                                    , ("remote", remote)
+                                    ]
                             }
                         []
-                        []
+                        [ "MCP server remote failed to start: MCP server requires OAuth authorization; run `agent mcp login <url>`"
+                        ]
+                        Set.empty
                         Set.empty
                         Nothing)
                         { mcpManagerExpanded = Just "alpha" }
@@ -104,20 +182,74 @@ spec = describe "Agent.CLI.McpManager" do
                 Text.isInfixOf "alpha-command 'arg with spaces'"
             frame `shouldSatisfy` Text.isInfixOf "TOKEN (values hidden)"
             frame `shouldNotSatisfy` Text.isInfixOf "do-not-render"
+            frame `shouldSatisfy` Text.isInfixOf " · http"
+            frame `shouldSatisfy` Text.isInfixOf "[needs auth]"
+            let remoteExpanded =
+                    expanded { mcpManagerExpanded = Just "remote" }
+            renderMcpManagerFrame False remoteExpanded
+                `shouldSatisfy` Text.isInfixOf "url: https://mcp.example.test/mcp"
+
+        it "renders the add form with Grok-style field labels" do
+            let adding =
+                    fromRightState
+                        (applyMcpManagerKey (PickerKeyChar 'a') state)
+                frame = renderMcpManagerFrame False adding
+            frame `shouldSatisfy` Text.isInfixOf "URL / Command"
+            frame `shouldSatisfy` Text.isInfixOf "Auto generated"
+            frame `shouldSatisfy` Text.isInfixOf "Tab/Shift+Tab field"
+
+    describe "fullscreen dashboard" do
+        it "offers add, restart when pending, and per-server actions including auth for HTTP" do
+            let pending =
+                    initialMcpManagerState
+                        defaultHarnessConfig
+                            { configMcpServers =
+                                Map.singleton "remote"
+                                    (httpServer "https://mcp.example.test/mcp")
+                            }
+                        []
+                        []
+                        (Set.singleton "remote")
+                        Set.empty
+                        Nothing
+                entries = mcpDashboardEntries pending
+            fmap fst entries
+                `shouldBe` [McpDashboardAdd, McpDashboardRestart, McpDashboardOpen 0]
+            mcpDashboardBody Nothing pending
+                `shouldSatisfy` Text.isInfixOf "restart pending"
+            case pending.mcpManagerEntries of
+                entry : _ ->
+                    fmap fst (mcpServerMenuEntries entry)
+                        `shouldBe`
+                            [ McpServerToggle
+                            , McpServerAuth
+                            , McpServerRemove
+                            , McpServerBack
+                            ]
+                [] -> expectationFailure "expected a configured HTTP server"
 
 server :: Bool -> Text.Text -> McpServerConfig
-server enabled command = McpServerConfig
-    { mcpEnabled = enabled
-    , mcpUrl = Nothing
-    , mcpCommand = command
-    , mcpArgs = []
-    , mcpCwd = Nothing
-    , mcpEnv = Map.empty
-    , mcpStartupTimeoutSeconds = 30
-    , mcpRequestTimeoutSeconds = 60
-    , mcpOAuth = Nothing
-    , mcpProtocol = McpProtocolAuto
-    , mcpRoots = False
-    , mcpSampling = False
-    , mcpLogLevel = Nothing
-    }
+server enabled command =
+    defaultMcpServerConfig
+        { mcpEnabled = enabled
+        , mcpCommand = command
+        }
+
+httpServer :: Text.Text -> McpServerConfig
+httpServer url =
+    defaultMcpServerConfig { mcpUrl = Just url }
+
+typeAddForm :: Text.Text -> McpManagerState -> McpManagerState
+typeAddForm text state =
+    foldl'
+        (\current char ->
+            fromRightState (applyMcpManagerKey (PickerKeyChar char) current))
+        state
+        (Text.unpack text)
+
+fromRightState
+    :: Either McpManagerAction McpManagerState -> McpManagerState
+fromRightState = \case
+    Right state -> state
+    Left action ->
+        error ("expected overlay state, got " <> show action)

--- a/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
@@ -228,6 +228,13 @@ spec = describe "Agent.CLI.McpManager" do
                             ]
                 [] -> expectationFailure "expected a configured HTTP server"
 
+        it "renders the authorization URL in the overlay when the browser cannot open" do
+            let url = "https://auth.example.test/authorize?client_id=mcp"
+                body = mcpAuthorizationBody False url
+            body `shouldSatisfy` Text.isInfixOf url
+            body `shouldSatisfy`
+                Text.isInfixOf "could not be opened automatically"
+
 server :: Bool -> Text.Text -> McpServerConfig
 server enabled command =
     defaultMcpServerConfig

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -260,6 +260,33 @@ spec = do
                 `shouldBe` Right (Mcp (McpDisable "github"))
             parseArgs ["mcp", "login", "https://example.com/mcp"]
                 `shouldBe` Right (Mcp (McpLogin "https://example.com/mcp" []))
+            parseArgs
+                [ "mcp"
+                , "add"
+                , "--transport"
+                , "http"
+                , "sentry"
+                , "https://mcp.sentry.dev/mcp"
+                ]
+                `shouldBe`
+                    Right
+                        (Mcp
+                            (McpAdd McpAddCommand
+                                { mcpAddName = "sentry"
+                                , mcpAddTransport = Just McpAddTransportHttp
+                                , mcpAddTarget = "https://mcp.sentry.dev/mcp"
+                                , mcpAddArgs = []
+                                }))
+            parseArgs ["mcp", "add", "files", "npx", "pkg"]
+                `shouldBe`
+                    Right
+                        (Mcp
+                            (McpAdd McpAddCommand
+                                { mcpAddName = "files"
+                                , mcpAddTransport = Nothing
+                                , mcpAddTarget = "npx"
+                                , mcpAddArgs = ["pkg"]
+                                }))
             parseArgs ["mcp", "enable"] `shouldSatisfy` isLeft
             parseArgs ["mcp", "disable"] `shouldSatisfy` isLeft
             usage `shouldContain` "agent-cli mcp list [--json]"

--- a/packages/agent-cli/test/Agent/CLI/PickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PickerSpec.hs
@@ -9,6 +9,8 @@ spec = do
         it "decodes Kitty keyboard protocol keys" do
             decodePickerKey "\ESC[13u" `shouldBe` Just PickerKeyConfirm
             decodePickerKey "\ESC[27u" `shouldBe` Just PickerKeyCancel
+            decodePickerKey "\t" `shouldBe` Just PickerKeyTab
+            decodePickerKey "\ESC[Z" `shouldBe` Just PickerKeyBackTab
             decodePickerKey "\ESC[97;2u" `shouldBe` Just (PickerKeyChar 'a')
 
         it "decodes modified CSI arrows" do


### PR DESCRIPTION
## Summary
- `/mcp` now stays in the UI instead of suspending fullscreen and prompting for a stdio command on stdin.
- Fullscreen uses Brick overlays (same pattern as `/login`). The inline overlay keeps a Grok-style add form: URL or command, plus an optional name.
- HTTP servers can be added from that form and authorized with `i`. Failed OAuth/401 servers show `[needs auth]`.
- `agent-cli mcp add [--transport stdio|http] <name> <command-or-url> [args...]` writes the same catalog from the CLI.

## Validation
- Nix/GHCi after rebasing onto current `origin/master`: `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`, then:
  - `:main --match "McpManager"` — 13 examples, 0 failures
  - `:main --match "McpCatalog"` — 14 examples, 0 failures
  - `:main --match "MCP catalog"` — parses MCP catalog commands, 0 failures
  - `:main --match "decodePickerKey"` — 7 examples, 0 failures
- `git diff --check` passed.
- Grok Build `/mcps` was inspected in tmux as the UX reference. Live OAuth in this session was not completed against a real provider.