### PR TITLE
Share incremental SSE framing between Responses and Gemini

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -105,6 +105,7 @@ library
                     , Agent.Tools.Types
                     , Agent.Tools.ViewImage
                     , Agent.Tools.RenderChart
+                    , Agent.Transport.SSE
                     , Agent.Transport.WebSocket
     other-modules:    Agent.Image.Normalize
                     , Agent.Loop.Backend
@@ -362,6 +363,7 @@ test-suite agent-core-test
                     , Agent.Tools.RenderChartSpec
                     , Agent.Tools.ResourceArbiterSpec
                     , Agent.ToolDSLSpec
+                    , Agent.Transport.SSESpec
                     , Agent.Transport.WebSocketSpec
                     , Paths_agent_core
     autogen-modules:  Paths_agent_core

--- a/packages/agent-core/src/Agent/Transport/SSE.hs
+++ b/packages/agent-core/src/Agent/Transport/SSE.hs
@@ -1,0 +1,138 @@
+-- | Provider-neutral incremental SSE framing. Field interpretation, UTF-8
+-- validation, and event decoding belong to the caller.
+module Agent.Transport.SSE
+    ( SseFramer
+    , newSseFramer
+    , feedSseFramer
+    , finishSseFramer
+    , dropTrailingCarriageReturn
+    , maxSseEventBytes
+    ) where
+
+import Agent.Error (ApiError(..))
+import qualified Data.ByteString as BS
+import qualified Data.Maybe as Maybe
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Encoding.Error as Text (lenientDecode)
+
+-- | Incomplete lines and blocks remain chunked until their delimiter arrives.
+-- The byte count includes all wire bytes, including comments, CRs, and LFs,
+-- and resets after each blank line.
+data SseFramer = SseFramer
+    { lineChunksRev :: ![BS.ByteString]
+    , blockLinesRev :: ![BS.ByteString]
+    , eventBytes :: !Int
+    }
+
+newSseFramer :: SseFramer
+newSseFramer = SseFramer [] [] 0
+
+-- | Feed an arbitrary HTTP chunk, decoding nonempty blocks in wire order.
+-- The callback runs before framing subsequent bytes so its errors take
+-- precedence over framing errors in later blocks of the same chunk.
+feedSseFramer
+    :: Text
+    -- ^ Provider name used in limit errors.
+    -> (BS.ByteString -> Either ApiError (Maybe event))
+    -> SseFramer
+    -> BS.ByteString
+    -> Either ApiError (SseFramer, [event])
+feedSseFramer provider decodeBlock framer chunk =
+    decodeAvailable framer chunk []
+  where
+    decodeAvailable current bytes events
+        | BS.null bytes = Right (current, reverse events)
+        | otherwise =
+            let (linePart, restWithNewline) = BS.break (== 0x0a) bytes
+            in if BS.null restWithNewline
+                then do
+                    next <- appendLinePart provider current linePart
+                    Right (next, reverse events)
+                else do
+                    withPart <- appendLinePart provider current linePart
+                    withNewline <- addEventBytes provider 1 withPart
+                    let line = completeLine withNewline
+                        afterLine = withNewline { lineChunksRev = [] }
+                    (next, decoded) <- consumeLine decodeBlock afterLine line
+                    decodeAvailable next (BS.tail restWithNewline)
+                        (maybe events (: events) decoded)
+
+-- | Accept a final event without a trailing newline or blank-line delimiter.
+-- Finishing does not add synthetic wire bytes to the size limit.
+finishSseFramer
+    :: (BS.ByteString -> Either ApiError (Maybe event))
+    -> SseFramer
+    -> Either ApiError [event]
+finishSseFramer decodeBlock framer = do
+    (afterLine, lineEvent) <-
+        if null framer.lineChunksRev
+            then Right (framer, Nothing)
+            else consumeLine decodeBlock
+                (framer { lineChunksRev = [] }) (completeLine framer)
+    blockEvent <- decodeBlockLines decodeBlock (reverse afterLine.blockLinesRev)
+    pure (Maybe.catMaybes [lineEvent, blockEvent])
+
+appendLinePart :: Text -> SseFramer -> BS.ByteString -> Either ApiError SseFramer
+appendLinePart provider framer chunk
+    | BS.null chunk = Right framer
+    | otherwise = do
+        withBytes <- addEventBytes provider (BS.length chunk) framer
+        pure withBytes { lineChunksRev = chunk : withBytes.lineChunksRev }
+
+addEventBytes :: Text -> Int -> SseFramer -> Either ApiError SseFramer
+addEventBytes provider amount framer
+    | amount <= maxSseEventBytes - framer.eventBytes =
+        Right framer { eventBytes = framer.eventBytes + amount }
+    | otherwise = Left $ JsonDecodeError
+        (provider <> " SSE event exceeds "
+            <> Text.pack (show maxSseEventBytes) <> " bytes")
+        (framerPreview framer)
+
+completeLine :: SseFramer -> BS.ByteString
+completeLine =
+    dropTrailingCarriageReturn . BS.concat . reverse . (.lineChunksRev)
+
+consumeLine
+    :: (BS.ByteString -> Either ApiError (Maybe event))
+    -> SseFramer
+    -> BS.ByteString
+    -> Either ApiError (SseFramer, Maybe event)
+consumeLine decodeBlock framer line
+    | BS.null line = do
+        decoded <- decodeBlockLines decodeBlock (reverse framer.blockLinesRev)
+        pure (newSseFramer, decoded)
+    | otherwise = Right
+        (framer { blockLinesRev = line : framer.blockLinesRev }, Nothing)
+
+decodeBlockLines
+    :: (BS.ByteString -> Either ApiError (Maybe event))
+    -> [BS.ByteString]
+    -> Either ApiError (Maybe event)
+decodeBlockLines _ [] = Right Nothing
+decodeBlockLines decodeBlock lines = decodeBlock (BS.intercalate "\n" lines)
+
+-- | Strip exactly one CR. A bare CR is not a line delimiter.
+dropTrailingCarriageReturn :: BS.ByteString -> BS.ByteString
+dropTrailingCarriageReturn bytes = case BS.unsnoc bytes of
+    Just (prefix, 0x0d) -> prefix
+    _ -> bytes
+
+framerPreview :: SseFramer -> Text
+framerPreview framer =
+    Text.decodeUtf8With Text.lenientDecode $
+        BS.concat $
+            takeByteChunks 2000 $
+                reverse framer.blockLinesRev <> reverse framer.lineChunksRev
+
+takeByteChunks :: Int -> [BS.ByteString] -> [BS.ByteString]
+takeByteChunks remaining _
+    | remaining <= 0 = []
+takeByteChunks _ [] = []
+takeByteChunks remaining (chunk : rest) =
+    let kept = BS.take remaining chunk
+    in kept : takeByteChunks (remaining - BS.length kept) rest
+
+maxSseEventBytes :: Int
+maxSseEventBytes = 64 * 1024 * 1024

