### PR TITLE
Fix stuck fullscreen state and stranded steering input

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -37,8 +37,8 @@ import Agent.CLI.Input
 import Agent.OpenAI.Models.Types (ModelInfo(..), modelServiceTierForRequest)
 import Agent.Runtime.Models ( catalogModelIds )
 import Agent.CLI.SteeringInputs
-    ( awaitBackgroundCompletion
-    , hasBackgroundCompletions
+    ( awaitSteeringInput
+    , readSteeringInputs
     )
 import Agent.CLI.Provider.Switch
     ( reportProviderUnavailable, requestStartupProviderFallback )
@@ -141,7 +141,7 @@ sessionContinuation =
 
 data ReplWake
     = ProviderUnavailableWake !ApiError
-    | BackgroundCompletionWake
+    | SteeringInputWake
 
 runPendingTurn
     :: PendingTurnPresentation
@@ -318,17 +318,17 @@ replWithDraft env@SessionEnv
                         Left text -> (ReplText text, True)
                         Right line -> (line, False)
     case mlineResult of
-        Left BackgroundCompletionWake -> do
+        Left SteeringInputWake -> do
             pending <-
-                hasBackgroundCompletions env.sessionSteeringInputs
-            if not pending
+                readSteeringInputs env.sessionSteeringInputs
+            if null pending
                 then replWithDraft env draft
                 else do
                     forM_ fullscreen \runtime ->
                         emitUiEvent runtime
                             (UiSystemMessage
-                                "Background task completed; resuming the agent.")
-                    -- Keep the notice in the normal steering queue so it is
+                                "Queued input received; resuming the agent.")
+                    -- Keep inputs in the normal steering queue so each is
                     -- acknowledged only after the provider commits it.
                     result <- runOneTurn env "" []
                     finishTurn env False result
@@ -394,21 +394,21 @@ readFullscreenPrompt
         \_ -> do
             startupUnavailable <- readIORef env.sessionStartupUnavailable
             failedTurn <- readIORef env.sessionLastFailedTurn
-            let backgroundWake =
+            let steeringWake =
                     case failedTurn of
                         -- Preserve the user's retry candidate. Its next retry
                         -- or replacement turn will consume the queued
-                        -- completion through normal steering.
+                        -- input through normal steering.
                         Just _ -> retry
                         Nothing ->
-                            BackgroundCompletionWake
-                                <$ awaitBackgroundCompletion
+                            SteeringInputWake
+                                <$ awaitSteeringInput
                                     env.sessionSteeringInputs
                 wake = case startupUnavailable of
-                    Nothing -> backgroundWake
+                    Nothing -> steeringWake
                     Just unavailable ->
                         (ProviderUnavailableWake <$> unavailable)
