### PR TITLE
Fix prompt typing recovery from transcript focus

### DIFF
--- a/docs/ghostty.md
+++ b/docs/ghostty.md
@@ -30,6 +30,18 @@ wrapped for tmux passthrough when `TMUX` is set.
 Ghostty may require clipboard-write permission in its configuration for OSC 52.
 tmux may likewise require escape-sequence passthrough to be enabled.
 
+## Fullscreen prompt focus
+
+In fullscreen mode, typing a printable character while the transcript has
+focus returns to the prompt and inserts that character at the existing cursor.
+This also works after switching terminal tabs, and applies in other terminals.
+Approval dialogs and other active input panels retain their own key handling.
+
+Tab or Escape returns from the transcript to the prompt without inserting text.
+Use arrows and Page Up/Page Down to navigate the transcript, Home/End to reach
+its beginning/end, and Ctrl+Y to copy the selected block. Plain `g`, `G`, and
+`y` enter text rather than invoking transcript commands.
+
 ## Recommended quick-terminal profile
 
 The harness works well as Ghostty's global quick terminal. Add a binding like

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
@@ -412,6 +412,7 @@ handleScrollbackKey = \case
     V.EvKey V.KRight [] -> toggle
     V.EvKey V.KEnter [] -> toggle
     V.EvKey (V.KChar 'y') [V.MCtrl] -> copySelected
+    V.EvKey (V.KChar '\EM') [] -> copySelected
     V.EvKey (V.KChar '\t') [] -> focusComposer
     V.EvKey V.KEsc [] -> focusComposer
     _ -> pure ()

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
@@ -143,7 +143,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
 import Control.Exception.Safe (finally, mask, onException, throwIO, tryAny)
 import Control.Exception (AsyncException(UserInterrupt))
-import Data.Char (isControl, isSpace)
+import Data.Char (isControl, isPrint, isSpace)
 import Data.Foldable (toList)
 import Data.IORef ( atomicModifyIORef' , modifyIORef' , newIORef , readIORef , writeIORef )
 import Data.List ( find , findIndex , intersperse , nub , sort , sortOn )
@@ -378,6 +378,18 @@ mouseScrollLines = 3
 
 handleScrollbackKey :: V.Event -> EventM Name AppState ()
 handleScrollbackKey = \case
+    V.EvKey (V.KChar character) modifiers
+        | isPrint character && all (== V.MShift) modifiers -> do
+            -- Typing expresses intent to edit, even when transcript focus was
+            -- retained across a terminal tab switch. The character already
+            -- contains the effect of Shift; the composer expects text keys
+            -- without modifiers.
+            focusComposer
+            Composer.handleComposerKey
+                applyLocalUiEventWith
+                handleCtrlC
+                scrollConversationPage
+                (V.EvKey (V.KChar character) [])
     V.EvKey V.KUp [] -> moveBlock (-1)
     V.EvKey V.KDown [] -> moveBlock 1
     V.EvKey V.KPageUp [] -> scrollConversationPage Up
@@ -396,17 +408,10 @@ handleScrollbackKey = \case
         vScrollToBeginning scroll
         queueConversationReflow
     V.EvKey V.KEnd [] -> resumeConversationFollow
-    V.EvKey (V.KChar 'g') [] -> do
-        leaveFollow
-        requestHistoryPage HistoryOlder
-        vScrollToBeginning scroll
-        queueConversationReflow
-    V.EvKey (V.KChar 'G') [] -> resumeConversationFollow
     V.EvKey V.KLeft [] -> toggle
     V.EvKey V.KRight [] -> toggle
     V.EvKey V.KEnter [] -> toggle
-    V.EvKey (V.KChar 'y') [] -> copySelected
-    V.EvKey (V.KChar ' ') [] -> focusComposer
+    V.EvKey (V.KChar 'y') [V.MCtrl] -> copySelected
     V.EvKey (V.KChar '\t') [] -> focusComposer
     V.EvKey V.KEsc [] -> focusComposer
     _ -> pure ()

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -289,7 +289,7 @@ drawFooter state =
                     FocusPermission ->
                         "↑↓ select  │  Enter choose  │  Esc deny"
                     FocusScrollback ->
