### PR TITLE
Show running background tasks above the CLI prompt

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
+++ b/packages/agent-cli/src/Agent/CLI/CodeModeRuntime.hs
@@ -80,6 +80,7 @@ import Agent.Tools.MultiAgents
     )
 import Agent.Tools.Types
     ( AppTool(..)
+    , BackgroundTaskStatus
     , ToolSchema(..)
     )
 import Control.Exception.Safe (tryAny)
@@ -165,6 +166,7 @@ data CodeModeSessionRuntime = CodeModeSessionRuntime
       -- enabled or disabled during the session.
     , codeModeNestedSlot :: !CodeModeNestedSlot
     , codeModeNestedToolNames :: ![Text]
+    , codeModeReadBackgroundTasks :: !(IO [BackgroundTaskStatus])
     , codeModeClose :: !(IO ())
     }
 
@@ -388,6 +390,7 @@ buildRuntime imageDetail mode strategy projection = do
             , codeModeProjectionStrategy = strategy
             , codeModeNestedSlot = slot
             , codeModeNestedToolNames = toolSet.codeModeNestedToolNames
+            , codeModeReadBackgroundTasks = toolSet.codeModeReadBackgroundTasks
             , codeModeClose = toolSet.closeCodeModeToolSet
             }
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -66,7 +66,7 @@ import Agent.CLI.Session.Lifecycle ( SessionContinuation(..) )
 import Agent.CLI.SessionEnv ( SessionEnv(..), SessionInboxRuntime(..) )
 import Agent.Runtime.SessionState qualified as RuntimeState
 import Agent.CLI.Skills ( skillInvocationCommand )
-import Agent.CLI.Status ( formatReplStatusLine )
+import Agent.CLI.Status ( formatReplStatusLine, formatBackgroundTaskStatus )
 import Agent.CLI.Style
     ( beginBackground,
       endBackground,
@@ -106,18 +106,21 @@ import Agent.Skills
     ( SkillInvocation(invocationSkill), Skill(skillUserInvocable) )
 import Agent.TUI.Model
     ( PromptState
-    , UiEvent(UiSetPromptLimitStatus, UiSystemMessage) )
+    , UiEvent(UiSetPromptLimitStatus, UiSystemMessage, UiSetBackgroundTaskStatus) )
 import Agent.Tools.PlanMode
     ( PlanModeEnv(planStateRef),
       PlanModeState(PlanPending, PlanActive) )
 import Agent.CLI.Session.Inbox (releaseInboxPending)
 import Control.Concurrent.Async ( race, withAsync )
