### PR TITLE
Evaluate MicroHs as a standalone code-mode runtime

### DIFF
--- a/experiments/microhs-code-mode/README.md
+++ b/experiments/microhs-code-mode/README.md
@@ -1,0 +1,199 @@
+# MicroHs Code Mode experiment
+
+Standalone feasibility experiment. **Bun remains the production Code Mode
+runtime. This is not an agent backend option and is not safe for untrusted
+source.** No production packages or tool registrations are changed.
+
+## Run
+
+From the repository root:
+
+```sh
+nix develop .#microhs-code-mode
+python3 -B experiments/microhs-code-mode/experiment.py
+python3 -B -m unittest discover -s experiments/microhs-code-mode -v
+python3 -B experiments/microhs-code-mode/experiment.py --benchmark --samples 7
+```
+
+For an untracked working copy of these new files, use
+`nix develop "path:$PWD#microhs-code-mode"` so Nix includes them. The dedicated
+shell provides pinned MicroHs, the same Bun version as the main flake, and
+Python. It does not build the GHC agent. Set `TMPDIR` to an existing temporary
+directory if your environment does not already supply it.
+
+The package pins upstream revision `455782164e75998b140d869c1b7cdde0c8a21508`
+and preloads its bundled `base.pkg`. No native executable is compiled per cell.
+
+Pass a trusted Haskell source file as the positional argument to run another
+cell. It must export `main`; for example:
+
+```haskell
+module Main(main) where
+import CodeMode
+
+main :: IO ()
+main = runCell $ do
+    result <- callTool "fixture.echo" (JsonObject [("answer", JsonNumber "42")])
+    emit result
+```
+
+The host recognizes only `fixture.echo`, `fixture.numbers` (an object with an
+integer `count` from 0 through 10000), and `fixture.denied` (always returns an
+error). These are local test functions, not real harness tools. The denial
+fixture tests error propagation, **not** the production approval interface.
+
+## Architecture
+
+`experiment.py` is a disposable Python test host using only the standard
+library. The evaluated code and its tool-call library are Haskell. This avoids
+adding experimental dependencies or runtime selection to the production host
+before feasibility is established.
+
+Each cell gets a fresh MicroHs process and a temporary working directory under
+`TMPDIR`. The host writes `Cell.hs`, invokes `mhs -q -r`, reads a `ready` frame,
+dispatches sequential `tool/call` requests, collects `content` frames, and
+awaits the `cell-1` completion. Source loading/typechecking occurs before
+`ready`. Protocol frames use newline-delimited JSON-RPC 2.0. Exceptions during
+execution become error responses; compiler failures appear on the diagnostic
+path. Previously emitted content is retained if execution fails.
+
+This deliberately implements only a **subset** of Code Mode semantics. Unlike
+the Bun worker, source arrives as a file rather than an `exec` request, and
+`emit` sends a raw JSON value rather than a production content block. There
+is no worker pool, parallel tool dispatch, yield/resume, persistent store,
+image/audio output, dynamic tool declarations, or production host integration.
+The small JSON codec preserves numeric lexemes rather than using floating-point
+arithmetic; it is experimental, not a replacement for the production codec.
+
+## Safety boundary
+
+Only run reviewed, trusted source. Clearing environment variables, using a
+temporary directory, and restricting the host dispatcher do **not** sandbox
+Haskell IO or FFI. A cell can still access the filesystem or invoke runtime
+primitives directly. The test host supplies no credentials, does not load MCP
+configuration, and cannot dispatch arbitrary real tools. It enforces a wall
+timeout and stdout/stderr byte limits and terminates/joins the worker process
+group on completion, error, or cancellation. It does not impose a heap limit.
+
+On Darwin, an exited but unreaped process group can report `EPERM` when
+signalled. Cleanup briefly waits for reaping and retries the signal; it does
+not silently ignore permission failures for live groups.
+
+Before exposing this to a model with real tools, enforce OS-level isolation,
+memory limits and restricted compiler/runtime capabilities, integrate the
+existing host approval path, and test cancellation and protocol compatibility
+against the production host. A restricted import list alone is insufficient.
+
+## Comparison method
+
+Recorded measurements and recommendation: [RESULTS.md](RESULTS.md).
+
+The integer-sum benchmarks below are decoder/traversal stress tests, not a
+representative assessment of Code Mode. `benchmark_workflows.py` adds synthetic
+API-shaped workflows: dependent ID lookup, record filtering/projection, sparse
+field extraction, and combining independent responses. It checks tool arguments
+and final output, alternates backends, and reports raw samples with medians.
+
+```sh
+python3 -B experiments/microhs-code-mode/benchmark_workflows.py --samples 7
+```
+
+These workflows compare the persistent native-decoder MicroHs prototype with
+the actual fresh Bun worker, not the production Bun idle pool. Zero-delay runs
+measure local end-to-end overhead; simulated tool waits are reported separately
+from total latency. They are not measurements of live services. The MicroHs
+baseline still converts the entire native JSON document into Haskell values,
+even for sparse extraction. No opaque-handle optimization is implemented here.
+Independent calls are executed sequentially for equivalence with the prototype;
+this does not measure Bun's parallel-call capability or production throughput.
+
+The benchmark performs one identical logical operation in each language:
+request an array of integers from a fake host tool, sum it, and emit the sum.
+Every output is checked against the expected checksum, preventing a failed or
+skipped computation from being reported as a fast sample. Workloads contain
+10, 1000, and 10000 integers; 1000 is repeated to check stability. Each row
+reports medians over the selected sample count.
+
+- `microhs-source`: fresh process with source loading/typechecking.
+- `microhs-cached`: fresh process with a disk compilation cache populated by
+  one excluded preparation run. This is **not** a persistent warm interpreter.
+- `bun-worker`: fresh process running the actual repository Bun worker with
+  its normal runtime flags. It does not measure the production idle pool.
+
+`ready_ms` measures launch through readiness; `elapsed_ms` measures launch
+through completion including the host round trip, excluding source-file
+creation and process cleanup. `cpu_ms` measures child user plus system CPU,
+including cleanup, excluding the Python host. These are end-to-end prototype
+measurements, not isolated language-runtime benchmarks. The Haskell prototype
+uses its own JSON parser and arbitrary-precision integer sum; Bun uses native
+JSON and JavaScript numbers (all measured sums are exactly representable).
+GHCi timings are not used. Allocation, peak memory, persistent-worker latency,
+and model task success rates are not measured by this benchmark.
+
+## Persistent REPL experiment
+
+`persistent.py` is a separate trusted-source host, not a production backend.
+It keeps one MicroHs interpreter alive and loads `CodeMode` once. Cells are
+single-line IO expressions (use explicit `do { ...; ... }` braces), rather than
+complete modules. Do not share an interpreter
+between trust domains: IO state and interpreter state can survive a cell.
+The adapter wraps each expression in `runCell` and waits for the REPL prompt
+after completion. Compile errors and caught runtime errors permit another cell;
+timeouts, cancellation, or protocol errors discard the worker. Create a new
+instance afterward; failed cells are never automatically replayed. Cells must
+not manipulate protocol IO, fork children, or alter REPL state directly.
+
+Python usage (with this experiment directory on the import path):
+
+```python
+from experiment import temporary_directory
+from persistent import PersistentMicroHs
+
+with temporary_directory() as directory:
+    async with PersistentMicroHs(directory) as worker:
+        first = await worker.execute('callTool "fixture.echo" (JsonNumber "42") >>= emit')
+        second = await worker.execute('emit (JsonString "another cell, same interpreter")')
+```
+
+Run the comparison inside the same Nix shell:
+
+```sh
+python3 -B experiments/microhs-code-mode/benchmark_persistent.py --samples 7
+```
+
+This reports one cold REPL initialization separately, then seven samples per
+workload in the same interpreter, including a repeated medium workload.
+Fresh MicroHs and fresh Bun are rerun as controls. Warm-cell elapsed time
+includes submission, typechecking/evaluation, host tool round trips, and
+completion synchronization, but excludes interpreter initialization. This is
+not a comparison against Bun's production idle pool. Raw elapsed samples are
+included; per-cell CPU, allocations, and peak memory are not measured here.
+
+## Native JSON FFI experiment
+
+This variant retains the Python host and JSON-over-stdio protocol. It tests
+calling yyjson from MicroHs through the C FFI, not embedding MicroHs into the
+production GHC host or removing serialization. Only response decoding changes;
+the JSON value representation, Haskell arithmetic, and output encoder remain
+the same. `callToolWithDecoder` selects the response decoder per call.
+
+The pinned MicroHs interpreter requires native functions to be registered in
+its compiled FFI table. The separate `mhs-native-json` executable supplies those
+registrations; the original `mhs` remains available as the baseline.
+
+Inside the experiment's Nix shell:
+
+```sh
+MICROHS_NATIVE_INTERPRETER=mhs-native-json python3 -B -m unittest discover \
+  -s experiments/microhs-code-mode -v
+python3 -B experiments/microhs-code-mode/benchmark_native.py \
+  --interpreter mhs-native-json --samples 7
+```
+
+The decoder comparison alternates execution order in one persistent interpreter
+and checks every result. It reports median end-to-end elapsed milliseconds for
+10, 1000, and 10000 integers, then repeats 1000. This includes conversion of the
+native parse tree into Haskell values; it is not yyjson's parsing time alone.
+Interpreter initialization is reported separately. No allocation, memory, or
+per-cell CPU improvement is claimed. The same trusted-source restrictions as
+the original REPL apply; an FFI is not a security boundary.

