### PR TITLE
Include gateway dictation error bodies in HTTP failures

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Dictation.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Dictation.hs
@@ -30,7 +30,8 @@ import Network.HTTP.Client qualified as HTTP
 import Network.HTTP.Client.MultipartFormData qualified as Multipart
 import Network.HTTP.Client.TLS (newTlsManager)
 import Network.HTTP.Types
-    ( hAccept
+    ( Status
+    , hAccept
     , hAuthorization
     , statusCode
     , statusIsSuccessful
@@ -248,9 +249,7 @@ postGatewayTranscription credential wav =
                         Left
                             "Dictation is not supported by this organization gateway."
                     | otherwise ->
-                        Left $
-                            "Gateway dictation returned HTTP "
-                                <> Text.pack (show (statusCode status))
+                        Left (gatewayDictationStatusError status responseBody)
 
 gatewayTranscriptionBoundary :: IO BS.ByteString
 gatewayTranscriptionBoundary =
@@ -265,6 +264,37 @@ instance Aeson.FromJSON GatewayTranscript where
     parseJSON =
         Aeson.withObject "GatewayTranscript" \object ->
             GatewayTranscript <$> object .: "text"
+
+newtype GatewayErrorEnvelope =
+    GatewayErrorEnvelope { gatewayErrorMessage :: Text }
+
+instance Aeson.FromJSON GatewayErrorEnvelope where
+    parseJSON =
+        Aeson.withObject "GatewayErrorEnvelope" \root -> do
+            err <- root .: "error"
+            Aeson.withObject "GatewayError" (\object ->
+                GatewayErrorEnvelope <$> object .: "message") err
+
+gatewayDictationStatusError :: Status -> BS.ByteString -> Text
+gatewayDictationStatusError status body =
+    "Gateway dictation returned HTTP "
+        <> Text.pack (show (statusCode status))
+        <> case gatewayErrorMessageFromBody body of
+            Just message -> ": " <> message
+            Nothing -> ""
+
+gatewayErrorMessageFromBody :: BS.ByteString -> Maybe Text
+gatewayErrorMessageFromBody body = do
+    envelope <-
+        either
+            (const Nothing)
+            Just
+            (Aeson.eitherDecodeStrict' body
+                :: Either String GatewayErrorEnvelope)
+    let trimmed = Text.strip envelope.gatewayErrorMessage
+    if Text.null trimmed
+        then Nothing
+        else Just (Text.take 200 (Text.unwords (Text.words trimmed)))
 
 decodeGatewayTranscript :: BS.ByteString -> Either Text Text
 decodeGatewayTranscript body =


### PR DESCRIPTION
## Summary
- Organization-gateway dictation failures were shown as a bare `Gateway dictation returned HTTP 429`.
- That 429 was often `No healthy transcription account is currently available`, not an xAI rate limit.
- Include the gateway JSON error message so the two cases are distinguishable.

Companion fix for actual Grok transcription: digitallyinduced/haskell-agent-gateway#150

## Test plan
- [x] GHCi loads `Agent.CLI.Gateway.Dictation`
- [x] `cabal test agent-cli-runtime:test:agent-cli-runtime-test --test-options='-m "gateway device authorization"'` (49 examples, including gateway dictation model-access)
- [ ] After a gateway 429, the composer shows the error message body rather than only the status code