### PR TITLE
Deliver follow-up messages to an already-open agent session

### DIFF
--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -95,6 +95,7 @@ library
                     , Agent.CLI.Session.Types
                     , Agent.CLI.Session.Activity
                     , Agent.CLI.Session.Observation
+                    , Agent.CLI.Session.Inbox
                     , Agent.CLI.Session.Request
                     , Agent.CLI.SessionLock
                     , Agent.CLI.Transcription
@@ -166,6 +167,7 @@ test-suite agent-cli-runtime-test
                     , Agent.CLI.NativeProcessSpec
                     , Agent.CLI.SessionActivitySpec
                     , Agent.CLI.SessionObservationSpec
+                    , Agent.CLI.SessionInboxSpec
                     , Agent.CLI.SessionRequestSpec
                     , Agent.CLI.TurnRecordSpec
                     , Agent.CLI.SessionThreadsSpec

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/Inbox.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/Inbox.hs
@@ -1,0 +1,302 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+-- | Same-user delivery of follow-up prompts to the process that already owns
+-- a persisted session. The wire format is private, explicitly versioned, and
+-- accepts only user-message envelopes — never execution commands.
+module Agent.CLI.Session.Inbox
+    ( SessionInbox
+    , inboxUnavailableError
+    , deliverSessionInboxMessage
+    , deliverSessionInboxMessageAt
+    , inboxSocketPath
+    , newSessionInbox
+    , releaseInboxPending
+    , takeInboxMessage
+    , withOptionalSessionInboxServer
+    , withSessionInboxServerAt
+    ) where
+
+import Agent.CLI.SessionLock (adjustSessionInboxPending)
+import Control.Concurrent.Async (mapConcurrently_, withAsync)
+import Control.Concurrent.STM
+import Control.Exception.Safe
+    ( IOException, bracket, bracketOnError, catch, finally, throwIO, try, tryAny )
+import Control.Monad (forever, unless, void, when)
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict', encode)
+import Data.Bits ((.&.))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as Builder
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import GHC.Generics (Generic)
+import Network.Socket
+import qualified Network.Socket.ByteString as Socket
+import System.Directory (createDirectoryIfMissing, getHomeDirectory, removeFile)
+import qualified System.FileLock as FileLock
+import System.FilePath (isAbsolute, (</>))
+import System.OsPath (OsPath)
+import System.Posix.Files
+    ( fileMode, fileOwner, getSymbolicLinkStatus, isDirectory, isSocket
+    , setFileMode
+    )
+import System.Posix.User (getEffectiveUserID)
+import System.Timeout (timeout)
+import System.Environment (lookupEnv)
+
+inboxUnavailableError :: Text
+inboxUnavailableError = "session inbox is unavailable"
+
+inboxMessageCountLimit :: Int
+inboxMessageCountLimit = 32
+
+inboxMessageByteLimit :: Int
+inboxMessageByteLimit = 1024 * 1024
+
+data SessionInbox = SessionInbox
+    { inboxQueue :: !(TBQueue Text)
+    , inboxSessionDir :: !(IORef (Maybe OsPath))
+    }
+
+data InboxEnvelope = InboxEnvelope
+    { version :: !Int
+    , sessionID :: !Text
+    , message :: !Text
+    } deriving (Eq, Show, Generic, ToJSON, FromJSON)
+
+data InboxReply = InboxReply
+    { version :: !Int
+    , accepted :: !Bool
+    , failure :: !(Maybe Text)
+    } deriving (Eq, Show, Generic, ToJSON, FromJSON)
+
+newSessionInbox :: IO SessionInbox
+newSessionInbox =
+    SessionInbox
+        <$> newTBQueueIO (fromIntegral inboxMessageCountLimit)
+        <*> newIORef Nothing
+
+takeInboxMessage :: SessionInbox -> STM Text
+takeInboxMessage inbox = readTBQueue inbox.inboxQueue
+
+releaseInboxPending :: SessionInbox -> IO ()
+releaseInboxPending inbox =
+    readIORef inbox.inboxSessionDir >>= mapM_ \sessionDir ->
+        void (adjustSessionInboxPending sessionDir (-1))
+
+inboxDirectory :: IO FilePath
+inboxDirectory = do
+    home <- getHomeDirectory
+    configured <- lookupEnv "HASKELL_AGENT_INBOX_DIRECTORY"
+    pure (fromMaybe (home </> ".haskell-agent" </> "inbox") configured)
+
+inboxSocketPath :: FilePath -> Text -> FilePath
+inboxSocketPath directory sessionID =
+    directory </> take 16 (show (hash (Text.encodeUtf8 sessionID) :: Digest SHA256))
+
+-- | Observation-style optional service: failure to open the endpoint must not
+-- prevent execution. Exceptions from the action or cleanup still propagate.
+withOptionalSessionInboxServer
+    :: SessionInbox -> Text -> OsPath -> IO a -> IO a
+withOptionalSessionInboxServer inbox sessionID sessionDir action = do
+    entered <- newIORef False
+    directory <- inboxDirectory
+    withSessionInboxServerAt directory inbox sessionID sessionDir (do
+        writeIORef entered True
+        action)
+        `catch` \(exception :: IOException) -> do
+            hasEntered <- readIORef entered
+            if hasEntered
+                then throwIO exception
+                else action
+
+withSessionInboxServerAt
+    :: FilePath
+    -> SessionInbox
+    -> Text
+    -> OsPath
+    -> IO a
+    -> IO a
+withSessionInboxServerAt directory inbox sessionID sessionDir action = do
+    validateSocketPath directory (inboxSocketPath directory sessionID)
+    createDirectoryIfMissing True directory
+    validateOwnedDirectory directory
+    setFileMode directory 0o700
+    writeIORef inbox.inboxSessionDir (Just sessionDir)
+    let path = inboxSocketPath directory sessionID
+    bracket (FileLock.tryLockFile (path <> ".lock") FileLock.Exclusive)
+        (mapM_ FileLock.unlockFile) \case
+            Nothing -> throwIO (userError "Session inbox is already owned.")
+            Just _ -> do
+                setFileMode (path <> ".lock") 0o600
+                removeOwnedSocket path
+                bracket (openServer path)
+                    (\server -> close server `finally` removeOwnedSocket path)
+                    \server ->
+                        withAsync
+                            (mapConcurrently_
+                                (\_ -> serveInbox server inbox sessionID sessionDir)
+                                [1 :: Int .. 4])
+                            (const action)
+
+serveInbox :: Socket -> SessionInbox -> Text -> OsPath -> IO ()
+serveInbox server inbox sessionID sessionDir = forever $
+    bracket (fst <$> accept server) close \client ->
+        void $ try @_ @IOException do
+            envelope <- receiveEnvelope client
+            reply <- handleEnvelope inbox sessionID sessionDir envelope
+            sendEnvelope client reply
+
+handleEnvelope
+    :: SessionInbox
+    -> Text
+    -> OsPath
+    -> InboxEnvelope
+    -> IO InboxReply
+handleEnvelope inbox sessionID sessionDir envelope
+    | envelope.version /= 1 =
+        pure (rejectReply "Unsupported session inbox protocol.")
+    | envelope.sessionID /= sessionID =
+        pure (rejectReply "Session inbox identifier mismatch.")
+    | Text.null (Text.strip envelope.message) =
+        pure (rejectReply "session inbox requires a non-empty message")
+    | BS.length (Text.encodeUtf8 envelope.message) > inboxMessageByteLimit =
+        pure (rejectReply "session inbox message exceeds the size limit")
+    | otherwise = do
+        queued <- enqueueInboxMessage inbox sessionDir envelope.message
+        pure $ if queued
+            then InboxReply { version = 1, accepted = True, failure = Nothing }
+            else rejectReply "session inbox is full"
+
+enqueueInboxMessage :: SessionInbox -> OsPath -> Text -> IO Bool
+enqueueInboxMessage inbox sessionDir message = do
+    _ <- adjustSessionInboxPending sessionDir 1
+    accepted <- atomically do
+        full <- isFullTBQueue inbox.inboxQueue
+        if full
+            then pure False
+            else writeTBQueue inbox.inboxQueue message >> pure True
+    unless accepted $
+        void (adjustSessionInboxPending sessionDir (-1))
+    pure accepted
+
+rejectReply :: Text -> InboxReply
+rejectReply message =
+    InboxReply { version = 1, accepted = False, failure = Just message }
+
+deliverSessionInboxMessage :: Text -> Text -> IO (Either Text ())
+deliverSessionInboxMessage sessionID message =
+    inboxDirectory >>= \directory ->
+        deliverSessionInboxMessageAt directory sessionID message
+
+deliverSessionInboxMessageAt
+    :: FilePath -> Text -> Text -> IO (Either Text ())
+deliverSessionInboxMessageAt directory sessionID message
+    | Text.null (Text.strip message) =
+        pure (Left "send_agent_session_message requires a non-empty message")
+    | BS.length (Text.encodeUtf8 message) > inboxMessageByteLimit =
+        pure (Left "session inbox message exceeds the size limit")
+    | otherwise = do
+        let path = inboxSocketPath directory sessionID
+            envelope = InboxEnvelope
+                { version = 1
+                , sessionID
+                , message
+                }
+        outcome <- tryAny $
+            timeout 1000000 $
+                bracket (socket AF_UNIX Stream defaultProtocol) close \client -> do
+                    validateSocketPath directory path
+                    validateOwnedDirectory directory
+                    directoryStatus <- getSymbolicLinkStatus directory
+                    unless (fileMode directoryStatus .&. 0o077 == 0) $
+                        throwIO (userError "Inbox directory is not private.")
+                    validatePrivateSocket path
+                    connect client (SockAddrUnix path)
+                    sendEnvelope client envelope
+                    receiveReply client
+        pure $ case outcome of
+            Left _ -> Left inboxUnavailableError
+            Right Nothing -> Left inboxUnavailableError
+            Right (Just reply)
+                | reply.version == 1 && reply.accepted -> Right ()
+                | reply.version == 1 ->
+                    Left (fromMaybe inboxUnavailableError reply.failure)
+                | otherwise -> Left inboxUnavailableError
+
+openServer :: FilePath -> IO Socket
+openServer path =
+    bracketOnError (socket AF_UNIX Stream defaultProtocol) close \server -> do
+        bind server (SockAddrUnix path)
+        setFileMode path 0o600
+        listen server 8
+        pure server
+
+validateOwnedDirectory :: FilePath -> IO ()
+validateOwnedDirectory path = do
+    status <- getSymbolicLinkStatus path
+    uid <- getEffectiveUserID
+    unless (isDirectory status && fileOwner status == uid) $
+        throwIO (userError "Inbox directory is not owned by the current user.")
+
+validateSocketPath :: FilePath -> FilePath -> IO ()
+validateSocketPath directory path = do
+    unless (isAbsolute directory && BS.length (Text.encodeUtf8 (Text.pack path)) < 104) $
+        throwIO (userError
+            "Inbox socket path must be absolute and shorter than 104 UTF-8 bytes; configure HASKELL_AGENT_INBOX_DIRECTORY.")
+
+validatePrivateSocket :: FilePath -> IO ()
+validatePrivateSocket path = do
+    status <- getSymbolicLinkStatus path
+    uid <- getEffectiveUserID
+    unless (isSocket status && fileOwner status == uid && fileMode status .&. 0o077 == 0) $
+        throwIO (userError "Inbox socket is not private to the current user.")
+
+removeOwnedSocket :: FilePath -> IO ()
+removeOwnedSocket path = do
+    result <- try @_ @IOException (validatePrivateSocket path)
+    case result of
+        Left _ -> pure ()
+        Right () -> removeFile path
+
+sendEnvelope :: ToJSON a => Socket -> a -> IO ()
+sendEnvelope client value = do
+    let bytes = LBS.toStrict (encode value)
+        prefix = LBS.toStrict
+            (Builder.toLazyByteString
+                (Builder.word32BE (fromIntegral (BS.length bytes))))
+    when (BS.length bytes > 32 * 1024 * 1024) $
+        throwIO (userError "Inbox envelope exceeds the size limit.")
+    Socket.sendAll client (prefix <> bytes)
+
+receiveEnvelope :: Socket -> IO InboxEnvelope
+receiveEnvelope client =
+    either (throwIO . userError) pure . eitherDecodeStrict'
+        =<< receiveBounded client
+
+receiveReply :: Socket -> IO InboxReply
+receiveReply client =
+    either (throwIO . userError) pure . eitherDecodeStrict'
+        =<< receiveBounded client
+
+receiveBounded :: Socket -> IO BS.ByteString
+receiveBounded client = do
+    prefix <- receiveExactly client 4
+    let count = BS.foldl' (\size byte -> size * 256 + fromIntegral byte) (0 :: Int) prefix
+    when (count <= 0 || count > 32 * 1024 * 1024) $
+        throwIO (userError "Invalid inbox frame size.")
+    receiveExactly client count
+
+receiveExactly :: Socket -> Int -> IO BS.ByteString
+receiveExactly client count = BS.concat . reverse <$> receive count []
+  where
+    receive 0 chunks = pure chunks
+    receive remaining chunks = do
+        bytes <- Socket.recv client (min remaining 65536)
+        when (BS.null bytes) (throwIO (userError "Inbox owner disconnected."))
+        receive (remaining - BS.length bytes) (bytes : chunks)

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/Threads.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/Threads.hs
@@ -11,7 +11,11 @@ module Agent.CLI.Session.Threads
 
 import Agent.CLI.Error (formatException)
 import Agent.CLI.SessionLock
