### PR TITLE
Move session exit handling into a scoped supervisor

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Interrupt.hs
+++ b/packages/agent-cli/src/Agent/CLI/Interrupt.hs
@@ -8,7 +8,9 @@ module Agent.CLI.Interrupt
     , exitConfirmWindow
     , decideCtrlC
     , newInterruptState
-    , withCtrlCHandler
+    , withSessionInterrupts
+    , withSessionInterruptScope
+    , requestSessionExit
     , withTurnCancel
     , resetIdleTurnCancel
     , noteIdleCtrlC
@@ -19,7 +21,14 @@ module Agent.CLI.Interrupt
     ) where
 
 import Agent.Cancel (CancelFlag, isCancelled, requestCancel, resetCancel)
-import Control.Concurrent (ThreadId, myThreadId, throwTo)
+import Control.Concurrent.MVar (MVar, newMVar, modifyMVarMasked, modifyMVarMasked_, withMVar)
+import Control.Concurrent.Async
+    ( AsyncCancelled(..), cancel, waitCatch, withAsync, withAsyncWithUnmask, waitSTM )
+import Control.Concurrent.STM
+    ( TMVar, atomically, newEmptyTMVarIO, readTMVar, tryPutTMVar
+    , isEmptyTMVar, takeTMVar, newTBQueueIO, readTBQueue, writeTBQueue, isFullTBQueue
+    , orElse
+    )
 import Control.Exception
     ( AsyncException(UserInterrupt)
     , fromException
@@ -29,15 +38,13 @@ import Control.Exception.Safe
     ( SomeException
     , SyncExceptionWrapper(..)
     , bracket
-    , bracket_
     , catchAny
     , catchAsync
     , catchIO
     , mask
     , throwIO
     )
-import Control.Monad (void)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Control.Monad (forever, unless, void)
 import Data.Text (Text)
 import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime)
 import System.Posix.Signals
@@ -73,7 +80,7 @@ data IdleCtrlCResult
     | QuitProcess
     deriving (Eq, Show)
 
--- | Pure policy used by the SIGINT handler and idle-prompt catcher.
+-- | Pure policy shared by signal and keyboard input.
 decideCtrlC :: CtrlCContext -> Bool -> CtrlCDecision
 decideCtrlC Idle withinWindow
     | withinWindow = ForceExit
@@ -84,42 +91,94 @@ decideCtrlC (TurnActive alreadyCancelled) _
 decideCtrlC Exiting _ = ForceExit
 
 data InterruptState = InterruptState
