### PR TITLE
Fix native fresh approvals being silently denied

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Approval/Decision.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval/Decision.hs
@@ -136,8 +136,8 @@ resolveApprovalPrompt :: ToolCall -> Maybe PermissionChoice -> ApprovalPlan
 resolveApprovalPrompt = resolveApprovalPromptWith False
 
 -- | Resolve an interactive decision. Sensitive calls accept only a one-call
--- approval: broader choices are treated as approval for this invocation
--- without changing global or session policy.
+-- approval. An unavailable prompt or unsupported broad choice is not a user
+-- denial, and must never authorize execution or change approval policy.
 resolveApprovalPromptWith
     :: Bool
     -> ToolCall
@@ -146,9 +146,14 @@ resolveApprovalPromptWith
 resolveApprovalPromptWith requiresExplicitApproval call choice
     | requiresExplicitApproval =
         case choice of
-            Nothing -> denied
+            Nothing -> CompleteApproval
+                (Left "Fresh approval was not obtained: the approval prompt was unavailable or closed without a decision. The tool was not run.")
+                []
             Just PermissionDeny -> denied
-            Just _ -> approved
+            Just PermissionAllowOnce -> approved
+            Just _ -> CompleteApproval
+                (Left "This tool requires fresh approval for this invocation; a remembered or blanket approval cannot authorize it. The tool was not run.")
+                []
     | isComputerToolCallKind call.callKind =
         case choice of
             Nothing -> denied

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -131,6 +131,8 @@ data NativeRunHooks = NativeRunHooks
     , nativeRegisterCancel :: !(IO () -> IO ())
     , nativeRegisterAgentSnapshot :: !(IO [AgentEntry] -> IO ())
     , nativeRequestApproval :: !(ToolCall -> IO (Maybe PermissionChoice))
+    -- | A fresh decision for this exact invocation, without remembered grants.
+    , nativeRequestFreshApproval :: !(ToolCall -> IO (Maybe PermissionChoice))
     , nativeRequestRootAccess :: !(OsPath -> IO Bool)
     , nativeToolGroups :: ![AppToolGroup]
     -- | Compose the final model-visible tool surface once, before the generic

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -973,7 +973,7 @@ buildSessionApprovalRuntime host controls SessionRequest{..} =
         -- their generic permission dialog.
         requestFreshApproval requested =
             case startup.startupNativeHooks of
-                Just _ -> pure Nothing
+                Just hooks -> hooks.nativeRequestFreshApproval requested
                 Nothing -> case promptRequest of
                     Just _ -> pure Nothing
                     Nothing -> case host.hostFullscreen of

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -258,13 +258,27 @@ spec = do
                             "✓ always allow run_terminal_command this session")
                     ]
 
-        it "never persists broader approval for an explicit-confirmation call" do
+        it "distinguishes unavailable fresh approval from an explicit denial" do
+            resolveApprovalPromptWith True mutatingCall Nothing
+                `shouldBe` CompleteApproval
+                    (Left "Fresh approval was not obtained: the approval prompt was unavailable or closed without a decision. The tool was not run.")
+                    []
+            resolveApprovalPromptWith True mutatingCall (Just PermissionDeny)
+                `shouldBe` CompleteApproval (Right False) []
+            resolveApprovalPromptWith True mutatingCall (Just PermissionAllowOnce)
+                `shouldBe` CompleteApproval (Right True) []
+
+        it "rejects broader approval for an explicit-confirmation call" do
             resolveApprovalPromptWith True mutatingCall
                 (Just PermissionAllowAll)
-                `shouldBe` CompleteApproval (Right True) []
+                `shouldBe` CompleteApproval
+                    (Left "This tool requires fresh approval for this invocation; a remembered or blanket approval cannot authorize it. The tool was not run.")
+                    []
             resolveApprovalPromptWith True mutatingCall
                 (Just PermissionAllowTool)