-                        "↑↓ blocks  │  Ctrl+J/K lines  │  PgUp/PgDn pages  │  wheel scroll  │  Tab/Space prompt  │  ⌘K meta"
+                        "↑↓ blocks  │  Ctrl+J/K lines  │  PgUp/PgDn pages  │  Ctrl+Y copy  │  Tab/Esc or type to prompt  │  ⌘K meta"
                     FocusComposer
                         | not state.appUi.uiAwaitingInput ->
                             "Enter steer  │  Ctrl+R dictate  │  Ctrl+Enter/Ctrl+O send now  │  Esc/Ctrl+C cancel  │  Tab scrollback  │  ⌘K meta"

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -3019,7 +3019,8 @@ spec = do
                     state.appUi.uiDraft `shouldBe` "before"
                     state.appUi.uiFocus `shouldBe` FocusScrollback
 
-        it "copies the selected transcript block with Ctrl-Y without editing the draft" do
+        forM_ [V.EvKey (V.KChar 'y') [V.MCtrl], V.EvKey (V.KChar '\EM') []] $ \copyEvent ->
+          it ("copies the selected transcript block without editing the draft: " <> show copyEvent) do
             copied <- newIORef Nothing
             initialState <- cachedHistoryState
                 [markerBlock (BlockId (-1)) "selected transcript text"]
@@ -3032,7 +3033,7 @@ spec = do
                     , appHistorySelectedBlock = Just (BlockId (-1))
                     }
             (_, finalState) <- runFullscreenScriptWithState state
-                [ FullscreenScriptVty (V.EvKey (V.KChar 'y') [V.MCtrl])
+                [ FullscreenScriptVty copyEvent
                 , FullscreenScriptHalt
                 ]
             readIORef copied `shouldReturn` Just "selected transcript text"

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -2971,6 +2971,82 @@ spec = do
             timeout 2_000_000 evictedPreviewKeys
                 `shouldReturn` Just []
 
+    describe "transcript typing focus recovery" do
+        it "inserts the first printable character at the existing draft cursor" do
+            forM_ [('a', []), ('G', [V.MShift]), ('g', []), ('y', []),
+                    (' ', []), ('!', [V.MShift]), ('λ', [])] $
+                \(character, modifiers) -> do
+                    state <- runTranscriptFocusInput []
+                        [V.EvKey (V.KChar character) modifiers]
+                    state.appUi.uiDraft
+                        `shouldBe` "be" <> Text.singleton character <> "fore"
+                    state.appUi.uiCursor `shouldBe` 3
+                    state.appUi.uiFocus `shouldBe` FocusComposer
+                    state.appHistorySelectedBlock `shouldBe` Nothing
+
+        it "preserves the whole typed prompt after returning to a terminal tab" do
+            state <- runTranscriptFocusInput []
+                ([V.EvLostFocus, V.EvGainedFocus]
+                    <> map (\character -> V.EvKey (V.KChar character) [])
+                        "guidance")
+            state.appUi.uiDraft `shouldBe` "beguidancefore"
+            state.appUi.uiFocus `shouldBe` FocusComposer
+
+        it "recovers while running even without a focus-gained event" do
+            state <- runTranscriptFocusInput [UiLoop TurnStarted]
+                [V.EvLostFocus, V.EvKey (V.KChar 'x') []]
+            state.appUi.uiDraft `shouldBe` "bexfore"
+            state.appUi.uiFocus `shouldBe` FocusComposer
+
+        it "keeps Tab and Escape as focus-only commands" do
+            forM_ [V.KChar '\t', V.KEsc] $ \key -> do
+                state <- runTranscriptFocusInput [] [V.EvKey key []]
+                state.appUi.uiDraft `shouldBe` "before"
+                state.appUi.uiFocus `shouldBe` FocusComposer
+
+        it "does not insert navigation keys or modified character shortcuts" do
+            forM_
+                [ V.EvKey V.KUp []
+                , V.EvKey V.KDown []
+                , V.EvKey V.KLeft []
+                , V.EvKey V.KRight []
+                , V.EvKey V.KEnter []
+                , V.EvKey (V.KChar 'j') [V.MCtrl]
+                , V.EvKey (V.KChar 'x') [V.MAlt]
+                , V.EvKey (V.KChar 'x') [V.MMeta]
+                ] $ \event -> do
+                    state <- runTranscriptFocusInput [] [event]
+                    state.appUi.uiDraft `shouldBe` "before"
+                    state.appUi.uiFocus `shouldBe` FocusScrollback
+
+        it "copies the selected transcript block with Ctrl-Y without editing the draft" do
+            copied <- newIORef Nothing
+            initialState <- cachedHistoryState
+                [markerBlock (BlockId (-1)) "selected transcript text"]
+            let runtime = initialState.appRuntime
+                state = initialState
+                    { appRuntime = runtime
+                        { runtimeCopy = \body ->
+                            writeIORef copied (Just body) >> pure True
+                        }
+                    , appHistorySelectedBlock = Just (BlockId (-1))
+                    }
+            (_, finalState) <- runFullscreenScriptWithState state
+                [ FullscreenScriptVty (V.EvKey (V.KChar 'y') [V.MCtrl])
+                , FullscreenScriptHalt
+                ]
+            readIORef copied `shouldReturn` Just "selected transcript text"
+            finalState.appUi.uiDraft `shouldBe` ""
+            finalState.appUi.uiFocus `shouldBe` FocusScrollback
+
+        it "does not redirect typing out of an approval overlay" do
+            state <- runTranscriptFocusInput
+                [UiPermissionShown "Approve a test operation"]
+                [V.EvKey (V.KChar 'x') []]
+            state.appUi.uiDraft `shouldBe` "before"
+            state.appUi.uiFocus `shouldBe` FocusPermission
+            state.appUi.uiPermission `shouldSatisfy` isJust
+
     describe "unfocused terminal recovery" do
         it "treats paste input as proof that focus returned" do
             timeout 2_000_000 unfocusedPasteRendersDraft
@@ -3405,6 +3481,19 @@ historyPlacement preview =
         , nativePreviewRows = 1
         , nativePreviewAttachment = preview.previewKittyAttachment
         }
