### PR TITLE
Show readable code-mode tool activity in the CLI

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/Render.hs
@@ -1096,7 +1096,7 @@ toolChrome name = case canonicalToolName name of
     "shell_command" -> ToolChromeShell
     "write_stdin" -> ToolChrome "Continued" ToolDetailMuted
     "run_ghci" -> ToolChromeShell
-    "exec" -> ToolChrome "$ exec" ToolDetailNone
+    "exec" -> ToolChrome "JavaScript execution" ToolDetailNone
     "get_task_output" -> ToolChrome "Read" ToolDetailMuted
     "wait_tasks" -> ToolChrome "Waited" ToolDetailMuted
     "kill_task" -> ToolChrome "Killed" ToolDetailMuted
@@ -1143,7 +1143,7 @@ formatToolBody color = formatToolBodyRelative color ""
 
 formatToolBodyRelative :: Bool -> Text -> ToolCall -> Text
 formatToolBodyRelative color workspace call = case canonicalToolName call.name of
-    "exec" -> roleToolCommand color call.arguments
+    "exec" -> ""
     _ ->
         Text.intercalate "\n" $
             map (paintDiffRelative color workspace) (toolCallDiffs call)

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -640,8 +640,9 @@ blockStateGlyph state target block
 
 shellBlockTitle :: UiBlock -> Text
 shellBlockTitle block
+    | block.blockTitle == "$ exec" = "JavaScript execution"
     | block.blockExpanded = block.blockTitle
-    | block.blockTitle `notElem` ["$ ghci", "$ exec"] = block.blockTitle
+    | block.blockTitle /= "$ ghci" = block.blockTitle
     | Text.null invocation = block.blockTitle
     | otherwise = block.blockTitle <> " · " <> invocation
   where

--- a/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/RenderSpec.hs
@@ -82,14 +82,36 @@ spec = do
                 ]
             stateToolCalls state `shouldBe` Map.empty
             stateActivity state `shouldBe` summarizeToolCallRelative "/workspace" complete
-        it "orders a nonempty body between the header and spinner refresh" do
-            let code = functionToolCall "code" "exec" "text(1)"
+        it "renders a compact exec wrapper without JavaScript source" do
+            let code = customToolCall "code" "exec" "text(1)"
                 (_, commands) = sequenceSteps [RenderToolStarted code, RenderToolStarted code]
             commands `shouldBe`
                 [ [ WriteToolLine (formatToolStartedRelative False "/workspace" code)
-                  , WriteToolLine "text(1)", RefreshToolThinking
+                  , RefreshToolThinking
                   ]
                 , [RefreshToolThinking]
+                ]
+            formatToolStartedRelative False "/workspace" code
+                `shouldSatisfy` Text.isInfixOf "JavaScript execution"
+            formatToolBody False code `shouldBe` ""
+
+        it "retains readable nested calls beside the compact exec wrapper" do
+            let execution = customToolCall "outer" "exec" "await tools.read_file({target_file: 'A.hs'});"
+                nested = functionToolCall "code-mode:1:read_file" "read_file" "{\"target_file\":\"A.hs\"}"
+                nestedResult = (result :: ToolCallResult){callId = nested.callId}
+                outerResult = result
+                    { callId = execution.callId
+                    , callKind = CustomCallKind, output = "Error: execution failed"
+                    }
+                (_, commands) = sequenceSteps
+                    [ RenderToolStarted execution, RenderToolStarted nested
+                    , RenderToolFinished nestedResult, RenderToolFinished outerResult
+                    ]
+            commands `shouldBe`
+                [ [WriteToolLine (formatToolStartedRelative False "/workspace" execution), RefreshToolThinking]
+                , [WriteToolLine (formatToolStartedRelative False "/workspace" nested), RefreshToolThinking]
+                , [WriteToolLine (truncateToolOutput "ok")]
+                , [WriteToolLine (truncateToolOutput "Error: execution failed")]
                 ]
 
         it "suppresses todo lines but retains their lifecycle" do

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -3036,6 +3036,7 @@ spec = do
                 reopenedText = renderShell reopened
                 ghciText = renderShell ghciCompleted
                 execText = renderShell execCompleted
+                execExpandedText = renderShell (reduceUi UiToggleSelected execCompleted)
                 failedText = renderShell failed
             collapsedText `shouldSatisfy`
                 Text.isInfixOf "$ printf shell-command"
@@ -3048,8 +3049,14 @@ spec = do
             ghciText `shouldNotSatisfy`
                 Text.isInfixOf "ghci-output-marker"
             execText `shouldSatisfy`
-                Text.isInfixOf "$ exec · text(\"exec-invocation-marker\");"
+                Text.isInfixOf "JavaScript execution"
             execText `shouldNotSatisfy`
