### PR TITLE
Add connected CLI memory profiling and journal regression benchmarks

### DIFF
--- a/packages/agent-cli/benchmark/ConnectedMemory.md
+++ b/packages/agent-cli/benchmark/ConnectedMemory.md
@@ -1,0 +1,130 @@
+# Connected CLI memory fixture
+
+`connected-memory-fixture.py` runs a bounded loopback Responses server and
+prepares a fresh isolated CLI home. `connected-memory-run.py` drives the actual
+optimized CLI through tmux, sampling its process RSS during startup, tool rounds,
+streaming text, idle, and graceful exit. No external model/provider is contacted.
+This is a full-runtime synthetic fixture, **not evidence about every connected
+real-world session**. MCP/provider inference and non-fixture integrations are
+not represented.
+
+Build the executable with identical optimized settings for baseline/candidate.
+Freeze the executable **and local shared libraries** before rebuilding.
+Run the scripts with Python 3.9+ inside `nix develop` so required tool/data paths
+are available. `TMPDIR` must be set; all generated artifacts stay beneath it.
+The server takes a **new** run directory and rejects existing directories.
+It also rejects roots too long for PostgreSQL and observation Unix sockets.
+On Linux use `--proc-home` when `TMPDIR` is long. This opens the TMPDIR-owned
+directory and uses `/proc/<fixture-pid>/fd/<fd>` as a short alias: no scratch
+directory is created outside TMPDIR. The fixture owns the fd until shutdown,
+stops only its exact isolated PostgreSQL cluster with `pg_ctl`, then closes it.
+Keep the fixture alive through CLI/resume; the alias is not a durable home after
+the fixture exits. Without Linux procfs, use a short tool-provided TMPDIR.
+When driving from another Nix shell, use the original fixture `TMPDIR`, not
+the new invocation's different temporary directory.
+
+```sh
+# For a Cabal build without installed data files, from the repository root:
+export agent_runtime_datadir="$PWD/packages/agent-runtime"
+export agent_cli_datadir="$PWD/packages/agent-cli"
+export agent_tui_datadir="$PWD/packages/agent-tui"
+python3 packages/agent-cli/benchmark/connected-memory-fixture.py \
+  --root "$TMPDIR/cm1" --cli /absolute/path/to/frozen/run \
+  --rounds 4 --argument-padding 0 --text-bytes 4096 \
+  --postgres-port 55439 --proc-home
+```
+
+Keep this server running; after `ready.json` exists, in another command:
+
+```sh
+python3 packages/agent-cli/benchmark/connected-memory-run.py \
+  --root "$TMPDIR/cm1" --turns 5 --idle-seconds 10
+```
+
+The fixture exposes `/status` plus atomic `status.json` numeric observations.
+Each user prompt `MEMORY_TURN_N` produces the configured number of read-only
+`read_file` calls against the generated `fixture.txt`, followed by streamed
+assistant text ending `MEMORY_DONE_N`. Progress is derived from completed call
+IDs in the request, so a transport retry does not silently advance work. The
+runner checks server completion; inspect pane captures and persisted transcript
+as well to verify successful tools and final UI state.
+
+For substantive generated file content rather than whitespace stress, add
+`--tool shell-write --write-lines 100`. Each round streams a `run_terminal_cmd`
+argument containing a literal, quoted heredoc of synthetic symbol declarations,
+writes `fixture-edit-<turn>-<round>.txt` only in the fresh fixture cwd, and returns
+its byte count. This explicit mode enables `--yolo` in the isolated CLI wrapper;
+no command or path is derived from incoming prompt content. `--write-lines`
+is bounded at 20,000. Inspect final generated files and successful tool outcomes,
+not only the server's final response marker. Both read-only and generated-write
+cases remain scripted fixtures, not evidence of general live-provider savings.
+
+For streamed terminal output, use fixture flags `--tool shell-output --rounds 2
+--output-bytes 262144 --output-chunks 200 --output-duration-ms 3000
+--text-bytes 256`. Each real `run_terminal_cmd` invocation runs the fixture's
+absolute Python interpreter, flushes synthetic output over three seconds, and
+writes a completion sentinel in the isolated cwd. The provider checks that
+sentinel before advancing. This mode enables isolated `--yolo`; no shell command
+is derived from incoming prompts. Output is bounded at 1 MiB per call. Use runner
+flags `--turns 1 --startup-seconds 30 --idle-seconds 3`; short startup waits can
+race database initialization. This is a reproducible output-heavy workload,
+not a claim about the frequency of large outputs in actual usage.
+
+For a manual smoke, launch `cm1/run-cli` in an owned tmux session and submit
+`MEMORY_TURN_1`, then `/quit`. `run-cli --resume SESSION_ID` preserves the same
+isolated home. To automate a resumed session while the fixture remains alive:
+
+```sh
+python3 packages/agent-cli/benchmark/connected-memory-run.py \
+  --root "$TMPDIR/cm1" --resume SESSION_ID --start-turn 6 --turns 5
+```
+
+`heap.csv` appends across processes, including PID/timestamps; per-drive RSS CSV
+and pane captures live in `drive-memory-*`. `cli-stderr.log` is replaced at each
+CLI launch, so preserve it before resuming if comparing final RTS summaries.
+Use a separate fresh directory per independent sample. Stop the owned fixture
+server with SIGTERM after the CLI exits; it also stops after `--max-seconds`.
+The wrapper uses `env -i` with an allowlist of tool/library/data paths and an
+isolated `HOME`, not user credentials, gateway settings, skills, or MCP config.
+Never point this harness at real user data or copy credential files into it.
+
+## Measurement controls
+
+* Default launch is `+RTS -N4 -T -s`; `heap.csv` uses the executable's existing
+  `HeapDiagnostics` hook. Normal `last_gc_*` samples may be stale or describe
+  minor collections. They are not necessarily current major-GC residency.
+* Use a separate fixture with `--force-gc` to collect before each observation,
+  and another with `--heap-profile` for `-hT -i0.1`. Both perturb GC behaviour.
+  Do not compare their timing/RSS against an uninstrumented baseline.
+* `rss.csv` observes only the CLI PID from the diagnostics file: `VmRSS` and
+  `VmHWM` in KiB, sampled every 250 ms. It does not claim total process-tree
+  memory or count the independent Python fixture.
+* The isolated home may start private PostgreSQL. Choose an unused
+  `--postgres-port` and retain/report server lifecycle separately. The fixture
+  stops its exact cluster on exit; stop the CLI first so its shutdown does not
+  race database teardown. `postgres-stop.log` records that cleanup.
+* Test unpadded normal arguments first. `--argument-padding 262144` adds harmless
+  JSON whitespace to the `read_file` arguments to isolate accumulation costs.
+  This is an explicit stress control, **not a representative normal tool call**.
+* Repeat baseline/candidate alternately at least three times; compare identical
+  turn/round counts, chunk sizes/delays, terminal size, input/output bytes, build
+  flags, startup/idle intervals, and PostgreSQL cold/warm status.
+* Defaults cap runtime at 30 minutes, request body at 64 MiB, requests at 1000,
+  and each connection read/write timeout at 15 seconds. Invalid prompts fail
+  rather than invoking any fallback model.
+
+### Streaming terminal output
+
+Use fixture flags `--tool shell-output --output-bytes 262144
+--output-chunks 200 --output-duration-ms 3000` to run a bounded Python command
+through the real `run_terminal_cmd` tool. It flushes 256 KiB over approximately
+three seconds, followed by a unique completion sentinel. The fixture requires
+that sentinel in the returned tool output before completing the driven turn.
+This mode uses the isolated fixture's `--yolo` launch, like `shell-write`.
+Python must be available in the allowlisted launch `PATH`.
+
+The runner also requires the final `MEMORY_DONE_N` and `✓ Finished` to render.
+Use `--startup-seconds 30` when initializing a cold PostgreSQL cluster; sending
+input while session storage is still opening is not a valid workload.
+Title requests and background transcript consumers return plain text, are
+logged with `auxiliary: true`, and never advance `completed_turn`.

