### PR TITLE
Style rejected MCP authorization callback pages

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -676,37 +676,33 @@ receiveCallback listener readyVar issuerRequired issuer expectedState = do
                     Warp.defaultSettings
         application request respond
             | Wai.requestMethod request /= methodGet =
-                respond (plainResponse status405 "Method Not Allowed")
+                respond (callbackResponse status405 OAuth.OAuthCallbackMethodNotAllowed)
             | Wai.rawPathInfo request /= "/callback" =
-                respond (plainResponse status404 "Not Found")
+                respond (callbackResponse status404 OAuth.OAuthCallbackNotFound)
             | Left _ <- validateMcpOAuthCallback issuerRequired issuer expectedState
                 (Wai.queryString request) =
-                respond (plainResponse status400 "Invalid authorization response")
+                respond (callbackResponse status400 OAuth.OAuthCallbackRejected)
             | otherwise = do
                 let callback = callbackFromQuery (Wai.queryString request)
                     finish = do
                         void (tryPutMVar resultVar callback)
                         readMVar shutdownVar >>= id
                 respond
-                    (Wai.responseLBS
-                        status200
-                        [ (hContentType, "text/html; charset=utf-8")
-                        , (hCacheControl, "no-store")
-                        , (hConnection, "close")
-                        , ("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
-                        ]
-                        OAuth.oauthCallbackSuccessPage)
+                    (callbackResponse status200 OAuth.OAuthCallbackReceived)
                     `finally` finish
     Warp.runSettingsSocket settings listener application
     readMVar resultVar
   where
-    plainResponse status body =
+    callbackResponse status presentation =
         Wai.responseLBS
             status
-            [ (hContentType, "text/plain; charset=utf-8")
+            [ (hContentType, "text/html; charset=utf-8")
+            , (hCacheControl, "no-store")
             , (hConnection, "close")
+            , ("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
+            , ("X-Content-Type-Options", "nosniff")
             ]
-            body
+            (OAuth.oauthCallbackPage presentation)
 
 -- | Validate untrusted callbacks before consuming the pending authorization.
 -- Duplicate security parameters are rejected rather than interpreted using

--- a/packages/agent-cli/test/Agent/CLI/McpOAuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpOAuthSpec.hs
@@ -12,8 +12,8 @@ import Data.Either (isLeft)
 import Data.IORef (IORef, newIORef, readIORef, modifyIORef')
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
-import Network.HTTP.Client (defaultManagerSettings, httpLbs, newManager, parseRequest, responseStatus)
-import Network.HTTP.Types (status200, status400, status401, status404, mkStatus)
+import Network.HTTP.Client (defaultManagerSettings, httpLbs, newManager, parseRequest, responseStatus, responseHeaders, responseBody, method)
+import Network.HTTP.Types (ResponseHeaders, status200, status400, status401, status404, status405, mkStatus)
 import Network.HTTP.Types.URI (Query, parseQuery, renderQuery)
 import Network.URI (parseURI, uriQuery)
 import qualified Network.Wai as Wai
@@ -199,7 +199,7 @@ spec = describe "MCP OAuth host authorization" do
             completed `shouldBe` Just ()
             readIORef requests `shouldReturn` []
 
-    it "keeps authorization pending after an invalid callback and accepts the matching callback" do
+    it "renders rejected callback pages without consuming pending authorization" do
         requests <- newIORef []
         Warp.testWithApplication (pure (authorizationFixture requests)) \port -> do
             let endpoint = "http://127.0.0.1:" <> Text.pack (show port) <> "/mcp"
@@ -212,6 +212,18 @@ spec = describe "MCP OAuth host authorization" do
                     ]))
                 response <- httpLbs request manager
                 responseStatus response `shouldBe` status400
+                responseBody response `shouldBe` OAuth.oauthCallbackPage OAuth.OAuthCallbackRejected
+                assertCallbackHeaders (responseHeaders response)
+                LazyBytes.toStrict (responseBody response) `shouldSatisfy` (not . Bytes.isInfixOf "untrusted-account")
+                notFoundRequest <- parseRequest (Bytes.unpack (redirect <> "/missing"))
+                notFoundResponse <- httpLbs notFoundRequest manager
+                responseStatus notFoundResponse `shouldBe` status404
+                responseBody notFoundResponse `shouldBe` OAuth.oauthCallbackPage OAuth.OAuthCallbackNotFound
+                assertCallbackHeaders (responseHeaders notFoundResponse)
+                methodResponse <- httpLbs (request { method = "POST" }) manager
+                responseStatus methodResponse `shouldBe` status405
+                responseBody methodResponse `shouldBe` OAuth.oauthCallbackPage OAuth.OAuthCallbackMethodNotAllowed
+                assertCallbackHeaders (responseHeaders methodResponse)
             fmap ((.tokenAccessToken) . fst) result `shouldBe` Right "token-account-a"
             readIORef requests `shouldReturn` ["account-a"]
   where
@@ -253,11 +265,22 @@ authorizeFixtureWith endpoint account beforeCallback = do
                     ]
             manager <- newManager defaultManagerSettings
             request <- parseRequest (Bytes.unpack callback)
