### PR TITLE
Replace handwritten helpers with Haskell library functions

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -342,7 +342,7 @@ library
                     , aeson >= 2.0
                     , ansi-terminal >= 1.0
                     , async
-                    , base >= 4.17 && < 5
+                    , base >= 4.19 && < 5
                     , base64-bytestring
                     , brick >= 2.9 && < 3
                     , bytestring

--- a/packages/agent-cli/src/Agent/CLI/AgentSessions/Render.hs
+++ b/packages/agent-cli/src/Agent/CLI/AgentSessions/Render.hs
@@ -10,6 +10,7 @@ import Agent.CLI.Session
 import Agent.Dialect (dialectSlug)
 import Agent.OsPath (unsafeToFilePath)
 import Agent.Provider (providerSlug)
+import Data.List (intercalate)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -38,7 +39,7 @@ renderAgentSession meta status activity turns =
             <> ["", "Recent turns: " <> Text.pack (show (length turns))]
             <> case turns of
                 [] -> ["  (none)"]
-                _ -> [""] <> intercalateBlank
+                _ -> [""] <> intercalate [""]
                     (zipWith renderSessionTurn [1 :: Int ..] turns)
 
 renderActivity :: SessionActivity -> [Text]
@@ -64,11 +65,6 @@ renderSessionTurn index turn =
             turn.turnAssistantText
         <> maybe [] (\text -> ["Error:", indentText text])
             turn.turnError
-
-intercalateBlank :: [[Text]] -> [Text]
-intercalateBlank = \case
-    [] -> []
-    first : rest -> first <> concatMap ("" :) rest
 
 indentText :: Text -> Text
 indentText = Text.intercalate "\n" . map ("  " <>) . Text.lines

--- a/packages/agent-cli/src/Agent/CLI/Picker.hs
+++ b/packages/agent-cli/src/Agent/CLI/Picker.hs
@@ -28,7 +28,7 @@ import Control.Concurrent.Async (race)
 import Control.Exception.Safe (bracket, throwIO, tryIO)
 import Control.Monad (when)
 import Data.Char (isDigit)
-import Data.List (elemIndex, findIndex)
+import Data.List (elemIndex, findIndex, stripPrefix, unsnoc)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -409,12 +409,6 @@ selectableRows frame = do
             ' ' : ' ' : c : _ -> c /= ' '
             _ -> False
 
-stripPrefix :: String -> String -> Maybe String
-stripPrefix prefix value
-    | Text.pack prefix `Text.isPrefixOf` Text.pack value =
-        Just (drop (length prefix) value)
-    | otherwise = Nothing
-
 splitOnce :: Char -> String -> Maybe (String, String)
 splitOnce delimiter value =
     case break (== delimiter) value of
@@ -433,10 +427,6 @@ listAt index values
     | otherwise = case drop index values of
         value : _ -> Just value
         [] -> Nothing
-
-unsnoc :: [a] -> Maybe ([a], a)
-unsnoc [] = Nothing
-unsnoc xs = Just (init xs, last xs)
 
 readDecimal :: String -> Maybe Int
 readDecimal chars

--- a/packages/agent-cli/src/Agent/CLI/Usage.hs
+++ b/packages/agent-cli/src/Agent/CLI/Usage.hs
@@ -22,6 +22,7 @@ import Agent.OpenRouter.Usage (OpenRouterUsage(..))
 import Agent.TUI.Model (PromptLimitStatus(..))
 import Agent.XAI.Usage (GrokUsageSnapshot, weeklyLimitLeft)
 import Control.Applicative ((<|>))
+import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Calendar (fromGregorian)
@@ -143,7 +144,7 @@ formatAccountUsage color now line =
                             , primaryWindow
                             , secondaryWindow
                             } ->
