### PR TITLE
Add explicit queue and steer prompt commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ An independent agent harness, written in Haskell.
 nix run --accept-flake-config "github:digitallyinduced/haskell-agent"
 ```
 
+## Steering and queued prompts
+
+While a fullscreen terminal turn is running, plain text prompts steer the current turn.
+Use `/steer <prompt>` to do this explicitly, or `/queue <prompt>` to wait
+until the current turn finishes. Bare `/queue` lists waiting prompts.
+When idle, either prompt command starts a new turn.
+
 ## Supported LLM Providers
 
 - OpenAI (Subscription)

--- a/packages/agent-cli/src/Agent/CLI/Command.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command.hs
@@ -265,7 +265,6 @@ simpleSlashCommands =
         , ("permissions", ReplPermissions)
         , ("fast", ReplSelection ReplToggleFast)
         , ("view-plan", ReplViewPlan)
-        , ("queue", ReplQueue)
         , ("transcript", ReplTranscript)
         , ("edit-prompt", ReplEditPrompt)
         , ("context", ReplContext)
@@ -335,6 +334,11 @@ parseSpecializedSlashCommand catalog raw spec args commandTail =
         "model" -> parseModelCommand args
         "theme" -> parseThemeCommand args
         "plan" -> parseOptionalTextCommand ReplPlan commandTail
+        "queue" ->
+            if Text.null commandTail
+                then ReplQueue
+                else ReplQueuedPrompt commandTail
+        "steer" -> parseRequiredTextCommand ReplPrompt spec commandTail
         "btw" ->
             parseRequiredTextCommand
                 ReplBtw

--- a/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Catalog.hs
@@ -22,7 +22,8 @@ slashCommands =
     , codexCmd "fast" [] "/fast" "Toggle the Fast service tier" False
     , cmd "plan" [] "/plan [description]" "Enter plan mode (or Shift+Tab)" True
     , cmd "view-plan" ["show-plan", "plan-view"] "/view-plan" "Show the saved session plan" False
-    , cmd "queue" [] "/queue" "Show prompts waiting in the input queue" False
+    , cmd "queue" [] "/queue [prompt]" "Queue a prompt after the current turn, or show queued prompts" True
+    , cmd "steer" [] "/steer <prompt>" "Steer the current turn (the default for plain prompts)" True
     , cmd "transcript" ["log"] "/transcript" "Open the session transcript in a pager" False
     , cmd "edit-prompt" [] "/edit-prompt" "Edit a prompt draft without submitting it" False
     , cmd "context" [] "/context" "Show context-window usage and estimates" False

--- a/packages/agent-cli/src/Agent/CLI/Command/Types.hs
+++ b/packages/agent-cli/src/Agent/CLI/Command/Types.hs
@@ -40,6 +40,7 @@ data ReplAction
     | ReplReload
     | ReplUpdateAndRestart
     | ReplPrompt Text
+    | ReplQueuedPrompt !Text
     | ReplExpandedPrompt !Text !Text
       -- ^ Original user-visible text and the model-visible expansion.
     | ReplInit

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl/Commands.hs
@@ -365,6 +365,8 @@ submitReplLine handlerContext finishTurn retryPendingTurn slashCatalog skillInvo
                         runMetaConsoleRequest request
                     ReplPrompt text ->
                         submitPrompt handlerContext finishTurn pasted continue color text
+                    ReplQueuedPrompt text ->
+                        submitPrompt handlerContext finishTurn pasted continue color text
                     ReplExpandedPrompt original expanded ->
                         submitExpandedTurnWithPaste
                             pasted continue color original expanded

--- a/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Composer.hs
@@ -423,6 +423,9 @@ steeringPrompt ui pasted text
         case parseReplLine text of
             ReplPrompt prompt -> Just (pasted, prompt)
             ReplExpandedPrompt _ prompt -> Just (pasted, prompt)
+            -- Keep explicit queued prompts on the normal input channel;
+            -- it is consumed only after the active turn returns.
+            ReplQueuedPrompt _ -> Nothing
             _ -> Nothing
 
 -- | Handle one composer key. The host supplies Ctrl-C policy and conversation

--- a/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/CommandSpec.hs
@@ -408,14 +408,34 @@ spec = do
             parseReplLine "/context" `shouldBe` ReplContext
             parseReplLine "/view-plan now"
                 `shouldBe` ReplCommandError "usage: /view-plan"
-            parseReplLine "/queue now"
-                `shouldBe` ReplCommandError "usage: /queue"
             parseReplLine "/transcript now"
                 `shouldBe` ReplCommandError "usage: /transcript"
             parseReplLine "/edit-prompt now"
                 `shouldBe` ReplCommandError "usage: /edit-prompt"
             parseReplLine "/context now"
                 `shouldBe` ReplCommandError "usage: /context"
+
+        it "queues a prompt while preserving the full suffix" do
+            parseReplLine "/queue inspect the tests"
+                `shouldBe` ReplQueuedPrompt "inspect the tests"
+            parseReplLine "/QUEUE   keep  spaces\nand newlines"
+                `shouldBe` ReplQueuedPrompt "keep  spaces\nand newlines"
+            parseReplLine "/queue /steer literal prompt"
+                `shouldBe` ReplQueuedPrompt "/steer literal prompt"
+            parseReplLine "/queue   "
+                `shouldBe` ReplQueue
+
+        it "steers explicitly while preserving the full suffix" do
+            parseReplLine "/steer inspect the tests"
+                `shouldBe` ReplPrompt "inspect the tests"
+            parseReplLine "/STEER   keep  spaces\nand newlines"
+                `shouldBe` ReplPrompt "keep  spaces\nand newlines"
+            parseReplLine "/steer /queue literal prompt"
+                `shouldBe` ReplPrompt "/queue literal prompt"
+            parseReplLine "/steer"
+                `shouldBe` ReplCommandError "usage: /steer <prompt>"
+            parseReplLine "/steer   "
+                `shouldBe` ReplCommandError "usage: /steer <prompt>"
 
         it "asks a side question with the full suffix" do
             parseReplLine "/btw why this file?"
@@ -483,6 +503,7 @@ spec = do
                     , "plan"
                     , "view-plan"
                     , "queue"
+                    , "steer"
                     , "transcript"
                     , "edit-prompt"
                     , "context"

--- a/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIAppSpec.hs
@@ -266,6 +266,50 @@ spec = do
                     <> map (`FullscreenScriptCachePresent` False) names
                     <> [FullscreenScriptHalt]
                 pure ()
+    describe "active-turn prompt routing" do
+        it "queues explicit queued prompts and steers explicit and plain prompts" $
+            withSystemTempDirectory "agent-tui-prompt-routing" \directory ->
+                bracket
+                    (lookupEnv "HOME")
+                    (\previous -> maybe (unsetEnv "HOME") (setEnv "HOME") previous)
+                    \_ -> do
+                        setEnv "HOME" directory
+                        forM_
+                            [ ("/queue inspect the tests", True)
+                            , ("/steer inspect the tests", False)
+                            , ("inspect the tests", False)
+                            ]
+                            \(draft, queuedPrompt) -> do
+                                completed <- timeout 5_000_000 do
+                                    steeringCalls <- newIORef []
+                                    let running = reduceUi
+                                            (UiSetDraft draft (Text.length draft)) $
+                                                reduceUi (UiLoop TurnStarted) initialUiState
+                                    baseRuntime <- newScriptRuntime running
+                                    let runtime = baseRuntime
+                                            { runtimeSteer = \pasted prompt -> do
+                                                modifyIORef' steeringCalls (<> [(pasted, prompt)])
+                                                pure (Right ())
+                                            }
+                                    (_, submitted) <- runFullscreenScriptWithState
+                                        (initialFullscreenAppState runtime [] AgentRoot [] 0)
+                                        [ FullscreenScriptVty (V.EvKey V.KEnter [])
+                                        , FullscreenScriptHalt
+                                        ]
+                                    queued <- toList <$> atomically
+                                        (Composer.readFullscreenInputs runtime.runtimeInput)
+                                    map (.fullscreenInputLine) queued `shouldBe`
+                                        if queuedPrompt then [ReplText draft] else []
+                                    map (.fullscreenInputQueued) queued `shouldBe`
+                                        if queuedPrompt then [True] else []
+                                    readIORef steeringCalls `shouldReturn`
+                                        if queuedPrompt
+                                            then []
+                                            else [(False, "inspect the tests")]
+                                    submitted.appUi.uiDraft `shouldBe` ""
+                                    submitted.appUi.uiRunning `shouldBe` True
+                                completed `shouldBe` Just ()
+
     describe "active-turn image paste" do
         it "shows a bracketed image paste before the REPL consumes it and survives delayed refreshes" $
             withPastedImageFixtures \path _ -> do

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -130,6 +130,34 @@ spec = describe "fullscreen composer" do
         steeringPrompt initialUiState True "not running"
             `shouldBe` Nothing
 
+    it "steers plain and explicit prompts while a turn is running" do
+        let running = initialUiState { uiRunning = True }
+        steeringPrompt running False "inspect the tests"
+            `shouldBe` Just (False, "inspect the tests")
+        steeringPrompt running False "/steer inspect the tests"
+            `shouldBe` Just (False, "inspect the tests")
+        steeringPrompt running True "/steer keep  spaces\nand newlines"
+            `shouldBe` Just (True, "keep  spaces\nand newlines")
+        steeringPrompt initialUiState False "/steer inspect the tests"
+            `shouldBe` Nothing
+        steeringPrompt running False "/steer"
+            `shouldBe` Nothing
+
+    it "keeps explicit queued prompts out of steering and immediate commands" do
+        let running = initialUiState { uiRunning = True }
+        steeringPrompt running False "/queue inspect the tests"
+            `shouldBe` Nothing
+        steeringPrompt running True "/queue keep  spaces\nand newlines"
+            `shouldBe` Nothing
+        steeringPrompt initialUiState False "/queue inspect the tests"
+            `shouldBe` Nothing
+        immediateReplCommand running (ReplText "/queue inspect the tests")
+            `shouldBe` Nothing
+        immediateReplCommand running (ReplPasted "/queue inspect the tests")
+            `shouldBe` Nothing
+        immediateBtwQuestion running (ReplText "/queue inspect the tests")
+            `shouldBe` Nothing
+
     it "keeps prompts with images out of text-only steering" do
         let prompt = initialUiState.uiPrompt
         steeringPrompt


### PR DESCRIPTION
## Summary
- Add `/queue <prompt>` to defer a prompt until the active fullscreen turn finishes.
- Add `/steer <prompt>` for explicit steering; plain prompts continue to steer by default.
- Preserve bare `/queue` as the queue listing command and update help, completion, documentation, and regression coverage.

## Validation
- Full CLI library loaded successfully in GHCi with `-fprefer-byte-code`.
- CommandSpec and TUIComposerSpec: 145 examples, 0 failures.
- Live fullscreen tmux smoke with a controlled runtime passed: queued prompt remained in the FIFO while explicit and default steering reached the steering callback; explicit command prefix was stripped.
- `git diff --check` passed.
- Additional TUIAppSpec routing regression was added, but its local execution remained unverified because the separate GHCi process stalled during startup.

Concurrent steering remains fullscreen-only; minimal mode continues to read prompts between turns.