-    ( sessionLockIsActive, sessionLockPath, sessionActivitySnapshot )
+    ( SessionWaitSnapshot(..)
+    , sessionLockIsActive
+    , sessionLockPath
+    , sessionWaitSnapshot
+    )
 import Agent.Runtime.SessionOwner
 import Control.Concurrent (threadDelay)
 import Control.Exception.Safe (tryAny)
@@ -78,17 +82,35 @@ prepareSessionThreadWait manager sessionId = do
     case captured of
         Just (SessionRunning, wait) -> pure (outcomeText <$> wait)
         _ -> do
-            (generation, active) <- sessionActivitySnapshot sessionDir
-            if active
-                then pure (waitExternal generation)
-                else pure $ maybe (pure "idle") (fmap outcomeText . snd) captured
+            snapshot <- sessionWaitSnapshot sessionDir
+            locked <- sessionLockIsActive (sessionLockPath sessionDir)
+            if snapshot.waitActivityActive
+                then pure (waitActivityThenInbox snapshot.waitActivityGeneration)
+                else if snapshot.waitInboxPending > 0 && locked
+                    then pure waitUntilQuiet
+                    else pure $ maybe (pure "idle") (fmap outcomeText . snd) captured
   where
     sessionDir = sessionDirectory manager sessionId
-    waitExternal generation = do
-        (current, active) <- sessionActivitySnapshot sessionDir
-        if active && (generation == current || generation == Nothing)
-            then threadDelay 100000 >> waitExternal current
+    waitActivityThenInbox generation = do
+        _ <- waitExternal generation
+        snapshot <- sessionWaitSnapshot sessionDir
+        locked <- sessionLockIsActive (sessionLockPath sessionDir)
+        if snapshot.waitInboxPending > 0 && locked
+            then waitUntilQuiet
             else pure "idle"
+    waitExternal generation = do
+        snapshot <- sessionWaitSnapshot sessionDir
+        if snapshot.waitActivityActive
+            && (generation == snapshot.waitActivityGeneration || generation == Nothing)
+            then threadDelay 100000 >> waitExternal snapshot.waitActivityGeneration
+            else pure ("idle" :: Text)
+    waitUntilQuiet = do
+        snapshot <- sessionWaitSnapshot sessionDir
+        locked <- sessionLockIsActive (sessionLockPath sessionDir)
+        if snapshot.waitActivityActive
+                || (snapshot.waitInboxPending > 0 && locked)
+            then threadDelay 100000 >> waitUntilQuiet
+            else pure ("idle" :: Text)
 
 sessionDirectory :: SessionThreadManager -> Text -> OsPath
 sessionDirectory manager sessionId =

