### PR TITLE
Expose MCP server icons through the native connection API

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/McpConnectionRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpConnectionRuntime.hs
@@ -3,6 +3,8 @@ module Agent.CLI.McpConnectionRuntime
     ( mcpConnectionCredentials
     , registerMcpConnectionRuntime
     , invalidateMcpConnectionRuntimes
+    , observeMcpConnectionInfo
+    , readMcpConnectionIcons
     ) where
 
 import Agent.CLI.Config (HarnessConfig(..), McpServerConfig(..), withHarnessConfigSnapshot, harnessConfigPath, mcpUsesConnectionCredentials)
@@ -18,6 +20,27 @@ import System.IO.Unsafe (unsafePerformIO)
 import System.OsPath (takeDirectory, (</>))
 import qualified Data.Text as Text
 import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
+
+-- Process-local, bounded metadata cache. Identity, generation and endpoint
+-- must all match; a removed/replaced connection cannot inherit another icon.
+{-# NOINLINE connectionIcons #-}
+connectionIcons :: IORef (Map.Map (Text.Text, Maybe Text.Text, Maybe Text.Text) [MCP.McpIcon])
+connectionIcons = unsafePerformIO (newIORef Map.empty)
+
+observeMcpConnectionInfo :: MCP.McpServerConfig -> MCP.McpServerInfo -> IO ()
+observeMcpConnectionInfo config info = case config.mcpServerConnection of
+    Nothing -> pure ()
+    Just identity -> atomicModifyIORef' connectionIcons \current ->
+        let key = (identity.mcpConnectionIdentifier,
+                identity.mcpConnectionGeneration, config.mcpServerUrl)
+            bounded = if Map.size current >= 256 then Map.empty else current
+            icons = take 8 $ filter (\icon -> Text.length icon.iconSrc <= 262144)
+                info.serverInfoIcons
+        in (Map.insert key icons bounded, ())
+
+readMcpConnectionIcons :: Text.Text -> Maybe Text.Text -> Text.Text -> IO [MCP.McpIcon]
+readMcpConnectionIcons identifier generation endpoint =
+    Map.findWithDefault [] (identifier, generation, Just endpoint) <$> readIORef connectionIcons
 
 runtimeInvalidators :: IORef (Map.Map Unique (IO ()))
 runtimeInvalidators = unsafePerformIO (newIORef Map.empty)

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -85,7 +85,7 @@ import Agent.CLI.Timestamp (MessageClock, parseMessageClock)
 import Agent.TUI.Motion (MotionMode(..))
 import Agent.Tools.Types (defaultToolEnv)
 import qualified Agent.MCP as MCP
-import Agent.CLI.McpConnectionRuntime (mcpConnectionCredentials, registerMcpConnectionRuntime)
+import Agent.CLI.McpConnectionRuntime (mcpConnectionCredentials, registerMcpConnectionRuntime, observeMcpConnectionInfo)
 import Control.Exception.Safe (finally, mask, onException)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -128,7 +128,10 @@ newNativeProcessRuntimeWithOrganizationIntegrations provider organizationProvide
             borrowedLocalProvider organizationProvider integrationToolEnv)
             `onException` closeIntegrationSupervisor localIntegrations
     core <- restore (NativeProcess.newNativeProcessRuntimeWithMcpHooks
-        MCP.defaultMcpHostHooks { MCP.mcpHostCredentials = mcpConnectionCredentials }
+        MCP.defaultMcpHostHooks
+            { MCP.mcpHostCredentials = mcpConnectionCredentials
+            , MCP.mcpHostServerInfo = observeMcpConnectionInfo
+            }
         root) `onException` (closeIntegrationSupervisor integrations
             `finally` closeIntegrationSupervisor localIntegrations)
     unregister <- registerMcpConnectionRuntime (NativeProcess.restartNativeMcpRuntime core)

--- a/packages/agent-mcp/src/Agent/MCP/Client/Internal/Core.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Client/Internal/Core.hs
@@ -48,7 +48,7 @@ import Agent.MCP.Types
       McpServerStatus(..),
       McpInitState(McpFailed, McpClosed, McpPending, McpInitializing,
                    McpReady),
-      McpHostHooks(mcpHostElicit, mcpHostRoots, mcpHostSample),
+      McpHostHooks(mcpHostElicit, mcpHostRoots, mcpHostSample, mcpHostServerInfo),
       McpServerConfig(mcpServerEnv, mcpServerCwd, mcpServerCommand,
                       mcpServerArgs, mcpServerStartupTimeoutSeconds, mcpServerProtocol,
                       mcpServerName, mcpServerUrl, mcpServerRootsEnabled,
@@ -85,7 +85,7 @@ import Control.Concurrent.STM
       TMVar )
 import Control.Exception.Safe
     ( bracketOnError, finally, onException, tryAny, MonadMask(mask) )