-                            `orElse` backgroundWake
+                            `orElse` steeringWake
             (withAsync
                 (refreshBackgroundTaskStatus env runtime (not (isJust failedTurn)))
                 \_ ->

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Repl.hs
@@ -38,7 +38,7 @@ import Agent.OpenAI.Models.Types (ModelInfo(..), modelServiceTierForRequest)
 import Agent.Runtime.Models ( catalogModelIds )
 import Agent.CLI.SteeringInputs
     ( awaitSteeringInput
-    , readSteeringInputs
+    , readSteeringTurn
     )
 import Agent.CLI.Provider.Switch
     ( reportProviderUnavailable, requestStartupProviderFallback )
@@ -319,8 +319,8 @@ replWithDraft env@SessionEnv
                         Right line -> (line, False)
     case mlineResult of
         Left SteeringInputWake -> do
-            pending <-
-                readSteeringInputs env.sessionSteeringInputs
+            (promptText, pending) <-
+                readSteeringTurn env.sessionSteeringInputs
             if null pending
                 then replWithDraft env draft
                 else do
@@ -329,8 +329,10 @@ replWithDraft env@SessionEnv
                             (UiSystemMessage
                                 "Queued input received; resuming the agent.")
                     -- Keep inputs in the normal steering queue so each is
-                    -- acknowledged only after the provider commits it.
-                    result <- runOneTurn env "" []
+                    -- acknowledged only after the provider commits it. The
+                    -- prompt text preserves user guidance in durable history;
+                    -- it does not add a second copy to provider inputs.
+                    result <- runOneTurn env promptText []
                     finishTurn env False result
         Left (ProviderUnavailableWake apiError) -> do
             -- The startup check is one-shot. If no fallback account is usable,

--- a/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
+++ b/packages/agent-cli/src/Agent/CLI/Session/Lifecycle.hs
@@ -43,7 +43,8 @@ import Agent.CLI.Session.Interaction
 import Agent.CLI.Session.Retry (waitAndRetryPendingTurn)
 import Agent.CLI.SessionEnv (SessionEnv(..))
 import Agent.CLI.Session.Workspace (WorkspaceContext(..))
-import Agent.CLI.SteeringInputs (hasBackgroundCompletionWake)
+import Agent.CLI.SteeringInputs
+    ( hasSteeringInputWake, suppressUserSteeringWake )
 import Agent.CLI.Render
     ( RenderConfig(..)
     , putTextLn
@@ -184,6 +185,7 @@ finishTurnWithCooldownRetry continuation allowCooldownRetry env exitAfter = \cas
             then pure RunQuit
             else continueAfterTurn continuation env
     TurnCancelled -> do
+        suppressUserSteeringWake env.sessionSteeringInputs
         case env.sessionFullscreen of
             Nothing -> putTrailingNewline env.sessionRender
             Just _ -> pure ()
@@ -278,11 +280,11 @@ continueAfterTurn continuation env
         queued <- case env.sessionFullscreen of
             Nothing -> pure False
             Just runtime -> hasQueuedFullscreenInput runtime
-        backgroundCompletion <-
-            hasBackgroundCompletionWake env.sessionSteeringInputs
+        steeringWake <-
+            hasSteeringInputWake env.sessionSteeringInputs
         failedTurn <- readIORef env.sessionLastFailedTurn
         let willWake = case env.sessionFullscreen of
-                Just _ -> backgroundCompletion && isNothing failedTurn
+                Just _ -> steeringWake && isNothing failedTurn
                 Nothing -> False
         when (not queued && not willWake) $
             notifyAttention env.sessionRender.renderStderr InputRequested

--- a/packages/agent-cli/src/Agent/CLI/SteeringInputs.hs
+++ b/packages/agent-cli/src/Agent/CLI/SteeringInputs.hs
@@ -12,6 +12,7 @@ module Agent.CLI.SteeringInputs
     , newSteeringInputs
     , prepareBackgroundCompletion
     , readSteeringInputs
+    , readSteeringTurn
     , steeringInputByteLimit
     , steeringInputCountLimit
     , suppressUserSteeringWake
@@ -21,7 +22,7 @@ import Agent.CLI.InputBudget
     ( logicalTurnInputBytes
     , saturatingAdd
     )
-import Agent.Loop (TurnInput)
+import Agent.Loop (TurnInput(..))
 import Data.Foldable (toList)
 import Control.Concurrent.STM
     ( STM
@@ -36,6 +37,7 @@ import Control.Concurrent.STM
     )
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
+import qualified Data.Text as Text
 
 steeringInputCountLimit :: Int
 steeringInputCountLimit = 128
@@ -156,6 +158,24 @@ readSteeringInputs :: SteeringInputs -> IO [TurnInput]
 readSteeringInputs (SteeringInputs ref) = do
     state <- readTVarIO ref
     pure [entry.steeringInput | entry <- toList state.steeringQueue]
+
+-- | Snapshot an idle wake's display text and pending inputs together. Inputs
+-- remain queued until the provider acknowledges them; the text is metadata
+-- for the enclosing turn, not another provider input. Background notices
+-- must not acquire the identity of a user submission.
+readSteeringTurn :: SteeringInputs -> IO (Text, [TurnInput])
+readSteeringTurn (SteeringInputs ref) = do
+    state <- readTVarIO ref
+    let entries = toList state.steeringQueue
+        userText entry =
+            case (entry.steeringBackgroundKey, entry.steeringInput) of
+                (Nothing, UserMessage text) -> [text]
+                (Nothing, UserMessageWithAttachments text _) -> [text]
+                _ -> []
+    pure
+        ( Text.intercalate "\n\n" (concatMap userText entries)
+        , map (.steeringInput) entries
+        )
 
 hasBackgroundCompletions :: SteeringInputs -> IO Bool
 hasBackgroundCompletions (SteeringInputs ref) = do

--- a/packages/agent-cli/src/Agent/CLI/SteeringInputs.hs
+++ b/packages/agent-cli/src/Agent/CLI/SteeringInputs.hs
@@ -1,19 +1,20 @@
 -- | A bounded queue of steering inputs retained while a turn is active.
 module Agent.CLI.SteeringInputs
     ( SteeringInputs
-    , awaitBackgroundCompletion
+    , awaitSteeringInput
     , clearSteeringInputs
     , commitSteeringInputs
     , dismissBackgroundCompletion
     , enqueueBackgroundCompletion
     , enqueueSteeringInputs
-    , hasBackgroundCompletionWake
+    , hasSteeringInputWake
     , hasBackgroundCompletions
     , newSteeringInputs
     , prepareBackgroundCompletion
     , readSteeringInputs
     , steeringInputByteLimit
     , steeringInputCountLimit
+    , suppressUserSteeringWake
     ) where
 
 import Agent.CLI.InputBudget
@@ -46,7 +47,7 @@ data SteeringEntry = SteeringEntry
     { steeringInput :: !TurnInput
     , steeringBytes :: !Int
     , steeringBackgroundKey :: !(Maybe Text)
-    , steeringBackgroundWake :: !Bool
+    , steeringWake :: !Bool
     }
 
 data SteeringState = SteeringState
@@ -73,7 +74,7 @@ enqueueSteeringInputs (SteeringInputs ref) inputs =
                     input
                     (logicalTurnInputBytes input)
                     Nothing
-                    False
+                    True
                 | input <- inputs
                 ]
             addedCount = length measured
@@ -163,22 +164,24 @@ hasBackgroundCompletions (SteeringInputs ref) = do
         any (maybe False (const True) . (.steeringBackgroundKey))
             state.steeringQueue
 
-hasBackgroundCompletionWake :: SteeringInputs -> IO Bool
-hasBackgroundCompletionWake (SteeringInputs ref) = do
+hasSteeringInputWake :: SteeringInputs -> IO Bool
+hasSteeringInputWake (SteeringInputs ref) = do
     state <- readTVarIO ref
-    pure $ any (.steeringBackgroundWake) state.steeringQueue
+    pure $ any (.steeringWake) state.steeringQueue
 
--- | Consume pending idle-wake edges without removing their notices. Keeping
--- notice queued preserves the loop's commit-on-provider-success semantics;
+-- | Consume pending idle-wake edges without removing their inputs. Every
+-- accepted input has an edge: guidance arriving after the active loop's final
+-- read must start a follow-up turn rather than remain stranded at the prompt.
+-- Keeping inputs queued preserves the loop's commit-on-provider-success semantics;
 -- consuming the edge prevents a failed synthetic turn from hot-looping.
-awaitBackgroundCompletion :: SteeringInputs -> STM ()
-awaitBackgroundCompletion (SteeringInputs ref) = do
+awaitSteeringInput :: SteeringInputs -> STM ()
+awaitSteeringInput (SteeringInputs ref) = do
     state <- readTVar ref
-    check $ any (.steeringBackgroundWake) state.steeringQueue
+    check $ any (.steeringWake) state.steeringQueue
     writeTVar ref state
         { steeringQueue =
             fmap
-                (\entry -> entry { steeringBackgroundWake = False })
+                (\entry -> entry { steeringWake = False })
                 state.steeringQueue
         }
 
@@ -199,6 +202,19 @@ dismissBackgroundCompletion (SteeringInputs ref) key =
             { steeringQueue = kept
             , steeringBytes = keptBytes
             }
+
+-- | Cancelling a turn must not immediately restart it with earlier guidance.
+-- Retain that guidance for the next explicit turn, without changing managed
+-- background completion wake behavior.
+suppressUserSteeringWake :: SteeringInputs -> IO ()
+suppressUserSteeringWake (SteeringInputs ref) =
+    atomically $ modifyTVar' ref \state ->
+        state
+            { steeringQueue = fmap suppress state.steeringQueue }
+  where
+    suppress entry = case entry.steeringBackgroundKey of
+        Nothing -> entry { steeringWake = False }
+        Just _ -> entry
 
 commitSteeringInputs :: SteeringInputs -> Int -> IO ()
 commitSteeringInputs (SteeringInputs ref) count =

--- a/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/AgentSessionsSpec.hs
@@ -8,8 +8,8 @@ import Agent.CLI.Options (ApprovalPolicy(..))
 import Agent.Runtime.Session
 import Agent.Runtime.SessionLock
 import Agent.CLI.SteeringInputs
-    ( awaitBackgroundCompletion, clearSteeringInputs, commitSteeringInputs
-    , hasBackgroundCompletionWake, newSteeringInputs
+    ( awaitSteeringInput, clearSteeringInputs, commitSteeringInputs
+    , hasSteeringInputWake, newSteeringInputs
     , prepareBackgroundCompletion, readSteeringInputs )
 import Agent.Dialect (DialectId(..))
 import Agent.Loop (TurnInput(..), defaultLoopDispatch)
@@ -605,11 +605,11 @@ spec = describe "Agent.CLI.AgentSessions" do
                 (\status -> void $ enqueue "child:turn-1" $
                     UserMessage (formatSessionCompletionNotice "child" status))
                 (pure (Right ()))
-            timeout 1000000 (atomically (awaitBackgroundCompletion steering))
+            timeout 1000000 (atomically (awaitSteeringInput steering))
                 `shouldReturn` Just ()
             -- Consuming the idle-wake edge must not consume the model input.
             readSteeringInputs steering `shouldReturn` [notice]
-            hasBackgroundCompletionWake steering `shouldReturn` False
+            hasSteeringInputWake steering `shouldReturn` False
             readSteeringInputs steering `shouldReturn` [notice]
             commitSteeringInputs steering 1
             readSteeringInputs steering `shouldReturn` []
@@ -627,13 +627,13 @@ spec = describe "Agent.CLI.AgentSessions" do
             putMVar gate ()
             waitForThreadStatus manager "child" "completed"
             readSteeringInputs steering `shouldReturn` []
-            hasBackgroundCompletionWake steering `shouldReturn` False
+            hasSteeringInputWake steering `shouldReturn` False
             -- New work belongs to the new conversation and can wake it.
             current <- prepareBackgroundCompletion steering
             current "child:turn-2" (UserMessage "new completion")
                 `shouldReturn` Right True
             readSteeringInputs steering `shouldReturn` [UserMessage "new completion"]
-            hasBackgroundCompletionWake steering `shouldReturn` True
+            hasSteeringInputWake steering `shouldReturn` True
 
     it "serializes and reports in-process session turns" $
         withTempSessionThreadManager ["blocked", "failed"] \_ manager -> do

--- a/packages/agent-cli/test/Agent/CLI/PendingInputsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PendingInputsSpec.hs
@@ -17,15 +17,18 @@ import Agent.CLI.PendingInputs
     , withPendingInputs
     )
 import Agent.CLI.SteeringInputs
-    ( awaitBackgroundCompletion
+    ( awaitSteeringInput
+    , clearSteeringInputs
     , commitSteeringInputs
     , dismissBackgroundCompletion
     , enqueueBackgroundCompletion
     , enqueueSteeringInputs
     , hasBackgroundCompletions
+    , hasSteeringInputWake
     , newSteeringInputs
     , readSteeringInputs
     , steeringInputCountLimit
+    , suppressUserSteeringWake
     )
 import Agent.Error (ApiError(..))
 import Agent.Loop
@@ -521,6 +524,14 @@ spec = do
             all (`notElem` [UserMessage "omitted one", UserMessage "omitted two"])
 
   describe "SteeringInputs" do
+    it "does not wake for an empty enqueue" do
+        steering <- newSteeringInputs
+        enqueueSteeringInputs steering [] `shouldReturn` Right ()
+        readSteeringInputs steering `shouldReturn` []
+        hasSteeringInputWake steering `shouldReturn` False
+        timeout 10000 (atomically (awaitSteeringInput steering))
+            `shouldReturn` Nothing
+
     it "bounds, commits, and admits steering inputs in order" do
         steering <- newSteeringInputs
         let queued =
@@ -539,12 +550,81 @@ spec = do
         readSteeringInputs steering `shouldReturn`
             drop 2 queued <> [UserMessage "new-1", UserMessage "new-2"]
 
-    it "wakes only for keyed background completions and dismisses them" do
+    it "wakes for ordinary input, retains it until commit, and does not hot-loop" do
+        steering <- newSteeringInputs
+        enqueueSteeringInputs steering [UserMessage "make a pr"]
+            `shouldReturn` Right ()
+        hasSteeringInputWake steering `shouldReturn` True
+        timeout 100000 (atomically (awaitSteeringInput steering))
+            `shouldReturn` Just ()
+        readSteeringInputs steering `shouldReturn` [UserMessage "make a pr"]
+        hasSteeringInputWake steering `shouldReturn` False
+        timeout 10000 (atomically (awaitSteeringInput steering))
+            `shouldReturn` Nothing
+        commitSteeringInputs steering 1
+        readSteeringInputs steering `shouldReturn` []
+
+    it "preserves the wake for guidance arriving after the active turn snapshot" do
+        steering <- newSteeringInputs
+        enqueueSteeringInputs steering [UserMessage "first"]
+            `shouldReturn` Right ()
+        snapshot <- readSteeringInputs steering
+        enqueueSteeringInputs steering [UserMessage "late"]
+            `shouldReturn` Right ()
+        commitSteeringInputs steering (length snapshot)
+        timeout 100000 (atomically (awaitSteeringInput steering))
+            `shouldReturn` Just ()
+        readSteeringInputs steering `shouldReturn` [UserMessage "late"]
+
+    it "does not wake for inputs already committed by the active turn" do
+        steering <- newSteeringInputs
+        enqueueSteeringInputs steering [UserMessage "consumed"]
+            `shouldReturn` Right ()
+        commitSteeringInputs steering 1
+        hasSteeringInputWake steering `shouldReturn` False
+        timeout 10000 (atomically (awaitSteeringInput steering))
+            `shouldReturn` Nothing
+
+    it "wakes again for new guidance after a previous wake was consumed" do
+        steering <- newSteeringInputs
+        enqueueSteeringInputs steering [UserMessage "first"]
+            `shouldReturn` Right ()
+        atomically (awaitSteeringInput steering)
+        enqueueSteeringInputs steering [UserMessage "second"]
+            `shouldReturn` Right ()
+        timeout 100000 (atomically (awaitSteeringInput steering))
+            `shouldReturn` Just ()
+        readSteeringInputs steering `shouldReturn`
+            [UserMessage "first", UserMessage "second"]
+        clearSteeringInputs steering
+        readSteeringInputs steering `shouldReturn` []
+        hasSteeringInputWake steering `shouldReturn` False
+
+    it "suppresses cancelled guidance wakes without dropping input or future wakes" do
+        steering <- newSteeringInputs
+        enqueueSteeringInputs steering [UserMessage "cancelled guidance"]
+            `shouldReturn` Right ()
+        suppressUserSteeringWake steering
+        hasSteeringInputWake steering `shouldReturn` False
+        readSteeringInputs steering `shouldReturn`
+            [UserMessage "cancelled guidance"]
+        enqueueSteeringInputs steering [UserMessage "new guidance"]
+            `shouldReturn` Right ()
+        hasSteeringInputWake steering `shouldReturn` True
+
+    it "preserves background wakes when suppressing cancelled guidance" do
+        steering <- newSteeringInputs
+        enqueueBackgroundCompletion steering "task-1" (UserMessage "completed")
+            `shouldReturn` Right True
+        suppressUserSteeringWake steering
+        hasSteeringInputWake steering `shouldReturn` True
+
+    it "deduplicates keyed background completions and dismisses them" do
         steering <- newSteeringInputs
         enqueueSteeringInputs steering [UserMessage "ordinary"]
             `shouldReturn` Right ()
-        timeout 10000 (atomically (awaitBackgroundCompletion steering))
-            `shouldReturn` Nothing
+        timeout 100000 (atomically (awaitSteeringInput steering))
+            `shouldReturn` Just ()
 
         enqueueBackgroundCompletion
             steering
@@ -557,9 +637,9 @@ spec = do
             (UserMessage "duplicate")
             `shouldReturn` Right False
         hasBackgroundCompletions steering `shouldReturn` True
-        timeout 100000 (atomically (awaitBackgroundCompletion steering))
+        timeout 100000 (atomically (awaitSteeringInput steering))
             `shouldReturn` Just ()
-        timeout 10000 (atomically (awaitBackgroundCompletion steering))
+        timeout 10000 (atomically (awaitSteeringInput steering))
             `shouldReturn` Nothing
         readSteeringInputs steering `shouldReturn`
             [UserMessage "ordinary", UserMessage "completed"]

--- a/packages/agent-cli/test/Agent/CLI/PendingInputsSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/PendingInputsSpec.hs
@@ -27,6 +27,7 @@ import Agent.CLI.SteeringInputs
     , hasSteeringInputWake
     , newSteeringInputs
     , readSteeringInputs
+    , readSteeringTurn
     , steeringInputCountLimit
     , suppressUserSteeringWake
     )
@@ -524,6 +525,33 @@ spec = do
             all (`notElem` [UserMessage "omitted one", UserMessage "omitted two"])
 
   describe "SteeringInputs" do
+    it "snapshots idle guidance as turn text without consuming or duplicating inputs" do
+        steering <- newSteeringInputs
+        let guidance = [UserMessage "make a pr", UserMessage "include tests"]
+        enqueueSteeringInputs steering guidance `shouldReturn` Right ()
+        atomically (awaitSteeringInput steering)
+        readSteeringTurn steering `shouldReturn`
+            ("make a pr\n\ninclude tests", guidance)
+        -- A failed attempt can read the same inputs again. Only the normal
+        -- provider acknowledgement removes them.
+        readSteeringTurn steering `shouldReturn`
+            ("make a pr\n\ninclude tests", guidance)
+        readSteeringInputs steering `shouldReturn` guidance
+        commitSteeringInputs steering (length guidance)
+        readSteeringTurn steering `shouldReturn` ("", [])
+
+    it "preserves attachment guidance text but excludes background notices from user text" do
+        steering <- newSteeringInputs
+        let attached = userMessageWithAttachments "inspect this"
+                [ImageAttachmentItem (ImageAttachment "image/png" "abc")]
+            background = UserMessage "background tool completed"
+        enqueueBackgroundCompletion steering "tool" background
+            `shouldReturn` Right True
+        readSteeringTurn steering `shouldReturn` ("", [background])
+        enqueueSteeringInputs steering [attached] `shouldReturn` Right ()
+        readSteeringTurn steering `shouldReturn`
+            ("inspect this", [background, attached])
+
     it "does not wake for an empty enqueue" do
         steering <- newSteeringInputs
         enqueueSteeringInputs steering [] `shouldReturn` Right ()

--- a/packages/agent-cli/test/Agent/CLI/SessionHistorySpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/SessionHistorySpec.hs
@@ -6,6 +6,10 @@ import Agent.Runtime.Session
     )
 import Agent.CLI.Session.ConversationStore (newConversationStore)
 import Agent.CLI.Session.History (hydrateUiHistory)
