### PR TITLE
Extract pure pending-input lifecycle model

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -237,6 +237,7 @@ library
                     , Agent.CLI.Options
                     , Agent.CLI.Permission
                     , Agent.CLI.PendingInputs
+                    , Agent.CLI.PendingInputs.Model
                     , Agent.CLI.InputBudget
                     , Agent.CLI.Picker
                     , Agent.CLI.Plan

--- a/packages/agent-cli/src/Agent/CLI/PendingInputs.hs
+++ b/packages/agent-cli/src/Agent/CLI/PendingInputs.hs
@@ -11,10 +11,13 @@ module Agent.CLI.PendingInputs
     , withPendingInputs
     ) where
 
-import Agent.CLI.InputBudget
-    ( logicalTurnInputBytes
-    , saturatingAdd
+import Agent.CLI.PendingInputs.Model
+    ( PendingNoticeKind(..)
+    , PendingState
+    , pendingInputByteLimit
+    , pendingInputCountLimit
     )
+import qualified Agent.CLI.PendingInputs.Model as Model
 import Agent.Loop
     ( Backend(..)
     , BackendMiddleware
@@ -23,44 +26,9 @@ import Agent.Loop
     )
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Exception.Safe (mask, onException)
-import Data.Foldable (toList)
 import Data.IORef (IORef, atomicModifyIORef')
 import qualified Data.IORef
-import qualified Data.Sequence as Seq
 import Data.Text (Text)
-
-pendingInputCountLimit :: Int
-pendingInputCountLimit = 256
-
-pendingInputByteLimit :: Int
-pendingInputByteLimit = 8 * 1024 * 1024
-
-data PendingNoticeKind
-    = PendingMcpNotice
-    | PendingSubagentNotice
-    deriving (Eq)
-
-data PendingEntry = PendingEntry
-    { entryInput :: !TurnInput
-    , entryBytes :: !Int
-    , entryNoticeKind :: !(Maybe PendingNoticeKind)
-    }
-
-data PendingState = PendingState
-    { pendingEpoch :: !Word
-    , pendingQueue :: !(Seq.Seq PendingEntry)
-    -- Includes the currently drained batch. That batch is still live and must
-    -- continue to consume the budget until submission succeeds or it requeues.
-    , pendingRetainedCount :: !Int
-    , pendingRetainedBytes :: !Int
-    , pendingOmissionReported :: !Bool
-    }
-
-data PendingBatch = PendingBatch
-    !Word
-    !(Seq.Seq PendingEntry)
-    !Int
-    !Int
 
 data PendingInputs = PendingInputs
     (IORef PendingState)
@@ -68,205 +36,43 @@ data PendingInputs = PendingInputs
 
 newPendingInputs :: IO PendingInputs
 newPendingInputs = PendingInputs
-    <$> Data.IORef.newIORef (PendingState 0 Seq.empty 0 0 False)
+    <$> Data.IORef.newIORef Model.emptyPendingState
     <*> newMVar ()
 
 clearPendingInputs :: PendingInputs -> IO ()
 clearPendingInputs (PendingInputs pending _) =
-    atomicModifyIORef' pending \state ->
-        (state { pendingEpoch = epochOf state + 1
-               , pendingQueue = Seq.empty
-               , pendingRetainedCount = 0
-               , pendingRetainedBytes = 0
-               , pendingOmissionReported = False
-               }, ())
+    atomicModifyIORef' pending Model.clearPendingState
 
-enqueuePendingInput
-    :: PendingInputs
-    -> TurnInput
-    -> IO (Either Text ())
+enqueuePendingInput :: PendingInputs -> TurnInput -> IO (Either Text ())
 enqueuePendingInput (PendingInputs pending _) input =
-    enqueueEntry pending (PendingEntry input (logicalTurnInputBytes input) Nothing)
+    atomicModifyIORef' pending (Model.enqueueInput input)
 
--- | Queue a generated notice. MCP state is latest-only, so a newer settled
--- snapshot replaces an older queued one. Subagent completions are not
--- interchangeable and receive the same explicit bounded failure as messages.
+-- | MCP snapshots replace queued snapshots; other notices remain ordered.
 enqueuePendingNotice
     :: PendingInputs
     -> PendingNoticeKind
     -> TurnInput
     -> IO (Either Text ())
 enqueuePendingNotice (PendingInputs pending _) kind input =
-    atomicModifyIORef' pending \state ->
-        let withoutPrevious =
-                if kind == PendingMcpNotice
-                    then removeNotice kind state
-                    else state
-            entry = PendingEntry input (logicalTurnInputBytes input) (Just kind)
-            (next, result) = appendEntry withoutPrevious entry
-        in case result of
-            Right () -> (next, Right ())
-            Left _ ->
-                ( state
-                    { pendingOmissionReported = True
-                    }
-                , if not state.pendingOmissionReported
-                    then Left pendingNoticeOmittedMessage
-                    else Right ()
-                )
-
-enqueueEntry
-    :: IORef PendingState
-    -> PendingEntry
-    -> IO (Either Text ())
-enqueueEntry pending entry =
-    atomicModifyIORef' pending \state ->
-        appendEntry state entry
-
-appendEntry :: PendingState -> PendingEntry -> (PendingState, Either Text ())
-appendEntry state entry
-    | nextCount > pendingInputCountLimit =
-        (state, Left pendingQueueFullMessage)
-    | nextBytes > pendingInputByteLimit =
-        (state, Left pendingQueueFullMessage)
-    | otherwise =
-        ( state
-            { pendingQueue = queueOf state Seq.|> entry
-            , pendingRetainedCount = nextCount
-            , pendingRetainedBytes = nextBytes
-            }
-        , Right ()
-        )
-  where
-    nextCount = state.pendingRetainedCount + 1
-    nextBytes = state.pendingRetainedBytes `saturatingAdd` entry.entryBytes
-
-pendingQueueFullMessage :: Text
-pendingQueueFullMessage =
-    "Root input queue is full; wait for the root agent to consume pending messages."
-
-removeNotice :: PendingNoticeKind -> PendingState -> PendingState
-removeNotice kind state =
-    state
-        { pendingQueue = kept
-        , pendingRetainedCount =
-            max 0 (state.pendingRetainedCount - removedCount)
-        , pendingRetainedBytes =
-            max 0 (state.pendingRetainedBytes - removedBytes)
-        }
-  where
-    (kept, removedCount, removedBytes) =
-        foldr removeOne (Seq.empty, 0, 0) (queueOf state)
-    removeOne entry (entries, count, bytes)
-        | entry.entryNoticeKind == Just kind =
-            ( entries
-            , count + 1
-            , bytes `saturatingAdd` entry.entryBytes
-            )
-        | otherwise = (entry Seq.<| entries, count, bytes)
-
-drainPendingInputs :: IORef PendingState -> IO PendingBatch
-drainPendingInputs pending =
-    atomicModifyIORef' pending \state ->
-        let drained = queueOf state
-        in
-        (state
-            { pendingQueue = Seq.empty
-            , pendingOmissionReported = False
-            }
-        , PendingBatch
-            (epochOf state)
-            drained
-            (Seq.length drained)
-            (foldr
-                (\entry total -> entry.entryBytes `saturatingAdd` total)
-                0
-                drained))
-
-pendingNoticeOmittedMessage :: Text
-pendingNoticeOmittedMessage =
-    "Root input queue is full; one or more background notices were omitted."
-
-requeuePendingInputs :: IORef PendingState -> PendingBatch -> IO ()
-requeuePendingInputs pending (PendingBatch epoch queued _ _) =
-    atomicModifyIORef' pending \state ->
-        if epochOf state == epoch
-            then
-                let (requeued, removedCount, removedBytes) =
-                        mergeRequeuedQueue queued (queueOf state)
-                in
-                ( state
-                    { pendingQueue = requeued
-                    , pendingRetainedCount =
-                        max 0 (state.pendingRetainedCount - removedCount)
-                    , pendingRetainedBytes =
-                        max 0 (state.pendingRetainedBytes - removedBytes)
-                    }
-                , ()
-                )
-            else (state, ())
-
--- A newer MCP snapshot may arrive while an older snapshot is in the drained
--- in-flight batch. If that submission fails, requeue only the newest snapshot
--- rather than exposing both stale and current state on the next attempt.
-mergeRequeuedQueue
-    :: Seq.Seq PendingEntry
-    -> Seq.Seq PendingEntry
-    -> (Seq.Seq PendingEntry, Int, Int)
-mergeRequeuedQueue drained current
-    | any ((== Just PendingMcpNotice) . (.entryNoticeKind)) current =
-        let (kept, removedCount, removedBytes) =
-                foldr removeStaleMcp (Seq.empty, 0, 0) drained
-        in (kept <> current, removedCount, removedBytes)
-    | otherwise = (drained <> current, 0, 0)
-  where
-    removeStaleMcp entry (entries, count, bytes)
-        | entry.entryNoticeKind == Just PendingMcpNotice =
-            ( entries
-            , count + 1
-            , bytes `saturatingAdd` entry.entryBytes
-            )
-        | otherwise = (entry Seq.<| entries, count, bytes)
-
-commitPendingInputs :: IORef PendingState -> PendingBatch -> IO ()
-commitPendingInputs pending (PendingBatch epoch _ count bytes) =
-    atomicModifyIORef' pending \state ->
-        if epochOf state == epoch
-            then
-                ( state
-                    { pendingRetainedCount =
-                        max 0 (state.pendingRetainedCount - count)
-                    , pendingRetainedBytes =
-                        max 0 (state.pendingRetainedBytes - bytes)
-                    }
-                , ()
-                )
-            else (state, ())
-
-epochOf :: PendingState -> Word
-epochOf state = state.pendingEpoch
-
-queueOf :: PendingState -> Seq.Seq PendingEntry
-queueOf state = state.pendingQueue
+    atomicModifyIORef' pending (Model.enqueueNotice kind input)
 
 withPendingInputs :: PendingInputs -> BackendMiddleware
 withPendingInputs (PendingInputs pending lifecycle) backend =
     backendWithCallbacks \state previous inputs callbacks ->
         mask \restore ->
             withMVar lifecycle \_ -> do
-                batch <- drainPendingInputs pending
-                let queued = case batch of
-                        PendingBatch _ values _ _ -> values
-                    requeue = requeuePendingInputs pending batch
+                batch <- atomicModifyIORef' pending Model.drain
+                let queued = Model.batchInputs batch
+                    requeue = atomicModifyIORef' pending (Model.requeue batch)
                     prefixed
-                        | Seq.null queued = inputs
+                        | null queued = inputs
                         | otherwise =
-                            ((.entryInput) <$> toList queued) <> inputs
+                            queued <> inputs
                 result <- restore
                     (backend.submitTurnWithCallbacks
                         state previous prefixed callbacks)
                     `onException` requeue
                 case result of
                     Left _ -> requeue
-                    Right _ -> commitPendingInputs pending batch
+                    Right _ -> atomicModifyIORef' pending (Model.commit batch)
                 pure result

--- a/packages/agent-cli/src/Agent/CLI/PendingInputs/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/PendingInputs/Model.hs
@@ -1,0 +1,235 @@
+-- | Internal pure lifecycle for pending parent inputs.
+--
+-- The interpreter serializes drain/submit/commit-or-requeue lifecycles. Each
+-- batch must be finished exactly once before draining again; enqueue and clear
+-- may interleave. Clear invalidates old batches by epoch, not by submission ID.
+module Agent.CLI.PendingInputs.Model
+    ( PendingState
+    , PendingBatch
+    , PendingNoticeKind(..)
+    , emptyPendingState
+    , clearPendingState
+    , enqueueInput
+    , enqueueNotice
+    , drain
+    , requeue
+    , commit
+    , batchInputs
+    , retainedCount
+    , retainedBytes
+    , pendingInputCountLimit
+    , pendingInputByteLimit
+    ) where
+
+import Agent.CLI.InputBudget (logicalTurnInputBytes, saturatingAdd)
+import Agent.Loop (TurnInput)
+import Data.Foldable (toList)
+import qualified Data.Sequence as Seq
+import Data.Text (Text)
+
+pendingInputCountLimit :: Int
+pendingInputCountLimit = 256
+
+pendingInputByteLimit :: Int
+pendingInputByteLimit = 8 * 1024 * 1024
+
+data PendingNoticeKind
+    = PendingMcpNotice
+    | PendingSubagentNotice
+    deriving (Eq)
+
+data PendingEntry = PendingEntry
+    { entryInput :: !TurnInput
+    , entryBytes :: !Int
+    , entryNoticeKind :: !(Maybe PendingNoticeKind)
+    }
+
+data PendingState = PendingState
+    { pendingEpoch :: !Word
+    , pendingQueue :: !(Seq.Seq PendingEntry)
+    -- Includes the currently drained batch. That batch is still live and must
+    -- continue to consume the budget until submission succeeds or it requeues.
+    , pendingRetainedCount :: !Int
+    , pendingRetainedBytes :: !Int
+    , pendingOmissionReported :: !Bool
+    }
+
+data PendingBatch = PendingBatch
+    !Word
+    !(Seq.Seq PendingEntry)
+    !Int
+    !Int
+
+emptyPendingState :: PendingState
+emptyPendingState = PendingState 0 Seq.empty 0 0 False
+
+retainedCount :: PendingState -> Int
+retainedCount state = state.pendingRetainedCount
+
+retainedBytes :: PendingState -> Int
+retainedBytes state = state.pendingRetainedBytes
+
+clearPendingState :: PendingState -> (PendingState, ())
+clearPendingState state =
+    (state { pendingEpoch = epochOf state + 1
+           , pendingQueue = Seq.empty
+           , pendingRetainedCount = 0
+           , pendingRetainedBytes = 0
+           , pendingOmissionReported = False
+           }, ())
+
+enqueueInput :: TurnInput -> PendingState -> (PendingState, Either Text ())
+enqueueInput input state =
+    appendEntry state (PendingEntry input (logicalTurnInputBytes input) Nothing)
+
+-- | Queue a generated notice. MCP state is latest-only, so a newer settled
+-- snapshot replaces an older queued one. Subagent completions are not
+-- interchangeable and receive the same explicit bounded failure as messages.
+enqueueNotice
+    :: PendingNoticeKind
+    -> TurnInput
+    -> PendingState
+    -> (PendingState, Either Text ())
+enqueueNotice kind input state =
+    let withoutPrevious =
+            if kind == PendingMcpNotice
+                then removeNotice kind state
+                else state
+        entry = PendingEntry input (logicalTurnInputBytes input) (Just kind)
+        (next, result) = appendEntry withoutPrevious entry
+    in case result of
+        Right () -> (next, Right ())
+        Left _ ->
+            ( state
+                { pendingOmissionReported = True
+                }
+            , if not state.pendingOmissionReported
+                then Left pendingNoticeOmittedMessage
+                else Right ()
+            )
+
+appendEntry :: PendingState -> PendingEntry -> (PendingState, Either Text ())
+appendEntry state entry
+    | nextCount > pendingInputCountLimit =
+        (state, Left pendingQueueFullMessage)
+    | nextBytes > pendingInputByteLimit =
+        (state, Left pendingQueueFullMessage)
+    | otherwise =
+        ( state
+            { pendingQueue = queueOf state Seq.|> entry
+            , pendingRetainedCount = nextCount
+            , pendingRetainedBytes = nextBytes
+            }
+        , Right ()
+        )
+  where
+    nextCount = state.pendingRetainedCount + 1
+    nextBytes = state.pendingRetainedBytes `saturatingAdd` entry.entryBytes
+
+pendingQueueFullMessage :: Text
+pendingQueueFullMessage =
+    "Root input queue is full; wait for the root agent to consume pending messages."
+
+removeNotice :: PendingNoticeKind -> PendingState -> PendingState
+removeNotice kind state =
+    state
+        { pendingQueue = kept
+        , pendingRetainedCount =
+            max 0 (state.pendingRetainedCount - removedCount)
+        , pendingRetainedBytes =
+            max 0 (state.pendingRetainedBytes - removedBytes)
+        }
+  where
+    (kept, removedCount, removedBytes) =
+        foldr removeOne (Seq.empty, 0, 0) (queueOf state)
+    removeOne entry (entries, count, bytes)
+        | entry.entryNoticeKind == Just kind =
+            ( entries
+            , count + 1
+            , bytes `saturatingAdd` entry.entryBytes
+            )
+        | otherwise = (entry Seq.<| entries, count, bytes)
+
+drain :: PendingState -> (PendingState, PendingBatch)
+drain state =
+    let drained = queueOf state
+    in
+    (state
+        { pendingQueue = Seq.empty
+        , pendingOmissionReported = False
+        }
+    , PendingBatch
+        (epochOf state)
+        drained
+        (Seq.length drained)
+        (foldr
+            (\entry total -> entry.entryBytes `saturatingAdd` total)
+            0
+            drained))
+
+pendingNoticeOmittedMessage :: Text
+pendingNoticeOmittedMessage =
+    "Root input queue is full; one or more background notices were omitted."
+
+requeue :: PendingBatch -> PendingState -> (PendingState, ())
+requeue (PendingBatch epoch queued _ _) state =
+    if epochOf state == epoch
+        then
+            let (requeued, removedCount, removedBytes) =
+                    mergeRequeuedQueue queued (queueOf state)
+            in
+            ( state
+                { pendingQueue = requeued
+                , pendingRetainedCount =
+                    max 0 (state.pendingRetainedCount - removedCount)
+                , pendingRetainedBytes =
+                    max 0 (state.pendingRetainedBytes - removedBytes)
+                }
+            , ()
+            )
+        else (state, ())
+
+-- A newer MCP snapshot may arrive while an older snapshot is in the drained
+-- in-flight batch. If that submission fails, requeue only the newest snapshot
+-- rather than exposing both stale and current state on the next attempt.
+mergeRequeuedQueue
+    :: Seq.Seq PendingEntry
+    -> Seq.Seq PendingEntry
+    -> (Seq.Seq PendingEntry, Int, Int)
+mergeRequeuedQueue drained current
+    | any ((== Just PendingMcpNotice) . (.entryNoticeKind)) current =
+        let (kept, removedCount, removedBytes) =
+                foldr removeStaleMcp (Seq.empty, 0, 0) drained
+        in (kept <> current, removedCount, removedBytes)
+    | otherwise = (drained <> current, 0, 0)
+  where
+    removeStaleMcp entry (entries, count, bytes)
+        | entry.entryNoticeKind == Just PendingMcpNotice =
+            ( entries
+            , count + 1
+            , bytes `saturatingAdd` entry.entryBytes
+            )
+        | otherwise = (entry Seq.<| entries, count, bytes)
+
+commit :: PendingBatch -> PendingState -> (PendingState, ())
+commit (PendingBatch epoch _ count bytes) state =
+    if epochOf state == epoch
+        then
+            ( state
+                { pendingRetainedCount =
+                    max 0 (state.pendingRetainedCount - count)
+                , pendingRetainedBytes =
+                    max 0 (state.pendingRetainedBytes - bytes)
+                }
+            , ()
+            )
+        else (state, ())
+
+epochOf :: PendingState -> Word
+epochOf state = state.pendingEpoch
+
+queueOf :: PendingState -> Seq.Seq PendingEntry
+queueOf state = state.pendingQueue
+
+batchInputs :: PendingBatch -> [TurnInput]
+batchInputs (PendingBatch _ entries _ _) = (.entryInput) <$> toList entries

--- a/packages/agent-cli/test/Agent/CLI/PendingInputsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PendingInputsSpec.hs
@@ -4,6 +4,8 @@ import Agent.CLI.InputBudget
     ( logicalTextBytes
     , logicalTurnInputBytes
     )
+import qualified Agent.CLI.PendingInputs.Model as Model
+import Control.Concurrent.Async (withAsync, cancel, waitCatch)
 import Agent.CLI.PendingInputs
     ( PendingNoticeKind(..)
     , clearPendingInputs
@@ -28,6 +30,7 @@ import Agent.CLI.SteeringInputs
 import Agent.Error (ApiError(..))
 import Agent.Loop
     ( Backend(..)
+    , BackendCallbacks(..)
     , BackendResult(..)
     , FileAttachment(..)
     , ImageAttachment(..)
@@ -36,6 +39,7 @@ import Agent.Loop
     , emptyBackendSnapshot
     , emptyTurnOutput
     , userMessageWithAttachments
+    , backendWithCallbacks
     )
 import Agent.ToolDispatch
     ( ToolCallKind(..)
@@ -59,6 +63,97 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+  describe "pending input pure lifecycle" do
+    it "retains the count budget through drain and retry, releasing it on commit" do
+        let full = foldl (\s _ -> fst (Model.enqueueInput (UserMessage "x") s))
+                Model.emptyPendingState [1 .. pendingInputCountLimit]
+            (inflight, batch) = Model.drain full
+            retried = fst (Model.requeue batch inflight)
+            (again, retryBatch) = Model.drain retried
+            committed = fst (Model.commit retryBatch again)
+        Model.retainedCount inflight `shouldBe` pendingInputCountLimit
+        Model.retainedBytes inflight `shouldBe` pendingInputCountLimit
+        snd (Model.enqueueInput (UserMessage "") inflight) `shouldSatisfy` isLeft
+        Model.batchInputs retryBatch `shouldBe` replicate pendingInputCountLimit (UserMessage "x")
+        Model.retainedCount committed `shouldBe` 0
+        Model.retainedBytes committed `shouldBe` 0
+        snd (Model.enqueueInput (UserMessage "new") committed) `shouldBe` Right ()
+
+    it "counts UTF-8 bytes in drained and newly queued inputs" do
+        let large = UserMessage (Text.replicate (pendingInputByteLimit `div` 2 - 1) "é")
+            (initial, accepted) = Model.enqueueInput large Model.emptyPendingState
+            (inflight, batch) = Model.drain initial
+            (full, acceptedLast) = Model.enqueueInput (UserMessage "é") inflight
+            committed = fst (Model.commit batch full)
+        accepted `shouldBe` Right ()
+        acceptedLast `shouldBe` Right ()
+        Model.retainedBytes full `shouldBe` pendingInputByteLimit
+        snd (Model.enqueueInput (UserMessage "x") full) `shouldSatisfy` isLeft
+        Model.retainedBytes committed `shouldBe` 2
+        Model.retainedCount committed `shouldBe` 1
+        queuedInputs committed `shouldBe` [UserMessage "é"]
+
+    it "invalidates in-flight batches on clear without releasing new-epoch budget" do
+        let old = fst (Model.enqueueInput (UserMessage "old") Model.emptyPendingState)
+            (inflight, batch) = Model.drain old
+            cleared = fst (Model.clearPendingState inflight)
+            fresh = fst (Model.enqueueInput (UserMessage "fresh") cleared)
+            staleFailure = fst (Model.requeue batch fresh)
+            staleSuccess = fst (Model.commit batch fresh)
+        map queuedInputs [cleared, staleFailure, staleSuccess]
+            `shouldBe` [[], [UserMessage "fresh"], [UserMessage "fresh"]]
+        map Model.retainedCount [cleared, staleFailure, staleSuccess]
+            `shouldBe` [0, 1, 1]
+        map Model.retainedBytes [cleared, staleFailure, staleSuccess]
+            `shouldBe` [0, 5, 5]
+
+    it "requeues ordered messages but only the newest in-flight MCP snapshot" do
+        let old = fst (Model.enqueueInput (UserMessage "old") Model.emptyPendingState)
+            notice = fst (Model.enqueueNotice PendingMcpNotice (UserMessage "connecting") old)
+            completion = fst (Model.enqueueNotice PendingSubagentNotice (UserMessage "done") notice)
+            (inflight, batch) = Model.drain completion
+            newer = fst (Model.enqueueNotice PendingMcpNotice (UserMessage "settled") inflight)
+            latest = fst (Model.enqueueNotice PendingMcpNotice (UserMessage "latest") newer)
+            current = fst (Model.enqueueInput (UserMessage "new") latest)
+            retried = fst (Model.requeue batch current)
+            expected = map UserMessage ["old", "done", "latest", "new"]
+            (drained, retryBatch) = Model.drain retried
+            committed = fst (Model.commit retryBatch drained)
+        queuedInputs retried `shouldBe` expected
+        Model.retainedCount retried `shouldBe` 4
+        Model.retainedBytes retried `shouldBe` sum (map logicalTurnInputBytes expected)
+        queuedInputs committed `shouldBe` []
+        Model.retainedBytes committed `shouldBe` 0
+
+    it "preserves the old notice on rejected replacement and resets omission reporting at drain and clear" do
+        let old = fst (Model.enqueueNotice PendingMcpNotice (UserMessage "old") Model.emptyPendingState)
+            oversized = UserMessage (Text.replicate (pendingInputByteLimit + 1) "x")
+            omit = Model.enqueueNotice PendingMcpNotice oversized
+            (reported, first) = omit old
+            (suppressed, second) = omit reported
+            (inflight, batch) = Model.drain suppressed
+            (reportedAgain, afterDrain) = omit inflight
+            retried = fst (Model.requeue batch reportedAgain)
+            (_, afterRetry) = omit retried
+            (_, afterClear) = omit (fst (Model.clearPendingState retried))
+        first `shouldBe` Left "Root input queue is full; one or more background notices were omitted."
+        second `shouldBe` Right ()
+        afterDrain `shouldBe` first
+        afterRetry `shouldBe` Right ()
+        afterClear `shouldBe` first
+        queuedInputs suppressed `shouldBe` [UserMessage "old"]
+        queuedInputs retried `shouldBe` [UserMessage "old"]
+        Model.retainedBytes retried `shouldBe` 3
+
+    it "commits only the drained batch, leaving arrivals for the next submission" do
+        let old = fst (Model.enqueueNotice PendingMcpNotice (UserMessage "old") Model.emptyPendingState)
+            (inflight, batch) = Model.drain old
+            current = fst (Model.enqueueNotice PendingMcpNotice (UserMessage "new") inflight)
+            committed = fst (Model.commit batch current)
+        queuedInputs committed `shouldBe` [UserMessage "new"]
+        Model.retainedCount committed `shouldBe` 1
+        Model.retainedBytes committed `shouldBe` 3
+
   describe "logicalTurnInputBytes" do
     it "counts ordered attachments and rich tool-result images" do
         let attached =
@@ -94,6 +189,71 @@ spec = do
                 + logicalTextBytes "high"
 
   describe "withPendingInputs" do
+    it "preserves recovery callbacks and requeues when a callback throws" do
+        pending <- newPendingInputs
+        enqueuePendingInput pending (UserMessage "old") `shouldReturn` Right ()
+        seen <- newIORef []
+        checkpoints <- newIORef []
+        let backend = withPendingInputs pending $ backendWithCallbacks
+                \state _ inputs callbacks -> do
+                    modifyIORef' seen (<> [inputs])
+                    callbacks.onRecoveryCheckpoint "checkpoint"
+                    pure $ Right BackendResult
+                        { backendOutput = emptyTurnOutput "ok" [] Nothing
+                        , backendState = state
+                        }
+            callbacks = BackendCallbacks
+                { onLoopEvent = const (pure ())
+                , onAsyncToolCall = const (pure ())
+                , onRecoveryCheckpoint = \value -> do
+                    modifyIORef' checkpoints (<> [value])
+                    enqueuePendingInput pending (UserMessage "arrival") `shouldReturn` Right ()
+                    ioError (userError "callback failed")
+                , onCompletedResponseItem = \_ _ -> pure ()
+                , onCancellationMode = const (pure ())
+                }
+        result <- tryAny $ backend.submitTurnWithCallbacks emptyBackendSnapshot Nothing
+            [UserMessage "parent"] callbacks
+        result `shouldSatisfy` isLeft
+        readIORef checkpoints `shouldReturn` ["checkpoint"]
+        _ <- backend.submitTurn emptyBackendSnapshot Nothing [] (const (pure ()))
+        _ <- backend.submitTurn emptyBackendSnapshot Nothing [] (const (pure ()))
+        readIORef seen `shouldReturn`
+            [ [UserMessage "old", UserMessage "parent"]
+            , [UserMessage "old", UserMessage "arrival"]
+            , []
+            ]
+
+    it "requeues after asynchronous cancellation and releases the lifecycle lock" do
+        pending <- newPendingInputs
+        enqueuePendingInput pending (UserMessage "old") `shouldReturn` Right ()
+        entered <- newEmptyMVar
+        blocked <- newEmptyMVar
+        let backend = withPendingInputs pending $ Backend
+                \_ _ _ _ -> putMVar entered () >> takeMVar blocked
+        timeout 2000000 (withAsync
+            (backend.submitTurn emptyBackendSnapshot Nothing [] (const (pure ())))
+            \worker -> do
+                takeMVar entered
+                enqueuePendingInput pending (UserMessage "new") `shouldReturn` Right ()
+                cancel worker
+                waitCatch worker >>= (\result -> result `shouldSatisfy` isLeft))
+            `shouldReturn` Just ()
+        seen <- newIORef []
+        let retry = withPendingInputs pending $ Backend
+                \state _ inputs _ -> do
+                    writeIORef seen inputs
+                    pure $ Right BackendResult
+                        { backendOutput = emptyTurnOutput "ok" [] Nothing
+                        , backendState = state
+                        }
+        timeout 2000000
+            (retry.submitTurn emptyBackendSnapshot Nothing [] (const (pure ())) >> pure ())
+            `shouldReturn` Just ()
+        readIORef seen `shouldReturn` [UserMessage "old", UserMessage "new"]
+        _ <- retry.submitTurn emptyBackendSnapshot Nothing [] (const (pure ()))
+        readIORef seen `shouldReturn` []
+
     it "commits queued inputs after a successful submission" do
         pending <- newPendingInputs
         enqueuePendingInput pending (UserMessage "child result")
@@ -407,3 +567,6 @@ spec = do
         dismissBackgroundCompletion steering "task-1"
         hasBackgroundCompletions steering `shouldReturn` False
         readSteeringInputs steering `shouldReturn` [UserMessage "ordinary"]
+
+queuedInputs :: Model.PendingState -> [TurnInput]
+queuedInputs = Model.batchInputs . snd . Model.drain


### PR DESCRIPTION
## Summary
- Move the complete pending-input lifecycle into a focused pure model: clear, enqueue, notice replacement, drain, requeue, and commit, reusing the existing queue helpers.
- Keep IORef atomic updates, lifecycle MVar scope, mask/onException behavior, backend callbacks, and retry ordering in the IO interpreter unchanged.
- Add pure lifecycle sequences and callback-exception/asynchronous-cancellation regression coverage; retain existing concurrency tests.

## Validation
- `nix develop -j1 -c cabal repl -j1 agent-cli:lib:agent-cli --build-depends=hspec`: verified `Ok, 252 modules loaded.`
- Loaded PendingInputsSpec in that REPL: **23 examples, 0 failures**.
- Regenerated agent-cli/package.nix with cabal2nix; output unchanged.
- Independent read-only review approved; git diff --check clean.
- Ran the modified CLI from GHCi in tmux with explicit worktree cwd. A child sent PENDING_CHILD_ACK to root during the live workflow; root acknowledged completion. Submitted a follow-up while busy, observed queued 1, and received QUEUED_INPUT_ACK with the queue cleared.

## Limits
Focused local suite, not the full local repository suite. Live smoke covers successful streaming/queued delivery; failure and concurrency checkpoints are covered by deterministic IO tests. No performance claim.