### PR TITLE
Expose a read-only harness catalog to local database tools

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Database.hs
+++ b/packages/agent-cli/src/Agent/CLI/Database.hs
@@ -1,8 +1,12 @@
--- | Model-facing tools for scoped, user-defined PostgreSQL data.
+-- | Model-facing tools for scoped PostgreSQL data.
 --
--- The storage package owns PostgreSQL connections, roles, schema isolation,
--- transactions, and result bounds.  This module deliberately depends only on
--- callbacks so the provider-neutral tool surface remains easy to test.
+-- Custom scopes (@user@, @repository@, @checkout@) are agent-created memory.
+-- The local CLI also exposes the runtime @harness@ catalog as a read-only
+-- query surface so the model can inspect durable sessions after compaction.
+-- Multi-tenant @agent-server@ embeddings omit that catalog.  The storage
+-- package owns connections, roles, isolation, transactions, and result
+-- bounds.  This module depends only on callbacks so the tool surface stays
+-- easy to test.
 module Agent.CLI.Database
     ( DatabaseScope(..)
     , databaseScopeDecoder
@@ -27,20 +31,31 @@ data DatabaseScope
     = DatabaseUserScope
     | DatabaseRepositoryScope
     | DatabaseCheckoutScope
+    | DatabaseHarnessScope
     deriving (Eq, Show)
 
+-- | Custom-data scopes used by learned skills and the native data browser.
+-- The runtime @harness@ catalog is not a provisioned custom scope.
 databaseScopeDecoder :: Hermes.Decoder DatabaseScope
-databaseScopeDecoder = Hermes.withText \case
+databaseScopeDecoder = databaseScopeDecoderWithHarness False
+
+databaseScopeDecoderWithHarness :: Bool -> Hermes.Decoder DatabaseScope
+databaseScopeDecoderWithHarness exposeHarness = Hermes.withText \case
         "user" -> pure DatabaseUserScope
         "repository" -> pure DatabaseRepositoryScope
         "checkout" -> pure DatabaseCheckoutScope
+        "harness"
+            | exposeHarness -> pure DatabaseHarnessScope
+            | otherwise ->
+                fail "the harness catalog is not available in this session"
         value ->
             fail
                 ("unknown database scope "
                     <> show value
-                    <> "; expected user, repository, or checkout")
+                    <> "; expected "
+                    <> expectedScopes exposeHarness)
 
--- | Storage callbacks for the three model-facing database operations.
+-- | Storage callbacks for the model-facing database operations.
 --
 -- Database and conversation-search results are rendered as labeled text because
 -- they are read by the model and humans rather than consumed as an API.
@@ -55,28 +70,36 @@ data DatabaseToolsEnv = DatabaseToolsEnv
         :: !(DatabaseScope -> Text -> Text -> IO (Either Text Text))
     , databaseSearchConversations
         :: !(Text -> Int -> IO (Either Text [ConversationSearchMatch]))
+    -- | Local CLI and personal native embeddings expose the runtime catalog.
+    -- @agent-server@ leaves this false so tenant agents cannot query harness
+    -- tables through model-authored SQL.
+    , databaseHarnessCatalogEnabled :: !Bool
+    -- | Stable session key for the current conversation, when reserved.
+    -- Included in harness-catalog tool text so the model can filter SQL after
+    -- compaction without guessing identifiers.
+    , databaseHarnessSessionId :: !(Maybe Text)
     }
 
 data SchemaArgs = SchemaArgs !DatabaseScope
 
-schemaArgsDecoder :: Hermes.Decoder SchemaArgs
-schemaArgsDecoder = Hermes.object $
-    SchemaArgs <$> Hermes.atKey "scope" databaseScopeDecoder
+schemaArgsDecoder :: Bool -> Hermes.Decoder SchemaArgs
+schemaArgsDecoder exposeHarness = Hermes.object $
+    SchemaArgs <$> Hermes.atKey "scope" (databaseScopeDecoderWithHarness exposeHarness)
 
 data QueryArgs = QueryArgs !DatabaseScope !Text
 
-queryArgsDecoder :: Hermes.Decoder QueryArgs
-queryArgsDecoder = Hermes.object $
+queryArgsDecoder :: Bool -> Hermes.Decoder QueryArgs
+queryArgsDecoder exposeHarness = Hermes.object $
         QueryArgs
-            <$> Hermes.atKey "scope" databaseScopeDecoder
+            <$> Hermes.atKey "scope" (databaseScopeDecoderWithHarness exposeHarness)
             <*> Hermes.atKey "sql" Hermes.text
 
 data ExecuteArgs = ExecuteArgs !DatabaseScope !Text !Text
 