--- a/packages/agent-cli-runtime/src/Agent/CLI/SessionLock.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/SessionLock.hs
@@ -4,15 +4,19 @@
 -- the advisory lock when the owning process exits, including after a crash.
 module Agent.CLI.SessionLock
     ( SessionLock
+    , SessionWaitSnapshot(..)
     , acquireSessionLock
     , acquireSessionActivityLock
+    , adjustSessionInboxPending
     , releaseSessionLock
     , sessionActivityLockPath
     , sessionActivityGeneration
     , sessionActivitySnapshot
+    , sessionInboxPending
     , sessionLockFilePath
     , sessionLockIsActive
     , sessionLockPath
+    , sessionWaitSnapshot
     ) where
 
 import Agent.CLI.Error (formatException)
@@ -32,6 +36,14 @@ import Text.Read (readMaybe)
 data SessionLock = SessionLock
     { lockFilePath :: !FilePath
     , sessionLockHandle :: !FileLock.FileLock
+    }
+
+-- | Cross-process view of work that waiters must drain: the current turn, if
+-- any, plus accepted inbox messages that have not yet started as a turn.
+data SessionWaitSnapshot = SessionWaitSnapshot
+    { waitActivityGeneration :: !(Maybe Integer)
+    , waitActivityActive :: !Bool
+    , waitInboxPending :: !Integer
     }
 
 sessionLockFilePath :: SessionLock -> FilePath
@@ -78,11 +90,53 @@ acquireSessionActivityLock sessionDir sessionId = do
 -- needs no gate: it cannot change the generation, and any following acquisition
 -- must wait until this snapshot has completed.
 sessionActivitySnapshot :: OsPath -> IO (Maybe Integer, Bool)
-sessionActivitySnapshot sessionDir =
+sessionActivitySnapshot sessionDir = do
+    snapshot <- sessionWaitSnapshot sessionDir
+    pure (snapshot.waitActivityGeneration, snapshot.waitActivityActive)
+
+sessionWaitSnapshot :: OsPath -> IO SessionWaitSnapshot
+sessionWaitSnapshot sessionDir =
     withPrivateFileLock (activityAdmissionPath sessionDir) $ do
         generation <- sessionActivityGeneration sessionDir
         active <- sessionLockIsActive (sessionActivityLockPath sessionDir)
-        pure (generation, active)
+        pending <- readSessionInboxPending sessionDir
+        pure SessionWaitSnapshot
+            { waitActivityGeneration = generation
+            , waitActivityActive = active
+            , waitInboxPending = pending
+            }
+
+-- | Accepted owner-inbox messages that have not yet started as a turn.
+sessionInboxPending :: OsPath -> IO Integer
+sessionInboxPending sessionDir =
+    withPrivateFileLock (activityAdmissionPath sessionDir) $
+        readSessionInboxPending sessionDir
+
+adjustSessionInboxPending :: OsPath -> Integer -> IO Integer
+adjustSessionInboxPending sessionDir delta =
+    withPrivateFileLock (activityAdmissionPath sessionDir) $ do
+        current <- readSessionInboxPending sessionDir
+        let next = max 0 (current + delta)
+        writeLazyFileAtomically
+            (sessionInboxPendingPath sessionDir)
+            0o600
+            (LBS.pack (show next))
+        pure next
+
+readSessionInboxPending :: OsPath -> IO Integer
+readSessionInboxPending sessionDir =
+    (do
+        bytes <- BS.readFile
+            (unsafeToFilePath (sessionInboxPendingPath sessionDir))
+        case readMaybe (BS.unpack bytes) of
+            Just value | value >= 0 -> pure value
+            _ -> ioError (userError "invalid session inbox pending count"))
+        `catchIOError` \err ->
+            if isDoesNotExistError err then pure 0 else ioError err
+
+sessionInboxPendingPath :: OsPath -> OsPath
+sessionInboxPendingPath sessionDir =
+    sessionDir </> unsafeEncodeUtf ".agent-inbox-pending"
 
 -- A monotonically increasing generation distinguishes rapid consecutive turns
 -- even if a cross-process waiter never observes the unlocked interval. The

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionInboxSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionInboxSpec.hs
@@ -1,0 +1,119 @@
+module Agent.CLI.SessionInboxSpec (spec) where
+
+import Agent.CLI.Session.Inbox
+import Agent.CLI.SessionLock
+    ( acquireSessionLock
+    , adjustSessionInboxPending
+    , releaseSessionLock
+    , sessionInboxPending
+    )
+import Control.Concurrent.STM (atomically)
+import Control.Exception.Safe (bracket, finally)
+import Control.Monad (void)
+import Data.Bits ((.&.))
+import Data.IORef (newIORef, readIORef, writeIORef)
+import System.Directory
+    ( createDirectory, getTemporaryDirectory, removeDirectoryRecursive, removeFile )
+import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.FilePath ((</>))
+import System.IO (hClose, openTempFile)
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Files (createSymbolicLink, fileMode, getFileStatus)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "CLI session inbox" do
+    it "delivers a message to the owning process" $
+        withDirectory \directory -> do
+            inbox <- newSessionInbox
+            let sessionDir = unsafeEncodeUtf directory
+            withSessionInboxServerAt directory inbox "session" sessionDir do
+                deliverSessionInboxMessageAt directory "session" "please continue"
+                    `shouldReturn` Right ()
+                atomically (takeInboxMessage inbox)
+                    `shouldReturn` "please continue"
+                sessionInboxPending sessionDir `shouldReturn` 1
+                releaseInboxPending inbox
+                sessionInboxPending sessionDir `shouldReturn` 0
+
+    it "rejects an empty message before touching the owner queue" $
+        withDirectory \directory -> do
+            inbox <- newSessionInbox
+            let sessionDir = unsafeEncodeUtf directory
+            withSessionInboxServerAt directory inbox "session" sessionDir do
+                deliverSessionInboxMessageAt directory "session" "   "
+                    `shouldReturn` Left
+                        "send_agent_session_message requires a non-empty message"
+                timeout 20000 (atomically (takeInboxMessage inbox))
+                    `shouldReturn` Nothing
+
+    it "uses private socket permissions and refuses a competing owner" $
+        withDirectory \directory -> do
+            inbox <- newSessionInbox
+            let sessionDir = unsafeEncodeUtf directory
+            withSessionInboxServerAt directory inbox "session" sessionDir do
+                status <- getFileStatus (inboxSocketPath directory "session")
+                fileMode status .&. 0o777 `shouldBe` 0o600
+                other <- newSessionInbox
+                withSessionInboxServerAt directory other "session" sessionDir
+                    (pure ())
+                    `shouldThrow` anyIOException
+
+    it "rejects symbolic-link directories rather than changing their permissions" $
+        withDirectory \directory -> do
+            let destination = directory </> "destination"
+                symbolic = directory </> "symbolic"
+            createDirectory destination
+            createSymbolicLink destination symbolic
+            inbox <- newSessionInbox
+            withSessionInboxServerAt
+                symbolic inbox "session" (unsafeEncodeUtf destination) (pure ())
+                `shouldThrow` anyIOException
+
+    it "reports unavailable when no owner is listening" $
+        withDirectory \directory ->
+            deliverSessionInboxMessageAt directory "missing" "hello"
+                `shouldReturn` Left inboxUnavailableError
+
+    it "falls back without an inbox when the endpoint cannot be opened" $
+        withDirectory \directory -> do
+            inbox <- newSessionInbox
+            entered <- newIORef False
+            withInboxDirectory (directory </> replicate 150 'x') $
+                withOptionalSessionInboxServer
+                    inbox "session" (unsafeEncodeUtf directory) do
+                        writeIORef entered True
+            readIORef entered `shouldReturn` True
+
+    it "keeps pending count aligned with accepted and released messages" $
+        withDirectory \directory -> do
+            let sessionDir = unsafeEncodeUtf directory
+            Right lock <- acquireSessionLock sessionDir "session"
+            flip finally (releaseSessionLock lock) do
+                adjustSessionInboxPending sessionDir 2
+                    `shouldReturn` 2
+                sessionInboxPending sessionDir `shouldReturn` 2
+                adjustSessionInboxPending sessionDir (-1)
+                    `shouldReturn` 1
+                void (adjustSessionInboxPending sessionDir (-5))
+                sessionInboxPending sessionDir `shouldReturn` 0
+
+withDirectory :: (FilePath -> IO a) -> IO a
+withDirectory action = do
+    temporary <- getTemporaryDirectory
+    bracket (do
+        (path, handle) <- openTempFile temporary "i"
+        hClose handle
+        removeFile path
+        createDirectory path
+        pure path) removeDirectoryRecursive action
+
+withInboxDirectory :: FilePath -> IO a -> IO a
+withInboxDirectory directory action =
+    bracket
+        (lookupEnv variable <* setEnv variable directory)
+        (maybe (unsetEnv variable) (setEnv variable))
+        (const action)
+  where
+    variable = "HASKELL_AGENT_INBOX_DIRECTORY"

