### PR TITLE
Deduplicate bounded session socket framing

### DIFF
--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -50,6 +50,7 @@ library
                     , Agent.CLI.Gateway.Origin
                     , Agent.CLI.Gateway.Usage
                     , Agent.CLI.Session.Storage
+                    , Agent.CLI.Session.Framing
                     , Agent.CLI.Session.TaskPlan
                     , Agent.CLI.Session.TempWorkspace
                     , Agent.CLI.Session.Transfer
@@ -142,6 +143,21 @@ library
                     , vector
                     , wai
                     , warp
+
+test-suite session-framing-test
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    ghc-options:      -threaded
+    hs-source-dirs:   test/framing src
+    main-is:          Spec.hs
+    other-modules:    Agent.CLI.Session.Framing
+    build-depends:    aeson
+                    , async
+                    , base >= 4.17 && < 5
+                    , bytestring
+                    , hspec >= 2.11 && < 2.12
+                    , network
+                    , safe-exceptions
 
 test-suite agent-cli-runtime-test
     import:           common-options

--- a/packages/agent-cli-runtime/package.nix
+++ b/packages/agent-cli-runtime/package.nix
@@ -26,7 +26,7 @@ mkDerivation {
   testHaskellDepends = [
     aeson agent-core agent-json agent-openai agent-responses
     agent-responses-types agent-store async base bytestring containers
-    directory filepath hspec http-client http-types QuickCheck
+    directory filepath hspec http-client http-types network QuickCheck
     safe-exceptions stm text time unix wai warp
   ];
   description = "Headless shared runtime for agent frontends";

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/Framing.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/Framing.hs
@@ -1,0 +1,48 @@
+-- | Private session IPC framing, independent of JSON and protocol error text.
+-- The daemon deliberately does not depend on this CLI runtime package: it has
+-- its own frame limit, exception type, and empty-frame policy.
+module Agent.CLI.Session.Framing
+    ( maximumFrameBytes
+    , sendFrame
+    , receiveFrame
+    ) where
+
+import Control.Exception.Safe (throwIO)
+import Control.Monad (when)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as Builder
+import qualified Data.ByteString.Lazy as LBS
+import Network.Socket (Socket)
+import qualified Network.Socket.ByteString as Socket
+
+maximumFrameBytes :: Int
+maximumFrameBytes = 32 * 1024 * 1024
+
+-- | Write the existing Word32 big-endian wire format. Outbound size policy
+-- belongs to the caller: Inbox bounds sends, while Observation historically
+-- only bounds receives.
+sendFrame :: Socket -> BS.ByteString -> IO ()
+sendFrame client bytes =
+    Socket.sendAll client (prefix <> bytes)
+  where
+    prefix = LBS.toStrict
+        (Builder.toLazyByteString (Builder.word32BE (fromIntegral (BS.length bytes))))
+
+-- | Read one nonempty frame, rejecting its length before reading its body.
+-- The supplied reader must have 'Socket.recv' semantics: return at most the
+-- requested bytes, with an empty result indicating EOF. Taking the reader as
+-- an argument also lets tests exercise short reads without socket scheduling.
+receiveFrame :: String -> String -> (Int -> IO BS.ByteString) -> IO BS.ByteString
+receiveFrame invalidSize disconnected receive = do
+    prefix <- receiveExactly 4
+    let count = BS.foldl' (\size byte -> size * 256 + fromIntegral byte) (0 :: Int) prefix
+    when (count <= 0 || count > maximumFrameBytes) $
+        throwIO (userError invalidSize)
+    receiveExactly count
+  where
+    receiveExactly count = BS.concat . reverse <$> go count []
+    go 0 chunks = pure chunks
+    go remaining chunks = do
+        bytes <- receive (min remaining 65536)
+        when (BS.null bytes) (throwIO (userError disconnected))
+        go (remaining - BS.length bytes) (bytes : chunks)

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/Inbox.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/Inbox.hs
@@ -18,6 +18,7 @@ module Agent.CLI.Session.Inbox
     ) where
 
 import Agent.CLI.SessionLock (adjustSessionInboxPending)
+import qualified Agent.CLI.Session.Framing as Framing
 import Control.Concurrent.Async (mapConcurrently_, withAsync)
 import Control.Concurrent.STM
 import Control.Exception.Safe
