### PR TITLE
Fix cancellation deadlocks during tool cleanup

### DIFF
--- a/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
@@ -33,6 +33,7 @@ import Agent.Tools.CodeMode.Protocol
     , encodeToolSuccess
     )
 import Agent.Json (RawJson)
+import Agent.Process (terminateProcessGroup)
 import Agent.Tools.CodeMode.Host.Types
     ( Cell(..)
     , CellObservation(..)
@@ -45,6 +46,7 @@ import Agent.Tools.CodeMode.Host.Types
     , ImageDetailVisibility(..)
     , IdleWorker(..)
     , WorkerPool(..)
+    , WorkerProcessHandle(..)
     , defaultCodeModeConfig
     )
 import Agent.Tools.CodeMode.Host.Availability
@@ -124,11 +126,10 @@ import System.IO
     )
 import System.Process
     ( CreateProcess(..)
-    , ProcessHandle
     , StdStream(..)
     , createProcess
+    , getPid
     , proc
-    , terminateProcess
     , waitForProcess
     )
 newCodeModeHost :: CodeModeConfig -> IO CodeModeHost
@@ -400,7 +401,7 @@ spawnIdleWorker config =
                         "code-mode worker script was not found: "
                             <> Text.pack config.workerScript
                 Just worker -> do
-                    started <- try @_ @SomeException $ createProcess $
+                    started <- try @_ @SomeException $ createWorkerProcess $
                         (proc executable
                             [ "--smol"
                             , "--no-install"
@@ -412,6 +413,7 @@ spawnIdleWorker config =
                             , std_out = CreatePipe
                             , std_err = CreatePipe
                             , env = Just []
+                            , create_group = True
                             }
                     case started of
                         Left err ->
@@ -457,12 +459,26 @@ spawnIdleWorker config =
                             pure $ Left $ CodeModeStartupError
                                 "failed to create all code-mode worker pipes"
 
+createWorkerProcess
+    :: CreateProcess
+    -> IO (Maybe Handle, Maybe Handle, Maybe Handle, WorkerProcessHandle)
+createWorkerProcess specification =
+    bracketOnError
+        (createProcess specification)
+        (\(input, output, stderr, processHandle) -> do
+            groupId <- getPid processHandle
+            stopIncompleteProcessMaybe input output stderr
+                (WorkerProcessHandle processHandle groupId))
+        \(input, output, stderr, processHandle) -> do
+            groupId <- getPid processHandle
+            pure (input, output, stderr, WorkerProcessHandle processHandle groupId)
+
 startCellFromProcess
     :: CodeModeHost
     -> Text
     -> [CodeModeToolMetadata]
     -> Bool
-    -> (Handle, Handle, Handle, ProcessHandle, Maybe (MVar ()), Maybe (Async Text))
+    -> (Handle, Handle, Handle, WorkerProcessHandle, Maybe (MVar ()), Maybe (Async Text))
     -> IO (Either CodeModeError Cell)
 startCellFromProcess host identifier tools alreadyReady
         (input, output, stderr, processHandle, existingWriter, existingStderr) = do
@@ -906,7 +922,7 @@ releaseCell host cell = do
 
 stopCell :: Cell -> IO ()
 stopCell cell = do
-    terminateQuietly cell.cellProcess
+    terminateWorkerProcess cell.cellProcess
     cancel cell.cellMonitor
     cancelCellCallbacks cell
     closeQuietly cell.cellInput
@@ -915,17 +931,17 @@ stopCell cell = do
     void $ waitCatch cell.cellStderr
     closeQuietly cell.cellOutput
     closeQuietly cell.cellErrorOutput
-    void $ try @_ @SomeException $ waitForProcess cell.cellProcess
+    reapWorkerProcess cell.cellProcess
 
 stopIdleWorker :: IdleWorker -> IO ()
 stopIdleWorker (IdleWorker input output errOut process _ stderrReader) = do
-    terminateQuietly process
+    terminateWorkerProcess process
     closeQuietly input
     cancel stderrReader
     void $ waitCatch stderrReader
     closeQuietly output
     closeQuietly errOut
-    void $ try @_ @SomeException $ waitForProcess process
+    reapWorkerProcess process
 
 cancelCellCallbacks :: Cell -> IO ()
 cancelCellCallbacks cell = do
@@ -937,12 +953,12 @@ stopIncomplete
     :: Handle
     -> Handle
     -> Handle
-    -> ProcessHandle
+    -> WorkerProcessHandle
     -> Async ()
     -> Async Text
     -> IO ()
 stopIncomplete input output stderr processHandle monitor stderrReader = do
-    terminateQuietly processHandle
+    terminateWorkerProcess processHandle
     closeQuietly input
     cancel monitor
     cancel stderrReader
@@ -950,45 +966,45 @@ stopIncomplete input output stderr processHandle monitor stderrReader = do
     void $ waitCatch stderrReader
     closeQuietly output
     closeQuietly stderr
-    void $ try @_ @SomeException $ waitForProcess processHandle
+    reapWorkerProcess processHandle
 
 stopIncompleteProcess
     :: Handle
     -> Handle
     -> Handle
-    -> ProcessHandle
+    -> WorkerProcessHandle
     -> IO ()
 stopIncompleteProcess input output stderr processHandle = do
-    terminateQuietly processHandle
+    terminateWorkerProcess processHandle
     mapM_ closeQuietly [input, output, stderr]
-    void $ try @_ @SomeException $ waitForProcess processHandle
+    reapWorkerProcess processHandle
 
 stopIncompleteProcessMaybe
     :: Maybe Handle
     -> Maybe Handle
     -> Maybe Handle
-    -> ProcessHandle
+    -> WorkerProcessHandle
     -> IO ()
 stopIncompleteProcessMaybe input output stderr processHandle = do
-    terminateQuietly processHandle
+    terminateWorkerProcess processHandle
     mapM_ (mapM_ closeQuietly) [input, output, stderr]
-    void $ try @_ @SomeException $ waitForProcess processHandle
+    reapWorkerProcess processHandle
 
 stopIncompleteReader
     :: Handle
     -> Handle
     -> Handle
-    -> ProcessHandle
+    -> WorkerProcessHandle
     -> Async Text
     -> IO ()
 stopIncompleteReader input output stderr processHandle stderrReader = do
-    terminateQuietly processHandle
+    terminateWorkerProcess processHandle
     closeQuietly input
     cancel stderrReader
     void $ waitCatch stderrReader
     closeQuietly output
     closeQuietly stderr
-    void $ try @_ @SomeException $ waitForProcess processHandle
+    reapWorkerProcess processHandle
 
 lookupCell :: CodeModeHost -> Text -> IO (Maybe Cell)
 lookupCell host identifier =
@@ -1032,9 +1048,17 @@ readAll handle =
         (\_ _ -> Just '\xfffd')
         <$> BS.hGetContents handle
 
-terminateQuietly :: ProcessHandle -> IO ()
-terminateQuietly processHandle =
-    void $ try @_ @SomeException $ terminateProcess processHandle
+-- Escalate before joining pipe readers or reaping the process. A TERM-only
+-- shutdown can wait forever, including inside Safe.onException's
+-- uninterruptible release handler. The shared policy polls one bounded signal
+-- sequence rather than nesting timeout/race cleanup threads.
+terminateWorkerProcess :: WorkerProcessHandle -> IO ()
+terminateWorkerProcess (WorkerProcessHandle processHandle groupId) =
+    terminateProcessGroup groupId processHandle
+
+reapWorkerProcess :: WorkerProcessHandle -> IO ()
+reapWorkerProcess (WorkerProcessHandle processHandle _) =
+    void $ try @_ @SomeException $ waitForProcess processHandle
 
 closeQuietly :: Handle -> IO ()
 closeQuietly handle =

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Host/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Host/Types.hs
@@ -15,6 +15,7 @@ import qualified Data.Map.Strict as Map
 import Data.IORef (IORef)
 import Data.Text (Text)
 import System.IO (Handle)
+import System.Posix.Types (ProcessGroupID)
 import System.Process (ProcessHandle)
 
 type CodeModeToolHandler =
@@ -93,12 +94,18 @@ data CellObservation
     | CellTerminating
     | CellClosed
 
+-- Capture the group identity at acquisition: getPid can return Nothing after
+-- the direct child has exited while descendants still retain its pipes.
+data WorkerProcessHandle = WorkerProcessHandle
+    !ProcessHandle
+    !(Maybe ProcessGroupID)
+
 data Cell = Cell
     { cellIdentifier :: !Text
     , cellInput :: !Handle
     , cellOutput :: !Handle
     , cellErrorOutput :: !Handle
-    , cellProcess :: !ProcessHandle
+    , cellProcess :: !WorkerProcessHandle
     , cellWriterLock :: !(MVar ())
     , cellResult :: !(TMVar (Either CodeModeError CellOutcome))
     , cellYields :: !(TQueue Value)
@@ -113,7 +120,7 @@ data IdleWorker = IdleWorker
     !Handle
     !Handle
     !Handle
-    !ProcessHandle
+    !WorkerProcessHandle
     !(MVar ())
     !(Async Text)
 

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -77,6 +77,8 @@ import Control.Concurrent.Async
     , concurrently
     , race
     , withAsync
+    , withAsyncWithUnmask
+    , wait
     , waitCatch
     )
 import Control.Concurrent.MVar
@@ -748,7 +750,14 @@ interruptShellCommand running =
             void $ try @_ @SomeException (signalProcessGroup sigINT groupId)
 
 stopShellCommand :: RunningCommand -> IO ()
-stopShellCommand running = do
+stopShellCommand running =
+    -- Safe finalizers enter uninterruptibly masked. Give the shutdown races
+    -- an interruptible child so they can cancel their losing waits, while
+    -- keeping the entire cleanup scoped and joined by the caller.
+    withAsyncWithUnmask (\unmask -> unmask (stopRunningCommand running)) wait
+
+stopRunningCommand :: RunningCommand -> IO ()
+stopRunningCommand running = do
     closeRunningStdin running
     finished <- tryReadMVar running.runningResult
     case finished of

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -28,9 +28,15 @@ import Agent.Tools.Scheduling
     , ToolSchedulingPlan(..)
     , schedulingPlansConflict
     )
