### PR TITLE
Extract shared semantic computer validation and bounded framing

### DIFF
--- a/packages/agent-computer-use/README.md
+++ b/packages/agent-computer-use/README.md
@@ -10,6 +10,13 @@ accessibility observations.
 - `Agent.ComputerUse.Backend` defines the desktop backend interface.
 - `Agent.ComputerUse.Accessibility` supplies snapshot and delta operations shared
   with the native bridge.
+- `Agent.ComputerUse.Semantic` validates semantic response JSON, accessibility
+  evidence, image envelopes and effect verdicts independently of the transport.
+  Transport adapters still own session identity and lifecycle checks.
+- `Agent.ComputerUse.Transport` supplies bounded length-prefixed framing only;
+  it is not an authenticated service or a socket client. Connection owners must
+  enforce deadlines and discard interrupted or malformed streams without
+  replaying input.
 - Input parsing and Linux Portal/X11/logind implementations are private modules.
 - Wire-level computer-use verdicts remain in `agent-core`'s
   `Agent.ComputerUse.Protocol`; core does not depend on this implementation.

--- a/packages/agent-computer-use/agent-computer-use.cabal
+++ b/packages/agent-computer-use/agent-computer-use.cabal
@@ -63,6 +63,8 @@ library
     exposed-modules:  Agent.ComputerUse
                     , Agent.ComputerUse.Backend
                     , Agent.ComputerUse.Accessibility
+                    , Agent.ComputerUse.Semantic
+                    , Agent.ComputerUse.Transport
 
 test-suite agent-computer-use-test
     import:           common-options, computer-use-modules
@@ -71,6 +73,10 @@ test-suite agent-computer-use-test
     main-is:          Spec.hs
     ghc-options:      -threaded
     other-modules:    Agent.ComputerUseSpec
+                    , Agent.ComputerUse.SemanticSpec
+                    , Agent.ComputerUse.TransportSpec
+                    , Agent.ComputerUse.Transport
+                    , Agent.ComputerUse.Semantic
                     , Agent.ComputerUse
                     , Agent.ComputerUse.Backend
                     , Agent.ComputerUse.Accessibility

