### PR TITLE
Extract shared tool setup into agent-runtime

### DIFF
--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -125,6 +125,25 @@ entry point. CLI startup still chooses the provider and assembles session,
 tools, persistence, and presentation. Server and native adapters still use that
 CLI startup path; this extraction does not remove their CLI dependency.
 
+## Implemented: shared tool assembly and startup ownership
+
+`Agent.Runtime.Tools.Dialects` owns Codex/Grok coding-tool assembly and
+filtering. Frontends supply plan, secret, and image hooks; the shared module
+does not import CLI options or terminal presentation. CLI and server consumers
+use this module directly rather than a CLI facade.
+
+`Agent.Runtime.Tools.Resources` owns session teardown domains, and
+`Agent.Runtime.Tools.Startup` acquires the five tool domains concurrently with
+context preload. Typed `Acquire` inputs retain each completed resource in its
+domain; failed or cancelled startup joins sibling acquisitions before scopes
+unwind. Shutdown order remains activities, code mode, session lock, computer
+use, LSP, web fetch, MCP, coding tools, scratch storage.
+
+This is a bounded extraction, not the complete session entry point. Concrete
+MCP/scratch setup, host-specific tool groups, terminal hooks, and session launch
+still live in CLI orchestration. Server still depends on `agent-cli` until
+those remaining composition boundaries move. No new Cabal package is needed.
+
 ## Remaining: move session composition and ownership out of the CLI
 
 ### Conversation-state ownership

--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -181,7 +181,6 @@ library
                     , Agent.CLI.Voice.Audio
                     , Agent.CLI.Voice.Transport
                     , Agent.CLI.Voice.Session
-                    , Agent.CLI.Dialects
                     , Agent.CLI.ExternalProgram
                     , Agent.CLI.FileUri
                     , Agent.CLI.ImagePreview
@@ -229,7 +228,6 @@ library
                     , Agent.CLI.Render
                     , Agent.CLI.ReplMode
                     , Agent.CLI.Runtime.MetaConsole
-                    , Agent.CLI.Runtime.Orchestration.Tools.Resources
                     , Agent.CLI.Resume
                     , Agent.CLI.Session.ConversationStore
                     , Agent.CLI.Session.History
@@ -564,9 +562,9 @@ test-suite agent-cli-test
                     , Agent.CLI.ConfigSpec
                     , Agent.CLI.ContextSpec
                     , Agent.CLI.ConnectivitySpec
-                    , Agent.CLI.DialectsSpec
                     , Agent.CLI.DatabaseSpec
                     , Agent.CLI.DesktopSpec
+                    , Agent.CLI.DialectsSpec
                     , Agent.CLI.ExternalProgramSpec
                     , Agent.CLI.FileUriSpec
                     , Agent.CLI.GatewayModelsSpec
@@ -619,7 +617,6 @@ test-suite agent-cli-test
                     , Agent.CLI.TranscriptExportSpec
                     , Agent.CLI.SessionHistorySpec
                     , Agent.CLI.SessionStateSpec
-                    , Agent.CLI.SessionResourcesSpec
                     , Agent.CLI.SessionTitleSpec
                     , Agent.CLI.SkillsSpec
                     , Agent.CLI.SubagentStoreSpec

--- a/packages/agent-cli/benchmark/Concurrency.hs
+++ b/packages/agent-cli/benchmark/Concurrency.hs
@@ -1,6 +1,6 @@
 module Main (main) where
 
-import Agent.CLI.Dialects (CodingTools(..), codingToolsFor)
+import Agent.Runtime.Tools.Dialects (CodingTools(..), codingToolsFor)
 import Agent.CLI.Options (defaultCliOptions)
 import Agent.CLI.PendingInputs
     ( PendingInputs

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Session.hs
@@ -48,7 +48,7 @@ import Agent.Runtime.Compaction.Provider
     , OccupancySnapshot
     )
 import Agent.Runtime.Database.Store (DatabaseScopes)
-import Agent.CLI.Dialects (CodingTools(..))
+import Agent.Runtime.Tools.Dialects (CodingTools(..))
 import Agent.Runtime.Error (formatApiErrorAt)
 import Agent.Runtime.GatewayClient
     ( GatewayCredential(gatewayBaseUrl)

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -28,7 +28,7 @@ import Agent.Runtime.Config (HarnessConfig(..))
 import Agent.Runtime.Database ( databaseTools )
 import Agent.Runtime.Database.Store
     (databaseToolsEnvForStore)
-import Agent.CLI.Dialects
+import Agent.Runtime.Tools.Dialects
     ( CodingTools(..),
       codingToolsForWithTypes,
       filterBashTools,
@@ -120,8 +120,10 @@ import Agent.ResourceScope
     , registerResource
     , logSlowCleanup
     )
-import Agent.CLI.Runtime.Orchestration.Tools.Resources
+import Agent.Runtime.Tools.Resources
     ( SessionResourceScopes(..), withSessionResourceScopes )
+import Agent.Runtime.Tools.Startup
+    ( ToolAcquisitions(..), ToolStartupResources(..), acquireToolStartup )
 import Agent.Skills
     ( SkillCatalog(..)
     , SkillInvocation
@@ -139,7 +141,7 @@ import Agent.Tools.Types
     , ToolEnv(..)
     , appToolsFromGroups
     )
-import Control.Concurrent.Async ( Concurrently(..), concurrently )
+import Control.Concurrent.Async ( concurrently )
 import Control.Exception.Safe
     ( SomeException, mask_, throwIO, try )
 import Control.Monad ( forM_, when, void )
@@ -161,15 +163,6 @@ import qualified Data.Text as Text (unpack, pack)
 data LocalToolRuntime = LocalToolRuntime
     { localCoding :: CodingTools
     , localInitialSkills :: SkillCatalog
-    }
-
-data StartupResources = StartupResources
-    { startupMcp :: McpRuntime
-    , startupLocalTools :: LocalToolRuntime
-    , startupWebFetch :: Maybe WebFetchRuntime
-    , startupLsp :: LspStartup
-    , startupComputerUse :: Maybe ComputerUse.ComputerUseRuntime
-    , startupInitialContext :: (SessionInitialContext, InitialContextPreload)
     }
 
 data CodingRuntime = CodingRuntime
@@ -228,42 +221,26 @@ runAgentTools request = withSessionResourceScopes \resources -> do
                 collaborationRuntime)
             (logSlowCleanup "session temporary resources" . (.scratchCleanup))
     integrationRuntime <- acquireSessionIntegrationRuntime request
