### PR TITLE
Simplify Meta Console secret collection with ExceptT

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
@@ -1,6 +1,7 @@
 -- | Meta Console planning, approval, and host-side action execution.
 module Agent.CLI.Runtime.Repl.MetaConsole
     ( handleMetaConsoleRequest
+    , collectMetaSecretsWith
     ) where
 
 import Agent.CLI.Command
@@ -66,6 +67,8 @@ import Agent.TUI.Model
 import Control.Exception.Safe
     ( displayException, finally, tryAny )
 import Control.Monad ( foldM )
+import Control.Monad.IO.Class ( liftIO )
+import Control.Monad.Trans.Except ( ExceptT, runExceptT, throwE )
 import Data.Aeson ( Value )
 import Data.IORef ( readIORef )
 import Data.Text ( Text )
@@ -291,62 +294,47 @@ collectMetaSecrets
     -> [Meta.MetaAction]
     -> IO (Either Text [MetaSecretValue])
 collectMetaSecrets runtime =
-    foldM (collectOneMetaSecret runtime) (Right [])
+    collectMetaSecretsWith (promptMetaSecret runtime)
+
+-- | Collect in action order, stopping at the first cancelled prompt.
+collectMetaSecretsWith
+    :: (Text -> Text -> IO (Maybe Text))
+    -> [Meta.MetaAction]
+    -> IO (Either Text [MetaSecretValue])
+collectMetaSecretsWith prompt actions =
+    runExceptT $ foldM (collectOneMetaSecret prompt) [] actions
 
 collectOneMetaSecret
-    :: MetaConsoleRuntime
-    -> Either Text [MetaSecretValue]
+    :: (Text -> Text -> IO (Maybe Text))
+    -> [MetaSecretValue]
     -> Meta.MetaAction
-    -> IO (Either Text [MetaSecretValue])
-collectOneMetaSecret _ result@(Left _) _ = pure result
-collectOneMetaSecret runtime (Right values) action = case action of
-    Meta.MetaSetMcpSecretEnv server key ->
-        promptMetaSecret
-            runtime
+    -> ExceptT Text IO [MetaSecretValue]
+collectOneMetaSecret prompt values action = case action of
+    Meta.MetaSetMcpSecretEnv server key -> do
+        value <- requireSecret
+            ("secret input for MCP server '" <> server <> "' was cancelled")
             ("MCP " <> server <> " · " <> key)
             ("Enter the value for environment variable "
                 <> key
                 <> " on MCP server "
                 <> server
                 <> ". It stays local and is never sent to the model.")
-            >>= \case
-                Nothing ->
-                    pure
-                        (Left
-                            ("secret input for MCP server '"
-                                <> server
-                                <> "' was cancelled"))
-                Just value ->
-                    pure
-                        (Right
-                            (values
-                                <> [ MetaMcpSecretValue
-                                        server key value
-                                   ]))
-    Meta.MetaSetLspSecretEnv server key ->
-        promptMetaSecret
-            runtime
+        pure (values <> [MetaMcpSecretValue server key value])
+    Meta.MetaSetLspSecretEnv server key -> do
+        value <- requireSecret
+            ("secret input for LSP server '" <> server <> "' was cancelled")
             ("LSP " <> server <> " · " <> key)
             ("Enter the value for environment variable "
                 <> key
                 <> " on LSP server "
                 <> server
                 <> ". It stays local and is never sent to the model.")
-            >>= \case
-                Nothing ->
-                    pure
-                        (Left
-                            ("secret input for LSP server '"
-                                <> server
-                                <> "' was cancelled"))
-                Just value ->
-                    pure
-                        (Right
-                            (values
-                                <> [ MetaLspSecretValue
-                                        server key value
-                                   ]))
-    _ -> pure (Right values)
+        pure (values <> [MetaLspSecretValue server key value])
+    _ -> pure values
+  where
+    requireSecret cancelled title body = do
+        value <- liftIO $ prompt title body
+        maybe (throwE cancelled) pure value
 
 promptMetaSecret
     :: MetaConsoleRuntime

