### PR TITLE
Persist submitted prompts on running server turns

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -252,9 +252,10 @@ queued -> running -> waiting_for_input -> running
 ```
 
 Only one turn may be active for a session. The process runs up to three turns
-from different sessions concurrently by default. Turn state is process-local;
-the most recent 1,000 terminal turn records are retained, while conversation
-history is durable.
+from different sessions concurrently by default. Turn records include the
+submitted `input` prompt, including while the turn is still queued or running.
+Turn execution state is process-local; the most recent 1,000 terminal turn
+records are retained, while conversation history is durable.
 
 When a mutating tool, root access, or plan interaction needs a decision:
 

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -253,9 +253,12 @@ queued -> running -> waiting_for_input -> running
 
 Only one turn may be active for a session. The process runs up to three turns
 from different sessions concurrently by default. Turn records include the
-submitted `input` prompt, including while the turn is still queued or running.
-Turn execution state is process-local; the most recent 1,000 terminal turn
-records are retained, while conversation history is durable.
+submitted prompt as both `input` (the create-turn request field) and
+`userText` (the same field as persisted `SessionTurn` history, the TUI, and
+native observation). The latest history page also overlays a queued or running
+turn as a `SessionTurn` with `userText` and `status`. Turn execution state is
+process-local; the most recent 1,000 terminal turn records are retained, while
+conversation history is durable.
 
 When a mutating tool, root access, or plan interaction needs a decision:
 

--- a/packages/agent-server-client/src/Agent/Server/Client/Protocol.hs
+++ b/packages/agent-server-client/src/Agent/Server/Client/Protocol.hs
@@ -428,6 +428,12 @@ parseAgentServerSseFrame rawFrame = do
                                     )
                             _ -> Right fields
 
+parseTurnUserText :: Object -> Parser Text
+parseTurnUserText value = do
+    userText <- fromMaybe "" <$> value .:? "userText"
+    input <- fromMaybe "" <$> value .:? "input"
+    pure (if Text.null userText then input else userText)
+
 parseTurn :: Object -> Parser AgentServerTurn
 parseTurn value =
     AgentServerTurn
@@ -441,7 +447,7 @@ parseTurn value =
         <*> value .: "startedAt"
         <*> value .: "finishedAt"
         <*> value .: "error"
-        <*> (fromMaybe "" <$> value .:? "input")
+        <*> parseTurnUserText value
 
 parseEventPayload :: Text -> Value -> Parser AgentServerEventPayload
 parseEventPayload eventType eventData =

--- a/packages/agent-server-client/src/Agent/Server/Client/Protocol.hs
+++ b/packages/agent-server-client/src/Agent/Server/Client/Protocol.hs
@@ -142,6 +142,7 @@ data AgentServerTurn = AgentServerTurn
     , agentServerTurnStartedAt :: !(Maybe UTCTime)
     , agentServerTurnFinishedAt :: !(Maybe UTCTime)
     , agentServerTurnError :: !(Maybe Text)
+    , agentServerTurnInput :: !Text
     }
     deriving (Eq, Show)
 
@@ -440,6 +441,7 @@ parseTurn value =
         <*> value .: "startedAt"
         <*> value .: "finishedAt"
         <*> value .: "error"
+        <*> (fromMaybe "" <$> value .:? "input")
 
 parseEventPayload :: Text -> Value -> Parser AgentServerEventPayload
 parseEventPayload eventType eventData =

--- a/packages/agent-server-client/test/Agent/Server/Client/ProtocolSpec.hs
+++ b/packages/agent-server-client/test/Agent/Server/Client/ProtocolSpec.hs
@@ -106,7 +106,8 @@ spec = describe "agent-server client protocol" do
                     <> "\"status\":\"queued\","
                     <> "\"createdAt\":\"2026-09-03T00:00:00Z\","
                     <> "\"startedAt\":null,\"finishedAt\":null,\"error\":null,"
-                    <> "\"input\":\"what would you like to improve\"}"
+                    <> "\"input\":\"what would you like to improve\","
+                    <> "\"userText\":\"what would you like to improve\"}"
         case Aeson.eitherDecodeStrict' payload of
             Left message -> expectationFailure message
             Right (turn :: AgentServerTurn) -> do
@@ -114,6 +115,21 @@ spec = describe "agent-server client protocol" do
                     `shouldBe` AgentServerTurnQueued
                 turn.agentServerTurnClientRequestId
                     `shouldBe` "01991f6d-7200-7000-8000-000000000003"
+                turn.agentServerTurnInput
+                    `shouldBe` "what would you like to improve"
+
+    it "decodes SessionTurn userText when input is omitted" do
+        let payload =
+                "{\"id\":\"01991f6d-7200-7000-8000-000000000001\","
+                    <> "\"sessionId\":\"2026-09-04-deadbeef\","
+                    <> "\"clientRequestId\":\"01991f6d-7200-7000-8000-000000000003\","
+                    <> "\"status\":\"running\","
+                    <> "\"createdAt\":\"2026-09-03T00:00:00Z\","
+                    <> "\"startedAt\":null,\"finishedAt\":null,\"error\":null,"
+                    <> "\"userText\":\"what would you like to improve\"}"
+        case Aeson.eitherDecodeStrict' payload of
+            Left message -> expectationFailure message
+            Right (turn :: AgentServerTurn) ->
                 turn.agentServerTurnInput
                     `shouldBe` "what would you like to improve"
 

--- a/packages/agent-server-client/test/Agent/Server/Client/ProtocolSpec.hs
+++ b/packages/agent-server-client/test/Agent/Server/Client/ProtocolSpec.hs
@@ -105,7 +105,8 @@ spec = describe "agent-server client protocol" do
                     <> "\"clientRequestId\":\"01991f6d-7200-7000-8000-000000000003\","
                     <> "\"status\":\"queued\","
                     <> "\"createdAt\":\"2026-09-03T00:00:00Z\","
-                    <> "\"startedAt\":null,\"finishedAt\":null,\"error\":null}"
+                    <> "\"startedAt\":null,\"finishedAt\":null,\"error\":null,"
+                    <> "\"input\":\"what would you like to improve\"}"
         case Aeson.eitherDecodeStrict' payload of
             Left message -> expectationFailure message
             Right (turn :: AgentServerTurn) -> do
@@ -113,6 +114,8 @@ spec = describe "agent-server client protocol" do
                     `shouldBe` AgentServerTurnQueued
                 turn.agentServerTurnClientRequestId
                     `shouldBe` "01991f6d-7200-7000-8000-000000000003"
+                turn.agentServerTurnInput
+                    `shouldBe` "what would you like to improve"
 
     it "rejects missing required nullable turn fields" do
         let payload =

--- a/packages/agent-server/openapi.json
+++ b/packages/agent-server/openapi.json
@@ -777,9 +777,10 @@
           "createdAt": { "type": "string", "format": "date-time" },
           "startedAt": { "type": ["string", "null"], "format": "date-time" },
           "finishedAt": { "type": ["string", "null"], "format": "date-time" },
-          "error": { "type": ["string", "null"] }
+          "error": { "type": ["string", "null"] },
+          "input": { "type": "string" }
         },
-        "required": ["id", "sessionId", "clientRequestId", "status", "createdAt", "startedAt", "finishedAt", "error"]
+        "required": ["id", "sessionId", "clientRequestId", "status", "createdAt", "startedAt", "finishedAt", "error", "input"]
       },
       "TurnCompletion": {
         "type": "object",

--- a/packages/agent-server/openapi.json
+++ b/packages/agent-server/openapi.json
@@ -706,7 +706,7 @@
                 "index": { "type": "integer" },
                 "turn": {
                   "type": "object",
-                  "description": "items is canonical history; displayItems is rendering-only failed partial output."
+                  "description": "A SessionTurn. userText is the submitted prompt. items is canonical history; displayItems is rendering-only failed partial output. An in-progress turn includes status queued, running, or waiting_for_input."
                 }
               },
               "required": ["index", "turn"]
@@ -778,9 +778,10 @@
           "startedAt": { "type": ["string", "null"], "format": "date-time" },
           "finishedAt": { "type": ["string", "null"], "format": "date-time" },
           "error": { "type": ["string", "null"] },
-          "input": { "type": "string" }
+          "input": { "type": "string" },
+          "userText": { "type": "string" }
         },
-        "required": ["id", "sessionId", "clientRequestId", "status", "createdAt", "startedAt", "finishedAt", "error", "input"]
+        "required": ["id", "sessionId", "clientRequestId", "status", "createdAt", "startedAt", "finishedAt", "error", "input", "userText"]
       },
       "TurnCompletion": {
         "type": "object",

--- a/packages/agent-server/src/Agent/Server/Application.hs
+++ b/packages/agent-server/src/Agent/Server/Application.hs
@@ -36,6 +36,7 @@ import Agent.Server.Supervisor
     , withSessionCleanup
     , withSessionMutation
     )
+import Agent.Server.Runtime.SessionCodec (overlayInProgressHistoryTurns)
 import Agent.Server.Types
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (race)
@@ -260,7 +261,8 @@ dispatchBoundary
             deleteSessionResponse
                 backend supervisor boundary sessionId headers
         ("GET", ["v1", "sessions", sessionId, "history"]) ->
-            sessionHistoryResponse backend boundary sessionId headers request
+            sessionHistoryResponse
+                backend supervisor boundary sessionId headers request
         ("POST", ["v1", "sessions", sessionId, "fork"]) ->
             forkSessionResponse
                 config backend supervisor boundary sessionId headers request
@@ -415,12 +417,13 @@ deleteSessionResponse backend supervisor boundary sessionId headers =
 
 sessionHistoryResponse
     :: Backend
+    -> Supervisor
     -> AccessBoundary
     -> Text
     -> [Header]
     -> Request
     -> IO (Either ApiError Response)
-sessionHistoryResponse backend boundary sessionId headers request = do
+sessionHistoryResponse backend supervisor boundary sessionId headers request = do
     let before =
             queryOptionalInteger "cursor" request >>= \case
                 Nothing ->
@@ -429,13 +432,33 @@ sessionHistoryResponse backend boundary sessionId headers request = do
         limit = queryLimit "limit" 50 100 request
     case (before, limit) of
         (Right cursor, Right pageLimit) ->
-            fmap
-                (fmap (jsonResponse status200 headers))
-                (backend.backendSessionHistory
-                    boundary
-                    sessionId
-                    cursor
-                    pageLimit)
+            backend.backendSessionHistory
+                boundary
+                sessionId
+                cursor
+                pageLimit
+                >>= \case
+                    Left err -> pure (Left err)
+                    Right history -> do
+                        overlaid <-
+                            case cursor of
+                                Just _ -> pure history
+                                Nothing ->
+                                    listKnownTurns
+                                        backend
+                                        supervisor
+                                        boundary
+                                        (Just sessionId)
+                                        >>= \case
+                                            Left _ -> pure history
+                                            Right turns ->
+                                                pure
+                                                    ( overlayInProgressHistoryTurns
+                                                        history
+                                                        turns
+                                                    )
+                        pure . Right $
+                            jsonResponse status200 headers overlaid
         _ -> pure $
             Left $
                 firstQueryError

--- a/packages/agent-server/src/Agent/Server/Runtime/SessionCodec.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime/SessionCodec.hs
@@ -5,6 +5,7 @@ module Agent.Server.Runtime.SessionCodec
     ( sessionValue
     , modelOptionValue
     , historyValue
+    , overlayInProgressHistoryTurns
     , storeArchiveFilter
     , encodeCursor
     , decodeCursor
@@ -12,14 +13,28 @@ module Agent.Server.Runtime.SessionCodec
     ) where
 
 import Agent.CLI.Models (ModelOption(..), ModelTarget(..))
-import Agent.CLI.Session (SessionMeta(..), SessionTurnPage(..))
+import Agent.CLI.Session
+    ( SessionMeta(..)
+    , SessionTurn(..)
+    , SessionTurnPage(..)
+    , TranscriptEffect(..)
+    )
 import Agent.Dialect (dialectSlug)
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider (providerSlug)
 import Agent.Server.Event (projectPublicValue)
-import Agent.Server.Types (ApiError(..), SessionArchiveFilter(..))
+import Agent.Server.Types
+    ( ApiError(..)
+    , SessionArchiveFilter(..)
+    , TurnRecord(..)
+    , TurnStatus(..)
+    , turnStatusText
+    )
 import Agent.Store.Postgres.Session qualified as StoreSession
-import Data.Aeson (Value, object, toJSON, (.=))
+import Data.Aeson (Result (..), Value (..), fromJSON, object, toJSON, (.=))
+import Data.Aeson.Key qualified as Key
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Foldable (toList)
 import Data.Int (Int64)
 import Data.Maybe (listToMaybe)
 import Data.Text (Text)
@@ -80,6 +95,78 @@ historyValue meta archived page = object
             then fst <$> listToMaybe page.pageTurns
             else Nothing
     ]
+
+-- | Append queued or running execution turns onto the latest history page as
+-- SessionTurn values. The prompt is @userText@, matching persisted history,
+-- the TUI, and native observation.
+overlayInProgressHistoryTurns :: Value -> [TurnRecord] -> Value
+overlayInProgressHistoryTurns history turns =
+    case history of
+        Object fields ->
+            let entries = case KeyMap.lookup (Key.fromText "data") fields of
+                    Just (Array values) -> toList values
+                    _ -> []
+                extras =
+                    zipWith inProgressEntry [baseIndex + 1 ..] active
+                active = filter inProgressTurn turns
+                baseIndex = case KeyMap.lookup (Key.fromText "total") fields of
+                    Just value
+                        | Just total <- integerToInt64Maybe value ->
+                            total
+                    _ -> fromIntegral (length entries)
+                fields' =
+                    KeyMap.insert
+                        (Key.fromText "data")
+                        (toJSON (entries <> extras))
+                        $ KeyMap.insert
+                            (Key.fromText "total")
+                            (toJSON (baseIndex + fromIntegral (length extras)))
+                            fields
+             in Object fields'
+        _ -> history
+  where
+    inProgressTurn turn =
+        turn.turnRecordStatus
+            `elem` [TurnQueued, TurnRunning, TurnWaitingForInput]
+            && not (Text.null (Text.strip turn.turnRecordInput))
+
+    inProgressEntry index turn =
+        object
+            [ "index" .= index
+            , "turn" .= inProgressTurnValue turn
+            ]
+
+inProgressTurnValue :: TurnRecord -> Value
+inProgressTurnValue turn =
+    case projectPublicValue (toJSON (inProgressSessionTurn turn)) of
+        Object fields ->
+            Object $
+                KeyMap.insert
+                    (Key.fromText "status")
+                    (toJSON (turnStatusText turn.turnRecordStatus))
+                    fields
+        other -> other
+
+inProgressSessionTurn :: TurnRecord -> SessionTurn
+inProgressSessionTurn turn =
+    SessionTurn
+        { turnAt = turn.turnRecordCreatedAt
+        , turnUserText = turn.turnRecordInput
+        , turnAssistantText = Nothing
+        , turnError = turn.turnRecordError
+        , turnResponseId = Nothing
+        , turnEffect = TranscriptAppend
+        , turnItems = []
+        , turnDisplayItems = []
+        , turnUsage = Nothing
+        , turnProviderTelemetry = []
+        }
+
+integerToInt64Maybe :: Value -> Maybe Int64
+integerToInt64Maybe value =
+    case fromJSON value of
+        Success n -> Just n
+        Error _ -> Nothing
 
 storeArchiveFilter
     :: SessionArchiveFilter

--- a/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime/TurnStore.hs
@@ -996,6 +996,7 @@ reserveTurn store tenantId instanceId boundary sessionId clientRequestId prompt 
                         clientRequestId.unClientRequestId
                     , ServerTurnStore.reserveServerTurnInputDigest =
                         turnInputDigest prompt
+                    , ServerTurnStore.reserveServerTurnInput = prompt
                     , ServerTurnStore.reserveServerTurnOwnerInstanceId =
                         instanceId
                     , ServerTurnStore.reserveServerTurnCreatedAt = now
@@ -1199,6 +1200,7 @@ storedTurnRecord boundary stored =
         , turnRecordStartedAt = stored.storedServerTurnStartedAt
         , turnRecordFinishedAt = stored.storedServerTurnFinishedAt
         , turnRecordError = stored.storedServerTurnError
+        , turnRecordInput = stored.storedServerTurnInput
         }
 
 storedTurnStatus :: ServerTurnStore.ServerTurnStatus -> TurnStatus

--- a/packages/agent-server/src/Agent/Server/Supervisor.hs
+++ b/packages/agent-server/src/Agent/Server/Supervisor.hs
@@ -392,6 +392,7 @@ submitTurn supervisor spec = do
             , turnRecordStartedAt = Nothing
             , turnRecordFinishedAt = Nothing
             , turnRecordError = Nothing
+            , turnRecordInput = spec.turnSpecPrompt
             }
 
 -- | Validate a session while holding the same per-boundary reservation that
@@ -503,6 +504,7 @@ enqueueTurn supervisor reservationHeld spec = do
             , turnRecordStartedAt = Nothing
             , turnRecordFinishedAt = Nothing
             , turnRecordError = Nothing
+            , turnRecordInput = spec.turnSpecPrompt
             }
 
 enqueueTurnRecord ::
@@ -521,9 +523,10 @@ enqueueTurnRecord supervisor reservationHeld spec record
     | record.turnRecordStatus /= TurnQueued =
         fail "only a queued reserved turn can be admitted"
     | otherwise =
-        atomically do
+        let admitted = record{turnRecordInput = spec.turnSpecPrompt}
+         in atomically do
             state <- readTVar supervisor.supervisorState
-            let now = record.turnRecordCreatedAt
+            let now = admitted.turnRecordCreatedAt
                 key = (spec.turnSpecBoundary, spec.turnSpecSessionId)
                 reserved = Set.member key state.stateActiveSessions
             if state.stateClosed
@@ -557,11 +560,11 @@ enqueueTurnRecord supervisor reservationHeld spec record
                                                     > maximumQueuedAttachmentBytesPerTenant
                                                 then pure (Left SubmitTenantQueueFull)
                                                 else do
-                                                    let turnId = record.turnRecordId
+                                                    let turnId = admitted.turnRecordId
                                                         slot =
                                                             TurnSlot
                                                                 { turnSlotSpec = spec
-                                                                , turnSlotRecord = record
+                                                                , turnSlotRecord = admitted
                                                                 , turnSlotCancelling = False
                                                                 , turnSlotCancel = Nothing
                                                                 , turnSlotAgents = pure toJSONEmptyArray
@@ -587,7 +590,7 @@ enqueueTurnRecord supervisor reservationHeld spec record
                                                                 withTurn
                                                     writeTVar supervisor.supervisorState state'
                                                     publishToSubscribers state' event
-                                                    pure (Right record)
+                                                    pure (Right admitted)
 
 cancelTurn ::
     Supervisor ->

--- a/packages/agent-server/src/Agent/Server/Types.hs
+++ b/packages/agent-server/src/Agent/Server/Types.hs
@@ -185,6 +185,7 @@ data TurnRecord = TurnRecord
     , turnRecordStartedAt :: !(Maybe UTCTime)
     , turnRecordFinishedAt :: !(Maybe UTCTime)
     , turnRecordError :: !(Maybe Text)
+    , turnRecordInput :: !Text
     }
     deriving (Eq, Show)
 
@@ -200,6 +201,7 @@ instance ToJSON TurnRecord where
             , "startedAt" .= turn.turnRecordStartedAt
             , "finishedAt" .= turn.turnRecordFinishedAt
             , "error" .= turn.turnRecordError
+            , "input" .= turn.turnRecordInput
             ]
 
 data TurnReservation

--- a/packages/agent-server/src/Agent/Server/Types.hs
+++ b/packages/agent-server/src/Agent/Server/Types.hs
@@ -202,6 +202,7 @@ instance ToJSON TurnRecord where
             , "finishedAt" .= turn.turnRecordFinishedAt
             , "error" .= turn.turnRecordError
             , "input" .= turn.turnRecordInput
+            , "userText" .= turn.turnRecordInput
             ]
 
 data TurnReservation

--- a/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
@@ -386,6 +386,8 @@ spec = describe "agent-server WAI application" do
             turnIds `shouldSatisfy` elem localTurnId
             LBS8.unpack listed.simpleBody
                 `shouldContain` "\"input\":\"hello\""
+            LBS8.unpack listed.simpleBody
+                `shouldContain` "\"userText\":\"hello\""
 
     it "exposes the submitted prompt on a running turn" do
         started <- newEmptyMVar
@@ -407,6 +409,8 @@ spec = describe "agent-server WAI application" do
             created.simpleStatus `shouldBe` status202
             LBS8.unpack created.simpleBody
                 `shouldContain` "\"input\":\"what would you like to improve\""
+            LBS8.unpack created.simpleBody
+                `shouldContain` "\"userText\":\"what would you like to improve\""
             takeMVar started
 
             listed <-
@@ -419,6 +423,21 @@ spec = describe "agent-server WAI application" do
             listed.simpleStatus `shouldBe` status200
             LBS8.unpack listed.simpleBody
                 `shouldContain` "\"input\":\"what would you like to improve\""
+            LBS8.unpack listed.simpleBody
+                `shouldContain` "\"userText\":\"what would you like to improve\""
+
+            history <-
+                perform
+                    application
+                    methodGet
+                    ["v1", "sessions", "session-a", "history"]
+                    validHeaders
+                    ""
+            history.simpleStatus `shouldBe` status200
+            LBS8.unpack history.simpleBody
+                `shouldContain` "\"userText\":\"what would you like to improve\""
+            LBS8.unpack history.simpleBody
+                `shouldContain` "\"status\":\"running\""
 
             putMVar finished ()
             takeMVar terminal

--- a/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
@@ -354,6 +354,7 @@ spec = describe "agent-server WAI application" do
                     , turnRecordStartedAt = Just createdAt
                     , turnRecordFinishedAt = Just createdAt
                     , turnRecordError = Nothing
+                    , turnRecordInput = ""
                     }
             backend =
                 fakeBackend
@@ -383,6 +384,44 @@ spec = describe "agent-server WAI application" do
             turnIds <- responseTurnIds listed
             length turnIds `shouldBe` 200
             turnIds `shouldSatisfy` elem localTurnId
+            LBS8.unpack listed.simpleBody
+                `shouldContain` "\"input\":\"hello\""
+
+    it "exposes the submitted prompt on a running turn" do
+        started <- newEmptyMVar
+        finished <- newEmptyMVar
+        let runner _ _ = do
+                putMVar started ()
+                takeMVar finished
+                pure (Right successfulOutput)
+            body =
+                "{\"clientRequestId\":\"01999999-1111-7111-8111-444444444444\",\"input\":\"what would you like to improve\"}"
+        withDurableApplication runner \application terminal -> do
+            created <-
+                perform
+                    application
+                    methodPost
+                    ["v1", "sessions", "session-a", "turns"]
+                    validHeaders
+                    body
+            created.simpleStatus `shouldBe` status202
+            LBS8.unpack created.simpleBody
+                `shouldContain` "\"input\":\"what would you like to improve\""
+            takeMVar started
+
+            listed <-
+                perform
+                    application
+                    methodGet
+                    ["v1", "turns"]
+                    validHeaders
+                    ""
+            listed.simpleStatus `shouldBe` status200
+            LBS8.unpack listed.simpleBody
+                `shouldContain` "\"input\":\"what would you like to improve\""
+
+            putMVar finished ()
+            takeMVar terminal
 
     it "distinguishes a remote turn from an unavailable agent snapshot" do
         createdAt <- getCurrentTime
@@ -400,6 +439,7 @@ spec = describe "agent-server WAI application" do
                     , turnRecordStartedAt = Just createdAt
                     , turnRecordFinishedAt = Nothing
                     , turnRecordError = Nothing
+                    , turnRecordInput = ""
                     }
             backend =
                 fakeBackend
@@ -439,6 +479,7 @@ spec = describe "agent-server WAI application" do
                     , turnRecordStartedAt = Nothing
                     , turnRecordFinishedAt = Nothing
                     , turnRecordError = Nothing
+                    , turnRecordInput = ""
                     }
             backend =
                 fakeBackend
@@ -894,6 +935,7 @@ spec = describe "agent-server WAI application" do
                     , turnRecordStartedAt = Nothing
                     , turnRecordFinishedAt = Nothing
                     , turnRecordError = Nothing
+                    , turnRecordInput = ""
                     }
         stored <- newMVar record
         let persistence =
@@ -970,6 +1012,7 @@ spec = describe "agent-server WAI application" do
                     , turnRecordStartedAt = Nothing
                     , turnRecordFinishedAt = Nothing
                     , turnRecordError = Nothing
+                    , turnRecordInput = ""
                     }
             runner _ _ =
                 (putMVar started () >> takeMVar never)
@@ -1054,6 +1097,7 @@ spec = describe "agent-server WAI application" do
                     , turnRecordStartedAt = Just createdAt
                     , turnRecordFinishedAt = Nothing
                     , turnRecordError = Nothing
+                    , turnRecordInput = ""
                     }
             backend =
                 fakeBackend
@@ -1263,7 +1307,7 @@ fakeBackend =
                         )
                     )
         , backendReserveTurn =
-            \boundary sessionId clientRequestId _ turnId createdAt ->
+            \boundary sessionId clientRequestId input turnId createdAt ->
                 pure . Right . TurnReservationCreated $
                     TurnRecord
                         { turnRecordId = turnId
@@ -1275,6 +1319,7 @@ fakeBackend =
                         , turnRecordStartedAt = Nothing
                         , turnRecordFinishedAt = Nothing
                         , turnRecordError = Nothing
+                        , turnRecordInput = input
                         }
         , backendLookupTurn = \_ _ -> pure (Right Nothing)
         , backendListTurns = \_ _ -> pure (Right [])
@@ -1348,6 +1393,7 @@ durableBackend ledger terminal runner =
                                         , turnRecordStartedAt = Nothing
                                         , turnRecordFinishedAt = Nothing
                                         , turnRecordError = Nothing
+                                        , turnRecordInput = input
                                         }
                                 entry =
                                     TestStoredTurn

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -178,6 +178,7 @@ spec = describe "turn supervisor" do
                         , turnRecordStartedAt = Nothing
                         , turnRecordFinishedAt = Nothing
                         , turnRecordError = Nothing
+                        , turnRecordInput = ""
                         }
             admission <-
                 async $

--- a/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Migrations.hs
@@ -495,6 +495,14 @@ coreMigrations =
         , migrationName = "persistent gateway model catalog cache"
         , migrationStatements = modelCatalogCacheSchemaStatements
         }
+    , Migration
+        { migrationVersion = 117
+        , migrationName = "durable server turn input text"
+        , migrationStatements =
+            [ "ALTER TABLE harness.server_turns\
+              \ ADD COLUMN IF NOT EXISTS input_text text NOT NULL DEFAULT ''"
+            ]
+        }
     ]
 
 -- | Specialize all runtime grants for a validated cluster-global role.

--- a/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/ServerTurn.hs
@@ -90,6 +90,7 @@ data StoredServerTurn = StoredServerTurn
     , storedServerTurnSessionId :: !Text
     , storedServerTurnClientRequestId :: !Text
     , storedServerTurnInputDigest :: !Text
+    , storedServerTurnInput :: !Text
     , storedServerTurnOwnerInstanceId :: !Text
     , storedServerTurnStatus :: !ServerTurnStatus
     , storedServerTurnCreatedAt :: !UTCTime
@@ -110,6 +111,7 @@ data ReserveServerTurn = ReserveServerTurn
     , reserveServerTurnSessionId :: !Text
     , reserveServerTurnClientRequestId :: !Text
     , reserveServerTurnInputDigest :: !Text
+    , reserveServerTurnInput :: !Text
     , reserveServerTurnOwnerInstanceId :: !Text
     , reserveServerTurnCreatedAt :: !UTCTime
     }
@@ -732,6 +734,7 @@ data RawServerTurn = RawServerTurn
     , rawSessionId :: !Text
     , rawClientRequestId :: !Text
     , rawInputDigest :: !Text
+    , rawInput :: !Text
     , rawOwnerInstanceId :: !Text
     , rawStatus :: !Text
     , rawCreatedAt :: !UTCTime
@@ -757,6 +760,7 @@ decodeServerTurn raw =
         , storedServerTurnSessionId = raw.rawSessionId
         , storedServerTurnClientRequestId = raw.rawClientRequestId
         , storedServerTurnInputDigest = raw.rawInputDigest
+        , storedServerTurnInput = raw.rawInput
         , storedServerTurnOwnerInstanceId = raw.rawOwnerInstanceId
         , storedServerTurnStatus = decodeStatus raw.rawStatus
         , storedServerTurnCreatedAt = raw.rawCreatedAt
@@ -803,7 +807,7 @@ isTerminal = not . isActive
 serverTurnColumns :: Text
 serverTurnColumns =
     "turn_id::text, tenant_id, gateway_identity,\
-    \ session_key, client_request_id::text, input_digest,\
+    \ session_key, client_request_id::text, input_digest, input_text,\
     \ owner_instance_id::text, status, server_turn.created_at,\
     \ started_at, finished_at, assistant_text, assistant_text_truncated,\
     \ response_id,\
@@ -816,6 +820,7 @@ serverTurnDecoder =
                 <$> Decoders.column (Decoders.nonNullable Decoders.text)
                 <*> Decoders.column (Decoders.nonNullable Decoders.text)
                 <*> Decoders.column (Decoders.nullable Decoders.text)
+                <*> Decoders.column (Decoders.nonNullable Decoders.text)
                 <*> Decoders.column (Decoders.nonNullable Decoders.text)
                 <*> Decoders.column (Decoders.nonNullable Decoders.text)
                 <*> Decoders.column (Decoders.nonNullable Decoders.text)
@@ -1065,9 +1070,9 @@ insertServerTurnStatement =
     mkStatement
         ( "INSERT INTO harness.server_turns AS server_turn\
           \ (turn_id, tenant_id, gateway_identity, session_key,\
-          \ client_request_id, input_digest, owner_instance_id, status, created_at)\
+          \ client_request_id, input_digest, input_text, owner_instance_id, status, created_at)\
           \ SELECT $1::uuid, $2, $3, session.session_key,\
-          \ $5::uuid, $6, $7::uuid, 'queued', $8\
+          \ $5::uuid, $6, $7, $8::uuid, 'queued', $9\
           \ FROM harness.sessions session\
           \ WHERE session.session_key = $4 AND session.deleted_at IS NULL\
           \ AND session.gateway_identity IS NOT DISTINCT FROM $3\
@@ -1086,6 +1091,9 @@ insertServerTurnStatement =
                     >$< Encoders.param (Encoders.nonNullable Encoders.text)
                )
             <> ( (.reserveServerTurnInputDigest)
+                    >$< Encoders.param (Encoders.nonNullable Encoders.text)
+               )
+            <> ( (.reserveServerTurnInput)
                     >$< Encoders.param (Encoders.nonNullable Encoders.text)
                )
             <> ( (.reserveServerTurnOwnerInstanceId)

--- a/packages/agent-store/test/Agent/Store/Postgres/ServerTurnRecoverySpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ServerTurnRecoverySpec.hs
@@ -69,6 +69,7 @@ exerciseRestartFence config firstPool fence = do
                     "01999999-0000-7000-8000-000000000032"
                 , reserveServerTurnInputDigest =
                     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                , reserveServerTurnInput = "hello world"
                 , reserveServerTurnOwnerInstanceId = instanceOne
                 , reserveServerTurnCreatedAt = createdAt
                 }

--- a/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
@@ -144,6 +144,7 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
                     "01999999-0000-7000-8000-000000000002"
                 , reserveServerTurnInputDigest =
                     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                , reserveServerTurnInput = "hello world"
                 , reserveServerTurnOwnerInstanceId = instanceOne
                 , reserveServerTurnCreatedAt = createdAt
                 }
@@ -232,6 +233,7 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
         Right (ServerTurnReserved stored) ->
             stored.storedServerTurnId == request.reserveServerTurnId
                 && stored.storedServerTurnStatus == ServerTurnQueued
+                && stored.storedServerTurnInput == "hello world"
         _ -> False
 
     reserveServerSessionMutation pool mutation


### PR DESCRIPTION
## Problem

`GET /v1/turns` did not include the submitted prompt. The console transcript only renders `SessionTurn.userText`. After a follow-up send, a refresh hid the user bubble until the turn finished and history items were available.

The TUI and native macOS app already use `SessionTurn.userText` (live `UiUserSubmitted` / observation `userText`, then persisted `harness.session_turns.user_text`). The web reconstructed the running turn from a separate execution record.

## Change

- Persist the prompt on `harness.server_turns.input_text` at reserve time.
- Emit it on turn JSON as both `input` (create-turn request field) and `userText` (the SessionTurn field).
- Overlay a queued or running turn onto the latest history page as a `SessionTurn` with `userText` and `status`.

Gateway maps that `userText` onto the console transcript. After this is deployed on Traumimo, a refresh while a follow-up is running shows the user text from the same shape as completed history.

## Tests

- `cabal test agent-server-test`: pass (117 examples), including a running-turn listing and history overlay.
- `cabal test agent-server-client-tests`: pass (33 examples).