+
+runTranscriptFocusInput :: [UiEvent] -> [V.Event] -> IO AppState
+runTranscriptFocusInput setup events = do
+    let ui = foldl (flip reduceUi) initialUiState
+            ([UiSetDraft "before" 2, UiFocusChanged FocusScrollback] <> setup)
+    runtime <- newScriptRuntime ui
+    let initialState =
+            (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                { appUi = ui
+                , appHistorySelectedBlock = Just (BlockId (-1))
+                }
+    snd <$> runFullscreenScriptWithState initialState
+        (map FullscreenScriptVty events <> [FullscreenScriptHalt])
 
 unfocusedPasteRendersDraft :: IO Bool
 unfocusedPasteRendersDraft = do


### PR DESCRIPTION
## Summary

When fullscreen transcript focus survives a terminal tab switch, ordinary typing previously did nothing (or invoked single-letter transcript commands). Treat printable input as intent to edit: focus the prompt and forward the first character at the existing cursor.

- Preserve Shift text, punctuation, spaces, and Unicode; do not redirect Ctrl/Alt/Meta shortcuts or approval dialogs.
- Keep navigation keys and Tab/Escape focus-only recovery. Replace plain `g`/`G` navigation with the existing Home/End bindings and move selected-block copying from `y` to Ctrl+Y.
- Update the footer hint and Ghostty documentation.

This addresses retained in-app transcript focus, not a confirmed macOS/Ghostty native-focus or rejection-sound root cause.

## Validation

- GHCi via `nix develop -c cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code`, then `:main --match "focus"`: **37 examples, 0 failures**.
- Live production fullscreen UI in tmux, launched from GHCi with an inert worker (no model requests): transcript-focused draft `before` at cursor 2 became `beXfore` after typing `X`; after Tab back to transcript, injected focus-loss/focus-gain sequences and `guidance G! ` produced `beXguidance G! fore`, with prompt focus restored.
- Regression coverage includes running-agent input without a focus-gained event, first-character preservation, focus-only commands, modified shortcuts, both modern and legacy Ctrl+Y encodings (also verified live in tmux), and approval isolation.
- `git diff --check` passed.