-                            catWindows
+                            catMaybes
                                 [ formatLabeledUsageWindow color
                                     <$> primaryWindow
                                 , formatLabeledUsageWindow color
@@ -179,7 +180,7 @@ formatUsageSummary now cooldownUntil result =
     windows snapshot = case snapshot.rateLimit of
         Nothing -> []
         Just usageLimit ->
-            catWindows
+            catMaybes
                 [ summarizeWindow <$> usageLimit.primaryWindow
                 , summarizeWindow <$> usageLimit.secondaryWindow
                 ]
@@ -282,14 +283,6 @@ shortAccountId :: Text -> Text
 shortAccountId accountId
     | Text.length accountId <= 12 = accountId
     | otherwise = Text.take 8 accountId <> "…"
-
-catWindows :: [Maybe Text] -> [Text]
-catWindows = concatMap maybeToList
-
-maybeToList :: Maybe a -> [a]
-maybeToList = \case
-    Nothing -> []
-    Just value -> [value]
 
 formatSeconds :: Int -> Text
 formatSeconds total =

--- a/packages/agent-cli/test/Agent/CLI/PickerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PickerSpec.hs
@@ -31,6 +31,10 @@ spec = do
             decodePickerKey "\ESC[1;1:3A" `shouldBe` Nothing
             decodePickerKey "\ESC[106;1:3u" `shouldBe` Nothing
 
+        it "ignores empty and truncated CSI sequences" do
+            map decodePickerKey ["", "\ESC[", "\ESC[1;", "\ESC[97;"]
+                `shouldBe` replicate 4 Nothing
+
     describe "decodeMouseEvent" do
         it "decodes SGR clicks, releases, and wheel events" do
             decodeMouseEvent "\ESC[<0;12;7M"
@@ -45,6 +49,18 @@ spec = do
         it "ignores unsupported buttons and malformed reports" do
             decodeMouseEvent "\ESC[<2;12;7M" `shouldBe` Nothing
             decodeMouseEvent "\ESC[<0;x;7M" `shouldBe` Nothing
+
+        it "requires the exact SGR prefix and a complete row and terminator" do
+            map decodeMouseEvent
+                [ ""
+                , "[<0;12;7M"
+                , " \ESC[<0;12;7M"
+                , "\ESC[<0;12;"
+                , "\ESC[<0;12;M"
+                , "\ESC[<0;12;7"
+                , "\ESC[<0;12;7Mx"
+                ]
+                `shouldBe` replicate 7 Nothing
 
     describe "mouseKeysForFrame" do
         let frame = "title\n› first\n  second\n  third\nfooter"

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -138,6 +138,7 @@ library
                     , crypton-connection
                     , directory
                     , entropy
+                    , extra
                     , filepath
                     , JuicyPixels
                     , process

--- a/packages/agent-core/package.nix
+++ b/packages/agent-core/package.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, agent-json, agent-process
 , agent-responses-types, async, base, base64-bytestring, bytestring
-, containers, crypton-connection, directory, entropy, filepath
-, hspec, JuicyPixels, lib, process, QuickCheck, resourcet, retry
-, safe-exceptions, scientific, stm, template-haskell, text
+, containers, crypton-connection, directory, entropy, extra
+, filepath, hspec, JuicyPixels, lib, process, QuickCheck, resourcet
+, retry, safe-exceptions, scientific, stm, template-haskell, text
 , text-builder, time, tls, transformers, unix, vector, websockets
 , yaml, zlib
 }:
@@ -14,8 +14,8 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-json agent-process agent-responses-types async base
     base64-bytestring bytestring containers crypton-connection
