### PR TITLE
Persist last-model on the primary Git clone

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Project.hs
+++ b/packages/agent-cli/src/Agent/CLI/Project.hs
@@ -1,11 +1,15 @@
 -- | Project-scoped settings under @<project>/.haskell-agent/settings.json@,
 -- plus the user-level last model under @~/.haskell-agent/settings.json@.
+-- Last-model is stored on the current checkout and on the primary Git clone
+-- so a later session in the same repository, including a fresh worktree,
+-- restores that selection instead of the catalog default.
 module Agent.CLI.Project
     ( ModelSwitchScope(..)
     , ProjectAccount(..)
     , ProjectModel(..)
     , ProjectSettings(..)
     , defaultProjectSettings
+    , inheritProjectLastModel
     , loadProjectSettings
     , loadUserSettings
     , projectDialectFor
@@ -13,6 +17,7 @@ module Agent.CLI.Project
     , projectModelFor
     , projectModelProvider
     , projectSettingsPath
+    , resolvePrimaryProjectRoot
     , resolveProjectRoot
     , saveProjectAutoApprove
     , saveProjectMaxConcurrentAgents
@@ -57,7 +62,14 @@ import System.Directory.OsPath
     , doesFileExist
     )
 import System.Exit (ExitCode(..))
-import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
+import System.OsPath
+    ( OsPath
+    , isAbsolute
+    , takeDirectory
+    , takeFileName
+    , unsafeEncodeUtf
+    , (</>)
+    )
 import System.Posix.Files (setFileMode)
 import System.Process (CreateProcess(..), proc, readCreateProcessWithExitCode)
 
@@ -213,12 +225,33 @@ lenient decoder =
 -- Uses @git rev-parse --show-toplevel@ so a linked worktree stays in that
 -- worktree instead of jumping to the primary clone. Falls back to @cwd@.
 -- Paths are canonicalized so macOS @/var@ vs @/private/var@ does not diverge.
+-- Checkout-local flags such as auto-approve stay here; last-model selection
+-- is also written to 'resolvePrimaryProjectRoot' so a later session in the
+-- same repository can find it.
 resolveProjectRoot :: OsPath -> IO OsPath
 resolveProjectRoot cwd = do
     root <- gitToplevel cwd >>= \case
         Just toplevel -> pure toplevel
         Nothing -> pure cwd
     canonicalizePath root
+
+-- | Primary clone that owns Git's common directory.
+-- Linked and managed worktrees share this checkout, so project last-model
+-- settings outlive a disposable worktree. Falls back to the current checkout
+-- when Git is unavailable or the common directory is not a @.git@ directory.
+resolvePrimaryProjectRoot :: OsPath -> IO OsPath
+resolvePrimaryProjectRoot checkout = do
+    canonical <- canonicalizePath checkout
+    gitCommonDir canonical >>= \case
+        Just common
+            | takeFileName common == unsafeEncodeUtf ".git" ->
+                let parent = takeDirectory common
+                in canonicalizePath $
+                    if isAbsolute common
+                        then parent
+                        else canonical
+        _ ->
+            pure canonical
 
 -- | Missing or unreadable settings files yield the defaults.
 loadProjectSettings :: OsPath -> IO ProjectSettings
@@ -240,17 +273,44 @@ loadProjectSettings projectRoot = do
 loadUserSettings :: OsPath -> IO ProjectSettings
 loadUserSettings = loadProjectSettings
 
--- | Prefer the checkout's last model. A missing checkout value falls back to
--- the user-level last model so a freshly created worktree inherits the model
--- from the previous session instead of catalog or auth defaults.
+-- | Prefer the current checkout's last model, then the primary clone, then
+-- the user-level default. A freshly created worktree therefore inherits the
+-- repository's last model instead of a different project's user default.
+-- Checkout-local settings such as auto-approve are unchanged.
 withInheritedLastModel
     :: ProjectSettings
     -> ProjectSettings
     -> ProjectSettings
