### PR TITLE
Accept whole-number JSON floats for integer tool arguments

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions.hs
@@ -78,6 +78,7 @@ import Agent.Dialect
 import Agent.Provider (Provider)
 import Agent.Json.Decode (optionalKey)
 import qualified Agent.Json.Decode as Hermes
+import Agent.ToolArgs (jsonInt)
 import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.ToolDispatch (typedTool)
 import Agent.Tools.Types
@@ -151,7 +152,7 @@ waitAgentSessionTool env = jsonTool
     (typedTool "wait_agent_session"
         (Hermes.object $ WaitAgentSessionArgs
             <$> Hermes.atKey "session_id" Hermes.text
-            <*> optionalKey "timeout_ms" Hermes.int)
+            <*> optionalKey "timeout_ms" jsonInt)
         (runWaitAgentSession env))
 
 runWaitAgentSession :: AgentSessionToolsEnv -> WaitAgentSessionArgs -> IO (Either Text Text)
@@ -355,7 +356,7 @@ readAgentSessionArgsDecoder :: Hermes.Decoder ReadAgentSessionArgs
 readAgentSessionArgsDecoder = Hermes.object $
     ReadAgentSessionArgs
         <$> Hermes.atKey "session_id" Hermes.text
-        <*> optionalKey "limit" Hermes.int
+        <*> optionalKey "limit" jsonInt
 
 readAgentSessionTool :: AgentSessionToolsEnv -> AppTool
 readAgentSessionTool env = jsonTool

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -541,7 +541,7 @@ spec = describe "schemasFromAppTools" do
 
     it "omits an empty required list from reserved collaboration schemas" do
         let wait = jsonAppTool "wait_agent" "Wait."
-                [ PropertySchema "timeout_ms" PropertyNumber False Nothing ]
+                [ PropertySchema "timeout_ms" PropertyInteger False Nothing ]
                 AlwaysReadOnly
                 (noArgsTool "wait_agent" (pure (Right "ok")))
         case schemasFromAppTools codexDialect [wait] of
@@ -638,7 +638,7 @@ spec = describe "schemasFromAppTools" do
                                 additionalProperties tool `shouldBe`
                                     Just False
                                 propertyType "timeout_ms" tool `shouldBe`
-                                    Just "number"
+                                    Just "integer"
                             other -> expectationFailure
                                 ("expected production wait_agent, got "
                                     <> show other)

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -11,7 +11,9 @@ module Agent.Codex.Dialect.Tools
     ) where
 
 import Agent.OsPath (fromText)
+import Control.Applicative ((<|>))
 import qualified Agent.Json.Decode as Json
