### PR TITLE
Extract pure OpenAI model cache state transitions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,7 @@
                     include = [
                         "app"
                         "benchmark"
+                        "internal"
                         "src"
                         "test"
                         "agent-openai.cabal"

--- a/packages/agent-openai/agent-openai.cabal
+++ b/packages/agent-openai/agent-openai.cabal
@@ -81,11 +81,12 @@ library
                     , Agent.OpenAI.ToolDSL
                     , Agent.OpenAI.ImageGeneration
     other-modules:    Agent.OpenAI.Compaction.Commands
+                    , Agent.OpenAI.Models.Manager.State
                     , Agent.OpenAI.Compaction.Request
                     , Agent.OpenAI.Models.Types.Enums
                     , Paths_agent_openai
     autogen-modules:  Paths_agent_openai
-    hs-source-dirs:   src
+    hs-source-dirs:   src internal
     build-depends:    base                  >= 4.14 && < 5
                     , agent-core            >= 0.1 && < 0.2
                     , agent-json            >= 0.1 && < 0.2
@@ -132,9 +133,10 @@ executable agent-openai-login
 test-suite agent-openai-test
     import:           common-opts
     type:             exitcode-stdio-1.0
-    hs-source-dirs:   test
+    hs-source-dirs:   test internal
     main-is:          Spec.hs
     other-modules:    Agent.OpenAI.AuthSpec
+                    , Agent.OpenAI.Models.Manager.State
                     , Agent.OpenAI.ClientSpec
                     , Agent.OpenAI.CredentialSpec
                     , Agent.OpenAI.ErrorSpec

--- a/packages/agent-openai/internal/Agent/OpenAI/Models/Manager/State.hs
+++ b/packages/agent-openai/internal/Agent/OpenAI/Models/Manager/State.hs
@@ -1,0 +1,77 @@
+-- | Pure catalog acceptance rules. The manager owns locking and executes cache
+-- actions only after publishing the corresponding state update.
+module Agent.OpenAI.Models.Manager.State
+    ( ModelsManagerState(..)
+    , CacheAction(..)
+    , initialState
+    , cachedState
+    , fetchedState
+    , notModifiedState
+    , responseCacheAction
+    , fetchCondition
+    ) where
+
+import Agent.OpenAI.Models.Cache (ModelsCacheEntry(..), ModelsCacheKey)
+import Agent.OpenAI.Models.Client (ModelsEndpointResponse(..), ModelsFetchCondition(..))
+import Agent.OpenAI.Models.Types
+    ( ModelsResponse(..), ModelInfo(..), ModelVisibility(..), mergeModelCatalogs )
+import Control.Applicative ((<|>))
+import Data.Text (Text)
+
+data ModelsManagerState = ModelsManagerState
+    { catalog :: !ModelsResponse
+    , etag :: !(Maybe Text)
+    , cacheKey :: !(Maybe ModelsCacheKey)
+    } deriving (Eq, Show)
+
+data CacheAction
+    = TouchCache
+    -- Store the original remote catalog, never the bundled overlay.
+    | StoreCache ModelsCacheKey ModelsResponse (Maybe Text)
+    deriving (Eq, Show)
+
+initialState :: ModelsResponse -> ModelsManagerState
+initialState bundled = ModelsManagerState bundled Nothing Nothing
+
+-- The Bool means authoritative ChatGPT discovery is enabled. A catalog without
+-- a listed model still needs the bundled fallback, even in that mode.
+acceptCatalog :: Bool -> ModelsResponse -> ModelsResponse -> ModelsResponse
+acceptCatalog authoritative bundled remote
+    | authoritative && any ((== ModelVisibilityList) . (.visibility)) remote.models = remote
+    | otherwise = mergeModelCatalogs bundled remote
+
+cachedState :: Bool -> ModelsResponse -> ModelsCacheEntry -> ModelsManagerState
+cachedState authoritative bundled entry = ModelsManagerState
+    { catalog = acceptCatalog authoritative bundled
+        (ModelsResponse entry.models entry.catalogGeneration)
+    , etag = entry.etag
+    , cacheKey = entry.cacheKey
+    }
+
+fetchedState
+    :: Bool -> ModelsResponse -> ModelsResponse -> Maybe Text -> ModelsCacheKey
+    -> ModelsManagerState
+fetchedState authoritative bundled remote etag key = ModelsManagerState
+    { catalog = acceptCatalog authoritative bundled remote
+    , etag
+    , cacheKey = Just key
+    }
+
+-- ETag fallback uses the pre-request snapshot; the catalog is retained from
+-- the state at commit. Keeping these inputs separate preserves the IO boundary.
+notModifiedState
+    :: Maybe Text -> Maybe Text -> ModelsCacheKey -> ModelsManagerState
+    -> ModelsManagerState
+notModifiedState previousEtag responseEtag key current = ModelsManagerState
+    { catalog = current.catalog
+    , etag = responseEtag <|> previousEtag
+    , cacheKey = Just key
+    }
+
+responseCacheAction :: ModelsEndpointResponse -> CacheAction
+responseCacheAction ModelsNotModified{} = TouchCache
+responseCacheAction ModelsFetched{catalog, etag, cacheKey} =
+    StoreCache cacheKey catalog etag
+
+fetchCondition :: ModelsManagerState -> Maybe ModelsFetchCondition
+fetchCondition current = ModelsFetchCondition <$> current.etag <*> current.cacheKey

--- a/packages/agent-openai/src/Agent/OpenAI/Models/Manager.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Models/Manager.hs
@@ -30,20 +30,17 @@ import Agent.OpenAI.Models.Cache
 import Agent.OpenAI.Models.Client
     ( ModelsEndpointClient(..)
     , ModelsEndpointResponse(..)
-    , ModelsFetchCondition(..)
     , packageClientVersion
     )
 import Agent.OpenAI.Models.Types
     ( ModelInfo(..)
     , ModelPreset
-    , ModelVisibility(..)
     , ModelsResponse(..)
     , availableModelPresets
     , defaultModelSlug
-    , mergeModelCatalogs
     , modelInfoForSlug
     )
-import Control.Applicative ((<|>))
+import Agent.OpenAI.Models.Manager.State
 import Control.Concurrent.MVar
 import Data.Text (Text)
 import Data.Time.Clock
@@ -82,12 +79,6 @@ defaultModelsManagerOptions = ModelsManagerOptions
     , remoteCatalogAuthoritative = True
     }
 
