### PR TITLE
Reduce CLI command-history memory with Text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,10 @@ separately and reverted because flattening the complete body for every Markdown
 render made it slower and allocated more than the strict-`Text` baseline.
 
 # haskell
+- Prefer strict `Text` for application text and retained textual state, and
+  `ByteString` for encoded or binary data. Keep `String` conversions at APIs
+  that require them; do not replace `FilePath` with `Text` mechanically.
+  Audit `Text.unpack` and `[Char]` as well as explicit `String` signatures.
 - Prefer Control.Exception.Safe over Control.Exception
 - Never use bare `Control.Concurrent.Async.async`. Prefer structured
   concurrency (`withAsync`, `race`, `concurrently`, etc.) so child lifetimes

--- a/packages/agent-cli/HEAP_ANALYSIS.md
+++ b/packages/agent-cli/HEAP_ANALYSIS.md
@@ -1,0 +1,89 @@
+# macOS memory investigation — 2026-09-12
+
+## Method and limits
+
+Measurements used the installed optimized Nix CLI (`7shn2y7g5njgqmr6ynhcz81zqdl0x80r`),
+ARM64 macOS 26.6.1, default `-N4 -M8G`, in separate temporary tmux sessions.
+The workload was minimal interactive startup followed by short model replies,
+with no tool calls. Filesystem skills, AGENTS.md, and computer use were disabled.
+This is not a large-transcript or MCP-heavy workload and does not establish the
+retained heap of the user's older, already-running binaries.
+
+Built-in `+RTS -T -S<file>` supplied GC observations; a separate `-hT -i1`
+run supplied closure-type profiles. Heap profiling perturbs collection behaviour.
+macOS physical footprint came from `vmmap -summary`, not summed RSS or virtual size.
+
+## Observations
+
+| Checkpoint | Live heap after major GC | Physical footprint |
+| --- | ---: | ---: |
+| Fresh baseline, before first prompt | about 25 MiB | 149.8 MiB |
+| Baseline after a short turn and idle | about 21.8 MiB | 84.4 MiB |
+| Baseline after another short turn and idle | about 21.8 MiB | 84.7 MiB |
+
+The settled baseline had about 62 MiB of dirty/resident anonymous VM, versus
+about 21.8 MiB live heap. Copying-GC space, allocation areas, unused capacity,
+and page-return behaviour must therefore be distinguished from live data.
+Native allocations, writable library data, and runtime metadata add further overhead.
+The 1 TiB GHC virtual reservation was unallocated; the 8 GiB setting is a limit,
+not a per-process allocation.
+
+A separate trial with `--disable-delayed-os-memory-return` did **not** improve
+footprint: it settled at 181.6 MiB with roughly the same 21.8 MiB live heap.
+Its anonymous VM included 83.3 MiB reported swapped out. These single runs were
+not matched for all timing and system-pressure effects, so do not infer a
+general regression or adopt that flag as a fix from this experiment.
+
+## History retention and remaining leads
+
+An idle closure profile totalled about 20.9 MiB, including 14.4 MiB of list
+cons cells. Byte arrays were about 1.6 MiB; ASN.1 decoding structures also
+contributed, consistent with certificate-related state. Closure types alone
+do not identify ownership of generic lists or byte arrays.
+
+The inline editor (`src/Agent/CLI/Input.hs`, `readHistory` and `editorLoop`)
+retains Haskeline history containing `String` values while waiting for input.
+It also creates a lazy `map Text.pack` view, which does not release the
+original history needed by the save path.
+
+An isolated optimized Haskeline harness confirmed the cost of this representation.
+It fully traversed the history and retained it in an IORef read after major GC;
+only numeric counts were printed. Across three runs, 8,897 entries containing
+530,427 characters occupied 12,991,400 live bytes versus a blank-process median
+of 48,720 bytes: **12.34 MiB additional live heap** from a roughly 540 KB file.
+RTS heap capacity was 55 MiB versus 21 MiB in the blank harness; this capacity
+delta is not a prediction of application physical-footprint savings.
+
+A subsequent paired three-run comparison (8,898 entries / 530,437 characters;
+another process had appended one entry) retained only fully evaluated strict
+`Text` entries instead. Median total live bytes fell from 12,991,648 to
+1,316,616: **11.13 MiB less live heap, about 90% of this representation's cost**.
+RTS heap capacity fell from 55 to 30 MiB in the isolated harness.
+The editor now retains compact history and reads/writes Text directly without
+deleting on-disk history. See [the implementation benchmark](benchmark/CommandHistory.md).
+End-to-end CLI footprint savings have not yet been measured.
+
+Converting after `readHistory` does not remove parsing allocation: cumulative
+allocation was about 92 MB for original history versus 94.4 MB for Text-only.
+The baseline CLI allocated roughly 22 GiB cumulatively during the short test;
+that is allocation churn, not simultaneous residency. A single history read
+does not explain it. Attribution of that churn remains open.
+
+Existing transcript eviction and major collection at turn completion are
+already implemented. The short-run results do not show substantial live-heap
+growth across turns, but cannot rule out leaks under other workloads.
+MCP fleet/catalog retention and output-artifact caches remain separate leads
+for larger sessions; their contribution was not isolated here.
+
+## Diagnostic implementation
+
+See [HEAP_DIAGNOSTICS.md](HEAP_DIAGNOSTICS.md) for the new opt-in numeric CSV
+sampler. Normal operation is unchanged when the variable is absent.
+Validation passed GHCi typechecking and an optimized standalone harness covering
+disabled mode, missing RTS statistics, invalid forced-GC settings, periodic/final
+samples, forced major collections, and append/header behaviour.
+
+The initial offline application build lacked a `hermes` source checkout.
+After fetching it, all 251 CLI library modules loaded successfully in Cabal GHCi.
+The new executable integration has not been deployed. Production memory
+measurements above use the existing executable, not the new sampler.

