### PR TITLE
Create agent-server sessions before Git repository checkout

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -4,6 +4,12 @@
 HTTP API. It manages durable PostgreSQL sessions, bounded process-local turn
 state, human approval requests, and a replayable Server-Sent Events stream.
 
+A create-session request that includes a GitHub repository returns as soon as
+the session record exists. Clone, credential configuration, and working-branch
+creation then run as session setup and are published on the event stream as
+`session.setup.started`, `session.setup.step`, `session.setup.completed`, and
+`session.setup.failed`. The first turn waits until that checkout finishes.
+
 ## Start it
 
 From the repository:

--- a/packages/agent-server/agent-server.cabal
+++ b/packages/agent-server/agent-server.cabal
@@ -54,6 +54,7 @@ library
                     , Agent.Server.PrivateFile
                     , Agent.Server.Runtime
                     , Agent.Server.RepositoryCheckout
+                    , Agent.Server.SessionSetup
                     , Agent.Server.Runtime.TurnStore
                     , Agent.Server.Sandbox
                     , Agent.Server.Sandbox.Worker
@@ -136,6 +137,7 @@ test-suite agent-server-test
                     , Agent.Server.ConfigSpec
                     , Agent.Server.EventSpec
                     , Agent.Server.RepositoryCheckoutSpec
+                    , Agent.Server.SessionSetupSpec
                     , Agent.Server.SandboxSpec
                     , Agent.Server.SupervisorSpec
                     , Agent.Server.TenantSpec

--- a/packages/agent-server/src/Agent/Server.hs
+++ b/packages/agent-server/src/Agent/Server.hs
@@ -14,9 +14,11 @@ import Agent.Server.Backend
 import Agent.Server.Config
 import Agent.Server.Runtime
     ( closeServerRuntime
+    , installSessionEventSink
     , openServerRuntime
     , serverRuntimeBackend
     )
+import Agent.Server.SessionSetup (SessionEventSink (..))
 import Agent.Server.Supervisor
 import Agent.Server.Tenant hiding (resolveTenantWorkspacePath)
 import Agent.Server.Types
@@ -82,6 +84,18 @@ runServer = do
                                     runTurn)
                                 closeSupervisor
                                 \supervisor -> do
+                                    installSessionEventSink ownedRuntime $
+                                        SessionEventSink
+                                            { emitSessionEvent =
+                                                \boundary sessionId eventType payload ->
+                                                    publishEvent
+                                                        supervisor
+                                                        boundary
+                                                        eventType
+                                                        Nothing
+                                                        (Just sessionId)
+                                                        payload
+                                            }
                                     application <-
                                         newApplication
                                             ApplicationConfig

--- a/packages/agent-server/src/Agent/Server/RepositoryCheckout.hs
+++ b/packages/agent-server/src/Agent/Server/RepositoryCheckout.hs
@@ -1,5 +1,11 @@
 module Agent.Server.RepositoryCheckout
     ( RepositoryCheckout(..)
+    , PreparedRepositoryLayout(..)
+    , RepositoryCheckoutOperation(..)
+    , CheckoutOperationStatus(..)
+    , prepareRepositoryLayout
+    , repositoryCheckoutOperations
+    , completeRepositoryCheckout
     , prepareRepositoryCheckout
     , cleanupRepositoryCheckout
     , validateDescriptor
@@ -8,6 +14,7 @@ module Agent.Server.RepositoryCheckout
     ) where
 
 import Control.Exception.Safe (tryAny)
+import Control.Monad (forM_)
 import Data.Char (isAlphaNum, isAscii, isControl, isSpace)
 import Data.List (isPrefixOf)
 import Data.Text (Text)
@@ -40,12 +47,36 @@ data RepositoryCheckout = RepositoryCheckout
     , cleanupCheckout :: !(IO ())
     }
 
-prepareRepositoryCheckout
+-- | Credential files and the empty checkout directory, before any Git
+-- network operations. Session creation uses this so the working directory
+-- exists while clone and branch creation run in the background.
+data PreparedRepositoryLayout = PreparedRepositoryLayout
+    { layoutWorkspaceRoot :: !FilePath
+    , layoutRoot :: !FilePath
+    , layoutCheckoutPath :: !FilePath
+    , layoutHelperPath :: !FilePath
+    , layoutBranch :: !Text
+    , layoutCleanup :: !(IO ())
+    }
+
+data RepositoryCheckoutOperation = RepositoryCheckoutOperation
+    { checkoutOperationId :: !Text
+    , checkoutOperationCommand :: !Text
+    , checkoutOperationArguments :: ![String]
+    }
+
+data CheckoutOperationStatus
+    = CheckoutOperationRunning
+    | CheckoutOperationCompleted
+    | CheckoutOperationFailed
+    deriving (Eq, Show)
+
+prepareRepositoryLayout
     :: FilePath
     -> Text
     -> RepositoryDescriptor
-    -> IO (Either Text RepositoryCheckout)
-prepareRepositoryCheckout workspaceRoot correlation descriptor =
+    -> IO (Either Text PreparedRepositoryLayout)
+prepareRepositoryLayout workspaceRoot correlation descriptor =
     case validateDescriptor descriptor of
         Left err -> pure (Left err)
         Right () -> do
@@ -69,17 +100,6 @@ prepareRepositoryCheckout workspaceRoot correlation descriptor =
                 makeExecutable helper
                 writeFile ghWrapper ghWrapperScript
                 makeExecutable ghWrapper
