### PR TITLE
Refactor visible loop bookkeeping into a pure state transition

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -270,6 +270,7 @@
                         "data"
                         "src"
                         "test"
+                        "test-visible-state"
                         "agent-core.cabal"
                         "LICENSE"
                         "README.md"

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -112,6 +112,7 @@ library
                     , Agent.Loop.EventPump
                     , Agent.Loop.Input
                     , Agent.Loop.Internal
+                    , Agent.Loop.VisibleState
                     , Agent.Loop.Output
                     , Agent.Loop.TokenUsage
                     , Agent.Subagents.Registry.Internal.Core
@@ -310,6 +311,36 @@ benchmark artifact-retrieval-bench
                     , bytestring
                     , directory
                     , text
+
+-- Compile the internal transition directly, without exposing it as public API.
+test-suite visible-loop-state-test
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test-visible-state, src
+    main-is:          Spec.hs
+    other-modules:    Agent.Dialect
+                    , Agent.Error
+                    , Agent.Loop.DisplayJournal
+                    , Agent.Loop.EventPump
+                    , Agent.Loop.Output
+                    , Agent.Loop.TokenUsage
+                    , Agent.Loop.VisibleState
+                    , Agent.Provider
+                    , Agent.Telemetry
+                    , Agent.TextBuffer
+                    , Agent.ToolDispatch
+    build-depends:    agent-json
+                    , agent-responses-types
+                    , aeson
+                    , async
+                    , base >= 4.14 && < 5
+                    , bytestring
+                    , containers
+                    , hspec
+                    , safe-exceptions
+                    , stm
+                    , text
+                    , time
 
 test-suite agent-core-test
     import:           common-opts

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -26,6 +26,7 @@ import Agent.Loop.Input
 import Agent.Loop.InputItems (turnInputsToItems)
 import Agent.Loop.Output
 import Agent.Loop.TokenUsage
+import Agent.Loop.VisibleState
 import Agent.Responses.Types
 import Agent.Telemetry (TurnTelemetry)
 import Agent.ToolDispatch
@@ -92,7 +93,7 @@ import Control.Exception.Safe
 import Control.Monad (when)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
-import Data.IORef (IORef, modifyIORef', newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, atomicModifyIORef', atomicWriteIORef, modifyIORef', newIORef, readIORef, writeIORef)
 import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
 import qualified Data.IntSet as IntSet
@@ -312,10 +313,7 @@ data LoopRuntime = LoopRuntime
     , loopRuntimeProgressRef :: IORef (BackendSnapshot, LoopProgress)
     , loopRuntimePendingRef :: IORef [TurnInput]
     , loopRuntimePendingSteeringRef :: IORef Int
-    , loopRuntimeUncommittedTextRef :: IORef ([[Text]], [Text])
-    , loopRuntimeUncommittedDisplayEventsRef
-        :: IORef DisplayJournal
-    , loopRuntimeProviderAttemptActiveRef :: IORef Bool
+    , loopRuntimeVisibleStateRef :: IORef VisibleLoopState
     , loopRuntimeProviderTelemetryRef :: IORef [TurnTelemetry]
     , loopRuntimeInitialSteering :: [TurnInput]
     }
@@ -345,9 +343,7 @@ initializeLoopRuntime config0 initialState firstInputs = do
     manager <- newAsyncToolManager
     eventAdmissionLock <- newMVar ()
     progressRef <- newIORef (initialState, NoResponseCommitted)
-    uncommittedTextRef <- newIORef ([], [])
-    uncommittedDisplayEventsRef <- newIORef emptyDisplayJournal
-    providerAttemptActiveRef <- newIORef False
+    visibleStateRef <- newIORef emptyVisibleLoopState
     providerTelemetryRef <- newIORef []
     initialSteering <- config0.loopReadSteering
     pendingRef <- newIORef (firstInputs <> initialSteering)
@@ -356,13 +352,11 @@ initializeLoopRuntime config0 initialState firstInputs = do
             { loopOnEvent = \event ->
                 -- Provider streaming and async host tools can publish at the
                 -- same time. Keep journal mutation and event-pump admission
-                -- in one total order instead of racing the IORefs below.
+                -- in one total order. An atomic state update alone would not
+                -- preserve admission order when the event pump backpressures.
                 withMVar eventAdmissionLock \_ -> do
-                    recordVisibleLoopEvent
-                        uncommittedTextRef
-                        uncommittedDisplayEventsRef
-                        providerAttemptActiveRef
-                        event
+                    atomicModifyIORef' visibleStateRef \state ->
+                        (recordVisibleLoopEvent event state, ())
                     emitLoopEvent eventPump event
             }
     pure LoopRuntime
