### PR TITLE
Follow Codex catalog tool_mode for code mode by default

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
@@ -18,6 +18,9 @@ module Agent.CLI.CodeModeRuntime
     , codexCatalogDefaultEffort
     , projectCodeModeTools
     , projectCodeModeToolsFor
+    , CodeModeRuntimePlan(..)
+    , codeModeRuntimePlan
+    , codeModeRuntimeFor
     , codeModeSessionRuntimeFor
     , imageGenerationCodeModeRuntimeFor
     , imageGenerationCodeModeProjection
@@ -126,6 +129,31 @@ data CodeModeProjectionStrategy
     = FullCodeModeProjection
     | ImageGenerationOnlyCodeModeProjection
     deriving (Eq, Show)
+
+-- | Which code-mode runtime to start after resolving catalog @tool_mode@.
+data CodeModeRuntimePlan
+    = PlanFullCodeMode
+    | PlanImageGenerationCodeMode
+    | PlanNoCodeMode
+    deriving (Eq, Show)
+
+-- | Codex resolves catalog @tool_mode@ first. @fallback@ applies only when
+-- the catalog omits a recognized selector. When full code mode is not
+-- allowed, catalog code-only models still wrap image generation in @exec@.
+codeModeRuntimePlan
+    :: Bool
+    -> ToolMode
+    -> Maybe ModelInfo
+    -> CodeModeRuntimePlan
+codeModeRuntimePlan allowFull fallback maybeInfo =
+    case resolved of
+        CodeOnlyToolMode
+            | allowFull -> PlanFullCodeMode
+            | otherwise -> PlanImageGenerationCodeMode
+        CodeToolMode -> PlanNoCodeMode
+        ConventionalToolMode -> PlanNoCodeMode
+  where
+    resolved = maybe fallback (toolModeForInfo fallback) maybeInfo
 
 data CodeModeSessionRuntime = CodeModeSessionRuntime
     { codeModeWireTools :: ![AppTool]
@@ -254,35 +282,47 @@ codexCatalogDefaultEffort info =
     reasoningEffortText
         <$> (info >>= defaultReasoningEffortForInfo)
 
--- | Build the code-mode session runtime when the catalog selects code mode.
+-- | Start the runtime selected by 'codeModeRuntimePlan'.
 -- 'Right Nothing' keeps conventional tools;
 -- 'Left' reports why code mode could not start (the caller should warn and
 -- fall back to direct tools rather than refuse to start the session).
-codeModeSessionRuntimeFor
-    :: Maybe ModelInfo
+codeModeRuntimeFor
+    :: CodeModeRuntimePlan
+    -> Maybe ModelInfo
     -> [AppTool]
     -> IO (Either Text (Maybe CodeModeSessionRuntime))
-codeModeSessionRuntimeFor maybeInfo tools =
-    case maybeInfo of
-        Nothing -> pure (Right Nothing)
-        Just info ->
-            case toolModeForInfo ConventionalToolMode info of
-                ConventionalToolMode -> pure (Right Nothing)
-                -- Mixed mode also augments every direct tool description with
-                -- its JavaScript invocation. Keep the established direct-mode
-                -- fallback until that provider projection is implemented.
-                CodeToolMode -> pure (Right Nothing)
-                CodeOnlyToolMode ->
-                    buildRuntime
-                        info
-                        CodeOnlyToolMode
-                        FullCodeModeProjection
-                        (projectCodeModeTools CodeOnlyToolMode tools)
+codeModeRuntimeFor plan maybeInfo tools =
+    case plan of
+        PlanNoCodeMode -> pure (Right Nothing)
+        PlanFullCodeMode ->
+            buildRuntime
+                (maybe ImageDetailVisible imageDetailVisibilityFor maybeInfo)
+                CodeOnlyToolMode
+                FullCodeModeProjection
+                (projectCodeModeTools CodeOnlyToolMode tools)
+        PlanImageGenerationCodeMode ->
+            imageGenerationCodeModeRuntimeFor maybeInfo tools
+
+-- | Build the full code-mode session runtime when the catalog or local
+-- fallback selects code-only mode.
+-- Mixed mode also augments every direct tool description with its JavaScript
+-- invocation; keep the established direct-mode fallback until that provider
+-- projection is implemented.
+codeModeSessionRuntimeFor
+    :: ToolMode
+    -> Maybe ModelInfo
+    -> [AppTool]
+    -> IO (Either Text (Maybe CodeModeSessionRuntime))
+codeModeSessionRuntimeFor fallback maybeInfo tools =
+    codeModeRuntimeFor
+        (codeModeRuntimePlan True fallback maybeInfo)
+        maybeInfo
+        tools
 
 -- | Catalog @code_mode_only@ models reserve @image_gen.imagegen@ but expect it
--- behind the @exec@ surface. When the user has not enabled full code mode,
--- project only image generation through @exec@ and leave every other tool
--- directly provider-visible.
+-- behind the @exec@ surface. When full code mode is disabled, project only
+-- image generation through @exec@ and leave every other tool directly
+-- provider-visible.
 imageGenerationCodeModeRuntimeFor
     :: Maybe ModelInfo
     -> [AppTool]
@@ -295,7 +335,7 @@ imageGenerationCodeModeRuntimeFor maybeInfo tools =
                     (toolModeForInfo ConventionalToolMode info)
                     tools ->
                 buildRuntime
-                    info
+                    (imageDetailVisibilityFor info)
                     CodeOnlyToolMode
                     ImageGenerationOnlyCodeModeProjection
                     projection
@@ -326,17 +366,17 @@ filterStartupUnavailableTools suppressDirectImageGeneration
     | otherwise = id
 
 buildRuntime
-    :: ModelInfo
+    :: ImageDetailVisibility
     -> ToolMode
     -> CodeModeProjectionStrategy
     -> CodeModeToolProjection
     -> IO (Either Text (Maybe CodeModeSessionRuntime))
-buildRuntime info mode strategy projection = do
+buildRuntime imageDetail mode strategy projection = do
     slot <- newCodeModeNestedSlot
     workerPath <- codeModeWorkerPath
     built <- newCodeModeToolSet
         mode
-        (imageDetailVisibilityFor info)
+        imageDetail
         workerPath
         (invokeThroughSlot slot)
         (map nestedSpecFor projection.nestedCodeModeTools)

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -51,6 +51,7 @@ import Agent.Loop
 import Agent.CLI.Options
     ( Command(..)
     , CliOptions(..)
+    , CodeModeOption(..)
     , ScreenMode(..)
     , defaultCliOptions
     , parseArgs
@@ -310,7 +311,7 @@ applyNativeStartupPolicy policy cwd = restrictContext . restrictFacilities
             , optPromptFile = Nothing
             , optManagedTurnFile = Nothing
             , optComputerUse = False
-            , optCodeMode = False
+            , optCodeMode = CodeModeDisabled
             }
 
 nativeGhciEnabled :: NativeShellMode -> Bool

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -8,6 +8,7 @@ module Agent.CLI.Options
     , McpAddCommand(..)
     , McpAddTransport(..)
     , McpCommand(..)
+    , CodeModeOption(..)
     , ScreenMode(..)
     , SessionOutputFormat(..)
     , SessionPageRequest(..)
@@ -124,6 +125,18 @@ data ScreenMode
     | ScreenMinimal
     deriving (Eq, Show)
 
+-- | How to start JavaScript code mode for a session.
+--
+-- Codex resolves catalog @tool_mode@ first. Local enablement is only the
+-- fallback when the catalog omits a recognized selector. Local disablement
+-- keeps conventional tools, wrapping only image generation for catalog
+-- code-only models.
+data CodeModeOption
+    = CodeModeCatalog
+    | CodeModeEnabled
+    | CodeModeDisabled
+    deriving (Eq, Show)
+
 data ApprovalAnswer
     = AllowOnce
     | AllowAlways
@@ -185,8 +198,9 @@ data CliOptions = CliOptions
     , optComputerUseExplicit :: !Bool
       -- ^ Whether a computer-use flag was supplied explicitly. This lets
       -- native clients opt in while non-interactive defaults stay safe.
-    , optCodeMode :: !Bool
-      -- ^ Honor catalog-selected JavaScript code mode (default: False).
+    , optCodeMode :: !CodeModeOption
+      -- ^ Whether to start JavaScript code mode. 'CodeModeCatalog' follows
+      -- the model catalog's @tool_mode@ (Codex default).
     , optScreenMode :: !ScreenMode
     , optMotionMode :: !MotionMode
     } deriving (Eq, Show)