+import qualified Agent.CLI.SteeringInputs as Steering
+import Agent.CLI.TUI.SessionHistory (sessionHistoryTurn)
+import Agent.CLI.TUI.History (HistoryTurn(..))
+import Control.Concurrent.STM (atomically)
 import Agent.Runtime.Session.History
     ( foldSessionItems
     , readLiveAttachments
@@ -66,6 +70,24 @@ spec = do
         readLiveAttachments conversationRef `shouldReturn` []
 
     describe "hydrateUiHistory" do
+      it "retains idle wake guidance in both text and detailed history" do
+        steering <- Steering.newSteeringInputs
+        Steering.enqueueSteeringInputs steering [UserMessage "late guidance"]
+            `shouldReturn` Right ()
+        atomically (Steering.awaitSteeringInput steering)
+        (promptText, inputs) <- Steering.readSteeringTurn steering
+        let turn = (sessionTurn promptText (Just "done") TranscriptAppend)
+                { turnItems = turnInputsToItems inputs }
+            textBlocks = Foldable.toList (hydrateUiHistory [turn]).uiBlocks
+            detailedBlocks = Foldable.toList
+                (sessionHistoryTurn (0 :: Int) turn).historyTurnBlocks
+            userBodies blocks =
+                [ block.blockBody | block <- blocks, block.blockKind == BlockUser ]
+        promptText `shouldBe` "late guidance"
+        userBodies textBlocks `shouldBe` ["late guidance"]
+        userBodies detailedBlocks `shouldBe` ["late guidance"]
+        Steering.readSteeringInputs steering `shouldReturn` inputs
+
       it "keeps pre-compaction blocks scrollable while appending the summary" do
         let before = sessionTurn "question" (Just "answer") TranscriptAppend
             compacted =

--- a/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIComposerSpec.hs
@@ -25,7 +25,15 @@ import Agent.CLI.Input
     )
 import Agent.CLI.TUI.Composer
 import Agent.CLI.TUI.Types
