### PR TITLE
Deduplicate OpenAI and xAI transcription receive loops

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -45,6 +45,7 @@ library
                     , Agent.ClientIdentity
                     , Agent.Cancel
                     , Agent.Concurrent
+                    , Agent.Transcription.Receive
                     , Agent.ComputerUse.Protocol
                     , Agent.Dialect
                     , Agent.Error
@@ -373,6 +374,7 @@ test-suite agent-core-test
                     , Agent.SubagentsSpec
                     , Agent.Subagents.TaskPathSpec
                     , Agent.TextBufferSpec
+                    , Agent.Transcription.ReceiveSpec
                     , Agent.TelemetrySpec
                     , Agent.ToolArgsSpec
                     , Agent.ToolDispatchSpec

--- a/packages/agent-core/src/Agent/Transcription/Receive.hs
+++ b/packages/agent-core/src/Agent/Transcription/Receive.hs
@@ -1,0 +1,113 @@
+-- | Sequential WebSocket transcription plumbing. Providers retain their event
+-- decoders, transcript reducers, and session/child ownership.
+module Agent.Transcription.Receive
+    ( ReceiveStep(..)
+    , receiveEvent
+    , awaitReady
+    , receiveTranscripts
+    , receiveLoop
+    , waitForCompletion
+    , waitForResult
+    ) where
+
+import qualified Agent.Json.Decode as Json
+import Control.Concurrent.MVar (MVar, takeMVar, tryPutMVar)
+import Control.Exception.Safe (SomeException, throwIO, tryAny)
+import Control.Monad (void)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Network.WebSockets as WS
+import qualified System.Timeout as Timeout
+
+-- | Updated provider state and an optional transcript notification. Completion
+-- includes provider errors, whose interpretation remains with the provider.
+data ReceiveStep state
+    = Continue state (Maybe Text)
+    | Complete state (Maybe Text)
+
+-- | Malformed messages are ignored; transport exceptions still propagate.
+-- The decoder session must belong to this sequential receive stream.
+receiveEvent
+    :: Json.DecoderSession
+    -> Json.Decoder event
+    -> WS.Connection
+    -> IO (Maybe event)
+receiveEvent session decoder connection = do
+    bytes <- WS.receiveData connection
+    either (const Nothing) Just <$> Json.decodeIO session decoder (LBS.toStrict bytes)
+
+-- | Bound the whole readiness handshake, not each individual read. Unrelated
+-- events (including malformed messages) do not reset the timeout.
+awaitReady
+    :: Int
+    -> String
+    -> IO (Maybe event)
+    -> (event -> Maybe (Either Text ()))
+    -> IO ()
+awaitReady timeoutMicros timeoutMessage receive classify =
+    Timeout.timeout timeoutMicros loop >>= maybe (fail timeoutMessage) pure
+  where
+    loop = do
+        event <- receive
+        case event >>= classify of
+            Nothing -> loop
+            Just (Left message) -> fail (Text.unpack message)
+            Just (Right ()) -> pure ()
+
+-- | The receiver owns accumulation; only the final state crosses threads.
+-- Synchronous read/reducer errors are published, and synchronous notification
+-- failures are ignored. Cancellation is never swallowed by either 'tryAny'.
+-- The caller must scope this action (e.g. with 'Control.Concurrent.Async.withAsync').
+receiveTranscripts
+    :: IO (Maybe event)
+    -> (event -> state -> ReceiveStep state)
+    -> state
+    -> MVar (Either SomeException state)
+    -> (Text -> IO ())
+    -> IO ()
+receiveTranscripts receive step initial finished onTranscript =
+    tryAny (receiveLoop receive step initial onTranscript) >>= void . tryPutMVar finished
+
+-- | Accumulate in the calling thread, allowing a scoped Async to own the
+-- result instead of publishing through a separate completion channel.
+receiveLoop
+    :: IO (Maybe event)
+    -> (event -> state -> ReceiveStep state)
+    -> state
+    -> (Text -> IO ())
+    -> IO state
+receiveLoop receive step initial onTranscript =
+    loop initial
+  where
+    loop previous =
+        receive >>= \case
+            Nothing -> loop previous
+            Just event ->
+                case step event previous of
+                    Continue current notification ->
+                        notify notification >> loop current
+                    Complete current notification ->
+                        notify notification >> pure current
+    notify = mapM_ (void . tryAny . onTranscript)
+
+-- | Wait for the receiver's result, preserving its original exception.
+waitForCompletion
+    :: Int
+    -> String
+    -> MVar (Either SomeException state)
+    -> IO state
+waitForCompletion timeoutMicros timeoutMessage finished =
+    waitForResult timeoutMicros timeoutMessage (takeMVar finished)
+
+-- | Bound a provider's completion wait without changing its cancellation
+-- policy. The supplied action may wait on an MVar or a scoped Async.
+waitForResult
+    :: Int
+    -> String
+    -> IO (Either SomeException state)
+    -> IO state
+waitForResult timeoutMicros timeoutMessage await =
+    Timeout.timeout timeoutMicros await >>= \case
+        Nothing -> fail timeoutMessage
+        Just result -> either throwIO pure result

