### PR TITLE
Return final snapshots from model picker refreshes

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
+++ b/packages/agent-cli/src/Agent/CLI/ModelPicker.hs
@@ -9,6 +9,10 @@ module Agent.CLI.ModelPicker
     , pickModelStateWithEffort
     , pickModelStateWithEffortAndUsage
     , pickModelStateWithUpdates
+    , ModelPickerSnapshot
+    , ModelPickerRefresh
+    , resolveModelPickerRefresh
+    , withModelPickerRefresh
     , refreshModelPickerState
     , formatCatalogListing
     , initialModelPickerState
@@ -52,7 +56,6 @@ import Control.Monad (join, unless)
 import Control.Concurrent.Async (withAsync)
 import Control.Concurrent.STM (atomically, newEmptyTMVarIO, takeTMVar, tryTakeTMVar, putTMVar)
 import Data.Char (isPrint)
-import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.List (elemIndex, findIndex)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
@@ -218,6 +221,33 @@ pickModelStateWithEffortAndUsage color currentEffort usage models = do
                     state0
             pure (join result)
 
+-- | Catalog, usage, and notice from one consistent refresh checkpoint.
+type ModelPickerSnapshot = (PickerState, Map.Map Text Text, Text)
+
+-- | Return the final snapshot, optionally publishing intermediate snapshots.
+-- 'Nothing' means no update; after publishing, return the latest snapshot.
+-- Callbacks must finish before the refresh returns.
+type ModelPickerRefresh =
+    (ModelPickerSnapshot -> IO ()) -> IO (Maybe ModelPickerSnapshot)
+
+-- | Non-interactive consumers need only the final result, not a callback log.
+resolveModelPickerRefresh
+    :: ModelPickerSnapshot -> ModelPickerRefresh -> IO ModelPickerSnapshot
+resolveModelPickerRefresh initial refresh =
+    fromMaybe initial <$> refresh (const (pure ()))
+
+-- | Scope the refresh worker and its conflated channel to the consumer.
+-- A final result is also an update, even if no intermediate was published.
+withModelPickerRefresh
+    :: ModelPickerRefresh -> (IO ModelPickerSnapshot -> IO a) -> IO a
+withModelPickerRefresh refresh consume = do
+    updates <- newEmptyTMVarIO
+    let publish snapshot = atomically do
+            _ <- tryTakeTMVar updates
+            putTMVar updates snapshot
+    withAsync (refresh publish >>= maybe (pure ()) publish) \_ ->
+        consume (atomically (takeTMVar updates))
+
 -- | A private, conflated update channel belongs to this invocation only.
 -- Network workers never draw directly or race the terminal's input decoder.
 pickModelStateWithUpdates
@@ -226,7 +256,7 @@ pickModelStateWithUpdates
     -> Text
     -> Map.Map Text Text
     -> PickerState
-    -> ((PickerState -> Map.Map Text Text -> Text -> IO ()) -> IO ())
+    -> ModelPickerRefresh
     -> IO (Maybe ModelPickerSelection)
 pickModelStateWithUpdates color currentEffort notice usage models refresh = do
     isTty <- hIsTerminalDevice stdin
@@ -234,21 +264,15 @@ pickModelStateWithUpdates color currentEffort notice usage models refresh = do
         then do
             -- A non-interactive listing cannot redraw after it is printed.
             -- Resolve the refresh first rather than printing a cold empty cache.
-            latest <- newIORef (models, usage, notice)
-            refresh \nextModels nextUsage nextNotice ->
-                writeIORef latest (nextModels, nextUsage, nextNotice)
-            (nextModels, nextUsage, nextNotice) <- readIORef latest
+            (nextModels, nextUsage, nextNotice) <-
+                resolveModelPickerRefresh (models, usage, notice) refresh
             unless (Text.null nextNotice) $
                 Text.hPutStrLn stderr (displayPickerText nextNotice)
             pickModelStateWithEffortAndUsage color currentEffort nextUsage nextModels
         else do
-            updates <- newEmptyTMVarIO
             let initial =
                     ((initialModelPickerState currentEffort models)
                         { modelPickerUsage = usage }, notice)
-                publish nextModels nextUsage nextNotice = atomically do
-                    _ <- tryTakeTMVar updates
-                    putTMVar updates (nextModels, nextUsage, nextNotice)
                 render (state, message) =
                     renderModelPickerFrame color state
                         <> "\n" <> roleMuted color (displayPickerText message)
@@ -256,10 +280,10 @@ pickModelStateWithUpdates color currentEffort notice usage models refresh = do
                     fmap (, message) (applyModelPickerEvent (toEvent key) state)
                 apply (nextModels, nextUsage, nextNotice) (state, _) =
                     (refreshModelPickerState currentEffort nextModels nextUsage state, nextNotice)