-                `shouldBe` CompleteApproval (Right True) []
+                `shouldBe` CompleteApproval
+                    (Left "This tool requires fresh approval for this invocation; a remembered or blanket approval cannot authorize it. The tool was not run.")
+                    []
         it "preserves project-wide approval semantics for a computer workflow" do
             let call = ToolCall
                     { callId = "computer-1"
@@ -481,7 +495,7 @@ spec = do
             permissionRequests <- newIORef (0 :: Int)
             let request _ = do
                     modifyIORef' permissionRequests (+ 1)
-                    pure (Just PermissionAllowAll)
+                    pure (Just PermissionAllowOnce)
                 sensitiveTool = tool "sensitive" AlwaysConfirm
                 sensitiveCall =
                     functionToolCall "call-sensitive" "sensitive" "{}"
@@ -502,7 +516,7 @@ spec = do
             permissionRequests <- newIORef (0 :: Int)
             let request _ = do
                     modifyIORef' permissionRequests (+ 1)
-                    pure (Just PermissionAllowAll)
+                    pure (Just PermissionAllowOnce)
                 approve call = approveToolDecisionWithReporter
                     request (\_ -> pure ()) policy allowed
                     (registry [callSensitiveTool]) plan call
@@ -534,7 +548,7 @@ spec = do
                 approve = approveToolDecisionWithReporterAndPersistenceClassified
                     (const (pure (Just True)))
                     (\_ -> modifyIORef' permissionRequests (+ 1)
-                        >> pure (Just PermissionAllowAll))
+                        >> pure (Just PermissionAllowOnce))
                     (\_ -> pure ())
                     (pure ())
                     policy allowed tools plan

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeInteraction.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeInteraction.hs
@@ -3,6 +3,7 @@
 module Agent.CLI.MacOS.NativeInteraction
     ( nativePlanModeHooks
     , requestApproval
+    , requestFreshApproval
     , requestApprovalFromClient
     , boundedApprovalArguments
     , requestRootAccessFromClient
@@ -233,7 +234,25 @@ requestApprovalFromClient
     -> TurnControl
     -> ToolCall
     -> IO (Maybe PermissionChoice)
-requestApprovalFromClient callback context control call = do
+requestApprovalFromClient = requestApprovalWithScope False
+
+-- | Never consult or populate the per-tool allowance for a fresh request.
+requestFreshApproval
+    :: FunPtr EventCallback
+    -> Ptr ()
+    -> TurnControl
+    -> ToolCall
+    -> IO (Maybe PermissionChoice)
+requestFreshApproval = requestApprovalWithScope True
+
+requestApprovalWithScope
+    :: Bool
+    -> FunPtr EventCallback
+    -> Ptr ()
+    -> TurnControl
+    -> ToolCall
+    -> IO (Maybe PermissionChoice)
+requestApprovalWithScope onceOnly callback context control call = do
     waiter <- newEmptyTMVarIO
     approvalId <- atomically do
         current <- readTVar control.turnControlApprovalCounter
@@ -245,7 +264,7 @@ requestApprovalFromClient callback context control call = do
         writeTVar control.turnControlApprovalCounter next
         modifyTVar'
             control.turnControlApprovals
-            (Map.insert approvalId waiter)
+            (Map.insert approvalId (onceOnly, waiter))
         pure approvalId
     let (arguments, truncated) = boundedApprovalArguments call
     sendEvent callback context $
@@ -261,6 +280,7 @@ requestApprovalFromClient callback context control call = do
                 , "argumentsEncrypted" Aeson..= call.argumentsEncrypted
                 , "async" Aeson..= (toolCallMode call == AsyncToolCall)
                 , "truncated" Aeson..= truncated
+                , "onceOnly" Aeson..= onceOnly
                 ]
             ]
     choice <- atomically (takeTMVar waiter)
@@ -270,7 +290,7 @@ requestApprovalFromClient callback context control call = do
             (Map.delete approvalId)
     case choice of
         PermissionAllowTool