--- a/experiments/microhs-code-mode/RESULTS.md
+++ b/experiments/microhs-code-mode/RESULTS.md
@@ -1,0 +1,219 @@
+# Initial results
+
+Measured on 2026-09-12, Apple M3 Max, macOS 26.6.1, arm64. MicroHs
+0.16.6.0 at the revision pinned in `nix/microhs.nix`, Bun 1.4.0, Python
+3.14.7. Command: `python3 -B experiments/microhs-code-mode/experiment.py
+--benchmark --samples 7` inside the dedicated Nix shell.
+
+Seven samples per row, median milliseconds. Every sample checks its sum and
+tool-call count. See README for timing boundaries and comparison caveats.
+
+| Backend | Integers | Ready | Complete | Child CPU |
+|---|---:|---:|---:|---:|
+| MicroHs source | 10 | 616.530 | 618.334 | 622.025 |
+| MicroHs disk cache | 10 | 9701.729 | 9703.299 | 9676.302 |
+| Bun worker | 10 | 23.599 | 27.444 | 28.959 |
+| MicroHs source | 1000 | 629.390 | 749.576 | 751.355 |
+| MicroHs disk cache | 1000 | 9507.804 | 9627.212 | 9605.126 |
+| Bun worker | 1000 | 21.608 | 24.955 | 27.533 |
+| MicroHs source | 10000 | 626.352 | 5494.884 | 5476.559 |
+| MicroHs disk cache | 10000 | 9540.103 | 14213.505 | 14158.799 |
+| Bun worker | 10000 | 22.783 | 27.139 | 29.325 |
+| MicroHs source (repeat) | 1000 | 617.588 | 741.049 | 740.204 |
+| MicroHs disk cache (repeat) | 1000 | 9485.888 | 9605.305 | 9577.220 |
+| Bun worker (repeat) | 1000 | 22.206 | 26.030 | 28.663 |
+
+## Interpretation
+
+The tool-call design is feasible: Haskell cells can invoke host functions,
+consume their JSON responses, and emit results. Static type errors occur before
+tool effects. This is not yet a viable drop-in replacement for Bun.
+
+The current fresh-process prototype is substantially slower than the actual
+Bun worker, even without measuring Bun's production idle pool. Source loading
+accounts for most small-cell latency. The large-array case also exposes a
+substantial execution/codec cost, which needs profiling before attributing it
+to the evaluator. No memory or allocation advantage has been measured.
+
+The tested `-C` disk-cache path is a regression, around 9.5–9.7 seconds to
+readiness; it is not a startup optimization in this configuration. Investigate
+cache serialization/loading and source invalidation before using it. A
+persistent interpreter is measured separately below; precompiled support-package
+optimization remains unmeasured.
+
+Recommendation: retain this as a standalone experiment, leave Bun unchanged,
+and address startup, JSON throughput, and OS isolation before real-tool
+integration.
+
+## Persistent REPL follow-up
+
+Same machine and versions, using `benchmark_persistent.py --samples 7` in the
+dedicated Nix shell. One interpreter loads CodeMode once and runs all warm
+samples sequentially. Fresh MicroHs and Bun controls are rerun alongside each
+workload. Every sample verifies the tool-call count and returned sum.
+
+REPL initialization took **19270.802 ms** (one observation, not a median),
+including imports and a successful probe cell. Warm timings exclude this cost
+and include expression compilation, tool round trip, evaluation, and return to
+the REPL prompt. Fresh timings include process startup. This does not compare
+against pooled Bun, nor measure per-cell CPU, memory, or allocations.
+
+Median complete latency in milliseconds, seven samples per entry:
+
+| Integers | Warm MicroHs REPL | Fresh MicroHs | Fresh Bun worker |
+|---|---:|---:|---:|
+| 10 | 163.419 | 628.037 | 26.210 |
+| 1000 | 285.620 | 737.681 | 26.288 |
+| 10000 | 5564.009 | 5416.737 | 26.992 |
+| 1000 (repeat) | 284.732 | 745.972 | 25.476 |
+
+Persistence reduces small-cell latency about 3.8x and medium-cell latency
+about 2.6x, excluding initialization. It does not improve the large-array
+workload in this run. The small cell remains about 6.2x slower than even a
+fresh Bun worker. The repeated medium workload returns to similar latency
+after the large workload, but this is not a long-running memory test.
+
+Conclusion: keeping a REPL works and amortizes some overhead, but does not
+make this implementation competitive with Bun. Profile per-expression
+compilation/linking and the JSON/evaluation path next; these timings alone
+do not isolate their contributions. Keep production Bun unchanged.
+
+The full suite passed: **14 tests**, including multiple cells in one process,
+recovery after compile/runtime errors and denied calls, timeout replacement,
+JSON/prompt framing, and output limits. The adapter is trusted-source only,
+not a sandbox. Direct cancellation is not separately tested; repeated
+cancellation during cleanup is not shielded.
+
+## Native JSON FFI (2026-09-12)
+
+`benchmark_native.py --interpreter mhs-native-json --samples 7` compares the
+ReadP decoder with yyjson 0.12.0 through statically registered C FFI wrappers.
+The pinned MicroHs C runtime and wrappers use the upstream optimized build
+(`-O3`). Both decoders run in the same persistent interpreter, alternating
+order each repetition, with identical tool replies, Json values, and Haskell
+summation. Every sample checked its result and tool-call count.
+
+Median complete warm-cell latency, milliseconds (seven samples each):
+
+| Integers | ReadP | Native yyjson + conversion | Speedup |
+|---|---:|---:|---:|
+| 10 | 165.230 | 164.948 | 1.00x |
+| 1000 | 286.798 | 213.228 | 1.35x |
+| 10000 | 5458.743 | 741.146 | 7.37x |
+| 1000 (repeat) | 287.376 | 211.259 | 1.36x |
+
+Initialization was 19886.215 ms (one observation), excluded from warm timings.
+Nix build/environment setup is excluded entirely. Measurements include cell
+compilation, stdio transport, native-to-Haskell conversion, evaluation, and
+completion synchronization, not just native parsing. No CPU, allocation, or
+memory measurements were taken. The optional sanitizer check did not run.
+
+Replacing this prototype's ReadP decoder removes most of the large-array
+latency, but leaves small-cell latency unchanged. This is evidence against
+the decoder implementation, not Haskell JSON libraries in general. Native
+conversion and arithmetic still execute through MicroHs; remaining time has
+not been profiled. Bun was not rerun in this comparison (the prior fresh Bun
+large-array median was 26.992 ms), so this is not a new head-to-head Bun test.
+
+Validation: the existing 14 tests passed after decoder parameterization; the
+optional native test passed separately, covering valid/invalid JSON, exact
+numeric lexemes, Unicode and embedded NUL, duplicate keys, nesting limits,
+dependent tool calls, denied calls, and subsequent recovery. Production Bun
+is unchanged; this remains a trusted-source experiment.
+
+## Representative synthetic workflows
+
+`benchmark_workflows.py` replaces the integer-sum stress test with customer-ID
+chaining, filtering 100/1,000 customer records and projecting two fields,
+extracting only a cursor and the first event ID from a 1,000-record response,
+and combining three independent responses. The independent calls are **serial
+in both backends**: this adapter does not measure production Bun's concurrent
+tool-call capability. These are plausible workflow shapes, not captured
+production traces or a claim about the frequency of particular workloads.
+
+The comparison retains the current native decoder's **full Haskell JSON-tree
+conversion**, including unused values. It does not benchmark opaque handles.
+Both languages receive identical fixture responses; every tool name, argument,
+call count, and final result is checked. Fixture construction is outside timing;
+host serialization, transport, worker parsing, expression compilation/evaluation,
+and output handling remain inside. MicroHs is warm; actual Bun workers start
+fresh using the same production worker script as previous measurements.
+
+Run with:
+
+```sh
+nix develop "path:$PWD#microhs-code-mode" -c \
+  python3 -B experiments/microhs-code-mode/benchmark_workflows.py --samples 7
+```
+
+Each backend is sampled seven times with alternating execution order, at zero
+and 100 ms simulated latency per call; the 100-record filter is repeated.
+`simulated_wait_ms` measures actual time spent awaiting the fixture delay,
+and `non_wait_ms` subtracts that measured duration from each sample (not merely
+the requested delay). It is **not CPU time**. Raw measurements and medians are
+printed as JSONL. No allocation or memory claims follow from this benchmark.
+
+Seven-sample run, same machine and native build as above. MicroHs startup was
+20,152.763 ms (one observation, excluded). All 168 timed executions validated.
+Times below are median elapsed milliseconds:
+
+| Workflow | Response bytes | MicroHs, zero delay | Bun, zero delay | MicroHs, 100 ms/call | Bun, 100 ms/call |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| ID chain, two calls | 77 | 158.286 | 27.070 | 358.483 | 229.975 |
+| Filter 100 | 17,330 | 197.622 | 26.920 | 302.447 | 128.188 |
+| Filter 1,000 | 176,030 | 544.379 | 28.861 | 651.926 | 129.814 |
+| Filter 100, repeat | 17,330 | 200.262 | 26.901 | 298.140 | 128.400 |
+| Sparse extraction, 1,000 events | 159,924 | 437.619 | 28.237 | 535.032 | 130.908 |
+| Three independent calls, serial | 42 | 163.969 | 26.786 | 468.120 | 331.198 |
+
+After subtracting measured sleep time, delayed MicroHs medians were
+156.623 / 201.379 / 550.855 / 197.067 / 433.961 / 165.233 ms respectively;
+Bun medians were 27.969 / 27.106 / 28.866 / 27.307 / 29.828 / 28.753 ms.
+These support a roughly 130 ms excess for small orchestration cells in this
+prototype, with additional response-size-dependent cost. They do not identify
+which compiler/runtime/conversion stage accounts for the gap.
+
+The first smoke attempted the same sparse workflow with a description repeated
+16 rather than two times per event (481,924 response bytes); MicroHs exited
+during the exchange, producing a broken-pipe error in the host. The smaller
+159,924-byte variant above passed. The larger failure is not included as a
+latency sample. A separate `getLine >>= print . length` diagnostic, without JSON
+parsing, passed with a 160,000-byte input but exited with `ERR: stack overflow`
+at 482,000 bytes. This exposes a line-input/evaluation limitation independently
+of JSON conversion; it is not an exact failure-threshold measurement. Do not
+interpret the table as evidence that large responses are robust.
+
+Validation: the 18-test regression suite passed. After adding async-handler
+error cleanup and its regression test, all four workflow tests passed, including
+error propagation through both backends and subsequent MicroHs cell recovery.
+
+### Readiness boundary, second run
+
+This run overlapped regression tests and diagnostics. Its timings are retained
+for diagnostic context only, not as controlled performance evidence. Use the
+first run above for the benchmark comparison.
+
+A second seven-sample run captured `ready_ms` without changing workloads.
+All 168 executions again validated. MicroHs startup was 19,903.753 ms.
+For MicroHs this boundary is submission through receipt of `runCell`'s ready
+frame, before fixture calls. For Bun it is process launch through worker
+readiness, **before submitting source**; these readiness numbers therefore
+describe different stages and must not be compared as compilation timings.
+
+| Workflow, zero delay | MicroHs elapsed | MicroHs ready | Bun elapsed | Bun ready |
+| --- | ---: | ---: | ---: | ---: |
+| ID chain | 153.807 | 152.691 | 26.275 | 22.751 |
+| Filter 100 | 195.242 | 164.645 | 26.255 | 22.852 |
+| Filter 1,000 | 543.332 | 219.565 | 27.777 | 22.821 |
+| Filter 100, repeat | 198.653 | 168.192 | 25.810 | 22.174 |
+| Sparse 1,000 | 431.425 | 158.741 | 27.787 | 23.263 |
+| Three serial calls | 163.029 | 161.772 | 26.478 | 23.002 |
+
+The small ID-chain cell spends nearly all elapsed time before this MicroHs
+ready boundary. That localizes the delay before tool orchestration, but does
+not separate parsing, typechecking, linking, runtime preparation, or transport.
+For delayed cells, MicroHs readiness medians remained 154.839 / 166.622 /
+217.386 / 162.775 / 157.130 / 158.901 ms in the same workflow order.
+The second run's complete raw results are retained as
+`$TMPDIR/microhs-workflows-ready-results.jsonl`; the first run is
+`$TMPDIR/microhs-workflows-results.jsonl`.

