### PR TITLE
Refactor review Git error handling with ExceptT

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Review.hs
+++ b/packages/agent-cli/src/Agent/CLI/Review.hs
@@ -14,6 +14,8 @@ import Agent.CLI.GitDiff
     , runSafeGit
     )
 import Agent.TUI.TextWidth (displayTerminalText)
+import Control.Monad (unless)
+import Control.Monad.Trans.Except (ExceptT(..), runExceptT, throwE)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -84,32 +86,24 @@ literal value =
 -- out branch is omitted because comparing it to HEAD cannot produce a useful
 -- branch review.
 listReviewBranches :: OsPath -> IO (Either Text [ReviewBranch])
-listReviewBranches cwd = do
-    repository <- requireWorkTree cwd
-    case repository of
-        Left err -> pure (Left err)
-        Right () ->
-            runSafeGit
-                cwd
-                []
-                [ "--no-pager"
-                , "for-each-ref"
-                , "--format=%(refname:short)%00%(HEAD)"
-                , "refs/heads/"
-                ] >>= \case
-                    Left err -> pure (Left err)
-                    Right output
-                        | output.gitCommandExitCode == ExitSuccess ->
-                            pure $
-                                Right
-                                    [ ReviewBranch branch
-                                    | (branch, current) <-
-                                        mapMaybe parseBranch
-                                            (Text.lines (gitOutputText output))
-                                    , not current
-                                    ]
-                        | otherwise ->
-                            pure (Left (commandFailure "git for-each-ref" output))
+listReviewBranches cwd = runExceptT do
+    requireWorkTree cwd
+    output <- ExceptT $ runSafeGit
+        cwd
+        []
+        [ "--no-pager"
+        , "for-each-ref"
+        , "--format=%(refname:short)%00%(HEAD)"
+        , "refs/heads/"
+        ]
+    unless (output.gitCommandExitCode == ExitSuccess) $
+        throwE (commandFailure "git for-each-ref" output)
+    pure
+        [ ReviewBranch branch
+        | (branch, current) <-
+            mapMaybe parseBranch (Text.lines (gitOutputText output))
+        , not current
+        ]
 
 parseBranch :: Text -> Maybe (Text, Bool)
 parseBranch line =
@@ -129,22 +123,17 @@ listReviewCommits
     :: OsPath
     -> Int
     -> IO (Either Text [ReviewCommit])
-listReviewCommits cwd requestedLimit = do
-    repository <- requireWorkTree cwd
-    case repository of
-        Left err -> pure (Left err)
-        Right () ->
-            runSafeGit cwd [] ["rev-parse", "--verify", "HEAD"] >>= \case
-                Left err -> pure (Left err)
-                Right headOutput
-                    | headOutput.gitCommandExitCode /= ExitSuccess ->
-                        pure (Right [])
-                    | otherwise ->
-                        loadCommits cwd (max 1 (min 200 requestedLimit))
+listReviewCommits cwd requestedLimit = runExceptT do
+    requireWorkTree cwd
+    headOutput <- ExceptT $
+        runSafeGit cwd [] ["rev-parse", "--verify", "HEAD"]
+    if headOutput.gitCommandExitCode /= ExitSuccess
+        then pure []
+        else loadCommits cwd (max 1 (min 200 requestedLimit))
 
-loadCommits :: OsPath -> Int -> IO (Either Text [ReviewCommit])
-loadCommits cwd limit =
-    runSafeGit
+loadCommits :: OsPath -> Int -> ExceptT Text IO [ReviewCommit]
+loadCommits cwd limit = do
+    output <- ExceptT $ runSafeGit
         cwd
         []
         [ "--no-pager"
@@ -152,16 +141,10 @@ loadCommits cwd limit =
         , "--max-count=" <> show limit
         , "--no-decorate"
         , "--pretty=format:%H%x00%h%x00%s%x1e"
-        ] >>= \case
-            Left err -> pure (Left err)
-            Right output
-                | output.gitCommandExitCode == ExitSuccess ->
-                    pure $
-                        Right
-                            (mapMaybe parseCommit
-                                (Text.splitOn "\x1e" (gitOutputText output)))
-                | otherwise ->
-                    pure (Left (commandFailure "git log" output))
+        ]
+    unless (output.gitCommandExitCode == ExitSuccess) $
+        throwE (commandFailure "git log" output)
+    pure (mapMaybe parseCommit (Text.splitOn "\x1e" (gitOutputText output)))
 
 parseCommit :: Text -> Maybe ReviewCommit
 parseCommit raw =
@@ -177,16 +160,14 @@ parseCommit raw =
                     }
         _ -> Nothing
 
-requireWorkTree :: OsPath -> IO (Either Text ())
-requireWorkTree cwd =
-    runSafeGit cwd [] ["rev-parse", "--is-inside-work-tree"] >>= \case
-        Left err -> pure (Left err)
-        Right output
-            | output.gitCommandExitCode == ExitSuccess
-            , Text.strip (gitOutputText output) == "true" ->
-                pure (Right ())
-            | otherwise ->
-                pure (Left "not a Git repository")
+requireWorkTree :: OsPath -> ExceptT Text IO ()
+requireWorkTree cwd = do
+    output <- ExceptT $
+        runSafeGit cwd [] ["rev-parse", "--is-inside-work-tree"]
+    unless
+        (output.gitCommandExitCode == ExitSuccess
+            && Text.strip (gitOutputText output) == "true") $
+        throwE "not a Git repository"
 
 commandFailure :: Text -> GitCommandOutput -> Text
 commandFailure command output =

--- a/packages/agent-cli/test/Agent/CLI/ReviewSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReviewSpec.hs
@@ -80,6 +80,27 @@ spec = describe "Agent.CLI.Review" do
                 git repo ["init"]
                 listReviewCommits repo 20 `shouldReturn` Right []
 
+        it "returns no branches when only the current branch exists" $
+            withTempGitRepo \repo ->
+                listReviewBranches repo `shouldReturn` Right []
+
+        it "clamps a non-positive commit limit to one" $
+            withTempGitRepo \repo -> do
+                commits <- expectRight =<< listReviewCommits repo 0
+                map (.reviewCommitSubject) commits
+                    `shouldBe` ["initial subject"]
+
+        it "propagates Git launch failures rather than returning an empty list" $
+            withTempDir "agent-review-missing-" \dir -> do
+                let missing = dir </> fromText "missing"
+                branches <- listReviewBranches missing
+                commits <- listReviewCommits missing 20
+                branches `shouldSatisfy` isFailure
+                commits `shouldSatisfy` isFailure
+  where
+    isFailure (Left err) = not (Text.null err)
+    isFailure (Right _) = False
+
 expectRight :: Either Text a -> IO a
 expectRight = \case
     Right value -> pure value


### PR DESCRIPTION
## Summary
- Replace nested Either handling in Review.hs with ExceptT and linear do notation.
- Preserve the public IO (Either Text ...) API, error messages, branch filtering, and commit-limit behavior.
- Add regression tests for current-branch-only repositories, non-positive limits, and Git launch failures.

## Validation
- Focused ReviewSpec run in GHCi: 10 examples, 0 failures; all 8 source modules loaded without compiler warnings or errors.
- git diff --check passes.
- No CLI UI changes.