### PR TITLE
Consolidate mail UTF-8 byte-bounded text helpers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -293,6 +293,7 @@
                     root = ./packages/agent-mail;
                     include = [
                         "src"
+                        "internal"
                         "test"
                         "agent-mail.cabal"
                         "package.nix"

--- a/packages/agent-mail/agent-mail.cabal
+++ b/packages/agent-mail/agent-mail.cabal
@@ -37,7 +37,8 @@ common common-options
 
 library
     import:          common-options
-    hs-source-dirs:  src
+    hs-source-dirs:  src internal
+    other-modules:  Agent.Mail.Utf8
     exposed-modules:
         Agent.Mail.Imap
         Agent.Mail.Mime
@@ -66,13 +67,15 @@ library
 test-suite agent-mail-test
     import:          common-options
     type:            exitcode-stdio-1.0
-    hs-source-dirs:  test
+    hs-source-dirs:  test internal
+    other-modules:  Agent.Mail.Utf8
     main-is:         Spec.hs
     build-depends:
         agent-mail
         , aeson
         , base
         , hspec >= 2.11 && < 2.12
+        , bytestring
         , http-types
         , text
         , time

--- a/packages/agent-mail/internal/Agent/Mail/Utf8.hs
+++ b/packages/agent-mail/internal/Agent/Mail/Utf8.hs
@@ -1,0 +1,22 @@
+-- | Internal byte-bounded text operations shared by mail codecs and types.
+module Agent.Mail.Utf8 (truncateUtf8, utf8Length) where
+
+import qualified Data.ByteString as BS
+import Data.Text (Text)
+import qualified Data.Text.Encoding as TextEncoding
+
+-- | Keep the longest whole-codepoint prefix fitting in the UTF-8 byte limit.
+-- Non-positive limits produce empty text. An incomplete final codepoint is
+-- dropped, never replaced with a replacement character.
+truncateUtf8 :: Int -> Text -> Text
+truncateUtf8 limit = decodePrefix . BS.take (max 0 limit) . TextEncoding.encodeUtf8
+  where
+    decodePrefix bytes =
+        case TextEncoding.decodeUtf8' bytes of
+            Right value -> value
+            Left _
+                | BS.null bytes -> ""
+                | otherwise -> decodePrefix (BS.init bytes)
+
+utf8Length :: Text -> Int
+utf8Length = BS.length . TextEncoding.encodeUtf8

--- a/packages/agent-mail/package.nix
+++ b/packages/agent-mail/package.nix
@@ -12,7 +12,9 @@ mkDerivation {
     crypton-connection http-client http-client-tls http-types network
     safe-exceptions tagsoup text time tls
   ];
-  testHaskellDepends = [ aeson base hspec http-types text time ];
+  testHaskellDepends = [
+    aeson base bytestring hspec http-types text time
+  ];
   description = "Low-level email types and provider transports";
   license = lib.meta.getLicenseFromSpdxId "MIT";
 }

--- a/packages/agent-mail/src/Agent/Mail/Mime.hs
+++ b/packages/agent-mail/src/Agent/Mail/Mime.hs
@@ -32,6 +32,7 @@ import qualified Data.Text.Encoding.Error as TextEncodingError
 import Text.HTML.TagSoup (innerText, parseTags)
 import Text.Read (readMaybe)
 import Agent.Mail.Types (MailDraftContent(..))
