### PR TITLE
Separate custom database scopes from the harness catalog

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Database.hs
+++ b/packages/agent-cli/src/Agent/CLI/Database.hs
@@ -9,7 +9,8 @@
 -- easy to test.
 module Agent.CLI.Database
     ( DatabaseScope(..)
-    , databaseScopeDecoder
+    , CustomDatabaseScope(..)
+    , customDatabaseScopeDecoder
     , ConversationSearchMatch(..)
     , DatabaseToolsEnv(..)
     , databaseTools
@@ -27,33 +28,41 @@ import Agent.Tools.Types
 import Data.Text (Text)
 import qualified Data.Text as Text
 
-data DatabaseScope
+-- | Provisioned custom data; unlike the runtime catalog, these scopes can be mutated.
+data CustomDatabaseScope
     = DatabaseUserScope
     | DatabaseRepositoryScope
     | DatabaseCheckoutScope
+    deriving (Eq, Show)
+
+-- | All queryable scopes. Only the custom branch can reach custom-data APIs.
+data DatabaseScope
+    = DatabaseCustomScope !CustomDatabaseScope
     | DatabaseHarnessScope
     deriving (Eq, Show)
 
 -- | Custom-data scopes used by learned skills and the native data browser.
 -- The runtime @harness@ catalog is not a provisioned custom scope.
-databaseScopeDecoder :: Hermes.Decoder DatabaseScope
-databaseScopeDecoder = databaseScopeDecoderWithHarness False
+customDatabaseScopeDecoder :: Hermes.Decoder CustomDatabaseScope
+customDatabaseScopeDecoder = Hermes.withText (customDatabaseScopeFromText False)
+
+customDatabaseScopeFromText :: MonadFail m => Bool -> Text -> m CustomDatabaseScope
+customDatabaseScopeFromText exposeHarness = \case
+    "user" -> pure DatabaseUserScope
+    "repository" -> pure DatabaseRepositoryScope
+    "checkout" -> pure DatabaseCheckoutScope
+    "harness" -> fail "the harness catalog is not available in this session"
+    value -> fail
+        ("unknown database scope " <> show value <> "; expected "
+            <> expectedScopes exposeHarness)
 
 databaseScopeDecoderWithHarness :: Bool -> Hermes.Decoder DatabaseScope
 databaseScopeDecoderWithHarness exposeHarness = Hermes.withText \case
-        "user" -> pure DatabaseUserScope
-        "repository" -> pure DatabaseRepositoryScope
-        "checkout" -> pure DatabaseCheckoutScope
         "harness"
             | exposeHarness -> pure DatabaseHarnessScope
             | otherwise ->
                 fail "the harness catalog is not available in this session"
-        value ->
-            fail
-                ("unknown database scope "
-                    <> show value
-                    <> "; expected "
-                    <> expectedScopes exposeHarness)
+        value -> DatabaseCustomScope <$> customDatabaseScopeFromText exposeHarness value
 
 -- | Storage callbacks for the model-facing database operations.
 --
@@ -67,7 +76,7 @@ data DatabaseToolsEnv = DatabaseToolsEnv
     , databaseRunQuery
         :: !(DatabaseScope -> Text -> IO (Either Text Text))
     , databaseRunExecute
-        :: !(DatabaseScope -> Text -> Text -> IO (Either Text Text))
+        :: !(CustomDatabaseScope -> Text -> Text -> IO (Either Text Text))
     , databaseSearchConversations
         :: !(Text -> Int -> IO (Either Text [ConversationSearchMatch]))
     -- | Local CLI and personal native embeddings expose the runtime catalog.
@@ -94,6 +103,8 @@ queryArgsDecoder exposeHarness = Hermes.object $
             <$> Hermes.atKey "scope" (databaseScopeDecoderWithHarness exposeHarness)
             <*> Hermes.atKey "sql" Hermes.text
 
+-- Keep the wire-level scope broad so harness writes retain their specific
+-- read-only error. Only a custom scope is passed to the mutation callback.
 data ExecuteArgs = ExecuteArgs !DatabaseScope !Text !Text
 
 executeArgsDecoder :: Bool -> Hermes.Decoder ExecuteArgs
@@ -170,13 +181,13 @@ executeTool env = jsonTool
         "database_execute"
         (executeArgsDecoder env.databaseHarnessCatalogEnabled)
         \(ExecuteArgs scope sql purpose) ->
-        if scope == DatabaseHarnessScope
-            then pure (Left harnessCatalogReadOnlyError)
-            else if Text.null (Text.strip sql)
+        case scope of
+            DatabaseHarnessScope -> pure (Left harnessCatalogReadOnlyError)
+            DatabaseCustomScope selected -> if Text.null (Text.strip sql)
                 then pure (Left "database SQL must not be empty")
                 else if Text.null (Text.strip purpose)
                     then pure (Left "database change purpose must not be empty")
-                    else env.databaseRunExecute scope purpose sql)
+                    else env.databaseRunExecute selected purpose sql)
 
 conversationSearchTool :: DatabaseToolsEnv -> AppTool
 conversationSearchTool env = jsonTool

