### PR TITLE
Extract pure tool lifecycle decisions from CLI rendering

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -11,6 +11,10 @@ module Agent.CLI.Render
     , stateThinkingVisible
     , stateToolCalls
     , RenderConfig(..)
+    , ToolRenderInputs(..)
+    , ToolRenderEvent(..)
+    , ToolRenderCommand(..)
+    , stepToolRender
     , clearThinking
     , commitThinking
     , emptyMarkdownStreamState
@@ -646,95 +650,109 @@ renderEventUnlocked config = \case
     ModelContextReset ->
         pure ()
 
+-- | The tool-lifecycle slice of the renderer's pure decision layer. These
+-- decisions need settings, but neither wall time nor terminal dimensions.
+data ToolRenderInputs = ToolRenderInputs
+    { toolRenderColor :: !Bool
+    , toolRenderWorkspace :: !Text
+    , toolRenderShowThinking :: !Bool
+    }
+
+data ToolRenderEvent
+    = RenderToolStarted ToolCall
+    | RenderToolUpdated ToolCall
+    | RenderToolFinished ToolCallResult
+
+data ToolRenderCommand
+    = WriteToolLine Text
+    | RefreshToolThinking
+    deriving (Eq, Show)
+
+-- | Run after committing thinking for a start event. The returned state is
+-- committed BEFORE interpreting commands: a failed write must not roll back
+-- call registration/removal. Spinner visibility is deliberately not predicted;
+-- its interpreter owns the existing lifecycle and partial-progress checkpoints.
+stepToolRender
+    :: ToolRenderInputs
+    -> ToolRenderEvent
+    -> RenderState
+    -> (RenderState, [ToolRenderCommand])
+stepToolRender inputs event state =
+    case event of
+        RenderToolStarted call ->
+            ( register call
+            , (if Map.member call.callId state.stateToolCalls
+                    || isTodoTool call.name
+                then []
+                else callLines call)
+                <> [RefreshToolThinking | inputs.toolRenderShowThinking]
+            )
+        -- Complete an early streamed placeholder once; the execution-time
+        -- start is then deduplicated by the registered call id.
+        RenderToolUpdated call ->
+            ( register call
+            , if maybe False (Text.null . Text.strip . (.arguments))
+                    (Map.lookup call.callId state.stateToolCalls)
+                    && not (Text.null (Text.strip call.arguments))
+                    && not (isTodoTool call.name)
+                then callLines call
+                else []
+            )
+        RenderToolFinished result ->
+            let previous = Map.lookup result.callId state.stateToolCalls
+                formatted = maybe result.output
+                    (\call -> formatToolOutputRelative
+                        inputs.toolRenderWorkspace call result.output)
+                    previous
+                commands = case previous of
+                    Just call | isTodoTool call.name -> []
+                    _ -> [WriteToolLine (roleToolOutput inputs.toolRenderColor
+                            (truncateToolOutput formatted))]
+            in ( state{stateToolCalls = Map.delete result.callId state.stateToolCalls}
+               , commands
+               )
+  where
+    register call =
+        state
+            { stateToolCalls = Map.insert call.callId call state.stateToolCalls
+            , stateActivity = summarizeToolCallRelative inputs.toolRenderWorkspace call
+            }
+    callLines call =
+        WriteToolLine (formatToolStartedRelative
+            inputs.toolRenderColor inputs.toolRenderWorkspace call)
+        : [ WriteToolLine extra
+          | let extra = formatToolBodyRelative
+                    inputs.toolRenderColor inputs.toolRenderWorkspace call
+          , not (Text.null extra)
+          ]
+
 renderToolStartedUnlocked :: RenderConfig -> ToolCall -> IO ()
 renderToolStartedUnlocked config call = do
+    -- Keep this effect before the pure step, not in a batched state update:
+    -- committing a thought can fail after clearing its buffer.
     commitThinkingUnlocked config