@@ -27,7 +28,6 @@ import Crypto.Hash (Digest, SHA256, hash)
 import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict', encode)
 import Data.Bits ((.&.))
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe)
@@ -267,12 +267,9 @@ removeOwnedSocket path = do
 sendEnvelope :: ToJSON a => Socket -> a -> IO ()
 sendEnvelope client value = do
     let bytes = LBS.toStrict (encode value)
-        prefix = LBS.toStrict
-            (Builder.toLazyByteString
-                (Builder.word32BE (fromIntegral (BS.length bytes))))
-    when (BS.length bytes > 32 * 1024 * 1024) $
+    when (BS.length bytes > Framing.maximumFrameBytes) $
         throwIO (userError "Inbox envelope exceeds the size limit.")
-    Socket.sendAll client (prefix <> bytes)
+    Framing.sendFrame client bytes
 
 receiveEnvelope :: Socket -> IO InboxEnvelope
 receiveEnvelope client =
@@ -285,18 +282,6 @@ receiveReply client =
         =<< receiveBounded client
 
 receiveBounded :: Socket -> IO BS.ByteString
-receiveBounded client = do
-    prefix <- receiveExactly client 4
-    let count = BS.foldl' (\size byte -> size * 256 + fromIntegral byte) (0 :: Int) prefix
-    when (count <= 0 || count > 32 * 1024 * 1024) $
-        throwIO (userError "Invalid inbox frame size.")
-    receiveExactly client count
-
-receiveExactly :: Socket -> Int -> IO BS.ByteString
-receiveExactly client count = BS.concat . reverse <$> receive count []
-  where
-    receive 0 chunks = pure chunks
-    receive remaining chunks = do
-        bytes <- Socket.recv client (min remaining 65536)
-        when (BS.null bytes) (throwIO (userError "Inbox owner disconnected."))
-        receive (remaining - BS.length bytes) (bytes : chunks)
+receiveBounded client =
+    Framing.receiveFrame "Invalid inbox frame size." "Inbox owner disconnected."
+        (Socket.recv client)

--- a/packages/agent-cli-runtime/src/Agent/CLI/Session/Observation.hs
+++ b/packages/agent-cli-runtime/src/Agent/CLI/Session/Observation.hs
@@ -23,6 +23,7 @@ module Agent.CLI.Session.Observation
     ) where
 
 import Agent.Loop (LoopEvent(..), NativeAgentStatus(..))
+import qualified Agent.CLI.Session.Framing as Framing
 import Agent.ToolDispatch (ToolCall, ToolCallResult(..), ToolCallMode(..), toolCallMode, toolCallResultMode)
 import Agent.ToolOutcome (toolOutcomeSucceeded)
 import Control.Concurrent (threadDelay)
@@ -34,7 +35,6 @@ import Crypto.Hash (Digest, SHA256, hash)
 import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict', encode)
 import Data.Bits ((.&.))
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable (toList)
 import Data.Int (Int64)
@@ -447,10 +447,8 @@ frameSince previous current =
     in current.frame { reset, events = map (.event) selected }
 
 sendEnvelope :: Socket -> ObservationEnvelope -> IO ()
-sendEnvelope client envelope = do
-    let bytes = LBS.toStrict (encode envelope)
-        prefix = LBS.toStrict (Builder.toLazyByteString (Builder.word32BE (fromIntegral (BS.length bytes))))
-    Socket.sendAll client (prefix <> bytes)
+sendEnvelope client envelope =
+    Framing.sendFrame client (LBS.toStrict (encode envelope))
 
 -- | Keeps watching across CLI turns/restarts. Cancellation interrupts reads and
 -- reconnect waits and closes the socket before returning to the caller.
@@ -487,18 +485,6 @@ observeSessionAt directory sessionID callback = reconnect True
 
 receiveEnvelope :: Socket -> IO ObservationEnvelope
 receiveEnvelope client = do
