### PR TITLE
Replace more handwritten helpers with Haskell library functions

### DIFF
--- a/packages/agent-claude/src/Agent/Claude/Auth.hs
+++ b/packages/agent-claude/src/Agent/Claude/Auth.hs
@@ -22,7 +22,7 @@ import Control.Exception.Safe
     , finally
     , tryAny
     )
-import Control.Monad (void)
+import Control.Monad (join, void)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Maybe (catMaybes)
@@ -275,7 +275,7 @@ optionalBool key =
         Json.withType \case
             Json.VBoolean -> Just <$> Json.bool
             _ -> pure Nothing)
-        >>= pure . (>>= id)
+        >>= pure . join
 
 optionalNonEmptyText :: Text -> Json.FieldsDecoder (Maybe Text)
 optionalNonEmptyText key = do
@@ -283,7 +283,7 @@ optionalNonEmptyText key = do
         Json.withType \case
             Json.VString -> Just <$> Json.text
             _ -> pure Nothing
-    pure (value >>= id >>= nonEmptyText)
+    pure (join value >>= nonEmptyText)
 
 nonEmptyText :: Text -> Maybe Text
 nonEmptyText value =

--- a/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
+++ b/packages/agent-claude/src/Agent/Claude/Internal/Messages.hs
@@ -59,6 +59,7 @@ import Claude.Agent.SDK.Types
     , messageUuid
     , modelUsageToUsage
     )
+import Control.Monad (join)
 import qualified Data.Aeson as AesonValue
 import qualified Data.Aeson.Encoding as Aeson
 import qualified Data.ByteString.Base64 as Base64
@@ -355,7 +356,7 @@ jsonTextField key raw =
                                     then Nothing
                                     else Just value
                         _ -> pure Nothing)
-                    >>= pure . (>>= id))
+                    >>= pure . join)
             raw
 
 appendUnknownWarning

--- a/packages/agent-cli/src/Agent/CLI/Btw.hs
+++ b/packages/agent-cli/src/Agent/CLI/Btw.hs
@@ -35,7 +35,7 @@ import Agent.Responses.Types
     , ToolChoiceMode(..)
     )
 import Control.Concurrent.Async (race)
-import Data.List (findIndex)
+import Data.List (dropWhileEnd, findIndex)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -178,7 +178,7 @@ isUnmatchedCall completed = \case
     _ -> False
 
 dropTrailingReasoning :: [ResponseItem] -> [ResponseItem]
-dropTrailingReasoning = reverse . dropWhile isReasoning . reverse
+dropTrailingReasoning = dropWhileEnd isReasoning
   where
     isReasoning ReasoningItemValue{} = True
     isReasoning _ = False

--- a/packages/agent-cli/src/Agent/CLI/GitDiff.hs
+++ b/packages/agent-cli/src/Agent/CLI/GitDiff.hs
@@ -22,7 +22,8 @@ import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except (ExceptT(..), except, runExceptT, throwE)
 import qualified Data.ByteString as ByteString
-import Data.List (intercalate, sort)
+import Data.List (intercalate)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -115,7 +116,7 @@ executableFilterOverrides cwd = do
 
 configuredFilterDrivers :: Text -> [Text]
 configuredFilterDrivers raw =
-    deduplicate . sort $
+    Set.toAscList . Set.fromList $
         foldMap driverForKey
             (filter (not . Text.null) (Text.splitOn "\0" raw))
   where
@@ -123,10 +124,6 @@ configuredFilterDrivers raw =
         case Text.stripSuffix ".clean" key of
             Just driver -> [driver]
             Nothing -> maybe [] pure (Text.stripSuffix ".process" key)
-
-    deduplicate [] = []
-    deduplicate (first : rest) =
-        first : deduplicate (dropWhile (== first) rest)
 
 runUntrackedDiff
     :: OsPath

--- a/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
+++ b/packages/agent-cli/src/Agent/CLI/ProviderFallback.hs
@@ -19,7 +19,7 @@ import Agent.Provider (BillingMode(..), Provider(..))
 import Data.Containers.ListUtils (nubOrdOn)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.List (sortOn)
+import Data.List (find, sortOn)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime)
@@ -165,12 +165,12 @@ fallbackCandidates catalog unavailable current currentModel err
                         ranked
         | otherwise = []
     currentPriority =
-        (.modelFallbackPriority) =<< safeHead
-            (filter
+        (.modelFallbackPriority) =<<
+            find
                 (\option ->
                     option.modelTarget.targetProvider == current
                         && option.modelTarget.targetModelId == currentModel)
-                ranked)
+                ranked
     otherProviderFallbacks =
         filter
             (\option ->
@@ -180,10 +180,6 @@ fallbackCandidates catalog unavailable current currentModel err
                     && option.modelTarget.targetProvider
                         `Set.notMember` unavailable)
             (nubOrdOn (.modelTarget.targetProvider) ranked)
