### PR TITLE
Fix Meta Console secret test module visibility

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/MetaConsole.hs
@@ -8,6 +8,7 @@ module Agent.CLI.Runtime.MetaConsole
     ( MetaSecretValue(..)
     , applyMetaConfigActions
     , buildMetaContext
+    , collectMetaSecretsWith
     , isMetaConfigAction
     , metaConfigRequiresRestart
     , runMetaPlanner
@@ -56,6 +57,8 @@ import Agent.ReasoningEffort (reasoningEffortText)
 import Agent.Responses.Types (ResponseCreateParams(..))
 import Control.Applicative ((<|>))
 import Control.Monad (foldM, when)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.=))
 import Data.IORef (readIORef)
@@ -84,6 +87,46 @@ instance Show MetaSecretValue where
             <> " "
             <> show key
             <> " <redacted>"
+
+-- | Collect in action order, stopping at the first cancelled prompt.
+collectMetaSecretsWith
+    :: (Text -> Text -> IO (Maybe Text))
+    -> [MetaAction]
+    -> IO (Either Text [MetaSecretValue])
+collectMetaSecretsWith prompt actions =
+    runExceptT $ foldM (collectOneMetaSecret prompt) [] actions
+
+collectOneMetaSecret
+    :: (Text -> Text -> IO (Maybe Text))
+    -> [MetaSecretValue]
+    -> MetaAction
+    -> ExceptT Text IO [MetaSecretValue]
+collectOneMetaSecret prompt values action = case action of
+    MetaSetMcpSecretEnv server key -> do
+        value <- requireSecret
+            ("secret input for MCP server '" <> server <> "' was cancelled")
+            ("MCP " <> server <> " · " <> key)
+            ("Enter the value for environment variable "
+                <> key
+                <> " on MCP server "
+                <> server
+                <> ". It stays local and is never sent to the model.")
+        pure (values <> [MetaMcpSecretValue server key value])
+    MetaSetLspSecretEnv server key -> do
+        value <- requireSecret
+            ("secret input for LSP server '" <> server <> "' was cancelled")
+            ("LSP " <> server <> " · " <> key)
+            ("Enter the value for environment variable "
+                <> key
+                <> " on LSP server "
+                <> server
+                <> ". It stays local and is never sent to the model.")
+        pure (values <> [MetaLspSecretValue server key value])
+    _ -> pure values
+  where
+    requireSecret cancelled title body = do
+        value <- liftIO $ prompt title body
+        maybe (throwE cancelled) pure value
 
 -- | Apply all persistent actions to one in-memory value.  The caller saves
 -- the result once, so a bad action cannot leave a partially-written plan.

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/MetaConsole.hs
@@ -1,7 +1,6 @@
 -- | Meta Console planning, approval, and host-side action execution.
 module Agent.CLI.Runtime.Repl.MetaConsole
     ( handleMetaConsoleRequest
-    , collectMetaSecretsWith
     ) where
 
 import Agent.CLI.Command
@@ -27,6 +26,7 @@ import Agent.CLI.Runtime.MetaConsole
     ( MetaSecretValue(..)
     , applyMetaConfigActions
     , buildMetaContext
+    , collectMetaSecretsWith
     , isMetaConfigAction
     , metaConfigRequiresRestart
     , runMetaPlanner
@@ -67,8 +67,6 @@ import Agent.TUI.Model
 import Control.Exception.Safe
     ( displayException, finally, tryAny )
 import Control.Monad ( foldM )
-import Control.Monad.IO.Class ( liftIO )
-import Control.Monad.Trans.Except ( ExceptT, runExceptT, throwE )
 import Data.Aeson ( Value )
 import Data.IORef ( readIORef )
 import Data.Text ( Text )
@@ -295,46 +293,6 @@ collectMetaSecrets
     -> IO (Either Text [MetaSecretValue])
 collectMetaSecrets runtime =
     collectMetaSecretsWith (promptMetaSecret runtime)
-
--- | Collect in action order, stopping at the first cancelled prompt.
-collectMetaSecretsWith
-    :: (Text -> Text -> IO (Maybe Text))
-    -> [Meta.MetaAction]
-    -> IO (Either Text [MetaSecretValue])
-collectMetaSecretsWith prompt actions =
-    runExceptT $ foldM (collectOneMetaSecret prompt) [] actions
-
-collectOneMetaSecret
-    :: (Text -> Text -> IO (Maybe Text))
-    -> [MetaSecretValue]
-    -> Meta.MetaAction
-    -> ExceptT Text IO [MetaSecretValue]
-collectOneMetaSecret prompt values action = case action of
-    Meta.MetaSetMcpSecretEnv server key -> do
-        value <- requireSecret
-            ("secret input for MCP server '" <> server <> "' was cancelled")
-            ("MCP " <> server <> " · " <> key)
-            ("Enter the value for environment variable "
-                <> key
-                <> " on MCP server "
-                <> server
-                <> ". It stays local and is never sent to the model.")
-        pure (values <> [MetaMcpSecretValue server key value])
-    Meta.MetaSetLspSecretEnv server key -> do
-        value <- requireSecret
-            ("secret input for LSP server '" <> server <> "' was cancelled")
-            ("LSP " <> server <> " · " <> key)
-            ("Enter the value for environment variable "
-                <> key
-                <> " on LSP server "
-                <> server
-                <> ". It stays local and is never sent to the model.")
-        pure (values <> [MetaLspSecretValue server key value])
-    _ -> pure values
-  where
-    requireSecret cancelled title body = do
-        value <- liftIO $ prompt title body
-        maybe (throwE cancelled) pure value
 
 promptMetaSecret
     :: MetaConsoleRuntime

--- a/packages/agent-cli/test/Agent/CLI/MetaConsoleRuntimeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/MetaConsoleRuntimeSpec.hs
@@ -16,9 +16,9 @@ import Agent.CLI.MetaConsole
 import Agent.CLI.Runtime.MetaConsole
     ( MetaSecretValue(..)
     , applyMetaConfigActions
+    , collectMetaSecretsWith
     )
 import Agent.MCP (McpLogLevel(..), McpProtocolPreference(..))
-import Agent.CLI.Runtime.Repl.MetaConsole (collectMetaSecretsWith)
 import Data.IORef (newIORef, modifyIORef', readIORef)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text


### PR DESCRIPTION
## Summary
- Fix the CLI test compilation failure introduced in #1236: the test imported a hidden REPL module.
- Move secret collection unchanged into the already-exposed Agent.CLI.Runtime.MetaConsole module and update imports.
- Keep the private REPL module hidden; no prompt or input-handling changes.
- Excludes the separate config-loader ExceptT refactor.

## Validation
- Ran the actual test component with `nix develop -c cabal repl agent-cli:test:agent-cli-test`, then `:main --match "Meta Console host executor"`.
- GHCi loaded 105 modules successfully; 9 examples, 0 failures; no compiler errors.
- `git diff --check` passed.