### PR TITLE
Simplify agent loop state and submission types

### DIFF
--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -211,63 +211,66 @@ emptyContinuationWarning :: Text
 emptyContinuationWarning =
     "The model produced no assistant text or tool calls after reasoning; stopping."
 
-data LoopCursor = LoopCursor
-    { cursorState :: !BackendSnapshot
-    , cursorProgress :: !LoopProgress
-    , cursorPreviousResponseId :: !(Maybe Text)
-    , cursorTurnsUsed :: !Int
-    , cursorInputs :: ![TurnInput]
-    , cursorSteeringCount :: !Int
-    , cursorLastOutput :: !(Maybe TurnOutput)
-    , cursorTokenUsage :: !TokenUsage
-    , cursorEmptyContinuations :: !Int
+-- | The loop's last owned checkpoint and the work following it. The state
+-- store may publish a newer reset/compaction; recovery must still check ownership.
+-- Normal execution and failure recovery read the same runtime-owned value.
+data LoopState = LoopState
+    { checkpoint :: !BackendSnapshot
+    , progress :: !LoopProgress
+    , pending :: !PendingInputs
+    , previousResponseId :: !(Maybe Text)
+    , turnsUsed :: !Int
+    , lastOutput :: !(Maybe TurnOutput)
+    , tokenUsage :: !TokenUsage
+    , emptyContinuations :: !Int
+    }
+
+-- | A response can absorb its inputs before the caller's steering queue is
+-- acknowledged. Clearing inputs must not erase that acknowledgement debt.
+data PendingInputs = PendingInputs
+    { inputs :: ![TurnInput]
+    , steeringToAcknowledge :: !Int
     }
 
 data CompletedTurnDecision
-    = ContinueLoop !LoopCursor
+    = ContinueLoop { nextEmptyContinuations :: !Int }
     | FinishLoop !LoopResult
     | WarnAndFinishLoop !LoopResult
 
 decideCompletedTurn
-    :: LoopCursor
+    :: LoopState
     -> TurnOutput
     -> [TurnInput]
-    -> Int
     -> CompletedTurnDecision
-decideCompletedTurn cursor turn continuation steeringCount
+decideCompletedTurn state turn continuation
     | not (null continuation) =
-        ContinueLoop cursor
-            { cursorPreviousResponseId = Just turn.responseId
-            , cursorTurnsUsed = nextTurnsUsed
-            , cursorInputs = continuation
-            , cursorSteeringCount = steeringCount
-            , cursorLastOutput = Just turn
-            , cursorTokenUsage = usage
-            , cursorEmptyContinuations = 0
-            }
+        ContinueLoop 0
     | hasVisibleAssistantText turn.assistantText =
         FinishLoop result
-    | cursor.cursorEmptyContinuations >= maxEmptyContinuations =
+    | state.emptyContinuations >= maxEmptyContinuations =
         WarnAndFinishLoop result
     | otherwise =
-        ContinueLoop cursor
-            { cursorPreviousResponseId = Just turn.responseId
-            , cursorTurnsUsed = nextTurnsUsed
-            , cursorInputs = []
-            , cursorSteeringCount = 0
-            , cursorLastOutput = Just turn
-            , cursorTokenUsage = usage
-            , cursorEmptyContinuations =
-                cursor.cursorEmptyContinuations + 1
-            }
+        ContinueLoop (state.emptyContinuations + 1)
   where
-    nextTurnsUsed = cursor.cursorTurnsUsed + 1
-    usage = addTokenUsage cursor.cursorTokenUsage turn.tokenUsage
+    nextTurnsUsed = state.turnsUsed + 1
+    usage = addTokenUsage state.tokenUsage turn.tokenUsage
     result = LoopResult
         { finalResponseId = turn.responseId
         , finalText = turn.assistantText
         , turnsUsed = nextTurnsUsed
         , tokenUsage = usage
+        }
+
+-- | Advance only continuation bookkeeping; the owned checkpoint is untouched.
+advanceLoopState :: TurnOutput -> PendingInputs -> Int -> LoopState -> LoopState
+advanceLoopState turn pending emptyContinuations state =
+    state
+        { previousResponseId = Just turn.responseId
+        , turnsUsed = state.turnsUsed + 1
+        , lastOutput = Just turn
+        , tokenUsage = addTokenUsage state.tokenUsage turn.tokenUsage
+        , pending
+        , emptyContinuations
         }
 
 runLoop
@@ -310,16 +313,30 @@ data LoopRuntime = LoopRuntime
     { loopRuntimeConfig :: LoopConfig
     , loopRuntimeEventPump :: LoopEventPump
     , loopRuntimeAsyncToolManager :: AsyncToolManager
-    , loopRuntimeProgressRef :: IORef (BackendSnapshot, LoopProgress)
-    , loopRuntimePendingRef :: IORef [TurnInput]
-    , loopRuntimePendingSteeringRef :: IORef Int
+    , loopRuntimeState :: IORef LoopState
     , loopRuntimeVisibleStateRef :: IORef VisibleLoopState
     , loopRuntimeProviderTelemetryRef :: IORef [TurnTelemetry]
-    , loopRuntimeInitialSteering :: [TurnInput]
     }
 
-type LoopSubmissionResult =
-    Either () (Either LoopError BackendResult)
+-- A returned response is not necessarily complete or a valid checkpoint.
+data SubmissionOutcome
+    = SubmissionReturned !BackendResult
+    | SubmissionCancelled
+    | SubmissionFailed !LoopError
+
+-- Closing consumes the journal and rejects any callbacks retained by a backend.
+data RecoveryJournal
+    = RecoveryClosed
+    | RecoveryOpen
+        { recoverySummary :: !(Maybe Text)
+        -- Newest first while the journal is open.
+        , recoveryItems :: ![(ResponseItem, Maybe ToolCall)]
+        }
+
+data AttemptVisibility = AttemptVisibility
+    { previousAttemptVisible :: !Bool
+    , currentAttemptVisible :: !Bool
+    }
 
 runLoopInputsUnsafe
     :: LoopConfig
@@ -328,26 +345,34 @@ runLoopInputsUnsafe
     -> [TurnInput]
     -> IO LoopExecution
 runLoopInputsUnsafe config0 initialState previousResponseId firstInputs = do
-    runtime <- initializeLoopRuntime config0 initialState firstInputs
-    runLoopWithEventPump runtime initialState previousResponseId firstInputs
+    runtime <- initializeLoopRuntime config0 initialState previousResponseId firstInputs
+    runLoopWithEventPump runtime
 
 initializeLoopRuntime
     :: LoopConfig
     -> BackendSnapshot
+    -> Maybe Text
     -> [TurnInput]
     -> IO LoopRuntime
-initializeLoopRuntime config0 initialState firstInputs = do
+initializeLoopRuntime config0 initialState previousResponseId firstInputs = do
     eventPump <- newEventPump config0.loopOnEvent
     -- Allocate only STM state here; the manager's workers remain scoped to
     -- runLoopWithEventPump.
     manager <- newAsyncToolManager
     eventAdmissionLock <- newMVar ()
-    progressRef <- newIORef (initialState, NoResponseCommitted)
     visibleStateRef <- newIORef emptyVisibleLoopState
     providerTelemetryRef <- newIORef []
     initialSteering <- config0.loopReadSteering
-    pendingRef <- newIORef (firstInputs <> initialSteering)
-    pendingSteeringRef <- newIORef (length initialSteering)
+    stateRef <- newIORef LoopState
+        { checkpoint = initialState
+        , progress = NoResponseCommitted
+        , pending = PendingInputs (firstInputs <> initialSteering) (length initialSteering)
+        , previousResponseId
+        , turnsUsed = 0
+        , lastOutput = Nothing
+        , tokenUsage = emptyTokenUsage
+        , emptyContinuations = 0
+        }
     let config = config0
             { loopOnEvent = \event ->
                 -- Provider streaming and async host tools can publish at the
@@ -363,30 +388,41 @@ initializeLoopRuntime config0 initialState firstInputs = do
         { loopRuntimeConfig = config
         , loopRuntimeEventPump = eventPump
         , loopRuntimeAsyncToolManager = manager
-        , loopRuntimeProgressRef = progressRef
-        , loopRuntimePendingRef = pendingRef
-        , loopRuntimePendingSteeringRef = pendingSteeringRef
+        , loopRuntimeState = stateRef
         , loopRuntimeVisibleStateRef = visibleStateRef
         , loopRuntimeProviderTelemetryRef = providerTelemetryRef
-        , loopRuntimeInitialSteering = initialSteering
         }
+
+-- Updates belong to the loop worker, or recovery after that worker is joined.
+-- Never restore an entire pre-submission snapshot after running effects.
+recordCheckpoint :: LoopRuntime -> BackendSnapshot -> IO ()
+recordCheckpoint runtime checkpoint =
+    modifyIORef' runtime.loopRuntimeState \state ->
+        state { checkpoint, progress = ResponseCommitted }
+
+setPendingInputs :: LoopRuntime -> [TurnInput] -> IO ()
+setPendingInputs runtime inputs =
+    modifyIORef' runtime.loopRuntimeState \state ->
+        state { pending = state.pending { inputs } }
+
+clearSteeringAcknowledgement :: LoopRuntime -> IO ()
+clearSteeringAcknowledgement runtime =
+    modifyIORef' runtime.loopRuntimeState \state ->
+        state { pending = state.pending { steeringToAcknowledge = 0 } }
 
 finishLoopExecution
     :: LoopRuntime
-    -> BackendSnapshot
-    -> LoopProgress
     -> Either LoopError LoopResult
     -> IO LoopExecution
-finishLoopExecution runtime state progress result = do
-    writeIORef runtime.loopRuntimeProgressRef (state, progress)
-    pending <- readIORef runtime.loopRuntimePendingRef
+finishLoopExecution runtime result = do
+    state <- readIORef runtime.loopRuntimeState
     visibleState <- readIORef runtime.loopRuntimeVisibleStateRef
     providerTelemetry <-
         reverse <$> readIORef runtime.loopRuntimeProviderTelemetryRef
     pure LoopExecution
-        { executionState = state.backendItems
-        , executionPendingInputs = pending
-        , executionProgress = progress
+        { executionState = state.checkpoint.backendItems
+        , executionPendingInputs = state.pending.inputs
+        , executionProgress = state.progress
         , executionUncommittedAssistantText =
             visibleAssistantText visibleState
         , executionUncommittedDisplayEvents = visibleDisplayEvents visibleState
@@ -394,111 +430,77 @@ finishLoopExecution runtime state progress result = do
         , executionResult = result
         }
 
-finishLoopCursor
-    :: LoopRuntime
-    -> LoopCursor
-    -> Either LoopError LoopResult
-    -> IO LoopExecution
-finishLoopCursor runtime cursor =
-    finishLoopExecution
-        runtime
-        cursor.cursorState
-        cursor.cursorProgress
-
 unexpectedLoopExecution
     :: LoopRuntime
-    -> BackendSnapshot
-    -> LoopProgress
     -> SomeException
     -> IO LoopExecution
-unexpectedLoopExecution runtime state progress exception =
-    finishLoopExecution runtime state progress
+unexpectedLoopExecution runtime exception =
+    finishLoopExecution runtime
         (Left (LoopUnexpected (exceptionSummary exception)))
 
-unexpectedLoopCursor
+protectLoop
     :: LoopRuntime
-    -> LoopCursor
-    -> SomeException
     -> IO LoopExecution
-unexpectedLoopCursor runtime _cursor exception = do
-    (state, progress) <- readIORef runtime.loopRuntimeProgressRef
-    unexpectedLoopExecution runtime state progress exception
+    -> IO LoopExecution
+protectLoop runtime action =
+    tryAny action >>= either (unexpectedLoopExecution runtime) pure
 
-protectLoopCursor
-    :: LoopRuntime
-    -> LoopCursor
-    -> IO LoopExecution
-    -> IO LoopExecution
-protectLoopCursor runtime cursor action =
-    tryAny action >>= either (unexpectedLoopCursor runtime cursor) pure
-
-runLoopCursor :: LoopRuntime -> LoopCursor -> IO LoopExecution
-runLoopCursor runtime cursor = do
+runLoopState :: LoopRuntime -> IO LoopExecution
+runLoopState runtime = do
     let config = runtime.loopRuntimeConfig
-    writeIORef runtime.loopRuntimeProgressRef
-        (cursor.cursorState, cursor.cursorProgress)
-    writeIORef runtime.loopRuntimePendingRef cursor.cursorInputs
-    writeIORef runtime.loopRuntimePendingSteeringRef cursor.cursorSteeringCount
-    if cursor.cursorTurnsUsed >= config.loopMaxTurns
-        then finishLoopCursor runtime cursor $ case cursor.cursorLastOutput of
+    state <- readIORef runtime.loopRuntimeState
+    if state.turnsUsed >= config.loopMaxTurns
+        then finishLoopExecution runtime $ case state.lastOutput of
             Just turn -> Left (LoopMaxTurns turn)
             Nothing -> Left LoopNoResponseId
-        else protectLoopCursor runtime cursor do
+        else protectLoop runtime do
             cancelled <- isCancelled config.loopCancel
             if cancelled
-                then finishLoopCursor runtime cursor
+                then finishLoopExecution runtime
                     (Left (LoopCancelled []))
                 else do
                     config.loopOnEvent TurnStarted
-                    submission <- submitLoopTurn runtime cursor
-                    (latestState, latestProgress) <-
-                        readIORef runtime.loopRuntimeProgressRef
-                    let interruptedCursor = cursor
-                            { cursorState = latestState
-                            , cursorProgress = latestProgress
-                            }
+                    submission <- submitLoopTurn runtime state
                     case submission of
-                        Left () ->
-                            finishLoopCursor runtime interruptedCursor
+                        SubmissionCancelled ->
+                            finishLoopExecution runtime
                                 (Left (LoopCancelled []))
-                        Right (Left err) ->
-                            finishLoopCursor runtime interruptedCursor (Left err)
-                        Right
-                            (Right BackendResult{backendOutput = turn})
+                        SubmissionFailed err ->
+                            finishLoopExecution runtime (Left err)
+                        SubmissionReturned BackendResult{backendOutput = turn}
                             | Text.null turn.responseId ->
-                                finishLoopCursor runtime interruptedCursor
+                                finishLoopExecution runtime
                                     (Left LoopNoResponseId)
-                        Right (Right BackendResult{..}) ->
-                            continueCommittedLoop
-                                runtime
-                                cursor
-                                    { cursorState = backendState
-                                    , cursorProgress = ResponseCommitted
-                                    }
-                                backendOutput
+                        SubmissionReturned BackendResult{backendOutput} ->
+                            continueCommittedLoop runtime backendOutput
 
 submitLoopTurn
     :: LoopRuntime
-    -> LoopCursor
-    -> IO LoopSubmissionResult
-submitLoopTurn runtime cursor = do
+    -> LoopState
+    -> IO SubmissionOutcome
+submitLoopTurn runtime state = do
     let config = runtime.loopRuntimeConfig
-    visibleAttempts <- newIORef (False, False)
+    visibleAttempts <- newIORef (AttemptVisibility False False)
     cancellationMode <- newIORef InterruptThenCancel
     -- The callback belongs to this submission, not to the backend process.
     -- Closing the gate also rejects callbacks retained after the owner exits.
-    recovery <- newMVar (True, Nothing, [])
-    let checkpoint text = modifyMVar_ recovery \(active, previous, items) ->
-            if active
-                then let bounded = Text.copy (Text.take 32768 text)
-                     in bounded `seq` pure (active, Just bounded, items)
-                else pure (active, previous, items)
-        completedItem item call = modifyMVar_ recovery \(active, summary, items) ->
-            pure (active, summary, if active then (item, call) : items else items)
-        clearRecovery = modifyMVar_ recovery \(active, _, _) ->
-            pure (active, Nothing, [])
-        closeRecovery = modifyMVar recovery \(_, summary, items) ->
-            pure ((False, Nothing, []), (summary, reverse items))
+    recovery <- newMVar (RecoveryOpen Nothing [])
+    let checkpoint text = modifyMVar_ recovery \case
+            RecoveryClosed -> pure RecoveryClosed
+            journal@RecoveryOpen{} ->
+                let bounded = Text.copy (Text.take 32768 text)
+                in bounded `seq` pure journal { recoverySummary = Just bounded }
+        completedItem item call = modifyMVar_ recovery \case
+            RecoveryClosed -> pure RecoveryClosed
+            journal@RecoveryOpen{recoveryItems} ->
+                pure journal { recoveryItems = (item, call) : recoveryItems }
+        clearRecovery = modifyMVar_ recovery \case
+            RecoveryClosed -> pure RecoveryClosed
+            RecoveryOpen{} -> pure (RecoveryOpen Nothing [])
+        closeRecovery = modifyMVar recovery \case
+            RecoveryClosed -> pure (RecoveryClosed, (Nothing, []))
+            RecoveryOpen{..} ->
+                pure (RecoveryClosed, (recoverySummary, reverse recoveryItems))
         publishRecovery = do
             (summary, items) <- closeRecovery
             current <- config.loopBackendState.readBackendState
@@ -509,7 +511,7 @@ submitLoopTurn runtime cursor = do
             case () of
                 _
                     | hasSummary || not (null items)
-                    , current == cursor.cursorState -> do
+                    , current == state.checkpoint -> do
                         let note = Text.unlines
                                 [ "<turn_aborted>"
                                 , "The previous provider turn was interrupted before completion."
@@ -524,7 +526,7 @@ submitLoopTurn runtime cursor = do
                             candidate = advanceBackendSnapshot
                                 current
                                 (current.backendItems
-                                    <> turnInputsToItems cursor.cursorInputs
+                                    <> turnInputsToItems state.pending.inputs
                                     <> map fst items
                                     <> if hasSummary
                                         then turnInputsToItems [UserMessage note]
@@ -534,13 +536,12 @@ submitLoopTurn runtime cursor = do
                             config.loopBackendState.commitBackendState candidate
                         acknowledgeManagedTools
                             (asyncToolManager runtime)
-                            cursor.cursorInputs
+                            state.pending.inputs
                             (catMaybes (map snd items))
-                        writeIORef runtime.loopRuntimeProgressRef
-                            (committed, ResponseCommitted)
-                        writeIORef runtime.loopRuntimePendingRef []
-                        config.loopCommitSteering cursor.cursorSteeringCount
-                        writeIORef runtime.loopRuntimePendingSteeringRef 0
+                        recordCheckpoint runtime committed
+                        setPendingInputs runtime []
+                        config.loopCommitSteering state.pending.steeringToAcknowledge
+                        clearSteeringAcknowledgement runtime
                 _ -> pure ()
     let onBackendEvent event = do
             case event of
@@ -548,21 +549,26 @@ submitLoopTurn runtime cursor = do
                     | visibleResponseActivity event ->
                         modifyIORef'
                             visibleAttempts
-                            (\(prior, _) -> (prior, True))
+                            (\visibility -> visibility { currentAttemptVisible = True })
                 -- A retry keeps the previous attempt visible while opening a
                 -- fresh current attempt.
                 ResponseRestarted _ -> do
                     clearRecovery
                     modifyIORef'
                         visibleAttempts
-                        (\(prior, current) -> (prior || current, False))
+                        (\visibility -> AttemptVisibility
+                            { previousAttemptVisible =
+                                visibility.previousAttemptVisible
+                                    || visibility.currentAttemptVisible
+                            , currentAttemptVisible = False
+                            })
                 -- The backend rolled that attempt back, but earlier restarted
                 -- attempts remain visible.
                 ResponseAttemptDiscarded -> do
                     clearRecovery
                     modifyIORef'
                         visibleAttempts
-                        (\(prior, _) -> (prior, False))
+                        (\visibility -> visibility { currentAttemptVisible = False })
                 _ -> pure ()
             config.loopOnEvent event
     -- Race the model call against cancel so Ctrl-C / Esc can stop reasoning
@@ -571,22 +577,24 @@ submitLoopTurn runtime cursor = do
         normalized <- (withAsync
             (restore $
                 config.loopBackend.submitTurnWithCallbacks
-                    (normalizeBackendSnapshotImages cursor.cursorState)
-                    cursor.cursorPreviousResponseId
-                    (normalizeTurnInputs cursor.cursorInputs)
+                    (normalizeBackendSnapshotImages state.checkpoint)
+                    state.previousResponseId
+                    (normalizeTurnInputs state.pending.inputs)
                     BackendCallbacks
                         { onLoopEvent = onBackendEvent
                         , onAsyncToolCall = \call ->
-                            withMVar recovery \(active, _, _) ->
-                                when active $
+                            withMVar recovery \case
+                                RecoveryClosed -> pure ()
+                                RecoveryOpen{} ->
                                     admitAsyncToolCall
                                         (asyncToolManager runtime)
                                         call
                         , onRecoveryCheckpoint = checkpoint
                         , onCompletedResponseItem = completedItem
                         , onCancellationMode = \mode ->
-                            withMVar recovery \(active, _, _) ->
-                                when active (writeIORef cancellationMode mode)
+                            withMVar recovery \case
+                                RecoveryClosed -> pure ()
+                                RecoveryOpen{} -> writeIORef cancellationMode mode
                         })
             \submission -> do
                 result <- restore $ race
@@ -604,65 +612,60 @@ submitLoopTurn runtime cursor = do
                             _ <- restore $
                                 timeout 2000000 (waitCatch submission)
                             pure ()
-                        pure (Left ())
+                        pure SubmissionCancelled
                     Right (Left exception) ->
                         -- Preserve the provider thread's asynchronous-exception
                         -- identity. Safe.throwIO would turn ThreadKilled into
                         -- LoopUnexpected.
                         Exception.throwIO exception
                     Right (Right completed) ->
-                        pure (Right completed)
+                        pure (either (SubmissionFailed . LoopTransport) SubmissionReturned completed)
                 case normalized of
-                    Right (Right backendResult@BackendResult{..})
+                    SubmissionReturned backendResult@BackendResult{..}
                         | not (Text.null backendOutput.responseId) -> do
                             committed <-
                                 config.loopBackendState.commitBackendState
                                     backendState
                             acknowledgeManagedTools
                                 (asyncToolManager runtime)
-                                cursor.cursorInputs
+                                state.pending.inputs
                                 backendOutput.toolCalls
-                            writeIORef runtime.loopRuntimeProgressRef
-                                (committed, ResponseCommitted)
+                            recordCheckpoint runtime committed
                             pure
-                                (Right
-                                    (Right backendResult
-                                        { backendState = committed
-                                        }))
+                                (SubmissionReturned backendResult
+                                    { backendState = committed
+                                    })
                     _ -> pure normalized)
             `onException` publishRecovery
         case normalized of
-            Right (Right BackendResult{backendOutput})
+            SubmissionReturned BackendResult{backendOutput}
                 | not (Text.null backendOutput.responseId) -> do
                     _ <- closeRecovery
                     pure normalized
             _ -> publishRecovery >> pure normalized
     case raced of
-        Left () -> pure (Left ())
-        Right (Left err) -> do
-            (priorVisible, currentVisible) <- readIORef visibleAttempts
-            let emitted = priorVisible || currentVisible
+        SubmissionCancelled -> pure SubmissionCancelled
+        SubmissionFailed (LoopTransport err) -> do
+            visibility <- readIORef visibleAttempts
+            let emitted =
+                    visibility.previousAttemptVisible || visibility.currentAttemptVisible
             when emitted $
                 config.loopOnEvent ResponseAttemptFailed
-            pure $ Right $ Left $
+            pure $ SubmissionFailed $
                 if emitted
                     then LoopTransportAfterOutput err
                     else LoopTransport err
-        Right (Right backendResult) ->
-            pure (Right (Right backendResult))
+        outcome -> pure outcome
 
 continueCommittedLoop
     :: LoopRuntime
-    -> LoopCursor
     -> TurnOutput
     -> IO LoopExecution
-continueCommittedLoop runtime cursor turn = do
+continueCommittedLoop runtime turn = do
     let config = runtime.loopRuntimeConfig
-    writeIORef runtime.loopRuntimeProgressRef
-        (cursor.cursorState, ResponseCommitted)
     -- The committed response absorbed every input submitted with it, and its
     -- assistant text now lives in the committed state.
-    writeIORef runtime.loopRuntimePendingRef []
+    setPendingInputs runtime []
     -- Async tool publishers may still be active. Reset the whole snapshot
     -- atomically without introducing a blocking checkpoint during commit.
     atomicWriteIORef runtime.loopRuntimeVisibleStateRef emptyVisibleLoopState
@@ -674,12 +677,12 @@ continueCommittedLoop runtime cursor turn = do
             modifyIORef'
                 runtime.loopRuntimeProviderTelemetryRef
                 (telemetry :)
-    protectLoopCursor runtime cursor do
+    protectLoop runtime do
         -- A cancel that landed during submitTurn after the race chose Right
         -- still counts, but its returned state is committed.
         cancelledMid <- isCancelled config.loopCancel
         if cancelledMid
-            then finishLoopCursor runtime cursor
+            then finishLoopExecution runtime
                 (Left (LoopCancelled []))
             else do
                 config.loopOnEvent (TurnFinished turn)
@@ -689,11 +692,12 @@ continueCommittedLoop runtime cursor turn = do
                         -- than an assistant completion. Leaving the enclosing
                         -- loop scope cancels and joins any async calls that
                         -- were announced before the incomplete response.
-                        finishLoopCursor runtime cursor
+                        finishLoopExecution runtime
                             (Left (LoopIncomplete turn))
                     TurnCompleted -> do
-                        config.loopCommitSteering cursor.cursorSteeringCount
-                        writeIORef runtime.loopRuntimePendingSteeringRef 0
+                        state <- readIORef runtime.loopRuntimeState
+                        config.loopCommitSteering state.pending.steeringToAcknowledge
+                        clearSteeringAcknowledgement runtime
                         racedResults <-
                             race
                                 (waitCancel config.loopCancel)
@@ -706,72 +710,49 @@ continueCommittedLoop runtime cursor turn = do
                                 -- 'runLoopWithEventPump'. Returning here lets
                                 -- that scope cancel and join a handler or an
                                 -- approval callback that has not completed.
-                                finishLoopCursor runtime cursor
+                                finishLoopExecution runtime
                                     (Left (LoopCancelled []))
                             Right results -> do
-                                writeIORef
-                                    runtime.loopRuntimePendingRef
-                                    (map CompletedTool results)
+                                setPendingInputs runtime (map CompletedTool results)
                                 cancelledAfter <-
                                     isCancelled config.loopCancel
                                 if cancelledAfter
-                                    then finishLoopCursor runtime cursor
+                                    then finishLoopExecution runtime
                                         (Left (LoopCancelled results))
                                     else do
                                         steering <- config.loopReadSteering
                                         let continuation =
                                                 map CompletedTool results
                                                     <> steering
-                                        case decideCompletedTurn
-                                            cursor
-                                            turn
-                                            continuation
-                                            (length steering) of
-                                            ContinueLoop nextCursor ->
-                                                runLoopCursor runtime nextCursor
+                                        latest <- readIORef runtime.loopRuntimeState
+                                        case decideCompletedTurn latest turn continuation of
+                                            ContinueLoop{nextEmptyContinuations} -> do
+                                                modifyIORef' runtime.loopRuntimeState $
+                                                    advanceLoopState turn
+                                                        (PendingInputs continuation (length steering))
+                                                        nextEmptyContinuations
+                                                runLoopState runtime
                                             FinishLoop result ->
-                                                finishLoopCursor runtime cursor
+                                                finishLoopExecution runtime
                                                     (Right result)
                                             WarnAndFinishLoop result -> do
                                                 config.loopOnEvent
                                                     (WarningRaised
                                                         emptyContinuationWarning)
-                                                finishLoopCursor runtime cursor
+                                                finishLoopExecution runtime
                                                     (Right result)
 
 runLoopWithEventPump
     :: LoopRuntime
-    -> BackendSnapshot
-    -> Maybe Text
-    -> [TurnInput]
     -> IO LoopExecution
-runLoopWithEventPump runtime initialState previousResponseId firstInputs =
+runLoopWithEventPump runtime =
     withAsync (runEventPump runtime.loopRuntimeEventPump) \eventWorker -> do
         let manager = asyncToolManager runtime
-            initialSteering = runtime.loopRuntimeInitialSteering
-            run =
-                runLoopCursor runtime LoopCursor
-                    { cursorState = initialState
-                    , cursorProgress = NoResponseCommitted
-                    , cursorPreviousResponseId = previousResponseId
-                    , cursorTurnsUsed = 0
-                    , cursorInputs = firstInputs <> initialSteering
-                    , cursorSteeringCount = length initialSteering
-                    , cursorLastOutput = Nothing
-                    , cursorTokenUsage = emptyTokenUsage
-                    , cursorEmptyContinuations = 0
-                    }
             handleManagerFailure exception
                 | isAsyncException exception =
                     Exception.throwIO exception
-                | otherwise = do
-                    (state, progress) <-
-                        readIORef runtime.loopRuntimeProgressRef
-                    unexpectedLoopExecution
-                        runtime
-                        state
-                        progress
-                        exception
+                | otherwise =
+                    unexpectedLoopExecution runtime exception
         execution <-
             withAsync
                 (runAsyncToolManager
@@ -787,16 +768,11 @@ runLoopWithEventPump runtime initialState previousResponseId firstInputs =
                                 (waitAsyncToolManagerFailure
                                     managerWorker
                                     manager))
-                            run
+                            (runLoopState runtime)
                     case raced of
-                        Left (Left failure) -> do
-                            (state, progress) <-
-                                readIORef
-                                    runtime.loopRuntimeProgressRef
+                        Left (Left failure) ->
                             handleLoopEventFailure
                                 (unexpectedLoopExecution runtime)
-                                state
-                                progress
                                 failure
                         Left (Right exception) ->
                             handleManagerFailure exception
@@ -811,18 +787,13 @@ runLoopWithEventPump runtime initialState previousResponseId firstInputs =
         -- of its sibling tools have already finished successfully.
         recovered <- tryAny (recoverManagedTools runtime manager execution) >>= \case
             Right recovered -> pure recovered
-            Left exception -> do
-                (state, progress) <- readIORef runtime.loopRuntimeProgressRef
-                unexpectedLoopExecution runtime state progress exception
+            Left exception ->
+                unexpectedLoopExecution runtime exception
         flushEventPump runtime.loopRuntimeEventPump >>= \case
             Left failure ->
-                readIORef runtime.loopRuntimeProgressRef
-                    >>= \(state, progress) ->
-                        handleLoopEventFailure
-                            (unexpectedLoopExecution runtime)
-                            state
-                            progress
-                            failure
+                handleLoopEventFailure
+                    (unexpectedLoopExecution runtime)
+                    failure
             Right () -> pure recovered
 
 -- | A tool result is acknowledged only when the response consuming it commits,
@@ -884,14 +855,14 @@ recoverManagedTools runtime manager execution = do
                     (\completed -> all ((/= completed.callId) . (.callId)) previous)
                     salvaged))
             other -> other
-    writeIORef runtime.loopRuntimePendingRef pending
+    setPendingInputs runtime pending
     if null orphans
         then pure execution
             { executionPendingInputs = pending
             , executionResult = result
             }
         else do
-            (owned, _) <- readIORef runtime.loopRuntimeProgressRef
+            owned <- (.checkpoint) <$> readIORef runtime.loopRuntimeState
             current <- runtime.loopRuntimeConfig.loopBackendState.readBackendState
             -- Reset/compaction may have installed a newer checkpoint. Do not
             -- resurrect a submission's superseded history.
@@ -909,16 +880,16 @@ recoverManagedTools runtime manager execution = do
                     -- A failed checkpoint must still return the trusted host
                     -- evidence as pending input, rather than lose it to an
                     -- exception escaping the detailed loop result.
-                    writeIORef runtime.loopRuntimePendingRef recoveryInputs
+                    setPendingInputs runtime recoveryInputs
                     committed <-
                         runtime.loopRuntimeConfig.loopBackendState.commitBackendState
                             candidate
-                    writeIORef runtime.loopRuntimeProgressRef
-                        (committed, ResponseCommitted)
-                    writeIORef runtime.loopRuntimePendingRef []
-                    steeringCount <- readIORef runtime.loopRuntimePendingSteeringRef
-                    runtime.loopRuntimeConfig.loopCommitSteering steeringCount
-                    writeIORef runtime.loopRuntimePendingSteeringRef 0
+                    recordCheckpoint runtime committed
+                    setPendingInputs runtime []
+                    state <- readIORef runtime.loopRuntimeState
+                    runtime.loopRuntimeConfig.loopCommitSteering
+                        state.pending.steeringToAcknowledge
+                    clearSteeringAcknowledgement runtime
                     pure execution
                         { executionState = committed.backendItems
                         , executionPendingInputs = []
@@ -973,14 +944,12 @@ managedRecoveryNote calls = Text.unlines
                     ]
 
 handleLoopEventFailure
-    :: (BackendSnapshot -> LoopProgress -> SomeException -> IO LoopExecution)
-    -> BackendSnapshot
-    -> LoopProgress
+    :: (SomeException -> IO LoopExecution)
     -> EventPumpFailure
     -> IO LoopExecution
-handleLoopEventFailure unexpected state progress = \case
+handleLoopEventFailure unexpected = \case
     EventPumpSyncFailure exception ->
-        unexpected state progress exception
+        unexpected exception
     EventPumpAsyncFailure exception ->
         Exception.throwIO exception
 

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -1744,6 +1744,38 @@ spec = describe "runLoop" do
         execution.executionPendingInputs `shouldBe`
             [CompletedTool (ToolCallResult "c1" "echo:hi" FunctionCallKind BlockingToolCall [] (Just ToolSucceeded))]
 
+    it "retains completed tools when reading the next steering inputs throws" do
+        submissions <- newIORef []
+        steeringReads <- newIORef (0 :: Int)
+        acknowledgements <- newIORef []
+        backend <- retainingEchoCall <$> scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [functionToolCall "c1" "echo" "{\"message\":\"hi\"}"]
+                Nothing
+            ]
+        config0 <- testConfig backend
+        let config = config0
+                { loopReadSteering = do
+                    count <- atomicModifyIORef' steeringReads \n -> (n + 1, n)
+                    if count == 0
+                        then pure [UserMessage "also verify tests"]
+                        else Safe.throwIO (userError "steering unavailable")
+                , loopCommitSteering = \count ->
+                    modifyIORef' acknowledgements (<> [count])
+                }
+        execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+        stored <- config.loopBackendState.readBackendState
+        execution.executionState `shouldBe` stored.backendItems
+        length execution.executionState `shouldBe` 1
+        execution.executionProgress `shouldBe` ResponseCommitted
+        execution.executionPendingInputs `shouldBe`
+            [CompletedTool (functionResult "c1" "echo:hi")]
+        execution.executionResult `shouldBe`
+            Left (LoopUnexpected "user error (steering unavailable)")
+        readIORef acknowledgements `shouldReturn` [1]
+        readIORef submissions `shouldReturn`
+            [(Nothing, [UserMessage "hello", UserMessage "also verify tests"])]
+
     it "interrupts the provider in-band before tearing down a cancelled submission" do
         started <- newEmptyMVar
         interrupted <- newEmptyMVar
@@ -2499,6 +2531,58 @@ spec = describe "runLoop" do
             , (Just "resp-1", [UserMessage "use the existing schema"])
             ]
         readIORef pending `shouldReturn` []
+
+    it "retains cleared input's steering acknowledgement debt through tool recovery" do
+        toolFinished <- newEmptyMVar
+        acknowledgements <- newIORef []
+        invocations <- newIORef (0 :: Int)
+        let initialInputs = [UserMessage "hello", UserMessage "also verify tests"]
+            call = asyncFunctionToolCall "saved" "save" "{}"
+            tool = asyncNoArgsTool "save" do
+                modifyIORef' invocations (+ 1)
+                pure (Right "saved once")
+            backend = backendWithCallbacks \state _ inputs callbacks -> do
+                inputs `shouldBe` initialInputs
+                callbacks.onAsyncToolCall call
+                -- The host work finishes, but the final provider response omits
+                -- its call. Teardown must retain it as attributed recovery.
+                takeMVar toolFinished
+                pure $ Right BackendResult
+                    { backendOutput = emptyTurnOutput "resp-1" [] (Just "done")
+                    , backendState = advanceBackendSnapshot state
+                        (turnInputsToItems inputs) Nothing
+                    }
+        config0 <- testConfig backend
+        let config = config0
+                { loopTools = registryFromTools [tool]
+                , loopReadSteering = pure [UserMessage "also verify tests"]
+                , loopCommitSteering = \count ->
+                    modifyIORef' acknowledgements (<> [count])
+                , loopOnEvent = \case
+                    ToolFinished _ -> putMVar toolFinished ()
+                    _ -> pure ()
+                , loopBackendState = config0.loopBackendState
+                    { commitBackendState = \snapshot -> do
+                        committed <- config0.loopBackendState.commitBackendState snapshot
+                        -- Deterministically cancel after publication but before
+                        -- normal completion can acknowledge the steering.
+                        requestCancel config0.loopCancel
+                        pure committed
+                    }
+                }
+        execution <- timeout concurrencyProbeMicros
+            (runLoopInputsDetailed config Nothing [UserMessage "hello"])
+            >>= maybe (fail "loop did not finish recovering the completed tool") pure
+        execution.executionProgress `shouldBe` ResponseCommitted
+        execution.executionPendingInputs `shouldBe` []
+        execution.executionResult `shouldBe` Left (LoopCancelled [])
+        take 2 execution.executionState `shouldBe` turnInputsToItems initialInputs
+        length execution.executionState `shouldBe` 3
+        show execution.executionState `shouldContain` "saved once"
+        stored <- config.loopBackendState.readBackendState
+        stored.backendItems `shouldBe` execution.executionState
+        readIORef acknowledgements `shouldReturn` [1]
+        readIORef invocations `shouldReturn` 1
 
     it "commits terminal incomplete responses without running their tools" do
         submissions <- newIORef []


### PR DESCRIPTION
## Summary
- Replace duplicated loop cursor/reference state with one LoopState and plain PendingInputs.
- Name submission outcomes, recovery journal states, and attempt visibility instead of nested Eithers and tuples.
- Preserve public APIs, checkpoint ownership, commit ordering, cancellation, and structured tool lifetimes.
- Add regressions for steering-read failure after completed tools and acknowledgement debt during cancellation recovery.

## Validation
Ran Agent.LoopSpec.spec through single-component GHCi (cabal repl agent-core:test:agent-core-test --disable-multi-repl inside nix develop): **117 examples, 0 failures**.

GHCi loaded successfully; git diff --check passed. No CLI UI changes.