### PR TITLE
Use Conduit for the Responses HTTP/SSE pipeline

### DIFF
--- a/packages/agent-responses/README.md
+++ b/packages/agent-responses/README.md
@@ -7,3 +7,26 @@ Provider-neutral protocol support for Responses-compatible model transports.
 - bounded incremental SSE framing shared by provider transports
 - streamed response merging
 - loop adapters for stateless Responses transports
+
+## Streaming pipeline
+
+The shared Responses HTTP/SSE path uses Conduit:
+
+```text
+timeout-aware body reader → decodeSseC → assembleResponseC
+```
+
+`consumeResponsesSse` composes these stages. The HTTP transport keeps its
+`withResponse` bracket around the whole pipeline; exceptions and cancellation
+unwind that scope. No background worker or extra queue is introduced. The sink
+delivers events in wire order before applying the existing assembly transition
+and stops requesting input at a terminal event.
+
+The decoder retains the existing SSE limits, UTF-8 validation, malformed-JSON
+skip policy, and final undelimited-event handling on normal EOF. Validation
+remains per input chunk: a hard decoding error prevents delivery of events from
+that chunk, even if it also contains a terminal event.
+
+Tool approval/execution, retry policy, recovery journals, checkpoint commits,
+and UI buffering remain outside this pipeline. WebSocket and other provider
+transports are unchanged.

--- a/packages/agent-responses/agent-responses.cabal
+++ b/packages/agent-responses/agent-responses.cabal
@@ -54,6 +54,7 @@ library
                     , Agent.Responses.SSE
                     , Agent.Responses.ResponseMerge
                     , Agent.Responses.StreamAssembly
+                    , Agent.Responses.StreamPipeline
                     , Agent.Responses.LoopBackend
     other-modules:    Agent.Responses.LoopBackend.Input
                     , Agent.Responses.LoopBackend.Output
@@ -68,6 +69,7 @@ library
                     , base64-bytestring
                     , bytestring
                     , containers
+                    , conduit               >= 1.3 && < 1.4
                     , http-client
                     , http-client-tls
                     , http-conduit
@@ -76,6 +78,7 @@ library
                     , safe-exceptions
                     , scientific
                     , text
+                    , transformers
                     , vector
 
 test-suite agent-responses-test
@@ -90,6 +93,7 @@ test-suite agent-responses-test
                     , Agent.Responses.ResponseMergeSpec
                     , Agent.Responses.SSESpec
                     , Agent.Responses.StreamAssemblySpec
+                    , Agent.Responses.StreamPipelineSpec
                     , Agent.Responses.TestSupport
     build-depends:    base >= 4.14 && < 5
                     , agent-core
@@ -104,7 +108,10 @@ test-suite agent-responses-test
                     , http-types
                     , QuickCheck >= 2.14 && < 2.16
                     , retry
+                    , conduit
+                    , safe-exceptions
                     , text
+                    , transformers
                     , wai
                     , warp
 

--- a/packages/agent-responses/package.nix
+++ b/packages/agent-responses/package.nix
@@ -1,8 +1,9 @@
 { mkDerivation, aeson, agent-core, agent-json
 , agent-responses-types, base, base64-bytestring, bytestring
-, containers, hermes-json, hspec, http-client, http-client-tls
-, http-conduit, http-types, lib, QuickCheck, retry, safe-exceptions
-, scientific, text, vector, wai, warp
+, conduit, containers, hermes-json, hspec, http-client
+, http-client-tls, http-conduit, http-types, lib, QuickCheck, retry
+, safe-exceptions, scientific, text, transformers, vector, wai
+, warp
 }:
 mkDerivation {
   pname = "agent-responses";
@@ -10,14 +11,14 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson agent-core agent-json agent-responses-types base
-    base64-bytestring bytestring containers hermes-json http-client
-    http-client-tls http-conduit retry safe-exceptions scientific text
-    vector
+    base64-bytestring bytestring conduit containers hermes-json
+    http-client http-client-tls http-conduit retry safe-exceptions
+    scientific text transformers vector
   ];
   testHaskellDepends = [
     aeson agent-core agent-json agent-responses-types base bytestring
-    containers hspec http-conduit http-types QuickCheck retry text wai
-    warp
+    conduit containers hspec http-conduit http-types QuickCheck retry
+    safe-exceptions text transformers wai warp
   ];
   benchmarkHaskellDepends = [
     aeson agent-core agent-json agent-responses-types base bytestring

--- a/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/HttpSSE.hs
@@ -8,19 +8,8 @@ module Agent.Responses.HttpSSE
 import Agent.Error (ApiError(..))
 import Agent.Http.Header (parseRetryAfterSeconds)
 import Agent.Http.Url (trimTrailingSlash)
-import Agent.Responses.SSE
-    ( feedSseDecoder
-    , finishSseDecoder
-    , newSseDecoder
-    )
-import Agent.Responses.StreamAssembly
-    ( StreamAssemblyConfig
-    , StreamAssemblyState
-    , StreamAssemblyStep(..)
-    , emptyStreamAssemblyState
-    , finishStreamWithoutTerminal
-    , stepStreamResponse
-    )
+import Agent.Responses.StreamAssembly (StreamAssemblyConfig)
+import Agent.Responses.StreamPipeline (consumeResponsesSse)
 import Agent.Responses.Types
 import Control.Exception.Safe (Exception, throwIO, tryAny)
 import qualified Data.ByteString as BS
@@ -60,10 +49,6 @@ data HttpSseConfig = HttpSseConfig
     , responseModelHint :: !(Maybe Text)
       -- ^ Request model used when a provider sends partial lifecycle objects.
     }
