### PR TITLE
Keep terminal charts from resizing while scrolling

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
@@ -97,6 +97,7 @@ import Agent.CLI.TUI.Motion ( advanceCompletionFlashes , appMotionTiming , compl
 import Agent.CLI.TUI.Render ( agentEntryWindow , agentPaneEntryLimit , agentPaneVisible , applyChildConversationUiEvent , choiceRowColumns , conversationUiForTarget , conversationScrollbarRenderer , drawApp , fullscreenBounds , fullscreenSurface , onboardingVisibleRowIndices , normalizeTextOverlayInsertion , maskedSecretText , quickStartRows , quickStartVisible , repositoryHeaderText , resumeSearchCursorColumn , selectedAgentConversation , textOverlayDisplayText )
 import Agent.CLI.TUI.ImagePreview ( NativePreviewPlacement(..)
     , TuiImagePreview(..)
+    , completePreviewExtent
     , nativePreviewPlacements
     , prepareTuiImagePreview
     , previewCountForWidth
@@ -717,9 +718,10 @@ placementFor
 placementFor state viewportBounds ordinal blockId index preview =
     lookupExtent (ConversationImage blockId index) >>= \case
         Just imageBounds
-            | extentInside viewportBounds imageBounds ->
+            | extentInside viewportBounds imageBounds
+            , let (columns, rows) = imageBounds.extentSize
+            , completePreviewExtent preview (columns, rows) ->
                 let Location (column, row) = imageBounds.extentUpperLeft
-                    (columns, rows) = imageBounds.extentSize
                     imageId =
                         submittedImageId
                             state.appRuntime.runtimeImagePreviewIdBase

--- a/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/ImagePreview.hs
@@ -11,6 +11,11 @@ module Agent.CLI.TUI.ImagePreview
     , prepareTuiImagePreview
     , previewCountForWidth
     , previewCellSize
+    , completePreviewExtent
+    , submittedPreviewMaxColumns
+    , submittedPreviewMaxRows
+    , toolImageMaxColumns
+    , toolImageMaxRows
     , previewImageAt
     , renderTuiImagePreview
     ) where
@@ -282,6 +287,39 @@ previewCellSize :: Int -> Int -> TuiImagePreview -> (Int, Int)
 previewCellSize maxColumns maxRows preview =
     let (pixelWidth, pixelHeight) = previewPixelSize maxColumns maxRows preview
     in (pixelWidth, (pixelHeight + 1) `div` 2)
+
+-- | Thumbnails attached to a submitted prompt.
+submittedPreviewMaxColumns :: Int
+submittedPreviewMaxColumns = 36
+
+submittedPreviewMaxRows :: Int
+submittedPreviewMaxRows = 12
+
+-- | Agent-displayed images, including charts, occupy a larger canvas.
+toolImageMaxColumns :: Int
+toolImageMaxColumns = 72
+
+toolImageMaxRows :: Int
+toolImageMaxRows = 24
+
+-- | Whether a Brick-reported cell rectangle is still the complete preview.
+-- Conversation widgets size themselves with the submitted or tool-image caps;
+-- Brick then clamps extents to the visible viewport. Kitty placements must
+-- ignore those fragments, otherwise the terminal stretches the bitmap into
+-- the leftover cells while scrolling.
+completePreviewExtent :: TuiImagePreview -> (Int, Int) -> Bool
+completePreviewExtent preview size@(columns, rows) =
+    columns > 0
+        && rows > 0
+        && any (size ==)
+            [ previewCellSize capColumns maxRows preview
+            | (capColumns, maxRows) <-
+                [ (columns, submittedPreviewMaxRows)
+                , (columns, toolImageMaxRows)
+                , (submittedPreviewMaxColumns, submittedPreviewMaxRows)
+                , (toolImageMaxColumns, toolImageMaxRows)
+                ]
+            ]
 
 -- | Match the centered Brick overlay layout with zero-based terminal-cell
 -- placements for Kitty graphics. The caption occupies the row immediately

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -26,7 +26,11 @@ import Agent.CLI.TUI.ImagePreview
     ( TuiImagePreview(previewBytes, previewMime, previewSourceWidth,
                       previewSourceHeight),
       previewCellSize,
-      renderTuiImagePreview )
+      renderTuiImagePreview,
+      submittedPreviewMaxColumns,
+      submittedPreviewMaxRows,
+      toolImageMaxColumns,
+      toolImageMaxRows )
 import Agent.CLI.TUI.LambdaArt ()
 import Agent.CLI.TUI.Motion
     ( motionModeForTerminalFocus, userActionPending )
@@ -424,7 +428,11 @@ submittedUserMessage state target block =
     nativePlaceholder index preview
         | not state.appRuntime.runtimeNativeImagePreviews = []
         | otherwise =