--- a/packages/agent-core/test/Agent/Transport/SSESpec.hs
+++ b/packages/agent-core/test/Agent/Transport/SSESpec.hs
@@ -1,0 +1,133 @@
+module Agent.Transport.SSESpec (spec) where
+
+import Agent.Error (ApiError(..))
+import Agent.Transport.SSE
+import Control.Monad (foldM, forM_)
+import qualified Data.ByteString as BS
+import qualified Data.Text as Text
+import Test.Hspec
+import Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import Test.QuickCheck (forAll, listOf, elements, chooseInt, (===))
+
+spec :: Spec
+spec = describe "shared SSE framing" do
+    modifyMaxSuccess (const 500) $
+        prop "matches independent whole-body framing for arbitrary bytes and chunks" $
+            forAll (listOf (elements [0, 10, 13, 32, 58, 97, 195, 255])) \bytes ->
+                forAll (listOf (chooseInt (0, 16))) \sizes ->
+                    let body = BS.pack bytes
+                    in frameChunks (splitChunks sizes body)
+                        === Right (referenceBlocks body)
+
+    it "handles every two-chunk split, bytewise input, and empty chunks" do
+        let body = "\n:first\r\nx\r\n\r\n\r\nlast\r"
+            expected = Right [":first\nx", "last"]
+        forM_ [0 .. BS.length body] \offset ->
+            frameChunks [BS.take offset body, "", BS.drop offset body]
+                `shouldBe` expected
+        frameChunks (map BS.singleton (BS.unpack body)) `shouldBe` expected
+
+    it "emits only complete blocks during feed and flushes the final block" do
+        (framer, events) <- expectRight $ feed "a\n\nb\nc"
+        events `shouldBe` ["a"]
+        finishSseFramer keep framer `shouldBe` Right ["b\nc"]
+
+    it "flushes empty, line-terminated, unterminated, and CR-terminated tails" do
+        forM_ ["", "\n", "\r", "\r\n\r\n"] \body ->
+            frameChunks [body] `shouldBe` Right []
+        forM_ ["a", "a\n", "a\r", "a\r\n", "a\n\r"] \body ->
+            frameChunks [body] `shouldBe` Right ["a"]
+
+    it "strips one trailing CR but does not treat bare CRs as delimiters" do
+        frameChunks ["a\rb\r\r\n\n"] `shouldBe` Right ["a\rb\r"]
+
+    it "skips empty blocks without invoking the event decoder" do
+        let result = do
+                (framer, events) <- feedSseFramer "Test"
+                    (const (Left callbackError)) newSseFramer "\n\r\n"
+                trailing <- finishSseFramer (const (Left callbackError)) framer
+                pure (events <> trailing :: [BS.ByteString])
+        result `shouldBe` Right []
+
+    it "retains callback skipping and reports callback errors before later limit errors" do
+        let decode block = if block == "skip" then Right Nothing else keep block
+        fmap snd (feedSseFramer "Test" decode newSseFramer "skip\n\nok\n\n")
+            `shouldBe` Right ["ok"]
+        fmap snd (feedSseFramer "Test" (const (Left callbackError))
+            newSseFramer ("bad\n\n" <> BS.replicate (maxSseEventBytes + 1) 97))
+            `shouldBe` (Left callbackError :: Either ApiError [BS.ByteString])
+
+    it "accepts the exact 64 MiB wire limit and resets it after each block" do
+        maxSseEventBytes `shouldBe` 64 * 1024 * 1024
+        let body = BS.replicate (maxSseEventBytes - 4) 97 <> "\r\n\r\n"
+        (framer, lengths) <- expectRight $
+            feedSseFramer "Test" keepLength newSseFramer body
+        lengths `shouldBe` [maxSseEventBytes - 4]
+        fmap snd (feedSseFramer "Test" keepLength framer body)
+            `shouldBe` Right lengths
+
+    it "counts newline delimiters against the limit and bounds error previews" do
+        (framer, _) <- expectRight $
+            feed (BS.replicate maxSseEventBytes 97)
+        fmap snd (feedSseFramer "Test" keep framer "\n")
+            `shouldBe` Left (limitError (Text.replicate 2000 "a"))
+        fmap snd (feedSseFramer "Test" keep framer "b")
+            `shouldBe` Left (limitError (Text.replicate 2000 "a"))
+        -- EOF adds no synthetic newline bytes.
+        finishSseFramer keepLength framer `shouldBe` Right [maxSseEventBytes]
+
+    it "counts completed lines and CRLF bytes, not just the current line" do
+        (framer, _) <- expectRight $
+            feed (":comment\r\n" <> BS.replicate (maxSseEventBytes - 10) 97)
+        fmap snd (feedSseFramer "Test" keep framer "\r")
+            `shouldBe` Left (limitError (":comment" <> Text.replicate 1992 "a"))
+
+    it "rejects an oversized first chunk with the existing empty preview" do
+        fmap snd (feed (BS.replicate (maxSseEventBytes + 1) 97))
+            `shouldBe` Left (limitError "")
+
+keep :: BS.ByteString -> Either ApiError (Maybe BS.ByteString)
+keep = Right . Just
+
+keepLength :: BS.ByteString -> Either ApiError (Maybe Int)
+keepLength = Right . Just . BS.length
+
+feed :: BS.ByteString -> Either ApiError (SseFramer, [BS.ByteString])
+feed = feedSseFramer "Test" keep newSseFramer
+
+frameChunks :: [BS.ByteString] -> Either ApiError [BS.ByteString]
+frameChunks chunks = do
+    (framer, events) <- foldM step (newSseFramer, []) chunks
+    trailing <- finishSseFramer keep framer
+    pure (events <> trailing)
+  where
+    step (framer, events) chunk = do
+        (next, completed) <- feedSseFramer "Test" keep framer chunk
+        pure (next, events <> completed)
+
+-- Deliberately independent of the incremental framer and its CR helper.
+referenceBlocks :: BS.ByteString -> [BS.ByteString]
+referenceBlocks = blocks . map stripCR . BS.split 10
+  where
+    stripCR line
+        | not (BS.null line) && BS.last line == 13 = BS.init line
+        | otherwise = line
+    blocks [] = []
+    blocks (line : rest) | BS.null line = blocks rest
+    blocks lines =
+        let (block, rest) = break BS.null lines
+        in BS.intercalate "\n" block : blocks rest
+
+splitChunks :: [Int] -> BS.ByteString -> [BS.ByteString]
+splitChunks [] bytes = [bytes]
+splitChunks (size : sizes) bytes =
+    BS.take size bytes : splitChunks sizes (BS.drop size bytes)
+
+callbackError :: ApiError
+callbackError = JsonDecodeError "callback failed" ""
+
+limitError :: Text.Text -> ApiError
+limitError = JsonDecodeError "Test SSE event exceeds 67108864 bytes"
+
+expectRight :: Show error => Either error value -> IO value
+expectRight = either (fail . show) pure

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -44,10 +44,12 @@ import qualified Agent.Tools.ViewImageSpec as ViewImageSpec
 import qualified Agent.Tools.RenderChartSpec as RenderChartSpec
 import qualified Agent.Tools.ResourceArbiterSpec as ResourceArbiterSpec
 import qualified Agent.Transport.WebSocketSpec as WebSocketSpec
