### PR TITLE
Refactor chart validation to retain typed chart data

### DIFF
--- a/packages/agent-core/src/Agent/Tools/RenderChart.hs
+++ b/packages/agent-core/src/Agent/Tools/RenderChart.hs
@@ -20,6 +20,8 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isControl)
 import Data.List (nub)
+import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Scientific (toRealFloat)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -86,65 +88,56 @@ renderChartResult input = do
     when (BS.length bytes > maximumDocumentBytes) $
         Left "render_chart: document exceeds 256 KiB; aggregate the data first."
     value <- either (Left . Text.pack) Right (eitherDecodeStrict' bytes)
-    summary <- either (Left . ("render_chart: " <>) . Text.pack) Right
+    chart <- either (Left . ("render_chart: " <>) . Text.pack) Right
         (parseEither validateDocument value)
     pure (encodeText (object
-        [ "type" .= ("chart" :: Text), "chart" .= value, "summary" .= summary ]))
+        [ "type" .= ("chart" :: Text), "chart" .= value, "summary" .= describeSummary chart ]))
 
 chartResultDocument :: Text -> Maybe Text
 chartResultDocument = fmap (encodeText . fst) . parseChartResult
 
 chartResultSummary :: Text -> Maybe Text
-chartResultSummary = fmap snd . parseChartResult
+chartResultSummary = fmap (describeSummary . snd) . parseChartResult
 
 -- | Accessible plain-text presentation shared by terminal views. Derive every
 -- label from the validated document, never from stored summary prose. Preserve
 -- Unicode even when a client's bitmap font cannot display it.
 chartResultFallback :: Text -> Maybe Text
-chartResultFallback input = do
-    (document, _) <- parseChartResult input
-    parseMaybe describeChart document
+chartResultFallback = fmap (describeChart . snd) . parseChartResult
+
+describeChart :: Chart -> Text
+describeChart chart =
+    Text.intercalate "\n" $
+        filter (not . Text.null)
+            [ safeLabel chart.title <> " [" <> kindText chart.kind <> " chart]"
+            , safeLabel chart.subtitle
+            , "X: " <> describeAxis chart.xAxis <> "; Y: " <> describeAxis chart.yAxis
+            , if null categories then "" else
+                "Categories: " <> Text.intercalate ", " categories
+            ] <> map describeSeries (NonEmpty.toList chart.series)
   where
-    describeChart = withObject "chart" \fields -> do
-        title <- fields .: "title"
-        kind <- fields .: "kind"
-        subtitle <- fields .:? "subtitle" .!= ""
-        xAxis <- fields .: "x_axis"
-        yAxis <- fields .: "y_axis"
-        xDescription <- describeAxis xAxis
-        yDescription <- describeAxis yAxis
-        axisType <- withObject "axis" (.: "type") xAxis
-        series <- fields .: "series" >>= traverse (describeSeries axisType)
-        let categories = nub (concatMap fst series)
-        pure (Text.intercalate "\n" $
-            filter (not . Text.null)
-                [ safeLabel title <> " [" <> kind <> " chart]"
-                , safeLabel subtitle
-                , "X: " <> xDescription <> "; Y: " <> yDescription
-                , if null categories then "" else
-                    "Categories: " <> Text.intercalate ", " categories
-                ] <> map snd series)
-    describeAxis = withObject "axis" \fields -> do
-        label <- fields .:? "label" .!= ""
-        unit <- fields .:? "unit" .!= ""
-        pure (safeLabel label <> if Text.null unit then "" else " (" <> safeLabel unit <> ")")
-    describeSeries axisType = withObject "series" \fields -> do
-        name <- fields .: "name"
-        points <- fields .: "points" :: Parser [Value]
-        categories <- if axisType == ("category" :: Text)
-            then traverse (withObject "point" (fmap safeLabel . (.: "x"))) points
-            else pure []
-        ordinates <- traverse (withObject "point" (\point -> point .: "y" >>= finiteNumber)) points
-        pure (categories, safeLabel name <> ": " <> Text.pack (show (length points))
-            <> (if length points == 1 then " point; range " else " points; range ")
-            <> numberText (minimum ordinates) <> " to " <> numberText (maximum ordinates))
+    categories = nub
+        [ safeLabel category
+        | series <- NonEmpty.toList chart.series
+        , point <- NonEmpty.toList series.points
+        , CategoryCoordinate category <- [point.x]
+        ]
+    describeAxis :: ChartAxis -> Text
+    describeAxis axis =
+        safeLabel axis.label <> if Text.null axis.unit then "" else " (" <> safeLabel axis.unit <> ")"
+    describeSeries :: ChartSeries -> Text
+    describeSeries series =
+        let first :| rest = fmap (.y) series.points
+        in safeLabel series.name <> ": " <> Text.pack (show (length series.points))
+            <> (if length series.points == 1 then " point; range " else " points; range ")
+            <> numberText (foldl min first rest) <> " to " <> numberText (foldl max first rest)
     safeLabel = Text.unwords . Text.words . Text.map \character ->
         if isControl character then ' ' else character
     numberText value
         | value == 0 = "0"
         | otherwise = Text.pack (showGFloat (Just 3) value "")
 