-            | not (isComputerToolCallKind call.callKind) ->
+            | not onceOnly && not (isComputerToolCallKind call.callKind) ->
             atomically $
                 modifyTVar'
                     control.turnControlAllowedTools
@@ -339,8 +359,16 @@ resolveApproval control request =
                         case Map.lookup
                             resolution.approvalResolutionId
                             current of
-                                Nothing -> pure False
-                                Just waiter -> do
+                                Nothing ->
+                                    pure (Left "approval request is no longer active")
+                                Just (onceOnly, _)
+                                    | onceOnly && choice /= PermissionAllowOnce
+                                        && choice /= PermissionDeny ->
+                                            pure (Left "this approval accepts only allow_once or deny")
+                                    | onceOnly && choice == PermissionAllowOnce
+                                        && not resolution.approvalResolutionOnceOnly ->
+                                            pure (Left "the client must confirm onceOnly support for this approval")
+                                Just (_, waiter) -> do
                                     published <- tryPutTMVar waiter choice
                                     if published
                                         then writeTVar
@@ -349,13 +377,12 @@ resolveApproval control request =
                                                 resolution.approvalResolutionId
                                                 current)
                                         else pure ()
-                                    pure published
-                    pure $
-                        if accepted
-                            then successEvent request.requestId True
-                            else failureEvent
-                                request.requestId
-                                "approval request is no longer active"
+                                    pure $
+                                        if published then Right ()
+                                        else Left "approval request is no longer active"
+                    pure $ case accepted of
+                        Right () -> successEvent request.requestId True
+                        Left message -> failureEvent request.requestId message
 
 permissionChoice :: Text -> Maybe PermissionChoice
 permissionChoice = \case

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeRequest.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeRequest.hs
@@ -109,6 +109,7 @@ instance Aeson.FromJSON TurnReference where
 data ApprovalResolution = ApprovalResolution
     { approvalResolutionId :: !Text
     , approvalResolutionDecision :: !Text
+    , approvalResolutionOnceOnly :: !Bool
     }
 
 instance Aeson.FromJSON ApprovalResolution where
@@ -116,6 +117,7 @@ instance Aeson.FromJSON ApprovalResolution where
         ApprovalResolution
             <$> object .: "approvalId"
             <*> object .: "decision"
+            <*> (object .:? "onceOnly" Aeson..!= False)
 
 data SessionPageRequest = SessionPageRequest
     { sessionPageId :: !Text

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
@@ -11,7 +11,8 @@ import Agent.CLI.MacOS.EngineMailbox (EngineMailbox, acceptEngineCommand)
 import Agent.CLI.MacOS.EngineState (EngineCommand(..))
 import Agent.CLI.MacOS.InteractionState (InteractionRuntime)
 import Agent.CLI.MacOS.NativeInteraction
-    ( nativePlanModeHooks, requestApproval, requestRootAccessFromClient )
+    ( nativePlanModeHooks, requestApproval, requestFreshApproval
+    , requestRootAccessFromClient )
 import Agent.CLI.MacOS.NativeLoopEvent (encodeNativeLoopEventWithChartCalls)
 import Agent.CLI.MacOS.NativeRequest (TurnStart(..))
 import Agent.CLI.MacOS.TurnEvents (nativeLoopEvent)
@@ -119,6 +120,8 @@ runNativeTurn
                 atomically . writeTVar control.turnControlAgentSnapshot
             , nativeRequestApproval =
                 requestApproval callback context control
+            , nativeRequestFreshApproval =
+                requestFreshApproval callback context control
             , nativeRequestRootAccess =
                 requestRootAccessFromClient callback context control
             , nativeToolGroups = [HostToolGroup nativeHostTools]

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnState.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnState.hs
@@ -72,7 +72,7 @@ data TurnControl = TurnControl
     , turnControlCancelled :: !(TVar Bool)
     , turnControlCancel :: !(TVar (IO ()))
     , turnControlApprovals
-        :: !(TVar (Map Text (TMVar PermissionChoice)))
+        :: !(TVar (Map Text (Bool, TMVar PermissionChoice)))
     , turnControlApprovalCounter :: !(TVar Int)
     , turnControlInteractionCounter :: !(TVar Int)
     , turnControlAllowedTools :: !(TVar (Set.Set Text))
@@ -152,7 +152,7 @@ cancelTurn control = do
         writeTVar control.turnControlApprovals Map.empty
         pure (Map.elems current)
     atomically $
-        forM_ waiters \waiter ->
+        forM_ waiters \(_, waiter) ->
             void (tryPutTMVar waiter PermissionDeny)
     interactionWaiters <- atomically do
         current <- readTVar

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeFFISpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeFFISpec.hs
@@ -17,21 +17,33 @@ import Agent.CLI.MacOS.Bridge
     , turnStartCleanupId
     )
 import Agent.CLI.MacOS.RepositoryWorkers (withRepositoryCallbackThread)