-    directory entropy filepath JuicyPixels process resourcet retry
-    safe-exceptions scientific stm template-haskell text time tls
+    directory entropy extra filepath JuicyPixels process resourcet
+    retry safe-exceptions scientific stm template-haskell text time tls
     transformers unix vector websockets yaml zlib
   ];
   testHaskellDepends = [

--- a/packages/agent-core/src/Agent/Http/Url.hs
+++ b/packages/agent-core/src/Agent/Http/Url.hs
@@ -3,6 +3,8 @@ module Agent.Http.Url
     ( trimTrailingSlash
     ) where
 
+import Data.List (dropWhileEnd)
+
 -- | Drop trailing @/@ characters from a URL prefix.
 trimTrailingSlash :: String -> String
-trimTrailingSlash = reverse . dropWhile (== '/') . reverse
+trimTrailingSlash = dropWhileEnd (== '/')

--- a/packages/agent-core/src/Agent/Skills.hs
+++ b/packages/agent-core/src/Agent/Skills.hs
@@ -50,12 +50,12 @@ import System.OsPath (OsPath, unsafeEncodeUtf)
 import Data.Aeson.Types (Parser, parseEither)
 import qualified Data.ByteString as BS
 import Data.Char (isAlphaNum)
+import Data.Containers.ListUtils (nubOrdOn)
 import Data.List (sort, sortOn)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Ord (Down(..))
-import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -823,16 +823,7 @@ skillMentionNames text =
     mentionChar c = isAlphaNum c || c `elem` ['-', ':']
 
 dedupe :: [SkillInvocation] -> [SkillInvocation]
-dedupe = go Set.empty
-  where
-    go :: Set Text -> [SkillInvocation] -> [SkillInvocation]
-    go _ [] = []
-    go seen (item:rest)
-        | skillSourceIdentity item.invocationSkill `Set.member` seen = go seen rest
-        | otherwise =
-            item : go
-                (Set.insert (skillSourceIdentity item.invocationSkill) seen)
-                rest
+dedupe = nubOrdOn (skillSourceIdentity . (.invocationSkill))
 
 skillSourceIdentity :: Skill -> Text
 skillSourceIdentity skill = case skill.skillSource of

--- a/packages/agent-core/src/Agent/Tools/Dangerous.hs
+++ b/packages/agent-core/src/Agent/Tools/Dangerous.hs
@@ -21,6 +21,7 @@ module Agent.Tools.Dangerous
 import Agent.JsonText (jsonTextField)
 import Agent.OsPath (fromText, toText, unsafeToFilePath)
 import Agent.Tools.FileSystem (pathTargetsSystemTemp)
+import Control.Monad.Extra (anyM)
 import Data.Char
     ( chr
     , digitToInt
@@ -576,13 +577,6 @@ percentDecodePath = Text.pack . decode . Text.unpack
             chr (digitToInt high * 16 + digitToInt low) : decode rest
     decode (char : rest) = char : decode rest
     decode [] = []
-
-anyM :: (a -> IO Bool) -> [a] -> IO Bool
-anyM _ [] = pure False
-anyM predicate (value : rest) =
-    predicate value >>= \case
-        True -> pure True
-        False -> anyM predicate rest
 
 hardcodedSystemTmpReason :: Text -> Text
 hardcodedSystemTmpReason command =

--- a/packages/agent-core/test/Agent/SkillsSpec.hs
+++ b/packages/agent-core/test/Agent/SkillsSpec.hs
@@ -252,6 +252,13 @@ spec = describe "Agent.Skills" do
         rendered `shouldSatisfy`
             maybe False (not . Text.isInfixOf "Always-active skill: always")
 
+    it "deduplicates dollar mentions in first-occurrence order" do
+        let deploy = fakeSkill "deploy" "deploy" UserSkill AgentSkills
+            review = fakeSkill "review" "review" UserSkill AgentSkills
+            invocations = buildSkillInvocations [] (SkillCatalog [deploy, review] [])
+        resolved <- expectRight (resolveSkillMentions invocations "$review $deploy $review $deploy")
+        map (.invocationName) resolved `shouldBe` ["review", "deploy"]
+
     it "resolves and deduplicates explicit dollar mentions" do
         let skill = fakeSkill "deploy" "deploy" UserSkill AgentSkills
         invocation <- expectSingleInvocation

--- a/packages/agent-mail/agent-mail.cabal
+++ b/packages/agent-mail/agent-mail.cabal
@@ -58,6 +58,7 @@ library
         , network >= 3.2 && < 3.3
         , crypton-connection >= 0.4.5 && < 0.5
         , safe-exceptions >= 0.1.7 && < 0.2
+        , split >= 0.2 && < 0.3
         , tagsoup >= 0.14 && < 0.15
         , text >= 2.0 && < 2.2
         , time >= 1.12 && < 1.15

--- a/packages/agent-mail/package.nix
+++ b/packages/agent-mail/package.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, async, base, base64-bytestring, bytestring
 , crypton, crypton-connection, hspec, http-client, http-client-tls
-, http-types, lib, network, safe-exceptions, tagsoup, text, time
-, tls
+, http-types, lib, network, safe-exceptions, split, tagsoup, text
+, time, tls
 }:
 mkDerivation {
   pname = "agent-mail";
@@ -10,7 +10,7 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson async base base64-bytestring bytestring crypton
     crypton-connection http-client http-client-tls http-types network
-    safe-exceptions tagsoup text time tls
+    safe-exceptions split tagsoup text time tls
   ];
   testHaskellDepends = [ aeson base hspec http-types text time ];
   description = "Low-level email types and provider transports";

--- a/packages/agent-mail/src/Agent/Mail/Transport.hs
+++ b/packages/agent-mail/src/Agent/Mail/Transport.hs
@@ -59,6 +59,7 @@ import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isControl, isDigit, isSpace)
 import Data.List (find, nub)
+import qualified Data.List.Split as Split
 import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -2859,11 +2860,7 @@ boundedCount hardMaximum requested =
     max 1 (min hardMaximum requested)
 
 chunksOf :: Int -> [value] -> [[value]]
-chunksOf requested values
-    | null values = []
-    | otherwise =
-        let (chunk, rest) = splitAt (max 1 requested) values
-        in chunk : chunksOf requested rest
+chunksOf requested = Split.chunksOf (max 1 requested)
 
 nonEmptyBytes :: Text -> Maybe BS.ByteString
 nonEmptyBytes value

