### PR TITLE
Preserve actionable errors across background turn completion

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -13,6 +13,7 @@ module Agent.CLI.NativeRuntime
     , NativeTurnRequest(..)
     , NativeMessageClock(..)
     , StartupFailure(..)
+    , exitFailedTurn
     , closeNativeProcessRuntime
     , newNativeProcessRuntime
     , newNativeProcessRuntimeWithIntegrations
@@ -28,6 +29,7 @@ module Agent.CLI.NativeRuntime
     ) where
 
 import qualified Agent.CLI.NativeProcess as NativeProcess
+import Agent.CLI.Session.Lifecycle (exitFailedTurn)
 import Agent.CLI.Session.Runner.Execution (applyNativeInteractionMode)
 import Agent.Integration.API
     ( IntegrationSupervisor

--- a/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderTransition.hs
@@ -58,7 +58,9 @@ data ProviderTransition = ProviderTransition
 data TurnResult
     = TurnSucceeded
     | TurnCancelled
-    | TurnFailed !PendingTurn
+    | TurnFailed !Text !PendingTurn
+      -- ^ User-facing failure text and the checkpoint retained for retry.
+      -- Carry the text even when session persistence is disabled.
     | TurnRestartRequested !Text !PendingTurn
     | TurnProviderUnavailable !ApiError !PendingTurn
 

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -1,6 +1,7 @@
 -- | Pending-turn execution and turn-completion transitions.
 module Agent.CLI.Session.Lifecycle
     ( SessionContinuation(..)
+    , exitFailedTurn
     , finishTurn
     , retryFailedTurn
     , runPendingTurn
@@ -72,6 +73,15 @@ data SessionContinuation = SessionContinuation
     { resumeSession :: SessionEnv -> IO RunResult
     , resumeSessionWithDraft :: SessionEnv -> Text -> IO RunResult
     }
+
+-- | Embedded turns must return the same actionable error as the transcript,
+-- rather than terminating their host or replacing the failure with a summary.
+-- Foreground one-shot invocations have already printed the error to stderr.
+exitFailedTurn :: Bool -> Text -> IO a
+exitFailedTurn background message =
+    if background
+        then throwIO (StartupFailure message)
+        else exitFailure
 
 runPendingTurn
     :: SessionContinuation
@@ -180,15 +190,11 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
         if shouldQuitAfterTurn env exitAfter
             then pure RunQuit
             else continuation.resumeSession env
-    TurnFailed pending -> do
+    TurnFailed message pending -> do
         writeIORef env.sessionLastFailedTurn
             (Just (setPendingExitAfter exitAfter pending))
         if exitAfter
-            then
-                if env.sessionBackground
-                    then
-                        throwIO (StartupFailure "agent turn failed")
-                    else exitFailure
+            then exitFailedTurn env.sessionBackground message
             else do
                 case env.sessionFullscreen of
                     Nothing -> putTrailingNewline env.sessionRender

--- a/packages/agent-cli/src/Agent/CLI/Turn.hs
+++ b/packages/agent-cli/src/Agent/CLI/Turn.hs
@@ -809,6 +809,7 @@ finishGeneralFailureTurn executed err = do
         fullscreen = env.sessionFullscreen
         finishedAt = executed.executedFinishedAt
         failureMessage = formatLoopErrorAt finishedAt err
+        persistedFailureMessage = formatLoopErrorPersistedAt finishedAt err
     restorePlanStateAfterIncomplete
         env.sessionPlanMode
         executed.executedPreparation.preparedInitialPlanState
@@ -849,11 +850,11 @@ finishGeneralFailureTurn executed err = do
     persistIncompleteTurn
         executed
         retained
-        (formatLoopErrorPersistedAt finishedAt err)
+        persistedFailureMessage
         maybeIncompleteTurn
         (uncommittedAssistantText executed.executedLoop)
     planState <- readIORef env.sessionPlanMode.planStateRef
-    pure $ TurnFailed PendingTurn
+    pure $ TurnFailed persistedFailureMessage PendingTurn
         { pendingPromptText = request.busyPromptText
         -- The live transcript checkpoints the exact stamped inputs, including
         -- attachments, so do not retain a second potentially large copy.

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -8,8 +8,7 @@ import Agent.CLI.Turn
     , takeGrokFirstTurnContext
     )
 import Agent.CLI.TurnState
-import Agent.CLI.Session.Lifecycle (exitFailedTurn)
-import Agent.CLI.Runtime.Types (StartupFailure(..))
+import Agent.CLI.NativeRuntime (StartupFailure(..), exitFailedTurn)
 import Agent.CLI.Compaction (AutomaticCompactionBoundary(..))
 import Agent.Error (ApiError(..))
 import Agent.Loop

--- a/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TurnSpec.hs
@@ -8,6 +8,8 @@ import Agent.CLI.Turn
     , takeGrokFirstTurnContext
     )
 import Agent.CLI.TurnState
+import Agent.CLI.Session.Lifecycle (exitFailedTurn)
+import Agent.CLI.Runtime.Types (StartupFailure(..))
 import Agent.CLI.Compaction (AutomaticCompactionBoundary(..))
 import Agent.Error (ApiError(..))
 import Agent.Loop
@@ -54,6 +56,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
 import System.OsPath (unsafeEncodeUtf)
+import System.Exit (ExitCode(..))
 import Test.Hspec
 import Test.QuickCheck (elements, forAll, listOf, property, (===))
 
@@ -89,6 +92,23 @@ displayAttemptEvents =
 
 spec :: Spec
 spec = do
+    describe "exitFailedTurn" do
+        it "preserves the complete background failure and recovery guidance" do
+            let message =
+                    "The request is too large.\n"
+                        <> "Remove large attachments or run /compact, then retry."
+            exitFailedTurn True message `shouldThrow`
+                (\(StartupFailure actual) -> actual == message)
+
+        it "preserves non-ASCII failure details without escaping them" do
+            let message = "Provider unavailable: Überlastung — retry later."
+            exitFailedTurn True message `shouldThrow`
+                (\(StartupFailure actual) -> actual == message)
+
+        it "retains the foreground one-shot failure exit status" do
+            exitFailedTurn False "The request is too large." `shouldThrow`
+                (== ExitFailure 1)
+
     describe "turnInputsWithContext" do
         it "orders plan-mode, task-plan, startup, and submitted inputs" do
             turnInputsWithContext

--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -175,6 +175,7 @@ test-suite agent-native-bridge-test
                     , Agent.CLI.ResourceAdminSpec
     build-depends:    agent-native-bridge
                     , agent-cli
+                    , agent-cli-runtime
                     , agent-responses-types
                     , agent-integration-api
                     , agent-core

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeSpec.hs
@@ -23,8 +23,7 @@ import Agent.CLI.GatewayClient
     , registerGatewayCredentialInvalidatorAt
     , saveGatewayCredentialAt
     )
