### PR TITLE
Honor --yolo for sandbox escalation

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Approval.hs
+++ b/packages/agent-cli/src/Agent/CLI/Approval.hs
@@ -265,7 +265,10 @@ approveToolDecisionWithReporterAndPersistenceClassifiedWithPrompt
                 Nothing -> classifyReadOnly call >>= \case
                     Just True -> pure ApprovalNotRequired
                     _ -> pure ApprovalPromptRequired
+            policy <- readIORef policyRef
             let requiresExplicit = requirement == FreshApprovalRequired
+                    || (requirement == SandboxEscalationApprovalRequired
+                        && policy /= ApproveAll)
                 readOnly = requirement == ApprovalNotRequired
             let nextFacts = facts
                     { readOnly = Just readOnly
@@ -346,6 +349,9 @@ childApprove policy tools call =
     decide FreshApprovalRequired =
         pure $ Left
             "This sensitive tool requires an explicit parent approval for every call."
+    decide SandboxEscalationApprovalRequired
+        | policy /= ApproveAll =
+            pure $ Left "Sandbox escalation requires parent approval or --yolo."
     decide requirement = case scopedToolPolicy policy tools call of
         ApproveAll -> pure (Right True)
         DenyMutating ->

--- a/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ApprovalSpec.hs
@@ -31,6 +31,7 @@ import Agent.Tools.Types
     , jsonAppTool
     , mkToolRegistry
     )
