### PR TITLE
Use the conversation starter's clock for model-facing stamps

### DIFF
--- a/packages/agent-cli-runtime/src/Agent/Runtime/Request.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/Request.hs
@@ -8,6 +8,7 @@ module Agent.Runtime.Request
     , NativeShellMode(..)
     , NativeSessionTarget(..)
     , NativeTurnRequest(..)
+    , NativeMessageClock(..)
     , validateNativeTurnRequest
     ) where
 
@@ -44,6 +45,15 @@ data NativeSessionTarget
 -- | Native turns exclude CLI-only capabilities such as worktree creation,
 -- computer use, and prompt files. The executing adapter supplies approval
 -- and plan callbacks for the selected interaction mode.
+-- | Conversation starter's wall-clock. Cloud hosts are typically UTC; the
+-- client supplies the zone abbreviation, UTC offset, and 12/24-hour cycle.
+data NativeMessageClock = NativeMessageClock
+    { nativeHourCycle :: !Text
+    , nativeTimeZoneName :: !Text
+    , nativeTimeZoneOffsetMinutes :: !Int
+    }
+    deriving (Eq, Show)
+
 data NativeTurnRequest = NativeTurnRequest
     { nativeTurnPrompt :: !Text
     , nativeTurnImages :: ![ImageAttachment]
@@ -54,6 +64,7 @@ data NativeTurnRequest = NativeTurnRequest
     , nativeTurnEffort :: !(Maybe ReasoningEffort)
     , nativeTurnInteractionMode :: !NativeInteractionMode
     , nativeTurnShellMode :: !NativeShellMode
+    , nativeTurnMessageClock :: !(Maybe NativeMessageClock)
     }
     deriving (Eq, Show)
 

--- a/packages/agent-cli-runtime/test/Agent/Runtime/RequestSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/Runtime/RequestSpec.hs
@@ -48,4 +48,5 @@ request = NativeTurnRequest
     , nativeTurnEffort = Nothing
     , nativeTurnInteractionMode = NativeAsk
     , nativeTurnShellMode = NativeShellNone
+    , nativeTurnMessageClock = Nothing
     }

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -11,6 +11,7 @@ module Agent.CLI.NativeRuntime
     , nativePreparedDiscovery
     , NativeSessionTarget(..)
     , NativeTurnRequest(..)
+    , NativeMessageClock(..)
     , StartupFailure(..)
     , closeNativeProcessRuntime
     , newNativeProcessRuntime
@@ -73,10 +74,12 @@ import Agent.CLI.Runtime.Orchestration.Types
     )
 import Agent.CLI.Runtime.Types (DevResult(..), StartupFailure(..))
 import Agent.Runtime.Request
-    ( NativeSessionTarget(..)
+    ( NativeMessageClock(..)
+    , NativeSessionTarget(..)
     , NativeTurnRequest(..)
     , validateNativeTurnRequest
     )
+import Agent.CLI.Timestamp (MessageClock, parseMessageClock)
 import Agent.TUI.Motion (MotionMode(..))
 import Agent.Tools.Types (defaultToolEnv)
 import qualified Agent.MCP as MCP
@@ -208,6 +211,7 @@ runNativeTurn runtime output hooks request =
 nativeTurnOptions :: NativeTurnRequest -> Either Text CliOptions
 nativeTurnOptions request = do
     validateNativeTurnRequest request
+    clock <- traverse parseNativeMessageClock request.nativeTurnMessageClock
     pure defaultCliOptions
             { optProvider = request.nativeTurnProvider
             , optModel = request.nativeTurnModel
@@ -228,7 +232,15 @@ nativeTurnOptions request = do
             , optComputerUse = False
             , optScreenMode = ScreenMinimal
             , optMotionMode = MotionOff
+            , optMessageClock = clock
             }
+
+parseNativeMessageClock :: NativeMessageClock -> Either Text MessageClock
+parseNativeMessageClock clock =
+    parseMessageClock
+        clock.nativeHourCycle
+        clock.nativeTimeZoneName
+        clock.nativeTimeZoneOffsetMinutes
 
 runNativeAgent
     :: NativeProcessRuntime

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -44,6 +44,7 @@ import Agent.CLI.Runtime.Options
     , GatewayCommand(..)
     , defaultEffortFor
     )
+import Agent.CLI.Timestamp (MessageClock)
 import Agent.TUI.Motion (MotionMode(..))
 import Data.Char (toLower)
 import Data.Foldable (asum)