-    alreadyVisible <- modifyRenderState config \state ->
-        ( state
-            { stateToolCalls = Map.insert call.callId call state.stateToolCalls
-            , stateActivity =
-                summarizeToolCallRelative config.renderWorkspace call
-            }
-        , Map.member call.callId state.stateToolCalls
-        )
-    unless (alreadyVisible || isTodoTool call.name) do
-        putTextLn config.renderStderr
-            (formatToolStartedRelative
-                config.renderColor
-                config.renderWorkspace
-                call)
-        let extra =
-                formatToolBodyRelative
-                    config.renderColor
-                    config.renderWorkspace
-                    call
-        unless (Text.null extra) do
-            putTextLn config.renderStderr extra
-    when config.renderShowThinking do
-        visible <- (.stateThinkingVisible) <$> readRenderState config
-        if visible
-            then paintThinkingFrame config
-            else startThinkingSpinnerUnlocked config
+    renderToolEventUnlocked config (RenderToolStarted call)
 
 renderToolFinishedUnlocked :: RenderConfig -> ToolCallResult -> IO ()
-renderToolFinishedUnlocked config result = do
-    calls <- modifyRenderState config \state ->
-        ( state{stateToolCalls = Map.delete result.callId state.stateToolCalls}
-        , state.stateToolCalls
-        )
-    let maybeCall = Map.lookup result.callId calls
-        formatted = maybe result.output
-            (\call ->
-                formatToolOutputRelative
-                    config.renderWorkspace
-                    call
-                    result.output)
-            maybeCall
-        painted = case maybeCall of
-            Just call
-                | isTodoTool call.name -> Nothing
-            _ ->
-                Just
-                    (roleToolOutput
-                        config.renderColor
-                        (truncateToolOutput formatted))
-    case painted of
-        Nothing -> pure ()
-        Just line -> putTextLn config.renderStderr line
+renderToolFinishedUnlocked config result =
+    renderToolEventUnlocked config (RenderToolFinished result)
 
 renderToolUpdatedUnlocked :: RenderConfig -> ToolCall -> IO ()