@@ -372,65 +366,10 @@ initializeLoopRuntime config0 initialState firstInputs = do
         , loopRuntimeProgressRef = progressRef
         , loopRuntimePendingRef = pendingRef
         , loopRuntimePendingSteeringRef = pendingSteeringRef
-        , loopRuntimeUncommittedTextRef = uncommittedTextRef
-        , loopRuntimeUncommittedDisplayEventsRef =
-            uncommittedDisplayEventsRef
-        , loopRuntimeProviderAttemptActiveRef = providerAttemptActiveRef
+        , loopRuntimeVisibleStateRef = visibleStateRef
         , loopRuntimeProviderTelemetryRef = providerTelemetryRef
         , loopRuntimeInitialSteering = initialSteering
         }
-
-recordVisibleLoopEvent
-    :: IORef ([[Text]], [Text])
-    -> IORef DisplayJournal
-    -> IORef Bool
-    -> LoopEvent
-    -> IO ()
-recordVisibleLoopEvent
-    uncommittedTextRef
-    uncommittedDisplayEventsRef
-    providerAttemptActiveRef
-    event = do
-        modifyIORef' uncommittedTextRef \(finished, current) ->
-            case event of
-                TextDelta delta -> (finished, delta : current)
-                -- A restarted attempt stays visible, marked failed,
-                -- until a later response commits or the turn ends.
-                ResponseRestarted _ ->
-                    finishCurrentTextAttempt finished current
-                ResponseAttemptDiscarded -> (finished, [])
-                _ -> (finished, current)
-        case event of
-            TurnStarted -> do
-                writeIORef providerAttemptActiveRef True
-                writeIORef uncommittedDisplayEventsRef emptyDisplayJournal
-            TurnFinished _ -> do
-                writeIORef providerAttemptActiveRef False
-                writeIORef uncommittedDisplayEventsRef emptyDisplayJournal
-            ResponseRestarted _ ->
-                modifyIORef'
-                    uncommittedDisplayEventsRef
-                    (recordDisplayEvent event)
-            ResponseAttemptDiscarded ->
-                modifyIORef'
-                    uncommittedDisplayEventsRef
-                    discardCurrentDisplayAttempt
-            _
-                | replayableDisplayEvent event -> do
-                    active <- readIORef providerAttemptActiveRef
-                    when active $
-                        modifyIORef'
-                            uncommittedDisplayEventsRef
-                            (recordDisplayEvent event)
-                | otherwise -> pure ()
-
-finishCurrentTextAttempt
-    :: [[Text]]
-    -> [Text]
-    -> ([[Text]], [Text])
-finishCurrentTextAttempt finished current
-    | null current = (finished, [])
-    | otherwise = (current : finished, [])
 
 finishLoopExecution
     :: LoopRuntime
@@ -441,26 +380,16 @@ finishLoopExecution
 finishLoopExecution runtime state progress result = do
     writeIORef runtime.loopRuntimeProgressRef (state, progress)
     pending <- readIORef runtime.loopRuntimePendingRef
-    (finishedChunks, currentChunks) <-
-        readIORef runtime.loopRuntimeUncommittedTextRef
-    displayEvents <-
-        displayEventsFromJournal
-            <$> readIORef runtime.loopRuntimeUncommittedDisplayEventsRef
+    visibleState <- readIORef runtime.loopRuntimeVisibleStateRef
     providerTelemetry <-
         reverse <$> readIORef runtime.loopRuntimeProviderTelemetryRef
-    let uncommittedText = Text.intercalate "\n\n" $
-            filter (not . Text.null) $
-                map (Text.concat . reverse)
-                    (reverse finishedChunks <> [currentChunks])
     pure LoopExecution
         { executionState = state.backendItems
         , executionPendingInputs = pending
         , executionProgress = progress
         , executionUncommittedAssistantText =
-            if Text.null uncommittedText
-                then Nothing
-                else Just uncommittedText
-        , executionUncommittedDisplayEvents = displayEvents
+            visibleAssistantText visibleState
+        , executionUncommittedDisplayEvents = visibleDisplayEvents visibleState
         , executionProviderTelemetry = providerTelemetry
         , executionResult = result
         }
