### PR TITLE
Deduplicate automatic provider fallback candidate selection

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Provider/Switch.hs
@@ -69,6 +69,7 @@ import Agent.CLI.ProviderAvailability
 import Agent.CLI.ProviderFallback
     ( allowsAutomaticBillingFallback
     , fallbackCandidates
+    , selectAutomaticProviderCandidateWith
     )
 import Agent.CLI.ProviderTransition
     ( PendingTurn
@@ -576,48 +577,15 @@ chooseAutomaticProviderTransition
     fallbackEnabled catalog cwd stderrHandle fullscreen
         sourceBilling current currentModel unavailable0 sessionId pending apiError
     | not fallbackEnabled = pure Nothing
-    | otherwise = tryCandidates unavailable0 candidates
-  where
-    candidates =
-        fallbackCandidates
-            catalog unavailable0 current currentModel apiError
-
-    tryCandidates unavailable = \case
-        [] -> pure Nothing
-        rawChoice : rest -> do
-            choice <- resolveModelOptionDialect rawChoice
-            validateAutomaticProviderTarget
-                cwd
-                sourceBilling
-                choice >>= \case
-                Left err -> do
-                    let failedProvider =
-                            choice.modelTarget.targetProvider
-                        unavailable' =
-                            markUnavailable failedProvider unavailable
-                        remaining =
-                            filter
-                                ((/= failedProvider)
-                                    . (.modelTarget.targetProvider))
-                                rest
-                        message =
-                            "skipping "
-                            <> providerSlug failedProvider
-                            <> ": "
-                            <> err
-                    case fullscreen of
-                        Nothing -> do
-                            color <- resolveColor stderrHandle
-                            putTextLn stderrHandle (roleMuted color message)
-                        Just runtime ->
-                            emitUiEvent runtime (UiSystemMessage message)
-                    tryCandidates unavailable' remaining
-                Right selected -> do
+    | otherwise =
+        selectAutomaticProviderCandidateWith
+            resolveModelOptionDialect
+            (validateAutomaticProviderTarget cwd sourceBilling)
+            reportSkipped
+            current unavailable0 candidates >>= \case
+                Nothing -> pure Nothing
+                Just (choice, selected, unavailable) -> do
                     let nextProvider = choice.modelTarget.targetProvider
-                        unavailable' =
-                            if nextProvider == current
-                                then unavailable
-                                else markUnavailable current unavailable
                         message
                             | nextProvider == current =
                                 currentModel
@@ -645,9 +613,22 @@ chooseAutomaticProviderTransition
                             (.selectedAccountId) <$> selected
                         , transitionSessionId = sessionId
                         , transitionPendingTurn = Just pending
-                        , transitionUnavailableProviders = unavailable'
+                        , transitionUnavailableProviders = unavailable
                         , transitionCause = AutomaticFallback sourceBilling
                         }
+  where
+    candidates =
+        fallbackCandidates
+            catalog unavailable0 current currentModel apiError
+
+    reportSkipped failedProvider err = do
+        let message = "skipping " <> providerSlug failedProvider <> ": " <> err
+        case fullscreen of
+            Nothing -> do
+                color <- resolveColor stderrHandle
+                putTextLn stderrHandle (roleMuted color message)
+            Just runtime ->
+                emitUiEvent runtime (UiSystemMessage message)
 
 chooseStartupProviderTransition
     :: Bool
@@ -665,44 +646,15 @@ chooseStartupProviderTransition
     fallbackEnabled catalog cwd fullscreen sourceBilling current currentModel
         unavailable0 sessionId apiError
     | not fallbackEnabled = pure Nothing
-    | otherwise = tryCandidates unavailable0 candidates
-  where
-    candidates =
-        fallbackCandidates
-            catalog unavailable0 current currentModel apiError
-
-    tryCandidates unavailable = \case
-        [] -> pure Nothing
-        rawChoice : rest -> do
-            choice <- resolveModelOptionDialect rawChoice
-            validateAutomaticProviderTarget
-                cwd
-                sourceBilling
-                choice >>= \case
-                Left err -> do
-                    let failedProvider =
-                            choice.modelTarget.targetProvider
-                        unavailable' =
-                            markUnavailable failedProvider unavailable
-                        remaining =
-                            filter
-                                ((/= failedProvider)
-                                    . (.modelTarget.targetProvider))
-                                rest
-                        message =
-                            "skipping "
-                            <> providerSlug failedProvider
-                            <> ": "
-                            <> err
-                    forM_ fullscreen \runtime ->
-                        emitUiEvent runtime (UiSystemMessage message)
-                    tryCandidates unavailable' remaining
-                Right selected -> do
+    | otherwise =
+        selectAutomaticProviderCandidateWith
+            resolveModelOptionDialect
+            (validateAutomaticProviderTarget cwd sourceBilling)
+            reportSkipped
+            current unavailable0 candidates >>= \case
+                Nothing -> pure Nothing
+                Just (choice, selected, unavailable) -> do
                     let nextProvider = choice.modelTarget.targetProvider
