### PR TITLE
Reduce clipboard capture memory with strict Text

### DIFF
--- a/packages/agent-cli/agent-cli.cabal
+++ b/packages/agent-cli/agent-cli.cabal
@@ -177,6 +177,7 @@ library
                     , Agent.CLI.Btw
                     , Agent.CLI.CancelWatch
                     , Agent.CLI.Clipboard
+                    , Agent.CLI.Clipboard.Process
                     , Agent.CLI.Claude
                     , Agent.CLI.ClaudeGatewayProxy
                     , Agent.CLI.CodeModeRuntime
@@ -570,6 +571,7 @@ test-suite agent-cli-test
                     , Agent.CLI.BtwSpec
                     , Agent.CLI.CancelWatchSpec
                     , Agent.CLI.ClipboardSpec
+                    , Agent.CLI.ClipboardTextSpec
                     , Agent.CLI.ClaudeGatewayProxySpec
                     , Agent.CLI.ClaudeSpec
                     , Agent.CLI.CommandSpec

--- a/packages/agent-cli/benchmark/ClipboardOutput.hs
+++ b/packages/agent-cli/benchmark/ClipboardOutput.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- Standalone optimized benchmark: see ClipboardOutput.md for build/run commands.
+module Main (main) where
+
+import Agent.CLI.Clipboard.Process (readClipboardProcessText)
+import Control.DeepSeq (force)
+import Control.Exception (evaluate)
+import Control.Monad (forM, forM_, unless)
+import qualified Data.ByteString as BS
+import Data.List (sort)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Data.Word (Word64)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.IO.Encoding (setLocaleEncoding, utf8)
+import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs, getEnv)
+import System.Exit (ExitCode(..))
+import System.FilePath ((</>))
+import System.IO.Temp (withTempDirectory)
+import System.Mem (performGC)
+import System.Process (readProcessWithExitCode)
+import Text.Printf (printf)
+
+type Output = (ExitCode, Text.Text, Text.Text)
+
+data Sample = Sample !Double !Double !Word64
+
+main :: IO ()
+main = do
+    -- Make the baseline's locale-sensitive decoder deterministic.
+    setLocaleEncoding utf8
+    enabled <- getRTSStatsEnabled
+    unless enabled (fail "Run with +RTS -T")
+    args <- getArgs
+    case args of
+        ["suite", count] -> do
+            let samples = read count
+            unless (samples > 0) (fail "sample count must be positive")
+            tmp <- getEnv "TMPDIR"
+            withTempDirectory tmp "clipboard-output" $ \dir -> do
+                putStrLn "kind,stdout_bytes,stderr_bytes,pass,method,median_elapsed_ms,median_cpu_ms,median_allocated_bytes"
+                forM_ ["ascii", "unicode"] $ \kind ->
+                    forM_ [1024, 65536, 1048576, 8388608] $ \size ->
+                        benchmark dir samples kind size "initial"
+                forM_ ["ascii", "unicode"] $ \kind ->
+                    benchmark dir samples kind 1048576 "repeat"
+        ["fixture", kind, size, out, err] -> do
+            _ <- writeFixture kind (read size) out err
+            pure ()
+        ["peak", method, out, err] -> do
+            -- No fixture generation, expected payload, baseline warmup, or
+            -- other method in this process: its high-water marks are isolated.
+            result <- capture method out err >>= evaluate . force
+            let (code, stdoutText, stderrText) = result
+            unless (code == ExitSuccess) (fail "fixture subprocess failed")
+            performGC
+            stats <- getRTSStats
+            print (Text.length stdoutText, Text.length stderrText)
+            printf "max_live_bytes=%d max_mem_in_use_bytes=%d\n"
+                (max_live_bytes stats) (max_mem_in_use_bytes stats)
+        _ -> fail "Usage: suite SAMPLES | fixture ascii|unicode BYTES OUT ERR | peak old|new OUT ERR"
+
+-- Always decode and force BOTH streams for both methods; not a stdout-only
+-- baseline that quietly discards the diagnostic stream.
+capture :: String -> FilePath -> FilePath -> IO Output
+capture method out err =
+    let command = "/bin/sh"
+        args = ["-ec", "/bin/cat \"$1\"; /bin/cat \"$2\" >&2", "fixture", out, err]
+    in case method of
+        "old" -> do
+            (code, stdoutString, stderrString) <-
+                readProcessWithExitCode command args ""
+            pure (code, Text.pack stdoutString, Text.pack stderrString)
+        "new" -> readClipboardProcessText command args
+        _ -> fail "method must be old or new"
+
+writeFixture :: String -> Int -> FilePath -> FilePath -> IO Output
+writeFixture kind bytes out err = do
+    unless (bytes >= 0) (fail "fixture size must be nonnegative")
+    unit <- case kind of
+        "ascii" -> pure "clipboard line\r\n"
+        "unicode" -> pure "aé中🙂\r\n"
+        _ -> fail "fixture kind must be ascii or unicode"
+    -- Repeat whole UTF-8 units, then pad with ASCII: exactly the requested byte
+    -- size without ever slicing a multibyte code point.
+    let unitBytes = BS.length (Text.encodeUtf8 unit)
+        (copies, padding) = bytes `divMod` unitBytes
+        stdoutText = Text.replicate copies unit <> Text.replicate padding "x"
+        stderrText = "fixture diagnostic: café 中 🙂\r\n"
+    expected <- evaluate (force (ExitSuccess, stdoutText, stderrText))
+    BS.writeFile out (Text.encodeUtf8 stdoutText)
+    BS.writeFile err (Text.encodeUtf8 stderrText)
+    pure expected
+
+benchmark :: FilePath -> Int -> String -> Int -> String -> IO ()
+benchmark dir count kind size pass = do
+    let out = dir </> "stdout"
+        err = dir </> "stderr"
+    expected@(_, _, stderrText) <- writeFixture kind size out err
+    -- Warm both methods and compare every character, including CR/LF, before
+    -- timing. Every measured result is also compared outside its interval.
+    forM_ ["old", "new"] $ \method ->
+        capture method out err >>= check expected
+    pairs <- forM [1 .. count] $ \index -> do
+        let methods = if odd index then ["old", "new"] else ["new", "old"]
+        forM methods $ \method -> do
+            sample <- measure expected (capture method out err)
+            pure (method, sample)
+    forM_ ["old", "new"] $ \method -> do
+        let samples = [sample | pair <- pairs, (name, sample) <- pair, name == method]
+        printf "%s,%d,%d,%s,%s,%.3f,%.3f,%d\n"
+            kind size (BS.length (Text.encodeUtf8 stderrText)) pass method
+            (median [elapsed | Sample elapsed _ _ <- samples])
+            (median [cpu | Sample _ cpu _ <- samples])
+            (median [allocated | Sample _ _ allocated <- samples])
+
+check :: Output -> Output -> IO ()
+check expected result =
+    unless (result == expected) (fail "captured output differs from fixture")
+
+measure :: Output -> IO Output -> IO Sample
+measure expected action = do
+    performGC
+    before <- getRTSStats
+    cpuBefore <- getCPUTime
+    wallBefore <- getMonotonicTimeNSec
+    result <- action >>= evaluate . force
+    wallAfter <- getMonotonicTimeNSec
+    cpuAfter <- getCPUTime
+    -- Flush per-capability allocation counters. This explicit post-sample GC
+    -- is outside timing; automatic collections during capture remain included.
+    performGC
+    after <- getRTSStats
+    check expected result
+    pure (Sample
+        (fromIntegral (wallAfter - wallBefore) / 1000000)
+        (fromIntegral (cpuAfter - cpuBefore) / 1000000000)
+        (allocated_bytes after - allocated_bytes before))
+
+median :: Ord a => [a] -> a
+median values = sort values !! (length values `div` 2)

