### PR TITLE
Align OpenAI interruption recovery with Codex

### DIFF
--- a/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
+++ b/packages/agent-claude/test/Agent/Claude/LoopBackendSpec.hs
@@ -1316,6 +1316,8 @@ spec = do
                                             _ -> pure ()
                                         , Loop.onAsyncToolCall = \_ -> pure ()
                                         , Loop.onRecoveryCheckpoint = writeIORef recovery
+                                        , Loop.onCompletedResponseItem = \_ _ -> pure ()
+                                        , Loop.onCancellationMode = const (pure ())
                                         }
                                 result <- timeout 5_000_000
                                     (backend.submitTurnWithCallbacks emptyBackendSnapshot Nothing

--- a/packages/agent-cli/src/Agent/CLI/Compaction.hs
+++ b/packages/agent-cli/src/Agent/CLI/Compaction.hs
@@ -1532,7 +1532,7 @@ autoCompactOpenAiBackendWithLimit getLimit absorbCompletedTools compactAction
         _ -> False
 
     compactThenSubmit tokenLimit oldTokens oldSnapshot oldHistory inputs
-            callbacks@(BackendCallbacks emitLoopEvent _ _) = do
+            callbacks@BackendCallbacks { onLoopEvent = emitLoopEvent } = do
         emitLoopEvent (ActivityUpdated "Compacting context…")
         -- Tool results complete protocol units that are already represented by
         -- calls in oldHistory. Put those results behind their calls before

--- a/packages/agent-core/src/Agent/Loop.hs
+++ b/packages/agent-core/src/Agent/Loop.hs
@@ -6,6 +6,7 @@
 module Agent.Loop
     ( Backend(Backend, submitTurn, submitTurnWithCallbacks)
     , BackendCallbacks(..)
+    , BackendCancellationMode(..)
     , BackendMiddleware
     , BackendContinuation(..)
     , BackendRevision(..)

--- a/packages/agent-core/src/Agent/Loop/Backend.hs
+++ b/packages/agent-core/src/Agent/Loop/Backend.hs
@@ -4,6 +4,7 @@
 module Agent.Loop.Backend
     ( Backend(Backend, submitTurn, submitTurnWithCallbacks)
     , BackendCallbacks(..)
+    , BackendCancellationMode(..)
     , BackendResult(..)
     , BackendRevision(..)
     , BackendContinuation(..)
@@ -107,6 +108,12 @@ type CallbackSubmitTurn =
     -> BackendCallbacks
     -> IO (Either ApiError BackendResult)
 
+-- | Subprocess-backed providers may need a protocol interrupt and a grace
+-- period. Streaming HTTP/WebSocket providers stop by cancelling the submission
+-- itself, which releases the response transport.
+data BackendCancellationMode = InterruptThenCancel | CancelSubmission
+    deriving (Eq, Show)
+
 data BackendCallbacks = BackendCallbacks
     { onLoopEvent :: !(LoopEvent -> IO ())
     , onAsyncToolCall :: !(ToolCall -> IO ())
@@ -115,6 +122,16 @@ data BackendCallbacks = BackendCallbacks
     -- channel: partial deltas, reasoning and raw protocol data do not belong
     -- here. The loop publishes the bounded summary only if submission fails.
     , onRecoveryCheckpoint :: !(Text -> IO ())
+    -- | Journal an independently completed output item for interruption
+    -- recovery. Providers must not send partial deltas here. This does not
+    -- commit a response ID or execute a blocking tool call; successful turns
+    -- still use the authoritative BackendResult instead of this journal.
+    -- The optional tool call must be the decoded call represented by the item.
+    , onCompletedResponseItem :: !(ResponseItem -> Maybe ToolCall -> IO ())
+    -- | Select cancellation for this submission before starting provider I/O.
+    -- A callback keeps this policy intact through backend middleware and
+    -- dynamic provider switching. The default is InterruptThenCancel.
+    , onCancellationMode :: !(BackendCancellationMode -> IO ())
     }
 
 data Backend = BackendInternal
@@ -144,6 +161,8 @@ backendWithCallbacks callbackSubmit =
             { onLoopEvent = onEvent
             , onAsyncToolCall = const (pure ())
             , onRecoveryCheckpoint = const (pure ())
+            , onCompletedResponseItem = \_ _ -> pure ()
+            , onCancellationMode = const (pure ())
             }
 
 data BackendStateStore = BackendStateStore

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -98,7 +98,7 @@ import Data.IntMap.Strict (IntMap)
 import qualified Data.IntSet as IntSet
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.List (sortOn)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -555,26 +555,31 @@ submitLoopTurn
 submitLoopTurn runtime cursor = do
     let config = runtime.loopRuntimeConfig
     visibleAttempts <- newIORef (False, False)
+    cancellationMode <- newIORef InterruptThenCancel
     -- The callback belongs to this submission, not to the backend process.
     -- Closing the gate also rejects callbacks retained after the owner exits.
-    recovery <- newMVar (True, Nothing)
-    let checkpoint text = modifyMVar_ recovery \(active, previous) ->
+    recovery <- newMVar (True, Nothing, [])
+    let checkpoint text = modifyMVar_ recovery \(active, previous, items) ->
             if active
                 then let bounded = Text.copy (Text.take 32768 text)
-                     in bounded `seq` pure (active, Just bounded)
-                else pure (active, previous)
-        clearRecovery = modifyMVar_ recovery \(active, _) ->
-            pure (active, Nothing)
-        closeRecovery = modifyMVar recovery \(_, summary) ->
-            pure ((False, Nothing), summary)
+                     in bounded `seq` pure (active, Just bounded, items)
+                else pure (active, previous, items)
+        completedItem item call = modifyMVar_ recovery \(active, summary, items) ->
+            pure (active, summary, if active then (item, call) : items else items)
+        clearRecovery = modifyMVar_ recovery \(active, _, _) ->
+            pure (active, Nothing, [])
+        closeRecovery = modifyMVar recovery \(_, summary, items) ->
+            pure ((False, Nothing, []), (summary, reverse items))
         publishRecovery = do
-            summary <- closeRecovery
+            (summary, items) <- closeRecovery
             current <- config.loopBackendState.readBackendState
             -- A compaction/reset owns its newer checkpoint. Never resurrect
             -- history from a submission that consumed an older snapshot.
-            case summary of
-                Just text
-                    | not (Text.null (Text.strip text))
+            let summaryText = fromMaybe "" summary
+                hasSummary = not (Text.null (Text.strip summaryText))
+            case () of
+                _
+                    | hasSummary || not (null items)
                     , current == cursor.cursorState -> do
                         let note = Text.unlines
                                 [ "<turn_aborted>"
@@ -583,7 +588,7 @@ submitLoopTurn runtime cursor = do
                                 , "External side effects may already exist. Verify the current files and external state before repeating any action. Unfinished operations have unknown outcomes."
                                 , "Resume this work only if the user asks."
                                 , "<interrupted_work>"
-                                , text
+                                , summaryText
                                 , "</interrupted_work>"
                                 , "</turn_aborted>"
                                 ]
@@ -591,14 +596,17 @@ submitLoopTurn runtime cursor = do
                                 current
                                 (current.backendItems
                                     <> turnInputsToItems cursor.cursorInputs
-                                    <> turnInputsToItems [UserMessage note])
+                                    <> map fst items
+                                    <> if hasSummary
+                                        then turnInputsToItems [UserMessage note]
+                                        else [])
                                 Nothing
                         committed <-
                             config.loopBackendState.commitBackendState candidate
                         acknowledgeManagedTools
                             (asyncToolManager runtime)
                             cursor.cursorInputs
-                            []
+                            (catMaybes (map snd items))
                         writeIORef runtime.loopRuntimeProgressRef
                             (committed, ResponseCommitted)
                         writeIORef runtime.loopRuntimePendingRef []
@@ -640,12 +648,16 @@ submitLoopTurn runtime cursor = do
                     BackendCallbacks
                         { onLoopEvent = onBackendEvent
                         , onAsyncToolCall = \call ->
-                            withMVar recovery \(active, _) ->
+                            withMVar recovery \(active, _, _) ->
                                 when active $
                                     admitAsyncToolCall
                                         (asyncToolManager runtime)
                                         call
                         , onRecoveryCheckpoint = checkpoint
+                        , onCompletedResponseItem = completedItem
+                        , onCancellationMode = \mode ->
+                            withMVar recovery \(active, _, _) ->
+                                when active (writeIORef cancellationMode mode)
                         })
             \submission -> do
                 result <- restore $ race
@@ -656,10 +668,13 @@ submitLoopTurn runtime cursor = do
                         -- Give structured providers a chance to preserve their
                         -- subprocess/session invariants before withAsync
                         -- force-cancels an unresponsive submission.
-                        _ <- restore $
-                            timeout 2000000 (tryAny config.loopInterrupt)
-                        _ <- restore $
-                            timeout 2000000 (waitCatch submission)
+                        mode <- readIORef cancellationMode
+                        when (mode == InterruptThenCancel) do
+                            _ <- restore $
+                                timeout 2000000 (tryAny config.loopInterrupt)
+                            _ <- restore $
+                                timeout 2000000 (waitCatch submission)
+                            pure ()
                         pure (Left ())
                     Right (Left exception) ->
                         -- Preserve the provider thread's asynchronous-exception

--- a/packages/agent-core/src/Agent/Transport/WebSocket.hs
+++ b/packages/agent-core/src/Agent/Transport/WebSocket.hs
@@ -6,6 +6,7 @@ module Agent.Transport.WebSocket
     , WebSocketSessionOptions(..)
     , defaultWebSocketSessionOptions
     , withWebSocketSession
+    , withOwnedWebSocketSession
     , closeWebSocketSession
     , withWebSocketRequest
     , withWebSocketRequestWithTimeout
@@ -27,7 +28,7 @@ import Agent.Retry
     ( ExceptionRetry(..)
     , retryingBeforeCommit
     )
-import Control.Concurrent.Async (withAsync)
+import Control.Concurrent.Async (waitCatchSTM, withAsync)
 import Control.Concurrent.STM
 import qualified Control.Exception as Exception
 import qualified Control.Exception.Safe as Safe
@@ -121,6 +122,48 @@ withWebSocketSession options connection action =
     withClientPings inner = case options.clientPingIntervalSeconds of
         Just seconds | seconds > 0 -> WS.withPingThread connection seconds (pure ()) inner
         _ -> inner
+
+-- | Own the physical connection independently of the caller's session action.
+-- An abandoned response ends the connection scope immediately, cancelling the
+-- pumps and releasing the socket even when the caller keeps the logical session
+-- alive. The connector must bracket its physical transport; merely returning a
+-- borrowed 'WS.Connection' cannot provide this guarantee.
+--
+-- The owner is scoped to this call, including during connection establishment.
+-- Setup exceptions propagate before the session action starts. Once published,
+-- connection failures are observed through the session's normal error state.
+withOwnedWebSocketSession
+    :: WebSocketSessionOptions
+    -> ((WS.Connection -> IO ()) -> IO ())
+    -> (WebSocketSession -> IO value)
+    -> IO value
+withOwnedWebSocketSession options connect action = do
+    published <- newEmptyTMVarIO
+    let ownConnection =
+            connect (\connection ->
+                withWebSocketSession options connection \session -> do
+                    atomically (putTMVar published session)
+                    atomically do
+                        state <- readTVar session.sessionState
+                        case state of
+                            SessionClosed{} -> pure ()
+                            SessionPoisoned{} -> pure ()
+                            _ -> retry)
+                `Safe.finally` atomically do
+                    available <- tryReadTMVar published
+                    case available of
+                        Just session -> closeSession session
+                            (ConnectionError "WebSocket connection owner stopped")
+                        Nothing -> pure ()
+    withAsync ownConnection \owner -> do
+        ready <- atomically $
+            (Right <$> readTMVar published)
+                `orElse` (Left <$> waitCatchSTM owner)
+        case ready of
+            Right session -> action session
+            Left (Left exception) -> Exception.throwIO exception
+            Left (Right ()) -> Safe.throwIO $
+                userError "WebSocket connector returned without a connection"
 
 -- | Close an idle reusable session and ask the writer pump to close the
 -- underlying WebSocket. Active requests observe the supplied connection error.

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -88,6 +88,80 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "runLoop" do
+    describe "completed output recovery" do
+        it "retains completed items on an exception and ignores late callbacks" do
+            escaped <- newEmptyMVar
+            let backend = backendWithCallbacks \_ _ _ callbacks -> do
+                    callbacks.onCompletedResponseItem stateMarker Nothing
+                    putMVar escaped callbacks.onCompletedResponseItem
+                    Exception.throwIO (userError "stream stopped")
+            config <- testConfig backend
+            execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+            execution.executionState `shouldBe`
+                (turnInputsToItems [UserMessage "hello"] <> [stateMarker])
+            late <- takeMVar escaped
+            late stateMarker Nothing
+            stored <- config.loopBackendState.readBackendState
+            stored.backendItems `shouldBe` execution.executionState
+            stored.backendContinuation `shouldBe` Nothing
+
+        it "retains the actual async result for a recovered completed call after cancellation" do
+            finished <- newEmptyMVar
+            joined <- newEmptyMVar
+            invocations <- newIORef (0 :: Int)
+            let call = asyncFunctionToolCall "saved" "save" "{}"
+                item = either (error . show) id $
+                    Json.decodeEither responseItemDecoder
+                        "{\"type\":\"function_call\",\"call_id\":\"saved\",\"name\":\"save\",\"arguments\":\"{}\",\"status\":\"completed\",\"async\":true}"
+                completed = (functionResult "saved" "file saved exactly once")
+                    { toolResultMode = AsyncToolCall }
+                tool = asyncNoArgsTool "save" do
+                    modifyIORef' invocations (+ 1)
+                    pure (Right "file saved exactly once")
+                backend = backendWithCallbacks \_ _ _ callbacks ->
+                    (do
+                        callbacks.onCancellationMode CancelSubmission
+                        callbacks.onCompletedResponseItem item (Just call)
+                        callbacks.onAsyncToolCall call
+                        threadDelay maxBound
+                        pure (Left (ConnectionError "unexpected provider return")))
+                    `Exception.finally` putMVar joined ()
+            config0 <- testConfig backend
+            let config = config0
+                    { loopTools = registryFromTools [tool]
+                    , loopOnEvent = \case
+                        ToolFinished result -> putMVar finished result
+                        _ -> pure ()
+                    }
+            withAsync (runLoopInputsDetailed config Nothing [UserMessage "fix it"]) \running -> do
+                timeout concurrencyProbeMicros (takeMVar finished)
+                    `shouldReturn` Just completed
+                requestCancel config.loopCancel
+                execution <- timeout concurrencyProbeMicros (wait running)
+                    >>= maybe (fail "cancel did not join the provider") pure
+                execution.executionProgress `shouldBe` ResponseCommitted
+                execution.executionState `shouldBe`
+                    (turnInputsToItems [UserMessage "fix it"] <> [item])
+                execution.executionPendingInputs `shouldBe` [CompletedTool completed]
+                execution.executionResult `shouldBe` Left (LoopCancelled [completed])
+                stored <- config.loopBackendState.readBackendState
+                stored.backendItems `shouldBe` execution.executionState
+                stored.backendContinuation `shouldBe` Nothing
+                tryReadMVar joined `shouldReturn` Just ()
+            readIORef invocations `shouldReturn` 1
+
+        mapM_ (\event ->
+            it ("discards completed items on " <> show event) do
+                let backend = backendWithCallbacks \_ _ _ callbacks -> do
+                        callbacks.onCompletedResponseItem stateMarker Nothing
+                        callbacks.onLoopEvent event
+                        pure (Left (ConnectionError "offline"))
+                config <- testConfig backend
+                execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+                execution.executionState `shouldBe` []
+                execution.executionProgress `shouldBe` NoResponseCommitted)
+            [ResponseAttemptDiscarded, ResponseRestarted "retry"]
+
     describe "interruption recovery checkpoints" do
         it "retains explicit recovery separately from unfinished display output" do
             let backend = backendWithCallbacks \_ _ _ callbacks -> do
@@ -172,6 +246,7 @@ spec = describe "runLoop" do
             reset <- newEmptyMVar
             let backend = backendWithCallbacks \_ _ _ callbacks -> do
                     callbacks.onRecoveryCheckpoint "obsolete work"
+                    callbacks.onCompletedResponseItem stateMarker Nothing
                     joinReset <- takeMVar reset
                     joinReset
                     pure (Left (ConnectionError "offline"))

--- a/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
+++ b/packages/agent-core/test/Agent/Transport/WebSocketSpec.hs
@@ -15,6 +15,7 @@ import Control.Concurrent
     , writeChan
     )
 import Control.Exception (Exception, SomeException, finally, throwIO, toException)