+import qualified Agent.Transport.SSESpec as SSESpec
 import Test.Hspec (hspec)
 
 main :: IO ()
 main = hspec do
+    SSESpec.spec
     JWTSpec.spec
     ClientIdentitySpec.spec
     CancelSpec.spec

--- a/packages/agent-gemini/src/Agent/Gemini/Stream.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Stream.hs
@@ -10,6 +10,8 @@ module Agent.Gemini.Stream
 
 import Agent.Error (ApiError(..))
 import Agent.Gemini.Types (GenerateContentResponse)
+import qualified Agent.Transport.SSE as SSE
+import Agent.Transport.SSE (dropTrailingCarriageReturn)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
@@ -18,66 +20,27 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
 import qualified Data.Text.Encoding.Error as TextEncoding (lenientDecode)
-import Data.Word (Word8)
 
--- | Incomplete lines and event blocks remain chunked until a terminating
--- newline arrives. This avoids repeatedly copying a large JSON frame when the
--- HTTP client splits it across many small chunks.
-data SseDecoder = SseDecoder
-    { decoderLineChunksRev :: ![BS.ByteString]
-    , decoderBlockLinesRev :: ![BS.ByteString]
-    , decoderEventBytes :: !Int
-    }
+-- | Gemini event decoding over the shared incremental SSE framer.
+newtype SseDecoder = SseDecoder SSE.SseFramer
 
 newSseDecoder :: SseDecoder