+                Text.isInfixOf "exec-invocation-marker"
+            execText `shouldNotSatisfy`
+                Text.isInfixOf "exec-output-marker"
+            execExpandedText `shouldSatisfy`
+                Text.isInfixOf "exec-invocation-marker"
+            execExpandedText `shouldSatisfy`
                 Text.isInfixOf "exec-output-marker"
             failedText `shouldSatisfy`
                 Text.isInfixOf "› ✗ $ false"

--- a/packages/agent-tui/src/Agent/TUI/Model/Block.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Block.hs
@@ -33,6 +33,9 @@ appendBlock kind title body detail blockState callId state =
             , blockExpanded =
                 kind `elem` [BlockUser, BlockAssistant, BlockSystem, BlockRecap, BlockError]
                     || (kind == BlockShell
+                        -- Execution source stays available on expansion,
+                        -- while nested operations provide the live activity.
+                        && title `notElem` ["JavaScript execution", "$ exec"]
                         && blockState `elem` [BlockStreaming, BlockRunning])
             , blockCallId = callId
             , blockInspectionGroupable = False

--- a/packages/agent-tui/src/Agent/TUI/Model/ToolResult.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/ToolResult.hs
@@ -122,7 +122,7 @@ blockCodeLanguage :: UiBlock -> Maybe Text
 blockCodeLanguage block
     | block.blockKind /= BlockShell = Nothing
     | Text.null (Text.strip block.blockDetail) = Nothing
-    | block.blockTitle == "$ exec" = Just "javascript"
+    | block.blockTitle `elem` ["JavaScript execution", "$ exec"] = Just "javascript"
     | otherwise = Just "haskell"
 
 outputLooksFailed :: Text -> Bool

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -77,6 +77,8 @@ summarizeToolCall = summarizeToolCallRelative ""
 -- | Like 'summarizeToolCall', but filesystem paths inside the workspace are
 -- shown relative to that workspace.
 summarizeToolCallRelative :: Text -> ToolCall -> Text
+summarizeToolCallRelative _ call
+    | canonicalToolName call.name == "exec" = "JavaScript execution"
 summarizeToolCallRelative workspace call =
     let verb = case canonicalToolName call.name of
             "mcp_call" -> mcpCallDisplayName call.arguments
@@ -135,7 +137,7 @@ toolCallTitle = toolCallTitleRelative ""
 toolCallTitleRelative :: Text -> ToolCall -> Text
 toolCallTitleRelative workspace call
     | canonicalToolName call.name == "run_ghci" = "$ ghci"
-    | canonicalToolName call.name == "exec" = "$ exec"
+    | canonicalToolName call.name == "exec" = "JavaScript execution"
     | otherwise = summarizeToolCallRelative workspace call
 
 -- | Separate a filesystem action from its path so renderers can style the

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -909,10 +909,96 @@ spec = describe "fullscreen UI reducer" do
         case Foldable.toList state.uiBlocks of
             [block] -> do
                 block.blockKind `shouldBe` BlockShell
-                block.blockTitle `shouldBe` "$ exec"
+                block.blockTitle `shouldBe` "JavaScript execution"
                 block.blockDetail `shouldBe` source
                 blockCodeLanguage block `shouldBe` Just "javascript"
+                blockCodeLanguage block{blockTitle = "$ exec"}
+                    `shouldBe` Just "javascript"
+                block.blockExpanded `shouldBe` False
+                state.uiActivity `shouldBe` "JavaScript execution"
             _ -> expectationFailure "expected one running exec block"