-            result <- withAsync (refresh publish) \_ ->
+            result <- withModelPickerRefresh refresh \nextUpdate ->
                 Picker.runOverlayWithDecoderAndUpdates
                     decodeModelPickerKey render step
-                    (atomically (takeTMVar updates)) apply initial
+                    nextUpdate apply initial
             pure (result >>= fst)
 
 -- | Preserve the filter, focused model identity, and each model's effort when

--- a/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Choices.hs
@@ -82,7 +82,7 @@ import Agent.Provider
     , getNextToken
     )
 import Control.Concurrent.Async (concurrently_)
-import Control.Concurrent.MVar (modifyMVar_, newMVar)
+import Control.Concurrent.MVar (modifyMVar_, newMVar, readMVar)
 import Control.Monad (unless, void)
 import Data.IORef (atomicModifyIORef', modifyIORef', newIORef, readIORef)
 import Data.List (elemIndex)
@@ -188,8 +188,8 @@ modelChoiceWithEffort
                 state <- newMVar (picker, usage, notice)
                 let refresh publish = do
                         let update transform = modifyMVar_ state \previous -> do
-                                let next@(models, values, message) = transform previous
-                                publish models values message
+                                let next = transform previous
+                                publish next
                                 pure next
                             updateUsage values = update \(models, previous, message) ->
                                 (models, Map.union values previous, message)
@@ -215,6 +215,7 @@ modelChoiceWithEffort
                                     refreshGatewayModelUsage access added updateUsage
                         concurrently_ refreshCatalog
                             (refreshGatewayModelUsage access picker.pickerAll updateUsage)
+                        Just <$> readMVar state
                 Right <$> pickModelStateWithUpdates
                     color currentEffort notice usage picker refresh
             Just runtime -> do

--- a/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ModelPickerSpec.hs
@@ -11,16 +11,128 @@ import Agent.CLI.ModelConfig
 import Agent.Dialect (DialectId(..))
 import Agent.Provider (Provider(..))
 import Agent.ReasoningEffort (ReasoningEffort(..))
-import Control.Exception.Safe (bracket)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar, tryTakeMVar)
+import Control.Exception.Safe (bracket, finally, throwIO)
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import GHC.IO.Handle (hDuplicate, hDuplicateTo)
 import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.IO (hClose, hFlush, hSeek, SeekMode(AbsoluteSeek), stdin, stderr)
+import System.IO.Temp (withSystemTempFile)
+import System.Timeout (timeout)
 import Test.Hspec
+
+-- Keep handle replacement scoped, including when the picker throws.
+captureNonTtyPicker :: IO a -> IO (a, Text.Text)
+captureNonTtyPicker action =
+    withSystemTempFile "model-picker-input" \_ input ->
+    withSystemTempFile "model-picker-output" \_ output -> do
+        let redirect target replacement inner =
+                bracket (hDuplicate target)
+                    (\saved -> hDuplicateTo saved target `finally` hClose saved)
+                    (\_ -> hDuplicateTo replacement target >> inner)
+        result <- redirect stdin input $ redirect stderr output action
+        hFlush output
+        hSeek output AbsoluteSeek 0
+        contents <- Text.hGetContents output
+        pure (result, contents)
 
 spec :: Spec
 spec = do
     catalog <- runIO readPackagedCatalog