-                runGit workspaceRoot
-                    [ "-c", "credential.helper=" <> helper
-                    , "-c", "credential.useHttpPath=true"
-                    , "clone", "--single-branch"
-                    , "--branch", Text.unpack descriptor.repositoryDefaultBranch
-                    , Text.unpack descriptor.repositoryCloneUrl
-                    , checkout
-                    ]
-                runGit workspaceRoot ["-C", checkout, "config", "credential.helper", helper]
-                runGit workspaceRoot ["-C", checkout, "config", "credential.useHttpPath", "true"]
-                runGit workspaceRoot ["-C", checkout, "switch", "-c", Text.unpack branch]
                 writeFile
                     (root </> "README")
                     ("GitHub CLI wrapper: " <> ghWrapper <> "\n")
@@ -88,7 +108,99 @@ prepareRepositoryCheckout workspaceRoot correlation descriptor =
                     _ <- tryAny cleanup
                     pure (Left "could not prepare repository checkout")
                 Right () ->
-                    pure (Right RepositoryCheckout{checkoutPath = checkout, checkoutBranch = branch, cleanupCheckout = cleanup})
+                    pure $
+                        Right
+                            PreparedRepositoryLayout
+                                { layoutWorkspaceRoot = workspaceRoot
+                                , layoutRoot = root
+                                , layoutCheckoutPath = checkout
+                                , layoutHelperPath = helper
+                                , layoutBranch = branch
+                                , layoutCleanup = cleanup
+                                }
+
+repositoryCheckoutOperations
+    :: PreparedRepositoryLayout
+    -> RepositoryDescriptor
+    -> [RepositoryCheckoutOperation]
+repositoryCheckoutOperations layout descriptor =
+    [ RepositoryCheckoutOperation
+        { checkoutOperationId = "clone"
+        , checkoutOperationCommand =
+            "git clone --single-branch --branch "
+                <> descriptor.repositoryDefaultBranch
+                <> " "
+                <> descriptor.repositoryCloneUrl
+        , checkoutOperationArguments =
+            [ "-c", "credential.helper=" <> layout.layoutHelperPath
+            , "-c", "credential.useHttpPath=true"
+            , "clone", "--single-branch"
+            , "--branch", Text.unpack descriptor.repositoryDefaultBranch
+            , Text.unpack descriptor.repositoryCloneUrl
+            , layout.layoutCheckoutPath
+            ]
+        }
+    , RepositoryCheckoutOperation
+        { checkoutOperationId = "credential-helper"
+        , checkoutOperationCommand =
+            "git config credential.helper git-credential-github-app"
+        , checkoutOperationArguments =
+            ["-C", layout.layoutCheckoutPath, "config", "credential.helper", layout.layoutHelperPath]
+        }
+    , RepositoryCheckoutOperation
+        { checkoutOperationId = "http-path"
+        , checkoutOperationCommand = "git config credential.useHttpPath true"
+        , checkoutOperationArguments =
+            ["-C", layout.layoutCheckoutPath, "config", "credential.useHttpPath", "true"]
+        }
+    , RepositoryCheckoutOperation
+        { checkoutOperationId = "switch-branch"
+        , checkoutOperationCommand = "git switch -c " <> layout.layoutBranch
+        , checkoutOperationArguments =
+            ["-C", layout.layoutCheckoutPath, "switch", "-c", Text.unpack layout.layoutBranch]
+        }
+    ]
+
+completeRepositoryCheckout
+    :: PreparedRepositoryLayout
+    -> RepositoryDescriptor
+    -> (RepositoryCheckoutOperation -> CheckoutOperationStatus -> IO ())
+    -> IO (Either Text RepositoryCheckout)
+completeRepositoryCheckout layout descriptor onStep = do
+    let operations = repositoryCheckoutOperations layout descriptor
+    outcome <- tryAny $
+        forM_ operations \operation -> do
+            onStep operation CheckoutOperationRunning
+            runGit layout.layoutWorkspaceRoot operation.checkoutOperationArguments
+            onStep operation CheckoutOperationCompleted
+    case outcome of
+        Left _ -> pure (Left "could not prepare repository checkout")
+        Right () ->
+            pure $
+                Right
+                    RepositoryCheckout
+                        { checkoutPath = layout.layoutCheckoutPath
+                        , checkoutBranch = layout.layoutBranch
+                        , cleanupCheckout = layout.layoutCleanup
+                        }
+
+-- | Create the layout and run every Git operation before returning. Callers
+-- that must not block on the network should use 'prepareRepositoryLayout'
+-- and 'completeRepositoryCheckout' separately.
+prepareRepositoryCheckout
+    :: FilePath
+    -> Text
+    -> RepositoryDescriptor
+    -> IO (Either Text RepositoryCheckout)
+prepareRepositoryCheckout workspaceRoot correlation descriptor =
+    prepareRepositoryLayout workspaceRoot correlation descriptor >>= \case
+        Left err -> pure (Left err)
+        Right layout ->
+            completeRepositoryCheckout layout descriptor (\_ _ -> pure ()) >>= \case
+                Left err -> do
+                    _ <- tryAny layout.layoutCleanup
+                    pure (Left err)
+                Right checkout -> pure (Right checkout)
 
 -- | Remove only checkouts created by 'prepareRepositoryCheckout'. The strict
 -- shape check prevents an arbitrary session cwd from becoming a deletion

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -4,6 +4,7 @@ module Agent.Server.Runtime
     , openServerRuntime
     , closeServerRuntime
     , serverRuntimeBackend
+    , installSessionEventSink
     , requestFreshToolApproval
     ) where
 
