### PR TITLE
Cache completed prose during fullscreen Markdown streaming

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -18,6 +18,7 @@ module Agent.CLI.TUI.App
     , choiceRowColumns
     , filterChoiceRowLimit
     , choiceClosesOnUiTransition
+    , finishedMarkdownProseCaches
     , adjustChoiceValue
     , drawApp
     , drawBlock

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -139,7 +139,7 @@ import Codec.Picture (pixelAt)
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
-import Control.Monad (forever, unless, void, when, (>=>))
+import Control.Monad (forM_, forever, unless, void, when, (>=>))
 import Control.Concurrent.STM ( STM , TMVar , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , writeTQueue , writeTVar )
 import Agent.CLI.Recap ( autoRecapAwayThreshold , autoRecapIdleThreshold , autoRecapRetryInterval )
 import Control.Monad.IO.Class (liftIO)
@@ -848,6 +848,13 @@ handleAgentSnapshotEvent selected entries = do
         && state.appAgentEntries == mergedEntries
         then pure ()
         else do
+            forM_ state.appAgentEntries \entry ->
+                evictFinishedMarkdownProse entry.agentTarget
+                    entry.agentConversation
+                    (maybe
+                        (reduceUi UiConversationCleared entry.agentConversation)
+                        (.agentConversation)
+                        (lookupAgentEntry entry.agentTarget mergedEntries))
             modify' \current ->
                 current
                     { appAgentSelected = normalized

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Reduce.hs
@@ -3,6 +3,7 @@
 module Agent.CLI.TUI.App.Reduce where
 
 import Agent.CLI.Clipboard ( formatImageSize )
+import Agent.TUI.Markdown (markdownStreamingCacheSections)
 import Agent.CLI.Dictation ( DictationControl(..)
     , DictationResult(..)
     , dictateWith
@@ -218,6 +219,8 @@ handleUiEvents uiEvents = do
         Just active ->
             liftIO (final.appRuntime.runtimeNativeProgress active)
     when shouldInvalidate invalidateCache
+    when (not shouldInvalidate && any uiEventMayRetireProse uiEvents) $
+        evictFinishedMarkdownProse AgentRoot initial.appUi final.appUi
     when shouldFollow $
         case final.appConversationAnchor of
             Just _ -> do
@@ -267,6 +270,43 @@ uiEventInvalidatesCache = \case
     UiConversationCleared -> True
     UiLoop (ToolRetracted _) -> True
     _ -> False
+
+-- Only these reducer transitions retire assistant streams. In particular,
+-- token deltas, clock ticks, and composer edits must not scan the current turn.
+uiEventMayRetireProse :: UiEvent -> Bool
+uiEventMayRetireProse = \case
+    UiTurnEnded _ -> True
+    UiTurnRestarted -> True
+    UiSetAwaitingInput True -> True
+    UiConversationCleared -> True
+    UiLoop (TurnFinished _) -> True
+    UiLoop (ResponseRestarted _) -> True
+    UiLoop ResponseAttemptDiscarded -> True
+    UiLoop ResponseAttemptFailed -> True
+    _ -> False
+
+-- | Only retire caches belonging to assistant blocks that stopped streaming.
+-- This also handles removed/restarted blocks and batched events, without
+-- invalidating completed history, code images, or another agent's live prose.
+finishedMarkdownProseCaches :: AgentTarget -> UiState -> UiState -> [Name]
+finishedMarkdownProseCaches target previous next =
+    [ MarkdownProseCache target block.blockId chunk section
+    | block <- toList (Seq.drop previous.uiTurnStartBlock previous.uiBlocks)
+    , block.blockKind == BlockAssistant
+    , block.blockState == BlockStreaming
+    , not (stillStreaming block.blockId)
+    , (chunk, section) <- markdownStreamingCacheSections block.blockBody
+    ]
+  where
+    stillStreaming blockId =
+        case Map.lookup blockId next.uiBlockIndices >>= (`Seq.lookup` next.uiBlocks) of
+            Just block -> block.blockKind == BlockAssistant
+                && block.blockState == BlockStreaming
+            Nothing -> False
+
+evictFinishedMarkdownProse :: AgentTarget -> UiState -> UiState -> EventM Name AppState ()
+evictFinishedMarkdownProse target previous next =
+    mapM_ invalidateCacheEntry (finishedMarkdownProseCaches target previous next)
 
 applyConversationUiEvent :: Int -> UiEvent -> AppState -> AppState
 applyConversationUiEvent renderedContentHeight uiEvent state =
@@ -518,7 +558,11 @@ applyLocalUiEventWith
     -> EventM Name AppState ()
 applyLocalUiEventWith event update = do
     advanceAppClockNow
+    previous <- get
     modify' (update . applyUiEvent event)
+    next <- get
+    when (uiEventMayRetireProse event) $
+        evictFinishedMarkdownProse AgentRoot previous.appUi next.appUi
 
 refreshNativeProgressKeepalive :: EventM Name AppState ()
 refreshNativeProgressKeepalive = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -39,7 +39,7 @@ import Agent.CLI.TUI.Types
       FullscreenRuntime(runtimeWaveTrough, runtimeMotionMode,
                         runtimeNativeImagePreviews, runtimeColor),
       activeTheme,
-      Name(ConversationBodyCache, CodeBlockCache, ConversationBlock,
+      Name(ConversationBodyCache, CodeBlockCache, MarkdownProseCache, ConversationBlock,
            ConversationBlockCache, ConversationImage, CodeCopy,
            MarkdownLink) )
 import Agent.CLI.Terminal ()
@@ -50,6 +50,7 @@ import Agent.TUI.Markdown
     ( codeWidgetWithSyntaxHighlighting,
       diffWidgetWithSyntaxHighlighting,
       markdownWidgetWithLinks,
+      markdownWidgetWithStreamingCache,
       markdownWidgetWithSyntaxHighlightingAndLinks )
 import Agent.TUI.Model
     ( blockCodeLanguage,
@@ -201,6 +202,23 @@ drawBlock state target ui block =
         waveElapsed = accentWaveElapsed state target block
         marker =
             txt (if highlighted then "❯ " else "  ")
+        -- Completed/history blocks already have a whole-block cache. Avoid
+        -- paying for cold prose-section cache entries when no appends remain.
+        assistantMarkdown =
+            if block.blockState == BlockStreaming
+                then markdownWidgetWithStreamingCache
+                    state.appSyntaxHighlighter
+                    MarkdownLink
+                    (\chunkIndex sectionIndex ->
+                        cached
+                            (MarkdownProseCache
+                                target
+                                block.blockId
+                                chunkIndex
+                                sectionIndex))
+                else markdownWidgetWithSyntaxHighlightingAndLinks
+                    state.appSyntaxHighlighter
+                    MarkdownLink
         content = case block.blockKind of
             BlockUser ->
                 withAttr Theme.userAttr $
@@ -221,9 +239,7 @@ drawBlock state target ui block =
                     padRight (Pad 1) $
                         timestampedMessage Theme.mutedAttr block.blockTimestamp $
                             withAttr Theme.assistantAttr
-                                (markdownWidgetWithSyntaxHighlightingAndLinks
-                                    state.appSyntaxHighlighter
-                                    MarkdownLink
+                                (assistantMarkdown
                                     (\codeIndex ->
                                         cached
                                             (CodeBlockCache

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -116,6 +116,7 @@ data Name
         !BlockId
         !Bool
     | CodeBlockCache !AgentTarget !BlockId !Int
+    | MarkdownProseCache !AgentTarget !BlockId !Int !Int
     | CodeCopy !AgentTarget !BlockId !Int
     | MarkdownLink !Text
     | ComposerArea

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1,7 +1,10 @@
 module Agent.CLI.TUIAppSpec (spec) where
 
+import qualified Agent.TUI.Theme as Theme
 import Agent.CLI.TUI.Keyboard (decodeKeyboardBody, classifyKeyboard, runKeyboardInput)
+import Agent.CLI.TUI.App (finishedMarkdownProseCaches)
 import Control.Monad (forM_, when)
+import Control.Monad.IO.Class (liftIO)
 import Graphics.Vty.Platform.Unix.Input.Classify.Types (KClass(..))
 
 import Agent.CLI.TUIAppSpec.AgentFixtures
@@ -142,6 +145,9 @@ import Brick
     , VScrollbarRenderer(..)
     , Widget
     , customMain
+    , cached
+    , getRenderState
+    , renderFinal
     , halt
     , hLimit
     , renderWidget
@@ -213,6 +219,51 @@ import Agent.Tools.RenderChart (renderChartResult)
 
 spec :: Spec
 spec = do
+    describe "streaming Markdown cache lifetime" do
+        let streaming =
+                reduceUi (UiLoop (TextDelta "one\n\ntwo\n\nTail")) $
+                    reduceUi (UiLoop TurnStarted) initialUiState
+            blockId = (Seq.index streaming.uiBlocks 0).blockId
+            expected target =
+                [MarkdownProseCache target blockId 1 1, MarkdownProseCache target blockId 1 2]
+        it "retires root prose on completion, cancellation, failure, and restart" do
+            forM_ [UiTurnEnded BlockComplete, UiTurnEnded BlockCancelled,
+                    UiTurnEnded BlockFailed, UiTurnRestarted,
+                    UiLoop (TurnFinished (emptyTurnOutput "" [] Nothing)),
+                    UiSetAwaitingInput True,
+                    UiLoop ResponseAttemptDiscarded, UiLoop ResponseAttemptFailed,
+                    UiLoop (ResponseRestarted "retry")] \event ->
+                finishedMarkdownProseCaches AgentRoot streaming (reduceUi event streaming)
+                    `shouldBe` expected AgentRoot
+        it "keeps caches live across append-only updates" do
+            finishedMarkdownProseCaches AgentRoot streaming
+                (reduceUi (UiLoop (TextDelta " grows")) streaming)
+                `shouldBe` []
+        it "scopes child completion and removal to the child's own keys" do
+            let target = AgentChild (SubagentId "worker")
+            finishedMarkdownProseCaches target streaming
+                (reduceUi (UiTurnEnded BlockComplete) streaming)
+                `shouldBe` expected target
+            finishedMarkdownProseCaches target streaming
+                (reduceUi UiConversationCleared streaming)
+                `shouldBe` expected target
+        it "does not evict already completed history again" do
+            let complete = reduceUi (UiTurnEnded BlockComplete) streaming
+            finishedMarkdownProseCaches AgentRoot complete complete `shouldBe` []
+        it "removes real Brick prose entries after terminal events" do
+            forM_ [UiTurnEnded BlockComplete, UiTurnEnded BlockCancelled,
+                    UiTurnEnded BlockFailed, UiSetAwaitingInput True,
+                    UiLoop ResponseAttemptDiscarded, UiLoop ResponseAttemptFailed,
+                    UiLoop (TurnFinished (emptyTurnOutput "" [] Nothing))] \event -> do
+                runtime <- newScriptRuntime streaming
+                let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+                    names = expected AgentRoot
+                _ <- runFullscreenScript initial $
+                    map (`FullscreenScriptCachePresent` True) names
+                    <> [FullscreenScriptApp (AppUi event)]
+                    <> map (`FullscreenScriptCachePresent` False) names
+                    <> [FullscreenScriptHalt]
+                pure ()
     describe "active-turn image paste" do
         it "shows a bracketed image paste before the REPL consumes it and survives delayed refreshes" $
             withPastedImageFixtures \path _ -> do
@@ -3012,6 +3063,7 @@ data FullscreenScriptEvent
     | FullscreenScriptMouseDown !Name !V.Button !B.Location
     | FullscreenScriptMouseRelease !Name !V.Button !B.Location
     | FullscreenScriptMouseUp !Name !B.Location
+    | FullscreenScriptCachePresent !Name !Bool
     | FullscreenScriptHalt
 
 data ReplacementScenario
@@ -3645,6 +3697,16 @@ runFullscreenScriptDetailedAt bounds initialState script = do
                         (MouseUp name Nothing location)
                 AppEvent FullscreenScriptHalt ->
                     halt
+                AppEvent (FullscreenScriptCachePresent name expected) -> do
+                    renderState <- getRenderState
+                    let (_, picture, _, _) =
+                            renderFinal Theme.terminalDefault
+                                [cached name (txt "CACHE_MISS_SENTINEL")]
+                                bounds (const Nothing) renderState
+                        present = not $
+                            "CACHE_MISS_SENTINEL" `Text.isInfixOf`
+                                renderedPictureTextAt bounds picture
+                    liftIO (present `shouldBe` expected)
                 VtyEvent event ->
                     fullscreenApp.appHandleEvent (VtyEvent event)
                 MouseDown name button modifiers location ->

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -11,6 +11,7 @@ copyright:          (c) 2026 digitally induced GmbH
 category:           Development
 build-type:         Simple
 extra-source-files: README.md
+                  , benchmark/FullscreenMarkdown.md
 
 common common-options
     default-language: GHC2021
@@ -90,5 +91,31 @@ test-suite agent-tui-test
                     , containers >= 0.6 && < 0.8
                     , hspec >= 2.11 && < 2.12
                     , QuickCheck >= 2.14 && < 2.16
+                    , text
+                    , vty
+
+benchmark fullscreen-markdown-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark, src
+    main-is:          FullscreenMarkdown.hs
+    ghc-options:      -O2 -rtsopts
+    other-modules:    Agent.TUI.FencedCode
+                    , Agent.TUI.Markdown
+                    , Agent.TUI.Markdown.Block
+                    , Agent.TUI.Markdown.Inline
+                    , Agent.TUI.Motion
+                    , Agent.TUI.Presentation
+                    , Agent.TUI.TextWidth
+                    , Agent.TUI.Theme
+    build-depends:    agent-core
+                    , agent-json
+                    , agent-syntax
+                    , aeson
+                    , aeson-pretty
+                    , base
+                    , brick
+                    , bytestring
+                    , containers
                     , text
                     , vty

--- a/packages/agent-tui/benchmark/FullscreenMarkdown.hs
+++ b/packages/agent-tui/benchmark/FullscreenMarkdown.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE BangPatterns #-}
+
+-- Render every streaming frame through Brick, retaining its image cache between
+-- frames and consuming Vty's actual display spans, not merely widget WHNF.
+module Main (main) where
+
+import qualified Agent.TUI.Markdown as Markdown
+import qualified Agent.TUI.Theme as Theme
+import Brick
+import Control.Exception (evaluate) -- safe-exceptions does not export evaluate.
+import Control.Monad (forM, unless)
+import Data.Char (ord)
+import Data.Foldable (toList)
+import Data.IORef (newIORef, readIORef)
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LazyText
+import qualified Graphics.Vty as V
+import Graphics.Vty.PictureToSpans (displayOpsForPic)
+import Graphics.Vty.Span (SpanOp(..))
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Name = Transcript | Code !Int | Prose !Int !Int | Link !Text
+    deriving (Eq, Ord, Read, Show)
+
+data Sample = Sample !Double !Double !Double
+
+type Renderer = Bool -> Text -> Widget Name
+
+-- This is the pre-optimization production path: append the strict body, parse
+-- the complete Markdown every frame, and cache only closed fenced-code bodies.
+baseline :: Text -> Widget Name
+baseline = Markdown.markdownWidgetWithSyntaxHighlightingAndLinks
+    Nothing Link (\index -> cached (Code index)) (\_ _ -> emptyWidget)
+
+optimized :: Text -> Widget Name
+optimized = Markdown.markdownWidgetWithStreamingCache
+    Nothing Link (\chunk section -> cached (Prose chunk section))
+    (\index -> cached (Code index)) (\_ _ -> emptyWidget)
+
+oldRenderer, newRenderer :: Renderer
+oldRenderer _ = baseline
+newRenderer streaming = if streaming then optimized else baseline
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    unless enabled (die "run with +RTS -T")
+    getArgs >>= \case
+        [mode, scenario, countArg, chunkArg, samplesArg] -> do
+            renderer <- case mode of
+                "old" -> pure oldRenderer
+                "new" -> pure newRenderer
+                _ -> die "mode must be old or new"
+            unless (scenario `elem`
+                ["prose", "prose-lines", "fence", "open-fence", "table", "open-table", "mixed", "resize",
+                 "history-prose", "history-mixed"])
+                (die "unknown scenario")
+            count <- positive countArg
+            chunkSize <- positive chunkArg
+            samples <- positive samplesArg
+            let input = frameInput scenario count chunkSize 0
+            case [(index, old, new) |
+                    (index, (old, new)) <- zip [0 :: Int ..]
+                        (zip (frames oldRenderer (scenario == "resize") input)
+                            (frames newRenderer (scenario == "resize") input)),
+                    old /= new] of
+                [] -> pure ()
+                (index, old, new) : _ ->
+                    die ("old/new per-frame display or click targets differ at "
+                        <> show index <> "\nOLD: " <> show old <> "\nNEW: " <> show new)
+            results <- forM [1 .. samples] \sample ->
+                measure renderer (scenario == "resize")
+                    (frameInput scenario count chunkSize sample)
+            printf "%s,%s,%d,%d,%d,%.6f,%.6f,%.0f\n"
+                mode scenario count chunkSize samples
+                (median [wall | Sample wall _ _ <- results])
+                (median [cpu | Sample _ cpu _ <- results])
+                (median [bytes | Sample _ _ bytes <- results])
+        _ -> die "usage: fullscreen-markdown-bench old|new SCENARIO COUNT CHUNK_CHARS SAMPLES"
+  where
+    positive raw = case reads raw of
+        [(n, "")] | n > 0 -> pure n
+        _ -> die ("expected positive integer: " <> raw)
+    median values = sort values !! (length values `div` 2)
+
+measure :: Renderer -> Bool -> [(Bool, Text)] -> IO Sample
+measure renderer resize input = do
+    _ <- evaluate (foldl' (\n (streaming, t) -> fromEnum streaming + n + textChecksum t) 0 input)
+    ref <- newIORef input
+    performGC
+    beforeStats <- getRTSStats
+    beforeCpu <- getCPUTime
+    beforeWall <- getMonotonicTimeNSec
+    fresh <- readIORef ref
+    !result <- evaluate (run renderer resize fresh)
+    afterWall <- getMonotonicTimeNSec
+    afterCpu <- getCPUTime
+    performGC
+    afterStats <- getRTSStats
+    _ <- evaluate result
+    pure (Sample
+        (fromIntegral (afterWall - beforeWall) / 1e6)
+        (fromIntegral (afterCpu - beforeCpu) / 1e9)
+        (fromIntegral (afterStats.allocated_bytes - beforeStats.allocated_bytes)))
+
+{-# NOINLINE run #-}
+run :: Renderer -> Bool -> [(Bool, Text)] -> Int
+run renderer resize = go "" emptyRenderState 0 (0 :: Int)
+  where
+    go !_ !_ !total !_ [] = total
+    go !body !state !total !frame ((streaming, delta) : rest) =
+        let !nextBody = body <> delta
+            width = if resize && (frame `div` 50) `mod` 2 == 1 then 40 else 80
+            region = (width, 30)
+            stateBefore =
+                if resize && frame `mod` 50 == 0 then emptyRenderState else state
+            widget = viewport Transcript Vertical $
+                vBox [renderer streaming nextBody, visible (txt " ")]
+            (nextState, picture, _, extents) =
+                renderFinal Theme.terminalDefault [widget] region
+                    (const Nothing) stateBefore
+            !checksum = foldl' (foldl' spanChecksum) 0
+                (displayOpsForPic picture region)
+                + foldl' (\n extent -> n + length (show extent)) 0 extents
+        in go nextBody nextState (total + checksum) (frame + 1) rest
+
+-- Equality checking deliberately stays outside the measurement. Compare the
+-- complete display operations (including styles/URLs) and click extents.
+frames :: Renderer -> Bool -> [(Bool, Text)] -> [([[(Char, V.Attr)]], [String])]
+frames renderer resize = go "" emptyRenderState (0 :: Int)
+  where
+    go _ _ _ [] = []
+    go body state frame ((streaming, delta) : rest) =
+        let nextBody = body <> delta
+            width = if resize && (frame `div` 50) `mod` 2 == 1 then 40 else 80
+            region = (width, 30)
+            before = if resize && frame `mod` 50 == 0 then emptyRenderState else state
+            widget = viewport Transcript Vertical $
+                vBox [renderer streaming nextBody, visible (txt " ")]
+            (nextState, picture, _, extents) =
+                renderFinal Theme.terminalDefault [widget] region (const Nothing) before
+        in ( map (concatMap spanCells . toList) (toList (displayOpsForPic picture region))
+            , sort (map show extents))
+            : go nextBody nextState (frame + 1) rest
+
+-- Span segmentation depends on image composition and is not observable.
+-- SpanOp's Show instance also omits text, so compare explicit payloads.
+spanCells :: SpanOp -> [(Char, V.Attr)]
+spanCells = \case
+    TextSpan{textSpanText, textSpanAttr} ->
+        [(character, textSpanAttr) | character <- LazyText.unpack textSpanText]
+    Skip count -> replicate count (' ', V.defAttr)
+    RowEnd count -> replicate count (' ', V.defAttr)
+
+spanChecksum :: Int -> SpanOp -> Int
+spanChecksum n = \case
+    TextSpan{textSpanText, textSpanAttr} ->
+        LazyText.foldl' (\s c -> s * 33 + ord c) n textSpanText
+            + length (show textSpanAttr)
+    Skip count -> n + count
+    RowEnd count -> n + count
+
+textChecksum :: Text -> Int
+textChecksum = Text.foldl' (\n c -> n * 33 + ord c) 5381
+
+emptyRenderState :: RenderState Name
+emptyRenderState = read
+    "RS {viewportMap = fromList [], rsScrollRequests = [], \
+    \observedNames = fromList [], renderCache = fromList [], \
+    \clickableNames = [], requestedVisibleNames_ = fromList [], \
+    \reportedExtents = fromList []}"
+
+chunks :: Int -> Text -> [Text]
+chunks size input
+    | Text.null input = []
+    | otherwise = let (prefix, suffix) = Text.splitAt size input
+                  in prefix : chunks size suffix
+
+frameInput :: String -> Int -> Int -> Int -> [(Bool, Text)]
+frameInput scenario count chunkSize nonce =
+    case Text.stripPrefix "history-" (Text.pack scenario) of
+        Just bodyScenario -> [(False, workload (Text.unpack bodyScenario) count nonce)]
+        Nothing ->
+            [(True, delta) | delta <- chunks chunkSize (workload scenario count nonce)]
+                <> [(False, "")]
+
+workload :: String -> Int -> Int -> Text
+workload scenario count nonce =
+    "# Response " <> Text.pack (show nonce) <> "\n\n" <> case scenario of
+        "prose" -> Text.replicate count (prose <> "\n")
+        "prose-lines" -> Text.replicate count prose
+        "fence" -> fence count <> prose
+        "open-fence" -> "```haskell\n" <> Text.replicate count code
+        "table" -> table count <> "\n" <> prose
+        "open-table" -> table count
+        _ -> Text.replicate count (prose <> "\n" <> fence 3 <> table 3 <> "\n")
+  where
+    prose = "A **bold** explanation with `inline code` and [docs](https://example.com).\n"
+    code = "value = map (+ 1) [1, 2, 3]\n"
+    row = "| item | **some value** |\n"
+    fence n = "```haskell\n" <> Text.replicate n code <> "```\n"
+    table n = "| Name | Value |\n| --- | --- |\n" <> Text.replicate n row

--- a/packages/agent-tui/benchmark/FullscreenMarkdown.md
+++ b/packages/agent-tui/benchmark/FullscreenMarkdown.md
@@ -1,0 +1,144 @@
+# Fullscreen streaming Markdown benchmark
+
+`FullscreenMarkdown.hs` retains the pre-optimization production path as
+`baseline`: strict `Text` append followed by whole-message Markdown rendering,
+with Brick's existing closed-code-body cache. `optimized` additionally caches
+completed prose sections. Both call the same underlying Markdown, layout, and
+syntax-support code. Completed/history messages use the original renderer:
+section caches are only useful while further appends are possible.
+
+## Reproduce
+
+From the repository root:
+
+```sh
+nix develop
+cabal build --offline agent-tui:bench:fullscreen-markdown-bench
+bin=$(cabal list-bin agent-tui:bench:fullscreen-markdown-bench)
+"$bin" old mixed 50 64 7 +RTS -T
+"$bin" new mixed 50 64 7 +RTS -T
+```
+
+Arguments are implementation, workload, count, chunk size in characters, and
+sample count. Output is CSV:
+
+```text
+implementation,workload,count,chunk_chars,samples,median_wall_ms,median_cpu_ms,median_allocated_bytes
+```
+
+The benchmark source and its renderer/support modules are compiled with `-O2`;
+shared dependency libraries use the normal Cabal optimization settings. It
+runs single-threaded with the default allocation area. Inputs are built and
+forced before measurement. A fresh input is read through an IORef inside the
+timed region, with a sample-specific heading and a `NOINLINE` consumer to avoid
+sharing previously evaluated results.
+
+Each delta appends the strict message body and renders an actual Brick frame
+through `renderFinal`, retaining `RenderState` between frames. The viewport is
+80×30 and follows a trailing visible marker, so the complete growing message
+is laid out while the visible tail is converted into Vty display spans. The
+consumer forces span text, attributes, and click extents. This includes cache
+construction, parsing, layout, image composition, viewport work, and display
+span conversion—not just widget construction or a checksum of source text.
+Each streaming workload also renders the completed message once after its last
+delta, using the original renderer and retaining the existing code cache.
+Thus the final full render is included rather than shifting work out of the
+measurement.
+GC before each sample is outside timing; GC after timing accounts for the
+unfinished nursery in allocation totals. Results are medians.
+
+Before measurement, every old/new frame is checked for equal explicit text
+and attributes and equal click extents. Span segmentation is normalized:
+different image compositions may split identical text into different spans.
+The check reads actual text because `SpanOp`'s `Show` instance omits it.
+
+## Workloads
+
+- `prose`: repeated blank-line-separated paragraphs containing bold, inline
+  code, and a link.
+- `prose-lines`: the same prose without blank separators, exercising the
+  uncached growing section.
+- `fence` / `open-fence`: one growing code fence, with/without a closing fence.
+- `table` / `open-table`: one growing table, with/without following prose.
+- `mixed`: repeated groups of one prose paragraph, a three-line code fence,
+  and a three-row table.
+- `resize`: mixed, alternating viewport width 80/40 every 50 frames and
+  clearing render state as a resize invalidates cached layouts.
+- `history-prose` / `history-mixed`: a cold, already-completed message rendered
+  once. These ignore the chunk-size argument.
+
+All source workloads are ASCII. Syntax highlighting is disabled in both paths;
+closed-code caches and link click targets are enabled.
+
+## Streaming results
+
+GHC 9.10.3, Intel i9-9900K, seven samples per case, including the final
+completion render. Allocation is decimal MB. Run each row using the command
+above with its workload, count and chunk size.
+
+| Workload | Count | Chunk | Wall old → new (ms) | CPU old → new (ms) | Allocated old → new (MB) |
+| --- | ---: | ---: | --- | --- | --- |
+| prose | 20 | 64 | 20.752 → 7.417 | 20.689 → 7.390 | 105.341 → 44.667 |
+| prose | 50 | 64 | 115.139 → 20.975 | 114.734 → 20.921 | 534.055 → 131.992 |
+| prose | 100 | 64 | 432.509 → 47.428 | 431.077 → 47.244 | 1910.340 → 298.162 |
+| mixed | 20 | 64 | 385.585 → 46.929 | 384.613 → 46.801 | 1347.121 → 228.169 |
+| mixed | 50 | 64 | 2622.406 → 149.306 | 2613.812 → 148.917 | 7796.406 → 719.116 |
+| prose-lines | 50 | 64 | 111.443 → 109.335 | 111.143 → 109.063 | 545.848 → 543.401 |
+| fence | 50 | 64 | 9.930 → 9.394 | 9.905 → 9.370 | 58.072 → 56.938 |
+| open-fence | 50 | 64 | 10.045 → 9.470 | 10.020 → 9.445 | 59.194 → 58.113 |
+| table | 50 | 64 | 48.237 → 44.789 | 48.127 → 44.679 | 203.759 → 190.348 |
+| open-table | 50 | 64 | 45.223 → 43.892 | 45.108 → 43.788 | 188.381 → 187.445 |
+| resize | 50 | 64 | 2484.609 → 200.429 | 2478.281 → 200.102 | 7828.209 → 859.181 |
+| prose | 50 | 16 | 438.547 → 62.856 | 437.358 → 62.493 | 2050.115 → 433.812 |
+| mixed | 50 | 16 | 9719.336 → 453.186 | 9694.422 → 452.007 | 30848.678 → 2440.931 |
+| prose | 50 | 256 | 32.028 → 10.719 | 31.960 → 10.695 | 151.057 → 55.947 |
+| mixed | 50 | 256 | 646.209 → 73.620 | 644.435 → 73.401 | 2049.664 → 288.685 |
+| mixed (repeat) | 50 | 64 | 2461.051 → 148.458 | 2454.735 → 148.066 | 7796.406 → 719.116 |
+
+The repeated mixed case retains a 16.6× CPU speedup and 90.8% allocation
+reduction. The 100-paragraph prose case improves CPU 9.1× and allocation 84.4%.
+
+## Verification
+
+The Markdown GHCi suite passed 66 examples, including every-character
+prefix comparisons with warm caches, Unicode, links, tables, fences, clipping,
+resize invalidation, and a test proving cached render bodies are not evaluated.
+The CLI and TUI loaded together in GHCi (262 modules).
+
+A real fullscreen tmux smoke streamed a 12-section response with headings,
+paragraphs, links, a table, and Haskell code. Resizing 100 → 64 → 100 columns
+and scrolling with Page Up/Page Down preserved the content and wrapping;
+the response reached its final marker and returned to an interactive prompt.
+
+## Scope
+
+This optimization removes repeated rendering of completed prose sections,
+including completed tables. It does not make the complete update path linear:
+strict body append, contextual fence parsing, section discovery, and image
+composition still revisit the growing message. Growing tables, open code
+fences, and prose without blank separators remain largely unchanged.
+
+These are renderer CPU/allocation measurements, not provider latency or an
+end-to-end application throughput claim.
+
+### Cold completed-message boundary
+
+An initial version applied section caching to every message. That regressed
+cold rendering of 50 prose paragraphs from 3.361 to 3.749 ms CPU (+11.5%) and
+15.757 to 16.084 MB allocated (+2.1%). That application of the optimization was
+removed: only `BlockStreaming` assistant messages use the new path.
+
+With the production dispatch, cold history uses the same renderer as before.
+GHC 9.10.3, Intel i9-9900K, medians of 31 samples:
+
+| Cold workload | CPU old → new (ms) | Allocated old → new (MB) |
+| --- | --- | --- |
+| 50 prose paragraphs | 3.254 → 3.247 | 15.757 → 15.757 |
+| 50 mixed groups | 24.410 → 24.694 | 78.138 → 78.138 |
+
+There is no benefit when a response arrives in one large delta and completes
+immediately: the speculative streaming cache has no later delta to amortize
+its construction. Including the final render, 50 prose paragraphs delivered
+in one delta measured 6.878 → 7.076 ms CPU and 31.513 → 31.841 MB allocated.
+The mixed equivalent measured 47.791 → 48.504 ms and 146.146 → 146.890 MB.
+The change targets incremental streaming, not this two-frame boundary case.

--- a/packages/agent-tui/benchmark/FullscreenMarkdown.md
+++ b/packages/agent-tui/benchmark/FullscreenMarkdown.md
@@ -142,3 +142,12 @@ its construction. Including the final render, 50 prose paragraphs delivered
 in one delta measured 6.878 → 7.076 ms CPU and 31.513 → 31.841 MB allocated.
 The mixed equivalent measured 47.791 → 48.504 ms and 146.146 → 146.890 MB.
 The change targets incremental streaming, not this two-frame boundary case.
+
+### Cache-lifecycle scope
+
+Production now evicts a terminating streaming message's prose cache entries
+through the CLI event loop, preserving its closed-code entries. The renderer
+and benchmark source are unchanged: the timings above include the final
+completed-message render, but exclude that targeted event-loop cleanup.
+The harness retains its prose entries until the sample ends, so these results
+do not measure production cache residency after completion.

--- a/packages/agent-tui/package.nix
+++ b/packages/agent-tui/package.nix
@@ -14,6 +14,10 @@ mkDerivation {
     agent-core agent-syntax base brick containers hspec QuickCheck text
     vty
   ];
+  benchmarkHaskellDepends = [
+    aeson aeson-pretty agent-core agent-json agent-syntax base brick
+    bytestring containers text vty
+  ];
   description = "Retained terminal UI for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -16,6 +16,7 @@ module Agent.TUI.Markdown
     , markdownWidgetWithCodeControls
     , markdownWidgetWithSyntaxHighlighting
     , markdownWidgetWithSyntaxHighlightingAndLinks
+    , markdownWidgetWithStreamingCache
     , parseInline
     ) where
 
@@ -156,6 +157,52 @@ markdownWidgetWithInteractions
         concatMap
             (renderChunk syntaxHighlighter linkName cacheCode codeHeader)
             (fenceChunks input)
+
+-- | Render an append-only Markdown message while retaining completed prose
+-- sections as well as closed code bodies. The prose callback receives the
+-- one-based fence-chunk and section indices. Cache keys must also be scoped to
+-- the message; invalidate them if existing text, rendering attributes, or
+-- available width changes.
+--
+-- Only sections ending with an empty, newline-terminated line are cached.
+-- This leaves potential table headers, growing tables, partial delimiters, and
+-- the current line live. Fence parsing still uses the complete source so that
+-- list-container context and copy-code indices remain identical.
+markdownWidgetWithStreamingCache
+    :: Ord n
+    => Maybe SyntaxHighlighter
+    -> (Text -> n)
+    -> (Int -> Int -> Widget n -> Widget n)
+    -> (Int -> Widget n -> Widget n)
+    -> (Int -> Text -> Widget n)
+    -> Text
+    -> Widget n
+markdownWidgetWithStreamingCache highlighter linkName cacheProse cacheCode codeHeader input =
+    vBox $
+        concatMap renderIndexedChunk (zip [1 ..] (fenceChunks input))
+  where
+    renderIndexedChunk (chunkIndex, FenceText prose) =
+        sections chunkIndex 1 prose
+    renderIndexedChunk (_, chunk) =
+        renderChunk highlighter (Just linkName) cacheCode codeHeader chunk
+
+    sections chunkIndex sectionIndex prose =
+        case Text.breakOn "\n\n" prose of
+            (_, suffix) | Text.null suffix ->
+                renderLines (Just linkName) (Text.lines prose)
+            (prefix, suffix) ->
+                cacheProse chunkIndex sectionIndex
+                    -- Brick consults size policies before looking up a cache
+                    -- entry. Do not force inline parsing/layout on that path.
+                    (B.Widget
+                        (if Text.all isSpace prefix then B.Fixed else B.Greedy)
+                        B.Fixed $
+                        B.render $
+                            vBox $
+                                renderLines
+                                    (Just linkName)
+                                    (Text.lines (prefix <> "\n\n")))
+                    : sections chunkIndex (sectionIndex + 1) (Text.drop 2 suffix)
 
 -- | Render a standalone code body with the same width bounding and optional
 -- syntax highlighting used by fenced Markdown blocks.

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -17,6 +17,7 @@ module Agent.TUI.Markdown
     , markdownWidgetWithSyntaxHighlighting
     , markdownWidgetWithSyntaxHighlightingAndLinks
     , markdownWidgetWithStreamingCache
+    , markdownStreamingCacheSections
     , parseInline
     ) where
 
@@ -203,6 +204,15 @@ markdownWidgetWithStreamingCache highlighter linkName cacheProse cacheCode codeH
                                     (Just linkName)
                                     (Text.lines (prefix <> "\n\n")))
                     : sections chunkIndex (sectionIndex + 1) (Text.drop 2 suffix)
+
+-- | Enumerate the prose cache keys a message may have populated while streaming.
+-- Use this when retiring an append-only message's section caches.
+markdownStreamingCacheSections :: Text -> [(Int, Int)]
+markdownStreamingCacheSections input =
+    [ (chunkIndex, sectionIndex)
+    | (chunkIndex, FenceText prose) <- zip [1 ..] (fenceChunks input)
+    , sectionIndex <- [1 .. Text.count "\n\n" prose]
+    ]
 
 -- | Render a standalone code body with the same width bounding and optional
 -- syntax highlighting used by fenced Markdown blocks.

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -23,12 +23,14 @@ import Brick
     , RenderState
     , ViewportType(..)
     , Widget
+    , cached
     , renderFinal
     , renderWidget
     , txt
     , viewport
     )
 import Brick.AttrMap (attrMapLookup)
+import qualified Brick.Types as B
 import Control.Monad (forM_)
 import Data.Char (isControl)
 import Data.Foldable (toList)
@@ -44,6 +46,64 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "fullscreen Markdown rendering" do
+    it "preserves images and link extents across every streamed prefix with warm prose caches" do
+        let inputs =
+                [ "# Heading\n\nUse **bold**, `code`, and [docs](https://example.com).\n\nNext"
+                , "| A | B |\n| --- | --- |\n| one | two |\n\nFollowing\n\n"
+                , "before\n\n```hs\nmain = pure ()\n```\n\nafter\n\n~~~\ncode\n~~~\n"
+                , "- list\n\n    ```hs\n    x = 1\n    ```\n\nTail"
+                , "a\n\n\n\n界 👩\x200d💻\n\n---\n\n> quote\n\n"
+                , "| potential | table |\n\n| -- | -- |\n"
+                , "before\n\n```hs`not a fence\n\n[link](https://example.com)\n\nTail"
+                ]
+        forM_ [12, 40, 80] \width ->
+            forM_ inputs \input ->
+                checkStreamingPictures width (Text.inits input)
+
+    it "keeps unterminated blank-looking lines live" do
+        checkStreamingPictures 30
+            [ "one\n\nsecond\n"
+            , "one\n\nsecond\n "
+            , "one\n\nsecond\n **third**"
+            , "one\n\nsecond\n **third**\n\n"
+            ]
+
+    it "preserves clipped sections and click extents with warm caches" do
+        forM_ [3, 7] \height ->
+            checkStreamingPicturesAtHeight height 18 $
+                Text.inits
+                    "A [long link](https://example.com/abcdefgh) that wraps.\n\n\
+                    \| A | B |\n| --- | --- |\n| first | second |\n\nTail"
+
+    it "rebuilds warm sections after resize cache invalidation" do
+        let body = "A [long link](https://example.com/abcdefgh) that wraps.\n\nTail"
+        checkStreamingFrames $
+            concatMap
+                (\region -> [(region, body), (region, body <> " grows")])
+                [(40, 20), (12, 3), (18, 7), (80, 20)]
+
+    it "does not evaluate completed prose render bodies on cache hits" do
+        let body = "[stable link](https://example.com)\n\nTail"
+            widget failOnRender =
+                markdownWidgetWithStreamingCache Nothing id
+                    (\chunk section sectionWidget ->
+                        cached (Text.pack (show (chunk, section))) $
+                            B.Widget (B.hSize sectionWidget) (B.vSize sectionWidget) $
+                                if failOnRender
+                                    then error "cached prose was rendered again"
+                                    else B.render sectionWidget)
+                    (\_ code -> code)
+                    (\_ _ -> txt "")
+                    body
+            (warm, _, _, _) =
+                renderFinal Theme.terminalDefault [widget False] (40, 20)
+                    (const Nothing) emptyRenderState
+            (_, picture, _, extents) =
+                renderFinal Theme.terminalDefault [widget True] (40, 20)
+                    (const Nothing) warm
+        V.imageHeight (V.picImage picture) `shouldSatisfy` (> 0)
+        map extentName extents `shouldBe` ["https://example.com"]
+
     it "parses strong, emphasis, code, and links" do
         parseInline
             "Use **bold**, *italics*, `code`, and [docs](https://example.com)."
@@ -1123,6 +1183,52 @@ emptyRenderState =
         \observedNames = fromList [], renderCache = fromList [], \
         \clickableNames = [], requestedVisibleNames_ = fromList [], \
         \reportedExtents = fromList []}"
+
+checkStreamingPictures :: Int -> [Text.Text] -> Expectation
+checkStreamingPictures = checkStreamingPicturesAtHeight 200
+
+checkStreamingPicturesAtHeight :: Int -> Int -> [Text.Text] -> Expectation
+checkStreamingPicturesAtHeight height width =
+    checkStreamingFrames . map ((width, height),)
+
+checkStreamingFrames :: [((Int, Int), Text.Text)] -> Expectation
+checkStreamingFrames = go Nothing emptyRenderState
+  where
+    go _ _ [] = pure ()
+    go previousRegion previous ((region, input) : rest) = do
+        let baseline = markdownWidgetWithLinks id input
+            streaming =
+                markdownWidgetWithStreamingCache
+                    Nothing
+                    id
+                    (\chunk section -> cached (Text.pack (show (chunk, section))))
+                    (\_ widget -> widget)
+                    (\_ _ -> txt "")
+                    input
+            (next, actual, _, actualExtents) =
+                renderFinal Theme.terminalDefault [streaming] region
+                    (const Nothing)
+                    -- Match the CLI's handleResizeEvent invalidation.
+                    (if previousRegion == Just region
+                        then previous
+                        else emptyRenderState)
+            (_, expected, _, expectedExtents) =
+                renderFinal Theme.terminalDefault [baseline] region
+                    (const Nothing) emptyRenderState
+            extentKey extent =
+                (extentName extent, extentUpperLeft extent, extentSize extent)
+            rows picture =
+                map (concatMap cells . toList) $
+                    toList (displayOpsForPic picture region)
+            cells = \case
+                TextSpan{textSpanText, textSpanAttr} ->
+                    map (, textSpanAttr) (LazyText.unpack textSpanText)
+                Skip count -> replicate count (' ', V.defAttr)
+                RowEnd count -> replicate count (' ', V.defAttr)
+        rows actual `shouldBe` rows expected
+        sortOn id (map extentKey actualExtents)
+            `shouldBe` sortOn id (map extentKey expectedExtents)
+        go (Just region) next rest
 
 spanRowText :: [SpanOp] -> Text.Text
 spanRowText =


### PR DESCRIPTION
## Summary

- Cache stable, blank-line-terminated prose sections during active fullscreen assistant streams; keep the changing tail live and preserve code caches and link targets.

- Keep the existing renderer for completed/history messages to avoid cold-cache overhead.

- Add warm-cache regression tests and a retained optimized old/new benchmark.

## Validation

- 66 Markdown examples passed in GHCi; CLI + TUI loaded successfully (262 modules).

- Live fullscreen tmux smoke passed streaming, table/code rendering, resizing 100 → 64 → 100 columns, and Page Up/Page Down.

- Regenerated package.nix; git diff --check passed.

## Benchmark details

# Fullscreen streaming Markdown benchmark

`FullscreenMarkdown.hs` retains the pre-optimization production path as
`baseline`: strict `Text` append followed by whole-message Markdown rendering,
with Brick's existing closed-code-body cache. `optimized` additionally caches
completed prose sections. Both call the same underlying Markdown, layout, and
syntax-support code. Completed/history messages use the original renderer:
section caches are only useful while further appends are possible.

## Reproduce

From the repository root:

```sh
nix develop
cabal build --offline agent-tui:bench:fullscreen-markdown-bench
bin=$(cabal list-bin agent-tui:bench:fullscreen-markdown-bench)
"$bin" old mixed 50 64 7 +RTS -T
"$bin" new mixed 50 64 7 +RTS -T
```

Arguments are implementation, workload, count, chunk size in characters, and
sample count. Output is CSV:

```text
implementation,workload,count,chunk_chars,samples,median_wall_ms,median_cpu_ms,median_allocated_bytes
```

The benchmark source and its renderer/support modules are compiled with `-O2`;
shared dependency libraries use the normal Cabal optimization settings. It
runs single-threaded with the default allocation area. Inputs are built and
forced before measurement. A fresh input is read through an IORef inside the
timed region, with a sample-specific heading and a `NOINLINE` consumer to avoid
sharing previously evaluated results.

Each delta appends the strict message body and renders an actual Brick frame
through `renderFinal`, retaining `RenderState` between frames. The viewport is
80×30 and follows a trailing visible marker, so the complete growing message
is laid out while the visible tail is converted into Vty display spans. The
consumer forces span text, attributes, and click extents. This includes cache
construction, parsing, layout, image composition, viewport work, and display
span conversion—not just widget construction or a checksum of source text.
Each streaming workload also renders the completed message once after its last
delta, using the original renderer and retaining the existing code cache.
Thus the final full render is included rather than shifting work out of the
measurement.
GC before each sample is outside timing; GC after timing accounts for the
unfinished nursery in allocation totals. Results are medians.

Before measurement, every old/new frame is checked for equal explicit text
and attributes and equal click extents. Span segmentation is normalized:
different image compositions may split identical text into different spans.
The check reads actual text because `SpanOp`'s `Show` instance omits it.

## Workloads

- `prose`: repeated blank-line-separated paragraphs containing bold, inline
  code, and a link.
- `prose-lines`: the same prose without blank separators, exercising the
  uncached growing section.
- `fence` / `open-fence`: one growing code fence, with/without a closing fence.
- `table` / `open-table`: one growing table, with/without following prose.
- `mixed`: repeated groups of one prose paragraph, a three-line code fence,
  and a three-row table.
- `resize`: mixed, alternating viewport width 80/40 every 50 frames and
  clearing render state as a resize invalidates cached layouts.
- `history-prose` / `history-mixed`: a cold, already-completed message rendered
  once. These ignore the chunk-size argument.

All source workloads are ASCII. Syntax highlighting is disabled in both paths;
closed-code caches and link click targets are enabled.

## Streaming results

GHC 9.10.3, Intel i9-9900K, seven samples per case, including the final
completion render. Allocation is decimal MB. Run each row using the command
above with its workload, count and chunk size.

| Workload | Count | Chunk | Wall old → new (ms) | CPU old → new (ms) | Allocated old → new (MB) |
| --- | ---: | ---: | --- | --- | --- |
| prose | 20 | 64 | 20.752 → 7.417 | 20.689 → 7.390 | 105.341 → 44.667 |
| prose | 50 | 64 | 115.139 → 20.975 | 114.734 → 20.921 | 534.055 → 131.992 |
| prose | 100 | 64 | 432.509 → 47.428 | 431.077 → 47.244 | 1910.340 → 298.162 |
| mixed | 20 | 64 | 385.585 → 46.929 | 384.613 → 46.801 | 1347.121 → 228.169 |
| mixed | 50 | 64 | 2622.406 → 149.306 | 2613.812 → 148.917 | 7796.406 → 719.116 |
| prose-lines | 50 | 64 | 111.443 → 109.335 | 111.143 → 109.063 | 545.848 → 543.401 |
| fence | 50 | 64 | 9.930 → 9.394 | 9.905 → 9.370 | 58.072 → 56.938 |
| open-fence | 50 | 64 | 10.045 → 9.470 | 10.020 → 9.445 | 59.194 → 58.113 |
| table | 50 | 64 | 48.237 → 44.789 | 48.127 → 44.679 | 203.759 → 190.348 |
| open-table | 50 | 64 | 45.223 → 43.892 | 45.108 → 43.788 | 188.381 → 187.445 |
| resize | 50 | 64 | 2484.609 → 200.429 | 2478.281 → 200.102 | 7828.209 → 859.181 |
| prose | 50 | 16 | 438.547 → 62.856 | 437.358 → 62.493 | 2050.115 → 433.812 |
| mixed | 50 | 16 | 9719.336 → 453.186 | 9694.422 → 452.007 | 30848.678 → 2440.931 |
| prose | 50 | 256 | 32.028 → 10.719 | 31.960 → 10.695 | 151.057 → 55.947 |
| mixed | 50 | 256 | 646.209 → 73.620 | 644.435 → 73.401 | 2049.664 → 288.685 |
| mixed (repeat) | 50 | 64 | 2461.051 → 148.458 | 2454.735 → 148.066 | 7796.406 → 719.116 |

The repeated mixed case retains a 16.6× CPU speedup and 90.8% allocation
reduction. The 100-paragraph prose case improves CPU 9.1× and allocation 84.4%.

## Verification

The Markdown GHCi suite passed 66 examples, including every-character
prefix comparisons with warm caches, Unicode, links, tables, fences, clipping,
resize invalidation, and a test proving cached render bodies are not evaluated.
The CLI and TUI loaded together in GHCi (262 modules).

A real fullscreen tmux smoke streamed a 12-section response with headings,
paragraphs, links, a table, and Haskell code. Resizing 100 → 64 → 100 columns
and scrolling with Page Up/Page Down preserved the content and wrapping;
the response reached its final marker and returned to an interactive prompt.

## Scope

This optimization removes repeated rendering of completed prose sections,
including completed tables. It does not make the complete update path linear:
strict body append, contextual fence parsing, section discovery, and image
composition still revisit the growing message. Growing tables, open code
fences, and prose without blank separators remain largely unchanged.

These are renderer CPU/allocation measurements, not provider latency or an
end-to-end application throughput claim.

### Cold completed-message boundary

An initial version applied section caching to every message. That regressed
cold rendering of 50 prose paragraphs from 3.361 to 3.749 ms CPU (+11.5%) and
15.757 to 16.084 MB allocated (+2.1%). That application of the optimization was
removed: only `BlockStreaming` assistant messages use the new path.

With the production dispatch, cold history uses the same renderer as before.
GHC 9.10.3, Intel i9-9900K, medians of 31 samples:

| Cold workload | CPU old → new (ms) | Allocated old → new (MB) |
| --- | --- | --- |
| 50 prose paragraphs | 3.254 → 3.247 | 15.757 → 15.757 |
| 50 mixed groups | 24.410 → 24.694 | 78.138 → 78.138 |

There is no benefit when a response arrives in one large delta and completes
immediately: the speculative streaming cache has no later delta to amortize
its construction. Including the final render, 50 prose paragraphs delivered
in one delta measured 6.878 → 7.076 ms CPU and 31.513 → 31.841 MB allocated.
The mixed equivalent measured 47.791 → 48.504 ms and 146.146 → 146.890 MB.
The change targets incremental streaming, not this two-frame boundary case.