### PR TITLE
Simplify config loading with ExceptT

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Config.hs
+++ b/packages/agent-cli/src/Agent/CLI/Config.hs
@@ -45,7 +45,7 @@ import Agent.CLI.PrivateFileLock (withPrivateFileLock)
 import Control.Exception.Safe (displayException, tryIO)
 import Control.Monad (forM_, unless, when)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Trans.Except (ExceptT(..), runExceptT, withExceptT)
+import Control.Monad.Trans.Except (ExceptT(..), except, runExceptT, withExceptT)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Bits ((.|.), rotateL, shiftL, xor)
@@ -626,46 +626,32 @@ withHarnessConfigSnapshot home action =
 
 loadHarnessConfigUnlocked
     :: OsPath -> IO (Either Text (Word64, HarnessConfig))
-loadHarnessConfigUnlocked home = do
+loadHarnessConfigUnlocked home = runExceptT do
     let path = harnessConfigPath home
-    exists <- doesFileExist path
-    bytesResult <-
+    exists <- liftIO (doesFileExist path)
+    bytes <- withExceptT (\exception ->
+        "Failed to read "
+            <> Text.pack (unsafeToFilePath path)
+            <> ": "
+            <> Text.pack (displayException exception)) $ ExceptT $
         if exists
             then tryIO
                 (retryOnFileBusy (LBS.readFile (unsafeToFilePath path)))
             else pure (Right (Aeson.encode defaultHarnessConfig))
-    case bytesResult of
-        Left exception ->
-            pure . Left $
-                "Failed to read "
-                    <> Text.pack (unsafeToFilePath path)
-                    <> ": "
-                    <> Text.pack (displayException exception)
-        Right bytes ->
-            case
-                if isBlankJson bytes
-                    then Right defaultHarnessConfig
-                    else decodeLazy harnessConfigDecoder bytes
-            of
-                Left err ->
-                    pure . Left $
-                        "Invalid "
-                            <> Text.pack (unsafeToFilePath path)
-                            <> ": "
-                            <> err
-                Right config ->
-                    case validateHarnessConfig config of
-                        Left err -> pure (Left err)
-                        Right valid -> do
-                            identified <- assignMcpConnectionIds valid
-                            if identified /= valid
-                                then fmap (fmap (, identified))
-                                    (writeHarnessConfigUnlocked home identified)
-                                else loadHarnessRevisionKeyUnlocked home >>= \case
-                                    Left err -> pure (Left err)
-                                    Right key ->
-                                        pure (Right
-                                            (keyedConfigRevision key bytes, valid))
+    config <- withExceptT (\err ->
+        "Invalid " <> Text.pack (unsafeToFilePath path) <> ": " <> err) $ except $
+        if isBlankJson bytes
+            then Right defaultHarnessConfig
+            else decodeLazy harnessConfigDecoder bytes
+    valid <- except (validateHarnessConfig config)
+    identified <- liftIO (assignMcpConnectionIds valid)
+    if identified /= valid
+        then do
+            revision <- ExceptT (writeHarnessConfigUnlocked home identified)
+            pure (revision, identified)
+        else do
+            key <- ExceptT (loadHarnessRevisionKeyUnlocked home)
+            pure (keyedConfigRevision key bytes, valid)
 
 -- | Atomically read, transform, validate, and replace the config while holding
 -- the process-shared config lock. The returned revision is for the exact bytes

--- a/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ConfigSpec.hs
@@ -113,6 +113,25 @@ spec = describe "Agent.CLI.Config" do
             writeConfig home " \n\t"
             loadHarnessConfig home `shouldReturn` Right defaultHarnessConfig
 
+    it "persists migrated identities and returns the revision of the migrated bytes" $
+        withTempDir "agent-config-" \home -> do
+            writeConfig home "{\"mcpServers\":{\"remote\":{\"url\":\"https://example.test/mcp\"}}}"
+            Right (revision, config) <- loadHarnessConfigSnapshot home
+            let server = config.configMcpServers Map.! "remote"
+            server.mcpConnectionId `shouldSatisfy` isJust
+            bytes <- LBS.readFile (filePath (harnessConfigPath home))
+            LBS.length bytes `shouldSatisfy` (> 0)
+            loadHarnessConfigSnapshot home `shouldReturn` Right (revision, config)
+            LBS.readFile (filePath (harnessConfigPath home)) `shouldReturn` bytes
+
+    it "does not rewrite valid configuration bytes when no migration is needed" $
+        withTempDir "agent-config-" \home -> do
+            let bytes = "{ \"maxConcurrentAgents\" : 3 }\n"
+            writeConfig home bytes
+            Right snapshot <- loadHarnessConfigSnapshot home
+            loadHarnessConfigSnapshot home `shouldReturn` Right snapshot
+            LBS.readFile (filePath (harnessConfigPath home)) `shouldReturn` bytes
+
     it "updates typed configuration without discarding unrelated fields" $
         withTempDir "agent-config-" \home -> do
             let original =


### PR DESCRIPTION
## Summary
- Flatten nested error handling in loadHarnessConfigUnlocked using ExceptT.
- Preserve read/decode errors, validation, migration persistence, and exact-byte revision behavior.
- Add regressions for migrated identities and preserving unchanged configuration bytes.

## Validation
- ConfigSpec in GHCi: 47 examples, 0 failures.
- git diff --check passed.