### PR TITLE
Use library Maybe helpers in external session providers

### DIFF
--- a/packages/agent-external-session/agent-external-session.cabal
+++ b/packages/agent-external-session/agent-external-session.cabal
@@ -58,6 +58,7 @@ library
                     , crypton
                     , direct-sqlite >= 2.3 && < 2.4
                     , directory
+                    , extra >= 1.7
                     , filepath
                     , network-uri
                     , process >= 1.6.26

--- a/packages/agent-external-session/package.nix
+++ b/packages/agent-external-session/package.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, agent-core, agent-json, agent-tools, async
 , base, bytestring, containers, crypton, direct-sqlite, directory
-, filepath, hspec, lib, network-uri, process, safe-exceptions
-, scientific, text, time, unix, vector
+, extra, filepath, hspec, lib, network-uri, process
+, safe-exceptions, scientific, text, time, unix, vector
 }:
 mkDerivation {
   pname = "agent-external-session";
@@ -9,8 +9,9 @@ mkDerivation {
   src = ./.;
   libraryHaskellDepends = [
     aeson agent-core agent-json agent-tools async base bytestring
-    containers crypton direct-sqlite directory filepath network-uri
-    process safe-exceptions scientific text time unix vector
+    containers crypton direct-sqlite directory extra filepath
+    network-uri process safe-exceptions scientific text time unix
+    vector
   ];
   testHaskellDepends = [
     aeson agent-core base bytestring direct-sqlite directory filepath

--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Claude.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Claude.hs
@@ -13,9 +13,10 @@ import Agent.CLI.ExternalSession.Types
 import Control.Applicative ((<|>))
 import Control.Exception.Safe (tryAny)
 import Control.Monad (filterM)
+import Control.Monad.Extra (firstJustM)
 import Data.Aeson (Value(..), decodeStrict', encode)
 import qualified Data.ByteString.Lazy as LBS
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding
@@ -486,7 +487,7 @@ truthy = \case
 
 firstNonEmptyText :: [Maybe Text] -> Text
 firstNonEmptyText values =
-    fromMaybe "" $ firstMaybe
+    fromMaybe "" $ listToMaybe
         [ value
         | Just value <- values
         , not (Text.null value)
@@ -496,17 +497,3 @@ nonEmptyText :: Text -> Maybe Text
 nonEmptyText value
     | Text.null value = Nothing
     | otherwise = Just value
-
-firstMaybe :: [value] -> Maybe value
-firstMaybe [] = Nothing
-firstMaybe (value : _) = Just value
-
-firstJustM
-    :: (input -> IO (Maybe output))
-    -> [input]
-    -> IO (Maybe output)
-firstJustM _ [] = pure Nothing
-firstJustM action (value : values) =
-    action value >>= \case
-        Just output -> pure (Just output)
-        Nothing -> firstJustM action values

--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Codex.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Codex.hs
@@ -13,6 +13,7 @@ import Agent.CLI.ExternalSession.Types
 import Control.Applicative ((<|>))
 import Control.Exception.Safe (tryAny)
 import Control.Monad (filterM, foldM, when)
+import Control.Monad.Extra (firstJustM)
 import Data.Aeson (Value(..), decodeStrict', encode)
 import qualified Data.Aeson.Key
 import qualified Data.Aeson.KeyMap as KeyMap
@@ -24,7 +25,7 @@ import Data.IORef
     , writeIORef
     )
 import Data.List (maximumBy)
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Ord (comparing)
 import Data.Scientific (fromFloatDigits)
 import qualified Data.Set as Set
@@ -204,7 +205,7 @@ codexMetadata env path
                                 ]
                     firstUser =
                         fromMaybe "" $
-                            firstMaybe
+                            listToMaybe
                                 [ userText text
                                 | record <- records
                                 , externalTextValue "type" record
@@ -449,7 +450,7 @@ codexTurn maxToolChars payload =
                 call = HistoricalToolCall callId "mcp_call"
                     (jsonPreview maxToolChars arguments)
                 rawResult =
-                    firstMaybe
+                    listToMaybe
                         [ if key == "error"
                             then Object
                                 (KeyMap.singleton
@@ -506,7 +507,7 @@ codexTurn maxToolChars payload =
     callOnly name keys =
         let arguments =
                 fromMaybe payload
-                    (firstMaybe (mapMaybe (`externalObjectValue` payload) keys))
+                    (listToMaybe (mapMaybe (`externalObjectValue` payload) keys))
             call = HistoricalToolCall
                 (protocolCallId payload)
                 name
@@ -519,7 +520,7 @@ codexTurn maxToolChars payload =
     resultOnly =
         let rawOutput =
                 fromMaybe payload $
-                    firstMaybe $
+                    listToMaybe $
                         mapMaybe
                             (`externalObjectValue` payload)
                             ["output", "result", "tools", "response", "content"]
@@ -632,26 +633,12 @@ nonEmptyText text
 
 firstNonEmptyText :: [Maybe Text] -> Text
 firstNonEmptyText values =
-    fromMaybe "" $ firstMaybe
+    fromMaybe "" $ listToMaybe
         [ value
         | Just value <- values
         , not (Text.null value)
         ]
 
-firstMaybe :: [value] -> Maybe value
-firstMaybe [] = Nothing
-firstMaybe (value : _) = Just value
-
 lastMaybe :: [value] -> Maybe value
 lastMaybe [] = Nothing
 lastMaybe values = Just (last values)
-
-firstJustM
-    :: (input -> IO (Maybe output))
-    -> [input]
-    -> IO (Maybe output)
-firstJustM _ [] = pure Nothing
-firstJustM action (value : values) =
-    action value >>= \case
-        Just output -> pure (Just output)
-        Nothing -> firstJustM action values

--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Cursor.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Cursor.hs
@@ -13,12 +13,13 @@ import Agent.CLI.ExternalSession.Types
 import Control.Applicative ((<|>))
 import Control.Exception.Safe (IOException, tryAny, tryIO)
 import Control.Monad (filterM, foldM)
+import Control.Monad.Extra (firstJustM)
 import Crypto.Hash (Digest, MD5, hash)
 import Data.Aeson (Value(..))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -386,7 +387,7 @@ findDesktop _env reference databasePath = do
                                 , externalTextValue "title" header
                                 ]
                             )
-                            (Text.unpack <$> firstMaybe paths)
+                            (Text.unpack <$> listToMaybe paths)
                             (externalObjectValue "createdAt" header)
                             (externalObjectValue "lastUpdatedAt" header)
             _ -> pure Nothing
@@ -497,10 +498,10 @@ readCursorStore candidate maxToolChars = do
         else readCursorRows maxToolChars "Cursor blob(s)" \consume ->
                 withReadOnlyDatabase store \database -> do
                     columns <- tableColumns database "blobs"
-                    let keyColumn = firstMaybe
+                    let keyColumn = listToMaybe
                             [ name | name <- ["id", "key", "hash"],
                                 name `Set.member` columns ]
-                        dataColumn = firstMaybe
+                        dataColumn = listToMaybe
                             [ name | name <- ["data", "value", "blob"],
                                 name `Set.member` columns ]
                     case (keyColumn, dataColumn) of
@@ -745,7 +746,7 @@ cursorCallsAndResults maxToolChars value =
 
 cursorFirstUserTitle :: Value -> Maybe Text
 cursorFirstUserTitle root =
-    firstMaybe
+    listToMaybe
         [ value.externalTurnText
         | value <- fst (cursorTurns 100 root)
         , value.externalTurnRole == "user"
@@ -837,23 +838,9 @@ truthy = \case
 
 firstNonEmptyText :: [Maybe Text] -> Text
 firstNonEmptyText values =
-    fromMaybe "" $ firstMaybe
+    fromMaybe "" $ listToMaybe
         [ value | Just value <- values, not (Text.null value) ]
-
-firstMaybe :: [value] -> Maybe value
-firstMaybe [] = Nothing
-firstMaybe (value : _) = Just value
 
 lastMaybe :: [value] -> Maybe value
 lastMaybe [] = Nothing
 lastMaybe values = Just (last values)
-
-firstJustM
-    :: (input -> IO (Maybe output))
-    -> [input]
-    -> IO (Maybe output)
-firstJustM _ [] = pure Nothing
-firstJustM action (value : values) =
-    action value >>= \case
-        Just output -> pure (Just output)
-        Nothing -> firstJustM action values

--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Grok.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Grok.hs
@@ -13,7 +13,7 @@ import Control.Applicative ((<|>))
 import Control.Monad (filterM)
 import Data.Aeson (Value(..))
 import qualified Data.Aeson.KeyMap as KeyMap
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Vector as Vector
@@ -39,7 +39,7 @@ findGrokById
 findGrokById env reference = do
     candidates <- discoverAllGrok env
     pure $
-        firstMaybe
+        listToMaybe
             [ candidate
             | candidate <- candidates
             , Text.toCaseFold candidate.candidateSessionId
@@ -326,12 +326,8 @@ truthy = \case
 
 firstNonEmptyText :: [Maybe Text] -> Text
 firstNonEmptyText values =
-    fromMaybe "" $ firstMaybe
+    fromMaybe "" $ listToMaybe
         [ value
         | Just value <- values
         , not (Text.null value)
         ]
-
-firstMaybe :: [value] -> Maybe value
-firstMaybe [] = Nothing
-firstMaybe (value : _) = Just value

--- a/packages/agent-external-session/test/Agent/CLI/ExternalSessionSpec.hs
+++ b/packages/agent-external-session/test/Agent/CLI/ExternalSessionSpec.hs
@@ -569,6 +569,49 @@ spec = describe "Agent.CLI.ExternalSession" do
             discoverExternalSessions fixture.env ExternalClaude 0
                 `shouldReturn` []
 
+    it "keeps the first nonempty Codex user title and handles an empty title list" $
+        withFixture \fixture -> do
+            let rollout =
+                    fixture.env.externalCodexRoot </> "sessions" </> "rollout-title.jsonl"
+                sessionId = "55555555-5555-5555-5555-555555555555"
+            forM_
+                [ ([], "(untitled)")
+                , (["", "First user title", "Later user title"], "First user title")
+                ] \(titles, expected) -> do
+                    writeJsonl rollout $
+                        codexMetadata fixture.cwd sessionId
+                            : map (responseMessage "user") titles
+                    candidates <- discoverExternalSessions fixture.env ExternalCodex 0
+                    map (.candidateTitle) candidates `shouldBe` [expected]
+
+    it "skips invalid Cursor ID matches and keeps the first valid directory" $
+        withFixture \fixture -> do
+            let sessionId = "66666666-6666-6666-6666-666666666666"
+                chats = fixture.env.externalCursorRoot </> "chats"
+            forM_ ["project-one", "project-two", "project-three"] \name ->
+                createDirectoryIfMissing True (chats </> name)
+            -- Follow the provider's filesystem order instead of assuming that
+            -- listDirectory sorts names or preserves creation order.
+            digests <- listDirectory chats
+            case digests of
+                invalid : selected : later : [] -> do
+                    LBS.writeFile (chats </> invalid </> Text.unpack sessionId) ""
+                    forM_ [selected, later] \digest -> do
+                        let directory = chats </> digest </> Text.unpack sessionId
+                        createDirectory directory
+                        LBS.writeFile (directory </> "meta.json") $
+                            encode $ object
+                                [ "id" .= sessionId
+                                , "name" .= ("Preferred name" :: Text)
+                                , "title" .= ("Fallback title" :: Text)
+                                ]
+                    session <- showReference fixture.env ExternalCursor sessionId 100
+                    session.externalSessionCandidate.candidatePath
+                        `shouldBe` chats </> selected </> Text.unpack sessionId
+                    session.externalSessionCandidate.candidateTitle
+                        `shouldBe` "Preferred name"
+                _ -> expectationFailure "expected three Cursor fixture projects"
+
     it "reads Cursor's native SQLite store and ignores system metadata" $
         withFixture \fixture -> do
             let sessionId = "33333333-3333-3333-3333-333333333333"


### PR DESCRIPTION
## Summary
- Replace four handwritten firstMaybe helpers with Data.Maybe.listToMaybe.
- Replace three handwritten firstJustM helpers with Control.Monad.Extra.firstJustM, preserving ordered short-circuit lookup.
- Add the extra dependency and regenerate package.nix.
- Add public API regressions for Codex title fallback/precedence and Cursor invalid-match fallback/first-valid selection.

## Validation
- External-session library loaded successfully in GHCi (10 modules).
- Actual external-session Cabal test component: 19 examples, zero failures.
- git diff --check passed.

Behavior-preserving cleanup; no performance claim.