### PR TITLE
Compact Claude against the provider-reported context window

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
               .#checks.x86_64-linux.package-boundaries
             # Repository integration tests deliberately exercise Git and gh
             # process timeouts; after their extraction they run in one suite.
-            timeout_minutes: 60
+            timeout_minutes: 90
           - name: Native CLI
             targets: .#checks.x86_64-linux.agent-cli-executable
           - name: Static CLI runtime

--- a/packages/agent-cli-runtime/config/models.default.json
+++ b/packages/agent-cli-runtime/config/models.default.json
@@ -155,8 +155,8 @@
       "id": "claude-fable-5-1",
       "connection": "claude-code",
       "dialect": "claude-code",
-      "context_window": 1048576,
-      "label": "5.1 · frontier · subscription · 1M context",
+      "context_window": 200000,
+      "label": "5.1 · frontier · subscription",
       "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"],
       "default_reasoning_effort": "high"
     }

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelConfigSpec.hs
@@ -46,6 +46,8 @@ spec = describe "Agent.CLI.ModelConfig" do
             `shouldBe` replicate 3 (Just 1_048_576)
         catalogContextWindowFor catalog "openrouter" "stealth/ox-alpha"
             `shouldBe` Just 1_048_576
+        catalogContextWindowFor catalog "claude-code" "claude-fable-5-1"
+            `shouldBe` Just 200_000
         fmap (.catalogModelId)
             (catalogModelsForConnection "openai" catalog)
             `shouldBe`

--- a/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/ModelsSpec.hs
@@ -111,7 +111,7 @@ spec = do
             fmap (.modelTarget.targetWireModelId) fable
                 `shouldBe` Just "claude-fable-5-1"
             fmap (.modelContextWindow) fable
-                `shouldBe` Just (Just 1048576)
+                `shouldBe` Just (Just 200000)
             fmap (.catalogModelDefaultReasoningEffort)
                 (catalogModelById catalog "claude-fable-5-1")
                 `shouldBe` Just (Just "high")

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -15,6 +15,7 @@ module Agent.CLI.Compaction
     , autoCompactOpenAiBackendWith
     , autoCompactOpenAiBackendWithApi
     , autoCompactBackendWith
+    , rememberReportedContextWindow
     , boundCompletedToolContinuations
     , compactOpenAIWith
     , installCompactOutcome
@@ -118,6 +119,9 @@ import Agent.Provider
     ( Provider(..)
     , TokenProvider
     , runWithTokenProvider
+    )
+import Agent.Telemetry
+    ( reportedContextWindow
     )
 import qualified Agent.OpenRouter.Client as OpenRouter
 import qualified Agent.OpenRouter.Options as OpenRouter
@@ -1431,6 +1435,25 @@ autoCompactOpenAiBackendWithApi compactAction =
         (const (pure ()))
         estimateProjectedFromCache
         (\_outcome _inputs -> pure CompactionNotInstalled)
+
+-- | Keep the latest positive context window from provider turn telemetry so
+-- later submissions can compact against the enforced limit, not the catalog.
+rememberReportedContextWindow
+    :: IORef (Maybe Int)
+    -> BackendMiddleware
+rememberReportedContextWindow reportedRef backend =
+    backendWithCallbacks \snapshot previous inputs callbacks -> do
+        result <-
+            backend.submitTurnWithCallbacks snapshot previous inputs callbacks
+        case result of
+            Right backendResult
+                | Just window <-
+                    backendResult.backendOutput.providerTelemetry
+                        >>= reportedContextWindow ->
+                    writeIORef reportedRef (Just window)
+            _ ->
+                pure ()
+        pure result
 
 -- | Provider-neutral automatic compaction. The caller supplies both the
 -- threshold and the isolated summarization action; successful checkpoints

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Claude.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Providers/Claude.hs
@@ -10,6 +10,7 @@ import Agent.CLI.Compaction
     , claudeAutoCompactTokenLimit
     , claudeCompactionInputLimit
     , installLiveCompactOutcome