+import Agent.Tools.IO
+    ( RunningCommand(..)
+    , startShellCommandWithCompletion
+    , stopShellCommand
+    )
 import Agent.Tools.Types
     ( ApprovalRule(..)
     , ToolExecutionPolicy(..)
+    , defaultToolEnv
     , jsonAppToolWithExecution
     , toolExecutionPolicyFor
     , withAsyncToolCalls
@@ -54,16 +60,18 @@ import Codec.Picture
 import Codec.Picture.Types (convertImage)
 import qualified Codec.Compression.Zlib as Zlib
 import Control.Concurrent (forkIO, threadDelay)
-import Control.Concurrent.Async (cancel, wait, withAsync)
+import Control.Concurrent.Async (cancel, poll, wait, withAsync)
 import Control.Concurrent.MVar
     ( newEmptyMVar
     , putMVar
     , readMVar
     , takeMVar
+    , tryPutMVar
     , tryReadMVar
     )
 import qualified Control.Exception as Exception
-import Control.Monad (when)
+import qualified Control.Exception.Safe as Safe
+import Control.Monad (void, when)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Bits (complement, shiftR, xor, (.&.))
@@ -81,6 +89,7 @@ import Data.IORef
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
+import Data.Time.Clock (getCurrentTime)
 import Data.Word (Word32)
 import System.Timeout (timeout)
 import System.OsPath (unsafeEncodeUtf)
@@ -1389,6 +1398,62 @@ spec = describe "runLoop" do
             timeout concurrencyProbeMicros (wait running)
                 `shouldReturn` Just (Left (LoopCancelled []))
             readMVar handlerFinished `shouldReturn` ()
+
+    it "joins asynchronous command cleanup after provider credentials are exhausted" do
+        let workdir = unsafeEncodeUtf "."
+        env <- defaultToolEnv workdir
+        callbackStarted <- newEmptyMVar
+        callbackFinished <- newEmptyMVar
+        releaseCallback <- newEmptyMVar
+        commandStarted <- newEmptyMVar
+        releaseHandler <- newEmptyMVar
+        cleanupMask <- newEmptyMVar
+        handlerFinished <- newEmptyMVar
+        retryAt <- getCurrentTime
+        let providerFailure = CredentialsExhausted retryAt []
+            call = asyncFunctionToolCall "async-command" "command" "{}"
+            acquire =
+                startShellCommandWithCompletion env workdir "true"
+                    (\_ ->
+                        (putMVar callbackStarted () >> readMVar releaseCallback)
+                            `Safe.finally` putMVar callbackFinished ())
+                    >>= either (Safe.throwString . Text.unpack) pure
+            release command = do
+                Exception.getMaskingState >>= putMVar cleanupMask
+                stopShellCommand command
+                putMVar handlerFinished ()
+            tool = asyncNoArgsTool "command" $
+                Safe.bracket acquire release \command -> do
+                    putMVar commandStarted command
+                    readMVar releaseHandler
+                    pure (Right "unexpected completion")
+            backend = backendWithCallbacks \_ _ _ callbacks -> do
+                callbacks.onAsyncToolCall call
+                void (readMVar commandStarted)
+                readMVar callbackStarted
+                pure (Left providerFailure)
+            unblock = do
+                void (tryPutMVar releaseCallback ())
+                void (tryPutMVar releaseHandler ())
+        config0 <- testConfig backend
+        let config = config0 { loopTools = registryFromTools [tool] }
+        withAsync (runLoop config Nothing "go") \running ->
+            (do
+                timeout 3000000 (readMVar cleanupMask)
+                    `shouldReturn` Just Exception.MaskedUninterruptible
+                -- Escape can arrive while provider failure is already
+                -- unwinding the asynchronous tool-manager scope.
+                requestCancel config.loopCancel
+                timeout 3000000 (wait running)
+                    `shouldReturn` Just (Left (LoopTransport providerFailure))
+                tryReadMVar handlerFinished `shouldReturn` Just ()
+                tryReadMVar callbackFinished `shouldReturn` Just ()
+                command <- readMVar commandStarted
+                poll command.runningSupervisor
+                    >>= (`shouldSatisfy` maybe False (const True)))
+            -- Release gates before withAsync joins a regressed worker, so the
+            -- expected timeout failure cannot strand the rest of the suite.
+            `Safe.finally` unblock
 
     it "cancels promptly while an admitted async call is awaiting approval" do
         approvalStarted <- newEmptyMVar

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -34,8 +34,8 @@ import Control.Concurrent
     , tryPutMVar
     )
 import Control.Concurrent.Async (cancel, wait, withAsync)