-            let (columns, rows) = previewCellSize 36 12 preview
+            let (columns, rows) =
+                    previewCellSize
+                        submittedPreviewMaxColumns
+                        submittedPreviewMaxRows
+                        preview
             in [ reportExtent
                     (ConversationImage block.blockId index) $
                     hLimit columns $
@@ -445,8 +453,10 @@ imagePreviewSummary preview =
 -- | Images the agent displayed with @show_image@ while this tool call ran.
 -- Only the root conversation carries previews; child viewports show the
 -- textual tool result alone. Native terminals get a placeholder extent that
--- the Kitty placement sync fills after each reflow; other terminals draw the
--- sampled bitmap directly.
+-- the Kitty placement sync fills after each reflow, and only while Brick
+-- still reports the complete cell rectangle. Cropped scrollback extents are
+-- left empty so the terminal cannot stretch the bitmap. Other terminals draw
+-- the sampled bitmap directly.
 toolImageSections :: AppState -> AgentTarget -> UiBlock -> [Widget Name]
 toolImageSections state target block =
     case target of
@@ -488,14 +498,6 @@ toolImageSections state target block =
                             maxColumns
                             toolImageMaxRows
                             preview
-
--- | Agent-displayed images are the point of the call, so they get a larger
--- canvas than the thumbnail attached to a submitted prompt.
-toolImageMaxColumns :: Int
-toolImageMaxColumns = 72
-
-toolImageMaxRows :: Int
-toolImageMaxRows = 24
 
 timestampedMessage :: AttrName -> Text -> Widget Name -> Widget Name
 timestampedMessage timestampAttr timestamp body

--- a/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIImagePreviewSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.TUIImagePreviewSpec (spec) where
 import Agent.CLI.TUI.ImagePreview
     ( NativePreviewPlacement(..)
     , TuiImagePreview(..)
+    , completePreviewExtent
     , imageDimensions
     , nativePreviewPlacements
     , prepareNativeTuiImagePreview
@@ -11,6 +12,10 @@ import Agent.CLI.TUI.ImagePreview
     , previewCellSize
     , previewImageAt
     , sameNativePreviewLayout
+    , submittedPreviewMaxColumns
+    , submittedPreviewMaxRows
+    , toolImageMaxColumns
+    , toolImageMaxRows
     )
 import Agent.CLI.TUI.App
     ( previewLogicalEncodedBytes
@@ -124,6 +129,58 @@ spec = do
                 Right preview -> do
                     previewCellSize 72 23 preview `shouldBe` (72, 20)
                     previewCellSize 48 12 preview `shouldBe` (42, 12)
+
+        it "rejects Brick extents cropped while scrolling a conversation image" do
+            let chartSource =
+                    generateImage
+                        (\_ _ -> PixelRGB8 10 20 30)
+                        960
+                        600
+                tallSource =
+                    generateImage
+                        (\_ _ -> PixelRGB8 10 20 30)
+                        100
+                        1000
+                attachment source = ImageAttachment
+                    { imageMime = "image/png"
+                    , imageBytes = LBS.toStrict (encodePng source)
+                    }
+            case (prepareTuiImagePreview (attachment chartSource)
+                , prepareTuiImagePreview (attachment tallSource)) of
+                (Right chart, Right tall) -> do
+                    let chartSize =
+                            previewCellSize
+                                toolImageMaxColumns
+                                toolImageMaxRows
+                                chart
+                        narrowChartSize =
+                            previewCellSize 50 toolImageMaxRows chart
+                        submittedSize =
+                            previewCellSize
+                                submittedPreviewMaxColumns
+                                submittedPreviewMaxRows
+                                chart
+                        tallSize =
+                            previewCellSize
+                                toolImageMaxColumns
+                                toolImageMaxRows
+                                tall
+                    completePreviewExtent chart chartSize
+                        `shouldBe` True
+                    completePreviewExtent chart narrowChartSize
+                        `shouldBe` True
+                    completePreviewExtent chart submittedSize
+                        `shouldBe` True
+                    completePreviewExtent tall tallSize
+                        `shouldBe` True
+                    completePreviewExtent chart
+                        (fst chartSize, snd chartSize `div` 2)
+                        `shouldBe` False
+                    completePreviewExtent chart
+                        (fst narrowChartSize, 8)
+                        `shouldBe` False
+                (Left err, _) -> expectationFailure (show err)
+                (_, Left err) -> expectationFailure (show err)
 
         it "does not force the ANSI sample when sizing native previews" do
             let attachment = ImageAttachment


### PR DESCRIPTION
## Summary
- Terminal charts (and other native conversation images) kept changing size while scrolling because Brick reports a cropped `reportExtent` for widgets that are only partly on screen.
- Kitty then stretched the full PNG into that leftover cell rectangle, so a 960×600 chart looked smaller whenever live output was paused and the image sat on the viewport edge.
- Native placements now use the complete preview cell size and are omitted while the Brick extent is a cropped fragment. Fully visible charts stay at a stable size; clipped ones leave an empty placeholder instead of a squashed overlay.

## Test plan
- `cabal test agent-cli:test:agent-cli-test --test-option='--match=rejects Brick extents cropped'`: 1 example, 0 failures.
- `cabal test agent-cli:test:agent-cli-test --test-option='--match=prepareTuiImagePreview' --test-option='--match=sameNativePreviewLayout' --test-option='--match=imageDimensions' --test-option='--match=submitted preview retention'`: 17 examples, 0 failures.
- tmux fullscreen smoke test (120×42): injected a 960×600 `render_chart` image and scrolled with Tab / Ctrl+J/K. Kitty placements were always `cols=72 rows=23` when fully visible; clipped scrollback omitted the overlay instead of shrinking `rows`.