--- a/packages/agent-cli/HEAP_DIAGNOSTICS.md
+++ b/packages/agent-cli/HEAP_DIAGNOSTICS.md
@@ -1,0 +1,52 @@
+# CLI heap diagnostics
+
+Use an optimized executable for memory investigations. GHCi is suitable for
+validating the diagnostic module, but its interpreter and loaded modules make
+its memory footprint unsuitable as an application baseline.
+
+```sh
+AGENT_HEAP_DIAGNOSTICS="$TMPDIR/agent_heap_observations.csv" \
+  agent-cli +RTS -T -RTS
+```
+
+The executable appends numeric CSV observations at startup, approximately once
+per second, and when the CLI action exits. It writes a header when the file is
+empty. Use a separate file for each concurrently running process. The parent
+directory must already exist. Unset the variable to disable the sampler.
+
+Each row contains Unix time, monotonic elapsed nanoseconds, process ID, whether
+a major collection was requested, collection counts, cumulative allocations,
+maximum residency, the most recent collection's heap statistics, and cumulative
+GC/mutator CPU and elapsed times. No prompts, tool contents, or credentials are
+recorded. Logging errors fail the diagnostic run rather than silently losing
+observations.
+
+## Interpretation
+
+- `last_gc_live_bytes` and related columns describe the **last completed GC**,
+  not necessarily a major collection or the current instant. Inspect
+  `last_gc_generation`, `gcs`, and `major_gcs`; repeated values while idle can
+  represent the same old collection.
+- `allocated_bytes` is cumulative allocation, not resident memory.
+- `last_gc_mem_in_use_bytes` includes RTS heap capacity, not just live objects.
+  It does not account for every native allocation or mapped executable page.
+- Compare these values with macOS `vmmap -summary PID` physical footprint.
+  Reserved virtual address space is not physical memory.
+
+For a separate, deliberately intrusive major-GC experiment:
+
+```sh
+AGENT_HEAP_DIAGNOSTICS="$TMPDIR/agent_heap_forced_collections.csv" \
+AGENT_HEAP_DIAGNOSTICS_FORCE_GC=1 \
+  agent-cli +RTS -T -RTS
+```
+
+This requests a major collection before every sample. It changes allocation,
+timing, and heap-return behaviour; do not treat it as a normal performance
+baseline. Other threads can collect between the request and the observation,
+so inspect the generation and collection counts even in this mode.
+
+Compare the same executable and workload at startup, after MCP discovery,
+after a completed turn, and during idle. Repeat runs before attributing a
+difference to a particular subsystem. Existing processes cannot acquire this
+instrumentation without restarting with the diagnostic-enabled executable.

--- a/packages/agent-cli/STRING_AUDIT.md
+++ b/packages/agent-cli/STRING_AUDIT.md
@@ -1,0 +1,32 @@
+# Application text representation audit
+
+2026-09-12. Static review of production Haskell under `packages`, including
+`String`, `[Char]`, and `Text.unpack`. This identifies candidates, not measured
+performance improvements outside the command-history benchmark.
+
+## Prioritized follow-up
+
+| Priority | Module | Finding and acceptance criteria |
+| --- | --- | --- |
+| High | `agent-cli/src/Agent/CLI/GitDiff.hs` | `GitCommandOutput` stores complete stdout/stderr as `String`. `readHandleStrict` decodes bytes to Text then unpacks; consumers repack. Retain Text directly, converting individual paths only at process boundaries. Benchmark large diffs and preserve NUL-separated paths and invalid-UTF-8 policy. |
+| High | `agent-tui/src/Agent/TUI/TextWidth.hs` | `graphemeClusters` unpacks entire input, constructs character lists, then packs clusters; width checks also unpack. Benchmark Text traversal/slices in actual rendering and cursor workloads; preserve combining marks, flags, ZWJ, modifiers and terminal-width compatibility. |
+| Medium | `agent-cli/src/Agent/CLI/Clipboard/{MacOS,Linux}.hs` | Process capture passes potentially large clipboard content through String. Prefer byte capture with explicit decoding and Text results. Preserve subprocess cleanup, errors, and paste behavior. |
+| Medium | `agent-tui/src/Agent/TUI/Markdown/Block.hs` | `splitTableRow` unpacks each row and constructs reversed character lists. Benchmark a Text scanner/builder; preserve escaped pipes and code spans. |
+| Medium | `agent-store/src/Agent/Store/Postgres/Custom/Sql.hs` | `splitTopLevelStatements` unpacks complete SQL batches and constructs character-list statements. Separate parser change with equivalence tests for dollar quotes, escaping and nested comments. |
+| Lower | `agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs` | Quote and ampersand scanning unpacks command text. Security-sensitive: preserve parser decisions before considering performance. |
+| Lower | `agent-mcp/src/Agent/MCP/Types.hs` | Arguments/environment retained as `[String]` and `[(String,String)]`. Text storage could defer conversion until process creation, but no significant memory contribution has been established. |
+
+## Boundaries that should remain explicit
+
+- `Aeson.String` already contains Text; it is not a linked-list String.
+- File paths need `FilePath` or `OsPath` semantics, not a mechanical Text substitution.
+- Process arguments/environment, `Show`/`Read`, `fail`, command-line parsers,
+  URI/WebSocket and FFI APIs may require String. Convert at those boundaries.
+- Small error messages, short terminal escape sequences, tiny character sets,
+  and base URLs are lower priority than large retained content.
+- Strict Text is the application-text default; ByteString is appropriate for
+  encoded/protocol or binary data. This convention is recorded in `AGENTS.md`.
+
+The history replacement is implemented separately. The candidates above are
+not changed in this audit; each needs focused compatibility tests and an
+optimized benchmark before making a performance claim.

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -350,6 +350,7 @@ library
                     , containers
                     , crypton-connection
                     , crypton