-    let acquireOwnedMcp =
-            snd <$> allocateAcquire resources.mcpResources
-                (mkAcquire
-                    (acquireMcpRuntime
-                        request toolStartup toolModelRuntime
-                        collaborationRuntime scratchRuntime integrationRuntime)
-                    (logSlowCleanup "session MCP resources" . (.runtimeCloseMcp)))
-        acquireOwnedCoding =
-            snd <$> allocateAcquire resources.codingResources
-                (acquireLocalToolRuntime
-                    request toolModelRuntime toolHostHooks
-                    collaborationRuntime scratchRuntime)
-        acquireOwnedWebFetch =
-            snd <$> allocateAcquire resources.webFetchResources
-                (mkAcquire
-                    (acquireWebFetchRuntime request toolStartup toolModelRuntime)
-                    (logSlowCleanup "web fetch runtime" . mapM_ closeWebFetchRuntime))
-        acquireOwnedLsp =
-            snd <$> allocateAcquire resources.lspResources
-                (mkAcquire
-                    (acquireLspStartup request toolStartup toolModelRuntime)
-                    (logSlowCleanup "language server runtime" . mapM_ closeLspRuntime . (.lspStartupRuntime)))
-        acquireOwnedComputerUse =
-            snd <$> allocateAcquire resources.computerUseResources
-                (mkAcquire
-                    (acquireComputerUseRuntime toolModelRuntime)
-                    (logSlowCleanup "computer use runtime" . mapM_ ComputerUse.closeComputerUseRuntime))
-    -- Startup is concurrent; resource scopes determine shutdown order.
-    startupResources <- runConcurrently $
-        StartupResources
-            <$> Concurrently acquireOwnedMcp
-            <*> Concurrently acquireOwnedCoding
-            <*> Concurrently acquireOwnedWebFetch
-            <*> Concurrently acquireOwnedLsp
-            <*> Concurrently acquireOwnedComputerUse
-            <*> Concurrently (prepareInitialContextPreload request toolModelRuntime)
+    startupResources <- acquireToolStartup resources ToolAcquisitions
+        { acquireMcp = mkAcquire
+            (acquireMcpRuntime
+                request toolStartup toolModelRuntime
+                collaborationRuntime scratchRuntime integrationRuntime)
+            (logSlowCleanup "session MCP resources" . (.runtimeCloseMcp))
+        , acquireCoding = acquireLocalToolRuntime
+            request toolModelRuntime toolHostHooks
+            collaborationRuntime scratchRuntime
+        , acquireWebFetch = mkAcquire
+            (acquireWebFetchRuntime request toolStartup toolModelRuntime)
+            (logSlowCleanup "web fetch runtime" . mapM_ closeWebFetchRuntime)
+        , acquireLsp = mkAcquire
+            (acquireLspStartup request toolStartup toolModelRuntime)
+            (logSlowCleanup "language server runtime" . mapM_ closeLspRuntime . (.lspStartupRuntime))
+        , acquireComputerUse = mkAcquire
+            (acquireComputerUseRuntime toolModelRuntime)
+            (logSlowCleanup "computer use runtime" . mapM_ ComputerUse.closeComputerUseRuntime)
+        , preloadContext = prepareInitialContextPreload request toolModelRuntime
+        }
     let mcpRuntime = startupResources.startupMcp
         localToolRuntime = startupResources.startupLocalTools
         webFetchRuntime = startupResources.startupWebFetch

--- a/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Runner/Execution.hs
@@ -108,7 +108,7 @@ import Agent.Runtime.ModelConfig
     ( catalogSupportsAsyncToolCallsForTransport
     )
 import Agent.Runtime.Error
-import Agent.CLI.Dialects
+import Agent.Runtime.Tools.Dialects
 import Agent.CLI.Dictation (dictationTargetForSession)
 import Agent.CLI.TUI.App
 import Agent.CLI.TUI.Composer (appendFullscreenInput)

--- a/packages/agent-cli/src/Agent/CLI/StartupContext.hs
+++ b/packages/agent-cli/src/Agent/CLI/StartupContext.hs
@@ -6,7 +6,7 @@ module Agent.CLI.StartupContext
     , loadAgentsContextWithPreload
     ) where
 
-import Agent.CLI.Dialects
+import Agent.Runtime.Tools.Dialects
     ( formatAgentsMdForDialect
     , globalAgentsHomeDir
     )

--- a/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
+++ b/packages/agent-cli/src/Agent/CLI/Subagents/Runtime.hs
@@ -70,7 +70,7 @@ import Agent.Runtime.ModelConfig
     (connectionSupportsDialect, organizationGatewayConnectionId)
 import Agent.CLI.Tools
     (hostedSearchToolNames, requireToolRegistry, schemasFromAppTools)
