### PR TITLE
Reuse gateway credentials for native mobile access

### DIFF
--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -14,6 +14,7 @@ build-type:         Simple
 extra-source-files: include/HaskellAgentBridge.h
 
 common common-options
+    build-depends:    http-client, http-client-tls, http-types, websockets, wuss
     default-language: GHC2021
     default-extensions: BlockArguments
                       , OverloadedStrings
@@ -93,6 +94,8 @@ foreign-library haskell-agent-bridge
                     , Agent.CLI.MacOS.AccountBridge
                     , Agent.CLI.MacOS.BrowserBridge
                     , Agent.CLI.MacOS.GatewayBridge
+                    , Agent.CLI.MacOS.MobileGateway
+                    , Agent.CLI.MacOS.MobileGatewayBridge
                     , Agent.CLI.MacOS.Marshalling
                     , Agent.CLI.MacOS.ComputerBridge
                     , Agent.CLI.MacOS.EngineMailbox
@@ -198,6 +201,7 @@ test-suite agent-native-bridge-test
                     , test/cbits/HaskellAgentBridgeIntegrationSmoke.c
                     , test/cbits/HaskellAgentBridgeTaskSmoke.c
                     , test/cbits/HaskellAgentBridgeSessionObservationSmoke.c
+                    , test/cbits/HaskellAgentBridgeMobileSmoke.c
                     , test/cbits/HaskellAgentBridgeMcpConnectionSmoke.c
                     , cbits/HaskellAgentBridgeRuntime.c
                     , cbits/HaskellAgentMcpKeychain.c
@@ -208,6 +212,7 @@ test-suite agent-native-bridge-test
                      , Agent.CLI.MacOS.SessionTransferBridge
                      , Agent.CLI.MacOS.SessionObservationBridge
                      , Agent.CLI.MacOS.SessionObservationBridgeSpec
+                     , Agent.CLI.MacOS.MobileGatewaySpec
                      , Agent.CLI.MacOS.AgentSnapshot
                      , Agent.CLI.MacOS.EngineCallbacks
                      , Agent.CLI.MacOS.EngineEvents
@@ -233,6 +238,8 @@ test-suite agent-native-bridge-test
                      , Agent.CLI.MacOS.AccountBridge
                      , Agent.CLI.MacOS.BrowserBridge
                      , Agent.CLI.MacOS.GatewayBridge
+                     , Agent.CLI.MacOS.MobileGateway
+                     , Agent.CLI.MacOS.MobileGatewayBridge
                      , Agent.CLI.MacOS.Marshalling
                      , Agent.CLI.MacOS.ComputerBridge
                      , Agent.CLI.MacOS.RepositoryWorkers

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -41,6 +41,7 @@ import Agent.CLI.MacOS.EngineHostRegistration ()
 import Agent.CLI.MacOS.EngineStaging ()
 import Agent.CLI.MacOS.EngineSubmission ()
 import Agent.CLI.MacOS.GatewayBridge (invokeGatewayCallbackOnce)