+import Agent.Mail.Utf8 (truncateUtf8, utf8Length)
 
 data ParsedMailMime = ParsedMailMime
     { parsedMailParts :: ![MimePart]
@@ -711,17 +712,3 @@ maximumMimeParameterSegments = 32
 
 maximumTextDecodeBytes :: Int
 maximumTextDecodeBytes = 512 * 1024
-
-truncateUtf8 :: Int -> Text -> Text
-truncateUtf8 maximum =
-    decodePrefix . BS.take maximum . TextEncoding.encodeUtf8
-  where
-    decodePrefix bytes =
-        case TextEncoding.decodeUtf8' bytes of
-            Right value -> value
-            Left _
-                | BS.null bytes -> ""
-                | otherwise -> decodePrefix (BS.init bytes)
-
-utf8Length :: Text -> Int
-utf8Length = BS.length . TextEncoding.encodeUtf8

--- a/packages/agent-mail/src/Agent/Mail/Types.hs
+++ b/packages/agent-mail/src/Agent/Mail/Types.hs
@@ -63,6 +63,7 @@ import Data.Aeson
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.Types as AesonTypes
+import Agent.Mail.Utf8 (truncateUtf8, utf8Length)
 import qualified Data.ByteString as BS
 import Data.Char
     ( isAlphaNum
@@ -73,7 +74,6 @@ import Data.Char
     )
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Encoding as TextEncoding
 import Data.Time
     ( Day
     , UTCTime
@@ -1104,19 +1104,6 @@ validDateRange after before =
 parseIsoDay :: Text -> Maybe Day
 parseIsoDay value =
     parseTimeM True defaultTimeLocale "%F" (Text.unpack value)
-
-utf8Length :: Text -> Int
-utf8Length = BS.length . TextEncoding.encodeUtf8
-
-truncateUtf8 :: Int -> Text -> Text
-truncateUtf8 limit = decodePrefix . BS.take (max 0 limit) . TextEncoding.encodeUtf8
-  where
-    decodePrefix bytes =
-        case TextEncoding.decodeUtf8' bytes of
-            Right value -> value
-            Left _
-                | BS.null bytes -> ""
-                | otherwise -> decodePrefix (BS.init bytes)
 
 boundedOpaque :: Text -> Text
 boundedOpaque = truncateUtf8 maximumOpaqueReferenceBytes

--- a/packages/agent-mail/test/Spec.hs
+++ b/packages/agent-mail/test/Spec.hs
@@ -7,6 +7,9 @@ import Agent.Mail.SecretCodec
 import Agent.Mail.Transport
 import Agent.Mail.Types
 import qualified Agent.Mail.Types as MailTypes
+import Agent.Mail.Utf8 (truncateUtf8, utf8Length)
+import Control.Monad (forM_)
+import qualified Data.ByteString as BS
 import Data.Aeson (Result(..), Value(..), object, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -21,6 +24,28 @@ import Test.Hspec
 
 main :: IO ()
 main = hspec do
+    describe "UTF-8 byte-bounded text" do
+        forM_
+            [ ("empty", "", [0])
+            , ("ASCII", "abc", [0, 1, 2, 3])
+            , ("two-byte", "éø", [0, 2, 4])
+            , ("three-byte", "€中", [0, 3, 6])
+            , ("four-byte", "😀🚀", [0, 4, 8])
+            , ("mixed", "aé€😀z", [0, 1, 3, 6, 10, 11])
+            ] \(label, input, boundaries) -> do
+                it (label <> ": measures encoded bytes") do
+                    utf8Length input `shouldBe` last boundaries
+                forM_ (minBound : [-2 .. last boundaries + 2] <> [maxBound]) \limit ->
+                    it (label <> ": truncates at byte limit " <> show limit) do
+                        let result = truncateUtf8 limit input
+                            bytes = TextEncoding.encodeUtf8 result
+                            fitting = takeWhile (<= max 0 limit) boundaries
+                            expected = Text.pack (take (length fitting - 1) (Text.unpack input))
+                        result `shouldBe` expected
+                        BS.length bytes `shouldSatisfy` (<= max 0 limit)
+                        TextEncoding.decodeUtf8' bytes `shouldBe` Right result
+                        result `shouldSatisfy` (`Text.isPrefixOf` input)
+
     describe "email domain types" do
         it "requires fail-closed account status flags" do
             let partial = object


### PR DESCRIPTION
## Summary
- Share truncation and encoded-length helpers in a private agent-mail module without dependency cycles or public API changes.
- Preserve whole-codepoint truncation, including non-positive bounds; leave WebFetch replacement semantics untouched.
- Add table-driven coverage of every byte boundary for ASCII, 2/3/4-byte and mixed text, empty input, negative/zero/exact/oversized limits, Int extremes, valid UTF-8, and byte bounds.
- Regenerate package.nix for the test bytestring dependency.

## Validation
- `nix develop -c cabal repl agent-mail:lib:agent-mail`: verified `Ok, 7 modules loaded.`
- `nix develop -c cabal repl agent-mail:test:agent-mail-test`, then `:main`: verified successful load and **115 examples, 0 failures**.
- `git diff --cached --check` and independent read-only review passed.

Behavior-preserving refactor; no performance claims. Based on origin/master (the repository has no main branch).