### PR TITLE
Insert [image N] labels when pasting images into the composer

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -32,12 +32,15 @@ module Agent.CLI.TUI.Composer
     , handleEffortControlClick
     , handlePromptControlClick
     , handleImageRemoveClick
+    , imagePlaceholder
     , immediateBtwQuestion
     , immediateReplCommand
+    , insertImagePlaceholders
     , isKillKey
     , newFullscreenInputBuffer
     , prepareBracketedPaste
     , processComposerPaste
+    , removeImagePlaceholderAt
     , promoteFullscreenInput
     , queuedFullscreenInputDisplays
     , readFullscreenInputs
@@ -247,6 +250,12 @@ handleImageRemoveClick applyUiEvent index = do
                             applyUiEvent (UiSetNotice (Just (warningNotice message))) id
                         Right () -> do
                             let pending = before <> after
+                                (draft, cursor) =
+                                    removeImagePlaceholderAt
+                                        ui.uiDraft
+                                        ui.uiCursor
+                                        (index + 1)
+                                        (length previous)
                             liftIO do
                                 writeIORef state.appRuntime.runtimeImagePreviews pending
                                 modifyIORef' state.appRuntime.runtimeImagePreviewRevision (+ 1)
@@ -255,11 +264,18 @@ handleImageRemoveClick applyUiEvent index = do
                             applyUiEvent
                                 (UiSetPrompt ui.uiPrompt { promptAttachments = length pending })
                                 id
+                            modifyUiResetSlash applyUiEvent (UiSetDraft draft cursor)
                             applyUiEvent
                                 (UiSetNotice (Just (successNotice "attachment removed")))
                                 id
-        else handlePromptControlClick applyUiEvent
-            (\draft -> ReplRemovePendingImage draft index)
+        else handlePromptControlClick applyUiEvent \keptDraft ->
+            let (draft, _) =
+                    removeImagePlaceholderAt
+                        keptDraft
+                        ui.uiCursor
+                        (index + 1)
+                        ui.uiPrompt.promptAttachments
+            in ReplRemovePendingImage draft index
 
 handleEffortControlClick
     :: ApplyLocalUiEvent
@@ -548,7 +564,7 @@ handleComposerKey
                         case nonEmptyClipboardText clipboardText of
                             Just text -> insertPastedText applyUiEvent text
                             Nothing ->
-                                submitRaw applyUiEvent (ReplClipboardPaste ui.uiDraft Nothing)
+                                handleActiveComposerPaste applyUiEvent Nothing
         V.EvKey V.KDel [] ->
             deleteAfter applyUiEvent
         V.EvKey V.KLeft modifiers
@@ -573,27 +589,8 @@ handleComposerKey
             scrollConversationPage Down
         V.EvKey (V.KChar character) [] ->
             insertText applyUiEvent (Text.singleton character)
-        V.EvPaste bytes | ui.uiRunning ->
+        V.EvPaste bytes ->
             handleActiveComposerPaste applyUiEvent (Just (decodePaste bytes))
-        V.EvPaste bytes -> do
-            let pasted = decodePaste bytes
-                (pastedDraft, pastedCursor, clipboardInput) =
-                    prepareBracketedPaste
-                        ui.uiAwaitingInput
-                        ui.uiDraft
-                        ui.uiCursor
-                        pasted
-            case clipboardInput of
-                Nothing -> do
-                    modifyUiResetSlash applyUiEvent
-                        (UiSetDraft pastedDraft pastedCursor)
-                    modify' \current -> current { appPasted = True }
-                Just replLine -> do
-                    when (not (Text.null pasted)) $
-                        modifyUi applyUiEvent
-                            (UiSetNotice
-                                (Just (progressNotice "Reading clipboard…")))
-                    submitRaw applyUiEvent replLine
         _ -> pure ()
     -- Only a kill directly followed by another kill accumulates into the
     -- kill buffer; any other key breaks the chain.