-newSseDecoder = SseDecoder
-    { decoderLineChunksRev = []
-    , decoderBlockLinesRev = []
-    , decoderEventBytes = 0
-    }
+newSseDecoder = SseDecoder SSE.newSseFramer
 
 feedSseDecoder
     :: SseDecoder
     -> BS.ByteString
     -> Either ApiError (SseDecoder, [GenerateContentResponse])
-feedSseDecoder decoder chunk =
-    decodeAvailable decoder chunk []
-  where
-    decodeAvailable current bytes responses
-        | BS.null bytes = Right (current, reverse responses)
-        | otherwise =
-            let (linePart, restWithNewline) = BS.break (== lineFeed) bytes
-            in if BS.null restWithNewline
-                then do
-                    next <- appendLinePart current linePart
-                    Right (next, reverse responses)
-                else do
-                    withPart <- appendLinePart current linePart
-                    withNewline <- addEventBytes 1 withPart
-                    let line = completeLine withNewline
-                        afterLine =
-                            withNewline { decoderLineChunksRev = [] }
-                    (next, decoded) <- consumeLine afterLine line
-                    decodeAvailable
-                        next
-                        (BS.tail restWithNewline)
-                        (maybe responses (: responses) decoded)
+feedSseDecoder (SseDecoder framer) chunk = do
+    (next, responses) <- SSE.feedSseFramer "Gemini" parseBlockBytes framer chunk
+    pure (SseDecoder next, responses)
 
 -- | Finish a stream, accepting a final event without a blank-line delimiter.
 finishSseDecoder
     :: SseDecoder
     -> Either ApiError [GenerateContentResponse]
-finishSseDecoder decoder = do
-    (afterLine, lineResponse) <-
-        if null decoder.decoderLineChunksRev
-            then Right (decoder, Nothing)
-            else
-                let line = completeLine decoder
-                    withoutLine = decoder { decoderLineChunksRev = [] }
-                in consumeLine withoutLine line
-    blockResponse <-
-        parseBlockLines (reverse afterLine.decoderBlockLinesRev)
-    pure (Maybe.catMaybes [lineResponse, blockResponse])
+finishSseDecoder (SseDecoder framer) =
+    SSE.finishSseFramer parseBlockBytes framer
 
 parseSseResponses
     :: Text
@@ -92,65 +55,6 @@ parseSseResponsesBytes bytes = do
     (decoder, responses) <- feedSseDecoder newSseDecoder bytes
     trailing <- finishSseDecoder decoder
     pure (responses <> trailing)
