### PR TITLE
Refactor CLI approval and computer-use flags into explicit overrides

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/NativeRuntime.hs
@@ -56,6 +56,7 @@ import Agent.Loop
 import Agent.CLI.Options
     ( Command(..)
     , CliOptions(..)
+    , Override(..)
     , CodeModeOption(..)
     , ScreenMode(..)
     , defaultCliOptions
@@ -224,8 +225,7 @@ nativeTurnOptions request = do
             , optModel = request.nativeTurnModel
             , optCwd = Just request.nativeTurnCwd
             , optWorktree = False
-            , optYolo = False
-            , optNoYolo = True
+            , optYolo = Explicit False
             , optEffort = request.nativeTurnEffort
             , optPrompt = Just request.nativeTurnPrompt
             , optPromptFile = Nothing
@@ -236,7 +236,7 @@ nativeTurnOptions request = do
             , optSaveSession = True
             , optGhci = nativeGhciEnabled request.nativeTurnShellMode
             , optBash = nativeBashEnabled request.nativeTurnShellMode
-            , optComputerUse = False
+            , optComputerUse = Explicit False
             , optScreenMode = ScreenMinimal
             , optMotionMode = MotionOff
             , optMessageClock = clock
@@ -325,11 +325,10 @@ applyNativeStartupPolicy policy cwd = restrictContext . restrictFacilities
         TurnScopedFacilities -> options
             { optCwd = Just cwd
             , optWorktree = False
-            , optYolo = False
-            , optNoYolo = True
+            , optYolo = Explicit False
             , optPromptFile = Nothing
             , optManagedTurnFile = Nothing
-            , optComputerUse = False
+            , optComputerUse = Explicit False
             , optCodeMode = CodeModeDisabled
             }
 

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -3,6 +3,7 @@ module Agent.CLI.Options
     ( ApprovalAnswer(..)
     , ApprovalPolicy(..)
     , CliOptions(..)
+    , Override(..)
     , Command(..)
     , GatewayCommand(..)
     , McpAddCommand(..)
@@ -15,6 +16,7 @@ module Agent.CLI.Options
     , StorageCommand(..)
     , WorktreeCommand(..)
     , defaultCliOptions
+    , applyBackgroundApproval
     , defaultEffortFor
     , freshSessionOptions
     , gatewayRoutingChanged
@@ -161,13 +163,19 @@ parseApprovalAnswer raw
         "yolo" -> AllowAll
         _ -> Deny
 
+-- | Keep an inherited default distinct from either explicit flag value.
+-- Parsing replaces the whole override, so opposite flags cannot coexist.
+data Override a = Inherit | Explicit !a
+    deriving (Eq, Show)
+
 data CliOptions = CliOptions
     { optProvider :: !(Maybe Provider)
     , optModel :: !(Maybe Text)
     , optCwd :: !(Maybe OsPath)
     , optWorktree :: !Bool
-    , optYolo :: !Bool
-    , optNoYolo :: !Bool
+    , optYolo :: !(Override Bool)
+      -- ^ Inherit the invocation/project approval defaults, or explicitly
+      -- enable/disable auto-approval. Managed denial is resolved separately.
     , optManagedDenyMutations :: !Bool
     , optMaxTurns :: !Int
     , optMaxConcurrentAgents :: !(Maybe Int)
@@ -193,12 +201,9 @@ data CliOptions = CliOptions
       -- ^ Expose the persistent run_ghci tool (default: False).
     , optBash :: !Bool
       -- ^ Expose the provider's explicit shell execution tool (default: True).
-    , optComputerUse :: !Bool
+    , optComputerUse :: !(Override Bool)
       -- ^ Allow the model to request control of the local Linux/macOS desktop.
       -- Interactive terminal sessions default to 'True'.
-    , optComputerUseExplicit :: !Bool
-      -- ^ Whether a computer-use flag was supplied explicitly. This lets
-      -- native clients opt in while non-interactive defaults stay safe.
     , optCodeMode :: !CodeModeOption
       -- ^ Whether to start JavaScript code mode. 'CodeModeCatalog' follows
       -- the model catalog's @tool_mode@ (Codex default).
@@ -214,8 +219,7 @@ defaultCliOptions = CliOptions
     , optModel = Nothing
     , optCwd = Nothing
     , optWorktree = False
-    , optYolo = False
-    , optNoYolo = False
+    , optYolo = Inherit
     , optManagedDenyMutations = False
     , optMaxTurns = defaultLoopMaxTurns
     , optMaxConcurrentAgents = Nothing
@@ -231,8 +235,7 @@ defaultCliOptions = CliOptions
     , optSkills = True
     , optGhci = False
     , optBash = True
-    , optComputerUse = True
-    , optComputerUseExplicit = False
+    , optComputerUse = Inherit
     , optCodeMode = CodeModeCatalog
     , optScreenMode = ScreenAuto
     , optMotionMode = MotionFull
@@ -272,26 +275,48 @@ isOneShot options =
 -- one-shot or non-interactive runs.
 resolveComputerUseEnabled :: CliOptions -> Bool -> Bool
 resolveComputerUseEnabled options stdinTty =
-    options.optComputerUse
-        && ( options.optComputerUseExplicit
-                || (stdinTty && not (isOneShot options))
-           )
+    case options.optComputerUse of
+        Inherit -> stdinTty && not (isOneShot options)
+        Explicit enabled -> enabled
 
 -- | One-shot without a TTY auto-approves so scripts do not hang, unless
 -- @--no-yolo@ is set. Interactive sessions prompt on mutating tools, unless
 -- project settings already enabled auto-approve (and @--no-yolo@ was not set).
 resolveApprovalPolicy :: CliOptions -> Bool -> Bool -> ApprovalPolicy
 resolveApprovalPolicy options isTty projectAutoApprove
-    | options.optYolo && not options.optNoYolo = ApproveAll
+    | options.optYolo == Explicit True = ApproveAll
     | options.optManagedDenyMutations = DenyMutating
-    | isJust options.optManagedTurnFile && options.optNoYolo =
+    | isJust options.optManagedTurnFile && options.optYolo == Explicit False =
         PromptMutating
-    | options.optNoYolo && not isTty = DenyMutating
+    | options.optYolo == Explicit False && not isTty = DenyMutating
     | not isTty && isOneShot options = ApproveAll
     | not isTty = DenyMutating
-    | options.optNoYolo = PromptMutating
+    | options.optYolo == Explicit False = PromptMutating
     | projectAutoApprove = ApproveAll
     | otherwise = PromptMutating
+
+-- | Preserve a parent's policy in a background turn without borrowing stdin.
+applyBackgroundApproval :: ApprovalPolicy -> CliOptions -> CliOptions
+applyBackgroundApproval policy options =
+    case policy of
+        ApproveAll ->
+            options
+                { optYolo = Explicit True
+                , optManagedDenyMutations = False
+                }
+        DenyMutating ->
+            options
+                { optYolo = Explicit False
+                , optManagedDenyMutations = True
+                }
+        PromptMutating ->
+            -- Background sessions cannot safely borrow the caller's stdin.
+            -- Keep the prompt policy marker; non-TTY one-shot resolution
+            -- conservatively denies mutating calls.
+            options
+                { optYolo = Explicit False
+                , optManagedDenyMutations = False
+                }
 
 parseArgs :: [String] -> Either String Command
 parseArgs args
@@ -564,14 +589,13 @@ optionUpdateParser = asum
     , flagUpdate "worktree" "Create a new git worktree"
         (\options -> options { optWorktree = True })
     , flagUpdate "yolo" "Auto-approve tools (computer use asks separately)"
-        (\options -> options { optYolo = True, optNoYolo = False })
+        (\options -> options { optYolo = Explicit True })
     , flagUpdate "no-yolo" "Deny mutating tools without a TTY"
-        (\options -> options { optNoYolo = True, optYolo = False })
+        (\options -> options { optYolo = Explicit False })
     , flagUpdate "managed-deny-mutations" "Deny mutations in a managed turn"
         (\options -> options
             { optManagedDenyMutations = True
-            , optNoYolo = True
-            , optYolo = False
+            , optYolo = Explicit False
             })
     , optionUpdate "max-turns" "N" "Stop after N model turns"
         (positiveIntReader "--max-turns")
@@ -625,13 +649,11 @@ optionUpdateParser = asum
     , boolFlagUpdate "computer-use" True
         "Enable local Linux/macOS computer use (default with a TTY)"
         (\value options -> options
-            { optComputerUse = value
-            , optComputerUseExplicit = True
+            { optComputerUse = Explicit value
             })
     , boolFlagUpdate "no-computer-use" False "Disable local computer use"
         (\value options -> options
-            { optComputerUse = value
-            , optComputerUseExplicit = True
+            { optComputerUse = Explicit value
             })
     , codeModeFlagUpdate "code-mode" CodeModeEnabled
         "Enable JavaScript code mode when the catalog omits tool_mode"

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Background.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Background.hs
@@ -3,7 +3,9 @@ module Agent.CLI.Runtime.Orchestration.Background
     , runInProcessSessionTurn
     ) where
 
-import Agent.CLI.Options ( ApprovalPolicy(..), CliOptions(..), ScreenMode(..) )
+import Agent.CLI.Options
+    ( ApprovalPolicy, CliOptions(..), Override(..), ScreenMode(..)
+    , applyBackgroundApproval )
 import Agent.CLI.Runtime.Orchestration.Types ( AgentRunMode, backgroundRunMode )
 import Agent.CLI.Runtime.Types ( DevResult(..) )
 import Agent.CLI.Session
@@ -52,32 +54,6 @@ runInProcessSessionTurn runAgent parentOptions policy ghciEnabled bashEnabled
                 , optSaveSession = True
                 , optGhci = ghciEnabled
                 , optBash = bashEnabled
-                , optComputerUse = False
-                , optComputerUseExplicit = True
+                , optComputerUse = Explicit False
                 , optScreenMode = ScreenMinimal
-                }
-
-applyBackgroundApproval :: ApprovalPolicy -> CliOptions -> CliOptions
-applyBackgroundApproval policy options =
-    case policy of
-        ApproveAll ->
-            options
-                { optYolo = True
-                , optNoYolo = False
-                , optManagedDenyMutations = False
-                }
-        DenyMutating ->
-            options
-                { optYolo = False
-                , optNoYolo = True
-                , optManagedDenyMutations = True
-                }
-        PromptMutating ->
-            -- Background sessions cannot safely borrow the caller's stdin.
-            -- Keep the prompt policy marker; non-TTY one-shot resolution
-            -- conservatively denies mutating calls.
-            options
-                { optYolo = False
-                , optNoYolo = True
-                , optManagedDenyMutations = False
                 }

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -38,7 +38,7 @@ import Agent.CLI.Options
       isOneShot,
       CliOptions(optMotionMode, optManagedTurnFile, optScreenMode,
                  optProvider, optModel, optWorktree, optEffort, optPrompt,
-                 optPromptFile, optResume, optCwd, optCodeMode, optYolo),
+                 optPromptFile, optResume, optCwd, optCodeMode, optYolo), Override(..),
       CodeModeOption(CodeModeEnabled),
       ScreenMode(ScreenMinimal) )
 import Agent.CLI.Provider.Switch
@@ -1097,7 +1097,7 @@ prepareAgentIterationAction request resources interface resumeLock
     , isNothing request.iterationTransition = do
         let options = request.iterationOptions
             prepareAccountUsage =
-                options.optYolo
+                options.optYolo == Explicit True
                     || isNothing interface.iterationFullscreen
                     || isJust options.optProvider
                     || isJust options.optModel

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Initialized.hs
@@ -63,7 +63,7 @@ import Agent.CLI.Models
       ModelTarget(ModelTarget, targetWireModelId, targetConnectionId, targetProvider,
                   targetModelId, targetDialect) )
 import Agent.CLI.Options