@@ -97,6 +98,16 @@ import Agent.Server.Identifier (newUUIDv7Text)
 import Agent.Server.Runtime.SessionCodec
 import Agent.Server.Runtime.Attachments (withMaterializedTurnFiles)
 import Agent.Server.RepositoryCheckout qualified as RepositoryCheckout
+import Agent.Server.SessionSetup
+    ( SessionEventSink(..)
+    , SessionSetupRegistry
+    , awaitSessionSetup
+    , cancelSessionSetup
+    , closeSessionSetupRegistry
+    , newSessionSetupRegistry
+    , noopSessionEventSink
+    , startRepositorySetup
+    )
 import Agent.Server.Runtime.TurnStore qualified as TurnStore
 import Agent.Server.Sandbox
     ( TenantSandbox
@@ -158,7 +169,7 @@ import Data.Aeson
     , (.=)
     )
 import Data.Bifunctor (first)
-import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.List (find)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -174,16 +185,22 @@ import System.OsPath (OsPath, unsafeEncodeUtf)
 data ServerRuntime = ServerRuntime
     { runtimeBackend :: !Backend
     , runtimeClose :: !(IO ())
+    , runtimeSessionEvents :: !(IORef SessionEventSink)
     }
 
 serverRuntimeBackend :: ServerRuntime -> Backend
 serverRuntimeBackend = (.runtimeBackend)
+
+installSessionEventSink :: ServerRuntime -> SessionEventSink -> IO ()
+installSessionEventSink runtime =
+    writeIORef runtime.runtimeSessionEvents
 
 openServerRuntime
     :: ResolvedServerConfig
     -> IO (Either Text ServerRuntime)
 openServerRuntime config = mask \restore -> do
     instanceId <- newUUIDv7Text
+    sessionEvents <- newIORef noopSessionEventSink
     case config.resolvedServerMode of
         MultiTenantMode multi -> do
             postgresConfig <-
@@ -200,6 +217,7 @@ openServerRuntime config = mask \restore -> do
                                 multi
                                 stores
                                 instanceId
+                                sessionEvents
                         pure $
                             Right ServerRuntime
                                 { runtimeBackend =
@@ -208,6 +226,7 @@ openServerRuntime config = mask \restore -> do
                                     closeTenantRuntimeManager manager
                                         `finally`
                                             closeTenantStoreManager stores
+                                , runtimeSessionEvents = sessionEvents
                                 }
         LocalSingleUserMode -> do
             postgresConfig <-
@@ -242,6 +261,7 @@ openServerRuntime config = mask \restore -> do
                                             (Left
                                                 "could not initialize the native agent runtime")
                                     Right native -> do
+                                        setups <- newSessionSetupRegistry
                                         let environment = RuntimeEnvironment
                                                 { environmentConfig = config
                                                 , environmentStore = store
@@ -254,6 +274,9 @@ openServerRuntime config = mask \restore -> do
                                                 , environmentHome =
                                                     config.resolvedHome
                                                 , environmentSandbox = Nothing
+                                                , environmentSetups = setups
+                                                , environmentSessionEvents =
+                                                    sessionEvents
                                                 }
                                             backend =
                                                 productionBackend
@@ -267,6 +290,8 @@ openServerRuntime config = mask \restore -> do
                                                         environment
                                                         `finally`
                                                             closeStore store
+                                                , runtimeSessionEvents =
+                                                    sessionEvents
                                                 }
 
 closeServerRuntime :: ServerRuntime -> IO ()
@@ -281,6 +306,8 @@ data RuntimeEnvironment = RuntimeEnvironment
     , environmentTenantId :: !TenantId
     , environmentHome :: !FilePath
     , environmentSandbox :: !(Maybe TenantSandbox)
+    , environmentSetups :: !SessionSetupRegistry
+    , environmentSessionEvents :: !(IORef SessionEventSink)
     }
 
 data TenantRuntimeSlot
@@ -300,6 +327,7 @@ data TenantRuntimeManager = TenantRuntimeManager
     , tenantRuntimeMaximum :: !Int
     , tenantRuntimeInstanceId :: !Text
     , tenantRuntimeState :: !(MVar TenantRuntimeState)
+    , tenantRuntimeSessionEvents :: !(IORef SessionEventSink)
     }
 
 data TenantRuntimeAcquisition
@@ -316,8 +344,9 @@ newTenantRuntimeManager
     -> MultiTenantConfig
     -> TenantStoreManager
     -> Text
+    -> IORef SessionEventSink
     -> IO TenantRuntimeManager
-newTenantRuntimeManager config multi stores instanceId = do
+newTenantRuntimeManager config multi stores instanceId sessionEvents = do
     state <- newMVar TenantRuntimeState
         { tenantRuntimeClosed = False
         , tenantRuntimeSlots = Map.empty
@@ -329,6 +358,7 @@ newTenantRuntimeManager config multi stores instanceId = do
         , tenantRuntimeMaximum = config.resolvedMaxActiveTenants
         , tenantRuntimeInstanceId = instanceId
         , tenantRuntimeState = state
+        , tenantRuntimeSessionEvents = sessionEvents
         }
 
 acquireTenantRuntime
@@ -507,7 +537,8 @@ createTenantRuntime manager tenant = mask \restore ->
                                                             (Left
                                                                 (tenantRuntimeUnavailable
                                                                     err))
-                                                    Right turnStoreOwner ->
+                                                    Right turnStoreOwner -> do
+                                                        setups <- newSessionSetupRegistry
                                                         pure $
                                                             Right
                                                                 RuntimeEnvironment