-
-    safeHead = \case
-        [] -> Nothing
-        value : _ -> Just value
 
 -- | A structured provider response that says the selected model or feature is
 -- unavailable. Unlike a bare HTTP 403, this is safe to recover from by trying

--- a/packages/agent-cli/src/Agent/CLI/Worktree/Ignored.hs
+++ b/packages/agent-cli/src/Agent/CLI/Worktree/Ignored.hs
@@ -4,7 +4,7 @@ module Agent.CLI.Worktree.Ignored (checkIgnoredPath) where
 
 import Control.Monad (unless)
 import qualified Data.ByteString as BS
-import Data.List (isPrefixOf)
+import Data.List (dropWhileEnd, isPrefixOf)
 import qualified System.Directory as Directory
 import System.FilePath ((</>), dropTrailingPathSeparator, takeFileName, takeDirectory, splitDirectories)
 import qualified System.Posix.Files as Posix
@@ -99,7 +99,7 @@ validStoreName name = case splitAt 32 name of
     _ -> False
 
 trim :: String -> String
-trim = reverse . dropWhile (`elem` ['\r', '\n']) . reverse
+trim = dropWhileEnd (`elem` ['\r', '\n'])
 
 nul :: String -> [String]
 nul [] = []

--- a/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/BtwSpec.hs
@@ -29,6 +29,18 @@ spec = do
             prompt `shouldSatisfy` Text.isSuffixOf "what does this do?\n"
 
     describe "trimDanglingToolSuffix" do