-                        unavailable' =
-                            if nextProvider == current
-                                then unavailable
-                                else markUnavailable current unavailable
                         message
                             | nextProvider == current =
                                 currentModel
@@ -725,9 +677,18 @@ chooseStartupProviderTransition
                             (.selectedAccountId) <$> selected
                         , transitionSessionId = sessionId
                         , transitionPendingTurn = Nothing
-                        , transitionUnavailableProviders = unavailable'
+                        , transitionUnavailableProviders = unavailable
                         , transitionCause = AutomaticFallback sourceBilling
                         }
+  where
+    candidates =
+        fallbackCandidates
+            catalog unavailable0 current currentModel apiError
+
+    reportSkipped failedProvider err =
+        forM_ fullscreen \runtime ->
+            emitUiEvent runtime (UiSystemMessage
+                ("skipping " <> providerSlug failedProvider <> ": " <> err))
 
 prepareProviderTransition
     :: TransitionCause
@@ -961,9 +922,6 @@ commitBackendOnSuccess
                         scope home projectRoot (Just transition) persist
             Left _ -> pure ()
         pure result
-
-markUnavailable :: Provider -> Set Provider -> Set Provider
-markUnavailable = Set.insert
 
 reloadAuth :: Provider -> Maybe TokenProvider -> IO (Either Text Text)
 reloadAuth ClaudeCodeProvider _ =

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -9,6 +9,7 @@ module Agent.CLI.ProviderFallback
     , ProviderRecoveryPreference(..)
     , providerRecoveryPreference
     , rankedModels
+    , selectAutomaticProviderCandidateWith
     ) where
 
 import Agent.CLI.ModelConfig (ModelCatalog)
