### PR TITLE
Show remaining message count in TUI scroll indicator

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -1216,6 +1216,8 @@ handleNormalMouseDown
     -> EventM Name AppState ()
 handleNormalMouseDown name button =
     case (name, button) of
+        (ConversationLatest, V.BLeft) ->
+            resumeConversationFollow
         (ComposerModel, V.BLeft) ->
             Composer.handleControlMouseDown ComposerModel
         (ComposerEffort, V.BLeft) ->

--- a/packages/agent-cli/src/Agent/CLI/TUI/MeasuredViewport.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/MeasuredViewport.hs
@@ -1,5 +1,8 @@
 -- | Viewport composition for fixed-height transcript chunks.
-module Agent.CLI.TUI.MeasuredViewport (measuredViewport) where
+module Agent.CLI.TUI.MeasuredViewport
+    ( measuredViewport
+    , measuredViewportWithFooter
+    ) where
 
 import Brick
 import Control.Monad.Reader (local)
@@ -11,7 +14,20 @@ import qualified Graphics.Vty as V
 -- Measurements still visit every chunk (usually a cache hit); only image
 -- composition is restricted to the visible range.
 measuredViewport :: (Ord n, Show n) => n -> Int -> [Widget n] -> Widget n
-measuredViewport name scrollbarWidth chunks
+measuredViewport name scrollbarWidth =
+    measuredViewportWithFooter name scrollbarWidth Nothing
+
+-- | An optional one-row footer receives the current viewport's exclusive
+-- bottom row and all measured extents in content coordinates, including those
+-- outside the viewport. Reserve its row before resolving scroll requests.
+measuredViewportWithFooter
+    :: (Ord n, Show n)
+    => n
+    -> Int
+    -> Maybe (Int -> [Extent n] -> Widget n)
+    -> [Widget n]
+    -> Widget n
+measuredViewportWithFooter name scrollbarWidth footer chunks
     | null chunks || any ((== Greedy) . vSize) chunks =
         viewport name Vertical (vBox chunks)
     | otherwise = Widget Greedy Greedy do
@@ -32,8 +48,14 @@ measuredViewport name scrollbarWidth chunks
                 { image = V.backgroundFill totalWidth totalHeight
                 , visibilityRequests = requests
                 }
-        resolved <- render $ viewport name Vertical $
-            Widget Fixed Fixed (pure geometry)
+        context <- getContext
+        let footerHeight = case footer of
+                Just _ | availHeight context > 1 -> 1
+                _ -> 0
+        resolved <- local (\c -> c
+            { availHeight = max 0 (availHeight c - footerHeight) }) $
+            render $ viewport name Vertical $
+                Widget Fixed Fixed (pure geometry)
         finalViewport <- unsafeLookupViewport name
         case finalViewport of
             Nothing -> pure resolved
@@ -57,16 +79,27 @@ measuredViewport name scrollbarWidth chunks
                     padBottom Max $ padRight Max $
                     translateBy (Location (-left, firstY - top)) $
                     Widget Fixed Fixed (pure combined)
-                pure content
-                    { image = if scrollbarWidth == 0
-                        then image content
-                        else V.horizJoin (image content)
-                            (V.cropLeft scrollbarWidth (image resolved))
-                    -- Match viewport's outer-to-inner extent ordering so
-                    -- child click targets take precedence over the viewport.
-                    , extents = extents resolved <> extents content
-                    , visibilityRequests = []
-                    }
+                let viewportResult = content
+                        { image = if scrollbarWidth == 0
+                            then image content
+                            else V.horizJoin (image content)
+                                (V.cropLeft scrollbarWidth (image resolved))
+                        -- Match viewport's outer-to-inner extent ordering so
+                        -- child click targets take precedence over the viewport.
+                        , extents = extents resolved <> extents content
+                        , visibilityRequests = []
+                        }
+                case footer of
+                    Just drawFooter | footerHeight > 0 ->
+                        render $ vBox
+                            [ Widget Fixed Fixed (pure viewportResult)
+                            , vLimit 1 $ drawFooter (top + height) $
+                                concat
+                                    [ extents (addResultOffset (Location (0, y)) result)
+                                    | (y, result) <- positioned
+                                    ]
+                            ]
+                    _ -> pure viewportResult
 
 -- Match vBox's decreasing height budget, including Brick's release limit.
 -- Measuring every child at 100000 would incorrectly expose content which an

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -43,7 +43,7 @@ import Agent.CLI.TUI.Types
       FullscreenRuntime(runtimeWaveTrough, runtimeMotionMode,
                         runtimeNativeImagePreviews, runtimeColor),
       activeTheme,
