### PR TITLE
Refactor transcription receivers to own recursive state

### DIFF
--- a/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
@@ -6,6 +6,7 @@ module Agent.OpenAI.Transcription
     , chatGPTTranscriptionBaseUrl
     , decodeChatGPTDictationEvent
     , decodeTranscriptEvent
+    , transcribeOnConnection
     , decodeTranscriptionResponse
     , encodePcm16Wav
     , openAITranscriptionModel
@@ -41,10 +42,7 @@ import Control.Concurrent.Async
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
 import Control.Concurrent.MVar
     ( MVar
-    , modifyMVar
     , newEmptyMVar
-    , newMVar
-    , readMVar
     , takeMVar
     , tryPutMVar
     , tryReadMVar
@@ -620,16 +618,14 @@ chatGPTStreamSession
                 Just (Left message) ->
                     pure (ChatGPTStreamUnavailable message)
                 Just (Right ()) -> do
-                    state <- newMVar emptyChatGPTStreamState
                     finished <- newEmptyMVar
                     withAsync
                         (receiveChatGPTDictation
                             connection
-                            state
                             finished
                             onTranscript)
                         \receiver ->
-                            runCapture state finished
+                            runCapture finished
                                 `finally` do
                                     cancel receiver
                                     ignoreSynchronousException $
@@ -637,7 +633,7 @@ chatGPTStreamSession
                                             connection
                                             ("done" :: Text)
   where
-    runCapture state finished = do
+    runCapture finished = do
         sendQueuedChatGPTAudio connection finished audio
         sendChatGPTMessage
             finished
@@ -651,8 +647,7 @@ chatGPTStreamSession
                         "ChatGPT dictation stream timed out while closing"
                 Just (Left message) ->
                     pure (ChatGPTStreamUnavailable message)
-                Just (Right ()) -> do
-                    current <- readMVar state
+                Just (Right current) -> do
                     let transcript =
                             Text.strip
                                 (renderChatGPTTranscript current)
@@ -664,7 +659,7 @@ chatGPTStreamSession
 
 sendQueuedChatGPTAudio
     :: WS.Connection
-    -> MVar (Either Text ())
+    -> MVar (Either Text ChatGPTStreamState)
     -> Chan (Maybe BS.ByteString)
     -> IO ()
 sendQueuedChatGPTAudio connection finished audio =
@@ -683,7 +678,7 @@ sendQueuedChatGPTAudio connection finished audio =
             sendQueuedChatGPTAudio connection finished audio
 
 sendChatGPTMessage
-    :: MVar (Either Text ())
+    :: MVar (Either Text ChatGPTStreamState)
     -> WS.Connection
     -> Text
     -> IO ()
@@ -721,22 +716,31 @@ awaitChatGPTSessionStarted connection = do
 
 receiveChatGPTDictation
     :: WS.Connection
-    -> MVar ChatGPTStreamState
-    -> MVar (Either Text ())
+    -> MVar (Either Text ChatGPTStreamState)
     -> (Text -> IO ())
     -> IO ()
-receiveChatGPTDictation connection state finished onTranscript =
-    tryAny loop >>= \case
+receiveChatGPTDictation connection finished onTranscript =
+    tryAny (loop emptyChatGPTStreamState) >>= \case
         Left err
             | isSyncException err ->
-                void $ tryPutMVar finished (receiverFailure err)
+                void $ tryPutMVar finished (Left (receiverFailure err))
             | otherwise ->
                 throwIO err
         Right result ->
             void (tryPutMVar finished result)
   where
-    loop = do
-        bytes <- WS.receiveData connection
+    loop :: ChatGPTStreamState -> IO (Either Text ChatGPTStreamState)
+    loop previous = do
+        -- A normal close also completes the transcript. Catch it at the
+        -- receive checkpoint where the receiver still owns the latest state.
+        received <- tryAny (WS.receiveData connection)
+        case received of
+            Left err
+                | Just (WS.CloseRequest 1000 _) <- fromException err ->
+                    pure (Right previous)
+                | otherwise -> throwIO err
+            Right bytes -> handleEvent previous bytes
+    handleEvent previous bytes =
         case decodeChatGPTDictationEvent bytes of
             Left message ->
                 pure $ Left
@@ -746,54 +750,30 @@ receiveChatGPTDictation connection state finished onTranscript =
                 case event of
                     ChatGPTSessionUpdated status
                         | status == "closed" ->
-                            pure (Right ())
+                            pure (Right previous)
                     ChatGPTTranscriptFailed message ->
                         pure (Left message)
                     ChatGPTSessionError True message ->
                         pure (Left message)
                     ChatGPTTranscriptDelta _ _ _ ->
-                        updateTranscript event >> loop
+                        updateTranscript event previous >>= loop
                     ChatGPTTranscriptSegment _ _ _ ->
-                        updateTranscript event >> loop
+                        updateTranscript event previous >>= loop
                     ChatGPTTranscriptFinal _ _ _ ->
-                        updateTranscript event >> loop
-                    _ -> do
-                        modifyMVar state \previous ->
-                            pure
-                                ( applyChatGPTDictationEvent
-                                    event
-                                    previous
-                                , ()
-                                )
-                        loop
-    updateTranscript event = do
-        notification <- modifyMVar state \previous ->
-            let next =
-                    applyChatGPTDictationEvent
-                        event
-                        previous
-                before = renderChatGPTTranscript previous
-                after = renderChatGPTTranscript next
-            in pure
-                ( next
-                , if after == before then Nothing else Just after
-                )
-        case notification of
-            Nothing ->
-                pure ()
-            Just transcript ->
-                ignoreSynchronousException
-                    (onTranscript transcript)
+                        updateTranscript event previous >>= loop
+                    _ -> loop (applyChatGPTDictationEvent event previous)
+    updateTranscript event previous = do
+        let next = applyChatGPTDictationEvent event previous
+            before = renderChatGPTTranscript previous
+            after = renderChatGPTTranscript next
+        unless (after == before) $
+            ignoreSynchronousException (onTranscript after)
+        pure next
 
-receiverFailure :: SomeException -> Either Text ()
+receiverFailure :: SomeException -> Text
 receiverFailure err =
-    case (fromException err :: Maybe WS.ConnectionException) of
-        Just (WS.CloseRequest 1000 _) ->
-            Right ()
-        _ ->
-            Left
-                ("ChatGPT dictation stream receive failed: "
-                    <> Text.pack (displayException err))
+    "ChatGPT dictation stream receive failed: "
+        <> Text.pack (displayException err)
 
 applyChatGPTDictationEvent
     :: ChatGPTDictationEvent
@@ -1188,28 +1168,31 @@ transcribe credential produceAudio onTranscript =
         [ ("Authorization"
           , "Bearer " <> Text.encodeUtf8 credential.accessToken)
         ]
-        \connection -> Json.withDecoderSession \decoderSession -> do
-            WS.sendTextData connection sessionUpdateMessage
-            awaitSessionUpdated decoderSession connection
-            state <- newMVar emptyTranscriptState
-            finished <- newEmptyMVar
-            withAsync
-                (receiveTranscripts
-                    decoderSession
-                    connection
-                    state
-                    finished
-                    onTranscript)
-                \receiver ->
-                    (do
-                        produceAudio \bytes ->
-                            WS.sendTextData connection (audioAppendMessage bytes)
-                        WS.sendTextData connection audioCommitMessage
-                        waitForTranscript state finished)
-                        `finally` do
-                            void (tryAny
-                                (WS.sendClose connection ("done" :: Text)))
-                            cancel receiver
+        \connection -> transcribeOnConnection connection produceAudio onTranscript
+
+-- | Run transcription on an already authenticated WebSocket. The caller owns
+-- the transport; this scopes the receiver and closes the transcription session.
+transcribeOnConnection
+    :: WS.Connection
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (Text -> IO ())
+    -> IO Text
+transcribeOnConnection connection produceAudio onTranscript =
+    Json.withDecoderSession \decoderSession -> do
+        WS.sendTextData connection sessionUpdateMessage
+        awaitSessionUpdated decoderSession connection
+        finished <- newEmptyMVar
+        withAsync
+            (receiveTranscripts decoderSession connection finished onTranscript)
+            \receiver ->
+                (do
+                    produceAudio \bytes ->
+                        WS.sendTextData connection (audioAppendMessage bytes)
+                    WS.sendTextData connection audioCommitMessage
+                    waitForTranscript finished)
+                    `finally` do
+                        void (tryAny (WS.sendClose connection ("done" :: Text)))
+                        cancel receiver
 
 sessionUpdateMessage :: Text
 sessionUpdateMessage =
@@ -1271,24 +1254,23 @@ awaitSessionUpdated decoderSession connection = do
 receiveTranscripts
     :: Json.DecoderSession
     -> WS.Connection
-    -> MVar TranscriptState
-    -> MVar (Either SomeException ())
+    -> MVar (Either SomeException TranscriptState)
     -> (Text -> IO ())
     -> IO ()
-receiveTranscripts decoderSession connection state finished onTranscript =
-    tryAny loop >>= void . tryPutMVar finished
+receiveTranscripts decoderSession connection finished onTranscript =
+    tryAny (loop emptyTranscriptState) >>= void . tryPutMVar finished
   where
-    loop = do
+    -- The receiver owns accumulation; only the final state crosses threads.
+    loop :: TranscriptState -> IO TranscriptState
+    loop previous = do
         bytes <- WS.receiveData connection
         Json.decodeIO
             decoderSession
             transcriptEventDecoder
             (LBS.toStrict bytes) >>= \case
-            Left _ -> loop
+            Left _ -> loop previous
             Right event -> do
-                current <- modifyMVar state \previous ->
-                    let next = applyTranscriptEvent event previous
-                    in pure (next, next)
+                let current = applyTranscriptEvent event previous
                 case event of
                     TranscriptDelta{} ->
                         notify current
@@ -1297,9 +1279,9 @@ receiveTranscripts decoderSession connection state finished onTranscript =
                     _ ->
                         pure ()
                 case event of
-                    TranscriptCompleted{} -> pure ()
-                    TranscriptError{} -> pure ()
-                    _ -> loop
+                    TranscriptCompleted{} -> pure current
+                    TranscriptError{} -> pure current
+                    _ -> loop current
     notify current =
         void (tryAny (onTranscript (renderTranscript current)))
 
@@ -1321,18 +1303,16 @@ applyTranscriptEvent event state =
             state
 
 waitForTranscript
-    :: MVar TranscriptState
-    -> MVar (Either SomeException ())
+    :: MVar (Either SomeException TranscriptState)
     -> IO Text
-waitForTranscript state finished = do
+waitForTranscript finished = do
     completedInTime <- Timeout.timeout (30 * 1_000_000) (takeMVar finished)
     case completedInTime of
         Nothing ->
             fail "timed out waiting for OpenAI Realtime transcription"
         Just (Left err) ->
             throwIO err
-        Just (Right ()) -> do
-            current <- readMVar state
+        Just (Right current) -> do
             case current.failure of
                 Just message ->
                     fail (Text.unpack message)

--- a/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
@@ -44,6 +44,57 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "OpenAI transcription" do
+    it "returns completed Realtime state despite malformed events and callback failures" do
+        callbacks <- newIORef []
+        let server pending = do
+                connection <- WS.acceptRequest pending
+                _ <- WS.receiveData connection :: IO Text
+                WS.sendTextData connection ("{\"type\":\"session.updated\"}" :: Text)
+                _ <- WS.receiveData connection :: IO Text
+                mapM_ (WS.sendTextData connection)
+                    [ "{\"type\":\"conversation.item.input_audio_transcription.delta\",\"delta\":\"hello \"}"
+                    , "invalid JSON"
+                    , "{\"type\":\"future.event\"}"
+                    , "{\"type\":\"conversation.item.input_audio_transcription.delta\",\"delta\":\"world\"}"
+                    , "{\"type\":\"conversation.item.input_audio_transcription.completed\",\"transcript\":\" final text \"}"
+                    :: Text
+                    ]
+                (WS.receiveData connection :: IO Text) `shouldThrow` anyException
+        withWebSocketServer server \port ->
+            Timeout.timeout (5 * 1_000_000)
+                (WS.runClient "127.0.0.1" port "/" \connection ->
+                    transcribeOnConnection connection (const (pure ())) \text -> do
+                        modifyIORef' callbacks (<> [text])
+                        throwString "callback failed")
+                `shouldReturn` Just "final text"
+        readIORef callbacks `shouldReturn` ["hello ", "hello world", " final text "]
+
+    it "retains ChatGPT state on a normal WebSocket close after callback failure" do
+        callbacks <- newIORef []
+        let server pending = do
+                connection <- WS.acceptRequest pending
+                _ <- WS.receiveData connection :: IO Text
+                sendEvent connection $ Aeson.object ["type" .= ("session.started" :: Text)]
+                _ <- WS.receiveData connection :: IO Text
+                sendEvent connection $ Aeson.object
+                    [ "type" .= ("transcript.delta" :: Text)
+                    , "utterance_id" .= ("u1" :: Text)
+                    , "revision" .= (1 :: Int)
+                    , "text" .= ("retained speech" :: Text)
+                    ]
+                WS.sendClose connection ("done" :: Text)
+        withWebSocketServer server \port ->
+            Timeout.timeout (5 * 1_000_000)
+                (transcribePcmWithChatGPTStreamAt
+                    ("ws://127.0.0.1:" <> Text.pack (show port) <> "/")
+                    []
+                    (const (pure ()))
+                    (\text -> do
+                        modifyIORef' callbacks (<> [text])
+                        throwString "callback failed"))
+                `shouldReturn` Just (Right "retained speech")
+        readIORef callbacks `shouldReturn` ["retained speech"]
+
     it "decodes incremental and completed transcript events" do
         decodeTranscriptEvent
             "{\"type\":\"conversation.item.input_audio_transcription.delta\",\"delta\":\"hello \"}"

--- a/packages/agent-xai/agent-xai.cabal
+++ b/packages/agent-xai/agent-xai.cabal
@@ -101,3 +101,5 @@ test-suite agent-xai-test
                     , safe-exceptions
                     , wai
                     , warp
+                    , network
+                    , websockets

--- a/packages/agent-xai/package.nix
+++ b/packages/agent-xai/package.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, agent-core, agent-json, agent-responses
 , agent-responses-types, async, base, base64-bytestring, bytestring
 , case-insensitive, containers, hspec, http-client, http-client-tls
-, http-conduit, http-types, lib, process, retry, safe-exceptions
-, text, time, wai, warp, websockets, wuss
+, http-conduit, http-types, lib, network, process, retry
+, safe-exceptions, text, time, wai, warp, websockets, wuss
 }:
 mkDerivation {
   pname = "agent-xai";
@@ -17,7 +17,8 @@ mkDerivation {
   testHaskellDepends = [
     aeson agent-core agent-json agent-responses agent-responses-types
     async base base64-bytestring bytestring case-insensitive containers
-    hspec http-types retry safe-exceptions text wai warp
+    hspec http-types network retry safe-exceptions text wai warp
+    websockets
   ];
   description = "Haskell client for the xAI Grok subscription transport";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-xai/src/Agent/XAI/Transcription.hs
+++ b/packages/agent-xai/src/Agent/XAI/Transcription.hs
@@ -2,6 +2,7 @@
 module Agent.XAI.Transcription
     ( TranscriptEvent(..)
     , decodeTranscriptEvent
+    , transcribeOnConnection
     , transcribeAudioWithXAI
     , transcribePcmWithXAI
     ) where
@@ -23,10 +24,7 @@ import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (cancel, withAsync)
 import Control.Concurrent.MVar
     ( MVar
-    , modifyMVar
     , newEmptyMVar
-    , newMVar
-    , readMVar
     , takeMVar
     , tryPutMVar
     )
@@ -190,23 +188,27 @@ transcribe credential produceAudio onTranscript = do
         , ("User-Agent"
           , Text.encodeUtf8 (grokUserAgent defaultGrokClientVersion))
         ]
-        \connection -> Json.withDecoderSession \decoderSession -> do
-            awaitCreated decoderSession connection
-            state <- newMVar emptyTranscriptState
-            finished <- newEmptyMVar
-            withAsync
-                (receiveTranscripts
-                    decoderSession
-                    connection
-                    state
-                    finished
-                    onTranscript)
-                \receiver -> do
+        \connection -> transcribeOnConnection connection produceAudio onTranscript
+
+-- | Run transcription on an already authenticated WebSocket. The caller owns
+-- the transport; this scopes the receiver and closes the transcription session.
+transcribeOnConnection
+    :: WS.Connection
+    -> ((BS.ByteString -> IO ()) -> IO ())
+    -> (Text -> IO ())
+    -> IO Text
+transcribeOnConnection connection produceAudio onTranscript =
+    Json.withDecoderSession \decoderSession -> do
+        awaitCreated decoderSession connection
+        finished <- newEmptyMVar
+        withAsync
+            (receiveTranscripts decoderSession connection finished onTranscript)
+            \receiver ->
                 (do
                     produceAudio (WS.sendBinaryData connection)
                     WS.sendTextData connection
                         ("{\"type\":\"audio.done\"}" :: Text)
-                    waitForTranscript state finished)
+                    waitForTranscript finished)
                     `finally` do
                         void (tryAny (WS.sendClose connection ("done" :: Text)))
                         cancel receiver