--- a/packages/agent-cli/benchmark/ClipboardOutput.md
+++ b/packages/agent-cli/benchmark/ClipboardOutput.md
@@ -1,0 +1,129 @@
+# Clipboard subprocess text capture
+
+This benchmark imports the production `readClipboardProcessText` helper and
+compares it with `readProcessWithExitCode` followed by `Text.pack`. Both methods
+capture, decode, and fully force **both** stdout and stderr. The benchmark also
+packs the baseline's short diagnostic stream, so both return the same tuple.
+It does not touch the user's clipboard or start any clipboard utility.
+
+## Reproduce
+
+From the repository root:
+
+```sh
+mkdir -p "$TMPDIR/clipboard-output-build"
+nix develop -c ghc -O2 -threaded -rtsopts -XBlockArguments -Wall \
+  -ipackages/agent-cli/src \
+  -outputdir "$TMPDIR/clipboard-output-build" \
+  packages/agent-cli/benchmark/ClipboardOutput.hs \
+  -o "$TMPDIR/clipboard-output-build/clipboard-output"
+nix develop -c "$TMPDIR/clipboard-output-build/clipboard-output" \
+  suite 21 +RTS -N4 -T -RTS
+```
+
+The standalone optimized build avoids compiling the unrelated CLI libraries.
+`-N4` matches the CLI's default capability count; the allocation area is the
+RTS default. The benchmark sets the Haskell locale encoding to UTF-8 so the
+baseline's locale-sensitive decoding is deterministic.
+
+Each sample launches real `/bin/sh` and `/bin/cat` subprocesses over private
+fixture files. Stdout is exactly 1 KiB, 64 KiB, 1 MiB, or 8 MiB of ASCII or
+mixed 1/2/3/4-byte UTF-8 characters, including CR/LF. Stderr is a short Unicode
+diagnostic. Fixture construction/writing and warmup are outside measurement.
+The 1 MiB cases repeat at the end; method order alternates within each case.
+All warmup and measured outputs are compared exactly against the fixture,
+including exit code and both streams, outside the measured interval.
+
+Elapsed time includes process startup, pipe IO, decoding, forcing the complete
+strict output, and automatic GC. CPU time and allocated bytes are for the
+parent Haskell process, not the fixture subprocesses. A GC before each sample
+resets the heap; a GC after the timing interval flushes RTS allocation counters.
+The CSV reports independent medians, not a single selected sample.
+
+These are capture-stage measurements, **not end-to-end paste latency**:
+clipboard provider delays, sanitization, prompt insertion and rendering are
+not included.
+
+## Peak memory (separate fresh processes)
+
+Generate fixtures once, then start a new process for each method and sample.
+Do not measure the `suite` process's high-water mark: that would mix fixture
+generation, retained expected output, warmups, and both implementations.
+
+```sh
+nix develop -c bash -c '
+  set -eu
+  bin="$1"
+  dir=$(mktemp -d "$TMPDIR/clipboard-output-peak.XXXXXX")
+  trap '\''rm -rf "$dir"'\'' EXIT
+  for kind in ascii unicode; do
+    for size in 1048576 8388608; do
+      "$bin" fixture "$kind" "$size" "$dir/out" "$dir/err" +RTS -T
+      for sample in 1 2 3 4 5 6 7; do
+        for method in old new; do
+          echo "$kind $size $sample $method"
+          /usr/bin/time -l "$bin" peak "$method" "$dir/out" "$dir/err" \
+            +RTS -N4 -T -RTS
+        done
+      done
+    done
+  done
+' _ "$TMPDIR/clipboard-output-build/clipboard-output"
+```
+
+The command uses macOS `time -l` (maximum RSS in bytes); on Linux use
+`/usr/bin/time -v` (maximum RSS in KiB). `peak` additionally prints RTS
+`max_live_bytes` (maximum sampled live heap at major GC) and
+`max_mem_in_use_bytes` (maximum RTS-managed memory). These are distinct from
+OS RSS and from cumulative allocated bytes. It forces both returned texts and
+keeps them live across a major GC, without loading a reference fixture into
+the parent. Equality is verified in `suite`; the isolated mode prints lengths.
+
+## Reference measurements
+
+2026-09-12, Apple M3 Max, arm64 macOS 26.6.1, Nix GHC 9.10.3,
+`text-2.1.3`, `process-1.6.26.1`, build/RTS settings above. Each cell is
+**old → new**, allocation in decimal MB (1,000,000 bytes). Stderr is 36 bytes.
+Twenty-one samples per method:
+
+| Stdout | Bytes | Elapsed ms | Parent CPU ms | Allocated MB |
+| --- | ---: | ---: | ---: | ---: |
+| ASCII | 1,024 | 10.192 → 9.827 | 0.723 → 0.793 | 0.215 → 0.174 |
+| ASCII | 65,536 | 10.365 → 10.214 | 1.256 → 0.948 | 3.077 → 0.322 |
+| ASCII | 1,048,576 | 42.858 → 13.469 | 35.444 → 3.637 | 46.635 → 2.524 |
+| ASCII | 8,388,608 | 328.115 → 36.969 | 324.307 → 26.824 | 371.869 → 19.124 |
+| Unicode | 1,024 | 10.685 → 11.369 | 0.735 → 0.765 | 0.198 → 0.179 |
+| Unicode | 65,536 | 10.769 → 10.743 | 1.265 → 0.939 | 1.760 → 0.352 |
+| Unicode | 1,048,576 | 25.911 → 13.163 | 18.861 → 3.584 | 25.554 → 2.982 |
+| Unicode | 8,388,608 | 183.187 → 34.260 | 177.177 → 24.807 | 203.246 → 22.716 |
+| ASCII repeat | 1,048,576 | 42.533 → 12.756 | 35.700 → 3.623 | 46.635 → 2.524 |
+| Unicode repeat | 1,048,576 | 26.349 → 13.555 | 18.845 → 3.778 | 25.558 → 2.986 |
+
+At 1–8 MiB the helper reduces allocation by approximately 88–95%, parent CPU
+by 81–92%, and elapsed time by 49–89% in this subprocess fixture. Both paths
+scale approximately linearly in allocation; this removes the large `String`
+intermediate, not a quadratic algorithm.
+
+Small payloads are a performance boundary, not a claimed latency win.
+The extra scoped-reader coordination costs roughly 0.03–0.07 ms parent CPU at
+1 KiB in this run. Their elapsed times are dominated by subprocess startup:
+an initial seven-sample run had Unicode 1 KiB at 10.259 → 9.845 ms, while the
+21-sample run had 10.685 → 11.369 ms. At 64 KiB the initial run had
+12.449 → 13.688 ms ASCII and 10.773 → 11.752 ms Unicode; the longer repeat
+above was effectively flat, while CPU and allocation improved in both runs.
+Do not interpret these sub-millisecond-to-millisecond wall-time variations
+as a reliable small-paste speedup.
+
+Seven independent fresh-process peak-memory samples per method, median
+high-water marks in **MiB** (1,048,576 bytes), old → new:
+
+| Stdout | Bytes | OS maximum RSS | RTS maximum live heap | RTS maximum memory in use |
+| --- | ---: | ---: | ---: | ---: |
+| ASCII | 1,048,576 | 64.609 → 34.672 | 16.781 → 1.106 | 53 → 23 |
+| ASCII | 8,388,608 | 338.609 → 60.734 | 149.618 → 8.101 | 327 → 49 |
+| Unicode | 1,048,576 | 54.594 → 36.703 | 8.856 → 1.106 | 43 → 25 |
+| Unicode | 8,388,608 | 213.594 → 58.703 | 89.813 → 8.106 | 202 → 47 |
+
+The output remains proportional to clipboard size: this is not a bounded-memory
+streaming API. Its improvement is avoiding the transient linked-list character
+representation while retaining the same decoded text.