@@ -203,6 +204,8 @@ data CliOptions = CliOptions
       -- the model catalog's @tool_mode@ (Codex default).
     , optScreenMode :: !ScreenMode
     , optMotionMode :: !MotionMode
+    -- | Conversation starter's wall-clock. 'Nothing' uses the process locale.
+    , optMessageClock :: !(Maybe MessageClock)
     } deriving (Eq, Show)
 
 defaultCliOptions :: CliOptions
@@ -233,6 +236,7 @@ defaultCliOptions = CliOptions
     , optCodeMode = CodeModeCatalog
     , optScreenMode = ScreenAuto
     , optMotionMode = MotionFull
+    , optMessageClock = Nothing
     }
 
 -- | Drop provider-visible routing and conversation inputs when a gateway

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -1666,6 +1666,7 @@ buildSessionEnv
         , sessionOnPersisted =
             persistenceRuntime.persistenceOnPersisted
         , sessionReset = skillsRuntime.skillResetSession
+        , sessionMessageClock = options.optMessageClock
         }
 
 installSessionActions

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -30,6 +30,7 @@ import Agent.Runtime.SessionState (SessionState)
 import Agent.CLI.Session.Workspace (WorkspaceContext)
 import Agent.CLI.SessionTitle (SessionTitleManager)
 import Agent.CLI.Terminal (TerminalCapabilities)
+import Agent.CLI.Timestamp (MessageClock)
 import Agent.CLI.SteeringInputs (SteeringInputs)
 import Agent.CLI.TUI.App (FullscreenRuntime)
 import Agent.Dialect (Dialect)
@@ -149,4 +150,6 @@ data SessionEnv = SessionEnv
     , sessionSetConcurrentLimit :: !(Int -> IO Text)
     , sessionOnPersisted :: !(SessionHandle -> IO ())
     , sessionReset :: !(IO ())
+    -- | Conversation starter's wall-clock. 'Nothing' uses the process locale.
+    , sessionMessageClock :: !(Maybe MessageClock)
     }