@@ -527,6 +558,10 @@ createTenantRuntime manager tenant = mask \restore ->
                                                                         tenant.resolvedTenantHome
                                                                     , environmentSandbox =
                                                                         Just sandbox
+                                                                    , environmentSetups =
+                                                                        setups
+                                                                    , environmentSessionEvents =
+                                                                        manager.tenantRuntimeSessionEvents
                                                                     }
 
 closeTenantRuntimeManager :: TenantRuntimeManager -> IO ()
@@ -563,12 +598,15 @@ closeTenantRuntimeManager manager = mask \restore -> do
 
 closeRuntimeEnvironment :: RuntimeEnvironment -> IO ()
 closeRuntimeEnvironment environment =
-    closeNativeProcessRuntime environment.environmentNative
+    closeSessionSetupRegistry environment.environmentSetups
         `finally`
-            ( mapM_ closeTenantSandbox environment.environmentSandbox
+            ( closeNativeProcessRuntime environment.environmentNative
                 `finally`
-                    TurnStore.closeTurnStoreOwner
-                        environment.environmentTurnStoreOwner
+                    ( mapM_ closeTenantSandbox environment.environmentSandbox
+                        `finally`
+                            TurnStore.closeTurnStoreOwner
+                                environment.environmentTurnStoreOwner
+                    )
             )
 
 multiTenantBackend :: Text -> TenantRuntimeManager -> Backend
@@ -952,21 +990,24 @@ createSessionForBoundary environment boundary request =
         boundary.accessTenantId
         request >>= \case
             Left err -> pure (Left err)
-            Right (cwd, cleanupOnFailure, repositoryBranch) ->
-                loadModelOptions environment boundary cwd >>= \case
-                    Left err -> cleanupOnFailure >> pure (Left err)
+            Right workspace ->
+                loadModelOptions
+                    environment
+                    boundary
+                    workspace.createWorkspaceCatalogCwd >>= \case
+                    Left err -> workspace.createWorkspaceCleanup >> pure (Left err)
                     Right (catalog, options) ->
                         case selectModel
                             boundary
                             catalog
                             options
                             request.createSessionModel of
-                                Left err -> cleanupOnFailure >> pure (Left err)
+                                Left err -> workspace.createWorkspaceCleanup >> pure (Left err)
                                 Right option ->
                                     case resolveEffort
                                         option.modelTarget.targetProvider
                                         request.createSessionEffort of
-                                            Left err -> cleanupOnFailure >> pure (Left err)
+                                            Left err -> workspace.createWorkspaceCleanup >> pure (Left err)
                                             Right effort -> do
                                                 created <- tryAny $
                                                     createSession SessionCreate
@@ -980,7 +1021,8 @@ createSessionForBoundary environment boundary request =
                                                         , createGatewayIdentity =
                                                             boundary.accessGatewayBoundary.gatewayBoundaryIdentity
                                                         , createCwd =
-                                                            unsafeEncodeUtf cwd
+                                                            unsafeEncodeUtf
+                                                                workspace.createWorkspaceCwd
                                                         , createEffort =
                                                             reasoningEffortText effort
                                                         , createTitleHint =
@@ -992,23 +1034,69 @@ createSessionForBoundary environment boundary request =
                                                                 request.createSessionTitle
                                                         }
                                                 case created of
-                                                    Left _ -> cleanupOnFailure
-                                                    Right _ -> pure ()
+                                                    Left _ -> workspace.createWorkspaceCleanup
+                                                    Right handle ->
+                                                        startPendingRepositorySetup
+                                                            environment
+                                                            boundary
+                                                            handle.sessionMeta.metaId
+                                                            workspace
                                                 pure case created of
                                                     Left _ ->
                                                         Left (internalApiError "could not create the session")
                                                     Right handle ->
-                                                        Right (sessionValue False handle.sessionMeta repositoryBranch)
+                                                        Right
+                                                            ( sessionValue
+                                                                False
+                                                                handle.sessionMeta
+                                                                workspace.createWorkspaceBranch
+                                                            )
+
+data CreateSessionWorkspace = CreateSessionWorkspace
+    { createWorkspaceCwd :: !FilePath
+    , createWorkspaceCatalogCwd :: !FilePath
+    , createWorkspaceCleanup :: !(IO ())
+    , createWorkspaceBranch :: !(Maybe Text)
+    , createWorkspacePending ::
+        !(Maybe
+            ( RepositoryCheckout.PreparedRepositoryLayout
+            , RepositoryDescriptor
+            ))
+    }
+
+startPendingRepositorySetup
+    :: RuntimeEnvironment
+    -> AccessBoundary
+    -> Text
+    -> CreateSessionWorkspace
+    -> IO ()
+startPendingRepositorySetup environment boundary sessionId workspace =
+    case workspace.createWorkspacePending of
+        Nothing -> pure ()
+        Just (layout, descriptor) -> do
+            sink <- readIORef environment.environmentSessionEvents
+            startRepositorySetup
+                environment.environmentSetups
+                (\eventType payload ->
+                    sink.emitSessionEvent
+                        boundary
+                        sessionId
+                        eventType
+                        payload)
+                sessionId
+                layout
+                descriptor
 
 resolveCreateSessionWorkspace
     :: ResolvedServerConfig
     -> TenantId
     -> CreateSessionRequest
-    -> IO (Either ApiError (FilePath, IO (), Maybe Text))
+    -> IO (Either ApiError CreateSessionWorkspace)
 resolveCreateSessionWorkspace config tenantId request =
     case request.createSessionRepository of
         Nothing ->