-      Name(ConversationBodyCache, CodeBlockCache, MarkdownProseCache, ConversationBlock,
+      Name(ConversationBodyCache, CodeBlockCache, MarkdownProseCache, ConversationBlock, ConversationMessage,
            ConversationBlockCache, ConversationImage, CodeCopy,
            MarkdownLink) )
 import Agent.CLI.Terminal ()
@@ -387,7 +387,9 @@ drawBlock state target ui block =
             padBottom (Pad 1) $
                 clickable
                     (ConversationBlock target block.blockId)
-                    hoveredRow
+                    ((if block.blockKind == BlockUser || block.blockKind == BlockAssistant
+                        then reportExtent (ConversationMessage target block.blockId)
+                        else id) hoveredRow)
     in if cacheableBlock state target ui block
         then cached
             (ConversationBlockCache

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -197,7 +197,7 @@ import qualified Graphics.Vty.CrossPlatform as Vty ()
 
 import Agent.CLI.TUI.Render.Blocks (cacheableBlock, todoStatusAttr)
 import Agent.CLI.TUI.Render.Overlays
-    ( drawNotice, drawFollowStatus, drawFooter, drawPermission, drawResume
+    ( drawNotice, drawFooter, drawPermission, drawResume
     , drawChoice, drawTextPrompt, drawMetaConsole, choiceRowColumns
     , filterChoiceRowLimit
     , onboardingVisibleRowIndices
@@ -261,7 +261,6 @@ drawMain state =
                 , drawNotice state
                 , Composer.drawQueuedInputs state.appUi
                 , Composer.drawSlashMenu state
-                , drawFollowStatus state.appUi
                 , drawLiveTodos (activeConversationUi state)
                 , drawPromptActivity state
                 , case textOverlay state of

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Overlays.hs
@@ -1,7 +1,6 @@
 -- | Notices and modal overlay rendering for the fullscreen UI.
 module Agent.CLI.TUI.Render.Overlays
     ( drawNotice
-    , drawFollowStatus
     , drawFooter
     , drawPermission
     , drawResume
@@ -92,7 +91,7 @@ import Agent.TUI.Model
       PermissionOverlay(permissionIndex, permissionSummary),
       UiNotice(noticeKind, noticeText),
       UiState(uiNotice, uiFocus, uiPermission, uiRunning,
-              uiAwaitingInput, uiFollow) )
+              uiAwaitingInput) )
 import Agent.TUI.Motion
     ( foregroundIndicator, waitingIndicator, MotionMode(MotionOff) )
 import Agent.TUI.Presentation ()
@@ -239,14 +238,6 @@ noticePresentation state = \case
             <> " "
         )
     NoticeError -> (Theme.errorAttr, "✗ ")
-
-drawFollowStatus :: UiState -> Widget Name
-drawFollowStatus state
-    | state.uiFollow = emptyWidget
-    | otherwise =
-        withAttr Theme.thinkingAttr $
-            padLeftRight 2 $
-                txt "↓ Live output paused · End to resume"
 
 drawFooter :: AppState -> Widget Name
 drawFooter state =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Transcript.hs
@@ -53,7 +53,7 @@ import Agent.CLI.TUI.Types
                appAgentEntries, appPullRequestURL, appSlashCatalog, appHistoryWindow, appUi,
                appAgentSelected),
       Name(QuickStartModel, CodeCopy, ConversationChunkCache,
-           ConversationReserve, QuickStartWorktree, QuickStartResume,
+           ConversationReserve, ConversationNewerGap, QuickStartWorktree, QuickStartResume,
            QuickStartCommands, QuickStartChangelog) )
 import Agent.CLI.Terminal ()
 import Agent.CLI.Timestamp ()
@@ -187,7 +187,7 @@ drawTranscriptContentChunks state =
             state.appHistoryWindow.historyWindowHasOlder
             state.appHistoryWindow.historyWindowPending
     newerGap =
-        historyGapWidget
+        map (reportExtent ConversationNewerGap) $ historyGapWidget
             HistoryNewer
             state.appHistoryWindow.historyWindowHasNewer
             state.appHistoryWindow.historyWindowPending

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Workspace.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Workspace.hs
@@ -36,11 +36,11 @@ import Agent.CLI.Resume ()
 import Agent.CLI.Secret ()
 import Agent.CLI.Status ()
 import Agent.CLI.Style ( motionGlyphSet )