-withInheritedLastModel project user =
-    case project.settingsLastModel of
-        Just _ -> project
-        Nothing -> project { settingsLastModel = user.settingsLastModel }
+    -> ProjectSettings
+withInheritedLastModel project primary user =
+    project
+        { settingsLastModel =
+            case project.settingsLastModel of
+                Just model -> Just model
+                Nothing ->
+                    case primary.settingsLastModel of
+                        Just model -> Just model
+                        Nothing -> user.settingsLastModel
+        }
+
+-- | Load checkout settings and fill in last-model from the primary clone and
+-- user defaults when the current checkout has none.
+inheritProjectLastModel
+    :: OsPath
+    -- ^ User home (@~/.haskell-agent/settings.json@).
+    -> OsPath
+    -- ^ Current checkout root.
+    -> ProjectSettings
+    -> IO ProjectSettings
+inheritProjectLastModel home projectRoot project = do
+    user <- loadUserSettings home
+    canonicalCheckout <- canonicalizePath projectRoot
+    primaryRoot <- resolvePrimaryProjectRoot canonicalCheckout
+    primary <-
+        if primaryRoot == canonicalCheckout
+            then pure project
+            else loadProjectSettings primaryRoot
+    pure (withInheritedLastModel project primary user)
 
 -- | Persist the project-wide auto-approve flag, creating @.haskell-agent@ as needed.
 saveProjectAutoApprove :: OsPath -> Bool -> IO ()
@@ -316,8 +376,9 @@ data ModelSwitchScope
     | SessionLocalSwitch
     deriving (Eq, Show)
 
--- | Persist a top-level switch on the current checkout and as the user-level
--- default. Session-local switches retain their target only in session state.
+-- | Persist a top-level switch on the current checkout, the primary clone
+-- when that is a different path, and the user-level default. Session-local
+-- switches retain their target only in session state.
 persistModelSwitch
     :: ModelSwitchScope
     -> OsPath
@@ -328,7 +389,11 @@ persistModelSwitch
     -> IO ()
 persistModelSwitch SessionLocalSwitch _ _ _ = pure ()
 persistModelSwitch TopLevelSwitch home projectRoot target = do
-    saveProjectModel projectRoot target
+    checkoutRoot <- canonicalizePath projectRoot
+    primaryRoot <- resolvePrimaryProjectRoot checkoutRoot
+    saveProjectModel checkoutRoot target
+    unless (primaryRoot == checkoutRoot) $
+        saveProjectModel primaryRoot target
     saveProjectModel home target
 
 projectModelProvider :: ProjectSettings -> Maybe Provider
@@ -363,10 +428,19 @@ updateProjectSettings projectRoot update = do
     writeLazyFileAtomically path 0o600 (Aeson.encode settings)
 
 gitToplevel :: OsPath -> IO (Maybe OsPath)
-gitToplevel dir = do
+gitToplevel dir =
+    gitRevParse dir ["rev-parse", "--show-toplevel"]
+
+gitCommonDir :: OsPath -> IO (Maybe OsPath)
+gitCommonDir dir =
+    gitRevParse dir
+        ["rev-parse", "--path-format=absolute", "--git-common-dir"]
+
+gitRevParse :: OsPath -> [String] -> IO (Maybe OsPath)
+gitRevParse dir args = do
     result <- tryIO $
         readCreateProcessWithExitCode
-            (proc "git" ["rev-parse", "--show-toplevel"])
+            (proc "git" args)
                 { cwd = Just (unsafeToFilePath dir) }
             ""
     pure $ case result of

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -65,12 +65,11 @@ import Agent.CLI.Models
 import Agent.CLI.Options
     ( CliOptions(optModel, optProvider, optSkills, optYolo) )
 import Agent.CLI.Project
