### PR TITLE
Expose typed installed skill catalog administration

### DIFF
--- a/packages/agent-native-bridge/agent-native-bridge.cabal
+++ b/packages/agent-native-bridge/agent-native-bridge.cabal
@@ -117,6 +117,7 @@ foreign-library haskell-agent-bridge
                     , Agent.CLI.MacOS.LearnedSkillsBridge
                     , Agent.CLI.MacOS.RepositoryInput
                     , Agent.CLI.MacOS.ResourceAdmin
+                    , Agent.CLI.MacOS.InstalledSkills
                     , Agent.CLI.MacOS.SessionTransferBridge
                     , Agent.CLI.MacOS.SessionObservationBridge
     c-sources:        cbits/HaskellAgentBridgeRuntime.c
@@ -199,6 +200,7 @@ test-suite agent-native-bridge-test
                     , unix
     if os(darwin)
         c-sources:    test/cbits/HaskellAgentBridgeBrowserSmoke.c
+                    , test/cbits/HaskellAgentBridgeInstalledSkillsSmoke.c
                     , test/cbits/HaskellAgentBridgeComputerSmoke.c
                     , test/cbits/HaskellAgentBridgeImageSmoke.c
                     , test/cbits/HaskellAgentBridgeIntegrationSmoke.c
@@ -211,6 +213,8 @@ test-suite agent-native-bridge-test
         frameworks:   Security, CoreFoundation
         include-dirs: include
         other-modules: Agent.CLI.MacOS.Bridge
+                     , Agent.CLI.MacOS.InstalledSkillsSpec
+                     , Agent.CLI.MacOS.InstalledSkills
                      , Agent.CLI.MacOS.BundledIntegrations
                      , Agent.CLI.MacOS.SessionTransferBridge
                      , Agent.CLI.MacOS.SessionObservationBridge

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/Bridge.hs
@@ -54,6 +54,7 @@ import Agent.CLI.MacOS.RepositoryChecks
 import Agent.CLI.MacOS.RepositoryDeliveryBridge ()
 import Agent.CLI.MacOS.RepositoryReviewBridge ()
 import Agent.CLI.MacOS.ResourceAdmin ()