-    { interruptActiveCancel :: !(IORef (Maybe CancelFlag))
-    , interruptLastWarn :: !(IORef (Maybe UTCTime))
-    , interruptExiting :: !(IORef Bool)
+    { interruptPolicy :: !(MVar InterruptPolicy)
+    , interruptExit :: !(TMVar ())
     , interruptOnMessage :: !(Text -> IO ())
+    }
+
+data SessionEvent a = ExitRequested | CtrlCReceived | SessionCompleted a
+
+-- Transitions and turn-target handoffs are serialized. No callback or blocking
+-- IO runs while holding this lock: CancelFlag operations only update STM.
+data InterruptPolicy = InterruptPolicy
+    { activeCancel :: !(Maybe CancelFlag)
+    , lastWarn :: !(Maybe UTCTime)
     }
 
 -- | @onMessage@ prints user-facing hints (already styled by the caller).
 newInterruptState :: (Text -> IO ()) -> IO InterruptState
 newInterruptState onMessage = do
-    active <- newIORef Nothing
-    lastWarn <- newIORef Nothing
-    exiting <- newIORef False
+    policy <- newMVar (InterruptPolicy Nothing Nothing)
+    exiting <- newEmptyTMVarIO
     pure InterruptState
-        { interruptActiveCancel = active
-        , interruptLastWarn = lastWarn
-        , interruptExiting = exiting
+        { interruptPolicy = policy
+        , interruptExit = exiting
         , interruptOnMessage = onMessage
         }
 
--- | Install SIGINT/SIGHUP/SIGTERM handlers for the dynamic extent of @action@.
--- Restores the previous handlers afterward. Force-exit rethrows
--- 'UserInterrupt' on the thread that entered this wrapper. This session-level
--- handler must never terminate its host process: the owner may be GHCi or an
--- embedded runtime, and remains responsible for releasing session resources.
+-- | Own a foreground session until completion or a confirmed exit request.
+-- Signal callbacks only publish intent. Keyboard adapters use the same exit
+-- latch; neither adapter throws exceptions into the session or kills its host.
+-- On exit, notify the UI owner before scoped cancellation joins the worker.
+-- 'Nothing' is a requested quit, not a provider failure or restart.
 --
--- The inline editor reads Ctrl-C directly while a prompt is active; use
--- 'noteIdleCtrlC' from that path instead. Fullscreen raw mode uses
--- 'noteFullscreenCtrlC'.
-withCtrlCHandler :: InterruptState -> IO a -> IO a
-withCtrlCHandler state action = do
-    mainTid <- myThreadId
-    let sigint = Catch (onSigInt mainTid state)
-        hangup = Catch (onHangup mainTid state)
+-- Cancellation joins are deliberately not advertised as bounded: finalizers
+-- must be interruptible. Abandoning a worker would let it use released session
+-- resources. Background/embedded callers should not install process signals.
+withSessionInterrupts :: InterruptState -> IO () -> IO a -> IO (Maybe a)
+withSessionInterrupts state onStop = withSessionInterruptScope state onStop id
+
+-- | Keep adapters installed through owner-side reporting as well as worker
+-- teardown. The wrapper runs outside the canceled worker scope, so it can
+-- report a quit or failure after joining without exposing the host's handlers.
+withSessionInterruptScope
+    :: InterruptState
+    -> IO ()
+    -> (IO (Maybe a) -> IO b)
+    -> IO a
+    -> IO b
+withSessionInterruptScope state onStop around action = do
+    signals <- newTBQueueIO 8
+    notices <- newEmptyTMVarIO
+    let sigint = Catch $ atomically do
+            full <- isFullTBQueue signals
+            exiting <- not <$> isEmptyTMVar state.interruptExit
+            unless (full || exiting) (writeTBQueue signals ())
+        hangup = Catch (requestSessionExit state)
+        -- Rendering a notice must not prevent the next signal from quitting.
+        renderNotices = forever (atomically (takeTMVar notices) >>= notify state)
+        publishNotice message = atomically $ void (tryPutTMVar notices message)
+        supervise worker renderer = do
+            event <- atomically $
+                (readTMVar state.interruptExit >> pure ExitRequested)
+                    `orElse` (readTBQueue signals >> pure CtrlCReceived)
+                    `orElse` (SessionCompleted <$> waitSTM worker)
+                    `orElse` (waitSTM renderer >> pure ExitRequested)
+            case event of
+                ExitRequested -> do
+                    onStop
+                    cancel worker
+                    -- Scoped cancellation joins the worker, but its exception
+                    -- is otherwise discarded. Preserve failed resource cleanup
+                    -- rather than reporting a successful requested quit.
+                    waitCatch worker >>= \case
+                        Right _ -> pure Nothing
+                        Left exception -> case fromException exception of
+                            Just AsyncCancelled -> pure Nothing
+                            Nothing -> throwIO exception
+                SessionCompleted result -> pure (Just result)
+                CtrlCReceived -> do
+                    noteCtrlC state >>= \case
+                        SoftCancel -> publishNotice "Interrupted; press Ctrl-C again to exit"
+                        WarnExit -> publishNotice "Press Ctrl-C again to exit"
+                        ForceExit -> pure ()
+                    supervise worker renderer
     withHandler sigINT sigint $
         withHandler sigHUP hangup $
-            withHandler sigTERM hangup action
+            withHandler sigTERM hangup $
+                around $
+                withAsyncWithUnmask (\unmask -> unmask action) \worker ->
+                    withAsync renderNotices (supervise worker)
   where
     -- Nest acquisition so a later installation failure also restores every
     -- handler already installed.
@@ -133,115 +192,63 @@ withCtrlCHandler state action = do
 -- Nested work (for example voice delegations) must not erase a parent hangup.
 resetIdleTurnCancel :: InterruptState -> CancelFlag -> IO ()
 resetIdleTurnCancel state cancel = do
-    active <- readIORef state.interruptActiveCancel
-    case active of
-        Nothing -> resetCancel cancel
-        Just _ -> pure ()
+    withMVar state.interruptPolicy \policy ->
+        case policy.activeCancel of
+            Nothing -> resetCancel cancel
+            Just _ -> pure ()
 
 withTurnCancel :: InterruptState -> CancelFlag -> IO a -> IO a
 withTurnCancel state cancel action =
     bracket
-        (do
-            previous <- readIORef state.interruptActiveCancel
-            writeIORef state.interruptActiveCancel (Just cancel)
-            pure previous)
-        (writeIORef state.interruptActiveCancel)
+        (modifyMVarMasked state.interruptPolicy \policy ->
+            pure (policy{activeCancel = Just cancel}, policy.activeCancel))
+        (\previous -> modifyMVarMasked_ state.interruptPolicy \policy ->
+            pure policy{activeCancel = previous})
         (const action)
 
 -- | Apply idle Ctrl-C policy from the inline editor.
 noteIdleCtrlC :: InterruptState -> IO IdleCtrlCResult
 noteIdleCtrlC state = do
-    now <- getCurrentTime
-    context <- ctrlCContext state
-    withinWindow <- isWithinWarnWindow state now
-    case decideCtrlC context withinWindow of
+    noteCtrlC state >>= \case
         WarnExit -> do
-            writeIORef state.interruptLastWarn (Just now)
             notify state "Press Ctrl-C again to exit"
             pure ContinuePrompt
-        ForceExit -> do
-            armForceExit state
-            pure QuitProcess
+        ForceExit -> pure QuitProcess
         SoftCancel ->
             pure ContinuePrompt
 
 -- | Apply the same double-Ctrl-C policy when a retained TUI owns stdin.
 -- The caller renders the returned decision in its own UI.
 noteFullscreenCtrlC :: InterruptState -> IO CtrlCDecision
-noteFullscreenCtrlC state = do
-    now <- getCurrentTime
-    mCancel <- readIORef state.interruptActiveCancel
-    withinWindow <- isWithinWarnWindow state now
-    context <- ctrlCContext state
-    let decision = decideCtrlC context withinWindow
-    case decision of
-        SoftCancel -> do
-            case mCancel of
-                Just cancel -> requestCancel cancel
-                Nothing -> pure ()
-            writeIORef state.interruptLastWarn (Just now)
-        WarnExit ->
-            writeIORef state.interruptLastWarn (Just now)
-        ForceExit ->
-            armForceExit state
-    pure decision
+noteFullscreenCtrlC = noteCtrlC
 
-onSigInt :: ThreadId -> InterruptState -> IO ()
-onSigInt mainTid state = do
-    now <- getCurrentTime
-    mCancel <- readIORef state.interruptActiveCancel
-    withinWindow <- isWithinWarnWindow state now
-    ctx <- ctrlCContext state
-    case decideCtrlC ctx withinWindow of
-        SoftCancel -> do
-            case mCancel of
-                Just cancel -> requestCancel cancel
-                Nothing -> pure ()
-            writeIORef state.interruptLastWarn (Just now)
-            notify state "Interrupted; press Ctrl-C again to exit"
-        WarnExit -> do
-            writeIORef state.interruptLastWarn (Just now)
-            notify state "Press Ctrl-C again to exit"
-        ForceExit ->
-            requestForceExit mainTid state
+-- | One transition shared by terminal keys and the session supervisor.
+noteCtrlC :: InterruptState -> IO CtrlCDecision
+noteCtrlC state =
+    modifyMVarMasked state.interruptPolicy \policy -> do
+        now <- getCurrentTime
+        exiting <- atomically (not <$> isEmptyTMVar state.interruptExit)
+        context <- if exiting then pure Exiting else
+            maybe (pure Idle) (fmap TurnActive . isCancelled) policy.activeCancel
+        let withinWindow = case policy.lastWarn of
+                Just previous -> let elapsed = diffUTCTime now previous
+                    in elapsed >= 0 && elapsed <= exitConfirmWindow
+                Nothing -> False
+            decision = decideCtrlC context withinWindow
+        case decision of
+            SoftCancel -> mapM_ requestCancel policy.activeCancel
+            WarnExit -> pure ()
+            ForceExit -> requestSessionExit state
+        pure (policy{lastWarn = if decision == ForceExit then Nothing else Just now}, decision)
 
--- | Closing the terminal or SIGTERM is a confirmed quit: there is no second
--- keypress, and GHCi ignores SIGHUP by default so the agent must handle it.
-onHangup :: ThreadId -> InterruptState -> IO ()
-onHangup = requestForceExit
-
-ctrlCContext :: InterruptState -> IO CtrlCContext
-ctrlCContext state = do
-    exiting <- readIORef state.interruptExiting
-    if exiting
-        then pure Exiting
-        else do
-            mCancel <- readIORef state.interruptActiveCancel
-            case mCancel of
-                Nothing -> pure Idle
-                Just cancel ->
-                    TurnActive <$> isCancelled cancel
-
-armForceExit :: InterruptState -> IO ()
-armForceExit state = do
-    writeIORef state.interruptExiting True
-    writeIORef state.interruptLastWarn Nothing
-
-requestForceExit :: ThreadId -> InterruptState -> IO ()
-requestForceExit mainTid state = do
-    armForceExit state
-    throwTo mainTid UserInterrupt
-
-isWithinWarnWindow :: InterruptState -> UTCTime -> IO Bool
-isWithinWarnWindow state now = do
-    lastWarn <- readIORef state.interruptLastWarn
-    pure $ case lastWarn of
-        Just t -> diffUTCTime now t <= exitConfirmWindow
-        Nothing -> False
+-- | Nonblocking, idempotent session shutdown. Safe for signal adapters and
+-- independent of turn cancellation, so nested turn scopes cannot erase it.
+requestSessionExit :: InterruptState -> IO ()
+requestSessionExit state = atomically $ void (tryPutTMVar state.interruptExit ())
 
 notify :: InterruptState -> Text -> IO ()
 notify state msg =
-    -- Best-effort: never let printing from the signal thread fail the handler.
+    -- Best-effort notice rendering; signal callbacks never print.
     state.interruptOnMessage msg `catchIO` \_ -> pure ()
 
 -- | Recognize a 'UserInterrupt' thrown with safe-exceptions' 'throwIO'.

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Flow.hs
@@ -565,7 +565,7 @@ runAgent
                         , restartChooseModel = chooseRecoveryModel
                         }
                 in
-                runFullscreen runtime $
+                fmap (fromMaybe RunQuit) $ runFullscreen runtime $
                     runFullscreenRestartLoop
                         callbacks
                         runtime

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -59,7 +59,7 @@ import Agent.CLI.Interrupt
     ( InterruptState
     , catchUserInterrupt
     , retryUserInterruptOnce
-    , withCtrlCHandler
+    , withSessionInterruptScope
     )
 import Agent.CLI.ManagedTurn ( ManagedTurnRequest(..) )
 import Agent.CLI.ModelConfig
@@ -195,7 +195,7 @@ import Agent.CLI.Subagents.Runtime
 import Agent.CLI.Subagents.Runtime.Types
     (SubagentSession, SubagentStoreRoot)
 import Agent.CLI.TUI.App
-    ( FullscreenRuntime, withFullscreenSuspended, emitUiEvent )
+    ( FullscreenRuntime, deferFullscreenOutput, requestFullscreenStop, emitUiEvent )
 import Agent.CLI.Terminal ( resolveColor )
 import Agent.CLI.Tools
     ( schemasFromAppToolsCodeModeWithHostedSearchAndAsyncCapability
@@ -1122,8 +1122,10 @@ runSessionWithInterruptHandling AgentSessionRequest
     } progName action
         | startup.startupBackground = action
         | otherwise =
-            withCtrlCHandler interrupt $
-                withResumeHintOnQuit fullscreen progName persist action
+            withSessionInterruptScope interrupt
+                (mapM_ requestFullscreenStop fullscreen)
+                (withResumeHintOnQuit fullscreen progName persist . fmap (fromMaybe RunQuit))
+                action
 
 launchPreparedSession
     :: AgentSessionRequest windowTitleResult
@@ -1445,14 +1447,16 @@ withResumeHintOnQuit fullscreen progName persist action = do
         RunQuit -> do
             case fullscreen of
                 Nothing -> printResumeHint progName persist
-                Just runtime ->
-                    withFullscreenSuspended runtime
-                        (printResumeHint progName persist)
+                Just runtime -> do
+                    -- Resolve persistence while the session still owns its
+                    -- resources. Only terminal output outlives this scope.
+                    sessionId <- retryUserInterruptOnce (ensurePersistenceSessionId persist)
+                    forM_ sessionId \identifier ->
+                        deferFullscreenOutput runtime
+                            (printResumeHintForId progName identifier)
         _ -> pure ()
-    -- An interrupt is the requested, graceful end of the CLI session.
-    -- Returning lets the surrounding brackets restore the SIGINT handler
-    -- and close tools without GHC's top-level exception handler printing
-    -- "user interrupt" and a backtrace.
+    -- Quit is a normal session result, including compatibility handling for
+    -- an external UserInterrupt. Surrounding resource scopes unwind normally.
     pure result
 
 -- | Report only a session that is already durable. In particular, do not try
@@ -1471,7 +1475,7 @@ printCrashResumeHint fullscreen progName persist =
             case fullscreen of
                 Nothing -> printResumeHintForId progName identifier
                 Just runtime ->
-                    withFullscreenSuspended runtime
+                    deferFullscreenOutput runtime
                         (printResumeHintForId progName identifier)
     ) `Safe.catchAny` \_ -> pure ()
 

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -29,6 +29,8 @@ module Agent.CLI.TUI.App
     , appEventLogicalBytes
     , closeAppEventMailbox
     , closeFullscreenChannels