-            _ <- httpLbs request manager
+            response <- httpLbs request manager
+            responseStatus response `shouldBe` status200
+            responseBody response `shouldBe` OAuth.oauthCallbackSuccessPage
+            assertCallbackHeaders (responseHeaders response)
             pure ()
     result <- timeout (10 * 1000000) $
         concurrently (authorizeMcpWith host defaultLoginOptions Nothing endpoint) complete
     pure (maybe (Left "Fixture authorization timed out") fst result)
+
+assertCallbackHeaders :: ResponseHeaders -> Expectation
+assertCallbackHeaders headers = do
+    lookup "Content-Type" headers `shouldBe` Just "text/html; charset=utf-8"
+    lookup "Cache-Control" headers `shouldBe` Just "no-store"
+    lookup "Content-Security-Policy" headers
+        `shouldBe` Just "default-src 'none'; style-src 'unsafe-inline'"
+    lookup "X-Content-Type-Options" headers `shouldBe` Just "nosniff"
 
 authorizationCallbackParameters
     :: Text.Text

--- a/packages/agent-mcp/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-mcp/src/Agent/MCP/OAuth.hs
@@ -44,7 +44,7 @@ module Agent.MCP.OAuth
       -- * Token endpoint requests
     , TokenExchange(..), exchangeAuthorizationCodeWith, exchangeAuthorizationCode
     , RefreshRequest(..), refreshAccessTokenWith, refreshAccessToken
-    , oauthCallbackSuccessPage
+    , OAuthCallbackPage(..), oauthCallbackPage, oauthCallbackSuccessPage
       -- * Persisted token records
     , OAuthTokenFile(..), OAuthTokenFileExtra(..), emptyOAuthTokenFileExtra
     , loadOAuthTokenFile, loadOAuthTokenFileExtra, loadOAuthTokenRecord
@@ -950,15 +950,28 @@ responseBodyText response =
     let body = Text.strip (decodeLenient (LBS.toStrict (LBS.take 2048 (responseBody response))))
     in if Text.null body then "(empty response body)" else body
 
+-- | Fixed presentation states: callback parameters must never become page copy.
+data OAuthCallbackPage
+    = OAuthCallbackReceived
+    | OAuthCallbackRejected
+    | OAuthCallbackNotFound
+    | OAuthCallbackMethodNotAllowed
+    | OAuthCallbackFailed
+    deriving (Eq, Show)
+
 -- | UTF-8 receipt page served by the interactive OAuth callback listener.
 -- Receipt does not imply permission was granted or the token exchange succeeded.
 -- Render fixed application copy only, never callback parameters.
 oauthCallbackSuccessPage :: LBS.ByteString
