### PR TITLE
Support fresh sandbox approval in the fullscreen CLI

### DIFF
--- a/docs/shell-sandbox-escalation.md
+++ b/docs/shell-sandbox-escalation.md
@@ -29,9 +29,10 @@ escalation justifications are rejected.
   `--yolo` or remembered tool approval. There is no permanent escalation choice.
 - Plan/read-only restrictions still apply. Child agents and hosts without a
   suitable fresh-confirmation channel must deny the request.
-  Currently the interactive line CLI supports this confirmation; native,
-  managed-turn and fullscreen session routes fail closed until their approval
-  protocols support the same warning and once-only semantics.
+  Interactive line and fullscreen CLIs and native hosts support this
+  confirmation. The fullscreen dialog defaults to Deny and offers only
+  Allow once or Deny. Managed-turn routes still fail closed until their
+  approval protocol supports the same warning and once-only semantics.
 - The trusted host dispatch supplies an opaque one-use authorization, separate
   from model arguments. It expires when dispatch finishes. Ordinary direct
   dispatch and all existing process APIs remain sandboxed.

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -988,7 +988,7 @@ buildSessionApprovalRuntime host controls SessionRequest{..} =
                 controls.controlToolRegistry
                 planMode
                 call
-        -- Existing external/fullscreen protocols do not carry once-only
+        -- Existing managed protocols do not carry once-only
         -- approval semantics. Do not silently downgrade a fresh request to
         -- their generic permission dialog.
         requestFreshApproval requested =
@@ -997,7 +997,9 @@ buildSessionApprovalRuntime host controls SessionRequest{..} =
                 Nothing -> case promptRequest of
                     Just _ -> pure Nothing
                     Nothing -> case host.hostFullscreen of
-                        Just _ -> pure Nothing
+                        Just runtime ->
+                            requestFullscreenPermissionOnce runtime
+                                (toText workspace.cwd) requested
                         Nothing ->
                             withStdinPaused stdinControl do
                                 color <- resolveColor host.hostStderrHandle

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -71,6 +71,7 @@ module Agent.CLI.TUI.App
     , resumeSearchCursorColumn
     , onboardingVisibleRowIndices
     , requestFullscreenPermission