--- a/packages/agent-responses-types/src/Agent/Responses/Types/Streaming.hs
+++ b/packages/agent-responses-types/src/Agent/Responses/Types/Streaming.hs
@@ -20,6 +20,8 @@ import Agent.Responses.Types.Items
     , responseItemDecoder
     )
 import Agent.Responses.Types.Response (Response, responseDecoder)
+import Control.Applicative ((<|>))
+import Control.Monad (join)
 import Data.Aeson hiding (TaggedObject)
 import qualified Data.Hermes as Hermes
 import Data.Text (Text)
@@ -719,16 +721,8 @@ turnStateFieldsDecoder = do
     nestedHeaders <- optionalAtKey "headers" $ Hermes.object do
         nestedHeader <- optionalAtKey "x-codex-turn-state" Hermes.text
         nestedAlias <- optionalAtKey "turn_state" Hermes.text
-        pure (firstJust nestedHeader nestedAlias)
-    pure
-        ( firstJust directHeader
-            (firstJust directAlias (maybe Nothing id nestedHeaders))
-        )
-
-firstJust :: Maybe value -> Maybe value -> Maybe value
-firstJust first second = case first of
-    Just value -> Just value
-    Nothing -> second
+        pure (nestedHeader <|> nestedAlias)
+    pure (directHeader <|> directAlias <|> join nestedHeaders)
 
 codexRateLimitsDecoder :: Hermes.Decoder CodexRateLimits
 codexRateLimitsDecoder = Hermes.object $

--- a/packages/agent-responses/src/Agent/Responses/Error.hs
+++ b/packages/agent-responses/src/Agent/Responses/Error.hs
@@ -23,6 +23,7 @@ import Agent.Json.Decode
     )
 import Control.Applicative ((<|>))
 import Control.Monad (join)
+import Data.Foldable (asum)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -139,9 +140,9 @@ providerErrorPayloadDecoder = object do
     payloadType <- join <$> atKeyOptional "type" (nullable text)
     code <- join <$> atKeyOptional "code" (nullable text)
     errorCode <- join <$> atKeyOptional "error_code" (nullable text)
-    message <- firstPresent
+    message <- asum
         <$> traverseOptionalText ["message", "detail", "msg", "description"]
-    retryAfter <- firstPresent <$> sequence
+    retryAfter <- asum <$> sequence
         [ join <$> atKeyOptional "resets_in_seconds" (nullable int)
         , join <$> atKeyOptional "retry_after" (nullable int)
         ]
@@ -178,9 +179,6 @@ errorValueDecoder =
 traverseOptionalText :: [Text] -> FieldsDecoder [Maybe Text]
 traverseOptionalText =
     traverse \key -> join <$> atKeyOptional key (nullable text)
-
-firstPresent :: [Maybe value] -> Maybe value
-firstPresent = firstJust
 
 errorTypeFromStatus :: Int -> ErrorType
 errorTypeFromStatus = \case
@@ -222,11 +220,6 @@ retryAfterFromMessage message = do
         character == '.' || character >= '0' && character <= '9'
     isAsciiLetter character =
         character >= 'a' && character <= 'z'
-
-firstJust :: [Maybe a] -> Maybe a
-firstJust [] = Nothing
-firstJust (Just value : _) = Just value
-firstJust (Nothing : rest) = firstJust rest
 
 isPreviousResponseIdError :: ApiError -> Bool
 isPreviousResponseIdError = \case

--- a/packages/agent-responses/test/Agent/Responses/SSESpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/SSESpec.hs
@@ -121,6 +121,32 @@ spec = describe "Responses SSE decoder" do
                         Text.isInfixOf "\"x-codex-turn-state\":\"direct\""
             [] -> expectationFailure "expected turn-state events"
 
+    it "keeps turn-state precedence and falls back through absent fields" do
+        let nested =
+                "\"headers\":{\"x-codex-turn-state\":\"nested\",\"turn_state\":\"nested-alias\"}"
+            fields =
+                [ "\"x-codex-turn-state\":\"direct\",\"turn_state\":\"alias\"," <> nested
+                , "\"turn_state\":\"alias\"," <> nested
+                , nested
+                , "\"headers\":{\"turn_state\":\"nested-alias\"}"
+                , "\"headers\":{}"
+                , "\"x-codex-turn-state\":\"\",\"turn_state\":\"alias\"," <> nested
+                ]
+        events <- expectRight $ parseSseEvents $ Text.concat
+            [ sseBlock "response.output_text.done"
+                ("{\"type\":\"response.output_text.done\"," <> field <> "}")
+            | field <- fields
+            ]
+        [turnState | OtherResponseStreamEvent { turnState } <- events]
+            `shouldBe`
+                [ Just "direct"
+                , Just "alias"
+                , Just "nested"
+                , Just "nested-alias"
+                , Nothing
+                , Just ""
+                ]
+
     it "round-trips typed Codex rate limits through Aeson encoding" do
         let payload =
                 "{\"type\":\"codex.rate_limits\",\"sequence_number\":7,"