+    , rememberReportedContextWindow
     , runClaudeBackendCompactHistoryWithLimits
     , runClaudeBackendCompactWithLimits
     )
@@ -40,7 +41,8 @@ import Agent.Loop
     , backendWithCallbacks
     )
 import Agent.OsPath (unsafeToFilePath)
-import Data.IORef (newIORef, writeIORef)
+import Agent.Telemetry (preferReportedContextWindow)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
 
 withClaudeProvider
@@ -51,6 +53,7 @@ withClaudeProvider
 withClaudeProvider ClaudeConfig{..}
         ProviderHost{compaction = ProviderCompaction{..}} use =
     withAuth \claudeAuth -> do
+        reportedWindowRef <- newIORef Nothing
         let permission =
                 ClaudeCodeManual
             claudeOptions =
@@ -63,11 +66,13 @@ withClaudeProvider ClaudeConfig{..}
                     }
             claudeContextWindow = do
                 currentParams <- readSessionRequestParams paramsRef
+                reported <- readIORef reportedWindowRef
                 pure $
-                    contextWindowForParams
-                        transportModel
-                        200_000
-                        currentParams
+                    preferReportedContextWindow reported $
+                        contextWindowForParams
+                            transportModel
+                            200_000
+                            currentParams
             claudeCompactThreshold = do
                 contextWindow <- claudeContextWindow
                 let hardLimit =
@@ -151,7 +156,9 @@ withClaudeProvider ClaudeConfig{..}
                             installAutomaticCompact
                             (readSessionRequestParams paramsRef)
                             contextTokensRef