--- a/packages/agent-cli/src/Agent/CLI/Clipboard/Linux.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard/Linux.hs
@@ -4,6 +4,7 @@ module Agent.CLI.Clipboard.Linux
     , readLinuxClipboardText
     ) where
 
+import Agent.CLI.Clipboard.Process (readClipboardProcessText)
 import Agent.Runtime.Error (formatException)
 import Agent.Loop (ImageAttachment(..))
 import Control.Exception.Safe (bracket, finally, tryAny)
@@ -100,12 +101,12 @@ linuxClipboardUnavailableError =
 
 runTextCmd :: FilePath -> [String] -> IO (Either Text Text)
 runTextCmd cmd args = do
-    result <- tryAny (readProcessWithExitCode cmd args "")
+    result <- tryAny (readClipboardProcessText cmd args)
     pure $ case result of
         Left ex -> Left (formatException ex)
-        Right (ExitSuccess, out, _) -> Right (Text.pack out)
+        Right (ExitSuccess, out, _) -> Right out
         Right (ExitFailure _, _, err) ->
-            Left (Text.strip (Text.pack err))
+            Left (Text.strip err)
 
 runBytesCmd :: FilePath -> [String] -> IO (Either Text ByteString)
 runBytesCmd cmd args = do

--- a/packages/agent-cli/src/Agent/CLI/Clipboard/MacOS.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard/MacOS.hs
@@ -9,6 +9,7 @@ module Agent.CLI.Clipboard.MacOS
     , readMacClipboardText
     ) where
 