-            fmap (, pure (), Nothing) <$> resolveTenantWorkspacePath config tenantId request.createSessionCwd
+            fmap workspaceWithoutRepository
+                <$> resolveTenantWorkspacePath config tenantId request.createSessionCwd
         Just descriptor
             | Just _ <- request.createSessionCwd ->
                 pure $
@@ -1023,7 +1111,7 @@ resolveCreateSessionWorkspace config tenantId request =
                     Left err -> pure (Left err)
                     Right workspaceRoot -> do
                         correlation <- newUUIDv7Text
-                        RepositoryCheckout.prepareRepositoryCheckout
+                        RepositoryCheckout.prepareRepositoryLayout
                             workspaceRoot
                             correlation
                             descriptor >>= \case
@@ -1035,13 +1123,30 @@ resolveCreateSessionWorkspace config tenantId request =
                                             , apiErrorMessage = message
                                             , apiErrorDetails = Nothing
                                             }
-                                Right checkout ->
+                                Right layout ->
                                     pure $
                                         Right
-                                            ( checkout.checkoutPath
-                                            , checkout.cleanupCheckout
-                                            , Just checkout.checkoutBranch
-                                            )
+                                            CreateSessionWorkspace
+                                                { createWorkspaceCwd =
+                                                    layout.layoutCheckoutPath
+                                                , createWorkspaceCatalogCwd =
+                                                    workspaceRoot
+                                                , createWorkspaceCleanup =
+                                                    layout.layoutCleanup
+                                                , createWorkspaceBranch =
+                                                    Just layout.layoutBranch
+                                                , createWorkspacePending =
+                                                    Just (layout, descriptor)
+                                                }
+  where
+    workspaceWithoutRepository cwd =
+        CreateSessionWorkspace
+            { createWorkspaceCwd = cwd
+            , createWorkspaceCatalogCwd = cwd
+            , createWorkspaceCleanup = pure ()
+            , createWorkspaceBranch = Nothing
+            , createWorkspacePending = Nothing
+            }
 
 getSessionForBoundary
     :: RuntimeEnvironment
@@ -1102,6 +1207,7 @@ deleteSessionForBoundary environment boundary sessionId =
     loadAuthorizedMeta environment boundary sessionId >>= \case
         Left err -> pure (Left err)
         Right meta -> do
+            cancelSessionSetup environment.environmentSetups sessionId
             deleted <-
                 first sessionOperationError
                     <$> deleteSession
@@ -1230,72 +1336,77 @@ runTurn environment control spec =
         spec.turnSpecSessionId >>= \case
             Left err -> pure (Left err.apiErrorMessage)
             Right meta ->
-                resolveTenantWorkspacePath
-                    environment.environmentConfig
-                    spec.turnSpecBoundary.accessTenantId
-                    (Just (unsafeToFilePath meta.metaCwd)) >>= \case
-                        Left err -> pure (Left err.apiErrorMessage)
-                        Right cwd ->
-                            case parseReasoningEffort meta.metaEffort of
-                                Left err -> pure (Left err)
-                                Right effort ->
-                                    withMaterializedTurnFiles cwd spec \turnPrompt ->
-                                        withFile "/dev/null" WriteMode \output -> do
-                                            finalOutput <- newIORef Nothing
-                                            let baseHooks =
-                                                    nativeHooks
-                                                        environment
-                                                        control
-                                                        spec.turnSpecSessionId
-                                                        cwd
-                                                        meta.metaDialect
-                                                hooks =
-                                                    baseHooks
-                                                        { nativeOnLoopEvent = \event -> do
-                                                            case event of
-                                                                Loop.TurnFinished value ->
-                                                                    writeIORef
-                                                                        finalOutput
-                                                                        (Just value)
-                                                                _ -> pure ()
-                                                            baseHooks.nativeOnLoopEvent event
-                                                        }
-                                            runNativeTurn
-                                                environment.environmentNative
-                                                output
-                                                hooks
-                                                NativeTurnRequest
-                                                    { nativeTurnPrompt =
-                                                        turnPrompt
-                                                    , nativeTurnImages =
-                                                        spec.turnSpecImages
-                                                    , nativeTurnSession =
-                                                        NativeResumeSession
-                                                            spec.turnSpecSessionId
-                                                    , nativeTurnProvider = Nothing
-                                                    , nativeTurnModel = Nothing
-                                                    , nativeTurnCwd =
-                                                        unsafeEncodeUtf cwd
-                                                    , nativeTurnEffort =
-                                                        Just effort
-                                                    , nativeTurnInteractionMode =
-                                                        serverInteractionMode
-                                                            environment
-                                                    , nativeTurnShellMode =
-                                                        tenantShellMode environment
-                                                    }
-                                                >>= \case
-                                                    Left err -> pure (Left err)
-                                                    Right () ->
-                                                        readIORef finalOutput
-                                                            >>= pure
-                                                                . maybe
-                                                                    ( Left
-                                                                        "agent turn completed without a terminal output"
-                                                                    )
-                                                                    ( Right
-                                                                        . turnExecutionOutput
-                                                                    )
+                awaitSessionSetup
+                    environment.environmentSetups
+                    spec.turnSpecSessionId >>= \case
+                    Left message -> pure (Left message)
+                    Right () ->
+                        resolveTenantWorkspacePath
+                            environment.environmentConfig
+                            spec.turnSpecBoundary.accessTenantId
+                            (Just (unsafeToFilePath meta.metaCwd)) >>= \case
+                                Left err -> pure (Left err.apiErrorMessage)
+                                Right cwd ->
+                                    case parseReasoningEffort meta.metaEffort of
+                                        Left err -> pure (Left err)
+                                        Right effort ->
+                                            withMaterializedTurnFiles cwd spec \turnPrompt ->
+                                                withFile "/dev/null" WriteMode \output -> do
+                                                    finalOutput <- newIORef Nothing
+                                                    let baseHooks =
+                                                            nativeHooks
+                                                                environment
+                                                                control
+                                                                spec.turnSpecSessionId
+                                                                cwd
+                                                                meta.metaDialect
+                                                        hooks =
+                                                            baseHooks
+                                                                { nativeOnLoopEvent = \event -> do
+                                                                    case event of
+                                                                        Loop.TurnFinished value ->
+                                                                            writeIORef
+                                                                                finalOutput
+                                                                                (Just value)
+                                                                        _ -> pure ()
+                                                                    baseHooks.nativeOnLoopEvent event
+                                                                }
+                                                    runNativeTurn
+                                                        environment.environmentNative
+                                                        output
+                                                        hooks
+                                                        NativeTurnRequest
+                                                            { nativeTurnPrompt =
+                                                                turnPrompt
+                                                            , nativeTurnImages =
+                                                                spec.turnSpecImages
+                                                            , nativeTurnSession =
+                                                                NativeResumeSession
+                                                                    spec.turnSpecSessionId
+                                                            , nativeTurnProvider = Nothing
+                                                            , nativeTurnModel = Nothing
+                                                            , nativeTurnCwd =
+                                                                unsafeEncodeUtf cwd
+                                                            , nativeTurnEffort =
+                                                                Just effort
+                                                            , nativeTurnInteractionMode =
+                                                                serverInteractionMode
+                                                                    environment
+                                                            , nativeTurnShellMode =
+                                                                tenantShellMode environment
+                                                            }
+                                                        >>= \case
+                                                            Left err -> pure (Left err)
+                                                            Right () ->
+                                                                readIORef finalOutput
+                                                                    >>= pure
+                                                                        . maybe
+                                                                            ( Left
+                                                                                "agent turn completed without a terminal output"
+                                                                            )
+                                                                            ( Right
+                                                                                . turnExecutionOutput
+                                                                            )
 
 turnExecutionOutput :: Loop.TurnOutput -> TurnExecutionOutput
 turnExecutionOutput output =

