### PR TITLE
Restore prompt focus when pasting from the transcript

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
@@ -380,6 +380,9 @@ mouseScrollLines = 3
 handleScrollbackKey :: V.Event -> EventM Name AppState ()
 handleScrollbackKey = \case
     event@V.EvPaste{} -> editComposer event
+    -- Legacy terminals encode Ctrl-V as the C0 SYN character.
+    V.EvKey (V.KChar '\SYN') [] ->
+        editComposer (V.EvKey (V.KChar 'v') [V.MCtrl])
     event@(V.EvKey (V.KChar 'v') modifiers)
         | V.MCtrl `elem` modifiers || V.MMeta `elem` modifiers ->
             editComposer event

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Navigation.hs
@@ -379,18 +379,17 @@ mouseScrollLines = 3
 
 handleScrollbackKey :: V.Event -> EventM Name AppState ()
 handleScrollbackKey = \case
+    event@V.EvPaste{} -> editComposer event
+    event@(V.EvKey (V.KChar 'v') modifiers)
+        | V.MCtrl `elem` modifiers || V.MMeta `elem` modifiers ->
+            editComposer event
     V.EvKey (V.KChar character) modifiers
         | isPrint character && all (== V.MShift) modifiers -> do
             -- Typing expresses intent to edit, even when transcript focus was
             -- retained across a terminal tab switch. The character already
             -- contains the effect of Shift; the composer expects text keys
             -- without modifiers.
-            focusComposer
-            Composer.handleComposerKey
-                applyLocalUiEventWith
-                handleCtrlC
-                scrollConversationPage
-                (V.EvKey (V.KChar character) [])
+            editComposer (V.EvKey (V.KChar character) [])
     V.EvKey V.KUp [] -> moveBlock (-1)
     V.EvKey V.KDown [] -> moveBlock 1
     V.EvKey V.KPageUp [] -> scrollConversationPage Up
@@ -418,6 +417,15 @@ handleScrollbackKey = \case
     V.EvKey V.KEsc [] -> focusComposer
     _ -> pure ()
   where
+    -- Reuse the composer's paste handling, including attachments and active
+    -- turns, instead of interpreting clipboard contents in navigation.
+    editComposer event = do
+        focusComposer
+        Composer.handleComposerKey
+            applyLocalUiEventWith
+            handleCtrlC
+            scrollConversationPage
+            event
     scroll = viewportScroll ConversationViewport
     moveBlock delta = do
         state <- get

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -3313,6 +3313,24 @@ spec = do
                 state.appUi.uiDraft `shouldBe` "before"
                 state.appUi.uiFocus `shouldBe` FocusComposer
 