-import Control.Monad ( void )
+import Control.Monad ( void, forM_ )
 import Control.Monad.Trans.Class ()
 import Control.Monad.Trans.Except ()
 import Data.Aeson ( KeyValue((.=)) )
@@ -348,6 +348,8 @@ ensureMcpClientReadyWith publishReady client = mask \restore -> do
                     closeMcpClient client
                 initialize = do
                     negotiateProtocol client
+                    info <- readTVarIO client.clientServerInfo
+                    forM_ info (client.clientHooks.mcpHostServerInfo client.clientConfig)
                     loggingWarnings <- configureLegacyLogging client
                     skillWarnings <- discoverMcpSkills client
                     startSubscriptions client

--- a/packages/agent-mcp/src/Agent/MCP/Types.hs
+++ b/packages/agent-mcp/src/Agent/MCP/Types.hs
@@ -87,6 +87,7 @@ data McpIcon = McpIcon
     { iconSrc :: !Text
     , iconMimeType :: !(Maybe Text)
     , iconSizes :: ![Text]
+    , iconTheme :: !(Maybe Text)
     } deriving (Eq, Show)
 
 mcpIconDecoder :: Json.Decoder McpIcon
@@ -94,6 +95,7 @@ mcpIconDecoder = Json.object do
     iconSrc <- Json.atKey "src" Json.text
     iconMimeType <- Json.optionalKey "mimeType" Json.text
     iconSizes <- Json.defaultKey [] "sizes" (Json.list Json.text)
+    iconTheme <- Json.optionalKey "theme" Json.text
     pure McpIcon{..}
 
 -- | A filesystem root offered by the host to an MCP server.
@@ -280,6 +282,8 @@ data McpHostHooks = McpHostHooks
     -- materialization of explicitly tagged MCP artifact resources.
     , mcpHostCredentials :: !(McpServerConfig -> IO (Maybe McpCredentialProvider))
     -- ^ Resolve by immutable server identity, never by URL alone.
+    , mcpHostServerInfo :: !(McpServerConfig -> McpServerInfo -> IO ())
+    -- ^ Observe negotiated metadata. Called on the startup worker; must not block.
     }
 
 defaultMcpHostHooks :: McpHostHooks
@@ -291,6 +295,7 @@ defaultMcpHostHooks = McpHostHooks
     , mcpHostClientVersion = "0.1.0"
     , mcpHostArtifactDirectory = Nothing
     , mcpHostCredentials = const (pure Nothing)
+    , mcpHostServerInfo = \_ _ -> pure ()
     }
 
 -- | A server's request for user input, delivered either as a legacy

--- a/packages/agent-mcp/test/Agent/MCPSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCPSpec.hs
@@ -256,6 +256,7 @@ spec = describe "Agent.MCP" do
                     { iconSrc = "https://example.com/icon.svg"
                     , iconMimeType = Just "image/svg+xml"
                     , iconSizes = ["any", "48x48"]
+                    , iconTheme = Nothing
                     }
                 ]
             icons =
@@ -269,6 +270,11 @@ spec = describe "Agent.MCP" do
                     <> icons <> "}") of
                 Left err -> expectationFailure (show err)
                 Right tool -> tool.discoveredIcons `shouldBe` expected
+        it "preserves icon appearance hints" do
+            case decode mcpToolDecoder
+                "{\"name\":\"run\",\"inputSchema\":{},\"icons\":[{\"src\":\"https://example.com/dark.png\",\"theme\":\"dark\"}]}" of
+                Left err -> expectationFailure (show err)
+                Right tool -> map (.iconTheme) tool.discoveredIcons `shouldBe` [Just "dark"]
         it "decodes prompt icons" do
             case decode mcpPromptDecoder
                 ("{\"name\":\"review\"," <> icons <> "}") of

--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -174,6 +174,7 @@ test-suite agent-native-bridge-test
                     , Agent.CLI.ResourceAdminSpec
     build-depends:    agent-native-bridge
                     , agent-cli
+                    , agent-cli-runtime
                     , agent-responses-types
                     , agent-integration-api
                     , agent-core
@@ -266,7 +267,6 @@ test-suite agent-native-bridge-test
                      , Agent.CLI.MacOS.BridgeHeaderSpec
                      , Agent.CLI.MacOS.BridgeFFISpec
         build-depends: agent-repository
-                     , agent-cli-runtime
                      , agent-openai
                      , agent-openrouter
                      , agent-xai

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/McpConnectionBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/McpConnectionBridge.hs
@@ -14,6 +14,9 @@ import Agent.CLI.MacOS.McpConnectionOperation (startMcpConnectionOperation)
 import Agent.CLI.MacOS.McpCredentialStore (ensureNativeMcpCredentialStore)
 import Agent.CLI.McpAdmin (McpAdminError(..), McpAdminSnapshot(..))
 import Agent.CLI.McpConnection
