### PR TITLE
Fix compaction recovery after interrupted connections

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/OpenAI.hs
@@ -21,9 +21,8 @@ import Agent.Loop
     )
 import qualified Agent.OpenAI.Client as OpenAIClient
 import Agent.OpenAI.LoopBackend
-    ( isOpenAiReplayUnsafeWebSocketTransportFailure
-    , isOpenAiWebSocketTransportFailure
-    , openAiAuxiliaryResponseSenderReconnecting
+    ( isOpenAiWebSocketTransportFailure
+    , openAiCompactionResponseSenderReconnecting
     , openAiBackendWithReasoningVisibility
     , openAiBackendWithTransportFallback
     , openAiResponseSenderReconnecting
@@ -94,20 +93,18 @@ lockedOpenAiSession networkRecovery gatewayOnly compactThreshold
                 request
                 previousResponseId
                 onEvent
-        sendAuxiliary request previousResponseId onEvent = do
+        sendCompaction request = do
             OpenAiPersistentConnection
                 credential
                 connectionHealthy
                 conn <-
                     readIORef activeConnection
-            openAiAuxiliaryResponseSenderReconnecting
+            openAiCompactionResponseSenderReconnecting
                 provider
                 credential
                 connectionHealthy
                 conn
                 request
-                previousResponseId
-                onEvent
         getTurnState = do
             OpenAiPersistentConnection _credential _connectionHealthy conn <-
                 readIORef activeConnection
@@ -148,17 +145,9 @@ lockedOpenAiSession networkRecovery gatewayOnly compactThreshold
                 then sendHttpCompaction request
                 else do
                     result <-
-                        sendAuxiliary request Nothing (const (pure ()))
+                        sendCompaction request
                     case result of
                         Left err
-                            | not gatewayOnly
-                            , isOpenAiReplayUnsafeWebSocketTransportFailure err -> do
-                                -- The socket is dead, so route later work over
-                                -- HTTP. Do not replay this compaction: an
-                                -- opaque checkpoint already arrived and the
-                                -- provider may have committed/billed it.
-                                writeIORef fallbackActive True
-                                pure result
                             | not gatewayOnly
                             , isOpenAiWebSocketTransportFailure err -> do
                                 writeIORef fallbackActive True

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -8,6 +8,8 @@ module Agent.OpenAI.LoopBackend
     , openAiBackendReconnecting
     , openAiAuxiliaryResponseSenderReconnecting
     , openAiAuxiliaryResponseSenderWithConnectionRecovery
+    , openAiCompactionResponseSenderReconnecting
+    , openAiCompactionResponseSenderWithConnectionRecovery
     , openAiResponseSenderReconnecting
     , openAiResponseSenderWithConnectionRecoveryWhen
     , openAiResponseSenderWithConnectionRecovery
@@ -205,6 +207,49 @@ openAiAuxiliaryResponseSenderReconnecting provider currentCredential
             currentCredential
             connectionHealthy
             conn)
+
+-- | Compaction has no streaming consumer: partial checkpoints are discarded,
+-- and only a successful response can be installed by the caller. Retrying an
+-- interrupted request can incur additional provider usage, but cannot repeat
+-- a tool execution or install two checkpoints. Keep this separate from the
+-- general auxiliary sender, whose callbacks may already have consumed output.
+openAiCompactionResponseSenderReconnecting
+    :: TokenProvider
+    -> Credential
+    -> IORef Bool
+    -> CodexConn
+    -> ResponseCreateParams
+    -> IO (Either ApiError Response)
+openAiCompactionResponseSenderReconnecting provider credential healthy conn request =
+    openAiResponseSenderWithRetryPolicy
+        transientStreamingResultPolicy
+        (const False)
+        (openAiResponseSenderReconnectingWhen
+            sendWsRequestWithEventsPreservingTurnState
+            (const False)
+            id
+            provider credential healthy conn)
+        request Nothing (const (pure ()))
+
+-- | Injectable compaction recovery. No event callback is exposed, so failed
+-- attempts cannot publish partial output before the request is replayed.
+openAiCompactionResponseSenderWithConnectionRecovery
+    :: IORef Bool
+    -> (ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> (Maybe ApiError
+        -> ResponseCreateParams
+        -> Maybe Text
+        -> (ResponseStreamEvent -> IO ())
+        -> IO (Either ApiError Response))
+    -> ResponseCreateParams
+    -> IO (Either ApiError Response)
+openAiCompactionResponseSenderWithConnectionRecovery healthy sendCurrent sendFresh request =
+    openAiResponseSenderWithConnectionRecoveryUsing
+        (const False) id healthy sendCurrent sendFresh
+        request Nothing (const (pure ()))
 
 openAiResponseSenderReconnectingWhen
     :: (CodexConn

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec/RecoverySpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec/RecoverySpec.hs
@@ -18,6 +18,64 @@ import Agent.OpenAI.LoopBackendSpec.Fixtures
 
 spec :: Spec
 spec = do
+    describe "compaction connection recovery" do
+        it "discards an interrupted checkpoint and reconnects with the original request" do
+            healthy <- newIORef True
+            requests <- newIORef []
+            let failure = ConnectionError "WebSocket receive idle timeout"
+                checkpoint = CompactionItemValue CompactionItem
+                    { itemId = Just "checkpoint-interrupted"
+                    , encryptedContent = Just "interrupted"
+                    }
+                response = testResponse "resp-recovered" [assistantItem "complete"]
+                sendCurrent request previous onEvent = do
+                    modifyIORef' requests (<> [(request, previous)])
+                    onEvent ResponseOutputItemDoneEvent
+                        { item = checkpoint
+                        , outputIndex = Just 0
+                        , sequenceNumber = Nothing
+                        }
+                    pure (Left failure)
+                sendFresh previousFailure request previous _onEvent = do
+                    previousFailure `shouldBe` Just failure
+                    readIORef healthy `shouldReturn` False
+                    modifyIORef' requests (<> [(request, previous)])
+                    pure (Right response)
+            openAiCompactionResponseSenderWithConnectionRecovery
+                healthy sendCurrent sendFresh baseParams
+                `shouldReturn` Right response
+            readIORef requests `shouldReturn`
+                [(baseParams, Nothing), (baseParams, Nothing)]
+
+        it "preserves connection errors after a fresh compaction also fails" do
+            healthy <- newIORef False
+            let failure = ConnectionError "WebSocket receive idle timeout"
+                sendCurrent _ _ _ = do
+                    expectationFailure "reused a failed connection"
+                    pure (Left failure)
+                sendFresh _ _ _ onEvent = do
+                    onEvent ResponseOutputItemDoneEvent
+                        { item = assistantItem "partial"
+                        , outputIndex = Just 0
+                        , sequenceNumber = Nothing
+                        }
+                    pure (Left failure)
+            openAiCompactionResponseSenderWithConnectionRecovery
+                healthy sendCurrent sendFresh baseParams
+                `shouldReturn` Left failure
+
+        it "does not reconnect for a rejected compaction request" do
+            healthy <- newIORef True
+            let failure = ProviderError InvalidRequestError "invalid request" Nothing
+                sendCurrent _ _ _ = pure (Left failure)
+                sendFresh _ _ _ _ = do
+                    expectationFailure "retried a permanent error"
+                    pure (Left failure)
+            openAiCompactionResponseSenderWithConnectionRecovery
+                healthy sendCurrent sendFresh baseParams
+                `shouldReturn` Left failure
+            readIORef healthy `shouldReturn` True
+
     describe "openAiBackendWithConnectionRecovery" do
         it "keeps auxiliary requests on the healthy reusable connection" do
             currentCalls <- newIORef (0 :: Int)


### PR DESCRIPTION
## Summary
- Give callback-free OpenAI compaction requests a dedicated reconnect and retry path, discarding partial output from failed attempts.
- Preserve replay protection for ordinary streamed and auxiliary responses.
- Allow existing HTTP fallback after compaction transport failures, while retaining the gateway-only restriction.

## Safety and limitations
Only a successful compaction response is installed. Retrying cannot repeat local tool execution or install partial checkpoints, but can incur additional provider usage. Retries remain bounded: prolonged outages can still exhaust the retry limit.

## Validation
- `nix develop -c cabal repl --offline agent-openai:test:agent-openai-test`: 3 compaction recovery tests and 14 existing connection recovery tests passed using `:main --match`.
- `nix develop -c cabal repl --offline agent-cli:lib:agent-cli agent-openai:lib:agent-openai`: 340 modules loaded successfully.
- `git diff --check` passed.
- No CLI UI changes.