-parseChartResult :: Text -> Maybe (Value, Text)
+parseChartResult :: Text -> Maybe (Value, Chart)
 parseChartResult input = do
     -- Envelope text adds only a bounded generated summary to the document.
     let bytes = TextEncoding.encodeUtf8 input
@@ -155,14 +148,46 @@ parseChartResult input = do
         resultType <- fields .: "type"
         unless (resultType == ("chart" :: Text)) (fail "Not a chart result")
         chart <- fields .: "chart"
-        summary <- validateDocument chart
+        validated <- validateDocument chart
         -- Recompute the fallback from validated data, not untrusted stored prose.
-        pure (chart, summary)) value
+        pure (chart, validated)) value
 
 encodeText :: Value -> Text
 encodeText = TextEncoding.decodeUtf8 . LBS.toStrict . encode
 
-validateDocument :: Value -> Parser Text
+-- Constructors stay private: rendering only consumes data accepted by validation.
+-- Keep the original Value separately for native consumers, preserving omitted/null
+-- metadata and exact JSON numbers rather than round-tripping through Double.
+data Chart = Chart
+    { kind :: ChartKind
+    , title :: Text
+    , subtitle :: Text
+    , xAxis :: ChartAxis
+    , yAxis :: ChartAxis
+    , series :: NonEmpty ChartSeries
+    }
+
+data ChartKind = Line | Bar | Area | Scatter deriving (Eq)
+data AxisType = CategoryAxis | NumberAxis | TimestampAxis deriving (Eq)
+data ChartAxis = ChartAxis { axisType :: AxisType, label :: Text, unit :: Text }
+data ChartSeries = ChartSeries { name :: Text, points :: NonEmpty ChartPoint }
+data ChartPoint = ChartPoint { x :: ChartCoordinate, y :: Double }
+
+kindText :: ChartKind -> Text
+kindText Line = "line"
+kindText Bar = "bar"
+kindText Area = "area"
+kindText Scatter = "scatter"
+
+describeSummary :: Chart -> Text
+describeSummary chart =
+    let pointCount = sum (fmap (length . (.points)) chart.series)
+    in "Rendered " <> chart.title <> " — " <> kindText chart.kind <> " chart; "
+        <> Text.pack (show (length chart.series)) <> " series, "
+        <> Text.pack (show pointCount)
+        <> (if pointCount == 1 then " point." else " points.")
+
+validateDocument :: Value -> Parser Chart
 validateDocument value = do
     unless (LBS.length (encode value) <= fromIntegral maximumDocumentBytes) $
         fail "Document exceeds 256 KiB"
@@ -170,70 +195,80 @@ validateDocument value = do
         exactFields ["version", "kind", "title", "subtitle", "x_axis", "y_axis", "series"] fields
         version <- fields .: "version" :: Parser Int
         unless (version == 1) (fail "Unsupported chart version; use version 1")
-        kind <- fields .: "kind"
-        unless (kind `elem` (["line", "bar", "area", "scatter"] :: [Text])) $
-            fail "kind must be line, bar, area, or scatter"
+        kind <- fields .: "kind" >>= \case
+            ("line" :: Text) -> pure Line
+            "bar" -> pure Bar
+            "area" -> pure Area
+            "scatter" -> pure Scatter
+            _ -> fail "kind must be line, bar, area, or scatter"
         title <- requiredText fields "title"