-
-data ConsumeResult
-    = ConsumeMore !StreamAssemblyState
-    | ConsumeDone !(Either ApiError Response)
 
 -- | POST one streaming Responses request and deliver decoded events in wire
 -- order. The request modifier supplies provider-specific authentication and
@@ -144,38 +129,9 @@ performResponsesHttpSse
                         then appendBodyTruncatedMessage classified
                         else classified
 
-    consumeSse body = go newSseDecoder emptyStreamAssemblyState
-      where
-        go decoder state = do
-            chunk <- readChunkWithin body
-            if BS.null chunk
-                then case finishSseDecoder decoder of
-                    Left err -> pure (Left err)
-                    Right trailing ->
-                        consumeEvents state trailing >>= \case
-                            ConsumeDone result -> pure result
-                            ConsumeMore finalState ->
-                                pure (finishStreamWithoutTerminal
-                                    assemblyConfig
-                                    finalState)
-                else case feedSseDecoder decoder chunk of
-                    Left err -> pure (Left err)
-                    Right (nextDecoder, events) -> do
-                        consumeEvents state events >>= \case
-                            ConsumeDone result -> pure result
-                            ConsumeMore nextState -> go nextDecoder nextState
-
-    consumeEvents state = \case
-        [] -> pure (ConsumeMore state)
-        event : rest -> do
-            emit event
-            case stepStreamResponse
-                    assemblyConfig
-                    responseModelHint
-                    state
-                    event of
-                StreamFinished result -> pure (ConsumeDone result)
-                StreamContinue next -> consumeEvents next rest
+    consumeSse body =
+        consumeResponsesSse assemblyConfig responseModelHint
+            (readChunkWithin body) emit
 
     consumeBodyBounded body = readChunks [] 0
       where

--- a/packages/agent-responses/src/Agent/Responses/SSE.hs
+++ b/packages/agent-responses/src/Agent/Responses/SSE.hs
@@ -4,6 +4,7 @@ module Agent.Responses.SSE
     , newSseDecoder
     , feedSseDecoder
     , finishSseDecoder
+    , decodeSseC
     , parseSseEvents
     , parseSseEventsBytes
     ) where
@@ -13,6 +14,9 @@ import qualified Agent.Responses.Codec as ResponsesCodec
 import Agent.Responses.Types (ResponseStreamEvent)
 import qualified Agent.Transport.SSE as SSE
 import Agent.Transport.SSE (dropTrailingCarriageReturn)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except (ExceptT, except)
+import Data.Conduit (ConduitT, await, yield)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.Maybe as Maybe
@@ -26,6 +30,24 @@ newtype SseDecoder = SseDecoder SSE.SseFramer
 
 newSseDecoder :: SseDecoder
 newSseDecoder = SseDecoder SSE.newSseFramer