@@ -734,9 +663,9 @@ continueCommittedLoop runtime cursor turn = do
     -- The committed response absorbed every input submitted with it, and its
     -- assistant text now lives in the committed state.
     writeIORef runtime.loopRuntimePendingRef []
-    writeIORef runtime.loopRuntimeUncommittedTextRef ([], [])
-    writeIORef runtime.loopRuntimeUncommittedDisplayEventsRef emptyDisplayJournal
-    writeIORef runtime.loopRuntimeProviderAttemptActiveRef False
+    -- Async tool publishers may still be active. Reset the whole snapshot
+    -- atomically without introducing a blocking checkpoint during commit.
+    atomicWriteIORef runtime.loopRuntimeVisibleStateRef emptyVisibleLoopState
     -- Result metadata belongs to the response commit even when a cancellation
     -- lands before the completion event is painted.
     case turn.providerTelemetry of

--- a/packages/agent-core/src/Agent/Loop/VisibleState.hs
+++ b/packages/agent-core/src/Agent/Loop/VisibleState.hs
@@ -1,0 +1,74 @@
+-- | Pure bookkeeping for output not yet absorbed by a response commit.
+-- This is display-only state; it must never enter backend/model history.
+module Agent.Loop.VisibleState
+    ( VisibleLoopState(..)
+    , emptyVisibleLoopState
+    , recordVisibleLoopEvent
+    , visibleAssistantText
+    , visibleDisplayEvents
+    ) where
+
+import Agent.Loop.DisplayJournal
+import Agent.Loop.Output (LoopEvent(..))
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- Attempts and their chunks are newest-first. Strict fields force each
+-- transition without flattening text or the deliberately lazy journal tails.
+data VisibleLoopState = VisibleLoopState
+    { finishedTextAttempts :: ![[Text]]
+    , currentTextChunks :: ![Text]
+    , displayJournal :: !DisplayJournal
+    , providerAttemptActive :: !Bool
+    }
+
+-- Also used at the response-commit checkpoint, before TurnFinished is emitted.
+emptyVisibleLoopState :: VisibleLoopState
+emptyVisibleLoopState = VisibleLoopState [] [] emptyDisplayJournal False
+
+recordVisibleLoopEvent :: LoopEvent -> VisibleLoopState -> VisibleLoopState
+recordVisibleLoopEvent event state = case event of
+    TurnStarted -> state
+        { providerAttemptActive = True
+        , displayJournal = emptyDisplayJournal
+        }
+    TurnFinished _ -> state
+        { providerAttemptActive = False
+        , displayJournal = emptyDisplayJournal
+        }
+    TextDelta delta -> state
+        { currentTextChunks = delta : state.currentTextChunks
+        , displayJournal = journalWithEvent
+        }
+    -- A restarted attempt stays visible until a response commits or the turn
+    -- ends. Discard removes only the current attempt, not earlier restarts.
+    ResponseRestarted _ -> state
+        { finishedTextAttempts =
+            if null state.currentTextChunks
+                then state.finishedTextAttempts
+                else state.currentTextChunks : state.finishedTextAttempts
+        , currentTextChunks = []
+        , displayJournal = recordDisplayEvent event state.displayJournal
+        }
+    ResponseAttemptDiscarded -> state
+        { currentTextChunks = []
+        , displayJournal = discardCurrentDisplayAttempt state.displayJournal
+        }
+    _ -> state { displayJournal = journalWithEvent }
+  where
+    journalWithEvent
+        | state.providerAttemptActive && replayableDisplayEvent event =
+            recordDisplayEvent event state.displayJournal
+        | otherwise = state.displayJournal
+
+visibleAssistantText :: VisibleLoopState -> Maybe Text
+visibleAssistantText state
+    | Text.null text = Nothing
+    | otherwise = Just text
+  where
+    text = Text.intercalate "\n\n" $ filter (not . Text.null) $
+        map (Text.concat . reverse)
+            (reverse state.finishedTextAttempts <> [state.currentTextChunks])
+
+visibleDisplayEvents :: VisibleLoopState -> [LoopEvent]
+visibleDisplayEvents state = displayEventsFromJournal state.displayJournal