+import Agent.CLI.MacOS.InstalledSkills ()
 import Agent.CLI.MacOS.SessionTransferBridge ()
 import Agent.CLI.MacOS.SessionObservationBridge ()
 import Agent.CLI.MacOS.TurnExecution (composeNativeTools, nativeExceptionMessage)

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/InstalledSkills.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/InstalledSkills.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+-- | Read-only filesystem skill catalog using the same discovery as sessions.
+module Agent.CLI.MacOS.InstalledSkills () where
+
+import Agent.CLI.Options (defaultCliOptions)
+import Agent.CLI.Project (resolveProjectRoot)
+import Agent.CLI.Skills (loadSkillsCatalogQuiet)
+import Agent.OsPath (toText)
+import Agent.Skills
+import Control.Concurrent (forkIO)
+import Control.Exception.Safe (displayException, tryAny)
+import Control.Monad (forM_, unless, void)
+import qualified Data.ByteString as BS
+import Data.List (find)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Encoding
+import Data.Word (Word8)
+import Foreign (FunPtr, Ptr, castPtr, nullFunPtr, nullPtr)
+import Foreign.C.String (CString)
+import Foreign.C.Types (CInt(..), CSize(..))
+import System.Directory.OsPath (doesDirectoryExist, getHomeDirectory)
+import System.OsPath (unsafeEncodeUtf)
+
+type InstalledSkillCallback =
+    Ptr () -> CInt -> CInt
+    -> CString -> CSize -> CString -> CSize -> CString -> CSize
+    -> CString -> CSize -> CString -> CSize -> IO ()
+
+foreign import ccall "dynamic"
+    invokeInstalledSkillCallback :: FunPtr InstalledSkillCallback -> InstalledSkillCallback
+
+foreign export ccall ha_installed_skill_list
+    :: Ptr Word8 -> CSize -> FunPtr InstalledSkillCallback -> Ptr () -> IO CInt
+
+foreign export ccall ha_installed_skill_read
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr InstalledSkillCallback -> Ptr () -> IO CInt
+
+ha_installed_skill_list
+    :: Ptr Word8 -> CSize -> FunPtr InstalledSkillCallback -> Ptr () -> IO CInt
+ha_installed_skill_list cwdPointer cwdLength callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = decodePath cwdPointer cwdLength >>= \case
+        Nothing -> pure 2
+        Just cwd -> runCatalog cwd Nothing callback context >> pure 0
+
+ha_installed_skill_read
+    :: Ptr Word8 -> CSize -> Ptr Word8 -> CSize
+    -> FunPtr InstalledSkillCallback -> Ptr () -> IO CInt
+ha_installed_skill_read cwdPointer cwdLength identityPointer identityLength callback context
+    | callback == nullFunPtr = pure 1
+    | otherwise = do
+        cwd <- decodePath cwdPointer cwdLength
+        identity <- decodePath identityPointer identityLength
+        case (cwd, identity) of
+            (Just directory, Just selected) ->
+                runCatalog directory (Just selected) callback context >> pure 0
+            _ -> pure 2
+
+-- Copy and validate before scheduling work. Absolute paths make workspace
+-- selection independent of the process working directory.
+decodePath :: Ptr Word8 -> CSize -> IO (Maybe Text)
+decodePath pointer count
+    | pointer == nullPtr || count == 0 || count > 32768 = pure Nothing
+    | otherwise = do
+        bytes <- BS.packCStringLen (castPtr pointer, fromIntegral count)
+        pure $ case Encoding.decodeUtf8' bytes of
+            Right value
+                | Text.isPrefixOf "/" value && not (Text.any (== '\0') value) ->
+                    Just value
+            _ -> Nothing
+
+runCatalog :: Text -> Maybe Text -> FunPtr InstalledSkillCallback -> Ptr () -> IO ()
+runCatalog directory selected callback context = void $ forkIO do
+    result <- tryAny do
+        let cwd = unsafeEncodeUtf (Text.unpack directory)
+        exists <- doesDirectoryExist cwd
+        unless exists (ioError (userError "The selected skill workspace directory does not exist."))
+        home <- getHomeDirectory
+        projectRoot <- resolveProjectRoot cwd
+        loadSkillsCatalogQuiet defaultCliOptions home projectRoot cwd
+    case result of
+        Left exception -> emitStatus callback context (-1) (Text.pack (displayException exception))
+        Right catalog -> do
+            forM_ catalog.catalogWarnings \warning ->
+                emitStatus callback context 2
+                    (toText warning.skillWarningPath <> ": " <> warning.skillWarningMessage)
+            case selected of
+                Nothing -> do
+                    forM_ catalog.catalogSkills (emitSkill callback context False)
+                    emitStatus callback context 1 ""
+                Just identity ->
+                    case find ((== Just identity) . skillIdentity) catalog.catalogSkills of
+                        Nothing -> emitStatus callback context (-2) "Installed skill is no longer available in this workspace."
+                        Just skill -> do
+                            emitSkill callback context True skill
+                            emitStatus callback context 1 ""
+
+skillIdentity :: Skill -> Maybe Text
+skillIdentity skill = case skill.skillSource of
+    FilesystemSkillSource{skillPath} -> Just (toText skillPath)
+    McpSkillSource{} -> Nothing
+
+emitSkill :: FunPtr InstalledSkillCallback -> Ptr () -> Bool -> Skill -> IO ()
+emitSkill callback context includeInstructions skill =
+    case skill.skillSource of
+        McpSkillSource{} -> pure ()
+        FilesystemSkillSource{skillPath, skillScope, skillFileText} ->
+            withText (toText skillPath) \identity identityLength ->
+            withText skill.skillName \name nameLength ->
+            withText skill.skillDescription \description descriptionLength ->
+            withText (if includeInstructions then skillFileText else "") \instructions instructionsLength ->
+                invokeInstalledSkillCallback callback context 0 (scopeValue skillScope)
+                    identity identityLength name nameLength description descriptionLength
+                    instructions instructionsLength nullPtr 0
+
+scopeValue :: SkillScope -> CInt
+scopeValue BuiltinSkill = 0
+scopeValue UserSkill = 1
+scopeValue RepositorySkill{} = 2
+
+emitStatus :: FunPtr InstalledSkillCallback -> Ptr () -> CInt -> Text -> IO ()
+emitStatus callback context status message =
+    withText message \pointer count ->
+        invokeInstalledSkillCallback callback context status (-1)
+            nullPtr 0 nullPtr 0 nullPtr 0 nullPtr 0 pointer count
+
+withText :: Text -> (CString -> CSize -> IO a) -> IO a
+withText text action = BS.useAsCStringLen (Encoding.encodeUtf8 text) \(pointer, count) ->
+    action pointer (fromIntegral count)