--- a/experiments/microhs-code-mode/benchmark_native.py
+++ b/experiments/microhs-code-mode/benchmark_native.py
@@ -1,0 +1,51 @@
+"""Compare JSON decoders in the same persistent MicroHs process."""
+
+import argparse
+import asyncio
+import json
+import statistics
+
+from experiment import temporary_directory
+from persistent import PersistentMicroHs
+
+
+async def benchmark(interpreter, samples):
+    with temporary_directory() as directory:
+        async with PersistentMicroHs(directory, interpreter=interpreter,
+                                     modules=("CodeMode.NativeJson",)) as worker:
+            probe = await worker.execute('decodeJsonNative "null" >>= either error emit')
+            if probe["content"] != [None] or "error" in probe["completion"]:
+                raise AssertionError(probe)
+            print(json.dumps({"startup_ms": worker.startup_ms}), flush=True)
+            for count in [10, 1000, 10000, 1000]:
+                measurements = {"readp": [], "native": []}
+                for sample in range(samples):
+                    # Alternate order to avoid assigning all drift to one decoder.
+                    order = ["readp", "native"] if sample % 2 == 0 else ["native", "readp"]
+                    for backend in order:
+                        decoder = "(pure . decodeJson)" if backend == "readp" else "decodeJsonNative"
+                        expression = (
+                            f'do {{ values <- callToolWithDecoder {decoder} "fixture.numbers" '
+                            f'(JsonObject [("count", JsonNumber "{count}")]); '
+                            'case values of { JsonArray entries -> emit (JsonNumber '
+                            '(show (sum [read value :: Integer | JsonNumber value <- entries]))); '
+                            '_ -> error "expected array" } }')
+                        result = await worker.execute(expression)
+                        if (result["content"] != [count * (count + 1) // 2]
+                                or result["calls"] != 1 or "error" in result["completion"]):
+                            raise AssertionError(result)
+                        measurements[backend].append(result["elapsed_ms"])
+                for backend, durations in measurements.items():
+                    print(json.dumps({"backend": backend, "count": count, "samples": samples,
+                                      "elapsed_ms": statistics.median(durations),
+                                      "raw_elapsed_ms": durations}), flush=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--interpreter", required=True)
+    parser.add_argument("--samples", type=int, default=7)
+    arguments = parser.parse_args()
+    if arguments.samples < 1:
+        parser.error("samples must be positive")
+    asyncio.run(benchmark(arguments.interpreter, arguments.samples))

--- a/experiments/microhs-code-mode/benchmark_persistent.py
+++ b/experiments/microhs-code-mode/benchmark_persistent.py
@@ -1,0 +1,50 @@
+"""Compare warm REPL cells with fresh MicroHs and Bun workers (trusted fixtures)."""
+
+import argparse
+import asyncio
+import json
+import statistics
+
+from experiment import haskell_cell, run_bun, run_haskell, temporary_directory
+from persistent import PersistentMicroHs
+
+
+async def benchmark(samples):
+    with temporary_directory() as directory:
+        async with PersistentMicroHs(directory) as worker:
+            print(json.dumps({"backend": "microhs-repl", "startup_ms": worker.startup_ms}), flush=True)
+            for count in [10, 1000, 10000, 1000]:
+                body = (
+                    f'do {{ values <- callTool "fixture.numbers" (JsonObject [("count", JsonNumber "{count}")]); '
+                    'case values of { '
+                    'JsonArray entries -> emit (JsonNumber (show (sum [read value :: Integer | JsonNumber value <- entries]))); '
+                    '_ -> error "expected array" } }')
+                javascript = f'text((await tools.fixture.numbers({{count: {count}}})).reduce((total, value) => total + value, 0));'
+                for backend in ["microhs-repl", "microhs-source", "bun-worker"]:
+                    results = []
+                    for _ in range(samples):
+                        if backend == "microhs-repl":
+                            result = await worker.execute(body)
+                        elif backend == "microhs-source":
+                            result = await run_haskell(haskell_cell(body), directory)
+                        else:
+                            result = await run_bun(javascript, directory)
+                        actual = result["content"]
+                        if backend == "bun-worker":
+                            actual = [json.loads(block["text"]) for block in actual]
+                        if ("error" in result["completion"] or result["calls"] != 1
+                                or actual != [count * (count + 1) // 2]):
+                            raise AssertionError(result)
+                        results.append(result["elapsed_ms"])
+                    print(json.dumps({"backend": backend, "count": count, "samples": samples,
+                        "elapsed_ms": round(statistics.median(results), 3),
+                        "raw_elapsed_ms": results}), flush=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", type=int, default=7)
+    arguments = parser.parse_args()
+    if arguments.samples < 1:
+        parser.error("samples must be positive")
+    asyncio.run(benchmark(arguments.samples))

--- a/experiments/microhs-code-mode/benchmark_workflows.py
+++ b/experiments/microhs-code-mode/benchmark_workflows.py
@@ -1,0 +1,154 @@
+"""Synthetic tool workflows: full-tree native MicroHs versus actual fresh Bun."""
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+import json
+import statistics
+import time
+
+from experiment import run_bun, temporary_directory
+from persistent import PersistentMicroHs
+
+
+@dataclass
+class Workflow:
+    name: str
+    haskell: str
+    javascript: str
+    exchanges: list
+    expected: object
+
+
+def workflows():
+    call = 'callToolWithDecoder decodeJsonNative'
+    # Helpers are deliberately local: their compilation is part of cell latency.
+    helpers = ('let { field key (JsonObject fields) = case lookup key fields of '
+               '{ Just value -> value; Nothing -> error "missing field" }; '
+               'field _ _ = error "expected object"; '
+               'entries (JsonArray values) = values; entries _ = error "expected array" }; ')
+    def cell(body):
+        return 'do { ' + helpers + body + ' }'
+    yield Workflow(
+        "chain-id",
+        cell(f'customer <- {call} "fixture.customer" (JsonObject [("email", JsonString "alex@example.test")]); '
+             f'subscription <- {call} "fixture.subscription" (JsonObject [("customerId", field "id" customer)]); '
+             'emit (field "plan" subscription)'),
+        'const customer = await tools.fixture.customer({email:"alex@example.test"}); '
+        'const subscription = await tools.fixture.subscription({customerId:customer.id}); text(subscription.plan);',
+        [("fixture.customer", {"email": "alex@example.test"}, {"id": "customer-42", "name": "Alex"}),
+         ("fixture.subscription", {"customerId": "customer-42"}, {"plan": "business", "status": "active"})],
+        "business")
+    for count, suffix in [(100, ""), (1000, ""), (100, "-repeat")]:
+        records = [{"id": f"customer-{index}", "name": f"Customer {index}",
+                    "status": "active" if index % 3 == 0 else "inactive",
+                    "email": f"user{index}@example.test", "country": "DE",
+                    "metadata": {"source": "import", "segment": "business"}}
+                   for index in range(count)]
+        yield Workflow(
+            f"filter-{count}{suffix}",
+            cell(f'response <- {call} "fixture.customers" (JsonObject [("limit", JsonNumber "{count}")]); '
+                 'emit (JsonArray [JsonObject [("id", field "id" row), ("name", field "name" row)] '
+                 '| row <- entries (field "data" response), '
+                 'case field "status" row of { JsonString status -> status == "active"; _ -> False }])'),
+            f'const response = await tools.fixture.customers({{limit:{count}}}); '
+            'text(response.data.filter(row => row.status === "active").map(({id,name}) => ({id,name})));',
+            [("fixture.customers", {"limit": count}, {"data": records, "hasMore": False})],
+            [{"id": record["id"], "name": record["name"]} for record in records if record["status"] == "active"])
+    records = [{"id": f"event-{index}", "description": "Detailed event payload. " * 2,
+                "metadata": {"source": "api", "tags": ["account", "billing", "audit"]}}
+               for index in range(1000)]
+    yield Workflow(
+        "sparse-1000",
+        cell(f'response <- {call} "fixture.events" (JsonObject []); '
+             'emit (JsonObject [("cursor", field "nextCursor" response), '
+             '("firstId", field "id" (head (entries (field "data" response))))])'),
+        'const response = await tools.fixture.events({}); '
+        'text({cursor:response.nextCursor,firstId:response.data[0].id});',
+        [("fixture.events", {}, {"data": records, "nextCursor": "page-2"})],
+        {"cursor": "page-2", "firstId": "event-0"})
+    yield Workflow(
+        "independent-sequential",
+        cell(f'customer <- {call} "fixture.customer" (JsonObject []); '
+             f'usage <- {call} "fixture.usage" (JsonObject []); '
+             f'plan <- {call} "fixture.plan" (JsonObject []); '
+             'emit (JsonObject [("name", field "name" customer), ("used", field "used" usage), '
+             '("limit", field "limit" plan)])'),
+        'const customer = await tools.fixture.customer({}); const usage = await tools.fixture.usage({}); '
+        'const plan = await tools.fixture.plan({}); text({name:customer.name,used:usage.used,limit:plan.limit});',
+        [("fixture.customer", {}, {"name": "Alex"}), ("fixture.usage", {}, {"used": 72}),
+         ("fixture.plan", {}, {"limit": 100})],
+        {"name": "Alex", "used": 72, "limit": 100})
+
+
+class FixtureHandler:
+    def __init__(self, workflow, latency_ms):
+        self.workflow = workflow
+        self.latency_ms = latency_ms
+        self.calls = 0
+        self.wait_ms = 0
+
+    async def __call__(self, name, arguments):
+        expected_name, expected_arguments, response = self.workflow.exchanges[self.calls]
+        if (name, arguments) != (expected_name, expected_arguments):
+            raise AssertionError((name, arguments, expected_name, expected_arguments))
+        self.calls += 1
+        if self.latency_ms:
+            started = time.perf_counter()
+            await asyncio.sleep(self.latency_ms / 1000)
+            self.wait_ms += (time.perf_counter() - started) * 1000
+        return response
+
+
+async def sample(workflow, backend, latency_ms, worker, directory):
+    handler = FixtureHandler(workflow, latency_ms)
+    if backend == "microhs-native-full-tree":
+        result = await worker.execute(workflow.haskell, timeout=120, handler=handler)
+        content = result["content"]
+    else:
+        result = await run_bun(workflow.javascript, directory, timeout=120, handler=handler,
+                               tools=list(dict.fromkeys(name for name, _, _ in workflow.exchanges)))
+        content = [block["text"] if isinstance(workflow.expected, str) else json.loads(block["text"])
+                   for block in result["content"]]
+    if ("error" in result["completion"] or content != [workflow.expected]
+            or result["calls"] != len(workflow.exchanges) or handler.calls != len(workflow.exchanges)):
+        raise AssertionError((workflow.name, backend, result))
+    return {"elapsed_ms": result["elapsed_ms"], "ready_ms": result["ready_ms"],
+            "simulated_wait_ms": handler.wait_ms,
+            "non_wait_ms": result["elapsed_ms"] - handler.wait_ms}
+
+
+async def benchmark(interpreter, samples):
+    with temporary_directory() as directory:
+        async with PersistentMicroHs(directory, interpreter=interpreter,
+                                     modules=("CodeMode.NativeJson",)) as worker:
+            print(json.dumps({"startup_ms": worker.startup_ms,
+                              "note": "MicroHs warm; Bun fresh. Native full-tree conversion. Sequential tool dispatch."}), flush=True)
+            for latency_ms in [0, 100]:
+                for workflow in workflows():
+                    measurements = {"microhs-native-full-tree": [], "bun-fresh": []}
+                    for index in range(samples):
+                        order = list(measurements)
+                        if index % 2:
+                            order.reverse()
+                        for backend in order:
+                            measurements[backend].append(
+                                await sample(workflow, backend, latency_ms, worker, directory))
+                    for backend, results in measurements.items():
+                        print(json.dumps({"workflow": workflow.name, "backend": backend,
+                                          "tool_latency_ms": latency_ms, "calls": len(workflow.exchanges),
+                                          "response_bytes": sum(len(json.dumps(response, ensure_ascii=True).encode())
+                                                                for _, _, response in workflow.exchanges),
+                                          "samples": samples,
+                                          **{key: statistics.median(result[key] for result in results)
+                                             for key in results[0]}, "raw": results}), flush=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--interpreter", default="mhs-native-json")
+    parser.add_argument("--samples", type=int, default=7)
+    arguments = parser.parse_args()
+    if arguments.samples < 1:
+        parser.error("samples must be positive")
+    asyncio.run(benchmark(arguments.interpreter, arguments.samples))

--- a/experiments/microhs-code-mode/experiment.py
+++ b/experiments/microhs-code-mode/experiment.py
@@ -1,0 +1,231 @@
+"""Trusted-source experiment only: no real tools, credentials, or OS sandbox."""
+
+import argparse
+import asyncio
+import contextlib
+import inspect
+import json
+import os
+from pathlib import Path
+import resource
+import shutil
+import signal
+import statistics
+import tempfile
+import time
+
+
+DIRECTORY = Path(__file__).resolve().parent
+REPOSITORY = DIRECTORY.parent.parent
+MAXIMUM_BYTES = 4 * 1024 * 1024
+
+
+def execute_fixture(name, arguments):
+    """Fixed, side-effect-free allowlist. Never dispatch a real harness tool."""
+    if name == "fixture.echo":
+        return arguments
+    if name == "fixture.numbers":
+        count = arguments.get("count") if isinstance(arguments, dict) else None
+        if type(count) is not int or not 0 <= count <= 10000:
+            raise ValueError("count must be an integer between 0 and 10000")
+        return list(range(1, count + 1))
+    if name == "fixture.denied":
+        raise ValueError("fixture approval denied")
+    raise ValueError("tool is not available: " + name)
+
+
+async def exchange(command, directory, request=None, timeout=30, handler=execute_fixture):
+    """Run a bounded protocol exchange and always terminate/join its process group."""
+    started = time.perf_counter()
+    usage_before = resource.getrusage(resource.RUSAGE_CHILDREN)
+    process = await asyncio.create_subprocess_exec(
+        *command, cwd=directory, env={"TMPDIR": str(directory)},
+        stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE, start_new_session=True,
+        limit=MAXIMUM_BYTES,
+    )
+    content = []
+    calls = []
+    diagnostic = bytearray()
+    received_bytes = 0
+
+    async def read_diagnostic():
+        while block := await process.stderr.read(8192):
+            diagnostic.extend(block)
+            if len(diagnostic) > MAXIMUM_BYTES:
+                raise ValueError("stderr output limit exceeded")
+
+    async def send(message):
+        process.stdin.write((json.dumps(message, ensure_ascii=True, allow_nan=False) + "\n").encode())
+        await process.stdin.drain()
+
+    async def receive():
+        nonlocal received_bytes
+        line = await process.stdout.readline()
+        if not line:
+            await process.wait()
+            raise RuntimeError("worker exited before completion: " + diagnostic.decode(errors="replace"))
+        received_bytes += len(line)
+        if received_bytes > MAXIMUM_BYTES:
+            raise ValueError("stdout output limit exceeded")
+        message = json.loads(line)
+        if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+            raise ValueError("invalid JSON-RPC message")
+        return message
+
+    async def conversation():
+        if (await receive()).get("method") != "ready":
+            raise ValueError("worker did not send ready")
+        ready_ms = (time.perf_counter() - started) * 1000
+        if request is not None:
+            await send(request)
+        while True:
+            message = await receive()
+            method = message.get("method")
+            if method == "tool/call":
+                identifier = message.get("id")
+                parameters = message.get("params")
+                if not isinstance(identifier, str) or identifier in calls:
+                    raise ValueError("invalid or duplicate tool request id")
+                if not isinstance(parameters, dict) or not isinstance(parameters.get("name"), str):
+                    raise ValueError("invalid tool parameters")
+                if "arguments" not in parameters:
+                    raise ValueError("missing tool arguments")
+                calls.append(identifier)
+                reply = {"jsonrpc": "2.0", "id": identifier}
+                try:
+                    reply["result"] = handler(parameters["name"], parameters["arguments"])
+                    if inspect.isawaitable(reply["result"]):
+                        reply["result"] = await reply["result"]
+                except ValueError as error:
+                    reply.pop("result", None)
+                    reply["error"] = {"code": -32000, "message": str(error)}
+                await send(reply)
+            elif method == "content":
+                content.append(message["params"]["value"])
+            elif method is None and message.get("id") == "cell-1":
+                if ("result" in message) == ("error" in message):
+                    raise ValueError("completion must contain exactly one result or error")
+                return {"content": content, "calls": len(calls), "completion": message,
+                        "ready_ms": ready_ms,
+                        "elapsed_ms": (time.perf_counter() - started) * 1000}
+            else:
+                raise ValueError("unexpected worker message")
+
+    try:
+        async with asyncio.timeout(timeout):
+            async with asyncio.TaskGroup() as group:
+                diagnostic_task = group.create_task(read_diagnostic())
+                result = await conversation()
+                diagnostic_task.cancel()
+    finally:
+        # Kill the whole group even if its leader has already exited.
+        with contextlib.suppress(ProcessLookupError):
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except PermissionError:
+                # Darwin reports EPERM for a zombie-only group. Reap and
+                # retry, without swallowing permission errors on live groups.
+                await asyncio.wait_for(process.wait(), timeout=1)
+                os.killpg(process.pid, signal.SIGKILL)
+        await process.wait()
+        process.stdin.close()
+    usage_after = resource.getrusage(resource.RUSAGE_CHILDREN)
+    result["cpu_ms"] = 1000 * (
+        usage_after.ru_utime + usage_after.ru_stime
+        - usage_before.ru_utime - usage_before.ru_stime
+    )
+    return result
+
+
+def executable(name):
+    path = shutil.which(name)
+    if path is None:
+        raise RuntimeError(f"{name} missing; enter nix develop .#microhs-code-mode")
+    return str(Path(path).absolute())
+
+
+async def run_haskell(source, directory, cache=False, timeout=30, handler=execute_fixture):
+    source_path = Path(directory) / "Cell.hs"
+    source_path.write_text(source)
+    command = [executable("mhs"), "-q", "-i" + str(DIRECTORY / "haskell")]
+    if cache:
+        command.append("-C" + str(Path(directory) / "compilation-cache"))
+    command += [str(source_path), "-r"]
+    return await exchange(command, directory, timeout=timeout, handler=handler)
+
+
+async def run_bun(source, directory, timeout=30, handler=execute_fixture, tools=None):
+    command = [executable("bun"), "--smol", "--no-install", "--no-env-file", "--no-addons",
+               str(REPOSITORY / "packages/agent-core/data/code-mode/worker.mjs")]
+    request = {"jsonrpc": "2.0", "id": "cell-1", "method": "exec", "params": {
+        "source": source, "tools": tools if tools is not None else ["fixture.echo", "fixture.numbers", "fixture.denied"],
+        "stored_values": {}, "image_detail_visible": True}}
+    return await exchange(command, directory, request=request, timeout=timeout, handler=handler)
+
+
+def haskell_cell(body):
+    return "module Main(main) where\nimport CodeMode\nmain :: IO ()\nmain = runCell $ do\n" + "\n".join(
+        "  " + line for line in body.splitlines()) + "\n"
+
+
+def temporary_directory():
+    return tempfile.TemporaryDirectory(prefix="microhs-code-mode-", dir=os.environ["TMPDIR"])
+
+
+async def benchmark(samples):
+    """Fresh worker each sample; cached means disk compilation cache, not warm VM."""
+    for count in [10, 1000, 10000, 1000]:
+        haskell = haskell_cell(
+            f'values <- callTool "fixture.numbers" (JsonObject [("count", JsonNumber "{count}")])\n'
+            'case values of\n'
+            '  JsonArray entries -> emit (JsonNumber (show (sum [read value :: Integer | JsonNumber value <- entries])))\n'
+            '  _ -> error "expected array"')
+        javascript = f'text((await tools.fixture.numbers({{count: {count}}})).reduce((total, value) => total + value, 0));'
+        for backend in ["microhs-source", "microhs-cached", "bun-worker"]:
+            with temporary_directory() as directory:
+                async def sample():
+                    if backend == "bun-worker":
+                        return await run_bun(javascript, directory)
+                    return await run_haskell(haskell, directory, cache=backend == "microhs-cached")
+                if backend == "microhs-cached":
+                    await sample()
+                results = []
+                for _ in range(samples):
+                    result = await sample()
+                    if "error" in result["completion"]:
+                        raise RuntimeError(result)
+                    expected = count * (count + 1) // 2
+                    # Bun text() wraps its output in a content block.
+                    actual = result["content"]
+                    if backend == "bun-worker":
+                        actual = [json.loads(block["text"]) for block in actual]
+                    if actual != [expected] or result["calls"] != 1:
+                        raise AssertionError(result)
+                    results.append(result)
+                print(json.dumps({"backend": backend, "count": count, "samples": samples,
+                    **{field: round(statistics.median(result[field] for result in results), 3)
+                       for field in ["ready_ms", "elapsed_ms", "cpu_ms"]}}), flush=True)
+
+
+async def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", nargs="?", type=Path, help="trusted Haskell module with main = runCell ...")
+    parser.add_argument("--benchmark", action="store_true")
+    parser.add_argument("--samples", type=int, default=7)
+    arguments = parser.parse_args()
+    if arguments.samples < 1:
+        parser.error("samples must be positive")
+    if arguments.benchmark:
+        await benchmark(arguments.samples)
+    else:
+        source = arguments.source or DIRECTORY / "haskell/Example.hs"
+        with temporary_directory() as directory:
+            result = await run_haskell(source.read_text(), directory)
+        print(json.dumps(result, indent=2))
+        if "error" in result["completion"]:
+            raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/experiments/microhs-code-mode/haskell/CodeMode.hs
+++ b/experiments/microhs-code-mode/haskell/CodeMode.hs
@@ -1,0 +1,97 @@
+-- Standalone, sequential prototype. This deliberately does not
+-- expose the production host or grant access to real tools.
+module CodeMode
+    ( module CodeMode.Json
+    , callTool
+    , callToolWithDecoder
+    , emit
+    , runCell
+    ) where
+
+import CodeMode.Json
+-- MicroHs ships Control.Exception but not the safe-exceptions package.
+-- All worker exceptions become protocol errors; process cancellation belongs
+-- to the external host. This module does not start concurrent computations.
+import Control.Exception (SomeException, catch, evaluate)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import System.IO (hFlush, stdout)
+import System.IO.Unsafe (unsafePerformIO)
+
+-- One invocation counter per worker process, reset for every runCell.
+-- Persistent workers serialize cells; concurrent cells are unsupported.
+{-# NOINLINE invocationCounter #-}
+invocationCounter :: IORef Int
+invocationCounter = unsafePerformIO (newIORef 0)
+
+send :: Json -> IO ()
+send value = do
+    let encoded = encodeJson value
+    -- Force the entire frame before writing, so a pure exception cannot leave
+    -- a truncated JSON frame in front of the subsequent failure response.
+    _ <- evaluate (length encoded)
+    putStrLn encoded
+    hFlush stdout
+
+frame :: [(String, Json)] -> Json
+frame fields = JsonObject (("jsonrpc", JsonString "2.0") : fields)
+
+callTool :: String -> Json -> IO Json
+callTool = callToolWithDecoder (pure . decodeJson)
+
+callToolWithDecoder :: (String -> IO (Either String Json)) -> String -> Json -> IO Json
+callToolWithDecoder decoder name arguments = do
+    previous <- readIORef invocationCounter
+    let sequenceNumber = previous + 1
+    writeIORef invocationCounter sequenceNumber
+    let identifier = JsonString ("tool-" ++ show sequenceNumber)
+    send (frame
+        [ ("id", identifier)
+        , ("method", JsonString "tool/call")
+        , ("params", JsonObject
+            [ ("name", JsonString name)
+            , ("arguments", arguments)
+            ])
+        ])
+    line <- getLine
+    decoded <- decoder line
+    case decoded of
+        Left message -> ioError (userError message)
+        Right response
+            | lookupField "jsonrpc" response /= Just (JsonString "2.0") ->
+                ioError (userError "unsupported host JSON-RPC version")
+            | lookupField "id" response /= Just identifier ->
+                ioError (userError "host response identifier mismatch")
+            | otherwise ->
+                case (lookupField "result" response, lookupField "error" response) of
+                    (Just result, Nothing) -> pure result
+                    (Nothing, Just failure) ->
+                        case lookupField "message" failure of
+                            Just (JsonString message) -> ioError (userError message)
+                            _ -> ioError (userError "invalid host error response")
+                    _ -> ioError (userError "host response requires result or error")
+
+emit :: Json -> IO ()
+emit value = send (frame
+    [ ("method", JsonString "content")
+    , ("params", JsonObject [("value", value)])
+    ])
+
+runCell :: IO () -> IO ()
+runCell action = catch execute reportFailure
+  where
+    execute = do
+        writeIORef invocationCounter 0
+        send (frame [("method", JsonString "ready")])
+        action
+        send (frame
+            [ ("id", JsonString "cell-1")
+            , ("result", JsonObject [("content", JsonArray [])])
+            ])
+    reportFailure :: SomeException -> IO ()
+    reportFailure exception = send (frame
+        [ ("id", JsonString "cell-1")
+        , ("error", JsonObject
+            [ ("code", JsonNumber "-32000")
+            , ("message", JsonString (show exception))
+            ])
+        ])

--- a/experiments/microhs-code-mode/haskell/CodeMode/Json.hs
+++ b/experiments/microhs-code-mode/haskell/CodeMode/Json.hs
@@ -1,0 +1,177 @@
+-- A dependency-free JSON codec for the MicroHs experiment. Numeric lexemes are
+-- preserved rather than rounded through Double. This is not a production codec.
+module CodeMode.Json
+    ( Json(..)
+    , encodeJson
+    , decodeJson
+    , lookupField
+    ) where
+
+import Control.Monad (replicateM)
+import Data.Char (chr, ord, digitToInt, isHexDigit)
+import Data.List (intercalate, nub)
+import Numeric (showHex)
+import Text.ParserCombinators.ReadP
+
+data Json
+    = JsonNull
+    | JsonBool Bool
+    | JsonNumber String
+    | JsonString String
+    | JsonArray [Json]
+    | JsonObject [(String, Json)]
+    deriving (Eq, Show)
+
+lookupField :: String -> Json -> Maybe Json
+lookupField key (JsonObject fields) = lookup key fields
+lookupField _ _ = Nothing
+
+encodeJson :: Json -> String
+encodeJson JsonNull = "null"
+encodeJson (JsonBool True) = "true"
+encodeJson (JsonBool False) = "false"
+encodeJson (JsonNumber value)
+    | validNumber value = value
+    | otherwise = error "invalid JSON number"
+encodeJson (JsonString value) = encodeString value
+encodeJson (JsonArray values) =
+    "[" ++ intercalate "," (map encodeJson values) ++ "]"
+encodeJson (JsonObject fields)
+    | length names /= length (nub names) = error "duplicate JSON object key"
+    | otherwise =
+        "{" ++ intercalate "," (map encodeField fields) ++ "}"
+  where
+    names = map fst fields
+    encodeField (key, value) = encodeString key ++ ":" ++ encodeJson value
+
+encodeString :: String -> String
+encodeString value = "\"" ++ concatMap encodeCharacter value ++ "\""
+
+encodeCharacter :: Char -> String
+encodeCharacter '"' = "\\\""
+encodeCharacter '\\' = "\\\\"
+encodeCharacter character
+    | code >= 0xd800 && code <= 0xdfff = error "unpaired JSON surrogate"
+    | code < 0x20 || code >= 0x7f =
+        if code <= 0xffff
+            then unicodeEscape code
+            else unicodeEscape (0xd800 + (code - 0x10000) `div` 1024)
+                ++ unicodeEscape (0xdc00 + (code - 0x10000) `mod` 1024)
+    | otherwise = [character]
+  where
+    code = ord character
+
+unicodeEscape :: Int -> String
+unicodeEscape value =
+    let digits = showHex value ""
+    in "\\u" ++ replicate (4 - length digits) '0' ++ digits
+
+decodeJson :: String -> Either String Json
+decodeJson source =
+    case readP_to_S (whitespace *> jsonValue 128 <* eof) source of
+        [(value, "")] -> Right value
+        _ -> Left "invalid JSON (maximum nesting depth is 128)"
+
+whitespace :: ReadP ()
+whitespace = skipMany (satisfy (`elem` " \t\r\n"))
+
+token :: ReadP a -> ReadP a
+token parser = parser <* whitespace
+
+jsonValue :: Int -> ReadP Json
+jsonValue depth
+    | depth <= 0 = pfail
+    | otherwise = token $
+        (string "null" >> pure JsonNull)
+        <++ (string "true" >> pure (JsonBool True))
+        <++ (string "false" >> pure (JsonBool False))
+        <++ (JsonString <$> jsonString)
+        <++ (JsonNumber <$> jsonNumber)
+        <++ (JsonArray <$> between (token (char '[')) (char ']')
+            (sepBy (jsonValue (depth - 1)) (token (char ','))))
+        <++ jsonObject depth
+
+jsonObject :: Int -> ReadP Json
+jsonObject depth = do
+    fields <- between (token (char '{')) (char '}')
+        (sepBy field (token (char ',')))
+    let names = map fst fields
+    if length names == length (nub names)
+        then pure (JsonObject fields)
+        else pfail
+  where
+    field = do
+        key <- token jsonString
+        _ <- token (char ':')
+        value <- jsonValue (depth - 1)
+        pure (key, value)
+
+jsonString :: ReadP String
+jsonString = between (char '"') (char '"') (many jsonCharacter)
+
+jsonCharacter :: ReadP Char
+jsonCharacter =
+    satisfy (\character ->
+        character /= '"' && character /= '\\' && ord character >= 0x20
+            && not (ord character >= 0xd800 && ord character <= 0xdfff))
+    <++ do
+        _ <- char '\\'
+        escaped <- get
+        case escaped of
+            '"' -> pure '"'
+            '\\' -> pure '\\'
+            '/' -> pure '/'
+            'b' -> pure '\b'
+            'f' -> pure '\f'
+            'n' -> pure '\n'
+            'r' -> pure '\r'
+            't' -> pure '\t'
+            'u' -> unicodeCharacter
+            _ -> pfail
+
+unicodeCharacter :: ReadP Char
+unicodeCharacter = do
+    first <- hexadecimalQuad
+    if first >= 0xd800 && first <= 0xdbff
+        then do
+            _ <- string "\\u"
+            second <- hexadecimalQuad
+            if second >= 0xdc00 && second <= 0xdfff
+                then pure (chr (0x10000 + (first - 0xd800) * 1024
+                    + second - 0xdc00))
+                else pfail
+        else if first >= 0xdc00 && first <= 0xdfff
+            then pfail
+            else pure (chr first)
+
+hexadecimalQuad :: ReadP Int
+hexadecimalQuad = do
+    digits <- replicateM 4 (satisfy isHexDigit)
+    pure (foldl (\value digit -> value * 16 + digitToInt digit) 0 digits)
+
+jsonNumber :: ReadP String
+jsonNumber = do
+    sign <- option "" (string "-")
+    integral <- string "0" <++ do
+        initial <- satisfy (\character -> character >= '1' && character <= '9')
+        remainder <- munch asciiDigit
+        pure (initial : remainder)
+    fractional <- option "" $ do
+        _ <- char '.'
+        digits <- munch1 asciiDigit
+        pure ('.' : digits)
+    exponent <- option "" $ do
+        marker <- satisfy (`elem` "eE")
+        exponentSign <- option "" ((string "+") <++ (string "-"))
+        digits <- munch1 asciiDigit
+        pure ([marker] ++ exponentSign ++ digits)
+    pure (sign ++ integral ++ fractional ++ exponent)
+
+asciiDigit :: Char -> Bool
+asciiDigit character = character >= '0' && character <= '9'
+
+validNumber :: String -> Bool
+validNumber value =
+    case readP_to_S (jsonNumber <* eof) value of
+        [(_, "")] -> True
+        _ -> False

--- a/experiments/microhs-code-mode/haskell/CodeMode/NativeJson.hs
+++ b/experiments/microhs-code-mode/haskell/CodeMode/NativeJson.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+-- Native parsing with the same Json representation and validation as the
+-- baseline. No native pointers escape decodeJsonNative.
+module CodeMode.NativeJson (decodeJsonNative) where
+
+import CodeMode.Json (Json(..))
+-- MicroHs ships Control.Exception, not the safe-exceptions package.
+import Control.Exception (bracket, evaluate)
+import Data.Char (ord)
+import Data.List (nub)
+import Foreign.C.String (CString, newCString, peekCStringLen)
+import Foreign.Marshal.Alloc (free)
+import Foreign.Ptr (Ptr, nullPtr)
+
+foreign import ccall "native_json_parse" nativeParse :: CString -> IO (Ptr ())
+foreign import ccall "native_json_free" nativeFree :: Ptr () -> IO ()
+foreign import ccall "native_json_root" nativeRoot :: Ptr () -> IO (Ptr ())
+foreign import ccall "native_json_kind" nativeKind :: Ptr () -> IO Int
+foreign import ccall "native_json_length" nativeLength :: Ptr () -> IO Int
+foreign import ccall "native_json_text" nativeText :: Ptr () -> IO CString
+foreign import ccall "native_json_child" nativeChild :: Ptr () -> IO (Ptr ())
+foreign import ccall "native_json_next" nativeNext :: Ptr () -> IO (Ptr ())
+
+decodeJsonNative :: String -> IO (Either String Json)
+decodeJsonNative source
+    | any invalidCharacter source = pure (Left "invalid JSON character")
+    | otherwise = bracket (newCString source) free $ \input ->
+        bracket (nativeParse input) nativeFree $ \document ->
+            if document == nullPtr
+                then pure (Left "invalid JSON")
+                else do
+                    root <- nativeRoot document
+                    result <- convertValue 128 root
+                    -- Force strings while the document is live: pointer-backed
+                    -- lazy conversion must not outlive nativeFree.
+                    _ <- evaluate (forceResult result)
+                    pure result
+  where
+    invalidCharacter character =
+        character == '\0' || (ord character >= 0xd800 && ord character <= 0xdfff)
+
+convertText :: Ptr () -> IO String
+convertText value = do
+    pointer <- nativeText value
+    count <- nativeLength value
+    peekCStringLen (pointer, count)
+
+convertValue :: Int -> Ptr () -> IO (Either String Json)
+convertValue depth value
+    | depth <= 0 = pure (Left "maximum JSON nesting depth is 128")
+    | otherwise = do
+        kind <- nativeKind value
+        case kind of
+            0 -> pure (Right JsonNull)
+            1 -> pure (Right (JsonBool False))
+            2 -> pure (Right (JsonBool True))
+            3 -> Right . JsonNumber <$> convertText value
+            4 -> Right . JsonString <$> convertText value
+            5 -> do
+                count <- nativeLength value
+                child <- nativeChild value
+                values <- convertArray (depth - 1) count child
+                pure (JsonArray <$> values)
+            6 -> do
+                count <- nativeLength value
+                child <- nativeChild value
+                fields <- convertObject (depth - 1) count child
+                pure $ do
+                    entries <- fields
+                    let names = map fst entries
+                    if length names /= length (nub names)
+                        then Left "duplicate JSON object key"
+                        else Right (JsonObject entries)
+            _ -> pure (Left "unexpected native JSON type")
+
+convertArray :: Int -> Int -> Ptr () -> IO (Either String [Json])
+convertArray _ 0 _ = pure (Right [])
+convertArray depth count value = do
+    converted <- convertValue depth value
+    case converted of
+        Left message -> pure (Left message)
+        Right entry -> do
+            next <- nativeNext value
+            remaining <- convertArray depth (count - 1) next
+            pure ((entry :) <$> remaining)
+
+convertObject :: Int -> Int -> Ptr () -> IO (Either String [(String, Json)])
+convertObject _ 0 _ = pure (Right [])
+convertObject depth count key = do
+    name <- convertText key
+    value <- nativeNext key
+    converted <- convertValue depth value
+    case converted of
+        Left message -> pure (Left message)
+        Right entry -> do
+            next <- nativeNext value
+            remaining <- convertObject depth (count - 1) next
+            pure (((name, entry) :) <$> remaining)
+
+forceResult :: Either String Json -> ()
+forceResult (Left message) = forceString message
+forceResult (Right value) = forceJson value
+
+forceString :: String -> ()
+forceString [] = ()
+forceString (character : rest) = character `seq` forceString rest
+
+forceJson :: Json -> ()
+forceJson JsonNull = ()
+forceJson (JsonBool value) = value `seq` ()
+forceJson (JsonNumber value) = forceString value
+forceJson (JsonString value) = forceString value
+forceJson (JsonArray values) = foldr (\value rest -> forceJson value `seq` rest) () values
+forceJson (JsonObject fields) =
+    foldr (\(name, value) rest -> forceString name `seq` forceJson value `seq` rest) () fields

--- a/experiments/microhs-code-mode/haskell/Example.hs
+++ b/experiments/microhs-code-mode/haskell/Example.hs
@@ -1,0 +1,20 @@
+module Main (main) where
+
+import CodeMode
+
+main :: IO ()
+main = runCell $ do
+    response <- callTool "fixture.numbers"
+        (JsonObject [("count", JsonNumber "5")])
+    case response of
+        JsonArray values -> do
+            numbers <- mapM requireInteger values
+            emit (JsonNumber (show (sum numbers)))
+        _ -> ioError (userError "fixture.numbers did not return an array")
+
+requireInteger :: Json -> IO Integer
+requireInteger (JsonNumber value) =
+    case reads value of
+        [(number, "")] -> pure number
+        _ -> ioError (userError "fixture.numbers returned a non-integer")
+requireInteger _ = ioError (userError "fixture.numbers returned a non-number")

--- a/experiments/microhs-code-mode/haskell/JsonSpec.hs
+++ b/experiments/microhs-code-mode/haskell/JsonSpec.hs
@@ -1,0 +1,91 @@
+module Main (main) where
+
+import CodeMode.Json
+-- MicroHs provides this base module, but not safe-exceptions.
+import Control.Exception (SomeException, evaluate, try)
+import Control.Monad (forM_, unless)
+
+main :: IO ()
+main = do
+    forM_ examples $ \value ->
+        assert ("round trip: " ++ show value)
+            (decodeJson (encodeJson value) == Right value)
+    forM_ invalidDocuments $ \document ->
+        assert ("reject: " ++ show document)
+            (case decodeJson document of Left _ -> True; Right _ -> False)
+    assert "surrogate pair"
+        (decodeJson "\"\\uD83D\\uDE00\"" == Right (JsonString "\x1f600"))
+    assert "all short escapes"
+        (decodeJson "\"\\\"\\\\\\/\\b\\f\\n\\r\\t\""
+            == Right (JsonString "\"\\/\b\f\n\r\t"))
+    assert "whitespace"
+        (decodeJson " \r\n\t { \"value\" : null } \r\n"
+            == Right (JsonObject [("value", JsonNull)]))
+    assert "preserve number precision"
+        (decodeJson "123456789012345678901234567890.123456789e+123"
+            == Right (JsonNumber "123456789012345678901234567890.123456789e+123"))
+    assert "nesting limit"
+        (case decodeJson (replicate 129 '[' ++ "0" ++ replicate 129 ']') of
+            Left _ -> True
+            Right _ -> False)
+    forM_ invalidValues $ \(label, value) -> do
+        result <- try (evaluate (length (encodeJson value)))
+            :: IO (Either SomeException Int)
+        assert ("encoding rejects: " ++ label)
+            (case result of Left _ -> True; Right _ -> False)
+    putStrLn "JSON codec tests passed"
+
+assert :: String -> Bool -> IO ()
+assert label condition =
+    unless condition (ioError (userError ("assertion failed: " ++ label)))
+
+examples :: [Json]
+examples =
+    [ JsonNull
+    , JsonBool True
+    , JsonBool False
+    , JsonNumber "0"
+    , JsonNumber "-0"
+    , JsonNumber "-12.34e-56"
+    , JsonString ""
+    , JsonString "\"\\\n\r\t\b\f\x00\x1f"
+    , JsonString "Unicode: \xe9 \x6f22 \x1f600"
+    , JsonArray [JsonNumber "42", JsonNull, JsonBool False]
+    , JsonObject [("nested", JsonObject [("value", JsonArray [])])]
+    ]
+
+invalidValues :: [(String, Json)]
+invalidValues =
+    [ ("non-finite number", JsonNumber "NaN")
+    , ("non-number suffix", JsonNumber "12 trailing")
+    , ("surrogate", JsonString "\xd800")
+    , ("duplicate keys", JsonObject [("value", JsonNull), ("value", JsonNull)])
+    , ("deferred number failure", JsonObject
+        [("prefix", JsonString "before"), ("invalid", JsonNumber "NaN")])
+    , ("deferred character failure", JsonString ['a', error "deferred character"])
+    ]
+
+invalidDocuments :: [String]
+invalidDocuments =
+    [ ""
+    , "01"
+    , "+1"
+    , ".1"
+    , "1."
+    , "1e"
+    , "1e+"
+    , "--1"
+    , "NaN"
+    , "Infinity"
+    , "[1,]"
+    , "{\"value\":1,}"
+    , "{\"value\":1,\"value\":2}"
+    , "\"\\x41\""
+    , "\"\\uD800\""
+    , "\"\\uDC00\""
+    , "\"\\uD800\\u0041\""
+    , "\"\\u12xz\""
+    , "\"raw\nnewline\""
+    , "null false"
+    , "\xa0null"
+    ]

--- a/experiments/microhs-code-mode/native/native_json.c
+++ b/experiments/microhs-code-mode/native/native_json.c
@@ -1,0 +1,63 @@
+/* Pinned MicroHs FFI wrappers for yyjson. The document owns all node pointers. */
+#include "mhsffi.h"
+#include <yyjson.h>
+#include <string.h>
+
+static yyjson_doc *native_json_parse(const char *source) {
+    return yyjson_read(source, strlen(source), YYJSON_READ_NUMBER_AS_RAW);
+}
+
+static intptr_t native_json_kind(yyjson_val *value) {
+    if (yyjson_is_null(value)) return 0;
+    if (yyjson_is_false(value)) return 1;
+    if (yyjson_is_true(value)) return 2;
+    if (yyjson_is_raw(value)) return 3;
+    if (yyjson_is_str(value)) return 4;
+    if (yyjson_is_arr(value)) return 5;
+    if (yyjson_is_obj(value)) return 6;
+    return -1;
+}
+
+static const char *native_json_text(yyjson_val *value) {
+    return yyjson_is_raw(value) ? yyjson_get_raw(value) : yyjson_get_str(value);
+}
+
+static yyjson_val *native_json_child(yyjson_val *value) {
+    return value + 1;
+}
+
+static yyjson_val *native_json_next(yyjson_val *value) {
+    /* yyjson's documented array iterator advances over nested containers. */
+    yyjson_arr_iter iterator;
+    iterator.idx = 0;
+    iterator.max = 1;
+    iterator.cur = value;
+    yyjson_arr_iter_next(&iterator);
+    return iterator.cur;
+}
+
+static from_t mhs_native_json_parse(int s) {
+    return mhs_from_Ptr(s, 1, native_json_parse(mhs_to_Ptr(s, 0)));
+}
+static from_t mhs_native_json_free(int s) {
+    yyjson_doc_free(mhs_to_Ptr(s, 0));
+    return mhs_from_Unit(s, 1);
+}
+static from_t mhs_native_json_root(int s) {
+    return mhs_from_Ptr(s, 1, yyjson_doc_get_root(mhs_to_Ptr(s, 0)));
+}
+static from_t mhs_native_json_kind(int s) {
+    return mhs_from_Int(s, 1, native_json_kind(mhs_to_Ptr(s, 0)));
+}
+static from_t mhs_native_json_length(int s) {
+    return mhs_from_Int(s, 1, yyjson_get_len(mhs_to_Ptr(s, 0)));
+}
+static from_t mhs_native_json_text(int s) {
+    return mhs_from_Ptr(s, 1, (void *)native_json_text(mhs_to_Ptr(s, 0)));
+}
+static from_t mhs_native_json_child(int s) {
+    return mhs_from_Ptr(s, 1, native_json_child(mhs_to_Ptr(s, 0)));
+}
+static from_t mhs_native_json_next(int s) {
+    return mhs_from_Ptr(s, 1, native_json_next(mhs_to_Ptr(s, 0)));
+}

--- a/experiments/microhs-code-mode/native/native_json_entries.h
+++ b/experiments/microhs-code-mode/native/native_json_entries.h
@@ -1,0 +1,8 @@
+{ "native_json_parse", 1, mhs_native_json_parse },
+{ "native_json_free", 1, mhs_native_json_free },
+{ "native_json_root", 1, mhs_native_json_root },
+{ "native_json_kind", 1, mhs_native_json_kind },
+{ "native_json_length", 1, mhs_native_json_length },
+{ "native_json_text", 1, mhs_native_json_text },
+{ "native_json_child", 1, mhs_native_json_child },
+{ "native_json_next", 1, mhs_native_json_next },

--- a/experiments/microhs-code-mode/persistent.py
+++ b/experiments/microhs-code-mode/persistent.py
@@ -1,0 +1,189 @@
+"""A trusted-source, sequential adapter for the pinned MicroHs text REPL.
+
+This is not a sandbox. Cells share a heap and process, and must not manipulate
+stdin/stdout, fork children, or change REPL state outside the adapter.
+"""
+
+import asyncio
+import inspect
+import contextlib
+import json
+import os
+import signal
+import time
+
+from experiment import DIRECTORY, MAXIMUM_BYTES, executable, execute_fixture
+
+
+class PersistentMicroHs:
+    def __init__(self, directory, startup_timeout=120, interpreter="mhs", modules=()):
+        self.directory = directory
+        self.interpreter = interpreter
+        self.modules = modules
+        self.startup_timeout = startup_timeout
+        self.process = None
+        self.closed = False
+        self.buffer = bytearray()
+        self.received_bytes = 0
+        self.lock = asyncio.Lock()
+
+    async def __aenter__(self):
+        if self.process is not None or self.closed:
+            raise RuntimeError("create a new MicroHs worker instead of reopening")
+        started = time.perf_counter()
+        try:
+            async with asyncio.timeout(self.startup_timeout):
+                self.process = await asyncio.create_subprocess_exec(
+                    executable(self.interpreter), "-q", "--stdin",
+                    "-i" + str(DIRECTORY / "haskell"),
+                    cwd=self.directory, env={"TMPDIR": str(self.directory)},
+                    stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.STDOUT, start_new_session=True,
+                    limit=MAXIMUM_BYTES,
+                )
+                await self._prompt()
+                await self._write("import CodeMode\n")
+                await self._prompt()
+                for module in self.modules:
+                    if not module or any(not (character.isalnum() or character in "._") for character in module):
+                        raise ValueError("invalid module name")
+                    await self._write("import " + module + "\n")
+                    await self._prompt()
+                # Verify that import succeeded, rather than treating any prompt
+                # (including one following an import error) as successful setup.
+                result = await self.execute("pure ()")
+                if "error" in result["completion"]:
+                    raise RuntimeError(result)
+                self.startup_ms = (time.perf_counter() - started) * 1000
+                return self
+        except BaseException:
+            await self.close()
+            raise
+
+    async def __aexit__(self, *exception):
+        await self.close()
+
+    async def close(self):
+        if self.closed:
+            return
+        self.closed = True
+        if self.process is None:
+            return
+        with contextlib.suppress(ProcessLookupError):
+            try:
+                os.killpg(self.process.pid, signal.SIGKILL)
+            except PermissionError:
+                # Darwin can report EPERM for zombie-only process groups.
+                await asyncio.wait_for(self.process.wait(), timeout=1)
+                os.killpg(self.process.pid, signal.SIGKILL)
+        self.process.stdin.close()
+        with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+            await self.process.stdin.wait_closed()
+        # Drain without retaining bytes: asyncio's process wait may otherwise
+        # await a paused pipe transport after an output-limit failure.
+        while await self.process.stdout.read(8192):
+            pass
+        await self.process.wait()
+
+    async def _write(self, text):
+        data = text.encode()
+        if len(data) > MAXIMUM_BYTES:
+            raise ValueError("input limit exceeded")
+        self.process.stdin.write(data)
+        await self.process.stdin.drain()
+
+    async def _event(self):
+        """Return a complete line or None for the pinned REPL's bare prompt."""
+        while True:
+            if self.buffer.startswith(b"> "):
+                del self.buffer[:2]
+                return None
+            newline = self.buffer.find(b"\n")
+            if newline >= 0:
+                line = bytes(self.buffer[:newline])
+                del self.buffer[:newline + 1]
+                return line
+            block = await self.process.stdout.read(8192)
+            if not block:
+                raise RuntimeError("MicroHs exited before prompt/completion")
+            self.received_bytes += len(block)
+            if self.received_bytes > MAXIMUM_BYTES:
+                raise ValueError("REPL output limit exceeded")
+            self.buffer.extend(block)
+
+    async def _prompt(self):
+        while await self._event() is not None:
+            pass
+
+    async def execute(self, expression, timeout=30, handler=execute_fixture):
+        """Evaluate one single-line IO () expression, e.g. do { a; b }.
+
+        Compile errors and caught runtime errors return an error completion and
+        retain the process. Timeout, cancellation, and protocol errors close it;
+        callers must create a replacement. Calls are serialized, never retried.
+        """
+        if "\n" in expression or "\r" in expression:
+            raise ValueError("use a single-line expression with explicit braces")
+        async with self.lock:
+            if self.closed or self.process is None:
+                raise RuntimeError("MicroHs worker is not open")
+            self.received_bytes = len(self.buffer)
+            started = time.perf_counter()
+            content, calls, diagnostics = [], set(), []
+            ready_ms, completion = None, None
+            try:
+                async with asyncio.timeout(timeout):
+                    await self._write("runCell (" + expression + ")\n")
+                    while True:
+                        line = await self._event()
+                        if line is None:
+                            if completion is None:
+                                if ready_ms is not None:
+                                    raise ValueError("cell returned without completion")
+                                completion = {"jsonrpc": "2.0", "id": "cell-1", "error": {
+                                    "code": -32000, "message": "\n".join(diagnostics)}}
+                            return {"content": content, "calls": len(calls),
+                                    "completion": completion, "ready_ms": ready_ms,
+                                    "elapsed_ms": (time.perf_counter() - started) * 1000}
+                        if not line.startswith(b"{"):
+                            diagnostics.append(line.decode(errors="replace"))
+                            continue
+                        message = json.loads(line)
+                        if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+                            raise ValueError("invalid JSON-RPC frame")
+                        method = message.get("method")
+                        if completion is not None:
+                            raise ValueError("frame after completion")
+                        if method == "ready" and ready_ms is None:
+                            ready_ms = (time.perf_counter() - started) * 1000
+                        elif ready_ms is None:
+                            raise ValueError("frame before ready")
+                        elif method == "tool/call":
+                            identifier, params = message.get("id"), message.get("params")
+                            if not isinstance(identifier, str) or identifier in calls:
+                                raise ValueError("invalid or duplicate call id")
+                            if (not isinstance(params, dict)
+                                    or not isinstance(params.get("name"), str)
+                                    or "arguments" not in params):
+                                raise ValueError("invalid tool parameters")
+                            calls.add(identifier)
+                            reply = {"jsonrpc": "2.0", "id": identifier}
+                            try:
+                                reply["result"] = handler(params["name"], params["arguments"])
+                                if inspect.isawaitable(reply["result"]):
+                                    reply["result"] = await reply["result"]
+                            except ValueError as error:
+                                reply.pop("result", None)
+                                reply["error"] = {"code": -32000, "message": str(error)}
+                            await self._write(json.dumps(reply, ensure_ascii=True, allow_nan=False) + "\n")
+                        elif method == "content":
+                            content.append(message["params"]["value"])
+                        elif method is None and message.get("id") == "cell-1":
+                            if ("result" in message) == ("error" in message):
+                                raise ValueError("invalid completion")
+                            completion = message
+                        else:
+                            raise ValueError("unexpected frame")
+            except BaseException:
+                await self.close()
+                raise

--- a/experiments/microhs-code-mode/test_experiment.py
+++ b/experiments/microhs-code-mode/test_experiment.py
@@ -1,0 +1,93 @@
+import asyncio
+import json
+import sys
+import subprocess
+import unittest
+
+from experiment import DIRECTORY, executable, exchange, haskell_cell, run_bun, run_haskell, temporary_directory
+
+
+class MicroHsExperimentTests(unittest.IsolatedAsyncioTestCase):
+    async def execute(self, body, **options):
+        with temporary_directory() as directory:
+            return await run_haskell(haskell_cell(body), directory, **options)
+
+    async def test_two_dependent_calls(self):
+        result = await self.execute(
+            'first <- callTool "fixture.echo" (JsonObject [("value", JsonNumber "42")])\n'
+            'second <- callTool "fixture.echo" first\nemit second')
+        self.assertEqual(result["content"], [{"value": 42}])
+        self.assertEqual(result["calls"], 2)
+        self.assertIn("result", result["completion"])
+
+    async def test_json_round_trip(self):
+        value = {"unicode": "Grüße λ 😀", "control": "\x00\b\f\n\r\t\x1f", "quote": '"\\',
+                 "values": [None, True, False, -50.25, 1e25, {"nested": []}]}
+        result = await self.execute(
+            'value <- callTool "fixture.echo" JsonNull\nemit value',
+            handler=lambda name, arguments: value)
+        self.assertEqual(result["content"], [value])
+
+    async def test_runtime_error_preserves_partial_content(self):
+        result = await self.execute('emit (JsonString "before failure")\nerror "deliberate failure"')
+        self.assertEqual(result["content"], ["before failure"])
+        self.assertIn("deliberate failure", result["completion"]["error"]["message"])
+
+    async def test_denied_tool(self):
+        result = await self.execute('callTool "fixture.denied" JsonNull >>= emit')
+        self.assertEqual(result["content"], [])
+        self.assertIn("approval denied", result["completion"]["error"]["message"])
+
+    async def test_invalid_encoding_does_not_write_partial_frame(self):
+        result = await self.execute('emit (JsonObject [("prefix", JsonString "before"), ("invalid", JsonNumber "NaN")])')
+        self.assertEqual(result["content"], [])
+        self.assertIn("error", result["completion"])
+
+    async def test_unavailable_tool(self):
+        result = await self.execute('callTool "unavailable.tool" JsonNull >>= emit')
+        self.assertIn("not available", result["completion"]["error"]["message"])
+
+    async def test_type_error_precedes_tool_effect(self):
+        calls = []
+        with self.assertRaises(ExceptionGroup):
+            await self.execute('callTool 123 JsonNull >>= emit',
+                               handler=lambda name, arguments: calls.append(name))
+        self.assertEqual(calls, [])
+
+    async def test_nontermination_times_out(self):
+        calls = []
+        with self.assertRaises(TimeoutError):
+            await self.execute('callTool "fixture.echo" JsonNull\nlet forever = forever in forever',
+                               timeout=10, handler=lambda name, arguments: calls.append(name))
+        self.assertEqual(calls, ["fixture.echo"])
+        # A cancelled worker must not prevent a subsequent cell from running.
+        result = await self.execute('emit (JsonBool True)')
+        self.assertEqual(result["content"], [True])
+
+    async def test_bun_baseline(self):
+        with temporary_directory() as directory:
+            result = await run_bun('text(await tools.fixture.echo({value: 42}));', directory)
+        self.assertEqual(result["calls"], 1)
+        self.assertEqual(json.loads(result["content"][0]["text"]), {"value": 42})
+
+    async def test_json_codec_specification(self):
+        with temporary_directory() as directory:
+            result = await asyncio.to_thread(subprocess.run,
+                [executable("mhs"), "-q", "-r", "-i" + str(DIRECTORY / "haskell"),
+                 str(DIRECTORY / "haskell/JsonSpec.hs")],
+                cwd=directory, capture_output=True, text=True, timeout=30, check=True)
+        self.assertIn("JSON codec tests passed", result.stdout)
+
+    async def test_invalid_worker_protocol(self):
+        with temporary_directory() as directory:
+            with self.assertRaises(ExceptionGroup):
+                await exchange([sys.executable, "-c", "print('{}', flush=True)"], directory)
+
+    async def test_output_limit(self):
+        with temporary_directory() as directory:
+            with self.assertRaises(ExceptionGroup):
+                await exchange([sys.executable, "-c", "print('x' * (5 * 1024 * 1024), flush=True)"], directory)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/microhs-code-mode/test_native.py
+++ b/experiments/microhs-code-mode/test_native.py
@@ -1,0 +1,52 @@
+"""Optional native decoder checks; set MICROHS_NATIVE_INTERPRETER to enable."""
+
+import json
+import os
+import unittest
+
+from experiment import temporary_directory
+from persistent import PersistentMicroHs
+
+
+@unittest.skipUnless(os.environ.get("MICROHS_NATIVE_INTERPRETER"), "native interpreter not configured")
+class NativeDecoderTests(unittest.IsolatedAsyncioTestCase):
+    async def test_native_decoder_and_tool_round_trip(self):
+        with temporary_directory() as directory:
+            async with PersistentMicroHs(
+                    directory, interpreter=os.environ["MICROHS_NATIVE_INTERPRETER"],
+                    modules=("CodeMode.NativeJson",)) as worker:
+                documents = ["null", "true", "false", "-0", "1.23e+400",
+                             '"Grüße λ 😀"', '"\\u0000\\n\\t"',
+                             '{"nested":[1,null,true,{"x":[]}]}',
+                             "123456789012345678901234567890.123456789e+123",
+                             "[" * 127 + "0" + "]" * 127]
+                # JSON string escaping is a Haskell-compatible literal here for ASCII
+                # input; direct Unicode is retained rather than using JSON's \\u syntax.
+                for document in documents:
+                    literal = json.dumps(document, ensure_ascii=False)
+                    result = await worker.execute(
+                        f'do {{ actual <- decodeJsonNative {literal}; '
+                        f'emit (JsonBool (actual == decodeJson {literal})) }}')
+                    self.assertEqual(result["content"], [True], result)
+                invalid = ["", "01", "+1", "1.", "1e+", "NaN", "Infinity", "[1,]",
+                           '{"a":1,"a":2}', '{"a":1,"\\u0061":2}',
+                           '"\\uD800"', '"\\uDC00"', '"\\uD800\\u0041"',
+                           "null false", "[" * 128 + "0" + "]" * 128]
+                for document in invalid:
+                    result = await worker.execute(
+                        f'do {{ actual <- decodeJsonNative {json.dumps(document)}; '
+                        'emit (JsonBool (case actual of { Left _ -> True; Right _ -> False })) }')
+                    self.assertEqual(result["content"], [True], result)
+                value = {"unicode": "Grüße λ 😀", "control": "\x00\b\f\n\r\t\x1f",
+                         "values": [None, True, False, -50.25, 10**40, {"nested": []}]}
+                result = await worker.execute(
+                    'do { first <- callToolWithDecoder decodeJsonNative "fixture.echo" JsonNull; '
+                    'second <- callToolWithDecoder decodeJsonNative "fixture.echo" first; emit second }',
+                    handler=lambda name, arguments: value if arguments is None else arguments)
+                self.assertEqual(result["content"], [value], result)
+                self.assertEqual(result["calls"], 2)
+                denied = await worker.execute(
+                    'callToolWithDecoder decodeJsonNative "fixture.denied" JsonNull >>= emit')
+                self.assertIn("approval denied", denied["completion"]["error"]["message"])
+                recovery = await worker.execute('emit (JsonBool True)')
+                self.assertEqual(recovery["content"], [True])

--- a/experiments/microhs-code-mode/test_persistent.py
+++ b/experiments/microhs-code-mode/test_persistent.py
@@ -1,0 +1,70 @@
+import asyncio
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+from experiment import temporary_directory
+from persistent import PersistentMicroHs
+
+
+class PersistentTests(unittest.IsolatedAsyncioTestCase):
+    async def test_distinct_cells_and_recovery(self):
+        with temporary_directory() as directory:
+            async with PersistentMicroHs(directory) as worker:
+                pid = worker.process.pid
+                first = await worker.execute('callTool "fixture.echo" (JsonNumber "42") >>= emit')
+                second = await worker.execute(
+                    'do { x <- callTool "fixture.echo" (JsonString "second"); '
+                    'callTool "fixture.echo" x >>= emit }')
+                self.assertEqual(first["content"], [42])
+                self.assertEqual(second["content"], ["second"])
+                self.assertEqual(second["calls"], 2)
+                value = {"text": "λ 😀\n> ", "null": None, "array": [False, 42]}
+                echoed = await worker.execute(
+                    'callTool "fixture.echo" JsonNull >>= emit',
+                    handler=lambda name, arguments: value)
+                self.assertEqual(echoed["content"], [value])
+                for expression in [
+                    'do { callTool "fixture.echo" JsonNull; emit True }',
+                    'callTool "fixture.denied" JsonNull >>= emit',
+                    'do { emit (JsonString "partial"); error "failure" }',
+                    'emit (',
+                ]:
+                    result = await worker.execute(expression)
+                    self.assertIn("error", result["completion"])
+                    if "emit True" in expression:
+                        self.assertEqual(result["calls"], 0)
+                    if '"partial"' in expression:
+                        self.assertEqual(result["content"], ["partial"])
+                    recovery = await worker.execute("emit (JsonBool True)")
+                    self.assertEqual(recovery["content"], [True])
+                    self.assertEqual(worker.process.pid, pid)
+                with self.assertRaises(TimeoutError):
+                    await worker.execute("let loop = loop in loop", timeout=0.5)
+                self.assertTrue(worker.closed)
+                self.assertIsNotNone(worker.process.returncode)
+                with self.assertRaises(RuntimeError):
+                    await worker.execute("pure ()")
+            async with PersistentMicroHs(directory) as replacement:
+                self.assertNotEqual(replacement.process.pid, pid)
+                self.assertEqual((await replacement.execute("emit JsonNull"))["content"], [None])
+                with patch("persistent.MAXIMUM_BYTES", 1024):
+                    with self.assertRaisesRegex(ValueError, "output limit"):
+                        await replacement.execute('emit (JsonString (replicate 2048 \'x\'))')
+                self.assertTrue(replacement.closed)
+
+    async def test_prompt_and_line_framing(self):
+        worker = PersistentMicroHs(".")
+        reader = asyncio.StreamReader()
+        worker.process = SimpleNamespace(stdout=reader)
+        reader.feed_data(b'> {"text": "> not a prompt"}\n> ')
+        self.assertIsNone(await worker._event())
+        self.assertEqual(await worker._event(), b'{"text": "> not a prompt"}')
+        self.assertIsNone(await worker._event())
+        reader.feed_eof()
+        with self.assertRaisesRegex(RuntimeError, "exited"):
+            await worker._event()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/microhs-code-mode/test_workflows.py
+++ b/experiments/microhs-code-mode/test_workflows.py
@@ -1,0 +1,39 @@
+import unittest
+
+from benchmark_workflows import FixtureHandler, workflows
+from experiment import run_bun, temporary_directory
+from persistent import PersistentMicroHs
+
+
+class WorkflowFixtureTests(unittest.IsolatedAsyncioTestCase):
+    async def test_async_tool_error_propagation(self):
+        async def denied(name, arguments):
+            raise ValueError("async denial")
+        with temporary_directory() as directory:
+            result = await run_bun('await tools.fixture.denied({});', directory, handler=denied)
+            self.assertIn("async denial", result["completion"]["error"]["message"])
+            async with PersistentMicroHs(directory) as worker:
+                result = await worker.execute('callTool "fixture.denied" JsonNull >>= emit', handler=denied)
+                self.assertIn("async denial", result["completion"]["error"]["message"])
+                self.assertEqual((await worker.execute('emit JsonNull'))["content"], [None])
+
+    async def test_exact_call_arguments_and_latency(self):
+        workflow = next(workflows())
+        handler = FixtureHandler(workflow, 1)
+        for name, arguments, expected in workflow.exchanges:
+            self.assertEqual(await handler(name, arguments), expected)
+        self.assertEqual(handler.calls, 2)
+        self.assertGreaterEqual(handler.wait_ms, 2)
+
+    async def test_wrong_dependent_identifier_rejected(self):
+        handler = FixtureHandler(next(workflows()), 0)
+        await handler("fixture.customer", {"email": "alex@example.test"})
+        with self.assertRaises(AssertionError):
+            await handler("fixture.subscription", {"customerId": "wrong"})
+
+    def test_workload_sizes_and_repeat(self):
+        cases = list(workflows())
+        self.assertEqual(len(cases), 6)
+        self.assertEqual(cases[1].expected, cases[3].expected)
+        self.assertEqual(len(cases[2].exchanges[0][2]["data"]), 1000)
+        self.assertEqual(len(cases[4].exchanges[0][2]["data"]), 1000)

--- a/flake.nix
+++ b/flake.nix
@@ -1448,6 +1448,12 @@
                 # same runtime tools as the native build. The native build
                 # remains available as `agent-cli`.
                 packages.default = agentCliStaticExecutable;
+                # Standalone evaluation experiment; not part of the agent closure.
+                packages.microhs = pkgs.callPackage ./nix/microhs.nix { };
+                packages.microhs-native-json = pkgs.callPackage ./nix/microhs.nix { nativeJson = true; };
+                devShells.microhs-code-mode = pkgs.mkShell {
+                    packages = [ self.packages.${system}.microhs self.packages.${system}.microhs-native-json bun_1_4 pkgs.python3 ];
+                };
                 packages.agent-cli-static = agentCliStaticExecutable;
                 packages.agent-cli = agentCliExecutable;
                 packages.agent-telegram = agentTelegramExecutable;

--- a/nix/microhs.nix
+++ b/nix/microhs.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchFromGitHub, makeWrapper, yyjson, nativeJson ? false }:
+
+stdenv.mkDerivation {
+  pname = if nativeJson then "microhs-native-json" else "microhs";
+  version = "0.16.6.0-unstable-2026-09-12";
+
+  src = fetchFromGitHub {
+    owner = "augustss";
+    repo = "MicroHs";
+    rev = "455782164e75998b140d869c1b7cdde0c8a21508";
+    hash = "sha256-xVztgPVjlYlvxpFDq2olQrkWb1fTfzzfMJb+1fhn0hE=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = lib.optional nativeJson yyjson;
+  postPatch = lib.optionalString nativeJson ''
+    cp ${../experiments/microhs-code-mode/native/native_json.c} generated/native_json.c
+    cp ${../experiments/microhs-code-mode/native/native_json_entries.h} generated/native_json_entries.h
+    substituteInPlace generated/mhs.c \
+      --replace-fail 'static const struct ffi_entry imp_table[] = {' \
+      '#include "native_json.c"
+static const struct ffi_entry imp_table[] = {
+#include "native_json_entries.h"'
+  '';
+  makeFlags = lib.optional nativeJson "MHSGMPCCLIBS=-lyyjson";
+  # Bootstrap the upstream combinator image with the C runtime, not GHC.
+  buildFlags = [ "bin/mhs" "bin/cpphs" ];
+  installPhase = ''
+    runHook preInstall
+    make oldinstall PREFIX="$out"
+    cp generated/base.pkg "$out/lib/mhs/base.pkg"
+    wrapProgram "$out/bin/mhs" \
+      --set MHSDIR "$out/lib/mhs" \
+      --add-flags "-p$out/lib/mhs/base.pkg" \
+      --prefix PATH : "$out/bin"
+    ${lib.optionalString nativeJson ''mv "$out/bin/mhs" "$out/bin/mhs-native-json"''}
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Small Haskell implementation with a combinator runtime";
+    homepage = "https://github.com/augustss/MicroHs";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    mainProgram = if nativeJson then "mhs-native-json" else "mhs";
+  };
+}


### PR DESCRIPTION
## Summary
- Add a standalone MicroHs experiment with fresh-process and persistent REPL execution, plus a native yyjson FFI decoder.
- Provide pinned Nix packages and a dedicated development shell; production Bun code mode remains unchanged.
- Preserve correctness tests and representative workflow benchmarks, including measured limitations.

## Findings
Seven-sample medians: ID chaining 158 ms MicroHs vs 27 ms fresh Bun; filtering 1,000 records 544 ms vs 29 ms. All 168 timed executions validated. The native decoder still constructs a full Haskell JSON tree; opaque handles are not implemented. A separate approximately 482 KB line-input diagnostic encounters a stack overflow. The second readiness run is explicitly excluded from controlled performance evidence because it overlapped diagnostics/tests.

This PR preserves an evaluation, not a proposed production replacement or overall performance improvement. Build settings, workload dimensions, benchmark commands, and results are in experiments/microhs-code-mode/RESULTS.md.

## Validation
- 18-test regression suite passed in the microhs-code-mode Nix shell with the native interpreter enabled.
- Four focused workflow tests passed after async-handler error cleanup, including both backend error propagation and subsequent MicroHs recovery.
- git diff --check passed.

Reproduce tests:
```sh
nix develop .#microhs-code-mode -c env MICROHS_NATIVE_INTERPRETER=mhs-native-json python3 -B -m unittest discover -s experiments/microhs-code-mode -v
```
Reproduce representative benchmarks:
```sh
nix develop .#microhs-code-mode -c python3 -B experiments/microhs-code-mode/benchmark_workflows.py --samples 7
```