--- a/packages/agent-cli/benchmark/ConnectedMemoryResults.md
+++ b/packages/agent-cli/benchmark/ConnectedMemoryResults.md
@@ -1,0 +1,88 @@
+# Connected memory: adjacent journal snapshots
+
+Baseline: `ed2a95290`; candidate: adjacent-only snapshot replacement in
+`Agent.Loop.DisplayJournal`, with both local helpers inlined. Linux,
+GHC 9.10.3, Cabal optimization level 2, dynamically linked executables,
+`+RTS -N4 -T -s`. Executables and all local shared libraries were frozen
+separately before rebuilding. See [fixture instructions](ConnectedMemory.md).
+
+These are actual CLI processes connected to a scripted loopback provider,
+including tool execution, persistence and terminal rendering. They are not
+live-model sessions or measurements of the complete process tree. PostgreSQL,
+the fixture server, and tmux are excluded from CLI RSS.
+
+## Ordinary read control
+
+Three independent fresh-home runs per variant, baseline group then candidate
+group (not alternating). Each run: 120×40 terminal, 10-second startup,
+three user turns with four reads of the same 100-line synthetic file per turn,
+4,096 bytes of final streamed text plus completion marker, three seconds idle
+after each turn, then `/quit`. No argument padding or forced collections.
+Background title requests receive plain text without advancing driven turns.
+
+| Metric | Before median | After median |
+|---|---:|---:|
+| Peak process RSS, KiB | 268,232 | 269,792 |
+| Maximum major-GC live bytes | 6,441,568 | 6,470,400 |
+| Allocated bytes at last diagnostic sample | 5,632,517,096 | 5,566,404,352 |
+| Mutator + GC CPU seconds at last sample | 2.292 | 2.160 |
+
+Peak RSS samples: before 267,408 / 269,932 / 268,232 KiB;
+after 270,920 / 269,792 / 267,884 KiB. The ranges overlap: **no ordinary-session
+memory improvement established** (median RSS increased 0.58%). Timing and
+allocation samples end before process exit and vary with background work;
+the small differences are not a speedup claim.
+
+## Streamed terminal-output comparison
+
+Three alternating baseline/candidate pairs, fresh isolated homes, 30-second
+startup, one turn with two real terminal commands. Each command emits 262,144
+bytes in 200 flushed chunks over three seconds; final assistant text is 256
+bytes plus completion marker. Three seconds idle, then `/quit`. Completion
+sentinels, rendered final response, and graceful exit were checked in every run.
+
+| Metric | Before median | After median |
+|---|---:|---:|
+| Peak process RSS, KiB | 270,808 | 269,488 |
+| Maximum major-GC live bytes | 8,323,840 | 8,283,336 |
+| Allocated bytes at last diagnostic sample | 17,762,847,400 | 17,726,850,216 |
+| Mutator + GC CPU seconds at last sample | 8.094 | 8.082 |
+
+Peak RSS samples: before 268,236 / 271,200 / 270,808 KiB;
+after 270,104 / 269,488 / 268,772 KiB. Median reduction is only 0.49%,
+with overlapping ranges: **no meaningful whole-process reduction established**.
+The isolated worst-case journal improvement does not translate to this
+full-CLI workload. These are shared-host measurements, not controlled CPU
+benchmarks; two abandoned diagnostic CLI processes were discovered and cleaned
+up afterward. They were excluded from per-PID memory, but may affect timing.
+
+## Where ordinary memory goes
+
+A separate `/proc/PID/smaps` snapshot during baseline startup measured
+254,844 KiB RSS. File-named mappings accounted for 221,432 KiB (87%);
+203,472 KiB was shared-clean. Total anonymous pages, including copy-on-write
+pages inside file mappings, were 50,708 KiB. PSS was 130,582 KiB.
+Do not add these overlapping categories or equate file-named mappings with
+entirely shared memory. This dynamically linked build's RSS is dominated by
+loaded code/data rather than the roughly 5–6 MB live Haskell heap.
+
+One read-control allocation trace had already allocated 3.16 GB before the
+first tool, out of approximately 5.6 GB for the session. This identifies
+startup/idle allocation churn as a further profiling target, not a proven
+function-level attribution. A smaller journal cannot remove mapped libraries.
+
+## Component evidence and validation
+
+[The journal benchmark](../../agent-core/benchmark/DisplayJournalRetention.md)
+shows about 99.3% less live memory for 1,000 consecutive cumulative snapshots
+of a single call. Interleaved calls and text are controls, not equivalent wins.
+The change retains only the latest adjacent superseding snapshot, preserving
+text, restart, cross-call, retraction, and repeated-finish boundaries.
+
+13 visible-state examples and 21 failed-display/event-delivery examples passed;
+the projection verifier passed 6,464 event prefixes. The optimized full CLI
+build passed. Actual file-write smoke tests verified generated file contents,
+rendered completion, graceful exit, and isolated database cleanup.
+
+The ordinary 20% whole-process memory goal remains unmet. Component retention
+savings must not be presented as an overall CLI reduction.

--- a/packages/agent-cli/benchmark/ConnectedMemoryResults.md
+++ b/packages/agent-cli/benchmark/ConnectedMemoryResults.md
@@ -1,6 +1,13 @@
-# Connected memory: adjacent journal snapshots
+# Connected memory: historical adjacent journal snapshot results
 
-Baseline: `ed2a95290`; candidate: adjacent-only snapshot replacement in
+**Historical measurements of rejected candidate `80be75c3`.**
+The PR now contains profiling, benchmarks, and regression coverage only:
+the production journal optimization has been removed because of CPU and
+allocation guardrail regressions. There is no new production memory change
+and no new whole-process memory savings claim. The actual CLI measurements
+below are retained as historical evidence, not results for the current PR.
+
+Baseline: `ed2a95290`; candidate: `80be75c3`, adjacent-only snapshot replacement in
 `Agent.Loop.DisplayJournal`, with both local helpers inlined. Linux,
 GHC 9.10.3, Cabal optimization level 2, dynamically linked executables,
 `+RTS -N4 -T -s`. Executables and all local shared libraries were frozen
@@ -71,13 +78,19 @@ first tool, out of approximately 5.6 GB for the session. This identifies
 startup/idle allocation churn as a further profiling target, not a proven
 function-level attribution. A smaller journal cannot remove mapped libraries.
 
-## Component evidence and validation
+## Historical component evidence and validation
 
-[The journal benchmark](../../agent-core/benchmark/DisplayJournalRetention.md)
-shows about 99.3% less live memory for 1,000 consecutive cumulative snapshots
+The historical candidate showed about 99.3% less live memory for 1,000 consecutive cumulative snapshots
 of a single call. Interleaved calls and text are controls, not equivalent wins.
-The change retains only the latest adjacent superseding snapshot, preserving
+That candidate retained only the latest adjacent superseding snapshot, preserving
 text, restart, cross-call, retraction, and repeated-finish boundaries.
+
+Its roughly 42% small-turn component CPU regression was not an accepted shipping
+trade-off. Follow-up designs also failed guardrails, so no journal optimization
+is being shipped. See
+[DisplayJournalRetention.md](../../agent-core/benchmark/DisplayJournalRetention.md)
+for the component experiments and their limitations. Those measurements must
+not be substituted for a connected whole-CLI rerun.
 
 13 visible-state examples and 21 failed-display/event-delivery examples passed;
 the projection verifier passed 6,464 event prefixes. The optimized full CLI