-executeArgsDecoder :: Hermes.Decoder ExecuteArgs
-executeArgsDecoder = Hermes.object $
+executeArgsDecoder :: Bool -> Hermes.Decoder ExecuteArgs
+executeArgsDecoder exposeHarness = Hermes.object $
         ExecuteArgs
-            <$> Hermes.atKey "scope" databaseScopeDecoder
+            <$> Hermes.atKey "scope" (databaseScopeDecoderWithHarness exposeHarness)
             <*> Hermes.atKey "sql" Hermes.text
             <*> Hermes.atKey "purpose" Hermes.text
 
@@ -103,32 +126,30 @@ databaseTools env =
 schemaTool :: DatabaseToolsEnv -> AppTool
 schemaTool env = jsonTool
     "database_schema"
-    ( "Inspect the user-defined PostgreSQL tables visible in one durable "
-        <> "scope. Returns tables, columns, keys, constraints, indexes, and "
-        <> "comments. Inspect this before querying or creating tables; "
-        <> "harness-internal schemas are never exposed."
-    )
-    [scopeProperty]
+    (schemaToolDescription env)
+    [scopeProperty env]
     True
     ParallelSafe
-    (typedTool "database_schema" schemaArgsDecoder \(SchemaArgs scope) ->
-        env.databaseDescribeScope scope)
+    (typedTool
+        "database_schema"
+        (schemaArgsDecoder env.databaseHarnessCatalogEnabled)
+        \(SchemaArgs scope) ->
+            env.databaseDescribeScope scope)
 
 queryTool :: DatabaseToolsEnv -> AppTool
 queryTool env = jsonTool
     "database_query"