@@ -216,7 +230,7 @@ defaultCliOptions = CliOptions
     , optBash = True
     , optComputerUse = True
     , optComputerUseExplicit = False
-    , optCodeMode = False
+    , optCodeMode = CodeModeCatalog
     , optScreenMode = ScreenAuto
     , optMotionMode = MotionFull
     }
@@ -615,10 +629,10 @@ optionUpdateParser = asum
             { optComputerUse = value
             , optComputerUseExplicit = True
             })
-    , boolFlagUpdate "code-mode" True "Enable catalog-selected code mode"
-        (\value options -> options { optCodeMode = value })
-    , boolFlagUpdate "no-code-mode" False "Use conventional tool calling"
-        (\value options -> options { optCodeMode = value })
+    , codeModeFlagUpdate "code-mode" CodeModeEnabled
+        "Enable JavaScript code mode when the catalog omits tool_mode"
+    , codeModeFlagUpdate "no-code-mode" CodeModeDisabled
+        "Disable full code mode even when the catalog selects it"
     , screenFlagUpdate "fullscreen" ScreenFullscreen
         "Use the retained full-screen TUI"
     , screenFlagUpdate "minimal" ScreenMinimal
@@ -668,6 +682,15 @@ screenFlagUpdate
 screenFlagUpdate name value description =
     flagUpdate name description
         (\options -> options { optScreenMode = value })