--- a/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
+++ b/packages/agent-runtime-daemon/src/Agent/Runtime/Daemon/Journal.hs
@@ -38,6 +38,7 @@ import Data.Foldable (toList)
 import Data.List (isInfixOf)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
+import Data.Maybe (listToMaybe)
 import qualified Data.Sequence as Seq
 import Data.Sequence (Seq)
 import Data.Text (Text)
@@ -301,7 +302,7 @@ replayAfter journal cursor =
 replayFromState :: Sequence -> JournalState -> Replay
 replayFromState cursor journalState =
     let events = toList journalState.retainedEvents
-        earliest = fmap (.sequenceNumber) (safeHead events)
+        earliest = fmap (.sequenceNumber) (listToMaybe events)
         replayGap =
             case earliest of
                 Nothing -> cursor < journalState.durableSnapshot.lastSequence
@@ -655,11 +656,6 @@ eventsPath config = config.directory </> "events.jsonl"
 
 encodeLine :: ToJSON value => value -> BS.ByteString
 encodeLine value = LBS.toStrict (encode value) <> "\n"
-
-safeHead :: [value] -> Maybe value
-safeHead = \case
-    value : _ -> Just value
-    [] -> Nothing
 
 takeLast :: Int -> [value] -> [value]
 takeLast count values = drop (max 0 (length values - max 0 count)) values

--- a/packages/agent-telegram/agent-telegram.cabal
+++ b/packages/agent-telegram/agent-telegram.cabal
@@ -77,6 +77,7 @@ library
                     , process >= 1.6.26
                     , retry >= 0.9.3.1 && < 0.10
                     , safe-exceptions
+                    , split >= 0.2 && < 0.3
                     , text >= 2.0 && < 2.2
                     , time
                     , unix

--- a/packages/agent-telegram/package.nix
+++ b/packages/agent-telegram/package.nix
@@ -2,7 +2,7 @@
 , agent-store, async, base, bytestring, containers, directory
 , filelock, filepath, hspec, http-client, http-client-tls
 , http-types, lib, optparse-applicative, process, retry
-, safe-exceptions, temporary, text, time, unix, vector
+, safe-exceptions, split, temporary, text, time, unix, vector
 }:
 mkDerivation {
   pname = "agent-telegram";
@@ -14,7 +14,7 @@ mkDerivation {
     aeson agent-cli-runtime agent-core agent-json agent-store async
     base bytestring containers directory filelock filepath http-client
     http-client-tls http-types optparse-applicative process retry
-    safe-exceptions text time unix vector
+    safe-exceptions split text time unix vector
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [

--- a/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
+++ b/packages/agent-telegram/src/Agent/Telegram/Bridge.hs
@@ -34,6 +34,7 @@ import Data.Aeson (Value(..))
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef, readIORef, writeIORef)
 import Data.List (isPrefixOf, sort)
+import qualified Data.List.Split as Split
 import Data.Functor ((<&>))
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe)
@@ -760,7 +761,4 @@ pathIsAllowed root path = do
 chunksOf :: Int -> [a] -> [[a]]
 chunksOf size values
     | size <= 0 = []
-    | null values = []
-    | otherwise =
-        let (chunk, rest) = splitAt size values
-        in chunk : chunksOf size rest
+    | otherwise = Split.chunksOf size values


### PR DESCRIPTION
## Summary
- Replace manual Maybe/list helpers with standard library functions, and use nubOrdOn, anyM, and split chunksOf.
- Preserve first-occurrence ordering, fallback precedence, short-circuiting, and existing nonpositive chunk-size behavior.
- Update Cabal dependencies and generated Nix expressions; require base >= 4.19 for Data.List.unsnoc.
- Add picker, skill-deduplication, and streaming precedence regressions.

## Validation
- Seven affected libraries loaded together in GHCi: 608 modules loaded successfully.
- Focused GHCi suites: Skills 20, Picker 12, SSE 15, Mail 35 examples; zero failures. SSE QuickCheck: 500 cases passed.
- Mail chunking: 168 old/new comparisons passed, including empty lists and sizes -2 through 5.
- Live source-backed tmux smoke: prompt/status rendering, model-picker Down navigation and Escape cancellation, graceful exit to GHCi.
- git diff --check passed.

Behavior-preserving cleanup; no performance claim.