-    prefix <- receiveExactly client 4
-    let count = BS.foldl' (\size byte -> size * 256 + fromIntegral byte) (0 :: Int) prefix
-    when (count <= 0 || count > 32 * 1024 * 1024) $
-        throwIO (userError "Invalid observation frame size.")
-    bytes <- receiveExactly client count
+    bytes <- Framing.receiveFrame "Invalid observation frame size." "Observation owner disconnected."
+        (Socket.recv client)
     either (throwIO . userError) pure (eitherDecodeStrict' bytes)
-
-receiveExactly :: Socket -> Int -> IO BS.ByteString
-receiveExactly client count = BS.concat . reverse <$> receive count []
-  where
-    receive 0 chunks = pure chunks
-    receive remaining chunks = do
-        bytes <- Socket.recv client (min remaining 65536)
-        when (BS.null bytes) (throwIO (userError "Observation owner disconnected."))
-        receive (remaining - BS.length bytes) (bytes : chunks)

--- a/packages/agent-cli-runtime/test/framing/Spec.hs
+++ b/packages/agent-cli-runtime/test/framing/Spec.hs
@@ -1,0 +1,128 @@
+module Main (main) where
+
+import Agent.CLI.Session.Framing
+import Control.Concurrent.Async (concurrently)
+import Control.Exception.Safe (bracket, throwIO)
+import Control.Monad (forM_, when)
+import Data.Aeson (Value, eitherDecodeStrict', encode, object, (.=))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (newIORef, readIORef, writeIORef, modifyIORef')
+import Network.Socket
+import qualified Network.Socket.ByteString as Socket
+import System.IO.Error (ioeGetErrorString)
+import System.Timeout (timeout)
+import Test.Hspec
+
+main :: IO ()
+main = hspec do
+    describe "session framing" do
+        it "retains the 32 MiB receive limit" $
+            maximumFrameBytes `shouldBe` 33554432
+
+        forM_ [("inbox", "Inbox"), ("observation", "Observation")] \(name, owner) -> do
+            let invalid = "Invalid " <> name <> " frame size."
+                disconnected = owner <> " owner disconnected."
+                receive = receiveFrame invalid disconnected
+
+            describe name do
+                it "assembles one-byte header and body fragments" do
+                    reader <- fragmentedReader (map BS.singleton [0, 0, 0, 5, 104, 101, 108, 108, 111])
+                    receive reader `shouldReturn` "hello"
+
+                forM_ [[], ["\0"], ["\0\0\0"], ["\0\0\0\5"], ["\0\0\0\5", "hel"]] \chunks ->
+                    it ("reports disconnect for truncated input " <> show chunks) do
+                        reader <- fragmentedReader chunks
+                        receive reader `shouldThrow` ((== disconnected) . ioeGetErrorString)
+
+                forM_ [BS.pack [0,0,0,0], BS.pack [2,0,0,1], BS.pack [128,0,0,0], BS.pack [255,255,255,255]] \header ->
+                    it ("rejects invalid/oversized length before a body read " <> show header) do
+                        calls <- newIORef (0 :: Int)
+                        let reader requested = do
+                                modifyIORef' calls (+ 1)
+                                requested `shouldBe` 4
+                                count <- readIORef calls
+                                when (count > 1) (expectationFailure "read body after invalid length")
+                                pure header
+                        receive reader `shouldThrow` ((== invalid) . ioeGetErrorString)
+                        readIORef calls `shouldReturn` 1
+
+                it "accepts the exact limit and caps all body reads at 64 KiB" do
+                    requests <- newIORef []
+                    first <- newIORef True
+                    let reader requested = do
+                            modifyIORef' requests (requested :)
+                            isFirst <- readIORef first
+                            writeIORef first False
+                            pure (if isFirst then BS.pack [2,0,0,0] else BS.replicate requested 120)
+                    body <- receive reader
+                    BS.length body `shouldBe` maximumFrameBytes
+                    reverse <$> readIORef requests `shouldReturn` (4 : replicate 512 65536)
+
+                it "does not consume the next frame" do
+                    reader <- fragmentedReader ["\0\0\0\1a\0\0\0\1b"]
+                    receive reader `shouldReturn` "a"
+                    receive reader `shouldReturn` "b"
+
+                it "preserves JSON round trips on real sockets" $
+                    withPair \sender receiver -> withinTimeout do
+                        let value = object ["version" .= (1 :: Int), "message" .= ("hello \955" :: String)]
+                            body = LBS.toStrict (encode value)
+                        (_, received) <- concurrently (sendFrame sender body) (receive (Socket.recv receiver))
+                        (eitherDecodeStrict' received :: Either String Value) `shouldBe` Right value
+
+                it "leaves JSON parsing and its errors to the caller" $
+                    withPair \sender receiver -> withinTimeout do
+                        (_, body) <- concurrently (sendFrame sender "{invalid") (receive (Socket.recv receiver))
+                        body `shouldBe` "{invalid"
+                        (eitherDecodeStrict' body :: Either String Value) `shouldSatisfy` either (const True) (const False)
+
+                it "reports real socket EOF midway through the body" $
+                    withPair \sender receiver -> withinTimeout do
+                        Socket.sendAll sender "\0\0\0\5hi"
+                        shutdown sender ShutdownSend
+                        receive (Socket.recv receiver) `shouldThrow` ((== disconnected) . ioeGetErrorString)
+
+        it "writes the existing big-endian prefix" $
+            withPair \sender receiver -> withinTimeout do
+                let body = BS.replicate 256 120
+                (_, received) <- concurrently
+                    (sendFrame sender body >> shutdown sender ShutdownSend)
+                    (readToEOF receiver)
+                received `shouldBe` BS.pack [0,0,1,0] <> body
+
+        it "retains the raw sender's empty-frame policy" $
+            withPair \sender receiver -> withinTimeout do
+                sendFrame sender BS.empty
+                shutdown sender ShutdownSend
+                readToEOF receiver `shouldReturn` BS.replicate 4 0
+
+-- Deterministically simulate recv's short-read contract, including splitting a
+-- supplied chunk at the requested boundary and returning empty only at EOF.
+fragmentedReader :: [BS.ByteString] -> IO (Int -> IO BS.ByteString)
+fragmentedReader chunks = do
+    remaining <- newIORef chunks
+    pure \requested -> do
+        queued <- readIORef remaining
+        case queued of
+            [] -> pure BS.empty
+            chunk : rest -> do
+                let (bytes, leftover) = BS.splitAt requested chunk
+                writeIORef remaining (if BS.null leftover then rest else leftover : rest)
+                pure bytes
+
+withPair :: (Socket -> Socket -> IO a) -> IO a
+withPair action =
+    bracket (socketPair AF_UNIX Stream defaultProtocol)
+        (\(sender, receiver) -> close sender >> close receiver)
+        (uncurry action)
+
+withinTimeout :: IO () -> IO ()
+withinTimeout action = do
+    result <- timeout 5000000 action
+    when (result == Nothing) (throwIO (userError "socket test timed out"))
+
+readToEOF :: Socket -> IO BS.ByteString
+readToEOF socket = do
+    bytes <- Socket.recv socket 65536
+    if BS.null bytes then pure BS.empty else (bytes <>) <$> readToEOF socket


### PR DESCRIPTION
## Summary
- Share private Inbox/Observation big-endian length-prefix send and bounded receive primitives, without expanding the public library API.
- Preserve the 32 MiB receive limit, 64 KiB read cap, nonempty receive policy, disconnect/invalid-size error text, and caller-owned JSON encoding/decoding. Inbox retains its outbound limit and error; Observation retains its existing unbounded send behavior.
- Add deterministic fragmented-read, truncated-header/body EOF, invalid/oversized-length, exact-limit/chunk-cap, frame-boundary, wire-format and real-socket JSON round-trip tests.

## Daemon evaluation
Deferred daemon reuse: agent-runtime-daemon is currently standalone (no internal package dependencies). Depending on agent-cli-runtime would pull in CLI/session/provider/storage concerns; extracting a new cross-package transport layer would broaden this focused change. Its configurable 1 MiB default, typed errors, uncapped recv requests and zero-length-to-JSON behavior remain untouched. A future neutral transport package can consolidate those policies explicitly.

## Validation
- `nix develop` → `cabal repl --offline agent-cli-runtime:test:session-framing-test` → `:main`: **33 examples, 0 failures**, confirmed successful GHCi module load.
- Regenerated `packages/agent-cli-runtime/package.nix` with `cabal2nix`.
- `git diff --check` passes.
- GHCi multi-component load: **92 modules loaded**, existing Inbox/Observation integration specs: **21 examples, 0 failures**. Run the test component first and restore the outer session TMPDIR inside nix develop to keep Unix socket paths within platform limits.
- Followed CI to completion with the wait-for-ci skill: **all 9 checks passed** on `afb4df9d53b4ef21590385e0ffb517adc7db72ec` (run 34685756163).

No UI changes and no performance claim.