-import Agent.CLI.Dialects
+import Agent.Runtime.Tools.Dialects
     ( CodingTools(..)
     , codingToolsFor
     , filterBashTools

--- a/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/DialectsSpec.hs
@@ -1,13 +1,5 @@
 module Agent.CLI.DialectsSpec (spec) where
 
-import Agent.CLI.Dialects
-    ( CodingTools(..)
-    , codingToolsFor
-    , filterBashTools
-    , filterGhciTools
-    , formatAgentsMdForDialect
-    , globalAgentsHomeDir
-    )
 import Agent.CLI.Options (defaultCliOptions)
 import Agent.CLI.StartupContext
     ( AgentsContextNotice(SuppressAgentsContextLoaded)
@@ -15,28 +7,8 @@ import Agent.CLI.StartupContext
     , loadAgentsContextWithPreload
     , preloadAgentsContext
     )
-import Agent.Dialect
-    ( claudeCodeDialect
-    , codexDialect
-    , genericResponsesDialect
-    , grokBuildDialect
-    )
-import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
-import Agent.ToolDispatch (noArgsTool)
-import Agent.Tools.Secret (SecretPromptHooks(..))
-import Agent.Tools.ShowImage (ImageDisplayHooks(..))
-import Agent.Tools.Types
-    ( AppTool(..)
-    , ApprovalRule(AlwaysReadOnly)
-    , ToolEnv
-    , appToolsFromGroups
-    , defaultToolEnv
-    , executionToolsFromGroups
-    , hostToolsFromGroups
-    , jsonAppTool
-    )
-import Control.Exception.Safe (bracket, finally)
-import Control.Monad (forM_)
+import Agent.Dialect (codexDialect)
+import Control.Exception.Safe (bracket)
 import qualified Data.ByteString as BS
 import Data.IORef (IORef, readIORef)
 import qualified Data.Text as Text
@@ -53,39 +25,7 @@ import System.Posix.Temp (mkdtemp)
 import Test.Hspec
 
 spec :: Spec
-spec = describe "Agent.CLI.Dialects" do
-    it "dispatches project-instruction formatting by dialect" do
-        let cwd = unsafeEncodeUtf "/repo"
-            loaded = LoadedAgentsMd
-                { loadedGlobal = Nothing
-                , loadedProject =
-                    [InstructionFile (unsafeEncodeUtf "/repo/AGENTS.md") "rules"]
-                , loadedWarnings = []
-                }
-        formatAgentsMdForDialect codexDialect cwd loaded
-            `shouldSatisfy`
-                maybe False (Text.isPrefixOf "# AGENTS.md instructions")
-        formatAgentsMdForDialect grokBuildDialect cwd loaded
-            `shouldSatisfy`
-                maybe False (Text.isInfixOf "<system-reminder>")
-        formatAgentsMdForDialect genericResponsesDialect cwd loaded
-            `shouldSatisfy`
-                maybe False (Text.isInfixOf "<system-reminder>")
-        formatAgentsMdForDialect claudeCodeDialect cwd loaded
-            `shouldSatisfy`
-                maybe False (Text.isPrefixOf "# AGENTS.md instructions")
-
-    it "uses each dialect's compatibility instruction home" do
-        let home = unsafeEncodeUtf "/home/u"
-        globalAgentsHomeDir codexDialect home
-            `shouldBe` unsafeEncodeUtf "/home/u/.codex"
-        globalAgentsHomeDir grokBuildDialect home
-            `shouldBe` unsafeEncodeUtf "/home/u/.grok"
-        globalAgentsHomeDir genericResponsesDialect home
-            `shouldBe` unsafeEncodeUtf "/home/u/.haskell-agent"
-        globalAgentsHomeDir claudeCodeDialect home
-            `shouldBe` unsafeEncodeUtf "/home/u/.claude"
-
+spec = describe "CLI dialect startup context" do
     it "keeps synchronous and preloaded AGENTS context equivalent" do
         withTempDirectory \directory -> do
             let home = directory </> "home"
@@ -182,123 +122,6 @@ spec = describe "Agent.CLI.Dialects" do
             context `shouldBe` Nothing
             warnings `shouldBe` ""
 
-    it "allocates only the AskUserQuestion MCP fallback for Claude Code" do
-        env <- defaultToolEnv (unsafeEncodeUtf "/tmp")
-        coding <- codingToolsFor claudeCodeDialect env Nothing Nothing Nothing Nothing
-        map (.appToolName) coding.codingAppTools
-            `shouldBe` ["ask_user_question"]
-        coding.codingClose
-
-    it "registers ask_secret only when root prompt hooks are supplied" do
-        withTempToolEnv \env ->
-            forM_ [codexDialect, grokBuildDialect] \dialect -> do
-                withoutSecret <-
-                    codingToolsFor dialect env Nothing Nothing Nothing Nothing
-                map (.appToolName) withoutSecret.codingAppTools
-                    `shouldNotContain` ["ask_secret"]
-                withoutSecret.codingClose
-
-                let hooks = SecretPromptHooks
-                        (const (pure (Right Nothing)))
-                withSecret <-
-                    codingToolsFor dialect env Nothing (Just hooks) Nothing Nothing
-                (map (.appToolName) withSecret.codingAppTools
-                    `shouldContain` ["ask_secret"])
-                    `finally` withSecret.codingClose
-
-    it "registers show_image only when image display hooks are supplied" do
-        withTempToolEnv \env ->
-            forM_ [codexDialect, grokBuildDialect] \dialect -> do
-                withoutImages <-
-                    codingToolsFor dialect env Nothing Nothing Nothing Nothing
-                map (.appToolName) withoutImages.codingAppTools
-                    `shouldNotContain` ["show_image"]
-                withoutImages.codingClose
-
-                let hooks = ImageDisplayHooks (const (pure (Right ())))
-                withImages <-
-                    codingToolsFor dialect env Nothing Nothing (Just hooks) Nothing
-                (map (.appToolName) withImages.codingAppTools
-                    `shouldContain` ["show_image"])
-                    `finally` withImages.codingClose
-
-    it "registers bounded artifact readers on coding tool surfaces" do
-        withTempToolEnv \env ->
-            forM_ [codexDialect, grokBuildDialect] \dialect -> do
-                coding <- codingToolsFor dialect env Nothing Nothing Nothing Nothing
-                let names = map (.appToolName) coding.codingAppTools
-                names `shouldContain`
-                    ["read_tool_output", "search_tool_output", "export_tool_output"]
-                names `shouldNotContain` ["analyze_tool_output"]
-                coding.codingClose
-
-    it "partitions execution tools from host services when constructed" do
-        withTempToolEnv \env ->
-            forM_
-                [ (codexDialect, "shell_command")
-                , (grokBuildDialect, "run_terminal_cmd")
-                ]
-                \(dialect, shellName) -> do
-                    coding <-
-                        codingToolsFor
-                            dialect env Nothing Nothing Nothing Nothing
-                    let names = map (.appToolName)
-                        executionNames =
-                            names
-                                (executionToolsFromGroups
-                                    coding.codingAppToolGroups)
-                        hostNames =
-                            names
-                                (hostToolsFromGroups
-                                    coding.codingAppToolGroups)
-                        assertions = do
-                            names
-                                (appToolsFromGroups
-                                    coding.codingAppToolGroups)
-                                `shouldBe` names coding.codingAppTools
-                            forM_
-                                [ "run_ghci"
-                                , "read_file"
-                                , "view_image"
-                                , shellName
-                                , "read_tool_output"
-                                , "search_tool_output"
-                                , "export_tool_output"
-                                ]
-                                \name ->
-                                    executionNames `shouldContain` [name]
-                            executionNames
-                                `shouldNotContain` ["ask_user_question"]
-                            hostNames `shouldContain` ["ask_user_question"]
-                            forM_
-                                ["read_file", shellName, "read_tool_output"]
-                                \name -> hostNames `shouldNotContain` [name]
-                    assertions `finally` coding.codingClose
-
-    it "filters shell and ghci tools independently" do
-        let tools = map fakeTool
-                [ "run_ghci"
-                , "read_file"
-                , "shell_command"
-                , "write_stdin"
-                , "run_terminal_cmd"
-                ]
-            names = map (.appToolName)
-        names (filterBashTools False tools)
-            `shouldBe` ["run_ghci", "read_file"]
-        names (filterGhciTools False tools)
-            `shouldBe`
-                [ "read_file"
-                , "shell_command"
-                , "write_stdin"
-                , "run_terminal_cmd"
-                ]
-
-withTempToolEnv :: (ToolEnv -> IO a) -> IO a
-withTempToolEnv action = do
-    withTempDirectory \directory ->
-        defaultToolEnv (unsafeEncodeUtf directory) >>= action
-
 withTempDirectory :: (FilePath -> IO a) -> IO a
 withTempDirectory action = do
     root <- getTemporaryDirectory
@@ -320,8 +143,3 @@ captureAgentsContext outputPath action = do
     context <- readIORef contextRef
     output <- TextIO.readFile outputPath
     pure (context, output)
-
-fakeTool :: Text.Text -> AppTool
-fakeTool name =
-    jsonAppTool name "" [] AlwaysReadOnly
-        (noArgsTool name (pure (Right "")))

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -95,7 +95,6 @@ import qualified Agent.CLI.ReviewSpec as ReviewSpec
 import qualified Agent.CLI.SecretSpec as SecretSpec
 import qualified Agent.CLI.SessionHistorySpec as SessionHistorySpec
 import qualified Agent.CLI.SessionStateSpec as SessionStateSpec
-import qualified Agent.CLI.SessionResourcesSpec as SessionResourcesSpec
 import qualified Agent.CLI.SessionTitleSpec as SessionTitleSpec
 import qualified Agent.CLI.SkillsSpec as SkillsSpec
 import qualified Agent.CLI.SubagentStoreSpec as SubagentStoreSpec
@@ -245,7 +244,6 @@ specs = do
     TerminalSpec.spec
     TextLayoutSpec.spec
     SessionStateSpec.spec
-    SessionResourcesSpec.spec
     SessionTitleSpec.spec
     SkillsSpec.spec
     SubagentStoreSpec.spec

--- a/packages/agent-runtime/agent-runtime.cabal
+++ b/packages/agent-runtime/agent-runtime.cabal
@@ -114,7 +114,12 @@ library
                     , Agent.Runtime.TurnEngine
                     , Agent.Runtime.TurnExecution
                     , Agent.Runtime.TurnState
+                    , Agent.Runtime.Tools.Dialects
+                    , Agent.Runtime.Tools.Resources
+                    , Agent.Runtime.Tools.Startup
     build-depends:    agent-accounts >= 0.1 && < 0.2
+                    , agent-codex-dialect >= 0.1 && < 0.2
+                    , agent-grok-build-dialect >= 0.1 && < 0.2
                     , agent-claude >= 0.1 && < 0.2
                     , agent-connectivity >= 0.1 && < 0.2
                     , agent-core >= 0.1 && < 0.2
@@ -150,6 +155,7 @@ library
                     , network
                     , network-uri
                     , process >= 1.6.26
+                    , resourcet
                     , safe-exceptions
                     , scientific
                     , stm
@@ -195,6 +201,9 @@ test-suite agent-runtime-test
     main-is:          Spec.hs
     ghc-options:      -threaded
     other-modules:    Agent.Runtime.RequestSpec
+                    , Agent.Runtime.Tools.DialectsSpec
+                    , Agent.Runtime.Tools.ResourcesSpec
+                    , Agent.Runtime.Tools.StartupSpec
                     , Agent.Runtime.ProviderRuntimeSpec
                     , Agent.Runtime.CompactionSpec
                     , Agent.Runtime.CompactionSpec.Fixtures
@@ -251,6 +260,7 @@ test-suite agent-runtime-test
                     , http-client
                     , http-types
                     , QuickCheck
+                    , resourcet
                     , safe-exceptions
                     , stm
                     , text

--- a/packages/agent-runtime/package.nix
+++ b/packages/agent-runtime/package.nix
@@ -1,14 +1,14 @@
 { mkDerivation, aeson, agent-accounts, agent-claude
-, agent-connectivity, agent-core, agent-gemini
-, agent-integration-api, agent-json, agent-mcp, agent-openai
-, agent-openrouter, agent-process, agent-responses
-, agent-responses-types, agent-server-client, agent-store
-, agent-tools, agent-xai, async, base, base64-bytestring
-, bytestring, containers, crypton, directory, entropy, filelock
-, filepath, hasql-pool, hspec, http-client, http-client-tls
-, http-types, lib, memory, network, network-uri, process
-, QuickCheck, safe-exceptions, scientific, stm, text, time
-, transformers, unix, vector, wai, warp
+, agent-codex-dialect, agent-connectivity, agent-core, agent-gemini
+, agent-grok-build-dialect, agent-integration-api, agent-json
+, agent-mcp, agent-openai, agent-openrouter, agent-process
+, agent-responses, agent-responses-types, agent-server-client
+, agent-store, agent-tools, agent-xai, async, base
+, base64-bytestring, bytestring, containers, crypton, directory
+, entropy, filelock, filepath, hasql-pool, hspec, http-client
+, http-client-tls, http-types, lib, memory, network, network-uri
+, process, QuickCheck, resourcet, safe-exceptions, scientific, stm
+, text, time, transformers, unix, vector, wai, warp
 }:
 mkDerivation {
   pname = "agent-runtime";
@@ -16,22 +16,23 @@ mkDerivation {
   src = ./.;
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [
-    aeson agent-accounts agent-claude agent-connectivity agent-core
-    agent-gemini agent-integration-api agent-json agent-mcp
-    agent-openai agent-openrouter agent-process agent-responses
+    aeson agent-accounts agent-claude agent-codex-dialect
+    agent-connectivity agent-core agent-gemini agent-grok-build-dialect
+    agent-integration-api agent-json agent-mcp agent-openai
+    agent-openrouter agent-process agent-responses
     agent-responses-types agent-server-client agent-store agent-tools
     agent-xai async base base64-bytestring bytestring containers
     crypton directory entropy filelock filepath hasql-pool http-client
     http-client-tls http-types memory network network-uri process
-    safe-exceptions scientific stm text time transformers unix vector
-    wai warp
+    resourcet safe-exceptions scientific stm text time transformers
+    unix vector wai warp
   ];
   testHaskellDepends = [
     aeson agent-accounts agent-connectivity agent-core agent-json
     agent-openai agent-openrouter agent-responses agent-responses-types
     agent-store agent-tools agent-xai async base bytestring containers
     directory filepath hspec http-client http-types network QuickCheck
-    safe-exceptions stm text time transformers unix wai warp
+    resourcet safe-exceptions stm text time transformers unix wai warp
   ];
   description = "Frontend-independent conversation and turn lifecycle";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-runtime/src/Agent/Runtime/Tools/Dialects.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Tools/Dialects.hs
@@ -1,4 +1,4 @@
-module Agent.CLI.Dialects
+module Agent.Runtime.Tools.Dialects
     ( CodingTools(..)
     , codingToolsFor
     , codingToolsForWithTypes

--- a/packages/agent-runtime/src/Agent/Runtime/Tools/Resources.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Tools/Resources.hs
@@ -1,7 +1,6 @@
--- | Ownership for one invocation of the tool/session runtime, including
--- conversation resets. Process-owned services and independent sessions do
--- not belong here.
-module Agent.CLI.Runtime.Orchestration.Tools.Resources
+-- | Session-owned tool domains. Process services and independent sessions
+-- belong to their own owners, not these scopes.
+module Agent.Runtime.Tools.Resources
     ( SessionResourceScopes(..)
     , withSessionResourceScopes
     ) where
@@ -23,13 +22,10 @@ data SessionResourceScopes = SessionResourceScopes
     , activityResources :: ResourceScope
     }
 
--- | Establish ownership before starting concurrent acquisitions. Their
--- completion order cannot change dependency teardown order.
---
--- Acquire unwinds in reverse: join session activities, stop the code-mode
--- dispatcher, release the session lock, close tools, then remove scratch
--- storage. Each domain uses the existing resourcet finalizer machinery;
--- there is no separate cleanup registry or worker supervisor here.
+-- | Establish ownership before concurrent acquisition. Completion order must
+-- not affect teardown: join activities, stop code mode, release the session
+-- lock, close tools, then remove scratch storage. Existing resourcet machinery
+-- runs every domain finalizer even when one fails.
 withSessionResourceScopes :: (SessionResourceScopes -> IO a) -> IO a
 withSessionResourceScopes = Acquire.with acquireSessionResourceScopes
 

--- a/packages/agent-runtime/src/Agent/Runtime/Tools/Startup.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Tools/Startup.hs
@@ -1,0 +1,53 @@
+-- | Concurrent tool acquisition with deterministic session ownership.
+-- Frontends supply concrete acquisitions and interaction hooks; this module
+-- knows neither terminal state nor CLI options.
+module Agent.Runtime.Tools.Startup
+    ( ToolAcquisitions(..)
+    , ToolStartupResources(..)
+    , acquireToolStartup
+    ) where
+
+import Agent.ResourceScope (allocateAcquire)
+import Agent.Runtime.Tools.Resources (SessionResourceScopes(..))
+import Control.Concurrent.Async (Concurrently(..))
+import Data.Acquire (Acquire)
+
+-- | Each acquisition must clean up partial initialization on failure. Completed
+-- resources are retained by their domain until the enclosing session ends.
+-- Context preload must scope any workers/resources internally.
+data ToolAcquisitions mcp coding web lsp computer context = ToolAcquisitions
+    { acquireMcp :: Acquire mcp
+    , acquireCoding :: Acquire coding
+    , acquireWebFetch :: Acquire web
+    , acquireLsp :: Acquire lsp
+    , acquireComputerUse :: Acquire computer
+    , preloadContext :: IO context
+    }
+
+data ToolStartupResources mcp coding web lsp computer context = ToolStartupResources
+    { startupMcp :: mcp
+    , startupLocalTools :: coding
+    , startupWebFetch :: web
+    , startupLsp :: lsp
+    , startupComputerUse :: computer
+    , startupInitialContext :: context
+    }
+
+-- | Run inside 'withSessionResourceScopes'. A failed/cancelled branch cancels
+-- and joins its siblings before the caller's scopes unwind. In particular,
+-- no acquisition worker can still use scratch storage during its teardown.
+acquireToolStartup
+    :: SessionResourceScopes
+    -> ToolAcquisitions mcp coding web lsp computer context
+    -> IO (ToolStartupResources mcp coding web lsp computer context)
+acquireToolStartup scopes acquisitions = runConcurrently $
+    ToolStartupResources
+        <$> owned scopes.mcpResources acquisitions.acquireMcp
+        <*> owned scopes.codingResources acquisitions.acquireCoding
+        <*> owned scopes.webFetchResources acquisitions.acquireWebFetch
+        <*> owned scopes.lspResources acquisitions.acquireLsp
+        <*> owned scopes.computerUseResources acquisitions.acquireComputerUse
+        <*> Concurrently acquisitions.preloadContext
+  where
+    owned scope acquisition =
+        Concurrently (snd <$> allocateAcquire scope acquisition)

--- a/packages/agent-runtime/test/Agent/Runtime/Tools/DialectsSpec.hs
+++ b/packages/agent-runtime/test/Agent/Runtime/Tools/DialectsSpec.hs
@@ -1,0 +1,206 @@
+module Agent.Runtime.Tools.DialectsSpec (spec) where
+
+import Agent.Runtime.Tools.Dialects
+    ( CodingTools(..)
+    , codingToolsFor
+    , filterBashTools
+    , filterGhciTools
+    , formatAgentsMdForDialect
+    , globalAgentsHomeDir
+    )
+import Agent.Dialect
+    ( claudeCodeDialect
+    , codexDialect
+    , genericResponsesDialect
+    , grokBuildDialect
+    )
+import Agent.ProjectInstructions (InstructionFile(..), LoadedAgentsMd(..))
+import Agent.ToolDispatch (noArgsTool)
+import Agent.Tools.Secret (SecretPromptHooks(..))
+import Agent.Tools.ShowImage (ImageDisplayHooks(..))
+import Agent.Tools.Types
+    ( AppTool(..)
+    , ApprovalRule(AlwaysReadOnly)
+    , ToolEnv
+    , appToolsFromGroups
+    , defaultToolEnv
+    , executionToolsFromGroups
+    , hostToolsFromGroups
+    , jsonAppTool
+    )
+import Control.Exception.Safe (bracket, finally)
+import Control.Monad (forM_)
+import qualified Data.Text as Text
+import System.Directory
+    ( getTemporaryDirectory
+    , removeDirectoryRecursive
+    )
+import System.FilePath ((</>))
+import System.OsPath (unsafeEncodeUtf)
+import System.Posix.Temp (mkdtemp)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "Agent.Runtime.Tools.Dialects" do
+    it "dispatches project-instruction formatting by dialect" do
+        let cwd = unsafeEncodeUtf "/repo"
+            loaded = LoadedAgentsMd
+                { loadedGlobal = Nothing
+                , loadedProject =
+                    [InstructionFile (unsafeEncodeUtf "/repo/AGENTS.md") "rules"]
+                , loadedWarnings = []
+                }
+        formatAgentsMdForDialect codexDialect cwd loaded
+            `shouldSatisfy`
+                maybe False (Text.isPrefixOf "# AGENTS.md instructions")
+        formatAgentsMdForDialect grokBuildDialect cwd loaded
+            `shouldSatisfy`
+                maybe False (Text.isInfixOf "<system-reminder>")
+        formatAgentsMdForDialect genericResponsesDialect cwd loaded
+            `shouldSatisfy`
+                maybe False (Text.isInfixOf "<system-reminder>")
+        formatAgentsMdForDialect claudeCodeDialect cwd loaded
+            `shouldSatisfy`
+                maybe False (Text.isPrefixOf "# AGENTS.md instructions")
+
+    it "uses each dialect's compatibility instruction home" do
+        let home = unsafeEncodeUtf "/home/u"
+        globalAgentsHomeDir codexDialect home
+            `shouldBe` unsafeEncodeUtf "/home/u/.codex"
+        globalAgentsHomeDir grokBuildDialect home
+            `shouldBe` unsafeEncodeUtf "/home/u/.grok"
+        globalAgentsHomeDir genericResponsesDialect home
+            `shouldBe` unsafeEncodeUtf "/home/u/.haskell-agent"
+        globalAgentsHomeDir claudeCodeDialect home
+            `shouldBe` unsafeEncodeUtf "/home/u/.claude"
+
+    it "allocates only the AskUserQuestion MCP fallback for Claude Code" do
+        directory <- getTemporaryDirectory
+        env <- defaultToolEnv (unsafeEncodeUtf directory)
+        coding <- codingToolsFor claudeCodeDialect env Nothing Nothing Nothing Nothing
+        map (.appToolName) coding.codingAppTools
+            `shouldBe` ["ask_user_question"]
+        coding.codingClose
+
+    it "registers ask_secret only when root prompt hooks are supplied" do
+        withTempToolEnv \env ->
+            forM_ [codexDialect, grokBuildDialect] \dialect -> do
+                withoutSecret <-
+                    codingToolsFor dialect env Nothing Nothing Nothing Nothing
+                map (.appToolName) withoutSecret.codingAppTools
+                    `shouldNotContain` ["ask_secret"]
+                withoutSecret.codingClose
+
+                let hooks = SecretPromptHooks
+                        (const (pure (Right Nothing)))
+                withSecret <-
+                    codingToolsFor dialect env Nothing (Just hooks) Nothing Nothing
+                (map (.appToolName) withSecret.codingAppTools
+                    `shouldContain` ["ask_secret"])
+                    `finally` withSecret.codingClose
+
+    it "registers show_image only when image display hooks are supplied" do
+        withTempToolEnv \env ->
+            forM_ [codexDialect, grokBuildDialect] \dialect -> do
+                withoutImages <-
+                    codingToolsFor dialect env Nothing Nothing Nothing Nothing
+                map (.appToolName) withoutImages.codingAppTools
+                    `shouldNotContain` ["show_image"]
+                withoutImages.codingClose
+
+                let hooks = ImageDisplayHooks (const (pure (Right ())))
+                withImages <-
+                    codingToolsFor dialect env Nothing Nothing (Just hooks) Nothing
+                (map (.appToolName) withImages.codingAppTools
+                    `shouldContain` ["show_image"])
+                    `finally` withImages.codingClose
+
+    it "registers bounded artifact readers on coding tool surfaces" do
+        withTempToolEnv \env ->
+            forM_ [codexDialect, grokBuildDialect] \dialect -> do
+                coding <- codingToolsFor dialect env Nothing Nothing Nothing Nothing
+                let names = map (.appToolName) coding.codingAppTools
+                names `shouldContain`
+                    ["read_tool_output", "search_tool_output", "export_tool_output"]
+                names `shouldNotContain` ["analyze_tool_output"]
+                coding.codingClose
+
+    it "partitions execution tools from host services when constructed" do
+        withTempToolEnv \env ->
+            forM_
+                [ (codexDialect, "shell_command")
+                , (grokBuildDialect, "run_terminal_cmd")
+                ]
+                \(dialect, shellName) -> do
+                    coding <-
+                        codingToolsFor
+                            dialect env Nothing Nothing Nothing Nothing
+                    let names = map (.appToolName)
+                        executionNames =
+                            names
+                                (executionToolsFromGroups
+                                    coding.codingAppToolGroups)
+                        hostNames =
+                            names
+                                (hostToolsFromGroups
+                                    coding.codingAppToolGroups)
+                        assertions = do
+                            names
+                                (appToolsFromGroups
+                                    coding.codingAppToolGroups)
+                                `shouldBe` names coding.codingAppTools
+                            forM_
+                                [ "run_ghci"
+                                , "read_file"
+                                , "view_image"
+                                , shellName
+                                , "read_tool_output"
+                                , "search_tool_output"
+                                , "export_tool_output"
+                                ]
+                                \name ->
+                                    executionNames `shouldContain` [name]
+                            executionNames
+                                `shouldNotContain` ["ask_user_question"]
+                            hostNames `shouldContain` ["ask_user_question"]
+                            forM_
+                                ["read_file", shellName, "read_tool_output"]
+                                \name -> hostNames `shouldNotContain` [name]
+                    assertions `finally` coding.codingClose
+
+    it "filters shell and ghci tools independently" do
+        let tools = map fakeTool
+                [ "run_ghci"
+                , "read_file"
+                , "shell_command"
+                , "write_stdin"
+                , "run_terminal_cmd"
+                ]
+            names = map (.appToolName)
+        names (filterBashTools False tools)
+            `shouldBe` ["run_ghci", "read_file"]
+        names (filterGhciTools False tools)
+            `shouldBe`
+                [ "read_file"
+                , "shell_command"
+                , "write_stdin"
+                , "run_terminal_cmd"
+                ]
+
+withTempToolEnv :: (ToolEnv -> IO a) -> IO a
+withTempToolEnv action = do
+    withTempDirectory \directory ->
+        defaultToolEnv (unsafeEncodeUtf directory) >>= action
+
+withTempDirectory :: (FilePath -> IO a) -> IO a
+withTempDirectory action = do
+    root <- getTemporaryDirectory
+    bracket
+        (mkdtemp (root </> "agent-runtime-dialects-"))
+        removeDirectoryRecursive
+        action
+
+fakeTool :: Text.Text -> AppTool
+fakeTool name =
+    jsonAppTool name "" [] AlwaysReadOnly
+        (noArgsTool name (pure (Right "")))

--- a/packages/agent-runtime/test/Agent/Runtime/Tools/ResourcesSpec.hs
+++ b/packages/agent-runtime/test/Agent/Runtime/Tools/ResourcesSpec.hs
@@ -1,6 +1,6 @@
-module Agent.CLI.SessionResourcesSpec (spec) where
+module Agent.Runtime.Tools.ResourcesSpec (spec) where
 
-import Agent.CLI.Runtime.Orchestration.Tools.Resources
+import Agent.Runtime.Tools.Resources
 import Agent.ResourceScope
     ( ResourceScope, allocateAcquire, registerResource, releaseResource )
 import Control.Concurrent.Async (Concurrently(..), cancel, race, withAsync)

--- a/packages/agent-runtime/test/Agent/Runtime/Tools/StartupSpec.hs
+++ b/packages/agent-runtime/test/Agent/Runtime/Tools/StartupSpec.hs
@@ -1,0 +1,131 @@
+module Agent.Runtime.Tools.StartupSpec (spec) where
+
+import Agent.ResourceScope (allocateAcquire)
+import Agent.Runtime.Tools.Resources
+import Agent.Runtime.Tools.Startup
+import Control.Concurrent.Async (cancel, withAsync)
+import Control.Concurrent.MVar
+    ( MVar, newEmptyMVar, putMVar, readMVar, takeMVar )
+import Control.Exception.Safe (finally, throwIO, tryAny)
+import Control.Monad (forM_, void)
+import Data.Acquire (Acquire, mkAcquire)
+import Data.Either (isLeft)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef)
+import Data.Text (Text)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "shared tool startup" do
+    it "acquires all domains concurrently and retains their typed results until scope exit" do
+        released <- newIORef []
+        mcp <- newEmptyMVar
+        coding <- newEmptyMVar
+        web <- newEmptyMVar
+        lsp <- newEmptyMVar
+        computer <- newEmptyMVar
+        let started = [mcp, coding, web, lsp, computer]
+        proceed <- newEmptyMVar
+        let acquisition :: MVar () -> Text -> a -> Acquire a
+            acquisition gate name value = mkAcquire
+                (putMVar gate () >> readMVar proceed >> pure value)
+                (const (record released name))
+        result <- timeout 2000000 $
+            withSessionResourceScopes \scopes -> do
+                resources <- acquireToolStartup scopes ToolAcquisitions
+                    { acquireMcp = acquisition mcp "mcp" (42 :: Int)
+                    , acquireCoding = acquisition coding "coding" ("coding result" :: Text)
+                    , acquireWebFetch = acquisition web "web" True
+                    , acquireLsp = acquisition lsp "lsp" (Just (7 :: Int))
+                    , acquireComputerUse = acquisition computer "computer" [1, 2 :: Int]
+                    , preloadContext = do
+                        -- A serialized startup deadlocks here: every tool
+                        -- must have started before any one can complete.
+                        forM_ started takeMVar
+                        putMVar proceed ()
+                        pure ("context" :: Text)
+                    }
+                resources.startupMcp `shouldBe` 42
+                resources.startupLocalTools `shouldBe` "coding result"
+                resources.startupWebFetch `shouldBe` True
+                resources.startupLsp `shouldBe` Just 7
+                resources.startupComputerUse `shouldBe` [1, 2]
+                resources.startupInitialContext `shouldBe` "context"
+                readIORef released `shouldReturn` []
+        result `shouldBe` Just ()
+        readIORef released `shouldReturn` ["computer", "lsp", "web", "mcp", "coding"]
+
+    it "joins a blocked sibling before releasing completed tools after context failure" do
+        released <- newIORef []
+        codingReady <- newEmptyMVar
+        mcpStarted <- newEmptyMVar
+        blocked <- newEmptyMVar
+        result <- timeout 2000000 $ tryAny $
+            withSessionResourceScopes \scopes -> do
+                retainScratch scopes released
+                void $ acquireToolStartup scopes ToolAcquisitions
+                    { acquireMcp = mkAcquire
+                        ((putMVar mcpStarted () >> takeMVar blocked :: IO ())
+                            `finally` record released "mcp acquisition stopped")
+                        (const (record released "mcp"))
+                    , acquireCoding = mkAcquire
+                        (putMVar codingReady ())
+                        (const (record released "coding"))
+                    , acquireWebFetch = pure ()
+                    , acquireLsp = pure ()
+                    , acquireComputerUse = pure ()
+                    , preloadContext = do
+                        takeMVar codingReady
+                        takeMVar mcpStarted
+                        throwIO (userError "context failed") :: IO ()
+                    }
+        result `shouldSatisfy` maybe False isLeft
+        readIORef released
+            `shouldReturn` ["mcp acquisition stopped", "coding", "scratch"]
+
+    it "joins startup workers and releases completed tools when its owner is cancelled" do
+        released <- newIORef []
+        codingReady <- newEmptyMVar
+        mcpStarted <- newEmptyMVar
+        contextStarted <- newEmptyMVar
+        blocked <- newEmptyMVar
+        let startup = withSessionResourceScopes \scopes -> do
+                retainScratch scopes released
+                void $ acquireToolStartup scopes ToolAcquisitions
+                    { acquireMcp = mkAcquire
+                        ((putMVar mcpStarted () >> readMVar blocked :: IO ())
+                            `finally` record released "mcp acquisition stopped")
+                        (const (record released "mcp"))
+                    , acquireCoding = mkAcquire
+                        (putMVar codingReady ())
+                        (const (record released "coding"))
+                    , acquireWebFetch = pure ()
+                    , acquireLsp = pure ()
+                    , acquireComputerUse = pure ()
+                    , preloadContext =
+                        (do
+                            takeMVar codingReady
+                            takeMVar mcpStarted
+                            putMVar contextStarted ()
+                            readMVar blocked)
+                            `finally` record released "context stopped"
+                    }
+        result <- timeout 2000000 $
+            withAsync startup \worker -> do
+                takeMVar contextStarted
+                cancel worker
+        result `shouldBe` Just ()
+        events <- readIORef released
+        -- Siblings may stop in either order, but both must be joined before
+        -- resource teardown starts.
+        take 2 events `shouldMatchList` ["mcp acquisition stopped", "context stopped"]
+        drop 2 events `shouldBe` ["coding", "scratch"]
+
+retainScratch :: SessionResourceScopes -> IORef [Text] -> IO ()
+retainScratch scopes released =
+    void $ allocateAcquire scopes.scratchResources $
+        mkAcquire (pure ()) (const (record released "scratch"))
+
+record :: IORef [Text] -> Text -> IO ()
+record events event =
+    atomicModifyIORef' events \previous -> (previous <> [event], ())

--- a/packages/agent-runtime/test/Spec.hs
+++ b/packages/agent-runtime/test/Spec.hs
@@ -1,6 +1,9 @@
 module Main (main) where
 
 import qualified Agent.Runtime.RequestSpec as Request
+import qualified Agent.Runtime.Tools.ResourcesSpec as ToolResources
+import qualified Agent.Runtime.Tools.DialectsSpec as ToolDialects
+import qualified Agent.Runtime.Tools.StartupSpec as ToolStartup
 import qualified Agent.Runtime.ProviderRuntimeSpec as ProviderRuntime
 import qualified Agent.Runtime.CompactionSpec as Compaction
 import qualified Agent.Runtime.StartupPolicySpec as StartupPolicy
@@ -33,6 +36,9 @@ import Test.Hspec
 
 main :: IO ()
 main = hspec do
+    ToolDialects.spec
+    ToolResources.spec
+    ToolStartup.spec
     Request.spec
     ProviderRuntime.spec
     Compaction.spec

--- a/packages/agent-server/src/Agent/Server/Sandbox/Worker.hs
+++ b/packages/agent-server/src/Agent/Server/Sandbox/Worker.hs
@@ -9,7 +9,7 @@ module Agent.Server.Sandbox.Worker
     , sandboxWorkerMain
     ) where
 
-import Agent.CLI.Dialects
+import Agent.Runtime.Tools.Dialects
     ( CodingTools(..)
     , codingToolsFor
     )

--- a/scripts/check-package-boundaries.sh
+++ b/scripts/check-package-boundaries.sh
@@ -21,6 +21,11 @@ for package in "$cli" "$external_session" "$repository" "$bridge" "$runtime" \
   [[ -d "$package" ]] || fail "missing package directory: $package"
 done
 
+if [[ -e "$cli/src/Agent/CLI/Dialects.hs" \
+  || -e "$cli/src/Agent/CLI/Runtime/Orchestration/Tools/Resources.hs" ]]; then
+  fail "shared tool assembly and ownership must remain in agent-runtime"
+fi
+
 python3 "$root/scripts/check-package-graph.py" "$root"
 [[ ! -e "$root/packages/agent-cli-runtime/agent-cli-runtime.cabal" ]] \
   || fail "agent-cli-runtime must be replaced by agent-runtime"
@@ -157,6 +162,11 @@ for registration in \
 done
 
 required_files=(
+  packages/agent-runtime/src/Agent/Runtime/Tools/Dialects.hs
+  packages/agent-runtime/src/Agent/Runtime/Tools/Resources.hs
+  packages/agent-runtime/src/Agent/Runtime/Tools/Startup.hs
+  packages/agent-runtime/test/Agent/Runtime/Tools/ResourcesSpec.hs
+  packages/agent-runtime/test/Agent/Runtime/Tools/StartupSpec.hs
   packages/agent-runtime/src/Agent/Runtime/Providers.hs
   packages/agent-runtime/src/Agent/Runtime/Providers/Types.hs
   packages/agent-runtime/src/Agent/Runtime/Providers/Common.hs


### PR DESCRIPTION
## Summary
- Move dialect tool assembly and session resource ownership from CLI into agent-runtime.
- Introduce typed concurrent tool startup with deterministic cleanup and cancellation.
- Move neutral tests into runtime and enforce package boundaries.
- Keep terminal hooks, concrete MCP/scratch setup, and session launch in CLI; no new Cabal package.

## Validation
- 18 focused runtime tests pass (dialects, ownership, startup cancellation).
- All libraries plus CLI/runtime test components load in GHCi: 895 modules.
- Nix package-boundary check passes.
- Generated Cabal/Nix expressions match; git diff --check passes.

No CLI presentation changes.