--- a/packages/agent-cli/src/Agent/CLI/Database/Store.hs
+++ b/packages/agent-cli/src/Agent/CLI/Database/Store.hs
@@ -14,6 +14,7 @@ module Agent.CLI.Database.Store
 import Agent.CLI.Database
     ( ConversationSearchMatch(..)
     , DatabaseScope(..)
+    , CustomDatabaseScope(..)
     , DatabaseToolsEnv(..)
     )
 import Agent.CLI.ModelConfig (organizationGatewayConnectionId)
@@ -171,8 +172,8 @@ databaseToolsEnvForStore
             DatabaseHarnessScope ->
                 fmap formatCatalog
                     <$> inspectSchema (storePool (trustedPool store)) "harness"
-            _ ->
-                withScopeDatabase store (scopeForDatabase scopes selected)
+            DatabaseCustomScope custom ->
+                withScopeDatabase store (scopeForDatabase scopes custom)
                     \database pool ->
                         fmap formatCatalog <$> inspectCustomSchema pool database
     , databaseRunQuery = \selected sql ->
@@ -185,33 +186,28 @@ databaseToolsEnvForStore
                     sql >>= \case
                     Left err -> pure (Left err)
                     Right result -> pure (Right (formatQueryResult result))
-            _ ->
-                withScopeDatabase store (scopeForDatabase scopes selected)
+            DatabaseCustomScope custom ->
+                withScopeDatabase store (scopeForDatabase scopes custom)
                     \database pool ->
                         queryCustom pool database defaultQueryLimits sql >>= \case
                             Left err -> pure (Left err)
                             Right result ->
                                 pure (Right (formatQueryResult result))
     , databaseRunExecute = \selected purpose sql ->
-        case selected of
-            DatabaseHarnessScope ->
-                pure $ Left
-                    "the harness catalog is read-only; use user, repository, or checkout to change agent-created tables"
-            _ ->
-                withScopeDatabase store (scopeForDatabase scopes selected)
-                    \database pool -> do
-                        sessionId <- currentSessionId
-                        fmap formatExecutionResult <$> executeCustom
-                            (storePool (trustedPool store))
-                            pool
-                            database
-                            CustomAuditContext
-                                { customAuditSessionId = sessionId
-                                , customAuditAgentId = Nothing
-                                }
-                            defaultQueryLimits
-                            purpose
-                            sql
+        withScopeDatabase store (scopeForDatabase scopes selected)
+            \database pool -> do
+                sessionId <- currentSessionId
+                fmap formatExecutionResult <$> executeCustom
+                    (storePool (trustedPool store))
+                    pool
+                    database
+                    CustomAuditContext
+                        { customAuditSessionId = sessionId
+                        , customAuditAgentId = Nothing
+                        }
+                    defaultQueryLimits
+                    purpose
+                    sql
     , databaseSearchConversations = \query limit ->
         searchConversationTurnsForBoundary
             (trustedPool store)
@@ -231,7 +227,7 @@ databaseToolsEnvForStore
 listDatabaseObjects
     :: Store
     -> DatabaseScopes
-    -> DatabaseScope
+    -> CustomDatabaseScope
     -> IO (Either Text [CatalogObject])
 listDatabaseObjects store scopes selected =
     withExistingScopeDatabase