+import Agent.Tools.ShellPermission (shellPermissionApproval)
 import Agent.Tools.PlanMode
     ( activatePlanMode
     , newPlanModeEnv
@@ -486,6 +487,55 @@ spec = do
                     "Blocked dangerous shell command"
                         `Text.isInfixOf` message
                 _ -> False
+
+        it "auto-approves sandbox escalation only under full access, including child calls" do
+            policy <- newIORef ApproveAll
+            allowed <- newIORef (Set.singleton "shell_command")
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/approval-test") Nothing
+            permissionRequests <- newIORef (0 :: Int)
+            let shellTool = tool "shell_command" (ClassifyApproval shellPermissionApproval)
+                tools = registry [shellTool]
+                call = functionToolCall "escalation" "shell_command"
+                    "{\"command\":\"pwd\",\"sandbox_permissions\":\"require_escalated\",\"justification\":\"Inspect directory\"}"
+                approve = approveToolDecisionWithReporterAndPersistenceClassified
+                    (const (pure (Just True)))
+                    (\_ -> modifyIORef' permissionRequests (+ 1) >> pure (Just PermissionAllowOnce))
+                    (\_ -> pure ()) (pure ()) policy allowed tools plan call
+            approve `shouldReturn` Right True
+            readIORef permissionRequests `shouldReturn` 0
+            childApprove ApproveAll tools call `shouldReturn` Right True
+            childApprove PromptMutating tools call `shouldReturn`
+                Left "Sandbox escalation requires parent approval or --yolo."
+            writeIORef policy PromptMutating
+            approve `shouldReturn` Right True
+            approve `shouldReturn` Right True
+            readIORef permissionRequests `shouldReturn` 2
+            writeIORef policy DenyMutating
+            approve `shouldReturn` Right False
+            readIORef permissionRequests `shouldReturn` 2
+            writeIORef policy ApproveAll
+            activatePlanMode plan
+            result <- approve
+            result `shouldSatisfy` either
+                (Text.isInfixOf "only editable file") (const False)
+
+        it "does not treat a tool-specific allowance as full access for escalation" do
+            policy <- newIORef PromptMutating
+            allowed <- newIORef (Set.singleton "shell_command")
+            plan <- newPlanModeEnv (unsafeEncodeUtf "/approval-test") Nothing
+            permissionRequests <- newIORef (0 :: Int)
+            let shellTool = tool "shell_command"
+                    (AutoApprove (ClassifyApproval shellPermissionApproval))
+                tools = registry [shellTool]
+                call = functionToolCall "escalation" "shell_command"
+                    "{\"command\":\"pwd\",\"sandbox_permissions\":\"require_escalated\",\"justification\":\"Inspect directory\"}"
+            approveToolDecisionWithReporter
+                (\_ -> modifyIORef' permissionRequests (+ 1) >> pure (Just PermissionDeny))
+                (\_ -> pure ()) policy allowed tools plan call
+                `shouldReturn` Right False
+            readIORef permissionRequests `shouldReturn` 1
+            childApprove PromptMutating tools call `shouldReturn`
+                Left "Sandbox escalation requires parent approval or --yolo."
 
         it "prompts for every explicit-confirmation call under ApproveAll" do
             policy <- newIORef ApproveAll

--- a/packages/agent-codex-dialect/README.md
+++ b/packages/agent-codex-dialect/README.md
@@ -6,12 +6,13 @@ formatting. Provider transport and authentication remain in `agent-openai`.
 
 `shell_command` defaults to the session sandbox. A command blocked by isolation
 may request `"sandbox_permissions":"require_escalated"` with a nonblank
-`justification`. The host must freshly approve that exact invocation; a model
+`justification`. The host must authorize that exact invocation: full access
+(`--yolo`) auto-approves it; otherwise fresh user approval is required. A model
 request alone never authorizes execution. On macOS this omits the outer
 Seatbelt wrapper while preserving the session `TMPDIR` and process lifecycle,
 allowing tools such as Swift Package Manager to apply their own sandbox.
 
 Escalation is not remembered. Nonempty `write_stdin` input to an escalated
-process also requires fresh approval, except an exact Ctrl-C cancellation.
+process follows the same approval policy, except an exact Ctrl-C cancellation.
 Reading output does not grant permission to send later input. Ordinary
 library dispatch fails closed when escalation has not been authorized.

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Tools.hs
@@ -184,7 +184,7 @@ shellCommandTool env session =
             , PropertySchema "yield_time_ms" PropertyInteger False $ Just
                 "Wait before returning a session_id for a command that is still running. Defaults to 10000 ms when neither timing control is set. Completion is reported automatically; do not repeatedly poll. Mutually exclusive with timeout_ms."
             , PropertySchema "sandbox_permissions" PropertyString False $ Just
-                "use_default (default), or require_escalated to request fresh approval to run this exact command outside the sandbox."
+                "use_default (default), or require_escalated to request authorization to run this exact command outside the sandbox. Full access (--yolo) auto-approves escalation; otherwise fresh user approval is required."
             , PropertySchema "justification" PropertyString False $ Just
                 "Required nonempty explanation when sandbox_permissions is require_escalated."
             ])
@@ -225,7 +225,7 @@ shellDescription =
     \- By default, a command that is still running after 10000 ms is retained and returned with a session_id. Completion is reported automatically; do not poll or run sleep commands while waiting.\n\
     \- Set `timeout_ms` only when the command should be stopped after a fixed runtime, or `yield_time_ms` to change the initial wait.\n\
     \- Use `write_stdin` only to send input, interrupt, inspect a current snapshot, or perform one bounded wait.\n\
-    \- If sandbox isolation blocks a required command (for example Swift package manifests), request require_escalated with a justification. This requires fresh user approval; do not automatically retry or disable isolation globally."
+    \- If sandbox isolation blocks a required command (for example Swift package manifests), request require_escalated with a justification. Full access (--yolo) auto-approves this request; otherwise fresh user approval is required. Never silently retry outside the sandbox or disable isolation globally."
 
 defaultShellYieldMs :: Int
 defaultShellYieldMs = 10000
@@ -344,7 +344,7 @@ writeStdinApproval session call =
             | maybe True (\input -> Text.null input || input == "\ETX") args.chars ->
                 pure ApprovalNotRequired
             | otherwise -> codexShellCommandIsEscalated session args.sessionId >>= \case
-                Right True -> pure FreshApprovalRequired
+                Right True -> pure SandboxEscalationApprovalRequired
                 _ -> pure ApprovalPromptRequired
         Left _ -> pure ApprovalPromptRequired
 

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -100,14 +100,14 @@ spec = describe "Codex dialect" do
                         ]
                     _ -> expectationFailure "missing shell tool"
 