-renderToolUpdatedUnlocked config call = do
-    previous <- modifyRenderState config \state ->
-        ( state
-            { stateToolCalls =
-                Map.insert call.callId call state.stateToolCalls
-            , stateActivity =
-                summarizeToolCallRelative config.renderWorkspace call
-            }
-        , Map.lookup call.callId state.stateToolCalls
-        )
-    -- An early streamed start may only show a placeholder. Append the
-    -- canonical rendering once when the done item supplies arguments;
-    -- the later execution-time ToolStarted is deduplicated by call id.
-    when
-        ( maybe False
-            (Text.null . Text.strip . (.arguments))
-            previous
-            && not (Text.null (Text.strip call.arguments))
-            && not (isTodoTool call.name)
-        ) do
-            putTextLn config.renderStderr
-                (formatToolStartedRelative
-                    config.renderColor
-                    config.renderWorkspace
-                    call)
-            let extra =
-                    formatToolBodyRelative
-                        config.renderColor
-                        config.renderWorkspace
-                        call
-            unless (Text.null extra) do
-                putTextLn config.renderStderr extra
+renderToolUpdatedUnlocked config call =
+    renderToolEventUnlocked config (RenderToolUpdated call)
+
+renderToolEventUnlocked :: RenderConfig -> ToolRenderEvent -> IO ()
+renderToolEventUnlocked config event = do
+    let inputs = ToolRenderInputs
+            config.renderColor config.renderWorkspace config.renderShowThinking
+    commands <- modifyRenderState config (stepToolRender inputs event)
+    forM_ commands \case
+        WriteToolLine line -> putTextLn config.renderStderr line
+        RefreshToolThinking -> do
+            visible <- (.stateThinkingVisible) <$> readRenderState config
+            if visible
+                then paintThinkingFrame config
+                else startThinkingSpinnerUnlocked config
 
 -- | Style assistant markdown when color is enabled; otherwise return plain text.
 -- The terminal theme owns the default assistant background.

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -55,7 +55,111 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "stepToolRender sequences" do
+        let inputs = ToolRenderInputs False "/workspace" True
+            placeholder = functionToolCall "c1" "shell_command" "  "
+            complete = functionToolCall "c1" "shell_command" "{\"command\":\"echo ok\"}"
+            result = ToolCallResult
+                { callId = "c1", output = "ok", callKind = FunctionCallKind
+                , toolResultMode = BlockingToolCall, toolResultImages = []
+                , toolResultOutcome = Nothing
+                }
+            sequenceSteps events =
+                mapAccumL (\state event -> stepToolRender inputs event state)
+                    emptyRenderState events
+        it "completes a placeholder once and deduplicates execution start" do
+            let (state, commands) = sequenceSteps
+                    [ RenderToolStarted placeholder, RenderToolUpdated complete
+                    , RenderToolUpdated complete, RenderToolStarted complete
+                    , RenderToolFinished result
+                    ]
+            commands `shouldBe`
+                [ [WriteToolLine (formatToolStartedRelative False "/workspace" placeholder), RefreshToolThinking]
+                , [WriteToolLine (formatToolStartedRelative False "/workspace" complete)]
+                , []
+                , [RefreshToolThinking]
+                , [WriteToolLine (truncateToolOutput "ok")]
+                ]
+            stateToolCalls state `shouldBe` Map.empty
+            stateActivity state `shouldBe` summarizeToolCallRelative "/workspace" complete
+        it "orders a nonempty body between the header and spinner refresh" do
+            let code = functionToolCall "code" "exec" "text(1)"
+                (_, commands) = sequenceSteps [RenderToolStarted code, RenderToolStarted code]
+            commands `shouldBe`
+                [ [ WriteToolLine (formatToolStartedRelative False "/workspace" code)
+                  , WriteToolLine "text(1)", RefreshToolThinking
+                  ]
+                , [RefreshToolThinking]
+                ]
+
+        it "suppresses todo lines but retains their lifecycle" do
+            let todo = functionToolCall "c1" "todo_write" ""
+                (state, commands) = sequenceSteps
+                    [ RenderToolStarted todo
+                    , RenderToolUpdated (todo{arguments = "{}"})
+                    , RenderToolFinished result
+                    ]
+            commands `shouldBe` [[RefreshToolThinking], [], []]
+            stateToolCalls state `shouldBe` Map.empty
+        it "tracks an update without a start and suppresses its later start" do
+            let (_, commands) = sequenceSteps
+                    [RenderToolUpdated complete, RenderToolStarted complete]
+            commands `shouldBe` [[], [RefreshToolThinking]]
+        it "prints unknown results and allows a completed id to start again" do
+            let (_, commands) = sequenceSteps
+                    [RenderToolFinished result, RenderToolStarted complete]
+            commands `shouldBe`
+                [ [WriteToolLine (truncateToolOutput "ok")]
+                , [WriteToolLine (formatToolStartedRelative False "/workspace" complete), RefreshToolThinking]
+                ]
+        it "keeps buffers untouched and honors disabled thinking" do
+            let initial = appendRenderReasoning "thought"
+                    (fst (streamMarkdown "unfinished **" emptyRenderState))
+                (state, commands) = stepToolRender
+                    (ToolRenderInputs False "/workspace" False)
+                    (RenderToolStarted complete) initial
+            commands `shouldBe` [WriteToolLine (formatToolStartedRelative False "/workspace" complete)]
+            snd (streamMarkdown "bold**\n" state)
+                `shouldBe` snd (streamMarkdown "bold**\n" initial)
+            textBufferToText (stateReasoningBuffer state) `shouldBe` "thought"
+            stateThinkingVisible state `shouldBe` stateThinkingVisible initial
+            stateLiveActive state `shouldBe` stateLiveActive initial
+
     describe "RenderState transitions" do