+import Agent.ToolArgs (jsonInt)
 import Agent.ToolDSL
     ( PropertySchema(..)
     , PropertyType(..)
@@ -299,7 +301,7 @@ data WriteStdinArgs = WriteStdinArgs
 writeStdinArgsDecoder :: Json.Decoder WriteStdinArgs
 writeStdinArgsDecoder = Json.object $
     WriteStdinArgs
-        <$> Json.atKey "session_id" Json.int
+        <$> Json.atKey "session_id" jsonInt
         <*> optionalText "chars"
         <*> optionalIntOrString "yield_time_ms"
 
@@ -547,14 +549,13 @@ optionalIntOrString key =
     Json.optionalKey key intOrString
 
 intOrString :: Json.Decoder Int
-intOrString = Json.withType \case
-    Json.VNumber -> Json.int
-    Json.VString -> Json.withText \value ->
-        case Text.signed Text.decimal (Text.strip value) of
-            Right (number, rest)
-                | Text.null rest -> pure number
-            _ -> fail "expected integer"
-    _ -> fail "expected integer"
+intOrString =
+    jsonInt
+        <|> Json.withText \value ->
+            case Text.signed Text.decimal (Text.strip value) of
+                Right (number, rest)
+                    | Text.null rest -> pure number
+                _ -> fail "expected integer"
 
 firstPresentText :: [Text] -> Json.FieldsDecoder Text
 firstPresentText keys = do

--- a/packages/agent-core/src/Agent/ToolArgs.hs
+++ b/packages/agent-core/src/Agent/ToolArgs.hs
@@ -8,6 +8,7 @@ module Agent.ToolArgs
     , reqInt
     , optText
     , optTextList
+    , jsonInt
     , optInt
     , optIntOrString
     , readExactInt
@@ -23,6 +24,7 @@ import Control.Monad (join)
 import Agent.Json.Decode (Decoder, FieldsDecoder)
 import Agent.Json (rawJsonDecoder)
 import qualified Agent.Json.Decode as Json
+import qualified Data.Scientific as Scientific
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Read as TextRead
@@ -58,7 +60,7 @@ reqTextList _ key =
 
 reqInt :: Object -> Text -> FieldsDecoder Int
 reqInt _ key =
-    Json.atKey key Json.int
+    Json.atKey key jsonInt
 
 -- | Optional string; an empty string counts as absent.
 optText :: Object -> Text -> FieldsDecoder (Maybe Text)
@@ -75,11 +77,20 @@ optTextList _ key =
     join <$> Json.atKeyOptional key
         (Json.nullable (Json.list Json.text <|> ((: []) <$> Json.text)))
 
+-- | Exact bounded integer from a JSON number. Whole-number floats such as
+-- @-50.0@ are accepted because models emit them for Schema @"number"@ and
+-- sometimes @"integer"@ fields; Hermes 'int' rejects those tokens.
+jsonInt :: Decoder Int
+jsonInt = do
+    value <- Json.scientific
+    maybe (fail "Expected integer") pure (Scientific.toBoundedInteger value)
+
 -- | Optional exact, bounded integer. An absent or null field is 'Nothing';
--- fractional, out-of-range, and wrongly typed values fail.
+-- whole-number JSON floats such as @-50.0@ are accepted. Fractional,
+-- out-of-range, and wrongly typed values fail.
 optInt :: Object -> Text -> FieldsDecoder (Maybe Int)
 optInt _ key =
-    join <$> Json.atKeyOptional key (Json.nullable Json.int)
+    join <$> Json.atKeyOptional key (Json.nullable jsonInt)
 
 -- | 'optInt' plus compatibility for integer strings emitted by some model
 -- tool surfaces.
@@ -88,7 +99,7 @@ optIntOrString _ key =
     join <$> Json.atKeyOptional key (Json.nullable intOrString)
   where
     intOrString =
-        Json.int
+        jsonInt
             <|> Json.withText
                 (\value -> maybe (fail "Expected integer") pure (readExactInt value))
 
@@ -127,7 +138,7 @@ optBoolStrict _ key =
 intOr :: Object -> Text -> Int -> FieldsDecoder Int
 intOr _ key def =
     maybe def id . join
-        <$> Json.atKeyOptional key (Json.nullable Json.int)
+        <$> Json.atKeyOptional key (Json.nullable jsonInt)
 
 -- | Optional array field decoded element-wise with the supplied Hermes
 -- decoder. The message is retained in the API for model-facing call sites;

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
@@ -472,11 +472,11 @@ waitTool host =
         waitDescription
         [ PropertySchema "cell_id" PropertyString True $ Just
             "Identifier of the running exec cell."
-        , PropertySchema "max_tokens" PropertyNumber False $ Just
+        , PropertySchema "max_tokens" PropertyInteger False $ Just
             "Output token budget for this wait call. Defaults to 10000 tokens."
         , PropertySchema "terminate" PropertyBoolean False $ Just
             "True stops the running exec cell; false or omitted waits for output."
-        , PropertySchema "yield_time_ms" PropertyNumber False $ Just
+        , PropertySchema "yield_time_ms" PropertyInteger False $ Just
             "Wait before yielding more output. Defaults to 10000 ms."
         ]
         AlwaysReadOnly

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -499,7 +499,7 @@ waitAgentArgsDecoder = objectArgsLenient \object_ -> do
 
 waitAgentTool :: MultiAgentContext -> AppTool
 waitAgentTool ctx = jsonTool "wait_agent" waitAgentDescription
-    [ PropertySchema "timeout_ms" PropertyNumber False $ Just
+    [ PropertySchema "timeout_ms" PropertyInteger False $ Just
         "Timeout in milliseconds. Defaults to 30000 ms."
     ]
     True

--- a/packages/agent-core/src/Agent/Tools/OutputArtifact.hs
+++ b/packages/agent-core/src/Agent/Tools/OutputArtifact.hs
@@ -125,13 +125,13 @@ artifactTools env analysis =
     [ jsonTool "read_tool_output"
         "Read oversized tool output. Defaults to a lossless character page; pass next_cursor as cursor to continue, including within single-line JSON. Explicit offset/limit selects legacy line previews."
         [ PropertySchema "handle" PropertyString True Nothing
-        , PropertySchema "offset" PropertyNumber False
+        , PropertySchema "offset" PropertyInteger False
             (Just "1-based line offset; defaults to 1.")
-        , PropertySchema "limit" PropertyNumber False
+        , PropertySchema "limit" PropertyInteger False
             (Just "Maximum 1000 lines; defaults to 200.")
-        , PropertySchema "cursor" PropertyNumber False
+        , PropertySchema "cursor" PropertyInteger False
             (Just "Zero-based Unicode character offset; defaults to 0. Use next_cursor from the previous page. Do not combine with offset/limit.")
-        , PropertySchema "max_chars" PropertyNumber False
+        , PropertySchema "max_chars" PropertyInteger False
             (Just "Maximum characters per page, up to 4096; defaults to 4096. Do not combine with offset/limit.")
         ]
         True ParallelSafe
@@ -141,11 +141,11 @@ artifactTools env analysis =
         [ PropertySchema "handle" PropertyString True Nothing
         , PropertySchema "pattern" PropertyString True Nothing
         , PropertySchema "case_insensitive" PropertyBoolean False Nothing
-        , PropertySchema "head_limit" PropertyNumber False
+        , PropertySchema "head_limit" PropertyInteger False
             (Just "Maximum occurrences per page, up to 200; defaults to 50. The byte budget may return fewer.")
-        , PropertySchema "cursor" PropertyNumber False
+        , PropertySchema "cursor" PropertyInteger False
             (Just "Zero-based Unicode character offset; defaults to 0. Continue with next_cursor.")
-        , PropertySchema "context_chars" PropertyNumber False
+        , PropertySchema "context_chars" PropertyInteger False
             (Just "Characters of context before and after each match; defaults to 200.")
         ]
         True ParallelSafe

--- a/packages/agent-core/test/Agent/ToolArgsSpec.hs
+++ b/packages/agent-core/test/Agent/ToolArgsSpec.hs
@@ -32,8 +32,24 @@ spec = describe "ToolArgs" do
         decodeSearch "{\"query\":\"invoice\",\"limit\":null}"
             `shouldBe` Right (SearchArgs "invoice" 10 Nothing)
 
+    it "accepts whole-number JSON floats for integers" do
+        decodeSearch "{\"query\":\"invoice\",\"limit\":5.0}"
+            `shouldBe` Right (SearchArgs "invoice" 5 Nothing)
+        decodeSearch "{\"query\":\"invoice\",\"limit\":-50.0}"
+            `shouldBe` Right (SearchArgs "invoice" (-50) Nothing)
+        Json.decodeText
+            (objectArgs \object -> reqInt object "offset")
+            "{\"offset\":-50.0}"
+            `shouldBe` Right (-50)
+        Json.decodeText
+            (objectArgs \object -> optIntOrString object "offset")
+            "{\"offset\":-50.0}"
+            `shouldBe` Right (Just (-50))
+
     it "rejects wrongly typed optional integers" do
         decodeSearch "{\"query\":\"invoice\",\"limit\":\"5\"}"
+            `shouldSatisfy` isLeft
+        decodeSearch "{\"query\":\"invoice\",\"limit\":1.9}"
             `shouldSatisfy` isLeft
 
     it "accepts stringy booleans only through the compatibility helper" do

--- a/packages/agent-core/test/Agent/Tools/OutputArtifactSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/OutputArtifactSpec.hs
@@ -22,10 +22,12 @@ import Agent.Tools.OutputArtifact
     , readOutputArtifact
     , writeOutputArtifact
     )
+import Agent.ToolDSL (PropertySchema(..), PropertyType(..))
 import Agent.Tools.Types
     ( AppTool(..)
     , ToolEnv(..)
     , defaultToolEnv
+    , jsonToolParameters
     , setToolSessionTmp
     )
 import Control.Concurrent.Async (mapConcurrently)
@@ -35,7 +37,7 @@ import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as LazyByteString
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.List (find, nub)
-import Data.Maybe (fromJust)
+import Data.Maybe (fromJust, fromMaybe)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
 import System.Directory
@@ -253,6 +255,50 @@ spec = describe "Agent.Tools.OutputArtifact" do
                                 <> "\",\"pattern\":\"amount\",\"context_chars\":30}")
                     result `shouldSatisfy` \case
                         Right value -> Text.isInfixOf "19900" value && Text.length value < 1000
+                        Left _ -> False
+
+    it "advertises integer pagination parameters" do
+        withTempEnv \env -> do
+            let types name =
+                    [ (property.propertyName, property.propertyType)
+                    | tool <- artifactTools env Nothing
+                    , tool.appToolName == name
+                    , property <- fromMaybe [] (jsonToolParameters tool)
+                    , property.propertyName `elem`
+                        ["offset", "limit", "cursor", "max_chars", "head_limit", "context_chars"]
+                    ]
+            types "read_tool_output" `shouldBe`
+                [ ("offset", PropertyInteger)
+                , ("limit", PropertyInteger)
+                , ("cursor", PropertyInteger)
+                , ("max_chars", PropertyInteger)
+                ]
+            types "search_tool_output" `shouldBe`
+                [ ("head_limit", PropertyInteger)
+                , ("cursor", PropertyInteger)
+                , ("context_chars", PropertyInteger)
+                ]
+
+    it "accepts whole-number JSON floats for line pagination" do
+        withTempEnv \env -> do
+            writeOutputArtifact env "alpha\nbeta\ngamma\n" >>= \case
+                Left err -> expectationFailure (Text.unpack err)
+                Right handle -> do
+                    result <- runArtifactTool env "read_tool_output" $
+                        functionToolCall "read" "read_tool_output"
+                            ("{\"handle\":\"" <> handle
+                                <> "\",\"offset\":2.0,\"limit\":1.0}")
+                    result `shouldSatisfy` \case
+                        Right value ->
+                            Text.isInfixOf "beta" value
+                                && not (Text.isInfixOf "SIMDException" value)
+                        Left _ -> False
+                    negative <- runArtifactTool env "read_tool_output" $
+                        functionToolCall "read" "read_tool_output"
+                            ("{\"handle\":\"" <> handle
+                                <> "\",\"offset\":-50.0}")
+                    negative `shouldSatisfy` \case
+                        Right value -> not (Text.isInfixOf "SIMDException" value)
                         Left _ -> False
 
     it "rejects mixed line and character pagination arguments" do

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Json.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Json.hs
@@ -8,7 +8,9 @@ module Agent.GrokBuild.Dialect.Json
     , textList
     ) where
 