-import Control.Exception.Safe (bracket, finally, throwIO, uninterruptibleMask_)
-import Control.Monad (void)
+import Control.Exception.Safe (bracket, finally, onException, throwIO, tryAny, uninterruptibleMask_)
+import Control.Monad (void, when)
 import Data.Aeson (Value(..))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -43,10 +43,57 @@ import qualified Data.List
 import Data.IORef
 import qualified Data.Text as Text
 import Data.Time.Clock (diffUTCTime, getCurrentTime)
-import System.Directory (doesFileExist)
+import System.Directory (doesFileExist, getTemporaryDirectory, removeFile)
 import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.IO (hClose, hPutStr, openTempFile)
+import System.Posix.Signals (nullSignal, sigKILL, signalProcess)
 import System.Timeout (timeout)
 import Test.Hspec
+
+-- Keep the failure case finite too: a regression must report a failed bound,
+-- not strand Hspec in the same uninterruptible finalizer as the application.
+assertShutdownCompletes :: IO () -> IO () -> IO ()
+assertShutdownCompletes terminateFixture shutdown =
+    withAsync shutdown \closing -> do
+        completed <- timeout 4000000 (wait closing)
+            `onException` terminateFixture
+        when (completed == Nothing) terminateFixture
+        wait closing
+        completed `shouldBe` Just ()
+
+withUnresponsiveWorker :: (CodeModeConfig -> IO () -> IO ()) -> IO ()
+withUnresponsiveWorker action = do
+    directory <- getTemporaryDirectory
+    bracket
+        (do
+            (script, handle) <- openTempFile directory "code-mode-shutdown.mjs"
+            hPutStr handle $ unlines
+                [ "import { writeFileSync } from 'node:fs';"
+                , "import { fileURLToPath } from 'node:url';"
+                , "process.on('SIGINT', () => {});"
+                , "process.on('SIGTERM', () => {});"
+                , "writeFileSync(fileURLToPath(import.meta.url) + '.pid', String(process.pid));"
+                , "console.log(JSON.stringify({jsonrpc: '2.0', method: 'ready'}));"
+                , "console.log(JSON.stringify({jsonrpc: '2.0', id: 'entered', method: 'tool/call', params: {name: 'entered', arguments: {}}}));"
+                , "process.stdin.resume();"
+                , "setInterval(() => {}, 1000);"
+                ]
+            hClose handle
+            pure script)
+        (\script -> do
+            void $ tryAny (removeFile (script <> ".pid"))
+            removeFile script)
+        \script -> do
+            let readProcessId = read <$> readFile (script <> ".pid")
+                terminateFixture = void $ tryAny $
+                    readProcessId >>= signalProcess sigKILL
+                config = (defaultCodeModeConfig script (\_ _ -> pure (Right Null)))
+                    { workerPoolSize = 1 }
+            (do
+                action config terminateFixture
+                processId <- readProcessId
+                signalProcess nullSignal processId `shouldThrow` anyIOException)
+                `finally` terminateFixture
 
 spec :: Spec
 spec = describe "code-mode Bun host" do
