### PR TITLE
Fix agent hangs from orphaned fullscreen choices

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Event.hs
@@ -483,6 +483,7 @@ handleAppEvent = \case
         handleCloseChoiceEvent reply
     AppAskDynamicAdjustableFilterChoice title body initial rows reply -> do
         state <- get
+        liftIO (dismissPendingChoice state)
         liftIO (state.appRuntime.runtimeNativeProgress False)
         modify' \current -> current
             { appChoice = Just $ dynamicChoiceDialog reply $
@@ -953,11 +954,12 @@ handleAskChoiceEvent
     -> EventM Name AppState ()
 handleAskChoiceEvent presentation title body initial rows reply = do
     state <- get
+    liftIO (dismissPendingChoice state)
     liftIO (state.appRuntime.runtimeNativeProgress False)
     modify' \current ->
         current
             { appChoice = Just $ PendingDialog
-                (atomically . putTMVar reply . fmap (.choiceSelectionIndex))
+                (void . atomically . tryPutTMVar reply . fmap (.choiceSelectionIndex))
                 ChoiceOverlay
                 { choicePresentation = presentation
                 , choiceTitle = title
@@ -987,11 +989,12 @@ handleAskFilterChoiceEvent
     -> EventM Name AppState ()
 handleAskFilterChoiceEvent title initial rows reply = do
     state <- get
+    liftIO (dismissPendingChoice state)
     liftIO (state.appRuntime.runtimeNativeProgress False)
     modify' \current ->
         current
             { appChoice = Just $ PendingDialog
-                (atomically . putTMVar reply . fmap (.choiceSelectionIndex))
+                (void . atomically . tryPutTMVar reply . fmap (.choiceSelectionIndex))
                 ChoiceOverlay
                 { choicePresentation = ChoiceDialog
                 , choiceTitle = title
@@ -1005,7 +1008,7 @@ handleAskFilterChoiceEvent title initial rows reply = do
                 , choiceAdjustmentIndices = []
                 , choiceCloseOnTurnEnd = False
                 , choiceDynamic = Nothing
-                , choiceReply = Nothing
+                , choiceReply = Just (ChoiceReply reply)
                 }
             , appAgentHover = Nothing
             }
@@ -1019,6 +1022,7 @@ handleAskAdjustableFilterChoiceEvent
     -> EventM Name AppState ()
 handleAskAdjustableFilterChoiceEvent title initial adjustableRows reply = do
     state <- get
+    liftIO (dismissPendingChoice state)
     liftIO (state.appRuntime.runtimeNativeProgress False)
     let rows =
             [ (label, detail)
@@ -1039,7 +1043,7 @@ handleAskAdjustableFilterChoiceEvent title initial adjustableRows reply = do
     modify' \current ->
         current
             { appChoice = Just $ PendingDialog
-                (atomically . putTMVar reply . replySelection)
+                (void . atomically . tryPutTMVar reply . replySelection)
                 ChoiceOverlay
                 { choicePresentation = ChoiceDialog
                 , choiceTitle = title
@@ -1065,7 +1069,7 @@ dynamicChoiceDialog
     -> PendingDialog (Maybe ChoiceSelection -> IO ()) ChoiceOverlay
 dynamicChoiceDialog reply choice =
     PendingDialog
-        (\selected -> atomically $ putTMVar reply do
+        (\selected -> void $ atomically $ tryPutTMVar reply do
             selection <- selected
             dynamic <- choice.choiceDynamic
             key <- lookup selection.choiceSelectionIndex (zip [0 ..] dynamic.dynamicChoiceKeys)

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Overlay.hs
@@ -378,6 +378,7 @@ resolveResume confirmed = do
 openCommandPalette :: EventM Name AppState ()
 openCommandPalette = do
     state <- get
+    liftIO (dismissPendingChoice state)
     let catalog = state.appSlashCatalog
         rows = commandPaletteRows catalog
         reply = \case

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -153,7 +153,7 @@ import Control.Applicative ((<|>))
 import Control.Concurrent.Async (race, wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
 import Control.Monad (forever, unless, void, when, (>=>))
-import Control.Concurrent.STM ( STM , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , writeTQueue , writeTVar )
+import Control.Concurrent.STM ( STM , TMVar , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , writeTQueue , writeTVar )
 import Agent.CLI.Notification
     ( AttentionRequest(PermissionRequested, SecretRequested)
     , notifyAttention
@@ -161,7 +161,7 @@ import Agent.CLI.Notification
 import Agent.CLI.Recap ( autoRecapAwayThreshold , autoRecapIdleThreshold , autoRecapRetryInterval )
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
-import Control.Exception.Safe (finally, mask, onException, throwIO, tryAny)
+import Control.Exception.Safe (bracket_, finally, mask, onException, throwIO, tryAny)
 import Control.Exception (AsyncException(UserInterrupt))
 import Data.Char (isControl, isSpace)
 import Data.Foldable (toList)
@@ -973,12 +973,11 @@ requestFullscreenPermissionOnce runtime workspace call = do
     reply <- newEmptyTMVarIO
     let summary = approvalToolCallPromptOnceRelative workspace call
     notifyAttention stderr PermissionRequested
-    enqueueAppEvent runtime
+    selected <- withFullscreenChoiceRequest runtime reply
         (AppAskChoice ChoicePlainDialog "Fresh approval required" summary 1
             [("Allow once", "Approve only this invocation"), ("Deny", "Do not run")]
             reply)
-    selected <- atomically (readTMVar reply)
-        `finally` enqueueAppEvent runtime (AppCloseChoice reply)
+        (atomically (readTMVar reply))
     pure $ Just case selected of
         Just 0 -> PermissionAllowOnce
         _ -> PermissionDeny
@@ -1020,9 +1019,9 @@ requestFullscreenPlanningChoice
     -> IO (Maybe Int)
 requestFullscreenPlanningChoice runtime body rows = do
     reply <- newEmptyTMVarIO
-    enqueueAppEvent runtime
+    withFullscreenChoiceRequest runtime reply
         (AppAskChoice ChoicePlanning "Planning question" body 0 rows reply)
-    atomically (readTMVar reply)
+        (atomically (readTMVar reply))
 
 requestFullscreenThemeChoice
     :: FullscreenRuntime
@@ -1031,9 +1030,9 @@ requestFullscreenThemeChoice
     -> IO (Maybe Int)
 requestFullscreenThemeChoice runtime initial rows = do
     reply <- newEmptyTMVarIO
-    enqueueAppEvent runtime
+    withFullscreenChoiceRequest runtime reply
         (AppAskChoice ChoiceTheme "Theme" "Choose a theme. Arrow keys preview it live; Enter applies it, Esc cancels." initial rows reply)
-    atomically (readTMVar reply)
+        (atomically (readTMVar reply))
 
 -- | Open a searchable choice whose right-hand value can be adjusted with
 -- left/right. Both returned indices refer to the original unfiltered row and
@@ -1068,9 +1067,22 @@ requestFullscreenChoiceWithBody
     -> IO (Maybe Int)
 requestFullscreenChoiceWithBody runtime title body initial rows = do
     reply <- newEmptyTMVarIO
-    enqueueAppEvent runtime
+    withFullscreenChoiceRequest runtime reply
         (AppAskChoice ChoiceDialog title body initial rows reply)
-    atomically (readTMVar reply)
+        (atomically (readTMVar reply))
+
+-- | Install cleanup before publishing the dialog. Closing is tied to its reply
+-- token, so a cancelled caller cannot close a replacement dialog.
+withFullscreenChoiceRequest
+    :: FullscreenRuntime
+    -> TMVar (Maybe Int)
+    -> AppEvent
+    -> IO a
+    -> IO a
+withFullscreenChoiceRequest runtime reply event =
+    bracket_
+        (enqueueAppEvent runtime event)
+        (enqueueAppEvent runtime (AppCloseChoice reply))
 
 -- | Show a choice overlay while waiting for an independent result. If the
 -- waiter finishes first, the overlay is closed without cancelling a later
@@ -1085,12 +1097,9 @@ requestFullscreenChoiceUntil
     -> IO (Either (Maybe Int) a)
 requestFullscreenChoiceUntil runtime title body initial rows wait = do
     reply <- newEmptyTMVarIO
-    enqueueAppEvent runtime
+    withFullscreenChoiceRequest runtime reply
         (AppAskChoice ChoiceDialog title body initial rows reply)
-    race
-        (atomically (readTMVar reply))
-        wait
-        `finally` enqueueAppEvent runtime (AppCloseChoice reply)
+        (race (atomically (readTMVar reply)) wait)
 
 -- | Open a read-only, scrollable Markdown document and wait for dismissal.
 requestFullscreenDocument
@@ -1100,9 +1109,9 @@ requestFullscreenDocument
     -> IO ()
 requestFullscreenDocument runtime title body = do
     reply <- newEmptyTMVarIO
-    enqueueAppEvent runtime
+    _ <- withFullscreenChoiceRequest runtime reply
         (AppAskChoice ChoiceDocument title body 0 [] reply)
-    _ <- atomically (readTMVar reply)
+        (atomically (readTMVar reply))
     pure ()
 
 -- | Open a choice overlay whose rows can be narrowed by typing. The returned
@@ -1116,9 +1125,9 @@ requestFullscreenFilterChoice
     -> IO (Maybe Int)
 requestFullscreenFilterChoice runtime title initial rows = do
     reply <- newEmptyTMVarIO
-    enqueueAppEvent runtime
+    withFullscreenChoiceRequest runtime reply
         (AppAskFilterChoice title initial rows reply)
-    atomically (readTMVar reply)
+        (atomically (readTMVar reply))
 
 requestFullscreenOnboarding
     :: FullscreenRuntime

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -37,6 +37,7 @@ module Agent.CLI.TUI.Types
     , ResumeActions(..)
     , ResumeOverlay(..)
     , choiceOverlay
+    , dismissPendingChoice
     , resumeOverlay
     , textOverlay
     , SyntaxHighlighterState(..)
@@ -500,6 +501,14 @@ data ResumeActions = ResumeActions
 
 choiceOverlay :: AppState -> Maybe ChoiceOverlay
 choiceOverlay state = (.dialogOverlay) <$> state.appChoice
+
+-- | A replaced dialog must release its caller, never silently abandon an
+-- approval or question. Replacement has the same fail-closed result as Esc.
+dismissPendingChoice :: AppState -> IO ()
+dismissPendingChoice state =
+    case state.appChoice of
+        Nothing -> pure ()
+        Just pending -> pending.dialogReply Nothing
 
 resumeOverlay :: AppState -> Maybe ResumeOverlay
 resumeOverlay state = (.dialogOverlay) <$> state.appResume

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -183,6 +183,7 @@ import Control.Concurrent.STM
     , readTVar
     , readTMVar
     , newEmptyTMVarIO
+    , putTMVar
     , newTChanIO
     , retry
     , tryReadTMVar
@@ -582,6 +583,30 @@ spec = do
                 `shouldBe` Just [("Current", "")]
 
     describe "idle choice closure" do
+        it "replaces a choice whose reply has already completed without blocking" do
+            runtime <- newScriptRuntime initialUiState
+            previous <- newEmptyTMVarIO
+            current <- newEmptyTMVarIO
+            atomically (putTMVar previous (Just 0))
+            result <- timeout 1_000_000 $
+                runFullscreenScriptWithState
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    [ FullscreenScriptApp
+                        (AppAskChoice ChoiceDialog "Completed approval" "" 0
+                            [("Allow", "")] previous)
+                    , FullscreenScriptApp
+                        (AppAskChoice ChoiceDialog "Current question" "" 0
+                            [("Continue", "")] current)
+                    , FullscreenScriptHalt
+                    ]
+            case result of
+                Nothing -> expectationFailure "replacing a completed reply blocked the event loop"
+                Just (_, replaced) ->
+                    fmap (.dialogOverlay.choiceTitle) replaced.appChoice
+                        `shouldBe` Just "Current question"
+            atomically (tryReadTMVar previous) `shouldReturn` Just (Just 0)
+            atomically (tryReadTMVar current) `shouldReturn` Nothing
+
         it "releases a displaced plan approval without approving it" do
             runtime <- newScriptRuntime initialUiState
             approval <- newEmptyTMVarIO

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -3,6 +3,7 @@ module Agent.CLI.TUIAppSpec (spec) where
 import qualified Agent.TUI.Theme as Theme
 import Agent.CLI.TUI.Keyboard (decodeKeyboardBody, classifyKeyboard, runKeyboardInput)
 import Agent.CLI.TUI.App (finishedMarkdownProseCaches)
+import qualified Agent.CLI.TUI.App.Runtime as Runtime
 import Control.Monad (forM_, when)
 import Control.Monad.IO.Class (liftIO)
 import Graphics.Vty.Platform.Unix.Input.Classify.Types (KClass(..))
@@ -172,7 +173,7 @@ import Agent.TUI.Presentation
     )
 import Agent.TUI.Motion
 import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, threadDelay)
-import Control.Concurrent.Async (waitCatch, withAsync)
+import Control.Concurrent.Async (cancel, waitCatch, withAsync)
 import Control.Exception.Safe (bracket, bracket_)
 import System.Environment (lookupEnv, setEnv, unsetEnv)
 import Control.Exception (AsyncException(UserInterrupt))
@@ -581,6 +582,87 @@ spec = do
                 `shouldBe` Just [("Current", "")]
 
     describe "idle choice closure" do
+        it "releases a displaced plan approval without approving it" do
+            runtime <- newScriptRuntime initialUiState
+            approval <- newEmptyTMVarIO
+            question <- newEmptyTMVarIO
+            let initial = initialFullscreenAppState runtime [] AgentRoot [] 0
+            (_, replaced) <- runFullscreenScriptWithState initial
+                [ FullscreenScriptApp
+                    (AppAskChoice ChoiceDialog "Enter plan mode?" "" 0
+                        [("Enter", ""), ("Stay", "")] approval)
+                , FullscreenScriptApp
+                    (AppAskChoice ChoicePlanning "Planning question" "" 0
+                        [("Continue", "")] question)
+                , FullscreenScriptHalt
+                ]
+            atomically (tryReadTMVar approval) `shouldReturn` Just Nothing
+            atomically (tryReadTMVar question) `shouldReturn` Nothing
+            (_, closed) <- runFullscreenScriptWithState replaced
+                [ FullscreenScriptApp (AppCloseChoice approval)
+                , FullscreenScriptVty (V.EvKey V.KEnter [])
+                , FullscreenScriptHalt
+                ]
+            atomically (tryReadTMVar question) `shouldReturn` Just (Just 0)
+            isNothing closed.appChoice `shouldBe` True
+
+        it "releases a choice displaced by a searchable or adjustable picker" do
+            forM_ (["filter", "adjustable", "dynamic"] :: [String]) \picker -> do
+                runtime <- newScriptRuntime initialUiState
+                approval <- newEmptyTMVarIO
+                indexReply <- newEmptyTMVarIO
+                adjustmentReply <- newEmptyTMVarIO
+                dynamicReply <- newEmptyTMVarIO
+                let replacement = case picker of
+                        "filter" -> AppAskFilterChoice "Select" 0 [("Item", "")] indexReply
+                        "adjustable" -> AppAskAdjustableFilterChoice "Select" 0
+                            [("Item", "", ["high"], 0)] adjustmentReply
+                        _ -> AppAskDynamicAdjustableFilterChoice "Select" "" 0
+                            [("item", "Item", "", ["high"], 0)] dynamicReply
+                _ <- runFullscreenScriptWithState
+                    (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                    [ FullscreenScriptApp
+                        (AppAskChoice ChoiceDialog "Enter plan mode?" "" 0
+                            [("Enter", "")] approval)
+                    , FullscreenScriptApp replacement
+                    , FullscreenScriptHalt
+                    ]
+                atomically (tryReadTMVar approval) `shouldReturn` Just Nothing
+
+        it "closes the published choice when its waiting caller is cancelled" do
+            runtime <- newScriptRuntime initialUiState
+            withAsync
+                (Runtime.requestFullscreenChoiceWithBody runtime "Enter plan mode?"
+                    "" 0 [("Enter", "")]) \worker -> do
+                published <- timeout 1_000_000 $ atomically do
+                    let AppEventMailbox mailbox = runtime.runtimeMailbox
+                    pending <- readTVar mailbox
+                    case
+                        [ (event, reply)
+                        | PendingEvent event@(AppAskChoice _ _ _ _ _ reply) <-
+                            toList pending.mailboxPendingEvents
+                        ] of
+                        entry : _ -> pure entry
+                        _ -> retry
+                case published of
+                    Nothing -> expectationFailure "choice was not published"
+                    Just (event, reply) -> do
+                        cancel worker
+                        let AppEventMailbox mailbox = runtime.runtimeMailbox
+                        pending <- atomically (readTVar mailbox)
+                        let closes =
+                                [ close
+                                | PendingEvent close@(AppCloseChoice token) <-
+                                    toList pending.mailboxPendingEvents
+                                , token == reply
+                                ]
+                        length closes `shouldBe` 1
+                        (_, closed) <- runFullscreenScriptWithState
+                            (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                            (map FullscreenScriptApp (event : closes) ++ [FullscreenScriptHalt])
+                        isNothing closed.appChoice `shouldBe` True
+                        atomically (tryReadTMVar reply) `shouldReturn` Just Nothing
+
         it "renders fresh approval details literally and denies on Escape" do
             runtime <- newScriptRuntime initialUiState
             reply <- newEmptyTMVarIO

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -3,7 +3,7 @@ module Agent.CLI.TUIAppSpec (spec) where
 import qualified Agent.TUI.Theme as Theme
 import Agent.CLI.TUI.Keyboard (decodeKeyboardBody, classifyKeyboard, runKeyboardInput)
 import Agent.CLI.TUI.App (finishedMarkdownProseCaches)
-import qualified Agent.CLI.TUI.App.Runtime as Runtime
+import qualified Agent.CLI.TUI.App as Runtime
 import Control.Monad (forM_, when)
 import Control.Monad.IO.Class (liftIO)
 import Graphics.Vty.Platform.Unix.Input.Classify.Types (KClass(..))


### PR DESCRIPTION
## Root cause
Fullscreen choices share a single `appChoice` slot. A second request replaced the first without resolving its reply TMVar, leaving the original tool worker blocked indefinitely. Concurrent Code Mode callbacks can reach this path, including planning approvals. Plain choice waits also lacked cancellation cleanup.

This fixes a confirmed implementation defect; the original screenshot cannot be conclusively attributed to it without its session trace.

## Changes
- Resolve displaced choices with `Nothing` (cancel/deny), preserving the existing latest-dialog behavior without implicitly approving anything.
- Make choice replies idempotent so duplicate completion cannot block the UI event loop.
- Bracket indexed choice requests with reply-token-specific cleanup; stale cleanup cannot close a newer dialog.
- Add regressions for displaced planning approvals, replacement by each picker type, caller cancellation, and stale closure.

## Validation
- Nix/GHCi: all 251 CLI library modules loaded.
- Full `Agent.CLI.TUIAppSpec.spec`: **212 examples, 0 failures**.
- Live tmux, production fullscreen runtime: two concurrent choice requests; second prompt remained visible, selecting Deny returned `(Nothing, Just 1)` and exited normally (no stranded worker).
- `git diff --check` passed.

## CI blocker
On head `21a454ea1dbcc38a19cd0efe5c77045c898ae19e`, both CLI builds and the server, runtime daemon, Telegram, and Linux integration groups passed. The CLI test build fails in an unrelated change from the merged `master` base (`a0c6e100bf8fd73089e60796d5ee1493bec251b7`): `MetaConsoleRuntimeSpec.hs:21` imports hidden module `Agent.CLI.Runtime.Repl.MetaConsole` (`collectMetaSecretsWith`). This import is absent from this branch and none of the affected files are changed by this PR. Fix that test's module access on master, then update/retest this PR. Extracted package tests were still running at the time of this report.

Failing job: https://github.com/digitallyinduced/haskell-agent/actions/runs/34689107481/job/103541474846