--- a/packages/agent-cli-runtime/test/Agent/CLI/SessionThreadsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/SessionThreadsSpec.hs
@@ -1,6 +1,11 @@
 module Agent.CLI.SessionThreadsSpec (spec) where
 
 import Agent.CLI.Session.Threads
+import Agent.CLI.SessionLock
+    ( acquireSessionLock
+    , adjustSessionInboxPending
+    , releaseSessionLock
+    )
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar
     ( newEmptyMVar, putMVar, takeMVar, tryTakeMVar )
@@ -10,7 +15,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified System.Directory as Directory
 import qualified System.FilePath as FilePath
-import System.OsPath (unsafeEncodeUtf)
+import System.OsPath (unsafeEncodeUtf, (</>))
 import System.Posix.Temp (mkdtemp)
 import System.Timeout (timeout)
 import Test.Hspec
@@ -78,6 +83,27 @@ spec = describe "shared session thread manager" do
             launchSessionThread manager "session" (pure (Right ()))
                 `shouldReturn` Right "started session session"
             waitForStatus manager "session" "completed"
+
+    it "waits for accepted inbox messages on an otherwise idle open session" $ do
+        tmp <- Directory.getTemporaryDirectory
+        bracket
+            (mkdtemp (tmp FilePath.</> "ha-inbox-wait"))
+            Directory.removeDirectoryRecursive
+            \root -> do
+                Directory.createDirectory (root FilePath.</> "session")
+                bracket
+                    (newSessionThreadManager (unsafeEncodeUtf root))
+                    closeSessionThreadManager
+                    \manager -> do
+                        let sessionDir =
+                                unsafeEncodeUtf root </> unsafeEncodeUtf "session"
+                        Right lock <- acquireSessionLock sessionDir "session"
+                        flip finally (releaseSessionLock lock) do
+                            _ <- adjustSessionInboxPending sessionDir 1
+                            wait <- prepareSessionThreadWait manager "session"
+                            timeout 50000 wait `shouldReturn` Nothing
+                            _ <- adjustSessionInboxPending sessionDir (-1)
+                            timeout 500000 wait `shouldReturn` Just "idle"
 
 -- Bound only interruptible handshakes, never wrap masked resource release in
 -- nested timeouts. The manager's bracket owns cancellation and joining.

--- a/packages/agent-cli-runtime/test/Spec.hs
+++ b/packages/agent-cli-runtime/test/Spec.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import qualified Agent.CLI.SessionActivitySpec as SessionActivitySpec
 import qualified Agent.CLI.SessionObservationSpec as SessionObservationSpec
+import qualified Agent.CLI.SessionInboxSpec as SessionInboxSpec
 import qualified Agent.CLI.SessionRequestSpec as SessionRequestSpec
 import qualified Agent.CLI.TurnRecordSpec as TurnRecordSpec
 import qualified Agent.CLI.SessionThreadsSpec as SessionThreadsSpec
@@ -33,6 +34,7 @@ main :: IO ()
 main = hspec do
     SessionActivitySpec.spec
     SessionObservationSpec.spec
+    SessionInboxSpec.spec
     SessionRequestSpec.spec
     TurnRecordSpec.spec
     SessionThreadsSpec.spec

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -59,6 +59,10 @@ import Agent.CLI.Session
     , sessionTempDirForId
     , sessionTitleFromPrompt
     )
+import Agent.CLI.SessionLock
+    ( sessionLockIsActive
+    , sessionLockPath
+    )
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.CLI.Models
     ( ModelOption(..)
@@ -105,6 +109,9 @@ data AgentSessionToolsEnv = AgentSessionToolsEnv
     , toolsSessionStatus :: !(Text -> IO Text)
     -- | Capture the current run now, then wait without following later runs.
     , toolsPrepareSessionWait :: !(Text -> IO (IO Text))
+    -- | Deliver to the process that already owns the session. 'Nothing'
+    -- means no owner inbox is listening; 'Just' is that owner's reply.
+    , toolsDeliverToOwner :: !(Text -> Text -> IO (Maybe (Either Text ())))
     }
 
 formatSessionCompletionNotice :: Text -> Text -> Text
@@ -133,7 +140,7 @@ data WaitAgentSessionArgs = WaitAgentSessionArgs
 waitAgentSessionTool :: AgentSessionToolsEnv -> AppTool
 waitAgentSessionTool env = jsonTool
     "wait_agent_session"
-    "Wait for another persisted session's current turn, not the lifetime of its conversation. Returns status and latest saved output, or timed_out. Already idle sessions return immediately. Locally managed turns report completed, failed, or cancelled; external turns report idle when their activity ends (the exit reason is unknown). Recent output may include a later resume. Use this instead of polling read_agent_session. Cancelling or timing out this wait does not cancel the target."
+    "Wait for another persisted session's current turn, not the lifetime of its conversation. Returns status and latest saved output, or timed_out. Already idle sessions return immediately unless they have accepted inbox messages that have not started yet. Locally managed turns report completed, failed, or cancelled; external turns report idle when their activity ends (the exit reason is unknown). Recent output may include a later resume. Use this instead of polling read_agent_session. Cancelling or timing out this wait does not cancel the target."
     [ PropertySchema "session_id" PropertyString True $ Just
         "Persisted target session id. Self-waits and circular waits are rejected."
     , PropertySchema "timeout_ms" PropertyInteger False $ Just
@@ -408,7 +415,7 @@ sendAgentSessionMessageArgsDecoder = Hermes.object $
 sendAgentSessionMessageTool :: AgentSessionToolsEnv -> AppTool
 sendAgentSessionMessageTool env = jsonTool
     "send_agent_session_message"
-    "Send a message to a persisted agent session by starting a resumed background turn. Use for explicitly requested independent/background work or continuation of that separate session, not to transfer responsibility for the current task. Returns the session id and status as readable text, not a completed result; fails if that session is already running. The interactive parent session is notified when this turn finishes."
+    "Send a message to a persisted agent session. If that session is already open, deliver the message to its owner: an idle session starts a new turn, and a session in the middle of a turn queues the message for after the current turn or receives it at a message boundary. If nobody owns the session, start a resumed background turn. Use for explicitly requested independent/background work or continuation of that separate session, not to transfer responsibility for the current task. Returns the session id and status as readable text, not a completed result. The interactive parent session is notified when a launched turn finishes."
     [ PropertySchema "session_id" PropertyString True $ Just
         "Persisted target session id."
     , PropertySchema "message" PropertyString True $ Just
@@ -436,11 +443,26 @@ runSendAgentSessionMessage env args
                 Right meta ->
                     case validateToolSessionBoundary env meta of
                         Left err -> pure (Left err)
-                        Right () ->
-                            launchToolSessionTurn
-                                env
-                                (sessionHandle env.toolsPool env.toolsRoot meta)
-                                args.message
+                        Right () -> do
+                            let handle =
+                                    sessionHandle
+                                        env.toolsPool env.toolsRoot meta
+                            env.toolsDeliverToOwner
+                                args.sessionId args.message >>= \case
+                                Just (Right ()) -> do
+                                    status <- env.toolsSessionStatus args.sessionId
+                                    pure $ Right $ renderSessionLaunch
+                                        args.sessionId
+                                        (if status == "idle" then "queued" else status)
+                                Just (Left err) -> pure (Left err)
+                                Nothing -> do
+                                    locked <- sessionLockIsActive
+                                        (sessionLockPath handle.sessionDir)
+                                    if locked
+                                        then pure $ Left $
+                                            "session " <> args.sessionId
+                                                <> " is already running"
+                                        else launchToolSessionTurn env handle args.message
 
 validateToolSessionBoundary
     :: AgentSessionToolsEnv

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -20,7 +20,8 @@ import Agent.CLI.AgentSessions
                            toolsTransportModel, toolsDialect, toolsAllowedModels,
                            toolsResolveModelOption,
                            toolsGatewayIdentity, toolsCwd, toolsEffort,
-                           toolsCurrentSessionId, toolsLaunchTurn, toolsPrepareSessionWait) )
+                           toolsCurrentSessionId, toolsLaunchTurn, toolsPrepareSessionWait,
+                           toolsDeliverToOwner) )
 import Agent.CLI.Auth (isGatewayLoadedAuth)
 import qualified Agent.CLI.ComputerUse as ComputerUse
 import Agent.CLI.Config (HarnessConfig(..))