@@ -247,7 +243,7 @@ listDatabaseObjects store scopes selected =
 loadDatabaseRows
     :: Store
     -> DatabaseScopes
-    -> DatabaseScope
+    -> CustomDatabaseScope
     -> Text
     -> Int64
     -> Int
@@ -449,13 +445,11 @@ withExistingScopeDatabase store scope missing action =
 
 type HasqlPool = Hasql.Pool.Pool
 
-scopeForDatabase :: DatabaseScopes -> DatabaseScope -> Scope
+scopeForDatabase :: DatabaseScopes -> CustomDatabaseScope -> Scope
 scopeForDatabase scopes = \case
     DatabaseUserScope -> scopes.userScope
     DatabaseRepositoryScope -> scopes.repositoryScope
     DatabaseCheckoutScope -> scopes.checkoutScope
-    DatabaseHarnessScope ->
-        error "scopeForDatabase: harness is the runtime catalog, not a custom scope"
 
 applicableDatabaseScopes :: DatabaseScopes -> [Scope]
 applicableDatabaseScopes scopes =

--- a/packages/agent-cli/src/Agent/CLI/LearnedSkills.hs
+++ b/packages/agent-cli/src/Agent/CLI/LearnedSkills.hs
@@ -20,7 +20,7 @@ module Agent.CLI.LearnedSkills
     , queueLearnedSkillContextWithOmissions
     ) where
 
-import Agent.CLI.Database (DatabaseScope(..), databaseScopeDecoder)
+import Agent.CLI.Database (CustomDatabaseScope(..), customDatabaseScopeDecoder)
 import Agent.CLI.Skills (resolveSkillContent)
 import Agent.MCP.Types (McpFleet)
 import Agent.Skills
@@ -62,7 +62,7 @@ import qualified Data.Text as Text
 import Data.Time.Clock (UTCTime)
 
 data LearnedSkillCreateRequest = LearnedSkillCreateRequest