+                    , deepseq
                     , directory
                     , dbus >= 1.4 && < 1.5
                     , entropy
@@ -392,13 +393,18 @@ executable agent-cli
     import:           common-options
     hs-source-dirs:   app
     main-is:          Main.hs
+    other-modules:    HeapDiagnostics
     -- Keep enough capabilities for concurrent agent work without multiplying
     -- the RTS allocation area by every host core.
     ghc-options:      -threaded -rtsopts "-with-rtsopts=-N4 -M8G"
     build-depends:    agent-cli
+                    , async
                     , base >= 4.17 && < 5
                     , directory
                     , filepath
+                    , safe-exceptions
+                    , time
+                    , unix
 
 executable eval-ghci-vs-bash
     import:           common-options
@@ -498,6 +504,24 @@ benchmark history-retention-bench
     build-depends:    agent-cli
                     , base >= 4.17 && < 5
                     , text
+
+benchmark command-history-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark, src
+    main-is:          CommandHistory.hs
+    other-modules:    Agent.CLI.Input.History
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T -N4"
+    build-depends:    agent-cli-runtime
+                    , base >= 4.17 && < 5
+                    , deepseq
+                    , directory
+                    , filepath
+                    , haskeline
+                    , safe-exceptions
+                    , temporary
+                    , text
+                    , unix
 
 benchmark history-eviction-bench
     import:           common-options
@@ -603,6 +627,7 @@ test-suite agent-cli-test
                     , Agent.CLI.ImagePreviewSpec
                     , Agent.CLI.ChartImageSpec
                     , Agent.CLI.InputSpec
+                    , Agent.CLI.InputHistorySpec
                     , Agent.CLI.InterruptSpec
                     , Agent.CLI.VoiceAudioSpec
                     , Agent.CLI.LoginSpec