-    ( "Run one read-only PostgreSQL query against user-defined tables in one "
-        <> "durable scope. The database enforces a read-only transaction, "
-        <> "timeouts, row limits, and scope isolation. Inspect the schema "
-        <> "first rather than guessing table or column names."
-    )
-    [ scopeProperty
+    (queryToolDescription env)
+    [ scopeProperty env
     , PropertySchema "sql" PropertyString True $ Just
         "One read-only PostgreSQL query. Do not include transaction control."
     ]
     True
     ParallelSafe
-    (typedTool "database_query" queryArgsDecoder \(QueryArgs scope sql) ->
+    (typedTool
+        "database_query"
+        (queryArgsDecoder env.databaseHarnessCatalogEnabled)
+        \(QueryArgs scope sql) ->
         if Text.null (Text.strip sql)
             then pure (Left "database query must not be empty")
             else env.databaseRunQuery scope sql)
@@ -136,16 +157,8 @@ queryTool env = jsonTool
 executeTool :: DatabaseToolsEnv -> AppTool
 executeTool env = jsonTool
     "database_execute"
-    ( "Execute a transactional PostgreSQL DDL/DML batch against user-defined "
-        <> "tables in one durable scope. Use this to create or alter structured "
-        <> "memory such as todos and to insert, update, or delete its rows. "
-        <> "Choose the narrowest correct scope, prefer existing suitable "
-        <> "tables, and add UUIDv7 primary keys using "
-        <> "`uuid PRIMARY KEY DEFAULT uuidv7()`, timestamps, constraints, "
-        <> "indexes, and comments when creating a schema. This is a mutating tool and "
-        <> "requires approval unless the active policy auto-approves it."
-    )
-    [ scopeProperty
+    (executeToolDescription env)
+    [ scopeProperty env
     , PropertySchema "sql" PropertyString True $ Just
         "Transactional PostgreSQL DDL/DML batch for the selected custom scope."
     , PropertySchema "purpose" PropertyString True $ Just
@@ -153,12 +166,17 @@ executeTool env = jsonTool
     ]
     False
     TurnSequential
-    (typedTool "database_execute" executeArgsDecoder \(ExecuteArgs scope sql purpose) ->
-        if Text.null (Text.strip sql)
-            then pure (Left "database SQL must not be empty")
-            else if Text.null (Text.strip purpose)
-                then pure (Left "database change purpose must not be empty")
-                else env.databaseRunExecute scope purpose sql)
+    (typedTool
+        "database_execute"
+        (executeArgsDecoder env.databaseHarnessCatalogEnabled)
+        \(ExecuteArgs scope sql purpose) ->
+        if scope == DatabaseHarnessScope
+            then pure (Left harnessCatalogReadOnlyError)
+            else if Text.null (Text.strip sql)
+                then pure (Left "database SQL must not be empty")
+                else if Text.null (Text.strip purpose)
+                    then pure (Left "database change purpose must not be empty")
+                    else env.databaseRunExecute scope purpose sql)
 
 conversationSearchTool :: DatabaseToolsEnv -> AppTool
 conversationSearchTool env = jsonTool
@@ -184,15 +202,92 @@ conversationSearchTool env = jsonTool
                 else fmap (fmap renderConversationSearchResult) $
                     env.databaseSearchConversations query limit)
 
-scopeProperty :: PropertySchema
-scopeProperty = PropertySchema
+scopeProperty :: DatabaseToolsEnv -> PropertySchema
+scopeProperty env = PropertySchema
     "scope"
-    (PropertyEnum ["user", "repository", "checkout"])
+    (PropertyEnum (scopeNames env.databaseHarnessCatalogEnabled))
     True
-    (Just
-        ( "Durable data scope: user for cross-project personal data, repository "
-            <> "for data shared by clones/worktrees, or checkout for this worktree."
-        ))
+    (Just (scopePropertyDescription env.databaseHarnessCatalogEnabled))
+
+scopeNames :: Bool -> [Text]
+scopeNames exposeHarness =
+    ["user", "repository", "checkout"]
+        <> ["harness" | exposeHarness]
+
+expectedScopes :: Bool -> String
+expectedScopes exposeHarness =
+    if exposeHarness
+        then "user, repository, checkout, or harness"
+        else "user, repository, or checkout"
+
+scopePropertyDescription :: Bool -> Text
+scopePropertyDescription exposeHarness =
+    "Durable data scope: user for cross-project personal data, repository "
+        <> "for data shared by clones/worktrees, or checkout for this worktree."
+        <> if exposeHarness
+            then
+                " harness is the local runtime catalog (sessions, turns, messages, "
+                    <> "tool calls). It is read-only and survives compaction."
+            else ""
+
+schemaToolDescription :: DatabaseToolsEnv -> Text
+schemaToolDescription env
+    | env.databaseHarnessCatalogEnabled =
+        "Inspect PostgreSQL tables visible in one durable scope. user, "
+            <> "repository, and checkout are agent-created memory. harness is "
+            <> "the local runtime catalog. Returns tables, columns, keys, "
+            <> "constraints, indexes, and comments. Inspect this before querying "
+            <> "or creating tables."
+    | otherwise =
+        "Inspect the user-defined PostgreSQL tables visible in one durable "
+            <> "scope. Returns tables, columns, keys, constraints, indexes, and "
+            <> "comments. Inspect this before querying or creating tables; "
+            <> "harness-internal schemas are never exposed."
+
+queryToolDescription :: DatabaseToolsEnv -> Text
+queryToolDescription env
+    | env.databaseHarnessCatalogEnabled =
+        "Run one read-only PostgreSQL query against one durable scope. The "
+            <> "database enforces a read-only transaction, timeouts, row limits, "
+            <> "and scope isolation. Inspect the schema first rather than guessing "
+            <> "table or column names."
+            <> harnessQueryGuidance env.databaseHarnessSessionId
+    | otherwise =
+        "Run one read-only PostgreSQL query against user-defined tables in one "
+            <> "durable scope. The database enforces a read-only transaction, "
+            <> "timeouts, row limits, and scope isolation. Inspect the schema "
+            <> "first rather than guessing table or column names."
+
+executeToolDescription :: DatabaseToolsEnv -> Text
+executeToolDescription env =
+    "Execute a transactional PostgreSQL DDL/DML batch against user-defined "
+        <> "tables in one durable scope. Use this to create or alter structured "
+        <> "memory such as todos and to insert, update, or delete its rows. "
+        <> "Choose the narrowest correct scope, prefer existing suitable "
+        <> "tables, and add UUIDv7 primary keys using "
+        <> "`uuid PRIMARY KEY DEFAULT uuidv7()`, timestamps, constraints, "
+        <> "indexes, and comments when creating a schema. This is a mutating tool and "
+        <> "requires approval unless the active policy auto-approves it."
+        <> if env.databaseHarnessCatalogEnabled
+            then " The harness catalog is read-only; do not use this tool to change it."
+            else ""
+
+harnessQueryGuidance :: Maybe Text -> Text
+harnessQueryGuidance sessionId =
+    " The harness scope is the runtime catalog: sessions, session_turns, "
+        <> "session_messages, session_function_calls, and related item tables. "
+        <> "Compaction replaces model context only; earlier turns remain queryable. "
+        <> "Filter on session_key (not the internal UUID) and turn_index. "
+        <> maybe
+            ""
+            (\value -> " This session's key is `" <> value <> "`. ")
+            sessionId
+        <> "Prefer targeted columns and WHERE clauses over selecting large "
+        <> "tool-output columns."
+
+harnessCatalogReadOnlyError :: Text
+harnessCatalogReadOnlyError =
+    "the harness catalog is read-only; use user, repository, or checkout to change agent-created tables"
 
 renderConversationSearchResult :: [ConversationSearchMatch] -> Text
 renderConversationSearchResult matches =

--- a/packages/agent-cli/src/Agent/CLI/Database/Store.hs
+++ b/packages/agent-cli/src/Agent/CLI/Database/Store.hs
@@ -37,8 +37,10 @@ import Agent.Store.Postgres.Custom
     , defaultQueryLimits
     , executeCustom
     , inspectCustomSchema
+    , inspectSchema
     , queryCustom
     , queryCustomJson
+    , querySchema
     )
 import Agent.Store.Postgres.Session
     ( ConversationSearchResult(..)
@@ -156,31 +158,60 @@ databaseToolsEnvForStore
     -- ^ Current root session id, when persistence has started.
     -> Maybe Text
     -- ^ Identity of the connected gateway credential, if any.
+    -> Bool
+    -- ^ Whether the local runtime catalog is queryable as @harness@.
+    -> Maybe Text
+    -- ^ Current session key to advertise in harness tool text.
     -> DatabaseToolsEnv
 databaseToolsEnvForStore
-        store scopes currentSessionId gatewayIdentity = DatabaseToolsEnv
+        store scopes currentSessionId gatewayIdentity
+        exposeHarnessCatalog harnessSessionId = DatabaseToolsEnv
     { databaseDescribeScope = \selected ->
-        withScopeDatabase store (scopeForDatabase scopes selected) \database pool ->
-            fmap formatCatalog <$> inspectCustomSchema pool database
+        case selected of
+            DatabaseHarnessScope ->
+                fmap formatCatalog
+                    <$> inspectSchema (storePool (trustedPool store)) "harness"
+            _ ->
+                withScopeDatabase store (scopeForDatabase scopes selected)
+                    \database pool ->
+                        fmap formatCatalog <$> inspectCustomSchema pool database
     , databaseRunQuery = \selected sql ->
-        withScopeDatabase store (scopeForDatabase scopes selected) \database pool ->
-            queryCustom pool database defaultQueryLimits sql >>= \case
-                Left err -> pure (Left err)
-                Right result -> pure (Right (formatQueryResult result))
+        case selected of
+            DatabaseHarnessScope ->
+                querySchema
+                    (storePool (trustedPool store))
+                    "harness"
+                    defaultQueryLimits
+                    sql >>= \case
+                    Left err -> pure (Left err)
+                    Right result -> pure (Right (formatQueryResult result))
+            _ ->
+                withScopeDatabase store (scopeForDatabase scopes selected)
+                    \database pool ->
+                        queryCustom pool database defaultQueryLimits sql >>= \case
+                            Left err -> pure (Left err)
+                            Right result ->
+                                pure (Right (formatQueryResult result))
     , databaseRunExecute = \selected purpose sql ->
-        withScopeDatabase store (scopeForDatabase scopes selected) \database pool -> do
-            sessionId <- currentSessionId
-            fmap formatExecutionResult <$> executeCustom
-                (storePool (trustedPool store))
-                pool
-                database
-                CustomAuditContext
-                    { customAuditSessionId = sessionId
-                    , customAuditAgentId = Nothing
-                    }
-                defaultQueryLimits
-                purpose
-                sql
+        case selected of
+            DatabaseHarnessScope ->
+                pure $ Left
+                    "the harness catalog is read-only; use user, repository, or checkout to change agent-created tables"
+            _ ->
+                withScopeDatabase store (scopeForDatabase scopes selected)
+                    \database pool -> do
+                        sessionId <- currentSessionId
+                        fmap formatExecutionResult <$> executeCustom
+                            (storePool (trustedPool store))
+                            pool
+                            database
+                            CustomAuditContext
+                                { customAuditSessionId = sessionId
+                                , customAuditAgentId = Nothing
+                                }
+                            defaultQueryLimits
+                            purpose
+                            sql
     , databaseSearchConversations = \query limit ->
         searchConversationTurnsForBoundary
             (trustedPool store)
@@ -191,6 +222,8 @@ databaseToolsEnvForStore
             Left err -> pure (Left (renderStoreError err))
             Right results ->
                 pure (Right (map searchResultValue results))
+    , databaseHarnessCatalogEnabled = exposeHarnessCatalog
+    , databaseHarnessSessionId = harnessSessionId
     }
 
 -- | List the table-like objects exposed by one existing user-defined scope.
@@ -421,6 +454,8 @@ scopeForDatabase scopes = \case
     DatabaseUserScope -> scopes.userScope
     DatabaseRepositoryScope -> scopes.repositoryScope
     DatabaseCheckoutScope -> scopes.checkoutScope
+    DatabaseHarnessScope ->
+        error "scopeForDatabase: harness is the runtime catalog, not a custom scope"
 
 applicableDatabaseScopes :: DatabaseScopes -> [Scope]
 applicableDatabaseScopes scopes =

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -680,12 +680,17 @@ assembleSessionToolsRuntime AgentToolsRequest
                                     artifactDirectory
                                     mcpFleet)
                         <> MCP.mcpFleetResourceTools mcpFleet
+    sessionId <- readIORef persistSlotRef >>= reservedSessionId
+    let exposeHarnessCatalog =
+            maybe True (.nativeExposeHarnessCatalog) startup.startupNativeHooks
         databaseToolsEnv =
             databaseToolsEnvForStore
                 startup.startupDatabaseStore
                 databaseScopes
                 (readIORef persistSlotRef >>= currentSessionId)
                 gatewayIdentity
+                exposeHarnessCatalog
+                sessionId
         learnedSkillToolsEnv =
             learnedSkillToolsEnvForStore
                 startup.startupDatabaseStore

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Types.hs
@@ -151,6 +151,10 @@ data NativeRunHooks = NativeRunHooks
     -- scope. Multi-tenant callers use the tenant id here because PostgreSQL
     -- roles are cluster-global even when each tenant has its own database.
     , nativeDatabaseScopeNamespace :: !(Maybe Text)
+    -- | When true, model-facing database tools can inspect the runtime
+    -- @harness@ catalog. The local CLI defaults to true when no native hooks
+    -- are present. @agent-server@ must leave this false.
+    , nativeExposeHarnessCatalog :: !Bool
     , nativeWorkspaceDiscovery :: !NativeWorkspaceDiscovery
     , nativeCapabilities :: !NativeRunCapabilities
     -- | Startup permissions owned by the embedding, not an options callback.

--- a/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Database
 import Agent.CLI.Database.Storage
 import Agent.CLI.Database.Store
     ( DatabaseBrowsePage(..)
+    , databaseToolsEnvForStore
     , deriveDatabaseScopes
     , listDatabaseObjects
     , loadDatabaseRows
@@ -42,7 +43,8 @@ import Agent.ToolDispatch
     , functionToolCall
     )
 import Agent.Tools.Types
-    ( appToolHandlers
+    ( AppTool(..)
+    , appToolHandlers
     )
 import Agent.ToolDispatch (dispatchToolCall)
 import Control.Exception.Safe (displayException, finally, onException)
@@ -99,6 +101,51 @@ spec = do
                 (functionToolCall "call-3" "database_schema"
                     "{\"scope\":\"organization\"}")
             result.output `shouldContainText` "expected user, repository, or checkout"
+
+        it "omits the harness catalog unless the embedding enables it" do
+            result <- dispatchToolCall dispatchConfig
+                (appToolHandlers (databaseTools testEnv))
+                (functionToolCall "call-6" "database_schema"
+                    "{\"scope\":\"harness\"}")
+            result.output `shouldContainText`
+                "the harness catalog is not available in this session"
+            schemaToolDescriptionFromEnv testEnv
+                `shouldContainText` "harness-internal schemas are never exposed."
+
+        it "exposes the harness catalog and session key when enabled" do
+            seen <- newIORef Nothing
+            let env = testEnv
+                    { databaseDescribeScope = \scope -> do
+                        writeIORef seen (Just scope)
+                        pure (Right "table sessions")
+                    , databaseHarnessCatalogEnabled = True
+                    , databaseHarnessSessionId = Just "2026-09-10-abc"
+                    }
+            result <- dispatchToolCall dispatchConfig
+                (appToolHandlers (databaseTools env))
+                (functionToolCall "call-7" "database_schema"
+                    "{\"scope\":\"harness\"}")
+            readIORef seen `shouldReturn` Just DatabaseHarnessScope
+            result.output `shouldContainText` "table sessions"
+            queryToolDescription env
+                `shouldContainText` "This session's key is `2026-09-10-abc`."
+            queryToolDescription env
+                `shouldContainText` "Compaction replaces model context only"
+
+        it "rejects mutating SQL against the harness catalog" do
+            called <- newIORef False
+            let env = testEnv
+                    { databaseRunExecute = \_ _ _ -> do
+                        writeIORef called True
+                        pure (Right "ok")
+                    , databaseHarnessCatalogEnabled = True
+                    }
+            result <- dispatchToolCall dispatchConfig
+                (appToolHandlers (databaseTools env))
+                (functionToolCall "call-8" "database_execute"
+                    "{\"scope\":\"harness\",\"sql\":\"delete from sessions\",\"purpose\":\"wipe\"}")
+            readIORef called `shouldReturn` False
+            result.output `shouldContainText` "the harness catalog is read-only"
 
         it "dispatches full-text search over past conversations" do
             seen <- newIORef Nothing
@@ -286,6 +333,25 @@ exerciseDataBrowser store stateDirectory =
                                 1
                                 >>= assertOffsetDataPage
 
+                            let harnessEnv =
+                                    databaseToolsEnvForStore
+                                        store
+                                        scopes
+                                        (pure Nothing)
+                                        Nothing
+                                        True
+                                        (Just "session-test")
+                            schemaResult <- dispatchToolCall dispatchConfig
+                                (appToolHandlers (databaseTools harnessEnv))
+                                (functionToolCall "call-9" "database_schema"
+                                    "{\"scope\":\"harness\"}")
+                            schemaResult.output `shouldContainText` "sessions"
+                            queryResult <- dispatchToolCall dispatchConfig
+                                (appToolHandlers (databaseTools harnessEnv))
+                                (functionToolCall "call-10" "database_query"
+                                    "{\"scope\":\"harness\",\"sql\":\"select count(*)::bigint as session_count from sessions\"}")
+                            queryResult.output `shouldContainText` "session_count:"
+
 seedBrowserTable
     :: Store
     -> StorePool
@@ -375,7 +441,21 @@ testEnv = DatabaseToolsEnv
     , databaseRunExecute = \_ _ _ -> pure (Right "ok")
     , databaseSearchConversations = \_ _ ->
         pure (Right [])
+    , databaseHarnessCatalogEnabled = False
+    , databaseHarnessSessionId = Nothing
     }
+
+queryToolDescription :: DatabaseToolsEnv -> Text
+queryToolDescription = toolDescription "database_query"
+
+schemaToolDescriptionFromEnv :: DatabaseToolsEnv -> Text
+schemaToolDescriptionFromEnv = toolDescription "database_schema"
+
+toolDescription :: Text -> DatabaseToolsEnv -> Text
+toolDescription name env =
+    case [tool.appToolDescription | tool <- databaseTools env, tool.appToolName == name] of
+        description : _ -> description
+        [] -> ""
 
 dispatchConfig :: ToolDispatchConfig
 dispatchConfig = ToolDispatchConfig

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/TurnExecution.hs
@@ -136,6 +136,7 @@ runNativeTurn
             , nativeHome = Nothing
             , nativeDatabaseStore = Nothing
             , nativeDatabaseScopeNamespace = Nothing
+            , nativeExposeHarnessCatalog = True
             , nativeWorkspaceDiscovery = DiscoverHostWorkspace
             , nativeCapabilities = fullNativeRunCapabilities
             , nativeStartupPolicy = hostNativeStartupPolicy

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -1470,6 +1470,7 @@ nativeHooks environment control sessionId cwd dialect = NativeRunHooks
     , nativeDatabaseScopeNamespace =
         renderTenantId environment.environmentTenantId
             <$ environment.environmentSandbox
+    , nativeExposeHarnessCatalog = False
     , nativeWorkspaceDiscovery =
         case environment.environmentSandbox of
             Nothing -> DiscoverHostWorkspace

--- a/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Custom.hs
@@ -4,10 +4,13 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Direct, scope-isolated PostgreSQL access for agent-created structured data.
+-- | Direct, scope-isolated PostgreSQL access for agent-created structured data,
+-- plus confined read-only inspection of named schemas such as @harness@.
 --
--- The caller supplies a pool connected as the selected scope role.  PostgreSQL
--- privileges isolate that role from harness-owned and sibling scope schemas.
+-- Custom-scope callers supply a pool connected as the selected scope role.
+-- PostgreSQL privileges isolate that role from harness-owned and sibling
+-- scope schemas. Named-schema reads ('inspectSchema', 'querySchema') instead
+-- require USAGE on the target schema for the already-connected role.
 module Agent.Store.Postgres.Custom
     ( QueryLimits(..)
     , defaultQueryLimits
@@ -21,8 +24,10 @@ module Agent.Store.Postgres.Custom
     , CustomExecutionResult(..)
     , inspectCustomSchema
     , inspectCustomSchemaSequential
+    , inspectSchema
     , queryCustom
     , queryCustomJson
+    , querySchema
     , executeCustom
     , normalizeCustomQuery
     , normalizeCustomExecution
@@ -127,6 +132,29 @@ catalogSchemaRowsSequential schema = do
     indexes <- Session.statement schema catalogIndexesStatement
     pure (objects, columns, constraints, indexes)
 
+-- | Inspect any schema the connected role has USAGE on. Unlike
+-- 'inspectCustomSchema', this does not require a generated scope role; the
+-- CLI harness catalog uses it against @ha_runtime@ and @harness@.
+inspectSchema
+    :: Pool
+    -> Text
+    -> IO (Either Text [CatalogObject])
+inspectSchema pool schema =
+    runPool pool session >>= \case
+        Left err -> pure (Left err)
+        Right (Left err) -> pure (Left err)
+        Right (Right value) -> pure (Right value)
+  where
+    session = do
+        allowed <- Session.statement schema schemaUsageStatement
+        if not allowed
+            then pure (Left schemaUsageError)
+            else do
+                (objects, columns, constraints, indexes) <-
+                    catalogSchemaRowsPipelined schema
+                pure $ Right $
+                    assembleCatalog objects columns constraints indexes
+
 queryCustom
     :: Pool
     -> ScopeDatabase
@@ -146,6 +174,24 @@ queryCustomJson
     -> IO (Either Text CustomQueryResult)
 queryCustomJson = queryCustomWith customJsonQueryStatement
 
+-- | Read-only query confined to one schema the connected role can use.
+-- Search path is that schema plus @pg_catalog@, matching custom-scope queries.
+querySchema
+    :: Pool
+    -> Text
+    -> QueryLimits
+    -> Text
+    -> IO (Either Text CustomQueryResult)
+querySchema pool schema limits rawQuery =
+    runBoundedQuery pool limits rawQuery \query -> do
+        allowed <- Tx.statement schema schemaUsageStatement
+        if not allowed
+            then pure (Left schemaUsageError)
+            else do
+                Tx.sql (confinementSqlForSchema schema limits)
+                Right <$> Tx.statement ()
+                    (customQueryStatement limits.queryMaxRows query)
+
 queryCustomWith
     :: (Int64 -> Text -> Statement () CustomQueryResult)
     -> Pool
@@ -154,26 +200,33 @@ queryCustomWith
     -> Text
     -> IO (Either Text CustomQueryResult)
 queryCustomWith statementFor scopePool database limits rawQuery =
+    runBoundedQuery scopePool limits rawQuery \query -> do
+        expectedIdentity <- Tx.statement
+            database.scopeDatabaseRole
+            scopeIdentityStatement
+        if not expectedIdentity
+            then pure (Left scopeIdentityError)
+            else do
+                Tx.sql (confinementSqlForSchema database.scopeDatabaseSchema limits)
+                Right <$> Tx.statement ()
+                    (statementFor limits.queryMaxRows query)
+
+runBoundedQuery
+    :: Pool
+    -> QueryLimits
+    -> Text
+    -> (Text -> Tx.Transaction (Either Text CustomQueryResult))
+    -> IO (Either Text CustomQueryResult)
+runBoundedQuery pool limits rawQuery runQuery =
     case validateLimits limits *> normalizeCustomQuery rawQuery of
         Left err -> pure (Left err)
-        Right query -> do
-            let statement =
-                    statementFor limits.queryMaxRows query
-                transaction = do
-                    expectedIdentity <- Tx.statement
-                        database.scopeDatabaseRole
-                        scopeIdentityStatement
-                    if not expectedIdentity
-                        then pure (Left scopeIdentityError)
-                        else do
-                            Tx.sql (confinementSql database limits)
-                            Right <$> Tx.statement () statement
-                session =
+        Right query ->
+            let session =
                     TxSessions.transactionNoRetry
                         TxSessions.ReadCommitted
                         TxSessions.Read
-                        transaction
-            runPool scopePool session >>= \case
+                        (runQuery query)
+            in runPool pool session >>= \case
                 Left err -> pure (Left err)
                 Right (Left err) -> pure (Left err)
                 Right (Right result)
@@ -242,7 +295,9 @@ executeCustom trustedPool scopePool database audit limits purpose rawSql
                                             then pure (Left scopeIdentityError)
                                             else do
                                                 Tx.sql
-                                                    (confinementSql database limits)
+                                                    (confinementSqlForSchema
+                                                        database.scopeDatabaseSchema
+                                                        limits)
                                                 Tx.sql (Text.encodeUtf8 sql)
                                                 pure (Right ())
                             case executionResult of
@@ -459,6 +514,19 @@ scopeIdentityStatement = mkStatement
 scopeIdentityError :: Text
 scopeIdentityError =
     "custom database pool is not authenticated directly as the selected scope role"
+
+schemaUsageError :: Text
+schemaUsageError =
+    "the connected PostgreSQL role cannot use that schema"
+
+schemaUsageStatement :: Statement Text Bool
+schemaUsageStatement = mkStatement
+    "select session_user = current_user\
+    \ and pg_catalog.has_schema_privilege(session_user, $1, 'USAGE')"
+    (Encoders.param (Encoders.nonNullable Encoders.text))
+    (Decoders.singleRow $
+        Decoders.column (Decoders.nonNullable Decoders.bool))
+    True
 
 replaceCatalogProjection
     :: Pool
@@ -874,11 +942,11 @@ auditFinishedStatement = mkStatement
     (fmap (> 0) Decoders.rowsAffected)
     True
 
-confinementSql :: ScopeDatabase -> QueryLimits -> ByteString.ByteString
-confinementSql database limits =
+confinementSqlForSchema :: Text -> QueryLimits -> ByteString.ByteString
+confinementSqlForSchema schema limits =
     Text.encodeUtf8 $
         "set local search_path = "
-            <> quoteIdentifier database.scopeDatabaseSchema
+            <> quoteIdentifier schema
             <> ", pg_catalog;"
             <> " set local standard_conforming_strings = on;"
             <> " set local statement_timeout = "

--- a/packages/agent-store/test/Agent/Store/Postgres/CustomSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/CustomSpec.hs
@@ -115,6 +115,39 @@ spec = describe "custom PostgreSQL SQL normalization" do
                                                             database
                                                     sequentialCatalog
                                                         `shouldBe` catalog
+                                                    harnessCatalog <- inspectSchema
+                                                        (storePool (trustedPool store))
+                                                        "harness"
+                                                    _ <- harnessCatalog
+                                                        `shouldSatisfyRight`
+                                                            (any
+                                                                (\object ->
+                                                                    object.catalogObjectKind
+                                                                        == "table"
+                                                                        && object.catalogObjectName
+                                                                            == "sessions"))
+                                                    harnessQuery <- querySchema
+                                                        (storePool (trustedPool store))
+                                                        "harness"
+                                                        defaultQueryLimits
+                                                        "SELECT count(*)::bigint AS session_count FROM sessions"
+                                                    _ <- harnessQuery
+                                                        `shouldSatisfyRight`
+                                                            (\queryResult ->
+                                                                not
+                                                                    queryResult.customQueryTruncated
+                                                                    && "session_count:"
+                                                                        `Text.isInfixOf`
+                                                                            queryResult.customQueryOutput)
+                                                    deniedHarness <- querySchema
+                                                        rawScope
+                                                        "harness"
+                                                        defaultQueryLimits
+                                                        "SELECT 1"
+                                                    deniedHarness
+                                                        `shouldBe`
+                                                            Left
+                                                                "the connected PostgreSQL role cannot use that schema"
                                                     result <- queryCustom
                                                         rawScope
                                                         database


### PR DESCRIPTION
## Summary

Local CLI and native agents can now inspect the runtime PostgreSQL catalog with `database_schema` / `database_query` and `scope: harness`. Compaction still replaces model context only; earlier turns, messages, and tool-call rows remain queryable.

This is the RLM-style recall path: the durable transcript stays in the store, and the model queries it instead of reloading the full history.

## Behavior

- CLI sessions and the macOS native embedding advertise `harness` and include the current session key in the tool text.
- Queries run as `ha_runtime` against the `harness` schema, with the same read-only transaction, row, and byte limits as custom scopes.
- `database_execute` cannot mutate harness tables.
- `agent-server` sets `nativeExposeHarnessCatalog = False`, so tenant agents do not get this scope.
- Learned-skill and native data-browser scopes stay `user` / `repository` / `checkout`.

## Tests

- CLI tool-surface coverage for the hidden server path, enabled harness scope plus session key, and rejected harness writes.
- Store coverage for inspecting and querying `harness.sessions` as the runtime role, and denying that schema to custom-scope roles.