--- a/packages/agent-core/test-visible-state/Spec.hs
+++ b/packages/agent-core/test-visible-state/Spec.hs
@@ -1,0 +1,103 @@
+module Main (main) where
+
+import Agent.Loop.Output
+import Agent.Loop.VisibleState
+import Agent.ToolDispatch (functionToolCall)
+import Test.Hspec
+
+main :: IO ()
+main = hspec $ describe "VisibleLoopState event sequences" do
+    it "starts empty and ignores live-only events" do
+        let state = events [ReasoningDelta "private", ResponseAttemptFailed]
+        visibleAssistantText state `shouldBe` Nothing
+        visibleDisplayEvents state `shouldBe` []
+        state.providerAttemptActive `shouldBe` False
+
+    it "preserves chunk and attempt order across restarts" do
+        let state = events
+                [ TurnStarted, TextDelta "a", TextDelta "b"
+                , ResponseRestarted "retry", TextDelta "c", TextDelta "d"
+                , ResponseRestarted "again", TextDelta "e"
+                ]
+        visibleAssistantText state `shouldBe` Just "ab\n\ncd\n\ne"
+        visibleDisplayEvents state `shouldBe`
+            [ TextDelta "ab", ResponseRestarted "retry"
+            , TextDelta "cd", ResponseRestarted "again", TextDelta "e"
+            ]
+        state.providerAttemptActive `shouldBe` True
+
+    it "discards only the current attempt and accepts recovery output" do
+        let state = events
+                [ TurnStarted, TextDelta "prior", ResponseRestarted "retry"
+                , TextDelta "discard", ToolStarted call
+                , ResponseAttemptDiscarded, ResponseAttemptDiscarded
+                , TextDelta "recovered", ResponseAttemptFailed
+                ]
+        visibleAssistantText state `shouldBe` Just "prior\n\nrecovered"
+        visibleDisplayEvents state `shouldBe`
+            [TextDelta "prior", ResponseRestarted "retry", TextDelta "recovered"]
+
+    it "does not create empty text attempts or separators" do
+        let state = events
+                [ TurnStarted, ResponseRestarted "empty"
+                , TextDelta "", ResponseRestarted "empty chunk"
+                , TextDelta "kept", ResponseRestarted "retry"
+                , TextDelta "", ResponseAttemptDiscarded
+                ]
+        visibleAssistantText state `shouldBe` Just "kept"
+        state.currentTextChunks `shouldBe` []
+        state.finishedTextAttempts `shouldBe` [["kept"], [""]]
+
+    it "gates tool display on provider activity but not text accumulation" do
+        let state = events
+                [ ToolStarted call, TextDelta "before"
+                , TurnStarted, TextDelta "during", ToolStarted call
+                , TurnFinished (emptyTurnOutput "response" [] Nothing)
+                , ToolOutputUpdated "c1" "late", TextDelta "after"
+                ]
+        visibleAssistantText state `shouldBe` Just "beforeduringafter"
+        visibleDisplayEvents state `shouldBe` []
+        state.providerAttemptActive `shouldBe` False
+
+    it "starts a fresh journal without resetting uncommitted text" do
+        let state = events
+                [ TurnStarted, TextDelta "old", ToolStarted call
+                , TurnStarted, TextDelta "new"
+                ]
+        visibleAssistantText state `shouldBe` Just "oldnew"
+        visibleDisplayEvents state `shouldBe` [TextDelta "new"]
+
+    it "keeps restart and discard boundaries even outside an active provider" do
+        let state = events
+                [ TextDelta "prior", ResponseRestarted "retry"
+                , TextDelta "discard", ResponseAttemptDiscarded
+                ]
+        visibleAssistantText state `shouldBe` Just "prior"
+        visibleDisplayEvents state `shouldBe` [ResponseRestarted "retry"]
+
+    it "scopes tool retraction to the current attempt when IDs repeat" do
+        let state = events
+                [ TurnStarted, ToolStarted call, TextDelta "prior"
+                , ResponseRestarted "retry", ToolStarted call
+                , ToolOutputUpdated "c1" "removed", ToolRetracted "c1"
+                , TextDelta "current"
+                ]
+        visibleDisplayEvents state `shouldBe`
+            [ToolStarted call, TextDelta "prior", ResponseRestarted "retry", TextDelta "current"]
+        visibleAssistantText state `shouldBe` Just "prior\n\ncurrent"
+
+    it "uses an empty snapshot at commit before completion is painted" do
+        -- The IO commit checkpoint installs this value directly, not via a
+        -- TurnFinished event (which deliberately does not clear text).
+        let committed = emptyVisibleLoopState
+            lateTool = recordVisibleLoopEvent (ToolOutputUpdated "c1" "late") committed
+            next = foldl' (flip recordVisibleLoopEvent) lateTool
+                [TurnStarted, TextDelta "next"]
+        visibleAssistantText lateTool `shouldBe` Nothing
+        visibleDisplayEvents lateTool `shouldBe` []
+        lateTool.providerAttemptActive `shouldBe` False
+        visibleAssistantText next `shouldBe` Just "next"
+        visibleDisplayEvents next `shouldBe` [TextDelta "next"]
+  where
+    events = foldl' (flip recordVisibleLoopEvent) emptyVisibleLoopState
+    call = functionToolCall "c1" "tool" "{}"