@@ -73,6 +120,29 @@ spec = describe "code-mode Bun host" do
                 withAsync (run (putMVar entered () >> takeMVar blocked)) \running -> do
                     timeout 5000000 (readMVar entered) `shouldReturn` Just ()
                     cancel running
+
+        it "escalates shutdown of an idle worker that ignores termination signals" $
+            withUnresponsiveWorker \config terminateFixture ->
+                assertShutdownCompletes terminateFixture $
+                    withCodeModeHost config (const (pure ()))
+
+        it "escalates cancellation of an executing worker that ignores termination signals" $
+            withUnresponsiveWorker \config terminateFixture -> do
+                entered <- newEmptyMVar
+                let activeConfig = config
+                        { workerPoolSize = 0
+                        , toolHandler = \_ _ ->
+                            putMVar entered () >> pure (Right Null)
+                        }
+                withCodeModeHost activeConfig \host ->
+                    withAsync
+                        (execCodeCell host "await new Promise(() => {});" ["entered"] 60000)
+                        \running -> (do
+                            timeout 5000000 (readMVar entered) `shouldReturn` Just ()
+                            assertShutdownCompletes terminateFixture (cancel running)
+                            terminateCodeCell host "1" `shouldReturn`
+                                Left (CodeModeUnknownCell "1"))
+                            `onException` terminateFixture
 
     it "resolves the bundled worker independently of the current directory" do
         worker <- bundledCodeModeWorkerPath

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -28,6 +28,7 @@ import Agent.Tools.IO
     , sessionTempProcessEnv
     , sessionSandboxProfile
     , startShellCommand