--- a/packages/agent-server/src/Agent/Server/SessionSetup.hs
+++ b/packages/agent-server/src/Agent/Server/SessionSetup.hs
@@ -1,0 +1,204 @@
+-- | Background Git checkout after a session already exists. Turns wait on
+-- the registry until clone and branch creation finish (or fail).
+module Agent.Server.SessionSetup
+    ( SessionEventSink(..)
+    , SessionSetupRegistry
+    , noopSessionEventSink
+    , newSessionSetupRegistry
+    , closeSessionSetupRegistry
+    , startRepositorySetup
+    , startRepositorySetupWith
+    , awaitSessionSetup
+    , cancelSessionSetup
+    ) where
+
+import Agent.Server.RepositoryCheckout
+    ( CheckoutOperationStatus(..)
+    , PreparedRepositoryLayout(..)
+    , RepositoryCheckout(..)
+    , RepositoryCheckoutOperation(..)
+    , completeRepositoryCheckout
+    )
+import Agent.Server.Types
+    ( AccessBoundary
+    , RepositoryDescriptor(..)
+    )
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (Async, async, cancel, race)
+import Control.Concurrent.MVar
+    ( MVar
+    , modifyMVar
+    , newEmptyMVar
+    , newMVar
+    , putMVar
+    , readMVar
+    , takeMVar
+    , tryPutMVar
+    )
+import Control.Exception.Safe (tryAny)
+import Control.Monad (void)
+import Data.Aeson (Value, object, (.=))
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+
+data SessionEventSink = SessionEventSink
+    { emitSessionEvent :: AccessBoundary -> Text -> Text -> Value -> IO ()
+    }
+
+noopSessionEventSink :: SessionEventSink
+noopSessionEventSink = SessionEventSink \_ _ _ _ -> pure ()
+
+newtype SessionSetupRegistry = SessionSetupRegistry (MVar (Map Text SessionSetup))
+
+data SessionSetup = SessionSetup
+    { setupDone :: !(MVar (Either Text RepositoryCheckout))
+    , setupWorker :: !(Async ())
+    }
+
+type CheckoutRunner
+    = PreparedRepositoryLayout
+    -> RepositoryDescriptor
+    -> (RepositoryCheckoutOperation -> CheckoutOperationStatus -> IO ())
+    -> IO (Either Text RepositoryCheckout)
+
+newSessionSetupRegistry :: IO SessionSetupRegistry
+newSessionSetupRegistry = SessionSetupRegistry <$> newMVar Map.empty
+
+closeSessionSetupRegistry :: SessionSetupRegistry -> IO ()
+closeSessionSetupRegistry (SessionSetupRegistry var) = do
+    setups <- modifyMVar var \current ->
+        pure (Map.empty, Map.elems current)
+    mapM_ abandon setups
+
+startRepositorySetup
+    :: SessionSetupRegistry
+    -> (Text -> Value -> IO ())
+    -> Text
+    -> PreparedRepositoryLayout
+    -> RepositoryDescriptor
+    -> IO ()
+startRepositorySetup registry emit sessionId layout descriptor =
+    startRepositorySetupWith
+        registry
+        emit
+        sessionId
+        layout
+        descriptor
+        completeRepositoryCheckout
+
+startRepositorySetupWith
+    :: SessionSetupRegistry
+    -> (Text -> Value -> IO ())
+    -> Text
+    -> PreparedRepositoryLayout
+    -> RepositoryDescriptor
+    -> CheckoutRunner
+    -> IO ()
+startRepositorySetupWith
+        (SessionSetupRegistry var)
+        emit
+        sessionId
+        layout
+        descriptor
+        complete = do
+    ready <- newEmptyMVar
+    done <- newEmptyMVar
+    worker <-
+        async $ do
+            takeMVar ready
+            runCheckout emit done layout descriptor complete
+    added <-
+        modifyMVar var \current ->
+            if Map.member sessionId current
+                then pure (current, False)
+                else
+                    pure
+                        ( Map.insert
+                            sessionId
+                            SessionSetup{setupDone = done, setupWorker = worker}
+                            current
+                        , True
+                        )
+    if added
+        then putMVar ready ()
+        else do
+            cancel worker
+            void $ tryPutMVar done (Left "repository checkout already in progress")
+
+awaitSessionSetup :: SessionSetupRegistry -> Text -> IO (Either Text ())
+awaitSessionSetup (SessionSetupRegistry var) sessionId = do
+    current <- readMVar var
+    case Map.lookup sessionId current of
+        Nothing -> pure (Right ())
+        Just setup ->
+            race
+                (threadDelay sessionSetupWaitMicroseconds)
+                (readMVar setup.setupDone)
+                >>= \case
+                    Left () -> pure (Left "repository checkout timed out")
+                    Right result -> pure (() <$ result)
+
+cancelSessionSetup :: SessionSetupRegistry -> Text -> IO ()
+cancelSessionSetup (SessionSetupRegistry var) sessionId = do
+    setup <-
+        modifyMVar var \current ->
+            pure (Map.delete sessionId current, Map.lookup sessionId current)
+    mapM_ abandon setup
+
+abandon :: SessionSetup -> IO ()
+abandon setup = do
+    cancel setup.setupWorker
+    void $ tryPutMVar setup.setupDone (Left "repository checkout cancelled")
+
+runCheckout
+    :: (Text -> Value -> IO ())
+    -> MVar (Either Text RepositoryCheckout)
+    -> PreparedRepositoryLayout
+    -> RepositoryDescriptor
+    -> CheckoutRunner
+    -> IO ()
+runCheckout emit done layout descriptor complete = do
+    emit "session.setup.started" $
+        object
+            [ "repository" .= descriptor.repositoryFullName
+            , "branch" .= descriptor.repositoryDefaultBranch
+            ]
+    let onStep operation status =
+            emit "session.setup.step" $
+                object
+                    [ "id" .= operation.checkoutOperationId
+                    , "command" .= operation.checkoutOperationCommand
+                    , "status" .= checkoutOperationStatusText status
+                    ]
+    result <- tryAny (complete layout descriptor onStep)
+    finished <- case result of
+        Left _ -> failCheckout emit layout "could not prepare repository checkout"
+        Right (Left message) -> failCheckout emit layout message
+        Right (Right checkout) -> do
+            emit "session.setup.completed" $
+                object
+                    [ "repository" .= descriptor.repositoryFullName
+                    , "branch" .= checkout.checkoutBranch
+                    ]
+            pure (Right checkout)
+    void $ tryPutMVar done finished
+
+failCheckout
+    :: (Text -> Value -> IO ())
+    -> PreparedRepositoryLayout
+    -> Text
+    -> IO (Either Text RepositoryCheckout)
+failCheckout emit layout message = do
+    emit "session.setup.failed" $ object ["message" .= message]
+    _ <- tryAny layout.layoutCleanup
+    pure (Left message)
+
+checkoutOperationStatusText :: CheckoutOperationStatus -> Text
+checkoutOperationStatusText = \case
+    CheckoutOperationRunning -> "running"
+    CheckoutOperationCompleted -> "completed"
+    CheckoutOperationFailed -> "failed"
+
+sessionSetupWaitMicroseconds :: Int
+sessionSetupWaitMicroseconds = 10 * 60 * 1_000_000