+import Control.Concurrent.Async (cancel, wait, withAsync)
 import qualified Control.Exception.Safe as Safe
 import Control.Retry
     ( RetryPolicyM
@@ -31,6 +32,7 @@ import Data.IORef
 import qualified Network.Connection as Connection
 import qualified Network.TLS as TLS
 import qualified Network.WebSockets as WS
+import qualified Network.WebSockets.Connection as WSConnection
 import qualified Network.WebSockets.Stream as WSStream
 import System.Timeout (timeout)
 import Test.Hspec
@@ -280,6 +282,83 @@ spec = describe "Agent.Transport.WebSocket" do
                         (ConnectionError
                             "WebSocket session invalidated: response consumer interrupted")
 
+    it "keeps an owned transport reusable after completed responses and closes it on scope exit" do
+        withConnectionPairAndClose \client server closeClient -> do
+            released <- newIORef False
+            let connect use =
+                    use client `finally` (closeClient >> writeIORef released True)
+                exchanges = [("first", "first response"), ("second", "second response")]
+            withAsync (serveRoundTrips server exchanges) \serverWorker -> do
+                withOwnedWebSocketSession testSessionOptions connect \session -> do
+                    withWebSocketRequest session (roundTrip "first")
+                        `shouldReturn` Right "first response"
+                    readIORef released `shouldReturn` False
+                    withWebSocketRequest session (roundTrip "second")
+                        `shouldReturn` Right "second response"
+                    readIORef released `shouldReturn` False
+                wait serverWorker
+            readIORef released `shouldReturn` True
+
+    it "releases an owned transport after cancellation while the session action remains alive" do
+        withConnectionPairAndClose \client server closeClient -> do
+            firstFrame <- newEmptyMVar
+            never <- newEmptyMVar
+            released <- newEmptyMVar
+            let connect use =
+                    use client `finally` (closeClient >> putMVar released ())
+            withOwnedWebSocketSession testSessionOptions connect \session -> do
+                withAsync (cancelledRequest session firstFrame never) \worker -> do
+                    assertFirstFrame server firstFrame
+                    assertQueuedFrame server
+                    cancel worker
+                requireWithin "owned transport was not released" (takeMVar released)
+                withWebSocketRequest session receiveWebSocketData
+                    `shouldReturn` Left
+                        (ConnectionError
+                            "WebSocket session invalidated: response consumer interrupted")
+
+    it "releases an owned transport without waiting for a blocked writer or close handshake" do
+        withConnectionPairAndClose \client _server closeClient -> do
+            writing <- newEmptyMVar
+            never <- newEmptyMVar
+            writerStopped <- newEmptyMVar
+            released <- newEmptyMVar
+            let blockedClient = client
+                    { WSConnection.connectionWrite = \_ ->
+                        (putMVar writing () >> takeMVar never)
+                            `finally` putMVar writerStopped ()
+                    }
+                connect use =
+                    use blockedClient `finally` (closeClient >> putMVar released ())
+            withOwnedWebSocketSession testSessionOptions connect \session -> do
+                withAsync (withWebSocketRequest session \request ->
+                    sendWebSocketText request "request") \worker -> do
+                    requireWithin "writer did not start" (takeMVar writing)
+                    cancel worker
+                requireWithin "writer was not joined" (takeMVar writerStopped)
+                requireWithin "blocked writer retained transport" (takeMVar released)
+
+    it "propagates owned connection establishment failures before invoking the session action" do
+        called <- newIORef False
+        withOwnedWebSocketSession testSessionOptions
+            (\_ -> throwIO UnexpectedConnectFailure)
+            (\_ -> writeIORef called True)
+            `shouldThrow` (\UnexpectedConnectFailure -> True)
+        readIORef called `shouldReturn` False
+
+    it "joins a cancelled owned connection attempt" do
+        connecting <- newEmptyMVar
+        never <- newEmptyMVar
+        released <- newEmptyMVar
+        let connect _ =
+                (putMVar connecting () >> takeMVar never)
+                    `finally` putMVar released ()
+        withAsync (withOwnedWebSocketSession testSessionOptions connect
+            (\_ -> expectationFailure "unexpected connected session")) \worker -> do
+            requireWithin "connection attempt did not start" (takeMVar connecting)
+            cancel worker
+        requireWithin "connection attempt was not joined" (takeMVar released)
+
 transientHandshakeException :: Int -> SomeException
 transientHandshakeException status =
     toException $ WS.MalformedResponse responseHead "Wrong response status"
@@ -446,7 +525,13 @@ testSessionOptions = defaultWebSocketSessionOptions
     }
 
 withConnectionPair :: (WS.Connection -> WS.Connection -> IO value) -> IO value
