### PR TITLE
Start HTTP MCP OAuth immediately and listen for the callback first

### DIFF
--- a/docs/mcp-oauth.md
+++ b/docs/mcp-oauth.md
@@ -15,8 +15,10 @@ agent-cli mcp login https://example.com/mcp --scope files:write
 agent-cli mcp logout https://example.com/mcp
 ```
 
-In an interactive session, `/mcp` can add the HTTP server and then authorize
-it with `i` without leaving the UI.
+In an interactive session, `/mcp` adds an HTTP server and starts the browser
+OAuth flow immediately. The local callback server is listening before the
+browser opens, so the provider redirect can complete without returning to the
+terminal first. `i` still re-authorizes a selected HTTP server.
 
 `--scope` (repeatable) requests additional scopes for step-up authorization;
 they are unioned with the scopes already granted for the same issuer. A `403`
@@ -57,11 +59,12 @@ error message.
    Previously granted scopes for the same issuer and any additional scopes
    requested for step-up authorization are unioned in. `offline_access` is
    added only when the authorization server advertises it.
-7. The browser is opened with `code_challenge`, `state`, `scope`, and the
-   canonical server URI as `resource`. On callback the `iss` parameter is
-   validated against the recorded issuer before anything else is inspected,
-   then `state` is verified and the code is exchanged (again with
-   `resource`, and `client_secret` for confidential pre-registered clients).
+7. A loopback callback server is started first, then the browser is opened
+   with `code_challenge`, `state`, `scope`, and the canonical server URI as
+   `resource`. On callback the `iss` parameter is validated against the
+   recorded issuer before anything else is inspected, then `state` is verified
+   and the code is exchanged (again with `resource`, and `client_secret` for
+   confidential pre-registered clients).
 
 The token record is written atomically with mode `0600` to
 `~/.haskell-agent/credentials/mcp/<hex(url)>.json` and is picked up by

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -45,10 +45,11 @@ next session (or `/mcp` `r` in a running one) picks up the change.
 
 In an interactive session, `/mcp` opens the server manager in the UI. Use the
 arrow keys or `j`/`k` to navigate, Enter to inspect tools, `a` to add a
-remote URL or local command, `i` to authorize an HTTP server with OAuth,
-Space to enable or disable it, `x` then `y` to remove it, and `r` to restart
-the MCP runtime. Saved changes restart the runtime while preserving the
-session. Environment variable values are never displayed.
+remote URL or local command (HTTP servers start OAuth immediately), `i` to
+re-authorize an HTTP server, Space to enable or disable it, `x` then `y` to
+remove it, and `r` to restart the MCP runtime. Saved changes restart the
+runtime while preserving the session. Environment variable values are never
+displayed.
 
 `mcpInitStrategy` accepts `auto`, `progressive`, or `blocking`. `auto` starts
 servers progressively for interactive sessions so the prompt is immediately

--- a/packages/agent-cli/src/Agent/CLI/McpManager.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpManager.hs
@@ -13,6 +13,7 @@ module Agent.CLI.McpManager
     , initialMcpManagerState
     , mcpEntryTransport
     , parseMcpCommand
+    , pendingHttpAuthorizationUrl
     , renderMcpManagerFrame
     , resolveMcpAddForm
     , runMcpManager
@@ -189,6 +190,13 @@ initialMcpManagerState config registrations warnings pending authorized notice =
         Just url ->
             maybe False isAuthFailure failed
                 || (Set.notMember url authorized && isJust failed)
+
+-- | HTTP servers that are not yet covered by a saved OAuth token record.
+pendingHttpAuthorizationUrl :: Set Text -> McpServerConfig -> Maybe Text
+pendingHttpAuthorizationUrl authorized server =
+    case server.mcpUrl of
+        Just url | Set.notMember url authorized -> Just url
+        _ -> Nothing
 
 authorizedMcpUrls :: OsPath -> HarnessConfig -> IO (Set Text)
 authorizedMcpUrls home config =
@@ -485,7 +493,7 @@ runMcpManager color home registrations warnings = do
                 Just McpManagerClose -> pure changed
                 Just McpManagerRestart -> pure True
                 Just (McpManagerSubmitAdd label server) ->
-                    persist
+                    persistThen
                         (config
                             { configMcpServers =
                                 Map.insert label server
@@ -493,6 +501,7 @@ runMcpManager color home registrations warnings = do
                             })
                         (Set.insert label pending)
                         ("Added " <> label)
+                        (authorizeAddedHttpServer label server)
                 Just (McpManagerToggle label) ->
                     case Map.lookup label config.configMcpServers of
                         Nothing ->
@@ -534,20 +543,13 @@ runMcpManager color home registrations warnings = do
                                             <> " is a local stdio server; OAuth is only used for HTTP servers"
                                         ))
                             Just url ->
-                                loginMcpWithResult defaultLoginOptions url >>= \case
-                                    Left err ->
-                                        loop revision config pending changed authorized
-                                            (Just (False, err))
-                                    Right message -> do
-                                        nextAuthorized <-
-                                            authorizedMcpUrls home config
-                                        loop revision config
-                                            (Set.insert label pending)
-                                            True
-                                            nextAuthorized
-                                            (Just (True, message))
+                                authorizeLabel label url revision config pending
+                                    changed False
       where
         persist updated pending' message =
+            persistThen updated pending' message loopAfterPersist
+
+        persistThen updated pending' message after =
             modifyHarnessConfig home
                 (\current _ ->
                     if current /= revision
@@ -559,7 +561,39 @@ runMcpManager color home registrations warnings = do
                         (Just (False, err))
                 Right (nextRevision, _, ()) -> do
                     nextAuthorized <- authorizedMcpUrls home updated
-                    loop nextRevision updated pending' True
+                    after
+                        nextRevision
+                        updated
+                        pending'
+                        nextAuthorized
+                        (Just (True, message))
+
+        loopAfterPersist nextRevision nextConfig nextPending nextAuthorized notice =
+            loop nextRevision nextConfig nextPending True nextAuthorized notice
+
+        authorizeAddedHttpServer label server nextRevision nextConfig nextPending nextAuthorized notice =
+            case pendingHttpAuthorizationUrl nextAuthorized server of
+                Nothing ->
+                    loop nextRevision nextConfig nextPending True nextAuthorized notice
+                Just url ->
+                    authorizeLabel label url nextRevision nextConfig nextPending
+                        True True
+
+        authorizeLabel label url nextRevision nextConfig nextPending nextChanged addedFirst =
+            loginMcpWithResult defaultLoginOptions url >>= \case
+                Left err ->
+                    loop nextRevision nextConfig nextPending nextChanged authorized
+                        (Just
+                            ( False
+                            , if addedFirst
+                                then "Added " <> label <> ". " <> err
+                                else err
+                            ))
+                Right message -> do
+                    nextAuthorized <- authorizedMcpUrls home nextConfig
+                    loop nextRevision nextConfig
+                        (Set.insert label nextPending)
+                        True
                         nextAuthorized
                         (Just (True, message))
 

--- a/packages/agent-cli/src/Agent/CLI/McpManager/Fullscreen.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpManager/Fullscreen.hs
@@ -32,6 +32,7 @@ import Agent.CLI.McpManager
     , authorizedMcpUrls
     , initialMcpManagerState
     , mcpEntryTransport
+    , pendingHttpAuthorizationUrl
     )
 import Agent.CLI.Login.Internal.Browser (openBrowser)
 import Agent.CLI.McpOAuth
@@ -43,12 +44,12 @@ import Agent.CLI.McpOAuth
 import Agent.CLI.TUI.App
     ( FullscreenRuntime
     , emitUiEvent
+    , requestFullscreenChoiceUntil
     , requestFullscreenChoiceWithBody
     , requestFullscreenText
     )
 import Agent.MCP (McpToolRegistration)
 import Agent.TUI.Model (UiEvent(UiSetNotice), progressNotice)
-import Control.Exception.Safe (bracket_)
 import System.Timeout (timeout)
 import Data.Char (isControl)
 import Data.Maybe (catMaybes)
@@ -205,11 +206,10 @@ runFullscreenMcpManager runtime home registrations warnings =
                                                         , snapshot
                                                         )
                                                 Right next ->
-                                                    pure
-                                                        ( Just (McpNotice True next.message)
-                                                        , next.persistedRevision
-                                                        , next.persistedSnapshot
-                                                        )
+                                                    authorizeAddedHttpServer
+                                                        next
+                                                        label
+                                                        (mcpServerForTarget target)
 
     serverMenu notice revision snapshot entry = do
         let actions = mcpServerMenuEntries entry
@@ -267,30 +267,13 @@ runFullscreenMcpManager runtime home registrations warnings =
                             snapshot
                             entry
                     Just url ->
-                        loginMcpWithHost
-                            (fullscreenMcpLoginHost runtime)
-                            defaultLoginOptions
+                        authorizeHttpServer
+                            False
+                            entry.mcpEntryName
                             url
-                            >>= \case
-                                Left err ->
-                                    serverMenu
-                                        (Just (McpNotice False err))
-                                        revision
-                                        snapshot
-                                        entry
-                                Right message -> do
-                                    nextAuthorized <-
-                                        authorizedMcpUrls home snapshot.snapshotConfig
-                                    dashboard
-                                        (Just (McpNotice True message))
-                                        revision
-                                        snapshot
-                                            { snapshotPending =
-                                                Set.insert entry.mcpEntryName
-                                                    snapshot.snapshotPending
-                                            , snapshotChanged = True
-                                            , snapshotAuthorized = nextAuthorized
-                                            }
+                            revision
+                            snapshot
+                            >>= continueDashboard
 
     afterPersist revision snapshot = \case
         Left err -> dashboard (Just (McpNotice False err)) revision snapshot
@@ -302,6 +285,53 @@ runFullscreenMcpManager runtime home registrations warnings =
 
     persist revision snapshot updated pending message =
         persistSnapshot home revision snapshot updated pending message
+
+    authorizeAddedHttpServer next label server =
+        case pendingHttpAuthorizationUrl
+            next.persistedSnapshot.snapshotAuthorized
+            server of
+            Nothing ->
+                pure
+                    ( Just (McpNotice True next.message)
+                    , next.persistedRevision
+                    , next.persistedSnapshot
+                    )
+            Just url ->
+                authorizeHttpServer
+                    True
+                    label
+                    url
+                    next.persistedRevision
+                    next.persistedSnapshot
+
+    authorizeHttpServer addedFirst label url revision snapshot = do
+        loginMcpWithHost
+            (fullscreenMcpLoginHost runtime)
+            defaultLoginOptions
+            url
+            >>= \case
+                Left err ->
+                    pure
+                        ( Just
+                            (McpNotice False $
+                                if addedFirst
+                                    then "Added " <> label <> ". " <> err
+                                    else err)
+                        , revision
+                        , snapshot
+                        )
+                Right message -> do
+                    nextAuthorized <-
+                        authorizedMcpUrls home snapshot.snapshotConfig
+                    pure
+                        ( Just (McpNotice True message)
+                        , revision
+                        , snapshot
+                            { snapshotPending = Set.insert label snapshot.snapshotPending
+                            , snapshotChanged = True
+                            , snapshotAuthorized = nextAuthorized
+                            }
+                        )
 
     confirmRemove name = do
         choice <-
@@ -527,33 +557,27 @@ fullscreenMcpLoginHost runtime =
             \message ->
                 emitUiEvent runtime
                     (UiSetNotice (Just (progressNotice message)))
-        , mcpLoginPresentAuthorization =
-            presentMcpAuthorizationFullscreen runtime
-        , mcpLoginAwaitCallback = \wait ->
-            withLoginProgress runtime "Waiting for MCP authorization…" $
-                timeout mcpOAuthCallbackTimeoutMicros wait
+        , mcpLoginAuthorize = authorizeMcpFullscreen runtime
         }
 
-presentMcpAuthorizationFullscreen
+authorizeMcpFullscreen
     :: FullscreenRuntime
     -> Text
-    -> IO (Either Text ())
-presentMcpAuthorizationFullscreen runtime url = do
+    -> IO a
+    -> IO (Either Text (Maybe a))
+authorizeMcpFullscreen runtime url wait = do
     opened <- openBrowser url
-    choice <-
-        requestFullscreenChoiceWithBody
+    outcome <-
+        requestFullscreenChoiceUntil
             runtime
             "Authorize MCP server"
             (mcpAuthorizationBody opened url)
             0
-            [ ( "Continue"
-              , "Finish browser authorization and continue"
-              )
-            , ("Cancel", "Stop without saving credentials")
-            ]
-    pure $ case choice of
-        Just 0 -> Right ()
-        _ -> Left "MCP authorization was cancelled."
+            [("Cancel", "Stop without saving credentials")]
+            (timeout mcpOAuthCallbackTimeoutMicros wait)
+    pure $ case outcome of
+        Left _ -> Left "MCP authorization was cancelled."
+        Right callback -> Right callback
 
 mcpAuthorizationBody :: Bool -> Text -> Text
 mcpAuthorizationBody opened url =
@@ -561,17 +585,10 @@ mcpAuthorizationBody opened url =
         [ "[Open the authorization page](" <> url <> ")."
         , if opened
             then
-                "A browser window was opened automatically. Complete the sign-in, then return here."
+                "A browser window was opened automatically. Complete the sign-in there. This view continues when the browser redirects back; you do not need to return here first."
             else
-                "The browser could not be opened automatically. Use the link above, then return here."
+                "The browser could not be opened automatically. Use the link above. This view continues when the browser redirects back."
         ]
-
-withLoginProgress :: FullscreenRuntime -> Text -> IO a -> IO a
-withLoginProgress runtime message =
-    bracket_
-        (emitUiEvent runtime
-            (UiSetNotice (Just (progressNotice message))))
-        (emitUiEvent runtime (UiSetNotice Nothing))
 
 markdownText :: Int -> Text -> Text
 markdownText limit =

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -27,14 +27,16 @@ import Agent.CLI.Login.Internal.Browser (openBrowser)
 import Agent.CLI.McpOAuthStore (loadMcpOAuthRecord, mcpOAuthStorePath, saveMcpOAuthRecord)
 import Agent.MCP (McpProtocolPreference(..))
 import qualified Agent.MCP.OAuth as OAuth
+import Control.Concurrent.Async (race, wait, waitCatch, withAsync)
 import Control.Concurrent.MVar
-    ( newEmptyMVar
+    ( MVar
+    , newEmptyMVar
     , putMVar
     , readMVar
     , tryPutMVar
     )
 import Network.URI (parseURI, uriAuthority, uriRegName, uriScheme, uriUserInfo, uriQuery)
-import Control.Exception.Safe (bracket, bracketOnError, finally, tryAny)
+import Control.Exception.Safe (bracket, bracketOnError, finally, throwIO, tryAny)
 import Control.Monad (forM_, unless, void, when)
 import Crypto.Hash (Digest, SHA256, hash)
 import Data.Char (isAsciiLower, isDigit)
@@ -89,10 +91,15 @@ data Callback = Callback
 
 -- | Host-owned presentation for MCP OAuth. The CLI prints to stdout; the
 -- fullscreen manager shows notices and the authorization URL in overlays.
+--
+-- 'mcpLoginAuthorize' is called only after the loopback callback server is
+-- already accepting connections, so the browser redirect can complete without
+-- a later confirmation step.
 data McpLoginHost = McpLoginHost
     { mcpLoginSay :: !(Text -> IO ())
-    , mcpLoginPresentAuthorization :: !(Text -> IO (Either Text ()))
-    , mcpLoginAwaitCallback :: !(IO Callback -> IO (Maybe Callback))
+    -- | Open the authorization URL and wait for the loopback callback. 'Left'
+    -- cancels the login; 'Right Nothing' is a timeout.
+    , mcpLoginAuthorize :: !(Text -> IO Callback -> IO (Either Text (Maybe Callback)))
     }
 
 mcpOAuthCallbackTimeoutMicros :: Int
@@ -102,14 +109,12 @@ defaultMcpLoginHost :: McpLoginHost
 defaultMcpLoginHost =
     McpLoginHost
         { mcpLoginSay = putStrLn . Text.unpack
-        , mcpLoginPresentAuthorization = \url -> do
+        , mcpLoginAuthorize = \url wait -> do
             opened <- openBrowser url
             unless opened $
                 putStrLn
                     "Could not launch a browser automatically; open the URL above."
-            pure (Right ())
-        , mcpLoginAwaitCallback =
-            timeout mcpOAuthCallbackTimeoutMicros
+            Right <$> timeout mcpOAuthCallbackTimeoutMicros wait
         }
 
 loginMcp :: Text -> IO ()
@@ -270,10 +275,13 @@ loginMcpWithHostThrow host options serverUrl = do
                 <> (if Text.null scopeText then "" else "&scope=" <> encode scopeText)
                 <> "&resource=" <> encode resourceUri
         host.mcpLoginSay ("Opening browser for MCP authorization: " <> authUrl)
-        host.mcpLoginPresentAuthorization authUrl >>= either failText (const (pure ()))
         callback <-
-            host.mcpLoginAwaitCallback (receiveCallback listener)
-                >>= maybe (failText "Timed out waiting for MCP OAuth callback") pure
+            withListeningCallback listener \awaitCallback ->
+                host.mcpLoginAuthorize authUrl awaitCallback >>= \case
+                    Left err -> failText err
+                    Right Nothing ->
+                        failText "Timed out waiting for MCP OAuth callback"
+                    Right (Just received) -> pure received
         -- RFC 9207: validate the issuer before acting on any other parameter,
         -- including error responses.
         either failText pure $ OAuth.validateAuthorizationResponseIssuer
@@ -445,14 +453,28 @@ callbackPort sock = do
     SockAddrInet port _ <- getSocketName sock
     pure (fromIntegral port)
 
-receiveCallback :: Socket -> IO Callback
-receiveCallback listener = do
+-- | Run the loopback HTTP server and invoke the action only after Warp is
+-- accepting connections, so the browser redirect cannot lose the race.
+withListeningCallback :: Socket -> (IO Callback -> IO a) -> IO a
+withListeningCallback listener action = do
+    readyVar <- newEmptyMVar
+    withAsync (receiveCallback listener readyVar) \callbackAsync -> do
+        race (waitCatch callbackAsync) (readMVar readyVar) >>= \case
+            Left (Left err) -> throwIO err
+            Left (Right _) ->
+                failText
+                    "MCP OAuth callback server exited before accepting connections"
+            Right () -> action (wait callbackAsync)
+
+receiveCallback :: Socket -> MVar () -> IO Callback
+receiveCallback listener readyVar = do
     resultVar <- newEmptyMVar
     shutdownVar <- newEmptyMVar
     let settings =
             Warp.setHost "127.0.0.1"
                 $ Warp.setMaxTotalHeaderLength 8_192
                 $ Warp.setInstallShutdownHandler (putMVar shutdownVar)
+                $ Warp.setBeforeMainLoop (void $ tryPutMVar readyVar ())
                     Warp.defaultSettings
         application request respond
             | Wai.requestMethod request /= methodGet =

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -73,6 +73,7 @@ module Agent.CLI.TUI.App
     , requestFullscreenPermission
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
+    , requestFullscreenChoiceUntil
     , requestFullscreenPlanningChoice
     , requestFullscreenPlanningText
     , requestFullscreenDocument

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -140,7 +140,7 @@ import Control.Applicative ((<|>))
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
 import Control.Monad (forM_, forever, unless, void, when, (>=>))
-import Control.Concurrent.STM ( STM , TMVar , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , writeTQueue , writeTVar )
+import Control.Concurrent.STM ( STM , TMVar , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , tryPutTMVar , writeTQueue , writeTVar )
 import Agent.CLI.Recap ( autoRecapAwayThreshold , autoRecapIdleThreshold , autoRecapRetryInterval )
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
@@ -479,6 +479,8 @@ handleAppEvent = \case
                 , dynamic.dynamicChoiceReply == reply ->
                     state { appChoice = Nothing }
             _ -> state
+    AppCloseChoice reply ->
+        handleCloseChoiceEvent reply
     AppAskDynamicAdjustableFilterChoice title body initial rows reply -> do
         state <- get
         liftIO (state.appRuntime.runtimeNativeProgress False)
@@ -925,6 +927,22 @@ handleAskPermissionEvent summary reply = do
                 , appAgentHover = Nothing
                 }
 
+handleCloseChoiceEvent
+    :: TMVar (Maybe Int)
+    -> EventM Name AppState ()
+handleCloseChoiceEvent reply = do
+    liftIO $ atomically (void $ tryPutTMVar reply Nothing)
+    state <- get
+    let matching = case state.appChoice of
+            Just pending
+                | Just (ChoiceReply token) <- pending.dialogOverlay.choiceReply
+                , token == reply ->
+                    True
+            _ -> False
+    when matching do
+        modify' \current -> current { appChoice = Nothing }
+        resumeNativeProgressIfRunning
+
 handleAskChoiceEvent
     :: ChoicePresentation
     -> Text
@@ -953,6 +971,7 @@ handleAskChoiceEvent presentation title body initial rows reply = do
                 , choiceAdjustmentIndices = []
                 , choiceCloseOnTurnEnd = False
                 , choiceDynamic = Nothing
+                , choiceReply = Just (ChoiceReply reply)
                 }
             , appAgentHover = Nothing
             }
@@ -986,6 +1005,7 @@ handleAskFilterChoiceEvent title initial rows reply = do
                 , choiceAdjustmentIndices = []
                 , choiceCloseOnTurnEnd = False
                 , choiceDynamic = Nothing
+                , choiceReply = Nothing
                 }
             , appAgentHover = Nothing
             }
@@ -1033,6 +1053,7 @@ handleAskAdjustableFilterChoiceEvent title initial adjustableRows reply = do
                 , choiceAdjustmentIndices = adjustmentIndices
                 , choiceCloseOnTurnEnd = False
                 , choiceDynamic = Nothing
+                , choiceReply = Nothing
                 }
             , appAgentHover = Nothing
             }

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -720,6 +720,7 @@ appEventLogicalBytes = \case
     AppUpdateDynamicAdjustableFilterChoice _ body rows ->
         dynamicChoiceLogicalBytes [body] rows
     AppCloseDynamicAdjustableFilterChoice _ -> 256
+    AppCloseChoice _ -> 256
     AppAskText _ title body draft _ ->
         saturatingAdd 256 (logicalTextsBytes [title, body, draft])
     AppAskResume browser _ _ _ _ ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -407,6 +407,7 @@ openCommandPalette = do
                 , choiceAdjustmentIndices = []
                 , choiceCloseOnTurnEnd = False
                 , choiceDynamic = Nothing
+                , choiceReply = Nothing
                 }
             , appAgentHover = Nothing
             }

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -149,7 +149,7 @@ import Brick.Widgets.Border.Style (unicodeRounded)
 import Brick.Widgets.Center (center, centerLayer, hCenter)
 import Codec.Picture (pixelAt)
 import Control.Applicative ((<|>))
-import Control.Concurrent.Async (wait, waitCatch, withAsync)
+import Control.Concurrent.Async (race, wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
 import Control.Monad (forever, unless, void, when, (>=>))
 import Control.Concurrent.STM ( STM , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , writeTQueue , writeTVar )
@@ -1050,6 +1050,26 @@ requestFullscreenChoiceWithBody runtime title body initial rows = do
     enqueueAppEvent runtime
         (AppAskChoice ChoiceDialog title body initial rows reply)
     atomically (readTMVar reply)
+
+-- | Show a choice overlay while waiting for an independent result. If the
+-- waiter finishes first, the overlay is closed without cancelling a later
+-- dialog. The left side is the user's selection, including 'Nothing' for Esc.
+requestFullscreenChoiceUntil
+    :: FullscreenRuntime
+    -> Text
+    -> Text
+    -> Int
+    -> [(Text, Text)]
+    -> IO a
+    -> IO (Either (Maybe Int) a)
+requestFullscreenChoiceUntil runtime title body initial rows wait = do
+    reply <- newEmptyTMVarIO
+    enqueueAppEvent runtime
+        (AppAskChoice ChoiceDialog title body initial rows reply)
+    race
+        (atomically (readTMVar reply))
+        wait
+        `finally` enqueueAppEvent runtime (AppCloseChoice reply)
 
 -- | Open a read-only, scrollable Markdown document and wait for dismissal.
 requestFullscreenDocument

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -319,6 +319,7 @@ handleEffortControlClick applyUiEvent = do
                             , choiceAdjustmentIndices = []
                             , choiceCloseOnTurnEnd = True
                             , choiceDynamic = Nothing
+                            , choiceReply = Nothing
                             }
                         }
                 vScrollToBeginning (viewportScroll OverlayViewport)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -9,6 +9,7 @@ module Agent.CLI.TUI.Types
     , DictationSession(..)
     , ChoicePresentation(..)
     , ChoiceOverlay(..)
+    , ChoiceReply(..)
     , DynamicChoice(..)
     , newDynamicChoice
     , refreshDynamicChoice
@@ -175,6 +176,8 @@ data AppEvent
         ![(Text, Text, Text, [Text], Int)]
     | AppCloseDynamicAdjustableFilterChoice
         !(TMVar (Maybe (Text, Int)))
+    | AppCloseChoice
+        !(TMVar (Maybe Int))
     | AppAskText
         !TextInputMode
         !Text
@@ -601,8 +604,21 @@ data ChoiceOverlay = ChoiceOverlay
     , choiceAdjustmentIndices :: ![Int]
     , choiceCloseOnTurnEnd :: !Bool
     , choiceDynamic :: !(Maybe DynamicChoice)
+    -- | Set for 'AppAskChoice' dialogs so a concurrent waiter can close this
+    -- overlay without cancelling a later dialog that reused the slot.
+    , choiceReply :: !(Maybe ChoiceReply)
     }
     deriving (Eq, Show)
+
+-- | Identity of an 'AppAskChoice' reply token. Equality is pointer equality
+-- of the underlying 'TMVar'.
+newtype ChoiceReply = ChoiceReply (TMVar (Maybe Int))
+
+instance Eq ChoiceReply where
+    ChoiceReply left == ChoiceReply right = left == right
+
+instance Show ChoiceReply where
+    show _ = "ChoiceReply"
 
 data DynamicChoice = DynamicChoice
     { dynamicChoiceReply :: !(TMVar (Maybe (Text, Int)))
@@ -629,6 +645,7 @@ newDynamicChoice title body initial rows reply = ChoiceOverlay
         [max 0 (min (max 0 (length values - 1)) index) | (_, _, _, values, index) <- rows]
     , choiceCloseOnTurnEnd = False
     , choiceDynamic = Just (DynamicChoice reply [key | (key, _, _, _, _) <- rows])
+    , choiceReply = Nothing
     }
 
 -- | Keep focus by model identity and adjustment by value, not by row index.

--- a/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpManagerSpec.hs
@@ -234,6 +234,19 @@ spec = describe "Agent.CLI.McpManager" do
             body `shouldSatisfy` Text.isInfixOf url
             body `shouldSatisfy`
                 Text.isInfixOf "could not be opened automatically"
+            body `shouldSatisfy` Text.isInfixOf "redirects back"
+            body `shouldNotSatisfy` Text.isInfixOf "Continue"
+
+        it "starts HTTP OAuth after add when no token is stored" do
+            let remote = httpServer "https://mcp.example.test/mcp"
+            pendingHttpAuthorizationUrl Set.empty remote
+                `shouldBe` Just "https://mcp.example.test/mcp"
+            pendingHttpAuthorizationUrl
+                (Set.singleton "https://mcp.example.test/mcp")
+                remote
+                `shouldBe` Nothing
+            pendingHttpAuthorizationUrl Set.empty (server True "stdio-command")
+                `shouldBe` Nothing
 
 server :: Bool -> Text.Text -> McpServerConfig
 server enabled command =

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -580,6 +580,46 @@ spec = do
             fmap (.dialogOverlay.choiceRows) updated.appChoice
                 `shouldBe` Just [("Current", "")]
 
+    describe "idle choice closure" do
+        it "closes the matching authorization dialog when the callback finishes" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, open) <- runFullscreenScriptWithState initial
+                [ FullscreenScriptApp
+                    (AppAskChoice ChoiceDialog "Authorize MCP server"
+                        "Complete sign-in" 0 [("Cancel", "Stop")] reply)
+                , FullscreenScriptHalt
+                ]
+            fmap (.dialogOverlay.choiceTitle) open.appChoice
+                `shouldBe` Just "Authorize MCP server"
+            (_, closed) <- runFullscreenScriptWithState open
+                [ FullscreenScriptApp (AppCloseChoice reply)
+                , FullscreenScriptHalt
+                ]
+            case closed.appChoice of
+                Nothing -> pure ()
+                Just _ -> expectationFailure "authorization dialog was not closed"
+            atomically (readTMVar reply) `shouldReturn` Nothing
+
+        it "does not close a later dialog that reused the overlay slot" do
+            runtime <- newScriptRuntime initialUiState
+            previous <- newEmptyTMVarIO
+            current <- newEmptyTMVarIO
+            let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, updated) <- runFullscreenScriptWithState initial
+                [ FullscreenScriptApp
+                    (AppAskChoice ChoiceDialog "Authorize MCP server"
+                        "Complete sign-in" 0 [("Cancel", "Stop")] previous)
+                , FullscreenScriptApp
+                    (AppAskChoice ChoiceDialog "MCP servers"
+                        "Select a server" 0 [("＋ Add MCP server", "Add")] current)
+                , FullscreenScriptApp (AppCloseChoice previous)
+                , FullscreenScriptHalt
+                ]
+            fmap (.dialogOverlay.choiceTitle) updated.appChoice
+                `shouldBe` Just "MCP servers"
+
     describe "durable chart previews" do
         it "queues history charts without rasterizing on reset or page load" do
             runtime <- newScriptRuntime initialUiState
@@ -4113,6 +4153,7 @@ choiceOverlay closeOnTurnEnd = ChoiceOverlay
     , choiceAdjustmentIndices = []
     , choiceCloseOnTurnEnd = closeOnTurnEnd
     , choiceDynamic = Nothing
+    , choiceReply = Nothing
     }
 
 keyboardEventsForReads :: [IO ByteString.ByteString] -> IO [V.Event]

--- a/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIPropertySpec.hs
@@ -676,6 +676,7 @@ applyAction action harness =
                                 , choiceAdjustmentIndices = []
                                 , choiceCloseOnTurnEnd = False
                                 , choiceDynamic = Nothing
+                                , choiceReply = Nothing
                                 }
                         , appTextPrompt = Nothing
                         }


### PR DESCRIPTION
## Summary

`/mcp` saved a new HTTP server and then required a separate Authenticate (`i`) step. In fullscreen, authorization also opened the browser first and only started the `127.0.0.1` callback server after **Continue**, so the provider redirect failed until you came back to the terminal.

This change:

- Starts the browser OAuth flow as soon as an HTTP MCP server is added, when no token is stored yet
- Starts the loopback callback server and waits until it is accepting connections before opening the browser
- Replaces the Continue gate with a Cancel overlay that continues automatically when the browser redirects back
- Leaves Authenticate available for later re-authorization; stdio servers still skip OAuth

## Test plan

- [x] `cabal repl agent-cli:test:agent-cli-test --repl-options=-fobject-code` then `:main --match "Agent.CLI.McpManager" --match "idle choice closure"` (17 examples, 0 failures)
- [ ] `/mcp` → add an HTTP MCP URL that requires OAuth and confirm the browser flow starts without opening Authenticate
- [ ] Complete the provider approval and confirm the `127.0.0.1` redirect succeeds without returning to press Continue
- [ ] Cancel from the authorization overlay and confirm the server is still added
- [ ] Add a stdio MCP command and confirm OAuth is not started