+import Agent.CLI.McpConnectionRuntime (readMcpConnectionIcons)
+import qualified Agent.MCP as MCP
+import Data.Maybe (fromMaybe)
 import Control.Monad (forM_, when)
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import qualified Data.Set as Set
@@ -33,6 +36,28 @@ type McpConnectionCallback =
 
 type McpConnectionAuthorizationCallback =
     Ptr () -> CString -> CSize -> IO ()
+
+type McpConnectionIconCallback =
+    Ptr () -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> IO ()
+
+foreign import ccall "dynamic"
+    invokeIconCallback :: FunPtr McpConnectionIconCallback -> McpConnectionIconCallback
+
+foreign export ccall ha_mcp_connections_list_with_icons
+    :: FunPtr McpConnectionCallback -> FunPtr McpConnectionIconCallback
+    -> Ptr () -> Ptr (Ptr ()) -> IO CInt
+
+ha_mcp_connections_list_with_icons
+    :: FunPtr McpConnectionCallback -> FunPtr McpConnectionIconCallback
+    -> Ptr () -> Ptr (Ptr ()) -> IO CInt
+ha_mcp_connections_list_with_icons callback icons context output = do
+    when (output /= nullPtr) (poke output nullPtr)
+    if icons == nullFunPtr then pure 1 else
+        withConnectionInputs callback output [] \_ ->
+            startConnectionResultWithIcons icons callback context output 0 do
+                home <- getHomeDirectory
+                listMcpConnections home
 
 foreign import ccall "dynamic"
     invokeConnectionCallback
@@ -167,7 +192,14 @@ startConnectionResult
     :: FunPtr McpConnectionCallback -> Ptr () -> Ptr (Ptr ()) -> CInt
     -> IO (Either McpAdminError (McpAdminSnapshot [McpConnection]))
     -> IO CInt
-startConnectionResult callback context output state action =
+startConnectionResult = startConnectionResultWithIcons nullFunPtr
+
+startConnectionResultWithIcons
+    :: FunPtr McpConnectionIconCallback
+    -> FunPtr McpConnectionCallback -> Ptr () -> Ptr (Ptr ()) -> CInt
+    -> IO (Either McpAdminError (McpAdminSnapshot [McpConnection]))
+    -> IO CInt
+startConnectionResultWithIcons icons callback context output state action =
     startMcpConnectionOperation output (ensureNativeMcpCredentialStore >> action) complete
         (emitConnectionTerminal callback context (-1) 0
             "MCP connection operation failed.")
@@ -181,6 +213,16 @@ startConnectionResult callback context output state action =
         forM_ snapshot.mcpAdminValue \connection -> do
             observed <- observedConnectionState state connection
             emitConnection callback context snapshot.mcpAdminRevision observed connection
+            when (icons /= nullFunPtr && connection.connectionEnabled) do
+                metadata <- readMcpConnectionIcons connection.connectionId
+                    connection.connectionGeneration connection.connectionUrl
+                forM_ metadata \icon ->
+                    withText connection.connectionId \identifier identifierLength ->
+                    withText icon.iconSrc \src srcLength ->
+                    withText (fromMaybe "" icon.iconMimeType) \mime mimeLength ->
+                    withText (fromMaybe "" icon.iconTheme) \theme themeLength ->
+                        invokeIconCallback icons context identifier identifierLength
+                            src srcLength mime mimeLength theme themeLength
         emitConnectionTerminal callback context 1 snapshot.mcpAdminRevision ""
 
 -- A configured endpoint (or a saved credential) is not evidence of readiness.

