### PR TITLE
Speed up Linux repository tests by bounding descriptor scans

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -786,7 +786,7 @@
                                     })
                                 [ pkgs.zstd ]);
                         agent-repository = localPackage
-                            (pkgs.haskell.lib.addTestToolDepends
+                            ((pkgs.haskell.lib.addTestToolDepends
                                 (pkgs.haskell.lib.overrideSrc
                                     (final.callPackage
                                         ./packages/agent-repository/package.nix
@@ -802,7 +802,24 @@
                                     pkgs.coreutils
                                     pkgs.git
                                     pkgs.python3
-                                ]);
+                                ]).overrideAttrs (old:
+                                    pkgs.lib.optionalAttrs
+                                        (packageMode == "check" && pkgs.stdenv.hostPlatform.isLinux)
+                                        {
+                                            # process-1.6.26.1 closes every possible FD
+                                            # before each isolated Git/gh spawn. Bound
+                                            # that scan inside the daemon's test builder,
+                                            # not the nix client or production runtime.
+                                            # Keep close_fds enabled; only lower the soft
+                                            # limit, and preserve already smaller limits.
+                                            preCheck = (old.preCheck or "") + ''
+                                                repositoryFdLimit=$(ulimit -Sn)
+                                                if [ "$repositoryFdLimit" = unlimited ] || [ "$repositoryFdLimit" -gt 4096 ]; then
+                                                    ulimit -Sn 4096
+                                                fi
+                                                echo "Repository test descriptor limit: $(ulimit -Sn)"
+                                            '';
+                                        }));
                         agent-cli = localPackage (pkgs.haskell.lib.addTestToolDepends
                             ((pkgs.haskell.lib.overrideSrc (final.callPackage ./packages/agent-cli/package.nix { }) {
                                 src =

--- a/nix/benchmarks/README.md
+++ b/nix/benchmarks/README.md
@@ -1,0 +1,61 @@
+# Repository subprocess descriptor-limit benchmark
+
+On Linux, `process-1.6.26.1` implements `close_fds=True` by scanning descriptor
+numbers up to `sysconf(_SC_OPEN_MAX)`. Repository integration tests spawn many
+isolated Git processes, so a large soft descriptor limit makes them expensive.
+The check-mode package now caps that limit at 4096 in `preCheck`, inside the
+Nix builder. Production/development packages and `close_fds` are unchanged.
+Already smaller soft limits and the hard limit are preserved.
+
+## Reproduce
+
+From the repository root on an x86_64 Linux builder with a hard limit of at least
+524288:
+
+```sh
+nix build --impure --no-link -L --file nix/benchmarks/repository-fd-limit.nix \
+  --argstr root "git+file://$PWD"
+nix build .#checks.x86_64-linux.agent-repository --no-link -L
+```
+
+The benchmark uses the actual check derivation, its compiled test binary and
+fixtures (GHC 9.10.3, process 1.6.26.1, check-mode optimization disabled to match
+CI). Only the soft descriptor limit varies. Three interleaved samples cover
+snapshot/diff parsing and the longer stage/unstage/restore/commit workflow.
+Each selection must run exactly one passing example. The entire suite runs
+afterward at 4096. This diagnostic loop is not part of normal CI.
+
+For another measurement of an already built derivation, add `--rebuild` to the
+first command. Ensure dependencies are cached first; do not interpret dependency
+downloads or compilation as test runtime. Avoid concurrent builds while timing.
+
+## Local results (2026-09-12)
+
+Hspec elapsed seconds, median of three samples:
+
+| Soft descriptor limit | Snapshot/diff | Mutation workflow |
+| ---: | ---: | ---: |
+| 524288 (comparison baseline) | 7.0427 | 31.2677 |
+| 65536 | 1.3088 | 5.7349 |
+| 4096 (mitigation) | 0.5275 | 2.2600 |
+
+The representative workflows improved about 13.4x and 13.8x. Some samples
+overlapped another local validation build, so these are diagnostic rather than
+isolated-machine precision measurements. All three samples show the same large
+effect. The normal patched Nix check passed all 68 examples in 32.3298 seconds
+(33 seconds for checkPhase). The unmodified local builder inherited 1048576,
+not the explicitly selected 524288 comparison baseline.
+
+A separate `-O2 -threaded` launch microbenchmark in `nix develop` corroborated
+the cause: median time for ten isolated `true` launches was 0.49872 seconds at
+524288 versus 0.00979 seconds at 1024 (five samples each). Tracing fifty launches
+at 1024 recorded 50200 failed close calls and no `close_range` calls.
+
+The previous hosted CI repository suite took 2496.3426 seconds in
+[job 103447425379](https://github.com/digitallyinduced/haskell-agent/actions/runs/34655674394/job/103447425379).
+That is a different machine/run, not a controlled before/after comparison.
+Hosted CI improvement still needs verification after publishing the change.
+
+Do not apply the test limit to production or disable `close_fds`: production
+may legitimately hold descriptors above 4096. A general runtime fix would need
+an upstream efficient close-range implementation with portable fallbacks.

--- a/nix/benchmarks/repository-fd-limit.nix
+++ b/nix/benchmarks/repository-fd-limit.nix
@@ -1,0 +1,31 @@
+# nix build --impure --no-link -L --file nix/benchmarks/repository-fd-limit.nix \
+#   --argstr root "git+file://$PWD"
+# Rebuild this derivation to repeat; the normal check runs no benchmark loop.
+{ root, system ? builtins.currentSystem }:
+let
+  flake = builtins.getFlake root;
+in
+flake.checks.${system}.agent-repository.overrideAttrs (old: {
+  preCheck = ''
+    echo "Builder descriptor limit: $(ulimit -Sn) (hard: $(ulimit -Hn))"
+    # Identical compiled code and fixtures, with only the soft limit varied.
+    # Subshells keep each trial's limit from affecting subsequent trials.
+    for sample in 1 2 3; do
+      for limit in 524288 4096 65536; do
+        for workload in \
+          "snapshots unusual paths and parses diff hunk coordinates" \
+          "stages, unstages, restores, and commits under fingerprint guards"; do
+          (
+            ulimit -Sn "$limit"
+            echo "FD_BENCH sample=$sample limit=$limit workload=$workload"
+            dist/build/agent-repository-test/agent-repository-test \
+              --match "$workload" | tee fd-bench-sample.log
+            grep -q '^1 example, 0 failures$' fd-bench-sample.log
+          )
+        done
+      done
+    done
+    # Also validate the entire suite at the candidate limit.
+    ulimit -Sn 4096
+  '' + (old.preCheck or "");
+})


### PR DESCRIPTION
## Summary
- Cap the soft file-descriptor limit at 4096 inside the Linux check-mode repository Nix builder, preserving smaller limits and the hard limit.
- Keep production/development behavior and close_fds subprocess isolation unchanged.
- Retain a reproducible benchmark and detailed results in nix/benchmarks/.

## Cause
process-1.6.26.1 scans possible descriptors before each isolated subprocess launch. Repository tests spawn many Git processes; high builder limits make this expensive.

## Validation and benchmarks
- Actual Nix check: 68 examples, 0 failures, 32.3298 seconds locally. Final staged Git-flake validation also passed.
- Three samples per limit, identical compiled test binary and fixtures, GHC 9.10.3/process 1.6.26.1, normal check-mode optimization disabled to match CI:

| Soft FD limit | Snapshot/diff median | Mutation workflow median |
| ---: | ---: | ---: |
| 524288 baseline | 7.0427s | 31.2677s |
| 65536 | 1.3088s | 5.7349s |
| 4096 mitigation | 0.5275s | 2.2600s |

Representative workflows improve approximately 13.4x and 13.8x. Some samples overlapped another validation build; all samples showed the same large effect.

A separate -O2 -threaded launch benchmark in nix develop measured ten isolated true launches at median 0.49872s versus 0.00979s at limits 524288 and 1024 (five samples each). Tracing corroborated repeated close calls, not close_range.

Reproduce:
```sh
nix build --impure --no-link -L --file nix/benchmarks/repository-fd-limit.nix --argstr root "git+file://$PWD"
nix build .#checks.x86_64-linux.agent-repository --no-link -L
```

The previous hosted repository suite took 2496.3426 seconds, but that is a different machine/run, not an apples-to-apples comparison. Hosted CI improvement remains to be verified.