-
-appendLinePart
-    :: SseDecoder
-    -> BS.ByteString
-    -> Either ApiError SseDecoder
-appendLinePart decoder chunk
-    | BS.null chunk = Right decoder
-    | otherwise = do
-        withBytes <- addEventBytes (BS.length chunk) decoder
-        pure withBytes
-            { decoderLineChunksRev =
-                chunk : withBytes.decoderLineChunksRev
-            }
-
-addEventBytes :: Int -> SseDecoder -> Either ApiError SseDecoder
-addEventBytes amount decoder
-    | amount <= maxSseEventBytes - decoder.decoderEventBytes =
-        Right decoder
-            { decoderEventBytes = decoder.decoderEventBytes + amount }
-    | otherwise = Left $ JsonDecodeError
-        ( "Gemini SSE event exceeds "
-            <> Text.pack (show maxSseEventBytes)
-            <> " bytes"
-        )
-        (decoderPreview decoder)
-
-completeLine :: SseDecoder -> BS.ByteString
-completeLine =
-    dropTrailingCarriageReturn
-        . BS.concat
-        . reverse
-        . (.decoderLineChunksRev)
-
-consumeLine
-    :: SseDecoder
-    -> BS.ByteString
-    -> Either
-        ApiError
-        (SseDecoder, Maybe GenerateContentResponse)
-consumeLine decoder line
-    | BS.null line = do
-        decoded <-
-            parseBlockLines (reverse decoder.decoderBlockLinesRev)
-        pure (newSseDecoder, decoded)
-    | otherwise =
-        Right
-            ( decoder
-                { decoderBlockLinesRev =
-                    line : decoder.decoderBlockLinesRev
-                }
-            , Nothing
-            )
-
-parseBlockLines
-    :: [BS.ByteString]
-    -> Either ApiError (Maybe GenerateContentResponse)
-parseBlockLines [] = Right Nothing
-parseBlockLines lines =
-    parseBlockBytes (BS.intercalate "\n" lines)
 
 parseBlockBytes
     :: BS.ByteString
@@ -193,35 +97,3 @@ isDonePayload bytes =
     Text.strip
         (TextEncoding.decodeUtf8With TextEncoding.lenientDecode bytes)
         == "[DONE]"
-
-dropTrailingCarriageReturn :: BS.ByteString -> BS.ByteString
-dropTrailingCarriageReturn bytes =
-    case BS.unsnoc bytes of
-        Just (prefix, byte)
-            | byte == carriageReturn -> prefix
-        _ -> bytes
-
-decoderPreview :: SseDecoder -> Text
-decoderPreview decoder =
-    TextEncoding.decodeUtf8With TextEncoding.lenientDecode
-        $ BS.concat
-        $ takeByteChunks 2000
-        $ reverse decoder.decoderBlockLinesRev
-            <> reverse decoder.decoderLineChunksRev
-
-takeByteChunks :: Int -> [BS.ByteString] -> [BS.ByteString]
-takeByteChunks remaining _
-    | remaining <= 0 = []
-takeByteChunks _ [] = []
-takeByteChunks remaining (chunk : rest) =
-    let kept = BS.take remaining chunk
-    in kept : takeByteChunks (remaining - BS.length kept) rest
-
-lineFeed :: Word8
-lineFeed = 0x0a
-
-carriageReturn :: Word8
-carriageReturn = 0x0d
-
-maxSseEventBytes :: Int
-maxSseEventBytes = 64 * 1024 * 1024

--- a/packages/agent-gemini/test/Agent/Gemini/StreamSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/StreamSpec.hs
@@ -1,28 +1,75 @@
 module Agent.Gemini.StreamSpec (spec) where
 
 import Agent.Gemini.Stream
+import Agent.Error (ApiError(..))
+import Agent.Gemini.Types (GenerateContentResponse)
+import Control.Monad (foldM, forM_)
+import qualified Data.ByteString as BS
+import Data.Either (isLeft)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
 import Test.Hspec
 
 spec :: Spec
 spec = describe "Gemini SSE decoder" do
-    it "handles CRLF and arbitrary chunk boundaries" do
-        let payload = "data: {\"responseId\":\"r\",\"candidates\":[]}\r\n\r\n"
-            chunks = ["data: {\"response", "Id\":\"r\",\"candidates\":[]}\r\n", "\r\n"]
-            result = do
-                (decoder, first) <- feedSseDecoder newSseDecoder (chunks !! 0)
-                (decoder2, second) <- feedSseDecoder decoder (chunks !! 1)
-                trailing <- finishSseDecoder decoder2
-                pure (first <> second <> trailing)
-        result `shouldBe` parseSseResponses payload
-        result `shouldSatisfy` either (const False) ((== 1) . length)
+    it "handles all split points and bytewise CRLF, UTF-8, multiline data, and EOF" do
+        let body = Text.encodeUtf8 $
+                "\r\n: keepalive\r\n\r\nid: 1\r\nevent: ignored\r\n\r\n"
+                <> "event: also-ignored\r\ndata:{\"responseId\":\"hé🙂\",\r\n"
+                <> "data: \"candidates\":[]}\r\n\r\n"
+                <> "data: \x2003[DONE]\x2003\r\n\r\n"
+                <> "data: {\"responseId\":\"last\",\"candidates\":[]}"
+            expected = parseSseResponses $
+                "data: {\"responseId\":\"hé🙂\",\"candidates\":[]}\n\n"
+                <> "data: {\"responseId\":\"last\",\"candidates\":[]}\n\n"
+        expected `shouldSatisfy` either (const False) ((== 2) . length)
+        forM_ [0 .. BS.length body] \offset ->
+            decodeChunks [BS.take offset body, "", BS.drop offset body]
+                `shouldBe` expected
+        decodeChunks (map BS.singleton (BS.unpack body)) `shouldBe` expected
 
     it "rejects malformed JSON" do
         parseSseResponses "data: {not-json}\n\n" `shouldSatisfy` isLeft