@@ -252,24 +254,23 @@ awaitCreated decoderSession connection = do
 receiveTranscripts
     :: Json.DecoderSession
     -> WS.Connection
-    -> MVar TranscriptState
-    -> MVar (Either SomeException ())
+    -> MVar (Either SomeException TranscriptState)
     -> (Text -> IO ())
     -> IO ()
-receiveTranscripts decoderSession connection state finished onTranscript =
-    tryAny loop >>= void . tryPutMVar finished
+receiveTranscripts decoderSession connection finished onTranscript =
+    tryAny (loop emptyTranscriptState) >>= void . tryPutMVar finished
   where
-    loop = do
+    -- The receiver owns accumulation; only the final state crosses threads.
+    loop :: TranscriptState -> IO TranscriptState
+    loop previous = do
         bytes <- WS.receiveData connection
         Json.decodeIO
             decoderSession
             transcriptEventDecoder
             (LBS.toStrict bytes) >>= \case
-            Left _ -> loop
+            Left _ -> loop previous
             Right event -> do
-                current <- modifyMVar state \previous ->
-                    let next = applyTranscriptEvent event previous
-                    in pure (next, next)
+                let current = applyTranscriptEvent event previous
                 case event of
                     TranscriptPartial{} ->
                         void (tryAny (onTranscript (renderTranscript current)))