-    it "requires fresh approval for escalation and rejects unapproved dispatch" do
+    it "requires exact-invocation authorization for escalation and rejects unapproved dispatch" do
         withTempDir \dir -> do
             env <- defaultToolEnv (unsafeEncodeUtf dir)
             bracket (newCodexCodingTools env Nothing Nothing) (.codexClose) \coding -> do
                 let call = functionToolCall "escalate" "shell_command"
                         "{\"command\":\"printf approved\",\"sandbox_permissions\":\"require_escalated\",\"justification\":\"Test exact command approval\",\"timeout_ms\":1000}"
                 case filter ((== "shell_command") . (.appToolName)) coding.codexAppTools of
-                    [tool] -> toolApprovalRequirement tool call `shouldReturn` FreshApprovalRequired
+                    [tool] -> toolApprovalRequirement tool call `shouldReturn` SandboxEscalationApprovalRequired
                     _ -> expectationFailure "missing shell tool"
                 denied <- dispatchToolCall testDispatchConfig (appToolHandlers coding.codexAppTools) call
                 denied.output `shouldSatisfy` Text.isInfixOf "fresh user approval"
@@ -147,7 +147,7 @@ spec = describe "Codex dialect" do
                                 ("{\"session_id\":" <> Text.pack (show sessionId) <> ",\"chars\":\"approved input\\n\",\"yield_time_ms\":1}")
                         case filter ((== "write_stdin") . (.appToolName)) coding.codexAppTools of
                             [tool] -> do
-                                toolApprovalRequirement tool input `shouldReturn` FreshApprovalRequired
+                                toolApprovalRequirement tool input `shouldReturn` SandboxEscalationApprovalRequired
                                 toolApprovalRequirement tool
                                     (functionToolCall "snapshot" "write_stdin"
                                         ("{\"session_id\":" <> Text.pack (show sessionId) <> "}"))
@@ -155,7 +155,7 @@ spec = describe "Codex dialect" do
                                 toolApprovalRequirement tool
                                     (functionToolCall "mixed-cancel" "write_stdin"
                                         ("{\"session_id\":" <> Text.pack (show sessionId) <> ",\"chars\":\"\\u0003whoami\\n\"}"))
-                                    `shouldReturn` FreshApprovalRequired
+                                    `shouldReturn` SandboxEscalationApprovalRequired
                             _ -> expectationFailure "missing stdin tool"
                         denied <- dispatchToolCall testDispatchConfig handlers input
                         denied.output `shouldSatisfy` Text.isInfixOf "fresh user approval"

--- a/packages/agent-core/src/Agent/ToolDispatch.hs
+++ b/packages/agent-core/src/Agent/ToolDispatch.hs
@@ -489,7 +489,8 @@ dispatchToolHandlerDetailed
 dispatchToolHandlerDetailed config maybeHandler call = do
     dispatchToolHandlerWithAuthorization Nothing config maybeHandler call
 
--- | Host boundary: call only after fresh user confirmation of this exact call.
+-- | Host boundary: call only after authorization of this exact call, either
+-- fresh user confirmation or full-access approval of sandbox escalation.
 -- Generic dispatch deliberately never supplies this capability.
 dispatchApprovedToolHandler
     :: ToolDispatchConfig -> Maybe ToolHandler -> ToolCall -> IO ToolCallResult

--- a/packages/agent-core/src/Agent/Tools/ShellPermission.hs
+++ b/packages/agent-core/src/Agent/Tools/ShellPermission.hs
@@ -1,5 +1,5 @@
 -- | Shell permission requests are untrusted input; execution authorization is
