### PR TITLE
Extract pure conversation store lifecycle transitions

### DIFF
--- a/packages/agent-cli-runtime/agent-cli-runtime.cabal
+++ b/packages/agent-cli-runtime/agent-cli-runtime.cabal
@@ -41,6 +41,7 @@ library
     hs-source-dirs:   src
     autogen-modules:  Paths_agent_cli_runtime
     other-modules:    Agent.CLI.Gateway.Account
+                    , Agent.Runtime.ConversationStore.Lifecycle
                     , Agent.CLI.Gateway.Catalog
                     , Agent.CLI.Gateway.Credentials
                     , Agent.CLI.Gateway.Dictation
@@ -143,6 +144,18 @@ library
                     , vector
                     , wai
                     , warp
+
+test-suite conversation-lifecycle-test
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   test/lifecycle src
+    main-is:          Spec.hs
+    other-modules:    Agent.Runtime.ConversationStore.Lifecycle
+    build-depends:    agent-core
+                    , agent-responses-types
+                    , base >= 4.17 && < 5
+                    , hspec >= 2.11 && < 2.12
+                    , text
 
 test-suite session-framing-test
     import:           common-options

--- a/packages/agent-cli-runtime/src/Agent/Runtime/ConversationStore.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/ConversationStore.hs
@@ -27,7 +27,6 @@ module Agent.Runtime.ConversationStore
 
 import Agent.Loop
     ( BackendContinuation(..)
-    , BackendRevision(..)
     , BackendSnapshot(..)
     , ImageAttachment
     )
@@ -41,10 +40,12 @@ import Control.Concurrent.MVar
     )
 import Control.Exception.Safe (bracket)
 import Data.Text (Text)
-import Data.Word (Word64)
-
-newtype TranscriptGeneration = TranscriptGeneration Word64
-    deriving (Eq, Ord, Show)
+import Agent.Runtime.ConversationStore.Lifecycle
+    ( ConversationState(..), TranscriptState(..), ResidentSource(..)
+    , TranscriptGeneration(..), ConversationResidency(..)
+    , openAiContinuation, snapshotFromState
+    )
+import qualified Agent.Runtime.ConversationStore.Lifecycle as Lifecycle
 
 -- | A durable location from which an exact transcript can be reconstructed.
 --
@@ -55,27 +56,7 @@ data TranscriptCheckpoint = TranscriptCheckpoint
     , checkpointLoad :: !(IO [ResponseItem])
     }
 
-data ConversationResidency
-    = ConversationResident
-    | ConversationCold
-    deriving (Eq, Show)
-
-data TranscriptState
-    = ResidentTranscript ![ResponseItem] !ResidentSource
-    | ColdTranscript !TranscriptCheckpoint
-
-data ResidentSource
-    = CommittedResident
-    | HydratedResident !TranscriptCheckpoint !Int
-
-data ConversationState = ConversationState
-    { stateGeneration :: !TranscriptGeneration
-    , stateTranscript :: !TranscriptState
-    , stateContinuation :: !(Maybe BackendContinuation)
-    , stateAttachments :: ![ImageAttachment]
-    }
-
-newtype ConversationStore = ConversationStore (MVar ConversationState)
+newtype ConversationStore = ConversationStore (MVar (ConversationState TranscriptCheckpoint))
 
 newConversationStore
     :: Maybe Text
@@ -136,47 +117,27 @@ withConversationBackendState
     -> (BackendSnapshot -> IO a)
     -> IO a
 withConversationBackendState
-        store@(ConversationStore stateVar)
+        (ConversationStore stateVar)
         action =
     bracket acquire release \(_, _, snapshot) ->
         action snapshot
   where
     acquire =
         modifyMVar stateVar \state ->
-            case state.stateTranscript of
-                ResidentTranscript items CommittedResident ->
+            case Lifecycle.acquireTranscript state of
+                Lifecycle.Acquired resident releaseHydration items ->
                     pure