@@ -684,7 +681,7 @@ queueComposerImages applyUiEvent images = do
                 queued <- liftIO $ atomically $
                     appendFullscreenInput state.appRuntime.runtimeInput FullscreenInput
                         { fullscreenInputLine = ReplClipboardPasteCaptured added
-                        , fullscreenInputQueued = True
+                        , fullscreenInputQueued = not state.appUi.uiAwaitingInput
                         , fullscreenInputDisplay = Nothing
                         , fullscreenInputFromInbox = False
                         }
@@ -693,6 +690,12 @@ queueComposerImages applyUiEvent images = do
                     Right () -> do
                         let pending = previous <> prepared
                             prompt = state.appUi.uiPrompt
+                            (draft, cursor) =
+                                insertImagePlaceholders
+                                    state.appUi.uiDraft
+                                    state.appUi.uiCursor
+                                    (length previous + 1)
+                                    (length added)
                         liftIO do
                             writeIORef state.appRuntime.runtimeImagePreviews pending
                             modifyIORef'
@@ -705,6 +708,7 @@ queueComposerImages applyUiEvent images = do
                         applyUiEvent
                             (UiSetPrompt prompt { promptAttachments = length pending })
                             id
+                        modifyUiResetSlash applyUiEvent (UiSetDraft draft cursor)
                         pure $ Right $
                             if rejected > 0
                                 then "image attached; some images exceeded the attachment limit"

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Logic.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Logic.hs
@@ -7,9 +7,12 @@ module Agent.CLI.TUI.Composer.Logic
     , combineKill
     , composerEscapeAction
     , currentSlashMenu
+    , imagePlaceholder
     , immediateBtwQuestion
     , immediateReplCommand
+    , insertImagePlaceholders
     , isKillKey
+    , removeImagePlaceholderAt
     , selectedSlashSuggestion
     , slashReplacement
     , undoLimit
@@ -26,6 +29,7 @@ import Agent.CLI.Command
 import Agent.CLI.Input (ReplLine(..))
 import Agent.CLI.TUI.Types (AppState(..))
 import Agent.TUI.Model (PromptState(..), UiEvent(..), UiState(..))
+import Data.Char (isSpace)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Graphics.Vty as V
@@ -39,6 +43,136 @@ combineKill KillForward killed buffer = buffer <> killed
 
 undoLimit :: Int
 undoLimit = 200