--- a/packages/agent-core/test/Agent/Transcription/ReceiveSpec.hs
+++ b/packages/agent-core/test/Agent/Transcription/ReceiveSpec.hs
@@ -1,0 +1,135 @@
+module Agent.Transcription.ReceiveSpec (spec) where
+
+import Agent.Transcription.Receive
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (cancel, withAsync)
+import Control.Concurrent.MVar
+import Control.Exception.Safe (finally)
+import Data.IORef
+import Data.Text (Text)
+import System.IO.Error (ioeGetErrorString)
+import qualified System.Timeout as Timeout
+import Test.Hspec
+
+spec :: Spec
+spec = describe "transcription receiver plumbing" do
+    it "ignores undecodable and unrelated events until readiness" do
+        next <- events [Nothing, Just "unknown", Just "ready", Just "remaining"]
+        awaitReady 1000000 "ready timeout" next ready
+        next `shouldReturn` Just "remaining"
+
+    it "reports readiness errors without consuming the next event" do
+        next <- events [Just "error", Just "ready"]
+        awaitReady 1000000 "ready timeout" next ready
+            `shouldThrow` message "provider failed"
+        next `shouldReturn` Just "ready"
+
+    it "times out and unwinds a blocked readiness read" do
+        blocked <- newEmptyMVar
+        released <- newEmptyMVar
+        awaitReady 10000 "ready timeout"
+            (takeMVar blocked `finally` putMVar released ()) ready
+            `shouldThrow` message "ready timeout"
+        tryTakeMVar released `shouldReturn` Just ()
+
+    it "bounds the entire readiness loop, not each individual read" do
+        let next = threadDelay 1000 >> pure (Just "unknown")
+        Timeout.timeout 1000000
+            (awaitReady 10000 "ready timeout" next ready
+                `shouldThrow` message "ready timeout")
+            `shouldReturn` Just ()
+
+    it "publishes only the final state after notifications, ignoring synchronous callback failures" do
+        next <- events [Nothing, Just "first", Just "done", Just "unread"]
+        finished <- newEmptyMVar
+        notifications <- newIORef []
+        receiveTranscripts next step [] finished \text -> do
+            unpublished <- isEmptyMVar finished
+            modifyIORef' notifications (<> [(text, unpublished)])
+            fail "callback failed"
+        waitForCompletion 1000000 "completion timeout" finished
+            `shouldReturn` ["first", "done"]
+        readIORef notifications `shouldReturn` [("first", True), ("done", True)]
+        next `shouldReturn` Just "unread"
+
+    it "delivers a read exception through completion" do
+        finished <- newEmptyMVar
+        receiveTranscripts (fail "read failed") step [] finished (const (pure ()))
+        waitForCompletion 1000000 "completion timeout" finished
+            `shouldThrow` message "read failed"
+
+    it "preserves silent updates and silent completion without notifying" do
+        next <- events [Just "update", Just "done", Just "unread"]
+        finished <- newEmptyMVar
+        notifications <- newIORef ([] :: [Text])
+        let silent text previous
+                | text == "done" = Complete (previous <> [text]) Nothing
+                | otherwise = Continue (previous <> [text]) Nothing
+        receiveTranscripts next silent [] finished
+            (\text -> modifyIORef' notifications (<> [text]))
+        waitForCompletion 1000000 "completion timeout" finished
+            `shouldReturn` ["update", "done"]
+        readIORef notifications `shouldReturn` []
+        next `shouldReturn` Just "unread"
+
+    it "does not overwrite or block on an already published result" do
+        finished <- newMVar (Right ["existing"])
+        Timeout.timeout 1000000
+            (receiveTranscripts (pure (Just "done")) step [] finished (const (pure ())))
+            `shouldReturn` Just ()
+        waitForCompletion 1000000 "completion timeout" finished
+            `shouldReturn` ["existing"]
+
+    it "times out waiting for completion without filling the result cell" do
+        finished <- newEmptyMVar
+        (waitForCompletion 10000 "completion timeout" finished :: IO [Text])
+            `shouldThrow` message "completion timeout"
+        isEmptyMVar finished `shouldReturn` True
+
+    it "cancels and joins a blocked receiver without publishing cancellation as a result" do
+        entered <- newEmptyMVar
+        blocked <- newEmptyMVar
+        released <- newEmptyMVar
+        finished <- newEmptyMVar
+        let next = (putMVar entered () >> takeMVar blocked)
+                `finally` putMVar released ()
+        withAsync (receiveTranscripts next step [] finished (const (pure ()))) \worker -> do
+            takeMVar entered
+            Timeout.timeout 1000000 (cancel worker) `shouldReturn` Just ()
+        tryTakeMVar released `shouldReturn` Just ()
+        isEmptyMVar finished `shouldReturn` True
+
+    it "cancels and joins a blocked callback rather than swallowing cancellation" do
+        entered <- newEmptyMVar
+        blocked <- newEmptyMVar
+        released <- newEmptyMVar
+        finished <- newEmptyMVar
+        let notify _ = (putMVar entered () >> takeMVar blocked)
+                `finally` putMVar released ()
+        withAsync (receiveTranscripts (pure (Just "done")) step [] finished notify) \worker -> do
+            takeMVar entered
+            Timeout.timeout 1000000 (cancel worker) `shouldReturn` Just ()
+        tryTakeMVar released `shouldReturn` Just ()
+        isEmptyMVar finished `shouldReturn` True
+
+ready :: Text -> Maybe (Either Text ())
+ready "ready" = Just (Right ())
+ready "error" = Just (Left "provider failed")
+ready _ = Nothing
+
+step :: Text -> [Text] -> ReceiveStep [Text]
+step text previous
+    | text == "done" = Complete (previous <> [text]) (Just text)
+    | otherwise = Continue (previous <> [text]) (Just text)
+
+events :: [Maybe Text] -> IO (IO (Maybe Text))
+events values = do
+    ref <- newIORef values
+    pure do
+        remaining <- readIORef ref
+        case remaining of
+            [] -> fail "unexpected extra read"
+            value : rest -> writeIORef ref rest >> pure value
+
+message :: String -> IOError -> Bool
+message expected err = ioeGetErrorString err == expected

--- a/packages/agent-core/test/Spec.hs
+++ b/packages/agent-core/test/Spec.hs
@@ -20,6 +20,7 @@ import qualified Agent.SkillsSpec as SkillsSpec
 import qualified Agent.SubagentsSpec as SubagentsSpec
 import qualified Agent.Subagents.TaskPathSpec as TaskPathSpec
 import qualified Agent.TextBufferSpec as TextBufferSpec
+import qualified Agent.Transcription.ReceiveSpec as TranscriptionReceiveSpec
 import qualified Agent.TelemetrySpec as TelemetrySpec
 import qualified Agent.ToolArgsSpec as ToolArgsSpec
 import qualified Agent.ToolDispatchSpec as ToolDispatchSpec
@@ -70,6 +71,7 @@ main = hspec do
     SubagentsSpec.spec
     TaskPathSpec.spec
     TextBufferSpec.spec
+    TranscriptionReceiveSpec.spec
     TelemetrySpec.spec
     ToolArgsSpec.spec
     ToolDispatchSpec.spec

--- a/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
@@ -21,6 +21,7 @@ import Agent.Error
     , isInlineRetryableProviderError
     )
 import qualified Agent.Json.Decode as Json