--- a/packages/agent-cli/benchmark/connected-memory-fixture.py
+++ b/packages/agent-cli/benchmark/connected-memory-fixture.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Bounded, loopback-only synthetic Responses endpoint; never contacts a provider.
+
+Creates a fresh isolated home/cwd and CLI launch wrapper beneath TMPDIR. The
+HTTP server logs numeric workload observations, never prompts/headers/tool data.
+This exercises a real CLI transport/tool/persistence/UI path, not real model
+inference. Large whitespace arguments are a stress control, not typical traffic.
+"""
+
+import argparse
+import http.server
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import time
+
+
+def bounded(low, high):
+    def parse(raw):
+        value = int(raw)
+        if not low <= value <= high:
+            raise argparse.ArgumentTypeError(f"must be between {low} and {high}")
+        return value
+    return parse
+
+
+def write_json(path, value):
+    temporary = path.with_suffix(path.suffix + ".new")
+    temporary.write_text(json.dumps(value, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+def user_text(item):
+    content = item.get("content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(part.get("text", "") for part in content
+                         if isinstance(part, dict))
+    return ""
+
+
+def request_position(body, rounds):
+    """Derive progress from transcript, so retries do not advance the fixture."""
+    items = body.get("input", [])
+    if not isinstance(items, list):
+        raise ValueError("input must be an array")
+    start, turn = None, None
+    for index, item in enumerate(items):
+        if isinstance(item, dict) and item.get("role") == "user":
+            match = re.search(r"\bMEMORY_TURN_(\d+)\b", user_text(item))
+            if match:
+                start, turn = index, int(match.group(1))
+    if start is None or not 1 <= turn <= 1000:
+        raise ValueError("requires synthetic MEMORY_TURN_1..1000 user marker")
+    prefix = f"call_memory_{turn}_"
+    completed = {
+        item.get("call_id") for item in items[start + 1:]
+        if isinstance(item, dict)
+        and item.get("type") == "function_call_output"
+        and isinstance(item.get("call_id"), str)
+        and item["call_id"].startswith(prefix)
+    }
+    # Require exact contiguous IDs; an unrelated response must not skip work.
+    expected = {prefix + str(index) for index in range(len(completed))}
+    if completed != expected or len(completed) > rounds:
+        raise ValueError("non-contiguous or excessive fixture tool outputs")
+    return turn, len(completed)
+
+
+def stream_events(turn, round_index, options, auxiliary=False):
+    response_id = f"resp_memory_{turn}_{round_index}"
+    response = dict(id=response_id, object="response", created_at=0,
+                    model="memory-fixture", status="in_progress", output=[])
+    yield "response.created", dict(response=response)
+    yield "response.in_progress", dict(response=response)
+    if round_index < options.rounds and not auxiliary:
+        call_id = f"call_memory_{turn}_{round_index}"
+        item_id = f"fc_memory_{turn}_{round_index}"
+        if options.tool == "shell-output":
+            # Only bounded integers and generated identifiers enter this code.
+            # Flush small chunks to exercise real tool progress callbacks.
+            script = ("import sys,time\n"
+                      f"total={options.output_bytes}; chunks={options.output_chunks}\n"
+                      "for i in range(chunks):\n"
+                      " n=total//chunks+(i<total%chunks)\n"
+                      " sys.stdout.write('x'*(n-1)+'\\n' if n else '')\n"
+                      " sys.stdout.flush()\n"
+                      f" time.sleep({options.output_duration_ms}/1000/chunks)\n"
+                      f"print('MEMORY_OUTPUT_DONE_{turn}_{round_index}')\n"
+                      f"open('output-done-{turn}-{round_index}', 'w').write(str(total))\n")
+            name = "run_terminal_cmd"
+            parameters = dict(command=shlex.quote(sys.executable) + " -u -c " + shlex.quote(script),
+                              timeout=30000,
+                              description="Stream bounded synthetic build output.")
+        elif options.tool == "shell-write":
+            filename = f"fixture-edit-{turn}-{round_index}.txt"
+            content = "".join(
+                f"symbol_{index:05d} = synthetic_value_{turn}_{round_index}_{index}\n"
+                for index in range(options.write_lines))
+            # Only generated literal content enters the quoted heredoc; neither
+            # paths nor command fragments come from the client's request.
+            command = (f"cat > {filename} <<'MEMORY_FIXTURE_EOF'\n"
+                       + content + f"MEMORY_FIXTURE_EOF\nwc -c < {filename}")
+            name = "run_terminal_cmd"
+            parameters = dict(command=command, timeout=10000,
+                              description="Write and measure a bounded synthetic fixture file.")
+        else:
+            name = "read_file"
+            parameters = {"target_file": "fixture.txt"}
+        # Padding is JSON whitespace, not an extra field visible to the tool.
+        arguments = (" " * options.argument_padding
+                     + json.dumps(parameters, separators=(",", ":")))
+        item = dict(type="function_call", id=item_id, call_id=call_id,
+                    name=name, arguments="", status="in_progress")
+        yield "response.output_item.added", dict(output_index=0, item=item)
+        for offset in range(0, len(arguments), options.chunk_bytes):
+            yield "response.function_call_arguments.delta", dict(
+                output_index=0, item_id=item_id,
+                delta=arguments[offset:offset + options.chunk_bytes])
+        yield "response.function_call_arguments.done", dict(
+            output_index=0, item_id=item_id, name=name, arguments=arguments)
+        final_item = dict(item, arguments=arguments, status="completed")
+    else:
+        item_id = f"msg_memory_{turn}"
+        line = "Synthetic coding result: parsed fixture, checked symbols, no changes.\n"
+        text = (line * (options.text_bytes // len(line) + 1))[:options.text_bytes]
+        text += f"\nMEMORY_DONE_{turn}\n"
+        if auxiliary:
+            text = "Synthetic fixture session"
+        item = dict(type="message", id=item_id, role="assistant",
+                    status="in_progress", content=[])
+        part = dict(type="output_text", text="", annotations=[])
+        yield "response.output_item.added", dict(output_index=0, item=item)
+        yield "response.content_part.added", dict(
+            output_index=0, item_id=item_id, content_index=0, part=part)
+        for offset in range(0, len(text), options.chunk_bytes):
+            yield "response.output_text.delta", dict(
+                output_index=0, item_id=item_id, content_index=0,
+                delta=text[offset:offset + options.chunk_bytes])
+        yield "response.output_text.done", dict(
+            output_index=0, item_id=item_id, content_index=0, text=text)
+        final_part = dict(part, text=text)
+        yield "response.content_part.done", dict(
+            output_index=0, item_id=item_id, content_index=0, part=final_part)
+        final_item = dict(item, content=[final_part], status="completed")
+    yield "response.output_item.done", dict(output_index=0, item=final_item)
+    yield "response.completed", dict(
+        response=dict(response, status="completed", output=[final_item],
+                      usage=dict(input_tokens=100, output_tokens=100, total_tokens=200)))
+
+
+class FixtureHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def setup(self):
+        super().setup()
+        self.connection.settimeout(15)
+
+    def log_message(self, *_):
+        pass
+
+    def reply_json(self, status, value):
+        data = json.dumps(value).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(data)
+        self.close_connection = True
+
+    def do_GET(self):
+        if self.path == "/status":
+            self.reply_json(200, self.server.observations)
+        else:
+            self.reply_json(404, {"error": "fixture endpoint not found"})
+
+    def do_POST(self):
+        options = self.server.options
+        if self.path != "/v1/responses":
+            self.reply_json(404, {"error": "fixture endpoint not found"})
+            return
+        try:
+            size = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            size = 0
+        if not 0 < size <= options.max_request_bytes:
+            self.reply_json(413, {"error": "missing or excessive Content-Length"})
+            return
+        if self.server.observations["requests"] >= options.max_requests:
+            self.reply_json(429, {"error": "fixture request bound reached"})
+            return
+        try:
+            body = json.loads(self.rfile.read(size))
+            if not isinstance(body, dict):
+                raise ValueError("expected object")
+            turn, round_index = request_position(body, options.rounds)
+            # A driven request ends with the runner's literal user marker.
+            # Background consumers can include that marker inside a transcript
+            # excerpt and can themselves advertise tools; those are still not
+            # driven turns. Never let either kind advance completion counters.
+            users = [item for item in body.get("input", [])
+                     if isinstance(item, dict) and item.get("role") == "user"]
+            auxiliary = (not body.get("tools") or not users or
+                         re.fullmatch(r"MEMORY_TURN_\d+",
+                                      user_text(users[-1]).strip()) is None)
+            if options.tool == "shell-output" and not auxiliary:
+                for item in body.get("input", []):
+                    if (isinstance(item, dict)
+                            and item.get("type") == "function_call_output"
+                            and str(item.get("call_id", "")).startswith(f"call_memory_{turn}_")):
+                        index = int(item["call_id"].rsplit("_", 1)[1])
+                        marker = Path(options.fixture_cwd) / f"output-done-{turn}-{index}"
+                        if not marker.exists() or marker.read_text() != str(options.output_bytes):
+                            raise ValueError("streamed output did not complete")
+            if options.tool == "read-file" and not auxiliary:
+                for item in body.get("input", []):
+                    if (isinstance(item, dict)
+                            and item.get("type") == "function_call_output"
+                            and str(item.get("call_id", "")).startswith(
+                                f"call_memory_{turn}_")):
+                        output = json.dumps(item.get("output", ""), ensure_ascii=False)
+                        if not all(
+                                f"symbol_{index:04d} = synthetic fixture line {index}"
+                                in output for index in range(options.file_lines)):
+                            raise ValueError("read_file did not return fixture content")
+        except (ValueError, TypeError, KeyError):
+            self.reply_json(400, {"error": "invalid synthetic fixture request"})
+            return
+        del body  # Do not retain the received conversation between requests.
+        observation = self.server.observations
+        observation["requests"] += 1
+        observation["request_bytes"] += size
+        observation["latest_turn"] = turn
+        observation["latest_round"] = round_index
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.close_connection = True
+        start = time.monotonic()
+        try:
+            for sequence, (kind, payload) in enumerate(stream_events(
+                    turn, round_index, options, auxiliary=auxiliary)):
+                if self.server.stop_requested or time.monotonic() >= self.server.deadline:
+                    raise TimeoutError("fixture lifetime bound reached")
+                event = dict(type=kind, sequence_number=sequence, **payload)
+                encoded = ("event: " + kind + "\ndata: "
+                           + json.dumps(event, separators=(",", ":")) + "\n\n").encode()
+                self.wfile.write(encoded)
+                self.wfile.flush()
+                observation["response_bytes"] += len(encoded)
+                if options.chunk_delay_ms and kind.endswith(".delta"):
+                    time.sleep(options.chunk_delay_ms / 1000)
+            if round_index == options.rounds and not auxiliary:
+                observation["completed_turn"] = turn
+            observation["completed_requests"] += 1
+            outcome = "completed"
+        except (BrokenPipeError, ConnectionResetError, TimeoutError):
+            observation["disconnected_requests"] += 1
+            outcome = "disconnected"
+        with self.server.log_path.open("a") as log:
+            log.write(json.dumps(dict(unix_seconds=time.time(), turn=turn,
+                                      round=round_index, request_bytes=size,
+                                      auxiliary=auxiliary,
+                                      elapsed_seconds=time.monotonic() - start,
+                                      outcome=outcome)) + "\n")
+        write_json(self.server.status_path, observation)
+
+
+def prepare(root, runtime_root, port, options):
+    home, cwd = runtime_root / "home", root / "cwd"
+    config = root / "home/.haskell-agent"
+    config.mkdir(parents=True)
+    cwd.mkdir()
+    (cwd / "fixture.txt").write_text(
+        "".join(f"symbol_{index:04d} = synthetic fixture line {index}\n"
+                for index in range(options.file_lines)))
+    write_json(config / "models.json", {
+        "version": 1,
+        "connections": {"memory-fixture": {
+            "api": "responses", "base_url": f"http://127.0.0.1:{port}/v1",
+            "api_key_optional": True, "request_timeout_seconds": 120}},
+        "models": [{"id": "memory-fixture", "connection": "memory-fixture",
+                    "model": "memory-fixture", "dialect": "generic-responses",
+                    "context_window": 1000000, "label": "loopback memory fixture"}]})
+    # Intentionally no ambient credentials, user configuration, or gateway.
+    environment = {key: value for key, value in os.environ.items()
+                   if key in {"PATH", "LD_LIBRARY_PATH", "LIBRARY_PATH",
+                              "AGENT_POSTGRES_BIN", "AGENT_SYNTAX_DIR", "TZDIR"}
+                   or (key.startswith("agent_") and key.endswith("_datadir"))}
+    environment.update(HOME=str(home), TMPDIR=os.environ["TMPDIR"],
+                       LANG="C.UTF-8", LC_ALL="C.UTF-8", TERM="xterm-256color",
+                       XDG_CONFIG_HOME=str(home / ".config"),
+                       XDG_CACHE_HOME=str(home / ".cache"),
+                       XDG_DATA_HOME=str(home / ".local/share"),
+                       XDG_STATE_HOME=str(home / ".local/state"),
+                       HASKELL_AGENT_INBOX_DIRECTORY=str(runtime_root / "inbox"),
+                       HASKELL_AGENT_OBSERVATION_DIRECTORY=str(runtime_root / "observation"),
+                       AGENT_HEAP_DIAGNOSTICS=str(root / "heap.csv"))
+    if options.force_gc:
+        environment["AGENT_HEAP_DIAGNOSTICS_FORCE_GC"] = "1"
+    if options.postgres_port:
+        environment["AGENT_POSTGRES_PORT"] = str(options.postgres_port)
+    command = ["env", "-i"] + [f"{key}={value}" for key, value in environment.items()]
+    command += [str(Path(options.cli).resolve()), "--model", "memory-fixture",
+                "--cwd", str(cwd), "--no-agents-md", "--no-skills", "--no-computer-use",
+                "--no-ghci", "--no-code-mode"]
+    if options.tool in {"shell-write", "shell-output"}:
+        # This opt-in workload writes only generated paths in the fresh cwd.
+        command += ["--yolo"]
+    # Arguments before RTS allow the same wrapper to run --resume <ID>.
+    script = ("#!/bin/sh\nexec " + shlex.join(command) + ' "$@" +RTS -N4 -T -s'
+              + (" -hT -i0.1" if options.heap_profile else "")
+              + " -RTS 2>" + shlex.quote(str(root / "cli-stderr.log")) + "\n")
+    (root / "run-cli").write_text(script)
+    (root / "run-cli").chmod(0o700)
+
+
+def stop_fixture_postgres(root):
+    """Stop only the fresh cluster this fixture home could have created."""
+    data = root / "home/.haskell-agent/postgres/data"
+    if not (data / "postmaster.pid").is_file():
+        return
+    binary = str(Path(os.environ["AGENT_POSTGRES_BIN"]) / "pg_ctl") \
+        if os.environ.get("AGENT_POSTGRES_BIN") else "pg_ctl"
+    with (root / "postgres-stop.log").open("w") as log:
+        try:
+            result = subprocess.run(
+                [binary, "-D", str(data), "-m", "fast", "-w", "-t", "30", "stop"],
+                stdout=log, stderr=subprocess.STDOUT, timeout=35, check=False)
+            if result.returncode:
+                raise RuntimeError("fixture PostgreSQL stop failed; inspect postgres-stop.log")
+        except subprocess.TimeoutExpired as error:
+            raise RuntimeError("fixture PostgreSQL stop timed out") from error
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True, help="new run directory under TMPDIR")
+    parser.add_argument("--cli", required=True, help="optimized CLI or frozen exec wrapper")
+    parser.add_argument("--port", type=bounded(0, 65535), default=0)
+    parser.add_argument("--postgres-port", type=bounded(1024, 65535))
+    parser.add_argument("--rounds", type=bounded(0, 100), default=4)
+    parser.add_argument("--tool", choices=["read-file", "shell-write", "shell-output"], default="read-file")
+    parser.add_argument("--output-bytes", type=bounded(1024, 1048576), default=262144)
+    parser.add_argument("--output-chunks", type=bounded(1, 1000), default=200)
+    parser.add_argument("--output-duration-ms", type=bounded(0, 10000), default=3000)
+    parser.add_argument("--write-lines", type=bounded(1, 20000), default=100)
+    parser.add_argument("--argument-padding", type=bounded(0, 8 * 1024 * 1024), default=0)
+    parser.add_argument("--text-bytes", type=bounded(0, 8 * 1024 * 1024), default=4096)
+    parser.add_argument("--file-lines", type=bounded(1, 1000), default=100)
+    parser.add_argument("--chunk-bytes", type=bounded(1, 65536), default=4096)
+    parser.add_argument("--chunk-delay-ms", type=bounded(0, 1000), default=5)
+    parser.add_argument("--max-request-bytes", type=bounded(1024, 128 * 1024 * 1024),
+                        default=64 * 1024 * 1024)
+    parser.add_argument("--max-requests", type=bounded(1, 10000), default=1000)
+    parser.add_argument("--max-seconds", type=bounded(1, 7200), default=1800)
+    parser.add_argument("--force-gc", action="store_true")
+    parser.add_argument("--heap-profile", action="store_true")
+    parser.add_argument("--proc-home", action="store_true",
+                        help="Linux: short /proc/PID/fd alias to TMPDIR-owned run directory")
+    options = parser.parse_args()
+    temporary_root = Path(os.environ["TMPDIR"]).resolve()
+    root = options.root.resolve()
+    if not root.is_relative_to(temporary_root) or root == temporary_root:
+        parser.error("--root must be a new child of TMPDIR")
+    if root.exists():
+        parser.error("--root already exists; use a fresh run directory")
+    # Resolve the executable before entering any fixture directory context.
+    options.cli = str(Path(options.cli).resolve())
+    options.fixture_cwd = str(root / "cwd")
+    runtime_root = root
+    root_fd = None
+    if options.proc_home:
+        if not Path("/proc/self/fd").is_dir():
+            parser.error("--proc-home requires Linux procfs")
+        # The underlying directory remains inside TMPDIR. Keeping this fd open
+        # owns the short alias through CLI/resume and exact-cluster shutdown.
+        root.mkdir(parents=True, mode=0o700)
+        root_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+        runtime_root = Path(f"/proc/{os.getpid()}/fd/{root_fd}")
+    socket_directory = runtime_root / "home/.haskell-agent/postgres/run"
+    observation_socket = runtime_root / "observation" / ("0" * 24)
+    if len(os.fsencode(socket_directory)) > 90 or len(os.fsencode(observation_socket)) >= 104:
+        parser.error("run root is too long for PostgreSQL/observation sockets; "
+                     "use --proc-home on Linux or a short tool-provided TMPDIR")
+    if root_fd is None:
+        root.mkdir(parents=True, mode=0o700)
+    try:
+        serve(root, runtime_root, options)
+    finally:
+        try:
+            stop_fixture_postgres(root)
+        finally:
+            if root_fd is not None:
+                os.close(root_fd)
+
+
+def serve(root, runtime_root, options):
+    with http.server.HTTPServer(("127.0.0.1", options.port), FixtureHandler) as server:
+        server.timeout = 0.25
+        server.options = options
+        server.log_path = root / "requests.jsonl"
+        server.status_path = root / "status.json"
+        server.observations = dict(requests=0, completed_requests=0,
+                                   disconnected_requests=0, request_bytes=0,
+                                   response_bytes=0, latest_turn=0,
+                                   latest_round=0, completed_turn=0)
+        prepare(root, runtime_root, server.server_port, options)
+        write_json(server.status_path, server.observations)
+        write_json(root / "ready.json", dict(port=server.server_port, pid=os.getpid(),
+                                           root=str(root), runtime_root=str(runtime_root),
+                                           options=vars(options) | {"root": str(root)}))
+        print(json.dumps({"root": str(root), "port": server.server_port}), flush=True)
+        server.stop_requested = False
+
+        def request_stop(*_):
+            server.stop_requested = True
+
+        signal.signal(signal.SIGTERM, request_stop)
+        signal.signal(signal.SIGINT, request_stop)
+        server.deadline = time.monotonic() + options.max_seconds
+        while not server.stop_requested and time.monotonic() < server.deadline:
+            server.handle_request()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/agent-cli/benchmark/connected-memory-run.py
+++ b/packages/agent-cli/benchmark/connected-memory-run.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Drive an already-prepared loopback fixture through an owned tmux session.
+
+Samples only the PID recorded by HeapDiagnostics, not the fixture server or
+PostgreSQL. Bounded waits and finally cleanup affect only this runner's pane.
+"""
+
+import argparse
+import csv
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import time
+import uuid
+
+
+def bounded(low, high):
+    def parse(raw):
+        value = int(raw)
+        if not low <= value <= high:
+            raise argparse.ArgumentTypeError(f"must be between {low} and {high}")
+        return value
+    return parse
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--turns", type=bounded(0, 1000), default=5)
+    parser.add_argument("--start-turn", type=bounded(1, 1000), default=1)
+    parser.add_argument("--startup-seconds", type=bounded(1, 120), default=10)
+    parser.add_argument("--idle-seconds", type=bounded(1, 120), default=10)
+    parser.add_argument("--turn-timeout", type=bounded(1, 600), default=120)
+    parser.add_argument("--resume")
+    options = parser.parse_args()
+    root = options.root.resolve()
+    if not root.is_relative_to(Path(os.environ["TMPDIR"]).resolve()):
+        parser.error("--root must be inside TMPDIR")
+    if not (root / "ready.json").exists() or not (root / "run-cli").is_file():
+        parser.error("start connected-memory-fixture.py first")
+    if options.start_turn + options.turns > 1001:
+        parser.error("last turn must be <= 1000")
+    name = "memory-" + uuid.uuid4().hex[:12]
+    output = root / ("drive-" + name)
+    output.mkdir()
+    phase = "startup"
+
+    def tmux(*arguments, check=True):
+        return subprocess.run(["tmux", *arguments], check=check,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              text=True, timeout=10)
+
+    def capture(label):
+        result = tmux("capture-pane", "-p", "-t", name, check=False)
+        (output / f"{label}.txt").write_text(result.stdout)
+        return result.stdout
+
+    def status():
+        return json.loads((root / "status.json").read_text())
+
+    with (output / "rss.csv").open("w", buffering=1) as log:
+        writer = csv.writer(log)
+        writer.writerow(["unix_seconds", "phase", "pid", "rss_kib", "peak_rss_kib"])
+
+        def sample():
+            heap_path = root / "heap.csv"
+            if not heap_path.exists():
+                return
+            with heap_path.open("rb") as heap:
+                heap.seek(0, 2)
+                length = heap.tell()
+                heap.seek(max(0, length - 4096))
+                lines = heap.read().splitlines()
+            for line in reversed(lines):
+                fields = line.split(b",")
+                if len(fields) == 18 and fields[2].isdigit():
+                    pid = int(fields[2])
+                    break
+            else:
+                return
+            try:
+                memory = {}
+                for line in Path(f"/proc/{pid}/status").read_text().splitlines():
+                    if line.startswith(("VmRSS:", "VmHWM:")):
+                        key, value, _ = line.split()
+                        memory[key] = int(value)
+                if "VmRSS:" in memory:
+                    writer.writerow([time.time(), phase, pid,
+                                     memory["VmRSS:"], memory["VmHWM:"]])
+            except FileNotFoundError:
+                pass
+
+        def wait_for(predicate, timeout, description):
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                sample()
+                if predicate():
+                    return
+                if (output / "exit-code").exists():
+                    raise RuntimeError(f"CLI exited before {description}")
+                time.sleep(0.25)
+            raise TimeoutError(description)
+
+        def idle(seconds):
+            deadline = time.monotonic() + seconds
+            wait_for(lambda: time.monotonic() >= deadline, seconds + 1, "idle interval")
+
+        def send(text):
+            tmux("send-keys", "-t", name, "-l", text)
+            time.sleep(0.15)
+            tmux("send-keys", "-t", name, "Enter")
+
+        command = [str(root / "run-cli")]
+        if options.resume:
+            command += ["--resume", options.resume]
+        shell = (shlex.join(command) + "; result=$?; printf '%s\\n' \"$result\" > "
+                 + shlex.quote(str(output / "exit-code")))
+        created = False
+        try:
+            tmux("new-session", "-d", "-s", name, "-x", "120", "-y", "40",
+                 "-c", str(root / "cwd"), shell)
+            created = True
+            idle(options.startup_seconds)
+            startup = capture("startup")
+            if "Couldn’t start the agent" in startup:
+                raise RuntimeError("CLI startup failed; see startup.txt")
+            for turn in range(options.start_turn, options.start_turn + options.turns):
+                phase = f"turn-{turn}"
+                send(f"MEMORY_TURN_{turn}")
+                wait_for(lambda: status()["completed_turn"] == turn,
+                         options.turn_timeout, f"turn {turn} completion")
+                # Network completion precedes final UI reduction/persistence.
+                idle(1)
+                def rendered():
+                    pane = tmux("capture-pane", "-p", "-t", name).stdout
+                    return f"MEMORY_DONE_{turn}" in pane and "✓ Finished" in pane
+                wait_for(rendered, options.turn_timeout,
+                         f"turn {turn} rendered completion")
+                capture(f"turn-{turn}")
+                fixture = json.loads((root / "ready.json").read_text())["options"]
+                if fixture["tool"] == "shell-write":
+                    for round_index in range(fixture["rounds"]):
+                        path = root / "cwd" / f"fixture-edit-{turn}-{round_index}.txt"
+                        expected = "".join(
+                            f"symbol_{index:05d} = synthetic_value_{turn}_{round_index}_{index}\n"
+                            for index in range(fixture["write_lines"]))
+                        if not path.is_file() or path.read_text() != expected:
+                            raise RuntimeError(f"tool output verification failed: {path.name}")
+                phase = f"idle-{turn}"
+                idle(options.idle_seconds)
+            phase = "shutdown"
+            capture("before-exit")
+            send("/quit")
+            wait_for(lambda: (output / "exit-code").exists(), 30, "graceful exit")
+            exit_code = int((output / "exit-code").read_text())
+            if exit_code != 0:
+                raise RuntimeError(f"CLI exit code {exit_code}")
+            (output / "result.json").write_text(json.dumps({
+                "status": "completed", "turns": options.turns,
+                "start_turn": options.start_turn, "fixture": status(),
+                "resumed": bool(options.resume)}) + "\n")
+            print(json.dumps({"output": str(output), "status": "completed"}))
+        finally:
+            if created and tmux("has-session", "-t", name, check=False).returncode == 0:
+                capture("failure")
+                # First request cancellation/exit, then close this owned pane.
+                tmux("send-keys", "-t", name, "C-c", check=False)
+                tmux("kill-session", "-t", name, check=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -191,6 +191,34 @@ benchmark display-journal-bench
                     , text
                     , time
 
+benchmark display-journal-retention-bench
+    import:           common-opts
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark, src
+    main-is:          DisplayJournalRetention.hs
+    other-modules:    Agent.Dialect
+                    , Agent.Error
+                    , Agent.Loop.DisplayJournal
+                    , Agent.Loop.EventPump
+                    , Agent.Loop.Output
+                    , Agent.Loop.TokenUsage
+                    , Agent.Provider
+                    , Agent.Telemetry
+                    , Agent.TextBuffer
+                    , Agent.ToolDispatch
+    ghc-options:      -O2 -threaded -rtsopts "-with-rtsopts=-T"
+    build-depends:    agent-json
+                    , agent-responses-types
+                    , aeson
+                    , async
+                    , base >= 4.14 && < 5
+                    , bytestring
+                    , containers
+                    , safe-exceptions
+                    , stm
+                    , text
+                    , time
+
 benchmark concurrent-discovery-bench
     import:           common-opts
     type:             exitcode-stdio-1.0

--- a/packages/agent-core/benchmark/DisplayJournal.hs
+++ b/packages/agent-core/benchmark/DisplayJournal.hs
@@ -36,6 +36,7 @@ data Workload
     | TextAfterToolSuccess
     | ToolsFailure
     | ToolsSuccess
+    | ToolsRetractOnce
     | RetryRetract
 
 data Sample = Sample
@@ -111,11 +112,12 @@ retainedJournal mode tools snapshots size = case mode of
         pure (project <$> readIORef ref, writeIORef ref empty)
 
 runBenchmark :: [String] -> IO ()
+runBenchmark args | length args == 5 = runBenchmark (args <> ["20"])
 runBenchmark args = do
     enabled <- getRTSStatsEnabled
     unless enabled $ die "RTS stats disabled; use +RTS -T"
     case args of
-        [modeArg, workloadArg, countArg, sizeArg, samplesArg] -> do
+        [modeArg, workloadArg, countArg, sizeArg, samplesArg, repetitionsArg] -> do
             mode <- case modeArg of
                 "old" -> pure Old
                 "new" -> pure New
@@ -127,11 +129,13 @@ runBenchmark args = do
                 "text-after-tool-success" -> pure TextAfterToolSuccess
                 "tools-failure" -> pure ToolsFailure
                 "tools-success" -> pure ToolsSuccess
+                "tools-retract-once" -> pure ToolsRetractOnce
                 "retry-retract" -> pure RetryRetract
                 _ -> die "unknown workload"
             count <- positive countArg
             size <- positive sizeArg
             sampleCount <- positive samplesArg
+            repetitions <- positive repetitionsArg
             validatePrefixes
             -- Separate fixtures prevent validation from evaluating timed work.
             old <- runJournal Old workload (fixture workload count size 0)
@@ -149,7 +153,7 @@ runBenchmark args = do
                 (median (map (.wallMs) samples) / fromIntegral repetitions)
                 (median (map (.cpuMs) samples) / fromIntegral repetitions)
                 (median (map (.allocated) samples) `div` fromIntegral repetitions)
-        _ -> die "usage: display-journal-bench old|new WORKLOAD COUNT BODY_BYTES SAMPLES"
+        _ -> die "usage: display-journal-bench old|new WORKLOAD COUNT BODY_BYTES SAMPLES [REPETITIONS]"
 
 -- Exercise removals at every position, shared update slots, discarded attempts,
 -- reused call ids and text chunk boundaries, including observations before a
@@ -207,9 +211,6 @@ positive raw = case reads raw of
     [(n, "")] | n > 0 -> pure n
     _ -> die ("expected positive integer: " <> raw)
 
-repetitions :: Int
-repetitions = 20
-
 -- Exercise the same strict IORef admission/clear/discard operations as
 -- recordVisibleLoopEvent. A failed turn forces retained projection; success
 -- drops it, matching the loop's TurnFinished branch. This deliberately
@@ -256,6 +257,9 @@ fixture workload count size salt = case workload of
     TextAfterToolSuccess -> ToolStarted (makeCall 1) : texts
     ToolsFailure -> tools
     ToolsSuccess -> tools
+    -- Keep every existing call so this measures the cost of rebuilding
+    -- surviving journal nodes, including the first retraction conversion.
+    ToolsRetractOnce -> tools <> [ToolRetracted "unrelated-call"]
     RetryRetract ->
         tools
             <> [ResponseRestarted "retry"]

--- a/packages/agent-core/benchmark/DisplayJournalRetention.hs
+++ b/packages/agent-core/benchmark/DisplayJournalRetention.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- Cumulative streamed tool snapshots, measured while the response attempt is
+-- still live. Unlike a prebuilt input list, the producer cannot root obsolete
+-- snapshots independently of the journal. Run independent processes for RSS.
+module Main (main) where
+
+import Agent.Loop.DisplayJournal
+import Agent.Loop.Output (LoopEvent(..))
+import Agent.ToolDispatch (ToolCall(..), functionToolCall)
+-- safe-exceptions does not export evaluate.
+import Control.Exception (evaluate)
+import Control.Exception.Safe (bracket)
+import Control.Monad (forM_, unless)
+import Data.Char (ord)
+import Data.List (foldl')
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Foreign.StablePtr (newStablePtr, freeStablePtr, deRefStablePtr)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+data Workload = Arguments | Output | Mixed | TextOnly
+    deriving (Eq, Show)
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    unless enabled (die "run with +RTS -T")
+    getArgs >>= \case
+        [kind, countArg, stepArg, callsArg, samplesArg] -> do
+            workload <- case kind of
+                "arguments" -> pure Arguments
+                "output" -> pure Output
+                "mixed" -> pure Mixed
+                "text" -> pure TextOnly
+                _ -> die "workload: arguments | output | mixed | text"
+            count <- positive countArg
+            step <- positive stepArg
+            calls <- positive callsArg
+            samples <- positive samplesArg
+            forM_ [1 .. samples] $ \sample ->
+                measure workload count step calls sample
+        _ -> die "usage: journal-retention WORKLOAD SNAPSHOTS_PER_CALL CHUNK_BYTES CALLS SAMPLES +RTS -T"
+
+positive :: String -> IO Int
+positive value = case reads value of
+    [(n, "")] | n > 0 -> pure n
+    _ -> die "dimensions must be positive integers"
+
+measure :: Workload -> Int -> Int -> Int -> Int -> IO ()
+measure workload count step calls sample = do
+    performGC
+    before <- getRTSStats
+    wall0 <- getMonotonicTimeNSec
+    cpu0 <- getCPUTime
+    bracket (build workload count step calls sample >>= newStablePtr)
+        freeStablePtr $ \root -> do
+            cpu1 <- getCPUTime
+            wall1 <- getMonotonicTimeNSec
+            -- Pin the raw, as-yet-unprojected journal across this collection.
+            performGC
+            admitted <- getRTSStats
+            projectionWall0 <- getMonotonicTimeNSec
+            projectionCpu0 <- getCPUTime
+            journal <- deRefStablePtr root
+            checksum <- evaluate $
+                foldl' (\acc event -> acc + eventChecksum event) 0
+                    (displayEventsFromJournal journal)
+            projectionCpu1 <- getCPUTime
+            projectionWall1 <- getMonotonicTimeNSec
+            performGC
+            projected <- getRTSStats
+            printf "workload=%s snapshots=%d chunk_bytes=%d calls=%d sample=%d admission_wall_ms=%.3f admission_cpu_ms=%.3f admission_allocated_bytes=%d admission_live_bytes=%d projection_wall_ms=%.3f projection_cpu_ms=%.3f projection_allocated_bytes=%d projected_live_bytes=%d checksum=%d\n"
+                (show workload) count step calls sample
+                (fromIntegral (wall1 - wall0) / 1e6 :: Double)
+                (fromIntegral (cpu1 - cpu0) / 1e9 :: Double)
+                (allocated_bytes admitted - allocated_bytes before)
+                (gcdetails_live_bytes (gc admitted))
+                (fromIntegral (projectionWall1 - projectionWall0) / 1e6 :: Double)
+                (fromIntegral (projectionCpu1 - projectionCpu0) / 1e9 :: Double)
+                (allocated_bytes projected - allocated_bytes admitted)
+                (gcdetails_live_bytes (gc projected))
+                checksum
+
+-- Payload construction is intentionally included in both variants. Each call
+-- advances one independent cumulative ASCII snapshot per round; no input event
+-- list survives. Projection occurs only AFTER the admission-live measurement.
+{-# NOINLINE build #-}
+build :: Workload -> Int -> Int -> Int -> Int -> IO DisplayJournal
+build workload count step calls salt = go 1 emptyDisplayJournal
+  where
+    go !roundIndex !journal
+        | roundIndex > count = pure journal
+        | otherwise = do
+            updated <- callLoop roundIndex 1 journal
+            go (roundIndex + 1) updated
+    callLoop !roundIndex !identifier !journal
+        | identifier > calls = pure journal
+        | otherwise = do
+            let callId = Text.pack ("call-" <> show identifier)
+                chunk = Text.singleton (toEnum (97 + (salt + identifier) `mod` 26))
+                size = if workload == TextOnly then step else roundIndex * step
+                payload = Text.replicate size chunk
+                call = functionToolCall callId "apply_patch" payload
+            -- Force every payload to model a decoded provider snapshot, even
+            -- when the journal implementation stores event payloads lazily.
+            _ <- evaluate (Text.length payload)
+            updated <- evaluate $ case workload of
+                Arguments -> recordDisplayEvent (ToolArgumentsUpdated call) journal
+                Output -> recordDisplayEvent (ToolOutputUpdated callId payload) journal
+                Mixed ->
+                    recordDisplayEvent (ToolOutputUpdated callId payload) $
+                        recordDisplayEvent (ToolArgumentsUpdated call) journal
+                TextOnly -> recordDisplayEvent (TextDelta payload) journal
+            callLoop roundIndex (identifier + 1) updated
+
+eventChecksum :: LoopEvent -> Int
+eventChecksum = \case
+    TextDelta text -> checksumText text
+    ToolArgumentsUpdated call -> checksumText call.arguments
+    ToolUpdated call -> checksumText call.arguments
+    ToolOutputUpdated _ output -> checksumText output
+    _ -> 1
+
+checksumText :: Text -> Int
+checksumText = Text.foldl' (\acc character -> acc + ord character) 0

--- a/packages/agent-core/benchmark/DisplayJournalRetention.md
+++ b/packages/agent-core/benchmark/DisplayJournalRetention.md
@@ -1,5 +1,11 @@
 # Cumulative display-journal retention
 
+**Rejected optimization; benchmark retained.** Production `DisplayJournal.hs`
+has been restored exactly to `ed2a95290`. This PR now adds profiling tools and
+behavior/performance guardrails, not a production memory optimization. The
+historical candidate below is `80be75c3`, available in this branch's history.
+Its component memory savings are not present in the restored implementation.
+
 `DisplayJournalRetention.hs` measures the journal while a response attempt is
 still live, before failure projection or successful completion clears it.
 It complements `DisplayJournal.hs`, whose ordinary successful/failed-turn
@@ -7,8 +13,8 @@ workloads guard against admission overhead.
 
 ## Method
 
-Compare separately built executables from the current implementation before
-adjacent snapshot replacement and the candidate after it. **This baseline is
+Compare separately built executables from baseline `ed2a95290` and the rejected
+candidate `80be75c3` (or a future redesign). **This baseline is
 not `DisplayJournalBaseline.hs`**, the older implementation used by the existing
 benchmark's `old` mode.
 
@@ -44,10 +50,10 @@ Admission live bytes therefore include the live journal and runtime overhead.
 Projection is measured separately and fully checksummed. Payload construction
 is included in admission allocations and CPU for both variants.
 
-## Component results
+## Historical component results (rejected candidate)
 
 GHC 9.10.3, `-O2`, `+RTS -N4 -T`, medians of three samples. Decimal MB.
-These compare the frozen current-before baseline with the final candidate,
+These compare the frozen baseline with the rejected `80be75c3` candidate,
 including both helper `INLINE` pragmas.
 
 | Workload | Live MB before → after | Admission allocated MB before → after | Admission CPU ms before → after |
@@ -119,13 +125,64 @@ tool calls measured median CPU 0.001292 → 0.001834 ms (about 42%, but only
 duplicated argument-update pattern matches passed `--verify` but did not remove
 the cost: a matched three-way sweep measured baseline 0.001272 ms, direct
 0.001798 ms, and inlined helpers 0.001813 ms. Both alternatives allocated
-6,697 bytes versus 6,641 before. Keep the shorter inlined implementation;
-the extra head inspection and ID comparison are not free. This is a measured
-component trade-off, not a claim of zero CPU regression.
+6,697 bytes versus 6,641 before. The extra head inspection and ID comparison
+are not free. This regression is not an acceptable shipping trade-off.
+
+## CPU follow-up: restore the baseline
+
+Further optimized, separately compiled experiments tried flat output nodes,
+argument-update tags, a strict journal head, forced admission inlining, and
+output-only replacement. None cleared all ordinary-workload guardrails.
+Consequently **all production journal changes were removed**, rather than
+trading a small-turn regression for a streaming/retraction regression.
+
+For the output-only flat-node experiment, three alternating process pairs
+(31 samples for tools, 15 for text, default 20 repetitions per sample) gave:
+
+| Workload | Baseline CPU ms → experiment | Baseline bytes → experiment |
+|---|---:|---:|
+| Successful tools, 4 calls × 16 updates | 0.001300 → 0.001236 | 6,641 → 5,617 |
+| Successful tools, 100 calls × 16 updates | 0.036770 → 0.034032 | 162,545 → 136,945 |
+| Text success, 1,000 × 16 B | 0.008268 → 0.009585 | 48,145 → 48,145 |
+| Text after tool success, 10,000 × 16 B | 0.127150 → 0.149774 | 480,169 → 480,169 |
+| Retry/retract, 100 calls | 2.392683 → 2.278436 | 9,893,129 → 10,475,529 |
+
+Thus the initial ~15% tool allocation win was rejected: text CPU and repeated
+retraction allocation regressed. Reversing process order confirmed the small
+text regression. Removing forced inlining and converting surviving output
+nodes back to ordinary events during retraction each addressed only part of
+the problem, not all guardrails.
+
+The smallest alternative changed only the `ToolOutputUpdated` admission arm:
+replace an adjacent same-ID output inside an ordinary `DisplayJournalEvent`,
+with no new constructor or `INLINE` pragma. Three alternating pairs of 31
+samples still measured four-call CPU 0.001307 → 0.001390 ms and 1,000-chunk
+text CPU 0.008099 → 0.008466 ms; allocations were unchanged. It was also
+rejected. These are component experiments, not whole-CLI CPU measurements.
+
+Reproduce guardrails with separately compiled `DisplayJournal.hs` executables,
+the flags above, and identical forced fixtures:
+
+```sh
+# Run inside nix develop, alternating BEFORE/AFTER for three process pairs.
+"$TIMING_BEFORE" new tools-success 4 64 31 +RTS -N4 -T
+"$TIMING_AFTER" new tools-success 4 64 31 +RTS -N4 -T
+"$TIMING_AFTER" new tools-retract-once 4 64 31 +RTS -N4 -T
+"$TIMING_AFTER" new retry-retract 100 64 31 +RTS -N4 -T
+"$TIMING_AFTER" new text-success 1000 16 15 +RTS -N4 -T
+"$TIMING_AFTER" new text-after-tool-success 10000 16 15 +RTS -N4 -T
+```
+
+Also cover tool counts 1/4/16/100, success/failure/retry, and all four text
+controls at 1,000/10,000 chunks. `tools-retract-once` retains all existing calls
+and retracts an unrelated ID, catching survivor-node reconstruction costs.
+Optional final `REPETITIONS` defaults to 20; record any override with the
+results, since CSV does not encode it. Increasing it changes fixture residency
+and GC/cache behavior and must not replace the default workload guardrails.
 
 ## Limits
 
-- Only adjacent same-call snapshots of the same projection kind are replaced.
+- The rejected candidate only replaced adjacent same-call snapshots of the same projection kind.
   Interleaved call IDs and alternating arguments/output remain negative controls.
 - Text and restart boundaries are not crossed; prior finishes are never replaced.
 - These numbers are **post-GC live heap and allocated bytes, not process RSS**.

--- a/packages/agent-core/benchmark/DisplayJournalRetention.md
+++ b/packages/agent-core/benchmark/DisplayJournalRetention.md
@@ -1,0 +1,134 @@
+# Cumulative display-journal retention
+
+`DisplayJournalRetention.hs` measures the journal while a response attempt is
+still live, before failure projection or successful completion clears it.
+It complements `DisplayJournal.hs`, whose ordinary successful/failed-turn
+workloads guard against admission overhead.
+
+## Method
+
+Compare separately built executables from the current implementation before
+adjacent snapshot replacement and the candidate after it. **This baseline is
+not `DisplayJournalBaseline.hs`**, the older implementation used by the existing
+benchmark's `old` mode.
+
+Build each revision with the same compiler and flags, keeping executables and
+object directories separate. For example, from the repository root:
+
+```sh
+export BENCHROOT="$TMPDIR/journal-before" # use journal-after for the candidate
+mkdir -p "$BENCHROOT"
+nix develop -c ghc -O2 -threaded -rtsopts \
+  -XGHC2021 -XDerivingStrategies -XBlockArguments -XOverloadedStrings \
+  -XOverloadedRecordDot -XDuplicateRecordFields -XNoFieldSelectors -XLambdaCase \
+  -ipackages/agent-core/src -ipackages/agent-json/src \
+  -ipackages/agent-responses-types/src -outputdir "$BENCHROOT" \
+  packages/agent-core/benchmark/DisplayJournalRetention.hs -o "$BENCHROOT/run"
+
+"$BENCHROOT/run" arguments 1000 64 1 3 +RTS -N4 -T -s
+"$BENCHROOT/run" output 1000 64 1 3 +RTS -N4 -T -s
+"$BENCHROOT/run" mixed 1000 64 1 3 +RTS -N4 -T -s
+"$BENCHROOT/run" arguments 500 64 4 3 +RTS -N4 -T -s
+"$BENCHROOT/run" text 10000 16 1 3 +RTS -N4 -T -s
+```
+
+Arguments are workload, snapshots per call, growth bytes per snapshot, call
+count, and sample count. `text` uses fixed-size chunks instead of cumulative
+snapshots. Calls alternate round-robin; `mixed` alternates argument and output
+updates for each call.
+
+Each cumulative ASCII payload is allocated and forced immediately before
+admission; there is no prebuilt input list retaining obsolete snapshots. A
+stable pointer roots the unprojected journal across a major collection.
+Admission live bytes therefore include the live journal and runtime overhead.
+Projection is measured separately and fully checksummed. Payload construction
+is included in admission allocations and CPU for both variants.
+
+## Component results
+
+GHC 9.10.3, `-O2`, `+RTS -N4 -T`, medians of three samples. Decimal MB.
+These compare the frozen current-before baseline with the final candidate,
+including both helper `INLINE` pragmas.
+
+| Workload | Live MB before → after | Admission allocated MB before → after | Admission CPU ms before → after |
+|---|---:|---:|---:|
+| Arguments, 100 × 64 B, one call | 0.488 → 0.160 | 0.349 → 0.408 | 0.053 → 0.078 |
+| Arguments, 500 × 64 B, one call | 8.226 → 0.190 | 8.138 → 8.430 | 2.513 → 2.416 |
+| Arguments, 1,000 × 64 B, one call | 32.302 → 0.222 | 32.274 → 32.858 | 12.112 → 5.647 |
+| Output, 1,000 × 64 B, one call | 32.322 → 0.218 | 32.322 → 32.850 | 12.339 → 6.022 |
+| Mixed, 1,000 × 64 B, one call | 32.362 → 32.394 | 32.362 → 32.434 | 15.780 → 11.746 |
+| Arguments, 500 × 64 B, four interleaved calls | 32.454 → 32.618 | 32.582 → 33.762 | 14.098 → 13.353 |
+| Text, 10,000 × 16 B | 1.034 → 1.038 | 2.562 → 2.562 | 0.653 → 0.419 |
+
+The final single-call snapshot is only 64,000 bytes; retaining every cumulative
+snapshot previously kept about 32 MB alive. Adjacent replacement cuts measured
+live bytes by approximately **99.3%** here. It does **not** eliminate producer
+allocation of cumulative snapshots. Comparing call IDs also forces some
+benchmark-generated identifier work earlier than the original admission path.
+
+All 33 projection checksums matched across the eleven tested configurations
+(arguments/output/mixed at 100/500/1,000 snapshots, four-call arguments, text).
+The existing `DisplayJournal.hs --verify` also passed.
+
+## Ordinary-workload guardrails and inlining
+
+Use `new` mode in both separately frozen versions of `DisplayJournal.hs` to
+compare current-before against current-after. Build it with the same command
+above, substituting `DisplayJournal.hs`, adding
+`-ipackages/agent-core/benchmark`, and choosing separate timing output directories.
+With those executable paths assigned to `TIMING_BEFORE` and `TIMING_AFTER`:
+
+```sh
+"$TIMING_BEFORE" new tools-success 4 64 7 +RTS -N4 -T
+"$TIMING_AFTER" new tools-success 4 64 7 +RTS -N4 -T
+"$TIMING_AFTER" --verify
+```
+
+The initial candidate introduced selector/helper thunks: ordinary interleaved
+tool workloads allocated an additional 408 bytes per call, roughly 25% on
+successful turns. Explicitly inlining the two local admission helpers reduced
+that to **56 additional bytes per turn**, independent of call count:
+
+| Successful tool calls | Before bytes/turn | Initial candidate | Inlined candidate |
+|---|---:|---:|---:|
+| 1 | 1,769 | 2,177 | 1,825 |
+| 4 | 6,641 | 8,273 | 6,697 |
+| 16 | 26,129 | 32,657 | 26,185 |
+| 100 | 162,545 | 203,345 | 162,601 |
+
+Failed turns likewise add 56 bytes; the two-attempt retry/retraction workload
+adds 112. All eight text controls (success/failure, with/without an initial tool,
+1,000/10,000 chunks) have exactly unchanged allocations.
+
+The inlined candidate independently passed verification and all 33 cumulative
+checksums. Single-call 1,000-snapshot live bytes remained approximately
+0.222 MB for arguments and 0.218 MB for output.
+
+CPU microbenchmarks are noisy. Alternating before/initial-candidate processes
+(three repetitions, 15 samples each) measured text controls essentially flat:
+1,000-chunk CPU medians 0.008728 → 0.008524 ms, and
+0.008668 → 0.008428 ms after a tool. Four-call tool turns added about
+0.000582 ms; 1,000-call turns were approximately flat. The inlined sweep still
+showed small absolute tool-admission overhead. Do not describe this change as
+universally faster.
+
+Fresh alternating processes confirmed the small-turn CPU cost rather than
+explaining it away as noise: five repetitions of 31 samples at four successful
+tool calls measured median CPU 0.001292 → 0.001834 ms (about 42%, but only
+0.542 microseconds per turn). An independently compiled alternative with direct
+duplicated argument-update pattern matches passed `--verify` but did not remove
+the cost: a matched three-way sweep measured baseline 0.001272 ms, direct
+0.001798 ms, and inlined helpers 0.001813 ms. Both alternatives allocated
+6,697 bytes versus 6,641 before. Keep the shorter inlined implementation;
+the extra head inspection and ID comparison are not free. This is a measured
+component trade-off, not a claim of zero CPU regression.
+
+## Limits
+
+- Only adjacent same-call snapshots of the same projection kind are replaced.
+  Interleaved call IDs and alternating arguments/output remain negative controls.
+- Text and restart boundaries are not crossed; prior finishes are never replaced.
+- These numbers are **post-GC live heap and allocated bytes, not process RSS**.
+  Measure RSS with an external process observer in independent runs.
+- This is a generated component workload, not a whole-CLI connected-session
+  measurement. It does not establish a 20% whole-application memory reduction.

--- a/packages/agent-core/src/Agent/Loop/DisplayJournal.hs
+++ b/packages/agent-core/src/Agent/Loop/DisplayJournal.hs
@@ -37,11 +37,9 @@ replayableDisplayEvent = \case
     ToolRetracted _ -> True
     _ -> False
 
--- Admission remains a cheap chunk/event cons operation, except that adjacent
--- superseded tool snapshots are replaced to release cumulative streamed payloads.
--- Successful responses clear the journal without projecting it; other
--- normalization waits until failed output is retained. Entries and text chunks
--- are newest-first. Tails deliberately
+-- Admission remains a cheap chunk/event cons operation: successful responses
+-- clear the journal without projecting it. Normalize only when failed output
+-- is retained. Entries and text chunks are newest-first. Tails deliberately
 -- remain lazy, preserving prefix release and sharing during retractions.
 data DisplayJournal
     = EmptyDisplayJournal
@@ -60,32 +58,14 @@ recordDisplayEvent event journal = case event of
         DisplayJournalText chunks rest ->
             DisplayJournalText (delta : chunks) rest
         _ -> DisplayJournalText [delta] journal
-    ToolUpdated call -> recordUpdate call.callId
-    ToolArgumentsUpdated call -> recordUpdate call.callId
     ToolOutputUpdated callId output ->
-        recordOutput callId
-            (ToolOutputUpdated callId (boundLoopToolOutput output))
+        DisplayJournalEvent
+            (ToolOutputUpdated callId (boundLoopToolOutput output)) journal
     ToolFinished result ->
-        recordOutput result.callId
-            (ToolFinished result { output = boundLoopToolOutput result.output })
+        DisplayJournalEvent
+            (ToolFinished result { output = boundLoopToolOutput result.output }) journal
     ToolRetracted callId -> retractRawTool callId journal
     _ -> DisplayJournalEvent event journal
-  where
-    -- Inspect only the head: never cross text, restart, or other event boundaries.
-    -- Updates share one projection slot; a finish suppresses earlier output
-    -- snapshots, but never another finish.
-    {-# INLINE recordUpdate #-}
-    recordUpdate callId = case journal of
-        DisplayJournalEvent (ToolUpdated previous) rest
-            | previous.callId == callId -> DisplayJournalEvent event rest
-        DisplayJournalEvent (ToolArgumentsUpdated previous) rest
-            | previous.callId == callId -> DisplayJournalEvent event rest
-        _ -> DisplayJournalEvent event journal
-    {-# INLINE recordOutput #-}
-    recordOutput callId boundedEvent = case journal of
-        DisplayJournalEvent (ToolOutputUpdated previousId _) rest
-            | previousId == callId -> DisplayJournalEvent boundedEvent rest
-        _ -> DisplayJournalEvent boundedEvent journal
 
 -- Retractions keep the former lazy-filter behavior: forcing the new journal
 -- immediately releases a removed leading prefix, and the remaining tail is

--- a/packages/agent-core/src/Agent/Loop/DisplayJournal.hs
+++ b/packages/agent-core/src/Agent/Loop/DisplayJournal.hs
@@ -37,9 +37,11 @@ replayableDisplayEvent = \case
     ToolRetracted _ -> True
     _ -> False
 
--- Admission remains a cheap chunk/event cons operation: successful responses
--- clear the journal without projecting it. Normalize only when failed output
--- is retained. Entries and text chunks are newest-first. Tails deliberately
+-- Admission remains a cheap chunk/event cons operation, except that adjacent
+-- superseded tool snapshots are replaced to release cumulative streamed payloads.
+-- Successful responses clear the journal without projecting it; other
+-- normalization waits until failed output is retained. Entries and text chunks
+-- are newest-first. Tails deliberately
 -- remain lazy, preserving prefix release and sharing during retractions.
 data DisplayJournal
     = EmptyDisplayJournal
@@ -58,14 +60,32 @@ recordDisplayEvent event journal = case event of
         DisplayJournalText chunks rest ->
             DisplayJournalText (delta : chunks) rest
         _ -> DisplayJournalText [delta] journal
+    ToolUpdated call -> recordUpdate call.callId
+    ToolArgumentsUpdated call -> recordUpdate call.callId
     ToolOutputUpdated callId output ->
-        DisplayJournalEvent
-            (ToolOutputUpdated callId (boundLoopToolOutput output)) journal
+        recordOutput callId
+            (ToolOutputUpdated callId (boundLoopToolOutput output))
     ToolFinished result ->
-        DisplayJournalEvent
-            (ToolFinished result { output = boundLoopToolOutput result.output }) journal
+        recordOutput result.callId
+            (ToolFinished result { output = boundLoopToolOutput result.output })
     ToolRetracted callId -> retractRawTool callId journal
     _ -> DisplayJournalEvent event journal
+  where
+    -- Inspect only the head: never cross text, restart, or other event boundaries.
+    -- Updates share one projection slot; a finish suppresses earlier output
+    -- snapshots, but never another finish.
+    {-# INLINE recordUpdate #-}
+    recordUpdate callId = case journal of
+        DisplayJournalEvent (ToolUpdated previous) rest
+            | previous.callId == callId -> DisplayJournalEvent event rest
+        DisplayJournalEvent (ToolArgumentsUpdated previous) rest
+            | previous.callId == callId -> DisplayJournalEvent event rest
+        _ -> DisplayJournalEvent event journal
+    {-# INLINE recordOutput #-}
+    recordOutput callId boundedEvent = case journal of
+        DisplayJournalEvent (ToolOutputUpdated previousId _) rest
+            | previousId == callId -> DisplayJournalEvent boundedEvent rest
+        _ -> DisplayJournalEvent boundedEvent journal
 
 -- Retractions keep the former lazy-filter behavior: forcing the new journal
 -- immediately releases a removed leading prefix, and the remaining tail is

--- a/packages/agent-core/test-visible-state/Spec.hs
+++ b/packages/agent-core/test-visible-state/Spec.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import Agent.Loop.Output
+import Agent.Loop.DisplayJournal
 import Agent.Loop.VisibleState
 import Agent.ToolDispatch
     ( functionToolCall, setToolCallArguments, ToolCallResult(..)
@@ -145,6 +146,59 @@ main = hspec $ describe "VisibleLoopState event sequences" do
         lateTool.providerAttemptActive `shouldBe` False
         visibleAssistantText next `shouldBe` Just "next"
         visibleDisplayEvents next `shouldBe` [TextDelta "next"]
+
+    it "discards snapshots without forcing superseded output" do
+        let old = error "discarded output was evaluated"
+            state = events
+                [ TurnStarted, ToolOutputUpdated "c1" "prior"
+                , ResponseRestarted "retry", ToolUpdated call
+                , ToolOutputUpdated "c1" old, ResponseAttemptDiscarded
+                ]
+        visibleDisplayEvents state `shouldBe`
+            [ToolOutputUpdated "c1" "prior", ResponseRestarted "retry"]
+
+    it "projects the latest output without evaluating its obsolete predecessor" do
+        let journal = recordDisplayEvent
+                (ToolOutputUpdated "c1" (error "superseded output was evaluated"))
+                emptyDisplayJournal
+        journal `seq` pure ()
+        displayEventsFromJournal
+            (recordDisplayEvent (ToolOutputUpdated "c1" "latest") journal)
+            `shouldBe` [ToolOutputUpdated "c1" "latest"]
+
+    it "projects a finish without evaluating the output snapshot it suppresses" do
+        let journal = recordDisplayEvent
+                (ToolOutputUpdated "c1" (error "suppressed output was evaluated"))
+                emptyDisplayJournal
+            finished = ToolCallResult
+                { callId = "c1", output = "finished", callKind = FunctionCallKind
+                , toolResultMode = BlockingToolCall, toolResultImages = []
+                , toolResultOutcome = Nothing
+                }
+        journal `seq` pure ()
+        displayEventsFromJournal (recordDisplayEvent (ToolFinished finished) journal)
+            `shouldBe` [ToolFinished finished]
+
+    it "keeps surviving output payloads lazy across repeated unrelated retractions" do
+        let journal = recordDisplayEvent
+                (ToolOutputUpdated "c1" (error "surviving output was evaluated"))
+                emptyDisplayJournal
+            retracted = recordDisplayEvent (ToolRetracted "other") journal
+            retractedAgain = recordDisplayEvent (ToolRetracted "another") retracted
+        journal `seq` pure ()
+        retracted `seq` pure ()
+        retractedAgain `seq` pure ()
+        displayEventsFromJournal
+            (recordDisplayEvent (ToolOutputUpdated "c1" "latest") retractedAgain)
+            `shouldBe` [ToolOutputUpdated "c1" "latest"]
+
+    it "releases an output head without evaluating the filtered tail" do
+        let journal = foldl' (flip recordDisplayEvent) emptyDisplayJournal
+                [ ToolOutputUpdated (error "tail ID was evaluated") "tail"
+                , TextDelta "boundary", ToolOutputUpdated "c1" "head"
+                ]
+            retracted = recordDisplayEvent (ToolRetracted "c1") journal
+        retracted `seq` (pure () :: IO ())
   where
     events = foldl' (flip recordVisibleLoopEvent) emptyVisibleLoopState
     call = functionToolCall "c1" "tool" "{}"

--- a/packages/agent-core/test-visible-state/Spec.hs
+++ b/packages/agent-core/test-visible-state/Spec.hs
@@ -2,7 +2,10 @@ module Main (main) where
 
 import Agent.Loop.Output
 import Agent.Loop.VisibleState
-import Agent.ToolDispatch (functionToolCall)
+import Agent.ToolDispatch
+    ( functionToolCall, setToolCallArguments, ToolCallResult(..)
+    , ToolCallKind(..), ToolCallMode(..)
+    )
 import Test.Hspec
 
 main :: IO ()
@@ -85,6 +88,50 @@ main = hspec $ describe "VisibleLoopState event sequences" do
         visibleDisplayEvents state `shouldBe`
             [ToolStarted call, TextDelta "prior", ResponseRestarted "retry", TextDelta "current"]
         visibleAssistantText state `shouldBe` Just "prior\n\ncurrent"
+
+    it "keeps only the latest alternating argument snapshot" do
+        let first = setToolCallArguments "partial" call
+            latest = setToolCallArguments "complete" call
+        visibleDisplayEvents (events
+            [TurnStarted, ToolStarted call, ToolUpdated first,
+             ToolArgumentsUpdated latest, ToolUpdated latest]) `shouldBe`
+            [ToolStarted call, ToolUpdated latest]
+
+    it "does not collapse text boundaries while superseding snapshots" do
+        visibleDisplayEvents (events
+            [ TurnStarted, TextDelta "before", ToolOutputUpdated "c1" "old"
+            , TextDelta "between", ToolOutputUpdated "c1" "new"
+            , ToolOutputUpdated "c1" "latest", TextDelta "after"
+            ]) `shouldBe`
+            [ TextDelta "before", TextDelta "between"
+            , ToolOutputUpdated "c1" "latest", TextDelta "after"
+            ]
+
+    it "retains other calls and earlier attempts when snapshots repeat" do
+        visibleDisplayEvents (events
+            [ TurnStarted, ToolOutputUpdated "c1" "prior"
+            , ResponseRestarted "retry", ToolOutputUpdated "c1" "first"
+            , ToolOutputUpdated "c2" "other", ToolOutputUpdated "c1" "second"
+            , ToolOutputUpdated "c1" "latest", ToolRetracted "c1"
+            ]) `shouldBe`
+            [ ToolOutputUpdated "c1" "prior", ResponseRestarted "retry"
+            , ToolOutputUpdated "c2" "other"
+            ]
+
+    it "preserves repeated finishes and output arriving after the final finish" do
+        let finished output = ToolCallResult
+                { callId = "c1", output, callKind = FunctionCallKind
+                , toolResultMode = BlockingToolCall, toolResultImages = []
+                , toolResultOutcome = Nothing
+                }
+            first = finished "first"
+            second = finished "second"
+        visibleDisplayEvents (events
+            [ TurnStarted, ToolOutputUpdated "c1" "old", ToolFinished first
+            , ToolOutputUpdated "c1" "between", ToolFinished second
+            , ToolOutputUpdated "c1" "late", ToolOutputUpdated "c1" "latest"
+            ]) `shouldBe`
+            [ToolFinished first, ToolFinished second, ToolOutputUpdated "c1" "latest"]
 
     it "uses an empty snapshot at commit before completion is painted" do
         -- The IO commit checkpoint installs this value directly, not via a


### PR DESCRIPTION
## Summary

Profiling/benchmark PR only. **The production journal optimization has been removed** to address the confirmed CPU regression. `packages/agent-core/src` is unchanged from baseline `ed2a95290`.

Retains the connected CLI/tmux memory harness, cumulative-journal retention benchmark, behavior/laziness coverage, and ordinary CPU/allocation guardrails. Adds a single-unrelated-retraction workload and optional benchmark repetitions.

## Why the optimization was removed

The previous candidate (`80be75c3`) increased four-tool component CPU from 1.292 to 1.834 microseconds per turn (~42%), while actual CLI RSS improvements were not meaningful. Multiple optimized redesigns were measured rather than accepting that trade-off:

- Flat output-only nodes reduced ordinary four-tool allocations 6,641 → 5,617 bytes and CPU 1.300 → 1.236 microseconds, but regressed 1,000-chunk text CPU 8.268 → 9.585 microseconds and 100-call retry/retraction allocation 9,893,129 → 10,475,529 bytes.
- Removing forced inlining and changing retraction representation addressed only parts of those regressions.
- Minimal output-only replacement using the original representation still measured four-tool CPU 1.307 → 1.390 microseconds, with unchanged allocations.

No redesign is shipped. Restoring the original production implementation removes the added CPU/allocation overhead, but also gives up the experimental journal-retention savings. The 20% ordinary whole-CLI memory target remains unmet.

## Measurements and reproduction

Linux, GHC 9.10.3, optimized `-O2`, `+RTS -N4 -T`. Equivalent forced fixtures, separately compiled baseline/candidates, three alternating process pairs; 31 tool samples and 15 text samples, default 20 repetitions. Multiple tool/text sizes, success/failure/retry and negative controls.

Commands, tables, and historical results:
- `packages/agent-core/benchmark/DisplayJournalRetention.md`
- `packages/agent-cli/benchmark/ConnectedMemory.md`
- `packages/agent-cli/benchmark/ConnectedMemoryResults.md`

Historical actual-CLI measurements refer explicitly to rejected `80be75c3`, not the current PR. Ordinary reads had no RSS improvement; streamed terminal-output median reduction was only 0.49% with overlapping ranges. Dynamic code/data mappings dominated the development binary's RSS.

## Validation

- Restored production source matches `ed2a95290` exactly.
- 18 visible-state/laziness examples pass in GHCi.
- Optimized full CLI and both journal benchmarks rebuilt; projection verifier and benchmark smoke checks pass.
- No new UI/runtime behavior is introduced. Historical connected tmux validation remains documented separately.

No merge requested.