--- a/packages/agent-core/test/Agent/Loop/EventDeliverySpec.hs
+++ b/packages/agent-core/test/Agent/Loop/EventDeliverySpec.hs
@@ -1,10 +1,11 @@
 module Agent.Loop.EventDeliverySpec (spec) where
 
 import Agent.Loop
+import Agent.Error (ApiError(..))
 import Agent.Loop.Fixtures
 import Agent.ToolDispatch
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (wait, withAsync)
+import Control.Concurrent.Async (concurrently_, wait, withAsync)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Exception.Safe (throwIO)
 import Data.IORef
@@ -14,6 +15,36 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    it "retains concurrent publishers in the same order as event-pump delivery" do
+        delivered <- newIORef []
+        let publish onEvent prefix = mapM_ (\index -> do
+                onEvent $ ToolStarted $ functionToolCall
+                    (prefix <> Text.pack (show index)) "tool" "{}"
+                onEvent $ TextDelta prefix) [1 .. 300 :: Int]
+            backend = Backend \_state _prev _inputs onEvent -> do
+                concurrently_ (publish onEvent "a") (publish onEvent "b")
+                pure (Left (ConnectionError "stopped"))
+            -- The pump and journal both coalesce adjacent text, but the pump
+            -- may deliver a partial chunk before the next delta is admitted.
+            normalize = foldr (\event rest -> case (event, rest) of
+                (TextDelta a, TextDelta b : tail) -> TextDelta (a <> b) : tail
+                _ -> event : rest) []
+            replayable = \case
+                ToolStarted _ -> True
+                TextDelta _ -> True
+                _ -> False
+        config0 <- testConfig backend
+        let config = config0 { loopOnEvent = \event -> do
+                modifyIORef' delivered (event :)
+                threadDelay 100 }
+        execution <- runLoopInputsDetailed config Nothing [UserMessage "go"]
+        seen <- normalize . filter replayable . reverse <$> readIORef delivered
+        execution.executionUncommittedDisplayEvents `shouldBe` seen
+        let text = maybe "" id execution.executionUncommittedAssistantText
+        Text.count "a" text `shouldBe` 300
+        Text.count "b" text `shouldBe` 300
+        length [() | ToolStarted _ <- seen] `shouldBe` 600
+
     it "serializes loopOnEvent across parallel tool calls" do
         inFlight <- newIORef (0 :: Int)
         maxInFlight <- newIORef (0 :: Int)


### PR DESCRIPTION
## Summary
- Consolidate uncommitted text, display journal, and provider activity into strict `VisibleLoopState` with a pure event transition.
- Retain the publisher lock across state recording and event-pump admission. Use atomic snapshot updates/reset without adding a blocking commit checkpoint; leave recovery, cancellation, and unrelated loop state unchanged.
- Add nine pure event-sequence tests and a concurrent-publisher journal/admission-order regression; retain existing concurrency coverage.
- Register the private test suite and its Nix source directory. Regenerated `package.nix` with cabal2nix (no resulting change).

## Validation
Resource-bounded GHCi validation via `GHCRTS=-M3G nix develop -j 1 -c cabal repl --offline -j1`:
- `agent-core:lib:agent-core`: **Ok, 81 modules loaded**, including Internal and VisibleState.
- `agent-core:test:visible-loop-state-test`, `:main`: **Ok, 12 modules loaded; 9 examples, 0 failures**.
- `agent-core:test:agent-core-test`, `Test.Hspec.hspec Agent.LoopSpec.spec`: **Ok, 49 modules loaded; 115 examples, 0 failures**, including async tool, event delivery, recovery, and cancellation tests.
- Reviewed the diff and synchronization boundaries; `git diff --check` passed.

This is a maintainability/correctness refactor, not a performance claim. Concurrency tests exercise representative schedules, not exhaustive interleavings.