+    , requestFullscreenPermissionOnce
     , requestFullscreenChoice
     , requestFullscreenChoiceWithBody
     , requestFullscreenChoiceUntil

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -47,6 +47,7 @@ import Agent.CLI.Command
 import Agent.CLI.Permission
     ( PermissionChoice(..)
     , approvalToolCallPromptRelative
+    , approvalToolCallPromptOnceRelative
     )
 import Agent.CLI.Resume ( ResumeBrowser(..)
     , ResumeEntry(..)
@@ -961,6 +962,26 @@ requestFullscreenPermission runtime workspace call = do
     notifyAttention stderr PermissionRequested
     enqueueAppEvent runtime (AppAskPermission summary reply)
     atomically (readTMVar reply)
+
+-- | Fresh approval must never offer a persistent permission grant.
+requestFullscreenPermissionOnce
+    :: FullscreenRuntime
+    -> Text
+    -> ToolCall
+    -> IO (Maybe PermissionChoice)
+requestFullscreenPermissionOnce runtime workspace call = do
+    reply <- newEmptyTMVarIO
+    let summary = approvalToolCallPromptOnceRelative workspace call
+    notifyAttention stderr PermissionRequested
+    enqueueAppEvent runtime
+        (AppAskChoice ChoicePlainDialog "Fresh approval required" summary 1
+            [("Allow once", "Approve only this invocation"), ("Deny", "Do not run")]
+            reply)
+    selected <- atomically (readTMVar reply)
+        `finally` enqueueAppEvent runtime (AppCloseChoice reply)
+    pure $ Just case selected of
+        Just 0 -> PermissionAllowOnce
+        _ -> PermissionDeny
 
 -- | Updates belong to this reply token, never to whichever dialog happens to
 -- be open later. The refresh worker is cancelled and joined when it closes.

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -70,7 +70,7 @@ import Agent.CLI.TUI.Types
       choiceVisibleRows,
       choiceOverlay,
       selectedChoiceIndex,
-      ChoicePresentation(ChoiceOnboarding, ChoiceDialog, ChoiceDocument,
+      ChoicePresentation(ChoiceOnboarding, ChoiceDialog, ChoicePlainDialog, ChoiceDocument,
                          ChoiceTheme, ChoicePlanning),
       AppState(appRuntime,
                appDictation, appTextPrompt, appMetaConsole,
@@ -276,6 +276,8 @@ drawFooter state =
                 "type to filter  │  ↑↓ navigate  │  Enter choose  │  Esc cancel"
             | choice.choicePresentation == ChoiceDocument ->
                 "↑↓ scroll  │  PgUp/PgDn pages  │  Esc back"
+            | choice.choicePresentation == ChoicePlainDialog ->
+                "↑↓ select  │  Enter choose  │  PgUp/PgDn details  │  Esc deny"
         (_, Nothing, Just _, _, _, _) ->
             if state.appUi.uiRunning
                 then "↑↓ select  │  Enter choose  │  Esc close  │  Ctrl+C cancel turn"
@@ -532,6 +534,7 @@ drawChoice appState choice
     | choice.choiceSearch = drawFilterChoice appState choice
     | otherwise = case choice.choicePresentation of
         ChoiceDialog -> drawDialogChoice appState choice
+        ChoicePlainDialog -> drawDialogChoice appState choice
         ChoicePlanning -> drawPlanningChoice appState choice
         ChoiceDocument -> drawDialogChoice appState choice
         ChoiceOnboarding -> drawOnboardingChoice appState choice
@@ -854,9 +857,11 @@ drawDialogChoice appState choice =
                                         else padBottom (Pad 1) $
                                             vLimitPercent 65 $
                                                 viewport OverlayViewport Vertical $
-                                                    markdownWidgetWithLinks
-                                                        MarkdownLink
-                                                        choice.choiceBody
+                                                    if choice.choicePresentation == ChoicePlainDialog
+                                                        then terminalTxtWrap choice.choiceBody
+                                                        else markdownWidgetWithLinks
+                                                            MarkdownLink
+                                                            choice.choiceBody
                                     , vBox $
                                         [ choiceRow
                                             appState

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -584,6 +584,8 @@ data AgentHover = AgentHover
 
 data ChoicePresentation
     = ChoiceDialog
+    -- | Literal, wrapped details: approval arguments must not become Markdown.
+    | ChoicePlainDialog
     | ChoicePlanning
     | ChoiceDocument
     | ChoiceOnboarding

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -581,6 +581,27 @@ spec = do
                 `shouldBe` Just [("Current", "")]
 
     describe "idle choice closure" do
+        it "renders fresh approval details literally and denies on Escape" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+                command = "echo [visible](hidden) `whoami` **literal**"
+            (_, open) <- runFullscreenScriptWithState initial
+                [ FullscreenScriptApp
+                    (AppAskChoice ChoicePlainDialog "Fresh approval required"
+                        command 1 [("Allow once", ""), ("Deny", "")] reply)
+                , FullscreenScriptHalt
+                ]
+            renderedAppText (120, 40) open `shouldSatisfy` Text.isInfixOf command
+            (_, closed) <- runFullscreenScriptWithState open
+                [ FullscreenScriptVty (V.EvKey V.KEsc [])
+                , FullscreenScriptHalt
+                ]
+            atomically (readTMVar reply) `shouldReturn` Nothing
+            case closed.appChoice of
+                Nothing -> pure ()
+                Just _ -> expectationFailure "fresh approval dialog was not closed"
+
         it "closes the matching authorization dialog when the callback finishes" do
             runtime <- newScriptRuntime initialUiState
             reply <- newEmptyTMVarIO

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -9,6 +9,7 @@ import Agent.CLI.AgentViewport
 import Agent.CLI.Command (ReplAction(ReplCopyPath))
 import Agent.CLI.Dictation (DictationTarget(..))
 import Agent.CLI.Interrupt (CtrlCDecision(..))
+import Agent.CLI.Permission (PermissionChoice(..), approvalToolCallPromptOnceRelative)
 import Agent.CLI.TUI.App
     ( appEventLogicalBytes
     , closeAppEventMailbox
@@ -18,6 +19,7 @@ import Agent.CLI.TUI.App
     , newFullscreenInputBuffer
     , newFullscreenRuntime
     , newFullscreenRuntimeWithSyntaxLoader
+    , requestFullscreenPermissionOnce
     , setFullscreenSessionActions
     )
 import Agent.CLI.TUI.Bridge
@@ -26,6 +28,7 @@ import Agent.CLI.TUI.Types
     ( AppEvent(..)
     , AppEventMailbox(..)
     , AppEventMailboxState(..)
+    , ChoicePresentation(..)
     , FullscreenRuntime(..)
     , FullscreenSessionActions(..)
     , PendingAppEvent(..)
@@ -43,7 +46,7 @@ import Agent.Subagents (SubagentId(..))
 import Agent.ToolDispatch (ToolCall(..), ToolCallResult(..), ToolCallKind(..), ToolCallMode(..), functionToolCall)
 import Agent.TUI.Motion (MotionMode(..))
 import Control.Concurrent.Async (wait, withAsync)
-import Control.Concurrent.STM (atomically, readTVarIO)
+import Control.Concurrent.STM (atomically, readTVar, readTVarIO, retry, putTMVar)
 import Control.Exception (MaskingState(MaskedUninterruptible), getMaskingState)
 import Control.Exception.Safe (finally, throwString)
 import Control.Monad (replicateM_)
@@ -57,6 +60,32 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "fullscreen TUI bridge" do
+    describe "fresh approval" do
+        let call = functionToolCall "fresh-shell" "shell_command"
+                "{\"command\":\"swift build\",\"sandbox_permissions\":\"require_escalated\",\"justification\":\"Nested sandbox blocked\"}"
+        mapM_ (\(label, selection, expected) ->
+            it label do
+                runtime <- newBridgeTestRuntime
+                result <- timeout 2000000 $
+                    withAsync (requestFullscreenPermissionOnce runtime "/workspace" call) \worker -> do
+                        let AppEventMailbox pendingRef = runtime.runtimeMailbox
+                        (body, initial, rows, reply) <- atomically do
+                            pending <- (.mailboxPendingEvents) <$> readTVar pendingRef
+                            case toList pending of
+                                [PendingEvent (AppAskChoice ChoicePlainDialog _ body initial rows reply)] ->
+                                    pure (body, initial, rows, reply)
+                                _ -> retry
+                        body `shouldBe` approvalToolCallPromptOnceRelative "/workspace" call
+                        initial `shouldBe` 1
+                        map fst rows `shouldBe` ["Allow once", "Deny"]
+                        atomically (putTMVar reply selection)
+                        wait worker
+                result `shouldBe` Just (Just expected))
+            [ ("grants only one invocation", Just 0, PermissionAllowOnce)
+            , ("denies explicitly", Just 1, PermissionDeny)
+            , ("denies cancellation", Nothing, PermissionDeny)
+            , ("rejects unknown choices", Just 2, PermissionDeny)
+            ]
     describe "pull request associations" do
         let url = "https://github.com/owner/repository/pull/42"
             previous = Just "https://github.com/owner/repository/pull/41"


### PR DESCRIPTION
## Summary

Fullscreen CLI sessions immediately rejected `sandbox_permissions: require_escalated` because their fresh-approval route returned no decision. This prevented recovery after a nested macOS sandbox failure such as SwiftPM's `sandbox_apply: Operation not permitted`.

- Route fullscreen requests through a dedicated Allow once / Deny dialog, defaulting to Deny.
- Render command details literally so Markdown cannot conceal arguments.
- Deny cancellation and unexpected choices; preserve fail-closed managed routes and existing one-use authorization enforcement.
- Add regression coverage and update the escalation documentation.

## Validation

- GHCi typechecked the changed libraries and tests.
- All five added regression cases pass; all three idle-choice-closure tests pass.
- Live fullscreen tmux check verified literal command/warning rendering, default Deny, Escape returning PermissionDeny, and Allow once returning PermissionAllowOnce. The fixture only displayed the dialog; it executed no escalated command and was removed afterward.
- Full TUI bridge suite: 32/33 pass. The unchanged `does not block producers when Brick is not draining events` test times out in GHCi, including an isolated retry.
- `git diff --check` passes.

The affected session must restart with the updated CLI before retrying fresh approval.