+
+-- | 1-based label inserted at the paste caret, e.g. @[image 1]@.
+imagePlaceholder :: Int -> Text
+imagePlaceholder n = "[image " <> Text.pack (show n) <> "]"
+
+-- | Insert labels for newly attached images at the caret so the model can
+-- tell which later word refers to which image.
+insertImagePlaceholders :: Text -> Int -> Int -> Int -> (Text, Int)
+insertImagePlaceholders draft cursor firstIndex addedCount
+    | addedCount <= 0 || firstIndex < 1 = (draft, clamped)
+    | otherwise = insertPlaceholderText draft clamped placeholders
+  where
+    clamped = clampCursor draft cursor
+    placeholders =
+        Text.unwords
+            [ imagePlaceholder n
+            | n <- [firstIndex .. firstIndex + addedCount - 1]
+            ]
+
+-- | Drop the label for a removed attachment and shift later labels down so
+-- they stay aligned with the remaining attachment order.
+removeImagePlaceholderAt :: Text -> Int -> Int -> Int -> (Text, Int)
+removeImagePlaceholderAt draft cursor removedIndex oldCount
+    | removedIndex < 1 || removedIndex > oldCount =
+        (draft, clampCursor draft cursor)
+    | otherwise =
+        let (without, mapRemoved) =
+                removeFirstPlaceholder draft (imagePlaceholder removedIndex)
+            cursorAfterRemove = mapRemoved (clampCursor draft cursor)
+            (renumbered, cursorFinal) =
+                foldl'
+                    (\(text, cur) n ->
+                        replaceAllAdjustingCursor
+                            text
+                            (imagePlaceholder n)
+                            (imagePlaceholder (n - 1))
+                            cur)
+                    (without, cursorAfterRemove)
+                    [removedIndex + 1 .. oldCount]
+        in (renumbered, clampCursor renumbered cursorFinal)
+
+insertPlaceholderText :: Text -> Int -> Text -> (Text, Int)
+insertPlaceholderText draft cursor inserted
+    | Text.null inserted = (draft, cursor)
+    | otherwise =
+        let before = Text.take cursor draft
+            after = Text.drop cursor draft
+            leading
+                | needsSpaceAfter before inserted = " "
+                | otherwise = ""
+            trailing
+                | Text.null after = " "
+                | needsSpaceBefore (leading <> inserted) after = " "
+                | otherwise = ""
+            text = leading <> inserted <> trailing
+        in (before <> text <> after, cursor + Text.length text)
+
+removeFirstPlaceholder :: Text -> Text -> (Text, Int -> Int)
+removeFirstPlaceholder haystack needle
+    | Text.null needle = (haystack, id)
+    | otherwise =
+        case Text.breakOn needle haystack of
+            (_, rest) | Text.null rest -> (haystack, id)
+            (before, rest) ->
+                let after = Text.drop (Text.length needle) rest
+                    start = Text.length before
+                    end = start + Text.length needle
+                    collapsedAfter =
+                        Text.take 1 after == " "
+                            && (Text.null before || Text.takeEnd 1 before == " ")
+                    collapsedBefore =
+                        Text.null after && Text.takeEnd 1 before == " "
+                    deletedStart = start - if collapsedBefore then 1 else 0
+                    deletedEnd = end + if collapsedAfter then 1 else 0
+                    joined
+                        | collapsedBefore = Text.dropEnd 1 before
+                        | collapsedAfter && Text.null before = Text.drop 1 after
+                        | collapsedAfter = before <> Text.drop 1 after
+                        | otherwise = before <> after
+                    mapCursor cursor
+                        | cursor <= deletedStart = cursor
+                        | cursor >= deletedEnd =
+                            cursor - (deletedEnd - deletedStart)
+                        | otherwise = deletedStart
+                in (joined, mapCursor)
+
+replaceAllAdjustingCursor :: Text -> Text -> Text -> Int -> (Text, Int)
+replaceAllAdjustingCursor haystack old new cursor
+    | Text.null old || old == new = (haystack, cursor)
+    | otherwise =
+        let pieces = Text.splitOn old haystack
+        in (Text.intercalate new pieces, mapCursor pieces)
+  where
+    oldLen = Text.length old
+    newLen = Text.length new
+    mapCursor pieces = go 0 0 pieces
+    go _ newOff [] = newOff
+    go oldOff newOff [_] = newOff + max 0 (cursor - oldOff)
+    go oldOff newOff (piece : rest) =
+        let pieceLen = Text.length piece
+            needleStart = oldOff + pieceLen
+            needleEnd = needleStart + oldLen
+        in if cursor <= needleStart
+            then newOff + (cursor - oldOff)
+            else if cursor < needleEnd
+                then newOff + pieceLen
+                else go needleEnd (newOff + pieceLen + newLen) rest
+
+clampCursor :: Text -> Int -> Int
+clampCursor text cursor = max 0 (min (Text.length text) cursor)
+
+needsSpaceAfter :: Text -> Text -> Bool
+needsSpaceAfter left right =
+    maybe False (not . isSpace) (lastChar left)
+        && maybe False (not . startsWithPunctuation) (firstChar right)
+
+needsSpaceBefore :: Text -> Text -> Bool
+needsSpaceBefore left right =
+    maybe False (not . isSpace) (lastChar left)
+        && maybe False (not . isSpace) (firstChar right)
+
+firstChar :: Text -> Maybe Char
+firstChar = fmap fst . Text.uncons
+
+lastChar :: Text -> Maybe Char
+lastChar = fmap snd . Text.unsnoc
+
+startsWithPunctuation :: Char -> Bool
+startsWithPunctuation char =
+    char `elem` (".,;:!?)]}" :: String)
 
 isKillKey :: V.Event -> Bool
 isKillKey = \case

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -277,8 +277,8 @@ spec = do
                     ]
                 length pasted.appImagePreviews `shouldBe` 1
                 pasted.appUi.uiPrompt.promptAttachments `shouldBe` 1