-                        ( state
+                        ( resident
                         , ( state.stateGeneration
-                          , False
+                          , releaseHydration
                           , snapshotFromState state items
                           )
                         )
-                ResidentTranscript items
-                        (HydratedResident checkpoint readers) ->
-                    pure
-                        ( state
-                            { stateTranscript =
-                                ResidentTranscript
-                                    items
-                                    (HydratedResident
-                                        checkpoint
-                                        (readers + 1))
-                            }
-                        , ( state.stateGeneration
-                          , True
-                          , snapshotFromState state items
-                          )
-                        )
-                ColdTranscript cold -> do
+                Lifecycle.LoadCheckpoint cold -> do
+                    -- Keep hydration under modifyMVar: a failed/cancelled load
+                    -- restores the cold state, and writers cannot interleave.
                     items <- cold.checkpointLoad
-                    let resident =
-                            state
-                                { stateTranscript =
-                                    ResidentTranscript
-                                        items
-                                        (HydratedResident cold 1)
-                                }
+                    let resident = Lifecycle.hydratedTranscript cold items state
                     pure
                         ( resident
                         , ( state.stateGeneration
@@ -186,7 +147,9 @@ withConversationBackendState
                         )
     release (generation, releaseHydration, _) =
         if releaseHydration
-            then releaseHydratedTranscript store generation
+            then modifyMVar_ stateVar \state ->
+                case Lifecycle.releaseHydratedTranscript generation state of
+                    (next, ()) -> pure next
             else pure ()
 
 -- | Publish a newer exact transcript and return its generation token.
@@ -195,17 +158,7 @@ commitConversationTranscript
     -> [ResponseItem]
     -> IO TranscriptGeneration
 commitConversationTranscript (ConversationStore stateVar) transcript =
-    modifyMVar stateVar \state -> do
-        let generation = nextGeneration state.stateGeneration
-        pure
-            ( state
-                { stateGeneration = generation
-                , stateTranscript =
-                    ResidentTranscript transcript CommittedResident
-                , stateContinuation = Nothing
-                }
-            , generation
-            )
+    modifyMVar stateVar (pure . Lifecycle.commitTranscript transcript)
 
 -- | Replace transcript state outside a backend commit without disturbing
 -- queued images. The legacy response-id argument is ignored: replacement
@@ -219,17 +172,7 @@ replaceConversationTranscript
         (ConversationStore stateVar)
         _previousResponseId
         transcript =
-    modifyMVar stateVar \state -> do
-        let generation = nextGeneration state.stateGeneration
-        pure
-            ( state
-                { stateGeneration = generation
-                , stateTranscript =
-                    ResidentTranscript transcript CommittedResident
-                , stateContinuation = Nothing
-                }
-            , generation
-            )
+    modifyMVar stateVar (pure . Lifecycle.commitTranscript transcript)
 
 -- | Release a resident transcript only when it is still the expected version.
 --
@@ -245,30 +188,11 @@ evictConversationTranscript
         expectedGeneration
         checkpoint =
     modifyMVar stateVar \state ->
-        case state.stateTranscript of
-            ResidentTranscript _ CommittedResident
-                | state.stateGeneration == expectedGeneration ->
-                    pure
-                        ( state
-                            { stateTranscript =
-                                ColdTranscript checkpoint
-                            }
-                        , True
-                        )
-            ResidentTranscript items (HydratedResident _ readers)
-                | state.stateGeneration == expectedGeneration ->
-                    -- Readers keep their immutable value, while their final
-                    -- release installs the newest durable checkpoint.
-                    pure
-                        ( state
-                            { stateTranscript =
-                                ResidentTranscript
-                                    items
-                                    (HydratedResident checkpoint readers)
-                            }
-                        , False
-                        )
-            _ -> pure (state, False)
+        -- Decide inside the callback, without forcing the new state. In
+        -- particular an exceptional generation comparison must restore the
+        -- old MVar, not publish a deferred exception as its next value.
+        case Lifecycle.evictTranscript expectedGeneration checkpoint state of
+            (next, evicted) -> pure (next, evicted)
 
 -- | Point an unchanged cold or currently hydrated transcript at an equivalent
 -- durable snapshot under a different identity (for example, after /fork).
@@ -280,19 +204,7 @@ retargetConversationCheckpoint
 retargetConversationCheckpoint
         (ConversationStore stateVar)
         checkpoint =
-    modifyMVar_ stateVar \state ->
-        pure state
-            { stateTranscript =
-                case state.stateTranscript of
-                    ColdTranscript _ ->
-                        ColdTranscript checkpoint
-                    ResidentTranscript items
-                            (HydratedResident _ readers) ->
-                        ResidentTranscript
-                            items
-                            (HydratedResident checkpoint readers)
-                    resident@ResidentTranscript{} -> resident
-            }
+    modifyMVar_ stateVar (pure . Lifecycle.retargetCheckpoint checkpoint)
 
 readConversationPreviousResponseId
     :: ConversationStore
@@ -315,21 +227,7 @@ commitConversationBackendState
     -> BackendSnapshot
     -> IO BackendSnapshot
 commitConversationBackendState (ConversationStore stateVar) candidate =
-    modifyMVar stateVar \state -> do
-        let generation = nextGeneration state.stateGeneration
-            committed = candidate
-                { backendRevision = generationRevision generation }
-        pure
-            ( state
-                { stateGeneration = generation
-                , stateTranscript =
-                    ResidentTranscript
-                        committed.backendItems
-                        CommittedResident
-                , stateContinuation = committed.backendContinuation
-                }
-            , committed
-            )
+    modifyMVar stateVar (pure . Lifecycle.commitBackendState candidate)
 
 readConversationAttachments
     :: ConversationStore
@@ -348,61 +246,8 @@ modifyConversationAttachments (ConversationStore stateVar) update =
 
 resetConversationStore :: ConversationStore -> IO ()
 resetConversationStore (ConversationStore stateVar) =
-    modifyMVar_ stateVar \state ->
-        pure state
-            { stateGeneration = nextGeneration state.stateGeneration
-            , stateTranscript =
-                ResidentTranscript [] CommittedResident
-            , stateContinuation = Nothing
-            , stateAttachments = []
-            }
-
-nextGeneration :: TranscriptGeneration -> TranscriptGeneration
-nextGeneration (TranscriptGeneration generation) =
-    TranscriptGeneration (generation + 1)
-
-generationRevision :: TranscriptGeneration -> BackendRevision
-generationRevision (TranscriptGeneration generation) =
-    BackendRevision generation
-
-openAiContinuation :: Maybe Text -> Maybe BackendContinuation
-openAiContinuation =
-    fmap (BackendContinuation "openai.responses")
+    modifyMVar_ stateVar (pure . Lifecycle.resetState)
 
 continuationResponseId :: Maybe BackendContinuation -> Maybe Text
 continuationResponseId =
     fmap (.continuationToken)
-
-snapshotFromState :: ConversationState -> [ResponseItem] -> BackendSnapshot
-snapshotFromState state items = BackendSnapshot
-    { backendItems = items
-    , backendRevision = generationRevision state.stateGeneration
-    , backendContinuation = state.stateContinuation
-    }
-
-releaseHydratedTranscript
-    :: ConversationStore
-    -> TranscriptGeneration
-    -> IO ()
-releaseHydratedTranscript
-        (ConversationStore stateVar)
-        expectedGeneration =
-    modifyMVar_ stateVar \state ->
-        if state.stateGeneration /= expectedGeneration
-            then pure state
-            else case state.stateTranscript of
-                ResidentTranscript _
-                        (HydratedResident checkpoint 1) ->
-                    pure state
-                        { stateTranscript = ColdTranscript checkpoint }
-                ResidentTranscript items
-                        (HydratedResident checkpoint readers) ->
-                    pure state
-                        { stateTranscript =
-                            ResidentTranscript
-                                items
-                                (HydratedResident
-                                    checkpoint
-                                    (readers - 1))
-                        }
-                _ -> pure state

--- a/packages/agent-cli-runtime/src/Agent/Runtime/ConversationStore/Lifecycle.hs
+++ b/packages/agent-cli-runtime/src/Agent/Runtime/ConversationStore/Lifecycle.hs
@@ -1,0 +1,173 @@
+-- | Pure conversation lifecycle. Checkpoints are opaque values: only the IO
+-- shell knows how to load them. All transitions run under that shell's lock.
+module Agent.Runtime.ConversationStore.Lifecycle
+    ( TranscriptGeneration(..)
+    , ConversationResidency(..)
+    , ConversationState(..)
+    , TranscriptState(..)
+    , ResidentSource(..)
+    , Acquisition(..)
+    , acquireTranscript
+    , hydratedTranscript
+    , releaseHydratedTranscript
+    , commitTranscript
+    , commitBackendState
+    , evictTranscript
+    , retargetCheckpoint
+    , resetState
+    , snapshotFromState
+    , openAiContinuation
+    ) where
+
+import Agent.Loop
+    ( BackendContinuation(..), BackendRevision(..), BackendSnapshot(..)
+    , ImageAttachment
+    )
+import Agent.Responses.Types (ResponseItem)
+import Data.Text (Text)
+import Data.Word (Word64)
+
+newtype TranscriptGeneration = TranscriptGeneration Word64
+    deriving (Eq, Ord, Show)
+
+data ConversationResidency = ConversationResident | ConversationCold
+    deriving (Eq, Show)
+
+data TranscriptState checkpoint
+    = ResidentTranscript ![ResponseItem] !(ResidentSource checkpoint)
+    | ColdTranscript !checkpoint
+    deriving (Eq, Show)
+
+data ResidentSource checkpoint
+    = CommittedResident
+    | HydratedResident !checkpoint !Int
+    deriving (Eq, Show)
+
+data ConversationState checkpoint = ConversationState
+    { stateGeneration :: !TranscriptGeneration
+    , stateTranscript :: !(TranscriptState checkpoint)
+    , stateContinuation :: !(Maybe BackendContinuation)
+    , stateAttachments :: ![ImageAttachment]
+    }
+    deriving (Eq, Show)
+
+-- | A resident acquisition increments the shared lease count, if needed.
+-- A cold acquisition requests IO without changing state. The shell must load
+-- and install the result under the SAME lock; failure leaves state untouched.
+data Acquisition checkpoint
+    = Acquired (ConversationState checkpoint) Bool [ResponseItem]
+    | LoadCheckpoint checkpoint
+
+acquireTranscript :: ConversationState checkpoint -> Acquisition checkpoint
+acquireTranscript state = case state.stateTranscript of
+    ResidentTranscript items CommittedResident -> Acquired state False items
+    ResidentTranscript items (HydratedResident checkpoint readers) ->
+        Acquired
+            state { stateTranscript = ResidentTranscript items
+                (HydratedResident checkpoint (readers + 1)) }
+            True items
+    ColdTranscript checkpoint -> LoadCheckpoint checkpoint
+
+-- | Complete a successful cold acquisition before releasing the store lock.
+hydratedTranscript
+    :: checkpoint -> [ResponseItem] -> ConversationState checkpoint
+    -> ConversationState checkpoint
+hydratedTranscript checkpoint items state = state
+    { stateTranscript = ResidentTranscript items (HydratedResident checkpoint 1) }
+
+-- | The outer pair separates deciding a release from evaluating the updated
+-- state. The shell scrutinizes it inside modifyMVar_'s callback, preserving
+-- the original exception checkpoint without forcing the new resident value.
+releaseHydratedTranscript
+    :: TranscriptGeneration -> ConversationState checkpoint
+    -> (ConversationState checkpoint, ())
+releaseHydratedTranscript expectedGeneration state
+    | state.stateGeneration /= expectedGeneration = (state, ())
+    | otherwise = case state.stateTranscript of
+        ResidentTranscript _ (HydratedResident checkpoint 1) ->
+            (state { stateTranscript = ColdTranscript checkpoint }, ())
+        ResidentTranscript items (HydratedResident checkpoint readers) ->
+            (state { stateTranscript = ResidentTranscript items
+                (HydratedResident checkpoint (readers - 1)) }, ())
+        _ -> (state, ())
+
+-- | Both manual commits and replacements invalidate provider continuation,
+-- but leave attachments alone.
+commitTranscript
+    :: [ResponseItem] -> ConversationState checkpoint
+    -> (ConversationState checkpoint, TranscriptGeneration)
+commitTranscript transcript state =
+    let generation = nextGeneration state.stateGeneration
+    in ( state
+            { stateGeneration = generation
+            , stateTranscript = ResidentTranscript transcript CommittedResident
+            , stateContinuation = Nothing
+            }
+       , generation
+       )
+
+commitBackendState
+    :: BackendSnapshot -> ConversationState checkpoint
+    -> (ConversationState checkpoint, BackendSnapshot)
+commitBackendState candidate state =
+    let generation = nextGeneration state.stateGeneration
+        committed = candidate { backendRevision = generationRevision generation }
+    in ( state
+            { stateGeneration = generation
+            , stateTranscript = ResidentTranscript committed.backendItems CommittedResident
+            , stateContinuation = committed.backendContinuation
+            }
+       , committed
+       )
+
+-- | A delayed eviction cannot affect a newer generation. Active readers keep
+-- their immutable items; only their final release installs the new checkpoint.
+evictTranscript
+    :: TranscriptGeneration -> checkpoint -> ConversationState checkpoint
+    -> (ConversationState checkpoint, Bool)
+evictTranscript expectedGeneration checkpoint state =
+    case state.stateTranscript of
+        ResidentTranscript _ CommittedResident
+            | state.stateGeneration == expectedGeneration ->
+                (state { stateTranscript = ColdTranscript checkpoint }, True)
+        ResidentTranscript items (HydratedResident _ readers)
+            | state.stateGeneration == expectedGeneration ->
+                ( state { stateTranscript = ResidentTranscript items
+                    (HydratedResident checkpoint readers) }
+                , False
+                )
+        _ -> (state, False)
+
+retargetCheckpoint
+    :: checkpoint -> ConversationState checkpoint -> ConversationState checkpoint
+retargetCheckpoint checkpoint state = state
+    { stateTranscript = case state.stateTranscript of
+        ColdTranscript _ -> ColdTranscript checkpoint
+        ResidentTranscript items (HydratedResident _ readers) ->
+            ResidentTranscript items (HydratedResident checkpoint readers)
+        resident@ResidentTranscript{} -> resident
+    }
+
+resetState :: ConversationState checkpoint -> ConversationState checkpoint
+resetState state = state
+    { stateGeneration = nextGeneration state.stateGeneration
+    , stateTranscript = ResidentTranscript [] CommittedResident
+    , stateContinuation = Nothing
+    , stateAttachments = []
+    }
+
+nextGeneration :: TranscriptGeneration -> TranscriptGeneration
+nextGeneration (TranscriptGeneration generation) = TranscriptGeneration (generation + 1)
+
+generationRevision :: TranscriptGeneration -> BackendRevision
+generationRevision (TranscriptGeneration generation) = BackendRevision generation
+
+openAiContinuation :: Maybe Text -> Maybe BackendContinuation
+openAiContinuation = fmap (BackendContinuation "openai.responses")
+
+snapshotFromState :: ConversationState checkpoint -> [ResponseItem] -> BackendSnapshot
+snapshotFromState state items = BackendSnapshot
+    { backendItems = items
+    , backendRevision = generationRevision state.stateGeneration
+    , backendContinuation = state.stateContinuation
+    }

--- a/packages/agent-cli-runtime/test/Agent/Runtime/ConversationStoreSpec.hs
+++ b/packages/agent-cli-runtime/test/Agent/Runtime/ConversationStoreSpec.hs
@@ -20,10 +20,108 @@ import Control.Exception.Safe (throwString)
 import Data.IORef
 import Data.Text (Text)
 import Test.Hspec
+import System.Timeout (timeout)
 
 spec :: Spec
 spec = do
     describe "ConversationStore" do
+        it "restores the lock when an eviction decision throws before publication" do
+            let items = [messageItem "unchanged"]
+            store <- newConversationStore Nothing items []
+            evictConversationTranscript store (error "generation comparison failed")
+                (TranscriptCheckpoint "unused" (pure [])) `shouldThrow` anyErrorCall
+            withConversationTranscript store (`shouldBe` items)
+            conversationResidency store `shouldReturn` ConversationResident
+
+        it "keeps the load under lock and publishes the acquired snapshot before a waiting commit" do
+            loading <- newEmptyMVar
+            finishLoad <- newEmptyMVar
+            writerStarted <- newEmptyMVar
+            writerDone <- newEmptyMVar
+            let oldItems = [messageItem "old"]
+                newItems = [messageItem "new"]
+                checkpoint = TranscriptCheckpoint "blocked" do
+                    putMVar loading ()
+                    takeMVar finishLoad
+                    pure oldItems
+            store <- newColdConversationStore (Just "old-response") checkpoint []
+            withAsync (withConversationBackendState store pure) \reader -> do
+                takeMVar loading
+                withAsync (do
+                    putMVar writerStarted ()
+                    result <- commitConversationBackendState store
+                        (BackendSnapshot newItems (BackendRevision 99)
+                            (Just (BackendContinuation "claude" "new-response")))
+                    putMVar writerDone result) \writer -> do
+                    takeMVar writerStarted
+                    timeout 100000 (takeMVar writerDone) `shouldReturn` Nothing
+                    putMVar finishLoad ()
+                    acquired <- wait reader
+                    acquired.backendItems `shouldBe` oldItems
+                    acquired.backendRevision `shouldBe` BackendRevision 0
+                    acquired.backendContinuation `shouldBe`
+                        Just (BackendContinuation "openai.responses" "old-response")
+                    wait writer
+                    committed <- takeMVar writerDone
+                    committed.backendRevision `shouldBe` BackendRevision 1
+                    withConversationBackendState store (`shouldBe` committed)
+
+        it "retargets nested hydration leases and only loads the new identity after final release" do
+            loads <- newIORef ([] :: [Text])
+            let items = [messageItem "same"]
+                checkpoint name = TranscriptCheckpoint name do
+                    modifyIORef' loads (<> [name])
+                    pure items
+            store <- newColdConversationStore Nothing (checkpoint "original") []
+            withConversationTranscript store \outer -> do
+                withConversationTranscript store \inner -> do
+                    inner `shouldBe` outer
+                    retargetConversationCheckpoint store (checkpoint "fork")
+                conversationResidency store `shouldReturn` ConversationResident
+                readIORef loads `shouldReturn` ["original"]
+            conversationResidency store `shouldReturn` ConversationCold
+            withConversationTranscript store (`shouldBe` items)
+            readIORef loads `shouldReturn` ["original", "fork"]
+
+        it "does not let a throwing old reader release a post-reset hydration lease" do
+            let checkpoint = TranscriptCheckpoint "old" (pure [messageItem "old"])
+            store <- newColdConversationStore Nothing checkpoint []
+            entered <- newEmptyMVar
+            finish <- newEmptyMVar
+            withAsync (withConversationTranscript store \_ -> do
+                putMVar entered ()
+                takeMVar finish
+                throwString "old reader failed") \reader -> do
+                takeMVar entered
+                resetConversationStore store
+                generation <- currentTranscriptGeneration store
+                evictConversationTranscript store generation
+                    (TranscriptCheckpoint "reset" (pure [])) `shouldReturn` True
+                withConversationTranscript store \items -> do
+                    items `shouldBe` []
+                    putMVar finish ()
+                    wait reader `shouldThrow` anyException
+                    conversationResidency store `shouldReturn` ConversationResident
+                conversationResidency store `shouldReturn` ConversationCold
+
+        it "retries a failed load without running the callback or losing other fields" do
+            attempts <- newIORef (0 :: Int)
+            callbacks <- newIORef (0 :: Int)
+            let image = ImageAttachment "image/png" "queued"
+                checkpoint = TranscriptCheckpoint "retry" do
+                    n <- atomicModifyIORef' attempts (\n -> (n + 1, n))
+                    if n == 0 then throwString "load failed" else pure []
+                callback _ = modifyIORef' callbacks (+ 1)
+            store <- newColdConversationStore (Just "response") checkpoint [image]
+            withConversationTranscript store callback `shouldThrow` anyException
+            readIORef callbacks `shouldReturn` 0
+            readConversationAttachments store `shouldReturn` [image]
+            readConversationPreviousResponseId store `shouldReturn` Just "response"
+            withConversationTranscript store callback
+            readIORef callbacks `shouldReturn` 1
+            readIORef attempts `shouldReturn` 2
+            conversationResidency store `shouldReturn` ConversationCold
+
         it "hydrates a cold transcript only for the scoped read" do
             loads <- newIORef (0 :: Int)
             let items = [messageItem "cold"]

--- a/packages/agent-cli-runtime/test/lifecycle/Spec.hs
+++ b/packages/agent-cli-runtime/test/lifecycle/Spec.hs
@@ -1,0 +1,114 @@
+module Main (main) where
+
+import Agent.Runtime.ConversationStore.Lifecycle
+import Agent.Loop (BackendContinuation(..), BackendRevision(..), BackendSnapshot(..), ImageAttachment(..))
+import Agent.Responses.Types
+import Data.Text (Text)
+import Test.Hspec
+
+main :: IO ()
+main = hspec do
+    describe "pure conversation lifecycle sequences" do
+        it "requests an inert checkpoint and counts nested leases through retarget and final release" do
+            case acquireTranscript initial of
+                LoadCheckpoint checkpoint -> checkpoint `shouldBe` "original"
+                Acquired{} -> expectationFailure "expected a load"
+            let first = hydratedTranscript "original" items initial
+            case acquireTranscript first of
+                LoadCheckpoint{} -> expectationFailure "must reuse hydrated items"
+                Acquired second release shared -> do
+                    release `shouldBe` True
+                    shared `shouldBe` items
+                    second.stateTranscript `shouldBe`
+                        ResidentTranscript items (HydratedResident "original" 2)
+                    let forked = retargetCheckpoint "fork" second
+                        oneLeft = fst (releaseHydratedTranscript initial.stateGeneration forked)
+                        cold = fst (releaseHydratedTranscript initial.stateGeneration oneLeft)
+                    oneLeft.stateTranscript `shouldBe`
+                        ResidentTranscript items (HydratedResident "fork" 1)
+                    cold `shouldBe` initial { stateTranscript = ColdTranscript "fork" }
+
+        it "defers explicit eviction until all readers release, without changing generation" do
+            let hydrated = hydratedTranscript "original" items initial
+                (pending, evicted) = evictTranscript initial.stateGeneration "persisted" hydrated
+                (cold, ()) = releaseHydratedTranscript initial.stateGeneration pending
+            evicted `shouldBe` False
+            pending.stateTranscript `shouldBe`
+                ResidentTranscript items (HydratedResident "persisted" 1)
+            cold `shouldBe` initial { stateTranscript = ColdTranscript "persisted" }
+            evictTranscript initial.stateGeneration "ignored" cold `shouldBe` (cold, False)
+
+        it "ignores delayed eviction and release after a newer commit and hydration" do
+            let old = hydratedTranscript "original" items initial
+                (committed, generation) = commitTranscript [messageItem "new"] old
+                (cold, evicted) = evictTranscript generation "new" committed
+                current = hydratedTranscript "new" [messageItem "new"] cold
+            evicted `shouldBe` True
+            evictTranscript old.stateGeneration "stale" current `shouldBe` (current, False)
+            releaseHydratedTranscript old.stateGeneration current `shouldBe` (current, ())
+            current.stateAttachments `shouldBe` initial.stateAttachments
+            current.stateContinuation `shouldBe` Nothing
+            fst (releaseHydratedTranscript generation current) `shouldBe` cold
+
+        it "reset invalidates old leases even after a subsequent cold acquisition" do
+            let old = hydratedTranscript "original" items initial
+                reset = resetState old
+                (cold, _) = evictTranscript reset.stateGeneration "empty" reset
+                current = hydratedTranscript "empty" [] cold
+            reset.stateGeneration `shouldBe` TranscriptGeneration 1
+            reset.stateAttachments `shouldBe` []
+            reset.stateContinuation `shouldBe` Nothing
+            reset.stateTranscript `shouldBe` ResidentTranscript [] CommittedResident
+            evictTranscript old.stateGeneration "stale" current `shouldBe` (current, False)
+            releaseHydratedTranscript old.stateGeneration current `shouldBe` (current, ())
+            fst (releaseHydratedTranscript reset.stateGeneration current) `shouldBe` cold
+
+        it "assigns authoritative revisions across backend commits, replacement and reset" do
+            let candidate = BackendSnapshot items (BackendRevision 999)
+                    (Just (BackendContinuation "claude" "token"))
+                (first, snapshot1) = commitBackendState candidate initial
+                (second, snapshot2) = commitBackendState
+                    candidate { backendRevision = BackendRevision 0 } first
+                (replaced, generation) = commitTranscript [] second
+                reset = resetState replaced
+            snapshot1.backendRevision `shouldBe` BackendRevision 1
+            snapshot2.backendRevision `shouldBe` BackendRevision 2
+            snapshotFromState second items `shouldBe` snapshot2
+            generation `shouldBe` TranscriptGeneration 3
+            replaced.stateContinuation `shouldBe` Nothing
+            replaced.stateAttachments `shouldBe` initial.stateAttachments
+            reset.stateGeneration `shouldBe` TranscriptGeneration 4
+            reset.stateAttachments `shouldBe` []
+            first.stateAttachments `shouldBe` initial.stateAttachments
+
+        it "leaves committed residents alone when acquiring, releasing or retargeting" do
+            let (committed, _) = commitTranscript items initial
+            retargetCheckpoint "ignored" committed `shouldBe` committed
+            releaseHydratedTranscript committed.stateGeneration committed `shouldBe` (committed, ())
+            case acquireTranscript committed of
+                LoadCheckpoint{} -> expectationFailure "committed transcript needs no load"
+                Acquired unchanged release shared -> do
+                    unchanged `shouldBe` committed
+                    release `shouldBe` False
+                    shared `shouldBe` items
+
+initial :: ConversationState Text
+initial = ConversationState
+    { stateGeneration = TranscriptGeneration 0
+    , stateTranscript = ColdTranscript "original"
+    , stateContinuation = openAiContinuation (Just "response")
+    , stateAttachments = [ImageAttachment "image/png" "image"]
+    }
+
+items :: [ResponseItem]
+items = [messageItem "original"]
+
+messageItem :: Text -> ResponseItem
+messageItem text = MessageItem ResponseMessage
+    { messageId = Nothing
+    , content = MessageContentText text
+    , role = RoleAssistant
+    , status = Nothing
+    , phase = Nothing
+    , passthrough = Nothing
+    }


### PR DESCRIPTION
## Summary

- Extract ConversationStore generation, continuation and transcript-residency transitions into a hidden pure lifecycle module, with opaque checkpoint values for inert sequence tests.
- Keep the existing MVar/bracket scopes, hydration under lock, atomic backend snapshots, callback order and exception checkpoints in the IO shell. No provider snapshot or consumer changes.
- Add pure sequences for stale generations, nested leases, retarget/final release, reset and continuation invalidation; extend IO regressions for load failures, waiting writers, nested retargets and stale throwing readers. Existing cancellation/concurrent-reader regressions remain intact.

## Validation
- Modified CLI/runtime named-library multi-repl in tmux: `Ok, 313 modules loaded.` Live turn, `/fork --no-worktree`, `/resume` original session, and resumed turn recalling the prior response all succeeded; no file changes.

- Independent read-only review: no blocking findings; documented deliberate transition-evaluation checkpoints and added the suggested exception/lock-recovery regression.
- Regenerated runtime package.nix with cabal2nix (unchanged).
- All local Cabal/Nix work uses `-j1`. Named runtime library GHCi: `Ok, 62 modules loaded.`
- Pure suite through GHCi: `Ok, two modules loaded.`; 6 examples, 0 failures.
- Runtime IO/integration suite through GHCi: `Ok, 31 modules loaded.`; ConversationStore 21, conversation session 10, turn engine 7, prepared turn execution 9 examples, all 0 failures.