@@ -88,6 +89,10 @@ import Agent.CLI.Session.Runtime.Types
     , StartupRuntime(startupDatabaseStore, startupNativeHooks, startupStdinTty) )
 import Agent.CLI.Session.Selection
     ( currentSessionId, reservedSessionId )
+import Agent.CLI.Session.Inbox
+    ( deliverSessionInboxMessage
+    , inboxUnavailableError
+    )
 import Agent.CLI.SessionLock
     ( acquireSessionLock,
       releaseSessionLock,
@@ -593,6 +598,11 @@ newSessionControlRuntime AgentToolsRequest
                 sessionThreadStatus processRuntime.processSessionThreads
             , toolsPrepareSessionWait =
                 prepareSessionThreadWait processRuntime.processSessionThreads
+            , toolsDeliverToOwner = \sessionId message ->
+                deliverSessionInboxMessage sessionId message >>= \case
+                    Left err | err == inboxUnavailableError ->
+                        pure Nothing
+                    other -> pure (Just other)
             }
         -- Persisted agent-session tools recursively start another native
         -- runtime, so they require an explicit collaboration capability from

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -30,7 +30,7 @@ import Agent.CLI.GatewayClient
     , gatewayModelIds
     )
 import Agent.CLI.Input
-    ( ReplLine
+    ( ReplLine(ReplText)
     , readReplLineWithCatalogForProvider
     , readReplLineWithCatalogForTarget
     )
@@ -63,7 +63,7 @@ import Agent.CLI.Session.Interaction
     , syncFullscreenContext
     )
 import Agent.CLI.Session.Lifecycle ( SessionContinuation(..) )
-import Agent.CLI.SessionEnv ( SessionEnv(..) )
+import Agent.CLI.SessionEnv ( SessionEnv(..), SessionInboxRuntime(..) )
 import Agent.Runtime.SessionState qualified as RuntimeState
 import Agent.CLI.Skills ( skillInvocationCommand )
 import Agent.CLI.Status ( formatReplStatusLine )
@@ -110,11 +110,12 @@ import Agent.TUI.Model
 import Agent.Tools.PlanMode
     ( PlanModeEnv(planStateRef),
       PlanModeState(PlanPending, PlanActive) )
-import Control.Concurrent.Async ( withAsync )
+import Agent.CLI.Session.Inbox (releaseInboxPending)
+import Control.Concurrent.Async ( race, withAsync )
 import Control.Concurrent.MVar ( withMVar )
-import Control.Concurrent.STM (orElse, retry)
+import Control.Concurrent.STM (atomically, orElse, retry, takeTMVar, tryTakeTMVar)
 import Control.Monad ( when, forM_ )
