### PR TITLE
Replace remaining Maybe helpers with library functions

### DIFF
--- a/packages/agent-accounts/agent-accounts.cabal
+++ b/packages/agent-accounts/agent-accounts.cabal
@@ -60,6 +60,7 @@ library
                     , bytestring
                     , containers
                     , directory
+                    , extra >= 1.7
                     , filepath
                     , network-uri
                     , safe-exceptions

--- a/packages/agent-accounts/package.nix
+++ b/packages/agent-accounts/package.nix
@@ -1,6 +1,6 @@
 { mkDerivation, aeson, agent-claude, agent-core, agent-gemini
 , agent-json, agent-openai, agent-openrouter, agent-server-client
-, agent-xai, async, base, bytestring, containers, directory
+, agent-xai, async, base, bytestring, containers, directory, extra
 , filepath, hspec, lib, network-uri, safe-exceptions, stm, text
 , time, transformers, unix
 }:
@@ -11,8 +11,8 @@ mkDerivation {
   libraryHaskellDepends = [
     aeson agent-claude agent-core agent-gemini agent-json agent-openai
     agent-openrouter agent-server-client agent-xai base bytestring
-    containers directory filepath network-uri safe-exceptions stm text
-    time transformers unix
+    containers directory extra filepath network-uri safe-exceptions stm
+    text time transformers unix
   ];
   testHaskellDepends = [
     aeson agent-core agent-json async base bytestring directory

--- a/packages/agent-accounts/src/Agent/Accounts/Auth/OpenAI.hs
+++ b/packages/agent-accounts/src/Agent/Accounts/Auth/OpenAI.hs
@@ -46,6 +46,7 @@ import Agent.Provider
 import Control.Applicative ((<|>))
 import Control.Concurrent.MVar (MVar, newMVar, withMVar)
 import Control.Monad (when)
+import Control.Monad.Extra (firstJustM)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
 import qualified Data.Aeson as Aeson
@@ -185,7 +186,7 @@ loadExternalOpenAiApiKeyDictationAuth =
 loadOpenAiApiKeyDictationAuthWith :: Bool -> IO (Maybe LoadedAuth)
 loadOpenAiApiKeyDictationAuthWith includeManaged =
     fmap (fmap loadedAuthForApiKey) $
-        firstJustM
+        firstJustM id
             ( [ loadEnvironmentApiKey "OPENAI_API_KEY"
               , loadEnvironmentApiKey "CODEX_API_KEY"
               , loadCodexEnvironmentApiKey
@@ -231,17 +232,6 @@ loadOpenAiApiKeyDictationAuthWith includeManaged =
                 (Text.pack (unsafeToFilePath filePath))
                 "OpenAI API key"
                 <$> (fileBytes >>= codexApiKeyFromJson)
-
-firstJustM :: [IO (Maybe value)] -> IO (Maybe value)
-firstJustM = \case
-    [] ->
-        pure Nothing
-    action : remaining ->
-        action >>= \case
-            Just value ->
-                pure (Just value)
-            Nothing ->
-                firstJustM remaining
 
 externalApiKeySource :: Text -> Text -> Text -> OpenAiApiKeySource
 externalApiKeySource source label accessToken =

--- a/packages/agent-computer-use/src/Agent/ComputerUse.hs
+++ b/packages/agent-computer-use/src/Agent/ComputerUse.hs
@@ -89,7 +89,6 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , ToolSchema(..)
     )
-import Control.Applicative ((<|>))
 import Control.Concurrent
     ( MVar
     , modifyMVar_
@@ -108,6 +107,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isControl, isDigit)
+import Data.Foldable (asum)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -735,7 +735,7 @@ validateComputerCall call
         Left "Computer call exceeds the 10-action limit."
     | exceedsList 64 call.pendingSafetyChecks =
         Left "Computer call exceeds the 64-safety-check limit."
-    | Just err <- firstJust
+    | Just err <- asum
         (map validateSafetyCheck call.pendingSafetyChecks
             <> map validateAction call.computerActions) =
         Left err
@@ -760,7 +760,7 @@ hasNonFinalScreenshot actions =
 validateComputerCallForDisplay :: (Int, Int) -> ComputerCall -> Either Text ()
 validateComputerCallForDisplay (width, height) call = do
     validateComputerCall call
-    case firstJust (map validatePoint (computerPoints call.computerActions)) of
+    case asum (map validatePoint (computerPoints call.computerActions)) of
         Just err -> Left err
         Nothing -> Right ()
   where
@@ -874,9 +874,6 @@ blockedComputerKeyCombination platform keys =
     shortcut value = \case
         Input.ComputerShortcutKey key -> key == value
         _ -> False
-
-firstJust :: [Maybe value] -> Maybe value
-firstJust = foldr (<|>) Nothing
 
 exceedsList :: Int -> [value] -> Bool
 exceedsList limit = not . null . drop limit
@@ -1536,7 +1533,7 @@ computerToolCallBlocked call
         case Json.decodeText computerToolInputDecoder call.arguments of
             Left _ -> Nothing
             Right input ->
-                firstJust
+                asum
                     [ blockedComputerKeyCombination os keys
                     | KeypressAction keys <- input.toolComputerActions
                     ]

--- a/packages/agent-computer-use/test/Agent/ComputerUseSpec.hs
+++ b/packages/agent-computer-use/test/Agent/ComputerUseSpec.hs
@@ -2768,6 +2768,17 @@ spec = do
                 `shouldBe` Left
                     "Unsupported computer action: \"future_action\""
 
+        it "reports the first invalid action without evaluating later actions" do
+            validateComputerCall
+                exampleCall
+                    { computerActions =
+                        [ WaitAction
+                        , DragAction [] []
+                        , error "validation continued after the first error"
+                        ]
+                    }
+                `shouldBe` Left "Computer drag path is empty."
+
         it "prevalidates every coordinate against the selected display" do
             validateComputerCallForDisplay
                 (1440, 900)

--- a/packages/agent-core/src/Agent/Image/Normalize.hs
+++ b/packages/agent-core/src/Agent/Image/Normalize.hs
@@ -35,6 +35,7 @@ import Codec.Picture.Types
     , pixelMap
     )
 import qualified Codec.Compression.Zlib.Internal as Zlib
+import Control.Monad (guard)
 import Control.Monad.ST.Lazy (runST)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as ByteString
@@ -237,10 +238,10 @@ encodedImageHeader bytes
 
 pngHeader :: ByteString -> Maybe EncodedImageHeader
 pngHeader bytes = do
-    guardMaybe (ByteString.length bytes >= 33)
+    guard (ByteString.length bytes >= 33)
     chunkLength <- word32Be bytes 8
-    guardMaybe (chunkLength == 13)
-    guardMaybe (ByteString.take 4 (ByteString.drop 12 bytes) == "IHDR")
+    guard (chunkLength == 13)
+    guard (ByteString.take 4 (ByteString.drop 12 bytes) == "IHDR")
     width <- word32Be bytes 16
     height <- word32Be bytes 20
     bitDepth <- byteAt bytes 24
@@ -248,9 +249,9 @@ pngHeader bytes = do
     compressionMethod <- byteAt bytes 26
     filterMethod <- byteAt bytes 27
     interlaceMethod <- byteAt bytes 28
-    guardMaybe (compressionMethod == 0)
-    guardMaybe (filterMethod == 0)
-    guardMaybe (interlaceMethod == 0 || interlaceMethod == 1)
+    guard (compressionMethod == 0)
+    guard (filterMethod == 0)
+    guard (interlaceMethod == 0 || interlaceMethod == 1)
     (samplesPerPixel, decodedBytesPerPixel) <-
         pngColorLayout bitDepth colorType
     (validWidth, validHeight) <- validDimensions width height
@@ -280,19 +281,19 @@ pngColorLayout
 pngColorLayout bitDepth colorType =
     case colorType of
         0 -> do
-            guardMaybe (bitDepth `elem` [1, 2, 4, 8, 16])
+            guard (bitDepth `elem` [1, 2, 4, 8, 16])
             pure (1, if bitDepth == 16 then 2 else 1)
         2 -> do
-            guardMaybe (bitDepth == 8 || bitDepth == 16)
+            guard (bitDepth == 8 || bitDepth == 16)
             pure (3, if bitDepth == 16 then 6 else 3)
         3 -> do
-            guardMaybe (bitDepth `elem` [1, 2, 4, 8])
+            guard (bitDepth `elem` [1, 2, 4, 8])
             pure (1, 4)
         4 -> do
-            guardMaybe (bitDepth == 8 || bitDepth == 16)
+            guard (bitDepth == 8 || bitDepth == 16)
             pure (2, if bitDepth == 16 then 4 else 2)
         6 -> do
-            guardMaybe (bitDepth == 8 || bitDepth == 16)
+            guard (bitDepth == 8 || bitDepth == 16)
             pure (4, if bitDepth == 16 then 8 else 4)
         _ -> Nothing
 
@@ -344,12 +345,12 @@ pngImageDataChunks bytes =
     totalBytes = toInteger (ByteString.length bytes)
 
     go offset chunkCount sawImageData endedImageData chunks = do
-        guardMaybe (chunkCount < maximumPngChunkCount)
-        guardMaybe (offset + 12 <= totalBytes)
+        guard (chunkCount < maximumPngChunkCount)
+        guard (offset + 12 <= totalBytes)
         chunkLength <- word32Be bytes (fromInteger offset)
         let dataOffset = offset + 8
             nextOffset = dataOffset + chunkLength + 4
-        guardMaybe (nextOffset <= totalBytes)
+        guard (nextOffset <= totalBytes)
         let chunkType =
                 ByteString.take 4
                     (ByteString.drop (fromInteger (offset + 4)) bytes)
@@ -358,7 +359,7 @@ pngImageDataChunks bytes =
                     (ByteString.drop (fromInteger dataOffset) bytes)
         case chunkType of
             "IDAT" -> do
-                guardMaybe (not endedImageData)
+                guard (not endedImageData)
                 go
                     nextOffset
                     (chunkCount + 1)
@@ -366,9 +367,9 @@ pngImageDataChunks bytes =
                     False
                     (chunkData : chunks)
             "IEND" -> do
-                guardMaybe (chunkLength == 0)
-                guardMaybe sawImageData
-                guardMaybe (nextOffset == totalBytes)
+                guard (chunkLength == 0)
+                guard sawImageData
+                guard (nextOffset == totalBytes)
                 pure (reverse chunks)
             _ ->
                 go
@@ -478,7 +479,7 @@ jpegDimensions bytes = findMarker 2
             marker
                 | jpegStartOfFrame marker -> do
                     segmentLength <- word16Be bytes (markerOffset + 1)
-                    guardMaybe (segmentLength >= 7)
+                    guard (segmentLength >= 7)
                     height <- word16Be bytes (markerOffset + 4)
                     width <- word16Be bytes (markerOffset + 6)
                     validDimensions width height
@@ -487,10 +488,10 @@ jpegDimensions bytes = findMarker 2
                     findMarker (markerOffset + 1)
                 | otherwise -> do
                     segmentLength <- word16Be bytes (markerOffset + 1)
-                    guardMaybe (segmentLength >= 2)
+                    guard (segmentLength >= 2)
                     let next =
                             markerOffset + 1 + fromInteger segmentLength
-                    guardMaybe (next > markerOffset && next <= scanLimit)
+                    guard (next > markerOffset && next <= scanLimit)
                     findMarker next
 
     jpegStartOfFrame marker =
@@ -508,7 +509,7 @@ jpegDimensions bytes = findMarker 2
 
 validDimensions :: Integer -> Integer -> Maybe (Integer, Integer)
 validDimensions width height = do
-    guardMaybe (width > 0 && height > 0)
+    guard (width > 0 && height > 0)
     pure (width, height)
 
 word16Be :: ByteString -> Int -> Maybe Integer
@@ -573,27 +574,22 @@ parseImageDataUrl url = do
     let (metadata, payloadWithComma) = Text.breakOn "," url
         loweredMetadata = Text.toLower metadata
         base64Suffix = ";base64"
-    guardMaybe (not (Text.null payloadWithComma))
-    guardMaybe ("data:image/" `Text.isPrefixOf` loweredMetadata)
-    guardMaybe (base64Suffix `Text.isSuffixOf` loweredMetadata)
+    guard (not (Text.null payloadWithComma))
+    guard ("data:image/" `Text.isPrefixOf` loweredMetadata)
+    guard (base64Suffix `Text.isSuffixOf` loweredMetadata)
     let encodedPayload = Text.drop 1 payloadWithComma
-    guardMaybe
+    guard
         (Text.length encodedPayload
             <= maximumEncodedImageBase64Characters)
     let mime =
             Text.drop 5
                 (Text.dropEnd (Text.length base64Suffix) metadata)
-    guardMaybe (not (Text.null mime))
+    guard (not (Text.null mime))
     bytes <-
         either (const Nothing) Just
             (Base64.decode
                 (TextEncoding.encodeUtf8 encodedPayload))
     pure (mime, bytes)
-
-guardMaybe :: Bool -> Maybe ()
-guardMaybe condition
-    | condition = Just ()
-    | otherwise = Nothing
 
 dynamicImageWidth :: DynamicImage -> Int
 dynamicImageWidth = dynamicMap imageWidth

--- a/packages/agent-mail/src/Agent/Mail/Transport.hs
+++ b/packages/agent-mail/src/Agent/Mail/Transport.hs
@@ -48,7 +48,7 @@ import Agent.Mail.Types
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception.Safe (SomeException, tryAny)
-import Control.Monad (foldM, unless, when)
+import Control.Monad (foldM, guard, unless, when)
 import qualified Data.Aeson as Aeson
 import Data.Aeson ((.:), (.:?))
 import Data.Aeson.Types (Parser, parseEither)
@@ -2630,8 +2630,8 @@ parseListLine raw = do
     let stripped = Text.strip raw
     guardPrefix "* list " stripped
     mailbox <- lastImapArgument stripped
-    whenMaybe (not (Text.any (`elem` ['\\', '"', '\r', '\n', '\NUL']) mailbox))
-    whenMaybe (Text.length (encodeImapMailboxId mailbox) <= 900)
+    guard (not (Text.any (`elem` ['\\', '"', '\r', '\n', '\NUL']) mailbox))
+    guard (Text.length (encodeImapMailboxId mailbox) <= 900)
     pure MailboxSummary
         { mailMailboxId = encodeImapMailboxId mailbox
         , mailMailboxName = mailbox
@@ -2722,7 +2722,7 @@ imapLiteralLength line = do
     let (before, suffix) = Text.breakOnEnd "{" stripped
         digits = Text.dropEnd 1 suffix
         normalized = Text.dropWhileEnd (== '+') digits
-    whenMaybe (not (Text.null before) && not (Text.null normalized)
+    guard (not (Text.null before) && not (Text.null normalized)
         && Text.all isDigit normalized)
     case reads (Text.unpack normalized) of
         [(value, "")] -> Just value
@@ -2732,10 +2732,6 @@ guardSuffix :: Text -> Text -> Maybe ()
 guardSuffix suffix value
     | suffix `Text.isSuffixOf` value = Just ()
     | otherwise = Nothing
-
-whenMaybe :: Bool -> Maybe ()
-whenMaybe True = Just ()
-whenMaybe False = Nothing
 
 parseHeaders :: Text -> [(Text, Text)]
 parseHeaders =

--- a/packages/agent-tui/src/Agent/TUI/Presentation.hs
+++ b/packages/agent-tui/src/Agent/TUI/Presentation.hs
@@ -66,7 +66,7 @@ import qualified Data.ByteString.Lazy as LazyByteString
 import Data.Char (isDigit, isSpace)
 import qualified Data.Foldable as Foldable
 import Data.List (sortOn)
-import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TextEncoding
@@ -1284,7 +1284,3 @@ askUserQuestionDetail arguments =
 decodeMaybe :: Hermes.Decoder a -> Text -> Maybe a
 decodeMaybe decoder input =
     either (const Nothing) Just (Hermes.decodeText decoder input)
-
-listToMaybe :: [a] -> Maybe a
-listToMaybe [] = Nothing
-listToMaybe (x : _) = Just x

--- a/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/PresentationSpec.hs
@@ -730,6 +730,13 @@ spec = describe "tool presentation" do
                 \□ Investigate Codex\n\
                 \✗ Skip leftover work"
 
+    it "keeps todo previews on the first entry and handles empty lists" do
+        let preview = todoCallPreview . functionToolCall "todo" "todo_write"
+        preview "{\"todos\":[]}" `shouldBe` ""
+        preview "{\"todos\":[{\"content\":\"First\"},{\"content\":\"Second\"}]}"
+            `shouldBe` "First"
+        preview "{\"todos\":[{}, {\"content\":\"Second\"}]}" `shouldBe` ""
+
     it "formats Codex update_plan output as the same checklist" do
         let call = functionToolCall "plan" "update_plan" "{\"plan\":[]}"
         toolCallTitle call `shouldBe` "update_plan"


### PR DESCRIPTION
## Summary
- Replace handwritten Maybe helpers with `listToMaybe`, `asum`, `guard`, and `firstJustM id` across TUI, computer-use, image normalization, mail, and OpenAI auth.
- Preserve first-result precedence, lazy validation, auth short-circuiting, and parser rejection behavior.
- Add regressions for first-error validation and first/empty todo previews; add the accounts `extra` dependency and regenerate its Nix expression.

## Validation
- GHCi: computer-use 103, TUI 277, accounts 15, mail 115 examples; zero failures.
- CLI OpenAI dictation auth fallback suite: 12 examples, zero failures.
- Temporary image API smoke: 5 examples, zero failures, covering valid/oversized PNGs and malformed input fallback.
- Live source-backed CLI/TUI smoke: 271 modules loaded; prompt/status, command palette opening/cancellation, and graceful exit verified.
- `git diff --check` passed.

Behavior-preserving cleanup; no performance claim.