-                pasted.appUi.uiDraft `shouldBe` "unfinished draft"
-                pasted.appUi.uiCursor `shouldBe` 4
+                pasted.appUi.uiDraft `shouldBe` "unfi [image 1] nished draft"
+                pasted.appUi.uiCursor `shouldBe` 15
                 prepared <- readIORef runtime.runtimeImagePreviews
                 map snd prepared == pasted.appImagePreviews `shouldBe` True
                 -- No REPL consumer is started: the captured image remains queued.
@@ -296,8 +296,8 @@ spec = do
                         refreshed.appImagePreviews == pasted.appImagePreviews
                             `shouldBe` True
                         refreshed.appUi.uiPrompt.promptAttachments `shouldBe` 1
-                        refreshed.appUi.uiDraft `shouldBe` "unfinished draft"
-                        refreshed.appUi.uiCursor `shouldBe` 4
+                        refreshed.appUi.uiDraft `shouldBe` "unfi [image 1] nished draft"
+                        refreshed.appUi.uiCursor `shouldBe` 15
 
         it "refreshes every other prompt field while preserving locally owned attachment counts" $
             withPastedImageFixtures \path _ -> do
@@ -323,8 +323,8 @@ spec = do
                     ]
                 pasted.appUi.uiPrompt
                     `shouldBe` incoming { promptAttachments = 1 }
-                pasted.appUi.uiDraft `shouldBe` "unfinished draft"
-                pasted.appUi.uiCursor `shouldBe` 4
+                pasted.appUi.uiDraft `shouldBe` "unfi [image 1] nished draft"
+                pasted.appUi.uiCursor `shouldBe` 15
                 let later = incoming
                         { promptModel = "subsequent-model"
                         , promptMode = "ask"
@@ -363,8 +363,8 @@ spec = do
                     ]
                 rejected.appImagePreviews == pasted.appImagePreviews `shouldBe` True
                 rejected.appUi.uiPrompt.promptAttachments `shouldBe` 1
-                rejected.appUi.uiDraft `shouldBe` "unfinished draft"
-                rejected.appUi.uiCursor `shouldBe` 4
+                rejected.appUi.uiDraft `shouldBe` "unfi [image 1] nished draft"
+                rejected.appUi.uiCursor `shouldBe` 15
                 after <- readIORef runtime.runtimeImagePreviews
                 after == before `shouldBe` True
                 readIORef runtime.runtimeImagePreviewRevision `shouldReturn` revision
@@ -485,14 +485,56 @@ spec = do
                     ]
                 rejected.appImagePreviews == pasted.appImagePreviews `shouldBe` True
                 rejected.appUi.uiPrompt.promptAttachments `shouldBe` 1
-                rejected.appUi.uiDraft `shouldBe` "unfinished draft"
-                rejected.appUi.uiCursor `shouldBe` 4
+                rejected.appUi.uiDraft `shouldBe` "unfi [image 1] nished draft"
+                rejected.appUi.uiCursor `shouldBe` 15
                 after <- readIORef runtime.runtimeImagePreviews
                 after == before `shouldBe` True
                 readIORef runtime.runtimeImagePreviewRevision `shouldReturn` revision
                 (.noticeText) <$> rejected.appUi.uiNotice
                     `shouldBe` Just
                         "Prompt queue is full; wait for a queued prompt to be consumed."
