### PR TITLE
Thread state through Claude and Cursor external readers

### DIFF
--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Claude.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Claude.hs
@@ -15,12 +15,6 @@ import Control.Exception.Safe (tryAny)
 import Control.Monad (filterM)
 import Data.Aeson (Value(..), decodeStrict', encode)
 import qualified Data.ByteString.Lazy as LBS
-import Data.IORef
-    ( IORef
-    , modifyIORef'
-    , newIORef
-    , readIORef
-    )
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -195,15 +189,15 @@ readClaude env candidate maxToolChars =
                                 record
                         pure (nextState, JsonlContinue)
             leaf <- claudeLeaf database
-            stateRef <- newIORef ClaudeReadState
-                { claudeTurnsFromLeaf = []
-                , claudeLastUser = Nothing
-                , claudeLastAssistant = Nothing
-                , claudeSkipped = indexState.claudeIndexUnindexable
-                , claudeOmissions = mempty
-                }
-            mapM_ (walkClaudeChain database maxToolChars stateRef) leaf
-            state <- readIORef stateRef
+            let initialState = ClaudeReadState
+                    { claudeTurnsFromLeaf = []
+                    , claudeLastUser = Nothing
+                    , claudeLastAssistant = Nothing
+                    , claudeSkipped = indexState.claudeIndexUnindexable
+                    , claudeOmissions = mempty
+                    }
+            state <- maybe (pure initialState)
+                (walkClaudeChain database maxToolChars initialState) leaf
             let unsafeWarnings =
                     [ warning
                         "unsafe_records_skipped"
@@ -326,13 +320,13 @@ data ClaudeReadState = ClaudeReadState
 walkClaudeChain
     :: Database
     -> Int
-    -> IORef ClaudeReadState
+    -> ClaudeReadState
     -> Text
-    -> IO ()
-walkClaudeChain database maxToolChars stateRef = go
+    -> IO ClaudeReadState
+walkClaudeChain database maxToolChars = go
   where
-    go uuid
-        | Text.null uuid = pure ()
+    go !state uuid
+        | Text.null uuid = pure state
         | otherwise = do
             execute database
                 "INSERT OR IGNORE INTO claude_visited (uuid) VALUES (?)"
@@ -346,19 +340,14 @@ walkClaudeChain database maxToolChars stateRef = go
                         [SQLText uuid]
                     case rows of
                         ([parent, payload] : _) -> do
-                            case decodePayload payload of
-                                Nothing ->
-                                    modifyIORef' stateRef \state ->
-                                        state
-                                            { claudeSkipped =
-                                                state.claudeSkipped + 1
-                                            }
-                                Just record ->
-                                    modifyIORef' stateRef
-                                        (addClaudeTurn maxToolChars record)
-                            go (sqlDataText parent)
-                        _ -> pure ()
-                _ -> pure ()
+                            let nextState = case decodePayload payload of
+                                    Nothing -> state
+                                        { claudeSkipped = state.claudeSkipped + 1 }
+                                    Just record ->
+                                        addClaudeTurn maxToolChars record state
+                            go nextState (sqlDataText parent)
+                        _ -> pure state
+                _ -> pure state
 
 decodePayload :: SQLData -> Maybe Value
 decodePayload = \case

--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Cursor.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Cursor.hs
@@ -17,8 +17,7 @@ import Crypto.Hash (Digest, MD5, hash)
 import Data.Aeson (Value(..))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
-import Data.IORef (modifyIORef', newIORef, readIORef)
-import qualified Data.IORef as IORef
+import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
 import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -410,20 +409,14 @@ readCursor env candidate maxToolChars = do
                             )
             pure (state, jsonlWarnings counters)
         Nothing -> do
-            stateRef <- newIORef (emptyBoundedTurns, mempty)
-            warningRef <- newIORef []
-            let consume value =
-                    modifyIORef' stateRef \state ->
-                        cursorStateStep maxToolChars state value
             if takeFileName candidate.candidatePath == "state.vscdb"
-                then readDesktopRows candidate consume warningRef
+                then readDesktopRows candidate maxToolChars
                 else do
                     directory <-
                         doesDirectoryExist candidate.candidatePath
                     if directory
-                        then readCursorStore candidate consume warningRef
-                        else readDesktopRows candidate consume warningRef
-            (,) <$> readIORef stateRef <*> readIORef warningRef
+                        then readCursorStore candidate maxToolChars
+                        else readDesktopRows candidate maxToolChars
     let turns = boundedRecent bounded
         unavailable =
             [ warning
@@ -494,16 +487,14 @@ cursorTranscriptForSession env sessionId cwd
 
 readCursorStore
     :: ExternalCandidate
-    -> (Value -> IO ())
-    -> IORef.IORef [ExternalWarning]
-    -> IO ()
-readCursorStore candidate consume warningRef = do
+    -> Int
+    -> IO ((BoundedTurns, ContentOmissions), [ExternalWarning])
+readCursorStore candidate maxToolChars = do
     let store = candidate.candidatePath </> "store.db"
     safe <- isSafeFile candidate.candidatePath store
     if not safe
-        then pure ()
-        else do
-            result <- tryAny $
+        then pure ((emptyBoundedTurns, mempty), [])
+        else readCursorRows maxToolChars "Cursor blob(s)" \consume ->
                 withReadOnlyDatabase store \database -> do
                     columns <- tableColumns database "blobs"
                     let keyColumn = firstMaybe
@@ -520,62 +511,67 @@ readCursorStore candidate consume warningRef = do
                                     <> keyName <> "\""
                                 )
                                 []
-                            consumeRows consume rows
-                        _ -> pure 0
-            case result of
-                Left exception ->
-                    modifyIORef' warningRef
-                        (<> [warning "cursor_store_error"
-                            (oneLine 200 (Text.pack (show exception)))])
-                Right unavailable -> appendUnavailable
-                    "Cursor blob(s)" unavailable warningRef
+                            consume rows
+                        _ -> consume []
 
 readDesktopRows
     :: ExternalCandidate
-    -> (Value -> IO ())
-    -> IORef.IORef [ExternalWarning]
-    -> IO ()
-readDesktopRows candidate consume warningRef = do
+    -> Int
+    -> IO ((BoundedTurns, ContentOmissions), [ExternalWarning])
+readDesktopRows candidate maxToolChars = do
     let prefix = "bubbleId:" <> candidate.candidateSessionId <> ":"
         composer = "composerData:" <> candidate.candidateSessionId
-    result <- tryAny $
+    readCursorRows maxToolChars "Cursor row(s)" \consume ->
         withReadOnlyDatabase candidate.candidatePath \database -> do
             rows <- queryRows database
                 "SELECT value FROM cursorDiskKV \
                 \WHERE key = ? OR substr(key, 1, length(?)) = ? ORDER BY key"
                 [SQLText composer, SQLText prefix, SQLText prefix]
-            consumeRows consume rows
+            consume rows
+
+-- Thread the fold state explicitly. The checkpoint is only for synchronous
+-- exceptions (including database close): previously consumed turns survive,
+-- but the unavailable-row warning is emitted only on complete success.
+readCursorRows
+    :: Int
+    -> Text
+    -> (([[SQLData]] -> IO ((BoundedTurns, ContentOmissions), Int))
+        -> IO ((BoundedTurns, ContentOmissions), Int))
+    -> IO ((BoundedTurns, ContentOmissions), [ExternalWarning])
+readCursorRows maxToolChars label readRows = do
+    let initialState = (emptyBoundedTurns, mempty)
+    checkpoint <- newIORef initialState
+    result <- tryAny $ readRows $
+        foldM (step (writeIORef checkpoint)) (initialState, 0)
     case result of
-        Left exception ->
-            modifyIORef' warningRef
-                (<> [warning "cursor_store_error"
-                    (oneLine 200 (Text.pack (show exception)))])
-        Right unavailable ->
-            appendUnavailable "Cursor row(s)" unavailable warningRef
-
-consumeRows :: (Value -> IO ()) -> [[SQLData]] -> IO Int
-consumeRows consume = foldM step 0
+        Left exception -> do
+            state <- readIORef checkpoint
+            pure (state, [warning "cursor_store_error"
+                (oneLine 200 (Text.pack (show exception)))])
+        Right (state, unavailable) ->
+            pure (state, unavailableWarnings label unavailable)
   where
-    step unavailable row =
+    step save (!state, !unavailable) row =
         case lastMaybe row >>= decodeJsonish of
-            Nothing -> pure (unavailable + 1)
-            Just value -> consume value >> pure unavailable
+            Nothing -> pure (state, unavailable + 1)
+            Just value -> do
+                let nextState = cursorStateStep maxToolChars state value
+                () <- nextState `seq` save nextState
+                pure (nextState, unavailable)
 
-appendUnavailable
+unavailableWarnings
     :: Text
     -> Int
-    -> IORef.IORef [ExternalWarning]
-    -> IO ()
-appendUnavailable label unavailable warningRef =
+    -> [ExternalWarning]
+unavailableWarnings label unavailable =
     if unavailable <= 0
-        then pure ()
-        else modifyIORef' warningRef
-            (<> [ warning
+        then []
+        else [ warning
                     "binary_content_unavailable"
                     ( Text.pack (show unavailable) <> " " <> label
                         <> " were binary, protobuf, or non-JSON and were not inferred."
                     )
-                ])
+                ]
 
 cursorTurns :: Int -> Value -> ([ExternalTurn], ContentOmissions)
 cursorTurns maxToolChars root = go [root] [] mempty

--- a/packages/agent-external-session/test/Agent/CLI/ExternalSessionSpec.hs
+++ b/packages/agent-external-session/test/Agent/CLI/ExternalSessionSpec.hs
@@ -509,6 +509,41 @@ spec = describe "Agent.CLI.ExternalSession" do
                         `shouldSatisfy` (<= 40)
                 [] -> expectationFailure "expected a recovered Claude tool call"
 
+    it "bounds Claude cycles and keeps summaries from beyond the retained turns" $
+        withFixture \fixture -> do
+            let transcript = fixture.cwd </> "cycle.jsonl"
+                record n = object
+                    [ "type" .= (if n == 1 then "user" else "assistant" :: Text)
+                    , "uuid" .= Text.pack (show n)
+                    , "parentUuid" .= Text.pack (show (if n == 1 then 205 else n - 1))
+                    , "timestamp" .= n
+                    , "cwd" .= fixture.cwd
+                    , "message" .= object ["content" .= Text.pack (show n)]
+                    ]
+            writeJsonl transcript (map record [1 .. 205 :: Int])
+            session <- showReference fixture.env ExternalClaude (Text.pack transcript) 100
+            map (.externalTurnText) session.externalSessionTurns
+                `shouldBe` map (Text.pack . show) [6 .. 205 :: Int]
+            session.externalSessionLastUserRequest `shouldBe` Just "1"
+            session.externalSessionLastAssistantAction `shouldBe` Just "205"
+
+    it "keeps Claude turns when a parent is missing and skips hidden ancestors" $
+        withFixture \fixture -> do
+            let transcript = fixture.cwd </> "missing-parent.jsonl"
+                record uuid parent hidden = object
+                    [ "type" .= ("user" :: Text)
+                    , "uuid" .= (uuid :: Text)
+                    , "parentUuid" .= (parent :: Text)
+                    , "isMeta" .= hidden
+                    , "cwd" .= fixture.cwd
+                    , "message" .= object ["content" .= uuid]
+                    ]
+            writeJsonl transcript
+                [record "hidden" "missing" True, record "visible" "hidden" False]
+            session <- showReference fixture.env ExternalClaude (Text.pack transcript) 100
+            map (.externalTurnText) session.externalSessionTurns `shouldBe` ["visible"]
+            warningCodes session `shouldContain` ["unsafe_records_skipped"]
+
     it "does not follow symlinked Claude transcripts during discovery" $
         withFixture \fixture -> do
             let slug = map
@@ -598,6 +633,41 @@ spec = describe "Agent.CLI.ExternalSession" do
             rendered `shouldExclude` "instruction-like metadata"
             rendered `shouldExclude` "cursor-image-secret"
             warningCodes session `shouldContain` ["image_content_omitted"]
+
+    it "folds Cursor desktop rows in key order with bounded turns and binary warnings" $
+        withFixture \fixture -> do
+            let store = fixture.root </> "state.vscdb"
+                sessionId = "44444444-4444-4444-4444-444444444444"
+            withDatabase store \database -> do
+                SQLite.exec database "CREATE TABLE composerHeaders (composerId TEXT, value TEXT)"
+                executeSql database "INSERT INTO composerHeaders VALUES (?, ?)"
+                    [SQLText sessionId, SQLText "{}"]
+                SQLite.exec database "CREATE TABLE cursorDiskKV (key TEXT, value TEXT)"
+                executeSql database "INSERT INTO cursorDiskKV VALUES (?, ?)"
+                    [ SQLText ("composerData:" <> sessionId)
+                    , SQLText $ renderJson $ object ["composerId" .= sessionId]
+                    ]
+                forM_ (reverse [1000 .. 1204 :: Int]) \n ->
+                    executeSql database "INSERT INTO cursorDiskKV VALUES (?, ?)"
+                        [ SQLText ("bubbleId:" <> sessionId <> ":" <> Text.pack (show n))
+                        , SQLText $ renderJson $ object
+                            [ "role" .= ("user" :: Text)
+                            , "text" .= Text.pack (show n)
+                            ]
+                        ]
+                executeSql database "INSERT INTO cursorDiskKV VALUES (?, ?)"
+                    [SQLText ("bubbleId:" <> sessionId <> ":bad"), SQLText "not JSON"]
+            let env = fixture.env { externalCursorDesktopStores = [store] }
+            session <- showReference env ExternalCursor sessionId 100
+            map (.externalTurnText) session.externalSessionTurns
+                `shouldBe` map (Text.pack . show) [1005 .. 1204 :: Int]
+            session.externalSessionLastUserRequest `shouldBe` Just "1204"
+            warningCodes session `shouldContain` ["binary_content_unavailable"]
+            withDatabase store \database ->
+                SQLite.exec database "DROP TABLE cursorDiskKV"
+            failed <- showReference env ExternalCursor sessionId 100
+            warningCodes failed `shouldContain`
+                ["cursor_store_error", "cursor_transcript_unavailable"]
 
     it "decodes Grok session directories and bounds streamed histories" $
         withFixture \fixture -> do


### PR DESCRIPTION
## Summary
- Thread ClaudeReadState through chain recursion, preserving SQLite-backed cycle detection and bounded retained turns.
- Return Cursor database fold results and warnings explicitly, retaining only the partial-result exception checkpoint (including database-close failures).
- Add regressions for Claude cycles/missing parents/retention and Cursor database ordering/retention/binary warnings/query errors.

This is a maintainability/correctness refactor, not a performance claim. Existing SQLite row materialization is unchanged. No Cabal metadata changed.

## Validation
- Resource-bounded nix develop / cabal repl (-j1, GHCRTS=-M3G): verified actual successful load of all 10 library modules.
- Test GHCi session: verified successful module load and 17 examples, 0 failures.
- Direct GHCi injected post-consumption failure: recovered Cursor turns retained and only cursor_store_error emitted (CHECKPOINT PASS).
- git diff --check and independent read-only diff review passed.