--- supplied separately by the host's fresh-confirmation dispatch boundary.
+-- supplied separately by the host's exact-invocation authorization boundary.
 module Agent.Tools.ShellPermission
     ( ShellPermissionRequest(..)
     , shellPermissionFieldsDecoder
@@ -47,6 +47,7 @@ shellPermissionApproval call =
         -- Resource-claim classification is not an authorization boundary:
         -- apparently read-only commands can execute configured programs.
         Right UseDefaultSandbox -> ApprovalPromptRequired
+        Right RequireEscalatedSandbox{} -> SandboxEscalationApprovalRequired
         -- Malformed requests fail closed and are rejected again by the handler.
         _ -> FreshApprovalRequired
 
@@ -65,7 +66,7 @@ shellExecutionAuthorization _ UseDefaultSandbox = Right DefaultShellExecution
 shellExecutionAuthorization (Just authorization) RequireEscalatedSandbox{} =
     Right (EscalatedShellExecution authorization)
 shellExecutionAuthorization Nothing RequireEscalatedSandbox{} =
-    Left "Sandbox escalation requires fresh user approval for this exact invocation."
+    Left "Sandbox escalation requires fresh user approval or --yolo authorization for this exact invocation."
 
 shellExecutionIsEscalated :: ShellExecutionAuthorization -> Bool
 shellExecutionIsEscalated DefaultShellExecution = False

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -130,6 +130,8 @@ data ToolAsyncCapability
 data ApprovalRequirement
     = ApprovalNotRequired
     | ApprovalPromptRequired
+    -- | Exact-invocation authorization; full-access policy may approve it.
+    | SandboxEscalationApprovalRequired
     | FreshApprovalRequired
     deriving (Eq, Show)
 
@@ -570,14 +572,15 @@ dispatchRegisteredToolCall config registry call =
         call
 
 -- | Dispatch after the host approval callback has accepted this exact call.
--- Only freshly confirmed tools receive an invocation capability.
+-- Fresh-confirmation and sandbox-escalation tools receive an invocation
+-- capability; the latter may be approved by the host's full-access policy.
 dispatchApprovedRegisteredToolCall
     :: ToolDispatchConfig -> ToolRegistry -> ToolCall -> IO ToolCallResult
 dispatchApprovedRegisteredToolCall config registry call =
     case lookupRegisteredTool call.name registry of
         Just tool -> do
             requirement <- toolApprovalRequirement tool call
-            if requirement == FreshApprovalRequired
+            if requirement `elem` [FreshApprovalRequired, SandboxEscalationApprovalRequired]
                 then dispatchApprovedToolHandler config (acceptedHandler registry call) call
                 else dispatchRegisteredToolCall config registry call
         Nothing -> dispatchRegisteredToolCall config registry call
@@ -661,11 +664,12 @@ toolRequiresExplicitApproval tool = requiresExplicit tool.appToolApproval
         AutoApprove original -> requiresExplicit original
         _ -> False
 
--- | Whether this invocation requires a fresh parent-user confirmation.
+-- | Whether this invocation requires exact-call authorization (fresh parent
+-- confirmation, or full-access policy approval for sandbox escalation).
 -- Unlike 'toolRequiresExplicitApproval', this evaluates call-sensitive rules.
 toolCallRequiresExplicitApproval :: AppTool -> ToolCall -> IO Bool
 toolCallRequiresExplicitApproval tool call =
-    (== FreshApprovalRequired) <$> toolApprovalRequirement tool call
+    (`elem` [FreshApprovalRequired, SandboxEscalationApprovalRequired]) <$> toolApprovalRequirement tool call
 
 toolAutoApproves :: AppTool -> Bool
 toolAutoApproves tool = case tool.appToolApproval of

--- a/packages/agent-core/test/Agent/ToolDispatchSpec.hs
+++ b/packages/agent-core/test/Agent/ToolDispatchSpec.hs
@@ -74,7 +74,7 @@ spec = describe "dispatchToolCall" do
                 `shouldReturn` ApprovalPromptRequired
             approval "{\"command\":\"touch file\"}" `shouldReturn` ApprovalPromptRequired
             approval "{\"command\":\"ls\",\"sandbox_permissions\":\"require_escalated\",\"justification\":\"Inspect outside sandbox\"}"
-                `shouldReturn` FreshApprovalRequired
+                `shouldReturn` SandboxEscalationApprovalRequired
             approval "{\"command\":\"ls\",\"sandbox_permissions\":\"unknown\"}"
                 `shouldReturn` FreshApprovalRequired
 

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Terminal.hs
@@ -72,7 +72,7 @@ runTerminalCmdTool session =
     , PropertySchema "background" PropertyBoolean False $ Just
         "Set to true for long-running commands that should run in the background (e.g., dev servers, long builds). Returns a task id immediately while the command keeps running in the background; you are notified on completion, so do not poll or sleep-wait for it."
     , PropertySchema "sandbox_permissions" PropertyString False $ Just
-        "use_default (default) or require_escalated. Escalation requires fresh user approval for this exact command."
+        "use_default (default) or require_escalated. Full access (--yolo) auto-approves escalation; otherwise fresh user approval is required for this exact command."
     , PropertySchema "justification" PropertyString False $ Just
         "Required nonblank explanation when sandbox_permissions is require_escalated."
     ]
