### PR TITLE
Simplify config transactions with ExceptT

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -44,6 +44,8 @@ import Agent.TUI.Theme
 import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Control.Exception.Safe (displayException, tryIO)
 import Control.Monad (forM_, unless, when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except (ExceptT(..), runExceptT, withExceptT)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Bits ((.|.), rotateL, shiftL, xor)
@@ -682,19 +684,14 @@ modifyHarnessConfigEffect
     -> (Word64 -> HarnessConfig -> IO (Either Text (HarnessConfig, a)))
     -> IO (Either Text (Word64, HarnessConfig, a))
 modifyHarnessConfigEffect home change =
-    withPrivateFileLock (harnessConfigLockPath home) do
-        loadHarnessConfigUnlocked home >>= \case
-            Left _ -> pure (Left "Unable to read the machine configuration")
-            Right (revision, config) ->
-                change revision config >>= \case
-                    Left err -> pure (Left err)
-                    Right (updated, value) -> do
-                        identified <- assignMcpConnectionIds updated
-                        writeHarnessConfigUnlocked home identified >>= \case
-                            Left err -> pure (Left err)
-                            Right nextRevision ->
-                                pure (Right
-                                    (nextRevision, identified, value))
+    withPrivateFileLock (harnessConfigLockPath home) $ runExceptT do
+        (revision, config) <-
+            withExceptT (const "Unable to read the machine configuration") $
+                ExceptT (loadHarnessConfigUnlocked home)
+        (updated, value) <- ExceptT (change revision config)
+        identified <- liftIO (assignMcpConnectionIds updated)
+        nextRevision <- ExceptT (writeHarnessConfigUnlocked home identified)
+        pure (nextRevision, identified, value)
 
 writeHarnessConfigUnlocked
     :: OsPath -> HarnessConfig -> IO (Either Text Word64)

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -501,6 +501,38 @@ spec = describe "Agent.CLI.Config" do
                 `shouldReturn`
                     Left "MCP server 'broken' must configure exactly one of url or command"
 
+    describe "modifyHarnessConfigEffect" do
+        it "redacts load errors and skips the callback" $
+            withTempDir "agent-config-" \home -> do
+                writeConfig home "{invalid-json"
+                result <- modifyHarnessConfigEffect home \_ config -> do
+                    expectationFailure "callback ran after a load failure"
+                    pure (Right (config, ()))
+                result `shouldBe` Left "Unable to read the machine configuration"
+
+        it "propagates callback errors without changing the file" $
+            withTempDir "agent-config-" \home -> do
+                let bytes = "{\"maxConcurrentAgents\":2}"
+                writeConfig home bytes
+                result <- modifyHarnessConfigEffect home \_ _ ->
+                    pure (Left "callback rejected the change" :: Either Text.Text (HarnessConfig, ()))
+                result `shouldBe` Left "callback rejected the change"
+                LBS.readFile (filePath (harnessConfigPath home)) `shouldReturn` bytes
+
+        it "passes the snapshot revision and returns the persisted config and callback value" $
+            withTempDir "agent-config-" \home -> do
+                writeConfig home "{\"maxConcurrentAgents\":2}"
+                Right (revision, initial) <- loadHarnessConfigSnapshot home
+                Right (nextRevision, updated, value) <-
+                    modifyHarnessConfigEffect home \seenRevision config -> do
+                        seenRevision `shouldBe` revision
+                        config `shouldBe` initial
+                        pure (Right (config { configMaxConcurrentAgents = Just 7 }, "done" :: Text.Text))
+                value `shouldBe` "done"
+                updated.configMaxConcurrentAgents `shouldBe` Just 7
+                nextRevision `shouldNotBe` revision
+                loadHarnessConfigSnapshot home `shouldReturn` Right (nextRevision, updated)
+
     it "serializes concurrent read-modify-write transactions without loss" $
         withTempDir "agent-config-" \home -> do
             let increment _ config =


### PR DESCRIPTION
## Summary
- Flatten nested Either handling in modifyHarnessConfigEffect using ExceptT.
- Preserve the file-lock scope, operation order, load-error redaction, and short-circuit behavior.
- Add regression tests for load failures, callback failures without file changes, and successful persistence with revision and callback value.

## Validation
- GHCi loaded the CLI library and ConfigSpec successfully, with no compiler errors.
- ConfigSpec: 45 examples, 0 failures.
- git diff --check passed.