-import Agent.CLI.TUI.History ( HistoryWindow(historyWindowTurns) )
+import Agent.CLI.TUI.History ( HistoryWindow(historyWindowTurns, historyWindowHasNewer) )
 import Agent.CLI.TUI.ImagePreview ()
 import Agent.CLI.TUI.LambdaArt ()
 import Agent.CLI.TUI.Motion ( isBackgroundAgentActive )
-import Agent.CLI.TUI.MeasuredViewport ( measuredViewport )
+import Agent.CLI.TUI.MeasuredViewport ( measuredViewportWithFooter )
 import Agent.CLI.TUI.Render.Transcript
     ( drawTranscript,
       drawTranscriptChunks,
@@ -53,7 +53,7 @@ import Agent.CLI.TUI.Types
       AppState(appAgentHover, appRuntime, appMotionElapsedMillis, appUi,
                appAgentSelected, appHistoryWindow, appAgentEntries, appPullRequestURL),
       FullscreenRuntime(runtimeMotionMode),
-      Name(AgentPopover, ConversationViewportExtent,
+      Name(AgentPopover, ConversationViewportExtent, ConversationMessage, ConversationBlock, ConversationLatest, ConversationNewerGap,
            ConversationViewport, AgentRow, AgentPane, MarkdownLink) )
 import Agent.CLI.Terminal ()
 import Agent.CLI.Timestamp ()
@@ -61,7 +61,7 @@ import Agent.Loop ()
 import Agent.Syntax ()
 import Agent.TUI.Markdown ()
 import Agent.TUI.Model
-    ( reduceUi, conversationIsEmpty, UiEvent, UiState(uiBlocks) )
+    ( reduceUi, conversationIsEmpty, UiEvent, UiState(uiBlocks, uiFollow) )
 import Agent.TUI.Motion ( quietIndicator )
 import Agent.TUI.Presentation ()
 import Agent.TUI.TextWidth ( displayTerminalText )
@@ -84,24 +84,23 @@ import Brick
       txt,
       vBox,
       vLimit,
-      viewport,
       withAttr,
       withBorderStyle,
       withVScrollBarRenderer,
       withVScrollBars,
       AttrName,
+      Extent(..),
       Location(Location),
       Context(availHeight, availWidth),
       Size(Fixed, Greedy),
       VScrollBarOrientation(OnRight),
       VScrollbarRenderer(..),
-      ViewportType(Vertical),
       Widget(render, Widget),
       Padding(Pad) )
 import Brick.BChan ()
 import Brick.Widgets.Border ( borderWithLabel )
 import Brick.Widgets.Border.Style ( unicodeRounded )
-import Brick.Widgets.Center ()
+import Brick.Widgets.Center (hCenter)
 import Codec.Picture ()
 import Control.Applicative ()
 import Control.Concurrent ()
@@ -135,14 +134,15 @@ import qualified Brick.Widgets.Border as Border ( borderAttr )
 import qualified Agent.CLI.TUI.Bridge as Bridge ()
 import qualified Agent.CLI.TUI.Composer as Composer ()
 import qualified Data.Map.Strict as Map ()
-import qualified Agent.CLI.TUI.Scroll as Scroll ()
+import qualified Agent.CLI.TUI.Scroll as Scroll
+    ( conversationMessagesBelow, conversationMessagesBelowLabel )
 import qualified Data.Sequence as Seq ( null )
 import qualified Data.Set as Set ()
 import qualified Data.Text as Text
     ( pack, takeWhileEnd, stripPrefix, breakOn )
 import qualified Data.Text.Encoding as TextEncoding ()
 import qualified Agent.TUI.Theme as Theme