--- a/packages/agent-cli/test/Agent/CLI/MetaConsoleRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MetaConsoleRuntimeSpec.hs
@@ -18,6 +18,8 @@ import Agent.CLI.Runtime.MetaConsole
     , applyMetaConfigActions
     )
 import Agent.MCP (McpLogLevel(..), McpProtocolPreference(..))
+import Agent.CLI.Runtime.Repl.MetaConsole (collectMetaSecretsWith)
+import Data.IORef (newIORef, modifyIORef', readIORef)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 import Test.Hspec
@@ -25,11 +27,60 @@ import Test.Hspec
     , describe
     , it
     , shouldBe
+    , shouldReturn
     , shouldSatisfy
     )
 
 spec :: Spec
 spec = describe "Meta Console host executor" do
+    describe "secret collection" do
+        it "does not prompt for an empty action list" do
+            collectMetaSecretsWith (\_ _ -> fail "unexpected prompt") []
+                `shouldReturn` Right []
+
+        it "collects MCP and LSP values in prompt order without changing whitespace" do
+            prompts <- newIORef []
+            let prompt title body = do
+                    modifyIORef' prompts (<> [(title, body)])
+                    pure (Just " test value ")
+            collectMetaSecretsWith prompt
+                [ MetaSetMcpEnabled "docs" True
+                , MetaSetMcpSecretEnv "docs" "TOKEN"
+                , MetaSetMcpEnabled "docs" False
+                , MetaSetLspSecretEnv "hls" "KEY"
+                ]
+                `shouldReturn` Right
+                    [ MetaMcpSecretValue "docs" "TOKEN" " test value "
+                    , MetaLspSecretValue "hls" "KEY" " test value "
+                    ]
+            readIORef prompts `shouldReturn`
+                [ ("MCP docs · TOKEN", "Enter the value for environment variable TOKEN on MCP server docs. It stays local and is never sent to the model.")
+                , ("LSP hls · KEY", "Enter the value for environment variable KEY on LSP server hls. It stays local and is never sent to the model.")
+                ]
+
+        it "stops after MCP cancellation" do
+            prompts <- newIORef []
+            let prompt title _ = do
+                    modifyIORef' prompts (<> [title])
+                    pure Nothing
+            collectMetaSecretsWith prompt
+                [MetaSetMcpSecretEnv "docs" "TOKEN", MetaSetLspSecretEnv "hls" "KEY"]
+                `shouldReturn` Left "secret input for MCP server 'docs' was cancelled"
+            readIORef prompts `shouldReturn` ["MCP docs · TOKEN"]
+
+        it "discards partial collection and stops after LSP cancellation" do
+            prompts <- newIORef []
+            let prompt title _ = do
+                    modifyIORef' prompts (<> [title])
+                    pure (if title == "MCP docs · TOKEN" then Just "" else Nothing)
+            collectMetaSecretsWith prompt
+                [ MetaSetMcpSecretEnv "docs" "TOKEN"
+                , MetaSetLspSecretEnv "hls" "KEY"
+                , MetaSetMcpSecretEnv "later" "TOKEN"
+                ]
+                `shouldReturn` Left "secret input for LSP server 'hls' was cancelled"
+            readIORef prompts `shouldReturn` ["MCP docs · TOKEN", "LSP hls · KEY"]
+
     it "updates public MCP fields while preserving env and OAuth credentials" do
         let existing = McpServerConfig
                 { mcpEnabled = True


### PR DESCRIPTION
## Summary
- Replace manually threaded Either state with ExceptT in Meta Console secret collection.
- Preserve prompt text, action order, secret values, and first-cancellation behavior.
- Add an injectable prompt callback and four regression tests for empty input, mixed actions, successful collection, and MCP/LSP cancellation.

## Validation
- CLI library and targeted spec loaded successfully in GHCi; no compiler errors.
- MetaConsoleRuntimeSpec: 9 examples, 0 failures.
- git diff --check passed.
- No changes to prompt rendering or input handling.