### PR TITLE
Refactor process output draining into a Conduit pipeline

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -133,6 +133,7 @@ library
                     , async >= 2.2.6 && < 2.3
                     , base64-bytestring
                     , bytestring
+                    , conduit >= 1.3 && < 1.4
                     , containers
                     , crypton-connection
                     , directory

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, agent-json, agent-process
 , agent-responses-types, async, base, base64-bytestring, bytestring
-, containers, crypton-connection, directory, entropy, filepath
-, hspec, JuicyPixels, lib, process, QuickCheck, resourcet, retry
-, safe-exceptions, scientific, stm, template-haskell, text
+, conduit, containers, crypton-connection, directory, entropy
+, filepath, hspec, JuicyPixels, lib, process, QuickCheck, resourcet
+, retry, safe-exceptions, scientific, stm, template-haskell, text
 , text-builder, time, tls, transformers, unix, vector, websockets
 , yaml, zlib
 }:
@@ -13,7 +13,7 @@ mkDerivation {
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [
     aeson agent-json agent-process agent-responses-types async base
-    base64-bytestring bytestring containers crypton-connection
+    base64-bytestring bytestring conduit containers crypton-connection
     directory entropy filepath JuicyPixels process resourcet retry
     safe-exceptions scientific stm template-haskell text time tls
     transformers unix vector websockets yaml zlib

--- a/packages/agent-core/src/Agent/Tools/IO.hs
+++ b/packages/agent-core/src/Agent/Tools/IO.hs
@@ -99,6 +99,8 @@ import Control.Exception.Safe
     , tryAny
     )
 import Control.Monad (unless, void, when)
+import Control.Monad.IO.Class (liftIO)
+import Data.Conduit (ConduitT, await, runConduit, yield, (.|))
 import Data.IORef
     ( IORef
     , atomicModifyIORef'
@@ -107,6 +109,7 @@ import Data.IORef
     , writeIORef
     )
 import Data.Maybe (fromMaybe)
+import Data.Void (Void)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.ByteString as BS
@@ -825,6 +828,9 @@ data DrainedOutput = DrainedOutput
 
 -- | Read a process stream in chunks. The live snapshot remains bounded; once
 -- it overflows, the complete stream is spilled to a session artifact.
+-- Keep raw bytes throughout capture/spill: decoding belongs to snapshot
+-- rendering, not the transport. The process owner still owns the handle and
+-- the concurrent stdout/stderr readers.
 drainHandle
     :: ToolEnv
     -> Text
@@ -838,25 +844,32 @@ drainHandle env _source handle ref recentRef = do
             readIORef writerRef >>= mapM_ (\writer -> do
                 _ <- finishOutputArtifact writer
                 pure ())
-    go writerRef Nothing False `onException` cleanup
+    runConduit (sourceProcessBytesC handle .| captureOutputC writerRef Nothing False)
+        `onException` cleanup
   where
     cap = env.toolStdoutCap
 
-    go writerRef writer disabled = do
-        chunk <- BS.hGetSome handle 8192
-        if BS.null chunk
-            then do
-                captured <- readIORef ref
-                artifact <- traverse finishOutputArtifact writer
-                writeIORef writerRef Nothing
-                pure DrainedOutput
-                    { drainedCaptured = captured
-                    , drainedArtifact = artifact
-                    }
-            else do
+    -- Unlike a take/limit conduit, this sink must await EOF even after the
+    -- capture cap is reached or spilling fails, otherwise the child can block
+    -- forever on a full pipe. Spill before publishing the bounded snapshot.
+    captureOutputC
+        :: IORef (Maybe OutputArtifactWriter)
+        -> Maybe OutputArtifactWriter
+        -> Bool
+        -> ConduitT BS.ByteString Void IO DrainedOutput
+    captureOutputC writerRef writer disabled = await >>= \case
+        Nothing -> liftIO do
+            captured <- readIORef ref
+            artifact <- traverse finishOutputArtifact writer
+            writeIORef writerRef Nothing
+            pure DrainedOutput
+                { drainedCaptured = captured
+                , drainedArtifact = artifact
+                }
+        Just chunk -> do
+            (nextWriter, nextDisabled) <- liftIO do
                 before <- readIORef ref
-                (nextWriter, nextDisabled) <-
-                    spillChunk writer disabled before chunk
+                next@(nextWriter, _) <- spillChunk writer disabled before chunk
                 writeIORef writerRef nextWriter
                 atomicModifyIORef' ref \soFar ->
                     (appendCapturedBytes cap chunk soFar, ())
@@ -865,7 +878,8 @@ drainHandle env _source handle ref recentRef = do
                         atomicModifyIORef' recent \soFar ->
                             (appendRecentBytes cap chunk soFar, ()))
                     recentRef
-                go writerRef nextWriter nextDisabled
+                pure next
+            captureOutputC writerRef nextWriter nextDisabled
 
     spillChunk
         :: Maybe OutputArtifactWriter
@@ -894,6 +908,17 @@ drainHandle env _source handle ref recentRef = do
                             Left _ -> do
                                 abortOutputArtifact writer
                                 pure (Nothing, True)
+
+-- | Demand-driven reads from a borrowed process pipe. No queue, text decoding,
+-- or handle finalizer is introduced; exceptions reach the process supervisor.
+sourceProcessBytesC :: Handle -> ConduitT () BS.ByteString IO ()
+sourceProcessBytesC handle = go
+  where
+    go = do
+        chunk <- liftIO (BS.hGetSome handle 8192)
+        unless (BS.null chunk) do
+            yield chunk
+            go
 
 emptyCapturedBytes :: CapturedBytes
 emptyCapturedBytes = CapturedBytes