--- a/packages/agent-cli/app/HeapDiagnostics.hs
+++ b/packages/agent-cli/app/HeapDiagnostics.hs
@@ -1,0 +1,113 @@
+-- | Opt-in numeric RTS observations for controlled memory investigations.
+--
+-- Normal sampling does not collect garbage. The @last_gc_*@ columns describe
+-- the latest completed collection, which can be a minor collection and can be
+-- stale while idle. They are not necessarily current major-GC residency.
+-- Setting @AGENT_HEAP_DIAGNOSTICS_FORCE_GC=1@ requests a major collection before
+-- each observation; this deliberately perturbs runtime behaviour and must not
+-- be used as an uninstrumented performance baseline.
+module HeapDiagnostics (withHeapDiagnostics) where
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (link, withAsync)
+import Control.Exception.Safe (finally)
+import Control.Monad (forever, unless, when)
+import Data.List (intercalate)
+import Data.Time.Clock.POSIX (getPOSIXTime)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (GCDetails(..), RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.Environment (lookupEnv)
+import System.Exit (die)
+import System.IO
+    ( BufferMode(LineBuffering)
+    , Handle
+    , IOMode(AppendMode)
+    , hFileSize
+    , hPutStrLn
+    , hSetBuffering
+    , withFile
+    )
+import System.Mem (performMajorGC)
+import System.Posix.Process (getProcessID)
+
+withHeapDiagnostics :: IO a -> IO a
+withHeapDiagnostics action =
+    lookupEnv "AGENT_HEAP_DIAGNOSTICS" >>= \case
+        Nothing -> action
+        Just path -> do
+            when (null path) $
+                die "AGENT_HEAP_DIAGNOSTICS must name a CSV output file."
+            enabled <- getRTSStatsEnabled
+            unless enabled $
+                die "AGENT_HEAP_DIAGNOSTICS requires RTS statistics: add +RTS -T -RTS."
+            forcedSetting <- lookupEnv "AGENT_HEAP_DIAGNOSTICS_FORCE_GC"
+            forceCollection <- case forcedSetting of
+                Nothing -> pure False
+                Just "0" -> pure False
+                Just "1" -> pure True
+                _ -> die "AGENT_HEAP_DIAGNOSTICS_FORCE_GC must be 0 or 1."
+            processId <- getProcessID
+            started <- getMonotonicTimeNSec
+            withFile path AppendMode \handle -> do
+                hSetBuffering handle LineBuffering
+                size <- hFileSize handle
+                when (size == 0) $ hPutStrLn handle header
+                let sample = do
+                        when forceCollection performMajorGC
+                        timestamp <- getPOSIXTime
+                        observed <- getMonotonicTimeNSec
+                        statistics <- getRTSStats
+                        writeSample handle
+                            [ show (realToFrac timestamp :: Double)
+                            , show (observed - started)
+                            , show processId
+                            , if forceCollection then "1" else "0"
+                            ]
+                            statistics
+                sample
+                (withAsync (forever (threadDelay 1000000 >> sample)) \worker -> do
+                    link worker
+                    action)
+                    `finally` sample
+
+header :: String
+header = intercalate ","
+    [ "unix_seconds"
+    , "observation_elapsed_ns"
+    , "pid"
+    , "forced_major_gc"
+    , "gcs"
+    , "major_gcs"
+    , "allocated_bytes"
+    , "max_live_bytes"
+    , "max_mem_in_use_bytes"
+    , "last_gc_generation"
+    , "last_gc_live_bytes"
+    , "last_gc_mem_in_use_bytes"
+    , "last_gc_large_objects_bytes"
+    , "last_gc_slop_bytes"
+    , "gc_cpu_ns"
+    , "gc_elapsed_ns"
+    , "mutator_cpu_ns"
+    , "mutator_elapsed_ns"
+    ]
+
+writeSample :: Handle -> [String] -> RTSStats -> IO ()
+writeSample handle prefix statistics =
+    hPutStrLn handle $ intercalate "," $
+        prefix <>
+            [ show statistics.gcs
+            , show statistics.major_gcs
+            , show statistics.allocated_bytes
+            , show statistics.max_live_bytes
+            , show statistics.max_mem_in_use_bytes
+            , show statistics.gc.gcdetails_gen
+            , show statistics.gc.gcdetails_live_bytes
+            , show statistics.gc.gcdetails_mem_in_use_bytes
+            , show statistics.gc.gcdetails_large_objects_bytes
+            , show statistics.gc.gcdetails_slop_bytes
+            , show statistics.gc_cpu_ns
+            , show statistics.gc_elapsed_ns
+            , show statistics.mutator_cpu_ns
+            , show statistics.mutator_elapsed_ns
+            ]

--- a/packages/agent-cli/app/Main.hs
+++ b/packages/agent-cli/app/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 import Agent.CLI (run)
 import Control.Monad (when)
+import HeapDiagnostics (withHeapDiagnostics)
 import System.Directory (canonicalizePath, doesFileExist)
 import System.Environment (getExecutablePath, lookupEnv, setEnv)
 import System.FilePath ((</>), searchPathSeparator, takeDirectory)
@@ -10,7 +11,7 @@ import System.IO.Error (catchIOError)
 main :: IO ()
 main = do
     configurePortableBundle
-    run
+    withHeapDiagnostics run
 
 -- | Configure resources shipped next to the standalone macOS executable.
 --

--- a/packages/agent-cli/benchmark/CommandHistory.hs
+++ b/packages/agent-cli/benchmark/CommandHistory.hs
@@ -1,0 +1,113 @@
+module Main (main) where
+
+import Agent.CLI.Input.History (appendReplHistoryAt, readReplHistoryAt)
+import Agent.CLI.PrivateFileLock (withPrivateFileLock)
+import Control.Exception (evaluate)
+import Control.Monad (replicateM, unless)
+import Data.IORef (newIORef, readIORef)
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (GCDetails(..), RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import qualified System.Console.Haskeline.History as Haskeline
+import System.CPUTime (getCPUTime)
+import System.Directory (copyFile)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Mem (performMajorGC)
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Files (setFileMode)
+import Text.Printf (printf)
+import Text.Read (readMaybe)
+
+-- Keep the original Haskeline representation alive as the old editor did.
+data Retained = Original Haskeline.History [Text] | Compact [Text]
+
+data Observation = Observation !Double !Double !Integer !Integer
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    unless enabled (die "enable RTS statistics with +RTS -T")
+    arguments <- getArgs
+    case arguments of
+        [operation, countArgument, widthArgument, samplesArgument] -> do
+            count <- positive countArgument
+            width <- positive widthArgument
+            samples <- positive samplesArgument
+            withSystemTempDirectory "command-history-benchmark" \directory -> do
+                let fixture = directory </> "fixture"
+                    working = directory </> "history"
+                    entries =
+                        [ Text.pack (show index) <> Text.replicate width "x"
+                        | index <- [1 .. count]
+                        ]
+                Haskeline.writeHistory fixture $
+                    foldr (Haskeline.addHistory . Text.unpack) Haskeline.emptyHistory entries
+                observations <- replicateM samples do
+                    copyFile fixture working
+                    measure (runOperation operation working)
+                let elapsed = [value | Observation value _ _ _ <- observations]
+                    cpu = [value | Observation _ value _ _ <- observations]
+                    allocated = [value | Observation _ _ value _ <- observations]
+                    live = [value | Observation _ _ _ value <- observations]
+                printf "%s,%d,%d,%d,%.3f,%.3f,%d,%d\n"
+                    operation count width samples (median elapsed) (median cpu)
+                    (median allocated) (median live)
+        _ -> die "usage: command-history-bench OPERATION ENTRIES WIDTH SAMPLES (+RTS -T); operations: original-read, compact-read, original-append, compact-append"
+
+positive :: String -> IO Int
+positive raw = case readMaybe raw of
+    Just value | value > 0 -> pure value
+    _ -> die "expected a positive integer"
+
+median :: Ord a => [a] -> a
+median values = sort values !! (length values `div` 2)
+
+runOperation :: String -> FilePath -> IO Retained
+runOperation operation path = case operation of
+    "original-read" -> do
+        history <- Haskeline.readHistory path
+        pure (Original history (map Text.pack (Haskeline.historyLines history)))
+    "compact-read" -> Compact <$> readReplHistoryAt path
+    "original-append" -> do
+        withPrivateFileLock (unsafeEncodeUtf (path <> ".lock")) do
+            history <- Haskeline.readHistory path
+            Haskeline.writeHistory path (Haskeline.addHistory "benchmark submission" history)
+            setFileMode path 0o600
+        pure (Compact [])
+    "compact-append" -> do
+        appendReplHistoryAt path "benchmark submission"
+        pure (Compact [])
+    _ -> die "unknown benchmark operation"
+
+checksum :: Retained -> Int
+checksum retained = case retained of
+    Original history entries ->
+        sum (map length (Haskeline.historyLines history)) + sum (map Text.length entries)
+    Compact entries -> sum (map Text.length entries)
+
+{-# NOINLINE measure #-}
+measure :: IO Retained -> IO Observation
+measure action = do
+    performMajorGC
+    before <- getRTSStats
+    started <- getMonotonicTimeNSec
+    cpuStarted <- getCPUTime
+    result <- action
+    retained <- newIORef result
+    _ <- evaluate (checksum result)
+    cpuFinished <- getCPUTime
+    finished <- getMonotonicTimeNSec
+    performMajorGC
+    after <- getRTSStats
+    -- The reference is read after collection, preventing dead-result elimination.
+    _ <- readIORef retained >>= evaluate . checksum
+    pure $ Observation
+        (fromIntegral (finished - started) / 1e6)
+        (fromIntegral (cpuFinished - cpuStarted) / 1e9)
+        (toInteger after.allocated_bytes - toInteger before.allocated_bytes)
+        (toInteger after.gc.gcdetails_live_bytes - toInteger before.gc.gcdetails_live_bytes)

--- a/packages/agent-cli/benchmark/CommandHistory.md
+++ b/packages/agent-cli/benchmark/CommandHistory.md
@@ -1,0 +1,72 @@
+# Command history: String versus Text
+
+Measured 2026-09-12 on ARM64 macOS, Nix GHC 9.10.3, optimized `-O2`,
+`+RTS -T -N4`. Synthetic newest-first entries contain an integer followed by
+60 ASCII characters. Each row is the median of five samples. Fixture creation
+and copying are outside measurement; reads and appends use the real history code.
+
+| Entries | Operation | Elapsed ms | CPU ms | Allocated bytes | Retained live bytes |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 1,000 | Original read | 3.718 | 3.759 | 11,248,720 | 1,658,872 |
+| 1,000 | Text read | 0.349 | 0.370 | 386,168 | 112,344 |
+| 9,000 | Original read | 52.391 | 55.413 | 102,488,032 | 15,185,056 |
+| 9,000 | Text read | 1.912 | 1.909 | 2,318,792 | 1,080,344 |
+| 18,000 | Original read | 111.547 | 119.387 | 206,478,784 | 30,669,032 |
+| 18,000 | Text read | 4.092 | 4.126 | 4,510,328 | 2,177,344 |
+| 1,000 | Original append | 5.315 | 5.480 | 14,561,312 | — |
+| 1,000 | Text append | 0.495 | 0.492 | 616,520 | — |
+| 9,000 | Original append | 52.438 | 59.953 | 131,945,040 | — |
+| 9,000 | Text append | 2.910 | 2.516 | 4,165,144 | — |
+| 18,000 | Original append | 119.979 | 130.918 | 265,797,488 | — |
+| 18,000 | Text append | 6.821 | 5.284 | 8,190,816 | — |
+
+A second independent 9,000-entry run produced 51.375/1.930 ms original/Text
+reads and 55.082/2.744 ms appends, with identical retained read heap.
+After the final caller-controlled whitespace adjustment, a fresh build and
+repeat inside `nix develop` confirmed 50.633/1.951 ms reads and 55.266/2.809 ms
+appends at 9,000 entries (five-sample medians). Read allocation was
+102,488,544/2,342,776 bytes and retained heap remained identical. A second
+repeat gave 52.040/1.942 ms reads and 54.877/2.704 ms appends. The 1,000- and
+18,000-entry repeats also improved both CPU time and allocation.
+At that size, retained heap drops 92.9% (14.48 to 1.03 MiB), and read allocation
+drops 97.7%. This is not a measurement of whole-application physical footprint.
+
+Original read retains both Haskeline's String history and a fully traversed Text
+view, modeling history navigation rather than untouched idle startup (where the
+old Text view was lazy). New read includes file-lock overhead. Both append
+variants reread under the private lock and rewrite the same file; this models
+the old fullscreen append, not the inline editor's former stale-snapshot save.
+Live bytes are major-GC deltas with results retained through an IORef;
+append returns no history, so its small negative GC deltas are not useful.
+Timing excludes the explicit post-operation major collection; allocation deltas
+include it. OS caches and concurrent system load can affect timing.
+
+## Reproduce
+
+From the repository root, using session temporary storage:
+
+```sh
+mkdir -p "$TMPDIR/command-history"
+nix develop -c ghc -O2 -Wall -threaded -rtsopts \
+  -XGHC2021 -XBlockArguments -XOverloadedStrings -XOverloadedRecordDot \
+  -XNoFieldSelectors -XDuplicateRecordFields -XLambdaCase \
+  -ipackages/agent-cli/src -ipackages/agent-cli-runtime/src -ipackages/agent-core/src \
+  -outputdir "$TMPDIR/command-history/objects" \
+  packages/agent-cli/benchmark/CommandHistory.hs \
+  -o "$TMPDIR/command-history/benchmark"
+for n in 1000 9000 18000 9000; do
+  for op in original-read compact-read original-append compact-append; do
+    nix develop -c "$TMPDIR/command-history/benchmark" "$op" "$n" 60 5 +RTS -T -N4
+  done
+done
+```
+
+The Cabal benchmark is registered as `command-history-bench`. Direct compilation
+was initially used because the offline Cabal build lacked a hermes checkout.
+Six focused GHCi tests pass: Haskeline format compatibility, malformed UTF-8,
+byte-identical writes, missing files/caller-controlled whitespace, duplicates, and concurrent appends
+with private permissions. After fetching the dependency, all 251 CLI library
+modules loaded successfully with `nix develop -c cabal repl agent-cli:lib:agent-cli`.
+The source-loaded inline editor was exercised in tmux: Unicode submission and
+Up-arrow recall both preserved `history café`. Full-agent startup in the isolated
+test home was blocked by macOS's PostgreSQL Unix-socket path length limit.

--- a/packages/agent-cli/package.nix
+++ b/packages/agent-cli/package.nix
@@ -29,7 +29,7 @@ mkDerivation {
     agent-responses-types agent-store agent-syntax agent-tui
     agent-webrtc agent-xai ansi-terminal async base base64-bytestring
     brick bytestring colour containers crypton crypton-connection dbus
-    directory entropy filelock filepath haskeline hasql-pool
+    deepseq directory entropy filelock filepath haskeline hasql-pool
     http-client http-client-tls http-types JuicyPixels memory mtl
     network network-uri optparse-applicative process resourcet retry
     safe-exceptions scientific stm tagsoup terminfo text time tls
@@ -37,8 +37,8 @@ mkDerivation {
   ];
   executableHaskellDepends = [
     aeson agent-cli-runtime agent-responses agent-responses-types
-    agent-store base bytestring containers directory filepath process
-    safe-exceptions text time unix
+    agent-store async base bytestring containers directory filepath
+    process safe-exceptions text time unix
   ];
   testHaskellDepends = [
     aeson agent-claude agent-cli-runtime agent-codex-dialect
@@ -55,8 +55,8 @@ mkDerivation {
     aeson agent-cli-runtime agent-core agent-json agent-mcp
     agent-openai agent-responses agent-responses-types agent-store
     agent-tui ansi-terminal async base brick bytestring colour
-    containers deepseq directory filepath JuicyPixels process
-    safe-exceptions stm text time unix vty
+    containers deepseq directory filepath haskeline JuicyPixels process
+    safe-exceptions stm temporary text time unix vty
   ];
   description = "Command-line interface for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-cli/src/Agent/CLI/Input.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input.hs
@@ -96,13 +96,6 @@ import System.Console.ANSI
     )
 import System.Console.ANSI.Codes
     ( cursorUpCode )
-import System.Console.Haskeline.History
-    ( addHistory
-    , emptyHistory
-    , historyLines
-    , readHistory
-    , writeHistory
-    )
 import System.Directory
     ( getHomeDirectory
     )
@@ -326,19 +319,17 @@ readInlineEditor
                     (hHideCursor stdout)
                     (\_ -> hShowCursor stdout >> hFlush stdout)
                     \() -> do
-                        history <-
+                        entries <-
                             if historyEnabled
-                                then
-                                    readHistory historyPath
-                                        `catchIO` \_ -> pure emptyHistory
-                                else pure emptyHistory
-                        let entries = map Text.pack (historyLines history)
-                            state =
+                                then readReplHistoryAt historyPath
+                                    `catchIO` \_ -> pure []
+                                else pure []
+                        let state =
                                 initialEditorState catalog slashEnabled initial
                         redrawEditor prompt state
-                        editorLoop history entries state
+                        editorLoop entries state
   where
-    editorLoop history entries state = do
+    editorLoop entries state = do
         key <- readEditorKey
         case (historyEnabled, key, currentMenu state) of
             (False, EditorEscape, Nothing) ->
@@ -358,9 +349,9 @@ readInlineEditor
           case requested of
             RedrawEditor -> do
                 redrawEditor prompt next
-                editorLoop history entries next
+                editorLoop entries next
             SubmitEditor ->
-                finish history next
+                finish next
             ReturnEditor line -> do
                 finishEditorLine prompt next
                 pure line
@@ -372,14 +363,14 @@ readInlineEditor
                             finishEditorLine prompt next
                             Text.putStrLn "^C"
                             redrawEditor prompt next
-                            editorLoop history entries next
+                            editorLoop entries next
                         QuitProcess -> do
                             finishEditorLine prompt next
                             pure ReplQuitInterrupt
             ClearEditorScreen -> do
                 Text.hPutStr stdout "\ESC[2J\ESC[H"
                 redrawEditor prompt next
-                editorLoop history entries next
+                editorLoop entries next
             DictateIntoEditor -> do
                 finishEditorLine prompt next
                 result <- tryAny $
@@ -409,22 +400,20 @@ readInlineEditor
                                 , editorSlashDismissed = False
                                 }
                 redrawEditor prompt state'
-                editorLoop history entries state'
+                editorLoop entries state'
             ReportEditorError message -> do
                 finishEditorLine prompt next
                 Text.putStrLn ("input ignored: " <> message)
                 redrawEditor prompt next
-                editorLoop history entries next
+                editorLoop entries next
             IgnoreEditorInput ->
-                editorLoop history entries next
-        finish history' state' = do
+                editorLoop entries next
+        finish state' = do
             finishEditorLine prompt state'
             let text = state'.editorText
             when historyEnabled $
                 unless (Text.all (== ' ') text) $
-                    writeHistory
-                        historyPath
-                        (addHistory (Text.unpack text) history')
+                    appendReplHistoryAt historyPath text
                         `catchIO` \_ -> pure ()
             pure $
                 if state'.editorPasted

--- a/packages/agent-cli/src/Agent/CLI/Input/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/Input/History.hs
@@ -3,21 +3,27 @@ module Agent.CLI.Input.History
     ( replHistoryPath
     , readReplHistory
     , appendReplHistory
+    , readReplHistoryAt
+    , appendReplHistoryAt
     , ensureHistoryParent
     , trySetMode
     ) where
 
 import Agent.CLI.PrivateFileLock (withPrivateFileLock)
+import Control.DeepSeq (force)
 import Control.Exception.Safe (catchIO)
 import Data.Char (isSpace)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import System.Console.Haskeline.History
-    ( addHistory
-    , emptyHistory
-    , historyLines
-    , readHistory
-    , writeHistory
+import qualified Data.Text.IO as Text
+import System.IO
+    ( IOMode(ReadMode, WriteMode)
+    , hSetEncoding
+    , hSetNewlineMode
+    , mkTextEncoding
+    , noNewlineTranslation
+    , utf8
+    , withFile
     )
 import System.Directory (createDirectoryIfMissing, getHomeDirectory)
 import System.FilePath (takeDirectory, (</>))
@@ -31,26 +37,50 @@ replHistoryPath home = home </> ".haskell-agent" </> "history"
 readReplHistory :: IO [Text]
 readReplHistory = do
     home <- getHomeDirectory
-    let path = replHistoryPath home
+    readReplHistoryAt (replHistoryPath home)
+
+-- | Fully evaluated, newest-first entries. Haskeline's on-disk representation
+-- is UTF-8 lines without newline translation or escaping; embedded newlines
+-- therefore become separate entries on the next read.
+readReplHistoryAt :: FilePath -> IO [Text]
+readReplHistoryAt path = do
     ensureHistoryParent path
-    withHistoryLock path do
-        history <- readHistory path `catchIO` \_ -> pure emptyHistory
-        pure (map Text.pack (historyLines history))
+    withHistoryLock path (readHistoryEntries path)
+
+readHistoryEntries :: FilePath -> IO [Text]
+readHistoryEntries path =
+    (withFile path ReadMode \handle -> do
+        encoding <- mkTextEncoding "UTF-8//TRANSLIT"
+        hSetEncoding handle encoding
+        hSetNewlineMode handle noNewlineTranslation
+        contents <- Text.hGetContents handle
+        pure $! force (Text.lines contents))
+        `catchIO` \_ -> pure []
 
 appendReplHistory :: Text -> IO ()
 appendReplHistory text
     | Text.all isSpace text = pure ()
     | otherwise = do
         home <- getHomeDirectory
-        let path = replHistoryPath home
-        ensureHistoryParent path
-        withHistoryLock path do
-            history <- readHistory path `catchIO` \_ -> pure emptyHistory
-            writeHistory path (addHistory (Text.unpack text) history)
-                `catchIO` \_ -> pure ()
-            trySetMode path 0o600
+        appendReplHistoryAt (replHistoryPath home) text
 
--- Haskeline rewrites history in place. Fullscreen input publication and
+-- | Read the current file under the write lock, rather than saving an editor's
+-- stale snapshot and discarding entries submitted by another process.
+-- The caller controls which submissions belong in history; this helper does
+-- not filter whitespace (inline and fullscreen have different policies).
+appendReplHistoryAt :: FilePath -> Text -> IO ()
+appendReplHistoryAt path text = do
+    ensureHistoryParent path
+    withHistoryLock path do
+        entries <- readHistoryEntries path
+        (withFile path WriteMode \handle -> do
+            hSetEncoding handle utf8
+            hSetNewlineMode handle noNewlineTranslation
+            Text.hPutStr handle (Text.unlines (text : entries)))
+            `catchIO` \_ -> pure ()
+        trySetMode path 0o600
+
+-- History is rewritten in place. Fullscreen input publication and
 -- command handling run concurrently, so serialize reads with that rewrite to
 -- avoid observing the temporary truncated file. The lock also coordinates
 -- independent harness processes sharing the same history.

--- a/packages/agent-cli/test/Agent/CLI/InputHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/InputHistorySpec.hs
@@ -1,0 +1,65 @@
+module Agent.CLI.InputHistorySpec (spec) where
+
+import Agent.CLI.Input.History
+import Control.Concurrent.Async (mapConcurrently_)
+import Data.Bits ((.&.))
+import qualified Data.ByteString as ByteString
+import Data.List (sort)
+import qualified Data.Text as Text
+import qualified System.Console.Haskeline.History as Haskeline
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Posix.Files (fileMode, getFileStatus)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "compact REPL history" do
+    it "reads the Haskeline format, including Unicode, duplicates and newlines" $
+        withHistoryPath \path -> do
+            let entries = ["newest", "日本語🙂", "duplicate", "duplicate", "one\ntwo", "", "last\r"]
+            Haskeline.writeHistory path $
+                foldr Haskeline.addHistory Haskeline.emptyHistory entries
+            expected <- map Text.pack . Haskeline.historyLines <$> Haskeline.readHistory path
+            readReplHistoryAt path `shouldReturn` expected
+    it "matches Haskeline decoding of malformed UTF-8 and an unterminated line" $
+        withHistoryPath \path -> do
+            ByteString.writeFile path (ByteString.pack [97, 255, 10, 98, 13, 10, 99])
+            expected <- map Text.pack . Haskeline.historyLines <$> Haskeline.readHistory path
+            readReplHistoryAt path `shouldReturn` expected
+    it "writes bytes identical to Haskeline without losing existing entries" $
+        withHistoryPath \path -> do
+            let reference = path <> ".reference"
+                entries = ["older", "日本語🙂", "duplicate", "duplicate"]
+                added = "one\ntwo\r\nthree"
+            Haskeline.writeHistory path $
+                foldr Haskeline.addHistory Haskeline.emptyHistory entries
+            original <- Haskeline.readHistory path
+            Haskeline.writeHistory reference (Haskeline.addHistory added original)
+            appendReplHistoryAt path (Text.pack added)
+            expected <- ByteString.readFile reference
+            ByteString.readFile path `shouldReturn` expected
+    it "returns empty history for missing files and leaves submission filtering to callers" $
+        withHistoryPath \path -> do
+            readReplHistoryAt path `shouldReturn` []
+            appendReplHistoryAt path "   "
+            readReplHistoryAt path `shouldReturn` ["   "]
+            appendReplHistoryAt path "\t"
+            readReplHistoryAt path `shouldReturn` ["\t", "   "]
+    it "keeps consecutive identical submissions" $
+        withHistoryPath \path -> do
+            appendReplHistoryAt path "duplicate"
+            appendReplHistoryAt path "duplicate"
+            readReplHistoryAt path `shouldReturn` ["duplicate", "duplicate"]
+    it "serializes concurrent appends and keeps private permissions" $
+        withHistoryPath \path -> do
+            let entries = map (Text.pack . show) [1 :: Int .. 20]
+            mapConcurrently_ (appendReplHistoryAt path) entries
+            actual <- readReplHistoryAt path
+            sort actual `shouldBe` sort entries
+            mode <- fileMode <$> getFileStatus path
+            mode .&. 0o777 `shouldBe` 0o600
+
+withHistoryPath :: (FilePath -> IO a) -> IO a
+withHistoryPath action =
+    withSystemTempDirectory "agent_history_test" \directory ->
+        action (directory </> "history")

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -59,6 +59,7 @@ import qualified Agent.CLI.GitDiffSpec as GitDiffSpec
 import qualified Agent.CLI.ImagePreviewSpec as ImagePreviewSpec
 import qualified Agent.CLI.ChartImageSpec as ChartImageSpec
 import qualified Agent.CLI.InputSpec as InputSpec
+import qualified Agent.CLI.InputHistorySpec as InputHistorySpec
 import qualified Agent.CLI.InterruptSpec as InterruptSpec
 import qualified Agent.CLI.VoiceAudioSpec as VoiceAudioSpec
 import qualified Agent.CLI.LoginSpec as LoginSpec
@@ -202,6 +203,7 @@ specs = do
     ImagePreviewSpec.spec
     ChartImageSpec.spec
     InputSpec.spec
+    InputHistorySpec.spec
     InterruptSpec.spec
     VoiceAudioSpec.spec
     LoginSpec.spec


### PR DESCRIPTION
## Summary
- Replace retained Haskeline `String` command history with strict `Text`, preserving the existing file format, duplicates, Unicode, locking and private permissions.
- Re-read current history under the append lock to preserve submissions from other processes; keep history read failures best-effort in the inline prompt.
- Add compatibility/concurrency tests, a reproducible optimized benchmark, opt-in heap diagnostics, and a prioritized String/Text audit. Document Text-first conventions.

## Performance
Synthetic 9,000-entry history, five-sample medians, GHC 9.10.3 `-O2 -N4`:
- Retained history heap: 15,185,056 → 1,080,344 bytes (**93% less**).
- Read allocations: 102,488,544 → 2,342,776 bytes (**98% less**).
- Read elapsed time: 50.6 → 1.95 ms.

This measures fully traversed history, not total process footprint. Multi-size and repeated results and methodology are in `benchmark/CommandHistory.md`.

## Validation
- Six focused GHCi history tests pass, including Haskeline byte compatibility, malformed UTF-8 and concurrent appends.
- All 251 CLI library modules load in Cabal GHCi.
- Source-loaded inline editor exercised in tmux: Unicode submission and Up-arrow recall.
- Heap diagnostics typecheck and standalone harness checks pass.
- Optimized benchmark rebuilt and rerun at 1,000 / 9,000 / 18,000 entries, with a repeated 9,000-entry run.
- `cabal2nix` output matches `package.nix`; `git diff --check` passes.
- Full-agent startup with an isolated test home was blocked by macOS's PostgreSQL Unix-socket path limit. No deployment or whole-process post-change memory claim.