-withConnectionPair action = do
+withConnectionPair action =
+    withConnectionPairAndClose \client server _ -> action client server
+
+withConnectionPairAndClose
+    :: (WS.Connection -> WS.Connection -> IO () -> IO value)
+    -> IO value
+withConnectionPairAndClose action = do
     clientToServer <- newChan
     serverToClient <- newChan
     clientStream <- makeChannelStream serverToClient clientToServer
@@ -464,7 +549,7 @@ withConnectionPair action = do
         []
     server <- requireWithin "timed out creating server connection" (takeMVar serverResult)
         >>= either throwIO pure
-    action client server `finally` do
+    action client server (WSStream.close clientStream) `finally` do
         WSStream.close clientStream
         WSStream.close serverStream
 

--- a/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/LoopBackend.hs
@@ -45,6 +45,7 @@ import qualified Agent.Responses.LoopBackend as Responses
 import Agent.Loop
     ( Backend(..)
     , BackendCallbacks(..)
+    , BackendCancellationMode(..)
     , BackendContinuation(..)
     , BackendMiddleware
     , BackendResult(..)
@@ -666,6 +667,27 @@ isOpenAiReplayUnsafeWebSocketTransportFailure = \case
         errorType == replayUnsafeWebSocketTransportType
     _ -> False
 
+-- A done event can also finish an explicitly incomplete item. Only retain
+-- supported, independently complete output; never replay truncated arguments
+-- or an unfinished assistant message as if it had completed.
+isCompletedOutputItem :: ResponseItem -> Bool
+isCompletedOutputItem = \case
+    MessageItem item -> complete item.status
+    FunctionCallItem item -> complete item.status
+    CustomToolCallItem item -> complete item.status
+    ComputerCallItem item -> complete item.computerCallStatus
+    ReasoningItemValue item -> complete item.status
+    LocalShellCallItem item -> complete item.status
+    ToolSearchCallItem item -> completeText item.status
+    ToolSearchOutputItem item -> completeText item.status
+    WebSearchCallItem item -> completeText item.status
+    ImageGenerationCallItem item -> completeText item.status
+    CompactionItemValue{} -> True
+    _ -> False
+  where
+    complete = maybe True (== ItemCompleted)
+    completeText = maybe True (== "completed")
+
 -- | Reset Codex sticky-routing state when a backend submission starts a new
 -- logical turn, while preserving it for tool continuations in the same turn.
 --
@@ -782,6 +804,7 @@ openAiBackendWithRetryPoliciesAndReasoningVisibility
 openAiBackendWithRetryPoliciesAndReasoningVisibility
         showRawReasoning transientPolicy reconnectPolicy send getParams =
     backendWithCallbacks \snapshot legacyPreviousResponseId inputs callbacks -> do
+        callbacks.onCancellationMode CancelSubmission
         baseParams <- sanitizeCodexRequest <$> getParams
         let history = snapshot.backendItems
             previousResponseId =
@@ -840,6 +863,15 @@ openAiBackendWithRetryPoliciesAndReasoningVisibility
                 , attemptObservation = emptyAttemptObservation
                 }
             result <- send request previousResponseId \event -> do