+import Control.Concurrent (threadDelay)
+import Control.Exception.Safe (finally)
 import Control.Concurrent.MVar ( withMVar )
 import Control.Concurrent.STM (atomically, orElse, retry, takeTMVar, tryTakeTMVar)
 import Control.Monad ( when, forM_ )
 import Data.IORef ( atomicModifyIORef', readIORef, writeIORef )
 import Data.Maybe ( fromMaybe, isJust )
 import Data.Text ( Text )
+import Data.Time.Clock (getCurrentTime)
 import System.Console.ANSI ( getTerminalSize )
 import System.Console.ANSI.Codes ( clearFromCursorToLineEndCode )
 import System.IO ( stdout, hFlush )
@@ -406,12 +409,30 @@ readFullscreenPrompt
                     Just unavailable ->
                         (ProviderUnavailableWake <$> unavailable)
                             `orElse` backgroundWake
-            readFullscreenLineOrWithCatalog
-                runtime
-                slashCatalog
-                promptState
-                draft
-                wake
+            (withAsync
+                (refreshBackgroundTaskStatus env runtime (not (isJust failedTurn)))
+                \_ ->
+                    readFullscreenLineOrWithCatalog
+                        runtime
+                        slashCatalog
+                        promptState
+                        draft
+                        wake)
+                `finally` emitUiEvent runtime (UiSetBackgroundTaskStatus [])
+
+-- | Scoped to the idle prompt, so elapsed time remains live without keeping a
+-- permanent polling worker or allowing a late update after a turn starts.
+refreshBackgroundTaskStatus :: SessionEnv -> FullscreenRuntime -> Bool -> IO ()
+refreshBackgroundTaskStatus env runtime canResume = refresh Nothing
+  where
+    refresh previous = do
+        tasks <- env.sessionReadBackgroundTasks
+        now <- getCurrentTime
+        let rows = formatBackgroundTaskStatus now canResume tasks
+        when (previous /= Just rows) $
+            emitUiEvent runtime (UiSetBackgroundTaskStatus rows)
+        threadDelay 1000000
+        refresh (Just rows)
 
 refreshPromptAccountLimit
     :: SessionEnv

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -33,7 +33,8 @@ import Agent.CLI.AgentViewport (AgentViewportEnv)
 import Agent.CLI.AgentViewport.Runtime
 import Agent.Tools.OutputArtifact
 import Agent.Tools.Background
-    ( setBackgroundTaskHooks )
+    ( setBackgroundTaskHooks, readBackgroundTasks, BackgroundTaskStatus(..) )
+import Data.List (sortOn)
 import Agent.CLI.SessionTitle
 import Agent.CLI.ManagedTurn
 import Agent.CLI.GatewayBridge
@@ -1589,6 +1590,11 @@ buildSessionEnv
     SessionEnv
         { sessionLoop = loopRuntime.loopRuntimeConfig
         , sessionSteeringInputs = controls.controlSteeringInputs
+        , sessionReadBackgroundTasks = do
+            shellTasks <- readBackgroundTasks toolEnv
+            codeCells <- maybe (pure []) (.codeModeReadBackgroundTasks) codeModeRuntime
+            pure $ sortOn (\task -> (task.taskStartedAt, task.taskKey))
+                (shellTasks <> codeCells)
         , sessionModelInfo = modelInfo
         , sessionBtwBackend = btwBackend
         , sessionQueueRecap = writeChan recapRequests

--- a/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
+++ b/packages/agent-cli/src/Agent/CLI/SessionEnv.hs
@@ -9,6 +9,7 @@ import Agent.CLI.Session.Request
     ( SessionRequestState
     )
 import Agent.CLI.ActiveAccount (ActiveAccountRef)
+import Agent.Tools.Background (BackgroundTaskStatus)
 import Agent.CLI.CancelWatch (StdinControl)
 import Agent.CLI.Interrupt (InterruptState)
 import Agent.CLI.AgentViewport (AgentViewportEnv)
@@ -71,6 +72,7 @@ data SessionInboxRuntime = SessionInboxRuntime
 data SessionEnv = SessionEnv
     { sessionLoop :: !LoopConfig
     , sessionSteeringInputs :: !SteeringInputs
+    , sessionReadBackgroundTasks :: !(IO [BackgroundTaskStatus])
     , sessionModelInfo :: !(Maybe ModelInfo)
     , sessionBtwBackend :: !BtwBackendFactory
     , sessionQueueRecap :: !(RecapRequest -> IO ())

--- a/packages/agent-cli/src/Agent/CLI/Status.hs
+++ b/packages/agent-cli/src/Agent/CLI/Status.hs
@@ -5,6 +5,7 @@ module Agent.CLI.Status
     , formatContextUsage
     , formatFooterAccount
     , formatReplStatusLine
+    , formatBackgroundTaskStatus
     , formatTokenUsage
     , formatTokenUsageOrZero
     , formatEstimatedTokensPerSecond
@@ -23,6 +24,8 @@ import Agent.CLI.ReplMode
     )
 import Agent.CLI.Style (roleMuted)
 import Agent.Loop (TokenUsage(..), emptyTokenUsage)
+import Agent.Tools.Background (BackgroundTaskStatus(..))
+import Data.Time.Clock (UTCTime, diffUTCTime)
 import System.OsPath (OsPath)
 import Agent.Tools.PlanMode
     ( PlanModeEnv(..)
@@ -33,6 +36,28 @@ import Control.Monad (when)
 import Data.IORef (IORef, readIORef, writeIORef)
 import Data.Text (Text)
 import qualified Data.Text as Text
+
+-- | A bounded, terminal-safe summary. Continuation is promised only when both
+-- the task and the current prompt have a registered automatic delivery path.
+formatBackgroundTaskStatus :: UTCTime -> Bool -> [BackgroundTaskStatus] -> [Text]
+formatBackgroundTaskStatus _ _ [] = []
+formatBackgroundTaskStatus now canResume tasks@(first : _) =
+    [ "◌ " <> Text.pack (show (length tasks))
+        <> (if length tasks == 1 then " background task" else " background tasks")
+        <> " · " <> elapsed <> " · " <> label
+    ]
+    <> [ "  Agent will resume when a shell task finishes."
+       | canResume && any (.taskAutoResume) tasks
+       ]
+  where
+    label = truncateDisplayText 100 $
+        Text.unwords (Text.words first.taskLabel)
+    seconds = max 0 (floor (diffUTCTime now first.taskStartedAt) :: Integer)
+    elapsed
+        | seconds < 60 = Text.pack (show seconds) <> "s"
+        | otherwise =
+            Text.pack (show (seconds `div` 60)) <> "m "
+                <> Text.pack (show (seconds `mod` 60)) <> "s"
 
 -- | Idle prompt chrome: model, reasoning effort, interaction mode, and active
 -- account on the left; session token totals and last generation rate right-aligned

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -654,6 +654,7 @@ uiEventLogicalBytes = \case
         logicalTextsBytes [branch, cwd, root]
     UiSetNotice notice ->
         maybe 128 (logicalTextBytes . (.noticeText)) notice
+    UiSetBackgroundTaskStatus rows -> logicalTextsBytes rows
     UiMoveSelection _ -> 128
     UiSelectBlock _ -> 128
     UiActivateBlock _ -> 128

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -21,6 +21,7 @@ module Agent.CLI.TUI.Composer
     , draftCursorLocation
     , draftWindowStart
     , drawComposer
+    , drawBackgroundTaskStatus
     , drawQueuedInputs
     , drawSlashMenu
     , fullscreenInputByteLimit

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer/Render.hs
@@ -4,6 +4,7 @@ module Agent.CLI.TUI.Composer.Render
     , drawSlashMenu
     , slashMenuWindowStart
     , drawQueuedInputs
+    , drawBackgroundTaskStatus
     , drawComposer
     , controlAttr
     , controlInteractionAttr
@@ -130,6 +131,19 @@ drawQueuedInputs state =
 queuePreview :: Text -> Text
 queuePreview text =
     truncateDisplayText 100 (Text.unwords (Text.words text))
+
+-- | Keep managed work visible without taking focus from the editable prompt.
+-- A new model turn uses the usual activity indicator instead.
+drawBackgroundTaskStatus :: UiState -> Widget Name
+drawBackgroundTaskStatus state
+    | state.uiRunning = emptyWidget
+    | otherwise =
+        padLeftRight 2 $
+            vBox
+                [ withAttr Theme.mutedAttr $
+                    vLimit 1 (terminalTxt row)
+                | row <- state.uiBackgroundTaskStatus
+                ]
 
 drawComposer :: AppState -> Widget Name
 drawComposer appState =

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Internal.hs
@@ -160,6 +160,7 @@ import qualified Brick.Widgets.Border as Border ()
 import qualified Agent.CLI.TUI.Bridge as Bridge ()
 import qualified Agent.CLI.TUI.Composer as Composer
     ( drawSlashMenu,
+      drawBackgroundTaskStatus,
       drawQueuedInputs,
       drawComposer )
 import qualified Data.Map.Strict as Map ()
@@ -263,6 +264,7 @@ drawMain state =
                 , Composer.drawSlashMenu state
                 , drawLiveTodos (activeConversationUi state)
                 , drawPromptActivity state
+                , Composer.drawBackgroundTaskStatus state.appUi
                 , case textOverlay state of
                     Just prompt
                         | prompt.textInputMode == TextInputPlanning ->

--- a/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ReplStatusSpec.hs
@@ -27,7 +27,10 @@ import Agent.CLI
 import Agent.CLI.Command (setModel, setReasoningEffort)
 import Agent.CLI.Input (terminalTextWidth)
 import Agent.CLI.Models (ModelOption(..), ModelTarget(..))
-import Agent.CLI.Status (formatContextUsage, formatTokenUsageOrZero)
+import Agent.CLI.Status (formatContextUsage, formatTokenUsageOrZero, formatBackgroundTaskStatus)
+import Agent.Tools.Background (BackgroundTaskStatus(..))
+import Data.Time.Clock (UTCTime(..), addUTCTime)
+import Data.Time.Calendar (fromGregorian)
 import Agent.CLI.ModelConfig
     ( ModelCatalog
     , decodeModelConfig
@@ -270,6 +273,48 @@ spec = do
                 withRestoredCurrentDirectory failAfterChangingDirectory
                     `shouldThrow` anyIOException
                 getCurrentDirectory `shouldReturn` original
+
+    describe "formatBackgroundTaskStatus" do
+        let started = UTCTime (fromGregorian 2026 9 12) 0
+            task = BackgroundTaskStatus "shell:1" "Release build" started True
+        it "hides the status when no managed work remains" do
+            formatBackgroundTaskStatus started True [] `shouldBe` []
+        it "shows the task count, elapsed time, and registered continuation" do
+            formatBackgroundTaskStatus (addUTCTime 272 started) True [task]
+                `shouldBe`
+                    [ "◌ 1 background task · 4m 32s · Release build"
+                    , "  Agent will resume when a shell task finishes."
+                    ]
+        it "does not promise continuation when retry is required" do
+            formatBackgroundTaskStatus started False [task]
+                `shouldBe` ["◌ 1 background task · 0s · Release build"]
+        it "does not promise continuation for unregistered tasks" do
+            formatBackgroundTaskStatus started True [task { taskAutoResume = False }]
+                `shouldBe` ["◌ 1 background task · 0s · Release build"]
+        it "counts multiple tasks and normalizes multiline command labels" do
+            let multiline = task { taskLabel = "release\n  build\tvalidation" }
+            formatBackgroundTaskStatus started False [multiline, task]
+                `shouldBe` ["◌ 2 background tasks · 0s · release build validation"]
+        it "clamps clock adjustments to zero elapsed time" do
+            formatBackgroundTaskStatus (addUTCTime (-1) started) False [task]
+                `shouldBe` ["◌ 1 background task · 0s · Release build"]
+        it "does not expose terminal controls from command labels" do
+            let unsafeTask = task { taskLabel = "\ESC[2Jbuild\BEL\DEL" }
+                rows = formatBackgroundTaskStatus started False [unsafeTask]
+            Text.concat rows `shouldSatisfy`
+                (not . Text.any (`elem` ['\ESC', '\BEL', '\DEL']))
+        it "bounds long command labels" do
+            let longTask = task { taskLabel = Text.replicate 200 "x" }
+            formatBackgroundTaskStatus started False [longTask]
+                `shouldBe`
+                    ["◌ 1 background task · 0s · " <> Text.replicate 99 "x" <> "…"]
+        it "limits continuation wording to shell tasks in a mixed snapshot" do
+            let cell = task { taskKey = "cell:1", taskLabel = "JavaScript cell", taskAutoResume = False }
+            formatBackgroundTaskStatus started True [cell, task]
+                `shouldBe`
+                    [ "◌ 2 background tasks · 0s · JavaScript cell"
+                    , "  Agent will resume when a shell task finishes."
+                    ]
 
     describe "formatReplStatusLine" do
         it "shows model, effort, interaction mode, and active account" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -3056,6 +3056,28 @@ spec = do
             failedText `shouldNotSatisfy`
                 Text.isInfixOf "failed-output-marker"
 
+    describe "background task prompt status" do
+        it "renders idle work above the editable prompt and hides it during a turn" do
+            runtime <- newScriptRuntime initialUiState
+            let base = initialFullscreenAppState runtime [] AgentRoot [] 0
+                idle = initialUiState
+                    { uiAwaitingInput = True
+                    , uiDraft = "follow-up message"
+                    , uiCursor = 17
+                    , uiBackgroundTaskStatus =
+                        [ "◌ 1 background task · 4m 32s · Release build"
+                        , "  Agent will resume when a shell task finishes."
+                        ]
+                    }
+                rendered ui = renderedAppText (100, 24) (base { appUi = ui })
+            rendered idle `shouldSatisfy` Text.isInfixOf "1 background task"
+            rendered idle `shouldSatisfy` Text.isInfixOf "follow-up message"
+            rendered idle `shouldSatisfy` Text.isInfixOf "Agent will resume"
+            rendered (idle { uiRunning = True })
+                `shouldNotSatisfy` Text.isInfixOf "1 background task"
+            rendered (idle { uiBackgroundTaskStatus = [] })
+                `shouldNotSatisfy` Text.isInfixOf "1 background task"
+
     describe "conversation scrollbar" do
         it "uses a visible trough that repaints old thumb cells" do
             let renderCell widget =

--- a/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Shell.hs
+++ b/packages/agent-codex-dialect/src/Agent/Codex/Dialect/Shell.hs
@@ -33,6 +33,8 @@ import Agent.Tools.Background
     , newCompletionGate
     , publishBackgroundTaskNotice
     , publishCompletion
+    , registerBackgroundTask
+    , removeBackgroundTask
     , suppressCompletion
     , systemReminder
     )
@@ -379,11 +381,14 @@ startManagedCommand authorization session workdir command =
                         else do
                             let commandId = store.storeNextId + 1
                                 key = codexCompletionKey commandId
+                                removeStatus =
+                                    removeBackgroundTask session.sessionEnv key
                             completion <- newCompletionGate
                             cursor <- newMVar initialRunningOutputCursor
                             yielded <- newEmptyMVar
                             runningVar <- newEmptyMVar
                             let publish result = do
+                                    removeStatus
                                     didYield <- readMVar yielded
                                     when didYield $
                                       publishCompletion completion do
@@ -402,13 +407,16 @@ startManagedCommand authorization session workdir command =
                                                     { commandStdout = out
                                                     , commandStderr = err
                                                     })
-                            startShellCommandWithInputAndCompletionAuthorized
+                            registerBackgroundTask
+                                session.sessionEnv key command True
+                            (startShellCommandWithInputAndCompletionAuthorized
                                 authorization
                                 session.sessionEnv
                                 workdir
                                 command
-                                publish >>= \case
-                                Left err ->
+                                publish `onException` removeStatus) >>= \case
+                                Left err -> do
+                                    removeStatus
                                     pure
                                         ( Just store
                                         , (completedToRelease, Left err)
@@ -426,6 +434,7 @@ startManagedCommand authorization session workdir command =
                                                     <*> pure (shellExecutionIsEscalated authorization)
                                             pure (commandId, task))
                                             `onException` do
+                                                removeStatus
                                                 void $ tryPutMVar yielded False
                                                 suppressCompletion completion $
                                                     dismissBackgroundTaskNotice
@@ -486,14 +495,18 @@ stopManagedCommand session task = do
     stopShellCommand task.managedRunning
 
 consumeManagedCompletion :: CodexShellSession -> ManagedCommand -> IO ()
-consumeManagedCompletion session task =
+consumeManagedCompletion session task = do
+    removeBackgroundTask
+        session.sessionEnv (codexCompletionKey task.managedId)
     consumeCompletion task.managedCompletion $
         dismissBackgroundTaskNotice
             session.sessionEnv
             (codexCompletionKey task.managedId)
 
 suppressManagedCompletion :: CodexShellSession -> ManagedCommand -> IO ()
-suppressManagedCompletion session task =
+suppressManagedCompletion session task = do
+    removeBackgroundTask
+        session.sessionEnv (codexCompletionKey task.managedId)
     suppressCompletion task.managedCompletion $
         dismissBackgroundTaskNotice
             session.sessionEnv

--- a/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
+++ b/packages/agent-codex-dialect/test/Agent/Codex/DialectSpec.hs
@@ -22,7 +22,8 @@ import Agent.Codex.Dialect.Shell
     )
 import Agent.Codex.Dialect.Tools (shellCommandIsReadOnly)
 import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
-import Agent.Tools.Background (setBackgroundTaskHooks)
+import Agent.Tools.Background
+    ( BackgroundTaskStatus(..), readBackgroundTasks, setBackgroundTaskHooks )
 import Agent.Tools.IO (CommandResult(..))
 import Agent.ToolDispatch
     ( ToolOutcome(..)
@@ -479,6 +480,7 @@ spec = describe "Codex dialect" do
                         Right _ ->
                             expectationFailure "stale command remained available"
                     readMVar notices `shouldReturn` Nothing
+                    readBackgroundTasks env `shouldReturn` []
 
     it "formats project instructions as a contextual user fragment" do
         let loaded = LoadedAgentsMd
@@ -741,6 +743,26 @@ spec = describe "Codex dialect" do
                         Text.isInfixOf "completion-output"
                     notice.noticeBody `shouldSatisfy`
                         Text.isInfixOf "do not call write_stdin"
+                    readBackgroundTasks env `shouldReturn` []
+
+    it "tracks retained commands without consuming output and clears status on reset" do
+        requireProcessSandbox
+        withTempDir \dir -> do
+            env <- defaultToolEnv (unsafeEncodeUtf dir)
+            bracket (newCodexShellSession env) closeCodexShellSession \session -> do
+                started <- startCodexShellCommand session env.toolCwd
+                    "read value; printf '%s' \"$value\"" 1 (\_ _ -> pure ())
+                commandId <- case started of
+                    Right CodexShellRunning { codexShellSessionId = identifier } ->
+                        pure identifier
+                    _ -> expectationFailure "expected a retained command" >> pure 0
+                active <- readBackgroundTasks env
+                map (.taskKey) active `shouldBe`
+                    ["codex-shell:" <> Text.pack (show commandId)]
+                map (.taskAutoResume) active `shouldBe` [True]
+                readBackgroundTasks env `shouldReturn` active
+                resetCodexShellSession session
+                readBackgroundTasks env `shouldReturn` []
 
     it "does not publish a notice when the initial wait returns the result" do
         requireProcessSandbox

--- a/packages/agent-core/src/Agent/Tools/Background.hs
+++ b/packages/agent-core/src/Agent/Tools/Background.hs
@@ -6,11 +6,15 @@
 -- so the pending input contains either the reminder or the explicit result.
 module Agent.Tools.Background
     ( CompletionGate
+    , BackgroundTaskStatus(..)
     , consumeCompletion
     , dismissBackgroundTaskNotice
     , newCompletionGate
     , publishBackgroundTaskNotice
     , publishCompletion
+    , readBackgroundTasks
+    , registerBackgroundTask
+    , removeBackgroundTask
     , setBackgroundTaskHooks
     , suppressCompletion
     , systemReminder
@@ -19,14 +23,39 @@ module Agent.Tools.Background
 import Agent.Tools.Types
     ( BackgroundTaskHooks(..)
     , BackgroundTaskNotice
+    , BackgroundTaskStatus(..)
     , ToolEnv(..)
     )
 import Control.Concurrent.MVar (MVar, modifyMVar, newMVar)
 import Control.Exception.Safe (tryAny)
 import Control.Monad (void)
-import Data.IORef (readIORef, writeIORef)
+import Data.IORef (atomicModifyIORef', readIORef, writeIORef)
+import qualified Data.Map.Strict as Map
+import Data.List (sortOn)
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Time.Clock (getCurrentTime)
+
+-- | Snapshot only: never consumes task output or completion notifications.
+readBackgroundTasks :: ToolEnv -> IO [BackgroundTaskStatus]
+readBackgroundTasks env =
+    sortOn (\task -> (task.taskStartedAt, task.taskKey)) . Map.elems
+        <$> readIORef env.toolBackgroundTasks
+
+-- | Register before starting the worker, so an immediate completion cannot
+-- remove its entry before insertion. Repeated registration preserves its age.
+registerBackgroundTask :: ToolEnv -> Text -> Text -> Bool -> IO ()
+registerBackgroundTask env key label autoResume = do
+    startedAt <- getCurrentTime
+    let status = BackgroundTaskStatus key label startedAt autoResume
+    atomicModifyIORef' env.toolBackgroundTasks \tasks ->
+        (Map.insertWith (\_ existing -> existing) key status tasks, ())
+
+-- | Idempotent removal on completion, failed start, cancellation, or shutdown.
+removeBackgroundTask :: ToolEnv -> Text -> IO ()
+removeBackgroundTask env key =
+    atomicModifyIORef' env.toolBackgroundTasks \tasks ->
+        (Map.delete key tasks, ())
 
 setBackgroundTaskHooks :: ToolEnv -> BackgroundTaskHooks -> IO ()
 setBackgroundTaskHooks env = writeIORef env.toolBackgroundTaskHooks

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Host.hs
@@ -18,6 +18,7 @@ module Agent.Tools.CodeMode.Host
     , execCodeCell
     , execCodeCellWithTools
     , newCodeModeHost
+    , readRunningCodeCells
     , terminateCodeCell
     , waitCodeCell
     , withCodeModeHost
@@ -102,7 +103,7 @@ import Control.Exception.Safe
     , onException
     , try
     )
-import Control.Monad (void)
+import Control.Monad (filterM, void)
 import Data.Aeson (ToJSON(toJSON), Value(..), object, (.=))
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString as BS
@@ -116,6 +117,8 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Vector as Vector
+import Data.Maybe (isNothing)
+import Data.Time.Clock (UTCTime, getCurrentTime)
 import System.IO
     ( BufferMode(..)
     , Handle
@@ -266,6 +269,15 @@ activeCellLimitError host = CodeModeResourceError $
     "too many active code-mode cells (limit "
         <> Text.pack (show (activeCellLimit host))
         <> ")"
+
+-- | Read activity without consuming output or claiming a cell's observer.
+-- Completed cells remain retained until an explicit wait, but are not running.
+readRunningCodeCells :: CodeModeHost -> IO [(Text, UTCTime)]
+readRunningCodeCells host = withMVar host.hostCells \cells -> do
+    running <- atomically $ filterM
+        (fmap isNothing . tryReadTMVar . (.cellResult))
+        (Map.elems cells)
+    pure [(cell.cellIdentifier, cell.cellStartedAt) | cell <- running]
 
 waitCodeCell
     :: CodeModeHost
@@ -504,6 +516,7 @@ startCellFromProcess host identifier tools alreadyReady
                                     stopIncompleteProcess
                                         input output stderr processHandle
                             observation <- newMVar CellIdle
+                            startedAt <- getCurrentTime
                             stderrReader <-
                                 case (alreadyReady, existingStderr) of
                                     (True, Just reader) -> pure reader
@@ -553,6 +566,7 @@ startCellFromProcess host identifier tools alreadyReady
                                 Right (Right ()) ->
                                     pure $ Right Cell
                                         { cellIdentifier = identifier
+                                        , cellStartedAt = startedAt
                                         , cellInput = input
                                         , cellOutput = output
                                         , cellErrorOutput = stderr

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Host/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Host/Types.hs
@@ -14,6 +14,7 @@ import Data.Aeson (Value)
 import qualified Data.Map.Strict as Map
 import Data.IORef (IORef)
 import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
 import System.IO (Handle)
 import System.Posix.Types (ProcessGroupID)
 import System.Process (ProcessHandle)
@@ -102,6 +103,7 @@ data WorkerProcessHandle = WorkerProcessHandle
 
 data Cell = Cell
     { cellIdentifier :: !Text
+    , cellStartedAt :: !UTCTime
     , cellInput :: !Handle
     , cellOutput :: !Handle
     , cellErrorOutput :: !Handle

--- a/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
+++ b/packages/agent-core/src/Agent/Tools/CodeMode/Tool.hs
@@ -54,6 +54,7 @@ import Agent.Tools.CodeMode.Host
     , defaultCodeModeConfig
     , execCodeCellWithTools
     , newCodeModeHost
+    , readRunningCodeCells
     , terminateCodeCell
     , waitCodeCell
     , withCodeModeHost
@@ -62,6 +63,7 @@ import Agent.Tools.CodeMode.Protocol (CodeModeToolMetadata(..))
 import Agent.Tools.Types
     ( AppTool(..)
     , ApprovalRule(..)
+    , BackgroundTaskStatus(..)
     , ToolExecutionPolicy(..)
     , ToolSchema(..)
     , freeformGrammarAppToolWithExecution
@@ -119,6 +121,7 @@ data CodeModeToolSet = CodeModeToolSet
     { codeModeTools :: ![AppTool]
       -- ^ The @exec@ and @wait@ tools, ready for registry and wire schemas.
     , codeModeNestedToolNames :: ![Text]
+    , codeModeReadBackgroundTasks :: !(IO [BackgroundTaskStatus])
     , closeCodeModeToolSet :: !(IO ())
     }
 
@@ -181,6 +184,20 @@ newCodeModeToolSet mode detailVisibility workerPath invoke specs =
                             pure $ Right CodeModeToolSet
                                 { codeModeTools = tools
                                 , codeModeNestedToolNames = names
+                                , codeModeReadBackgroundTasks = do
+                                    cells <- readRunningCodeCells host
+                                    pure
+                                        [ BackgroundTaskStatus
+                                            { taskKey = "code-mode:" <> identifier
+                                            , taskLabel = "JavaScript cell " <> identifier
+                                            , taskStartedAt = startedAt
+                                            -- Cells require an explicit wait; unlike
+                                            -- shell tasks, they do not enqueue a
+                                            -- completion wake for the agent.
+                                            , taskAutoResume = False
+                                            }
+                                        | (identifier, startedAt) <- cells
+                                        ]
                                 , closeCodeModeToolSet =
                                     closeCodeModeHost host
                                 }

--- a/packages/agent-core/src/Agent/Tools/Types.hs
+++ b/packages/agent-core/src/Agent/Tools/Types.hs
@@ -7,6 +7,7 @@ module Agent.Tools.Types
     , hostToolsFromGroups
     , BackgroundTaskHooks(..)
     , BackgroundTaskNotice(..)
+    , BackgroundTaskStatus(..)
     , ToolSchema(..)
     , ApprovalRule(..)
     , ApprovalRequirement(..)
@@ -93,6 +94,7 @@ import Data.IORef
     )
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
 import qualified Data.Text as Text
 import System.OsPath
     ( OsPath
@@ -214,6 +216,17 @@ data BackgroundTaskNotice = BackgroundTaskNotice
     , noticeBody :: !Text
     } deriving (Eq, Show)
 
+-- | Live managed work, independent of retained output and completion notices.
+-- Auto-resume denotes a worker with a completion delivery callback; the UI
+-- must also account for whether the session has installed delivery hooks and
+-- can accept an automatic turn.
+data BackgroundTaskStatus = BackgroundTaskStatus
+    { taskKey :: !Text
+    , taskLabel :: !Text
+    , taskStartedAt :: !UTCTime
+    , taskAutoResume :: !Bool
+    } deriving (Eq, Show)
+
 data BackgroundTaskHooks = BackgroundTaskHooks
     { backgroundTaskCompleted :: !(BackgroundTaskNotice -> IO Bool)
     , backgroundTaskDismissed :: !(Text -> IO ())
@@ -255,6 +268,7 @@ data ToolEnv = ToolEnv
       -- Stored behind an IORef because the CLI runner is installed after the
       -- provider-native tool runtimes are constructed.
     , toolBackgroundTaskHooks :: !(IORef BackgroundTaskHooks)
+    , toolBackgroundTasks :: !(IORef (Map.Map Text BackgroundTaskStatus))
       -- | Soft-cancel latch for the active turn. Shell tools race against it.
     , toolCancel :: !CancelFlag
     }
@@ -270,6 +284,7 @@ defaultToolEnv cwd = do
     sessionTmp <- newIORef Nothing
     outputMemory <- newOutputArtifactMemoryStore
     backgroundTaskHooks <- newIORef noBackgroundTaskHooks
+    backgroundTasks <- newIORef Map.empty
     pure ToolEnv
         { toolCwd = dropTrailingPathSeparator cwd
         , toolResourceArbiter = arbiter
@@ -285,6 +300,7 @@ defaultToolEnv cwd = do
         , toolOutputMemoryCap = 16 * 1024 * 1024
         , toolStdoutCap = 16 * 1024
         , toolBackgroundTaskHooks = backgroundTaskHooks
+        , toolBackgroundTasks = backgroundTasks
         , toolCancel = cancel
         }
 

--- a/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/CodeMode/HostSpec.hs
@@ -440,6 +440,40 @@ spec = describe "code-mode Bun host" do
                     ]
                 }
 
+    it "reads running cell activity without consuming completion output" do
+        releaseHandler <- newEmptyMVar
+        let config = defaultCodeModeConfig
+                "data/code-mode/worker.mjs"
+                (\_ _ -> readMVar releaseHandler >> pure (Right Null))
+        withCodeModeHost config \host -> do
+            before <- getCurrentTime
+            started <- execCodeCell host
+                "await tools.gate({}); text('completed output');"
+                ["gate"] 1
+            started `shouldBe` Right CodeModeRunning
+                { cellId = "1", cellOutput = emptyContent }
+            tasks <- readRunningCodeCells host
+            map fst tasks `shouldBe` ["1"]
+            map snd tasks `shouldSatisfy` all (>= before)
+            readRunningCodeCells host `shouldReturn` tasks
+            putMVar releaseHandler ()
+            let awaitCompletion = readRunningCodeCells host >>= \case
+                    [] -> pure ()
+                    _ -> threadDelay 1000 >> awaitCompletion
+            timeout 5000000 awaitCompletion `shouldReturn` Just ()
+            waitCodeCell host "1" 1000 `shouldReturn` Right CodeModeFinished
+                { cellId = "1", cellValue = textContent "completed output" }
+
+    it "removes running cell activity when the host closes" do
+        let config = defaultCodeModeConfig
+                "data/code-mode/worker.mjs"
+                (\_ _ -> pure (Left "no tools"))
+        withCodeModeHost config \host -> do
+            _ <- execCodeCell host "await new Promise(() => {});" [] 1
+            map fst <$> readRunningCodeCells host `shouldReturn` ["1"]
+            closeCodeModeHost host
+            readRunningCodeCells host `shouldReturn` []
+
     it "retains a yielded cell until it is terminated" do
         let config = defaultCodeModeConfig
                 "data/code-mode/worker.mjs"
@@ -461,6 +495,7 @@ spec = describe "code-mode Bun host" do
                 { cellId = "1"
                 , cellValue = emptyContent
                 }
+        readRunningCodeCells host `shouldReturn` []
         closeCodeModeHost host
 
     it "returns output accumulated after the last timed yield on termination" do

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -2,9 +2,13 @@ module Agent.Tools.IOSpec (spec) where
 
 import Agent.Cancel (requestCancel)
 import Agent.Tools.Background
-    ( consumeCompletion
+    ( BackgroundTaskStatus(..)
+    , consumeCompletion
     , newCompletionGate
     , publishCompletion
+    , readBackgroundTasks
+    , registerBackgroundTask
+    , removeBackgroundTask
     , suppressCompletion
     , systemReminder
     )
@@ -85,6 +89,29 @@ fromFilePath = unsafeEncodeUtf
 
 spec :: Spec
 spec = describe "Agent.Tools.IO" do
+    describe "background task status" do
+        it "preserves task age on repeated registration and reads without consumption" do
+            env <- defaultToolEnv (fromFilePath ".")
+            registerBackgroundTask env "shell:1" "release build" True
+            initial <- readBackgroundTasks env
+            map (.taskLabel) initial `shouldBe` ["release build"]
+            map (.taskAutoResume) initial `shouldBe` [True]
+            registerBackgroundTask env "shell:1" "replacement label" False
+            readBackgroundTasks env `shouldReturn` initial
+            readBackgroundTasks env `shouldReturn` initial
+
+        it "keeps independent tasks and removes completed entries idempotently" do
+            env <- defaultToolEnv (fromFilePath ".")
+            registerBackgroundTask env "shell:1" "build" True
+            registerBackgroundTask env "cell:1" "script" False
+            removeBackgroundTask env "shell:1"
+            remaining <- readBackgroundTasks env
+            map (.taskKey) remaining `shouldBe` ["cell:1"]
+            map (.taskAutoResume) remaining `shouldBe` [False]
+            removeBackgroundTask env "shell:1"
+            removeBackgroundTask env "cell:1"
+            readBackgroundTasks env `shouldReturn` []
+
     describe "background completion delivery" do
         it "publishes once and lets one explicit result dismiss it" do
             events <- newIORef ([] :: [Text.Text])

--- a/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
+++ b/packages/agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs
@@ -44,6 +44,8 @@ import Agent.Tools.Background
     , newCompletionGate
     , publishBackgroundTaskNotice
     , publishCompletion
+    , registerBackgroundTask
+    , removeBackgroundTask
     , suppressCompletion
     , systemReminder
     )
@@ -65,7 +67,7 @@ import Agent.Tools.Types
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (mapConcurrently_, race)
 import Control.Concurrent.MVar
-import Control.Exception.Safe (mask, onException, throwIO, tryAny)
+import Control.Exception.Safe (bracketOnError, mask, onException, throwIO, tryAny)
 import Control.Monad (forM, void)
 import Data.IORef
 import Data.List (sortOn)
@@ -326,18 +328,27 @@ startBackgroundCommand authorization session command =
                                 -- command owns the persistent session.
                                 let wrapped =
                                         executionScript authorization shell False command
-                                    publish result =
+                                    removeStatus =
+                                        removeBackgroundTask session.grokEnv
+                                            (grokCompletionKey taskId)
+                                    publish result = do
+                                        removeStatus
                                         publishCompletion completion $
                                             publishBackgroundTaskNotice
                                                 session.grokEnv
                                                 (grokCompletionNotice
                                                     taskId command result)
-                                    suppress =
+                                    suppress = do
+                                        removeStatus
                                         suppressCompletion completion $
                                             dismissBackgroundTaskNotice
                                                 session.grokEnv
                                                 (grokCompletionKey taskId)
                                 started <- tryAny $
+                                  bracketOnError
+                                    (registerBackgroundTask session.grokEnv
+                                        (grokCompletionKey taskId) command True)
+                                    (const removeStatus) \() ->
                                     allocateResource session.grokResources
                                         (startShellCommandWithCompletionAuthorized
                                             authorization
@@ -350,7 +361,8 @@ startBackgroundCommand authorization session command =
                                                 pure)
                                         stopShellCommand
                                 case started of
-                                    Left exception ->
+                                    Left exception -> do
+                                        removeStatus
                                         pure
                                             ( shell
                                             , Left (Text.pack (show exception))
@@ -522,14 +534,18 @@ killTask session taskId = do
             pure $ "killed " <> taskId <> "\n" <> formatCommandResult result
 
 consumeTaskCompletion :: GrokSession -> BackgroundTask -> IO ()
-consumeTaskCompletion session task =
+consumeTaskCompletion session task = do
+    removeBackgroundTask
+        session.grokEnv (grokCompletionKey task.backgroundId)
     consumeCompletion task.backgroundCompletion $
         dismissBackgroundTaskNotice
             session.grokEnv
             (grokCompletionKey task.backgroundId)
 
 suppressTaskCompletion :: GrokSession -> BackgroundTask -> IO ()
-suppressTaskCompletion session task =
+suppressTaskCompletion session task = do
+    removeBackgroundTask
+        session.grokEnv (grokCompletionKey task.backgroundId)
     suppressCompletion task.backgroundCompletion $
         dismissBackgroundTaskNotice
             session.grokEnv

--- a/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
+++ b/packages/agent-grok-build-dialect/test/Agent/GrokBuild/DialectSpec.hs
@@ -33,7 +33,8 @@ import Agent.ToolDispatch
     , functionToolCall
     )
 import Agent.Tools.Scheduling (schedulingPlansConflict)
-import Agent.Tools.Background (setBackgroundTaskHooks)
+import Agent.Tools.Background
+    ( BackgroundTaskStatus(..), readBackgroundTasks, setBackgroundTaskHooks )
 import Agent.Tools.IO (CommandResult(..))
 import Agent.Tools.Types
     ( AppTool(..)
@@ -506,8 +507,13 @@ spec = describe "Grok Build dialect" do
                     Right runningId -> pure runningId
                     Left err -> expectationFailure (Text.unpack err) >> pure ""
                 waitForFile output `shouldReturn` True
+                active <- readBackgroundTasks env
+                map (.taskKey) active `shouldBe` ["grok-terminal:t1"]
+                map (.taskAutoResume) active `shouldBe` [True]
+                readBackgroundTasks env `shouldReturn` active
 
                 resetGrokSessionTemp session (unsafeEncodeUtf nextScratch)
+                readBackgroundTasks env `shouldReturn` []
                 setToolSessionTmp env (Just (unsafeEncodeUtf nextScratch))
 
                 before <- Text.readFile output
@@ -536,6 +542,7 @@ spec = describe "Grok Build dialect" do
                     Text.isInfixOf "completion-output"
                 notice.noticeBody `shouldSatisfy`
                     Text.isInfixOf "do not call get_task_output"
+                readBackgroundTasks env `shouldReturn` []
 
     it "retracts a completion notice when output is read explicitly" do
         requireProcessSandbox

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -176,6 +176,8 @@ reduceUi event state = case event of
         state { uiBranch = branch, uiCwd = cwd, uiWorkspaceRoot = workspace }
     UiSetNotice notice ->
         state { uiNotice = notice, uiNoticeElapsedMillis = 0 }
+    UiSetBackgroundTaskStatus rows ->
+        state { uiBackgroundTaskStatus = rows }
     UiMoveSelection delta ->
         moveSelection delta state
     UiSelectBlock ident ->
@@ -299,6 +301,7 @@ clearConversation state =
         , uiShellPolls = Map.empty
         , uiRetryCountdown = Nothing
         , uiTodos = []
+        , uiBackgroundTaskStatus = []
         , uiGenerating = False
         , uiGenerationChars = 0
         , uiGenerationMillis = 0

--- a/packages/agent-tui/src/Agent/TUI/Model/State.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/State.hs
@@ -48,6 +48,7 @@ initialUiState = UiState
     , uiContextWindow = Nothing
     , uiPermission = Nothing
     , uiNotice = Nothing
+    , uiBackgroundTaskStatus = []
     , uiRetryCountdown = Nothing
     , uiNoticeElapsedMillis = 0
     , uiElapsedMillis = 0

--- a/packages/agent-tui/src/Agent/TUI/Model/Types.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Types.hs
@@ -159,6 +159,8 @@ data UiState = UiState
     , uiContextWindow :: !(Maybe Int)
     , uiPermission :: !(Maybe PermissionOverlay)
     , uiNotice :: !(Maybe UiNotice)
+    -- | Live managed work, independent of the last model response.
+    , uiBackgroundTaskStatus :: ![Text]
     , uiRetryCountdown :: !(Maybe RetryCountdown)
     , uiNoticeElapsedMillis :: !Int
     , uiElapsedMillis :: !Int
@@ -201,6 +203,7 @@ data UiEvent
     | UiSetAwaitingInput !Bool
     | UiSetRepository !Text !Text !Text
     | UiSetNotice !(Maybe UiNotice)
+    | UiSetBackgroundTaskStatus ![Text]
     | UiMoveSelection !Int
     | UiSelectBlock !BlockId
     | UiActivateBlock !BlockId

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -28,6 +28,19 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "fullscreen UI reducer" do
+    it "updates background work without changing the draft or adding transcript blocks" do
+        let draft = reduceUi (UiSetDraft "follow-up message" 4) initialUiState
+            active = reduceUi (UiSetBackgroundTaskStatus ["1 background task"]) draft
+            completed = reduceUi (UiSetBackgroundTaskStatus []) active
+        active.uiBackgroundTaskStatus `shouldBe` ["1 background task"]
+        active.uiDraft `shouldBe` draft.uiDraft
+        active.uiCursor `shouldBe` draft.uiCursor
+        active.uiBlocks `shouldBe` draft.uiBlocks
+        completed.uiBackgroundTaskStatus `shouldBe` []
+    it "does not restore stale background work when the conversation is cleared" do
+        let active = reduceUi (UiSetBackgroundTaskStatus ["1 background task"]) initialUiState
+        (reduceUi UiConversationCleared active).uiBackgroundTaskStatus `shouldBe` []
+
     it "cycles across all four permission choices" do
         let shown = reduceUi (UiPermissionShown "write a file") initialUiState
             moved count = iterate (reduceUi (UiPermissionMoved 1)) shown !! count


### PR DESCRIPTION
## Summary
- Show running background-task count, elapsed time, and task label above the idle fullscreen prompt.
- Explain when shell completion will resume the agent; include running JavaScript cells without promising automatic continuation for them.
- Keep status reads non-consuming and refresh with a prompt-scoped worker; clear finished/cancelled work without disturbing the draft.

## Validation
- GHCi typecheck of CLI and affected dependencies (560 modules), and CLI test dependencies (665 modules).
- ReplStatusSpec: 53 passing; TUI ModelSpec: 84 passing; focused TUI render test: passing.
- IOSpec: 45 passing; Codex DialectSpec: 34 passing; Grok DialectSpec: 25 passing.
- Live tmux fullscreen presentation/input smoke: status shown above composer, draft remains editable, clearing status preserves draft. This is not a model-driven auto-resume end-to-end test.
- HostSpec: 39 passing, including JavaScript-cell lifecycle/non-consuming status regressions, using the flake-provided Bun (the home-directory Bun caused initial worker timeouts).

## CI
- Native CLI, extracted packages, server, runtime daemon, and Telegram checks passed.
- CLI package tests fail before execution because the existing `MetaConsoleRuntimeSpec` imports the hidden module `Agent.CLI.Runtime.Repl.MetaConsole`. Both the test import and Cabal visibility predate this PR and are unchanged here.
- Linux integrations and static CLI runtime were still pending when this failure was investigated.