+import Agent.CLI.Clipboard.Process (readClipboardProcessText)
 import Agent.Runtime.Error (formatException)
 import Agent.Loop (ImageAttachment(..))
 import Control.Exception.Safe (bracket, finally, tryAny)
@@ -60,12 +61,12 @@ readMacClipboardImage = do
 
 readMacClipboardText :: IO (Either Text Text)
 readMacClipboardText = do
-    result <- tryAny (readProcessWithExitCode "pbpaste" [] "")
+    result <- tryAny (readClipboardProcessText "pbpaste" [])
     pure $ case result of
         Left ex -> Left (formatException ex)
-        Right (ExitSuccess, out, _) -> Right (Text.pack out)
+        Right (ExitSuccess, out, _) -> Right out
         Right (ExitFailure _, _, err) ->
-            Left (Text.strip (Text.pack err))
+            Left (Text.strip err)
 
 readMacClipboardPaths :: IO [FilePath]
 readMacClipboardPaths = do

--- a/packages/agent-cli/src/Agent/CLI/Clipboard/Process.hs
+++ b/packages/agent-cli/src/Agent/CLI/Clipboard/Process.hs
@@ -1,0 +1,42 @@
+-- | Text capture for clipboard commands, without an intermediate String.
+module Agent.CLI.Clipboard.Process
+    ( readClipboardProcessText
+    ) where
+
+import Control.Concurrent.Async (concurrently)
+import Data.Text (Text)
+import qualified Data.Text.IO as Text
+import System.Exit (ExitCode)
+import System.IO (hClose)
+import System.Process
+    ( CreateProcess(..)
+    , StdStream(CreatePipe)
+    , proc
+    , waitForProcess
+    , withCreateProcess
+    )
+
+-- | Run a command with empty stdin and capture both streams as strict Text.
+-- Leave the handles' locale encoding and newline translation unchanged, just
+-- like readProcessWithExitCode. Both streams must be drained concurrently to
+-- avoid blocking a child that fills its stderr pipe while producing stdout.
+-- The process and reader threads are scoped so failures and cancellation clean
+-- up the handles and child rather than leaving background readers behind.
+readClipboardProcessText :: FilePath -> [String] -> IO (ExitCode, Text, Text)
+readClipboardProcessText cmd args =
+    withCreateProcess
+        (proc cmd args)
+            { std_in = CreatePipe
+            , std_out = CreatePipe
+            , std_err = CreatePipe
+            }
+        \input output errors process ->
+            case (input, output, errors) of
+                (Just stdinHandle, Just stdoutHandle, Just stderrHandle) -> do
+                    hClose stdinHandle
+                    (out, err) <- concurrently
+                        (Text.hGetContents stdoutHandle)
+                        (Text.hGetContents stderrHandle)
+                    code <- waitForProcess process
+                    pure (code, out, err)
+                _ -> ioError (userError "clipboard process pipes unavailable")