--- a/packages/agent-computer-use/src/Agent/ComputerUse/Semantic.hs
+++ b/packages/agent-computer-use/src/Agent/ComputerUse/Semantic.hs
@@ -1,0 +1,298 @@
+-- | Transport-independent validation of bounded semantic computer responses.
+-- Transport adapters retain responsibility for session identity and framing.
+module Agent.ComputerUse.Semantic
+    ( SemanticComputerResponse(..)
+    , SemanticComputerResult(..)
+    , validateSemanticComputerResponse
+    ) where
+
+import Agent.ComputerUse.Accessibility
+import Agent.ComputerUse.Protocol
+import Agent.ToolDispatch (ToolResultImage(..))
+import Codec.Picture (DynamicImage, dynamicMap, imageHeight, imageWidth, pixelAt)
+import Codec.Picture.Jpg (decodeJpeg)
+import Codec.Picture.Png (decodePng)
+import Control.Exception (evaluate)
+import Control.Exception.Safe (tryAny)
+import Control.Monad (guard, when)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Bits ((.&.), complement, shiftR, xor)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base64 as Base64
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TextEncoding
+import Data.Word (Word8, Word32)
+
+data SemanticComputerResponse = SemanticComputerResponse
+    { semanticResultBytes :: !BS.ByteString
+    , semanticAccessibilityBytes :: !BS.ByteString
+    , semanticImageBytes :: !BS.ByteString
+    -- | 0: absent, 1: PNG, 2: JPEG. Unknown formats are rejected.
+    , semanticImageFormat :: !Int
+    } deriving (Eq, Show)
+
+data SemanticComputerResult = SemanticComputerResult
+    { semanticResultValue :: !Aeson.Value
+    , semanticAccessibility :: !(Maybe AccessibilityObservation)
+    , semanticImage :: !(Maybe ToolResultImage)
+    } deriving (Eq, Show)
+
+validateSemanticComputerResponse
+    :: SemanticComputerRequest
+    -> AccessibilityDeltaState
+    -> SemanticComputerResponse
+    -> IO (Either Text (SemanticComputerResult, AccessibilityDeltaState))
+validateSemanticComputerResponse request state response =
+    case metadata of
+        Left err -> pure (Left err)
+        Right object -> do
+            decodedImage <- decodeImage
+                (semanticComputerRequestWantsScreenshot request)
+                response.semanticImageFormat response.semanticImageBytes
+            pure do
+                image <- decodedImage
+                let (observation, successor) = case request of
+                        ListComputerTargets -> (Nothing, state)
+                        _ -> let (value, next) =
+                                    decodeAccessibility response.semanticAccessibilityBytes state
+                             in (Just value, next)
+                    objectWithAccessibility = maybe object
+                        (\value -> KeyMap.insert "accessibility_state"
+                            (Aeson.toJSON value) object) observation
+                    freshEvidence = maybe False accessibilityIsFresh observation
+                        || maybe False (const True) image
+                result <- insertDefaultVerdict request freshEvidence objectWithAccessibility
+                pure (SemanticComputerResult (Aeson.Object result) observation image, successor)
+  where
+    metadata = do
+        when (BS.length response.semanticResultBytes > 1024 * 1024) $
+            Left "The native computer result exceeds its bounded buffer."
+        when (BS.length response.semanticAccessibilityBytes > 512 * 1024) $
+            Left "The native computer accessibility exceeds its bounded buffer."
+        when (BS.length response.semanticImageBytes > 16 * 1024 * 1024) $
+            Left "The native computer image exceeds its bounded buffer."
+        value <- case Aeson.eitherDecodeStrict' response.semanticResultBytes of
+            Left err -> Left
+                ("The native computer host returned invalid result JSON: " <> Text.pack err)
+            Right decoded -> Right decoded
+        object <- case value of
+            Aeson.Object fields -> Right fields
+            _ -> Left "The native computer host result must be a JSON object."
+        when (containsDataImage value) $
+            Left "The native computer host embedded screenshot data in result JSON."
+        when (request == ListComputerTargets
+                && not (BS.null response.semanticAccessibilityBytes)) $
+            Left "The native computer host returned accessibility data for list_targets."
+        pure object
+    accessibilityIsFresh = \case
+        AccessibilityFull{} -> True
+        AccessibilityDelta{} -> True
+        AccessibilityUnavailable{} -> False
+
+insertDefaultVerdict
+    :: SemanticComputerRequest -> Bool -> Aeson.Object -> Either Text Aeson.Object
+insertDefaultVerdict request freshEvidence object
+    | Just value <- KeyMap.lookup verdictKey object =
+        case (Aeson.fromJSON value :: Aeson.Result ComputerUseVerdict) of
+            Aeson.Success verdict -> do
+                when (verdict.computerUseVerdictFreshObservation && not freshEvidence) $
+                    Left
+                        "The native computer host verdict claims a fresh observation without returning fresh accessibility or image evidence."
+                case request of
+                    ActOnComputerTarget{}
+                        | ComputerUseObservation <- verdict.computerUseVerdictEffect ->
+                            Left "The native computer host verdict cannot classify an input request as an observation."
+                    _ -> Right ()
+                Right object
+            Aeson.Error err ->
+                Left ("The native computer host returned an invalid verdict: " <> Text.pack err)
+    | ActOnComputerTarget{} <- request =
+        Right (KeyMap.insert verdictKey (Aeson.toJSON verdict) object)
+    | otherwise = Right object
+  where
+    verdictKey = Key.fromText computerUseVerdictField
+    verdict = case KeyMap.lookup "ok" object of
+        Just (Aeson.Bool False) -> suspectedNoopComputerUseVerdict freshEvidence
+        _ -> unverifiedComputerUseVerdict freshEvidence
+
+decodeAccessibility
+    :: BS.ByteString -> AccessibilityDeltaState
+    -> (AccessibilityObservation, AccessibilityDeltaState)
+decodeAccessibility bytes state
+    | BS.null bytes = unavailableAccessibilityObservation
+        "Native accessibility snapshot unavailable." state
+    | otherwise = case decodeAccessibilitySnapshot bytes of
+        Left err -> unavailableAccessibilityObservation
+            ("The native computer host returned invalid accessibility JSON: " <> err) state
+        Right snapshot -> advanceAccessibilityObservation state snapshot
+
+decodeImage :: Bool -> Int -> BS.ByteString -> IO (Either Text (Maybe ToolResultImage))
+decodeImage includeScreenshot format bytes
+    | BS.null bytes && format == 0 = pure (Right Nothing)
+    | not includeScreenshot =
+        pure (Left "The native computer host returned an unrequested screenshot.")
+    | BS.null bytes =
+        pure (Left "The native computer host returned an empty screenshot.")
+    | otherwise = do
+        decodedMime <- imageMime format bytes
+        pure do
+            mime <- decodedMime
+            pure (Just (ToolResultImage
+                ("data:" <> mime <> ";base64,"
+                    <> TextEncoding.decodeUtf8 (Base64.encode bytes))
+                Nothing))
+
+imageMime :: Int -> BS.ByteString -> IO (Either Text Text)
+imageMime format bytes = case format of
+    1 -> validateDecodedImage "image/png"
+        "The native computer host returned malformed PNG data." (validPng bytes)
+    2 -> validateDecodedImage "image/jpeg"
+        "The native computer host returned malformed JPEG data." (validJpeg bytes)
+    _ -> pure (Left "The native computer host returned an unsupported image format.")
+
+validateDecodedImage :: Text -> Text -> Bool -> IO (Either Text Text)
+validateDecodedImage mime malformed valid = do
+    attempted <- tryAny (evaluate valid)
+    pure case attempted of
+        Right True -> Right mime
+        Right False -> Left malformed
+        Left _ -> Left malformed
+
+containsDataImage :: Aeson.Value -> Bool
+containsDataImage = \case
+    Aeson.Object object -> any containsDataImage object
+    Aeson.Array values -> any containsDataImage values
+    Aeson.String value -> "data:image/" `Text.isPrefixOf` Text.toLower value
+    _ -> False
+
+validPng :: BS.ByteString -> Bool
+validPng bytes = case pngEnvelope bytes of
+    Nothing -> False
+    Just dimensions -> decodedImageMatches dimensions (decodePng bytes)
+
+pngEnvelope :: BS.ByteString -> Maybe (Int, Int)
+pngEnvelope bytes = do
+    guard (BS.length bytes >= 45)
+    guard (BS.take 8 bytes == BS.pack [137, 80, 78, 71, 13, 10, 26, 10])
+    validChunks True False Nothing (BS.drop 8 bytes)
+  where
+    validChunks firstChunk sawImageData dimensions remaining = do
+        guard (BS.length remaining >= 12)
+        guard (chunkLength <= BS.length remaining - 12)
+        guard (chunkChecksum == crc32 checksumInput)
+        if firstChunk
+            then do
+                guard (chunkType == "IHDR")
+                guard (chunkLength == 13)
+                headerDimensions <- validHeader chunkData
+                validChunks False False (Just headerDimensions) rest
+            else case chunkType of
+                "IHDR" -> Nothing
+                "IDAT" -> validChunks False True dimensions rest
+                "IEND" -> do
+                    guard (chunkLength == 0)
+                    guard sawImageData
+                    guard (BS.null rest)
+                    dimensions
+                _ -> validChunks False sawImageData dimensions rest
+      where
+        chunkLength = word32At remaining 0
+        chunkType = BS.take 4 (BS.drop 4 remaining)
+        chunkData = BS.take chunkLength (BS.drop 8 remaining)
+        checksumInput = BS.take (4 + chunkLength) (BS.drop 4 remaining)
+        chunkChecksum = fromIntegral (word32At remaining (8 + chunkLength))
+        rest = BS.drop (12 + chunkLength) remaining
+    validHeader header = do
+        guard (BS.length header == 13)
+        let width = word32At header 0
+            height = word32At header 4
+        guard (dimensionsSafeToDecode (width, height))
+        guard (BS.index header 10 == 0)
+        guard (BS.index header 11 == 0)
+        guard (BS.index header 12 <= 1)
+        pure (width, height)
+
+validJpeg :: BS.ByteString -> Bool
+validJpeg bytes = case jpegDimensions bytes of
+    Nothing -> False
+    Just dimensions -> decodedImageMatches dimensions (decodeJpeg bytes)
+
+jpegDimensions :: BS.ByteString -> Maybe (Int, Int)
+jpegDimensions bytes = do
+    guard (BS.length bytes >= 14)
+    guard (BS.take 2 bytes == BS.pack [255, 216])
+    guard (BS.drop (BS.length bytes - 2) bytes == BS.pack [255, 217])
+    validSegments Nothing (BS.drop 2 bytes)
+  where
+    validSegments dimensions remaining =
+        case nextMarker remaining of
+            Nothing -> Nothing
+            Just (marker, afterMarker)
+                | marker == 0xd9 -> Nothing
+                | standaloneMarker marker -> validSegments dimensions afterMarker
+                | BS.length afterMarker < 2 -> Nothing
+                | segmentLength < 2 || segmentLength > BS.length afterMarker -> Nothing
+                | marker == 0xda -> dimensions
+                | startOfFrame marker -> do
+                    guard (segmentLength >= 8)
+                    let height = word16At afterMarker 3
+                        width = word16At afterMarker 5
+                    guard (dimensionsSafeToDecode (width, height))
+                    validSegments (Just (width, height)) (BS.drop segmentLength afterMarker)
+                | otherwise -> validSegments dimensions (BS.drop segmentLength afterMarker)
+              where
+                segmentLength = word16At afterMarker 0
+    nextMarker remaining =
+        case BS.elemIndex 255 remaining of
+            Nothing -> Nothing
+            Just markerStart ->
+                case BS.uncons (BS.dropWhile (== 255) (BS.drop markerStart remaining)) of
+                    Nothing -> Nothing
+                    Just (0, rest) -> nextMarker rest
+                    Just (marker, rest) -> Just (marker, rest)
+    standaloneMarker marker =
+        marker == 0x01 || marker == 0xd8 || (marker >= 0xd0 && marker <= 0xd7)
+    startOfFrame marker =
+        marker >= 0xc0 && marker <= 0xcf && marker `notElem` [0xc4, 0xc8, 0xcc]
+
+decodedImageMatches :: (Int, Int) -> Either String DynamicImage -> Bool
+decodedImageMatches expected = \case
+    Left _ -> False
+    Right image -> dynamicMap
+        (\raster ->
+            let width = imageWidth raster
+                height = imageHeight raster
+            in (width, height) == expected
+                && (pixelAt raster (width - 1) (height - 1) `seq` True)) image
+
+dimensionsSafeToDecode :: (Int, Int) -> Bool
+dimensionsSafeToDecode (width, height) =
+    width > 0 && height > 0 && width <= 8192 && height <= 8192
+        && toInteger width * toInteger height <= 25000000
+
+crc32 :: BS.ByteString -> Word32
+crc32 = complement . BS.foldl' update maxBound
+  where
+    update :: Word32 -> Word8 -> Word32
+    update checksum byte = advance 8 (checksum `xor` fromIntegral byte)
+    advance :: Int -> Word32 -> Word32
+    advance 0 value = value
+    advance count value = advance (count - 1)
+        (if value .&. 1 == 1
+            then (value `shiftR` 1) `xor` 0xedb88320
+            else value `shiftR` 1)
+
+word16At :: BS.ByteString -> Int -> Int
+word16At bytes offset =
+    fromIntegral (BS.index bytes offset) * 256
+        + fromIntegral (BS.index bytes (offset + 1))
+
+word32At :: BS.ByteString -> Int -> Int
+word32At bytes offset =
+    fromIntegral (BS.index bytes offset) * 16777216
+        + fromIntegral (BS.index bytes (offset + 1)) * 65536
+        + fromIntegral (BS.index bytes (offset + 2)) * 256
+        + fromIntegral (BS.index bytes (offset + 3))