+
+-- | Decode chunks under downstream demand, flushing only on normal EOF.
+-- Keep the existing per-chunk validation boundary: a framing/UTF-8 error in
+-- a chunk is reported before any events from that chunk are delivered.
+-- Empty chunks here are harmless; the transport source owns EOF detection.
+decodeSseC
+    :: Monad m
+    => ConduitT BS.ByteString ResponseStreamEvent (ExceptT ApiError m) ()
+decodeSseC = go newSseDecoder
+  where
+    go decoder = await >>= \case
+        Nothing -> do
+            trailing <- lift (except (finishSseDecoder decoder))
+            mapM_ yield trailing
+        Just chunk -> do
+            (next, events) <- lift (except (feedSseDecoder decoder chunk))
+            mapM_ yield events
+            go next
 
 -- | Feed an arbitrary HTTP body chunk. Completed events are returned in wire
 -- order as soon as their terminating blank line arrives.

--- a/packages/agent-responses/src/Agent/Responses/StreamPipeline.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamPipeline.hs
@@ -1,0 +1,65 @@
+-- | Demand-driven Responses streaming, separate from transport ownership and
+-- the agent's approval, execution, retry and checkpoint state machines.
+module Agent.Responses.StreamPipeline
+    ( consumeResponsesSse
+    , assembleResponseC
+    ) where
+
+import Agent.Error (ApiError)
+import Agent.Responses.SSE (decodeSseC)
+import Agent.Responses.StreamAssembly
+    ( StreamAssemblyConfig
+    , StreamAssemblyStep(..)
+    , emptyStreamAssemblyState
+    , finishStreamWithoutTerminal
+    , stepStreamResponse
+    )
+import Agent.Responses.Types (Response, ResponseStreamEvent)
+import Control.Monad (unless)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except (ExceptT, except, runExceptT)
+import qualified Data.ByteString as BS
+import Data.Conduit (ConduitT, await, runConduit, yield, (.|))
+import Data.Text (Text)
+import Data.Void (Void)
+
+-- | Consume a body reader whose empty chunk denotes EOF. The caller must keep
+-- the transport bracket open for this entire action and enforce read timeouts.
+-- No worker or queue is introduced: callback failure/cancellation unwinds the
+-- pipeline, and a terminal event stops further body reads. Exceptions are left
+-- to the transport's existing classification boundary.
+consumeResponsesSse
+    :: StreamAssemblyConfig
+    -> Maybe Text
+    -> IO BS.ByteString
+    -> (ResponseStreamEvent -> IO ())
+    -> IO (Either ApiError Response)
+consumeResponsesSse config modelHint readChunk emit =
+    runExceptT $ runConduit $
+        sourceChunks .| decodeSseC .| assembleResponseC config modelHint emit
+  where
+    sourceChunks = do
+        chunk <- liftIO readChunk
+        unless (BS.null chunk) do
+            yield chunk
+            sourceChunks
+
+-- | Deliver each event before applying the existing assembly transition,
+-- including terminal/error events. Stopping here prevents later callbacks in
+-- the same decoded chunk. Tool admission remains the callback owner's job.
+assembleResponseC
+    :: Monad m
+    => StreamAssemblyConfig
+    -> Maybe Text
+    -> (ResponseStreamEvent -> m ())
+    -> ConduitT ResponseStreamEvent Void (ExceptT ApiError m) Response
+assembleResponseC config modelHint emit = go emptyStreamAssemblyState
+  where
+    go state = await >>= \case
+        Nothing -> lift (except (finishStreamWithoutTerminal config state))
+        Just event -> do
+            lift (lift (emit event))
+            case stepStreamResponse config modelHint state event of
+                StreamFinished result -> lift (except result)
+                StreamContinue next -> go next