--- a/packages/agent-cli/src/Agent/CLI/Timestamp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Timestamp.hs
@@ -6,7 +6,9 @@
 -- the model echoes a stamp.
 module Agent.CLI.Timestamp
     ( HourCycle(..)
+    , MessageClock(..)
     , currentShortMessageTimestamp
+    , parseMessageClock
     , renderMessageTimestamp
     , renderContextualMessageTimestamp
     , renderShortMessageTimestamp
@@ -14,6 +16,7 @@ module Agent.CLI.Timestamp
     , stampUserTextAt
     , stampTurnInputs
     , stampTurnInputsSince
+    , stampTurnInputsSinceWith
     , shouldShowMessageTimestamp
     , stripBracketedTimestamps
     , timeContextGuidance
@@ -27,7 +30,7 @@ import qualified Data.Text as Text
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.Time.LocalTime
-    ( TimeZone
+    ( TimeZone(..)
     , getCurrentTimeZone
     , getZonedTime
     , localDay
@@ -41,6 +44,40 @@ import System.Process (readProcessWithExitCode)
 
 data HourCycle = Hour12 | Hour24
     deriving (Eq, Show)
+
+-- | Explicit wall-clock used instead of the process locale. Cloud agent
+-- servers run in UTC; the conversation starter's timezone and 12/24-hour
+-- preference have to be supplied by the client.
+data MessageClock = MessageClock
+    { messageHourCycle :: !HourCycle
+    , messageTimeZone :: !TimeZone
+    }
+    deriving (Eq, Show)
+
+-- | Parse a client-supplied clock. Offset is minutes east of UTC.
+parseMessageClock :: Text -> Text -> Int -> Either Text MessageClock
+parseMessageClock hourCycleText zoneName offsetMinutes = do
+    hourCycle <- case Text.toLower (Text.strip hourCycleText) of
+        "h12" -> Right Hour12
+        "h24" -> Right Hour24
+        _ -> Left "hourCycle must be h12 or h24"
+    name <- parseTimeZoneName zoneName
+    if offsetMinutes < -14 * 60 || offsetMinutes > 14 * 60
+        then Left "timeZoneOffsetMinutes must be between -840 and 840"
+        else
+            Right
+                MessageClock
+                    { messageHourCycle = hourCycle
+                    , messageTimeZone =
+                        TimeZone offsetMinutes (offsetMinutes /= 0) (Text.unpack name)
+                    }
+
+parseTimeZoneName :: Text -> Either Text Text
+parseTimeZoneName raw =
+    let name = Text.strip raw
+    in if validTimeZoneName name
+        then Right name
+        else Left "timeZoneName must be a short zone abbreviation such as CEST or GMT+2"
 
 -- | Format @utc@ in @tz@ as @[YYYY-MM-DD HH:MM TZ]@.
 renderMessageTimestamp :: TimeZone -> UTCTime -> Text
@@ -126,13 +163,28 @@ stampTurnInputsSince
     -- ^ Previous conversation activity.
     -> [TurnInput]
     -> IO [TurnInput]
-stampTurnInputsSince startedAt previousAt inputs = do
+stampTurnInputsSince = stampTurnInputsSinceWith Nothing
+
+-- | Like 'stampTurnInputsSince', but an explicit clock wins over the process
+-- locale. Cloud agent-server uses this so stamps follow the conversation
+-- starter rather than the UTC host.
+stampTurnInputsSinceWith
+    :: Maybe MessageClock
+    -> UTCTime
+    -- ^ Conversation start.
+    -> Maybe UTCTime
+    -- ^ Previous conversation activity.
+    -> [TurnInput]
+    -> IO [TurnInput]
+stampTurnInputsSinceWith clock startedAt previousAt inputs = do
     now <- getCurrentTime
     if not (shouldShowMessageTimestamp previousAt now)
         then pure inputs
         else do
-            tz <- getCurrentTimeZone
-            hourCycle <- systemHourCycle
+            (hourCycle, tz) <- case clock of
+                Just MessageClock{messageHourCycle, messageTimeZone} ->
+                    pure (messageHourCycle, messageTimeZone)
+                Nothing -> (,) <$> systemHourCycle <*> getCurrentTimeZone
             let stamp = renderContextualMessageTimestamp hourCycle tz startedAt now
             pure (map (mapTurnInputUserText (appendStamp stamp)) inputs)
 
@@ -232,10 +284,32 @@ matchTimestamp s = do
     afterSpace <- case Text.uncons afterTime of
         Just (' ', rest) -> Just rest
         _ -> Nothing
-    let (tz, rest1) = Text.span isAsciiUpper afterSpace
+    (tz, rest1) <- matchTimeZoneName afterSpace
     case Text.uncons rest1 of
         Just (']', rest2) | not (Text.null tz) -> Just rest2
         _ -> Nothing
+
+matchTimeZoneName :: Text -> Maybe (Text, Text)
+matchTimeZoneName s =
+    let (letters, rest) = Text.span isAsciiUpper s
+    in if Text.null letters
+        then Nothing
+        else case Text.uncons rest of
+            Just (sign, afterSign)
+                | sign == '+' || sign == '-' ->
+                    let (digits, rest2) = Text.span isDigit afterSign
+                        width = Text.length digits
+                    in if width >= 1 && width <= 4
+                        then Just (letters <> Text.cons sign digits, rest2)
+                        else Nothing
+            _ -> Just (letters, rest)
+
+validTimeZoneName :: Text -> Bool
+validTimeZoneName name =
+    case matchTimeZoneName name of
+        Just (matched, leftover) ->
+            Text.null leftover && matched == name && Text.length name <= 10
+        Nothing -> False
 
 matchClock :: Text -> Maybe Text
 matchClock s =

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -103,7 +103,7 @@ import Agent.CLI.Terminal
     , resolveColor
     )
 import Agent.CLI.Timestamp
-    ( stampTurnInputsSince
+    ( stampTurnInputsSinceWith
     , stripBracketedTimestamps
     )
 import Agent.CLI.TurnState
@@ -399,7 +399,8 @@ prepareBusyTurn request = do
     (conversationStartedAt, previousActivityAt) <-
         timestampConversationBounds env.sessionPersist
     stampedInputs <-
-        stampTurnInputsSince
+        stampTurnInputsSinceWith
+            env.sessionMessageClock
             conversationStartedAt
             previousActivityAt
             turnInputs0

--- a/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
@@ -5,6 +5,7 @@ import Agent.CLI.NativeRuntime
     , NativeInteractionMode(..)
     , NativeSessionTarget(..)
     , NativeShellMode(..)
+    , NativeMessageClock(..)
     , NativeTurnRequest(..)
     , NativeWorkspaceDiscovery(..)
     , nativeLoadsHostWorkspaceContext
@@ -38,7 +39,9 @@ import Agent.Provider (Provider(..))
 import Agent.Loop (ImageAttachment(..))
 import Agent.CLI.Project (defaultProjectSettings)
 import Agent.ReasoningEffort (ReasoningEffort(..))
+import Agent.CLI.Timestamp (HourCycle(..), MessageClock(..))
 import Agent.TUI.Motion (MotionMode(..))
+import Data.Time.LocalTime (TimeZone(..))
 import System.OsPath (unsafeEncodeUtf)
 import Test.Hspec
 
@@ -196,6 +199,7 @@ spec = describe "nativeTurnOptions" do
                 , nativeTurnEffort = Just EffortHigh
                 , nativeTurnInteractionMode = NativeAsk
                 , nativeTurnShellMode = NativeShellNone
+                , nativeTurnMessageClock = Nothing
                 }
         options <- shouldReturnRight (nativeTurnOptions request)
         options.optPrompt `shouldBe` Just "fix the tests"
@@ -213,6 +217,7 @@ spec = describe "nativeTurnOptions" do
         options.optBash `shouldBe` False
         options.optScreenMode `shouldBe` ScreenMinimal
         options.optMotionMode `shouldBe` MotionOff
+        options.optMessageClock `shouldBe` Nothing
 
     it "maps resume and shell mode without parsing argv" do
         let request = baseRequest
@@ -223,6 +228,34 @@ spec = describe "nativeTurnOptions" do
         options.optResume `shouldBe` Just "session-123"
         options.optGhci `shouldBe` True
         options.optBash `shouldBe` True
+
+    it "lowers a conversation clock onto CLI options" do
+        let request = baseRequest
+                { nativeTurnMessageClock =
+                    Just
+                        NativeMessageClock
+                            { nativeHourCycle = "h24"
+                            , nativeTimeZoneName = "CEST"
+                            , nativeTimeZoneOffsetMinutes = 120
+                            }
+                }
+        options <- shouldReturnRight (nativeTurnOptions request)
+        options.optMessageClock
+            `shouldBe` Just (MessageClock Hour24 (TimeZone 120 True "CEST"))
+
+    it "rejects an invalid conversation clock before admission" do
+        nativeTurnOptions
+            (baseRequest
+                { nativeTurnMessageClock =
+                    Just
+                        NativeMessageClock
+                            { nativeHourCycle = "h24"
+                            , nativeTimeZoneName = "Europe/Berlin"
+                            , nativeTimeZoneOffsetMinutes = 120
+                            }
+                })
+            `shouldBe` Left
+                "timeZoneName must be a short zone abbreviation such as CEST or GMT+2"
 
     it "rejects an empty resume id before runtime admission" do
         nativeTurnOptions
@@ -293,6 +326,7 @@ baseRequest = NativeTurnRequest
     , nativeTurnEffort = Nothing
     , nativeTurnInteractionMode = NativeAsk
     , nativeTurnShellMode = NativeShellNone
+    , nativeTurnMessageClock = Nothing
     }
 
 conflictingOptions :: CliOptions

--- a/packages/agent-cli/test/Agent/CLI/TimestampSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TimestampSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Timestamp
 import Data.Time.Calendar (fromGregorian)
 import Data.Time.Clock (UTCTime(..), addUTCTime, secondsToDiffTime)
 import Data.Time.LocalTime (TimeZone(..), minutesToTimeZone)
+import Data.Either (isLeft)
 import qualified Data.Text as Text
 import Test.Hspec
 
@@ -102,6 +103,23 @@ spec = do
                 `shouldBe` "Okay"
             stripBracketedTimestamps "Okay [2026-09-01 9:40pm EDT]"
                 `shouldBe` "Okay"
+            stripBracketedTimestamps "Okay [11:15 GMT+2]"
+                `shouldBe` "Okay"
+
+    describe "parseMessageClock" do
+        it "accepts a 24-hour European clock" do
+            parseMessageClock "h24" "CEST" 120
+                `shouldBe` Right (MessageClock Hour24 cest)
+
+        it "accepts GMT offset names" do
+            parseMessageClock "h12" "GMT+2" 120
+                `shouldBe` Right
+                    (MessageClock Hour12 (TimeZone 120 True "GMT+2"))
+
+        it "rejects incomplete clocks" do
+            parseMessageClock "h13" "CEST" 120 `shouldSatisfy` isLeft
+            parseMessageClock "h24" "Europe/Berlin" 120 `shouldSatisfy` isLeft
+            parseMessageClock "h24" "CEST" 900 `shouldSatisfy` isLeft
 
     describe "timeContextGuidance" do
         it "teaches the model about stamps and forbids echoing them" do

--- a/packages/agent-server/src/Agent/Server/Application.hs
+++ b/packages/agent-server/src/Agent/Server/Application.hs
@@ -723,6 +723,7 @@ createTurn backend supervisor boundary sessionId request
                 , turnSpecImages = request.createTurnImages
                 , turnSpecFiles = request.createTurnFiles
                 , turnSpecBoundary = boundary
+                , turnSpecMessageClock = request.createTurnMessageClock
                 }
             validateSession =
                 fmap (fmap (const ())) $

