### PR TITLE
Refactor MCP credentials into an application-scoped runtime

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/McpConnectionCredentials.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpConnectionCredentials.hs
@@ -3,7 +3,8 @@
 -- by the native host; no URL-indexed or plaintext-file fallback is permitted.
 module Agent.CLI.McpConnectionCredentials
     ( McpCredentialStore(..)
-    , installMcpCredentialStore
+    , CredentialRuntime
+    , newCredentialRuntime
     , loadMcpConnectionRecord
     , saveMcpConnectionRecord
     , deleteMcpConnectionRecord
@@ -21,13 +22,11 @@ import Control.Concurrent.MVar
 import Control.Exception.Safe (tryAny)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
-import Data.IORef
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Network.HTTP.Client.TLS (getGlobalManager)
-import System.IO.Unsafe (unsafePerformIO)
 import System.OsPath (OsPath)
 
 -- | A nonsecret stable lock file serializes refresh across application
@@ -51,21 +50,19 @@ data McpCredentialStore = McpCredentialStore
     , credentialStoreDelete :: Text -> IO (Either Text ())
     }
 
-credentialStore :: IORef (Maybe McpCredentialStore)
-credentialStore = unsafePerformIO (newIORef Nothing)
-{-# NOINLINE credentialStore #-}
+-- | Application-owned credentials and coordination. Share one runtime across
+-- all sessions using the same store. The store is fixed at construction, so a
+-- consumer can never observe partially installed platform credentials.
+data CredentialRuntime = CredentialRuntime
+    { credentialStore :: !(Maybe McpCredentialStore)
+    , connectionLocks :: !(MVar (Map.Map Text (MVar ())))
+    , refreshLocks :: !(MVar (Map.Map Text (MVar ())))
+    }
 
--- | Install once during native process initialization, before operations start.
-installMcpCredentialStore :: McpCredentialStore -> IO ()
-installMcpCredentialStore store = writeIORef credentialStore (Just store)
-
-connectionLocks :: MVar (Map.Map Text (MVar ()))
-connectionLocks = unsafePerformIO (newMVar Map.empty)
-{-# NOINLINE connectionLocks #-}
-
-refreshLocks :: MVar (Map.Map Text (MVar ()))
-refreshLocks = unsafePerformIO (newMVar Map.empty)
-{-# NOINLINE refreshLocks #-}
+-- | 'Nothing' explicitly selects unavailable protected storage (no fallback).
+newCredentialRuntime :: Maybe McpCredentialStore -> IO CredentialRuntime
+newCredentialRuntime store =
+    CredentialRuntime store <$> newMVar Map.empty <*> newMVar Map.empty
 
 withIdentifierLock :: MVar (Map.Map Text (MVar ())) -> Text -> IO a -> IO a
 withIdentifierLock registry identifier action = do
@@ -78,10 +75,10 @@ withIdentifierLock registry identifier action = do
     withMVar lock (const action)
 
 withConnectionStore
-    :: Text -> (McpCredentialStore -> IO (Either Text a)) -> IO (Either Text a)
-withConnectionStore identifier action =
-    withIdentifierLock connectionLocks identifier $
-        readIORef credentialStore >>= \case
+    :: CredentialRuntime -> Text -> (McpCredentialStore -> IO (Either Text a)) -> IO (Either Text a)
+withConnectionStore runtime identifier action =
+    withIdentifierLock runtime.connectionLocks identifier $
+        case runtime.credentialStore of
             Nothing -> pure (Left "Protected MCP credential storage is unavailable")
             Just store -> tryAny (action store) >>= \case
                 Left _ -> pure (Left "Protected MCP credential operation failed")
@@ -98,51 +95,51 @@ loadRecord store identifier =
                 Left _ -> Left "Protected MCP credential record is invalid"
                 Right record -> Right (Just record)
 
-loadMcpConnectionRecord :: Text
+loadMcpConnectionRecord :: CredentialRuntime -> Text
     -> IO (Either Text (Maybe (OAuthTokenFile, OAuthTokenFileExtra)))
-loadMcpConnectionRecord identifier =
-    withConnectionStore identifier \store -> loadRecord store identifier
+loadMcpConnectionRecord runtime identifier =
+    withConnectionStore runtime identifier \store -> loadRecord store identifier
 
-saveMcpConnectionRecord :: Text -> OAuthTokenFile -> OAuthTokenFileExtra
+saveMcpConnectionRecord :: CredentialRuntime -> Text -> OAuthTokenFile -> OAuthTokenFileExtra
     -> IO (Either Text ())
-saveMcpConnectionRecord identifier record extra =
-    withConnectionStore identifier \store ->
+saveMcpConnectionRecord runtime identifier record extra =
+    withConnectionStore runtime identifier \store ->
         store.credentialStoreSave identifier
             (LBS.toStrict (encodeOAuthTokenRecord record extra))
 
-deleteMcpConnectionRecord :: Text -> IO (Either Text ())
-deleteMcpConnectionRecord identifier =
-    withConnectionStore identifier \store -> store.credentialStoreDelete identifier
+deleteMcpConnectionRecord :: CredentialRuntime -> Text -> IO (Either Text ())
+deleteMcpConnectionRecord runtime identifier =
+    withConnectionStore runtime identifier \store -> store.credentialStoreDelete identifier
 
-mcpConnectionCredentialProvider :: Text -> McpCredentialProvider
-mcpConnectionCredentialProvider identifier =
-    mcpConnectionCredentialProviderWith identifier id
+mcpConnectionCredentialProvider :: CredentialRuntime -> Text -> McpCredentialProvider
+mcpConnectionCredentialProvider runtime identifier =
+    mcpConnectionCredentialProviderWith runtime identifier id
 
 -- | The host gate validates the captured generation under the catalog lock.
 -- It wraps only protected storage, never a network request. Lock ordering is
 -- consistently catalog -> store; refresh serialization is independent.
 mcpConnectionCredentialProviderWith
-    :: Text
+    :: CredentialRuntime -> Text
     -> (forall a. IO (Either Text a) -> IO (Either Text a))
     -> McpCredentialProvider
-mcpConnectionCredentialProviderWith identifier gate =
-    mcpConnectionCredentialProviderWithRefresh identifier gate \request -> do
+mcpConnectionCredentialProviderWith runtime identifier gate =
+    mcpConnectionCredentialProviderWithRefresh runtime identifier gate \request -> do
         manager <- getGlobalManager
         refreshAccessTokenWith manager request
 
 mcpConnectionCredentialProviderWithRefresh
-    :: Text
+    :: CredentialRuntime -> Text
     -> (forall a. IO (Either Text a) -> IO (Either Text a))
     -> (RefreshRequest -> IO OAuthTokenResponse)
     -> McpCredentialProvider
-mcpConnectionCredentialProviderWithRefresh identifier gate refresh = McpCredentialProvider
+mcpConnectionCredentialProviderWithRefresh runtime identifier gate refresh = McpCredentialProvider
     { mcpCredentialAccessToken = accessToken False
     , mcpCredentialRefreshAccessToken =
         accessToken True >>= pure . (>>= maybe (Left "MCP authorization is required") Right)
     }
   where
-    accessToken forceRefresh = withIdentifierLock refreshLocks identifier $
-        gate (loadMcpConnectionRecord identifier) >>= \case
+    accessToken forceRefresh = withIdentifierLock runtime.refreshLocks identifier $
+        gate (loadMcpConnectionRecord runtime identifier) >>= \case
             Left err -> pure (Left err)
             Right Nothing -> pure (Right Nothing)
             Right (Just (current, extra)) -> do
@@ -166,7 +163,7 @@ mcpConnectionCredentialProviderWithRefresh identifier gate refresh = McpCredenti
                                         , tokenExpiresAt = fmap (completed +) tokens.expiresIn
                                         }
                                     updatedExtra = extra { extraScope = tokens.scope <|> extra.extraScope }
-                                gate (withConnectionStore identifier \store ->
+                                gate (withConnectionStore runtime identifier \store ->
                                     loadRecord store identifier >>= \case
                                         Right (Just (latest, latestExtra))
                                             | encodeOAuthTokenRecord latest latestExtra

--- a/packages/agent-cli/src/Agent/CLI/McpConnectionRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/McpConnectionRuntime.hs
@@ -8,7 +8,7 @@ module Agent.CLI.McpConnectionRuntime
     ) where
 
 import Agent.CLI.Config (HarnessConfig(..), McpServerConfig(..), withHarnessConfigSnapshot, harnessConfigPath, mcpUsesConnectionCredentials)
-import Agent.CLI.McpConnectionCredentials (mcpConnectionCredentialProviderWith, withMcpConnectionRefreshLock)
+import Agent.CLI.McpConnectionCredentials (CredentialRuntime, mcpConnectionCredentialProviderWith, withMcpConnectionRefreshLock)
 import Agent.OsPath (fromText)
 import qualified Agent.MCP as MCP
 import qualified Data.Map.Strict as Map
@@ -64,15 +64,15 @@ invalidateMcpConnectionRuntimes =
 -- | Explicit host metadata, not names or URLs, selects protected credentials.
 -- Removed/stale identities remain authoritative and cannot fall back to
 -- legacy tokens. The generation participates in fleet configuration equality.
-mcpConnectionCredentials :: MCP.McpServerConfig -> IO (Maybe MCP.McpCredentialProvider)
-mcpConnectionCredentials runtime = case runtime.mcpServerConnection of
+mcpConnectionCredentials :: CredentialRuntime -> MCP.McpServerConfig -> IO (Maybe MCP.McpCredentialProvider)
+mcpConnectionCredentials credentials runtime = case runtime.mcpServerConnection of
     Nothing -> pure Nothing
     Just identity -> do
         home <- getHomeDirectory
         let identifier = identity.mcpConnectionIdentifier
             valid = not (Text.null identifier) && Text.length identifier <= 128
                 && Text.all (\c -> isAsciiLower c || isAsciiUpper c || isDigit c || c == '-') identifier
-            provider = mcpConnectionCredentialProviderWith identifier (gate identity)
+            provider = mcpConnectionCredentialProviderWith credentials identifier (gate identity)
             lockPath = takeDirectory (harnessConfigPath home) </>
                 fromText ("mcp-refresh-" <> identifier <> ".lock")
         pure (Just (if valid then withMcpConnectionRefreshLock lockPath provider

--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -18,6 +18,7 @@ module Agent.CLI.NativeRuntime
     , newNativeProcessRuntime
     , newNativeProcessRuntimeWithIntegrations
     , newNativeProcessRuntimeWithOrganizationIntegrations
+    , newNativeProcessRuntimeWithCredentialRuntime
     , nativeProcessIntegrationSupervisor
     , acquireNativeLocalIntegrationRuntime
     , nativeTurnOptions
@@ -88,6 +89,7 @@ import Agent.TUI.Motion (MotionMode(..))
 import Agent.Tools.Types (defaultToolEnv)
 import qualified Agent.MCP as MCP
 import Agent.CLI.McpConnectionRuntime (mcpConnectionCredentials, registerMcpConnectionRuntime, observeMcpConnectionInfo)
+import Agent.CLI.McpConnectionCredentials (CredentialRuntime, newCredentialRuntime)
 import Control.Exception.Safe (finally, mask, onException)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -117,7 +119,16 @@ newNativeProcessRuntimeWithIntegrations provider =
 newNativeProcessRuntimeWithOrganizationIntegrations
     :: IntegrationProvider -> Maybe OrganizationIntegrationProvider
     -> OsPath -> IO NativeProcessRuntime
-newNativeProcessRuntimeWithOrganizationIntegrations provider organizationProvider root = mask \restore -> do
+newNativeProcessRuntimeWithOrganizationIntegrations provider organizationProvider root = do
+    credentials <- newCredentialRuntime Nothing
+    newNativeProcessRuntimeWithCredentialRuntime credentials provider organizationProvider root
+
+-- | The application supplies one credential runtime shared by every process
+-- owner and catalog operation. Never allocate its lock registries per session.
+newNativeProcessRuntimeWithCredentialRuntime
+    :: CredentialRuntime -> IntegrationProvider -> Maybe OrganizationIntegrationProvider
+    -> OsPath -> IO NativeProcessRuntime
+newNativeProcessRuntimeWithCredentialRuntime credentials provider organizationProvider root = mask \restore -> do
     integrationToolEnv <- restore (defaultToolEnv root)
     localIntegrations <- restore (newIntegrationSupervisor provider integrationToolEnv)
     -- Direct turns borrow the same local owner used by native account settings.
@@ -131,7 +142,7 @@ newNativeProcessRuntimeWithOrganizationIntegrations provider organizationProvide
             `onException` closeIntegrationSupervisor localIntegrations
     core <- restore (NativeProcess.newNativeProcessRuntimeWithMcpHooks
         MCP.defaultMcpHostHooks
-            { MCP.mcpHostCredentials = mcpConnectionCredentials
+            { MCP.mcpHostCredentials = mcpConnectionCredentials credentials
             , MCP.mcpHostServerInfo = observeMcpConnectionInfo
             }
         root) `onException` (closeIntegrationSupervisor integrations

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Internal.hs
@@ -101,6 +101,7 @@ import System.IO ( stderr )
 
 import qualified Agent.MCP as MCP
 import Agent.CLI.McpConnectionRuntime (mcpConnectionCredentials)
+import Agent.CLI.McpConnectionCredentials (newCredentialRuntime)
 import Data.IORef (atomicModifyIORef', newIORef, readIORef)
 import qualified Data.Text as Text
 
@@ -226,6 +227,9 @@ runAgentWithRestarts options =
                 rootsRef <- newIORef Nothing
                 samplingRef <- newIORef Nothing
                 toolResourceArbiter <- newToolResourceArbiter 1024
+                -- Shared by the application supervisor, including background
+                -- sessions and restarts; CLI has no protected native store.
+                credentials <- newCredentialRuntime Nothing
                 cleanupStarted <- newIORef False
                 cleanupRequest <- newEmptyMVar
                 -- Cleanup is intentionally process-scoped rather than
@@ -241,7 +245,7 @@ runAgentWithRestarts options =
                                 { MCP.mcpHostElicit = readIORef elicitationRef
                                 , MCP.mcpHostRoots = readIORef rootsRef
                                 , MCP.mcpHostSample = readIORef samplingRef
-                                , MCP.mcpHostCredentials = mcpConnectionCredentials
+                                , MCP.mcpHostCredentials = mcpConnectionCredentials credentials
                                 }
                             `onException`
                                 closeIntegrationSupervisor integrationSupervisor

--- a/packages/agent-cli/test/Agent/CLI/McpConnectionCredentialsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/McpConnectionCredentialsSpec.hs
@@ -15,9 +15,81 @@ import System.Timeout (timeout)
 
 spec :: Spec
 spec = describe "connection credential storage" do
+    it "constructs unavailable storage explicitly and keeps independent runtimes isolated" do
+        unavailable <- newCredentialRuntime Nothing
+        first <- newMemoryRuntime
+        let record = OAuthTokenFile "client" "https://authorization.example/token" "first" "refresh" Nothing
+            firstProvider = mcpConnectionCredentialProvider first "same"
+            unavailableProvider = mcpConnectionCredentialProvider unavailable "same"
+        saveMcpConnectionRecord first "same" record emptyOAuthTokenFileExtra `shouldReturn` Right ()
+        second <- newMemoryRuntime
+        saveMcpConnectionRecord second "same" (record { tokenAccessToken = "second" })
+            emptyOAuthTokenFileExtra `shouldReturn` Right ()
+        firstProvider.mcpCredentialAccessToken `shouldReturn` Right (Just "first")
+        unavailableProvider.mcpCredentialAccessToken
+            `shouldReturn` Left "Protected MCP credential storage is unavailable"
+        saveMcpConnectionRecord unavailable "same" record emptyOAuthTokenFileExtra
+            `shouldReturn` Left "Protected MCP credential storage is unavailable"
+        deleteMcpConnectionRecord unavailable "same"
+            `shouldReturn` Left "Protected MCP credential storage is unavailable"
+        deleteMcpConnectionRecord second "same" `shouldReturn` Right ()
+        firstProvider.mcpCredentialAccessToken `shouldReturn` Right (Just "first")
+
+    it "shares refresh serialization across providers but not across runtimes" do
+        runtime <- newMemoryRuntime
+        independent <- newMemoryRuntime
+        started <- newEmptyMVar
+        resume <- newEmptyMVar
+        count <- newIORef (0 :: Int)
+        let record = OAuthTokenFile "client" "https://authorization.example/token" "old" "refresh" (Just 0)
+            refreshed = OAuthTokenSuccess (OAuthTokens "rotated" Nothing (Just 3600) Nothing)
+            refresh _ = do
+                atomicModifyIORef' count (\n -> (n + 1, ()))
+                putMVar started ()
+                takeMVar resume
+                pure refreshed
+            first = mcpConnectionCredentialProviderWithRefresh runtime "same" id refresh
+            second = mcpConnectionCredentialProviderWithRefresh runtime "same" id refresh
+            separate = mcpConnectionCredentialProviderWithRefresh independent "same" id (const (pure refreshed))
+        saveMcpConnectionRecord runtime "same" record emptyOAuthTokenFileExtra `shouldReturn` Right ()
+        saveMcpConnectionRecord independent "same" record emptyOAuthTokenFileExtra `shouldReturn` Right ()
+        result <- timeout 5000000 $
+            withAsync first.mcpCredentialAccessToken \worker -> do
+                takeMVar started
+                -- A hidden process-wide registry would deadlock here.
+                separate.mcpCredentialAccessToken `shouldReturn` Right (Just "rotated")
+                timeout 100000 second.mcpCredentialAccessToken `shouldReturn` Nothing
+                readIORef count `shouldReturn` 1
+                withAsync second.mcpCredentialAccessToken \other -> do
+                    putMVar resume ()
+                    a <- wait worker
+                    b <- wait other
+                    pure (a, b)
+        result `shouldBe` Just (Right (Just "rotated"), Right (Just "rotated"))
+        readIORef count `shouldReturn` 1
+
+    it "serializes store access within a runtime without locking other runtimes" do
+        started <- newEmptyMVar
+        resume <- newEmptyMVar
+        runtime <- newCredentialRuntime $ Just McpCredentialStore
+            { credentialStoreLoad = \_ -> putMVar started () >> takeMVar resume >> pure (Right Nothing)
+            , credentialStoreSave = \_ _ -> pure (Right ())
+            , credentialStoreDelete = const (pure (Right ()))
+            }
+        independent <- newMemoryRuntime
+        result <- timeout 5000000 $
+            withAsync (loadMcpConnectionRecord runtime "same") \worker -> do
+                takeMVar started
+                loadMcpConnectionRecord independent "same" `shouldReturn` Right Nothing
+                timeout 100000 (deleteMcpConnectionRecord runtime "same") `shouldReturn` Nothing
+                putMVar resume ()
+                wait worker `shouldReturn` Right Nothing
+                deleteMcpConnectionRecord runtime "same"
+        result `shouldBe` Just (Right ())
+
     it "serializes shared refresh locks and reloads rotated credentials" $
       withSystemTempDirectory "mcp-refresh-lock" \directory -> do
-        installMemoryStore
+        runtime <- newMemoryRuntime
         count <- newIORef (0 :: Int)
         started <- newEmptyMVar
         resume <- newEmptyMVar
@@ -29,8 +101,8 @@ spec = describe "connection credential storage" do
                 takeMVar resume
                 pure (OAuthTokenSuccess (OAuthTokens "rotated" (Just "rotated-refresh") (Just 3600) Nothing))
             provider = withMcpConnectionRefreshLock lockPath
-                (mcpConnectionCredentialProviderWithRefresh "shared" id refresh)
-        saveMcpConnectionRecord "shared" record emptyOAuthTokenFileExtra `shouldReturn` Right ()
+                (mcpConnectionCredentialProviderWithRefresh runtime "shared" id refresh)
+        saveMcpConnectionRecord runtime "shared" record emptyOAuthTokenFileExtra `shouldReturn` Right ()
         result <- timeout 5000000 $
             withAsync provider.mcpCredentialAccessToken \first -> do
                 takeMVar started
@@ -44,7 +116,7 @@ spec = describe "connection credential storage" do
 
     it "keeps two accounts at one endpoint independent through replacement and deletion" do
         records <- newIORef Map.empty
-        installMcpCredentialStore McpCredentialStore
+        runtime <- newCredentialRuntime $ Just McpCredentialStore
             { credentialStoreLoad = \identifier -> Right . Map.lookup identifier <$> readIORef records
             , credentialStoreSave = \identifier bytes ->
                 modifyIORef' records (Map.insert identifier bytes) >> pure (Right ())
@@ -54,21 +126,21 @@ spec = describe "connection credential storage" do
         let first = OAuthTokenFile "client" "https://authorization.example/token" "first-token" "first-refresh" Nothing
             second = first { tokenAccessToken = "second-token", tokenRefreshToken = "second-refresh" }
             extra = emptyOAuthTokenFileExtra { extraResource = Just "https://server.example/mcp" }
-            firstProvider = mcpConnectionCredentialProvider "first"
-            secondProvider = mcpConnectionCredentialProvider "second"
-        saveMcpConnectionRecord "first" first extra `shouldReturn` Right ()
-        saveMcpConnectionRecord "second" second extra `shouldReturn` Right ()
+            firstProvider = mcpConnectionCredentialProvider runtime "first"
+            secondProvider = mcpConnectionCredentialProvider runtime "second"
+        saveMcpConnectionRecord runtime "first" first extra `shouldReturn` Right ()
+        saveMcpConnectionRecord runtime "second" second extra `shouldReturn` Right ()
         firstProvider.mcpCredentialAccessToken `shouldReturn` Right (Just "first-token")
         secondProvider.mcpCredentialAccessToken `shouldReturn` Right (Just "second-token")
-        saveMcpConnectionRecord "first" (first { tokenAccessToken = "replacement" }) extra `shouldReturn` Right ()
+        saveMcpConnectionRecord runtime "first" (first { tokenAccessToken = "replacement" }) extra `shouldReturn` Right ()
         firstProvider.mcpCredentialAccessToken `shouldReturn` Right (Just "replacement")
         secondProvider.mcpCredentialAccessToken `shouldReturn` Right (Just "second-token")
-        deleteMcpConnectionRecord "first" `shouldReturn` Right ()
+        deleteMcpConnectionRecord runtime "first" `shouldReturn` Right ()
         firstProvider.mcpCredentialAccessToken `shouldReturn` Right Nothing
         secondProvider.mcpCredentialAccessToken `shouldReturn` Right (Just "second-token")
 
     it "rejects a refresh after generation changes without blocking lifecycle writes" do
-        installMemoryStore
+        runtime <- newMemoryRuntime
         generation <- newIORef (0 :: Int)
         started <- newEmptyMVar
         resume <- newEmptyMVar
@@ -77,47 +149,47 @@ spec = describe "connection credential storage" do
                 if current == 0 then action else pure (Left "stale generation")
             refresh _ = putMVar started () >> takeMVar resume >>
                 pure (OAuthTokenSuccess (OAuthTokens "stale-refreshed" Nothing (Just 3600) Nothing))
-            provider = mcpConnectionCredentialProviderWithRefresh "racing" gate refresh
-        saveMcpConnectionRecord "racing" record emptyOAuthTokenFileExtra `shouldReturn` Right ()
+            provider = mcpConnectionCredentialProviderWithRefresh runtime "racing" gate refresh
+        saveMcpConnectionRecord runtime "racing" record emptyOAuthTokenFileExtra `shouldReturn` Right ()
         withAsync provider.mcpCredentialAccessToken \worker -> do
             takeMVar started
             writeIORef generation 1
-            saveMcpConnectionRecord "racing" (record { tokenAccessToken = "replacement" })
+            saveMcpConnectionRecord runtime "racing" (record { tokenAccessToken = "replacement" })
                 emptyOAuthTokenFileExtra `shouldReturn` Right ()
             putMVar resume ()
             wait worker `shouldReturn` Left "stale generation"
-        loaded <- loadMcpConnectionRecord "racing"
+        loaded <- loadMcpConnectionRecord runtime "racing"
         fmap (fmap ((.tokenAccessToken) . fst)) loaded `shouldBe` Right (Just "replacement")
 
     it "does not resurrect credentials deleted while refresh is in flight" do
-        installMemoryStore
+        runtime <- newMemoryRuntime
         started <- newEmptyMVar
         resume <- newEmptyMVar
         let record = OAuthTokenFile "client" "https://authorization.example/token" "old" "refresh" (Just 0)
             refresh _ = putMVar started () >> takeMVar resume >>
                 pure (OAuthTokenSuccess (OAuthTokens "refreshed" Nothing (Just 3600) Nothing))
-            provider = mcpConnectionCredentialProviderWithRefresh "deleted" id refresh
-        saveMcpConnectionRecord "deleted" record emptyOAuthTokenFileExtra `shouldReturn` Right ()
+            provider = mcpConnectionCredentialProviderWithRefresh runtime "deleted" id refresh
+        saveMcpConnectionRecord runtime "deleted" record emptyOAuthTokenFileExtra `shouldReturn` Right ()
         withAsync provider.mcpCredentialAccessToken \worker -> do
             takeMVar started
-            deleteMcpConnectionRecord "deleted" `shouldReturn` Right ()
+            deleteMcpConnectionRecord runtime "deleted" `shouldReturn` Right ()
             putMVar resume ()
             wait worker `shouldReturn` Left "MCP authorization changed during refresh"
-        loadMcpConnectionRecord "deleted" `shouldReturn` Right Nothing
+        loadMcpConnectionRecord runtime "deleted" `shouldReturn` Right Nothing
 
     it "does not disclose malformed protected storage bytes in errors" do
-        installMcpCredentialStore McpCredentialStore
+        runtime <- newCredentialRuntime $ Just McpCredentialStore
             { credentialStoreLoad = const (pure (Right (Just "secret-invalid-record")))
             , credentialStoreSave = \_ _ -> pure (Right ())
             , credentialStoreDelete = const (pure (Right ()))
             }
-        loadMcpConnectionRecord "malformed"
+        loadMcpConnectionRecord runtime "malformed"
             `shouldReturn` Left "Protected MCP credential record is invalid"
 
-installMemoryStore :: IO ()
-installMemoryStore = do
+newMemoryRuntime :: IO CredentialRuntime
+newMemoryRuntime = do
     records <- newIORef Map.empty
-    installMcpCredentialStore McpCredentialStore
+    newCredentialRuntime $ Just McpCredentialStore
         { credentialStoreLoad = \identifier -> Right . Map.lookup identifier <$> readIORef records
         , credentialStoreSave = \identifier bytes ->
             atomicModifyIORef' records (\current -> (Map.insert identifier bytes current, Right ()))

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineHandle.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineHandle.hs
@@ -11,7 +11,7 @@ import Agent.CLI.MacOS.EngineLifecycle (workerLifecycle)
 import Agent.CLI.MacOS.EngineMailbox (newEngineMailboxIO, closeEngineMailbox)
 import Agent.CLI.MacOS.EngineState (Engine(..), EngineCommand(..))
 import Agent.CLI.MacOS.InteractionState (InteractionRuntime(..))
-import Agent.CLI.MacOS.McpCredentialStore (ensureNativeMcpCredentialStore)
+import Agent.CLI.MacOS.McpCredentialStore (nativeMcpCredentialRuntime)
 import Agent.CLI.Session (sessionsRoot)
 import Agent.CLI.SessionAdmin (managedPostgresConfigForHome)
 import Control.Concurrent.Async (asyncWithUnmask, cancel, waitCatch)
@@ -36,7 +36,6 @@ ha_engine_create callback context
     | callback == nullFunPtr = pure nullPtr
     | otherwise = do
         created <- tryAny do
-            ensureNativeMcpCredentialStore
             home <- getHomeDirectory
             config <- managedPostgresConfigForHome home
             commands <- newEngineMailboxIO
@@ -61,6 +60,7 @@ ha_engine_create callback context
                 worker <- asyncWithUnmask \unmask ->
                     unmask
                         (workerLifecycle
+                            nativeMcpCredentialRuntime
                             callback
                             context
                             config

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineLifecycle.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/EngineLifecycle.hs
@@ -27,6 +27,7 @@ import Agent.CLI.MacOS.NativeSupervisor
 import Agent.CLI.MacOS.TurnState
 import Agent.CLI.MacOS.Marshalling (withText)
 import Agent.CLI.NativeRuntime
+import Agent.CLI.McpConnectionCredentials (CredentialRuntime)
 import Agent.Loop (ImageAttachment)
 import Agent.Store.Postgres (ManagedPostgresConfig)
 import Control.Concurrent.MVar (newMVar)
@@ -42,7 +43,8 @@ import Foreign.Ptr (FunPtr, Ptr, castPtr, nullPtr)
 import System.OsPath (OsPath)
 
 workerLifecycle
-    :: FunPtr EventCallback
+    :: CredentialRuntime
+    -> FunPtr EventCallback
     -> Ptr ()
     -> ManagedPostgresConfig
     -> OsPath
@@ -54,13 +56,13 @@ workerLifecycle
     -> TVar (Map Text NativeTurnOptions)
     -> InteractionRuntime
     -> IO ()
-workerLifecycle
+workerLifecycle credentials
         callback context config root commands stagedImages browser computer chartRenderingEnabled
         stagedTurnOptions interactions =
     (do
         store <- newMVar Nothing
-        processRuntime <- newNativeProcessRuntimeWithOrganizationIntegrations
-            bundledIntegrationProvider bundledOrganizationIntegrationProvider root
+        processRuntime <- newNativeProcessRuntimeWithCredentialRuntime
+            credentials bundledIntegrationProvider bundledOrganizationIntegrationProvider root
         workerRegistry <- newTVarIO Map.empty
         integrationWorkers <- newIntegrationWorkerRegistry
         let closeResources =

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/McpConnectionBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/McpConnectionBridge.hs
@@ -11,7 +11,7 @@ module Agent.CLI.MacOS.McpConnectionBridge
 
 import Agent.CLI.MacOS.Marshalling (decodeUtf8Input, withText)
 import Agent.CLI.MacOS.McpConnectionOperation (startMcpConnectionOperation)
-import Agent.CLI.MacOS.McpCredentialStore (ensureNativeMcpCredentialStore)
+import Agent.CLI.MacOS.McpCredentialStore (nativeMcpCredentialRuntime)
 import Agent.CLI.McpAdmin (McpAdminError(..), McpAdminSnapshot(..))
 import Agent.CLI.McpConnection
 import Agent.CLI.McpConnectionRuntime (readMcpConnectionIcons)
@@ -141,7 +141,7 @@ ha_mcp_connection_remove expected identifier identifierLength callback context o
         [connectionId] -> startConnectionResult callback context output 0 do
             home <- getHomeDirectory
             fmap (fmap (\snapshot -> snapshot { mcpAdminValue = [] })) $
-                removeMcpConnection home expected connectionId
+                removeMcpConnection nativeMcpCredentialRuntime home expected connectionId
         _ -> pure 2
 
 ha_mcp_connection_authorize
@@ -156,7 +156,7 @@ ha_mcp_connection_authorize expected identifier identifierLength authorization
             [connectionId] -> startConnectionResult callback context output 3 do
                 home <- getHomeDirectory
                 fmap (fmap singletonSnapshot) $
-                    authorizeMcpConnection home expected connectionId \url ->
+                    authorizeMcpConnection nativeMcpCredentialRuntime home expected connectionId \url ->
                         withText url (invokeAuthorizationCallback authorization context)
                             >> pure (Right ())
             _ -> pure 2
@@ -200,7 +200,7 @@ startConnectionResultWithIcons
     -> IO (Either McpAdminError (McpAdminSnapshot [McpConnection]))
     -> IO CInt
 startConnectionResultWithIcons icons callback context output state action =
-    startMcpConnectionOperation output (ensureNativeMcpCredentialStore >> action) complete
+    startMcpConnectionOperation output action complete
         (emitConnectionTerminal callback context (-1) 0
             "MCP connection operation failed.")
   where

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/McpCredentialStore.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/McpCredentialStore.hs
@@ -1,25 +1,20 @@
--- | Install the platform credential implementation before the native runtime
--- can start MCP connections. Registration itself performs no Keychain access.
-module Agent.CLI.MacOS.McpCredentialStore (ensureNativeMcpCredentialStore) where
+-- | Application-scoped credential ownership at the handle-free C ABI boundary.
+-- All engines and catalog operations borrow the same fully initialized runtime.
+-- Construction performs no Keychain access.
+module Agent.CLI.MacOS.McpCredentialStore (nativeMcpCredentialRuntime) where
 
 import Agent.CLI.MacOS.McpKeychain
 import Agent.CLI.McpConnectionCredentials
-    ( McpCredentialStore(..), installMcpCredentialStore )
-import Control.Concurrent.MVar (MVar, modifyMVar_, newMVar)
-import Control.Monad (unless)
+    ( CredentialRuntime, McpCredentialStore(..), newCredentialRuntime )
 import System.IO.Unsafe (unsafePerformIO)
 
-credentialStoreInstalled :: MVar Bool
-credentialStoreInstalled = unsafePerformIO (newMVar False)
-{-# NOINLINE credentialStoreInstalled #-}
-
-ensureNativeMcpCredentialStore :: IO ()
-ensureNativeMcpCredentialStore =
-    modifyMVar_ credentialStoreInstalled \installed -> do
-        unless installed $
-            installMcpCredentialStore McpCredentialStore
-                { credentialStoreLoad = readMcpKeychain
-                , credentialStoreSave = writeMcpKeychain
-                , credentialStoreDelete = deleteMcpKeychain
-                }
-        pure True
+-- The existing C ABI has no application handle. Keep the sole singleton here,
+-- not in the credential implementation: there is no separate install step or
+-- mutable store that an engine can observe before initialization completes.
+nativeMcpCredentialRuntime :: CredentialRuntime
+nativeMcpCredentialRuntime = unsafePerformIO $ newCredentialRuntime $ Just McpCredentialStore
+    { credentialStoreLoad = readMcpKeychain
+    , credentialStoreSave = writeMcpKeychain
+    , credentialStoreDelete = deleteMcpKeychain
+    }
+{-# NOINLINE nativeMcpCredentialRuntime #-}

--- a/packages/agent-native-bridge/src/Agent/CLI/McpConnection.hs
+++ b/packages/agent-native-bridge/src/Agent/CLI/McpConnection.hs
@@ -19,7 +19,7 @@ module Agent.CLI.McpConnection
 
 import Agent.CLI.Config (HarnessConfig(..), McpServerConfig(..), withHarnessConfigSnapshot, mcpUsesConnectionCredentials)
 import Agent.CLI.McpAdmin
-import Agent.CLI.McpConnectionCredentials (loadMcpConnectionRecord, saveMcpConnectionRecord, deleteMcpConnectionRecord)
+import Agent.CLI.McpConnectionCredentials (CredentialRuntime, loadMcpConnectionRecord, saveMcpConnectionRecord, deleteMcpConnectionRecord)
 import Agent.CLI.McpConnectionRuntime (invalidateMcpConnectionRuntimes, observeMcpConnectionInfo)
 import Agent.CLI.McpOAuth (McpOAuthHost(..), authorizeMcpWith, defaultLoginOptions)
 import Agent.MCP (McpProtocolPreference(..))
@@ -50,12 +50,12 @@ data McpConnection = McpConnection
     deriving (Eq, Show)
 
 authorizeMcpConnection
-    :: OsPath -> Word64 -> Text -> (Text -> IO (Either Text ()))
+    :: CredentialRuntime -> OsPath -> Word64 -> Text -> (Text -> IO (Either Text ()))
     -> IO (Either McpAdminError (McpAdminSnapshot McpConnection))
-authorizeMcpConnection = authorizeMcpConnectionWith McpConnectionAuthorizationHost
-    { connectionLoadCredential = loadMcpConnectionRecord
+authorizeMcpConnection credentials = authorizeMcpConnectionWith McpConnectionAuthorizationHost
+    { connectionLoadCredential = loadMcpConnectionRecord credentials
     , connectionSaveCredential = \identifier (record, extra) ->
-        saveMcpConnectionRecord identifier record extra
+        saveMcpConnectionRecord credentials identifier record extra
     , connectionProbe = probeMcpConnection
     }
 
@@ -267,9 +267,9 @@ setMcpConnectionEnabled home expected identifier enabled = do
         Right server { mcpEnabled = enabled, mcpConnectionGeneration = Just generation }
 
 removeMcpConnection
-    :: OsPath -> Word64 -> Text
+    :: CredentialRuntime -> OsPath -> Word64 -> Text
     -> IO (Either McpAdminError (McpAdminSnapshot ()))
-removeMcpConnection = removeMcpConnectionWith deleteMcpConnectionRecord
+removeMcpConnection credentials = removeMcpConnectionWith (deleteMcpConnectionRecord credentials)
 
 removeMcpConnectionWith
     :: (Text -> IO (Either Text ())) -> OsPath -> Word64 -> Text

--- a/packages/agent-native-bridge/test/Agent/CLI/MacOS/McpKeychainSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/MacOS/McpKeychainSpec.hs
@@ -1,14 +1,25 @@
 module Agent.CLI.MacOS.McpKeychainSpec (spec) where
 
 import Agent.CLI.MacOS.McpKeychain
+import Agent.CLI.MacOS.McpCredentialStore (nativeMcpCredentialRuntime)
+import Agent.CLI.McpConnectionCredentials (loadMcpConnectionRecord, deleteMcpConnectionRecord)
+import Control.Concurrent.Async (concurrently)
 import qualified Data.ByteString as BS
 import Data.Either (isLeft)
-import Test.Hspec (Spec, describe, it, shouldSatisfy)
+import Test.Hspec (Spec, describe, it, shouldSatisfy, shouldReturn)
 
 -- These cases are rejected before Security.framework is called. Automated
 -- tests must not alter the developer's login keychain or trigger consent UI.
 spec :: Spec
 spec = describe "MCP Keychain input boundary" do
+    it "has a native backend on concurrent first use without a prior engine or install step" do
+        concurrently
+            (fmap (fmap (const ())) (loadMcpConnectionRecord nativeMcpCredentialRuntime ""))
+            (deleteMcpConnectionRecord nativeMcpCredentialRuntime "")
+            `shouldReturn`
+                ( Left "Cannot read MCP credentials from Keychain. Unlock your login keychain and try again."
+                , Left "Cannot remove MCP credentials from Keychain. Unlock your login keychain and try again."
+                )
     it "rejects missing account identifiers without querying the login keychain" do
         readMcpKeychain "" >>= (`shouldSatisfy` isLeft)
         writeMcpKeychain "" "private-record" >>= (`shouldSatisfy` isLeft)

--- a/packages/agent-native-bridge/test/Agent/CLI/McpConnectionSpec.hs
+++ b/packages/agent-native-bridge/test/Agent/CLI/McpConnectionSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Config (HarnessConfig(..), McpServerConfig(..), loadHarnessConf
 import Control.Concurrent.Async (concurrently)
 import Agent.CLI.McpAdmin
 import Agent.CLI.McpConnection
+import Agent.CLI.McpConnectionCredentials (newCredentialRuntime)
 import Control.Exception.Safe (bracket)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import qualified Data.Map.Strict as Map
@@ -16,6 +17,19 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.CLI.McpConnection" do
+    it "uses the supplied unavailable runtime and keeps removal retryable" $
+        withTempDir \home -> do
+            credentials <- newCredentialRuntime Nothing
+            Right initial <- listMcpConnections home
+            Right added <- createMcpConnection home initial.mcpAdminRevision
+                "Account" "https://example.test/mcp"
+            removeMcpConnection credentials home added.mcpAdminRevision
+                added.mcpAdminValue.connectionId
+                `shouldReturn` Left (McpAdminInvalid "Protected MCP credential storage is unavailable")
+            Right listed <- listMcpConnections home
+            listed.mcpAdminRevision `shouldBe` added.mcpAdminRevision
+            listed.mcpAdminValue `shouldBe` [added.mcpAdminValue]
+
     it "migrates legacy CLI connections once and manages them by identity without renaming keys" $
         withTempDir \home -> do
             path <- decodeUtf (harnessConfigPath home)


### PR DESCRIPTION
## Summary
- Replace the credential implementation’s mutable global store and lock registries with an opaque `CredentialRuntime` constructed in IO and passed explicitly to consumers.
- Share credentials across CLI sessions/restarts and native engines/catalog operations. The handle-free native C ABI retains one fully constructed boundary singleton, with no separate install step or initialization flag.
- Preserve unavailable-store errors, refresh serialization, private cross-process locks, generation gates, lock ordering, and sanitized credential errors.
- Add focused runtime isolation, shared-versus-independent concurrency, unavailable-store, and native first-use regressions. No performance claims or CLI UI changes.

## Validation
- GHCi multi-library load: `agent-cli:lib:agent-cli agent-native-bridge:lib:agent-native-bridge` — verified `Ok, 255 modules loaded.`
- GHCi CLI credential tests — verified successful load and **8 examples, 0 failures**.
- GHCi native-bridge connection tests — verified successful load and **12 examples, 0 failures**.
- `git diff --check` passed.
- macOS-only Keychain initialization regression added but not executable on this Linux host.
- No Cabal changes; package.nix regeneration not needed.