+
+    it "rejects malformed JSON at every split and on EOF instead of skipping it" do
+        forM_ ["data: {not-json}", "data: {not-json}\n\ndata: {\"candidates\":[]}\n\n"] \body ->
+            forM_ [0 .. BS.length body] \offset ->
+                decodeChunks [BS.take offset body, BS.drop offset body]
+                    `shouldSatisfy` \case
+                        Left (JsonDecodeError message preview) ->
+                            "Invalid Gemini SSE JSON: " `Text.isPrefixOf` message
+                                && preview == "{not-json}"
+                        _ -> False
+
+    it "waits for the block boundary to reject UTF-8, including non-data lines" do
+        (decoder, events) <- expectRight $
+            feedSseDecoder newSseDecoder ": \xc3"
+        events `shouldBe` []
+        let invalid result = case result of
+                Left (JsonDecodeError message _) ->
+                    "Invalid UTF-8 in Gemini SSE event: " `Text.isPrefixOf` message
+                _ -> False
+        fmap snd (feedSseDecoder decoder "\x28\n\n") `shouldSatisfy` invalid
+        finishSseDecoder decoder `shouldSatisfy` invalid
+
+    it "keeps the Gemini limit error label" do
+        fmap snd (feedSseDecoder newSseDecoder (BS.replicate (64 * 1024 * 1024 + 1) 97))
+            `shouldBe` Left (JsonDecodeError "Gemini SSE event exceeds 67108864 bytes" "")
 
     it "does not silently accept an error envelope as an empty response" do
         parseSseResponses
             "data: {\"error\":{\"message\":\"stream failed\"}}\n\n"
             `shouldSatisfy` isLeft
+
+decodeChunks :: [BS.ByteString] -> Either ApiError [GenerateContentResponse]
+decodeChunks chunks = do
+    (decoder, events) <- foldM step (newSseDecoder, []) chunks
+    trailing <- finishSseDecoder decoder
+    pure (events <> trailing)
   where
-    isLeft (Left _) = True
-    isLeft _ = False
+    step (decoder, events) chunk = do
+        (next, completed) <- feedSseDecoder decoder chunk
+        pure (next, events <> completed)
+
+expectRight :: Show error => Either error value -> IO value
+expectRight = either (fail . show) pure

--- a/packages/agent-responses/src/Agent/Responses/SSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/SSE.hs
@@ -11,6 +11,8 @@ module Agent.Responses.SSE
 import Agent.Error (ApiError(..))
 import qualified Agent.Responses.Codec as ResponsesCodec
 import Agent.Responses.Types (ResponseStreamEvent)
+import qualified Agent.Transport.SSE as SSE
+import Agent.Transport.SSE (dropTrailingCarriageReturn)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.Maybe as Maybe
@@ -18,23 +20,12 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Encoding.Error as Text (lenientDecode)
-import Data.Word (Word8)
 
--- | Incremental SSE decoder. Incomplete lines and event blocks stay chunked
--- until their terminating blank line arrives, avoiding repeated copies and
--- rescans when one large event spans many HTTP chunks.
-data SseDecoder = SseDecoder
-    { decoderLineChunksRev :: ![BS.ByteString]
-    , decoderBlockLinesRev :: ![BS.ByteString]
-    , decoderEventBytes :: !Int
-    }
+-- | Responses event decoding over the shared incremental SSE framer.
+newtype SseDecoder = SseDecoder SSE.SseFramer
 
 newSseDecoder :: SseDecoder
-newSseDecoder = SseDecoder
-    { decoderLineChunksRev = []
-    , decoderBlockLinesRev = []
-    , decoderEventBytes = 0
-    }
+newSseDecoder = SseDecoder SSE.newSseFramer
 
 -- | Feed an arbitrary HTTP body chunk. Completed events are returned in wire
 -- order as soon as their terminating blank line arrives.