+
+codeModeFlagUpdate
+    :: String
+    -> CodeModeOption
+    -> String
+    -> Options.Parser OptionUpdate
+codeModeFlagUpdate name value description =
+    flagUpdate name description
+        (\options -> options { optCodeMode = value })
 
 textReader :: Options.ReadM Text
 textReader = Text.pack <$> Options.str

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -39,6 +39,7 @@ import Agent.CLI.Options
       CliOptions(optMotionMode, optManagedTurnFile, optScreenMode,
                  optProvider, optModel, optWorktree, optEffort, optPrompt,
                  optPromptFile, optResume, optCwd, optCodeMode, optYolo),
+      CodeModeOption(CodeModeEnabled),
       ScreenMode(ScreenMinimal) )
 import Agent.CLI.Provider.Switch
     ( continueAutomaticFallback, reportProviderUnavailable )
@@ -318,7 +319,7 @@ runAgentWithRuntime processRuntime runMode options = do
             RunEnableCodeMode sessionId ->
                 let nextOptions =
                         (restartSessionOptions current sessionId)
-                            { optCodeMode = True }
+                            { optCodeMode = CodeModeEnabled }
                 in go fullscreenInputs sessionState nextOptions Nothing
             RunProviderStartFailed apiError ->
                 case transition of

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Restart.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Restart.hs
@@ -3,7 +3,10 @@ module Agent.CLI.Runtime.Orchestration.Restart
     , runFullscreenRestartLoop
     ) where
 
-import Agent.CLI.Options ( CliOptions(optCodeMode) )
+import Agent.CLI.Options
+    ( CliOptions(optCodeMode)
+    , CodeModeOption(CodeModeEnabled)
+    )
 import Agent.CLI.ProviderTransition
     ( ProviderTransition(..), TransitionCause(AutomaticFallback) )
 import Agent.CLI.Runtime.Types ( PreparedAgent(..), RunResult(..) )
@@ -63,7 +66,7 @@ runFullscreenRestartLoop callbacks runtime =
                 RunEnableCodeMode sessionId -> do
                     let nextOptions =
                             (callbacks.restartOptions options sessionId)
-                                { optCodeMode = True }
+                                { optCodeMode = CodeModeEnabled }
                     retryStartup nextOptions Nothing
                 RunSwitchProvider next -> do
                     let nextOptions =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -30,12 +30,17 @@ import Agent.CLI.Claude
     , newClaudeSessionRuntimeSlot
     )
 import Agent.CLI.CodeModeRuntime
-    ( CodeModeSessionRuntime(..),
-      CodexCatalogSession(..),
-      codeModeSessionRuntimeFor,
-      filterStartupUnavailableTools,
-      imageGenerationCodeModeRuntimeFor,
-      loadCodexCatalogModelInfo )
+    ( CodeModeRuntimePlan(..)
+    , CodeModeSessionRuntime(..)
+    , CodexCatalogSession(..)
+    , codeModeRuntimeFor
+    , codeModeRuntimePlan
+    , filterStartupUnavailableTools
+    , loadCodexCatalogModelInfo
+    )
+import Agent.Tools.CodeMode.Tool
+    ( ToolMode(CodeOnlyToolMode, ConventionalToolMode)
+    )
 import Agent.CLI.Compaction
     ( AutomaticCompactionBoundary
     , CompactOutcome
@@ -66,6 +71,7 @@ import Agent.CLI.ModelConfig
 import Agent.CLI.Models (ModelTarget(targetConnectionId))
 import Agent.CLI.Options
     ( ApprovalPolicy
+    , CodeModeOption(..)
     , isOneShot
     , CliOptions(optCodeMode, optCompactThreshold, optShowRawReasoning)
     )
@@ -463,9 +469,9 @@ prepareSessionCodeRuntime AgentSessionRequest
     , mcpInstructions
     } = do
     today <- utctDay <$> getCurrentTime