+        it "restores prompt focus and inserts a paste, including after returning to a terminal tab" do
+            forM_ [[], [UiLoop TurnStarted]] $ \setup ->
+                forM_ [[], [V.EvLostFocus], [V.EvLostFocus, V.EvGainedFocus]] $ \focusEvents -> do
+                    state <- runTranscriptFocusInput setup
+                        (focusEvents <> [V.EvPaste (encoded "first\nsecond λ")])
+                    state.appUi.uiDraft `shouldBe` "befirst\nsecond λfore"
+                    state.appUi.uiCursor `shouldBe` 16
+                    state.appUi.uiFocus `shouldBe` FocusComposer
+                    state.appHistorySelectedBlock `shouldBe` Nothing
+
+        it "does not redirect paste out of an approval overlay" do
+            state <- runTranscriptFocusInput
+                [UiPermissionShown "Approve a test operation"]
+                [V.EvPaste (encoded "paste text")]
+            state.appUi.uiDraft `shouldBe` "before"
+            state.appUi.uiFocus `shouldBe` FocusPermission
+            state.appUi.uiPermission `shouldSatisfy` isJust
+
         it "does not insert navigation keys or modified character shortcuts" do
             forM_
                 [ V.EvKey V.KUp []

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -176,6 +176,7 @@ import Control.Concurrent (newEmptyMVar, putMVar, takeMVar, threadDelay)
 import Control.Concurrent.Async (cancel, waitCatch, withAsync)
 import Control.Exception.Safe (bracket, bracket_)
 import System.Environment (lookupEnv, setEnv, unsetEnv)
+import qualified System.Directory as Directory
 import Control.Exception (AsyncException(UserInterrupt))
 import qualified Control.Exception as Exception
 import Control.Concurrent.STM
@@ -3331,6 +3332,28 @@ spec = do
             state.appUi.uiFocus `shouldBe` FocusPermission
             state.appUi.uiPermission `shouldSatisfy` isJust
 
+        it "restores prompt focus for legacy and modified clipboard shortcuts" do
+            withClipboardTextFixture do
+                forM_
+                    [ V.EvKey (V.KChar '\SYN') []
+                    , V.EvKey (V.KChar 'v') [V.MCtrl]
+                    , V.EvKey (V.KChar 'v') [V.MMeta]
+                    ] $ \pasteEvent ->
+                    forM_ [[], [V.EvLostFocus], [V.EvLostFocus, V.EvGainedFocus]] $ \focusEvents -> do
+                        state <- runTranscriptFocusInput [] (focusEvents <> [pasteEvent])
+                        state.appUi.uiDraft `shouldBe` "beclipboard textfore"
+                        state.appUi.uiCursor `shouldBe` 16
+                        state.appUi.uiFocus `shouldBe` FocusComposer
+                        state.appHistorySelectedBlock `shouldBe` Nothing
+
+        it "does not redirect legacy clipboard input out of an approval overlay" do
+            state <- runTranscriptFocusInput
+                [UiPermissionShown "Approve a test operation"]
+                [V.EvKey (V.KChar '\SYN') []]
+            state.appUi.uiDraft `shouldBe` "before"
+            state.appUi.uiFocus `shouldBe` FocusPermission
+            state.appUi.uiPermission `shouldSatisfy` isJust
+
         it "does not insert navigation keys or modified character shortcuts" do
             forM_
                 [ V.EvKey V.KUp []
@@ -3972,6 +3995,24 @@ unfocusedStreamingRefreshesOnMotionTick = do
             ]
     rendered <- runFullscreenScript initialState script
     pure $ encoded marker `ByteString.isInfixOf` rendered
+
+-- Exercise the platform clipboard reader without accessing the user's clipboard.
+withClipboardTextFixture :: IO a -> IO a
+withClipboardTextFixture action =
+    withSystemTempDirectory "agent-tui-clipboard-text" \directory -> do
+        shell <- Directory.findExecutable "sh" >>= maybe
+            (fail "clipboard fixture requires a shell") pure
+        forM_ ["pbpaste", "wl-paste", "xclip"] $ \command -> do
+            let path = directory </> command
+            writeFile path ("#!" <> shell <> "\nprintf '%s' 'clipboard text'\n")
+            permissions <- Directory.getPermissions path
+            Directory.setPermissions path (Directory.setOwnerExecutable True permissions)
+        bracket
+            (lookupEnv "PATH")
+            (\previous -> maybe (unsetEnv "PATH") (setEnv "PATH") previous)
+            \_ -> do
+                setEnv "PATH" directory
+                action
 
 withPastedImageFixtures :: (FilePath -> FilePath -> IO a) -> IO a
 withPastedImageFixtures action =


### PR DESCRIPTION
## Summary
- Route bracketed paste and Ctrl/Meta+V from transcript focus to the existing composer handler.
- Normalize legacy Ctrl-V (C0 SYN) to the composer-supported Ctrl-V event.
- Preserve the current draft and insertion position, including during active turns.
- Keep approval overlays in control of their input.

Ordinary printable typing already recovers prompt focus; this fixes the remaining confirmed paste gap. The reported native macOS rejection sound was not independently reproduced.

## Validation
- GHCi under Nix: `:main --match transcript` in `cabal repl agent-cli:test:agent-cli-test` — 62 examples, 0 failures.
- Live fullscreen agent under GHCi in tmux: entered a draft, moved its cursor, selected the transcript, injected terminal focus loss/gain and multiline Unicode bracketed paste. Prompt focus recovered and text was inserted at the existing cursor without losing the draft.
- Additional live tmux check: raw Ctrl-V byte `0x16` after focus loss/gain restored prompt focus and inserted controlled fixture clipboard text at the existing cursor. The real clipboard was not accessed.
- Regression coverage includes legacy and modified clipboard shortcuts, idle/running bracketed paste, missing focus-gained events, multiline Unicode, and approval overlays.
- `git diff --check` passed.
- Earlier full local GHCi suite: 3433 examples, 39 failures, 1 pending. Failures were 37 PostgreSQL socket-directory-too-long errors and 2 non-TTY model-picker IllegalOperation errors in the local test environment.