--- a/packages/agent-responses/test/Agent/Responses/StreamPipelineSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamPipelineSpec.hs
@@ -1,0 +1,165 @@
+module Agent.Responses.StreamPipelineSpec (spec) where
+
+import Agent.Error (ApiError(..))
+import Agent.Responses.SSE (decodeSseC, parseSseEventsBytes)
+import Agent.Responses.StreamAssembly
+import Agent.Responses.StreamPipeline (consumeResponsesSse)
+import Agent.Responses.Types
+import Control.Exception (AsyncException(..))
+import qualified Control.Exception as Exception
+import Control.Exception.Safe (bracket_, throwIO)
+import Control.Monad.Trans.Except (runExceptT)
+import qualified Data.ByteString as BS
+import Data.Conduit (await, runConduit, yield, (.|))
+import Data.IORef
+import qualified Data.Text.Encoding as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Responses Conduit pipeline" do
+    it "decodes UTF-8 and CRLF across every two-chunk split, including EOF flush" do
+        let bytes = Text.encodeUtf8
+                ": café\r\n\r\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"réponse\"}}\r\n\r\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"réponse\",\"status\":\"completed\"}}"
+        expected <- runChunks [bytes]
+        mapM_ (\offset -> do
+            actual <- runChunks (filter (not . BS.null)
+                [BS.take offset bytes, BS.drop offset bytes])
+            actual `shouldBe` expected)
+            [0 .. BS.length bytes]
+        response <- expectRight (fst expected)
+        response.responseId `shouldBe` "réponse"
+        snd expected `shouldBe` [EventResponseCreated, EventResponseCompleted]
+
+    it "handles single-byte chunks" do
+        expected <- runChunks [completeStream]
+        actual <- runChunks (map BS.singleton (BS.unpack completeStream))
+        actual `shouldBe` expected
+
+    it "does not treat empty decoder input chunks as EOF" do
+        result <- runExceptT $ runConduit $
+            mapM_ yield [BS.take 3 completeStream, "", BS.drop 3 completeStream]
+                .| decodeSseC .| collect
+        result `shouldBe` parseSseEventsBytes completeStream
+
+    it "assembles streamed tool arguments without reading ahead of callbacks" do
+        let chunks =
+                [ created
+                , "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc-1\",\"call_id\":\"call-1\",\"name\":\"read_file\",\"arguments\":\"\"}}\n\n"
+                , "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc-1\",\"output_index\":0,\"delta\":\"{\\\"path\\\":\\\"\"}\n\n"
+                , "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc-1\",\"output_index\":0,\"delta\":\"README.md\\\"}\"}\n\n"
+                , "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"response-1\",\"status\":\"completed\"}}\n\n"
+                ]
+        remaining <- newIORef chunks
+        reads <- newIORef (0 :: Int)
+        callbacks <- newIORef (0 :: Int)
+        let readChunk = do
+                n <- readIORef reads
+                -- The previous callback must finish before another read.
+                readIORef callbacks `shouldReturn` n
+                modifyIORef' reads (+ 1)
+                atomicModifyIORef' remaining \case
+                    [] -> ([], "")
+                    chunk : rest -> (rest, chunk)
+            emit _ = do
+                n <- atomicModifyIORef' callbacks (\n -> (n + 1, n + 1))
+                readIORef reads `shouldReturn` n
+        result <- consumeResponsesSse config (Just "test") readChunk emit
+        response <- expectRight result
+        [(callId, name, arguments)
+            | FunctionCallItem FunctionCall { callId, name, arguments }
+                <- response.output]
+            `shouldBe` [("call-1", "read_file", "{\"path\":\"README.md\"}")]
+        readIORef reads `shouldReturn` length chunks
+        readIORef callbacks `shouldReturn` length chunks
+
+    it "stops reads and callbacks at a terminal event in a multi-event chunk" do
+        reads <- newIORef (0 :: Int)
+        seen <- newIORef []
+        let readChunk = do
+                n <- atomicModifyIORef' reads (\n -> (n + 1, n))
+                if n == 0 then pure (completeStream <> created)
+                    else throwIO (userError "read after terminal")
+        result <- consumeResponsesSse config (Just "test") readChunk
+            (\event -> modifyIORef' seen (<> [responseStreamEventType event]))
+        _ <- expectRight result
+        readIORef reads `shouldReturn` 1
+        readIORef seen `shouldReturn` [EventResponseCreated, EventResponseCompleted]
+
+    it "preserves chunk validation before callbacks, even after a terminal frame" do
+        (result, seen) <- runChunks
+            [completeStream <> "data: " <> BS.singleton 255 <> "\n\n"]
+        result `shouldSatisfy` isDecodeError
+        seen `shouldBe` []
+
+    it "preserves callbacks from previous chunks when a later chunk fails" do
+        (result, seen) <- runChunks [created, "data: " <> BS.singleton 255 <> "\n\n"]
+        result `shouldSatisfy` isDecodeError
+        seen `shouldBe` [EventResponseCreated]
+
+    it "reports missing terminal after emitting the final unterminated event" do
+        (result, seen) <- runChunks [BS.take (BS.length created - 2) created]
+        result `shouldBe` Left (JsonDecodeError "missing terminal" "")
+        seen `shouldBe` [EventResponseCreated]
+
+    it "unwinds the caller's bracket when a callback fails without another read" do
+        closed <- newIORef False
+        reads <- newIORef (0 :: Int)
+        let action = bracket_ (pure ()) (writeIORef closed True) $
+                consumeResponsesSse config Nothing
+                    (modifyIORef' reads (+ 1) >> pure completeStream)
+                    (const (throwIO (userError "callback failed")))
+        action `shouldThrow` anyIOException
+        readIORef closed `shouldReturn` True
+        readIORef reads `shouldReturn` 1
+
+    it "propagates source exceptions and releases the caller's resource" do
+        closed <- newIORef False
+        let action = bracket_ (pure ()) (writeIORef closed True) $
+                consumeResponsesSse config Nothing
+                    (throwIO (userError "read failed")) (const (pure ()))
+        action `shouldThrow` anyIOException
+        readIORef closed `shouldReturn` True
+
+    it "propagates asynchronous cancellation and releases the caller's resource" do
+        closed <- newIORef False
+        let action = bracket_ (pure ()) (writeIORef closed True) $
+                consumeResponsesSse config Nothing
+                    (pure completeStream) (const (Exception.throwIO UserInterrupt))
+        action `shouldThrow` (== UserInterrupt)
+        readIORef closed `shouldReturn` True
+
+config :: StreamAssemblyConfig
+config = StreamAssemblyConfig
+    { missingCompletionMessage = "missing terminal"
+    , classifyStreamError = \err -> ConnectionError err.message
+    , classifyFailedResponse = ConnectionError . failedStreamResponseMessage
+    , incompleteAsFailure = False
+    }
+
+created :: BS.ByteString
+created = "data: {\"type\":\"response.created\",\"response\":{\"id\":\"response-1\"}}\n\n"
+
+completeStream :: BS.ByteString
+completeStream = created <>
+    "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"response-1\",\"status\":\"completed\"}}\n\n"
+
+runChunks chunks = do
+    remaining <- newIORef chunks
+    seen <- newIORef []
+    let readChunk = atomicModifyIORef' remaining \case
+            [] -> ([], "")
+            chunk : rest -> (rest, chunk)
+    result <- consumeResponsesSse config (Just "test") readChunk
+        (\event -> modifyIORef' seen (<> [responseStreamEventType event]))
+    events <- readIORef seen
+    pure (result, events)
+
+collect = await >>= \case
+    Nothing -> pure []
+    Just event -> (event :) <$> collect
+
+isDecodeError (Left JsonDecodeError{}) = True
+isDecodeError _ = False
+
+expectRight (Right value) = pure value
+expectRight (Left err) = expectationFailure (show err) >> fail "expected Right"

--- a/packages/agent-responses/test/Spec.hs
+++ b/packages/agent-responses/test/Spec.hs
@@ -9,6 +9,7 @@ import qualified Agent.Responses.LoopBackendSpec as LoopBackendSpec
 import qualified Agent.Responses.ResponseMergeSpec as ResponseMergeSpec
 import qualified Agent.Responses.SSESpec as SSESpec
 import qualified Agent.Responses.StreamAssemblySpec as StreamAssemblySpec
+import qualified Agent.Responses.StreamPipelineSpec as StreamPipelineSpec
 
 main :: IO ()
 main = hspec do
@@ -19,3 +20,4 @@ main = hspec do
     ResponseMergeSpec.spec
     SSESpec.spec
     StreamAssemblySpec.spec
+    StreamPipelineSpec.spec


### PR DESCRIPTION
## Summary
- Compose body reads, incremental SSE decoding, and response assembly with Conduit.
- Preserve callback ordering, per-chunk validation, terminal stopping, cancellation, and transport-owned cleanup/timeouts.
- Leave tool execution, approvals, retries, checkpoints, and other transports unchanged.
- Add 11 pipeline regression tests and update Cabal/Nix dependencies and documentation.

## Validation
- Library successfully loaded in GHCi (16 modules).
- `nix develop -c cabal repl agent-responses:test:agent-responses-test`, then `:main`: 154 examples, 0 failures.
- `git diff --check` passed.

This is a structural refactor; no performance improvement is claimed.