-    ( assistantAttr,
+    ( thinkingAttr, assistantAttr,
       baseAttr,
       borderActiveAttr,
       borderAttr,
@@ -232,8 +232,8 @@ drawConversationPane state =
             reportExtent ConversationViewportExtent $
                 withVScrollBarRenderer conversationScrollbarRenderer $
                     withVScrollBars OnRight $
-                        viewport ConversationViewport Vertical $
-                            padLeftRight 2 (drawAgentConversation state entry)
+                        conversationViewport state
+                            [padLeftRight 2 (drawAgentConversation state entry)]
         Nothing
             | conversationIsEmpty state.appUi
                 && Seq.null
@@ -250,10 +250,52 @@ drawConversationPane state =
                                 withVScrollBarRenderer
                                     conversationScrollbarRenderer $
                                     withVScrollBars OnRight $
-                                        measuredViewport ConversationViewport 1 $
+                                        conversationViewport state $
                                             map (padLeftRight 2)
                                                 (drawTranscriptChunks state)
                            ]
+
+conversationViewport :: AppState -> [Widget Name] -> Widget Name
+conversationViewport state =
+    measuredViewportWithFooter ConversationViewport 1 footer
+  where
+    footer
+        | state.appUi.uiFollow = Nothing
+        | otherwise = Just \bottom measuredExtents ->
+            let messageCount = Scroll.conversationMessagesBelow bottom
+                    [ (top, height)
+                    | extent <- measuredExtents
+                    , ConversationMessage target _ <- [extent.extentName]
+                    , let Location (_, top) = extent.extentUpperLeft
+                    , let (_, height) = extent.extentSize
+                    , target == state.appAgentSelected
+                    ]
+                hasNewer =
+                    state.appAgentSelected == AgentRoot
+                        && state.appHistoryWindow.historyWindowHasNewer
+                        && or
+                            [ height > 0 && top + height > bottom
+                            | extent <- measuredExtents
+                            , extent.extentName == ConversationNewerGap
+                            , let Location (_, top) = extent.extentUpperLeft
+                            , let (_, height) = extent.extentSize
+                            ]
+                otherContentBelow = or
+                    [ height > 0 && top + height > bottom
+                    | extent <- measuredExtents
+                    , ConversationBlock target _ <- [extent.extentName]
+                    , target == state.appAgentSelected
+                    , let Location (_, top) = extent.extentUpperLeft
+                    , let (_, height) = extent.extentSize
+                    ]
+                indicator label = hCenter $
+                    clickable ConversationLatest $
+                        withAttr Theme.thinkingAttr (txt label)
+            in case Scroll.conversationMessagesBelowLabel hasNewer messageCount of
+                Nothing
+                    | otherContentBelow -> indicator "↓ Latest output · Click to resume"
+                    | otherwise -> txt " "
+                Just label -> indicator label
 
 selectedChildEntry :: AppState -> Maybe AgentEntry
 selectedChildEntry state =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Scroll.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Scroll.hs
@@ -12,10 +12,29 @@ module Agent.CLI.TUI.Scroll
     , reconcileConversationFollow
     , reflowConversationAnchor
     , startConversationAnchor
+    , conversationMessagesBelow
+    , conversationMessagesBelowLabel
     ) where
 
 import Agent.TUI.Model (BlockId)
 import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | Count message extents whose final rendered row is below the viewport.
+-- A partially visible message still has content to read. Zero-height hidden
+-- messages and padding outside message extents do not contribute.
+conversationMessagesBelow :: Int -> [(Int, Int)] -> Int
+conversationMessagesBelow bottom =
+    length . filter (\(top, height) -> height > 0 && top + height > bottom)
+
+conversationMessagesBelowLabel :: Bool -> Int -> Maybe Text
+conversationMessagesBelowLabel hasNewer count
+    | count <= 0 && not hasNewer = Nothing
+    | otherwise = Just $
+        "↓ " <> Text.pack (show (max 0 count))
+            <> (if hasNewer then "+" else "")
+            <> (if count == 1 && not hasNewer then " Message" else " Messages")
+            <> " · Click to resume"
 
 data ConversationPhase
     = ConversationFillingPage

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -102,6 +102,9 @@ data Name
     | PlanningPanel
     | PlanningSubmit
     | ConversationBlock !AgentTarget !BlockId
+    | ConversationMessage !AgentTarget !BlockId
+    | ConversationLatest
+    | ConversationNewerGap
     | ConversationChunkCache
         !AgentTarget
         !BlockId

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -1167,6 +1167,30 @@ spec = do
                     RowEnd width -> Text.replicate width " "
             rendered `shouldSatisfy` Text.isInfixOf marker
 