+        it "does not register a tool when committing its preceding thought fails" do
+            withRenderConfig True False \config handle _ -> do
+                renderEvent config (ReasoningDelta "pending thought")
+                hClose handle
+                renderEvent config (ToolStarted (functionToolCall "c1" "exec" "text(1)"))
+                    `shouldThrow` anyIOException
+                state <- readIORef config.renderState
+                stateToolCalls state `shouldBe` Map.empty
+                textBufferToText (stateReasoningBuffer state) `shouldBe` ""
+
+        it "retains tool registration and skips spinner restart when tool output fails" do
+            withRenderConfig True False \config handle _ -> do
+                hClose handle
+                let call = functionToolCall "failed-write" "shell_command" "{}"
+                renderEvent config (ToolStarted call) `shouldThrow` anyIOException
+                state <- readIORef config.renderState
+                Map.lookup "failed-write" (stateToolCalls state) `shouldBe` Just call
+                stateThinkingVisible state `shouldBe` False
+                spinner <- readIORef config.renderThinkingSpinner
+                isJust spinner `shouldBe` False
+
+        it "retains tool removal when result output fails" do
+            withRenderConfig False False \config handle _ -> do
+                let call = functionToolCall "c1" "shell_command" "{}"
+                renderEvent config (ToolStarted call)
+                hClose handle
+                renderEvent config (ToolFinished ToolCallResult
+                    { callId = "c1", output = "result", callKind = FunctionCallKind
+                    , toolResultMode = BlockingToolCall, toolResultImages = []
+                    , toolResultOutcome = Nothing
+                    }) `shouldThrow` anyIOException
+                state <- readIORef config.renderState
+                stateToolCalls state `shouldBe` Map.empty
+
         it "starts a fresh turn while retaining immutable defaults" do
             let started =
                     beginRenderTurn


### PR DESCRIPTION
## Summary

Extract the tool-lifecycle slice of the minimal CLI renderer into `stepToolRender`, with explicit display settings, pure state transitions, and ordered output/refresh commands. This covers call-id deduplication, placeholder argument completion, todo suppression, activity updates, and result lookup/formatting rather than merely wrapping IO.

Keep the existing output lock and synchronization checkpoints: a start commits preceding thinking before registration, state registration/removal precedes writes, and the spinner interpreter rereads visibility only after preceding output succeeds. Streaming, restart orchestration, time/dimension sampling, and model picker behavior are unchanged. This slice needs settings but no clock or dimensions; extracting the rest of `renderEventUnlocked` remains follow-up work.

## Regression coverage

- Six pure sequence tests cover lifecycle decisions, ordered header/body/refresh output, disabled thinking, and preservation of reasoning/Markdown buffers.
- Three closed-handle tests cover partial progress when thought commit, tool output, or result output fails.
- Read-only independent diff review completed with no outstanding findings.

## Validation

- `nix develop -c cabal repl agent-cli:lib:agent-cli -j1`: verified `Ok, 251 modules loaded.`
- `GHCRTS=-M4G nix develop -c cabal repl agent-cli:lib:agent-cli -j1 --repl-options='-package hspec'`, adding `Agent/CLI/RenderSpec.hs` and running `Test.Hspec.hspec Agent.CLI.RenderSpec.spec`: **87 examples, 0 failures**.

- Live modified library in GHCi/tmux: actual `gpt-5.6-sol` turn streamed a shell placeholder, completed arguments/result, and Markdown bullets; prompt returned. Deterministic real-TTY `renderEvent` replay covered thinking before/after `ResponseRestarted`, duplicate starts, split Markdown deltas, and turn cleanup. Verified `(stateThinkingVisible,stateLiveActive) == (False,False)` and spinner `Nothing`. Restart was injected, not a provider failure.

Maintainability/correctness refactor only; no performance claim or Cabal metadata changes.