+    describe "model picker refresh" do
+        let models = initialPickerState catalog "xai" XAIProvider "grok-4.6" GrokBuildDialect
+            initial = (models, Map.empty, "Loading models…")
+            intermediate = (models, Map.singleton "grok-4.6" "25%", "Refreshing…")
+            final = (models { pickerAll = [] }, Map.empty, "No models available")
+            await action = timeout 1_000_000 action >>= maybe
+                (fail "model picker refresh timed out") pure
+
+        it "retains the initial non-TTY snapshot when there is no update" do
+            resolveModelPickerRefresh initial (const (pure Nothing))
+                `shouldReturn` initial
+
+        it "uses the returned non-TTY snapshot without requiring publication" do
+            resolveModelPickerRefresh initial (const (pure (Just final)))
+                `shouldReturn` final
+
+        it "uses the final non-TTY result rather than intermediate callbacks" do
+            let refresh publish = publish intermediate >> pure (Just final)
+            resolveModelPickerRefresh initial refresh `shouldReturn` final
+
+        it "prints only the returned non-TTY catalog and escaped notice" do
+            let refresh publish = do
+                    publish intermediate
+                    pure (Just (models { pickerAll = [] }, Map.empty, "Unavailable\nShowing cache"))
+            (result, output) <- captureNonTtyPicker $
+                pickModelStateWithUpdates False EffortHigh "Loading models…" Map.empty models refresh
+            result `shouldBe` Nothing
+            output `shouldSatisfy` Text.isInfixOf "Unavailable↵Showing cache"
+            output `shouldSatisfy` (not . Text.isInfixOf "Refreshing…")
+            output `shouldSatisfy` (not . Text.isInfixOf "grok-4.6")
+
+        it "prints the initial non-TTY catalog and notice when no update arrives" do
+            (result, output) <- captureNonTtyPicker $
+                pickModelStateWithUpdates False EffortHigh "Cached models" Map.empty models
+                    (const (pure Nothing))
+            result `shouldBe` Nothing
+            output `shouldSatisfy` Text.isInfixOf "Cached models"
+            output `shouldSatisfy` Text.isInfixOf "grok-4.6"
+
+        it "does not swallow non-TTY refresh exceptions after publication" do
+            let refresh publish = publish intermediate >> throwIO (userError "refresh failed")
+            resolveModelPickerRefresh initial refresh `shouldThrow` anyIOException
+
+        it "delivers intermediate updates before refresh completion, then the final result" do
+            gate <- newEmptyMVar
+            let refresh publish = do
+                    publish intermediate
+                    takeMVar gate
+                    pure (Just final)
+            await $ withModelPickerRefresh refresh \next -> do
+                next `shouldReturn` intermediate
+                putMVar gate ()
+                next `shouldReturn` final
+
+        it "delivers a final-only interactive refresh" do
+            await (withModelPickerRefresh (const (pure (Just final))) id)
+                `shouldReturn` final
+
+        it "conflates intermediate updates without blocking the publisher" do
+            published <- newEmptyMVar
+            gate <- newEmptyMVar
+            let refresh publish = do
+                    publish initial
+                    publish intermediate
+                    putMVar published ()
+                    takeMVar gate
+                    pure (Just final)
+            await $ withModelPickerRefresh refresh \next -> do
+                takeMVar published
+                next `shouldReturn` intermediate
+                putMVar gate ()
+                next `shouldReturn` final
+
+        it "cancels and joins a blocked refresh when the interactive consumer closes" do
+            stopped <- newEmptyMVar
+            gate <- newEmptyMVar
+            let refresh publish =
+                    (publish intermediate >> takeMVar gate >> pure (Just final))
+                        `finally` putMVar stopped ()
+            await (withModelPickerRefresh refresh id) `shouldReturn` intermediate
+            tryTakeMVar stopped `shouldReturn` Just ()
+
+        it "retains a published update when the interactive worker fails" do
+            stopped <- newEmptyMVar
+            let refresh publish =
+                    (publish intermediate >> throwIO (userError "refresh failed"))
+                        `finally` putMVar stopped ()
+            await $ withModelPickerRefresh refresh \next -> do
+                takeMVar stopped
+                next `shouldReturn` intermediate
+
     describe "decodePickerKey" do
         it "maps arrows while keeping printable keys available to search" do
             decodePickerKey "\ESC[A" `shouldBe` Just PickerUp


### PR DESCRIPTION
## Summary

Return an explicit final model-picker snapshot from refreshes, with optional intermediate publications. Non-TTY listing now consumes that result directly instead of accumulating callbacks in an IORef; no-update refreshes retain the initial snapshot.

Keep the interactive conflated TMVar and scoped worker, including cancellation/join and existing exception behavior. The gateway caller retains its MVar-protected catalog/usage merge and returns the final snapshot after both concurrent refreshes finish.

This is a maintainability/correctness refactor, not a performance claim. No Render.hs or Cabal metadata changes.

## Validation

- Resource-bounded `nix develop -c env GHCRTS=-M4G cabal repl agent-cli:lib:agent-cli -j1`: verified `Ok, 251 modules loaded.`
- Added ModelPickerSpec and GatewayModelsSpec in GHCi with hspec/temporary exposed: verified `Ok, 253 modules reloaded.` and **54 examples, 0 failures** (11 new regression examples).
- Coverage includes real non-TTY listing/notice escaping and fallback, final-only and intermediate updates, exceptions, conflation, and scoped cancellation. Existing gateway tests cover preserved filter/focus/effort and refresh lifecycle.
- Live modified `Agent.CLI.run` in tmux, explicit worktree cwd, minimal UI, connected organization gateway: `/model` displayed catalog/usage, search narrowed rows, right arrow adjusted effort, Escape restored the unchanged session prompt.
- Reviewed focused three-file diff; `git diff --check` passed.

Local validation was targeted GHCi tests and live UI smoke, not the complete compiled test suite. Network error cases use deterministic regression tests rather than inducing live gateway failures.