--- a/packages/agent-core/test/Agent/Tools/IOSpec.hs
+++ b/packages/agent-core/test/Agent/Tools/IOSpec.hs
@@ -679,6 +679,66 @@ spec = describe "Agent.Tools.IO" do
     it "preserves oversized foreground output in an artifact" do
         withTempDir checkForegroundOutputArtifact
 
+    it "drains both pipes after capture and artifact storage limits are reached" do
+        withTempDir \dir -> do
+            requireProcessSandbox
+            let osDir = fromFilePath dir
+            base <- defaultToolEnv osDir
+            setToolSessionTmp base (Just osDir)
+            let env = base { toolStdoutCap = 64, toolOutputArtifactCap = 128 }
+            result <- checkBothPipesDrain env osDir
+            let checkArtifact :: Text.Text -> Maybe OutputArtifact -> Expectation
+                checkArtifact expected = \case
+                    Nothing -> expectationFailure "expected capped output artifact"
+                    Just artifact -> do
+                        artifact.artifactObservedBytes `shouldBe` 262144
+                        artifact.artifactStoredBytes `shouldBe` 128
+                        artifact.artifactTruncated `shouldBe` True
+                        readOutputArtifact env artifact.artifactHandle
+                            `shouldReturn` Right (Text.replicate 64 expected)
+            checkArtifact "x\n" result.commandStdoutArtifact
+            checkArtifact "y\n" result.commandStderrArtifact
+
+    it "drains both capped pipes when artifact storage is unavailable" do
+        withTempDir \dir -> do
+            requireProcessSandbox
+            let osDir = fromFilePath dir
+            base <- defaultToolEnv osDir
+            setToolSessionTmp base Nothing
+            result <- checkBothPipesDrain (base { toolStdoutCap = 64 }) osDir
+            result.commandStdoutArtifact `shouldBe` Nothing
+            result.commandStderrArtifact `shouldBe` Nothing
+
+    it "drains both capped pipes when creating an artifact fails" do
+        withTempDir \dir -> do
+            requireProcessSandbox
+            let osDir = fromFilePath dir
+            base <- defaultToolEnv osDir
+            setToolSessionTmp base (Just osDir)
+            -- A regular file at the artifact-directory path fails reliably,
+            -- including when the tests run as a privileged user.
+            writeFile (dir </> "tool-output-artifacts") "not a directory"
+            result <- checkBothPipesDrain (base { toolStdoutCap = 64 }) osDir
+            result.commandStdoutArtifact `shouldBe` Nothing
+            result.commandStderrArtifact `shouldBe` Nothing
+
+    it "preserves UTF-8 through a capture limit inside a code point" do
+        withTempDir \dir -> do
+            requireProcessSandbox
+            let osDir = fromFilePath dir
+            base <- defaultToolEnv osDir
+            setToolSessionTmp base (Just osDir)
+            let env = base { toolStdoutCap = 2 }
+            result <- runShellCommand env osDir "printf 'a\\342\\202\\254z'" 5000
+            result.commandExitCode `shouldBe` Just 0
+            result.commandStdout `shouldSatisfy` Text.isPrefixOf "a\xfffd"
+            case result.commandStdoutArtifact of
+                Nothing -> expectationFailure "expected complete UTF-8 artifact"
+                Just artifact -> do
+                    artifact.artifactObservedBytes `shouldBe` 5
+                    readOutputArtifact env artifact.artifactHandle
+                        `shouldReturn` Right "a€z"
+
     it "collects both output streams from a background shell command" do
         withTempDir checkBackgroundOutput
 
@@ -769,6 +829,25 @@ checkForegroundOutputCap dir = do
     result <- runShellCommand env osDir "yes x | head -c 262144" 5000
     Text.length result.commandStdout `shouldSatisfy` (< 128)
     result.commandStdout `shouldSatisfy` Text.isInfixOf "[truncated"
+
+checkBothPipesDrain env osDir = do
+    -- Each producer exceeds a pipe buffer by a wide margin. Both must reach
+    -- EOF even when no more bytes can be retained for the user.
+    result <- runShellCommand env osDir
+        "(yes x | head -c 262144) & (yes y | head -c 262144 >&2) & wait"
+        5000
+    result.commandTimedOut `shouldBe` False
+    result.commandCancelled `shouldBe` False
+    result.commandExitCode `shouldBe` Just 0
+    result.commandStdout `shouldSatisfy`
+        Text.isPrefixOf (Text.replicate 32 "x\n")
+    result.commandStderr `shouldSatisfy`
+        Text.isPrefixOf (Text.replicate 32 "y\n")
+    mapM_ (\output -> do
+        Text.length output `shouldSatisfy` (< 128)
+        output `shouldSatisfy` Text.isInfixOf "[truncated")
+        [result.commandStdout, result.commandStderr]
+    pure result
 
 checkBackgroundOutputArtifact dir = do
     requireProcessSandbox


### PR DESCRIPTION
## Summary
Stacked on #1227; this diff contains only the process-output follow-up.

- Split process pipe reads and output capture into a Conduit source and sink.
- Preserve raw-byte artifacts, capped previews, concurrent stdout/stderr draining, and existing cancellation/resource ownership.
- Continue draining to EOF after capture/storage limits or artifact failures.
- Add four regressions covering both oversized pipes, unavailable/failed artifact storage, and a UTF-8 code point split by the capture cap.
- Regenerate agent-core/package.nix for the Conduit dependency.

This is a structural refactor; no performance improvement is claimed.

## Validation
- GHCi library load: 82 modules loaded.
- GHCi test load: 50 modules loaded.
- Agent.Tools.IOSpec and Agent.Tools.OutputArtifactSpec: 70 examples, 0 failures, 2 existing macOS-only pending tests on Linux.
- git diff --check passed.