### PR TITLE
Simplify resume entry loading with ExceptT

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -68,6 +68,7 @@ import Agent.Responses.Types (ResponseItem(..))
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.Store.Postgres.Session (ConversationSearchResult(..))
 import Control.Monad (forM)
+import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import Data.Char (isAlphaNum)
 import Data.Containers.ListUtils (nubOrd)
 import qualified Data.Map.Strict as Map
@@ -231,21 +232,11 @@ publishResumeHistoryAfterBoundary boundaryResult publish =
         Right () -> publish >> pure (Right ())
 
 loadResumeEntry :: StorePool -> OsPath -> Text -> IO (Either Text ResumeEntry)
-loadResumeEntry pool root sessionId =
-    loadSessionMeta pool root sessionId >>= \case
-        Left err -> pure (Left err)
-        Right meta ->
-            loadRecentSessionTurns pool root sessionId 50 >>= \case
-                Left err -> pure (Left err)
-                Right page ->
-                    loadSessionResumeStats pool root sessionId >>= \case
-                        Left err -> pure (Left err)
-                        Right stats ->
-                            pure $ Right $
-                                resumeEntryFromPage
-                                    meta
-                                    stats
-                                    (map snd page.pageTurns)
+loadResumeEntry pool root sessionId = runExceptT do
+    meta <- ExceptT $ loadSessionMeta pool root sessionId
+    page <- ExceptT $ loadRecentSessionTurns pool root sessionId 50
+    stats <- ExceptT $ loadSessionResumeStats pool root sessionId
+    pure $ resumeEntryFromPage meta stats (map snd page.pageTurns)
 
 -- | Build a loaded resume entry from a bounded transcript page plus
 -- full-session aggregates. Counts and the first prompt describe the whole


### PR DESCRIPTION
## Summary
- Replace three nested `Either` cases in `loadResumeEntry` with a linear `ExceptT` block.
- Preserve the public return type, loading order, first-error short circuit, and 50-turn transcript limit.
- No behavior or dependency changes.

## Validation
- `git diff --check` passed.
- `nix develop -c cabal repl agent-cli:lib:agent-cli`: CLI library loaded successfully.
- Loaded `test/Agent/CLI/ResumeSpec.hs` in GHCi with `-itest -package hspec` and ran `Test.Hspec.hspec Agent.CLI.ResumeSpec.spec`: **32 examples, 0 failures**.