+    , startShellCommandWithCompletion
     , startShellCommandWithInput
     , stopShellCommand
     , writeShellCommandInput
@@ -44,9 +45,11 @@ import Agent.Tools.Types
     , setToolSessionTmp
     )
 import Control.Concurrent (forkIO, newEmptyMVar, putMVar, takeMVar, threadDelay)
-import Control.Concurrent.MVar (readMVar)
-import Control.Exception.Safe (bracket, tryIO)
-import Control.Monad (replicateM)
+import Control.Concurrent.MVar (readMVar, tryPutMVar)
+import Control.Concurrent.Async (poll, waitCatch, withAsync)
+import Control.Exception.Safe (bracket, finally, tryIO)
+import qualified Control.Exception as Exception
+import Control.Monad (replicateM, void)
 import qualified Data.ByteString.Lazy.Char8 as LBS8
 import Data.Either (isLeft, isRight)
 import Data.IORef
@@ -75,6 +78,7 @@ import System.Info (os)
 import System.Posix.Temp (mkdtemp)
 import System.Posix.Files (deviceID, fileID, getFileStatus)
 import System.Process (readProcessWithExitCode)
+import System.Timeout (timeout)
 import Test.Hspec
 
 fromFilePath = unsafeEncodeUtf
@@ -696,6 +700,34 @@ spec = describe "Agent.Tools.IO" do
             writeShellCommandInput running "hello\n" `shouldReturn` Right ()
             result <- readMVar running.runningResult
             result.commandStdout `shouldBe` "got:hello"