--- a/packages/agent-computer-use/src/Agent/ComputerUse/Transport.hs
+++ b/packages/agent-computer-use/src/Agent/ComputerUse/Transport.hs
@@ -1,0 +1,86 @@
+-- | Bounded framing for the local computer service. This module does not
+-- authenticate peers or retry requests. A connection owner must discard the
+-- stream after any framing failure or interrupted read/write: its position is
+-- then unknown, and replaying a computer action is not safe.
+module Agent.ComputerUse.Transport
+    ( FrameLimit
+    , frameLimit
+    , FrameFailure(..)
+    , encodeFrame
+    , receiveFrame
+    ) where
+
+import Data.Bits (shiftL, shiftR, (.|.))
+import qualified Data.ByteString as BS
+import Data.Word (Word32)
+
+-- | The configured bound is checked before reading a payload. Separate
+-- request and response limits can be used without changing the framing.
+newtype FrameLimit = FrameLimit Int
+    deriving (Eq, Show)
+
+frameLimit :: Int -> Maybe FrameLimit
+frameLimit size
+    | size > 0 && toInteger size <= toInteger (maxBound :: Word32) =
+        Just (FrameLimit size)
+    | otherwise = Nothing
+
+data FrameFailure
+    = EmptyFrame
+    | FrameExceedsLimit
+    | TruncatedFrame
+    | ReaderExceedsRequestedLength
+    deriving (Eq, Show)
+
+-- | Four-byte unsigned little-endian payload length followed by the payload.
+-- Empty payloads are not protocol messages; EOF is represented separately.
+encodeFrame :: FrameLimit -> BS.ByteString -> Either FrameFailure BS.ByteString
+encodeFrame (FrameLimit limit) payload
+    | BS.null payload = Left EmptyFrame
+    | BS.length payload > limit = Left FrameExceedsLimit
+    | otherwise = Right (header <> payload)
+  where
+    size = fromIntegral (BS.length payload) :: Word32
+    header = BS.pack [fromIntegral (size `shiftR` offset) | offset <- [0, 8, 16, 24]]
+
+-- | Read one frame. The supplied reader must return at most the requested
+-- byte count, and an empty chunk only at EOF. Exceptions (including async
+-- cancellation) propagate to the connection owner. No worker is detached.
+-- 'Right Nothing' means clean EOF before the first header byte only.
+receiveFrame
+    :: FrameLimit
+    -> (Int -> IO BS.ByteString)
+    -> IO (Either FrameFailure (Maybe BS.ByteString))
+receiveFrame (FrameLimit limit) receive = do
+    headerResult <- readExactly receive 4
+    case headerResult of
+        Left failure -> pure (Left failure)
+        Right Nothing -> pure (Right Nothing)
+        Right (Just header) -> do
+            let size = decodeLength header
+            if size == 0
+                then pure (Left EmptyFrame)
+                else if toInteger size > toInteger limit
+                    then pure (Left FrameExceedsLimit)
+                    else readExactly receive (fromIntegral size) >>= \case
+                        Right Nothing -> pure (Left TruncatedFrame)
+                        result -> pure result
+
+decodeLength :: BS.ByteString -> Word32
+decodeLength = BS.foldr (\byte rest -> fromIntegral byte .|. (rest `shiftL` 8)) 0
+
+readExactly
+    :: (Int -> IO BS.ByteString)
+    -> Int
+    -> IO (Either FrameFailure (Maybe BS.ByteString))
+readExactly receive count = go count []
+  where
+    go remaining chunks
+        | remaining == 0 = pure (Right (Just (BS.concat (reverse chunks))))
+        | otherwise = do
+            chunk <- receive remaining
+            if BS.length chunk > remaining
+                then pure (Left ReaderExceedsRequestedLength)
+                else if BS.null chunk
+                    then pure (if null chunks then Right Nothing else Left TruncatedFrame)
+                    else go (remaining - BS.length chunk) (chunk : chunks)