+import Agent.CLI.MacOS.MobileGatewayBridge ()
 import Agent.CLI.MacOS.InteractionState
 import Agent.CLI.MacOS.LearnedSkillsBridge ()
 import Agent.CLI.MacOS.McpConnectionBridge ()

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/MobileGateway.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/MobileGateway.hs
@@ -1,0 +1,221 @@
+{-# LANGUAGE DeriveAnyClass #-}
+module Agent.CLI.MacOS.MobileGateway
+    ( MobileSession, MobileRelay, MobileFailure(..)
+    , openSession, closeSession, sessionBaseURL
+    , registerRunner, listPairings, revokePairing, wakePairing
+    , openRelay, closeRelay, sendRelay, receiveRelay, validPairingID
+    ) where
+
+import Agent.CLI.GatewayClient
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.Async (race_)
+import Control.Concurrent.STM
+import Control.Exception.Safe (Exception, throwIO, bracketOnError, finally, tryAny)
+import Control.Monad (forever, unless, when, void)
+import Data.Aeson
+import Data.Aeson.Types (Parser, parseEither)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+import Data.Char (isHexDigit)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Network.HTTP.Client as HTTP
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types.Status (statusCode)
+import qualified Network.WebSockets as WS
+import qualified Wuss
+import System.Timeout (timeout)
+
+-- Never expose HTTP exceptions: they may contain Authorization headers.
+data MobileFailure = AccountUnavailable | InvalidMobileInput | MobileUnavailable
+    deriving (Show, Exception)
+
+data MobileSession = MobileSession
+    { credential :: GatewayCredential
+    , closed :: TVar Bool
+    , unregister :: IO ()
+    }
+
+sessionBaseURL :: MobileSession -> Text
+sessionBaseURL session = session.credential.gatewayBaseUrl
+
+openSession :: IO MobileSession
+openSession = do
+    closed <- newTVarIO False
+    bracketOnError
+        (registerGatewayCredentialInvalidator (atomically $ writeTVar closed True))
+        id
+        \unregister -> withGatewayCredentialLease do
+            credential <- loadGatewayCredential >>= \case
+                Right (Just value) -> pure value
+                _ -> throwIO AccountUnavailable
+            _ <- either (const $ throwIO AccountUnavailable) pure
+                (validateBaseUrl credential.gatewayBaseUrl)
+            let session = MobileSession{credential, closed, unregister}
+            ensureOpen session
+            pure session
+
+closeSession :: MobileSession -> IO ()
+closeSession session = do
+    atomically $ writeTVar session.closed True
+    session.unregister
+
+ensureOpen :: MobileSession -> IO ()
+ensureOpen session = do
+    closed <- readTVarIO session.closed
+    when closed $ throwIO AccountUnavailable
+
+-- Called under the credential lease. Identity is never exported.
+checkIdentity :: MobileSession -> IO ()
+checkIdentity session = do
+    ensureOpen session
+    current <- loadGatewayCredential
+    unless (case current of
+        Right (Just value) ->
+            gatewayCredentialIdentity value == gatewayCredentialIdentity session.credential
+        _ -> False) do
+        atomically $ writeTVar session.closed True
+        throwIO AccountUnavailable
+
+validPairingID :: Text -> Bool
+validPairingID value =
+    Text.length value == 36 && and
+        [if elem index [8,13,18,23] then char == '-' else isHexDigit char
+        | (index, char) <- zip [0 :: Int ..] (Text.unpack value)]
+
+pairingPath :: Text -> IO Text
+pairingPath value
+    | validPairingID value = pure $ "/api/v1/mobile/runner/pairings/" <> Text.toLower value
+    | otherwise = throwIO InvalidMobileInput
+
+maximumBytes :: Int
+maximumBytes = 1024 * 1024
+
+bounded :: IO a -> IO a
+bounded action = timeout (20 * 1000000) action >>= maybe (throwIO MobileUnavailable) pure
+
+request :: MobileSession -> BS.ByteString -> Text -> Value -> IO BS.ByteString
+request session method suffix body = bounded $ withGatewayCredentialLease do
+    checkIdentity session
+    initial <- HTTP.parseRequest $ Text.unpack (sessionBaseURL session <> suffix)
+    let request = initial
+            { HTTP.method = method
+            , HTTP.redirectCount = 0
+            , HTTP.checkResponse = \_ _ -> pure ()
+            , HTTP.responseTimeout = HTTP.responseTimeoutMicro (15 * 1000000)
+            , HTTP.requestHeaders =
+                [("Authorization", "Bearer " <> Text.encodeUtf8 session.credential.gatewayAccessToken)
+                ,("Content-Type", "application/json")]
+            , HTTP.requestBody = HTTP.RequestBodyLBS (encode body)
+            }
+    manager <- HTTP.newManager tlsManagerSettings
+    finally (HTTP.withResponse request manager \response -> do
+        let status = statusCode response.responseStatus
+        unless (status >= 200 && status < 300 || method == "DELETE" && status == 404) $
+            throwIO MobileUnavailable
+        let collect size chunks = do
+                chunk <- HTTP.brRead response.responseBody
+                let total = size + BS.length chunk
+                when (total > maximumBytes) $ throwIO MobileUnavailable
+                if BS.null chunk then pure (BS.concat $ reverse chunks)
+                else collect total (chunk:chunks)
+        collect 0 []) (HTTP.closeManager manager)
+
+decodeResponse :: (Value -> Parser a) -> BS.ByteString -> IO a
+decodeResponse parser bytes = either (const $ throwIO MobileUnavailable) pure
+    (eitherDecodeStrict' bytes >>= parseEither parser)
+
+registerRunner :: MobileSession -> Text -> Text -> IO Text
+registerRunner session deviceID name = do
+    unless (validPairingID deviceID && not (Text.null name) && Text.length name <= 160) $
+        throwIO InvalidMobileInput
+    bytes <- request session "POST" "/api/v1/mobile/runner"
+        (object ["device_id" .= deviceID, "name" .= name,
+                 "capabilities" .= object ["protocol" .= (1 :: Int)]])
+    decodeResponse (withObject "runner" (.: "id")) bytes
+
+listPairings :: MobileSession -> IO [(Text, Text)]
+listPairings session = do
+    bytes <- request session "GET" "/api/v1/mobile/runner/pairings" Null
+    result <- decodeResponse (withObject "pairings" \o -> do
+        rows <- o .: "data"
+        mapM (withObject "pairing" \p -> (,) <$> p .: "id" <*> (p .:? "mobile_name" .!= "")) rows) bytes
+    unless (length result <= 1024 && all (validPairingID . fst) result) $
+        throwIO MobileUnavailable
+    pure result
+
+revokePairing :: MobileSession -> Text -> IO ()
+revokePairing session pairingID = do
+    path <- pairingPath pairingID
+    void $ request session "DELETE" path Null
+
+wakePairing :: MobileSession -> Text -> IO ()
+wakePairing session pairingID = do
+    path <- pairingPath pairingID
+    void $ request session "POST" (path <> "/wake") Null
+
+data MobileRelay = MobileRelay
+    { session :: MobileSession
+    , closed :: TVar Bool
+    , incoming :: TBQueue BS.ByteString
+    , outgoing :: TBQueue BS.ByteString
+    }
+
+relayAlive :: MobileRelay -> STM ()
+relayAlive relay = do
+    stopped <- (||) <$> readTVar relay.closed <*> readTVar relay.session.closed
+    when stopped $ throwSTM AccountUnavailable
+
+closeRelay :: MobileRelay -> IO ()
+closeRelay relay = atomically $ writeTVar relay.closed True
+
+sendRelay :: MobileRelay -> BS.ByteString -> IO ()
+sendRelay relay bytes = bounded do
+    when (BS.length bytes > maximumBytes) $ throwIO InvalidMobileInput
+    atomically $ relayAlive relay >> writeTBQueue relay.outgoing bytes
+
+receiveRelay :: MobileRelay -> IO BS.ByteString
+receiveRelay relay = atomically $ relayAlive relay >> readTBQueue relay.incoming
+
+openRelay :: MobileSession -> Text -> IO MobileRelay
+openRelay session pairingID = do
+    unless (validPairingID pairingID) $ throwIO InvalidMobileInput
+    withGatewayCredentialLease $ checkIdentity session
+    relay <- MobileRelay session <$> newTVarIO False <*> newTBQueueIO 8 <*> newTBQueueIO 8
+    ready <- newEmptyTMVarIO
+    let stop = atomically do
+            stopped <- (||) <$> readTVar relay.closed <*> readTVar session.closed
+            check stopped
+        -- Cross-process changes also close sockets. No lifetime credential lease.
+        monitor = forever do
+            threadDelay 1000000
+            withGatewayCredentialLease $ checkIdentity session
+        connect = do
+            endpoint <- HTTP.parseRequest $ Text.unpack $
+                sessionBaseURL session <> "/api/v1/mobile/relay/" <> Text.toLower pairingID <> "/runner"
+            let options = WS.defaultConnectionOptions
+                    { WS.connectionFramePayloadSizeLimit = WS.SizeLimit (fromIntegral maximumBytes)
+                    , WS.connectionMessageDataSizeLimit = WS.SizeLimit (fromIntegral maximumBytes)
+                    }
+                headers = [("Authorization", "Bearer " <> Text.encodeUtf8 session.credential.gatewayAccessToken)]
+                client connection = do
+                    atomically $ relayAlive relay >> putTMVar ready ()
+                    race_
+                        (forever do
+                            bytes <- WS.receiveData connection
+                            when (BS.length bytes > maximumBytes) $ throwIO MobileUnavailable
+                            atomically $ relayAlive relay >> writeTBQueue relay.incoming bytes)
+                        (forever do
+                            bytes <- atomically $ relayAlive relay >> readTBQueue relay.outgoing
+                            WS.sendBinaryData connection bytes)
+            if endpoint.secure
+                then Wuss.runSecureClientWith (BSC.unpack endpoint.host) (fromIntegral endpoint.port)
+                    (BSC.unpack endpoint.path) options headers client
+                else WS.runClientWith (BSC.unpack endpoint.host) endpoint.port
+                    (BSC.unpack endpoint.path) options headers client
+    _ <- forkIO $ finally (void $ tryAny $ race_ stop (race_ monitor connect)) (closeRelay relay)
+    outcome <- tryAny $ bounded $ atomically $ relayAlive relay >> readTMVar ready
+    case outcome of
+        Left _ -> closeRelay relay >> throwIO MobileUnavailable
+        Right () -> pure relay

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/MobileGatewayBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/MobileGatewayBridge.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module Agent.CLI.MacOS.MobileGatewayBridge where
+
+import qualified Agent.CLI.MacOS.MobileGateway as Mobile
+import Control.Concurrent (forkIO)
+import Control.Concurrent.STM
+import Control.Exception.Safe (tryAny, throwIO, fromException, bracketOnError)
+import Control.Monad (void, when, forM_)
+import qualified Data.ByteString as BS
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
+import Data.Word (Word8, Word64)
+import Foreign hiding (void)
+import Foreign.C.Types
+import System.IO.Unsafe (unsafePerformIO)
+
+-- One completion callback shape, carrying only typed result fields:
+-- opaque handle, UTF-8 value/name, or an encrypted binary frame.
+type Callback = Ptr () -> CInt -> Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> IO ()
+foreign import ccall "dynamic" invoke :: FunPtr Callback -> Callback
+
+data Resource = Session Mobile.MobileSession | Relay Mobile.MobileRelay
+resources :: TVar (Word64, Map.Map Word64 Resource)
+resources = unsafePerformIO $ newTVarIO (1, Map.empty)
+{-# NOINLINE resources #-}
+
+insertResource :: Resource -> IO Word64
+insertResource resource = atomically do
+    (next, entries) <- readTVar resources
+    when (next == maxBound || Map.size entries >= 1024) $ throwSTM Mobile.MobileUnavailable
+    writeTVar resources (next + 1, Map.insert next resource entries)
+    pure next
+
+sessionFor :: Word64 -> IO Mobile.MobileSession
+sessionFor handle = atomically do
+    (_, entries) <- readTVar resources
+    case Map.lookup handle entries of
+        Just (Session session) -> pure session
+        _ -> throwSTM Mobile.AccountUnavailable
+
+relayFor :: Word64 -> IO Mobile.MobileRelay
+relayFor handle = atomically do
+    (_, entries) <- readTVar resources
+    case Map.lookup handle entries of
+        Just (Relay relay) -> pure relay
+        _ -> throwSTM Mobile.AccountUnavailable
+
+deliver :: FunPtr Callback -> Ptr () -> CInt -> Word64 -> BS.ByteString -> BS.ByteString -> IO ()
+deliver callback context status handle value name =
+    BS.useAsCStringLen value \(p,n) ->
+        BS.useAsCStringLen name \(q,m) ->
+            invoke callback context status handle (castPtr p) (fromIntegral n) (castPtr q) (fromIntegral m)
+
+start :: FunPtr Callback -> Ptr () -> IO (Word64, BS.ByteString) -> IO CInt
+start callback context action
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        void $ forkIO do
+            result <- tryAny action
+            case result of
+                Right (handle, bytes) -> deliver callback context 0 handle bytes BS.empty
+                Left err -> deliver callback context
+                    (case fromException err of
+                        Just Mobile.AccountUnavailable -> 2
+                        Just Mobile.InvalidMobileInput -> 1
+                        _ -> 3) 0 BS.empty BS.empty
+        pure 0
+
+input :: Ptr Word8 -> CSize -> IO Text
+input ptr size
+    | size > 4096 || (ptr == nullPtr && size /= 0) = throwIO Mobile.InvalidMobileInput
+    | otherwise = do
+        bytes <- if size == 0 then pure BS.empty else BS.packCStringLen (castPtr ptr, fromIntegral size)
+        either (const $ throwIO Mobile.InvalidMobileInput) pure (Text.decodeUtf8' bytes)
+
+foreign export ccall ha_mobile_session_open :: FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_session_open :: FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_session_open callback context = start callback context $
+    bracketOnError Mobile.openSession Mobile.closeSession \session -> do
+        handle <- insertResource (Session session)
+        pure (handle, Text.encodeUtf8 $ Mobile.sessionBaseURL session)
+
+foreign export ccall ha_mobile_handle_close :: Word64 -> IO CInt
+ha_mobile_handle_close :: Word64 -> IO CInt
+ha_mobile_handle_close handle = do
+    result <- tryAny do
+        resource <- atomically do
+            (next, entries) <- readTVar resources
+            writeTVar resources (next, Map.delete handle entries)
+            pure $ Map.lookup handle entries
+        case resource of
+            Just (Session session) -> Mobile.closeSession session
+            Just (Relay relay) -> Mobile.closeRelay relay
+            Nothing -> pure ()
+    pure $ either (const 3) (const 0) result
+
+foreign export ccall ha_mobile_runner_register :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_runner_register :: Word64 -> Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_runner_register handle p n q m callback context = do
+    copied <- tryAny $ (,) <$> input p n <*> input q m
+    start callback context do
+        (deviceID, name) <- either throwIO pure copied
+        session <- sessionFor handle
+        runner <- Mobile.registerRunner session deviceID name
+        pure (0, Text.encodeUtf8 runner)
+
+foreign export ccall ha_mobile_pairings_list :: Word64 -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_pairings_list :: Word64 -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_pairings_list handle callback context = start callback context do
+    session <- sessionFor handle
+    rows <- Mobile.listPairings session
+    forM_ rows \(identifier, name) ->
+        deliver callback context 4 0 (Text.encodeUtf8 identifier) (Text.encodeUtf8 name)
+    pure (0, BS.empty)
+
+pairingOperation :: (Mobile.MobileSession -> Text -> IO ()) -> Word64 -> Ptr Word8 -> CSize -> FunPtr Callback -> Ptr () -> IO CInt
+pairingOperation action handle p n callback context = do
+    copied <- tryAny $ input p n
+    start callback context do
+        pairing <- either throwIO pure copied
+        session <- sessionFor handle
+        action session pairing
+        pure (0, BS.empty)
+
+foreign export ccall ha_mobile_pairing_revoke :: Word64 -> Ptr Word8 -> CSize -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_pairing_revoke :: Word64 -> Ptr Word8 -> CSize -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_pairing_revoke = pairingOperation Mobile.revokePairing
+
+foreign export ccall ha_mobile_pairing_wake :: Word64 -> Ptr Word8 -> CSize -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_pairing_wake :: Word64 -> Ptr Word8 -> CSize -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_pairing_wake = pairingOperation Mobile.wakePairing
+
+foreign export ccall ha_mobile_relay_open :: Word64 -> Ptr Word8 -> CSize -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_relay_open :: Word64 -> Ptr Word8 -> CSize -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_relay_open handle p n callback context = do
+    copied <- tryAny $ input p n
+    start callback context do
+        pairing <- either throwIO pure copied
+        session <- sessionFor handle
+        bracketOnError (Mobile.openRelay session pairing) Mobile.closeRelay \relay -> do
+            identifier <- insertResource (Relay relay)
+            pure (identifier, BS.empty)
+
+foreign export ccall ha_mobile_relay_send :: Word64 -> Ptr Word8 -> CSize -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_relay_send :: Word64 -> Ptr Word8 -> CSize -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_relay_send handle p n callback context
+    | n > 1048576 || (p == nullPtr && n /= 0) = pure 1
+    | otherwise = do
+        bytes <- if n == 0 then pure BS.empty else BS.packCStringLen (castPtr p, fromIntegral n)
+        start callback context do
+            relay <- relayFor handle
+            Mobile.sendRelay relay bytes
+            pure (0, BS.empty)
+
+foreign export ccall ha_mobile_relay_receive :: Word64 -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_relay_receive :: Word64 -> FunPtr Callback -> Ptr () -> IO CInt
+ha_mobile_relay_receive handle callback context = start callback context do
+    relay <- relayFor handle
+    bytes <- Mobile.receiveRelay relay
+    pure (0, bytes)

--- a/packages/agent-native-bridge/include/HaskellAgentBridge.h
+++ b/packages/agent-native-bridge/include/HaskellAgentBridge.h
@@ -2046,6 +2046,40 @@ int32_t ha_gateway_connect_exchange(
     ha_gateway_result_callback callback,
     void *context
 );
+/* Mobile uses the saved main gateway account. No credential crosses this ABI.
+ * All async functions return 0 when accepted (one terminal callback), 1 on
+ * invalid arguments, or 3 if unavailable (no callback on nonzero return).
+ * Callback status: 0 success, 1 invalid input, 2 account changed/unavailable,
+ * 3 transport/server failure, 4 pairing row (nonterminal, list only).
+ * Callbacks run on runtime threads, serially per operation; context is opaque.
+ * Buffers are callback-scoped and must be copied; null is allowed at length 0.
+ * Input buffers are copied before return. Text is UTF-8; max 4096 input bytes.
+ * Open returns an owned nonzero handle; session value is the inherited base URL.
+ * Register returns runner ID in value. List emits ID/value and name, then status
+ * 0. Receive returns an encrypted frame (max 1 MiB); send accepts the same bound.
+ * Other success fields are empty/zero. No server error text is exposed.
+ * Close is synchronous/idempotent and invalidates pending operations. Closing a
+ * session also stops its relays; every returned handle still needs closing.
+ * Receive completes when data arrives or the relay/session closes. HTTP and
+ * relay-open/send operations time out. Calls may execute concurrently.
+ */
+typedef void (*ha_mobile_callback)(
+    void *context, int32_t status, uint64_t handle,
+    const uint8_t *value, size_t value_length,
+    const uint8_t *name, size_t name_length);
+int32_t ha_mobile_session_open(ha_mobile_callback callback, void *context);
+int32_t ha_mobile_handle_close(uint64_t handle);
+int32_t ha_mobile_runner_register(uint64_t session,
+    const uint8_t *device_id, size_t device_id_length,
+    const uint8_t *name, size_t name_length,
+    ha_mobile_callback callback, void *context);
+int32_t ha_mobile_pairings_list(uint64_t session, ha_mobile_callback callback, void *context);
+int32_t ha_mobile_pairing_revoke(uint64_t session, const uint8_t *pairing_id, size_t length, ha_mobile_callback callback, void *context);
+int32_t ha_mobile_pairing_wake(uint64_t session, const uint8_t *pairing_id, size_t length, ha_mobile_callback callback, void *context);
+int32_t ha_mobile_relay_open(uint64_t session, const uint8_t *pairing_id, size_t length, ha_mobile_callback callback, void *context);
+int32_t ha_mobile_relay_send(uint64_t relay, const uint8_t *bytes, size_t length, ha_mobile_callback callback, void *context);
+int32_t ha_mobile_relay_receive(uint64_t relay, ha_mobile_callback callback, void *context);
+
 int32_t ha_gateway_disconnect(
     ha_gateway_result_callback callback,
     void *context

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/MobileGatewaySpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/MobileGatewaySpec.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+module Agent.CLI.MacOS.MobileGatewaySpec (spec) where
+
+import Agent.CLI.MacOS.MobileGateway (validPairingID)
+import qualified Agent.CLI.MacOS.MobileGateway as Mobile
+import Agent.CLI.GatewayClient (GatewayCredential(..), saveGatewayCredential, loadGatewayCredential)
+import Agent.CLI.MacOS.MobileGatewayBridge
+import Control.Concurrent.MVar
+import Control.Exception.Safe (bracket)
+import Foreign
+import Foreign.C.Types
+import System.Directory (getTemporaryDirectory, createDirectory, removeFile, removePathForcibly)
+import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.IO (openTempFile, hClose)
+import Test.Hspec
+
+foreign import ccall "ha_mobile_validation_smoke" nativeSmoke :: IO CInt
+foreign import ccall "wrapper" wrapCallback :: Callback -> IO (FunPtr Callback)
+
+spec :: Spec
+spec = describe "account-backed mobile gateway" do
+    it "closes only the mobile session, preserving main credentials" $ withIsolatedHome do
+        saveGatewayCredential fixtureCredential `shouldReturn` Right ()
+        bracket Mobile.openSession Mobile.closeSession $ \session -> do
+            Mobile.closeSession session
+            Mobile.listPairings session `shouldThrow` isAccountUnavailable
+            credential <- loadGatewayCredential
+            case credential of
+                Right (Just _) -> pure ()
+                _ -> expectationFailure "Main account was removed"
+    it "invalidates old sessions on account replacement before network I/O" $ withIsolatedHome do
+        saveGatewayCredential fixtureCredential `shouldReturn` Right ()
+        bracket Mobile.openSession Mobile.closeSession $ \session -> do
+            saveGatewayCredential (fixtureCredential { gatewayAccessToken = "replacement-fixture" })
+                `shouldReturn` Right ()
+            Mobile.listPairings session `shouldThrow` isAccountUnavailable
+    it "validates every native entry point without credentials" $
+        nativeSmoke `shouldReturn` 0
+    it "rejects path injection in pairing identifiers" do
+        validPairingID "01234567-89ab-cdef-0123-456789abcdef" `shouldBe` True
+        map validPairingID ["../runner", "", "01234567-89ab-cdef-0123-456789abcdef/relay"] `shouldBe` [False, False, False]
+    it "completes invalid handles with a sanitized account error" do
+        received <- newEmptyMVar
+        bracket (wrapCallback $ \_ status handle _ count _ nameCount ->
+            putMVar received (status, handle, count, nameCount)) freeHaskellFunPtr $ \callback -> do
+                ha_mobile_pairings_list 0 callback nullPtr `shouldReturn` 0
+                takeMVar received `shouldReturn` (2, 0, 0, 0)
+    it "rejects oversized frames before dereferencing input" do
+        bracket (wrapCallback $ \_ _ _ _ _ _ _ -> expectationFailure "Rejected call invoked callback")
+            freeHaskellFunPtr $ \callback -> do
+                ha_mobile_relay_send 0 nullPtr 1048577 callback nullPtr `shouldReturn` 1
+
+fixtureCredential :: GatewayCredential
+fixtureCredential = GatewayCredential "https://gateway.example" "wss://gateway.example/ws" "test-fixture"
+
+isAccountUnavailable :: Mobile.MobileFailure -> Bool
+isAccountUnavailable Mobile.AccountUnavailable = True
+isAccountUnavailable _ = False
+
+-- Sequential Hspec examples; never touch the developer's credential directory.
+withIsolatedHome :: IO a -> IO a
+withIsolatedHome action = bracket create removePathForcibly $ \home ->
+    bracket (lookupEnv "HOME") (maybe (unsetEnv "HOME") (setEnv "HOME")) $ \_ ->
+        setEnv "HOME" home >> action
+  where
+    create = do
+        temporary <- getTemporaryDirectory
+        (path, handle) <- openTempFile temporary "mobile-gateway-test"
+        hClose handle
+        removeFile path
+        createDirectory path
+        pure path

--- a/packages/agent-native-bridge/test/Spec.hs
+++ b/packages/agent-native-bridge/test/Spec.hs
@@ -15,6 +15,7 @@ import qualified Agent.CLI.McpConnectionSpec as McpConnectionSpec
 import qualified Agent.CLI.ResourceAdminSpec as ResourceAdminSpec
 #ifdef darwin_HOST_OS
 import qualified Agent.CLI.MacOS.AccountConnectionSpec as AccountConnectionSpec
+import qualified Agent.CLI.MacOS.MobileGatewaySpec as MobileGatewaySpec
 import qualified Agent.CLI.MacOS.BridgeFFISpec as BridgeFFISpec
 import qualified Agent.CLI.MacOS.BridgeHeaderSpec as BridgeHeaderSpec
 import qualified Agent.CLI.MacOS.BridgeSpec as BridgeSpec
@@ -39,6 +40,7 @@ main = hspec do
     RepositoryInputSpec.spec
 #ifdef darwin_HOST_OS
     AccountConnectionSpec.spec
+    MobileGatewaySpec.spec
     BrowserBridgeFFISpec.spec
     BridgeFFISpec.spec
     BridgeHeaderSpec.spec

--- a/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeMobileSmoke.c
+++ b/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeMobileSmoke.c
@@ -1,0 +1,16 @@
+#include "HaskellAgentBridge.h"
+
+/* No credentials or network: exercise every exported entry point. */
+int ha_mobile_validation_smoke(void) {
+    if (ha_mobile_session_open(NULL, NULL) != 1) return 1;
+    if (ha_mobile_runner_register(0, NULL, 0, NULL, 0, NULL, NULL) != 1) return 2;
+    if (ha_mobile_pairings_list(0, NULL, NULL) != 1) return 3;
+    if (ha_mobile_pairing_revoke(0, NULL, 0, NULL, NULL) != 1) return 4;
+    if (ha_mobile_pairing_wake(0, NULL, 0, NULL, NULL) != 1) return 5;
+    if (ha_mobile_relay_open(0, NULL, 0, NULL, NULL) != 1) return 6;
+    if (ha_mobile_relay_send(0, NULL, 0, NULL, NULL) != 1) return 7;
+    if (ha_mobile_relay_receive(0, NULL, NULL) != 1) return 8;
+    if (ha_mobile_handle_close(0) != 0) return 9;
+    if (ha_mobile_handle_close(0) != 0) return 10;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add typed native mobile session, runner registration, pairing, and relay operations.
- Keep gateway credentials in the runtime and invalidate mobile sessions on account replacement.
- Add C ABI validation and credential-lifecycle regression tests.

## Validation
- Native Darwin regression suite: 160 examples, 0 failures.
- Companion app validation and real-device pairing remain incomplete.

Companion: https://github.com/digitallyinduced/haskell-agent-macos/pull/244