-    ( loadProjectSettings,
-      loadUserSettings,
+    ( inheritProjectLastModel,
+      loadProjectSettings,
       projectAccountFor,
       projectModelProvider,
       resolveProjectRoot,
-      withInheritedLastModel,
       ProjectAccount(projectAccountId, projectAccountSelectionId),
       ProjectModel(projectModelTarget),
       ProjectSettings(settingsLastModel) )
@@ -376,12 +375,13 @@ prepareInitializedWorkspace request = do
     checkpoint "workspace scopes ready"
     let loadWorkspaceMetadata =
             concurrently
-                (concurrently
-                    (maybe
-                        (loadProjectSettings projectRoot)
-                        (pure . (.nativeDiscoveryProjectSettings))
-                        preparedDiscovery)
-                    (loadUserSettings home))
+                (do
+                    projectSettings0 <-
+                        maybe
+                            (loadProjectSettings projectRoot)
+                            (pure . (.nativeDiscoveryProjectSettings))
+                            preparedDiscovery
+                    inheritProjectLastModel home projectRoot projectSettings0)
                 (concurrently
                     (loadModelCatalogAt home
                         (maybe
@@ -401,7 +401,7 @@ prepareInitializedWorkspace request = do
         shouldPreloadSkills =
             request.initializedOptions.optSkills
                 && isNothing preparedDiscovery
-    (((projectSettings0, userSettings), (catalogResult, branch)),
+    ((projectSettings, (catalogResult, branch)),
         initializedSkills) <-
         if shouldPreloadSkills
             then concurrently loadWorkspaceMetadata loadInitialSkills
@@ -409,8 +409,6 @@ prepareInitializedWorkspace request = do
                 metadata <- loadWorkspaceMetadata
                 pure (metadata, SkillCatalog [] [])
     checkpoint "workspace metadata and skills ready"
-    let projectSettings =
-            withInheritedLastModel projectSettings0 userSettings
     catalog <- either
         (startupDie startup)
         pure

--- a/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProjectSpec.hs
@@ -56,7 +56,7 @@ spec = describe "Agent.CLI.Project" do
                 `shouldBe` fromFilePath "/Users/marc/.haskell-agent/settings.json"
 
     describe "withInheritedLastModel" do
-        it "inherits the user last model when the checkout has none" do
+        it "inherits the user last model when checkout and primary have none" do
             let userModel =
                     ProjectModel
                         { projectModelTarget =
@@ -67,30 +67,61 @@ spec = describe "Agent.CLI.Project" do
                     { settingsLastModel = Just userModel }
                 project = defaultProjectSettings
                     { settingsAutoApprove = True }
-                merged = withInheritedLastModel project user
+                merged = withInheritedLastModel project defaultProjectSettings user
             merged.settingsLastModel `shouldBe` Just userModel
             merged.settingsAutoApprove `shouldBe` True
 
-        it "keeps a checkout last model instead of the user default" do
+        it "inherits the primary last model before the user default" do
+            let primaryModel =
+                    ProjectModel
+                        { projectModelTarget =
+                            target XAIProvider "xai"
+                                "grok-4.6" "grok-4.6" GrokBuildDialect
+                        }
+                userModel =
+                    ProjectModel
+                        { projectModelTarget =
+                            target OpenAIProvider "openai"
+                                "gpt-5.6-sol" "gpt-5.6-sol" CodexDialect
+                        }
+                primary = defaultProjectSettings
+                    { settingsLastModel = Just primaryModel }
+                user = defaultProjectSettings
+                    { settingsLastModel = Just userModel }
+                project = defaultProjectSettings
+                    { settingsAutoApprove = True }
+                merged = withInheritedLastModel project primary user
+            merged.settingsLastModel `shouldBe` Just primaryModel
+            merged.settingsAutoApprove `shouldBe` True
+
+        it "keeps a checkout last model instead of primary or user defaults" do
             let checkoutModel =
                     ProjectModel
                         { projectModelTarget =
                             target OpenAIProvider "openai"
                                 "gpt-5.6-sol" "gpt-5.6-sol" CodexDialect
                         }
-                userModel =
+                primaryModel =
                     ProjectModel
                         { projectModelTarget =
                             target XAIProvider "xai"
                                 "grok-4.6" "grok-4.6" GrokBuildDialect
                         }
+                userModel =
+                    ProjectModel
+                        { projectModelTarget =
+                            target OpenAIProvider "openai"
+                                "gpt-6-astra" "gpt-6-astra" CodexDialect
+                        }
                 user = defaultProjectSettings
                     { settingsLastModel = Just userModel }
+                primary = defaultProjectSettings
+                    { settingsLastModel = Just primaryModel }
                 project = defaultProjectSettings
                     { settingsLastModel = Just checkoutModel
                     , settingsAutoApprove = True
                     }
-                merged = withInheritedLastModel project user
+                merged = withInheritedLastModel project primary user
             merged.settingsLastModel `shouldBe` Just checkoutModel
             merged.settingsAutoApprove `shouldBe` True
 
@@ -191,6 +222,71 @@ spec = describe "Agent.CLI.Project" do
                     userSettings.settingsLastModel
                         `shouldBe` projectSettings.settingsLastModel
                     userSettingsPath home `shouldBe` projectSettingsPath home
+
+        it "writes a worktree model switch to the primary clone without moving auto-approve" $
+            withTempDir "agent-wt-" \root ->
+                withTempDir "agent-home-" \home -> do
+                    let mainRepo = root </> fromFilePath "main"
+                        linked = root </> fromFilePath "linked"
+                    createDirectoryIfMissing True mainRepo
+                    git_ mainRepo ["init"]
+                    git_ mainRepo ["config", "user.email", "test@example.com"]
+                    git_ mainRepo ["config", "user.name", "Test"]
+                    git_ mainRepo ["config", "commit.gpgsign", "false"]
+                    git_ mainRepo ["commit", "--allow-empty", "-m", "init"]
+                    git_ mainRepo ["worktree", "add", "--detach", toFilePath linked]
+                    primary <- canonicalizePath mainRepo
+                    worktree <- canonicalizePath linked
+                    saveProjectAutoApprove primary False
+                    saveProjectAutoApprove worktree True
+                    persistModelSwitch TopLevelSwitch home worktree
+                        (target XAIProvider "xai"
+                            "grok-4.6" "grok-4.6" GrokBuildDialect)
+
+                    primarySettings <- loadProjectSettings primary
+                    worktreeSettings <- loadProjectSettings worktree
+                    userSettings <- loadUserSettings home
+                    let expectedModel = Just ProjectModel
+                            { projectModelTarget =
+                                target XAIProvider "xai"
+                                    "grok-4.6" "grok-4.6" GrokBuildDialect
+                            }
+                    resolvePrimaryProjectRoot worktree `shouldReturn` primary
+                    primarySettings.settingsAutoApprove `shouldBe` False
+                    worktreeSettings.settingsAutoApprove `shouldBe` True
+                    primarySettings.settingsLastModel `shouldBe` expectedModel
+                    worktreeSettings.settingsLastModel `shouldBe` expectedModel
+                    userSettings.settingsLastModel `shouldBe` expectedModel
+
+        it "inherits a primary last model into a fresh worktree" $
+            withTempDir "agent-wt-" \root ->
+                withTempDir "agent-home-" \home -> do
+                    let mainRepo = root </> fromFilePath "main"
+                        linked = root </> fromFilePath "linked"
+                    createDirectoryIfMissing True mainRepo
+                    git_ mainRepo ["init"]
+                    git_ mainRepo ["config", "user.email", "test@example.com"]
+                    git_ mainRepo ["config", "user.name", "Test"]
+                    git_ mainRepo ["config", "commit.gpgsign", "false"]
+                    git_ mainRepo ["commit", "--allow-empty", "-m", "init"]
+                    git_ mainRepo ["worktree", "add", "--detach", toFilePath linked]
+                    primary <- canonicalizePath mainRepo
+                    worktree <- canonicalizePath linked
+                    saveProjectModel primary
+                        (target XAIProvider "xai"
+                            "grok-4.6" "grok-4.6" GrokBuildDialect)
+                    saveProjectModel home
+                        (target OpenAIProvider "openai"
+                            "gpt-5.6-sol" "gpt-5.6-sol" CodexDialect)
+                    saveProjectAutoApprove worktree True
+                    checkoutSettings <- loadProjectSettings worktree
+                    inherited <- inheritProjectLastModel home worktree checkoutSettings
+                    inherited.settingsAutoApprove `shouldBe` True
+                    inherited.settingsLastModel `shouldBe` Just ProjectModel
+                        { projectModelTarget =
+                            target XAIProvider "xai"
+                                "grok-4.6" "grok-4.6" GrokBuildDialect
+                        }
 
         it "keeps a delegated model switch out of checkout and user settings" $
             withTempDir "agent-project-" \project ->
@@ -367,6 +463,21 @@ spec = describe "Agent.CLI.Project" do
                 settings.settingsAutoApprove `shouldBe` True
                 primarySettings <- loadProjectSettings =<< canonicalizePath mainRepo
                 primarySettings.settingsAutoApprove `shouldBe` False
+
+        it "resolves a linked worktree to the primary clone" $
+            withTempDir "agent-wt-" \root -> do
+                let mainRepo = root </> fromFilePath "main"
+                    linked = root </> fromFilePath "linked"
+                createDirectoryIfMissing True mainRepo
+                git_ mainRepo ["init"]
+                git_ mainRepo ["config", "user.email", "test@example.com"]
+                git_ mainRepo ["config", "user.name", "Test"]
+                git_ mainRepo ["config", "commit.gpgsign", "false"]
+                git_ mainRepo ["commit", "--allow-empty", "-m", "init"]
+                git_ mainRepo ["worktree", "add", "--detach", toFilePath linked]
+                expected <- canonicalizePath mainRepo
+                resolvePrimaryProjectRoot linked `shouldReturn` expected
+                resolvePrimaryProjectRoot mainRepo `shouldReturn` expected
 
         it "falls back to cwd outside a git repo" $
             withTempDir "agent-nogit-" \root -> do

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeModelCatalog.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/NativeModelCatalog.hs
@@ -23,7 +23,11 @@ import Agent.CLI.Models
     , selectedOption
     )
 import Agent.CLI.Project
-    ( ProjectModel(..), ProjectSettings(..), loadProjectSettings, resolveProjectRoot )
+    ( ProjectModel(..)
+    , inheritProjectLastModel
+    , loadProjectSettings
+    , resolveProjectRoot
+    )
 import Agent.CLI.Session (SessionMeta(..))
 import Agent.Dialect (dialectSlug)
 import Agent.Provider (Provider(..), providerSlug)
@@ -47,6 +51,7 @@ loadNativeModelCatalog
     contextResult <- currentModelContext
         store
         root
+        home
         requestedCwd
         gatewayIdentity
         request.modelsListSessionId
@@ -113,10 +118,11 @@ currentModelContext
     :: Store
     -> OsPath
     -> OsPath
+    -> OsPath
     -> Maybe Text
     -> Maybe Text
     -> IO (Either Text (OsPath, Maybe ModelTarget))
-currentModelContext store root cwd gatewayIdentity = \case
+currentModelContext store root home cwd gatewayIdentity = \case
     Just sessionId ->
         validateNativeSessionBoundary
             (trustedPool store)
@@ -132,7 +138,8 @@ currentModelContext store root cwd gatewayIdentity = \case
                             ))
     Nothing -> do
         projectRoot <- resolveProjectRoot cwd
-        settings <- loadProjectSettings projectRoot
+        checkoutSettings <- loadProjectSettings projectRoot
+        settings <- inheritProjectLastModel home projectRoot checkoutSettings
         pure $ Right
             ( cwd
             , (.projectModelTarget) <$> settings.settingsLastModel


### PR DESCRIPTION
## Summary

Switching models in a project did not stick for later `agent-cli` sessions in that repository. A live switch wrote last-model to the current Git checkout and `~/.haskell-agent/settings.json`. With `--worktree`, the current checkout is a disposable worktree, so the original project never received the selection. A new session in the same repo then used the catalog default (`gpt-5.6-sol`) instead of the model last used there (for example Grok).

This change:

- Resolves the primary clone from Git's common directory
- Writes a top-level model switch to the current checkout, the primary clone when that path differs, and the user default
- Restores last-model in order: current checkout, primary clone, then user settings
- Leaves auto-approve worktree-local

## Test plan

- [x] `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code` then `:main --match "Agent.CLI.Project"` (26 examples, 0 failures)
- [ ] In a repository, `agent-cli --worktree`, switch to Grok, quit
- [ ] Open a new `agent-cli` in the same repository (with or without `--worktree`) and confirm it starts on Grok
- [ ] Confirm `/always-approve` in a worktree still does not change auto-approve on the primary clone