+    , deferFullscreenOutput
+    , requestFullscreenStop
     , emitUiEvent
     , enqueueAppEvent
     , externalUrlCommand

--- a/packages/agent-cli/src/Agent/CLI/TUI/App.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App.hs
@@ -90,6 +90,9 @@ module Agent.CLI.TUI.App
     , requestFullscreenText
     , runFullscreen
     , withFullscreenWorker
+    , withFullscreenFinalOutput
+    , enqueueMailboxEvent
+    , eventPump
     , commitFullscreenImagePreviews
     , commitFullscreenHistoryTurn
     , resetHistoryPage

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -152,7 +152,7 @@ import Control.Applicative ((<|>))
 import Control.Concurrent.Async (wait, waitCatch, withAsync)
 import Control.Concurrent (threadDelay)
 import Control.Monad (forever, unless, void, when, (>=>))
-import Control.Concurrent.STM ( STM , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , writeTQueue , writeTVar )
+import Control.Concurrent.STM ( STM , atomically , check , flushTQueue , newEmptyTMVarIO , newTQueueIO , newTVarIO , orElse , putTMVar , readTVar , readTMVar , readTQueue , registerDelay , retry , takeTMVar , tryPutTMVar , writeTQueue , writeTVar )
 import Agent.CLI.Recap ( autoRecapAwayThreshold , autoRecapIdleThreshold , autoRecapRetryInterval )
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
@@ -193,7 +193,10 @@ eventPump :: FullscreenRuntime -> IO ()
 eventPump runtime = loop
   where
     loop = do