-    { createRequestScope :: !DatabaseScope
+    { createRequestScope :: !CustomDatabaseScope
     , createRequestSlug :: !Text
     , createRequestTitle :: !Text
     , createRequestDescription :: !Text
@@ -76,7 +76,7 @@ data LearnedSkillCreateRequest = LearnedSkillCreateRequest
     deriving (Eq, Show)
 
 data LearnedSkillUpdateRequest = LearnedSkillUpdateRequest
-    { updateRequestScope :: !DatabaseScope
+    { updateRequestScope :: !CustomDatabaseScope
     , updateRequestSlug :: !Text
     , updateRequestExpectedRevision :: !Integer
     , updateRequestTitle :: !(Maybe Text)
@@ -91,7 +91,7 @@ data LearnedSkillUpdateRequest = LearnedSkillUpdateRequest
     deriving (Eq, Show)
 
 data LearnedSkillArchiveRequest = LearnedSkillArchiveRequest
-    { archiveRequestScope :: !DatabaseScope
+    { archiveRequestScope :: !CustomDatabaseScope
     , archiveRequestSlug :: !Text
     , archiveRequestExpectedRevision :: !Integer
     , archiveRequestChangeSummary :: !Text
@@ -100,7 +100,7 @@ data LearnedSkillArchiveRequest = LearnedSkillArchiveRequest
     deriving (Eq, Show)
 
 data LearnedSkillRollbackRequest = LearnedSkillRollbackRequest
-    { rollbackRequestScope :: !DatabaseScope
+    { rollbackRequestScope :: !CustomDatabaseScope
     , rollbackRequestSlug :: !Text
     , rollbackRequestExpectedRevision :: !Integer
     , rollbackRequestTargetRevision :: !Integer
@@ -348,7 +348,7 @@ data LearnedSkillToolsEnv = LearnedSkillToolsEnv
     { learnedSkillSearch
         :: !(Text -> Int -> IO (Either Text LearnedSkillSearchResponse))
     , learnedSkillRead
-        :: !(DatabaseScope -> Text -> Maybe Integer -> IO (Either Text LearnedSkillView))
+        :: !(CustomDatabaseScope -> Text -> Maybe Integer -> IO (Either Text LearnedSkillView))
     , learnedSkillCreate
         :: !(LearnedSkillCreateRequest -> IO (Either Text LearnedSkillMutationResponse))
     , learnedSkillUpdate
@@ -367,20 +367,20 @@ searchArgsDecoder = Hermes.object $
             <$> Hermes.atKey "query" Hermes.text
             <*> defaultKey 10 "limit" Hermes.int
 
-data ViewArgs = ViewArgs !Text !(Maybe DatabaseScope) !(Maybe Integer)
+data ViewArgs = ViewArgs !Text !(Maybe CustomDatabaseScope) !(Maybe Integer)
 
 viewArgsDecoder :: Hermes.Decoder ViewArgs
 viewArgsDecoder = Hermes.object $
         ViewArgs
             <$> Hermes.atKey "name" Hermes.text
-            <*> optionalKey "scope" databaseScopeDecoder
+            <*> optionalKey "scope" customDatabaseScopeDecoder
             <*> optionalKey "revision" integer
 
 learnedSkillCreateRequestDecoder :: Hermes.Decoder LearnedSkillCreateRequest
 learnedSkillCreateRequestDecoder = Hermes.object do
         activation <- optionalKey "activation" learnedSkillActivationDecoder
         LearnedSkillCreateRequest
-            <$> Hermes.atKey "scope" databaseScopeDecoder
+            <$> Hermes.atKey "scope" customDatabaseScopeDecoder
             <*> Hermes.atKey "slug" Hermes.text
             <*> Hermes.atKey "title" Hermes.text
             <*> Hermes.atKey "description" Hermes.text
@@ -394,7 +394,7 @@ learnedSkillCreateRequestDecoder = Hermes.object do
 learnedSkillUpdateRequestDecoder :: Hermes.Decoder LearnedSkillUpdateRequest
 learnedSkillUpdateRequestDecoder = Hermes.object $
         LearnedSkillUpdateRequest
-            <$> Hermes.atKey "scope" databaseScopeDecoder
+            <$> Hermes.atKey "scope" customDatabaseScopeDecoder
             <*> Hermes.atKey "slug" Hermes.text
             <*> Hermes.atKey "expected_revision" integer
             <*> optionalKey "title" Hermes.text
@@ -409,7 +409,7 @@ learnedSkillUpdateRequestDecoder = Hermes.object $
 learnedSkillArchiveRequestDecoder :: Hermes.Decoder LearnedSkillArchiveRequest
 learnedSkillArchiveRequestDecoder = Hermes.object $
         LearnedSkillArchiveRequest
-            <$> Hermes.atKey "scope" databaseScopeDecoder
+            <$> Hermes.atKey "scope" customDatabaseScopeDecoder
             <*> Hermes.atKey "slug" Hermes.text
             <*> Hermes.atKey "expected_revision" integer
             <*> Hermes.atKey "change_summary" Hermes.text
@@ -418,7 +418,7 @@ learnedSkillArchiveRequestDecoder = Hermes.object $
 learnedSkillRollbackRequestDecoder :: Hermes.Decoder LearnedSkillRollbackRequest
 learnedSkillRollbackRequestDecoder = Hermes.object $
         LearnedSkillRollbackRequest
-            <$> Hermes.atKey "scope" databaseScopeDecoder
+            <$> Hermes.atKey "scope" customDatabaseScopeDecoder
             <*> Hermes.atKey "slug" Hermes.text
             <*> Hermes.atKey "expected_revision" integer
             <*> Hermes.atKey "target_revision" integer

--- a/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DatabaseSpec.hs
@@ -4,6 +4,7 @@ import Agent.CLI.Database
 import Agent.CLI.Database.Storage
 import Agent.CLI.Database.Store
     ( DatabaseBrowsePage(..)
+    , applicableDatabaseScopes
     , databaseToolsEnvForStore
     , deriveDatabaseScopes
     , listDatabaseObjects
@@ -51,6 +52,8 @@ import Control.Exception.Safe (displayException, finally, onException)
 import Data.Aeson ((.=), object)
 import qualified Data.Aeson as Aeson
 import Data.IORef
+import Data.Either (isLeft)
+import Agent.Json.Decode qualified as Hermes
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory
@@ -65,7 +68,40 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "custom database scopes" do
+        it "decodes the existing custom wire strings" do
+            Hermes.decodeEither customDatabaseScopeDecoder "\"user\""
+                `shouldBe` Right DatabaseUserScope
+            Hermes.decodeEither customDatabaseScopeDecoder "\"repository\""
+                `shouldBe` Right DatabaseRepositoryScope
+            Hermes.decodeEither customDatabaseScopeDecoder "\"checkout\""
+                `shouldBe` Right DatabaseCheckoutScope
+
+        it "cannot decode the runtime catalog as custom data" do
+            Hermes.decodeEither customDatabaseScopeDecoder "\"harness\""
+                `shouldSatisfy` isLeft
+
     describe "databaseTools" do
+        mapM_ (\(wireScope, selected) ->
+            it ("dispatches custom mutations for " <> Text.unpack wireScope) do
+                seen <- newIORef Nothing
+                let env = testEnv
+                        { databaseRunExecute = \scope purpose sql -> do
+                            writeIORef seen (Just (scope, purpose, sql))
+                            pure (Right "ok")
+                        }
+                _ <- dispatchToolCall dispatchConfig
+                    (appToolHandlers (databaseTools env))
+                    (functionToolCall "custom-execute" "database_execute"
+                        ("{\"scope\":\"" <> wireScope
+                            <> "\",\"sql\":\"select 1\",\"purpose\":\"test\"}"))
+                readIORef seen `shouldReturn`
+                    Just (selected, "test", "select 1"))
+            [ ("user", DatabaseUserScope)
+            , ("repository", DatabaseRepositoryScope)
+            , ("checkout", DatabaseCheckoutScope)
+            ]
+
         it "dispatches a read-only query to the selected scope" do
             seen <- newIORef Nothing
             let env = testEnv
@@ -78,7 +114,7 @@ spec = do
                 (functionToolCall "call-1" "database_query"
                     "{\"scope\":\"user\",\"sql\":\"select * from todos\"}")
             readIORef seen `shouldReturn`
-                Just (DatabaseUserScope, "select * from todos")
+                Just (DatabaseCustomScope DatabaseUserScope, "select * from todos")
             result.output `shouldContainText` "title: test"
 
         it "rejects empty mutating SQL before calling storage" do
@@ -227,6 +263,18 @@ spec = do
             runStorageCommand env StorageDoctor `shouldReturn` Right "doctor"
 
     describe "deriveDatabaseScopes" do
+        it "maps every custom scope to its corresponding durable scope" do
+            directory <- getCurrentDirectory
+            deriveDatabaseScopes directory directory >>= \case
+                Left err -> expectationFailure (Text.unpack err)
+                Right scopes ->
+                    map (scopeForDatabase scopes)
+                        [ DatabaseUserScope
+                        , DatabaseRepositoryScope
+                        , DatabaseCheckoutScope
+                        ]
+                        `shouldBe` applicableDatabaseScopes scopes
+
         it "is stable for one state directory and checkout" do
             first <- deriveDatabaseScopes
                 "/tmp/haskell-agent-state"

--- a/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/LearnedSkillsSpec.hs
@@ -1,7 +1,7 @@
 module Agent.CLI.LearnedSkillsSpec (spec) where
 
 import Agent.CLI (learnAboutUserOnboardingPrompt)
-import Agent.CLI.Database (DatabaseScope(..))
+import Agent.CLI.Database (CustomDatabaseScope(..))
 import Agent.CLI.LearnedSkills
 import Agent.CLI.LearnedSkills.Store
     ( loadLearnedSkillsWithPreload
@@ -135,6 +135,31 @@ spec = do
             readIORef learnedSeen `shouldReturn`
                 Just (DatabaseRepositoryScope, "postgres-session", Just 2)
             learnedResult.output `shouldContainText` "Learned body"
+
+        it "rejects harness scope before reading or mutating learned skills" do
+            called <- newIORef False
+            invocationsRef <- newIORef []
+            let env = testEnv
+                    { learnedSkillRead = \_ _ _ -> do
+                        writeIORef called True
+                        pure (Right testLearnedSkillView)
+                    , learnedSkillArchive = \_ -> do
+                        writeIORef called True
+                        pure (Right testMutationResponse)
+                    }
+                handlers =
+                    appToolHandlers (learnedSkillTools invocationsRef Nothing env)
+            viewResult <- dispatchToolCall dispatchConfig handlers
+                (functionToolCall "harness-view" "view_skill"
+                    "{\"scope\":\"harness\",\"name\":\"test\"}")
+            archiveResult <- dispatchToolCall dispatchConfig handlers
+                (functionToolCall "harness-archive" "skill_archive"
+                    "{\"scope\":\"harness\",\"slug\":\"test\",\"expected_revision\":1,\"change_summary\":\"test\",\"evidence\":\"test\"}")
+            readIORef called `shouldReturn` False
+            viewResult.output `shouldContainText`
+                "the harness catalog is not available in this session"
+            archiveResult.output `shouldContainText`
+                "the harness catalog is not available in this session"
 
         it "rejects invalid mutations before calling storage" do
             called <- newIORef False

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/DatabaseBrowseBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/DatabaseBrowseBridge.hs
@@ -5,7 +5,7 @@
 -- | Read-only scoped database browsing and callback-scoped row marshalling.
 module Agent.CLI.MacOS.DatabaseBrowseBridge () where
 
-import Agent.CLI.Database (DatabaseScope(..))
+import Agent.CLI.Database (CustomDatabaseScope(..))
 import Agent.CLI.Database.Store
     ( DatabaseBrowsePage(..), DatabaseScopes, deriveDatabaseScopes
     , listDatabaseObjects, loadDatabaseRows )
@@ -175,7 +175,7 @@ loadDataCatalogFor cwd =
 
 loadDataPageFor
     :: FilePath
-    -> DatabaseScope
+    -> CustomDatabaseScope
     -> Text
     -> Int64
     -> Int
@@ -241,7 +241,7 @@ dataObjectKind = \case
     "materialized_view" -> 1
     _ -> 0
 
-dataScopeFromCode :: CInt -> Maybe DatabaseScope
+dataScopeFromCode :: CInt -> Maybe CustomDatabaseScope
 dataScopeFromCode = \case
     0 -> Just DatabaseUserScope
     1 -> Just DatabaseRepositoryScope

--- a/packages/agent-native-bridge/src/Agent/CLI/ResourceAdmin.hs
+++ b/packages/agent-native-bridge/src/Agent/CLI/ResourceAdmin.hs
@@ -29,7 +29,7 @@ import Agent.CLI.Database.Store
     , applicableDatabaseScopes
     , scopeForDatabase
     )
-import Agent.CLI.Database (DatabaseScope(..))
+import Agent.CLI.Database (CustomDatabaseScope(..))
 import Agent.Store.Postgres (Store, trustedPool)
 import Agent.Store.Postgres.Scope
     ( Scope(..)


### PR DESCRIPTION
## Summary
- Separate `CustomDatabaseScope` (user/repository/checkout) from queryable `DatabaseScope`, which also includes harness.
- Make `scopeForDatabase` total and narrow mutation callbacks, learned-skill requests, and native browser APIs to custom scopes.
- Preserve scope wire strings, native numeric scope codes, existing error messages, and the read-only harness boundary. This is a type-design refactor, not a claim of an exposed crash or a performance improvement.

## Validation
- `nix develop -c cabal repl agent-cli:lib:agent-cli agent-native-bridge:lib:agent-native-bridge`: verified `Ok, 255 modules loaded.`
- `nix develop -c cabal repl agent-cli:test:agent-cli-test`: verified `Ok, 105 modules loaded.`, then ran `Test.Hspec.hspec (Agent.CLI.DatabaseSpec.spec >> Agent.CLI.LearnedSkillsSpec.spec)`: **31 examples, 0 failures**, including PostgreSQL-backed browser coverage.
- Focused regression coverage for custom scope decoding/mapping/dispatch and harness rejection before learned-skill callbacks.
- Reviewed diff and `git diff --check` passed. No CLI UI behavior or Cabal changes; tmux and package.nix regeneration are not applicable. macOS-only FFI changes were reviewed but cannot be loaded on this Linux host.