@@ -104,7 +104,7 @@ terminalResourceClaims call =
 terminalDescription :: Text
 terminalDescription =
     "Run a bash command and return its output.\n\
-    \- If a command fails because of the sandbox (for example SwiftPM sandbox_apply: Operation not permitted), request require_escalated with a justification; never silently retry outside the sandbox. Approval is per command, even with auto-approval enabled.\n\
+    \- If a command fails because of the sandbox (for example SwiftPM sandbox_apply: Operation not permitted), request require_escalated with a justification; never silently retry outside the sandbox. Full access (--yolo) auto-approves this request; otherwise fresh user approval is required per command.\n\
     \- Escalated commands run from the turn cwd with a fresh shell, without replaying or updating persistent terminal cwd/environment. Use an explicit cd in the approved command if needed.\n\
     \- Always set a timeout for commands that may hang.\n\
     \- Use `$TMPDIR` as the only temporary-file root. Put task-specific subdirectories there; do not create alternate scratch directories in the home directory or workspace. Literal `/tmp` and `/private/tmp` paths are rejected.\n\

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -98,12 +98,12 @@ spec = describe "Grok Build dialect" do
                 ]
             close
 
-    it "requires fresh approval and rejects unapproved terminal escalation" do
+    it "requires exact-invocation authorization and rejects unapproved terminal escalation" do
         withGrokRegistry \registry close -> do
             let call = escalatedTerminalCall "printf approved" False
             let tool = maybe (error "missing terminal") id $
                     lookupRegisteredTool "run_terminal_cmd" registry
-            toolApprovalRequirement tool call `shouldReturn` FreshApprovalRequired
+            toolApprovalRequirement tool call `shouldReturn` SandboxEscalationApprovalRequired
             result <- dispatchRegisteredToolCall testDispatchConfig registry call
             result.output `shouldSatisfy` Text.isInfixOf "requires fresh user approval"
             close


### PR DESCRIPTION
## Summary
- Auto-approve explicit sandbox escalation under the global full-access (`--yolo`) policy, including child calls and input to escalated shell sessions.
- Preserve exact-invocation authorization, normal-mode prompts, plan-mode restrictions, and unrelated sensitive-action consent.
- Update tool guidance and regression coverage.

## Validation
- Focused GHCi suites: 141 passed, 0 failures, 14 pending because sandbox-exec was unavailable.
- Loaded 549 modules in a multi-package GHCi session.
- Live tmux: verified --yolo startup and directly exercised the escalation permission dialog and Escape denial. Model-driven end-to-end check was blocked by the provider rejecting the existing collaboration.wait_agent schema.
- git diff --check passed.