-oauthCallbackSuccessPage = LBS.fromStrict $ Encoding.encodeUtf8 $ Text.concat
+oauthCallbackSuccessPage = oauthCallbackPage OAuthCallbackReceived
+
+-- | Branded callback pages with fixed, credential-free instructions.
+oauthCallbackPage :: OAuthCallbackPage -> LBS.ByteString
+oauthCallbackPage presentation = LBS.fromStrict $ Encoding.encodeUtf8 $ Text.concat
     [ "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
     , "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
     , "<meta name=\"color-scheme\" content=\"light dark\">"
-    , "<title>Authorization response received · Haskell Agent</title><style>"
+    , "<title>", documentTitle, " · Haskell Agent</title><style>"
     , ":root{color-scheme:light dark;--background:#f5f7fb;--surface:#fff;"
     , "--text:#192231;--secondary:#606b7c;--border:#e5e9f0;"
     , "--status-background:#edf3ff;--status-color:#2460dc}"
@@ -978,6 +991,7 @@ oauthCallbackSuccessPage = LBS.fromStrict $ Encoding.encodeUtf8 $ Text.concat
     , ".status{display:grid;place-items:center;width:64px;height:64px;margin:0 auto 24px;"
     , "border-radius:50%;background:var(--status-background);color:var(--status-color)}"
     , ".status svg{width:30px;height:30px}"
+    , ".status.error{background:#fff0e6;color:#a34112}"
     , "h1{margin:0 0 14px;font-size:27px;line-height:1.2;letter-spacing:-.8px;font-weight:650;"
     , "text-wrap:balance}p{margin:0;color:var(--secondary);font-size:15px;line-height:1.65;"
     , "text-wrap:pretty}.next-step{margin-top:28px;padding-top:24px;border-top:1px solid var(--border)}"
@@ -986,17 +1000,54 @@ oauthCallbackSuccessPage = LBS.fromStrict $ Encoding.encodeUtf8 $ Text.concat
     , "@media(max-width:380px){.card{padding:32px 22px}h1{font-size:24px}}"
     , "@media(prefers-color-scheme:dark){:root{--background:#11151c;--surface:#1b212b;"
     , "--text:#edf1f8;--secondary:#a4afc0;--border:#303947;"
-    , "--status-background:#243653;--status-color:#9bbfff}}"
+    , "--status-background:#243653;--status-color:#9bbfff}"
+    , ".status.error{background:#442c22;color:#ffb68e}}"
     , "</style></head><body><main class=\"confirmation\">"
     , "<header class=\"brand\"><span class=\"brand-mark\" aria-hidden=\"true\">λ</span>"
     , "Haskell Agent</header><section class=\"card\" aria-labelledby=\"confirmation-title\">"
-    , "<div class=\"status\" aria-hidden=\"true\">"
+    , "<div class=\"status", if presentation == OAuthCallbackReceived then "" else " error"
+    , "\" aria-hidden=\"true\">"
     , "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.8\""
     , " stroke-linecap=\"round\" stroke-linejoin=\"round\">"
-    , "<path d=\"M9 10 4 15l5 5M4 15h10a6 6 0 0 0 0-12\"/></svg></div>"
-    , "<h1 id=\"confirmation-title\">Return to Haskell Agent</h1>"
-    , "<p>Your authorization response was received.</p>"
+    , if presentation == OAuthCallbackReceived
+        then "<path d=\"M9 10 4 15l5 5M4 15h10a6 6 0 0 0 0-12\"/>"
+        else "<circle cx=\"12\" cy=\"12\" r=\"9\"/><path d=\"M12 7v6m0 4h.01\"/>"
+    , "</svg></div>"
+    , "<h1 id=\"confirmation-title\">", heading, "</h1>"
+    , "<p>", message, "</p>"
     , "<div class=\"next-step\"><strong>Continue in the app</strong>"
-    , "<p>Return to the app to check the connection status.</p></div></section>"
+    , "<p>", nextStep, "</p></div></section>"
     , "<p class=\"footer\">You can safely close this tab.</p></main></body></html>"
     ]