--- a/packages/agent-cli/test/Agent/CLI/ClipboardTextSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/ClipboardTextSpec.hs
@@ -1,0 +1,152 @@
+module Agent.CLI.ClipboardTextSpec (spec) where
+
+import Agent.CLI.Clipboard (readClipboardText)
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (cancel, waitCatch, withAsync)
+import Control.Exception.Safe (bracket)
+import Data.Either (isLeft)
+import qualified Data.Text as Text
+import GHC.IO.Encoding (getLocaleEncoding, setLocaleEncoding)
+import System.Directory
+    ( Permissions(executable), createDirectory, doesFileExist, getPermissions
+    , getTemporaryDirectory, removeFile, removePathForcibly, setPermissions
+    )
+import System.Environment (getEnv, lookupEnv, setEnv, unsetEnv)
+import System.FilePath ((</>))
+import System.Info (os)
+import System.IO (TextEncoding, hClose, latin1, openBinaryTempFile, utf8)
+import System.Timeout (timeout)
+import Test.Hspec
+
+-- PATH contains only our fixtures, never the real clipboard readers. These
+-- tests deliberately do not call the image/type probes or mutate the clipboard.
+spec :: Spec
+spec = sequential $ describe "clipboard text subprocesses" do
+    it "preserves Unicode under the locale UTF-8 decoder" $
+        withUtf8 $ withReader "printf '\\303\\251\\346\\227\\245\\360\\237\\230\\200\\n'" $
+            readClipboardText `shouldReturn` Right "é日😀\n"
+
+    it "retains the configured non-UTF-8 locale decoder" $
+        withEncoding latin1 $ withReader "printf '\\377\\351'" $
+            readClipboardText `shouldReturn` Right "ÿé"
+
+    it "preserves empty output" $
+        withReader "exit 0" $
+            readClipboardText `shouldReturn` Right ""
+
+    it "preserves whitespace, CRLF, and trailing newlines exactly" $
+        withReader "printf '  one\\r\\ntwo\\n\\n'" $
+            readClipboardText `shouldReturn` Right "  one\r\ntwo\n\n"
+
+    it "rejects malformed output instead of silently replacing bytes" $
+        withUtf8 $ withReader "printf '\\377'" do
+            readClipboardText >>= (`shouldSatisfy` isLeft)
+
+    it "rejects malformed stderr even when the command succeeds" $
+        withUtf8 $ withReader "printf ok; printf '\\377' >&2" do
+            readClipboardText >>= (`shouldSatisfy` isLeft)
+
+    it "returns stripped stderr for a nonzero exit" $
+        withReader "printf ignored; printf '  first error\\n\\n' >&2; exit 7" $
+            readClipboardText `shouldReturn` Left "first error"
+
+    it "preserves Unicode diagnostics" $
+        withUtf8 $ withReader "printf ' \\303\\251\\346\\227\\245\\n' >&2; exit 1" $
+            readClipboardText `shouldReturn` Left "é日"
+
+    it "preserves an empty error for a nonzero exit with no stderr" $
+        withReader "exit 1" $
+            readClipboardText `shouldReturn` Left ""
+
+    it "closes the child's empty stdin" $
+        withReader "if IFS= read -r line; then printf unexpected; else printf eof; fi" $
+            timeout 5000000 readClipboardText `shouldReturn` Just (Right "eof")
+
+    it "returns an error when the executable is unavailable" $
+        withReaders [] do
+            readClipboardText >>= (`shouldSatisfy` isLeft)
+
+    it "drains stdout and stderr together beyond pipe capacity" $
+        withReader
+            ("chunk=abcdefghijklmnopqrstuvwxyz0123456789\n"
+                <> "i=0\nwhile [ \"$i\" -lt 8192 ]; do\n"
+                <> "printf '%s' \"$chunk\"\nprintf '%s' \"$chunk\" >&2\n"
+                <> "i=$((i + 1))\ndone") do
+            timeout 10000000 readClipboardText `shouldReturn`
+                Just (Right (Text.replicate 8192 "abcdefghijklmnopqrstuvwxyz0123456789"))
+
+    it "propagates cancellation and terminates the child" $
+        withReader
+            ("trap 'printf stopped > \"${0%/*}/stopped\"; exit 0' TERM\n"
+                <> "printf ready > \"${0%/*}/ready\"\n"
+                <> "while :; do :; done") do
+            directory <- getEnv "PATH"
+            withAsync readClipboardText \reader -> do
+                timeout 5000000 (awaitFile (directory </> "ready"))
+                    `shouldReturn` Just ()
+                timeout 5000000 (cancel reader) `shouldReturn` Just ()
+                waitCatch reader >>= (`shouldSatisfy` isLeft)
+                timeout 5000000 (awaitFile (directory </> "stopped"))
+                    `shouldReturn` Just ()
+
+    it "falls back from Wayland to X11 after an error" $
+        linuxOnly $ withReaders
+            [("wl-paste", "printf 'wayland failed' >&2; exit 1")
+            ,("xclip", "printf 'x11 text\\n'")] $
+                readClipboardText `shouldReturn` Right "x11 text\n"
+
+    it "keeps the first error when both Linux readers fail" $
+        linuxOnly $ withReaders
+            [("wl-paste", "printf ' first error\\n' >&2; exit 1")
+            ,("xclip", "printf 'second error' >&2; exit 2")] $
+                readClipboardText `shouldReturn` Left "first error"
+
+    it "accepts an empty successful Wayland read without falling back" $
+        linuxOnly $ withReaders
+            [("wl-paste", "exit 0"), ("xclip", "printf unexpected")] $
+                readClipboardText `shouldReturn` Right ""
+
+withUtf8 :: IO a -> IO a
+withUtf8 = withEncoding utf8
+
+withEncoding :: TextEncoding -> IO a -> IO a
+withEncoding encoding action = bracket getLocaleEncoding setLocaleEncoding \_ -> do
+    setLocaleEncoding encoding
+    action
+
+awaitFile :: FilePath -> IO ()
+awaitFile path = do
+    exists <- doesFileExist path
+    if exists then pure () else threadDelay 10000 >> awaitFile path
+
+linuxOnly :: IO () -> IO ()
+linuxOnly action
+    | os == "linux" = action
+    | otherwise = pendingWith "Linux-only clipboard fallback"
+
+withReader :: String -> IO () -> IO ()
+withReader script = withReaders [("pbpaste", script), ("wl-paste", script)]
+
+withReaders :: [(FilePath, String)] -> IO () -> IO ()
+withReaders scripts action
+    | os /= "darwin" && os /= "linux" = pendingWith "Unix clipboard subprocess fixture"
+    | otherwise = do
+        temporary <- getTemporaryDirectory
+        bracket
+            (do
+                (directory, handle) <- openBinaryTempFile temporary "agent-clipboard-text-"
+                hClose handle
+                removeFile directory
+                createDirectory directory
+                pure directory)
+            removePathForcibly
+            \directory -> do
+                mapM_ (\(name, body) -> do
+                    let path = directory </> name
+                    writeFile path ("#!/bin/sh\n" <> body <> "\n")
+                    permissions <- getPermissions path
+                    setPermissions path permissions { executable = True }) scripts
+                bracket
+                    (lookupEnv "PATH")
+                    (maybe (unsetEnv "PATH") (setEnv "PATH"))
+                    \_ -> setEnv "PATH" directory >> action