+
+    it "bounds supervisor shutdown from an uninterruptible finalizer" do
+        withTempDir \dir -> do
+            let osDir = fromFilePath dir
+            env <- defaultToolEnv osDir
+            callbackStarted <- newEmptyMVar
+            releaseCallback <- newEmptyMVar
+            cleanupMask <- newEmptyMVar
+            Right running <- startShellCommandWithCompletion env osDir "true" \_ -> do
+                putMVar callbackStarted ()
+                readMVar releaseCallback
+            let unblock = void (tryPutMVar releaseCallback ())
+                release = unblock >> stopShellCommand running
+            (do
+                timeout 3000000 (readMVar callbackStarted) `shouldReturn` Just ()
+                let cleanup = do
+                        Exception.getMaskingState >>= putMVar cleanupMask
+                        stopShellCommand running
+                withAsync (pure () `finally` cleanup) \stopping ->
+                    (do
+                        readMVar cleanupMask `shouldReturn` Exception.MaskedUninterruptible
+                        completed <- timeout 3000000 (waitCatch stopping)
+                        completed `shouldSatisfy` maybe False isRight
+                        poll running.runningSupervisor >>= (`shouldSatisfy` maybe False (const True)))
+                    -- Release the blocked callback before joining a regressed
+                    -- shutdown, so a test failure cannot hang the test suite.
+                    `finally` unblock)
+                `finally` release
 
     it "caps live and final background output" do
         withTempDir checkBackgroundOutputCap


### PR DESCRIPTION
## Summary
- Fix shell cleanup deadlocking inside uninterruptibly masked finalizers: run shutdown races in an explicitly unmasked, scoped child and join it before returning.
- Capture code-mode worker process groups at acquisition and escalate termination before joining readers or reaping workers, including startup rollback.
- Add regressions for masked shell shutdown, cancellation after provider credential exhaustion, and idle/executing workers that ignore INT and TERM.

## Why
An agent can remain stuck even after Esc when cleanup itself cannot accept cancellation. A shutdown race inherits the finalizer's uninterruptible mask and blocks joining its losing wait. Separately, TERM-only code-mode shutdown can wait indefinitely for a stubborn worker.

## Validation
Run through GHCi with `nix develop -c cabal repl --offline agent-core:test:agent-core-test agent-core:lib:agent-core`:
- Shell suite: 43 examples, 0 failures, 6 pending due to local sandbox limitations.
- Loop suite: 110 examples, 0 failures.
- Both stubborn-worker shutdown regressions: 2 examples, 0 failures.
- All 129 loaded modules compile; `git diff --check` passes.
- Shell shutdown and integrated cancellation regressions fail against the previous implementation and pass with this fix.

## Outstanding validation
Draft pending investigation of broader code-mode execution stalls. A focused run of `executes a fresh cell and delegates tool effects` returned `CodeModeRunning` with empty output rather than the expected `CodeModeFinished`. The broader HostSpec run was interrupted after failures; its cause and relationship to this change are not established. The passing shutdown regressions do not constitute a clean full code-mode suite.