-        optionalText fields "subtitle"
+        subtitle <- optionalText fields "subtitle"
         xAxis <- fields .: "x_axis" >>= validateAxis False
-        _ <- fields .: "y_axis" >>= validateAxis True
+        yAxis <- fields .: "y_axis" >>= validateAxis True
         series <- fields .: "series" :: Parser [Value]
-        unless (not (null series) && length series <= 8) $
-            fail "Supply between 1 and 8 series"
-        seriesInfo <- traverse (validateSeries kind xAxis) series
-        let names = map fst seriesInfo
-            pointCount = sum (map snd seriesInfo)
-        unless (Set.size (Set.fromList names) == length names) $
+        nonemptySeries <- boundedNonEmpty 8 "Supply between 1 and 8 series" series
+        seriesInfo <- traverse (validateSeries kind xAxis.axisType) nonemptySeries
+        let names = fmap (.name) seriesInfo
+            pointCount = sum (fmap (length . (.points)) seriesInfo)
+        unless (Set.size (Set.fromList (NonEmpty.toList names)) == length names) $
             fail "Series names must be unique"
         unless (pointCount <= 2000) (fail "At most 2000 total points; aggregate the data first")
-        pure ("Rendered " <> title <> " — " <> kind <> " chart; "
-            <> Text.pack (show (length series)) <> " series, "
-            <> Text.pack (show pointCount)
-            <> (if pointCount == 1 then " point." else " points."))
+        pure (Chart kind title subtitle xAxis yAxis seriesInfo)
         ) value
 
-validateAxis :: Bool -> Value -> Parser Text
+validateAxis :: Bool -> Value -> Parser ChartAxis
 validateAxis numericOnly = withObject "axis" \fields -> do
     exactFields ["type", "label", "unit"] fields
     axisType <- if numericOnly
         then maybe "number" id <$> fields .:? "type"
-        else fields .: "type"
-    unless (axisType `elem` if numericOnly then ["number"] else ["category", "number", "timestamp"]) $
+        else fields .: "type" :: Parser Text
+    typedAxis <- case axisType of
+        "number" -> pure NumberAxis
+        "category" -> pure CategoryAxis
+        "timestamp" -> pure TimestampAxis
+        _ -> fail "Axis type is unsupported; y_axis must be numeric"
+    when (numericOnly && typedAxis /= NumberAxis) $
         fail "Axis type is unsupported; y_axis must be numeric"
-    optionalText fields "label"
-    optionalText fields "unit"
-    pure axisType
+    label <- optionalText fields "label"
+    unit <- optionalText fields "unit"
+    pure (ChartAxis typedAxis label unit)
 
 data ChartCoordinate = NumericCoordinate Double | TimestampCoordinate UTCTime | CategoryCoordinate Text
     deriving (Eq, Ord)
 
-validateSeries :: Text -> Text -> Value -> Parser (Text, Int)
+boundedNonEmpty :: Int -> String -> [a] -> Parser (NonEmpty a)
+boundedNonEmpty limit message values = case NonEmpty.nonEmpty values of
+    Just nonempty | length nonempty <= limit -> pure nonempty
+    _ -> fail message
+
+validateSeries :: ChartKind -> AxisType -> Value -> Parser ChartSeries
 validateSeries kind axisType = withObject "series" \fields -> do
     exactFields ["name", "points"] fields
     name <- requiredText fields "name"
     points <- fields .: "points" :: Parser [Value]
-    unless (not (null points) && length points <= 2000) $
-        fail "Each series must contain between 1 and 2000 points"
-    coordinates <- traverse (validatePoint axisType) points
-    when (kind `elem` ["line", "area"] && axisType /= "category") $
+    nonemptyPoints <- boundedNonEmpty 2000 "Each series must contain between 1 and 2000 points" points
+    validatedPoints <- traverse (validatePoint axisType) nonemptyPoints
+    let coordinates = map (.x) (NonEmpty.toList validatedPoints)
+    when (kind `elem` [Line, Area] && axisType /= CategoryAxis) $
         unless (and (zipWith coordinateIncreasing coordinates (drop 1 coordinates))) $
             fail "Line/area x values must be strictly increasing"