--- a/packages/agent-cli/test/Spec.hs
+++ b/packages/agent-cli/test/Spec.hs
@@ -40,6 +40,7 @@ import qualified Agent.CLI.AuthSpec as AuthSpec
 import qualified Agent.CLI.BtwSpec as BtwSpec
 import qualified Agent.CLI.CancelWatchSpec as CancelWatchSpec
 import qualified Agent.CLI.ClipboardSpec as ClipboardSpec
+import qualified Agent.CLI.ClipboardTextSpec as ClipboardTextSpec
 import qualified Agent.CLI.ClaudeGatewayProxySpec as ClaudeGatewayProxySpec
 import qualified Agent.CLI.ClaudeSpec as ClaudeSpec
 import qualified Agent.CLI.CommandSpec as CommandSpec
@@ -185,6 +186,7 @@ specs = do
     BtwSpec.spec
     CancelWatchSpec.spec
     ClipboardSpec.spec
+    ClipboardTextSpec.spec
     ClaudeGatewayProxySpec.spec
     ClaudeSpec.spec
     CommandSpec.spec


### PR DESCRIPTION
## Summary
- Capture macOS/Linux clipboard text stdout and stderr directly as strict Text, avoiding whole-buffer String intermediates.
- Preserve locale decoding, newlines, error selection, and Linux fallback order. Scope concurrent readers and process cleanup; image/path readers are unchanged.
- Add compatibility tests and a reproducible optimized subprocess benchmark.