+import qualified Agent.Transcription.Receive as Receive
 import Agent.Provider
     ( BillingMode(..)
     , Credential(..)
@@ -1233,24 +1234,15 @@ encodeText :: Aeson.Value -> Text
 encodeText = Text.decodeUtf8 . LBS.toStrict . Aeson.encode
 
 awaitSessionUpdated :: Json.DecoderSession -> WS.Connection -> IO ()
-awaitSessionUpdated decoderSession connection = do
-    updated <- Timeout.timeout (10 * 1_000_000) loop
-    case updated of
-        Nothing ->
-            fail "timed out waiting for OpenAI Realtime session.updated"
-        Just () ->
-            pure ()
-  where
-    loop = do
-        bytes <- WS.receiveData connection
-        Json.decodeIO
-            decoderSession
-            transcriptEventDecoder
-            (LBS.toStrict bytes) >>= \case
-            Right SessionUpdated -> pure ()
-            Right TranscriptError{transcriptMessage} ->
-                fail (Text.unpack transcriptMessage)
-            _ -> loop
+awaitSessionUpdated decoderSession connection =
+    Receive.awaitReady
+        (10 * 1_000_000)
+        "timed out waiting for OpenAI Realtime session.updated"
+        (Receive.receiveEvent decoderSession transcriptEventDecoder connection)
+        \case
+            SessionUpdated -> Just (Right ())
+            TranscriptError{transcriptMessage} -> Just (Left transcriptMessage)
+            _ -> Nothing
 
 receiveTranscripts
     :: Json.DecoderSession
@@ -1258,32 +1250,17 @@ receiveTranscripts
     -> (Text -> IO ())
     -> IO TranscriptState
 receiveTranscripts decoderSession connection onTranscript =
-    loop emptyTranscriptState
+    Receive.receiveLoop
+        (Receive.receiveEvent decoderSession transcriptEventDecoder connection)
+        step emptyTranscriptState onTranscript
   where
-    -- The receiver owns accumulation; only the final state crosses threads.
-    loop :: TranscriptState -> IO TranscriptState
-    loop previous = do
-        bytes <- WS.receiveData connection
-        Json.decodeIO
-            decoderSession
-            transcriptEventDecoder
-            (LBS.toStrict bytes) >>= \case
-            Left _ -> loop previous
-            Right event -> do
-                let current = applyTranscriptEvent event previous
-                case event of
-                    TranscriptDelta{} ->
-                        notify current
-                    TranscriptCompleted{} ->
-                        notify current
-                    _ ->
-                        pure ()
-                case event of
-                    TranscriptCompleted{} -> pure current
-                    TranscriptError{} -> pure current
-                    _ -> loop current
-    notify current =
-        void (tryAny (onTranscript (renderTranscript current)))
+    step event previous =
+        let current = applyTranscriptEvent event previous
+        in case event of
+            TranscriptDelta{} -> Receive.Continue current (Just (renderTranscript current))
+            TranscriptCompleted{} -> Receive.Complete current (Just (renderTranscript current))
+            TranscriptError{} -> Receive.Complete current Nothing
+            _ -> Receive.Continue current Nothing
 
 applyTranscriptEvent :: TranscriptEvent -> TranscriptState -> TranscriptState
 applyTranscriptEvent event state =
@@ -1306,7 +1283,8 @@ waitForTranscript
     :: Async TranscriptState
     -> IO Text
 waitForTranscript receiver = do
-    completedInTime <- Timeout.timeout (30 * 1_000_000) do
+    current <- Receive.waitForResult
+        (30 * 1_000_000) "timed out waiting for OpenAI Realtime transcription" do
         result <- waitCatch receiver
         case result of
             -- The former tryAny completion channel was never filled when the
@@ -1314,20 +1292,14 @@ waitForTranscript receiver = do
             -- cancellation of the parent still interrupts this wait.
             Left err | not (isSyncException err) -> STM.atomically STM.retry
             _ -> pure result
-    case completedInTime of
+    case current.failure of
+        Just message ->
+            fail (Text.unpack message)
         Nothing ->
-            fail "timed out waiting for OpenAI Realtime transcription"
-        Just (Left err) ->
-            throwIO err
-        Just (Right current) -> do
-            case current.failure of
-                Just message ->
-                    fail (Text.unpack message)
-                Nothing ->
-                    let transcript = Text.strip (renderTranscript current)
-                    in if Text.null transcript
-                        then fail "OpenAI transcription produced no text"
-                        else pure transcript
+            let transcript = Text.strip (renderTranscript current)
+            in if Text.null transcript
+                then fail "OpenAI transcription produced no text"
+                else pure transcript
 
 renderTranscript :: TranscriptState -> Text
 renderTranscript state =

--- a/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs
@@ -54,7 +54,12 @@ spec = describe "OpenAI transcription" do
         let server pending = do
                 connection <- WS.acceptRequest pending
                 _ <- WS.receiveData connection :: IO Text
-                WS.sendTextData connection ("{\"type\":\"session.updated\"}" :: Text)
+                mapM_ (WS.sendTextData connection)
+                    [ "invalid JSON"
+                    , "{\"type\":\"future.event\"}"
+                    , "{\"type\":\"session.updated\"}"
+                    :: Text
+                    ]
                 _ <- WS.receiveData connection :: IO Text
                 mapM_ (WS.sendTextData connection)
                     [ "{\"type\":\"conversation.item.input_audio_transcription.delta\",\"delta\":\"hello \"}"
@@ -89,6 +94,10 @@ spec = describe "OpenAI transcription" do
     it "propagates a Realtime error event and closes the session" do
         let server = realtimeServer \connection -> do
                 expectCommit connection
+                sendEvent connection $ Aeson.object
+                    [ "type" .= ("conversation.item.input_audio_transcription.delta" :: Text)
+                    , "delta" .= ("interim" :: Text)
+                    ]
                 sendEvent connection $ Aeson.object
                     [ "type" .= ("error" :: Text)
                     , "message" .= ("bad audio" :: Text)
@@ -170,6 +179,23 @@ spec = describe "OpenAI transcription" do
                             readMVar callbackStopped `shouldReturn` Just ())
                     `shouldReturn` Just ())
         [False, True]
+
+    it "rejects readiness errors before producing audio" do
+        produced <- newIORef False
+        let server pending = do
+                connection <- WS.acceptRequest pending
+                _ <- WS.receiveData connection :: IO Text
+                WS.sendTextData connection
+                    ("{\"type\":\"error\",\"error\":{\"message\":\"not ready\"}}" :: Text)
+        Timeout.timeout (5 * 1_000_000)
+            (withWebSocketServer server \port ->
+                WS.runClient "127.0.0.1" port "/" \connection ->
+                    transcribeOnConnection connection
+                        (const (modifyIORef' produced (const True)))
+                        (const (pure ()))
+                        `shouldThrow` (\err -> ioeGetErrorString err == "not ready"))
+            `shouldReturn` Just ()
+        readIORef produced `shouldReturn` False
 
     it "retains ChatGPT state on a normal WebSocket close after callback failure" do
         callbacks <- newIORef []
@@ -661,6 +687,7 @@ spec = describe "OpenAI transcription" do
                 Left
                     (ChatGPTDictationStreamUnavailable
                         "Dictation WebSocket URL must use WS, WSS, HTTP, or HTTPS")
+
 realtimeServer :: (WS.Connection -> IO ()) -> WS.ServerApp
 realtimeServer action pending = do
     connection <- WS.acceptRequest pending

--- a/packages/agent-xai/src/Agent/XAI/Transcription.hs
+++ b/packages/agent-xai/src/Agent/XAI/Transcription.hs
@@ -9,6 +9,7 @@ module Agent.XAI.Transcription
 
 import Agent.Error (ApiError(..))
 import qualified Agent.Json.Decode as Json
+import qualified Agent.Transcription.Receive as Receive
 import Agent.XAI.Options
     ( defaultGrokClientVersion
     , grokClientIdentifier
@@ -25,8 +26,6 @@ import Control.Concurrent.Async (cancel, withAsync)
 import Control.Concurrent.MVar
     ( MVar
     , newEmptyMVar
-    , takeMVar
-    , tryPutMVar
     )
 import Control.Exception.Safe
     ( SomeException
@@ -56,7 +55,6 @@ import System.Process
     , terminateProcess
     , waitForProcess
     )
-import qualified System.Timeout as Timeout
 import qualified Wuss
 
 data TranscriptEvent
@@ -232,24 +230,15 @@ sttLanguage = do
             || char == '_'
 
 awaitCreated :: Json.DecoderSession -> WS.Connection -> IO ()
-awaitCreated decoderSession connection = do
-    next <- Timeout.timeout (10 * 1_000_000) loop
-    case next of
-        Nothing ->
-            fail "timed out waiting for xAI transcript.created"
-        Just () ->
-            pure ()
-  where
-    loop = do
-        bytes <- WS.receiveData connection
-        Json.decodeIO
-            decoderSession
-            transcriptEventDecoder
-            (LBS.toStrict bytes) >>= \case
-            Right TranscriptCreated -> pure ()
-            Right TranscriptError{transcriptMessage} ->
-                fail (Text.unpack transcriptMessage)
-            _ -> loop
+awaitCreated decoderSession connection =
+    Receive.awaitReady
+        (10 * 1_000_000)
+        "timed out waiting for xAI transcript.created"
+        (Receive.receiveEvent decoderSession transcriptEventDecoder connection)
+        \case
+            TranscriptCreated -> Just (Right ())
+            TranscriptError{transcriptMessage} -> Just (Left transcriptMessage)
+            _ -> Nothing
 
 receiveTranscripts
     :: Json.DecoderSession
@@ -258,30 +247,17 @@ receiveTranscripts
     -> (Text -> IO ())
     -> IO ()
 receiveTranscripts decoderSession connection finished onTranscript =
-    tryAny (loop emptyTranscriptState) >>= void . tryPutMVar finished
+    Receive.receiveTranscripts
+        (Receive.receiveEvent decoderSession transcriptEventDecoder connection)
+        step emptyTranscriptState finished onTranscript
   where
-    -- The receiver owns accumulation; only the final state crosses threads.
-    loop :: TranscriptState -> IO TranscriptState
-    loop previous = do
-        bytes <- WS.receiveData connection
-        Json.decodeIO
-            decoderSession
-            transcriptEventDecoder
-            (LBS.toStrict bytes) >>= \case
-            Left _ -> loop previous
-            Right event -> do
-                let current = applyTranscriptEvent event previous
-                case event of
-                    TranscriptPartial{} ->
-                        void (tryAny (onTranscript (renderTranscript current)))
-                    TranscriptDone{} ->
-                        void (tryAny (onTranscript (renderTranscript current)))
-                    _ ->
-                        pure ()
-                case event of
-                    TranscriptDone{} -> pure current
-                    TranscriptError{} -> pure current
-                    _ -> loop current
+    step event previous =
+        let current = applyTranscriptEvent event previous
+        in case event of
+            TranscriptPartial{} -> Receive.Continue current (Just (renderTranscript current))
+            TranscriptDone{} -> Receive.Complete current (Just (renderTranscript current))
+            TranscriptError{} -> Receive.Complete current Nothing
+            _ -> Receive.Continue current Nothing
 
 applyTranscriptEvent :: TranscriptEvent -> TranscriptState -> TranscriptState
 applyTranscriptEvent event state =
@@ -317,21 +293,16 @@ waitForTranscript
     :: MVar (Either SomeException TranscriptState)
     -> IO Text
 waitForTranscript finished = do
-    completedInTime <- Timeout.timeout (30 * 1_000_000) (takeMVar finished)
-    case completedInTime of
+    current <- Receive.waitForCompletion
+        (30 * 1_000_000) "timed out waiting for xAI transcription" finished
+    case current.failure of
+        Just message ->
+            fail (Text.unpack message)
         Nothing ->
-            fail "timed out waiting for xAI transcription"
-        Just (Left err) ->
-            throwIO err
-        Just (Right current) -> do
-            case current.failure of
-                Just message ->
-                    fail (Text.unpack message)
-                Nothing ->
-                    let transcript = renderTranscript current
-                    in if Text.null transcript
-                        then fail "xAI transcription produced no text"
-                        else pure transcript
+            let transcript = renderTranscript current
+            in if Text.null transcript
+                then fail "xAI transcription produced no text"
+                else pure transcript
 
 renderTranscript :: TranscriptState -> Text
 renderTranscript state =

--- a/packages/agent-xai/test/Agent/XAI/TranscriptionSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/TranscriptionSpec.hs
@@ -15,6 +15,51 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "xAI transcription events" do
+    it "replaces partial hypotheses rather than appending them" do
+        callbacks <- newIORef []
+        withTranscriptServer
+            [ "{\"type\":\"transcript.partial\",\"text\":\"hel\"}"
+            , "{\"type\":\"transcript.partial\",\"text\":\"hello\"}"
+            , "{\"type\":\"transcript.partial\",\"text\":\"hello world\",\"speech_final\":true}"
+            , "{\"type\":\"transcript.done\",\"text\":\"\"}"
+            ]
+            (\connection -> transcribeOnConnection connection (const (pure ()))
+                (\text -> modifyIORef' callbacks (<> [text])))
+            `shouldReturn` "hello world"
+        readIORef callbacks `shouldReturn` ["hel", "hello", "hello world", "hello world"]
+
+    it "rejects readiness errors before producing audio" do
+        produced <- newIORef False
+        withRawTranscriptServer
+            (\connection -> WS.sendTextData connection
+                ("{\"type\":\"error\",\"message\":\"not ready\"}" :: Text))
+            (\connection ->
+                transcribeOnConnection connection
+                    (const (modifyIORef' produced (const True)))
+                    (const (pure ()))
+                    `shouldThrow` (\err -> ioeGetErrorString err == "not ready"))
+        readIORef produced `shouldReturn` False
+
+    it "propagates transport closure before completion" do
+        withRawTranscriptServer
+            (\connection -> do
+                WS.sendTextData connection ("{\"type\":\"transcript.created\"}" :: Text)
+                _ <- WS.receiveData connection :: IO Text
+                WS.sendClose connection ("early" :: Text)
+                (WS.receiveData connection :: IO Text) `shouldThrow` anyException)
+            (\connection ->
+                transcribeOnConnection connection (const (pure ())) (const (pure ()))
+                    `shouldThrow` (\(_ :: WS.ConnectionException) -> True))
+
+    it "closes the connection when the audio producer fails" do
+        withRawTranscriptServer
+            (\connection -> do
+                WS.sendTextData connection ("{\"type\":\"transcript.created\"}" :: Text)
+                (WS.receiveData connection :: IO Text) `shouldThrow` anyException)
+            (\connection ->
+                transcribeOnConnection connection (const (fail "producer failed")) (const (pure ()))
+                    `shouldThrow` (\err -> ioeGetErrorString err == "producer failed"))
+
     it "cancels a receiver blocked in a transcript callback" do
         entered <- newEmptyMVar
         blocked <- newEmptyMVar
@@ -80,6 +125,22 @@ spec = describe "xAI transcription events" do
 
 withTranscriptServer :: [Text] -> (WS.Connection -> IO a) -> IO a
 withTranscriptServer events action =
+    withRawTranscriptServer
+        (\connection -> do
+            mapM_ (WS.sendTextData connection)
+                [ "invalid JSON"
+                , "{\"type\":\"future.event\"}"
+                , "{\"type\":\"transcript.created\"}"
+                :: Text
+                ]
+            (WS.receiveData connection :: IO Text)
+                `shouldReturn` "{\"type\":\"audio.done\"}"
+            mapM_ (WS.sendTextData connection) events
+            (WS.receiveData connection :: IO Text) `shouldThrow` anyException)
+        action
+
+withRawTranscriptServer :: (WS.Connection -> IO ()) -> (WS.Connection -> IO a) -> IO a
+withRawTranscriptServer serve action =
     requireLoopbackListener >>
     bracket (WS.makeListenSocket "127.0.0.1" 0) Socket.close \listener -> do
         Socket.SockAddrInet port _ <- Socket.getSocketName listener
@@ -88,14 +149,12 @@ withTranscriptServer events action =
                 flip finally (Socket.close socket) do
                     pending <- WS.makePendingConnection socket WS.defaultConnectionOptions
                     connection <- WS.acceptRequest pending
-                    WS.sendTextData connection ("{\"type\":\"transcript.created\"}" :: Text)
-                    (WS.receiveData connection :: IO Text)
-                        `shouldReturn` "{\"type\":\"audio.done\"}"
-                    mapM_ (WS.sendTextData connection) events
-                    (WS.receiveData connection :: IO Text) `shouldThrow` anyException
+                    serve connection
         withAsync server \worker -> do
-            result <- Timeout.timeout (5 * 1_000_000) $
-                WS.runClient "127.0.0.1" (fromIntegral port) "/" action
+            result <- Timeout.timeout (5 * 1_000_000) do
+                value <- WS.runClient "127.0.0.1" (fromIntegral port) "/" action
+                wait worker
+                pure value
             case result of
                 Nothing -> expectationFailure "transcription timed out" >> fail "timeout"
-                Just value -> wait worker >> pure value
+                Just value -> pure value


### PR DESCRIPTION
## Summary
- Share OpenAI/xAI WebSocket read/decode, whole-handshake readiness timeout, receiver accumulation/notification, and timeout/result handling in `Agent.Transcription.Receive`. Preserve the newer OpenAI Async completion channel and its asynchronous-exit timeout policy; xAI retains its MVar publication adapter.
- Keep provider event decoders, reducers, text/error interpretation, wire messages, and existing structured receiver ownership in the providers. OpenAI still appends deltas; xAI still replaces partial hypotheses and accumulates finalized speech.
- Use the existing `agent-core` dependency boundary: no new package or dependencies. Preserve 10-second readiness and 30-second completion timeouts, best-effort synchronous callbacks, and asynchronous cancellation propagation.

## Validation
- GHCi 9.10.3 inside `nix develop`: loaded the shared module, both provider modules, and all three transcription specs from source (`Ok, 15 modules loaded.`).
- Shared receiver: 11 examples; OpenAI transcription: 20 examples; xAI transcription: 10 examples. All passed, zero failures. Includes loopback WebSocket integration tests, full OpenAI completion-timeout tests, and short-timeout/blocked-reader/blocked-callback lifecycle tests.
- `git diff --check` passes. Regenerated `agent-core/package.nix` with `cabal2nix` from its package directory; output unchanged.
- No CLI UI changes; no live UI smoke test needed. This is a deduplication refactor, with no performance claim.

<details>
<summary>Reproduce the focused GHCi run</summary>

```bash
printf '%s\n' 'import Test.Hspec' \
  'hspec Agent.Transcription.ReceiveSpec.spec' \
  'hspec Agent.OpenAI.TranscriptionSpec.spec' \
  'hspec Agent.XAI.TranscriptionSpec.spec' ':quit' |
nix develop -c ghci -ignore-dot-ghci -XGHC2021 \
  -XOverloadedStrings -XOverloadedRecordDot -XDuplicateRecordFields -XNoFieldSelectors \
  -XLambdaCase -XBlockArguments -XRecordWildCards -XNamedFieldPuns -XNumericUnderscores \
  -XTypeApplications -XScopedTypeVariables -XPackageImports -XDerivingStrategies \
  -Wall -Werror=incomplete-patterns -Werror=incomplete-uni-patterns -Werror=missing-fields \
  -ipackages/agent-core/src -ipackages/agent-json/src \
  -ipackages/agent-openai/src -ipackages/agent-xai/src \
  -ipackages/agent-core/test -ipackages/agent-openai/test -ipackages/agent-xai/test \
  packages/agent-core/test/Agent/Transcription/ReceiveSpec.hs \
  packages/agent-openai/test/Agent/OpenAI/TranscriptionSpec.hs \
  packages/agent-xai/test/Agent/XAI/TranscriptionSpec.hs
```

Require the successful module-load line and all three nonzero example counts with zero failures, not just GHCi's process exit code.
</details>