-import Agent.Loop (ImageAttachment(..))
+import Agent.CLI.SteeringInputs
+    ( awaitSteeringInput
+    , commitSteeringInputs
+    , enqueueSteeringInputs
+    , hasSteeringInputWake
+    , newSteeringInputs
+    , readSteeringInputs
+    )
+import Agent.Loop (ImageAttachment(..), TurnInput(..))
 import Agent.TUI.Model
     ( NoticeKind(..)
     , PromptState(..)
@@ -656,6 +664,41 @@ spec = describe "fullscreen composer" do
                 (pure ("provider unavailable" :: Text))
         fmap (.fullscreenInputLine) result
             `shouldBe` Right (ReplText "submitted")
+
+    it "wakes an idle prompt reader for late guidance without consuming the input" do
+        buffer <- newFullscreenInputBuffer
+        steering <- newSteeringInputs
+        let readPrompt = fmap (fmap (.fullscreenInputLine)) $ atomically $
+                takeFullscreenInputOr buffer (awaitSteeringInput steering)
+        withAsync readPrompt \reader -> do
+            timeout 20_000 (wait reader) `shouldReturn` Nothing
+            enqueueSteeringInputs steering [UserMessage "make a pr"]
+                `shouldReturn` Right ()
+            timeout 1_000_000 (wait reader) `shouldReturn` Just (Left ())
+        readSteeringInputs steering `shouldReturn` [UserMessage "make a pr"]
+        hasSteeringInputWake steering `shouldReturn` False
+        timeout 20_000 readPrompt `shouldReturn` Nothing
+        commitSteeringInputs steering 1
+        readSteeringInputs steering `shouldReturn` []
+
+    it "leaves a simultaneous guidance wake intact when a submitted prompt wins" do
+        buffer <- newFullscreenInputBuffer
+        steering <- newSteeringInputs
+        atomically (appendFullscreenInput buffer (input (ReplText "submitted")))
+            `shouldReturn` Right ()
+        enqueueSteeringInputs steering [UserMessage "guidance"]
+            `shouldReturn` Right ()
+        let readPrompt = fmap (fmap (.fullscreenInputLine)) $ atomically $
+                takeFullscreenInputOr buffer (awaitSteeringInput steering)
+        result <- readPrompt
+        result `shouldBe` Right (ReplText "submitted")
+        hasSteeringInputWake steering `shouldReturn` True
+        readSteeringInputs steering `shouldReturn` [UserMessage "guidance"]
+        -- The explicit turn consumes this guidance through the normal loop;
+        -- its commit must remove the edge, avoiding a redundant synthetic turn.
+        commitSteeringInputs steering 1
+        hasSteeringInputWake steering `shouldReturn` False
+        timeout 20_000 readPrompt `shouldReturn` Nothing
 
     it "bounds queued prompts and admits another after consumption" do
         buffer <- newFullscreenInputBuffer

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -113,7 +113,7 @@ reduceUi event state = case event of
                 , uiCursor = 0
                 , uiFollow = True
                 , uiNotice =
-                    Just (progressNotice "Steering the current turn…")
+                    Just (progressNotice "Guidance queued…")
                 , uiNoticeElapsedMillis = 0
                 }
     UiInputQueued text ->