+
+        it "keeps pasted images addressable in the prompt the model will receive" $
+            withPastedImageFixtures \firstPath secondPath -> do
+                let running = reduceUi (UiSetDraft "here we should change that" 15) $
+                        reduceUi (UiLoop TurnStarted) initialUiState
+                runtime <- newScriptRuntime running
+                (_, pasted) <- runFullscreenScriptWithState
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack firstPath)))
+                    , FullscreenScriptApp (AppUi (UiSetDraft
+                        "here we should [image 1] change that" 36))
+                    , FullscreenScriptVty (V.EvPaste (encoded (Text.pack secondPath)))
+                    , FullscreenScriptHalt
+                    ]
+                pasted.appUi.uiDraft
+                    `shouldBe` "here we should [image 1] change that [image 2] "
+                pasted.appUi.uiCursor `shouldBe` 47
+                length pasted.appImagePreviews `shouldBe` 2
+                (_, removed) <- runFullscreenScriptWithState pasted
+                    [ FullscreenScriptMouseDown (ComposerImageRemove 0) V.BLeft (B.Location (0, 0))
+                    , FullscreenScriptMouseUp (ComposerImageRemove 0) (B.Location (0, 0))
+                    , FullscreenScriptHalt
+                    ]
+                removed.appUi.uiDraft
+                    `shouldBe` "here we should change that [image 1] "
+                length removed.appImagePreviews `shouldBe` 1
+
+        it "inserts image labels while the composer is idle and awaiting input" $
+            withPastedImageFixtures \path _ -> do
+                let idle = reduceUi (UiSetDraft "here we should change that" 15) $
+                        reduceUi (UiSetAwaitingInput True) initialUiState
+                runtime <- newScriptRuntime idle
+                (_, pasted) <- runFullscreenScriptWithState
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    [ FullscreenScriptVty (V.EvPaste (encoded (Text.pack path)))
+                    , FullscreenScriptHalt
+                    ]
+                pasted.appUi.uiDraft
+                    `shouldBe` "here we should [image 1] change that"
+                pasted.appUi.uiCursor `shouldBe` 25
+                length pasted.appImagePreviews `shouldBe` 1
+                pasted.appUi.uiAwaitingInput `shouldBe` True
 
     describe "dynamic model choice" do
         it "preserves filter, selected identity, and effort across reordered rows" do

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -357,6 +357,34 @@ spec = describe "fullscreen composer" do
             (Just "/images/example.png")
             `shouldReturn` ComposerPasteFailed "attachment limit reached"
 
+    it "inserts numbered image labels at the paste caret" do
+        insertImagePlaceholders "here we should change that" 15 1 1
+            `shouldBe` ("here we should [image 1] change that", 25)
+        insertImagePlaceholders "here we should [image 1] change that" 36 2 1
+            `shouldBe` ("here we should [image 1] change that [image 2] ", 47)
+        insertImagePlaceholders "unfinished draft" 4 1 1
+            `shouldBe` ("unfi [image 1] nished draft", 15)
+        insertImagePlaceholders "" 0 1 2
+            `shouldBe` ("[image 1] [image 2] ", 20)
+
+    it "removes an image label and renumbers later labels" do
+        removeImagePlaceholderAt
+            "here we should [image 1] change that [image 2] "
+            25
+            1
+            2
+            `shouldBe` ("here we should change that [image 1] ", 15)
+        removeImagePlaceholderAt
+            "here we should [image 1] change that [image 2] "
+            47
+            2
+            2
+            `shouldBe` ("here we should [image 1] change that ", 37)
+        removeImagePlaceholderAt "see attached [image 10] now" 0 10 10
+            `shouldBe` ("see attached now", 0)
+        removeImagePlaceholderAt "plain draft" 4 1 1
+            `shouldBe` ("plain draft", 4)
+
     it "inserts dictation at the cursor with word-safe spacing" do
         insertDictation "please now" 6 "fix this"
             `shouldBe` ("please fix this now", 15)


### PR DESCRIPTION
## Summary

Pasting an image into the prompt composer attached the bytes as a sidecar and left the draft unchanged. A prompt such as `here we should [paste] change something so it looks like that [paste]` reached the model as plain text with two unlabeled images, so "this" and "that" had no referent.

The composer now inserts `[image 1]`, `[image 2]`, … at the caret when an image is attached, and removes/renumbers those labels when a thumbnail is deleted. The submitted prompt therefore names each image in place:

```
here we should [image 1] change something so it looks like that [image 2]
```

## Test plan

- [x] `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code` then `:main --match "image label" --match "active-turn image paste" --match "pasted images addressable"` (10 examples, 0 failures)
- [ ] Paste one image mid-sentence in the live composer and confirm `[image 1]` appears at the caret
- [ ] Paste a second image later in the same draft and confirm `[image 2]`
- [ ] Remove the first thumbnail and confirm the remaining label becomes `[image 1]`