--- a/packages/agent-server/src/Agent/Server/Runtime.hs
+++ b/packages/agent-server/src/Agent/Server/Runtime.hs
@@ -44,6 +44,7 @@ import Agent.CLI.NativeRuntime
     )
 import Agent.Runtime.Request
     ( NativeInteractionMode(..)
+    , NativeMessageClock(..)
     , NativeSessionTarget(..)
     , NativeShellMode(..)
     , NativeTurnRequest(..)
@@ -1394,6 +1395,9 @@ runTurn environment control spec =
                                                                     environment
                                                             , nativeTurnShellMode =
                                                                 tenantShellMode environment
+                                                            , nativeTurnMessageClock =
+                                                                fmap nativeClock
+                                                                    spec.turnSpecMessageClock
                                                             }
                                                         >>= \case
                                                             Left err -> pure (Left err)
@@ -1407,6 +1411,14 @@ runTurn environment control spec =
                                                                             ( Right
                                                                                 . turnExecutionOutput
                                                                             )
+
+nativeClock :: TurnMessageClock -> NativeMessageClock
+nativeClock clock =
+    NativeMessageClock
+        { nativeHourCycle = clock.turnHourCycle
+        , nativeTimeZoneName = clock.turnTimeZoneName
+        , nativeTimeZoneOffsetMinutes = clock.turnTimeZoneOffsetMinutes
+        }
 
 turnExecutionOutput :: Loop.TurnOutput -> TurnExecutionOutput
 turnExecutionOutput output =