--- a/packages/agent-computer-use/test/Agent/ComputerUse/SemanticSpec.hs
+++ b/packages/agent-computer-use/test/Agent/ComputerUse/SemanticSpec.hs
@@ -1,0 +1,59 @@
+module Agent.ComputerUse.SemanticSpec (spec) where
+
+import Agent.ComputerUse.Accessibility
+import Agent.ComputerUse.Protocol
+import Agent.ComputerUse.Semantic
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import Data.Either (isLeft, isRight)
+import Data.List.NonEmpty (NonEmpty(..))
+import Test.Hspec
+
+spec :: Spec
+spec = describe "transport-independent semantic responses" do
+    it "accepts a target list without image or accessibility data" do
+        result <- validate ListComputerTargets emptyResponse
+        result `shouldSatisfy` isRight
+    it "rejects non-object result metadata" do
+        result <- validate ListComputerTargets emptyResponse
+            { semanticResultBytes = "[]" }
+        result `shouldSatisfy` isLeft
+    it "rejects embedded screenshot data in nested metadata" do
+        result <- validate ListComputerTargets emptyResponse
+            { semanticResultBytes = "{\"nested\":[\"data:image/png;base64,AAAA\"]}" }
+        result `shouldSatisfy` isLeft
+    it "rejects accessibility data attached to a target list" do
+        result <- validate ListComputerTargets emptyResponse
+            { semanticAccessibilityBytes = "{}" }
+        result `shouldSatisfy` isLeft
+    it "rejects an unrequested screenshot" do
+        result <- validate (ObserveComputerTarget False) emptyResponse
+            { semanticImageBytes = "invalid", semanticImageFormat = 1 }
+        result `shouldSatisfy` isLeft
+    it "rejects malformed requested images" do
+        result <- validate (ObserveComputerTarget True) emptyResponse
+            { semanticImageBytes = "invalid", semanticImageFormat = 1 }
+        result `shouldSatisfy` isLeft
+    it "rejects oversized channels before JSON decoding" do
+        result <- validate ListComputerTargets emptyResponse
+            { semanticResultBytes = BS.replicate (1024 * 1024 + 1) 32 }
+        result `shouldSatisfy` isLeft
+    it "marks delivered input as unverified without fresh evidence" do
+        result <- validate actionRequest emptyResponse
+        case result of
+            Right (response, _) -> case response.semanticResultValue of
+                Aeson.Object object -> KeyMap.lookup "verdict" object
+                    `shouldBe` Just (Aeson.toJSON (unverifiedComputerUseVerdict False))
+                _ -> expectationFailure "Expected object result"
+            Left err -> expectationFailure (show err)
+    it "rejects claims of fresh evidence when all evidence is absent" do
+        result <- validate actionRequest emptyResponse
+            { semanticResultBytes =
+                "{\"verdict\":{\"effect\":\"unverifiable\",\"decision\":\"inspect_fresh_state\",\"fresh_observation\":true,\"hint\":\"fresh\"}}" }
+        result `shouldSatisfy` isLeft
+  where
+    validate request = validateSemanticComputerResponse request initialAccessibilityDeltaState
+    emptyResponse = SemanticComputerResponse "{}" BS.empty BS.empty 0
+    actionRequest = ActOnComputerTarget
+        (PerformComputerAction "element" "AXPress" :| []) False

