### PR TITLE
Retain Git command output as strict Text

### DIFF
--- a/packages/agent-cli/STRING_AUDIT.md
+++ b/packages/agent-cli/STRING_AUDIT.md
@@ -1,14 +1,21 @@
 # Application text representation audit
 
 2026-09-12. Static review of production Haskell under `packages`, including
-`String`, `[Char]`, and `Text.unpack`. This identifies candidates, not measured
-performance improvements outside the command-history benchmark.
+`String`, `[Char]`, and `Text.unpack`. Remaining candidates are unmeasured;
+implemented changes link to their own benchmarks below.
+
+## Implemented follow-up
+
+GitDiff now retains stdout/stderr as strict `Text`, including `/review` error
+handling. NUL splitting operates on Text and converts individual paths to
+`FilePath` at the process boundary. UTF-8 decoding remains lenient. See
+`benchmark/GitOutput.md` for the isolated representation benchmark; this is
+not a measurement of whole-process memory or Git execution time.
 
 ## Prioritized follow-up
 
 | Priority | Module | Finding and acceptance criteria |
 | --- | --- | --- |
-| High | `agent-cli/src/Agent/CLI/GitDiff.hs` | `GitCommandOutput` stores complete stdout/stderr as `String`. `readHandleStrict` decodes bytes to Text then unpacks; consumers repack. Retain Text directly, converting individual paths only at process boundaries. Benchmark large diffs and preserve NUL-separated paths and invalid-UTF-8 policy. |
 | High | `agent-tui/src/Agent/TUI/TextWidth.hs` | `graphemeClusters` unpacks entire input, constructs character lists, then packs clusters; width checks also unpack. Benchmark Text traversal/slices in actual rendering and cursor workloads; preserve combining marks, flags, ZWJ, modifiers and terminal-width compatibility. |
 | Medium | `agent-cli/src/Agent/CLI/Clipboard/{MacOS,Linux}.hs` | Process capture passes potentially large clipboard content through String. Prefer byte capture with explicit decoding and Text results. Preserve subprocess cleanup, errors, and paste behavior. |
 | Medium | `agent-tui/src/Agent/TUI/Markdown/Block.hs` | `splitTableRow` unpacks each row and constructs reversed character lists. Benchmark a Text scanner/builder; preserve escaped pipes and code spans. |
@@ -27,6 +34,17 @@ performance improvements outside the command-history benchmark.
 - Strict Text is the application-text default; ByteString is appropriate for
   encoded/protocol or binary data. This convention is recorded in `AGENTS.md`.
 
-The history replacement is implemented separately. The candidates above are
+Further review identified these compatibility boundaries:
+
+- TextWidth predicates can migrate before segmentation. Preserve exactly two
+  regional indicators for flags and character-count cursor offsets, not UTF-8
+  byte offsets. Benchmark complete rendering/cursor consumers, not only helpers.
+- Markdown table scanning repeatedly packs the remaining suffix when looking
+  for closing backticks. Preserve escape parity and the existing closing-run
+  length rule while replacing this with Text traversal.
+- Clipboard byte capture must not silently change locale-based strict decoding
+  into lenient UTF-8. Preserve backend fallback order and first-error selection.
+
+The history replacement is implemented separately. The remaining candidates above are
 not changed in this audit; each needs focused compatibility tests and an
 optimized benchmark before making a performance claim.