-    -- Catalog models provide the per-model instructions template. Full code
-    -- mode remains opt-in, while code_mode_only models still route the
-    -- reserved image-generation tool through exec.
+    -- Catalog models provide the per-model instructions template. Codex
+    -- catalog @tool_mode@ selects full code mode; local --code-mode is only
+    -- the fallback when the catalog omits a recognized selector.
     sessionModelInfo <-
         loadCodexCatalogModelInfo
             stateDirectory
@@ -488,20 +494,28 @@ prepareSessionCodeRuntime AgentSessionRequest
                 startup.startupNativeHooks
         includeHostedSearch =
             nativeCapabilities.nativeProviderHostedTools
+        allowFullCodeMode = options.optCodeMode /= CodeModeDisabled
+        codeModeFallback = case options.optCodeMode of
+            CodeModeEnabled -> CodeOnlyToolMode
+            _ -> ConventionalToolMode
+        codeModePlan =
+            codeModeRuntimePlan
+                allowFullCodeMode
+                codeModeFallback
+                sessionModelInfo
         initializeCodeMode
             | not nativeCapabilities.nativeHostExtensions =
                 pure (Right Nothing)
-            | options.optCodeMode =
-                codeModeSessionRuntimeFor sessionModelInfo tools
             | otherwise =
-                imageGenerationCodeModeRuntimeFor sessionModelInfo tools
-        codeModeFallbackWarning
-            | options.optCodeMode =
-                "code mode unavailable; falling back to compatible \
-                \direct tools: "
-            | otherwise =
-                "image generation code mode unavailable; \
-                \disabling image generation: "
+                codeModeRuntimeFor codeModePlan sessionModelInfo tools
+        codeModeFallbackWarning =
+            case codeModePlan of
+                PlanImageGenerationCodeMode ->
+                    "image generation code mode unavailable; \
+                    \disabling image generation: "
+                _ ->
+                    "code mode unavailable; falling back to compatible \
+                    \direct tools: "
     -- Attach cleanup during acquisition, before warnings or subsequent startup
     -- work can throw. The enclosing session owns this scope.
     (_, initializedCodeMode) <-

--- a/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
@@ -28,6 +28,7 @@ import Agent.CLI.GatewayClient (GatewayCredential(..))
 import Agent.CLI.IntegrationGateway (gatewayIntegrationMcpConfig)
 import Agent.CLI.Options
     ( CliOptions(..)
+    , CodeModeOption(..)
     , ScreenMode(..)
     , defaultCliOptions
     )
@@ -130,7 +131,7 @@ spec = describe "nativeTurnOptions" do
                 , optAgentsMd = False
                 , optSkills = False
                 , optComputerUse = False
-                , optCodeMode = False
+                , optCodeMode = CodeModeDisabled
                 }
         actual `shouldBe` expected
         applyNativeStartupPolicy restrictedNativeStartupPolicy cwd actual
@@ -305,7 +306,7 @@ conflictingOptions = defaultCliOptions
     , optAgentsMd = True
     , optSkills = True
     , optComputerUse = True
-    , optCodeMode = True
+    , optCodeMode = CodeModeEnabled
     , optPrompt = Just "preserve supplied input"
     , optResume = Just "preserve-session"
     }

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -494,14 +494,17 @@ spec = do
                 True
                 `shouldBe` True
 
-        it "uses conventional tool calling by default" do
-            defaultCliOptions.optCodeMode `shouldBe` False
+        it "follows catalog tool_mode by default" do
+            defaultCliOptions.optCodeMode `shouldBe` CodeModeCatalog
             parseArgs ["--code-mode"]
                 `shouldBe` Right (RunAgent defaultCliOptions
-                    { optCodeMode = True })
+                    { optCodeMode = CodeModeEnabled })
+            parseArgs ["--no-code-mode"]
+                `shouldBe` Right (RunAgent defaultCliOptions
+                    { optCodeMode = CodeModeDisabled })
             parseArgs ["--code-mode", "--no-code-mode"]
                 `shouldBe` Right (RunAgent defaultCliOptions
-                    { optCodeMode = False })
+                    { optCodeMode = CodeModeDisabled })
 
         it "keeps ghci disabled by default and enables it explicitly" do
             parseArgs []

