### PR TITLE
Share MCP OAuth workflow and align credential reuse

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -699,6 +699,7 @@ test-suite agent-cli-test
                     , bytestring
                     , colour
                     , containers
+                    , crypton
                     , directory
                     , dbus >= 1.4 && < 1.5
                     , filepath
@@ -709,6 +710,7 @@ test-suite agent-cli-test
                     , http-client
                     , http-types
                     , JuicyPixels
+                    , memory
                     , network
                     , network-uri
                     , process

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -46,10 +46,10 @@ mkDerivation {
     agent-integration-api agent-json agent-mcp agent-openai
     agent-openrouter agent-responses agent-responses-types agent-store
     agent-tui agent-xai ansi-terminal async base base64-bytestring
-    brick bytestring colour containers dbus directory filelock filepath
-    haskeline hspec http-client http-types JuicyPixels network
-    network-uri process QuickCheck resourcet safe-exceptions stm
-    temporary text time transformers unix vty vty-unix wai warp
+    brick bytestring colour containers crypton dbus directory filelock
+    filepath haskeline hspec http-client http-types JuicyPixels memory
+    network network-uri process QuickCheck resourcet safe-exceptions
+    stm temporary text time transformers unix vty vty-unix wai warp
   ];
   benchmarkHaskellDepends = [
     aeson agent-cli-runtime agent-core agent-json agent-mcp

--- a/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpOAuth.hs
@@ -159,20 +159,57 @@ authorizeMcp
     -> Maybe McpOAuthConfig
     -> Text
     -> IO (OAuth.OAuthTokenFile, OAuth.OAuthTokenFileExtra)
-authorizeMcp host options oauthConfig serverUrl = do
-    either (const (failText "MCP authorization requires an HTTPS endpoint without embedded credentials or a fragment."))
+authorizeMcp host = runMcpOAuth OAuthWorkflowHost
+    { workflowSay = const (pure ())
+    , workflowError = const
+    , workflowLoadPrevious = host.oauthLoadPrevious >>= \case
+        Left _ -> failText "MCP credentials could not be read from protected storage."
+        Right record -> pure record
+    , workflowAuthorize = \url awaitCallback -> do
+        host.oauthOpenBrowser url
+            >>= either (const (failText "The authorization browser could not be opened.")) pure
+        awaitCallback
+    }
+
+-- | Only presentation, error disclosure and credential loading vary by owner.
+-- The protocol engine returns credentials; it cannot persist them or configure
+-- a server. In particular the runtime owner must still check its generation
+-- before committing the returned record.
+data OAuthWorkflowHost = OAuthWorkflowHost
+    { workflowSay :: Text -> IO ()
+    , workflowError :: Text -> Text -> Text
+    -- ^ Safe public summary, detailed CLI diagnostic.
+    , workflowLoadPrevious :: IO (Maybe (OAuth.OAuthTokenFile, OAuth.OAuthTokenFileExtra))
+    , workflowAuthorize :: Text -> IO Callback -> IO Callback
+    }
+
+runMcpOAuth
+    :: OAuthWorkflowHost
+    -> LoginOptions
+    -> Maybe McpOAuthConfig
+    -> Text
+    -> IO (OAuth.OAuthTokenFile, OAuth.OAuthTokenFileExtra)
+runMcpOAuth host options oauthConfig serverUrl = do
+    let reject :: Text -> Text -> IO a
+        reject summary = failText . host.workflowError summary
+    either (reject "MCP authorization requires an HTTPS endpoint without embedded credentials or a fragment.")
         pure (OAuth.validateOAuthEndpoint serverUrl)
     let resourceUri = OAuth.canonicalResourceUri serverUrl
     manager <- newTlsManager
     challenge <- OAuth.probeAuthorizationChallenge manager serverUrl >>= \case
-        Left _ -> pure Nothing
-        Right probe -> pure probe.probeChallenge
+        Left err -> do
+            host.workflowSay ("Warning: " <> err <> "; falling back to well-known discovery.")
+            pure Nothing
+        Right probe -> do
+            when (probe.probeStatus /= 401 && probe.probeStatus /= 403) $
+                host.workflowSay
+                    ("Note: the MCP server answered the unauthenticated probe with HTTP "
+                        <> Text.pack (show probe.probeStatus) <> "; continuing with discovery.")
+            pure probe.probeChallenge
     resource <- OAuth.discoverProtectedResourceMetadata manager serverUrl
         (challenge >>= (.challengeResourceMetadata))
-            >>= either (const (failText "MCP authorization metadata could not be discovered or validated.")) pure
-    stored <- host.oauthLoadPrevious >>= \case
-        Left _ -> failText "MCP credentials could not be read from protected storage."
-        Right record -> pure record
+            >>= either (reject "MCP authorization metadata could not be discovered or validated.") pure
+    stored <- host.workflowLoadPrevious
     let storedIssuer = stored >>= (.extraIssuer) . snd
     issuer <- case resource.authorizationServers of
         [] -> failText "MCP protected resource metadata did not advertise an authorization server"
@@ -180,15 +217,24 @@ authorizeMcp host options oauthConfig serverUrl = do
             Just previous | previous `elem` resource.authorizationServers -> previous
             _ -> first
     metadata <- OAuth.discoverAuthorizationServerMetadata manager issuer
-        >>= either (const (failText "OAuth authorization server metadata could not be discovered or validated.")) pure
+        >>= either (reject "OAuth authorization server metadata could not be discovered or validated.") pure
     forM_ [metadata.authorizationEndpoint, metadata.tokenEndpoint] \endpoint ->
-        either (const (failText "OAuth metadata contains an unsafe authorization or token endpoint."))
+        either (reject "OAuth metadata contains an unsafe authorization or token endpoint.")
             pure (OAuth.validateOAuthEndpoint endpoint)
-    either (const (failText "The authorization server must support S256 PKCE.")) pure (OAuth.checkPkceSupport metadata)
+    either (reject "The authorization server must support S256 PKCE.") pure (OAuth.checkPkceSupport metadata)
     let recordedIssuer = fromMaybe issuer metadata.issuer
         sameIssuer = storedIssuer == Just recordedIssuer
-            && maybe True ((== Just resourceUri) . (.extraResource) . snd) stored
-        previous = if sameIssuer then stored else Nothing
+        -- A missing legacy resource is not evidence that this record belongs
+        -- to the current resource. Do not carry its client secret or scopes.
+        sameResource = (stored >>= (.extraResource) . snd) == Just resourceUri
+        previous = if sameIssuer && sameResource then stored else Nothing
+    when (isJust stored && not sameIssuer) $
+        host.workflowSay
+            ("Note: the authorization server changed to " <> recordedIssuer
+                <> "; the previous client registration and granted scopes will not be reused.")
+    when (isJust stored && sameIssuer && not sameResource) $
+        host.workflowSay
+            "Note: the stored OAuth resource does not match; the previous client registration and granted scopes will not be reused."
     let preferredPort = previous >>= (.extraRedirectUri) . snd >>= OAuth.loopbackRedirectPort
     bracket (openCallbackSocket preferredPort) close $ \listener -> do
         port <- callbackPort listener
@@ -217,24 +263,30 @@ authorizeMcp host options oauthConfig serverUrl = do
                 , registrationRedirectUri = redirect
                 }
         plan <- either