--- a/packages/agent-computer-use/test/Agent/ComputerUse/TransportSpec.hs
+++ b/packages/agent-computer-use/test/Agent/ComputerUse/TransportSpec.hs
@@ -1,0 +1,71 @@
+module Agent.ComputerUse.TransportSpec (spec) where
+
+import Agent.ComputerUse.Transport
+import Control.Exception.Safe (throwIO)
+import qualified Data.ByteString as BS
+import Data.IORef
+import Test.Hspec
+
+spec :: Spec
+spec = describe "local computer service framing" do
+    it "rejects non-positive limits" do
+        frameLimit 0 `shouldBe` Nothing
+        frameLimit (-1) `shouldBe` Nothing
+    it "encodes an unsigned little-endian length" do
+        encodeFrame limit "abc" `shouldBe` Right (BS.pack [3, 0, 0, 0] <> "abc")
+    it "rejects empty and oversized outgoing frames" do
+        encodeFrame limit "" `shouldBe` Left EmptyFrame
+        encodeFrame limit (BS.replicate 1025 0) `shouldBe` Left FrameExceedsLimit
+    it "reassembles one-byte reads" do
+        reader <- fragmentedReader (BS.pack [3, 0, 0, 0] <> "abc")
+        receiveFrame limit reader `shouldReturn` Right (Just "abc")
+    it "accepts the exact limit and decodes multi-byte lengths" do
+        let payload = BS.replicate 1024 65
+        case encodeFrame limit payload of
+            Left failure -> expectationFailure (show failure)
+            Right encoded -> do
+                BS.take 4 encoded `shouldBe` BS.pack [0, 4, 0, 0]
+                reader <- fragmentedReader encoded
+                receiveFrame limit reader `shouldReturn` Right (Just payload)
+    it "does not consume the next frame" do
+        reader <- fragmentedReader (BS.pack [1, 0, 0, 0, 65, 1, 0, 0, 0, 66])
+        receiveFrame limit reader `shouldReturn` Right (Just "A")
+        receiveFrame limit reader `shouldReturn` Right (Just "B")
+        receiveFrame limit reader `shouldReturn` Right Nothing
+    it "distinguishes clean EOF from a truncated header" do
+        receiveFrame limit (const (pure BS.empty)) `shouldReturn` Right Nothing
+        reader <- fragmentedReader (BS.pack [1, 0])
+        receiveFrame limit reader `shouldReturn` Left TruncatedFrame
+    it "rejects EOF at the start or middle of a payload" do
+        mapM_ (\bytes -> do
+            reader <- fragmentedReader bytes
+            receiveFrame limit reader `shouldReturn` Left TruncatedFrame)
+            [BS.pack [2, 0, 0, 0], BS.pack [2, 0, 0, 0, 65]]
+    it "rejects empty incoming messages" do
+        reader <- fragmentedReader (BS.replicate 4 0)
+        receiveFrame limit reader `shouldReturn` Left EmptyFrame
+    it "checks the bound before requesting payload bytes" do
+        calls <- newIORef (0 :: Int)
+        let reader _ = do
+                call <- atomicModifyIORef' calls (\n -> (n + 1, n))
+                if call == 0 then pure (BS.replicate 4 255)
+                    else expectationFailure "payload read after oversized header" >> pure BS.empty
+        receiveFrame limit reader `shouldReturn` Left FrameExceedsLimit
+        readIORef calls `shouldReturn` 1
+    it "rejects a reader violating its byte bound" do
+        receiveFrame limit (const (pure (BS.replicate 5 0)))
+            `shouldReturn` Left ReaderExceedsRequestedLength
+    it "propagates IO exceptions rather than retrying" do
+        receiveFrame limit (const (throwIO (userError "connection lost")))
+            `shouldThrow` anyIOException
+  where
+    limit = case frameLimit 1024 of
+        Just value -> value
+        Nothing -> error "invalid test frame limit"
+
+fragmentedReader :: BS.ByteString -> IO (Int -> IO BS.ByteString)
+fragmentedReader bytes = do
+    remaining <- newIORef bytes
+    pure \requested -> atomicModifyIORef' remaining \current ->
+        let (chunk, rest) = BS.splitAt (min 1 requested) current
+        in (rest, chunk)

--- a/packages/agent-computer-use/test/Spec.hs
+++ b/packages/agent-computer-use/test/Spec.hs
@@ -1,7 +1,12 @@
 module Main (main) where
 
 import Agent.ComputerUseSpec qualified as ComputerUseSpec
+import Agent.ComputerUse.SemanticSpec qualified as SemanticSpec
+import Agent.ComputerUse.TransportSpec qualified as TransportSpec
 import Test.Hspec (hspec)
 
 main :: IO ()
-main = hspec ComputerUseSpec.spec
+main = hspec do
+    ComputerUseSpec.spec
+    SemanticSpec.spec
+    TransportSpec.spec

--- a/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
+++ b/packages/agent-native-bridge/ffi/Agent/CLI/MacOS/ComputerBridge.hs
@@ -28,24 +28,21 @@ module Agent.CLI.MacOS.ComputerBridge
 import Agent.ComputerUse.Accessibility
     ( AccessibilityDeltaState
     , AccessibilityObservation(..)
-    , advanceAccessibilityObservation
-    , decodeAccessibilitySnapshot
     , initialAccessibilityDeltaState
-    , unavailableAccessibilityObservation
+    )
+import Agent.ComputerUse.Semantic
+    ( SemanticComputerResponse(..)
+    , SemanticComputerResult(..)
+    , validateSemanticComputerResponse
     )
 import Agent.ComputerUse.Protocol