--- a/packages/agent-native-bridge/include/HaskellAgentBridge.h
+++ b/packages/agent-native-bridge/include/HaskellAgentBridge.h
@@ -988,6 +988,50 @@ int32_t ha_data_rows_load(
 );
 
 /*
+ * Installed filesystem skills (read-only).
+ *
+ * Uses session discovery, including bundled, home and workspace skill roots,
+ * precedence, depth limits and validation. No row limit or pagination is
+ * applied here. Discovery warnings are emitted so omitted invalid files are
+ * not silently presented as a complete successful catalog.
+ *
+ * cwd and identity must be absolute UTF-8 paths without NUL, 1..32768 bytes,
+ * and non-NULL. Inputs are copied before return. Identity is the absolute
+ * SKILL.md path emitted by list; read only resolves identities in the current
+ * workspace catalog, never arbitrary files. Source: 0 bundled, 1 personal,
+ * 2 project. Name is the invocation name; description is its full description.
+ * List omits instructions; read returns the complete SKILL.md text.
+ *
+ * Return: 0 accepted, 1 missing callback, 2 invalid input. Rejected calls never
+ * invoke the callback. Accepted calls run on a dedicated Haskell worker,
+ * off the calling thread. Callbacks for one request are serial; requests may
+ * overlap. Status 0 is an item, 2 a nonterminal discovery warning (error text),
+ * 1 successful completion, -1 failure, -2 read identity not found. Exactly one
+ * terminal callback (1 or negative) occurs unless the process exits. A read
+ * emits one item on success followed by completion. There is no cancellation.
+ *
+ * All callback buffers are UTF-8, callback-scoped and must be copied before
+ * return. Omitted buffers may be NULL with zero length and must not be
+ * dereferenced. Source is -1 on non-item callbacks. context may be NULL and
+ * is returned unchanged. Caller retains callback/context until terminal event.
+ */
+typedef void (*ha_installed_skill_callback)(
+    void *context, int32_t status, int32_t source,
+    const char *identity, size_t identity_length,
+    const char *name, size_t name_length,
+    const char *description, size_t description_length,
+    const char *instructions, size_t instructions_length,
+    const char *error, size_t error_length);
+
+int32_t ha_installed_skill_list(
+    const uint8_t *cwd, size_t cwd_length,
+    ha_installed_skill_callback callback, void *context);
+int32_t ha_installed_skill_read(
+    const uint8_t *cwd, size_t cwd_length,
+    const uint8_t *identity, size_t identity_length,
+    ha_installed_skill_callback callback, void *context);
+
+/*
  * Typed Skills / Memory administration.
  *
  * A learned skill is the durable, versioned memory resource used by future

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/InstalledSkillsSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/InstalledSkillsSpec.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Agent.CLI.MacOS.InstalledSkillsSpec (spec) where
+
+import Agent.CLI.MacOS.InstalledSkills ()
+import Control.Exception.Safe (bracket)
+import Foreign.C.String (CString, withCString)
+import Foreign.C.Types (CInt(..))
+import System.Directory
+    ( canonicalizePath, createDirectory, createDirectoryIfMissing
+    , getTemporaryDirectory, removeFile, removePathForcibly )
+import System.FilePath ((</>))
+import System.IO (hClose, openTempFile)
+import Test.Hspec
+
+foreign import ccall safe "ha_installed_skills_abi_smoke"
+    installedSkillsSmoke :: CString -> IO CInt
+
+spec :: Spec
+spec = describe "Installed filesystem skills native ABI" do
+    it "lists, reads, reports warnings, rejects invalid inputs and confines reads to the catalog" $
+        bracket createFixture removePathForcibly \directory ->
+            withCString directory \pointer ->
+                installedSkillsSmoke pointer `shouldReturn` 0
+  where
+    createFixture = do
+        temporary <- getTemporaryDirectory
+        (path, handle) <- openTempFile temporary "installed-skills-catalog"
+        hClose handle
+        removeFile path
+        createDirectory path
+        createDirectory (path </> ".git")
+        let valid = path </> ".agents" </> "skills" </> "catalog-fixture"
+            invalid = path </> ".agents" </> "skills" </> "invalid-fixture"
+        createDirectoryIfMissing True valid
+        createDirectoryIfMissing True invalid
+        writeFile (valid </> "SKILL.md")
+            "---\nname: catalog-fixture\ndescription: Catalog fixture description\n---\nFixture instructions\n"
+        writeFile (invalid </> "SKILL.md") "Missing required frontmatter"
+        canonicalizePath path

--- a/packages/agent-native-bridge/test/Spec.hs
+++ b/packages/agent-native-bridge/test/Spec.hs
@@ -14,6 +14,7 @@ import qualified Agent.CLI.McpAdminSpec as McpAdminSpec
 import qualified Agent.CLI.McpConnectionSpec as McpConnectionSpec
 import qualified Agent.CLI.ResourceAdminSpec as ResourceAdminSpec
 #ifdef darwin_HOST_OS
+import qualified Agent.CLI.MacOS.InstalledSkillsSpec as InstalledSkillsSpec
 import qualified Agent.CLI.MacOS.AccountConnectionSpec as AccountConnectionSpec
 import qualified Agent.CLI.MacOS.MobileGatewaySpec as MobileGatewaySpec
 import qualified Agent.CLI.MacOS.BridgeFFISpec as BridgeFFISpec
@@ -39,6 +40,7 @@ main = hspec do
     RepositoryWorkersSpec.spec
     RepositoryInputSpec.spec
 #ifdef darwin_HOST_OS
+    InstalledSkillsSpec.spec
     AccountConnectionSpec.spec
     MobileGatewaySpec.spec
     BrowserBridgeFFISpec.spec

--- a/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeInstalledSkillsSmoke.c
+++ b/packages/agent-native-bridge/test/cbits/HaskellAgentBridgeInstalledSkillsSmoke.c
@@ -1,0 +1,110 @@
+#include "HaskellAgentBridge.h"
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+typedef struct {
+    _Atomic int terminal;
+    int items;
+    int warnings;
+    int source;
+    int invalid;
+    int terminal_count;
+    char *identity;
+    char *instructions;
+} skill_result;
+
+static char *copy_text(const char *text, size_t count) {
+    char *copy = malloc(count + 1);
+    if (count) memcpy(copy, text, count);
+    copy[count] = '\0';
+    return copy;
+}
+
+static void receive_skill(void *context, int32_t status, int32_t source,
+    const char *identity, size_t identity_length,
+    const char *name, size_t name_length,
+    const char *description, size_t description_length,
+    const char *instructions, size_t instructions_length,
+    const char *error, size_t error_length) {
+    skill_result *result = context;
+    if (status == 0) {
+        if (!identity || !identity_length || !name || !name_length
+                || !description || !description_length || source < 0 || source > 2)
+            result->invalid = 1;
+        if (name_length == strlen("catalog-fixture")
+                && memcmp(name, "catalog-fixture", name_length) == 0) {
+            result->items++;
+            result->source = source;
+            free(result->identity);
+            free(result->instructions);
+            result->identity = copy_text(identity, identity_length);
+            result->instructions = copy_text(instructions, instructions_length);
+        }
+    } else if (status == 2) {
+        result->warnings++;
+        if (!error || !error_length) result->invalid = 1;
+    } else {
+        result->terminal_count++;
+        atomic_store(&result->terminal, status);
+    }
+}
+
+static int await_result(skill_result *result) {
+    for (int attempt = 0; attempt < 3000; attempt++) {
+        if (atomic_load(&result->terminal)) return 1;
+        usleep(10000);
+    }
+    return 0;
+}
+
+/* Heap contexts deliberately survive a timeout, so late callbacks remain safe. */
+int ha_installed_skills_abi_smoke(const char *cwd) {
+    skill_result *listing = calloc(1, sizeof(*listing));
+    if (ha_installed_skill_list((const uint8_t *)cwd, strlen(cwd), NULL, NULL) != 1) return 1;
+    if (ha_installed_skill_list(NULL, 0, receive_skill, listing) != 2) return 2;
+    if (ha_installed_skill_read((const uint8_t *)cwd, strlen(cwd),
+            NULL, 0, receive_skill, listing) != 2) return 3;
+    static const uint8_t invalid_utf8[] = {'/', 0xff};
+    static const uint8_t embedded_nul[] = {'/', 0, 'a'};
+    if (ha_installed_skill_list(invalid_utf8, sizeof(invalid_utf8),
+            receive_skill, listing) != 2
+            || ha_installed_skill_list(embedded_nul, sizeof(embedded_nul),
+                receive_skill, listing) != 2
+            || ha_installed_skill_list((const uint8_t *)"relative", 8,
+                receive_skill, listing) != 2
+            || ha_installed_skill_list((const uint8_t *)cwd, 32769,
+                receive_skill, listing) != 2
+            || atomic_load(&listing->terminal) != 0) return 10;
+    if (ha_installed_skill_list((const uint8_t *)cwd, strlen(cwd),
+            receive_skill, listing) != 0 || !await_result(listing)) return 4;
+    if (atomic_load(&listing->terminal) != 1 || listing->terminal_count != 1
+            || listing->items != 1 || listing->source != 2 || listing->invalid
+            || !listing->identity || listing->instructions[0] != '\0'
+            || listing->warnings < 1) return 5;
+
+    skill_result *reading = calloc(1, sizeof(*reading));
+    if (ha_installed_skill_read((const uint8_t *)cwd, strlen(cwd),
+            (const uint8_t *)listing->identity, strlen(listing->identity),
+            receive_skill, reading) != 0 || !await_result(reading)) return 6;
+    if (atomic_load(&reading->terminal) != 1 || reading->terminal_count != 1
+            || reading->items != 1 || reading->invalid
+            || !strstr(reading->instructions, "Fixture instructions")
+            || strcmp(reading->identity, listing->identity) != 0) return 7;
+
+    skill_result *missing = calloc(1, sizeof(*missing));
+    if (ha_installed_skill_read((const uint8_t *)cwd, strlen(cwd),
+            (const uint8_t *)cwd, strlen(cwd), receive_skill, missing) != 0
+            || !await_result(missing)) return 8;
+    if (atomic_load(&missing->terminal) != -2 || missing->terminal_count != 1
+            || missing->items != 0) return 9;
+    free(listing->identity);
+    free(listing->instructions);
+    free(reading->identity);
+    free(reading->instructions);
+    free(listing);
+    free(reading);
+    free(missing);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add purpose-specific asynchronous C ABI calls for installed skill listing and instruction reading.
- Use the authoritative runtime catalog, with typed source/status values, warnings, and callback lifetime documentation.
- Add catalog tests and a native C callback smoke test.

## Integration
Replayed narrowly onto the current macOS runtime pin 53284f70; existing ABI is preserved. macOS application consumes published commit da9068d20b9c58db52e90cadf569c04b6faa5278.

## Validation
Original implementation passed 164 native examples and the packaged macOS Nix build. Reconciled native suite is running; CI will validate the PR merge revision.