--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -5,12 +5,20 @@ import Agent.CLI.ChartImage (terminalChartTool)
 import Agent.CLI.ComputerUse (computerUseTool)
 import Agent.CLI.CodeModeRuntime
     ( CodeModeProjectionStrategy(..)
+    , CodeModeRuntimePlan(..)
     , CodeModeToolProjection(..)
+    , codeModeRuntimePlan
     , filterStartupUnavailableTools
     , imageGenerationCodeModeProjection
     , projectCodeModeTools
     , projectCodeModeToolsFor
     )
+import Agent.OpenAI.Models
+    ( ModelInfo(..)
+    , loadBundledModelsOrThrow
+    , modelInfoForSlug
+    )
+import qualified Agent.OpenAI.Models.Types as OpenAIModels
 import Agent.Tools.RenderChart (renderChartResult)
 import Agent.Tools.ShowImage (ImageDisplayHooks(..), ImageDisplayRequest(..))
 import Agent.Dialect
@@ -274,6 +282,47 @@ spec = describe "schemasFromAppTools" do
                     ]
         map (.appToolName) refreshTools
             `shouldBe` ["read_file", "computer"]
+
+    it "starts full code mode for catalog code_mode_only models by default" do
+        catalog <- loadBundledModelsOrThrow
+        let sol = modelInfoForSlug "gpt-5.6-sol" catalog
+            terra = modelInfoForSlug "gpt-5.6-terra" catalog
+            luna = modelInfoForSlug "gpt-5.6-luna" catalog
+            astra = modelInfoForSlug "gpt-6-astra" catalog
+            gpt55 = modelInfoForSlug "gpt-5.5" catalog
+        codeModeRuntimePlan True ConventionalToolMode (Just sol)
+            `shouldBe` PlanFullCodeMode
+        codeModeRuntimePlan True ConventionalToolMode (Just terra)
+            `shouldBe` PlanFullCodeMode
+        codeModeRuntimePlan True ConventionalToolMode (Just luna)
+            `shouldBe` PlanFullCodeMode
+        codeModeRuntimePlan True ConventionalToolMode (Just astra)
+            `shouldBe` PlanFullCodeMode
+        codeModeRuntimePlan True ConventionalToolMode (Just gpt55)
+            `shouldBe` PlanNoCodeMode
+        codeModeRuntimePlan True ConventionalToolMode Nothing
+            `shouldBe` PlanNoCodeMode
+
+    it "uses local --code-mode only when the catalog omits tool_mode" do
+        catalog <- loadBundledModelsOrThrow
+        let sol = modelInfoForSlug "gpt-5.6-sol" catalog
+            gpt55 = modelInfoForSlug "gpt-5.5" catalog
+            direct = sol { toolMode = Just OpenAIModels.ToolModeDirect }
+        codeModeRuntimePlan True CodeOnlyToolMode (Just gpt55)
+            `shouldBe` PlanFullCodeMode
+        codeModeRuntimePlan True CodeOnlyToolMode Nothing
+            `shouldBe` PlanFullCodeMode
+        codeModeRuntimePlan True CodeOnlyToolMode (Just direct)
+            `shouldBe` PlanNoCodeMode
+
+    it "wraps only image generation when full code mode is disabled" do
+        catalog <- loadBundledModelsOrThrow
+        let sol = modelInfoForSlug "gpt-5.6-sol" catalog
+            gpt55 = modelInfoForSlug "gpt-5.5" catalog
+        codeModeRuntimePlan False ConventionalToolMode (Just sol)
+            `shouldBe` PlanImageGenerationCodeMode
+        codeModeRuntimePlan False ConventionalToolMode (Just gpt55)
+            `shouldBe` PlanNoCodeMode
 
     it "nests only imagegen for code-only models when full code mode is off" do
         let tools = map testTool ["read_file", "imagegen", "shell_command"]


### PR DESCRIPTION
## Summary
- Codex resolves JavaScript code mode from catalog `tool_mode`, not from a local opt-in flag. `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, and `gpt-6-astra` advertise `code_mode_only`, so agent-cli now starts the full nested `exec`/`wait` surface for those models by default.
- `--code-mode` / `/codemod` remain the local fallback when the catalog omits a recognized selector (for example `gpt-5.5`). Catalog `direct` still wins.
- `--no-code-mode` and restricted native startup disable the full nested surface. Catalog code-only models then wrap only image generation through `exec`.

## Test plan
- GHCi `agent-cli:test:agent-cli-test`: catalog plan, flag parsing, and restricted native startup examples (8 examples, 0 failures).