-            (const (failText "The authorization server requires a registered OAuth client. Configure a client ID or client metadata URL."))
+            (reject "The authorization server requires a registered OAuth client. Configure a client ID or client metadata URL.")
             pure (OAuth.selectClientRegistration registrationOptions metadata)
         client <- case plan of
-            OAuth.UsePreRegisteredClient pre ->
+            OAuth.UsePreRegisteredClient pre -> do
+                host.workflowSay
+                    "Using the pre-registered OAuth client from ~/.haskell-agent/config.json."
                 pure ResolvedClient
                     { resolvedClientId = pre.preRegisteredClientId
                     , resolvedClientSecret = pre.preRegisteredClientSecret
                     , resolvedSource = OAuth.ClientIdPreRegistered
                     , resolvedMetadataUrl = Nothing
                     }
-            OAuth.UseClientIdMetadataDocument url ->
+            OAuth.UseClientIdMetadataDocument url -> do
+                host.workflowSay
+                    ("Using the Client ID Metadata Document " <> url <> " as client_id.")
                 pure ResolvedClient
                     { resolvedClientId = url
                     , resolvedClientSecret = Nothing
                     , resolvedSource = OAuth.ClientIdMetadataDocument
                     , resolvedMetadataUrl = Just url
                     }
-            OAuth.ReuseDynamicRegistration clientId ->
+            OAuth.ReuseDynamicRegistration clientId -> do
+                host.workflowSay
+                    "Reusing the dynamic client registration from the previous login."
                 pure ResolvedClient
                     { resolvedClientId = clientId
                     , resolvedClientSecret = previous >>= (.extraClientSecret) . snd
@@ -246,7 +298,7 @@ authorizeMcp host options oauthConfig serverUrl = do
                     { registrationClientName = "Haskell Agent"
                     , registrationRedirectUris = [redirect]
                     , registrationScopes = scopes
-                    } >>= either (const (failText "OAuth client registration failed.")) pure
+                    } >>= either (reject "OAuth client registration failed.") pure
                 pure ResolvedClient
                     { resolvedClientId = registration.clientId
                     , resolvedClientSecret = registration.clientSecret
@@ -268,15 +320,15 @@ authorizeMcp host options oauthConfig serverUrl = do
         callback <-
             withListeningCallback listener
                 metadata.authorizationResponseIssParameterSupported recordedIssuer state
-                \awaitCallback -> do
-                    host.oauthOpenBrowser authUrl
-                        >>= either (const (failText "The authorization browser could not be opened.")) pure
-                    awaitCallback
-        either (const (failText "MCP OAuth callback issuer mismatch.")) pure $ OAuth.validateAuthorizationResponseIssuer
+                (host.workflowAuthorize authUrl)
+        -- Validate issuer before interpreting even an error response.
+        either (reject "MCP OAuth callback issuer mismatch.") pure $ OAuth.validateAuthorizationResponseIssuer
             metadata.authorizationResponseIssParameterSupported recordedIssuer callback.callbackIss
         when (callback.callbackState /= Just state) (failText "MCP OAuth callback state mismatch")
-        forM_ callback.callbackError \_ ->
-            failText "MCP authorization was not granted."
+        forM_ callback.callbackError \err ->
+            reject "MCP authorization was not granted."
+                ("MCP authorization was not granted: " <> err
+                    <> maybe "" (\description -> " (" <> description <> ")") callback.callbackErrorDescription)
         code <- maybe (failText "MCP OAuth callback did not contain an authorization code") pure callback.callbackCode
         OAuth.exchangeAuthorizationCodeWith manager OAuth.TokenExchange
             { exchangeEndpoint = metadata.tokenEndpoint
@@ -287,7 +339,7 @@ authorizeMcp host options oauthConfig serverUrl = do
             , exchangeCodeVerifier = verifier
             , exchangeResource = Just resourceUri
             } >>= \case
-                OAuth.OAuthTokenFailure _ -> failText "OAuth token exchange failed."
+                OAuth.OAuthTokenFailure err -> reject "OAuth token exchange failed." err
                 OAuth.OAuthTokenSuccess tokens -> do
                     now :: Int <- round <$> getPOSIXTime
                     let tokenFile = OAuth.OAuthTokenFile
@@ -346,190 +398,45 @@ loginMcpWithHostThrow host options serverUrl = do
     home <- Dir.getHomeDirectory
     harness <- loadHarnessConfig home >>= either failText pure
     let oauthConfig = lookupServerOAuthConfig serverUrl harness
-        resourceUri = OAuth.canonicalResourceUri serverUrl
-    manager <- newTlsManager
-    challenge <- OAuth.probeAuthorizationChallenge manager serverUrl >>= \case
-        Left err -> do
-            host.mcpLoginSay
-                ("Warning: " <> err <> "; falling back to well-known discovery.")
-            pure Nothing
-        Right probe -> do
-            when (probe.probeStatus /= 401 && probe.probeStatus /= 403) $
-                host.mcpLoginSay
-                    ("Note: the MCP server answered the unauthenticated probe with HTTP "
-                        <> Text.pack (show probe.probeStatus)
-                        <> "; continuing with discovery.")
-            pure probe.probeChallenge
-    resource <- OAuth.discoverProtectedResourceMetadata manager serverUrl
-        (challenge >>= (.challengeResourceMetadata)) >>= either failText pure
-    stored <- loadMcpOAuthRecord serverUrl >>= \case
-        Left err -> do
-            host.mcpLoginSay
-                ("Warning: ignoring unreadable MCP OAuth record: " <> err)
-            pure Nothing
-        Right record -> pure record
-    let storedIssuer = stored >>= (.extraIssuer) . snd
-    issuer <- case resource.authorizationServers of
-        [] -> failText "MCP protected resource metadata did not advertise an authorization server"
-        first : _ -> pure case storedIssuer of
-            Just previous | previous `elem` resource.authorizationServers -> previous
-            _ -> first
-    metadata <- OAuth.discoverAuthorizationServerMetadata manager issuer >>= either failText pure
-    either failText pure (OAuth.checkPkceSupport metadata)
-    let recordedIssuer = fromMaybe issuer metadata.issuer
-        sameIssuer = storedIssuer == Just recordedIssuer
-        previous = if sameIssuer then stored else Nothing
-    when (isJust stored && not sameIssuer) $
+        workflow = OAuthWorkflowHost
+            { workflowSay = host.mcpLoginSay
+            , workflowError = \_ detail -> detail
+            , workflowLoadPrevious = loadMcpOAuthRecord serverUrl >>= \case
+                Left err -> do
+                    host.mcpLoginSay
+                        ("Warning: ignoring unreadable MCP OAuth record: " <> err)
+                    pure Nothing
+                Right record -> pure record
+            , workflowAuthorize = \url awaitCallback -> do
+                host.mcpLoginSay ("Opening browser for MCP authorization: " <> url)
+                host.mcpLoginAuthorize url awaitCallback >>= \case
+                    Left err -> failText err
+                    Right Nothing -> failText "Timed out waiting for MCP OAuth callback"
+                    Right (Just received) -> pure received
+            }
+    (tokenFile, extra) <- runMcpOAuth workflow options oauthConfig serverUrl
+    when (Text.null tokenFile.tokenRefreshToken) $
         host.mcpLoginSay
-            ("Note: the authorization server changed to " <> recordedIssuer
-                <> "; the previous client registration and granted scopes will not be reused.")
-    let preferredPort = previous >>= (.extraRedirectUri) . snd >>= OAuth.loopbackRedirectPort
-    bracket (openCallbackSocket preferredPort) close $ \listener -> do
-        port <- callbackPort listener
-        let redirect = "http://127.0.0.1:" <> Text.pack (show port) <> "/callback"
-            scopes = OAuth.planScopes OAuth.ScopePlan
-                { scopeSources = OAuth.ScopeSources
-                    { scopeChallenge = maybe [] OAuth.challengeScopes challenge
-                    , scopeResourceMetadata = resource.scopesSupported
-                    , scopeConfigured = maybe [] (.mcpOAuthScopes) oauthConfig
-                    }
-                , scopePreviouslyGranted = maybe [] Text.words (previous >>= (.extraScope) . snd)
-                , scopeAdditional = options.loginAdditionalScopes
-                , scopeAuthorizationServerSupported = metadata.scopesSupportedByServer
-                }
-            registrationOptions = OAuth.RegistrationOptions
-                { registrationPreRegistered = oauthConfig >>= \config ->
-                    (\clientId -> OAuth.PreRegisteredClient clientId config.mcpOAuthClientSecret)
-                        <$> config.mcpOAuthClientId
-                , registrationClientIdMetadataUrl = oauthConfig >>= (.mcpOAuthClientIdMetadataUrl)
-                , registrationStored = previous >>= \(file, extra) ->
-                    OAuth.StoredClient
-                        <$> extra.extraIssuer
-                        <*> pure file.tokenClientId
-                        <*> extra.extraClientIdSource
-                        <*> pure extra.extraRedirectUri
-                , registrationRedirectUri = redirect
-                }
-        plan <- either failText pure (OAuth.selectClientRegistration registrationOptions metadata)
-        client <- case plan of
-            OAuth.UsePreRegisteredClient pre -> do
-                host.mcpLoginSay
-                    "Using the pre-registered OAuth client from ~/.haskell-agent/config.json."
-                pure ResolvedClient
-                    { resolvedClientId = pre.preRegisteredClientId
-                    , resolvedClientSecret = pre.preRegisteredClientSecret
-                    , resolvedSource = OAuth.ClientIdPreRegistered
-                    , resolvedMetadataUrl = Nothing
-                    }
-            OAuth.UseClientIdMetadataDocument url -> do
-                host.mcpLoginSay
-                    ("Using the Client ID Metadata Document " <> url <> " as client_id.")
-                pure ResolvedClient
-                    { resolvedClientId = url
-                    , resolvedClientSecret = Nothing
-                    , resolvedSource = OAuth.ClientIdMetadataDocument
-                    , resolvedMetadataUrl = Just url
-                    }
-            OAuth.ReuseDynamicRegistration clientId -> do
-                host.mcpLoginSay
-                    "Reusing the dynamic client registration from the previous login."
-                pure ResolvedClient
-                    { resolvedClientId = clientId
-                    , resolvedClientSecret = Nothing
-                    , resolvedSource = OAuth.ClientIdDynamicRegistration
-                    , resolvedMetadataUrl = Nothing
-                    }
-            OAuth.UseDynamicRegistration endpoint -> do
-                registration <- OAuth.registerClientWith manager endpoint OAuth.ClientRegistrationRequest
-                    { registrationClientName = "Haskell Agent"
-                    , registrationRedirectUris = [redirect]
-                    , registrationScopes = scopes
-                    } >>= either failText pure
-                pure ResolvedClient
-                    { resolvedClientId = registration.clientId
-                    , resolvedClientSecret = registration.clientSecret
-                    , resolvedSource = OAuth.ClientIdDynamicRegistration
-                    , resolvedMetadataUrl = Nothing
-                    }
-        verifier <- randomUrlBytes 32
-        state <- randomUrlBytes 24
-        let codeChallenge = Base64.encodeUnpadded (BA.convert (hash (Encoding.encodeUtf8 verifier) :: Digest SHA256))
-            scopeText = Text.unwords scopes
-            separator = if "?" `Text.isInfixOf` metadata.authorizationEndpoint then "&" else "?"
-            authUrl = metadata.authorizationEndpoint <> separator
-                <> "response_type=code&client_id=" <> encode client.resolvedClientId
-                <> "&redirect_uri=" <> encode redirect
-                <> "&code_challenge=" <> Encoding.decodeUtf8 codeChallenge
-                <> "&code_challenge_method=S256&state=" <> encode state
-                <> (if Text.null scopeText then "" else "&scope=" <> encode scopeText)
-                <> "&resource=" <> encode resourceUri
-        host.mcpLoginSay ("Opening browser for MCP authorization: " <> authUrl)
-        callback <-
-            withListeningCallback listener
-                metadata.authorizationResponseIssParameterSupported recordedIssuer state
-                \awaitCallback ->
-                    host.mcpLoginAuthorize authUrl awaitCallback >>= \case
-                        Left err -> failText err
-                        Right Nothing ->
-                            failText "Timed out waiting for MCP OAuth callback"
-                        Right (Just received) -> pure received
-        -- RFC 9207: validate the issuer before acting on any other parameter,
-        -- including error responses.
-        either failText pure $ OAuth.validateAuthorizationResponseIssuer
-            metadata.authorizationResponseIssParameterSupported recordedIssuer callback.callbackIss
-        when (callback.callbackState /= Just state) (failText "MCP OAuth callback state mismatch")
-        forM_ callback.callbackError \err ->
-            failText ("MCP authorization was not granted: " <> err
-                <> maybe "" (\description -> " (" <> description <> ")") callback.callbackErrorDescription)
-        code <- maybe (failText "MCP OAuth callback did not contain an authorization code") pure callback.callbackCode
-        OAuth.exchangeAuthorizationCodeWith manager OAuth.TokenExchange
-            { exchangeEndpoint = metadata.tokenEndpoint
-            , exchangeClientId = client.resolvedClientId
-            , exchangeClientSecret = client.resolvedClientSecret
-            , exchangeCode = code
-            , exchangeRedirectUri = redirect
-            , exchangeCodeVerifier = verifier
-            , exchangeResource = Just resourceUri
-            } >>= \case
-                OAuth.OAuthTokenFailure err -> failText err
-                OAuth.OAuthTokenSuccess tokens -> do
-                    now :: Int <- round <$> getPOSIXTime
-                    let tokenFile = OAuth.OAuthTokenFile
-                            client.resolvedClientId metadata.tokenEndpoint tokens.accessToken
-                            (fromMaybe "" tokens.refreshToken)
-                            (fmap (now +) tokens.expiresIn)
-                        granted = fromMaybe scopeText tokens.scope
-                        extra = OAuth.OAuthTokenFileExtra
-                            { extraIssuer = Just recordedIssuer
-                            , extraScope = if Text.null (Text.strip granted) then Nothing else Just granted
-                            , extraResource = Just resourceUri
-                            , extraClientIdSource = Just client.resolvedSource
-                            , extraClientIdMetadataUrl = client.resolvedMetadataUrl
-                            , extraClientSecret = client.resolvedClientSecret
-                            , extraRedirectUri = Just redirect
-                            }
-                    when (Text.null tokenFile.tokenRefreshToken) $
-                        host.mcpLoginSay
-                            "Warning: MCP provider returned no refresh token; reauthorization may be required."
-                    saveMcpOAuthRecord serverUrl tokenFile extra
-                        >>= either failText pure
-                    registerAuthorizedMcpServer home serverUrl >>= \case
-                        Left err -> failText
-                            ("MCP authorization was saved, but server registration failed: " <> err)
-                        Right (name, enabled) -> do
-                            let followUp =
-                                    if enabled
-                                        then "Start a new session to connect this server."
-                                        else
-                                            "This server remains disabled. Enable it with: agent-cli mcp enable "
-                                                <> shellQuote name
-                                message =
-                                    "MCP authorization saved. MCP server configured: "
-                                        <> name
-                                        <> ". "
-                                        <> followUp
-                            host.mcpLoginSay message
-                            pure message
+            "Warning: MCP provider returned no refresh token; reauthorization may be required."
+    saveMcpOAuthRecord serverUrl tokenFile extra
+        >>= either failText pure
+    registerAuthorizedMcpServer home serverUrl >>= \case
+        Left err -> failText
+            ("MCP authorization was saved, but server registration failed: " <> err)
+        Right (name, enabled) -> do
+            let followUp =
+                    if enabled
+                        then "Start a new session to connect this server."
+                        else
+                            "This server remains disabled. Enable it with: agent-cli mcp enable "
+                                <> shellQuote name
+                message =
+                    "MCP authorization saved. MCP server configured: "
+                        <> name
+                        <> ". "
+                        <> followUp
+            host.mcpLoginSay message
+            pure message
 
 -- | Register only after the token record has been persisted successfully.
 -- Re-read under the configuration lock so browser-time edits are preserved.

--- a/packages/agent-cli/test/Agent/CLI/McpOAuthSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpOAuthSpec.hs
@@ -1,10 +1,15 @@
 module Agent.CLI.McpOAuthSpec (spec) where
 
 import Agent.CLI.McpOAuth
+import Agent.CLI.McpOAuthStore (loadMcpOAuthRecord, saveMcpOAuthRecord, mcpOAuthStorePath)
 import qualified Agent.MCP.OAuth as OAuth
 import Control.Concurrent.Async (cancel, concurrently, waitCatch, withAsync)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
-import Control.Exception.Safe (tryAny)
+import Control.Exception.Safe (bracket, tryAny)
+import Control.Monad (forM_)
+import Crypto.Hash (Digest, SHA256, hash)
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString.Base64.URL as Base64
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Char8 as Bytes
 import qualified Data.ByteString.Lazy as LazyBytes
@@ -18,11 +23,164 @@ import Network.HTTP.Types.URI (Query, parseQuery, renderQuery)
 import Network.URI (parseURI, uriQuery)
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
+import qualified System.Directory as Directory
+import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.FilePath ((</>))
+import System.Posix.Temp (mkdtemp)
+import System.OsPath (decodeUtf, unsafeEncodeUtf)
 import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
 spec = describe "MCP OAuth host authorization" do
+    forM_ [False, True] \cli -> describe (if cli then "CLI workflow" else "runtime workflow") do
+        it "retains a reused dynamic client secret and binds PKCE and resource through exchange" $
+            withOAuthHome do
+                registrations <- newIORef (0 :: Int)
+                exchanges <- newIORef []
+                urls <- newIORef []
+                Warp.testWithApplication (pure (recordingFixture registrations exchanges)) \port -> do
+                    let endpoint = "http://127.0.0.1:" <> Text.pack (show port) <> "/mcp"
+                    first <- runRecordedAuthorization cli endpoint Nothing urls
+                    let (previousFile, previousExtra) = first
+                        previous = (previousFile, previousExtra { OAuth.extraScope = Just "requested-scope" })
+                    second <- runRecordedAuthorization cli endpoint (Just previous) urls
+                    readIORef registrations `shouldReturn` 1
+                    snd second `shouldBe` snd first
+                    (snd second).extraClientSecret `shouldBe` Just "dynamic-secret"
+                    (snd first).extraScope `shouldBe` Just "server-granted"
+                    (fst second).tokenAccessToken `shouldBe` "access-token"
+                    (fst second).tokenRefreshToken `shouldBe` "refresh-token"
+                    (fst second).tokenEndpoint `shouldBe` Text.dropEnd 4 endpoint <> "/token"
+                    (fst second).tokenExpiresAt `shouldSatisfy` (/= Nothing)
+                    authQueries <- readIORef urls
+                    tokenQueries <- readIORef exchanges
+                    length authQueries `shouldBe` 2
+                    length tokenQueries `shouldBe` 2
+                    lookup "scope" (last authQueries) `shouldBe` Just (Just "requested-scope")
+                    forM_ (zip authQueries tokenQueries) \(authQuery, tokenQuery) -> do
+                        lookup "client_secret" tokenQuery `shouldBe` Just (Just "dynamic-secret")
+                        lookup "resource" authQuery `shouldBe` Just (Just (Encoding.encodeUtf8 endpoint))
+                        lookup "resource" tokenQuery `shouldBe` lookup "resource" authQuery
+                        lookup "redirect_uri" tokenQuery `shouldBe` lookup "redirect_uri" authQuery
+                        lookup "code_challenge_method" authQuery `shouldBe` Just (Just "S256")
+                        verifier <- maybe (fail "missing verifier") pure (lookup "code_verifier" tokenQuery >>= id)
+                        let challenge = Base64.encodeUnpadded (BA.convert (hash verifier :: Digest SHA256))
+                        lookup "code_challenge" authQuery `shouldBe` Just (Just challenge)
+
+        forM_ ["missing resource", "different resource", "different issuer"] \binding ->
+            it ("does not reuse registration or scopes with " <> binding) $
+                withOAuthHome do
+                    registrations <- newIORef (0 :: Int)
+                    exchanges <- newIORef []
+                    urls <- newIORef []
+                    Warp.testWithApplication (pure (recordingFixture registrations exchanges)) \port -> do
+                        let endpoint = "http://127.0.0.1:" <> Text.pack (show port) <> "/mcp"
+                        (file, extra) <- runRecordedAuthorization cli endpoint Nothing urls
+                        let previous = (file, extra
+                                { OAuth.extraResource = case binding of
+                                    "missing resource" -> Nothing
+                                    "different resource" -> Just "https://other.example/mcp"
+                                    _ -> extra.extraResource
+                                , OAuth.extraIssuer = if binding == "different issuer"
+                                    then Just "https://other.example" else extra.extraIssuer
+                                , OAuth.extraScope = Just "private-old-scope"
+                                })
+                        _ <- runRecordedAuthorization cli endpoint (Just previous) urls
+                        readIORef registrations `shouldReturn` 2
+                        queries <- readIORef urls
+                        lookup "scope" (last queries) `shouldBe` Nothing
+
+        it "uses requested scopes when the token response omits scope, refresh token, and expiry" $
+            withOAuthHome do
+                registrations <- newIORef (0 :: Int)
+                exchanges <- newIORef []
+                urls <- newIORef []
+                omitOptional <- newIORef False
+                let fixture request respond = do
+                        omit <- readIORef omitOptional
+                        if omit && Wai.rawPathInfo request == "/token"
+                            then respond (Wai.responseLBS status200 [("Content-Type", "application/json")]
+                                "{\"access_token\":\"minimal-token\",\"token_type\":\"Bearer\"}")
+                            else recordingFixture registrations exchanges request respond
+                Warp.testWithApplication (pure fixture) \port -> do
+                    let endpoint = "http://127.0.0.1:" <> Text.pack (show port) <> "/mcp"
+                    first <- runRecordedAuthorization cli endpoint Nothing urls
+                    modifyIORef' omitOptional (const True)
+                    (file, extra) <- runRecordedAuthorization cli endpoint (Just first) urls
+                    file.tokenAccessToken `shouldBe` "minimal-token"
+                    file.tokenRefreshToken `shouldBe` ""
+                    file.tokenExpiresAt `shouldBe` Nothing
+                    extra.extraScope `shouldBe` Just "server-granted"
+                    queries <- readIORef urls
+                    lookup "scope" (last queries) `shouldBe` Just (Just "server-granted")
+
+    it "aborts unreadable runtime storage with a redacted error but lets CLI warn and recover" $
+        withOAuthHome do
+            registrations <- newIORef (0 :: Int)
+            exchanges <- newIORef []
+            urls <- newIORef []
+            notices <- newIORef []
+            Warp.testWithApplication (pure (recordingFixture registrations exchanges)) \port -> do
+                let endpoint = "http://127.0.0.1:" <> Text.pack (show port) <> "/mcp"
+                    runtimeHost = McpOAuthHost
+                        { oauthLoadPrevious = pure (Left "private-storage-detail")
+                        , oauthOpenBrowser = \_ -> fail "browser must not open"
+                        }
+                authorizeMcpWith runtimeHost defaultLoginOptions Nothing endpoint
+                    `shouldReturn` Left "MCP credentials could not be read from protected storage."
+                readIORef registrations `shouldReturn` 0
+                _ <- runRecordedAuthorization True endpoint Nothing urls
+                home <- Directory.getHomeDirectory
+                path <- decodeUtf (mcpOAuthStorePath (unsafeEncodeUtf home) endpoint)
+                Bytes.writeFile path "invalid json"
+                _ <- runRecordedAuthorizationWithSay (\notice -> modifyIORef' notices (<> [notice]))
+                    True endpoint Nothing urls
+                readIORef registrations `shouldReturn` 2
+                readIORef notices >>= (`shouldSatisfy`
+                    any (Text.isPrefixOf "Warning: ignoring unreadable MCP OAuth record:"))
+
+    it "rejects an unsafe CLI server endpoint before any network request" $
+        withOAuthHome do
+            requests <- newIORef (0 :: Int)
+            let fixture _ respond = do
+                    modifyIORef' requests (+ 1)
+                    respond (Wai.responseLBS status404 [] "")
+                host = McpLoginHost
+                    { mcpLoginSay = const (pure ())
+                    , mcpLoginAuthorize = \_ _ -> fail "browser must not open"
+                    }
+            Warp.testWithApplication (pure fixture) \port -> do
+                result <- loginMcpWithHost host defaultLoginOptions
+                    ("http://user:secret@127.0.0.1:" <> Text.pack (show port) <> "/mcp")
+                result `shouldSatisfy` isLeft
+                readIORef requests `shouldReturn` 0
+
+    it "rejects unsafe discovered endpoints in the CLI before registration or browser presentation" $
+        withOAuthHome $
+            forM_ [True, False] \browserEndpoint -> do
+                effects <- newIORef []
+                let unsafe = "https://user:secret@example.test/authorize"
+                    fixture request respond = do
+                        if Wai.rawPathInfo request == "/register"
+                            then modifyIORef' effects (<> ["registration"])
+                            else pure ()
+                        authorizationFixtureWithEndpoints
+                            (if browserEndpoint then const unsafe else id)
+                            (if browserEndpoint then id else const unsafe)
+                            effects request respond
+                    host = McpLoginHost
+                        { mcpLoginSay = const (pure ())
+                        , mcpLoginAuthorize = \_ _ -> do
+                            modifyIORef' effects (<> ["browser"])
+                            pure (Left "unexpected browser")
+                        }
+                Warp.testWithApplication (pure fixture) \port -> do
+                    result <- loginMcpWithHost host defaultLoginOptions
+                        ("http://127.0.0.1:" <> Text.pack (show port) <> "/mcp")
+                    result `shouldSatisfy` isLeft
+                    readIORef effects `shouldReturn` []
+
     it "rejects unsafe discovered browser and token endpoints before registration or browser presentation" do
         mapM_ (\unsafe -> mapM_ (\browserEndpoint -> do
             effects <- newIORef []
@@ -311,3 +469,88 @@ authorizationFixtureWithEndpoints browserEndpoint tokenEndpoint requests request
                 , "expires_in" Aeson..= (3600 :: Int)
                 ])
         _ -> respond (Wai.responseLBS status404 [] "")
+
+-- Exercise both public adapters, including CLI persistence, against the same
+-- protocol fixture. A fresh HOME ensures runtime authorization never silently
+-- writes credentials and CLI tests cannot touch the developer's credentials.
+withOAuthHome :: IO a -> IO a
+withOAuthHome action = do
+    temporary <- Directory.getTemporaryDirectory
+    bracket (mkdtemp (temporary </> "mcp-oauth-")) Directory.removePathForcibly \home ->
+        bracket (lookupEnv "HOME") (maybe (unsetEnv "HOME") (setEnv "HOME")) \_ -> do
+            setEnv "HOME" home
+            action
+
+runRecordedAuthorization
+    :: Bool
+    -> Text.Text
+    -> Maybe (OAuth.OAuthTokenFile, OAuth.OAuthTokenFileExtra)
+    -> IORef [Query]
+    -> IO (OAuth.OAuthTokenFile, OAuth.OAuthTokenFileExtra)
+runRecordedAuthorization = runRecordedAuthorizationWithSay (const (pure ()))
+
+-- Keep the same fixture usable for a tmux/GHCi smoke with the real CLI
+-- presentation: pass defaultMcpLoginHost.mcpLoginSay instead of silence.
+runRecordedAuthorizationWithSay
+    :: (Text.Text -> IO ())
+    -> Bool
+    -> Text.Text
+    -> Maybe (OAuth.OAuthTokenFile, OAuth.OAuthTokenFileExtra)
+    -> IORef [Query]
+    -> IO (OAuth.OAuthTokenFile, OAuth.OAuthTokenFileExtra)
+runRecordedAuthorizationWithSay say cli endpoint previous urls = do
+    let complete url = do
+            uri <- maybe (fail "invalid authorization URL") pure (parseURI (Text.unpack url))
+            modifyIORef' urls (<> [parseQuery (Bytes.pack (uriQuery uri))])
+            (redirect, state, issuer) <- authorizationCallbackParameters endpoint url
+            manager <- newManager defaultManagerSettings
+            request <- parseRequest (Bytes.unpack (redirect <> renderQuery True
+                [("state", Just state), ("iss", Just issuer), ("code", Just "account")]))
+            response <- httpLbs request manager
+            responseStatus response `shouldBe` status200
+    if cli
+        then do
+            forM_ previous \(file, extra) ->
+                saveMcpOAuthRecord endpoint file extra `shouldReturn` Right ()
+            let host = defaultMcpLoginHost
+                    { mcpLoginSay = say
+                    , mcpLoginAuthorize = \url await -> do
+                        complete url
+                        Right <$> timeout (10 * 1000000) await
+                    }
+            result <- loginMcpWithHost host defaultLoginOptions endpoint
+            either (fail . Text.unpack) (const (pure ())) result
+            loadMcpOAuthRecord endpoint >>= either (fail . Text.unpack)
+                (maybe (fail "CLI did not persist tokens") pure)
+        else do
+            let host = McpOAuthHost
+                    { oauthLoadPrevious = pure (Right previous)
+                    , oauthOpenBrowser = \url -> complete url >> pure (Right ())
+                    }
+            result <- authorizeMcpWith host defaultLoginOptions Nothing endpoint
+            loadMcpOAuthRecord endpoint `shouldReturn` Right Nothing
+            either (fail . Text.unpack) pure result
+
+recordingFixture :: IORef Int -> IORef [Query] -> Wai.Application
+recordingFixture registrations exchanges request respond =
+    let json value = respond (Wai.responseLBS status200 [("Content-Type", "application/json")] (Aeson.encode value))
+    in case Wai.rawPathInfo request of
+        "/register" -> do
+            modifyIORef' registrations (+ 1)
+            json (Aeson.object
+                [ "client_id" Aeson..= ("fixture-client" :: Text.Text)
+                , "client_secret" Aeson..= ("dynamic-secret" :: Text.Text)
+                ])
+        "/token" -> do
+            body <- Wai.strictRequestBody request
+            modifyIORef' exchanges (<> [parseQuery (LazyBytes.toStrict body)])
+            json (Aeson.object
+                [ "access_token" Aeson..= ("access-token" :: Text.Text)
+                , "refresh_token" Aeson..= ("refresh-token" :: Text.Text)
+                , "token_type" Aeson..= ("Bearer" :: Text.Text)
+                , "expires_in" Aeson..= (3600 :: Int)
+                , "scope" Aeson..= ("server-granted" :: Text.Text)
+                ])
+        _ -> do
+            ignored <- newIORef []
+            authorizationFixture ignored request respond


### PR DESCRIPTION
## Summary
- Route runtime authorization and CLI login through one private workflow for discovery, client registration, PKCE, callback validation, token exchange and token construction.
- Resolve correctness differences: retain reused dynamic client secrets in CLI login; require matching issuer **and explicit resource** before reusing registration/scopes (legacy records without a resource re-register); validate initial and discovered authorization/token endpoints consistently before credentials or browser interaction.
- Preserve adapter boundaries: runtime redaction and non-persistence, CLI logging/configuration/token storage, unreadable-storage policies and existing timeout/cancellation behavior remain separate.
- Add regression coverage through both public adapters, including actual PKCE verifier/challenge binding and repeat login. Regenerate package.nix for test dependencies.

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli`: 251 modules loaded successfully.
- GHCi: McpOAuthSpec, McpManagerSpec and McpConnectionCredentialsSpec: **50 examples, 0 failures** (30 OAuth examples).
- Live tmux/GHCi smoke: real CLI login flow with default CLI logger, loopback OAuth/callback fixture and isolated HOME; initial login and legacy-resource re-registration messages inspected. Browser callback automated; no external provider credentials used.
- `git diff --check` clean.