## Measurements
Nix GHC 9.10.3, Apple M3 Max, macOS, -O2 and +RTS -N4 -T; ASCII/Unicode 1 KiB–8 MiB, 21 samples, alternating methods and repeated 1 MiB cases. Exact output comparisons include both streams.
- 1–8 MiB allocation decreases 88–95%; parent CPU decreases 81–92%.
- Separate fresh-process 8 MiB ASCII peak RSS: 338.6 → 60.7 MiB; Unicode: 213.6 → 58.7 MiB (seven-sample medians).
- Small-payload boundary: about 0.03–0.07 ms additional parent CPU at 1 KiB; no universal small-paste latency claim.
- These measure capture overhead, not idle agent memory or end-to-end paste latency. Commands and complete results: packages/agent-cli/benchmark/ClipboardOutput.md.

## Validation
- Focused GHCi spec: 16 examples, zero failures, three Linux-only pending on macOS; the three Linux fallback cases also passed when invoked against the Linux implementation directly.
- UTF-8/Latin-1, malformed stdout/stderr, simultaneous large streams, stdin EOF, cancellation and child termination tested using fake readers only.
- Source-loaded CLI editor exercised in isolated tmux: Ctrl-V returned exact Unicode/multiline fixture, restored display and submission preserved it. Full CLI orchestration was not exercised; no real clipboard payload accessed.
- Generated package.nix unchanged; git diff --check clean.

Sanitizer experiments and their unrelated local tests/docs are excluded.