-import Data.IORef ( readIORef, writeIORef )
+import Data.IORef ( atomicModifyIORef', readIORef, writeIORef )
 import Data.Maybe ( fromMaybe, isJust )
 import Data.Text ( Text )
 import System.Console.ANSI ( getTerminalSize )
@@ -233,6 +234,7 @@ replWithDraft env@SessionEnv
                 gatewayAccess
                 (currentModel params)
         Nothing -> Right <$> withMVar render.renderLock \_ -> do
+            let inbox = env.sessionInboxRuntime.inboxInline
             -- The inline editor redraws its ANSI frame with several writes.
             -- Keep the renderer out for the complete prompt lifetime so a
             -- late tool event cannot be spliced into the composer row.
@@ -283,24 +285,35 @@ replWithDraft env@SessionEnv
                         <> if stdoutColor
                             then Text.pack clearFromCursorToLineEndCode
                             else mempty
-            result <- case gatewayAccess of
-                Just gateway ->
-                    readReplLineWithCatalogForTarget
-                        (dictationTargetForSession
-                            env.sessionProvider
-                            (Just gateway))
-                        slashCatalog
-                        interrupt chromePrompt draft
-                Nothing ->
-                    readReplLineWithCatalogForProvider
-                        provider
-                        slashCatalog
-                        interrupt chromePrompt draft
-            when terminal.terminalSemanticPrompts $
-                emitTerminalSequence terminal stdout osc133PromptEnd
-            Text.putStr (endBackground stdoutColor)
-            hFlush stdout
-            pure result
+            let finishChrome = do
+                    when terminal.terminalSemanticPrompts $
+                        emitTerminalSequence terminal stdout osc133PromptEnd
+                    Text.putStr (endBackground stdoutColor)
+                    hFlush stdout
+                readLine = case gatewayAccess of
+                    Just gateway ->
+                        readReplLineWithCatalogForTarget
+                            (dictationTargetForSession
+                                env.sessionProvider
+                                (Just gateway))
+                            slashCatalog
+                            interrupt chromePrompt draft
+                    Nothing ->
+                        readReplLineWithCatalogForProvider
+                            provider
+                            slashCatalog
+                            interrupt chromePrompt draft
+            queued <- atomically (tryTakeTMVar inbox)
+            case queued of
+                Just text -> do
+                    finishChrome
+                    pure (ReplText text, True)
+                Nothing -> do
+                    outcome <- race (atomically (takeTMVar inbox)) readLine
+                    finishChrome
+                    pure $ case outcome of
+                        Left text -> (ReplText text, True)
+                        Right line -> (line, False)
     case mlineResult of
         Left BackgroundCompletionWake -> do
             pending <-
@@ -326,22 +339,35 @@ replWithDraft env@SessionEnv
                 Nothing -> do
                     reportProviderUnavailable fullscreen apiError
                     replWithDraft env ""
-        Right mline -> do
+        Right (mline, fromInbox) -> do
             -- Any user action wins the startup race. In particular, a prompt
             -- already submitted while the preflight was running proceeds on
             -- the selected provider and leaves request-time fallback in charge.
             writeIORef startupUnavailableRef Nothing
-            handleReplLine
-                env
-                (replWithDraft env)
-                (finishTurn env)
-                (SessionLifecycle.retryFailedTurn sessionContinuation env)
-                slashCatalog
-                skillInvocations
-                stdoutColor
-                planState
-                policy
-                mline
+            submitReplLine env fromInbox $
+                handleReplLine
+                    env
+                    (replWithDraft env)
+                    (finishTurn env)
+                    (SessionLifecycle.retryFailedTurn sessionContinuation env)
+                    slashCatalog
+                    skillInvocations
+                    stdoutColor
+                    planState
+                    policy
+                    mline
+
+submitReplLine :: SessionEnv -> Bool -> IO RunResult -> IO RunResult
+submitReplLine env fromInbox action = do
+    when fromInbox $
+        writeIORef env.sessionInboxRuntime.inboxTurn True
+    result <- action
+    leftover <- atomicModifyIORef'
+        env.sessionInboxRuntime.inboxTurn
+        (\active -> (False, active))
+    when leftover $
+        releaseInboxPending env.sessionInboxRuntime.inboxMessages
+    pure result
 
 readFullscreenPrompt
     :: SessionEnv
@@ -351,7 +377,7 @@ readFullscreenPrompt
     -> Text
     -> Maybe GatewayModelAccess
     -> Text
-    -> IO (Either ReplWake ReplLine)
+    -> IO (Either ReplWake (ReplLine, Bool))
 readFullscreenPrompt
     env
     runtime

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -79,6 +79,12 @@ import Agent.CLI.Session
 import Agent.CLI.Session.History
 import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import qualified Agent.CLI.Session.Observation as Observation
+import Agent.CLI.Session.Inbox
+    ( newSessionInbox
+    , releaseInboxPending
+    , takeInboxMessage
+    , withOptionalSessionInboxServer
+    )
 import Agent.CLI.SessionEnv
 import Agent.Runtime.SessionState qualified as RuntimeState
 import Agent.CLI.SessionLock
@@ -102,7 +108,9 @@ import Agent.CLI.Error
 import Agent.CLI.Dialects
 import Agent.CLI.Dictation (dictationTargetForSession)
 import Agent.CLI.TUI.App
-import Agent.CLI.TUI.Types (FullscreenRuntime(..))
+import Agent.CLI.TUI.Composer (appendFullscreenInput)
+import Agent.CLI.TUI.Types (FullscreenInput(..), FullscreenRuntime(..))
+import Agent.CLI.Input (ReplLine(ReplText))
 import Agent.TUI.Model
 import Agent.TUI.Motion
 import Agent.CLI.WindowTitle
@@ -122,17 +130,20 @@ import Agent.Tools.MultiAgents
 import Agent.Tools.PlanMode
 import Agent.Tools.Types
 import Agent.OsPath
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (Async, withAsync)
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
-import Control.Concurrent.MVar (MVar, modifyMVar_, newMVar, withMVar)
-import Control.Concurrent.STM (STM)
+import Control.Concurrent.MVar
+    ( MVar, modifyMVar_, newEmptyMVar, newMVar, takeMVar, tryPutMVar, withMVar )
+import Control.Concurrent.STM
+    ( STM, atomically, newEmptyTMVarIO, putTMVar )
 import Control.Exception.Safe
     ( catchAny
     , mask_
     , onException
     , uninterruptibleMask_
     )
-import Control.Monad (forM_, unless, void, when)
+import Control.Monad (forM_, forever, unless, void, when)
 import Data.IORef
 import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
@@ -184,6 +195,7 @@ data SessionHostRuntime = SessionHostRuntime
     , hostApprovalLock :: !(MVar ())
     , hostObservationPublisher
         :: !(IORef (Maybe Observation.SessionObservationPublisher))
+    , hostInboxRuntime :: !SessionInboxRuntime
     , hostNativeCapabilities :: !NativeRunCapabilities
     , hostLoadsWorkspaceContext :: !Bool
     , hostPreparedWorkspaceEnvironment
@@ -209,6 +221,12 @@ newSessionHostRuntime SessionRequest{..} = do
     approvalLock <- newMVar ()
     observationPublisher <- newIORef Nothing
     observationInputWaitCount <- newMVar (0 :: Int)
+    inboxRuntime <- SessionInboxRuntime
+        <$> newSessionInbox
+        <*> newEmptyMVar
+        <*> newIORef False
+        <*> newIORef False
+        <*> newEmptyTMVarIO
     let fullscreen = startup.startupFullscreen
         nativeCapabilities =
             maybe
@@ -344,6 +362,7 @@ newSessionHostRuntime SessionRequest{..} = do
         , hostIoLock = ioLock
         , hostApprovalLock = approvalLock
         , hostObservationPublisher = observationPublisher
+        , hostInboxRuntime = inboxRuntime
         , hostNativeCapabilities = nativeCapabilities
         , hostLoadsWorkspaceContext = loadsHostWorkspaceContext
         , hostPreparedWorkspaceEnvironment = preparedWorkspaceEnvironment
@@ -1411,10 +1430,12 @@ newSessionPersistenceRuntime
                 either (const Nothing) Just <$>
                     acquireSessionActivityLock
                         handle.sessionDir handle.sessionMeta.metaId
-        endTurnActivity =
+        endTurnActivity = do
             Activity.endTurnActivity turnActivity releaseSessionLock
+            writeIORef host.hostInboxRuntime.inboxTurnActive False
         beginTurnActivity = mask_ $
             (do
+                writeIORef host.hostInboxRuntime.inboxTurnActive True
                 Activity.beginTurnActivity turnActivity
                 case persist of
                     PersistenceDisabled -> pure ()
@@ -1422,7 +1443,12 @@ newSessionPersistenceRuntime
                         readIORef slotRef >>= \case
                             PersistencePending{} -> pure ()
                             PersistenceActive handle ->
-                                void (acquireTurnActivity handle))
+                                void (acquireTurnActivity handle)
+                fromInbox <- atomicModifyIORef'
+                    host.hostInboxRuntime.inboxTurn
+                    (\active -> (False, active))
+                when fromInbox $
+                    releaseInboxPending host.hostInboxRuntime.inboxMessages)
                 `onException` endTurnActivity
         notifyNativeSessionId sessionId = do
             shouldNotify <-
@@ -1443,6 +1469,7 @@ newSessionPersistenceRuntime
             -- Preserve the established lock order: own the session before
             -- attempting its best-effort activity marker.
             onPersisted handle
+            void (tryPutMVar host.hostInboxRuntime.inboxReady handle)
             acquired <- acquireTurnActivity handle
             notifyNativeSessionId handle.sessionMeta.metaId
                 `onException`
@@ -1565,6 +1592,7 @@ buildSessionEnv
         , sessionPersist = persist
         , sessionObservationPublisher = host.hostObservationPublisher
         , sessionObservationEnabled = isNothing startup.startupNativeHooks
+        , sessionInboxRuntime = host.hostInboxRuntime
         , sessionDatabasePool =
             trustedPool startup.startupDatabaseStore
         , sessionTitleManager = titleManager
@@ -1883,17 +1911,67 @@ runSessionWorkers
                 MCP.mcpFleetWaitForSkillRegistrations fleet previous
             env.sessionRefreshSkills True
             waitForChange fleet current
-    result <- withAsync host.hostWindowTitle.windowTitleWorker \_ ->
-        withMcpSkillWatcher $
-            case host.hostFullscreen of
-                Just _ ->
-                    withAsync btwWorker \_ ->
+    result <- withAsync (runSessionInboxOwner env) \_ ->
+        withAsync host.hostWindowTitle.windowTitleWorker \_ ->
+            withMcpSkillWatcher $
+                case host.hostFullscreen of
+                    Just _ ->
+                        withAsync btwWorker \_ ->
+                            withAsync recapWorker (const sessionAction)
+                    Nothing ->
                         withAsync recapWorker (const sessionAction)
-                Nothing ->
-                    withAsync recapWorker (const sessionAction)
     _ <- waitForSessionTitleResults 5000000 titleManager
     applyPendingSessionTitles env
     pure result