--- a/packages/agent-server/src/Agent/Server/Types.hs
+++ b/packages/agent-server/src/Agent/Server/Types.hs
@@ -37,6 +37,7 @@ module Agent.Server.Types
     , PatchSessionRequest(..)
     , ForkSessionRequest(..)
     , CreateTurnRequest(..)
+    , TurnMessageClock(..)
     , FileAttachment(..)
     , ResolveRequest(..)
     , SessionArchiveFilter(..)
@@ -162,6 +163,16 @@ data TurnSpec = TurnSpec
     , turnSpecImages :: ![ImageAttachment]
     , turnSpecFiles :: ![FileAttachment]
     , turnSpecBoundary :: !AccessBoundary
+    , turnSpecMessageClock :: !(Maybe TurnMessageClock)
+    }
+    deriving (Eq, Show)
+
+-- | Conversation starter's wall-clock, forwarded onto native turns so stamps
+-- are not formatted in the UTC locale of a cloud host.
+data TurnMessageClock = TurnMessageClock
+    { turnHourCycle :: !Text
+    , turnTimeZoneName :: !Text
+    , turnTimeZoneOffsetMinutes :: !Int
     }
     deriving (Eq, Show)
 
@@ -431,6 +442,7 @@ data CreateTurnRequest = CreateTurnRequest
     , createTurnInput :: !Text
     , createTurnImages :: ![ImageAttachment]
     , createTurnFiles :: ![FileAttachment]
+    , createTurnMessageClock :: !(Maybe TurnMessageClock)
     }
     deriving (Eq, Show)
 
@@ -438,7 +450,14 @@ instance FromJSON CreateTurnRequest where
     parseJSON = withObject "CreateTurnRequest" \value -> do
         rejectUnknownFields
             "CreateTurnRequest"
-            ["clientRequestId", "input", "images", "files"]
+            [ "clientRequestId"
+            , "input"
+            , "images"
+            , "files"
+            , "hourCycle"
+            , "timeZoneName"
+            , "timeZoneOffsetMinutes"
+            ]
             value
         rawRequestId <- value .:? "clientRequestId"
         requestId <- case rawRequestId of
@@ -465,7 +484,21 @@ instance FromJSON CreateTurnRequest where
                 > maxTurnAttachmentBytesTotal
             )
             (fail "images and files are limited to 20 MiB decoded in total")