-                            handle.loopBackend
+                            (rememberReportedContextWindow
+                                reportedWindowRef
+                                handle.loopBackend)
                 use ProviderRuntime
                     { sessionBackend = SessionBackend
                         { backend = compactingBackend

--- a/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CompactionSpec.hs
@@ -7,6 +7,7 @@ import Agent.CLI.Compaction
     ( CompactOutcome(..)
     , CompactionInstall(..)
     , autoCompactBackendWith
+    , rememberReportedContextWindow
     , autoCompactOpenAiBackendWith
     , autoCompactOpenAiBackendWithApi
     , autoCompactOpenAiBackendWithSender
@@ -34,6 +35,11 @@ import Agent.CLI.Compaction
 import Agent.Connectivity (withConnectionRecoveryUsing)
 import Agent.Error (ApiError(..), ErrorType(..))
 import Agent.Loop
+import Agent.Telemetry
+    ( ModelTelemetry(..)
+    , TurnTelemetry(..)
+    , preferReportedContextWindow
+    )
 import Agent.OpenAI.Compaction
     ( assistantSummaryItem
     , compactionTriggerItem
@@ -75,6 +81,7 @@ import Control.Exception
     , try
     )
 import Data.IORef
+import qualified Data.Map.Strict as Map
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Text as Text
@@ -815,6 +822,15 @@ spec = do
         it "matches Claude Code headroom for a 200k context window" do
             claudeAutoCompactTokenLimit 200_000 `shouldBe` 144_000
             claudeCompactionInputLimit 200_000 `shouldBe` 167_000
+
+        it "compacts against Claude's reported window instead of a 1M catalog" do
+            preferReportedContextWindow (Just 200_000) 1_048_576
+                `shouldBe` 200_000
+            claudeAutoCompactTokenLimit
+                (preferReportedContextWindow (Just 200_000) 1_048_576)
+                `shouldBe` 144_000
+            claudeAutoCompactTokenLimit 1_048_576
+                `shouldBe` 822_860
 
         it "uses an isolated fresh backend and records summary usage" do
             let history = [userTextItem "old context"]
@@ -2005,6 +2021,49 @@ spec = do
                         ("expected one bounded tool result, got "
                             <> show submitted)
             readIORef events `shouldReturn` [ModelContextReset]
+
+        it "records a provider-reported context window from turn telemetry" do
+            reported <- newIORef Nothing
+            let telemetry = TurnTelemetry
+                    { telemetryDurationMs = Nothing
+                    , telemetryApiDurationMs = Nothing
+                    , telemetryCostUsd = Nothing
+                    , telemetryStopReason = Nothing
+                    , telemetryProviderTurns = Nothing
+                    , telemetryModels =
+                        Map.singleton "claude-fable-5-1" ModelTelemetry
+                            { modelInputTokens = 12_329
+                            , modelOutputTokens = 96_202
+                            , modelCacheReadInputTokens = 14_482_321
+                            , modelCacheCreationInputTokens = 263_166
+                            , modelWebSearchRequests = Just 0
+                            , modelCostUsd = Just 11.35
+                            , modelContextWindow = Just 200_000
+                            , modelMaxOutputTokens = Just 32_000
+                            , modelCanonicalName = Just "claude-fable-5-1"
+                            , modelProviderName = Just "firstParty"
+                            }
+                    , telemetryStructuredOutput = Nothing
+                    }
+                base = Backend \state _ _ _ ->
+                    pure $ successful state TurnOutput
+                        { responseId = "claude-session"
+                        , toolCalls = []
+                        , assistantText = Just "ok"
+                        , tokenUsage = TokenUsage 12_329 96_202 14_482_321
+                        , contextUsage = Just (TokenUsage 180_000 500 0)
+                        , providerTelemetry = Just telemetry
+                        , completion = TurnCompleted
+                        }
+                backend = rememberReportedContextWindow reported base
+            result <-
+                backend.submitTurn
+                    (initialBackendSnapshot [userTextItem "old"])
+                    (Just "claude-session")
+                    [UserMessage "continue"]
+                    (const (pure ()))
+            result `shouldSatisfy` either (const False) (const True)
+            readIORef reported `shouldReturn` Just 200_000
 
         it "records provider-reported occupancy after a successful turn" do
             let history = [userTextItem "old"]

--- a/packages/agent-core/src/Agent/Telemetry.hs
+++ b/packages/agent-core/src/Agent/Telemetry.hs
@@ -8,6 +8,8 @@ module Agent.Telemetry
     , modelTelemetryDecoder
     , turnTelemetryDecoder
     , turnTelemetryListDecoder
+    , reportedContextWindow
+    , preferReportedContextWindow
     , telemetrySummary
     ) where
 
@@ -108,6 +110,27 @@ turnTelemetryDecoder = Json.object $
 
 turnTelemetryListDecoder :: Json.Decoder [TurnTelemetry]
 turnTelemetryListDecoder = Json.list turnTelemetryDecoder
+
+-- | Tightest positive context window reported for models used in this turn.
+-- Catalog metadata is not consulted; Claude Code may enforce 200k while a
+-- catalog entry still names a larger window.
+reportedContextWindow :: TurnTelemetry -> Maybe Int
+reportedContextWindow telemetry =
+    case
+        [ window
+        | model <- Map.elems telemetry.telemetryModels
+        , Just window <- [model.modelContextWindow]
+        , window > 0
+        ] of
+        [] -> Nothing
+        windows -> Just (minimum windows)
+
+-- | Prefer a positive provider-reported window over catalog metadata.
+preferReportedContextWindow :: Maybe Int -> Int -> Int
+preferReportedContextWindow reported fallback =
+    case reported of
+        Just window | window > 0 -> window
+        _ -> fallback
 
 nonNegativeInt :: Json.Decoder Int
 nonNegativeInt = do

--- a/packages/agent-core/test/Agent/TelemetrySpec.hs
+++ b/packages/agent-core/test/Agent/TelemetrySpec.hs
@@ -46,6 +46,25 @@ spec = describe "provider turn telemetry" do
             `shouldBe`
                 "$0.0123 · 2.5s · 3 provider turns · stop end_turn · context 140/200000"
 
+    it "prefers the tightest positive provider-reported context window" do
+        reportedContextWindow sampleTelemetry `shouldBe` Just 200000
+        reportedContextWindow sampleTelemetry
+            { telemetryModels = Map.empty
+            }
+            `shouldBe` Nothing
+        reportedContextWindow sampleTelemetry
+            { telemetryModels =
+                Map.fromList
+                    [ ("claude-fable-5-1", (sampleModel 1048576)
+                        { modelContextWindow = Just 200000 })
+                    , ("helper", sampleModel 1048576)
+                    ]
+            }
+            `shouldBe` Just 200000
+        preferReportedContextWindow (Just 200000) 1048576 `shouldBe` 200000
+        preferReportedContextWindow Nothing 1048576 `shouldBe` 1048576
+        preferReportedContextWindow (Just 0) 200000 `shouldBe` 200000
+
     it "rejects negative counters and non-finite costs" do
         Json.decodeText turnTelemetryDecoder
             "{\"duration_ms\":-1,\"models\":{}}"
@@ -54,6 +73,20 @@ spec = describe "provider turn telemetry" do
             "{\"cost_usd\":1e999,\"models\":{}}"
             `shouldSatisfy` isLeft
 
+sampleModel :: Int -> ModelTelemetry
+sampleModel window = ModelTelemetry
+    { modelInputTokens = 100
+    , modelOutputTokens = 20
+    , modelCacheReadInputTokens = 30
+    , modelCacheCreationInputTokens = 10
+    , modelWebSearchRequests = Just 1
+    , modelCostUsd = Just 0.0123
+    , modelContextWindow = Just window
+    , modelMaxOutputTokens = Just 32000
+    , modelCanonicalName = Just "claude-test-202608"
+    , modelProviderName = Just "firstParty"
+    }
+
 sampleTelemetry :: TurnTelemetry
 sampleTelemetry = TurnTelemetry
     { telemetryDurationMs = Just 2500
@@ -61,18 +94,7 @@ sampleTelemetry = TurnTelemetry
     , telemetryCostUsd = Just 0.0123
     , telemetryStopReason = Just "end_turn"
     , telemetryProviderTurns = Just 3
-    , telemetryModels = Map.singleton "claude-test" ModelTelemetry
-        { modelInputTokens = 100
-        , modelOutputTokens = 20
-        , modelCacheReadInputTokens = 30
-        , modelCacheCreationInputTokens = 10
-        , modelWebSearchRequests = Just 1
-        , modelCostUsd = Just 0.0123
-        , modelContextWindow = Just 200000
-        , modelMaxOutputTokens = Just 32000
-        , modelCanonicalName = Just "claude-test-202608"
-        , modelProviderName = Just "firstParty"
-        }
+    , telemetryModels = Map.singleton "claude-test" (sampleModel 200000)
     , telemetryStructuredOutput =
         Just (rawJsonFromEncoding (Aeson.toEncoding
             (Aeson.object ["answer" Aeson..= (42 :: Int)])))


### PR DESCRIPTION
## Summary

A long Claude Fable 5.1 session through the organization gateway overflowed on the next user turn (`ContextWindowExceeded` after partial output). Claude Code telemetry reported `context_window: 200000`, but the catalog advertised 1M, so auto-compact used an ~823k threshold and never ran.

Claude auto-compact, summary size, and the TUI context display now prefer the latest positive `models.*.context_window` from turn telemetry. The catalog is only the fallback until the first report. Fable's shipped catalog window is 200k to match that reported limit.

## Test plan

- [x] `agent-core` telemetry tests: tightest positive reported window, prefer reported over catalog
- [x] `agent-cli` compaction tests: 200k report yields the 144k Claude auto-compact threshold; middleware records the window from turn telemetry
- [x] `agent-cli-runtime` catalog tests: Fable 5.1 is 200k
- [ ] CI on this PR