@@ -42,41 +33,15 @@ feedSseDecoder
     :: SseDecoder
     -> BS.ByteString
     -> Either ApiError (SseDecoder, [ResponseStreamEvent])
-feedSseDecoder decoder chunk =
-    decodeAvailable decoder chunk []
-  where
-    decodeAvailable current bytes events
-        | BS.null bytes = Right (current, reverse events)
-        | otherwise =
-            let (linePart, restWithNewline) = BS.break (== lineFeed) bytes
-            in if BS.null restWithNewline
-                then do
-                    next <- appendLinePart current linePart
-                    Right (next, reverse events)
-                else do
-                    withPart <- appendLinePart current linePart
-                    withNewline <- addEventBytes 1 withPart
-                    let line = completeLine withNewline
-                        afterLine = withNewline { decoderLineChunksRev = [] }
-                    (next, decoded) <- consumeLine afterLine line
-                    decodeAvailable
-                        next
-                        (BS.tail restWithNewline)
-                        (maybe events (: events) decoded)
+feedSseDecoder (SseDecoder framer) chunk = do
+    (next, events) <- SSE.feedSseFramer "Responses" parseBlockBytes framer chunk
+    pure (SseDecoder next, events)
 
 -- | Finish an SSE stream, accepting a final event without a trailing blank
 -- line.
 finishSseDecoder :: SseDecoder -> Either ApiError [ResponseStreamEvent]
-finishSseDecoder decoder = do
-    (afterLine, lineEvent) <-
-        if null decoder.decoderLineChunksRev
-            then Right (decoder, Nothing)
-            else
-                let line = completeLine decoder
-                    withoutLine = decoder { decoderLineChunksRev = [] }
-                in consumeLine withoutLine line
-    blockEvent <- parseBlockLines (reverse afterLine.decoderBlockLinesRev)
-    pure (Maybe.catMaybes [lineEvent, blockEvent])
+finishSseDecoder (SseDecoder framer) =
+    SSE.finishSseFramer parseBlockBytes framer
 
 -- | Decode a complete SSE body into the canonical typed Responses event union.
 parseSseEvents :: Text -> Either ApiError [ResponseStreamEvent]
@@ -89,56 +54,6 @@ parseSseEventsBytes bytes = do
     (decoder, events) <- feedSseDecoder newSseDecoder bytes
     trailing <- finishSseDecoder decoder
     pure (events <> trailing)
-
-appendLinePart :: SseDecoder -> BS.ByteString -> Either ApiError SseDecoder
-appendLinePart decoder chunk
-    | BS.null chunk = Right decoder
-    | otherwise = do
-        withBytes <- addEventBytes (BS.length chunk) decoder
-        pure withBytes
-            { decoderLineChunksRev =
-                chunk : withBytes.decoderLineChunksRev
-            }
-
-addEventBytes :: Int -> SseDecoder -> Either ApiError SseDecoder
-addEventBytes amount decoder
-    | amount <= maxSseEventBytes - decoder.decoderEventBytes =
-        Right decoder
-            { decoderEventBytes = decoder.decoderEventBytes + amount }
-    | otherwise = Left $ JsonDecodeError
-        ( "Responses SSE event exceeds "
-            <> Text.pack (show maxSseEventBytes)
-            <> " bytes"
-        )
-        (decoderPreview decoder)
-
-completeLine :: SseDecoder -> BS.ByteString
-completeLine =
-    dropTrailingCarriageReturn
-        . BS.concat
-        . reverse
-        . (.decoderLineChunksRev)
-
-consumeLine
-    :: SseDecoder
-    -> BS.ByteString
-    -> Either ApiError (SseDecoder, Maybe ResponseStreamEvent)
-consumeLine decoder line
-    | BS.null line = do
-        decoded <- parseBlockLines (reverse decoder.decoderBlockLinesRev)
-        pure (newSseDecoder, decoded)
-    | otherwise =
-        Right
-            ( decoder
-                { decoderBlockLinesRev =
-                    line : decoder.decoderBlockLinesRev
-                }
-            , Nothing
-            )
-
-parseBlockLines :: [BS.ByteString] -> Either ApiError (Maybe ResponseStreamEvent)
-parseBlockLines [] = Right Nothing
-parseBlockLines lines = parseBlockBytes (BS.intercalate "\n" lines)
 
 parseBlockBytes :: BS.ByteString -> Either ApiError (Maybe ResponseStreamEvent)
 parseBlockBytes bytes = case Text.decodeUtf8' bytes of
@@ -191,33 +106,3 @@ decodeEvent eventType dataBytes =
                 dataBytes
         Nothing ->
             ResponsesCodec.decodeResponseStreamEvent dataBytes