-    ( CliOptions(optModel, optProvider, optSkills, optYolo) )
+    ( CliOptions(optModel, optProvider, optSkills, optYolo), Override(..) )
 import Agent.CLI.Project
     ( inheritProjectLastModel,
       loadProjectSettings,
@@ -638,7 +638,7 @@ loadInitializedAuth request targets =
         (Nothing, Nothing) -> do
             (startupAuth, accountUsage) <- loadPreparedOrStartupAuth
                 request.initializedPreparedAuth
-                (options.optYolo
+                (options.optYolo == Explicit True
                     && targets.initializedCheckStartupUsageInBackground)
                 startup
                 request.initializedTransition

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Model.hs
@@ -15,7 +15,7 @@ import Agent.CLI.Models
     ( ModelOption(..), ModelTarget(..), defaultModelFor, rawModelOption
     , resolveConfiguredModel, resolvePersistedDialect )
 import Agent.CLI.Options
-    ( ApprovalPolicy(..), CliOptions(..), defaultEffortFor
+    ( ApprovalPolicy(..), CliOptions(..), Override(..), defaultEffortFor
     , normalizeReasoningEffortForDialect, resolveApprovalPolicy )
 import Agent.CLI.Project (ProjectModel(..), ProjectSettings(..))
 import Agent.CLI.Runtime.Orchestration.Tools.Request
@@ -289,6 +289,6 @@ resolveToolModel AgentToolsRequest
                     Just _ -> False
                     Nothing -> hooks.nativeInteractionMode == NativeYolo
             Nothing ->
-                not options.optNoYolo
-                    && (options.optYolo
+                options.optYolo /= Explicit False
+                    && (options.optYolo == Explicit True
                         || projectSettings.settingsAutoApprove)

--- a/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/NativeRuntimeSpec.hs
@@ -28,10 +28,11 @@ import System.IO.Temp (withSystemTempDirectory)
 import Agent.CLI.GatewayClient (GatewayCredential(..))
 import Agent.CLI.IntegrationGateway (gatewayIntegrationMcpConfig)
 import Agent.CLI.Options
-    ( CliOptions(..)
+    ( CliOptions(..), Override(..)
     , CodeModeOption(..)
     , ScreenMode(..)
     , defaultCliOptions
+    , resolveComputerUseEnabled
     )
 import Agent.Runtime.StartupPolicy
 import Control.Monad (forM_)
@@ -120,6 +121,23 @@ spec = describe "nativeTurnOptions" do
             (unsafeEncodeUtf "/admitted") conflictingOptions
             `shouldBe` conflictingOptions
 
+    it "preserves host computer-use opt-in and always disables restricted turns" do
+        forM_ [Inherit, Explicit False, Explicit True] \computer ->
+            forM_ [False, True] \tty ->
+                forM_ [False, True] \oneShot -> do
+                    let options = defaultCliOptions
+                            { optComputerUse = computer
+                            , optPrompt = if oneShot then Just "hi" else Nothing
+                            }
+                        cwd = unsafeEncodeUtf "/admitted"
+                        host = applyNativeStartupPolicy hostNativeStartupPolicy cwd options
+                        restricted = applyNativeStartupPolicy restrictedNativeStartupPolicy cwd options
+                        expected = case computer of
+                            Inherit -> tty && not oneShot
+                            Explicit enabled -> enabled
+                    resolveComputerUseEnabled host tty `shouldBe` expected
+                    resolveComputerUseEnabled restricted tty `shouldBe` False
+
     it "enforces every restricted startup setting against conflicting options" do
         let cwd = unsafeEncodeUtf "/admitted"
             actual = applyNativeStartupPolicy restrictedNativeStartupPolicy cwd
@@ -127,13 +145,12 @@ spec = describe "nativeTurnOptions" do
             expected = conflictingOptions
                 { optCwd = Just cwd
                 , optWorktree = False
-                , optYolo = False
-                , optNoYolo = True
+                , optYolo = Explicit False
                 , optPromptFile = Nothing
                 , optManagedTurnFile = Nothing
                 , optAgentsMd = False
                 , optSkills = False
-                , optComputerUse = False
+                , optComputerUse = Explicit False
                 , optCodeMode = CodeModeDisabled
                 }
         actual `shouldBe` expected
@@ -180,12 +197,11 @@ spec = describe "nativeTurnOptions" do
                         options.optGhci `shouldBe` lowered.optGhci
                         options.optBash `shouldBe` lowered.optBash
                         options.optCwd `shouldBe` Just request.nativeTurnCwd
-                        options.optYolo `shouldBe` False
-                        options.optNoYolo `shouldBe` True
+                        options.optYolo `shouldBe` Explicit False
                         options.optWorktree `shouldBe` False
                         options.optPromptFile `shouldBe` Nothing
                         options.optManagedTurnFile `shouldBe` Nothing
-                        options.optComputerUse `shouldBe` False
+                        options.optComputerUse `shouldBe` Explicit False
 
     it "lowers a new typed turn without enabling native-only capabilities" do
         let cwd = unsafeEncodeUtf "/tmp/project"
@@ -209,10 +225,9 @@ spec = describe "nativeTurnOptions" do
         options.optCwd `shouldBe` Just cwd
         options.optEffort `shouldBe` Just EffortHigh
         options.optSaveSession `shouldBe` True
-        options.optNoYolo `shouldBe` True
-        options.optYolo `shouldBe` False
+        options.optYolo `shouldBe` Explicit False
         options.optWorktree `shouldBe` False
-        options.optComputerUse `shouldBe` False
+        options.optComputerUse `shouldBe` Explicit False
         options.optGhci `shouldBe` False
         options.optBash `shouldBe` False
         options.optScreenMode `shouldBe` ScreenMinimal
@@ -270,8 +285,7 @@ spec = describe "nativeTurnOptions" do
                 (baseRequest
                     { nativeTurnInteractionMode = NativeYolo }
                 )
-        options.optYolo `shouldBe` False
-        options.optNoYolo `shouldBe` True
+        options.optYolo `shouldBe` Explicit False
 
     it "rejects an invalid resume in auto-approval mode under either policy" do
         forM_ [hostNativeStartupPolicy, restrictedNativeStartupPolicy] \policy -> do
@@ -333,13 +347,12 @@ conflictingOptions :: CliOptions
 conflictingOptions = defaultCliOptions
     { optCwd = Just (unsafeEncodeUtf "/untrusted")
     , optWorktree = True
-    , optYolo = True
-    , optNoYolo = False
+    , optYolo = Explicit True
     , optPromptFile = Just (unsafeEncodeUtf "/untrusted/prompt")
     , optManagedTurnFile = Just (unsafeEncodeUtf "/untrusted/turn")
     , optAgentsMd = True
     , optSkills = True
-    , optComputerUse = True
+    , optComputerUse = Explicit True
     , optCodeMode = CodeModeEnabled
     , optPrompt = Just "preserve supplied input"
     , optResume = Just "preserve-session"

--- a/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/OptionsSpec.hs
@@ -1,6 +1,7 @@
 module Agent.CLI.OptionsSpec (spec) where
 
 import Agent.CLI.Options
+import Control.Monad (forM_, replicateM)
 import Agent.Dialect (DialectId(..))
 import Agent.Loop (defaultLoopMaxTurns)
 import System.OsPath (unsafeEncodeUtf)
@@ -11,8 +12,88 @@ import Test.Hspec
 
 fromFilePath = unsafeEncodeUtf
 
+policyOptions :: Bool -> Bool -> Bool -> CliOptions
+policyOptions prompt file managed = defaultCliOptions
+    { optPrompt = if prompt then Just "hi" else Nothing
+    , optPromptFile = if file then Just (fromFilePath "prompt.md") else Nothing
+    , optManagedTurnFile = if managed then Just (fromFilePath "turn.json") else Nothing
+    }
+
 spec :: Spec
 spec = do
+    describe "policy override matrices" do
+        -- Enumerate every combination of policy inputs, including overlapping
+        -- one-shot sources and the managed-denial marker.
+        forM_ [(yolo, deny, tty, project, prompt, file, managed)
+              | yolo <- [Inherit, Explicit False, Explicit True]
+              , deny <- [False, True], tty <- [False, True]
+              , project <- [False, True], prompt <- [False, True]
+              , file <- [False, True], managed <- [False, True]] $
+            \inputs@(yolo, deny, tty, project, prompt, file, managed) ->
+                it ("resolves approvals " <> show inputs) do
+                    let options = (policyOptions prompt file managed)
+                            { optYolo = yolo, optManagedDenyMutations = deny }
+                        -- A decision table independent of the resolver's
+                        -- ordered guards: explicit yolo wins even over a
+                        -- previous managed denial; no-yolo retains remote
+                        -- prompting only for managed turns.
+                        expected = case (yolo, deny) of
+                            (Explicit True, _) -> ApproveAll
+                            (_, True) -> DenyMutating
+                            (Explicit False, False)
+                                | managed || tty -> PromptMutating
+                                | otherwise -> DenyMutating
+                            (Inherit, False)
+                                | tty -> if project then ApproveAll else PromptMutating
+                                | prompt || file || managed -> ApproveAll
+                                | otherwise -> DenyMutating
+                    resolveApprovalPolicy options tty project `shouldBe` expected
+
+        forM_ [(computer, tty, prompt, file, managed)
+              | computer <- [Inherit, Explicit False, Explicit True]
+              , tty <- [False, True], prompt <- [False, True]
+              , file <- [False, True], managed <- [False, True]] $
+            \inputs@(computer, tty, prompt, file, managed) ->
+                it ("resolves computer use " <> show inputs) do
+                    let options = (policyOptions prompt file managed)
+                            { optComputerUse = computer }
+                        expected = case computer of
+                            Inherit -> (tty, prompt, file, managed) == (True, False, False, False)
+                            Explicit enabled -> enabled
+                    resolveComputerUseEnabled options tty `shouldBe` expected
+
+        -- All sequences through length four cover repetition, reversal, and
+        -- interleaving of both override families and sticky managed denial.
+        forM_ (concatMap (\n -> replicateM n
+                ["--yolo", "--no-yolo", "--managed-deny-mutations",
+                 "--computer-use", "--no-computer-use"]) [0 .. 4]) $ \flags ->
+            it ("parses ordered overrides " <> show flags) do
+                let lastValue yes no = case reverse (filter (\flag -> flag == yes || flag `elem` no) flags) of
+                        [] -> Inherit
+                        flag : _ -> Explicit (flag == yes)
+                parseArgs flags `shouldBe` Right (RunAgent defaultCliOptions
+                    { optYolo = lastValue "--yolo" ["--no-yolo", "--managed-deny-mutations"]
+                    , optComputerUse = lastValue "--computer-use" ["--no-computer-use"]
+                    , optManagedDenyMutations = "--managed-deny-mutations" `elem` flags
+                    })
+
+        forM_ [(policy, yolo, deny, project)
+              | policy <- [ApproveAll, PromptMutating, DenyMutating]
+              , yolo <- [Inherit, Explicit False, Explicit True]
+              , deny <- [False, True], project <- [False, True]] $
+            \inputs@(policy, yolo, deny, project) ->
+                it ("preserves background approval safety " <> show inputs) do
+                    let options = applyBackgroundApproval policy defaultCliOptions
+                            { optPrompt = Just "background turn"
+                            , optYolo = yolo
+                            , optManagedDenyMutations = deny
+                            }
+                        expected = case policy of
+                            ApproveAll -> ApproveAll
+                            PromptMutating -> DenyMutating
+                            DenyMutating -> DenyMutating
+                    resolveApprovalPolicy options False project `shouldBe` expected
+
     describe "worktree administration" do
         it "parses dry-run and inactivity override" do
             parseArgs ["worktree", "gc", "--dry-run"]
@@ -113,7 +194,7 @@ spec = do
                     , optModel = Just "grok-4.6"
                     , optCwd = Just (fromFilePath "/tmp/work")
                     , optBash = True
-                    , optYolo = True
+                    , optYolo = Explicit True
                     , optMaxTurns = 3
                     , optMaxConcurrentAgents = Just 64
                     , optCompactThreshold = Just 1200
@@ -201,16 +282,14 @@ spec = do
         it "applies approval flags in command-line order" do
             parseArgs ["--yolo", "--no-yolo", "--yolo"]
                 `shouldBe` Right (RunAgent defaultCliOptions
-                    { optYolo = True
-                    , optNoYolo = False
+                    { optYolo = Explicit True
                     })
             parseArgs
                 [ "--managed-deny-mutations"
                 , "--yolo"
                 ]
                 `shouldBe` Right (RunAgent defaultCliOptions
-                    { optYolo = True
-                    , optNoYolo = False
+                    { optYolo = Explicit True
                     , optManagedDenyMutations = True
                     })
 
@@ -434,22 +513,18 @@ spec = do
                 `shouldBe` Right (RunAgent defaultCliOptions { optBash = True })
 
         it "tracks explicit computer-use overrides with last-flag-wins semantics" do
-            defaultCliOptions.optComputerUse `shouldBe` True
-            defaultCliOptions.optComputerUseExplicit `shouldBe` False
+            defaultCliOptions.optComputerUse `shouldBe` Inherit
             parseArgs ["--no-computer-use"]
                 `shouldBe` Right (RunAgent defaultCliOptions
-                    { optComputerUse = False
-                    , optComputerUseExplicit = True
+                    { optComputerUse = Explicit False
                     })
             parseArgs ["--no-computer-use", "--computer-use"]
                 `shouldBe` Right (RunAgent defaultCliOptions
-                    { optComputerUse = True
-                    , optComputerUseExplicit = True
+                    { optComputerUse = Explicit True
                     })
             parseArgs ["--computer-use", "--no-computer-use"]
                 `shouldBe` Right (RunAgent defaultCliOptions
-                    { optComputerUse = False
-                    , optComputerUseExplicit = True
+                    { optComputerUse = Explicit False
                     })
 
         it "defaults computer use to TTY sessions while honoring explicit flags" do
@@ -457,15 +532,13 @@ spec = do
             resolveComputerUseEnabled defaultCliOptions False `shouldBe` False
             resolveComputerUseEnabled
                 defaultCliOptions
-                    { optComputerUse = True
-                    , optComputerUseExplicit = True
+                    { optComputerUse = Explicit True
                     }
                 False
                 `shouldBe` True
             resolveComputerUseEnabled
                 defaultCliOptions
-                    { optComputerUse = False
-                    , optComputerUseExplicit = True
+                    { optComputerUse = Explicit False
                     }
                 True
                 `shouldBe` False
@@ -488,8 +561,7 @@ spec = do
             resolveComputerUseEnabled
                 defaultCliOptions
                     { optPrompt = Just "hi"
-                    , optComputerUse = True
-                    , optComputerUseExplicit = True
+                    , optComputerUse = Explicit True
                     }
                 True
                 `shouldBe` True
@@ -521,14 +593,14 @@ spec = do
                 `shouldBe` ApproveAll
 
         it "denies mutating tools without a TTY when --no-yolo is set" do
-            resolveApprovalPolicy defaultCliOptions { optNoYolo = True } False False
+            resolveApprovalPolicy defaultCliOptions { optYolo = Explicit False } False False
                 `shouldBe` DenyMutating
 
         it "keeps managed non-TTY turns in remote prompt mode" do
             resolveApprovalPolicy
                 defaultCliOptions
                     { optManagedTurnFile = Just (fromFilePath "turn.json")
-                    , optNoYolo = True
+                    , optYolo = Explicit False
                     }
                 False
                 False
@@ -550,12 +622,12 @@ spec = do
 
         it "prompts on a TTY unless --yolo is set" do
             resolveApprovalPolicy defaultCliOptions True False `shouldBe` PromptMutating
-            resolveApprovalPolicy defaultCliOptions { optYolo = True } True False
+            resolveApprovalPolicy defaultCliOptions { optYolo = Explicit True } True False
                 `shouldBe` ApproveAll
 
         it "honors project auto-approve on a TTY unless --no-yolo is set" do
             resolveApprovalPolicy defaultCliOptions True True `shouldBe` ApproveAll
-            resolveApprovalPolicy defaultCliOptions { optNoYolo = True } True True
+            resolveApprovalPolicy defaultCliOptions { optYolo = Explicit False } True True
                 `shouldBe` PromptMutating
 
     describe "parseApprovalAnswer" do


### PR DESCRIPTION
## Summary
- Replace the coordinated approval and computer-use Boolean pairs with `Override Bool` (`Inherit | Explicit Bool`), making contradictory flags unrepresentable.
- Preserve last-flag-wins parsing, sticky managed denial and remote prompting, no-TTY/project defaults, native opt-in, background restrictions, and Claude bypass behavior.
- Keep default resolution explicit; move the existing pure background approval translation into Options for direct regression coverage.

## Validation
- GHCi: actual successful CLI load (251 modules), then successful reload with four focused specs (255 modules).
- OptionsSpec, NativeRuntimeSpec, ApprovalSpec, ComputerUseSpec: **1,333 examples, 0 failures**.
- Exhaustive approval/computer policy input matrices, every sequence of the five relevant flags through length four (781 sequences), background policy and native startup coverage.
- Live fullscreen tmux from the dedicated worktree: opposite approval flag orders produce `yolo`/`ask`; disabled computer-use startup omits the computer tool, interactive default includes it; `/computer-use on` retains the explicit approval-required notice. No model turn or desktop control performed.
- `git diff --check` passes. No Cabal changes. Maintainability only; no performance claims.