-import Agent.CLI.NativeRuntime (StartupFailure(..))
-import Agent.CLI.Session.Lifecycle (exitFailedTurn)
+import Agent.CLI.NativeRuntime (StartupFailure(..), exitFailedTurn)
 import Agent.CLI.MacOS.TurnEvents (turnFailedEvent)
 import Control.Concurrent
     ( newEmptyMVar

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/BridgeSpec.hs
@@ -24,6 +24,8 @@ import Agent.CLI.GatewayClient
     , saveGatewayCredentialAt
     )
 import Agent.CLI.NativeRuntime (StartupFailure(..))
+import Agent.CLI.Session.Lifecycle (exitFailedTurn)
+import Agent.CLI.MacOS.TurnEvents (turnFailedEvent)
 import Control.Concurrent
     ( newEmptyMVar
     , newMVar
@@ -40,6 +42,7 @@ import Control.Exception.Safe
     , displayException
     , throwString
     , toException
+    , tryAny
     )
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy.Char8 as LBS8
@@ -362,6 +365,21 @@ nativeTurnBoundarySpec =
 nativeFailureSpec :: Spec
 nativeFailureSpec =
     describe "native turn failures" do
+        it "delivers background turn failure guidance in the terminal event" do
+            let message =
+                    "The request is too large.\n"
+                        <> "Remove large attachments or run /compact, then retry."
+            result <- tryAny (exitFailedTurn True message :: IO ())
+            case result of
+                Right () -> expectationFailure "expected a turn failure"
+                Left exception ->
+                    turnFailedEvent "failed-turn" (nativeExceptionMessage exception)
+                        `shouldBe` Aeson.object
+                            [ "event" Aeson..= ("turn.failed" :: String)
+                            , "turnId" Aeson..= ("failed-turn" :: String)
+                            , "error" Aeson..= message
+                            ]
+
         it "displays a startup failure without its constructor wrapper" do
             displayException
                 (StartupFailure


### PR DESCRIPTION
## Summary
- Carry the formatted failure message through TurnFailed alongside the retry checkpoint.
- Return the original failure and recovery guidance to embedded clients instead of the generic agent turn failed exception.
- Preserve foreground exit behavior and add regression coverage for multiline and Unicode errors, exit status, and native terminal events.
- Expose the failure boundary through the native-runtime facade and declare the bridge test suite runtime dependency.
- Based on runtime revision 00e8f702beeec961a11af7843c66de148b0abc86 to preserve the current native interaction-mode and voice integration APIs.

## Validation
- git diff --check passed; range-diff confirms the fix is unchanged after rebasing.
- GHCi loaded all 251 CLI modules at 31fa08480bd039f6ab32b4d9888ad552e7de279c.
- Focused GHCi assertions passed for exact multiline recovery text, Unicode text, and foreground ExitFailure 1.
- CLI package tests and native/static CLI builds passed in CI; remaining checks are being monitored.