### PR TITLE
Expose gateway organization identity through the native bridge

### DIFF
--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -40,7 +40,8 @@ library
     import:           common-options
     hs-source-dirs:   src
     autogen-modules:  Paths_agent_cli_runtime
-    other-modules:    Agent.CLI.Gateway.Catalog
+    other-modules:    Agent.CLI.Gateway.Account
+                    , Agent.CLI.Gateway.Catalog
                     , Agent.CLI.Gateway.Credentials
                     , Agent.CLI.Gateway.Dictation
                     , Agent.CLI.Gateway.Http

--- a/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Account.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Gateway/Account.hs
@@ -1,0 +1,66 @@
+module Agent.CLI.Gateway.Account (GatewayAccount(..), fetchGatewayAccount) where
+
+import Agent.CLI.Gateway.Credentials (loadGatewayCredential, validateGatewayCredential, withGatewayCredentialLease)
+import Agent.CLI.Gateway.Http (readBoundedBody)
+import Agent.ClientIdentity (gatewayUserAgent)
+import Agent.Server.Client.GatewayIdentity (GatewayCredential(..))
+import Control.Exception.Safe (tryAny)
+import Data.Aeson (FromJSON(..), eitherDecodeStrict', withObject, (.:), (.:?))
+import Data.ByteString qualified as BS
+import Data.ByteString.Base64 qualified as Base64
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Network.HTTP.Client qualified as HTTP
+import Network.HTTP.Client.TLS (newTlsManager)
+import Network.HTTP.Types (statusCode)
+
+data GatewayAccount = GatewayAccount
+    { organizationId :: !Text
+    , organizationName :: !Text
+    , userName :: !Text
+    , iconPng :: !BS.ByteString
+    } deriving (Eq, Show)
+
+instance FromJSON GatewayAccount where
+    parseJSON = withObject "GatewayAccount" \value -> do
+        organization <- value .: "organization"
+        user <- value .: "user"
+        organizationId <- organization .: "id"
+        organizationName <- organization .: "name"
+        userName <- user .: "name"
+        icon <- organization .:? "iconDataUrl"
+        let iconPng = case icon >>= Text.stripPrefix "data:image/png;base64," of
+                Just encoded | Text.length encoded <= 350000 ->
+                    either (const BS.empty) id (Base64.decode (Text.encodeUtf8 encoded))
+                _ -> BS.empty
+        pure GatewayAccount{..}
+
+-- Keep the profile tied to the credential lease, never expose its token.
+fetchGatewayAccount :: IO (Either Text (Maybe GatewayAccount))
+fetchGatewayAccount = withGatewayCredentialLease do
+    loadGatewayCredential >>= \case
+        Left message -> pure (Left message)
+        Right Nothing -> pure (Right Nothing)
+        Right (Just credential) -> case validateGatewayCredential credential of
+            Left _ -> pure (Left "Gateway credential is invalid.")
+            Right () -> do
+                outcome <- tryAny do
+                    manager <- newTlsManager
+                    userAgent <- gatewayUserAgent
+                    initial <- HTTP.parseRequest (Text.unpack (Text.dropWhileEnd (== '/') credential.gatewayBaseUrl <> "/api/v1/account"))
+                    let request = initial
+                            { HTTP.requestHeaders = [("Authorization", "Bearer " <> Text.encodeUtf8 credential.gatewayAccessToken), ("Accept", "application/json"), ("User-Agent", userAgent)]
+                            , HTTP.redirectCount = 0
+                            , HTTP.checkResponse = \_ _ -> pure ()
+                            , HTTP.responseTimeout = HTTP.responseTimeoutMicro 5000000
+                            }
+                    HTTP.withResponse request manager \response -> do
+                        body <- readBoundedBody 400000 (HTTP.responseBody response)
+                        pure (statusCode (HTTP.responseStatus response), body)
+                pure case outcome of
+                    Right (200, Just body) -> case eitherDecodeStrict' body of
+                        Right account -> Right (Just account)
+                        Left _ -> Left "The gateway account response could not be read."
+                    Right (404, _) -> Right Nothing
+                    _ -> Left "The gateway account could not be loaded."

--- a/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/GatewayClient.hs
@@ -4,6 +4,8 @@
 -- private modules; this facade preserves the API used by CLI and native hosts.
 module Agent.CLI.GatewayClient
     ( GatewayCredential(..)
+    , GatewayAccount(..)
+    , fetchGatewayAccount
     , GatewayModel(..)
     , GatewayModelCatalogResponse(..)
     , GatewayModelProtocol(..)
@@ -74,6 +76,7 @@ module Agent.CLI.GatewayClient
     ) where
 
 import Agent.CLI.Gateway.Catalog
+import Agent.CLI.Gateway.Account
 import Agent.CLI.Gateway.Credentials
 import Agent.CLI.Gateway.OAuth
 import Agent.CLI.Gateway.OAuth.Protocol

--- a/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/CLI/GatewayClientSpec.hs
@@ -60,6 +60,15 @@ decodeGatewayModels bytes =
 
 spec :: Spec
 spec = describe "gateway device authorization" do
+    it "decodes gateway organization identity and optional icon bytes" do
+        let decode = Aeson.eitherDecodeStrict' :: BS.ByteString -> Either String GatewayAccount
+        decode "{\"organization\":{\"id\":\"org\",\"name\":\"Example\",\"iconDataUrl\":\"data:image/png;base64,aWNvbg==\"},\"user\":{\"name\":\"Alex\"}}"
+            `shouldBe` Right (GatewayAccount "org" "Example" "Alex" "icon")
+        decode "{\"organization\":{\"id\":\"org\",\"name\":\"Example\"},\"user\":{\"name\":\"Alex\"}}"
+            `shouldBe` Right (GatewayAccount "org" "Example" "Alex" BS.empty)
+        decode "{\"organization\":{\"id\":\"org\",\"name\":\"Example\",\"iconDataUrl\":\"https://example.test/logo.png\"},\"user\":{\"name\":\"Alex\"}}"
+            `shouldBe` Right (GatewayAccount "org" "Example" "Alex" BS.empty)
+
     it "invalidates idle credential owners before replacement and logout complete" $
         withTempHome \home ->
             withHomeEnvironment home do

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/GatewayBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/GatewayBridge.hs
@@ -6,6 +6,8 @@ module Agent.CLI.MacOS.GatewayBridge (invokeGatewayCallbackOnce) where
 
 import Agent.CLI.GatewayClient
     ( GatewayCredential(..)
+    , GatewayAccount(..)
+    , fetchGatewayAccount
     , GatewayDeviceAuthorization(..)
     , GatewayPollResult(..)
     , exchangeNativeGatewayAuthorizationCodeWith
@@ -20,6 +22,7 @@ import Control.Concurrent (forkIO)
 import Control.Exception.Safe (tryAny)
 import Control.Monad (void)
 import Data.Maybe (fromMaybe)
+import Data.ByteString qualified as BS
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Word (Word8)
@@ -32,6 +35,42 @@ type GatewayStatusCallback =
     -> CString -> CSize
     -> CString -> CSize
     -> IO ()
+
+type GatewayAccountCallback =
+    Ptr () -> CInt
+    -> CString -> CSize
+    -> CString -> CSize
+    -> CString -> CSize
+    -> CString -> CSize
+    -> CString -> CSize
+    -> IO ()
+
+foreign import ccall "dynamic"
+    invokeGatewayAccountCallback :: FunPtr GatewayAccountCallback -> GatewayAccountCallback
+
+foreign export ccall ha_gateway_account
+    :: FunPtr GatewayAccountCallback -> Ptr () -> IO CInt
+
+ha_gateway_account :: FunPtr GatewayAccountCallback -> Ptr () -> IO CInt
+ha_gateway_account callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        _ <- forkIO do
+            result <- tryAny fetchGatewayAccount
+            case result of
+                Right (Right (Just account)) ->
+                    withText account.organizationId \orgId orgIdLength ->
+                    withText account.organizationName \orgName orgNameLength ->
+                    withText account.userName \name nameLength ->
+                    BS.useAsCStringLen account.iconPng \(icon, iconLength) ->
+                        invokeGatewayAccountCallback callback context 0
+                            orgId orgIdLength orgName orgNameLength name nameLength
+                            icon (fromIntegral iconLength) nullPtr 0
+                Right (Right Nothing) ->
+                    invokeGatewayAccountCallback callback context 1 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0
+                _ -> withText "The gateway account could not be loaded." \message length ->
+                    invokeGatewayAccountCallback callback context (-1) nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 message length
+        pure 0
 
 type GatewayConnectStartCallback =
     Ptr () -> CInt

--- a/packages/agent-native-bridge/include/HaskellAgentBridge.h
+++ b/packages/agent-native-bridge/include/HaskellAgentBridge.h
@@ -42,6 +42,22 @@ typedef void (*ha_event_callback)(
 );
 
 /*
+ * Account status: 0 = profile, 1 = disconnected/unsupported, -1 = error.
+ * Icon is PNG bytes, or length 0 if absent. All buffers are callback-scoped;
+ * NULL is valid only with length 0. Copy them before returning.
+ * Runs on a worker thread. Returns 0 when accepted, 1 for a NULL callback.
+ */
+typedef void (*ha_gateway_account_callback)(
+    void *context, int32_t status,
+    const uint8_t *organization_id, size_t organization_id_length,
+    const uint8_t *organization_name, size_t organization_name_length,
+    const uint8_t *user_name, size_t user_name_length,
+    const uint8_t *icon_png, size_t icon_png_length,
+    const uint8_t *error, size_t error_length
+);
+int32_t ha_gateway_account(ha_gateway_account_callback callback, void *context);
+
+/*
  * Remote MCP connections have immutable IDs independent of display names and
  * endpoint URLs. Identical endpoints may have independently authorized accounts.
  * No credentials are exposed by this interface.

--- a/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeImageSmoke.c
+++ b/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeImageSmoke.c
@@ -62,6 +62,10 @@ int ha_image_attachment_abi_smoke(void) {
  * credential-store access.
  */
 int ha_gateway_abi_smoke(void) {
+    ha_gateway_account_callback account_callback = NULL;
+    if (ha_gateway_account(account_callback, NULL) != 1) {
+        return 28;
+    }
     ha_gateway_status_callback status_callback = NULL;
     ha_gateway_connect_start_callback start_callback = NULL;
     ha_gateway_poll_callback poll_callback = NULL;


### PR DESCRIPTION
## Summary
- Retrieve the authenticated gateway account profile with bounded response and icon data.
- Export a typed asynchronous ha_gateway_account C ABI with explicit buffer ownership and status values.
- Add account decoding coverage and native ABI smoke coverage.

## Validation
- Native bridge Nix check passes.
- Matching bridge builds and targeted host Swift integration tests pass.
- The broader runtime Nix check is blocked by seven failures in unchanged agent-core IO tests.

## Compatibility
Missing account endpoints or icons are handled without requiring an icon. Gateway support must be deployed for organization profiles to appear.