--- a/packages/agent-native-bridge/include/HaskellAgentBridge.h
+++ b/packages/agent-native-bridge/include/HaskellAgentBridge.h
@@ -107,6 +107,24 @@ typedef void (*ha_mcp_connection_authorization_callback)(
 int32_t ha_mcp_connections_list(
     ha_mcp_connection_callback callback, void *context, void **out_operation
 );
+/* Like list, with zero or more advertised icons after each row and before the
+ * terminal callback. No network I/O: only metadata negotiated in this process.
+ * Both callbacks are required, serial on the operation worker. UTF-8 buffers
+ * are callback-scoped; copy before returning. Empty MIME/theme means absent.
+ * Icons are untrusted: consumers must validate URLs and image content.
+ * All list status, cancellation, context and handle ownership rules apply.
+ */
+typedef void (*ha_mcp_connection_icon_callback)(
+    void *context,
+    const uint8_t *connection_id, size_t connection_id_length,
+    const uint8_t *src, size_t src_length,
+    const uint8_t *mime_type, size_t mime_type_length,
+    const uint8_t *theme, size_t theme_length
+);
+int32_t ha_mcp_connections_list_with_icons(
+    ha_mcp_connection_callback callback, ha_mcp_connection_icon_callback icons,
+    void *context, void **out_operation
+);
 int32_t ha_mcp_connection_create(
     uint64_t expected_revision,
     const uint8_t *display_name, size_t display_name_length,

--- a/packages/agent-native-bridge/src/Agent/CLI/McpConnection.hs
+++ b/packages/agent-native-bridge/src/Agent/CLI/McpConnection.hs
@@ -20,7 +20,7 @@ module Agent.CLI.McpConnection
 import Agent.CLI.Config (HarnessConfig(..), McpServerConfig(..), withHarnessConfigSnapshot, mcpUsesConnectionCredentials)
 import Agent.CLI.McpAdmin
 import Agent.CLI.McpConnectionCredentials (loadMcpConnectionRecord, saveMcpConnectionRecord, deleteMcpConnectionRecord)
-import Agent.CLI.McpConnectionRuntime (invalidateMcpConnectionRuntimes)
+import Agent.CLI.McpConnectionRuntime (invalidateMcpConnectionRuntimes, observeMcpConnectionInfo)
 import Agent.CLI.McpOAuth (McpOAuthHost(..), authorizeMcpWith, defaultLoginOptions)
 import Agent.MCP (McpProtocolPreference(..))
 import qualified Agent.MCP as MCP
@@ -91,7 +91,8 @@ probeMcpConnection server credential = do
         Right value -> value
   where
     hooks = MCP.defaultMcpHostHooks
-        { MCP.mcpHostCredentials = const $ pure $ Just MCP.McpCredentialProvider
+        { MCP.mcpHostServerInfo = observeMcpConnectionInfo
+        , MCP.mcpHostCredentials = const $ pure $ Just MCP.McpCredentialProvider
             { MCP.mcpCredentialAccessToken =
                 pure (Right ((.tokenAccessToken) . fst <$> credential))
             , MCP.mcpCredentialRefreshAccessToken =
@@ -100,7 +101,7 @@ probeMcpConnection server credential = do
         }
     runtimeConfig = MCP.McpServerConfig
         { MCP.mcpServerName = connectionServerName (fromMaybe "probe" server.mcpConnectionId)
-        , MCP.mcpServerConnection = Nothing
+        , MCP.mcpServerConnection = (\identifier -> MCP.McpConnectionIdentity identifier server.mcpConnectionGeneration Nothing) <$> server.mcpConnectionId
         , MCP.mcpServerUrl = server.mcpUrl
         , MCP.mcpServerCommand = ""
         , MCP.mcpServerArgs = []

--- a/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeMcpConnectionSmoke.c
+++ b/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeMcpConnectionSmoke.c
@@ -16,6 +16,16 @@ static void connection_callback(
     if (context) (*(int *)context)++;
 }
 
+static void icon_callback(
+    void *context, const uint8_t *identifier, size_t identifier_length,
+    const uint8_t *src, size_t src_length, const uint8_t *mime, size_t mime_length,
+    const uint8_t *theme, size_t theme_length
+) {
+    (void)identifier; (void)identifier_length; (void)src; (void)src_length;
+    (void)mime; (void)mime_length; (void)theme; (void)theme_length;
+    if (context) (*(int *)context)++;
+}
+
 static void authorization_callback(void *context, const uint8_t *url, size_t length) {
     (void)url; (void)length;
     if (context) (*(int *)context)++;
@@ -50,6 +60,12 @@ int ha_mcp_connection_validation_smoke(void) {
     if (ha_mcp_connection_authorize(0, invalid_utf8, 1, authorization_callback,
             connection_callback, &callbacks, &operation) != 2 || operation) return 10;
     ha_mcp_connection_operation_cancel(NULL);
+    if (ha_mcp_connections_list_with_icons(NULL, icon_callback,
+            &callbacks, &operation) != 1 || operation) return 12;
+    if (ha_mcp_connections_list_with_icons(connection_callback, NULL,
+            &callbacks, &operation) != 1 || operation) return 13;
+    if (ha_mcp_connections_list_with_icons(connection_callback, icon_callback,
+            &callbacks, NULL) != 1) return 14;
     ha_mcp_connection_operation_destroy(NULL);
     return callbacks ? 11 : 0;
 }


### PR DESCRIPTION
## Summary
- Observe server icon metadata from MCP initialization and retain bounded connection-scoped metadata.
- Preserve light/dark appearance hints.
- Expose icons through typed UTF-8 native callbacks without changing the existing connection-list ABI.
- Extend metadata tests and C ABI smoke coverage.

## Validation
- GHCi type-check of runtime packages passed.
- Focused icon and appearance tests passed.
- Full native build remains unverified: one build exhausted disk space; another stopped during native bridge compilation without a diagnostic.