+  where
+    (documentTitle, heading, message, nextStep) = case presentation of
+        OAuthCallbackReceived ->
+            ( "Authorization response received"
+            , "Return to Haskell Agent"
+            , "Your authorization response was received."
+            , "Return to the app to check the connection status."
+            )
+        OAuthCallbackRejected ->
+            ( "Invalid authorization response"
+            , "Invalid authorization response"
+            , "This response could not be verified. Your sign-in is still waiting."
+            , "Return to the original sign-in tab to continue, or check the connection status in the app."
+            )
+        OAuthCallbackNotFound ->
+            ( "Page not found"
+            , "Page not found"
+            , "This address is not an authorization callback."
+            , "Return to the original sign-in tab to continue, or check the connection status in the app."
+            )
+        OAuthCallbackMethodNotAllowed ->
+            ( "Request not supported"
+            , "Request not supported"
+            , "This authorization callback does not support that request method."
+            , "Return to the original sign-in tab to continue, or check the connection status in the app."
+            )
+        OAuthCallbackFailed ->
+            ( "Connection unsuccessful"
+            , "Haskell Agent could not connect"
+            , "The authorization response could not be accepted."
+            , "Return to Haskell Agent to see the error and try again."
+            )

--- a/packages/agent-mcp/test/Agent/MCP/OAuthSpec.hs
+++ b/packages/agent-mcp/test/Agent/MCP/OAuthSpec.hs
@@ -11,6 +11,33 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.MCP.OAuth" do
+    describe "oauthCallbackPage" do
+        it "preserves the receipt compatibility entry point" do
+            oauthCallbackPage OAuthCallbackReceived `shouldBe` oauthCallbackSuccessPage
+
+        mapM_ (\(presentation, heading) ->
+            it ("renders a branded, self-contained error page for " <> show presentation) do
+                let page = Encoding.decodeUtf8 (LBS.toStrict (oauthCallbackPage presentation))
+                page `shouldSatisfy` Text.isInfixOf heading
+                page `shouldSatisfy` Text.isInfixOf "class=\"status error\""
+                page `shouldSatisfy` Text.isInfixOf "aria-labelledby=\"confirmation-title\""
+                page `shouldSatisfy` Text.isInfixOf "@media(prefers-color-scheme:dark)"
+                page `shouldSatisfy` Text.isInfixOf "width=device-width, initial-scale=1"
+                mapM_ (\fragment -> page `shouldSatisfy` (not . Text.isInfixOf fragment))
+                    ["<script", "<link", "src=", "href=", "url(", "<form"]
+            )
+            [ (OAuthCallbackRejected, "Invalid authorization response")
+            , (OAuthCallbackNotFound, "Page not found")
+            , (OAuthCallbackMethodNotAllowed, "Request not supported")
+            , (OAuthCallbackFailed, "Haskell Agent could not connect")
+            ]
+
+        it "keeps rejected callback instructions distinct from completed failure" do
+            let page presentation = Encoding.decodeUtf8 (LBS.toStrict (oauthCallbackPage presentation))
+            page OAuthCallbackRejected `shouldSatisfy` Text.isInfixOf "Your sign-in is still waiting."
+            page OAuthCallbackRejected `shouldSatisfy` Text.isInfixOf "original sign-in tab"
+            page OAuthCallbackFailed `shouldSatisfy` Text.isInfixOf "see the error and try again."
+
     describe "oauthCallbackSuccessPage" do
         let page = Encoding.decodeUtf8 (LBS.toStrict oauthCallbackSuccessPage)
         it "acknowledges receipt without claiming the connection succeeded" do


### PR DESCRIPTION
## Summary
- Replace plain-text MCP callback 400/404/405 pages with the existing branded card design, including responsive layouts, dark mode, and clear next steps.
- Share a fixed-state renderer for receipt and error pages; never interpolate callback values or load external assets.
- Preserve HTTP statuses, callback validation, and pending-listener behavior; consistently apply no-store, CSP, and nosniff headers.

## Validation
- Added renderer coverage for each error state and loopback regression coverage for rejected requests followed by a valid callback.
- Full `Agent.MCP.OAuthSpec`: 58 examples, 0 failures in GHCi under `nix develop`.
- Chrome visual/layout checks: all five states in light/dark at 1280px, 375px, and 320px (30 cases), no overflow.
- Full `Agent.CLI.McpOAuthSpec`: 17 examples, 0 failures in GHCi, including invalid/404/405 requests followed by a valid callback.
- All 326 library modules loaded successfully in the multi-package GHCi session.
- All nine CI checks passed for `1710115775b2fe462d9975e2338cbd516bbcb81a`.