@@ -278,9 +279,9 @@ receiveTranscripts decoderSession connection state finished onTranscript =
                     _ ->
                         pure ()
                 case event of
-                    TranscriptDone{} -> pure ()
-                    TranscriptError{} -> pure ()
-                    _ -> loop
+                    TranscriptDone{} -> pure current
+                    TranscriptError{} -> pure current
+                    _ -> loop current
 
 applyTranscriptEvent :: TranscriptEvent -> TranscriptState -> TranscriptState
 applyTranscriptEvent event state =
@@ -313,18 +314,16 @@ applyTranscriptEvent event state =
         | otherwise = values <> [text]
 
 waitForTranscript
-    :: MVar TranscriptState
-    -> MVar (Either SomeException ())
+    :: MVar (Either SomeException TranscriptState)
     -> IO Text
-waitForTranscript state finished = do
+waitForTranscript finished = do
     completedInTime <- Timeout.timeout (30 * 1_000_000) (takeMVar finished)
     case completedInTime of
         Nothing ->
             fail "timed out waiting for xAI transcription"
         Just (Left err) ->
             throwIO err
-        Just (Right ()) -> do
-            current <- readMVar state
+        Just (Right current) -> do
             case current.failure of
                 Just message ->
                     fail (Text.unpack message)

--- a/packages/agent-xai/test/Agent/XAI/TestSupport.hs
+++ b/packages/agent-xai/test/Agent/XAI/TestSupport.hs
@@ -1,5 +1,6 @@
 module Agent.XAI.TestSupport
     ( withLoopbackApplication
+    , requireLoopbackListener
     ) where
 
 import Control.Exception (IOException, try)