+
+runSessionInboxOwner :: SessionEnv -> IO ()
+runSessionInboxOwner env =
+    case env.sessionPersist of
+        PersistenceDisabled -> forever (threadDelay 100000000)
+        PersistenceEnabled slotRef -> do
+            readIORef slotRef >>= \case
+                PersistenceActive handle ->
+                    void (tryPutMVar env.sessionInboxRuntime.inboxReady handle)
+                PersistencePending{} -> pure ()
+            handle <- takeMVar env.sessionInboxRuntime.inboxReady
+            withOptionalSessionInboxServer
+                env.sessionInboxRuntime.inboxMessages
+                handle.sessionMeta.metaId
+                handle.sessionDir
+                (forwardInboxMessages env)
+
+forwardInboxMessages :: SessionEnv -> IO ()
+forwardInboxMessages env = forever do
+    message <- atomically (takeInboxMessage env.sessionInboxRuntime.inboxMessages)
+    injected <- injectInboxMessage env message
+    unless injected $
+        releaseInboxPending env.sessionInboxRuntime.inboxMessages
+
+injectInboxMessage :: SessionEnv -> Text.Text -> IO Bool
+injectInboxMessage env message = do
+    active <- readIORef env.sessionInboxRuntime.inboxTurnActive
+    case env.sessionFullscreen of
+        Just runtime -> do
+            result <- atomically $
+                appendFullscreenInput runtime.runtimeInput FullscreenInput
+                    { fullscreenInputLine = ReplText message
+                    , fullscreenInputQueued = True
+                    , fullscreenInputDisplay = Just message
+                    , fullscreenInputFromInbox = True
+                    }
+            pure $ either (const False) (const True) result
+        Nothing
+            | active ->
+                enqueueSteeringInputs
+                    env.sessionSteeringInputs
+                    [UserMessage message] >>= \case
+                    Left _ -> pure False
+                    Right () -> do
+                        releaseInboxPending env.sessionInboxRuntime.inboxMessages
+                        pure True
+            | otherwise -> do
+                atomically (putTMVar env.sessionInboxRuntime.inboxInline message)
+                pure True
 
 runSession
     :: SessionRunnerContinuation

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -1,6 +1,7 @@
 -- | Mutable session state shared by the REPL, one-shot turns, and plan mode.
 module Agent.CLI.SessionEnv
     ( PreparedWorkspaceEnvironment(..)
+    , SessionInboxRuntime(..)
     , SessionEnv(..)
     ) where
 
@@ -23,6 +24,7 @@ import Agent.CLI.Compaction
 import Agent.CLI.Options (ApprovalPolicy)
 import Agent.CLI.Render (RenderConfig)
 import Agent.CLI.Session (Persistence, SessionHandle)
+import Agent.CLI.Session.Inbox (SessionInbox)
 import Agent.CLI.Session.Observation (SessionObservationPublisher)
 import Agent.Runtime.SessionState (SessionState)
 import Agent.CLI.Session.Workspace (WorkspaceContext)
@@ -48,11 +50,21 @@ import Agent.Store.Postgres.Connection (StorePool)
 import Data.IORef (IORef)
 import Data.Set (Set)
 import Data.Text (Text)
-import Control.Concurrent.STM (STM)
+import Control.Concurrent.MVar (MVar)
+import Control.Concurrent.STM (STM, TMVar)
 
 data PreparedWorkspaceEnvironment = PreparedWorkspaceEnvironment
     { preparedOperatingSystem :: !Text
     , preparedShell :: !Text
+    }
+
+-- | Cross-process follow-up delivery for the process that owns this session.
+data SessionInboxRuntime = SessionInboxRuntime
+    { inboxMessages :: !SessionInbox
+    , inboxReady :: !(MVar SessionHandle)
+    , inboxTurn :: !(IORef Bool)
+    , inboxTurnActive :: !(IORef Bool)
+    , inboxInline :: !(TMVar Text)
     }
 
 data SessionEnv = SessionEnv
@@ -82,6 +94,7 @@ data SessionEnv = SessionEnv
     -- presentation callback. Nested follow-ups reuse the same service.
     , sessionObservationPublisher :: !(IORef (Maybe SessionObservationPublisher))
     , sessionObservationEnabled :: !Bool
+    , sessionInboxRuntime :: !SessionInboxRuntime
     , sessionDatabasePool :: !StorePool
     , sessionTitleManager :: !SessionTitleManager
     , sessionTitleTurnCount :: !(IORef Int)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -1450,6 +1450,7 @@ handleCommandPaletteSelection = \case
                     , fullscreenInputQueued = queued
                     , fullscreenInputDisplay =
                         if queued then Just command else Nothing
+                    , fullscreenInputFromInbox = False
                     }
         case result of
             Left message ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -1133,6 +1133,7 @@ submitMetaConsole = do
                             { fullscreenInputLine = ReplMeta request
                             , fullscreenInputQueued = queued
                             , fullscreenInputDisplay = Nothing
+                            , fullscreenInputFromInbox = False
                             }
                 case result of
                     Left message ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -749,7 +749,7 @@ readFullscreenLine runtime skills prompt initial = do
         runtime skills [] prompt initial retry
     case result of
         Left impossible -> pure impossible
-        Right line -> pure line
+        Right (line, _) -> pure line
 
 readFullscreenLineWithCatalog
     :: FullscreenRuntime
@@ -762,7 +762,7 @@ readFullscreenLineWithCatalog runtime catalog prompt initial = do
         runtime catalog prompt initial retry
     case result of
         Left impossible -> pure impossible
-        Right line -> pure line
+        Right (line, _) -> pure line
 
 readFullscreenLineWithModels
     :: FullscreenRuntime
@@ -776,7 +776,7 @@ readFullscreenLineWithModels runtime skills modelIds prompt initial = do
         runtime skills modelIds prompt initial retry
     case result of
         Left impossible -> pure impossible
-        Right line -> pure line
+        Right (line, _) -> pure line
 
 -- | Wait for either user input or a session-level wakeup. The input branch is
 -- deliberately left-biased: once Enter has queued a prompt, provider startup
@@ -788,7 +788,7 @@ readFullscreenLineOr
     -> PromptState
     -> Text
     -> STM wake
-    -> IO (Either wake ReplLine)
+    -> IO (Either wake (ReplLine, Bool))
 readFullscreenLineOr runtime skills prompt initial wake = do
     readFullscreenLineOrWithModels runtime skills [] prompt initial wake
 
@@ -799,7 +799,7 @@ readFullscreenLineOrWithModels
     -> PromptState
     -> Text
     -> STM wake
-    -> IO (Either wake ReplLine)
+    -> IO (Either wake (ReplLine, Bool))
 readFullscreenLineOrWithModels
         runtime skills modelIds prompt initial wake = do
     readFullscreenLineOrWithCatalog
@@ -817,7 +817,7 @@ readFullscreenLineOrWithCatalog
     -> PromptState
     -> Text
     -> STM wake
-    -> IO (Either wake ReplLine)
+    -> IO (Either wake (ReplLine, Bool))
 readFullscreenLineOrWithCatalog
         runtime catalog prompt initial wake = do
     enqueueAppEvent runtime (AppSetSlashCatalog catalog)
@@ -838,7 +838,7 @@ readFullscreenLineOrWithCatalog
                     case input.fullscreenInputDisplay of
                         Just _ -> UiQueuedInputStarted
                         Nothing -> UiSetAwaitingInput False
-            pure (Right input.fullscreenInputLine)
+            pure (Right (input.fullscreenInputLine, input.fullscreenInputFromInbox))
 
 -- | Fullscreen Vty configuration, including legacy terminal overrides.
 -- 'Agent.CLI.TUI.Keyboard' decodes CSI-u before this compatibility table,

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -196,6 +196,7 @@ handlePromptControlClick applyUiEvent choice = do
                     { fullscreenInputLine = choice ui.uiDraft
                     , fullscreenInputQueued = False
                     , fullscreenInputDisplay = Nothing
+                    , fullscreenInputFromInbox = False
                     }
             case queued of
                 Left message ->
@@ -239,6 +240,7 @@ handleImageRemoveClick applyUiEvent index = do
                             { fullscreenInputLine = ReplRemoveCapturedImage image
                             , fullscreenInputQueued = True
                             , fullscreenInputDisplay = Nothing
+                            , fullscreenInputFromInbox = False
                             }
                     case queued of
                         Left message ->