--- a/packages/agent-server/test/Agent/Server/SessionSetupSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SessionSetupSpec.hs
@@ -1,0 +1,130 @@
+module Agent.Server.SessionSetupSpec (spec) where
+
+import Agent.Server.RepositoryCheckout
+    ( CheckoutOperationStatus(..)
+    , PreparedRepositoryLayout(..)
+    , RepositoryCheckout(..)
+    , RepositoryCheckoutOperation(..)
+    , prepareRepositoryLayout
+    , repositoryCheckoutOperations
+    )
+import Agent.Server.SessionSetup
+    ( awaitSessionSetup
+    , closeSessionSetupRegistry
+    , newSessionSetupRegistry
+    , startRepositorySetupWith
+    )
+import Agent.Server.Types (RepositoryDescriptor(..))
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Monad (forM_)
+import Data.IORef (atomicModifyIORef', newIORef, readIORef)
+import Data.Text (Text)
+import System.Directory (doesDirectoryExist, doesFileExist)
+import System.IO.Temp (withSystemTempDirectory)
+import Test.Hspec
+
+spec :: Spec
+spec = do
+    describe "repository checkout operations" do
+        it "names the clone and working-branch Git commands" do
+            withSystemTempDirectory "agent-server-checkout" \root -> do
+                prepareRepositoryLayout root "01testcorrelation" validDescriptor
+                    >>= \case
+                        Left err -> fail (show err)
+                        Right layout -> do
+                            let commands =
+                                    map
+                                        (.checkoutOperationCommand)
+                                        (repositoryCheckoutOperations layout validDescriptor)
+                                cloneCommand :: Text
+                                cloneCommand =
+                                    "git clone --single-branch --branch main https://github.com/digitallyinduced/haskell-agent.git"
+                                switchCommand :: Text
+                                switchCommand = "git switch -c agent/01testcorrelation"
+                            commands `shouldSatisfy` elem cloneCommand
+                            commands `shouldSatisfy` elem switchCommand
+                            doesDirectoryExist layout.layoutCheckoutPath
+                                `shouldReturn` False
+                            doesFileExist layout.layoutHelperPath
+                                `shouldReturn` True
+                            layout.layoutCleanup
+
+    describe "session repository setup" do
+        it "returns from start before Git operations finish" do
+            withSystemTempDirectory "agent-server-setup" \root -> do
+                layout <-
+                    prepareRepositoryLayout root "01testcorrelation" validDescriptor
+                        >>= either (fail . show) pure
+                started <- newEmptyMVar
+                release <- newEmptyMVar
+                events <- newIORef []
+                registry <- newSessionSetupRegistry
+                let complete pendingLayout _descriptor onStep = do
+                        putMVar started ()
+                        takeMVar release
+                        forM_
+                            (repositoryCheckoutOperations pendingLayout validDescriptor)
+                            \operation -> do
+                                _ <- onStep operation CheckoutOperationRunning
+                                onStep operation CheckoutOperationCompleted
+                        pure $
+                            Right
+                                RepositoryCheckout
+                                    { checkoutPath = pendingLayout.layoutCheckoutPath
+                                    , checkoutBranch = pendingLayout.layoutBranch
+                                    , cleanupCheckout = pendingLayout.layoutCleanup
+                                    }
+                    emit eventType payload =
+                        atomicModifyIORef' events \current ->
+                            (current <> [(eventType, payload)], ())
+                startRepositorySetupWith
+                    registry
+                    emit
+                    "session-1"
+                    layout
+                    validDescriptor
+                    complete
+                takeMVar started
+                recordedBeforeFinish <- readIORef events
+                recordedBeforeFinish
+                    `shouldSatisfy`
+                        (any (\(eventType, _) -> eventType == "session.setup.started"))
+                putMVar release ()
+                awaitSessionSetup registry "session-1" `shouldReturn` Right ()
+                recorded <- readIORef events
+                map fst recorded
+                    `shouldSatisfy`
+                        (\types ->
+                            elem ("session.setup.started" :: Text) types
+                                && elem ("session.setup.step" :: Text) types
+                                && elem ("session.setup.completed" :: Text) types)
+                closeSessionSetupRegistry registry
+
+        it "fails the waiting turn when checkout fails" do
+            withSystemTempDirectory "agent-server-setup-fail" \root -> do
+                layout <-
+                    prepareRepositoryLayout root "01testcorrelation" validDescriptor
+                        >>= either (fail . show) pure
+                registry <- newSessionSetupRegistry
+                let complete _ _ _ =
+                        pure (Left "git clone failed")
+                startRepositorySetupWith
+                    registry
+                    (\_ _ -> pure ())
+                    "session-1"
+                    layout
+                    validDescriptor
+                    complete
+                awaitSessionSetup registry "session-1"
+                    `shouldReturn` Left "git clone failed"
+                closeSessionSetupRegistry registry
+
+validDescriptor :: RepositoryDescriptor
+validDescriptor =
+    RepositoryDescriptor
+        { repositoryFullName = "digitallyinduced/haskell-agent"
+        , repositoryCloneUrl = "https://github.com/digitallyinduced/haskell-agent.git"
+        , repositoryDefaultBranch = "main"
+        , repositoryCredentialBrokerUrl = "https://gateway.example/api/v1/github/repository-token"
+        , repositoryCredentialLease = "opaque-lease"
+        }

--- a/packages/agent-server/test/Spec.hs
+++ b/packages/agent-server/test/Spec.hs
@@ -7,6 +7,7 @@ import Agent.Server.AuthSpec qualified
 import Agent.Server.ConfigSpec qualified
 import Agent.Server.EventSpec qualified
 import Agent.Server.RepositoryCheckoutSpec qualified
+import Agent.Server.SessionSetupSpec qualified
 import Agent.Server.SandboxSpec qualified
 import Agent.Server.SupervisorSpec qualified
 import Agent.Server.TenantSpec qualified
@@ -25,6 +26,7 @@ main = do
                 Agent.Server.ConfigSpec.spec
                 Agent.Server.EventSpec.spec
                 Agent.Server.RepositoryCheckoutSpec.spec
+                Agent.Server.SessionSetupSpec.spec
                 Agent.Server.SupervisorSpec.spec
                 Agent.Server.TenantSpec.spec
                 Agent.Server.SandboxSpec.spec


### PR DESCRIPTION
## Summary

- Return from `sessions.create` as soon as the session record exists, instead of waiting for Git clone, credential configuration, and working-branch creation.
- Run those Git operations as session setup and publish `session.setup.started`, `session.setup.step`, `session.setup.completed`, and `session.setup.failed` with the command currently executing.
- Hold the first turn until checkout finishes so the agent still starts in the isolated repository.

This unblocks the console from navigating to a new session immediately. Companion UI: digitallyinduced/haskell-agent-gateway#145.

## Test plan

- [x] `cabal test agent-server:agent-server-test` (116 examples)
- [ ] Create a cloud session with a GitHub repository and confirm `sessions.create` returns before clone completes
- [ ] Confirm setup events appear on the session stream, then the first turn starts in the new checkout
- [ ] Confirm a failed clone emits `session.setup.failed` and does not start the turn