@@ -22,6 +23,41 @@ import Data.List (sortOn)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime)
+
+-- | Select a validated fallback and its account without committing a transition.
+-- Callers supply dialect resolution, target/account validation, and reporting;
+-- startup and per-turn messaging and pending-turn policy remain outside the loop.
+selectAutomaticProviderCandidateWith
+    :: (ModelOption -> IO ModelOption)
+    -> (ModelOption -> IO (Either Text account))
+    -> (Provider -> Text -> IO ())
+    -> Provider
+    -> Set Provider
+    -> [ModelOption]
+    -> IO (Maybe (ModelOption, account, Set Provider))
+selectAutomaticProviderCandidateWith resolve validate reportSkipped current =
+    tryCandidates
+  where
+    tryCandidates unavailable = \case
+        [] -> pure Nothing
+        rawChoice : rest -> do
+            choice <- resolve rawChoice
+            validate choice >>= \case
+                Left err -> do
+                    let failedProvider = choice.modelTarget.targetProvider
+                        unavailable' = Set.insert failedProvider unavailable
+                        remaining =
+                            filter
+                                ((/= failedProvider) . (.modelTarget.targetProvider))
+                                rest
+                    reportSkipped failedProvider err
+                    tryCandidates unavailable' remaining
+                Right selected -> do
+                    let unavailable' =
+                            if choice.modelTarget.targetProvider == current
+                                then unavailable
+                                else Set.insert current unavailable
+                    pure (Just (choice, selected, unavailable'))
 
 -- | Keep brief provider cooldowns invisible to the user. Longer waits are
 -- eligible for cross-provider fallback instead of making the CLI appear hung.

--- a/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ProviderFallbackSpec.hs
@@ -5,7 +5,8 @@ import Agent.CLI.ModelConfig
     , decodeModelConfig
     , packagedModelCatalogPath
     )
-import Agent.CLI.Models (ModelOption(..), ModelTarget(..))
+import Agent.CLI.AccountSelection (SelectedAccount(..))
+import Agent.CLI.Models (ModelOption(..), ModelTarget(..), rawModelOption)
 import Agent.CLI.ProviderFallback
     ( allowsAutomaticBillingFallback
     , automaticCooldownRetryDelay
@@ -14,7 +15,9 @@ import Agent.CLI.ProviderFallback
     , ProviderRecoveryPreference(..)
     , providerRecoveryPreference
     , rankedModels
+    , selectAutomaticProviderCandidateWith
     )
+import Agent.Dialect (DialectId(..))
 import Agent.Error
     ( ApiError(..)
     , ErrorType(..)
@@ -22,6 +25,7 @@ import Agent.Error
     )
 import Agent.Provider (BillingMode(..), Provider(..))
 import qualified Data.ByteString.Lazy as LBS
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
@@ -31,6 +35,86 @@ import Test.Hspec
 spec :: Spec
 spec = do
     catalog <- runIO readPackagedCatalog
+    describe "selectAutomaticProviderCandidateWith" do
+        let openai = rawModelOption OpenAIProvider "gpt-6-astra"
+            grok = rawModelOption XAIProvider "grok-4.6"
+            gemini = rawModelOption GeminiProvider "gemini-3.7-flash"
+            ignoreSkipped _ _ = pure ()
+
+        it "does no resolution, validation, or reporting for no candidates" do
+            let unexpected = fail "unexpected candidate effect"
+            selectAutomaticProviderCandidateWith
+                (const unexpected) (const (unexpected :: IO (Either Text.Text ())))
+                (\_ _ -> unexpected) OpenAIProvider Set.empty []
+                `shouldReturn` Nothing
+
+        it "resolves before validating and returns the selected account unchanged" do
+            events <- newIORef ([] :: [Text.Text])
+            let resolved = openai
+                    { modelTarget = openai.modelTarget { targetDialect = GrokBuildDialect } }
+                account = SelectedAccount OpenAIProvider "selection-id"
+                    "account-id" SubscriptionBilled "selected account"
+                resolve choice = do
+                    choice `shouldBe` openai
+                    modifyIORef' events (<> ["resolve"])
+                    pure resolved
+                validate choice = do
+                    choice `shouldBe` resolved
+                    modifyIORef' events (<> ["validate"])
+                    pure (Right (Just account))
+                unavailable = Set.singleton GeminiProvider
+            selectAutomaticProviderCandidateWith resolve validate
+                (\_ _ -> expectationFailure "successful candidate was skipped")
+                OpenAIProvider unavailable [openai, grok]
+                `shouldReturn` Just (resolved, Just account, unavailable)
+            readIORef events `shouldReturn` ["resolve", "validate"]
+
+        it "filters every remaining model of a rejected provider and retains prior failures" do
+            events <- newIORef ([] :: [Text.Text])
+            let resolve choice = do
+                    modifyIORef' events (<> ["resolve " <> choice.modelTarget.targetModelId])
+                    pure choice
+                validate choice = do
+                    modifyIORef' events (<> ["validate " <> choice.modelTarget.targetModelId])
+                    pure $ if choice.modelTarget.targetProvider == XAIProvider
+                        then Left "no usable account"
+                        else Right (Nothing :: Maybe SelectedAccount)
+                skipped provider err = do
+                    provider `shouldBe` XAIProvider
+                    err `shouldBe` "no usable account"
+                    modifyIORef' events (<> ["skip"])
+            selectAutomaticProviderCandidateWith resolve validate skipped
+                OpenAIProvider (Set.singleton OpenRouterProvider)
+                [grok, rawModelOption XAIProvider "another-grok", gemini, openai]
+                `shouldReturn` Just
+                    ( gemini, Nothing
+                    , Set.fromList [OpenRouterProvider, XAIProvider, OpenAIProvider]
+                    )
+            readIORef events `shouldReturn`
+                [ "resolve grok-4.6", "validate grok-4.6", "skip"
+                , "resolve gemini-3.7-flash", "validate gemini-3.7-flash"
+                ]
+
+        it "keeps the current provider available after an earlier rejection" do
+            let validate choice = pure $
+                    if choice.modelTarget.targetProvider == XAIProvider
+                        then Left "unavailable"
+                        else Right ()
+            selectAutomaticProviderCandidateWith pure validate ignoreSkipped
+                OpenAIProvider Set.empty [grok, openai]
+                `shouldReturn` Just (openai, (), Set.singleton XAIProvider)
+
+        it "returns no selection after exhausting providers and reports each once" do
+            skipped <- newIORef []
+            selectAutomaticProviderCandidateWith pure
+                (const (pure (Left "unavailable" :: Either Text.Text ())))
+                (\provider err -> modifyIORef' skipped (<> [(provider, err)]))
+                OpenAIProvider Set.empty
+                [grok, gemini, rawModelOption XAIProvider "another-grok"]
+                `shouldReturn` Nothing
+            readIORef skipped `shouldReturn`
+                [(XAIProvider, "unavailable"), (GeminiProvider, "unavailable")]
+
     describe "allowsAutomaticBillingFallback" do
         it "blocks subscription-to-API-credit fallback" do
             allowsAutomaticBillingFallback


### PR DESCRIPTION
## Summary
- Extract the shared candidate-selection loop into ProviderFallback: resolve dialects, validate targets/select accounts, filter rejected providers, and track unavailable providers.
- Keep startup and per-turn messaging, transition cause, session ID, and pending-turn handling in their existing callers.
- Add five deterministic regression cases covering effect ordering, selected-account/dialect preservation, rejected-provider filtering, same-provider vs cross-provider tracking, and exhaustion.

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli`: verified `Ok, 251 modules loaded.`
- GHCi with `--build-depends=hspec`: ProviderFallbackSpec + ProviderTransitionSpec, **36 examples, 0 failures**.
- Live GHCi agent in tmux (`--minimal`, explicit dedicated-worktree cwd): startup prompt, `/model` picker, Esc cancellation and exit exercised; captured panes inspected.
- `git diff --check` passes.

Focused refactor only; no intended behavior or performance change.