@@ -684,6 +686,7 @@ queueComposerImages applyUiEvent images = do
                         { fullscreenInputLine = ReplClipboardPasteCaptured added
                         , fullscreenInputQueued = True
                         , fullscreenInputDisplay = Nothing
+                        , fullscreenInputFromInbox = False
                         }
                 case queued of
                     Left message -> pure (Left message)
@@ -844,6 +847,7 @@ sendNow applyUiEvent = do
                                     else ReplText draft
                             , fullscreenInputQueued = True
                             , fullscreenInputDisplay = Just draft
+                            , fullscreenInputFromInbox = False
                             }
                 case promoted of
                     Left message ->
@@ -903,6 +907,7 @@ enqueueInput applyUiEvent state replLine display clearDraft = do
             { fullscreenInputLine = replLine
             , fullscreenInputQueued = queued
             , fullscreenInputDisplay = display
+            , fullscreenInputFromInbox = False
             }
     case result of
         Left message -> do

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Buffer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Buffer.hs
@@ -152,6 +152,7 @@ takeFullscreenInput (FullscreenInputBuffer inputs retainedBytes closed) = do
             { fullscreenInputLine = ReplEof
             , fullscreenInputQueued = False
             , fullscreenInputDisplay = Nothing
+            , fullscreenInputFromInbox = False
             }
         else case Seq.viewl queued of
             EmptyL -> retry

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -251,6 +251,7 @@ data FullscreenInput = FullscreenInput
     { fullscreenInputLine :: !ReplLine
     , fullscreenInputQueued :: !Bool
     , fullscreenInputDisplay :: !(Maybe Text)
+    , fullscreenInputFromInbox :: !Bool
     }
 
 -- | Runtime ownership of the syntax grammar cache. Keeping the active bit and

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -406,6 +406,34 @@ spec = describe "Agent.CLI.AgentSessions" do
             selfResult `shouldSatisfy`
                 Text.isInfixOf "cannot message the current agent session"
 
+    it "delivers to an open session owner instead of starting a competing turn" $
+        withTempEnv \env launched -> do
+            handle <- createSession (testCreate env.toolsPool env.toolsRoot)
+            let target = handle.sessionMeta.metaId
+                ownerEnv = env
+                    { toolsDeliverToOwner = \_ _ -> pure (Just (Right ()))
+                    , toolsSessionStatus = const (pure "running")
+                    }
+            result <- runTool ownerEnv "send_agent_session_message" $
+                "{\"session_id\":\"" <> target <> "\",\"message\":\"continue\"}"
+            result `shouldSatisfy` Text.isInfixOf "Status: running"
+            launchedNow <- readIORef launched
+            length launchedNow `shouldBe` 0
+
+    it "does not start a competing turn when the target session is already open" $
+        withTempEnv \env launched -> do
+            handle <- createSession (testCreate env.toolsPool env.toolsRoot)
+            Right lock <- acquireSessionLock
+                handle.sessionDir handle.sessionMeta.metaId
+            flip finally (releaseSessionLock lock) do
+                result <- runTool env "send_agent_session_message" $
+                    "{\"session_id\":\""
+                        <> handle.sessionMeta.metaId
+                        <> "\",\"message\":\"continue\"}"
+                result `shouldSatisfy` Text.isInfixOf "already running"
+                launchedNow <- readIORef launched
+                length launchedNow `shouldBe` 0
+
     it "keeps persisted gateway sessions portable across direct and gateway modes" $
         withTempEnv \env launched -> do
             let gatewayCreate =
@@ -1018,6 +1046,7 @@ withTempEnv action =
                 , toolsLaunchTurn = launch
                 , toolsSessionStatus = const (pure "running")
                 , toolsPrepareSessionWait = const (pure (pure "idle"))
+                , toolsDeliverToOwner = \_ _ -> pure Nothing
                 }
         action env launched
 

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -304,7 +304,7 @@ spec = do
                 revision <- readIORef runtime.runtimeImagePreviewRevision
                 replicateM_ (Composer.fullscreenInputCountLimit - 1) do
                     atomically (Composer.appendFullscreenInput runtime.runtimeInput
-                        (FullscreenInput ReplEof True Nothing))
+                        (FullscreenInput ReplEof True Nothing False))
                         `shouldReturn` Right ()
                 (_, rejected) <- runFullscreenScriptWithState pasted
                     [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack secondPath)))
@@ -425,7 +425,7 @@ spec = do
                 revision <- readIORef runtime.runtimeImagePreviewRevision
                 replicateM_ (Composer.fullscreenInputCountLimit - 1) do
                     atomically (Composer.appendFullscreenInput runtime.runtimeInput
-                        (FullscreenInput ReplEof True Nothing))
+                        (FullscreenInput ReplEof True Nothing False))
                         `shouldReturn` Right ()
                 (_, rejected) <- runFullscreenScriptWithState pasted
                     [ FullscreenScriptMouseDown (ComposerImageRemove 0) V.BLeft (B.Location (0, 0))
@@ -693,6 +693,7 @@ spec = do
                     { fullscreenInputLine = ReplText "queued prompt"
                     , fullscreenInputQueued = True
                     , fullscreenInputDisplay = Just "queued prompt"
+                    , fullscreenInputFromInbox = False
                     }
             atomically (Composer.appendFullscreenInput runtime.runtimeInput input)
                 `shouldReturn` Right ()
@@ -1544,6 +1545,7 @@ spec = do
                             { fullscreenInputLine = ReplEof
                             , fullscreenInputQueued = True
                             , fullscreenInputDisplay = Nothing
+                            , fullscreenInputFromInbox = False
                             }
                     case result of
                         Left message -> error (Text.unpack message)

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -607,11 +607,13 @@ spec = describe "fullscreen composer" do
                 { fullscreenInputLine = ReplText "active"
                 , fullscreenInputQueued = False
                 , fullscreenInputDisplay = Just "active"
+                , fullscreenInputFromInbox = False
                 }
             appendFullscreenInput buffer FullscreenInput
                 { fullscreenInputLine = ReplText "queued"
                 , fullscreenInputQueued = True
                 , fullscreenInputDisplay = Just "queued"
+                , fullscreenInputFromInbox = False
                 }
         queuedFullscreenInputDisplays buffer
             `shouldReturn` Seq.singleton "queued"
@@ -634,6 +636,7 @@ spec = describe "fullscreen composer" do
                     ReplText (Text.pack (show index))
                 , fullscreenInputQueued = True
                 , fullscreenInputDisplay = Nothing
+                , fullscreenInputFromInbox = False
                 }
         accepted <- atomically $
             mapM (appendFullscreenInput buffer . prompt)
@@ -689,6 +692,7 @@ spec = describe "fullscreen composer" do
         { fullscreenInputLine = replLine
         , fullscreenInputQueued = True
         , fullscreenInputDisplay = Nothing
+        , fullscreenInputFromInbox = False
         }
 
 wrapDraftProperty :: DraftCase -> Property


### PR DESCRIPTION
## Summary

`send_agent_session_message` could not coordinate with a session that was already open. It started a competing `--resume`, reported `Status: running`, then failed to take the exclusive session lock. `wait_agent_session` then waited on that phantom failed turn instead of the live session.

Open sessions now listen on a same-user inbox socket (same privacy model as session observation). `send_agent_session_message`:

1. Delivers to the owning process when an inbox is listening.
2. Otherwise starts a resumed background turn only if the session is not locked.
3. Fails clearly, without launching a competing worker, if the session is locked and has no inbox.

The owner queues a new user turn in the TUI, or steers a live one-shot/native turn. `wait_agent_session` waits for accepted inbox messages as well as the current activity lock.

## Test plan

- [x] `agent-cli-runtime` inbox protocol tests (delivery, empty reject, private socket, competing owner, unavailable, optional fallback, pending count)
- [x] `wait_agent_session` waits while inbox pending is nonzero on an idle open session
- [x] `send_agent_session_message` uses owner delivery instead of launching; refuses a competing launch when the lock is held
- [x] Fullscreen input construction tests still pass
- [ ] CI on this PR