### PR TITLE
Reduce streaming preview churn and snapshot retention

### DIFF
--- a/packages/agent-core/benchmark/JournalAdmission.hs
+++ b/packages/agent-core/benchmark/JournalAdmission.hs
@@ -1,0 +1,122 @@
+module Main (main) where
+
+import qualified Agent.Loop.DisplayJournal as New
+import qualified JournalBefore as Old
+import Agent.Loop.Output (LoopEvent(..))
+import Agent.ToolDispatch (ToolCall(..), functionToolCall)
+-- safe-exceptions does not export evaluate; no exception handling is needed here.
+import Control.Exception (evaluate)
+import Control.Monad (forM_, unless)
+import Data.Char (ord)
+import Data.IORef
+import Data.List (inits)
+import qualified Data.Text as Text
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+import System.CPUTime
+import System.Environment (getArgs)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    unless enabled $ fail "use +RTS -T"
+    args <- getArgs
+    case args of
+        [mode, shape, countArg, sizeArg, samplesArg] -> do
+            let count = read countArg
+                size = read sizeArg
+                samples = read samplesArg
+            unless (count > 0 && size > 0 && samples > 0) $ fail "positive sizes required"
+            unless (shape `elem` ["arguments", "interleaved", "text"])
+                $ fail "unknown shape"
+            verify
+            expected <- verifyWorkload shape count size
+            -- Warm up each consumer; all measured inputs are freshly generated.
+            forM_ ["old", "new"] \variant -> build variant shape count size >>= projectChecksum
+            putStrLn "variant,shape,count,size,sample,cpu_ms,wall_ms,allocated_bytes,live_bytes"
+            forM_ [1 .. samples :: Int] \sample ->
+                forM_ (if odd sample then ["old", "new"] else ["new", "old"]) \variant ->
+                    if mode == "all" || mode == variant then measure variant shape count size sample expected else pure ()
+        _ -> fail "usage: bench old|new|all arguments|interleaved|text COUNT SIZE SAMPLES"
+
+{-# NOINLINE verifyWorkload #-}
+verifyWorkload :: String -> Int -> Int -> IO Int
+verifyWorkload shape count size = do
+    old <- build "old" shape count size >>= id
+    new <- build "new" shape count size >>= id
+    unless (old == new) $ fail "workload projection mismatch"
+    projectChecksum (pure old)
+
+-- Keep the IORef behind closures across the collection, without retaining an
+-- input event list. Every snapshot payload is generated and forced on arrival.
+{-# NOINLINE build #-}
+build :: String -> String -> Int -> Int -> IO (IO [LoopEvent])
+build mode shape count size = case mode of
+    "old" -> go Old.emptyDisplayJournal Old.recordDisplayEvent Old.displayEventsFromJournal
+    "new" -> go New.emptyDisplayJournal New.recordDisplayEvent New.displayEventsFromJournal
+    _ -> fail "unknown mode"
+  where
+    go empty record project = do
+        ref <- newIORef empty
+        forM_ [1 .. count] \index -> do
+            let callId = if shape == "interleaved" && even index then "b" else "a"
+                payload = Text.replicate (if shape == "text" then size else min 65536 (index * size))
+                    (Text.singleton (toEnum (97 + index `mod` 26)))
+                event = if shape == "text" then TextDelta payload
+                    else ToolArgumentsUpdated (functionToolCall callId "apply_patch" payload)
+            _ <- evaluate (eventChecksum event)
+            modifyIORef' ref (record event)
+        pure (project <$> readIORef ref)
+
+measure :: String -> String -> Int -> Int -> Int -> Int -> IO ()
+measure mode shape count size sample expected = do
+    performGC
+    before <- getRTSStats
+    cpu0 <- getCPUTime
+    wall0 <- getMonotonicTimeNSec
+    project <- build mode shape count size
+    -- Include natural GC, but keep this diagnostic full collection outside clocks.
+    wall1 <- getMonotonicTimeNSec
+    cpu1 <- getCPUTime
+    performGC
+    after <- getRTSStats
+    actual <- projectChecksum project
+    unless (actual == expected) $ fail "measured workload checksum mismatch"
+    printf "%s,%s,%d,%d,%d,%.6f,%.6f,%d,%d\n" mode shape count size sample
+        (fromIntegral (cpu1 - cpu0) / 1e9 :: Double)
+        (fromIntegral (wall1 - wall0) / 1e6 :: Double)
+        (allocated_bytes after - allocated_bytes before)
+        (gcdetails_live_bytes (gc after))
+
+projectChecksum :: IO [LoopEvent] -> IO Int
+projectChecksum project = do
+    events <- project
+    evaluate (sum (map eventChecksum events))
+
+eventChecksum :: LoopEvent -> Int
+eventChecksum = \case
+    TextDelta text -> checksum text
+    ToolUpdated call -> checksum call.arguments
+    ToolArgumentsUpdated call -> checksum call.arguments
+    _ -> 0
+  where checksum = Text.foldl' (\n c -> n + ord c) 0
+
+verify :: IO ()
+verify = do
+    let call = functionToolCall "a" "apply_patch" "x"
+        events =
+            [ ToolUpdated call, ToolArgumentsUpdated call, TextDelta "x"
+            , ToolOutputUpdated "a" "1", ToolOutputUpdated "a" "2"
+            , ResponseRestarted "retry", ToolUpdated call
+            , ToolArgumentsUpdated call, ToolRetracted "a", TextDelta "y"
+            ]
+    forM_ (inits events) \prefix -> do
+        let old = foldl (flip Old.recordDisplayEvent) Old.emptyDisplayJournal prefix
+            new = foldl (flip New.recordDisplayEvent) New.emptyDisplayJournal prefix
+        unless (Old.displayEventsFromJournal old == New.displayEventsFromJournal new)
+            $ fail "prefix projection mismatch"
+        unless (Old.displayEventsFromJournal (Old.discardCurrentDisplayAttempt old)
+                == New.displayEventsFromJournal (New.discardCurrentDisplayAttempt new))
+            $ fail "discard projection mismatch"

--- a/packages/agent-core/benchmark/JournalAdmission.md
+++ b/packages/agent-core/benchmark/JournalAdmission.md
@@ -1,0 +1,78 @@
+# Adjacent display-journal snapshot retention
+
+This benchmark compares the actual `Agent.Loop.DisplayJournal` at `f37672e5`
+with the working-tree implementation. It measures the journal downstream of
+provider event projection, not Conduit decoding, network latency, UI rendering,
+or end-to-end agent performance.
+
+```sh
+nix develop -c env TMPDIR="$TMPDIR" \
+  python3 packages/agent-core/benchmark/journal-admission-build.py
+nix develop -c env TMPDIR="$TMPDIR" \
+  python3 packages/agent-core/benchmark/journal-admission-run.py
+```
+
+The build uses GHC `-O2 -threaded -rtsopts`, compiling both journal algorithms
+and their shared dependencies with identical flags. The runner uses
+`+RTS -T -N1`, eleven samples in alternating old/new order, both paths warmed,
+and two complete rounds. The build also runs the existing `DisplayJournal.hs`
+6,464 mixed-prefix comparisons against its independent historical list
+baseline (duplicate starts/finishes, retries, retractions, and discards).
+Each measured workload's full projected output is compared outside timing.
+
+## Workloads and measurement boundaries
+
+- `arguments`: 32/128/256 independently allocated argument snapshots, growing
+  by 256 ASCII bytes per event (8/32/64 KiB final snapshots). Their repeated
+  character varies by event to prevent payload reuse. This models cumulative
+  preview size and ownership, not valid tool JSON or provider parsing.
+- `interleaved`: the same payloads alternating between two call IDs; this
+  deliberately exercises the limitation of adjacent-only replacement.
+- `text`: 1,000/10,000 independent 16-byte text deltas, guarding ordinary
+  text admission against snapshot-specific overhead.
+
+Each payload is generated and its character checksum forced on arrival, then
+admitted through strict IORef updates, as in loop bookkeeping. Both consumers
+pay the same generation/checksum work. There is no retained input event list.
+CPU and wall time cover generation and admission, including natural GC but
+not explicit boundary collections or failed-history projection. Allocation
+is sampled after a full collection to include the final nursery.
+
+`live_bytes` is whole-process live heap **after admission and a full GC, before
+projection**, not peak RSS or whole-agent memory. The construction frame has
+returned and the journal is kept alive by an IORef-backed projection closure
+used after collection. Final output is also checksummed. Raw samples are in
+`$TMPDIR/journal-admission-bench/final-*.csv`.
+
+## Measured results
+
+Local optimized run, September 12, 2026. Each row gives the two independent
+round medians, old → new; milliseconds unless marked bytes.
+
+| Workload | CPU, round 1 / round 2 | Wall, round 1 / round 2 | Live bytes |
+| --- | --- | --- | --- |
+| Arguments, 32 snapshots | 0.0934→0.0937 / 0.0934→0.0937 | 0.0931→0.0933 / 0.0931→0.0933 | 264,376→132,936 |
+| Arguments, 128 snapshots | 1.412→1.411 / 1.410→1.410 | 1.412→1.415 / 1.412→1.413 | 2,256,608→157,552 |
+| Arguments, 256 snapshots | 7.028→5.793 / 6.944→5.839 | 6.996→5.796 / 6.922→5.843 | 8,582,888→190,328 |
+| Interleaved, 256 snapshots | 6.215→6.375 / 6.182→6.213 | 6.190→6.355 / 6.154→6.192 | 8,583,208→8,583,208 |
+| Text, 10,000 deltas | 0.456→0.440 / 0.455→0.439 | 0.457→0.441 / 0.455→0.438 | 1,004,496→1,004,496 |
+
+The largest adjacent-snapshot workload retained **97.8% less live heap** and
+used **15.9–17.6% less CPU**. Allocation was identical: 8,508,760 bytes for
+256 snapshots and 2,801,368 bytes for 10,000 text deltas. Interleaving defeats
+the optimization and measured 0.5–2.6% slower in these rounds; no universal
+speedup is claimed. The tiny text improvement is not a structural benefit:
+the text algorithm is unchanged, and alternative dispatch layouts moved
+these small timings in either direction. Live-byte measurements can differ
+by a few bytes between rounds due to harness state.
+
+## Scope
+
+Replacing obsolete adjacent snapshots does not stop producing those snapshots,
+so allocated bytes need not decrease. It lets old payloads die earlier and
+reduces GC work when the old journal would have promoted them.
+
+This is deliberately not a globally indexed journal: matching only the head
+keeps admission constant-time and preserves text/event ordering, restart
+boundaries, retractions and ID reuse. Nonadjacent snapshots still use the
+existing projection-time deduplication. Live delivery remains unchanged.

--- a/packages/agent-core/benchmark/journal-admission-build.py
+++ b/packages/agent-core/benchmark/journal-admission-build.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Build working journal against the frozen pre-admission-dedup journal."""
+import os
+from pathlib import Path
+import subprocess
+
+out = Path(os.environ["TMPDIR"]) / "journal-admission-bench"
+out.mkdir(parents=True, exist_ok=True)
+baseline = subprocess.check_output(["git", "show",
+    "f37672e5:packages/agent-core/src/Agent/Loop/DisplayJournal.hs"], text=True)
+(out / "JournalBefore.hs").write_text(baseline.replace(
+    "module Agent.Loop.DisplayJournal", "module JournalBefore"))
+extensions = ["OverloadedStrings", "OverloadedRecordDot", "DuplicateRecordFields",
+    "NoFieldSelectors", "LambdaCase", "BlockArguments", "DeriveGeneric",
+    "RecordWildCards", "NamedFieldPuns", "NumericUnderscores", "TypeApplications",
+    "ScopedTypeVariables", "DerivingStrategies", "GeneralizedNewtypeDeriving",
+    "DataKinds", "FlexibleContexts", "TupleSections", "PackageImports"]
+packages = ["base", "aeson", "bytestring", "text", "containers", "async", "stm",
+    "transformers", "time", "vector", "scientific", "hermes-json",
+    "safe-exceptions", "deepseq"]
+command = ["ghc", "-O2", "-threaded", "-rtsopts", "-hide-all-packages",
+    *["-X" + e for e in extensions],
+    *[x for p in packages for x in ["-package", p]],
+    *["-ipackages/" + p + "/src" for p in
+      ["agent-core", "agent-responses-types", "agent-json"]],
+    "-i" + str(out), "-outputdir", str(out)]
+subprocess.run([*command, "packages/agent-core/benchmark/JournalAdmission.hs",
+    "-o", str(out / "bench")], check=True)
+# The existing exhaustive mixed-prefix harness compares against the older
+# independently written list baseline, including duplicate starts/finishes.
+subprocess.run([*command, "-ipackages/agent-core/benchmark",
+    "packages/agent-core/benchmark/DisplayJournal.hs",
+    "-o", str(out / "verify")], check=True)
+subprocess.run([str(out / "verify"), "--verify", "+RTS", "-T"], check=True)
+print(out / "bench")

--- a/packages/agent-core/benchmark/journal-admission-run.py
+++ b/packages/agent-core/benchmark/journal-admission-run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Repeated paired medians; build first with journal-admission-build.py."""
+import csv
+import io
+import os
+from pathlib import Path
+import statistics
+import subprocess
+
+root = Path(os.environ["TMPDIR"]) / "journal-admission-bench"
+print("round,shape,count,size,variant,cpu_ms,wall_ms,allocated_bytes,live_bytes")
+for repeat in (1, 2):
+    cases = [(shape, n, 256) for shape in ("arguments", "interleaved") for n in (32, 128, 256)]
+    cases += [("text", n, 16) for n in (1000, 10000)]
+    for shape, count, size in cases:
+        raw = subprocess.check_output([str(root / "bench"), "all", shape,
+            str(count), str(size), "11", "+RTS", "-T", "-N1"], text=True)
+        (root / f"final-{repeat}-{shape}-{count}.csv").write_text(raw)
+        rows = list(csv.DictReader(io.StringIO(raw)))
+        for mode in ("old", "new"):
+            selected = [r for r in rows if r["variant"] == mode]
+            medians = [statistics.median(float(r[key]) for r in selected)
+                for key in ("cpu_ms", "wall_ms", "allocated_bytes", "live_bytes")]
+            print(",".join(map(str, [repeat, shape, count, size, mode, *medians])), flush=True)

--- a/packages/agent-core/src/Agent/Loop/DisplayJournal.hs
+++ b/packages/agent-core/src/Agent/Loop/DisplayJournal.hs
@@ -37,9 +37,10 @@ replayableDisplayEvent = \case
     ToolRetracted _ -> True
     _ -> False
 
--- Admission remains a cheap chunk/event cons operation: successful responses
--- clear the journal without projecting it. Normalize only when failed output
--- is retained. Entries and text chunks are newest-first. Tails deliberately
+-- Admission remains constant-time, replacing only superseded adjacent snapshots.
+-- Successful responses clear the journal without projecting it; other
+-- normalization waits until failed output is retained. Entries and text chunks
+-- are newest-first. Tails deliberately
 -- remain lazy, preserving prefix release and sharing during retractions.
 data DisplayJournal
     = EmptyDisplayJournal
@@ -59,13 +60,34 @@ recordDisplayEvent event journal = case event of
             DisplayJournalText (delta : chunks) rest
         _ -> DisplayJournalText [delta] journal
     ToolOutputUpdated callId output ->
-        DisplayJournalEvent
-            (ToolOutputUpdated callId (boundLoopToolOutput output)) journal
+        recordSnapshot (ToolOutputUpdated callId (boundLoopToolOutput output))
+            journal
     ToolFinished result ->
         DisplayJournalEvent
             (ToolFinished result { output = boundLoopToolOutput result.output }) journal
     ToolRetracted callId -> retractRawTool callId journal
-    _ -> DisplayJournalEvent event journal
+    _ -> recordSnapshot event journal
+
+-- Release superseded adjacent snapshots at admission, not just when a failed
+-- attempt is projected. Cumulative argument previews otherwise retain every
+-- earlier prefix until commit. Inspect only the head: scanning across text,
+-- other calls, or restart boundaries would make admission depend on history
+-- size. Nonadjacent snapshots retain the existing projection-time deduplication.
+recordSnapshot :: LoopEvent -> DisplayJournal -> DisplayJournal
+recordSnapshot event = \case
+    DisplayJournalEvent previous rest
+        | replaces previous -> DisplayJournalEvent event rest
+    journal -> DisplayJournalEvent event journal
+  where
+    replaces previous = case (event, previous) of
+        (ToolUpdated call, ToolUpdated old) -> call.callId == old.callId
+        (ToolUpdated call, ToolArgumentsUpdated old) -> call.callId == old.callId
+        (ToolArgumentsUpdated call, ToolUpdated old) -> call.callId == old.callId
+        (ToolArgumentsUpdated call, ToolArgumentsUpdated old) ->
+            call.callId == old.callId
+        (ToolOutputUpdated callId _, ToolOutputUpdated oldId _) ->
+            callId == oldId
+        _ -> False
 
 -- Retractions keep the former lazy-filter behavior: forcing the new journal
 -- immediately releases a removed leading prefix, and the remaining tail is

--- a/packages/agent-core/test/Agent/Loop/FailedDisplaySpec.hs
+++ b/packages/agent-core/test/Agent/Loop/FailedDisplaySpec.hs
@@ -10,6 +10,46 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+    it "keeps the latest adjacent argument or metadata snapshot in its original order" do
+        let first = functionToolCall "c1" "read_file" "first"
+            final = functionToolCall "c1" "grep" "final"
+            events =
+                [ ToolStarted first
+                , ToolArgumentsUpdated first
+                , ToolUpdated final
+                , ToolArgumentsUpdated final
+                , TextDelta "after"
+                ]
+        let backend = Backend \_state _prev _inputs onEvent -> do
+                mapM_ onEvent events
+                pure (Left (ConnectionError "down"))
+        config <- testConfig backend
+        execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+        execution.executionUncommittedDisplayEvents
+            `shouldBe` [ToolStarted first, ToolArgumentsUpdated final, TextDelta "after"]
+
+    it "does not collapse snapshot kinds or reused ids across restart boundaries" do
+        let call = functionToolCall "same" "read_file" "{}"
+            events =
+                [ ToolUpdated call
+                , ToolOutputUpdated "same" "old"
+                , ToolOutputUpdated "same" "latest"
+                , ResponseRestarted "retry"
+                , ToolArgumentsUpdated call
+                , ToolArgumentsUpdated (setToolCallArguments "new" call)
+                ]
+            backend = Backend \_state _prev _inputs onEvent -> do
+                mapM_ onEvent events
+                pure (Left (ConnectionError "down"))
+        config <- testConfig backend
+        execution <- runLoopInputsDetailed config Nothing [UserMessage "hello"]
+        execution.executionUncommittedDisplayEvents `shouldBe`
+            [ ToolUpdated call
+            , ToolOutputUpdated "same" "latest"
+            , ResponseRestarted "retry"
+            , ToolArgumentsUpdated (setToolCallArguments "new" call)
+            ]
+
     it "marks a transport failure after streamed output as interrupted" do
         observed <- newIORef []
         let backend = Backend \_state _prev _inputs onEvent -> do

--- a/packages/agent-responses/benchmark/PreviewSaturation.hs
+++ b/packages/agent-responses/benchmark/PreviewSaturation.hs
@@ -1,0 +1,96 @@
+module Main (main) where
+
+import qualified Agent.Responses.LoopBackend.ToolArgumentPreview as New
+import qualified BaselinePreview as Old
+import Agent.Responses.Types
+import Agent.Responses.Codec (decodeResponseStreamEvent)
+import Agent.Loop (LoopEvent(..))
+import Agent.ToolDispatch (ToolCall(..))
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.Text as Text
+import Control.Exception (evaluate)
+import Control.Monad (forM_, replicateM, unless)
+import Data.IORef
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+-- Force every projected event, including preview bodies, warnings and final
+-- completion. Comparison is outside timing; checksums remain inside each run.
+fingerprint :: [LoopEvent] -> Int
+fingerprint = sum . map \case
+    ToolArgumentsUpdated call -> checksum call.arguments
+    ToolUpdated call -> checksum call.arguments
+    event -> sum (map fromEnum (show event))
+  where
+    checksum = Text.foldl' (\n c -> n + fromEnum c) 0
+
+replay step initial events = do
+    state <- newIORef initial
+    total <- newIORef (0 :: Int)
+    forM_ events \event -> do
+        emitted <- atomicModifyIORef' state \s -> step event s
+        value <- evaluate (fingerprint emitted)
+        modifyIORef' total (+ value)
+    readIORef total
+
+decode :: String -> ResponseStreamEvent
+decode = either (error . Text.unpack) id . decodeResponseStreamEvent . LBS.toStrict . LBS.pack
+
+main :: IO ()
+main = do
+    [name, n, r, s] <- getArgs
+    let count = read n :: Int
+        reps = read r :: Int
+        samples = read s :: Int
+        event = decode "{\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc\",\"output_index\":0,\"delta\":\"abcdefghijklmnop\"}"
+        argumentDelta text = decode (LBS.unpack (Aeson.encode (Aeson.object
+            [ "type" Aeson..= ("response.function_call_arguments.delta" :: Text.Text)
+            , "item_id" Aeson..= ("fc" :: Text.Text)
+            , "output_index" Aeson..= (0 :: Int)
+            , "delta" Aeson..= text
+            ])))
+        events =
+            [decode ("{\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc\",\"call_id\":\"call\",\"name\":\"" <> name <> "\",\"arguments\":\"\"}}")]
+            <> [argumentDelta ("{\"command\":\"" :: Text.Text)]
+            <> replicate count event
+            <> [argumentDelta ("\"}" :: Text.Text)]
+            <> [decode ("{\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc\",\"call_id\":\"call\",\"name\":\"" <> name <> "\",\"arguments\":\"\"}}")]
+        variants =
+            [ ("old" :: String, replay Old.toolArgumentStreamStep Old.emptyToolArgumentStreamState events)
+            , ("new", replay New.toolArgumentStreamStep New.emptyToolArgumentStreamState events)
+            ]
+    unless (minimum [count,reps,samples] > 0) (fail "positive dimensions required")
+    getRTSStatsEnabled >>= \enabled -> unless enabled (fail "requires +RTS -T")
+    _ <- evaluate (sum (map (length . show) events))
+    oldEvents <- projected Old.toolArgumentStreamStep Old.emptyToolArgumentStreamState events
+    newEvents <- projected New.toolArgumentStreamStep New.emptyToolArgumentStreamState events
+    unless (oldEvents == newEvents) (fail "projected events differ")
+    expected <- snd (head variants)
+    putStrLn "variant,tool,deltas,reps,sample,cpu_ms,wall_ms,allocated_bytes"
+    forM_ [1..samples] \sample ->
+        forM_ (if odd sample then variants else reverse variants) \(label,run) -> do
+            performGC
+            before <- getRTSStats
+            cpu0 <- getCPUTime
+            wall0 <- getMonotonicTimeNSec
+            results <- replicateM reps run
+            unless (all (== expected) results) (fail "checksum mismatch")
+            wall1 <- getMonotonicTimeNSec
+            cpu1 <- getCPUTime
+            performGC
+            after <- getRTSStats
+            printf "%s,%s,%d,%d,%d,%.6f,%.6f,%.0f\n" label name count reps sample
+                (fromIntegral (cpu1-cpu0) / 1e9 / fromIntegral reps :: Double)
+                (fromIntegral (wall1-wall0) / 1e6 / fromIntegral reps :: Double)
+                (fromIntegral (after.allocated_bytes-before.allocated_bytes) / fromIntegral reps :: Double)
+  where
+    projected step initial events = do
+        ref <- newIORef initial
+        results <- mapM (\event -> atomicModifyIORef' ref \state ->
+            let (next, output) = step event state in (next, map show output)) events
+        evaluate (Text.pack (concat (concat results)))

--- a/packages/agent-responses/benchmark/PreviewSaturation.md
+++ b/packages/agent-responses/benchmark/PreviewSaturation.md
@@ -1,0 +1,91 @@
+# Bounded tool-preview saturation benchmark
+
+Reproduce from the repository root with an existing Cabal build plan and
+registered `agent-core`, `agent-json`, and `agent-responses-types` libraries:
+
+```sh
+nix develop -c env TMPDIR="$TMPDIR" \
+  python3 packages/agent-responses/benchmark/preview-saturation.py
+```
+
+The script extracts the unchanged production preview module from `f37672e5`
+as `BaselinePreview`, compiles it and the working-tree module together with
+GHC `-O2 -threaded -rtsopts`, and runs with `+RTS -T -N1`.
+Shared dependencies are the same registered Cabal libraries for both variants.
+The temporary package environment retains Cabal's package database declarations
+but not its whole-project exposed package list. Explicit dependency IDs come
+from the Cabal plan, avoiding accidental selection of different Nix versions.
+
+This measures the actual `toolArgumentStreamStep`, including identity
+resolution, bounded preview accumulation, shell partial-JSON parsing, event
+publication, runaway counters, and sparse item-done recovery. It is **not**
+an HTTP/WebSocket, response-assembly, tool execution, renderer, or whole-agent
+memory benchmark. No peak-residency claim follows from its allocation numbers.
+
+Each input is one function call, a JSON `{"command":"..."}` argument split into
+N 16-character ASCII deltas plus opening/closing fragments, and a sparse done
+item. `read_file` selects generic raw previews; its synthetic command field is
+not a schema-valid read_file argument and no tool is dispatched.
+`shell_command` exercises actual live command preview parsing. Input is decoded
+and forced outside timing. Every emitted event's full shown representation
+is compared between old/new outside timing; inside timing preview bodies are
+forced with a character checksum, and warning/activity events are forced too.
+The IORef state transition models the production projection callback.
+
+Raw preview capacity is 65,536 characters; shell capacity is 4,096.
+N=100/1,000/10,000/50,000 distinguishes below-cap, crossing-cap and saturated
+behavior. Seven samples alternate old/new order; each sample batches
+20/10/3/1 replays respectively. The 10,000-delta cases are repeated.
+Reported CPU/wall/allocation are independent medians normalized per replay.
+Explicit GCs before/after timing flush RTS allocation accounting; GCs during
+replay remain timed. Raw CSVs are under `$TMPDIR/preview-saturation/run-*.csv`.
+Machine: Linux x86_64, Core i9-9900K, GHC 9.10.3; no CPU isolation.
+
+## Initial matrix
+
+CPU ms / wall ms / allocated bytes, old → fast-path candidate:
+
+| Tool / deltas | CPU | Wall | Bytes |
+|---|---|---|---|
+| raw / 100 | 0.0403 → 0.0414 | 0.0404 → 0.0416 | 193,080 → 193,080 |
+| raw / 1,000 | 0.6159 → 0.6357 | 0.6185 → 0.6379 | 2,283,369 → 2,283,369 |
+| raw / 10,000 | 8.999 → 8.866 | 9.027 → 8.884 | 24,943,813 → 22,251,133 |
+| raw / 50,000 | 21.393 → 25.007 | 21.597 → 25.066 | 88,105,840 → 67,173,160 |
+| shell / 100 | 0.5811 → 0.5839 | 0.5828 → 0.5859 | 3,583,211 → 3,583,211 |
+| shell / 1,000 | 3.066 → 3.060 | 3.077 → 3.070 | 21,155,889 → 20,816,169 |
+| shell / 10,000 | 5.895 → 5.574 | 5.915 → 5.591 | 41,052,928 → 36,609,208 |
+| shell / 50,000 | 18.477 → 16.890 | 18.513 → 16.936 | 129,525,448 → 106,841,728 |
+| raw / 10,000 repeat | 8.966 → 8.794 | 8.991 → 8.814 | 24,943,813 → 22,251,133 |
+| shell / 10,000 repeat | 5.976 → 5.749 | 5.996 → 5.767 | 41,052,928 → 36,609,208 |
+
+Repeating the whole matrix gave raw/50,000 CPU 21.384 → 18.797 ms
+(wall 21.421 → 18.830) with the same allocation, so the initial large-case
+slowdown was not stable. However raw/1,000 remained slower, 0.6247 → 0.6368
+ms (wall 0.6259 → 0.6380), with unchanged allocation. The early saturation
+guard was therefore redesigned to run only after the existing publish test.
+
+## Retained implementation
+
+The saturation guard now runs on the non-publishing branch. Two full matrices
+showed no below-cap timing regression, with unchanged below-cap allocation.
+The second matrix is reproduced here (CPU ms / wall ms / bytes, old → new):
+
+| Tool / deltas | CPU | Wall | Bytes |
+|---|---|---|---|
+| raw / 100 | 0.0409 → 0.0404 | 0.0410 → 0.0405 | 193,080 → 193,080 |
+| raw / 1,000 | 0.8340 → 0.8187 | 0.8361 → 0.8203 | 2,283,369 → 2,283,369 |
+| raw / 10,000 | 12.515 → 12.136 | 12.539 → 12.165 | 24,943,813 → 23,715,573 |
+| raw / 50,000 | 24.653 → 23.212 | 24.709 → 23.269 | 88,105,840 → 78,557,600 |
+| shell / 100 | 0.6382 → 0.6242 | 0.6396 → 0.6258 | 3,583,211 → 3,583,211 |
+| shell / 1,000 | 3.354 → 3.250 | 3.363 → 3.264 | 21,155,889 → 21,000,929 |
+| shell / 10,000 | 6.166 → 5.842 | 6.181 → 5.857 | 41,052,928 → 39,025,968 |
+| shell / 50,000 | 19.265 → 17.627 | 19.304 → 17.668 | 129,525,448 → 119,178,488 |
+| raw / 10,000 repeat | 12.539 → 12.002 | 12.564 → 12.031 | 24,943,813 → 23,715,573 |
+| shell / 10,000 repeat | 6.185 → 5.883 | 6.202 → 5.908 | 41,052,928 → 39,025,968 |
+
+Across both matrices, saturated 10,000/50,000-delta cases used approximately
+3–9% less CPU, and 5–11% fewer allocated bytes. This is a small projection
+optimization, not evidence of faster network/token delivery. Absolute timings
+changed with machine load; only paired old/new runs should be compared.
+Below-cap improvements should be treated as noise/code-layout effects, not
+an intentional optimization. All event-equivalence checks passed.

--- a/packages/agent-responses/benchmark/preview-saturation.py
+++ b/packages/agent-responses/benchmark/preview-saturation.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Run in nix develop with TMPDIR preserved; builds optimized real modules."""
+import csv
+import io
+import json
+import os
+from pathlib import Path
+import statistics
+import subprocess
+
+out = Path(os.environ["TMPDIR"]) / "preview-saturation"
+out.mkdir(parents=True, exist_ok=True)
+revision = "f37672e5"
+source = subprocess.check_output(["git", "show",
+    f"{revision}:packages/agent-responses/src/Agent/Responses/LoopBackend/ToolArgumentPreview.hs"], text=True)
+(out / "BaselinePreview.hs").write_text(source.replace(
+    "module Agent.Responses.LoopBackend.ToolArgumentPreview", "module BaselinePreview"))
+extensions = ["OverloadedStrings", "OverloadedRecordDot", "DuplicateRecordFields",
+    "NoFieldSelectors", "LambdaCase", "BlockArguments", "DeriveGeneric",
+    "RecordWildCards", "NamedFieldPuns", "NumericUnderscores", "TypeApplications",
+    "ScopedTypeVariables", "DerivingStrategies", "GeneralizedNewtypeDeriving",
+    "DataKinds", "FlexibleContexts", "TupleSections", "PackageImports"]
+plan = json.loads(Path("dist-newstyle/cache/plan.json").read_text())
+package_ids = {p["pkg-name"]: p["id"] for p in plan["install-plan"]}
+environment = subprocess.check_output(
+    ["cabal", "exec", "--", "sh", "-c", 'cat "$GHC_ENVIRONMENT"'], text=True)
+env_path = out / "package.environment"
+env_path.write_text("\n".join(line for line in environment.splitlines()
+    if line.startswith(("clear-package-db", "global-package-db", "package-db "))) + "\n")
+subprocess.run(["ghc", "-package-env", str(env_path), "-O2", "-threaded", "-rtsopts", "-hide-all-packages",
+    *["-X" + e for e in extensions],
+    *[x for p in ["base", "text", "containers", "aeson", "bytestring", "hermes-json"]
+      for x in ["-package-id", package_ids[p]]],
+    "-package", "agent-core", "-package", "agent-json",
+    "-package", "agent-responses-types",
+    "-ipackages/agent-responses/src", "-i" + str(out),
+    "-outputdir", str(out), "packages/agent-responses/benchmark/PreviewSaturation.hs",
+    "-o", str(out / "bench")], check=True)
+print("tool,deltas,variant,cpu_ms,wall_ms,allocated_bytes", flush=True)
+for index, (tool, count, reps) in enumerate([
+        ("read_file", 100, 20), ("read_file", 1000, 10),
+        ("read_file", 10000, 3), ("read_file", 50000, 1),
+        ("shell_command", 100, 20), ("shell_command", 1000, 10),
+        ("shell_command", 10000, 3), ("shell_command", 50000, 1),
+        ("read_file", 10000, 3), ("shell_command", 10000, 3)]):
+    raw = subprocess.check_output([str(out / "bench"), tool, str(count),
+        str(reps), "7", "+RTS", "-T", "-N1"], text=True)
+    (out / f"run-{index}.csv").write_text(raw)
+    rows = list(csv.DictReader(io.StringIO(raw)))
+    for variant in ["old", "new"]:
+        selected = [row for row in rows if row["variant"] == variant]
+        values = [statistics.median(float(row[key]) for row in selected)
+            for key in ["cpu_ms", "wall_ms", "allocated_bytes"]]
+        print(",".join(map(str, [tool, count, variant, *values])), flush=True)

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend/ToolArgumentPreview.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend/ToolArgumentPreview.hs
@@ -535,12 +535,16 @@ updateBufferedLiveCall
                 Map.insert key nextPreview state.rawPreviewsByCallId
             }
         updatedCall = withToolArguments call rawArguments
+    -- Once the bounded prefix is full, keep its existing state. Activity and
+    -- runaway counters still advance in updateToolArguments for every delta.
     in if shouldPublish
         then
             ( trackUpdatedToolCall updatedCall withPreview
             , Just updatedCall
             )
-        else (withPreview, Nothing)
+        else if room <= 0
+            then (state, Nothing)
+            else (withPreview, Nothing)
 
 finishBufferedLiveCall
     :: Int

--- a/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/LoopBackendSpec.hs
@@ -1978,6 +1978,27 @@ streamProjectionSpec = describe "newStreamEventToLoopEvents" do
             (customInputDelta "ct-1" "call-9" "still not retained")
         second `shouldBe` []
 
+    it "counts saturated preview deltas and still accepts canonical completion" do
+        projectEvent <- newStreamEventToLoopEvents False
+        _ <- projectEvent
+            (customToolCallAdded "ct-1" "call-9" "apply_patch")
+        _ <- projectEvent
+            (customInputDelta "ct-1" "call-9" (Text.replicate 65536 "p"))
+        quiet <- projectEvent
+            (customInputDelta "ct-1" "call-9" (Text.replicate 34463 "x"))
+        quiet `shouldBe` []
+        warning <- projectEvent (customInputDelta "ct-1" "call-9" "x")
+        warning `shouldBe`
+            [ WarningRaised
+                ("The model has streamed 100k chars of apply_patch "
+                    <> "arguments in one response; it may be stuck in a "
+                    <> "repetition loop.")
+            ]
+        completed <- projectEvent
+            (customToolCallDone "ct-1" "call-9" "apply_patch" "canonical")
+        completed `shouldBe`
+            [ToolUpdated (customToolCall "call-9" "apply_patch" "canonical")]
+
     it "flushes accumulated custom input when input done omits it" do
         projectEvent <- newStreamEventToLoopEvents False
         _ <- projectEvent

--- a/packages/agent-responses/test/Agent/Responses/StreamPipelineSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/StreamPipelineSpec.hs
@@ -41,6 +41,31 @@ spec = describe "Responses Conduit pipeline" do
                 .| decodeSseC .| collect
         result `shouldBe` parseSseEventsBytes completeStream
 
+    it "delivers a fragmented event before reading the next event" do
+        remaining <- newIORef (map BS.singleton (BS.unpack created) <> [completeStream])
+        reads <- newIORef (0 :: Int)
+        let readChunk = do
+                n <- atomicModifyIORef' reads (\n -> (n + 1, n))
+                if n >= BS.length created
+                    then throwIO (userError "read ahead of callback")
+                    else atomicModifyIORef' remaining \case
+                        [] -> ([], "")
+                        chunk : rest -> (rest, chunk)
+            emit _ = do
+                readIORef reads `shouldReturn` BS.length created
+                throwIO (userError "callback stopped")
+        consumeResponsesSse config Nothing readChunk emit
+            `shouldThrow` (\err -> show (err :: IOError) == "user error (callback stopped)")
+
+    it "validates UTF-8 even in ignored comment and unknown-field lines" do
+        mapM_ (\bad -> do
+            (result, seen) <- runChunks [created <> bad <> "\n\n"]
+            result `shouldSatisfy` isDecodeError
+            seen `shouldBe` [])
+            [prefix <> BS.pack invalid
+            | prefix <- [": comment ", "ignored: "]
+            , invalid <- [[255], [192,175], [237,160,128], [244,144,128,128], [226,130]]]
+
     it "assembles streamed tool arguments without reading ahead of callbacks" do
         let chunks =
                 [ created


### PR DESCRIPTION
## Summary

Stacked on #1246 (`refactor/conduit-process-output`).

- Stop rebuilding raw tool-preview state after its bounded prefix is full, while preserving activity/warning counters and canonical completion.
- Release obsolete adjacent same-call argument/output snapshots when recording the display journal, rather than retaining every cumulative prefix until commit.
- Preserve live delivery, retry boundaries, interleaved event ordering, and final response assembly.
- Add regression tests and reproducible optimized old/new benchmarks. Earlier experimental provider/process benchmarks are not included.

## Performance

GHC 9.10.3, `-O2 -threaded -rtsopts`, `+RTS -T -N1`, inside `nix develop`. Alternating old/new samples, medians, repeated matrices; baseline production modules frozen at `f37672e5`. Outputs forced and compared outside timing.

| Workload | Before → after |
| --- | --- |
| 256 adjacent argument snapshots growing to 64 KiB: post-GC live heap | 8,582,888 → 190,328 bytes (−97.8%) |
| Same workload: CPU, two rounds | 7.028 → 5.793 ms / 6.944 → 5.839 ms |
| Same workload: wall, two rounds | 6.996 → 5.796 ms / 6.922 → 5.843 ms |
| Same workload: allocation | unchanged, 8,508,760 bytes |
| Saturated previews, 10k–50k deltas | CPU −3–9%, allocation −5–11% |

Journal cases cover 32/128/256 growing snapshots, alternating call IDs, and 1k/10k text deltas. Preview cases cover 100/1k/10k/50k 16-character deltas, raw and shell previews, seven samples and repeated representative cases. Journal uses eleven samples and two rounds.

**Draft / remaining performance boundary:** alternating calls defeat adjacent replacement and measured 0.5–2.6% slower with unchanged retention. Under the repository's no-regression rule, this journal part needs redesign or removal before shipping; the preview fast path has no persistent below-cap regression. These are local stage measurements, not whole-agent memory or network latency claims. Live heap is measured after admission and full GC, not peak RSS.

Full tables and methodology:
- `packages/agent-core/benchmark/JournalAdmission.md`
- `packages/agent-responses/benchmark/PreviewSaturation.md`

```sh
nix develop -c env TMPDIR="$TMPDIR" python3 packages/agent-core/benchmark/journal-admission-build.py
nix develop -c env TMPDIR="$TMPDIR" python3 packages/agent-core/benchmark/journal-admission-run.py
nix develop -c env TMPDIR="$TMPDIR" python3 packages/agent-responses/benchmark/preview-saturation.py
```

## Validation

- GHCi `agent-core:test:agent-core-test`: FailedDisplaySpec + LoopSpec, **129 examples, 0 failures**, successful 50-module load.
- GHCi `agent-responses:test:agent-responses-test`: LoopBackendSpec + StreamPipelineSpec + SSESpec, **107 examples, 0 failures**, successful 10-module load.
- Optimized journal independent oracle: **6,464 mixed-prefix equivalence checks passed**, including retries, retractions and discards.
- Benchmark workload equality and per-sample checksum smoke checks passed.
- `git diff --check` passed. No Cabal dependency changes.