+
+    it "keeps streaming exec source collapsed and retains it for expansion" do
+        let source = "const answer = await tools.read_file({target_file: \"A.hs\"});"
+            partialCall = customToolCall "c1" "exec" ""
+            call = customToolCall "c1" "exec" source
+            started = apply [UiLoop TurnStarted, UiLoop (ToolStarted partialCall)]
+            updated = reduceUi (UiLoop (ToolArgumentsUpdated call)) started
+            running = reduceUi (UiLoop (ToolStarted call)) updated
+            completed = reduceUi (UiLoop (ToolFinished
+                ToolCallResult
+                    { toolResultMode = BlockingToolCall
+                    , toolResultImages = []
+                    , toolResultOutcome = Nothing
+                    , callId = "c1"
+                    , output = "done"
+                    , callKind = CustomCallKind
+                    })) running
+            expanded = reduceUi UiToggleSelected completed
+        map (.blockExpanded) (Foldable.toList started.uiBlocks) `shouldBe` [False]
+        map (.blockExpanded) (Foldable.toList running.uiBlocks) `shouldBe` [False]
+        map (.blockExpanded) (Foldable.toList expanded.uiBlocks) `shouldBe` [True]
+        map (.blockDetail) (Foldable.toList expanded.uiBlocks) `shouldBe` [source]
+        running.uiActivity `shouldBe` "JavaScript execution"
+
+    it "retains independent parallel nested operations beside collapsed exec" do
+        let source = "await Promise.all([tools.inspect_configuration(), tools.inspect_dependencies()]);"
+            execution = customToolCall "c1" "exec" source
+            configurationCall = functionToolCall
+                "code-mode:1:inspect_configuration" "inspect_configuration" "{}"
+            dependenciesCall = functionToolCall
+                "code-mode:2:inspect_dependencies" "inspect_dependencies" "{}"
+            running = apply
+                [ UiLoop TurnStarted
+                , UiLoop (ToolStarted execution)
+                , UiLoop (ToolStarted configurationCall)
+                , UiLoop (ToolStarted dependenciesCall)
+                ]
+            dependenciesFinished = reduceUi (UiLoop (ToolFinished
+                ToolCallResult
+                    { toolResultMode = BlockingToolCall
+                    , toolResultImages = []
+                    , toolResultOutcome = Nothing
+                    , callId = "code-mode:2:inspect_dependencies"
+                    , output = "done"
+                    , callKind = FunctionCallKind
+                    })) running
+            configurationFailed = reduceUi (UiLoop (ToolFinished
+                ToolCallResult
+                    { toolResultMode = BlockingToolCall
+                    , toolResultImages = []
+                    , toolResultOutcome = Nothing
+                    , callId = "code-mode:1:inspect_configuration"
+                    , output = "Error: denied"
+                    , callKind = FunctionCallKind
+                    })) dependenciesFinished
+            executionFailed = reduceUi (UiLoop (ToolFinished
+                ToolCallResult
+                    { toolResultMode = BlockingToolCall
+                    , toolResultImages = []
+                    , toolResultOutcome = Nothing
+                    , callId = "c1"
+                    , output = "Error: nested operation failed"
+                    , callKind = CustomCallKind
+                    })) configurationFailed
+            blocks = Foldable.toList executionFailed.uiBlocks
+        map (.blockState) (Foldable.toList dependenciesFinished.uiBlocks)
+            `shouldBe` [BlockRunning, BlockRunning, BlockComplete]
+        map (.blockState) blocks `shouldBe` [BlockFailed, BlockFailed, BlockComplete]
+        map (.blockTitle) blocks
+            `shouldBe` ["JavaScript execution", "inspect_configuration", "inspect_dependencies"]
+        map (.blockBody) blocks
+            `shouldBe` ["Error: nested operation failed", "Error: denied", "done"]
+        Map.null executionFailed.uiToolCalls `shouldBe` True
+        case blocks of
+            block : _ -> do
+                block.blockExpanded `shouldBe` False
+                block.blockDetail `shouldBe` source
+                let expanded = reduceUi (UiActivateBlock block.blockId) executionFailed
+                fmap (.blockExpanded) (Foldable.find
+                    ((== block.blockId) . (.blockId)) expanded.uiBlocks)
+                    `shouldBe` Just True
+            _ -> expectationFailure "expected retained execution and nested operations"
 
     it "renders the public Grok terminal alias as a shell block" do
         let call = functionToolCall

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -346,7 +346,8 @@ spec = describe "tool presentation" do
     it "renders exec source and hides successful protocol boilerplate" do
         let source = "const result = await tools.grep({pattern: \"needle\"});\ntext(result);"
             call = customToolCall "exec" "exec" source
-        toolCallTitle call `shouldBe` "$ exec"
+        toolCallTitle call `shouldBe` "JavaScript execution"
+        summarizeToolCall call `shouldBe` "JavaScript execution"
         toolCallInput call `shouldBe` source
         formatToolOutput call
             "Script completed\nWall time 0.1 seconds\nOutput:\nmatch"


### PR DESCRIPTION
## Summary
- Replace raw JavaScript in default CLI tool activity with a compact “JavaScript execution” label.
- Keep existing nested tool calls readable and execution details collapsed by default in the TUI, with source and output available on expansion.
- Add regression coverage for streaming, parallel nested results, failures, and legacy execution titles.

## Validation
- GHCi typechecked the affected libraries and test modules (387 modules loaded).
- TUI ModelSpec and PresentationSpec: 116 examples, 0 failures.
- Actual renderer exercised in tmux/GHCi: compact execution label, readable nested file call, retained output and errors, no raw JavaScript.
- Live CLI smoke completed, but the code-mode worker readiness probe timed out and fell back to direct tools; provider-to-code-mode end-to-end validation remains unverified.
- CLI test execution did not complete locally: the single-component test REPL stalled compiling dependencies. The combined REPL typechecked tests but could not import them for execution due to multi-unit visibility.
- git diff --check passed.