+        it "handles empty histories and a reasoning-only prefix before a live call" do
+            trimDanglingToolSuffix [] `shouldBe` []
+            trimDanglingToolSuffix
+                [reasoningItem, reasoningItem, functionCallItem "live"]
+                `shouldBe` []
+
+        it "drops only trailing reasoning while preserving earlier reasoning" do
+            let prefix = [reasoningItem, userItem "before"]
+            trimDanglingToolSuffix
+                (prefix <> [reasoningItem, reasoningItem, functionCallItem "live"])
+                `shouldBe` prefix
+
         it "keeps complete tool pairs" do
             let items =
                     [ userItem "before"

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal/Operations.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal/Operations.hs
@@ -30,7 +30,7 @@ import Control.Concurrent.Async (race)
 import Control.Concurrent.MVar (withMVar)
 import Control.Concurrent.STM
 import Control.Exception.Safe (finally)
-import Control.Monad (void)
+import Control.Monad (filterM, void)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -272,7 +272,7 @@ interruptActiveSubagents registry =
             wasClosed <- readTVar registry.registryClosed
             writeTVar registry.registryClosed True
             agents <- Map.elems <$> readTVar registry.registryAgents
-            records <- filterMSTM isActiveRecord agents
+            records <- filterM isActiveRecord agents
             pure (wasClosed, records)
         (do
             settled <- mapConcurrentlyBounded 8
@@ -319,14 +319,6 @@ data InterruptDisposition
     = InterruptUnchanged
     | InterruptSettled
     | InterruptWait
-
-filterMSTM :: (a -> STM Bool) -> [a] -> STM [a]
-filterMSTM predicate = fmap reverse . go []
-  where
-    go kept [] = pure kept
-    go kept (value : rest) = do
-        include <- predicate value
-        go (if include then value : kept else kept) rest
 
 -- | Re-admit a previously persisted agent that is not currently in the
 -- in-memory map (e.g. after close, or across a process restart within the

--- a/packages/agent-core/src/Agent/Subagents/Registry/Internal/Operations.hs
+++ b/packages/agent-core/src/Agent/Subagents/Registry/Internal/Operations.hs
@@ -31,6 +31,7 @@ import Control.Concurrent.MVar (withMVar)
 import Control.Concurrent.STM
 import Control.Exception.Safe (finally)
 import Control.Monad (filterM, void)
+import Control.Monad.Extra (concatMapM)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -203,7 +204,7 @@ abortRootTurn registry rootTurnId =
         records <- atomically do
             modifyTVar' registry.registryAbortedRootTurns (Set.insert rootTurnId)
             agents <- Map.elems <$> readTVar registry.registryAgents
-            fmap concat $ mapM selectOwned agents
+            concatMapM selectOwned agents
         settled <- mapConcurrentlyBounded 8
             (interruptRecordForTurn registry rootTurnId)
             records
@@ -623,7 +624,7 @@ listAgents
 listAgents registry pathPrefix = atomically do
     agents <- readTVar registry.registryAgents
     let prefix = maybe "" Text.strip pathPrefix
-    fmap concat $ mapM
+    concatMapM
         (\record -> do
             status <- phaseStatus <$> readTVar record.recordPhase
             let pathText = taskPathText record.recordTaskPath
@@ -763,7 +764,7 @@ takeAgentUpdatesSTM registry caller = do
     cursors <- readTVar registry.registryWaitCursors
     let cursor = Map.findWithDefault 0 caller cursors
     agents <- readTVar registry.registryAgents
-    updates <- fmap concat $ mapM (recordUpdateAfter caller cursor) (Map.elems agents)
+    updates <- concatMapM (recordUpdateAfter caller cursor) (Map.elems agents)
     case updates of
         [] -> retry
         _ -> do

--- a/packages/agent-core/test/Agent/SubagentsSpec.hs
+++ b/packages/agent-core/test/Agent/SubagentsSpec.hs
@@ -1024,6 +1024,38 @@ spec = describe "Agent.Subagents" do
             Left _ -> False
         closeSubagentRegistry registry
 
+    it "interrupts every active record while preserving completed records" do
+        started <- newEmptyTMVarIO
+        registry <- newSubagentRegistry
+            (defaultSubagentConfig { maxConcurrent = 2 })
+            (fromFilePath "/tmp")
+            (\_ _ prompt _ ->
+                if messagePayload prompt == "completed"
+                    then pure $ Right LoopResult
+                        { finalResponseId = "done"
+                        , finalText = Just "done"
+                        , turnsUsed = 1
+                        , tokenUsage = emptyTokenUsage
+                        }
+                    else do
+                        atomically $ putTMVar started ()
+                        atomically retry)
+            (\_ _ -> pure ())
+        Right completed <- spawnSubagent registry Nothing 0 "completed" Nothing
+        _ <- waitSubagents registry [completed] 15000
+        getStatus registry completed `shouldReturn` Completed (Just "done")
+        Right first <- spawnSubagent registry Nothing 0 "first" Nothing
+        atomically $ takeTMVar started
+        Right second <- spawnSubagent registry Nothing 0 "second" Nothing
+        atomically $ takeTMVar started
+
+        interruptActiveSubagents registry
+
+        getStatus registry first `shouldReturn` Interrupted
+        getStatus registry second `shouldReturn` Interrupted
+        getStatus registry completed `shouldReturn` Completed (Just "done")
+        closeSubagentRegistry registry
+
     it "aborts only descendants owned by the failed root turn" do
         ownedStarted <- newEmptyTMVarIO
         unrelatedStarted <- newEmptyTMVarIO

--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Content.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Content.hs
@@ -40,7 +40,7 @@ import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Lazy as LBS
 import Data.Foldable (toList)
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import Data.Scientific (formatScientific, FPFormat(Generic))
 import Data.Sequence (Seq((:<|), (:|>)))
 import qualified Data.Sequence as Seq
@@ -565,7 +565,7 @@ lastOuterRequest raw =
               in extractTagged "current_request" suffix
             | offset <- starts
             ]
-    in clipped . Text.strip <$> lastMaybe (mapMaybe id candidates)
+    in clipped . Text.strip <$> lastMaybe (catMaybes candidates)
 
 occurrences :: Text -> Text -> [Int]
 occurrences needle haystack

--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Claude.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Claude.hs
@@ -16,7 +16,7 @@ import Control.Monad (filterM)
 import Control.Monad.Extra (firstJustM)
 import Data.Aeson (Value(..), decodeStrict', encode)
 import qualified Data.ByteString.Lazy as LBS
-import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
+import Data.Maybe (catMaybes, fromMaybe, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding
@@ -39,7 +39,7 @@ discoverClaude env cwd = do
                 filter isClaudeTranscript . concat
                     <$> traverse directoryChildren projectDirectories
     safePaths <- filterM (isSafeFile projects) paths
-    candidates <- mapMaybe id <$> traverse (claudeMetadata env) safePaths
+    candidates <- catMaybes <$> traverse (claudeMetadata env) safePaths
     filterM (\candidate ->
         maybe (pure False) (`samePath` cwd) candidate.candidateCwd)
         candidates

--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Codex.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Codex.hs
@@ -25,7 +25,7 @@ import Data.IORef
     , writeIORef
     )
 import Data.List (maximumBy)
-import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
+import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe)
 import Data.Ord (comparing)
 import Data.Scientific (fromFloatDigits)
 import qualified Data.Set as Set
@@ -86,7 +86,7 @@ discoverCodex env cwd = do
                                     <> "ORDER BY " <> updatedExpression
                                     <> " DESC, id ASC"
                         rows <- queryRows database sql []
-                        Just . mapMaybe id <$> traverse
+                        Just . catMaybes <$> traverse
                             (candidateFromDatabaseRow env cwd)
                             rows
         pure (either (const Nothing) id result)
@@ -94,7 +94,7 @@ discoverCodex env cwd = do
         paths <- recursiveFiles
             (env.externalCodexRoot </> "sessions")
             isCodexTranscript
-        candidates <- mapMaybe id <$> traverse (codexMetadata env) paths
+        candidates <- catMaybes <$> traverse (codexMetadata env) paths
         filterM (\candidate ->
             if candidate.candidateSource
                     `notElem` ["codex-cli", "codex-vscode"]

--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Cursor.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Cursor.hs
@@ -20,7 +20,7 @@ import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
 import Data.List (dropWhileEnd)
-import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
+import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -50,7 +50,7 @@ discoverCursor env cwd = do
             (hash (encodeUtf8 (Text.pack canonicalCwd)) :: Digest MD5)
         chats = env.externalCursorRoot </> "chats" </> digest
     cliDirectories <- directoryChildren chats
-    cli <- mapMaybe id <$> traverse
+    cli <- catMaybes <$> traverse
         (\directory -> cursorCliCandidate env directory (Just cwd))
         cliDirectories
     desktop <- concat <$> traverse (discoverDesktop env cwd)
@@ -70,7 +70,7 @@ discoverDesktop _env cwd databasePath = do
         else tryAny
             (withReadOnlyDatabase databasePath \database -> do
                 headers <- cursorHeaderValues database
-                mapMaybe id <$> traverse (headerCandidate databasePath) headers)
+                catMaybes <$> traverse (headerCandidate databasePath) headers)
             >>= pure . either (const []) id
   where
     headerCandidate databasePath header
@@ -163,7 +163,7 @@ discoverCursorTranscripts env cwd = do
     let projects = env.externalCursorRoot </> "projects"
     paths <- recursiveFiles projects
         (Text.isSuffixOf ".jsonl" . Text.pack)
-    mapMaybe id <$> traverse (cursorTranscriptCandidate env cwd) paths
+    catMaybes <$> traverse (cursorTranscriptCandidate env cwd) paths
 
 cursorTranscriptCandidate
     :: ExternalSessionEnv
@@ -371,7 +371,7 @@ findDesktop _env reference databasePath = do
     result <- tryAny $
         withReadOnlyDatabase databasePath \database -> do
             headers <- cursorHeaderValues database
-            mapMaybe id <$> traverse convert headers
+            catMaybes <$> traverse convert headers
     pure (either (const []) id result)
   where
     convert header =

--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Cursor.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Cursor.hs
@@ -19,6 +19,7 @@ import Data.Aeson (Value(..))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.IORef (modifyIORef', newIORef, readIORef, writeIORef)
+import Data.List (dropWhileEnd)
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
@@ -244,7 +245,7 @@ cursorProjectSlug =
     trimDashes . map (\character ->
         if isAsciiAlphaNumeric character then character else '-')
   where
-    trimDashes = reverse . dropWhile (== '-') . reverse . dropWhile (== '-')
+    trimDashes = dropWhileEnd (== '-') . dropWhile (== '-')
     isAsciiAlphaNumeric character =
         character >= 'A' && character <= 'Z'
             || character >= 'a' && character <= 'z'

--- a/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Grok.hs
+++ b/packages/agent-external-session/src/Agent/CLI/ExternalSession/Provider/Grok.hs
@@ -13,7 +13,7 @@ import Control.Applicative ((<|>))
 import Control.Monad (filterM)
 import Data.Aeson (Value(..))
 import qualified Data.Aeson.KeyMap as KeyMap
-import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
+import Data.Maybe (catMaybes, fromMaybe, listToMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Vector as Vector
@@ -29,7 +29,7 @@ discoverGrok env cwd = do
     let sessions = env.externalGrokRoot </> "sessions"
     encodedDirectories <- directoryChildren sessions
     sessionDirectories <- concat <$> traverse directoryChildren encodedDirectories
-    mapMaybe id <$> traverse (metadataInDirectory env) sessionDirectories
+    catMaybes <$> traverse (metadataInDirectory env) sessionDirectories
         >>= filterM (candidateMatchesCwd cwd)
 
 findGrokById
@@ -54,7 +54,7 @@ discoverAllGrok env = do
     let sessions = env.externalGrokRoot </> "sessions"
     encodedDirectories <- directoryChildren sessions
     sessionDirectories <- concat <$> traverse directoryChildren encodedDirectories
-    mapMaybe id <$> traverse (metadataInDirectory env) sessionDirectories
+    catMaybes <$> traverse (metadataInDirectory env) sessionDirectories
 
 metadataInDirectory
     :: ExternalSessionEnv

--- a/packages/agent-gemini/src/Agent/Gemini/Auth.hs
+++ b/packages/agent-gemini/src/Agent/Gemini/Auth.hs
@@ -26,6 +26,7 @@ module Agent.Gemini.Auth
     , pkceChallenge
     ) where
 
+import Control.Applicative ((<|>))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.MVar
     ( newEmptyMVar
@@ -55,7 +56,7 @@ import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import Data.Bifunctor (first)
 import Data.Char (isDigit, toLower)
-import Data.List (find)
+import Data.List (dropWhileEnd, find)
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -232,7 +233,7 @@ codeAssistOptionsFromEnv = do
         defaultCodeAssistOptions.baseUrl
     googleCloudProject <- nonEmptyEnv "GOOGLE_CLOUD_PROJECT"
     googleCloudProjectId <- nonEmptyEnv "GOOGLE_CLOUD_PROJECT_ID"
-    let configuredProject = googleCloudProject `orElse` googleCloudProjectId
+    let configuredProject = googleCloudProject <|> googleCloudProjectId
     pure defaultCodeAssistOptions { baseUrl, configuredProject }
 
 data CodeAssistUser = CodeAssistUser
@@ -352,7 +353,7 @@ refreshAccessToken options oldRefreshToken = do
         (\(tokens :: OAuthTokens) -> OAuthTokens
             { accessToken = tokens.accessToken
             , refreshToken =
-                tokens.refreshToken `orElse` Just oldRefreshToken
+                tokens.refreshToken <|> Just oldRefreshToken
             , expiresInSeconds = tokens.expiresInSeconds
             , tokenType = tokens.tokenType
             , scope = tokens.scope
@@ -404,8 +405,8 @@ setupCodeAssistWithValidation options bearerToken validationPresenter =
                 { projectId = project
                 , userTier =
                     fromMaybe "standard-tier"
-                        (paidTierId `orElse` tier.tierId)
-                , userTierName = paidTierName `orElse` tier.name
+                        (paidTierId <|> tier.tierId)
+                , userTierName = paidTierName <|> tier.name
                 }
         Nothing -> do
             let tier = fromMaybe legacyTier
@@ -727,7 +728,7 @@ renderOperationError operationError =
 
 requireProject :: LoadResponse -> Maybe Text -> IO Text
 requireProject response configured = case
-    response.cloudaicompanionProject `orElse` configured of
+    response.cloudaicompanionProject <|> configured of
         Just project | not (Text.null (Text.strip project)) -> pure project
         _ -> fail
             "This Google account requires GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID"
@@ -904,11 +905,7 @@ randomUrlText bytes =
     TextEncoding.decodeUtf8 . Base64Url.encodeUnpadded <$> getEntropy bytes
 
 trimSlash :: String -> String
-trimSlash = reverse . dropWhile (== '/') . reverse
-
-orElse :: Maybe value -> Maybe value -> Maybe value
-orElse (Just value) _ = Just value
-orElse Nothing right = right
+trimSlash = dropWhileEnd (== '/')
 
 nonEmptyEnv :: String -> IO (Maybe Text)
 nonEmptyEnv key = lookupEnv key >>= \case

--- a/packages/agent-gemini/test/Agent/Gemini/AuthSpec.hs
+++ b/packages/agent-gemini/test/Agent/Gemini/AuthSpec.hs
@@ -213,6 +213,22 @@ spec = do
                 readIORef calls `shouldReturn`
                     ["/v1internal:loadCodeAssist"]
 
+        it "strips trailing base URL slashes and prefers the returned project" do
+            calls <- newIORef []
+            withLoopbackApplication (pure (existingUserApp calls)) \port -> do
+                let options = (testCodeAssistOptions port)
+                        { baseUrl = localBaseUrl port <> "/v1internal///"
+                        , configuredProject = Just "configured-project"
+                        }
+                result <- setupCodeAssist options "bearer"
+                result `shouldBe` Right CodeAssistUser
+                    { projectId = "managed-project"
+                    , userTier = "free-tier"
+                    , userTierName = Just "Gemini Code Assist"
+                    }
+                readIORef calls `shouldReturn`
+                    ["/v1internal:loadCodeAssist"]
+
         it "prefers paid-tier metadata for an existing account" do
             withLoopbackApplication (pure paidUserApp) \port ->
                 setupCodeAssist (testCodeAssistOptions port) "bearer"

--- a/packages/agent-mcp/src/Agent/MCP/OAuth.hs
+++ b/packages/agent-mcp/src/Agent/MCP/OAuth.hs
@@ -63,7 +63,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isAlphaNum, isSpace, toLower)
-import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
@@ -205,7 +205,7 @@ instance Aeson.FromJSON OAuthTokenFileExtra where
             <*> o Aeson..:? "redirect_uri"
 
 tokenExtraPairs :: OAuthTokenFileExtra -> [AesonTypes.Pair]
-tokenExtraPairs extra = mapMaybe id
+tokenExtraPairs extra = catMaybes
     [ ("issuer" Aeson..=) <$> extra.extraIssuer
     , ("scope" Aeson..=) <$> extra.extraScope
     , ("resource" Aeson..=) <$> extra.extraResource
@@ -387,9 +387,7 @@ probeAuthorizationChallenge manager endpoint = do
             let challenges = [value | (name, value) <- HC.responseHeaders response, name == "WWW-Authenticate"]
             in Right AuthorizationProbe
                 { probeStatus = statusCode (responseStatus response)
-                , probeChallenge = case mapMaybe parseWwwAuthenticate challenges of
-                    challenge : _ -> Just challenge
-                    [] -> Nothing
+                , probeChallenge = listToMaybe (mapMaybe parseWwwAuthenticate challenges)
                 }
 
 -- ---------------------------------------------------------------------------

--- a/packages/agent-openai/src/Agent/OpenAI/Live/Signaling.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Live/Signaling.hs
@@ -28,6 +28,7 @@ import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import Data.Char (isAsciiLower, isAsciiUpper, isDigit, isHexDigit)
+import Data.List (dropWhileEnd)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -96,7 +97,7 @@ gatewayLiveEndpoint baseUrl = do
         || not (null uri.uriQuery) || not (null uri.uriFragment)
         then invalid
         else Right (secure, authority.uriRegName, port,
-            reverse (dropWhile (== '/') (reverse uri.uriPath)) <> "/v1/voice")
+            dropWhileEnd (== '/') uri.uriPath <> "/v1/voice")
   where
     invalid = Left "Invalid gateway voice endpoint; HTTPS is required except on loopback."
 

--- a/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
+++ b/packages/agent-openai/src/Agent/OpenAI/Transcription.hs
@@ -67,6 +67,7 @@ import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Data.List (dropWhileEnd)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -995,7 +996,7 @@ chatGPTStreamEndpointAt websocketUrl = do
 
 dropTrailingSlashes :: String -> String
 dropTrailingSlashes =
-    reverse . dropWhile (== '/') . reverse
+    dropWhileEnd (== '/')
 
 ignoreSynchronousException :: IO () -> IO ()
 ignoreSynchronousException action =

--- a/packages/agent-openai/test/Agent/OpenAI/LiveSpec.hs
+++ b/packages/agent-openai/test/Agent/OpenAI/LiveSpec.hs
@@ -143,6 +143,8 @@ spec = describe "Codex Live protocol" do
     it "routes gateway voice only to the configured secure origin" do
         gatewayLiveEndpoint "https://gateway.example/base/" `shouldBe`
             Right (True, "gateway.example", 443, "/base/v1/voice")
+        gatewayLiveEndpoint "https://gateway.example/base///" `shouldBe`
+            Right (True, "gateway.example", 443, "/base/v1/voice")
         gatewayLiveEndpoint "http://127.0.0.1:8080" `shouldBe`
             Right (False, "127.0.0.1", 8080, "/v1/voice")
         mapM_ (\url -> gatewayLiveEndpoint url `shouldSatisfy` isLeft)

--- a/packages/agent-responses/src/Agent/Responses/Error.hs
+++ b/packages/agent-responses/src/Agent/Responses/Error.hs
@@ -50,7 +50,7 @@ mkOpenAIError errorType message code retryAfter =
     ProviderError
         (classifyErrorType errorType message code)
         (appendErrorCode code message)
-        (retryAfter `orElse` retryAfterFromMessage message)
+        (retryAfter <|> retryAfterFromMessage message)
 
 classifyErrorType :: ErrorType -> Text -> Maybe Text -> ErrorType
 classifyErrorType errorType message code
@@ -279,7 +279,3 @@ mentionsMissingFunctionCallOutput :: Text -> Bool
 mentionsMissingFunctionCallOutput =
     Text.isInfixOf "no tool output found for function call"
         . Text.toLower
-
-orElse :: Maybe a -> Maybe a -> Maybe a
-orElse (Just value) _ = Just value
-orElse Nothing fallback = fallback

--- a/packages/agent-responses/src/Agent/Responses/GenericClient.hs
+++ b/packages/agent-responses/src/Agent/Responses/GenericClient.hs
@@ -43,6 +43,7 @@ import Agent.Responses.StreamAssembly
     , failedStreamResponseMessage
     )
 import Agent.Responses.Types
+import Control.Applicative ((<|>))
 import Control.Retry
     ( RetryPolicyM
     , exponentialBackoff
@@ -223,8 +224,5 @@ nonEmptyText _ = Nothing
 addRetryAfter :: Maybe Int -> ApiError -> ApiError
 addRetryAfter fallback = \case
     ProviderError errorType message retryAfter ->
-        ProviderError errorType message (retryAfter `orElse` fallback)
+        ProviderError errorType message (retryAfter <|> fallback)
     errorValue -> errorValue
-
-Just value `orElse` _ = Just value
-Nothing `orElse` fallback = fallback

--- a/packages/agent-responses/src/Agent/Responses/LoopBackend/ToolArgumentPreview.hs
+++ b/packages/agent-responses/src/Agent/Responses/LoopBackend/ToolArgumentPreview.hs
@@ -30,6 +30,7 @@ import Data.IntMap.Strict (IntMap)
 import qualified Data.IntMap.Strict as IntMap
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Foldable (asum)
 import Data.Maybe (fromMaybe, isJust, maybeToList)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -293,14 +294,13 @@ resolveToolValue
     -> Maybe value
 resolveToolValue outputIndex identities byOutputIndex byIdentity fallback =
     (outputIndex >>= (`IntMap.lookup` byOutputIndex))
-        <|> firstJust
+        <|> asum
             [ Map.lookup identity byIdentity
             | Just identity <- identities
             ]
         <|> if hasLocator then Nothing else fallback
   where
     hasLocator = isJust outputIndex || any isJust identities
-    firstJust = foldr (<|>) Nothing
 
 -- Keep live previews useful without retaining unbounded repeated strict Text
 -- values for runaway calls. Shell previews only need one command line, while

--- a/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
+++ b/packages/agent-responses/src/Agent/Responses/StreamAssembly.hs
@@ -42,6 +42,7 @@ import Data.IntSet (IntSet)
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
+import Data.Foldable (asum)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -623,7 +624,7 @@ findIdentityIndex
     -> StreamAssemblyState
     -> Maybe Int
 findIdentityIndex identities state =
-    foldr (<|>) Nothing (map findValue values)
+    asum (map findValue values)
   where
     values = [identity | Just identity <- identities]
     findValue identity =

--- a/packages/agent-responses/test/Agent/Responses/GenericClientSpec.hs
+++ b/packages/agent-responses/test/Agent/Responses/GenericClientSpec.hs
@@ -117,6 +117,14 @@ spec = do
                 `shouldBe`
                     ProviderError RateLimitError "slow" (Just 12)
 
+        it "prefers a retry delay from the error body over the header" do
+            classifyFailure
+                429
+                (Just 12)
+                "{\"error\":{\"type\":\"rate_limit_error\",\"message\":\"slow\",\"retry_after\":3}}"
+                `shouldBe`
+                    ProviderError RateLimitError "slow" (Just 3)
+
     describe "retryTransientResultWithPolicy" do
         it "retries transient failures before any event is emitted" do
             attempts <- newIORef (0 :: Int)

--- a/packages/agent-runtime/src/Agent/Runtime/Project.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Project.hs
@@ -53,7 +53,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import System.Directory.OsPath
@@ -211,7 +211,7 @@ projectSettingsDecoder = Hermes.object do
             -- A malformed or obsolete model selection should not discard
             -- unrelated project settings such as auto-approve.
             , settingsLastModel = lastModelValue >>= id
-            , settingsLastAccounts = mapMaybe id lastAccountsValue
+            , settingsLastAccounts = catMaybes lastAccountsValue
             , settingsMaxConcurrentAgents = maxConcurrentAgents
             }
 

--- a/packages/agent-xai/src/Agent/XAI/Options.hs
+++ b/packages/agent-xai/src/Agent/XAI/Options.hs
@@ -21,6 +21,7 @@ import Agent.Provider.Options
     , lookupNonEmptyEnv
     , parseModelOverrides
     )
+import Data.List (dropWhileEnd)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import qualified Data.Maybe as Maybe
@@ -142,7 +143,7 @@ defaultClientOptions = ClientOptions
 gatewayClientOptions :: String -> ClientOptions
 gatewayClientOptions gatewayBaseUrl =
     defaultClientOptions
-        { baseUrl = reverse (dropWhile (== '/') (reverse gatewayBaseUrl)) <> "/v1"
+        { baseUrl = dropWhileEnd (== '/') gatewayBaseUrl <> "/v1"
         , preserveModelNames = True
         , requestRedirectCount = 0
         }

--- a/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
+++ b/packages/agent-xai/test/Agent/XAI/ResponsesSpec.hs
@@ -36,6 +36,8 @@ spec = do
         it "preserves authoritative gateway aliases instead of inferring models" do
             let options = gatewayClientOptions "https://gateway.example/"
             options.baseUrl `shouldBe` "https://gateway.example/v1"
+            (gatewayClientOptions "https://gateway.example/base///").baseUrl
+                `shouldBe` "https://gateway.example/base/v1"
             options.requestRedirectCount `shouldBe` 0
             mapModel options "organization-research"
                 `shouldBe` "organization-research"

--- a/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/MessageParser.hs
+++ b/packages/claude-agent-sdk-haskell/src/Claude/Agent/SDK/Internal/MessageParser.hs
@@ -188,7 +188,7 @@ streamEventDecoder = Json.object do
     event <- Json.atKeyOptional "event" rawJsonDecoder
         >>= maybe (fail "stream event is missing `event`") pure
     streamToolUse <- Json.atKeyOptional "event" streamToolUseDecoder
-        >>= pure . (>>= id)
+        >>= pure . join
     parentToolUseId <- optionalNonEmptyText "parent_tool_use_id"
     hasParentToolUseId <- parentFieldPresent
     pure StreamEvent{..}
@@ -200,7 +200,7 @@ streamToolUseDecoder = Json.withType \case
         case eventType of
             Just "content_block_start" ->
                 Json.atKeyOptional "content_block" streamToolBlockDecoder
-                    >>= pure . (>>= id)
+                    >>= pure . join
             _ -> pure Nothing
     _ -> pure Nothing
 
@@ -466,7 +466,7 @@ optionalOrigin key =
                     Right origin ->
                         pure (Just origin)
             _ -> pure Nothing)
-        >>= pure . (>>= id)
+        >>= pure . join
 
 originDecoder :: RawJson -> Json.Decoder MessageOrigin
 originDecoder raw = Json.object do
@@ -489,7 +489,7 @@ requiredText
     -> Json.FieldsDecoder Text
 requiredText key err =
     Json.atKeyOptional key tolerantOptionalText >>= \value ->
-        maybe (fail (Text.unpack err)) pure (value >>= id)
+        maybe (fail (Text.unpack err)) pure (join value)
 
 requiredNonEmptyText
     :: Text
@@ -498,7 +498,7 @@ requiredNonEmptyText
 requiredNonEmptyText key err =
     Json.atKeyOptional key tolerantOptionalText >>= \value ->
         maybe (fail (Text.unpack err)) pure
-            (value >>= id >>= nonEmptyText)
+            (join value >>= nonEmptyText)
 
 requiredBool
     :: Text
@@ -506,22 +506,22 @@ requiredBool
     -> Json.FieldsDecoder Bool
 requiredBool key err =
     Json.atKeyOptional key tolerantOptionalBool >>= \value ->
-        maybe (fail (Text.unpack err)) pure (value >>= id)
+        maybe (fail (Text.unpack err)) pure (join value)
 
 optionalText :: Text -> Json.FieldsDecoder (Maybe Text)
 optionalText key =
     (Json.atKeyOptional key tolerantOptionalText)
-        >>= pure . (>>= id)
+        >>= pure . join
 
 optionalNonEmptyText :: Text -> Json.FieldsDecoder (Maybe Text)
 optionalNonEmptyText key =
     Json.atKeyOptional key tolerantOptionalText >>= \value ->
-        pure (value >>= id >>= nonEmptyText)
+        pure (join value >>= nonEmptyText)
 
 optionalBool :: Text -> Json.FieldsDecoder (Maybe Bool)
 optionalBool key =
     (Json.atKeyOptional key tolerantOptionalBool)
-        >>= pure . (>>= id)
+        >>= pure . join
 
 optionalRaw :: Text -> Json.FieldsDecoder (Maybe RawJson)
 optionalRaw key =
@@ -529,7 +529,7 @@ optionalRaw key =
         Json.withType \case
             Json.VNull -> pure Nothing
             _ -> Just <$> rawJsonDecoder)
-        >>= pure . (>>= id)
+        >>= pure . join
 
 optionalTyped
     :: Text
@@ -540,7 +540,7 @@ optionalTyped key decoder =
         Json.withType \case
             Json.VNull -> pure Nothing
             _ -> Just <$> decoder)
-        >>= pure . (>>= id)
+        >>= pure . join
 
 optionalNumber
     :: Text
@@ -551,7 +551,7 @@ optionalNumber key decoder =
         Json.withType \case
             Json.VNumber -> Just <$> decoder
             _ -> pure Nothing)
-        >>= pure . (>>= id)
+        >>= pure . join
 
 nonNegativeNumber :: Text -> Json.FieldsDecoder Int
 nonNegativeNumber key =
@@ -561,7 +561,7 @@ optionalNonNegativeNumber :: Text -> Json.FieldsDecoder (Maybe Int)
 optionalNonNegativeNumber key =
     fmap (\value -> if value >= 0 then Just value else Nothing)
         <$> optionalNumber key Json.int
-        >>= pure . (>>= id)
+        >>= pure . join
 
 optionalNonNegativeNumberDefault :: Text -> Json.FieldsDecoder Int
 optionalNonNegativeNumberDefault key =


### PR DESCRIPTION
## Summary
- Use `join` for nested Maybe flattening in Claude SDK parsing, authentication and message interpretation.
- Use `concatMapM` for three subagent registry STM traversals and `catMaybes` for remembered account settings.
- Replace the registry's handwritten STM filter with `filterM` and Gemini auth's Maybe fallback with `(<|>)`.
- Use `dropWhileEnd` for Git CR/LF trimming, Gemini/OpenAI/xAI URL slashes, and Cursor project-slug dashes.
- Use `find` for CLI provider lookup and `Set` for ascending unique Git filter-driver names.
- Use `catMaybes` in external-session content and `asum`/`(<|>)` in Responses identity lookup and retry-delay fallback.
- Add regressions for subagent filtering, URL trimming, project precedence, and body retry-delay precedence over headers.
- Use `catMaybes` throughout external-session discovery and OAuth metadata, `listToMaybe` for the first parsed OAuth challenge, and `dropWhileEnd` for reasoning before an unmatched side-question tool call.

Behavior-preserving cleanup; no new dependencies or performance claims. Keep helpers whose alternatives change laziness or special empty-value behavior.

## Validation
- Claude parser batch: SDK MessageParser 12 and full agent-claude suite 81 examples passed in actual Cabal GHCi components.
- Latest registry/settings batch: Subagents 50 and Project 26 examples passed in actual Cabal GHCi test components.
- Real Cabal GHCi test components loaded successfully; zero failures:
  - Worktree 68, Subagents 50, Gemini Auth 23.
  - CLI ProviderFallback/GitDiff 38, external-session 19.
  - CLI Btw 15, MCP OAuth 58; external-session 19 rerun after discovery cleanup.
  - OpenAI Live/Transcription 56, OpenAI Error 23, xAI Responses 28.
  - Full Responses suite 145, including 1,100 QuickCheck cases.
- Old/new worktree trimming agreed on 19,531 inputs.
- `git diff --check` passed.