-        pending <- atomically (takePendingAppEvent runtime.runtimeMailbox)
+        pending <- atomically $
+            (readTMVar runtime.runtimeStopRequested
+                >> pure (PendingEvent AppStop))
+                `orElse` takePendingAppEvent runtime.runtimeMailbox
         delivered <- case pending of
             PendingUi first -> do
                 threadDelay uiFrameDelayMicros
@@ -206,7 +209,17 @@ eventPump runtime = loop
             PendingEvent event ->
                 pure event
         writeBChan runtime.runtimeEvents delivered
-        loop
+        case delivered of
+            AppStop -> pure ()
+            _ -> loop
+
+-- | Ask the terminal owner to halt without waiting for capacity in either
+-- display queue. Publication is idempotent, including after Brick has exited.
+-- Normal worker completion still enqueues an ordered AppStop so its final
+-- display events are rendered first; confirmed user shutdown uses this lane.
+requestFullscreenStop :: FullscreenRuntime -> IO ()
+requestFullscreenStop runtime =
+    atomically (void (tryPutTMVar runtime.runtimeStopRequested ()))
 
 uiFrameDelayMicros :: Int
 uiFrameDelayMicros = 16000

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Run.hs
@@ -155,7 +155,6 @@ import Agent.CLI.Recap ( autoRecapAwayThreshold , autoRecapIdleThreshold , autoR
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State.Strict (modify')
 import Control.Exception.Safe (finally, onException, throwIO, tryAny)
-import Control.Exception (AsyncException(UserInterrupt))
 import Data.Char (isControl, isSpace)
 import Data.Foldable (toList)
 import Data.IORef ( atomicModifyIORef' , modifyIORef' , newIORef , readIORef , writeIORef )
@@ -194,13 +193,11 @@ import Agent.CLI.TUI.App.Event
 -- The grace interval bounds cooperative shutdown only. If it expires, scope
 -- exit cancels and joins the worker; we never abandon it or kill the host
 -- process. Resource finalizers must themselves provide interruptible cleanup.
-withFullscreenWorker :: (Async a -> IO ()) -> IO a -> (Async a -> IO ()) -> IO a
+withFullscreenWorker :: (Async a -> IO ()) -> IO a -> (Async a -> IO ()) -> IO (Maybe a)
 withFullscreenWorker closeChannels workerAction runUi =
     withAsyncWithUnmask (\unmask -> unmask workerAction) \worker -> do
         runUi worker `finally` closeChannels worker
-        timeout 2_000_000 (wait worker) >>= \case
-            Just result -> pure result
-            Nothing -> throwIO UserInterrupt
+        timeout 2_000_000 (wait worker)
 
 closeFullscreenChannels :: FullscreenRuntime -> Async a -> IO ()
 closeFullscreenChannels runtime worker = do
@@ -213,8 +210,17 @@ closeFullscreenChannels runtime worker = do
             Nothing -> Composer.closeFullscreenInputBuffer runtime.runtimeInput
             Just _ -> pure ()
 
-runFullscreen :: FullscreenRuntime -> IO a -> IO a
-runFullscreen runtime workerAction = do
+-- | The outermost terminal scope owns final diagnostics. Remove them before
+-- attempting output so cleanup cannot print them twice. A failed diagnostic
+-- must neither hide the session's original failure nor suppress later hints.
+withFullscreenFinalOutput :: FullscreenRuntime -> IO a -> IO a
+withFullscreenFinalOutput runtime action =
+    action `finally` do
+        pending <- atomically (flushTQueue runtime.runtimeFinalOutput)
+        mapM_ (void . tryAny) pending
+
+runFullscreen :: FullscreenRuntime -> IO a -> IO (Maybe a)
+runFullscreen runtime workerAction = withFullscreenFinalOutput runtime do
     history <- readReplHistory
     (initialAgent, initialAgents) <- runtime.runtimeAgentSnapshot
     initialClock <- getMonotonicTimeNSec

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Runtime.hs
@@ -292,6 +292,8 @@ newFullscreenRuntimeWithSyntaxLoaderAndTheme
     color
     initial = do
         events <- newBChan appEventChannelCapacity
+        stopRequested <- newEmptyTMVarIO
+        finalOutput <- newTQueueIO
         mailbox <- AppEventMailbox <$> newTVarIO AppEventMailboxState
             { mailboxClosed = False
             , mailboxPendingEvents = Seq.empty
@@ -335,6 +337,8 @@ newFullscreenRuntimeWithSyntaxLoaderAndTheme
         pure FullscreenRuntime
             { runtimeEvents = events
             , runtimeMailbox = mailbox
+            , runtimeStopRequested = stopRequested
+            , runtimeFinalOutput = finalOutput
             , runtimeInput = inputBuffer
             , runtimeCancel =
                 readIORef sessionActions >>= (.sessionCancel)
@@ -1177,6 +1181,17 @@ requestFullscreenSecret runtime title body = do
             ""
             reply)
     atomically (takeTMVar reply)
+
+-- | Queue best-effort final diagnostics for the terminal owner. Unlike
+-- 'withFullscreenSuspended', this never waits for Brick and remains usable
+-- while the worker unwinds after the display mailbox has closed.
+--
+-- The action runs after session workers and Vty have released their resources.
+-- Capture the diagnostic data now; do not defer resource acquisition or refer
+-- to a provider/session handle that teardown will close.
+deferFullscreenOutput :: FullscreenRuntime -> IO () -> IO ()
+deferFullscreenOutput runtime action =
+    atomically (writeTQueue runtime.runtimeFinalOutput action)
 
 withFullscreenSuspended :: FullscreenRuntime -> IO a -> IO a
 withFullscreenSuspended runtime action = do

--- a/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Types.hs
@@ -413,6 +413,12 @@ commandPaletteActionAt index catalog
 data FullscreenRuntime = FullscreenRuntime
     { runtimeEvents :: !(BChan AppEvent)
     , runtimeMailbox :: !AppEventMailbox
+    -- | Forced shutdown bypasses display backpressure. The event pump gives
+    -- this one-shot control lane priority over queued rendering work.
+    , runtimeStopRequested :: !(TMVar ())
+    -- | Final diagnostics belong to the terminal owner, not the display
+    -- mailbox: they must survive its closure and run after Vty is restored.
+    , runtimeFinalOutput :: !(TQueue (IO ()))
     , runtimeInput :: !FullscreenInputBuffer
     , runtimeCancel :: !(IO ())
     , runtimeSteer :: !(Bool -> Text -> IO (Either Text ()))

--- a/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InterruptSpec.hs
@@ -1,7 +1,9 @@
 module Agent.CLI.InterruptSpec (spec) where
 
 import Agent.CLI.Interrupt
-import Agent.Cancel (newCancelFlag, isCancelled, requestCancel)
+import Agent.Cancel (newCancelFlag, isCancelled, requestCancel, waitCancel)
+import Control.Concurrent.Async (concurrently)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import qualified Control.Exception as Base
 import Control.Exception (AsyncException(ThreadKilled, UserInterrupt))
 import Control.Exception.Safe (bracket, finally, throwIO, toSyncException)
@@ -9,6 +11,7 @@ import Control.Monad (forM_, void)
 import Data.IORef
 import System.Posix.Signals (Handler(..), Signal, installHandler, sigHUP, sigINT, sigTERM)
 import Test.Hspec
+import System.Timeout (timeout)
 
 spec :: Spec
 spec = do
@@ -63,30 +66,136 @@ spec = do
             noteFullscreenCtrlC state `shouldReturn` ForceExit
             noteFullscreenCtrlC state `shouldReturn` ForceExit
 
-    describe "withCtrlCHandler" do
-        it "keeps repeated confirmed interrupts within the session boundary" do
+        it "serializes simultaneous Ctrl-C requests against the active turn" do
             state <- newInterruptState (const (pure ()))
-            withCtrlCHandler state do
-                noteIdleCtrlC state `shouldReturn` ContinuePrompt
-                noteIdleCtrlC state `shouldReturn` QuitProcess
-                forM_ [1 :: Int, 2] \_ ->
-                    catchUserInterrupt
-                        (invokeInstalledHandler sigINT >> pure False)
-                        (pure True)
-                        `shouldReturn` True
+            flag <- newCancelFlag
+            decisions <- withTurnCancel state flag $
+                concurrently (noteFullscreenCtrlC state) (noteFullscreenCtrlC state)
+            decisions `shouldSatisfy`
+                (`elem` [(SoftCancel, ForceExit), (ForceExit, SoftCancel)])
+            isCancelled flag `shouldReturn` True
+
+    describe "withSessionInterrupts" do
+        it "preserves a normally completed action without requesting UI stop" do
+            state <- newInterruptState (const (pure ()))
+            withSessionInterrupts state
+                (expectationFailure "Unexpected UI stop")
+                (pure (42 :: Int))
+                `shouldReturn` Just 42
+
+        it "joins a keyboard-cancelled action after notifying its UI owner" do
+            state <- newInterruptState (const (pure ()))
+            blocked <- newEmptyMVar
+            events <- newIORef ([] :: [String])
+            let record event = atomicModifyIORef' events \old -> (old <> [event], ())
+            timeout 1_000_000
+                (withSessionInterrupts state (record "stop") $
+                    (do
+                        noteIdleCtrlC state `shouldReturn` ContinuePrompt
+                        void (noteIdleCtrlC state)
+                        takeMVar blocked)
+                    `finally` record "joined")
+                `shouldReturn` Just (Nothing :: Maybe ())
+            readIORef events `shouldReturn` ["stop", "joined"]
 
         it "treats hangup and termination as confirmed session quit" do
             forM_ [sigHUP, sigTERM] \signal -> do
                 state <- newInterruptState (const (pure ()))
-                catchUserInterrupt
-                    (withCtrlCHandler state
-                        (invokeInstalledHandler signal >> pure False))
-                    (pure True)
-                    `shouldReturn` True
+                blocked <- newEmptyMVar
+                joined <- newIORef False
+                timeout 1_000_000
+                    (withSessionInterrupts state (pure ()) $
+                        (invokeInstalledHandler signal >> takeMVar blocked)
+                            `finally` writeIORef joined True)
+                    `shouldReturn` Just (Nothing :: Maybe ())
+                readIORef joined `shouldReturn` True
                 noteIdleCtrlC state `shouldReturn` QuitProcess
 
-        it "restores previous signal handlers after an exceptional session exit" do
-            forM_ [sigINT, sigHUP, sigTERM] \signal -> do
+        it "soft-cancels the first SIGINT and quits on the next" do
+            messages <- newEmptyMVar
+            state <- newInterruptState (putMVar messages)
+            flag <- newCancelFlag
+            blocked <- newEmptyMVar
+            joined <- newIORef False
+            timeout 1_000_000
+                (withSessionInterrupts state (pure ()) $
+                    withTurnCancel state flag $
+                        (do
+                            invokeInstalledHandler sigINT
+                            waitCancel flag
+                            takeMVar messages
+                                `shouldReturn` "Interrupted; press Ctrl-C again to exit"
+                            invokeInstalledHandler sigINT
+                            takeMVar blocked)
+                        `finally` writeIORef joined True)
+                `shouldReturn` Just (Nothing :: Maybe ())
+            readIORef joined `shouldReturn` True
+
+        it "keeps repeated exit requests from interrupting a worker finalizer" do
+            state <- newInterruptState (const (pure ()))
+            blocked <- newEmptyMVar
+            joined <- newIORef False
+            timeout 1_000_000
+                (withSessionInterrupts state (pure ()) $
+                    (requestSessionExit state >> takeMVar blocked)
+                        `finally` do
+                            forM_ [sigINT, sigHUP, sigTERM] invokeInstalledHandler
+                            requestSessionExit state
+                            writeIORef joined True)
+                `shouldReturn` Just (Nothing :: Maybe ())
+            readIORef joined `shouldReturn` True
+
+        it "quits on the second SIGINT while the first notice is blocked" do
+            noticeStarted <- newEmptyMVar
+            noticeBlocked <- newEmptyMVar
+            noticeJoined <- newIORef False
+            state <- newInterruptState \_ ->
+                (putMVar noticeStarted () >> takeMVar noticeBlocked)
+                    `finally` writeIORef noticeJoined True
+            workerBlocked <- newEmptyMVar
+            workerJoined <- newIORef False
+            timeout 1_000_000
+                (withSessionInterrupts state (pure ()) $
+                    (do
+                        invokeInstalledHandler sigINT
+                        takeMVar noticeStarted
+                        invokeInstalledHandler sigINT
+                        takeMVar workerBlocked)
+                    `finally` writeIORef workerJoined True)
+                `shouldReturn` Just (Nothing :: Maybe ())
+            readIORef workerJoined `shouldReturn` True
+            readIORef noticeJoined `shouldReturn` True
+
+        it "prioritizes queued Ctrl-C requests over a completed provider transition" do
+            state <- newInterruptState (const (pure ()))
+            timeout 1_000_000
+                (withSessionInterrupts state (pure ()) do
+                    invokeInstalledHandler sigINT
+                    invokeInstalledHandler sigINT
+                    pure ("provider transition" :: String))
+                `shouldReturn` Just Nothing
+
+        it "propagates worker failures instead of reporting a requested quit" do
+            state <- newInterruptState (const (pure ()))
+            withSessionInterrupts state
+                (expectationFailure "Unexpected UI stop")
+                (ioError (userError "provider failed") :: IO ())
+                `shouldThrow` anyIOException
+
+        it "propagates failed worker cleanup during a requested quit" do
+            state <- newInterruptState (const (pure ()))
+            blocked <- newEmptyMVar
+            timeout 1_000_000
+                (withSessionInterrupts state (pure ()) $
+                    (requestSessionExit state >> takeMVar blocked :: IO ())
+                        -- Model a dependency finalizer that propagates its
+                        -- cleanup failure. Safe.finally instead preserves the
+                        -- original async cancellation over synchronous errors.
+                        `Base.finally` ioError (userError "cleanup failed"))
+                `shouldThrow` anyIOException
+
+        it "restores previous handlers after normal and exceptional exits" do
+            forM_ [(signal, fails) | signal <- [sigINT, sigHUP, sigTERM], fails <- [False, True]] \(signal, fails) -> do
                 restored <- newIORef False
                 bracket
                     (installHandler signal
@@ -94,11 +203,39 @@ spec = do
                     (\previous -> void (installHandler signal previous Nothing))
                     \_ -> do
                         state <- newInterruptState (const (pure ()))
-                        catchUserInterrupt
-                            (withCtrlCHandler state (Base.throwIO UserInterrupt))
-                            (pure ())
+                        let session = withSessionInterrupts state (pure ()) $
+                                if fails then ioError (userError "session failed") else pure ()
+                        if fails
+                            then session `shouldThrow` anyIOException
+                            else session `shouldReturn` Just ()
                         invokeInstalledHandler signal
                         readIORef restored `shouldReturn` True
+
+    describe "withSessionInterruptScope" do
+        it "retains latched signal handlers through post-join reporting" do
+            forM_ [sigINT, sigHUP, sigTERM] \signal -> do
+                previousCalled <- newIORef False
+                joined <- newIORef False
+                blocked <- newEmptyMVar
+                state <- newInterruptState (const (pure ()))
+                bracket
+                    (installHandler signal
+                        (Catch (writeIORef previousCalled True)) Nothing)
+                    (\previous -> void (installHandler signal previous Nothing))
+                    \_ -> do
+                        let report supervise = do
+                                supervise `shouldReturn` (Nothing :: Maybe ())
+                                readIORef joined `shouldReturn` True
+                                forM_ [sigINT, sigHUP, sigTERM] invokeInstalledHandler
+                                noteFullscreenCtrlC state `shouldReturn` ForceExit
+                                readIORef previousCalled `shouldReturn` False
+                        timeout 1_000_000
+                            (withSessionInterruptScope state (pure ()) report $
+                                (requestSessionExit state >> takeMVar blocked)
+                                    `finally` writeIORef joined True)
+                            `shouldReturn` Just ()
+                        invokeInstalledHandler signal
+                        readIORef previousCalled `shouldReturn` True
 
     describe "isWrappedUserInterrupt" do
         it "recognizes a synchronously wrapped UserInterrupt" do
@@ -157,13 +294,14 @@ spec = do
             readIORef attempts `shouldReturn` 2
 
 -- Invoke the installed callback directly rather than deliver a process-wide
--- signal to the test runner or GHCi. The callback still targets the session's
--- owning thread, exercising the same exception path as the signal dispatcher.
+-- signal to the test runner or GHCi. Restore the callback before invoking it,
+-- since publishing exit can let the supervisor restore its outer handler.
 invokeInstalledHandler :: Signal -> IO ()
-invokeInstalledHandler signal =
-    bracket
+invokeInstalledHandler signal = do
+    installed <- bracket
         (installHandler signal Ignore Nothing)
         (\previous -> void (installHandler signal previous Nothing))
-        \case
-            Catch handler -> handler
-            _ -> expectationFailure "Expected a session signal handler"
+        pure
+    case installed of
+        Catch handler -> handler
+        _ -> expectationFailure "Expected a session signal handler"

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -3,6 +3,9 @@ module Agent.CLI.TUIAppSpec (spec) where
 import qualified Agent.TUI.Theme as Theme
 import Agent.CLI.TUI.Keyboard (decodeKeyboardBody, classifyKeyboard, runKeyboardInput)
 import Agent.CLI.TUI.App (finishedMarkdownProseCaches)
+import Agent.CLI.TUI.App.Run (withFullscreenFinalOutput)
+import Agent.CLI.TUI.App.Mailbox (enqueueMailboxEvent, eventPump)
+import Brick.BChan (readBChan)
 import Control.Monad (forM_, when)
 import Control.Monad.IO.Class (liftIO)
 import Graphics.Vty.Platform.Unix.Input.Classify.Types (KClass(..))
@@ -27,7 +30,10 @@ import Agent.CLI.Resume
     )
 import Agent.CLI.TUI.App
     ( applyStoredFullscreenWindowTitle
+    , closeAppEventMailbox
     , closeFullscreenChannels
+    , deferFullscreenOutput
+    , requestFullscreenStop
     , withFullscreenWorker
     , applyMetaConsoleEdit
     , applyTextPromptEdit
@@ -179,6 +185,7 @@ import Control.Exception (AsyncException(UserInterrupt))
 import qualified Control.Exception as Exception
 import Control.Concurrent.STM
     ( atomically
+    , orElse
     , readTVar
     , readTMVar
     , newEmptyTMVarIO
@@ -757,6 +764,97 @@ spec = do
             finalText `shouldSatisfy` Text.isInfixOf "PR #42"
             finalText `shouldBe` renderedAppText bounds finalState
 
+    describe "fullscreen stop control lane" do
+        it "publishes stop without capacity and prioritizes it over queued display work" do
+            runtime <- newScriptRuntime initialUiState
+            reply <- newEmptyTMVarIO
+            -- An opaque suspension occupies the entire payload budget and
+            -- control reserve. Even an ordinary AppStop cannot be enqueued.
+            History.enqueueAppEvent runtime (AppSuspend (pure ()) reply)
+            atomically
+                ((enqueueMailboxEvent runtime.runtimeMailbox AppStop >> pure True)
+                    `orElse` pure False)
+                `shouldReturn` False
+            timeout 1_000_000
+                (replicateM_ 3 (requestFullscreenStop runtime))
+                `shouldReturn` Just ()
+            timeout 1_000_000 (eventPump runtime) `shouldReturn` Just ()
+            delivered <- readBChan runtime.runtimeEvents
+            case delivered of
+                AppStop -> pure ()
+                _ -> expectationFailure "expected stop ahead of the suspended display action"
+            isNothing <$> atomically (tryReadTMVar reply) `shouldReturn` True
+
+        it "remains nonblocking after the display mailbox closes" do
+            runtime <- newScriptRuntime initialUiState
+            atomically (closeAppEventMailbox runtime.runtimeMailbox)
+            timeout 1_000_000
+                (replicateM_ 3 (requestFullscreenStop runtime))
+                `shouldReturn` Just ()
+
+    describe "fullscreen final output" do
+        it "waits for worker teardown and terminal restoration before printing" do
+            runtime <- newScriptRuntime initialUiState
+            started <- newEmptyMVar
+            blocked <- newEmptyMVar
+            events <- newIORef ([] :: [String])
+            let record label = atomicModifyIORef' events \previous ->
+                    (previous <> [label], ())
+                worker =
+                    bracket_
+                        (putMVar started ())
+                        (do
+                            record "worker stopped"
+                            deferFullscreenOutput runtime (record "resume hint"))
+                        (takeMVar blocked :: IO ())
+            timeout 1_000_000
+                (withFullscreenFinalOutput runtime $
+                    bracket_
+                        (pure ())
+                        (record "terminal restored")
+                        (withFullscreenWorker
+                            (closeFullscreenChannels runtime)
+                            worker
+                            (\_ -> takeMVar started >> ioError (userError "UI failure"))))
+                `shouldThrow` (== userError "UI failure")
+            readIORef events `shouldReturn`
+                ["worker stopped", "terminal restored", "resume hint"]
+
+        it "survives mailbox closure and drains each diagnostic only once" do
+            runtime <- newScriptRuntime initialUiState
+            events <- newIORef ([] :: [String])
+            let record label = modifyIORef' events (<> [label])
+            withFullscreenFinalOutput runtime do
+                deferFullscreenOutput runtime (record "before closure")
+                atomically (closeAppEventMailbox runtime.runtimeMailbox)
+                deferFullscreenOutput runtime (record "after closure")
+                readIORef events `shouldReturn` []
+            withFullscreenFinalOutput runtime (pure ())
+            readIORef events `shouldReturn` ["before closure", "after closure"]
+
+        it "preserves the session failure and continues after a diagnostic fails" do
+            runtime <- newScriptRuntime initialUiState
+            events <- newIORef ([] :: [String])
+            let record label = modifyIORef' events (<> [label])
+            (withFullscreenFinalOutput runtime do
+                deferFullscreenOutput runtime do
+                    record "failed hint"
+                    ioError (userError "output failure")
+                deferFullscreenOutput runtime (record "later hint")
+                ioError (userError "session failure"))
+                `shouldThrow` (== userError "session failure")
+            withFullscreenFinalOutput runtime (pure ())
+            readIORef events `shouldReturn` ["failed hint", "later hint"]
+
+        it "prints final diagnostics while preserving an external interrupt" do
+            runtime <- newScriptRuntime initialUiState
+            printed <- newIORef False
+            (withFullscreenFinalOutput runtime do
+                deferFullscreenOutput runtime (writeIORef printed True)
+                Exception.throwIO UserInterrupt)
+                `shouldThrow` (== UserInterrupt)
+            readIORef printed `shouldReturn` True
+
     describe "fullscreen worker ownership" do
         it "closes input and preserves a cooperative worker result" do
             closed <- newEmptyMVar
@@ -765,7 +863,7 @@ spec = do
                     (const (putMVar closed ()))
                     (takeMVar closed >> pure (42 :: Int))
                     (const (pure ())))
-                `shouldReturn` Just 42
+                `shouldReturn` Just (Just 42)
 
         it "closes input and joins the worker when the UI fails" do
             started <- newEmptyMVar
@@ -821,14 +919,11 @@ spec = do
                         (writeIORef stopped True)
                         (takeMVar blocked :: IO ())
             timeout 5_000_000
-                (catchUserInterrupt
-                    (withFullscreenWorker
-                        (const (writeIORef closed True))
-                        worker
-                        (\_ -> takeMVar started)
-                        >> pure False)
-                    (pure True))
-                `shouldReturn` Just True
+                (withFullscreenWorker
+                    (const (writeIORef closed True))
+                    worker
+                    (\_ -> takeMVar started))
+                `shouldReturn` Just Nothing
             readIORef closed `shouldReturn` True
             readIORef stopped `shouldReturn` True
 
@@ -855,7 +950,7 @@ spec = do
                 (closeFullscreenChannels runtime)
                 (pure (42 :: Int))
                 (void . waitCatch)
-                `shouldReturn` 42
+                `shouldReturn` Just 42
             queued <- atomically (Composer.readFullscreenInputs runtime.runtimeInput)
             fmap (.fullscreenInputLine) (toList queued)
                 `shouldBe` [ReplText "queued prompt"]
@@ -869,7 +964,7 @@ spec = do
                     (closeFullscreenChannels runtime)
                     (atomically (Composer.takeFullscreenInput runtime.runtimeInput))
                     (const (pure ()))
-            fmap (.fullscreenInputLine) result `shouldBe` Just ReplEof
+            fmap (fmap (.fullscreenInputLine)) result `shouldBe` Just (Just ReplEof)
 
     describe "dictation readiness" do
         it "does not erase a transcript that arrives before the ready event" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -2,9 +2,7 @@ module Agent.CLI.TUIAppSpec (spec) where
 
 import qualified Agent.TUI.Theme as Theme
 import Agent.CLI.TUI.Keyboard (decodeKeyboardBody, classifyKeyboard, runKeyboardInput)
-import Agent.CLI.TUI.App (finishedMarkdownProseCaches)
-import Agent.CLI.TUI.App.Run (withFullscreenFinalOutput)
-import Agent.CLI.TUI.App.Mailbox (enqueueMailboxEvent, eventPump)
+import Agent.CLI.TUI.App (finishedMarkdownProseCaches, withFullscreenFinalOutput, enqueueMailboxEvent, eventPump)
 import Brick.BChan (readBChan)
 import Control.Monad (forM_, when)
 import Control.Monad.IO.Class (liftIO)

--- a/packages/agent-core/src/Agent/Cancel.hs
+++ b/packages/agent-core/src/Agent/Cancel.hs
@@ -2,7 +2,7 @@
 --
 -- Soft-cancel asks the current turn to stop and return to the REPL without
 -- tearing the process down. The CLI maps the first Ctrl-C (and Esc) onto
--- this flag; a second Ctrl-C still raises 'UserInterrupt' for full exit.
+-- this flag; a second Ctrl-C requests session exit through the CLI supervisor.
 module Agent.Cancel
     ( CancelFlag
     , newCancelFlag


### PR DESCRIPTION
## Summary

Replace manual exit exception delivery with a scoped session supervisor. Signal handlers now publish intent, while keyboard input and signals share one Ctrl-C policy and the supervisor owns cancellation and joining.

- Keep signal handlers installed through cleanup and final reporting; preserve worker cleanup failures.
- Give fullscreen shutdown a nonblocking, idempotent stop channel independent of the event mailbox.
- Print fullscreen resume hints only after terminal restoration, and represent cooperative shutdown timeout as a result rather than a synthetic interrupt.

The grace interval bounds cooperative waiting, not finalizer execution; cleanup still needs to be interruptible.

## Validation

- CLI library loaded successfully in GHCi (251 modules).
- InterruptSpec: 29 examples passed in each of 20 consecutive runs.
- TUIAppSpec: 214 examples passed.
- Live tmux checks: double Ctrl-C exits inline and fullscreen sessions, restores the terminal, prints one resume hint, and leaves GHCi alive; fullscreen resume/re-exit also passed.
- `git diff --check` passed.
