### PR TITLE
fix(openai): preserve reserved wait_agent number schema

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ToolsSpec.hs
@@ -590,7 +590,7 @@ spec = describe "schemasFromAppTools" do
 
     it "omits an empty required list from reserved collaboration schemas" do
         let wait = jsonAppTool "wait_agent" "Wait."
-                [ PropertySchema "timeout_ms" PropertyInteger False Nothing ]
+                [ PropertySchema "timeout_ms" PropertyNumber False Nothing ]
                 AlwaysReadOnly
                 (noArgsTool "wait_agent" (pure (Right "ok")))
         case schemasFromAppTools codexDialect [wait] of
@@ -686,8 +686,10 @@ spec = describe "schemasFromAppTools" do
                                 required_ tool `shouldBe` Nothing
                                 additionalProperties tool `shouldBe`
                                     Just False
+                                -- This is the provider's reserved wire schema,
+                                -- not the runtime's integer argument type.
                                 propertyType "timeout_ms" tool `shouldBe`
-                                    Just "integer"
+                                    Just "number"
                             other -> expectationFailure
                                 ("expected production wait_agent, got "
                                     <> show other)

--- a/packages/agent-core/src/Agent/Tools/MultiAgents.hs
+++ b/packages/agent-core/src/Agent/Tools/MultiAgents.hs
@@ -499,7 +499,9 @@ waitAgentArgsDecoder = objectArgsLenient \object_ -> do
 
 waitAgentTool :: MultiAgentContext -> AppTool
 waitAgentTool ctx = jsonTool "wait_agent" waitAgentDescription
-    [ PropertySchema "timeout_ms" PropertyInteger False $ Just
+    -- OpenAI reserves collaboration.wait_agent and requires type "number"
+    -- exactly, even though the runtime decodes whole milliseconds as Int.
+    [ PropertySchema "timeout_ms" PropertyNumber False $ Just
         "Timeout in milliseconds. Defaults to 30000 ms."
     ]
     True


### PR DESCRIPTION
## Summary

Restore `collaboration.wait_agent.timeout_ms` to the exact OpenAI reserved schema (`number`, not `integer`). Keep the whole-millisecond runtime decoder unchanged. Restore the production-schema regression assertion and document why the wire type intentionally differs from the runtime type.

This fixes the regression introduced by 0fbbde2857577488b346392b66aa358957420717, which inadvertently reverted the schema fix from 7cbb6e638d17c2c837b900c6a753faf860257e97.

## Reproduction

With the installed CLI at 62b1ea9, a one-turn `gpt-5.6-sol` request succeeds in default code mode but fails with `--no-code-mode`:

> Invalid Value: 'tools'. Function 'collaboration.wait_agent' is reserved for use by this model and must match the configured schema.

Default code mode hides this tool behind `exec`, avoiding the direct reserved-schema validation.

## Validation

- `git diff --check` passes.
- All 35 `Agent.CLI.ToolsSpec` tests pass through Nix/Cabal multi-package GHCi, loading both modified production code and tests.
- Live verification with the patched code loaded through GHCi: the same one-turn `gpt-5.6-sol --no-code-mode` request now returns `OK` successfully (previously rejected by the provider).