+                -- Like Codex, retain independently completed items even when
+                -- the response itself never reaches response.completed. Text
+                -- deltas remain display-only; no continuation is checkpointed.
+                case event of
+                    ResponseOutputItemDoneEvent { item }
+                        | isCompletedOutputItem item ->
+                        callbacks.onCompletedResponseItem item
+                            (Responses.responseItemToToolCall item)
+                    _ -> pure ()
                 loopEvents <- atomicModifyIORef' attemptState $
                     openAiAttemptStep showRawReasoning event
                 mapM_ (\loopEvent -> do
@@ -858,7 +890,8 @@ openAiBackendWithRetryPoliciesAndReasoningVisibility
                     ) loopEvents
                 case event of
                     ResponseOutputItemDoneEvent { item }
-                        | Just call <- Responses.responseItemToToolCall item
+                        | isCompletedOutputItem item
+                        , Just call <- Responses.responseItemToToolCall item
                         , AsyncToolCall <- toolCallMode call -> do
                             atomicModifyIORef' attemptState \state ->
                                 (state { attemptObservation =

--- a/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/WebSocketClient.hs
@@ -416,14 +416,13 @@ runConnectionAttemptWithPolicyAndTurnState retryPolicy sharedTurnState
             WebSocket.retryTransientWsConnectWithPolicy
                 retryPolicy
                 \connected ->
-                    runCredentialWebSocket endpoint headers \conn -> do
+                    WebSocket.withOwnedWebSocketSession
+                        WebSocket.defaultWebSocketSessionOptions
+                        (runCredentialWebSocket endpoint headers)
+                        \session -> do
                         connected
-                        WebSocket.withWebSocketSession
-                            WebSocket.defaultWebSocketSessionOptions
-                            conn
-                            (\session -> do
-                                turnState <- maybe newCodexTurnState pure sharedTurnState
-                                action (CodexWsConn session turnState) credential)
+                        turnState <- maybe newCodexTurnState pure sharedTurnState
+                        action (CodexWsConn session turnState) credential
 
 data WebSocketEndpoint = WebSocketEndpoint
     { endpointSecure :: !Bool

--- a/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec/StateSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LoopBackendSpec/StateSpec.hs
@@ -5,21 +5,106 @@ import Agent.Error
     , ErrorType(..)
     )
 import Agent.Loop
+import Agent.Cancel (requestCancel)
 import Agent.OpenAI.Error (mkOpenAIError)
 import Agent.OpenAI.LoopBackend
 import Agent.Responses.Request (stripReplayedItemStatus)
 import Agent.Responses.Types
 import Agent.ToolDispatch
 import Control.Monad (forM_)
+import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import qualified Control.Exception as Exception
 import Control.Retry (constantDelay, limitRetries)
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.IORef
 import qualified Data.Text as Text
 import Test.Hspec
+import System.Timeout (timeout)
 import Agent.OpenAI.LoopBackendSpec.Fixtures
 
 spec :: Spec
 spec = do
+    describe "OpenAI interruption recovery" do
+        it "replays completed items without a response ID after cancellation, not partial text" do
+            ready <- newEmptyMVar
+            release <- newEmptyMVar
+            requests <- newIORef []
+            joined <- newIORef False
+            let complete = assistantItem "finished commentary"
+                pending = functionCallItem "pending" "read_file" "{}"
+                send request previous onEvent = do
+                    modifyIORef' requests (<> [(inputItems request, previous)])
+                    onEvent ResponseOutputItemDoneEvent
+                        { item = complete, outputIndex = Just 0, sequenceNumber = Nothing }
+                    onEvent ResponseOutputItemDoneEvent
+                        { item = pending, outputIndex = Just 1, sequenceNumber = Nothing }
+                    onEvent (deltaEvent EventOutputTextDelta "unfinished final answer")
+                    putMVar ready ()
+                    takeMVar release `Exception.finally` writeIORef joined True
+                    pure (Left (ConnectionError "interrupted"))
+                backend = openAiBackendWithRetryPolicies
+                    (limitRetries 0) (limitRetries 0) send (pure baseParams)
+                history = turnInputsToItems [UserMessage "earlier"]
+                snapshot = advanceBackendSnapshot emptyBackendSnapshot history
+                    (Just (BackendContinuation "openai.responses" "previous-complete"))
+            config0 <- loopConfig backend
+            _ <- config0.loopBackendState.commitBackendState snapshot
+            let config = config0 { loopInterrupt = expectationFailure "OpenAI must cancel the stream directly" }
+            withAsync (runLoopInputsDetailed config Nothing [UserMessage "continue"]) \running -> do
+                timeout 1000000 (takeMVar ready) `shouldReturn` Just ()
+                requestCancel config.loopCancel
+                result <- timeout 1000000 (wait running)
+                execution <- maybe (expectationFailure "OpenAI cancellation waited for a grace period" >> fail "timeout") pure result
+                readIORef joined `shouldReturn` True
+                execution.executionResult `shouldBe` Left (LoopCancelled [])
+                execution.executionState `shouldBe`
+                    (history <> turnInputsToItems [UserMessage "continue"] <> [complete, pending])
+                execution.executionProgress `shouldBe` ResponseCommitted
+                show execution.executionState `shouldNotContain` "unfinished final answer"
+            recovered <- config.loopBackendState.readBackendState
+            recovered.backendContinuation `shouldBe` Nothing
+            let next = openAiBackendWith
+                    (\request previous _ -> do
+                        modifyIORef' requests (<> [(inputItems request, previous)])
+                        pure (Right (testResponse "next-complete" [assistantItem "done"])))
+                    (pure baseParams)
+            _ <- next.submitTurn recovered Nothing [UserMessage "go"] (const (pure ()))
+            seen <- readIORef requests
+            map snd seen `shouldBe` [Just "previous-complete", Nothing]
+            fst (last seen) `shouldBe` map stripReplayedItemStatus
+                (recovered.backendItems <> turnInputsToItems [UserMessage "go"])
+
+        it "does not duplicate journaled items when the whole response succeeds" do
+            let complete = assistantItem "done"
+                send _ _ onEvent = do
+                    onEvent ResponseOutputItemDoneEvent
+                        { item = complete, outputIndex = Just 0, sequenceNumber = Nothing }
+                    pure (Right (testResponse "complete" [complete]))
+            config <- loopConfig (openAiBackendWith send (pure baseParams))
+            execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+            execution.executionState `shouldBe`
+                (turnInputsToItems [UserMessage "hello"] <> [complete])
+            snapshot <- config.loopBackendState.readBackendState
+            backendContinuationToken "openai.responses" snapshot `shouldBe` Just "complete"
+
+        it "does not recover partial deltas or explicitly incomplete done items" do
+            let unfinished item = case item of
+                    MessageItem message -> MessageItem message { status = Just ItemIncomplete }
+                    FunctionCallItem call -> FunctionCallItem call { status = Just ItemIncomplete }
+                    _ -> item
+                send _ _ onEvent = do
+                    onEvent (deltaEvent EventOutputTextDelta "half an answer")
+                    mapM_ (\item -> onEvent ResponseOutputItemDoneEvent
+                        { item = unfinished item, outputIndex = Nothing, sequenceNumber = Nothing })
+                        [assistantItem "partial", functionCallItem "partial-call" "read_file" "{\"path\":"]
+                    pure (Left (ConnectionError "offline"))
+            config <- loopConfig (openAiBackendWithRetryPolicies
+                (limitRetries 0) (limitRetries 0) send (pure baseParams))
+            execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+            execution.executionState `shouldBe` []
+            execution.executionProgress `shouldBe` NoResponseCommitted
+
     describe "statelessResponsesBackend" do
         it "replays the local transcript on tool follow-ups" do
             seen <- newIORef []
@@ -785,6 +870,8 @@ spec = do
                         BackendCallbacks
                             { onLoopEvent = const (pure ())
                             , onRecoveryCheckpoint = const (pure ())
+                            , onCompletedResponseItem = \_ _ -> pure ()
+                            , onCancellationMode = const (pure ())
                             , onAsyncToolCall =
                                 \call -> modifyIORef' admitted (call.callId :)
                             }
@@ -834,6 +921,8 @@ spec = do
                 BackendCallbacks
                     { onLoopEvent = const (pure ())
                     , onRecoveryCheckpoint = const (pure ())
+                    , onCompletedResponseItem = \_ _ -> pure ()
+                    , onCancellationMode = const (pure ())
                     , onAsyncToolCall =
                         \call -> modifyIORef' admitted (call.callId :)
                     }

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -157,6 +157,8 @@ accountReplaySpec = describe "stateless Responses account replay boundary" $
                     BackendCallbacks
                         { onLoopEvent = \value -> modifyIORef' events (<> [value])
                         , onRecoveryCheckpoint = const (pure ())
+                        , onCompletedResponseItem = \_ _ -> pure ()
+                        , onCancellationMode = const (pure ())
                         , onAsyncToolCall = \_ -> modifyIORef' admissions (+ 1)
                         }
                 result `shouldBe` Left rejected
@@ -1278,6 +1280,8 @@ backendSpec = describe "tokenProviderStatelessResponsesBackend" do
             BackendCallbacks
                 { onLoopEvent = const (pure ())
                 , onRecoveryCheckpoint = const (pure ())
+                , onCompletedResponseItem = \_ _ -> pure ()
+                , onCancellationMode = const (pure ())
                 , onAsyncToolCall =
                     \call -> modifyIORef' announced (<> [call])
                 }


### PR DESCRIPTION
## Summary

- Align OpenAI interruption with Codex: cancel the submission directly rather than waiting for a cooperative interrupt grace period.
- Give OpenAI WebSocket sessions scoped ownership of the physical connection so an abandoned response closes the socket and joins its reader/writer workers, even if the surrounding logical session remains alive.
- Journal independently completed response items for interruption recovery. Preserve completed tool results, leave partial text display-only, reject explicitly incomplete items, and resume through full retained-history replay without a continuation ID.
- Discard obsolete recovery items on retries and resets, ignore late callbacks, and avoid duplicating items after a successful response. Other providers retain their existing cancellation policy.

The ordinary Responses streaming path signals cancellation by releasing the transport, not by sending a `response.cancel` message. This does not guarantee immediate termination of provider-side computation or billing.

## Validation

- Ran the combined `Agent.OpenAI.LoopBackendSpec`, `Agent.LoopSpec`, `Agent.Responses.LoopBackendSpec`, and `Agent.Transport.WebSocketSpec` suites in GHCi under `nix develop`: **314 examples, 0 failures**.
- The GHCi invocation interpreted the changed core/OpenAI/Responses sources, selected exact dependency unit IDs from Cabal's plan, and evaluated:
  ```haskell
  Test.Hspec.hspec
    (Agent.OpenAI.LoopBackendSpec.spec
      >> Agent.LoopSpec.spec
      >> Agent.Responses.LoopBackendSpec.spec
      >> Agent.Transport.WebSocketSpec.spec)
  ```
- WebSocket transport suite also passed 100 repetitions (25 examples per run), covering blocked writers, setup cancellation, and connection release.
- `git diff --check` passed.

No UI rendering changes; no live provider requests were required for these regression tests.