-    ( ComputerUseEffect(..)
-    , ComputerUseVerdict(..)
-    , SemanticComputerOperation(..)
+    ( SemanticComputerOperation(..)
     , SemanticComputerRequest(..)
-    , computerUseVerdictField
     , encodeSemanticComputerRequest
-    , suspectedNoopComputerUseVerdict
     , semanticComputerRequestDecoder
     , semanticComputerRequestOperation
     , semanticComputerRequestSchema
     , semanticComputerRequestWantsScreenshot
-    , unverifiedComputerUseVerdict
     )
 import Agent.ToolDispatch
     ( ToolHandlerResult(..)
@@ -59,26 +56,12 @@ import Agent.Tools.Types
     , ToolExecutionPolicy(..)
     , ToolSchema(..)
     )
-import Codec.Picture
-    ( DynamicImage
-    , dynamicMap
-    , imageHeight
-    , imageWidth
-    , pixelAt
-    )
-import Codec.Picture.Jpg (decodeJpeg)
-import Codec.Picture.Png (decodePng)
 import qualified Control.Concurrent.MVar as MVar
-import Control.Exception (evaluate)
 import qualified Control.Exception.Safe as Exception
 import Control.Exception.Safe (finally, mask_, onException, tryAny)
-import Control.Monad (guard, when)
+import Control.Monad (when)
 import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Key
-import qualified Data.Aeson.KeyMap as KeyMap
-import Data.Bits ((.&.), complement, shiftR, xor)
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef, atomicModifyIORef', newIORef)
 import qualified Data.Map.Strict as Map
@@ -378,8 +361,6 @@ invokeComputerSessionRequest session request =
                 Right (Right response) -> do
                     validated <- validateResponse
                         request
-                        operation
-                        includeScreenshot
                         accessibilityState
                         response
                     case validated of
@@ -402,170 +383,27 @@ data RawComputerResponse = RawComputerResponse
 
 validateResponse
     :: SemanticComputerRequest
-    -> CInt
-    -> Bool
     -> AccessibilityDeltaState
     -> RawComputerResponse
     -> IO (Either Text (NativeComputerResult, AccessibilityDeltaState))
-validateResponse request operation includeScreenshot accessibilityState response =
-    case validateMetadata of
-        Left err -> pure (Left err)
-        Right (object, accessibility, successorAccessibility) -> do
-            decodedImage <- decodeImage
-                includeScreenshot
-                response.rawImageFormat
-                response.rawImage
-            pure do
-                image <- decodedImage
-                let resultWithAccessibility = maybe object
-                        (\observation ->
-                            KeyMap.insert
-                                "accessibility_state"
-                                (Aeson.toJSON observation)
-                                object)
-                        accessibility
-                    freshEvidence =
-                        maybe False accessibilityIsFresh accessibility
-                            || maybe False (const True) image
-                resultObject <-
-                    insertDefaultVerdict
-                        request
-                        freshEvidence
-                        resultWithAccessibility
-                pure
-                    ( NativeComputerResult
-                        { nativeComputerResultValue = Aeson.Object resultObject
-                        , nativeComputerAccessibility = accessibility
-                        , nativeComputerImage = image
-                        }
-                    , successorAccessibility
-                    )
-  where
-    validateMetadata = do
-        when (response.rawSessionToken /= 0) $
-            Left "The native computer host changed a live session token."
-        value <- case Aeson.eitherDecodeStrict' response.rawResult of
-            Left err -> Left
-                ("The native computer host returned invalid result JSON: "
-                    <> Text.pack err)
-            Right decoded -> Right decoded
-        object <- case value of
-            Aeson.Object fields -> Right fields
-            _ -> Left "The native computer host result must be a JSON object."
-        when (containsDataImage value) $
-            Left "The native computer host embedded screenshot data in result JSON."
-        when (operation == operationList
-                && not (BS.null response.rawAccessibility)) $
-            Left "The native computer host returned accessibility data for list_targets."
-        let (observation, newAccessibilityState) =
-                decodeAccessibility response.rawAccessibility accessibilityState
-            (accessibility, successorAccessibility)
-                | operation == operationList =
-                    (Nothing, accessibilityState)
-                | otherwise =
-                    (Just observation, newAccessibilityState)
-        pure (object, accessibility, successorAccessibility)
-
-    accessibilityIsFresh = \case
-        AccessibilityFull{} -> True
-        AccessibilityDelta{} -> True
-        AccessibilityUnavailable{} -> False
-
-insertDefaultVerdict
-    :: SemanticComputerRequest
-    -> Bool
-    -> Aeson.Object
-    -> Either Text Aeson.Object
-insertDefaultVerdict request freshEvidence object
-    | Just value <- KeyMap.lookup verdictKey object =
-        case
-            (Aeson.fromJSON value :: Aeson.Result ComputerUseVerdict)
-        of
-            Aeson.Success hostVerdict -> do
-                validateHostVerdict request freshEvidence hostVerdict
-                Right object
-            Aeson.Error err ->
-                Left
-                    ( "The native computer host returned an invalid verdict: "
-                    <> Text.pack err
-                    )
-    | not (isAct request) = Right object
-    | otherwise =
-        Right (KeyMap.insert verdictKey (Aeson.toJSON verdict) object)
-  where
-    verdictKey = Key.fromText computerUseVerdictField
-    verdict :: ComputerUseVerdict
-    verdict =
-        case KeyMap.lookup "ok" object of
-            Just (Aeson.Bool False) ->
-                suspectedNoopComputerUseVerdict freshEvidence
-            _ -> unverifiedComputerUseVerdict freshEvidence
-    isAct = \case
-        ActOnComputerTarget{} -> True
-        _ -> False
-
-validateHostVerdict
-    :: SemanticComputerRequest
-    -> Bool
-    -> ComputerUseVerdict
-    -> Either Text ()
-validateHostVerdict request freshEvidence verdict
-    | verdict.computerUseVerdictFreshObservation
-    , not freshEvidence =
-        Left
-            ( "The native computer host verdict claims a fresh observation "
-            <> "without returning fresh accessibility or image evidence."
-            )
-    | ActOnComputerTarget{} <- request
-    , ComputerUseObservation <- verdict.computerUseVerdictEffect =
-        Left
-            ( "The native computer host verdict cannot classify an input "
-            <> "request as an observation."
-            )
-    | otherwise = Right ()
-
-decodeAccessibility
-    :: BS.ByteString
-    -> AccessibilityDeltaState
-    -> (AccessibilityObservation, AccessibilityDeltaState)
-decodeAccessibility bytes state
-    | BS.null bytes =
-        unavailableAccessibilityObservation
-            "Native accessibility snapshot unavailable."
-            state
-    | otherwise =
-        case decodeAccessibilitySnapshot bytes of
-            Left err ->
-                unavailableAccessibilityObservation
-                    ( "The native computer host returned invalid accessibility JSON: "
-                        <> err
-                    )
-                    state
-            Right snapshot ->
-                advanceAccessibilityObservation state snapshot
-
-decodeImage
-    :: Bool
-    -> CInt
-    -> BS.ByteString
-    -> IO (Either Text (Maybe ToolResultImage))
-decodeImage includeScreenshot imageFormat bytes
-    | BS.null bytes && imageFormat == imageNone = pure (Right Nothing)
-    | not includeScreenshot =
-        pure (Left "The native computer host returned an unrequested screenshot.")
-    | BS.null bytes =
-        pure (Left "The native computer host returned an empty screenshot.")
+validateResponse request accessibilityState response
+    | response.rawSessionToken /= 0 =
+        pure (Left "The native computer host changed a live session token.")
     | otherwise = do
-        decodedMime <- imageMime imageFormat bytes
+        validated <- validateSemanticComputerResponse request accessibilityState
+            SemanticComputerResponse
+                { semanticResultBytes = response.rawResult
+                , semanticAccessibilityBytes = response.rawAccessibility
+                , semanticImageBytes = response.rawImage
+                , semanticImageFormat = fromIntegral response.rawImageFormat
+                }
         pure do
-            mime <- decodedMime
-            pure (Just (ToolResultImage
-                ( "data:"
-                    <> mime
-                    <> ";base64,"
-                    <> TextEncoding.decodeUtf8 (Base64.encode bytes)
-                )
-                Nothing))
+            (result, successor) <- validated
+            pure (NativeComputerResult
+                { nativeComputerResultValue = result.semanticResultValue
+                , nativeComputerAccessibility = result.semanticAccessibility
+                , nativeComputerImage = result.semanticImage
+                }, successor)
 
 acquireCurrentGeneration
     :: ComputerHost
@@ -736,204 +574,6 @@ closeInvalidOpen registration token =
         _ <- tryAny
             (invokeComputerRaw registration operationClose token False BS.empty)
         pure ()
-
-imageMime :: CInt -> BS.ByteString -> IO (Either Text Text)
-imageMime imageFormat bytes = case imageFormat of
-    1 -> validateDecodedImage
-        "image/png"
-        "The native computer host returned malformed PNG data."
-        (validPng bytes)
-    2 -> validateDecodedImage
-        "image/jpeg"
-        "The native computer host returned malformed JPEG data."
-        (validJpeg bytes)
-    _ -> pure
-        (Left "The native computer host returned an unsupported image format.")
-
-validateDecodedImage :: Text -> Text -> Bool -> IO (Either Text Text)
-validateDecodedImage mime malformed valid = do
-    attempted <- tryAny (evaluate valid)
-    pure case attempted of
-        Right True -> Right mime
-        Right False -> Left malformed
-        Left _ -> Left malformed
-
-containsDataImage :: Aeson.Value -> Bool
-containsDataImage = \case
-    Aeson.Object object -> any containsDataImage object
-    Aeson.Array values -> any containsDataImage values
-    Aeson.String value ->
-        "data:image/" `Text.isPrefixOf` Text.toLower value
-    _ -> False
-
-validPng :: BS.ByteString -> Bool
-validPng bytes =
-    case pngEnvelope bytes of
-        Nothing -> False
-        Just dimensions ->
-            decodedImageMatches dimensions (decodePng bytes)
-
-pngEnvelope :: BS.ByteString -> Maybe (Int, Int)
-pngEnvelope bytes = do
-    guard (BS.length bytes >= 45)
-    guard (BS.take 8 bytes == pngSignature)
-    validChunks True False Nothing (BS.drop 8 bytes)
-  where
-    pngSignature = BS.pack [137, 80, 78, 71, 13, 10, 26, 10]
-    validChunks firstChunk sawImageData dimensions remaining = do
-        guard (BS.length remaining >= 12)
-        guard (chunkLength <= BS.length remaining - 12)
-        guard (chunkChecksum == crc32 checksumInput)
-        if firstChunk
-            then do
-                guard (chunkType == "IHDR")
-                guard (chunkLength == 13)
-                headerDimensions <- validHeader chunkData
-                validChunks False False (Just headerDimensions) rest
-            else case chunkType of
-                "IHDR" -> Nothing
-                "IDAT" ->
-                    validChunks False True dimensions rest
-                "IEND" -> do
-                    guard (chunkLength == 0)
-                    guard sawImageData
-                    guard (BS.null rest)
-                    dimensions
-                _ ->
-                    validChunks False sawImageData dimensions rest
-      where
-        chunkLength = word32At remaining 0
-        chunkType = BS.take 4 (BS.drop 4 remaining)
-        chunkData = BS.take chunkLength (BS.drop 8 remaining)
-        checksumInput =
-            BS.take (4 + chunkLength) (BS.drop 4 remaining)
-        chunkChecksum =
-            fromIntegral (word32At remaining (8 + chunkLength))
-        rest = BS.drop (12 + chunkLength) remaining
-    validHeader header = do
-        guard (BS.length header == 13)
-        let width = word32At header 0
-            height = word32At header 4
-        guard (dimensionsSafeToDecode (width, height))
-        guard (BS.index header 10 == 0)
-        guard (BS.index header 11 == 0)
-        guard (BS.index header 12 <= 1)
-        pure (width, height)
-
-validJpeg :: BS.ByteString -> Bool
-validJpeg bytes =
-    case jpegDimensions bytes of
-        Nothing -> False
-        Just dimensions ->
-            decodedImageMatches dimensions (decodeJpeg bytes)
-
-jpegDimensions :: BS.ByteString -> Maybe (Int, Int)
-jpegDimensions bytes = do
-    guard (BS.length bytes >= 14)
-    guard (BS.take 2 bytes == BS.pack [255, 216])
-    guard (BS.drop (BS.length bytes - 2) bytes == BS.pack [255, 217])
-    validSegments Nothing (BS.drop 2 bytes)
-  where
-    validSegments dimensions remaining =
-        case nextMarker remaining of
-            Nothing -> Nothing
-            Just (marker, afterMarker)
-                | marker == 0xd9 -> Nothing
-                | standaloneMarker marker ->
-                    validSegments dimensions afterMarker
-                | BS.length afterMarker < 2 -> Nothing
-                | segmentLength < 2
-                    || segmentLength > BS.length afterMarker -> Nothing
-                | marker == 0xda -> dimensions
-                | startOfFrame marker -> do
-                    guard (segmentLength >= 8)
-                    let height = word16At afterMarker 3
-                        width = word16At afterMarker 5
-                    guard (dimensionsSafeToDecode (width, height))
-                    validSegments
-                        (Just (width, height))
-                        (BS.drop segmentLength afterMarker)
-                | otherwise ->
-                    validSegments dimensions
-                        (BS.drop segmentLength afterMarker)
-              where
-                segmentLength = word16At afterMarker 0
-    nextMarker remaining =
-        case BS.elemIndex 255 remaining of
-            Nothing -> Nothing
-            Just markerStart ->
-                let markerBytes = BS.drop markerStart remaining
-                    afterFill = BS.dropWhile (== 255) markerBytes
-                in case BS.uncons afterFill of
-                    Nothing -> Nothing
-                    Just (0, rest) -> nextMarker rest
-                    Just (marker, rest) -> Just (marker, rest)
-    standaloneMarker marker =
-        marker == 0x01
-            || marker == 0xd8
-            || (marker >= 0xd0 && marker <= 0xd7)
-    startOfFrame marker =
-        marker >= 0xc0
-            && marker <= 0xcf
-            && marker `notElem` [0xc4, 0xc8, 0xcc]
-
-decodedImageMatches
-    :: (Int, Int)
-    -> Either String DynamicImage
-    -> Bool
-decodedImageMatches expectedDimensions = \case
-    Left _ -> False
-    Right image ->
-        dynamicMap
-            (\raster ->
-                let width = imageWidth raster
-                    height = imageHeight raster
-                in
-                    (width, height) == expectedDimensions
-                        && (pixelAt raster (width - 1) (height - 1)
-                            `seq` True))
-            image
-
-dimensionsSafeToDecode :: (Int, Int) -> Bool
-dimensionsSafeToDecode (width, height) =
-    width > 0
-        && height > 0
-        && width <= maximumDecodedImageSide
-        && height <= maximumDecodedImageSide
-        && toInteger width * toInteger height <= maximumDecodedImagePixels
-
-maximumDecodedImageSide :: Int
-maximumDecodedImageSide = 8192
-
-maximumDecodedImagePixels :: Integer
-maximumDecodedImagePixels = 25000000
-
-crc32 :: BS.ByteString -> Word32
-crc32 = complement . BS.foldl' update maxBound
-  where
-    update :: Word32 -> Word8 -> Word32
-    update checksum byte =
-        advance 8 (checksum `xor` fromIntegral byte)
-
-    advance :: Int -> Word32 -> Word32
-    advance 0 value = value
-    advance count value =
-        advance (count - 1)
-            (if value .&. 1 == 1
-                then (value `shiftR` 1) `xor` 0xedb88320
-                else value `shiftR` 1)
-
-word16At :: BS.ByteString -> Int -> Int
-word16At bytes offset =
-    fromIntegral (BS.index bytes offset) * 256
-        + fromIntegral (BS.index bytes (offset + 1))
-
-word32At :: BS.ByteString -> Int -> Int
-word32At bytes offset =
-    fromIntegral (BS.index bytes offset) * 16777216
-        + fromIntegral (BS.index bytes (offset + 1)) * 65536
-        + fromIntegral (BS.index bytes (offset + 2)) * 256
-        + fromIntegral (BS.index bytes (offset + 3))
 
 computerFailureMessage :: CInt -> BS.ByteString -> Text
 computerFailureMessage status bytes =


### PR DESCRIPTION
Move semantic computer response validation from the native callback bridge into `agent-computer-use`, allowing future transports to reuse JSON, accessibility, image, and verdict checks while preserving native session-token validation and ABI behavior.

Add bounded length-prefixed framing with explicit EOF/truncation handling and no automatic retries. These are protocol foundations only: this PR does not expose an authenticated socket service, add CLI/MCP clients, or implement bound-window coordinate fallback. Separate macOS repository changes are not included.

## Validation
- 9 semantic response tests passed.
- 12 framing tests passed.
- 10 existing native bridge tests passed, including the C ABI fixture.
- Full computer-use test component loaded in Nix GHCi.
- `cabal2nix` regeneration unchanged; `git diff --check` clean.