@@ -787,15 +787,17 @@ finishVisibleTool result state =
                 _ -> state.uiTodos
         next =
             state
-                { uiRunning = True
-                , uiAwaitingInput = False
-                , uiActivity = "Thinking…"
+                { uiActivity =
+                    if state.uiRunning
+                        then "Thinking…"
+                        else state.uiActivity
                 , uiToolCalls =
                     Map.delete result.callId state.uiToolCalls
                 , uiTodos = todos
                 }
     in case activeCall of
-        Nothing -> next
+        -- Nested or late completions are not evidence of an active turn.
+        Nothing -> state
         Just (blockIndex, call)
             | blockIndex < Seq.length state.uiBlocks
             , Just _ <- trackedShellOwner call next ->

--- a/packages/agent-tui/src/Agent/TUI/Model/Shell.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Shell.hs
@@ -106,9 +106,10 @@ finishShellPoll sessionId result state =
     let
         next =
             state
-                { uiRunning = True
-                , uiAwaitingInput = False
-                , uiActivity = "Thinking…"
+                { uiActivity =
+                    if state.uiRunning
+                        then "Thinking…"
+                        else state.uiActivity
                 , uiShellPolls =
                     Map.delete result.callId state.uiShellPolls
                 }

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -418,6 +418,47 @@ spec = describe "fullscreen UI reducer" do
         map (.blockBody) (Foldable.toList state.uiBlocks)
             `shouldBe` ["failed partial", "complete retry"]
 
+    it "ignores unknown tool completions without reviving an idle turn" do
+        let result = ToolCallResult
+                { toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
+                , callId = "late-nested-call"
+                , output = "done"
+                , callKind = FunctionCallKind
+                }
+            finished = apply
+                [ UiLoop TurnStarted
+                , UiLoop (TurnFinished (emptyTurnOutput "r1" [] (Just "done")))
+                ]
+            idle = reduceUi (UiSetAwaitingInput True) finished
+            writing = apply [UiLoop TurnStarted, UiLoop (TextDelta "next answer")]
+        mapM_ (\state -> reduceUi (UiLoop (ToolFinished result)) state
+            `shouldBe` state) [finished, idle, writing]
+
+    it "updates a late tracked tool result without reviving an idle turn" do
+        let call = functionToolCall "c1" "read_file" "{}"
+            result = ToolCallResult
+                { toolResultMode = BlockingToolCall
+                , toolResultImages = []
+                , toolResultOutcome = Nothing
+                , callId = "c1"
+                , output = "contents"
+                , callKind = FunctionCallKind
+                }
+            idle = apply
+                [ UiLoop TurnStarted
+                , UiLoop (ToolStarted call)
+                , UiSetAwaitingInput True
+                ]
+            completed = reduceUi (UiLoop (ToolFinished result)) idle
+        completed.uiRunning `shouldBe` False
+        completed.uiAwaitingInput `shouldBe` True
+        completed.uiActivity `shouldBe` idle.uiActivity
+        completed.uiToolCalls `shouldBe` mempty
+        map (.blockState) (Foldable.toList completed.uiBlocks)
+            `shouldBe` [BlockComplete]
+
     it "matches tool completion by call id" do
         let call = functionToolCall "c1" "run_terminal_cmd" "{\"command\":\"git status\"}"
             result = ToolCallResult
@@ -723,6 +764,17 @@ spec = describe "fullscreen UI reducer" do
         polled.uiToolCalls `shouldBe` mempty
         polled.uiShellProcesses `shouldBe` mempty
         polled.uiShellPolls `shouldBe` mempty
+
+        let idle = reduceUi (UiSetAwaitingInput True) waiting
+            late = reduceUi
+                (UiLoop (ToolFinished (finished { callId = "poll-1" }))) idle
+        late.uiRunning `shouldBe` False
+        late.uiAwaitingInput `shouldBe` True
+        late.uiActivity `shouldBe` idle.uiActivity
+        late.uiShellPolls `shouldBe` mempty
+        late.uiShellProcesses `shouldBe` mempty
+        map (.blockState) (Foldable.toList late.uiBlocks)
+            `shouldBe` [BlockComplete]
 
     it "keeps the command tracked when an empty poll itself is cancelled" do
         let command =
@@ -2190,7 +2242,7 @@ spec = describe "fullscreen UI reducer" do
         map (.blockBody) (Foldable.toList state.uiBlocks)
             `shouldBe` ["keep the schema"]
         (.noticeText) <$> state.uiNotice
-            `shouldBe` Just "Steering the current turn…"
+            `shouldBe` Just "Guidance queued…"
 
     it "promotes a send-now draft ahead of existing queued inputs" do
         let state =


### PR DESCRIPTION
## Summary
- Prevent unknown tool completions from changing UI state, and preserve idle lifecycle flags when updating tracked tool/shell-poll results.
- Give accepted guidance an atomic idle-wake edge so input arriving after the active loop's final steering read starts a follow-up turn instead of remaining stranded.
- Retain commit-on-provider-success semantics, avoid repeated automatic retries, and suppress ordinary guidance wakes after cancellation without dropping the input or changing background completion behavior.
- Say "Guidance queued…" rather than claiming the current turn will necessarily consume it.
- Preserve guidance queued at idle wake in saved turn metadata, without duplicate provider delivery or background notices leaking into user text.

## Root cause
The reducer treated tool completion as evidence that a turn was running, including completions with unknown call IDs. This could change an idle prompt back to "Thinking…". The composer then routed new text as steering, but ordinary steering had no idle wake path. Separately, guidance could miss the active loop's final input check even without a stale UI event.

The original reducer's idle + unknown ToolFinished failure was reproduced in GHCi; the patched reducer preserves idle state. This establishes the failure path, not the exact event producer/timing in the reported screenshot. Late ToolStarted events are outside this patch's scope.

## Validation
- GHCi (explicit test component in cabal multi-repl): PendingInputsSpec (32), SessionHistorySpec (11), TUIHistorySpec (50), and TUIComposerSpec (62) — 155 examples, 0 failures. Includes saved-history regression coverage for idle-wake guidance.
- GHCi: full Agent.TUI.ModelSpec — 88 examples, 0 failures, including unknown/tracked late completions and late shell-poll completion.
- Source-loaded CLI + TUI GHCi: 256 modules loaded successfully.
- Live fullscreen tmux smoke using the changed CLI and TUI: completed `SMOKE_ONE`, accepted a follow-up prompt, completed `SMOKE_TWO`, and returned to the idle `Enter send` prompt after each turn; exited cleanly. Startup reported a code-mode readiness warning and used the existing direct-tool fallback.