--- a/packages/agent-cli/benchmark/GitOutput.hs
+++ b/packages/agent-cli/benchmark/GitOutput.hs
@@ -1,0 +1,117 @@
+module Main (main) where
+
+import Agent.TUI.TextWidth (displayTerminalText)
+import Control.Exception (evaluate)
+import Control.Monad (replicateM, unless)
+import qualified Data.ByteString as ByteString
+import Data.Char (ord)
+import Data.IORef (newIORef, readIORef)
+import Data.List (sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Encoding
+import Data.Text.Encoding.Error (lenientDecode)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performMajorGC)
+import Text.Printf (printf)
+import Text.Read (readMaybe)
+
+-- Separate producer and consumer boundaries match GitCommandOutput crossing
+-- runSafeGit's IO boundary. Prevent fusion from deleting the old representation.
+data OriginalOutput = OriginalOutput !String
+data TextOutput = TextOutput !Text
+
+{-# NOINLINE originalCapture #-}
+originalCapture :: ByteString.ByteString -> OriginalOutput
+originalCapture = OriginalOutput . Text.unpack . Encoding.decodeUtf8With lenientDecode
+
+{-# NOINLINE textCapture #-}
+textCapture :: ByteString.ByteString -> TextOutput
+textCapture = TextOutput . Encoding.decodeUtf8With lenientDecode
+
+{-# NOINLINE originalConsume #-}
+originalConsume :: OriginalOutput -> Text
+originalConsume (OriginalOutput value) = Text.pack value
+
+{-# NOINLINE textConsume #-}
+textConsume :: TextOutput -> Text
+textConsume (TextOutput value) = value
+
+data Observation = Observation !Double !Double !Integer !Int
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    unless enabled (die "enable RTS statistics with +RTS -T")
+    arguments <- getArgs
+    case arguments of
+        [operation, sizeArgument, sampleArgument] -> do
+            count <- positive sizeArgument
+            samples <- positive sampleArgument
+            -- Mix ordinary diff text, Unicode, terminal controls and malformed
+            -- UTF-8. Input construction is outside all measured intervals.
+            let line = Encoding.encodeUtf8 "+value = \"café 日本 👩\x200d💻\"\t-- change\n"
+                input = ByteString.concat (replicate count line)
+                    <> ByteString.pack [255, 10]
+            _ <- evaluate (ByteString.length input)
+            reference <- newIORef input
+            transform <- case operation of
+                "original-output" -> pure (originalConsume . originalCapture)
+                "text-output" -> pure (textConsume . textCapture)
+                "original-render" -> pure (displayTerminalText . originalConsume . originalCapture)
+                "text-render" -> pure (displayTerminalText . textConsume . textCapture)
+                _ -> die "unknown operation"
+            observations <- replicateM samples $
+                measure (transform <$> readIORef reference)
+            -- Check complete values, not only additive checksums. Keep this
+            -- compatibility validation outside all measured intervals.
+            let original = originalConsume (originalCapture input)
+                replacement = textConsume (textCapture input)
+            unless (original == replacement
+                && displayTerminalText original == displayTerminalText replacement)
+                (die "original and Text pipelines produced different output")
+            let elapsed = [value | Observation value _ _ _ <- observations]
+                cpu = [value | Observation _ value _ _ <- observations]
+                allocated = [value | Observation _ _ value _ <- observations]
+                checksums = [value | Observation _ _ _ value <- observations]
+            checksum <- case checksums of
+                first : rest
+                    | all (== first) rest -> pure first
+                    | otherwise -> die "unstable checksum"
+                [] -> die "no benchmark observations"
+            printf "%s,%d,%d,%d,%.3f,%.3f,%d,%d\n"
+                operation count (ByteString.length input) samples
+                (median elapsed) (median cpu) (median allocated) checksum
+        _ -> die "usage: git-output-benchmark OPERATION FIXTURE_UNITS SAMPLES +RTS -T"
+
+positive :: String -> IO Int
+positive raw = case readMaybe raw of
+    Just value | value > 0 -> pure value
+    _ -> die "expected a positive integer"
+
+median :: Ord a => [a] -> a
+median values = sort values !! (length values `div` 2)
+
+{-# NOINLINE measure #-}
+measure :: IO Text -> IO Observation
+measure action = do
+    performMajorGC
+    before <- getRTSStats
+    cpuBefore <- getCPUTime
+    timeBefore <- getMonotonicTimeNSec
+    output <- action
+    checksum <- evaluate (Text.foldl' (\total char -> total + ord char) 0 output)
+    timeAfter <- getMonotonicTimeNSec
+    cpuAfter <- getCPUTime
+    -- Flush allocation counters; this collection is outside the timed interval.
+    performMajorGC
+    after <- getRTSStats
+    pure (Observation
+        (fromIntegral (timeAfter - timeBefore) / 1e6)
+        (fromIntegral (cpuAfter - cpuBefore) / 1e9)
+        (toInteger after.allocated_bytes - toInteger before.allocated_bytes)
+        checksum)

--- a/packages/agent-cli/benchmark/GitOutput.md
+++ b/packages/agent-cli/benchmark/GitOutput.md
@@ -1,0 +1,111 @@
+# Git output representation benchmark
+
+`GitOutput.hs` compares the original Git output conversion pipeline with strict
+`Text` retention. Both pipelines start with the same fully constructed strict
+`ByteString` and perform lenient UTF-8 decoding inside the measured interval:
+
+- `original-output`: decode, unpack into a strict `String` field, pack at the
+  consumer boundary, and force a character checksum.
+- `text-output`: decode into a strict `Text` field and force the same checksum.
+- `original-render` and `text-render`: additionally run the production
+  `displayTerminalText` sanitizer before computing the checksum.
+
+The capture and consume functions are `NOINLINE` to preserve the producer and
+consumer separation across `runSafeGit`'s IO boundary. Input is read from an
+`IORef` for every sample so the transformed output cannot be shared across
+samples. Each sample performs a major GC before measurement and another after
+the timed interval to flush allocation counters. The reported allocation
+includes this bookkeeping; elapsed and CPU times exclude the explicit GCs.
+
+Each fixture unit contains an added diff line with Latin text, Japanese text,
+a ZWJ emoji, and a tab. A single invalid UTF-8 byte and newline terminate the
+complete fixture. The byte count is reported explicitly. Seven samples are
+aggregated by median, over three sizes and a repeated intermediate size.
+After measurement, the benchmark checks complete old/new `Text` equality both
+before and after sanitization, in addition to verifying checksum stability
+across samples.
+
+## Reproduction
+
+Run from the repository root:
+
+```sh
+mkdir -p "$TMPDIR/git-output-benchmark"
+nix develop -c ghc -O2 -Wall -threaded -rtsopts \
+  -XGHC2021 -XBlockArguments -XOverloadedStrings -XOverloadedRecordDot \
+  -ipackages/agent-tui/src \
+  -outputdir "$TMPDIR/git-output-benchmark/objects" \
+  packages/agent-cli/benchmark/GitOutput.hs \
+  -o "$TMPDIR/git-output-benchmark/benchmark"
+nix develop -c sh -c '
+  for n in 1000 10000 100000 10000; do
+    for operation in original-output text-output original-render text-render; do
+      "$1" "$operation" "$n" 7 +RTS -T -N4
+    done
+  done
+' sh "$TMPDIR/git-output-benchmark/benchmark"
+```
+
+CSV columns: operation, fixture units, input bytes, samples, median elapsed
+milliseconds, median CPU milliseconds, median allocated bytes, checksum.
+
+## Results
+
+Measured 2026-09-12 on macOS ARM64, GHC 9.10.3, `-O2`, `+RTS -T -N4`.
+Old and new checksums matched for every corresponding workload.
+
+| Pipeline | Input bytes | Old elapsed ms | Text elapsed ms | Old CPU ms | Text CPU ms | Old allocated bytes | Text allocated bytes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Output | 46,002 | 0.421 | 0.157 | 0.430 | 0.162 | 2,555,264 | 47,912 |
+| Output + sanitizer | 46,002 | 6.798 | 7.195 | 7.227 | 7.563 | 28,844,936 | 26,337,552 |
+| Output | 460,002 | 4.179 | 1.544 | 4.494 | 1.562 | 25,270,816 | 461,912 |
+| Output + sanitizer | 460,002 | 72.093 | 68.065 | 76.004 | 71.465 | 288,152,488 | 263,343,552 |
+| Output | 4,600,002 | 42.153 | 15.087 | 44.810 | 15.258 | 258,979,520 | 4,601,912 |
+| Output + sanitizer | 4,600,002 | 717.581 | 686.012 | 753.581 | 717.236 | 2,887,781,192 | 2,633,403,552 |
+| Output (repeat) | 460,002 | 4.074 | 1.617 | 4.324 | 1.625 | 25,270,816 | 461,912 |
+| Output + sanitizer (repeat) | 460,002 | 69.313 | 69.069 | 73.195 | 72.556 | 288,152,488 | 263,343,552 |
+
+The output-only pipeline allocates approximately 98% less. Including the
+existing sanitizer, the reduction is approximately 9%; the sanitizer remains
+the dominant allocation source. Render timings are variable, particularly
+for small inputs, so this is not evidence for a consistent rendering speedup.
+
+The initial small rendering case was slower with Text. A 31-sample repeat in
+both execution orders did not reproduce that regression:
+
+```sh
+nix develop -c sh -c '
+  for operation in text-render original-render original-render text-render; do
+    "$1" "$operation" 1000 31 +RTS -T -N4
+  done
+' sh "$TMPDIR/git-output-benchmark/benchmark"
+```
+
+| Execution order | Operation | Median elapsed ms | Median CPU ms |
+| ---: | --- | ---: | ---: |
+| 1 | text-render | 5.826 | 6.186 |
+| 2 | original-render | 5.911 | 6.266 |
+| 3 | original-render | 6.369 | 6.782 |
+| 4 | text-render | 6.191 | 6.501 |
+
+Allocation counts were identical to the corresponding seven-sample results.
+
+## Scope
+
+This measures decoding, representation conversion and downstream consumption,
+not just construction of a lazy list head. The rendering variants include the
+existing grapheme-based sanitizer, which has its own allocations unchanged by
+the Git output migration.
+
+It does not measure Git subprocess execution, pipe reads, concurrent stderr,
+path splitting, terminal painting, whole-agent physical footprint, or retained
+heap. In particular, allocation reductions must not be described as equivalent
+reductions in total process memory. Other content distributions may have
+different costs.
+
+An initial fixture put an invalid byte after every 46-byte line. Its unchanged
+lenient decoder dominated both pipelines: `text-output` median elapsed time was
+2.708 ms at 48 KB and 251.546 ms at 480 KB. This densely malformed case is not
+representative of ordinary UTF-8 Git diffs and obscures conversion costs; the
+recorded representative results instead use one malformed suffix. This change
+does not address the decoder's behavior on densely malformed input.

--- a/packages/agent-cli/src/Agent/CLI/GitDiff.hs
+++ b/packages/agent-cli/src/Agent/CLI/GitDiff.hs
@@ -42,8 +42,8 @@ import System.Timeout (timeout)
 
 data GitCommandOutput = GitCommandOutput
     { gitCommandExitCode :: !ExitCode
-    , gitCommandStdout :: !String
-    , gitCommandStderr :: !String
+    , gitCommandStdout :: !Text
+    , gitCommandStderr :: !Text
     }
     deriving (Eq, Show)
 
@@ -113,11 +113,11 @@ executableFilterOverrides cwd = do
         , (driver <> ".required", "false")
         ]
 
-configuredFilterDrivers :: String -> [Text]
+configuredFilterDrivers :: Text -> [Text]
 configuredFilterDrivers raw =
     deduplicate . sort $
         foldMap driverForKey
-            (filter (not . Text.null) (Text.splitOn "\0" (Text.pack raw)))
+            (filter (not . Text.null) (Text.splitOn "\0" raw))
   where
     driverForKey key =
         case Text.stripSuffix ".clean" key of
@@ -131,7 +131,7 @@ configuredFilterDrivers raw =
 runUntrackedDiff
     :: OsPath
     -> [(Text, Text)]
-    -> String
+    -> FilePath
     -> ExceptT Text IO Text
 runUntrackedDiff cwd overrides path =
     runDiff cwd overrides
@@ -281,26 +281,19 @@ untrackedListArguments =
     , "-z"
     ]
 
-nulSeparatedPaths :: String -> [String]
+nulSeparatedPaths :: Text -> [FilePath]
 nulSeparatedPaths =
-    filter (not . null) . splitOnNul
-  where
-    splitOnNul [] = []
-    splitOnNul value =
-        let (path, rest) = break (== '\0') value
-        in path : case rest of
-            [] -> []
-            _ : remaining -> splitOnNul remaining
+    map Text.unpack . filter (not . Text.null) . Text.splitOn "\0"
 
 gitOutputText :: GitCommandOutput -> Text
-gitOutputText = Text.pack . (.gitCommandStdout)
+gitOutputText = (.gitCommandStdout)
 
 gitFailure :: Text -> GitCommandOutput -> Text
 gitFailure command output =
     displayTerminalText command
         <> " failed with "
         <> Text.pack (show output.gitCommandExitCode)
-        <> case Text.strip (Text.pack output.gitCommandStderr) of
+        <> case Text.strip output.gitCommandStderr of
             "" -> ""
             stderr -> ": " <> displayTerminalText stderr
 
@@ -333,9 +326,7 @@ gitCommandTimeoutMicros = 30 * 1_000_000
 processCleanupTimeoutMicros :: Int
 processCleanupTimeoutMicros = 2 * 1_000_000
 
-readHandleStrict :: Handle -> IO String
+readHandleStrict :: Handle -> IO Text
 readHandleStrict handle = do
     contents <- ByteString.hGetContents handle
-    pure
-        (Text.unpack
-            (Text.decodeUtf8With lenientDecode contents))
+    pure (Text.decodeUtf8With lenientDecode contents)

--- a/packages/agent-cli/src/Agent/CLI/Review.hs
+++ b/packages/agent-cli/src/Agent/CLI/Review.hs
@@ -174,6 +174,6 @@ commandFailure command output =
     command
         <> " failed with "
         <> Text.pack (show output.gitCommandExitCode)
-        <> case Text.strip (Text.pack output.gitCommandStderr) of
+        <> case Text.strip output.gitCommandStderr of
             "" -> ""
             stderr -> ": " <> displayTerminalText stderr

--- a/packages/agent-cli/test/Agent/CLI/GitDiffSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/GitDiffSpec.hs
@@ -23,6 +23,13 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "Agent.CLI.GitDiff" do
+    it "retains Unicode, NULs and lenient decoding in both output streams" $
+        withFakeGit
+            [ "capture) printf 'caf\\303\\251\\000\\377'; printf '\\342\\202' >&2;;" ]
+            \repo ->
+                runSafeGit repo [] ["capture"] `shouldReturn`
+                    Right (GitCommandOutput ExitSuccess "café\0\xfffd" "\xfffd\xfffd")
+
     it "reports a directory outside Git without failing" $
         withTempDir "agent-diff-not-git-" \dir ->
             getGitDiff dir `shouldReturn` Right GitDiffNotRepository
@@ -37,6 +44,7 @@ spec = describe "Agent.CLI.GitDiff" do
             git repo ["add", "README"]
             writeUtf8 (repo </> fromText "new file.txt") "new\n"
             writeUtf8 (repo </> fromText "line\nbreak.txt") "odd\n"
+            writeUtf8 (repo </> fromText "café.txt") "Unicode content\n"
 
             result <- getGitDiff repo
             diff <- expectDiff result
@@ -45,6 +53,7 @@ spec = describe "Agent.CLI.GitDiff" do
             diff `shouldSatisfy` Text.isInfixOf "new file.txt"
             diff `shouldSatisfy` Text.isInfixOf "break.txt"
             diff `shouldSatisfy` Text.isInfixOf "odd"
+            diff `shouldSatisfy` Text.isInfixOf "Unicode content"
 
     it "includes staged files in an unborn repository" $
         withTempDir "agent-git-diff-unborn-" \repo -> do


### PR DESCRIPTION
## Summary

- Retain Git stdout/stderr as strict `Text`, eliminating decode/unpack/repack conversions, including `/review` errors.
- Split NUL-separated output as `Text`; convert individual filenames to `FilePath` only at process boundaries.
- Preserve lenient UTF-8 decoding and existing process/security behavior.
- Document remaining String audit candidates and add a reproducible optimized baseline benchmark.

## Validation

- 20 GitDiff and Review examples passed in GHCi inside `nix develop`.
- Tests cover Unicode filenames, NUL-separated output, malformed UTF-8, repository helpers, and error handling.
- Full old/new benchmark output equality checked before and after sanitization at all three sizes.
- `git diff --check` passes.
- This is an internal representation change; terminal appearance and input handling are unchanged.

## Benchmark

GHC 9.10.3, macOS ARM64, `-O2`, `+RTS -T -N4`, inside `nix develop`. Seven samples per case, median elapsed/CPU time and allocated bytes; inputs 46,002, 460,002 and 4,600,002 bytes, with the intermediate size repeated. Unicode diff lines include tabs and one malformed UTF-8 suffix. Inputs are constructed outside measurement and results are forced.

At 4,600,002 input bytes:

| Pipeline | Old elapsed | Text elapsed | Old CPU | Text CPU | Old allocated bytes | Text allocated bytes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Decode/conversion/consumption | 42.153 ms | 15.087 ms | 44.810 ms | 15.258 ms | 258,979,520 | 4,601,912 |
| Including terminal sanitizer | 717.581 ms | 686.012 ms | 753.581 ms | 717.236 ms | 2,887,781,192 | 2,633,403,552 |

Approximately 98% less allocation in the output-only pipeline and 9% less including the unchanged sanitizer. Rendering timings vary; no consistent rendering speedup or whole-process memory reduction is claimed. An initially slower small-render result did not reproduce in 31-sample repeats in both execution orders. Dense malformed UTF-8 exposes an unchanged decoder performance boundary, documented separately.

Full results, repeat measurements, and scope: [GitOutput.md](packages/agent-cli/benchmark/GitOutput.md).

### Reproduction

```sh
mkdir -p "$TMPDIR/git-output-benchmark"
nix develop -c ghc -O2 -Wall -threaded -rtsopts \
  -XGHC2021 -XBlockArguments -XOverloadedStrings -XOverloadedRecordDot \
  -ipackages/agent-tui/src \
  -outputdir "$TMPDIR/git-output-benchmark/objects" \
  packages/agent-cli/benchmark/GitOutput.hs \
  -o "$TMPDIR/git-output-benchmark/benchmark"
nix develop -c sh -c '
  for n in 1000 10000 100000 10000; do
    for operation in original-output text-output original-render text-render; do
      "$1" "$operation" "$n" 7 +RTS -T -N4
    done
  done
' sh "$TMPDIR/git-output-benchmark/benchmark"
```