+import Control.Applicative ((<|>))
 import qualified Agent.Json.Decode as Json
+import Agent.ToolArgs (jsonInt)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Read as Text
@@ -27,7 +29,7 @@ optionalTextValue key =
 
 optionalInt :: Text -> Json.FieldsDecoder (Maybe Int)
 optionalInt key =
-    Json.optionalKey key Json.int
+    Json.optionalKey key jsonInt
 
 optionalIntOrString :: Text -> Json.FieldsDecoder (Maybe Int)
 optionalIntOrString key =
@@ -47,14 +49,13 @@ textList = Json.withType \case
     _ -> fail "expected a string or array of strings"
 
 intOrString :: Json.Decoder Int
-intOrString = Json.withType \case
-    Json.VNumber -> Json.int
-    Json.VString -> Json.withText \value ->
-        case Text.signed Text.decimal (Text.strip value) of
-            Right (number, rest)
-                | Text.null rest -> pure number
-            _ -> fail "expected integer"
-    _ -> fail "expected integer"
+intOrString =
+    jsonInt
+        <|> Json.withText \value ->
+            case Text.signed Text.decimal (Text.strip value) of
+                Right (number, rest)
+                    | Text.null rest -> pure number
+                _ -> fail "expected integer"
 
 boolOrString :: Json.Decoder Bool
 boolOrString = Json.withType \case


### PR DESCRIPTION
## Summary
- `read_tool_output` advertised JSON Schema `"type": "number"` for `offset`/`limit`/`cursor` while decoding with Hermes `Json.int`. simdjson then rejected whole-number floats such as `-50.0` with `INCORRECT_TYPE`, which is the Grok `SIMDException` on `/offset`.
- Advertise those count and offset fields as `PropertyInteger`.
- Decode model-facing integers with `Scientific.toBoundedInteger` so `5`, `-50.0`, and other whole-number JSON floats succeed, while `1.9` still fails.

## Test plan
- GHCi `agent-core:test:agent-core-test`: ToolArgs plus the new OutputArtifact pagination examples (10 examples, 0 failures).
- GHCi `agent-cli:test:agent-cli-test --repl-options=-fobject-code`: wait_agent schema examples (2 examples, 0 failures).