-    pure (name, length points)
+    pure (ChartSeries name validatedPoints)
 
 coordinateIncreasing :: ChartCoordinate -> ChartCoordinate -> Bool
 coordinateIncreasing left right = left < right
 
-validatePoint :: Text -> Value -> Parser ChartCoordinate
+validatePoint :: AxisType -> Value -> Parser ChartPoint
 validatePoint axisType = withObject "point" \fields -> do
     exactFields ["x", "y"] fields
-    _ <- fields .: "y" >>= finiteNumber
-    case axisType of
-        "number" -> NumericCoordinate <$> (fields .: "x" >>= finiteNumber)
-        "timestamp" -> do
+    y <- fields .: "y" >>= finiteNumber
+    x <- case axisType of
+        NumberAxis -> NumericCoordinate <$> (fields .: "x" >>= finiteNumber)
+        TimestampAxis -> do
             text <- requiredText fields "x"
             maybe (fail "Timestamp must be a valid UTC YYYY-MM-DDTHH:mm:ss[.fraction]Z")
                 (pure . TimestampCoordinate) (parseTimestamp text)
-        _ -> CategoryCoordinate <$> requiredText fields "x"
+        CategoryAxis -> CategoryCoordinate <$> requiredText fields "x"
+    pure (ChartPoint x y)
 
 finiteNumber :: Value -> Parser Double
 finiteNumber (Number number) =
@@ -271,10 +306,11 @@ requiredText fields key = do
         fail (Text.unpack (Key.toText key) <> " must not be blank")
     pure text
 
-optionalText :: Object -> Key.Key -> Parser ()
+optionalText :: Object -> Key.Key -> Parser Text
 optionalText fields key = do
-    text <- fields .:? key
-    maybe (pure ()) validateText text
+    text <- fields .:? key .!= ""
+    validateText text
+    pure text
 
 validateText :: Text -> Parser ()
 validateText text = unless (Text.length text <= 200) $

--- a/packages/agent-core/test/Agent/Tools/RenderChartSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/RenderChartSpec.hs
@@ -33,6 +33,48 @@ spec = describe "Agent.Tools.RenderChart" do
             renderChartResult (document kind "number" [point (Number 1) (-4)])
                 `shouldSatisfy` isRight) ["line", "bar", "area", "scatter"]
 
+    it "derives exact singleton fallbacks for every kind and axis type" do
+        mapM_ (\(kind, axis, coordinate) ->
+            (renderChartResult (document kind axis [point coordinate (-4)])
+                >>= maybe (Left "Missing fallback") Right . chartResultFallback)
+                `shouldBe` Right (Text.intercalate "\n"
+                    (["Revenue [" <> kind <> " chart]", "X: ; Y: Revenue (EUR)"]
+                    <> (if axis == "category" then ["Categories: April"] else [])
+                    <> ["Sales: 1 point; range -4.000 to -4.000"])))
+            [(kind, axis, coordinate)
+            | kind <- ["line", "bar", "area", "scatter"]
+            , (axis, coordinate) <- [("number", Number 1), ("category", String "April")
+                , ("timestamp", String "2026-09-07T12:30:00.123Z")]
+            ]
+
+    it "preserves category order, deduplication, series counts and ranges" do
+        let input = "{\"version\":1,\"kind\":\"bar\",\"title\":\"Revenue\",\"subtitle\":null,\"x_axis\":{\"type\":\"category\",\"label\":null},\"y_axis\":{\"type\":null,\"unit\":null},\"series\":[{\"name\":\"Sales\",\"points\":[{\"x\":\" B \",\"y\":0},{\"x\":\"A\",\"y\":-2},{\"x\":\"B\",\"y\":3}]},{\"name\":\"Costs\",\"points\":[{\"x\":\"C\",\"y\":1}]}]}"
+        case renderChartResult input of
+            Left err -> expectationFailure (Text.unpack err)
+            Right output -> do
+                chartResultSummary output `shouldBe`
+                    Just "Rendered Revenue — bar chart; 2 series, 4 points."
+                chartResultFallback output `shouldBe` Just (Text.intercalate "\n"
+                    ["Revenue [bar chart]", "X: ; Y: ", "Categories: B, A, C"
+                    , "Sales: 3 points; range -2.000 to 3.000"
+                    , "Costs: 1 point; range 1.000 to 1.000"])
+
+    it "ignores stored summary prose and rejects empty persisted point collections" do
+        let envelope input = "{\"type\":\"chart\",\"summary\":false,\"chart\":" <> input <> "}"
+            valid = document "bar" "number" [point (Number 1) 0]
+        chartResultSummary (envelope valid) `shouldBe`
+            Just "Rendered Revenue — bar chart; 1 series, 1 point."
+        chartResultFallback (envelope valid) `shouldBe`
+            Just "Revenue [bar chart]\nX: ; Y: Revenue (EUR)\nSales: 1 point; range 0 to 0"
+        mapM_ (\project -> project (envelope (document "bar" "number" [])) `shouldBe` Nothing)
+            [chartResultDocument, chartResultSummary, chartResultFallback]
+
+    it "retains exact wire numbers rather than encoding validated Doubles" do
+        let input = Text.replace "\"y\":2" "\"y\":9007199254740993" $
+                document "bar" "number" [point (Number 1) 2]
+        (renderChartResult input >>= maybe (Left "Missing document") Right . chartResultDocument)
+            `shouldBe` Right input
+
     it "keeps every Unicode category in the accessible chart fallback" do
         let labels = ["地域" <> Text.pack (show index) | index <- [1 :: Int .. 12]]
             input = document "bar" "category" [point (String label) 2 | label <- labels]