-        pure (CreateTurnRequest requestId input images files)
+        clock <- parseTurnMessageClock value
+        pure (CreateTurnRequest requestId input images files clock)
+
+parseTurnMessageClock :: Object -> Parser (Maybe TurnMessageClock)
+parseTurnMessageClock value = do
+    hourCycle <- value .:? "hourCycle"
+    zoneName <- value .:? "timeZoneName"
+    offset <- value .:? "timeZoneOffsetMinutes"
+    case (hourCycle, zoneName, offset) of
+        (Nothing, Nothing, Nothing) -> pure Nothing
+        (Just cycleText, Just name, Just minutes) ->
+            pure (Just (TurnMessageClock cycleText name minutes))
+        _ ->
+            fail
+                "hourCycle, timeZoneName, and timeZoneOffsetMinutes must be supplied together"
 
 data FileAttachment = FileAttachment
     { fileName :: !Text

--- a/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
+++ b/packages/agent-server/test/Agent/Server/ApplicationSpec.hs
@@ -107,6 +107,26 @@ spec = describe "agent-server WAI application" do
         request.createTurnImages
             `shouldBe` [ImageAttachment "image/png" "\x89PNG\r\n\x1a\n"]
         request.createTurnFiles `shouldBe` []
+        request.createTurnMessageClock `shouldBe` Nothing
+
+    it "decodes a conversation clock on turn requests" do
+        let decode body = eitherDecode body :: Either String CreateTurnRequest
+        request <-
+            case decode
+                "{\"input\":\"hello\",\"hourCycle\":\"h24\",\"timeZoneName\":\"CEST\",\"timeZoneOffsetMinutes\":120}"
+            of
+                Left err -> expectationFailure err >> fail "unreachable"
+                Right decoded -> pure decoded
+        request.createTurnMessageClock
+            `shouldBe` Just
+                TurnMessageClock
+                    { turnHourCycle = "h24"
+                    , turnTimeZoneName = "CEST"
+                    , turnTimeZoneOffsetMinutes = 120
+                    }
+        decode
+            "{\"input\":\"hello\",\"hourCycle\":\"h24\",\"timeZoneName\":\"CEST\"}"
+            `shouldSatisfy` isLeft
 
     it "decodes opaque generic files and rejects unsafe names" do
         let decode body = eitherDecode body :: Either String CreateTurnRequest

--- a/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
+++ b/packages/agent-server/test/Agent/Server/SupervisorSpec.hs
@@ -1130,6 +1130,7 @@ turnSpecFor boundary sessionId =
         , turnSpecImages = []
         , turnSpecFiles = []
         , turnSpecBoundary = boundary
+        , turnSpecMessageClock = Nothing
         }
 
 testOutput :: TurnExecutionOutput

--- a/packages/agent-server/test/internal/AttachmentScopeCheck.hs
+++ b/packages/agent-server/test/internal/AttachmentScopeCheck.hs
@@ -27,6 +27,7 @@ main = withWorkspace \cwd -> do
             , turnSpecImages = []
             , turnSpecFiles = [FileAttachment "hello.txt" "text/plain" "hello"]
             , turnSpecBoundary = accessBoundary localPrincipal (GatewayBoundary Nothing)
+            , turnSpecMessageClock = Nothing
             }
         empty = do
             remaining <- listDirectory attachments


### PR DESCRIPTION
## Summary
- Cloud agent-server hosts typically run in UTC, so pause stamps on user turns became `[11:15 UTC]`.
- Accept an optional conversation clock on `turns.create`: `hourCycle` (`h12`/`h24`), `timeZoneName` (for example `CEST` or `GMT+2`), and `timeZoneOffsetMinutes`.
- Native turns use that clock instead of the process locale. CLI/TUI sessions keep the host locale when the fields are omitted.
- Zone names like `GMT+2` are recognized when stripping echoed stamps.

## Test plan
- [x] `cabal test agent-cli --test-option=--match=Timestamp`
- [x] `cabal test agent-cli --test-option=--match=parseMessageClock`
- [x] `cabal test agent-cli --test-option=--match=clock` (native turn clock lowering)
- [x] `cabal test agent-cli-runtime --test-option=--match=validateNativeTurnRequest`
- [x] `cabal test agent-server:agent-server-test --test-option=--match=decodes`
- [ ] Deploy this before the matching haskell-agent-gateway PR, which forwards the starter's clock on turn create