--- a/packages/agent-xai/test/Agent/XAI/TranscriptionSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/TranscriptionSpec.hs
@@ -1,10 +1,65 @@
 module Agent.XAI.TranscriptionSpec (spec) where
 
 import Agent.XAI.Transcription
+import Agent.XAI.TestSupport (requireLoopbackListener)
+import Control.Concurrent (newEmptyMVar, putMVar, takeMVar)
+import Control.Concurrent.Async (cancel, wait, withAsync)
+import Control.Exception.Safe (bracket, finally, throwString)
+import Data.IORef (modifyIORef', newIORef, readIORef)
+import Data.Text (Text)
+import qualified Network.Socket as Socket
+import qualified Network.WebSockets as WS
+import qualified System.Timeout as Timeout
+import System.IO.Error (ioeGetErrorString)
 import Test.Hspec
 
 spec :: Spec
 spec = describe "xAI transcription events" do
+    it "cancels a receiver blocked in a transcript callback" do
+        entered <- newEmptyMVar
+        blocked <- newEmptyMVar
+        withTranscriptServer
+            ["{\"type\":\"transcript.partial\",\"text\":\"interim\"}"]
+            (\connection ->
+                withAsync
+                    (transcribeOnConnection connection (const (pure ())) \_ ->
+                        putMVar entered () >> takeMVar blocked)
+                    \worker -> do
+                        takeMVar entered
+                        Timeout.timeout (1 * 1_000_000) (cancel worker)
+                            `shouldReturn` Just ())
+
+    it "returns accumulated speech on empty done despite malformed events and callback failures" do
+        callbacks <- newIORef []
+        withTranscriptServer
+            [ "{\"type\":\"transcript.partial\",\"text\":\"hello\",\"speech_final\":true}"
+            , "invalid JSON"
+            , "{\"type\":\"future.event\"}"
+            , "{\"type\":\"transcript.partial\",\"text\":\"world\",\"speech_final\":true}"
+            , "{\"type\":\"transcript.done\",\"text\":\"\"}"
+            ]
+            (\connection -> transcribeOnConnection connection (const (pure ())) \text -> do
+                modifyIORef' callbacks (<> [text])
+                throwString "callback failed")
+            `shouldReturn` "hello world"
+        readIORef callbacks `shouldReturn` ["hello", "hello world", "hello world"]
+
+    it "prefers nonempty done text over accumulated partials" do
+        withTranscriptServer
+            [ "{\"type\":\"transcript.partial\",\"text\":\"interim\"}"
+            , "{\"type\":\"transcript.done\",\"text\":\" final \"}"
+            ]
+            (\connection -> transcribeOnConnection connection (const (pure ())) (const (pure ())))
+            `shouldReturn` "final"
+
+    it "delivers provider errors through completion instead of returning partial text" do
+        withTranscriptServer
+            [ "{\"type\":\"transcript.partial\",\"text\":\"interim\"}"
+            , "{\"type\":\"error\",\"message\":\"provider failed\"}"
+            ]
+            (\connection -> transcribeOnConnection connection (const (pure ())) (const (pure ())))
+            `shouldThrow` (\err -> ioeGetErrorString err == "provider failed")
+
     it "decodes partial and final transcript events" do
         decodeTranscriptEvent
             "{\"type\":\"transcript.partial\",\"text\":\"hello\",\"is_final\":false,\"speech_final\":false}"
@@ -22,3 +77,25 @@ spec = describe "xAI transcription events" do
     it "ignores forward-compatible server events" do
         decodeTranscriptEvent "{\"type\":\"usage.updated\",\"tokens\":1}"
             `shouldBe` Right TranscriptUnknown
+
+withTranscriptServer :: [Text] -> (WS.Connection -> IO a) -> IO a
+withTranscriptServer events action =
+    requireLoopbackListener >>
+    bracket (WS.makeListenSocket "127.0.0.1" 0) Socket.close \listener -> do
+        Socket.SockAddrInet port _ <- Socket.getSocketName listener
+        let server = do
+                (socket, _) <- Socket.accept listener
+                flip finally (Socket.close socket) do
+                    pending <- WS.makePendingConnection socket WS.defaultConnectionOptions
+                    connection <- WS.acceptRequest pending
+                    WS.sendTextData connection ("{\"type\":\"transcript.created\"}" :: Text)
+                    (WS.receiveData connection :: IO Text)
+                        `shouldReturn` "{\"type\":\"audio.done\"}"
+                    mapM_ (WS.sendTextData connection) events
+                    (WS.receiveData connection :: IO Text) `shouldThrow` anyException
+        withAsync server \worker -> do
+            result <- Timeout.timeout (5 * 1_000_000) $
+                WS.runClient "127.0.0.1" (fromIntegral port) "/" action
+            case result of
+                Nothing -> expectationFailure "transcription timed out" >> fail "timeout"
+                Just value -> wait worker >> pure value


### PR DESCRIPTION
## Summary
- Replace receiver-only transcript state MVars with explicit recursive state in OpenAI Realtime, ChatGPT dictation, and xAI STT.
- Deliver final state through the existing completion channel. Preserve sender failure coordination, timeouts, cancellation, and callback exception handling; retain ChatGPT state on normal WebSocket close.
- Reuse existing pure event reducers. Expose connection-level session entry points for loopback regression tests without credentials.
- Add regression coverage for accumulation, final text precedence, malformed/unknown events, provider errors, callback failures, normal close, and cancellation during a blocked callback. Regenerate xAI package.nix for test dependencies.

## Validation
- nix develop --max-jobs 1 --cores 2 -c env GHCRTS=-M3G cabal repl -j1 agent-openai:lib:agent-openai agent-xai:lib:agent-xai: verified Ok, 48 modules loaded.
- Single-component cabal repl -j1 agent-openai:test:agent-openai-test and agent-xai:test:agent-xai-test under the same Nix/heap bounds, running :main --match transcription: 13 OpenAI and 6 xAI examples, zero failures. Verified successful GHCi loads and test counts, not just exit codes.
- git diff --check; generated package.nix comparison; independent read-only concurrency review.

Maintainability/correctness refactor, with no performance claim. Validation uses loopback WebSockets, not live provider credentials or microphone hardware. Existing production timeout durations are unchanged.