@@ -75,6 +117,17 @@ spec = describe "Agent.Tools.RenderChart" do
         renderChartResult (document "scatter" "number" points) `shouldSatisfy` isRight
         renderChartResult (document "line" "number" [point (Number 1) 1, point (Number 1) 2])
             `shouldSatisfy` isLeft
+
+    it "bounds total points across nonempty series" do
+        let input count = encodeText (object
+                [ "version" .= (1 :: Int), "kind" .= ("bar" :: Text), "title" .= ("Revenue" :: Text)
+                , "x_axis" .= object ["type" .= ("number" :: Text)]
+                , "y_axis" .= object []
+                , "series" .= [object ["name" .= name, "points" .= replicate size (point (Number 1) 2)]
+                    | (name, size) <- [("Sales" :: Text, 1000), ("Costs", count)]]
+                ])
+        renderChartResult (input 1000) `shouldSatisfy` isRight
+        renderChartResult (input 1001) `shouldSatisfy` isLeft
 
     it "rejects timestamps more precise than milliseconds for every kind" do
         let points = map (\timestamp -> point (String timestamp) 2)
@@ -120,6 +173,9 @@ spec = describe "Agent.Tools.RenderChart" do
                 , "y_axis" .= object [], "series" .= values
                 ])
         renderChartResult (input [series ("Sales" :: Text), series "Sales"]) `shouldSatisfy` isLeft
+        renderChartResult (input ([] :: [Value])) `shouldSatisfy` isLeft
+        renderChartResult (input [series (Text.pack (show index)) | index <- [1 :: Int .. 8]])
+            `shouldSatisfy` isRight
         renderChartResult (input [series (Text.pack (show index)) | index <- [1 :: Int .. 9]])
             `shouldSatisfy` isLeft
 


### PR DESCRIPTION
## Summary
- Parse chart documents into a private validated Chart domain with kind/axis ADTs and nonempty series/point collections.
- Derive summary and accessible fallback from typed data, removing fallback JSON reparsing and hidden list-extrema invariants.
- Preserve the original JSON Value for native consumers, exact numbers, nullable/omitted metadata, all validation and size limits, and output formatting.

This is a maintainability refactor, not a demonstrated crash fix or performance claim: existing validation already protected minimum/maximum.

## Validation
- nix develop: cabal repl agent-core:lib:agent-core (Ok, 82 modules loaded).
- cabal repl agent-core:lib:agent-core --repl-options="-package hspec", then :add test/Agent/Tools/RenderChartSpec.hs and Test.Hspec.hspec Agent.Tools.RenderChartSpec.spec: 21 examples, 0 failures.
- Regression coverage includes every kind/axis singleton fallback, multi-series ranges/category order, forged summaries, empty persisted points, precise wire numbers and collection boundaries.
- git diff --check and focused diff review passed.
- No Cabal, native consumer, or CLI UI behavior changes.