-
-dropTrailingCarriageReturn :: BS.ByteString -> BS.ByteString
-dropTrailingCarriageReturn bytes = case BS.unsnoc bytes of
-    Just (prefix, byte) | byte == carriageReturn -> prefix
-    _ -> bytes
-
-decoderPreview :: SseDecoder -> Text
-decoderPreview decoder =
-    Text.decodeUtf8With Text.lenientDecode $
-        BS.concat $
-            takeByteChunks 2000 $
-                reverse decoder.decoderBlockLinesRev
-                    <> reverse decoder.decoderLineChunksRev
-
-takeByteChunks :: Int -> [BS.ByteString] -> [BS.ByteString]
-takeByteChunks remaining _
-    | remaining <= 0 = []
-takeByteChunks _ [] = []
-takeByteChunks remaining (chunk : rest) =
-    let kept = BS.take remaining chunk
-    in kept : takeByteChunks (remaining - BS.length kept) rest
-
-lineFeed :: Word8
-lineFeed = 0x0a
-
-carriageReturn :: Word8
-carriageReturn = 0x0d
-
-maxSseEventBytes :: Int
-maxSseEventBytes = 64 * 1024 * 1024

--- a/packages/agent-responses/test/Agent/Responses/SSESpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/SSESpec.hs
@@ -4,7 +4,7 @@ import Agent.Error (ApiError(..))
 import Agent.Responses.SSE
 import qualified Agent.Responses.Codec as Codec
 import Agent.Responses.Types
-import Control.Monad (foldM)
+import Control.Monad (foldM, forM_)
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import qualified Data.ByteString as BS
@@ -60,6 +60,28 @@ spec = describe "Responses SSE decoder" do
             "event: ping\nid: 1\n\n"
                 <> "data: " <> completedJson <> "\n\n"
         eventTypes events `shouldBe` [EventResponseCompleted]
+
+    it "uses the first event override and skips malformed JSON across every split and EOF" do
+        let body =
+                "data: {not-json}\r\n\r\nevent: response.first\r\n"
+                <> "event: response.second\r\ndata:{\"vendor_field\":true}\r\n\r\n"
+                <> "event: response.first\r\ndata:{\"type\":\"response.wrong\"}\r\n\r\n"
+                <> "data: {also-not-json}"
+        forM_ [0 .. BS.length body] \offset -> do
+            events <- decodeChunks [BS.take offset body, "", BS.drop offset body]
+            eventTypes events `shouldBe` [StreamEventUnknown "response.first"]
+        events <- decodeChunks (map BS.singleton (BS.unpack body))
+        eventTypes events `shouldBe` [StreamEventUnknown "response.first"]
+
+    it "keeps the Responses limit error label" do
+        fmap snd (feedSseDecoder newSseDecoder (BS.replicate (64 * 1024 * 1024 + 1) 97))
+            `shouldBe` Left (JsonDecodeError "Responses SSE event exceeds 67108864 bytes" "")
+
+    it "rejects invalid UTF-8 in non-data lines on EOF" do
+        parseSseEventsBytes ": \xc3" `shouldSatisfy` \case
+            Left (JsonDecodeError message _) ->
+                "Invalid UTF-8 in Responses SSE event: " `Text.isPrefixOf` message
+            _ -> False
 
     it "accepts Unicode whitespace around the done sentinel" do
         events <- expectRight $ parseSseEvents $


### PR DESCRIPTION
## Summary
- Extract provider-neutral chunk buffering, line/block framing, CRLF handling, 64 MiB wire limits, bounded previews, and EOF flushing into `Agent.Transport.SSE`.
- Place framing in `agent-core`, already a dependency of both providers, without adding package dependencies or coupling either provider to the other.
- Keep provider event decoding local: Responses skips malformed JSON and retains first `event:` handling (including disagreement checks); Gemini rejects malformed JSON. Preserve callback-error ordering within chunks.
- Add shared framing tests with an independent whole-body oracle, randomized chunk boundaries, exhaustive split points, bytewise input, limits, and flushing; extend provider regressions for UTF-8, multiline data, comments, sentinels, malformed JSON, and event fields.

## Validation
- GHCi 9.10.3: all affected libraries and test modules loaded via multi-unit `cabal repl` (176 modules).
- Executed the shared framing, Responses SSE, and Gemini stream specs in GHCi with Cabal-plan package IDs: **31 examples, 0 failures**, including two **500-case QuickCheck properties**.
- Regenerated `agent-core/package.nix` with `cabal2nix` (unchanged); `git diff --check` clean.
- Refactoring only; no performance claims or benchmark changes.

Implemented in a new dedicated worktree and branch. CI will be watched before handoff.