+import Agent.CLI.MacOS.EngineEvents (EventCallback)
+import Agent.CLI.MacOS.InteractionState (InteractionRuntime(..))
+import Agent.CLI.MacOS.NativeInteraction (requestFreshApproval, resolveApproval)
+import Agent.CLI.MacOS.NativeRequest (BridgeRequest(..))
+import Agent.CLI.MacOS.TurnState (TurnControl(..), newTurnControl)
+import Agent.CLI.Permission (PermissionChoice(..))
+import Agent.ToolDispatch (ToolCall(..), ToolCallKind(..))
 import Control.Concurrent.Async (concurrently, withAsync)
-import Control.Concurrent.MVar (newEmptyMVar, putMVar, readMVar)
+import Control.Concurrent.MVar (newEmptyMVar, newMVar, putMVar, readMVar)
 import Control.Concurrent.STM
     ( atomically
     , newEmptyTMVarIO
     , newTVarIO
     , readTMVar
     , readTVarIO
+    , writeTVar
     )
 import Control.Exception.Safe (bracket, finally, tryAny)
 import Data.Either (isRight)
-import Data.IORef (newIORef)
+import Data.IORef (newIORef, modifyIORef', readIORef, writeIORef)
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
 import qualified Data.Map.Strict as Map
-import Foreign.C.Types (CInt(..))
+import qualified Data.Set as Set
+import Foreign.Ptr (FunPtr, castPtr, freeHaskellFunPtr, nullPtr)
+import Foreign.C.Types (CInt(..), CSize(..))
 import Foreign.StablePtr (castStablePtrToPtr, newStablePtr)
 import System.Directory
     ( createDirectory
@@ -41,6 +53,7 @@ import System.Directory
     )
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import System.IO (hClose, openTempFile)
+import System.Timeout (timeout)
 import Test.Hspec
     ( Spec
     , describe
@@ -67,12 +80,85 @@ foreign import ccall "ha_native_turn_options_stage_smoke"
 
 foreign import ccall "ha_turn_staging_discard_smoke"
     turnStagingDiscardSmoke :: IO CInt
+
+foreign import ccall "wrapper"
+    makeApprovalEventCallback :: EventCallback -> IO (FunPtr EventCallback)
+
+withinApprovalDeadline :: IO () -> IO ()
+withinApprovalDeadline action =
+    timeout 5000000 action `shouldReturn` Just ()
 #else
 import Test.Hspec (Spec, describe, it, pendingWith, shouldReturn)
 #endif
 
 spec :: Spec
 spec = describe "native bridge FFI" do
+#ifdef darwin_HOST_OS
+    it "requests fresh approvals despite remembered tool grants and rejects broad decisions" $ withinApprovalDeadline do
+        interactions <- InteractionRuntime
+            <$> newTVarIO Nothing <*> newMVar () <*> newTVarIO Map.empty
+        control <- newTurnControl "fresh-approval-test" Nothing Nothing interactions
+        atomically $
+            writeTVar control.turnControlAllowedTools (Set.singleton "shell_command")
+        events <- newIORef []
+        resolutions <- newIORef []
+        decision <- newIORef "allow_once"
+        let call = ToolCall
+                { callId = "fresh-call"
+                , name = "shell_command"
+                , arguments = "{\"command\":\"pwd\",\"sandbox_permissions\":\"require_escalated\",\"justification\":\"Inspect directory\"}"
+                , callKind = FunctionCallKind
+                , argumentsEncrypted = False
+                }
+            callback _ pointer length = do
+                bytes <- BS.packCStringLen (castPtr pointer, fromIntegral length)
+                case Aeson.decodeStrict' bytes of
+                    Just event@(Aeson.Object object)
+                        | Just (Aeson.Object approval) <- KeyMap.lookup "approval" object
+                        , Just identifier <- KeyMap.lookup "id" approval -> do
+                            modifyIORef' events (<> [event])
+                            let resolution selectedDecision marker = BridgeRequest
+                                    "resolve" "approval.resolve"
+                                    (Aeson.object
+                                        ([ "approvalId" Aeson..= identifier
+                                         , "decision" Aeson..= (selectedDecision :: String)
+                                         ] <> maybe [] (\value -> ["onceOnly" Aeson..= (value :: Bool)]) marker))
+                            broad <- resolveApproval control (resolution "allow_tool" (Just True))
+                            legacy <- resolveApproval control (resolution "allow_once" Nothing)
+                            unsupported <- resolveApproval control (resolution "allow_once" (Just False))
+                            selected <- readIORef decision
+                            exact <- resolveApproval control
+                                (resolution selected (if selected == "deny" then Nothing else Just True))
+                            stale <- resolveApproval control (resolution "allow_once" (Just True))
+                            modifyIORef' resolutions (<> [broad, legacy, unsupported, exact, stale])
+                    _ -> pure ()
+        bracket (makeApprovalEventCallback callback) freeHaskellFunPtr \handler -> do
+            requestFreshApproval handler nullPtr control call
+                `shouldReturn` Just PermissionAllowOnce
+            requestFreshApproval handler nullPtr control call
+                `shouldReturn` Just PermissionAllowOnce
+            writeIORef decision "deny"
+            requestFreshApproval handler nullPtr control call
+                `shouldReturn` Just PermissionDeny
+        recorded <- readIORef events
+        length recorded `shouldBe` 3
+        let approvalField key (Aeson.Object object)
+                | Just (Aeson.Object approval) <- KeyMap.lookup "approval" object =
+                    KeyMap.lookup key approval
+            approvalField _ _ = Nothing
+        map (approvalField "onceOnly") recorded `shouldBe` replicate 3 (Just (Aeson.Bool True))
+        map (approvalField "arguments") recorded `shouldBe` replicate 3 (Just (Aeson.String call.arguments))
+        results <- readIORef resolutions
+        let resultEvent (Aeson.Object object) = KeyMap.lookup "ok" object
+            resultEvent _ = Nothing
+        map resultEvent results `shouldBe`
+            concat (replicate 3
+                [Just (Aeson.Bool False), Just (Aeson.Bool False), Just (Aeson.Bool False)
+                , Just (Aeson.Bool True), Just (Aeson.Bool False)])
+        readTVarIO control.turnControlAllowedTools
+            `shouldReturn` Set.singleton "shell_command"
+        Map.null <$> readTVarIO control.turnControlApprovals `shouldReturn` True
+#endif
     it "stages copied images and completes restart before destroy returns" do
 #ifdef darwin_HOST_OS
         imageAttachmentStageSmoke `shouldReturn` 0

--- a/packages/agent-server/agent-server.cabal
+++ b/packages/agent-server/agent-server.cabal
@@ -131,6 +131,7 @@ test-suite agent-server-test
     hs-source-dirs:   test
     main-is:          Spec.hs
     other-modules:    Agent.Server.ApplicationSpec
+                    , Agent.Server.ApprovalSpec
                     , Agent.Server.AuthSpec
                     , Agent.Server.ConfigSpec
                     , Agent.Server.EventSpec
@@ -141,6 +142,7 @@ test-suite agent-server-test
     ghc-options:      -threaded
     build-depends:    agent-server
                     , agent-core
+                    , agent-cli-runtime
                     , aeson
                     , async
                     , base >= 4.17 && < 5

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -4,6 +4,7 @@ module Agent.Server.Runtime
     , openServerRuntime
     , closeServerRuntime
     , serverRuntimeBackend
+    , requestFreshToolApproval
     ) where
 
 import Agent.CLI.GatewayBoundary
@@ -1331,7 +1332,8 @@ nativeHooks environment control sessionId cwd dialect = NativeRunHooks
         control.turnControlSetAgents
             (projectAgentEntries <$> snapshot)
     , nativeRequestApproval = requestToolApproval control
-    , nativeRequestFreshApproval = const (pure Nothing)
+    , nativeRequestFreshApproval =
+        requestFreshToolApproval control.turnControlRequestInput
     , nativeRequestRootAccess =
         case environment.environmentSandbox of
             Just _ -> const (pure False)
@@ -1407,10 +1409,26 @@ requestToolApproval
     -> ToolCall
     -> IO (Maybe PermissionChoice)
 requestToolApproval control call =
-    control.turnControlRequestInput HumanRequestSpec
+    requestToolApprovalWithScope False control.turnControlRequestInput call
+
+-- | Ask for this exact invocation, even when ordinary approvals are remembered.
+-- Never offer or accept a reusable grant on this path.
+requestFreshToolApproval
+    :: (HumanRequestSpec -> IO (Either Text HumanResponse))
+    -> ToolCall
+    -> IO (Maybe PermissionChoice)
+requestFreshToolApproval = requestToolApprovalWithScope True
+
+requestToolApprovalWithScope
+    :: Bool
+    -> (HumanRequestSpec -> IO (Either Text HumanResponse))
+    -> ToolCall
+    -> IO (Maybe PermissionChoice)
+requestToolApprovalWithScope onceOnly requestInput call =
+    requestInput HumanRequestSpec
         { humanRequestSpecKind = ToolApprovalRequest
         , humanRequestSpecPrompt =
-            "Allow mutating tool "
+            (if onceOnly then "Allow this invocation only of tool " else "Allow mutating tool ")
                 <> call.name
                 <> " (call "
                 <> call.callId
@@ -1419,16 +1437,15 @@ requestToolApproval control call =
                     then "<encrypted>"
                     else call.arguments
         , humanRequestSpecOptions =
-            [ "allow_once"
-            , "allow_tool"
-            , "deny"
-            ]
+            if onceOnly
+                then ["allow_once", "deny"]
+                else ["allow_once", "allow_tool", "deny"]
         } >>= \case
             Left _ -> pure Nothing
             Right response ->
                 pure case response.humanResponseDecision of
                     "allow_once" -> Just PermissionAllowOnce
-                    "allow_tool" -> Just PermissionAllowTool
+                    "allow_tool" | not onceOnly -> Just PermissionAllowTool
                     "deny" -> Just PermissionDeny
                     _ -> Nothing
 

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -1331,6 +1331,7 @@ nativeHooks environment control sessionId cwd dialect = NativeRunHooks
         control.turnControlSetAgents
             (projectAgentEntries <$> snapshot)
     , nativeRequestApproval = requestToolApproval control
+    , nativeRequestFreshApproval = const (pure Nothing)
     , nativeRequestRootAccess =
         case environment.environmentSandbox of
             Just _ -> const (pure False)

--- a/packages/agent-server/test/Agent/Server/ApprovalSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApprovalSpec.hs
@@ -1,0 +1,48 @@
+module Agent.Server.ApprovalSpec (spec) where
+
+import Agent.CLI.Permission.Types (PermissionChoice(..))
+import Agent.Server.Runtime (requestFreshToolApproval)
+import Agent.Server.Types
+import Agent.ToolDispatch (ToolCall(..), ToolCallKind(..))
+import Control.Monad (forM_)
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.Text qualified as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "server fresh tool approval" do
+    it "prompts for every exact invocation and offers only once or deny" do
+        requests <- newIORef []
+        let requestInput request = do
+                modifyIORef' requests (<> [request])
+                pure (Right (HumanResponse "allow_once" Nothing))
+        requestFreshToolApproval requestInput call
+            `shouldReturn` Just PermissionAllowOnce
+        requestFreshToolApproval requestInput call
+            `shouldReturn` Just PermissionAllowOnce
+        captured <- readIORef requests
+        length captured `shouldBe` 2
+        forM_ captured \request -> do
+            request.humanRequestSpecKind `shouldBe` ToolApprovalRequest
+            request.humanRequestSpecOptions `shouldBe` ["allow_once", "deny"]
+            request.humanRequestSpecPrompt `shouldSatisfy` Text.isInfixOf call.arguments
+            request.humanRequestSpecPrompt `shouldSatisfy` Text.isInfixOf call.callId
+            request.humanRequestSpecPrompt `shouldSatisfy` Text.isInfixOf call.name
+
+    it "accepts denial and fails closed for broad or missing decisions" do
+        requestFreshToolApproval (const (pure (Right (HumanResponse "deny" Nothing)))) call
+            `shouldReturn` Just PermissionDeny
+        forM_ ["allow_tool", "allow_all", "unknown"] \decision ->
+            requestFreshToolApproval (const (pure (Right (HumanResponse decision Nothing)))) call
+                `shouldReturn` Nothing
+        requestFreshToolApproval (const (pure (Left "cancelled"))) call
+            `shouldReturn` Nothing
+
+call :: ToolCall
+call = ToolCall
+    { callId = "fresh-call"
+    , name = "shell_command"
+    , arguments = "{\"command\":\"pwd\",\"sandbox_permissions\":\"require_escalated\",\"justification\":\"Inspect directory\"}"
+    , callKind = FunctionCallKind
+    , argumentsEncrypted = False
+    }

--- a/packages/agent-server/test/Spec.hs
+++ b/packages/agent-server/test/Spec.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Test.Hspec (hspec)
 import Agent.Server.ApplicationSpec qualified
+import Agent.Server.ApprovalSpec qualified
 import Agent.Server.AuthSpec qualified
 import Agent.Server.ConfigSpec qualified
 import Agent.Server.EventSpec qualified
@@ -19,6 +20,7 @@ main = do
             Agent.Server.SandboxSpec.fakeSandboxRunner arguments
         _ ->
             hspec do
+                Agent.Server.ApprovalSpec.spec
                 Agent.Server.AuthSpec.spec
                 Agent.Server.ConfigSpec.spec
                 Agent.Server.EventSpec.spec


### PR DESCRIPTION
## Problem
Native fresh-approval requests returned no decision without displaying a prompt. The runtime then incorrectly reported "Tool call rejected by user."

## Changes
- Route fresh requests through the native approval bridge with explicit once-only scope.
- Bypass remembered grants; reject blanket decisions and stale responses.
- Require onceOnly acknowledgment on grants so older auto-approving clients fail closed.
- Distinguish unavailable/closed prompts from an explicit user denial.
- Route server-hosted fresh approvals through per-invocation human requests offering only `allow_once` and `deny`.

## Validation
- ApprovalSpec: 55 examples, 0 failures via Nix/GHCi.
- Native FFI regression: passed, covering repeat prompts, exact invocation, missing/false acknowledgment, stale responses, denial, and unchanged remembered grants.
- Server fresh-approval regressions: 2 examples, 0 failures; server library compiled.

All runtime CI checks passed for `34dd9d412`.

Requires the matching native macOS UI companion: https://github.com/digitallyinduced/haskell-agent-macos/pull/229 (CI green on `f6b96a81`).