-data ModelsManagerState = ModelsManagerState
-    { catalog :: !ModelsResponse
-    , etag :: !(Maybe Text)
-    , cacheKey :: !(Maybe ModelsCacheKey)
-    }
-
 data ModelsManager = ModelsManager
     { bundledCatalog :: !ModelsResponse
     , options :: !ModelsManagerOptions
@@ -105,11 +96,7 @@ newModelsManagerWithBundled
     -> ModelsManagerOptions
     -> IO ModelsManager
 newModelsManagerWithBundled bundledCatalog options = do
-    state <- newMVar ModelsManagerState
-        { catalog = bundledCatalog
-        , etag = Nothing
-        , cacheKey = Nothing
-        }
+    state <- newMVar (initialState bundledCatalog)
     refreshLock <- newMVar ()
     pure ModelsManager { .. }
 
@@ -204,16 +191,9 @@ tryLoadCache manager =
                 Left _ -> pure Nothing
                 Right Nothing -> pure Nothing
                 Right (Just entry) -> do
-                    let catalog = applyRemoteCatalog manager ModelsResponse
-                            { models = entry.models
-                            , catalogGeneration = entry.catalogGeneration
-                            }
-                    modifyMVar_ manager.state \_ -> pure ModelsManagerState
-                        { catalog
-                        , etag = entry.etag
-                        , cacheKey = entry.cacheKey
-                        }
-                    pure (Just catalog)
+                    let next = cachedState (authoritativeCatalog manager) manager.bundledCatalog entry
+                    modifyMVar_ manager.state \_ -> pure next
+                    pure (Just next.catalog)
 
 fetchRemote
     :: ModelsManager
@@ -226,45 +206,34 @@ fetchRemote manager =
                 Right <$> currentModelCatalog manager
         Just endpoint -> do
             current <- readMVar manager.state
-            let condition = ModelsFetchCondition
-                    <$> current.etag
-                    <*> current.cacheKey
+            let condition = fetchCondition current
+                previousEtag = current.etag
             endpoint.fetchModels condition >>= \case
                 Left err -> pure (Left err)
-                Right ModelsNotModified{etag, cacheKey} -> do
-                    let nextEtag = etag <|> current.etag
+                Right response@ModelsNotModified{etag, cacheKey} -> do
                     modifyMVar_ manager.state \current@ModelsManagerState{} ->
-                        pure ModelsManagerState
-                            { catalog = current.catalog
-                            , etag = nextEtag
-                            , cacheKey = Just cacheKey
-                            }
-                    touchCache manager
+                        pure (notModifiedState previousEtag etag cacheKey current)
+                    runCacheAction manager (responseCacheAction response)
                     Right <$> currentModelCatalog manager
-                Right ModelsFetched
+                Right response@ModelsFetched
                         { catalog = remote
                         , etag
                         , cacheKey
                         } -> do
-                    let catalog = applyRemoteCatalog manager remote
-                    modifyMVar_ manager.state \_ -> pure ModelsManagerState
-                        { catalog
-                        , etag
-                        , cacheKey = Just cacheKey
-                        }
-                    storeCache manager cacheKey remote etag
-                    pure (Right catalog)
+                    let next = fetchedState (authoritativeCatalog manager) manager.bundledCatalog remote etag cacheKey
+                    modifyMVar_ manager.state \_ -> pure next
+                    runCacheAction manager (responseCacheAction response)
+                    pure (Right next.catalog)
 
-applyRemoteCatalog :: ModelsManager -> ModelsResponse -> ModelsResponse
-applyRemoteCatalog manager remote
-    | manager.options.remoteCatalogAuthoritative
-        && maybe False (.usesChatGptAuth) manager.options.endpointClient
-        && any ((== ModelVisibilityList) . (.visibility)) remote.models =
-            remote
-    | otherwise =
-        mergeModelCatalogs
-            manager.bundledCatalog
-            remote
+authoritativeCatalog :: ModelsManager -> Bool
+authoritativeCatalog manager =
+    manager.options.remoteCatalogAuthoritative && managerUsesChatGptAuth manager
+
+-- Deliberately outside the state MVar and after its commit, but still inside
+-- refreshLock. Cache exceptions must not roll back a fetched catalog.
+runCacheAction :: ModelsManager -> CacheAction -> IO ()
+runCacheAction manager TouchCache = touchCache manager
+runCacheAction manager (StoreCache key remote etag) = storeCache manager key remote etag
 
 storeCache
     :: ModelsManager

--- a/packages/agent-openai/test/Agent/OpenAI/ModelsManagerSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/ModelsManagerSpec.hs
@@ -2,8 +2,11 @@ module Agent.OpenAI.ModelsManagerSpec (spec) where
 
 import Agent.Error (ApiError(..))
 import Agent.OpenAI.Models
+import qualified Agent.OpenAI.Models.Manager.State as State
 import Control.Concurrent (threadDelay)
-import Control.Concurrent.Async (mapConcurrently)
+import Control.Concurrent.Async (mapConcurrently, withAsync, wait, cancel)
+import Control.Concurrent.MVar
+import Control.Exception.Safe (throwIO)
 import Data.Bits ((.&.))
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef
@@ -12,10 +15,51 @@ import Data.Time.Clock
 import System.FilePath ((</>))
 import System.IO.Temp (withSystemTempDirectory)
 import System.Posix.Files (fileID, fileMode, getFileStatus)
+import System.Timeout (timeout)
 import Test.Hspec
 
 spec :: Spec
 spec = do
+    describe "pure model state" do
+        it "tracks fetched, 304, and untagged replacement sequences with scoped conditions" do
+            let bundled = catalogOf [testModel "bundled" 0]
+                remote = catalogOf [testModel "remote" 1]
+                keyA = testCacheKey "a"
+                keyB = testCacheKey "b"
+                initial = State.initialState bundled
+                fetched = State.fetchedState True bundled remote (Just "v1") keyA
+                renewed = State.notModifiedState fetched.etag Nothing keyB fetched
+                retagged = State.notModifiedState renewed.etag (Just "v2") keyB renewed
+                replaced = State.fetchedState False bundled remote Nothing keyA
+            State.fetchCondition initial `shouldBe` Nothing
+            State.fetchCondition fetched `shouldBe` Just (ModelsFetchCondition "v1" keyA)
+            renewed.catalog `shouldBe` remote
+            State.fetchCondition renewed `shouldBe` Just (ModelsFetchCondition "v1" keyB)
+            State.fetchCondition retagged `shouldBe` Just (ModelsFetchCondition "v2" keyB)
+            State.fetchCondition replaced `shouldBe` Nothing
+            replaced.cacheKey `shouldBe` Just keyA
+            map (.slug) replaced.catalog.models `shouldBe` ["bundled", "remote"]
+            State.responseCacheAction (ModelsFetched remote Nothing keyA)
+                `shouldBe` State.StoreCache keyA remote Nothing
+            State.responseCacheAction (ModelsNotModified Nothing keyB)
+                `shouldBe` State.TouchCache
+
+        it "accepts cached metadata verbatim and applies the same fallback policy as fetching" do
+            let bundled = catalogOf [testModel "bundled" 0]
+                hidden = (testModel "hidden" 1) { visibility = ModelVisibilityHide }
+                entry = (cacheEntry (read "2026-09-12 00:00:00 UTC")
+                    (testCacheKey "a") "1" [hidden]) { cacheKey = Nothing, catalogGeneration = Just 9 }
+                cached = State.cachedState True bundled entry
+                fetched = State.fetchedState True bundled
+                    (ModelsResponse entry.models entry.catalogGeneration) entry.etag (testCacheKey "a")
+                renewed = State.notModifiedState cached.etag Nothing (testCacheKey "b") cached
+            cached.catalog `shouldBe` fetched.catalog
+            map (.slug) cached.catalog.models `shouldBe` ["bundled", "hidden"]
+            cached.catalog.catalogGeneration `shouldBe` Just 9
+            cached.cacheKey `shouldBe` Nothing
+            State.fetchCondition cached `shouldBe` Nothing
+            State.fetchCondition renewed `shouldBe` Just (ModelsFetchCondition "\"etag\"" (testCacheKey "b"))
+
     describe "model cache" do
         it "accepts fresh matching entries and rejects stale/version/key mismatches" do
             withSystemTempDirectory "models-cache" \directory -> do
@@ -106,6 +150,123 @@ spec = do
                     Right _ -> False
 
     describe "ModelsManager" do
+        it "keeps bundled state with no endpoint for every strategy" do
+            let bundled = catalogOf [testModel "bundled" 0]
+            manager <- newModelsManagerWithBundled bundled defaultModelsManagerOptions
+            mapM_ (\strategy -> refreshModelCatalogEither manager strategy `shouldReturn` Right bundled)
+                [RefreshOnline, RefreshOffline, RefreshOnlineIfUncached]
+            getCurrentEtag manager `shouldReturn` Nothing
+
+        it "does not fetch on an offline miss but fetches on an online-if-uncached miss" do
+            calls <- newIORef (0 :: Int)
+            let bundled = catalogOf [testModel "bundled" 0]
+                remote = catalogOf [testModel "remote" 1]
+            manager <- newModelsManagerWithBundled bundled defaultModelsManagerOptions
+                { endpointClient = Just (countingEndpoint calls
+                    [ModelsFetched remote (Just "v1") (testCacheKey "a")]) }
+            refreshModelCatalog manager RefreshOffline `shouldReturn` bundled
+            readIORef calls `shouldReturn` 0
+            refreshModelCatalog manager RefreshOnlineIfUncached `shouldReturn` remote
+            readIORef calls `shouldReturn` 1
+
+        it "retains committed state on endpoint errors and exceptions and releases the refresh lock" do
+            calls <- newIORef (0 :: Int)
+            let remote = catalogOf [testModel "remote" 0]
+                key = testCacheKey "a"
+                endpoint = testEndpoint True True \condition -> do
+                    n <- atomicModifyIORef' calls \n -> (n + 1, n)
+                    if n == 0 then pure (Right (ModelsFetched remote (Just "v1") key))
+                    else do
+                        condition `shouldBe` Just (ModelsFetchCondition "v1" key)
+                        if n == 1 then pure (Left (ConnectionError "offline"))
+                        else if n == 2 then throwIO (userError "fetch failed")
+                        else pure (Right (ModelsNotModified Nothing key))
+            manager <- newModelsManagerWithBundled (catalogOf []) defaultModelsManagerOptions
+                { endpointClient = Just endpoint }
+            refreshModelCatalog manager RefreshOnline `shouldReturn` remote
+            refreshModelCatalogEither manager RefreshOnline
+                `shouldReturn` Left (ConnectionError "offline")
+            refreshModelCatalog manager RefreshOnline `shouldThrow` anyIOException
+            currentModelCatalog manager `shouldReturn` remote
+            getCurrentEtag manager `shouldReturn` Just "v1"
+            timeout 1_000_000 (refreshModelCatalog manager RefreshOnline)
+                `shouldReturn` Just remote
+
+        it "commits before a cache-directory exception and can refresh again afterwards" do
+            withSystemTempDirectory "models-manager" \directory -> do
+                let blocked = directory </> "file"
+                    remote = catalogOf [testModel "remote" 0]
+                    key = testCacheKey "a"
+                writeFile blocked "not a directory"
+                manager <- newModelsManagerWithBundled (catalogOf []) defaultModelsManagerOptions
+                    { endpointClient = Just (testEndpoint True True
+                        (\_ -> pure (Right (ModelsFetched remote (Just "v1") key))))
+                    , cachePath = Just (blocked </> "cache.json")
+                    }
+                refreshModelCatalog manager RefreshOnline `shouldThrow` anyIOException
+                currentModelCatalog manager `shouldReturn` remote
+                getCurrentEtag manager `shouldReturn` Just "v1"
+                -- The unchanged-ETag touch tolerates cache IO errors; it does not store.
+                timeout 1_000_000 (refreshIfNewEtag manager "v1") `shouldReturn` Just remote
+
+        it "stores only remote data then touches a 304 cache without replacing its ETag" do
+            withSystemTempDirectory "models-manager" \directory -> do
+                calls <- newIORef (0 :: Int)
+                let path = directory </> "cache.json"
+                    key = testCacheKey "a"
+                    bundled = catalogOf [testModel "bundled" 0]
+                    remote = catalogOf [testModel "remote" 1]
+                    endpoint = testEndpoint True True \condition -> do
+                        n <- atomicModifyIORef' calls \n -> (n + 1, n)
+                        if n == 0 then pure (Right (ModelsFetched remote (Just "v1") key))
+                        else do
+                            condition `shouldBe` Just (ModelsFetchCondition "v1" key)
+                            pure (Right (ModelsNotModified (if n == 1 then Nothing else Just "v2") key))
+                manager <- newModelsManagerWithBundled bundled defaultModelsManagerOptions
+                    { endpointClient = Just endpoint, cachePath = Just path
+                    , cacheKey = key, clientVersion = "1", remoteCatalogAuthoritative = False }
+                merged <- refreshModelCatalog manager RefreshOnline
+                map (.slug) merged.models `shouldBe` ["bundled", "remote"]
+                now <- getCurrentTime
+                disk <- loadFreshModelsCache now 300 key "1" path
+                case disk of
+                    Right (Just entry) -> do
+                        entry.models `shouldBe` remote.models
+                        entry.etag `shouldBe` Just "v1"
+                        storeModelsCache path entry { fetchedAt = addUTCTime (-301) now }
+                            `shouldReturn` Right ()
+                    _ -> expectationFailure ("missing fetched cache: " <> show disk)
+                refreshModelCatalog manager RefreshOnline `shouldReturn` merged
+                getCurrentEtag manager `shouldReturn` Just "v1"
+                touched <- loadFreshModelsCache now 300 key "1" path
+                touched `shouldSatisfy` \case
+                    Right (Just entry) -> entry.etag == Just "v1"
+                        && entry.models == remote.models && entry.fetchedAt >= now
+                    _ -> False
+                refreshModelCatalog manager RefreshOnline `shouldReturn` merged
+                getCurrentEtag manager `shouldReturn` Just "v2"
+                loadFreshModelsCache now 300 key "1" path `shouldReturn` touched
+
+        it "leaves reads available during a fetch and releases the lock after cancellation" do
+            started <- newEmptyMVar
+            blocked <- newEmptyMVar
+            calls <- newIORef (0 :: Int)
+            let bundled = catalogOf [testModel "bundled" 0]
+                remote = catalogOf [testModel "remote" 0]
+                endpoint = testEndpoint True True \_ -> do
+                    n <- atomicModifyIORef' calls \n -> (n + 1, n)
+                    if n == 0 then putMVar started () >> takeMVar blocked else pure ()
+                    pure (Right (ModelsFetched remote (Just "v1") (testCacheKey "a")))
+            manager <- newModelsManagerWithBundled bundled defaultModelsManagerOptions
+                { endpointClient = Just endpoint }
+            withAsync (refreshModelCatalog manager RefreshOnline) \first -> do
+                timeout 1_000_000 (takeMVar started) `shouldReturn` Just ()
+                timeout 1_000_000 (currentModelCatalog manager) `shouldReturn` Just bundled
+                cancel first
+            getCurrentEtag manager `shouldReturn` Nothing
+            withAsync (refreshModelCatalog manager RefreshOnline) \second ->
+                timeout 1_000_000 (wait second) `shouldReturn` Just remote
+
         it "preserves an explicitly requested OpenAI model and otherwise uses catalog priority" do
             manager <- newModelsManagerWithBundled
                 (catalogOf


### PR DESCRIPTION
## Summary
- Move catalog acceptance and cache/fetch/304 state updates into a focused internal pure module; no public API expansion or generic effect framework.
- Make touch versus raw-remote store decisions explicit. Retain state MVar, refreshLock, network/disk checkpoints, and commit-before-cache-effect ordering.
- Add pure sequences and disk-backed regression tests for ETag/key preservation, bundled overlays, missing endpoints/cache misses, errors, exceptions, cancellation, and read availability.

## Validation
- `nix develop -j1 -c cabal repl -j1 agent-openai:lib:agent-openai`: verified `Ok, 38 modules loaded.` and no failed load/compiler errors.
- `nix develop -j1 -c cabal repl -j1 agent-openai:test:agent-openai-test`, then `hspec (ModelsManagerSpec.spec >> ModelsClientSpec.spec >> ModelsTypesSpec.spec)`: 40 examples, 0 failures; successful module load verified.
- Independent read-only review passed after addressing disk-sequence coverage. `git diff --check` passed.
- Regenerated package.nix from the package directory; unchanged output.

## Limits
No UI changes or performance claims. Relevant integration workflow exercised through real manager/disk tests and local HTTP client tests; no live provider request or full repository suite.