+    describe "messages below indicator" do
+        it "shows a count while scrolled up and resumes following when clicked" do
+            let transcript = Text.unlines
+                    ([ "Earlier row " <> Text.pack (show index)
+                     | index <- [1 .. 100 :: Int]
+                     ] <> ["LATEST_MESSAGE_MARKER"])
+                ui = reduceUi (UiAssistantHistory transcript) initialUiState
+                bounds = (80, 24)
+            runtime <- newScriptRuntime ui
+            let initial = (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    { appUi = ui }
+            (_, frames, finalState) <- runFullscreenScriptDetailedAt bounds initial
+                [ FullscreenScriptMouseDown ConversationViewport
+                    V.BScrollUp (B.Location (0, 0))
+                , FullscreenScriptMouseDown ConversationLatest
+                    V.BLeft (B.Location (0, 0))
+                , FullscreenScriptHalt
+                ]
+            let rendered = map (renderedPictureTextAt bounds) frames
+            rendered `shouldSatisfy` any (Text.isInfixOf "1 Message")
+            last rendered `shouldSatisfy` Text.isInfixOf "LATEST_MESSAGE_MARKER"
+            last rendered `shouldSatisfy` (not . Text.isInfixOf "Click to resume")
+            finalState.appUi.uiFollow `shouldBe` True
+
     describe "planning question panel" do
         forM_ [False, True] \textPrompt ->
             describe (if textPrompt then "custom answer" else "choice") do

--- a/packages/agent-cli/test/Agent/CLI/TUIMeasuredViewportSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIMeasuredViewportSpec.hs
@@ -2,13 +2,15 @@
 
 module Agent.CLI.TUIMeasuredViewportSpec (spec) where
 
-import Agent.CLI.TUI.MeasuredViewport (measuredViewport)
+import Agent.CLI.TUI.MeasuredViewport (measuredViewport, measuredViewportWithFooter)
+import Agent.CLI.TUI.Scroll (conversationMessagesBelow, conversationMessagesBelowLabel)
 import Brick
     ( App(..)
     , AttrMap
     , BrickEvent(..)
     , CursorLocation
     , EventM
+    , Extent(..)
     , Location(..)
     , VScrollbarRenderer(..)
     , ViewportType(Vertical)
@@ -36,6 +38,7 @@ import Brick
     , showCursor
     , showFirstCursor
     , txtWrap
+    , txt
     , vBox
     , viewport
     , viewportScroll
@@ -73,9 +76,10 @@ data Name
     = Transcript
     | Chunk !Int
     | ChunkCache !Int
+    | NewerGap
     deriving (Eq, Ord, Show)
 
-data Renderer = Ordinary | Measured | OrdinaryScrollbar | MeasuredScrollbar
+data Renderer = Ordinary | Measured | OrdinaryScrollbar | MeasuredScrollbar | MeasuredFooter
 
 data ScriptEvent
     = ScrollBy !Int
@@ -89,6 +93,41 @@ data ScriptEvent
 spec :: Spec
 spec =
     describe "measuredViewport" do
+        it "drops the lower-bound marker after scrolling past a newer-history gap" do
+            let content =
+                    [ reportExtent (Chunk 0) $ vBox (replicate 4 (txt "history"))
+                    , reportExtent NewerGap (txt "unloaded history")
+                    , reportExtent (Chunk 1) $ vBox (replicate 4 (txt "live message"))
+                    ]
+            (beforeGap, _) <- runScript MeasuredFooter (40, 5) content [Stop]
+            snd (last beforeGap) `shouldContain` "1+ Messages"
+            (afterGap, _) <- runScript MeasuredFooter (40, 5) content
+                [ScrollBy 2, Stop]
+            snd (last afterGap) `shouldContain` "1 Message"
+            snd (last afterGap) `shouldNotContain` "+ Messages"
+            (bottom, _) <- runScript MeasuredFooter (40, 5) content
+                [ScrollEnd, Stop]
+            snd (last bottom) `shouldNotContain` "Message"
+
+        it "counts offscreen cached message extents after scrolling and resizing" do
+            let content =
+                    [ cached (ChunkCache index) $
+                        reportExtent (Chunk index) $
+                            vBox (replicate 3 (txt "message"))
+                    | index <- [0 .. 3]
+                    ]
+            (initial, _) <- runScript MeasuredFooter (40, 5) content [Stop]
+            snd (last initial) `shouldContain` "3 Messages"
+            (scrolled, _) <- runScript MeasuredFooter (40, 5) content
+                [ScrollBy 3, Stop]
+            snd (last scrolled) `shouldContain` "2 Messages"
+            (resized, _) <- runScript MeasuredFooter (40, 5) content
+                [Resize (40, 10), Stop]
+            snd (last resized) `shouldContain` "1 Message"
+            (bottom, _) <- runScript MeasuredFooter (40, 5) content
+                [ScrollEnd, Stop]
+            snd (last bottom) `shouldNotContain` "Message"
+
         it "uses an oracle which detects rendered text differences" do
             first <- runScript Ordinary (20, 3)
                 [txtWrap "expected text"] [Stop]
@@ -245,6 +284,8 @@ runScriptChoosing chooseCursor renderer initialBounds content script = do
                         ( map (concatMap spanCharacters . toList) $
                             toList (displayOpsForPic picture bounds)
                         , V.picCursor picture
+                        , map (map snd . concatMap spanCharacters . toList) $
+                            toList (displayOpsForPic picture bounds)
                         )
                 modifyIORef' picturesRef ((bounds, normalized) :)
                 displayContext <- V.mkDisplayContext output output bounds
@@ -367,6 +408,8 @@ drawRenderer renderer content =
     joinBorders $ case renderer of
         Ordinary -> viewport Transcript Vertical (vBox content)
         Measured -> measuredViewport Transcript 0 content
+        MeasuredFooter ->
+            measuredViewportWithFooter Transcript 0 (Just drawFooter) content
         OrdinaryScrollbar ->
             withVScrollBarRenderer testScrollbarRenderer $
                 withVScrollBars OnRight $
@@ -375,6 +418,24 @@ drawRenderer renderer content =
             withVScrollBarRenderer testScrollbarRenderer $
                 withVScrollBars OnRight $
                     measuredViewport Transcript 1 content
+  where
+    drawFooter bottom measuredExtents =
+        maybe (txt " ") txt $
+            conversationMessagesBelowLabel
+                (or
+                    [ height > 0 && top + height > bottom
+                    | extent <- measuredExtents
+                    , extent.extentName == NewerGap
+                    , let Location (_, top) = extent.extentUpperLeft
+                    , let (_, height) = extent.extentSize
+                    ]) $
+                conversationMessagesBelow bottom
+                    [ (top, height)
+                    | extent <- measuredExtents
+                    , Chunk _ <- [extent.extentName]
+                    , let Location (_, top) = extent.extentUpperLeft
+                    , let (_, height) = extent.extentSize
+                    ]
 
 testScrollbarRenderer :: VScrollbarRenderer Name
 testScrollbarRenderer =

--- a/packages/agent-cli/test/Agent/CLI/TUIScrollSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIScrollSpec.hs
@@ -6,6 +6,33 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "fullscreen conversation scrolling" do
+    describe "messages below the viewport" do
+        it "counts completely hidden and partially visible messages" do
+            conversationMessagesBelow 10 [(0, 4), (4, 6), (8, 5), (15, 3)]
+                `shouldBe` 2
+
+        it "does not count zero-height messages or a message ending at the boundary" do
+            conversationMessagesBelow 10 [(5, 5), (20, 0)]
+                `shouldBe` 0
+
+        it "updates when scrolling, resizing, or appending a message" do
+            let messages = [(0, 5), (6, 5), (12, 5)]
+            conversationMessagesBelow 7 messages `shouldBe` 2
+            conversationMessagesBelow 12 messages `shouldBe` 1
+            conversationMessagesBelow 17 messages `shouldBe` 0
+            conversationMessagesBelow 17 (messages <> [(18, 4)]) `shouldBe` 1
+
+        it "formats singular, plural, and unloaded-history lower bounds" do
+            conversationMessagesBelowLabel False 1
+                `shouldBe` Just "↓ 1 Message · Click to resume"
+            conversationMessagesBelowLabel False 12
+                `shouldBe` Just "↓ 12 Messages · Click to resume"
+            conversationMessagesBelowLabel True 1
+                `shouldBe` Just "↓ 1+ Messages · Click to resume"
+            conversationMessagesBelowLabel True 0
+                `shouldBe` Just "↓ 0+ Messages · Click to resume"
+            conversationMessagesBelowLabel False 0 `shouldBe` Nothing
+
     describe "conversationScrollGesture" do
         it "ignores scrolling when an empty session has no viewport" do
             conversationScrollGesture False 3 Nothing


### PR DESCRIPTION
## Summary
- Replace the TUI's generic scrolled-up hint with a clickable `↓ N Messages · Click to resume` indicator.
- Count user/assistant messages below the measured viewport, including partially visible messages, rather than lines or tool output.
- Update counts on scrolling and resize; hide the indicator at the latest messages. Use a lower-bound `+` when unloaded newer history remains below and a latest-output fallback for tool-only content.
- Preserve existing keyboard shortcuts and add click-to-jump behavior for root and child-agent conversations.

## Validation
- GHCi: focused scroll and measured-viewport regression tests: 36 examples, 0 failures.
- GHCi: fullscreen application suite, including indicator and click-to-resume regression: 208 examples, 0 failures.
- Live TUI smoke test in tmux with a synthetic transcript: scroll, resize, and return to latest.
