### PR TITLE
Extract shared startup policy into agent-runtime

### DIFF
--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -50,6 +50,25 @@ finalize. A failure after loop execution must not retroactively roll it back.
 
 ### Native startup policy boundary
 
+`Agent.Runtime.Startup.Model` resolves typed model startup inputs into model
+identity, transport mapping, dialect, reasoning effort, and resume/context
+invalidation decisions. Its resume input contains only the persisted fields
+used by those decisions. Gateway selections remain authoritative; remembered
+project dialects only apply to the matching provider, and changed custom-model
+wire mappings invalidate the previous target using the existing rules.
+
+`Agent.Runtime.Startup.Policy` owns approval defaults, native interaction-mode
+approval, Claude bypass eligibility, and dialect effort normalization. A live
+native interaction-mode callback always prevents provider-side Claude bypass,
+including when the initial mode is Yolo. `Agent.Runtime.Startup.Gateway` owns
+pure gateway catalog projection and model selection; saved aliases are hints,
+not an authority for the provider assigned by the current gateway catalog.
+
+The CLI translates `CliOptions`, native hooks, project settings, and session
+metadata into these inputs. It retains credential/catalog IO, startup messages,
+and provider client-option construction. This is not yet a shared session
+startup entry point, and does not remove the server's CLI dependency.
+
 `Agent.CLI.NativeRuntime` remains the legacy execution adapter. It translates
 the native startup policy after preparing typed requests or legacy arguments.
 Restricted startup pins the admitted cwd and disables worktrees, automatic

--- a/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
+++ b/packages/agent-cli/src/Agent/CLI/GatewayModels.hs
@@ -12,8 +12,7 @@ module Agent.CLI.GatewayModels
 import Agent.Runtime.GatewayClient
     ( GatewayCredential
     , GatewayModelAccess
-    , GatewayModel(..)
-    , GatewayModelProvider(..)
+    , GatewayModel
     , loadGatewayCredentialAt
     , newGatewayModelAccess
     , refreshGatewayModels
@@ -22,19 +21,13 @@ import Agent.Runtime.ModelConfig
     ( ModelCatalog
     , loadModelCatalogAt
     )
-import Agent.Runtime.Models
-    ( ModelOption(modelTarget)
-    , ModelTarget(targetProvider, targetModelId)
-    , gatewayModelOptions
-    , modelCatalog
-    , resolveModelOptionById
+import Agent.Runtime.Models (ModelOption)
+import Agent.Runtime.Startup.Gateway
+    ( modelOptionsForGatewayModels
+    , modelOptionsForGatewayState
+    , selectGatewayModelOption
     )
-import Agent.Provider
-    ( Provider (ClaudeCodeProvider, OpenAIProvider, XAIProvider) )
-import Data.List (find, nubBy)
-import Data.Maybe (mapMaybe)
 import Data.Text (Text)
-import Data.Text qualified as Text
 import System.OsPath (OsPath)
 
 -- | Resolve authoritative routing before initializing the provider runtime.
@@ -48,46 +41,6 @@ withGatewayModelsForStartup
     -> IO result
 withGatewayModelsForStartup access select continue =
     refreshGatewayModels access >>= continue . (>>= select)
-
--- | Select from a credential-scoped gateway catalog before authentication.
--- Saved targets supply an alias preference, never provider identity: older
--- gateway sessions recorded Grok aliases as OpenAI targets.
-selectGatewayModelOption
-    :: [ModelOption]
-    -> Maybe Text
-    -> Maybe Provider
-    -> [ModelTarget]
-    -> Either Text ModelOption
-selectGatewayModelOption options requestedModel requestedProvider targetHints =
-    case requestedModel of
-        Just modelId ->
-            case resolveModelOptionById options modelId of
-                Nothing ->
-                    Left
-                        ("Model " <> modelId
-                            <> " is not offered by the organization gateway.")
-                Just option
-                    | matchesProvider option -> Right option
-                    | otherwise ->
-                        Left
-                            "The selected gateway model does not use the requested provider."
-        Nothing ->
-            case find matchesProvider (preferredOptions <> options) of
-                Just option -> Right option
-                Nothing ->
-                    Left
-                        (case requestedProvider of
-                            Just _ ->
-                                "The organization gateway does not offer any models for the requested provider."
-                            Nothing ->
-                                "The organization gateway does not offer any models.")
-  where
-    preferredOptions =
-        mapMaybe
-            (resolveModelOptionById options . (.targetModelId))
-            targetHints
-    matchesProvider option =
-        maybe True (== option.modelTarget.targetProvider) requestedProvider
 
 loadGatewayModelOptionsAt
     :: OsPath
@@ -129,32 +82,3 @@ loadGatewayModelOptionsWithCredentialAt home cwd credential =
                                     (modelOptionsForGatewayModels
                                         catalog models)
                                 ))
-
-modelOptionsForGatewayModels
-    :: ModelCatalog
-    -> [GatewayModel]
-    -> [ModelOption]
-modelOptionsForGatewayModels catalog models =
-    concatMap modelOptions $
-        nubBy (\first second -> first.gatewayModelId == second.gatewayModelId)
-            (filter (publicAlias . (.gatewayModelId)) models)
-  where
-    modelOptions model =
-        gatewayModelOptions catalog
-            (case model.gatewayModelProvider of
-                GatewayOpenAIProvider -> OpenAIProvider
-                GatewayXAIProvider -> XAIProvider
-                GatewayAnthropicProvider -> ClaudeCodeProvider)
-            [model.gatewayModelId]
-    publicAlias modelId =
-        not ("router-" `Text.isPrefixOf` modelId)
-            && modelId /= "traumimmo-translation"
-
-modelOptionsForGatewayState
-    :: ModelCatalog
-    -> Maybe [GatewayModel]
-    -> [ModelOption]
-modelOptionsForGatewayState catalog = \case
-    Nothing -> modelCatalog catalog
-    Just models ->
-        modelOptionsForGatewayModels catalog models

--- a/packages/agent-cli/src/Agent/CLI/Options.hs
+++ b/packages/agent-cli/src/Agent/CLI/Options.hs
@@ -33,14 +33,19 @@ module Agent.CLI.Options
     ) where
 
 import System.OsPath (OsPath, unsafeEncodeUtf)
-import Agent.Dialect (DialectId(..))
 import Agent.Loop (defaultLoopMaxTurns)
 import Agent.Provider (Provider(..), parseProvider)
 import Agent.ReasoningEffort
-    ( ReasoningEffort(..)
+    ( ReasoningEffort
     , parseReasoningEffort
     )
-import qualified Agent.ReasoningEffort as ReasoningEffort
+import Agent.Runtime.Startup.Policy
+    ( ApprovalInputs(..)
+    , resolveApproval
+    , reasoningEfforts
+    , reasoningEffortsForDialect
+    , normalizeReasoningEffortForDialect
+    )
 import Agent.Runtime.Options
     ( ApprovalPolicy(..)
     , GatewayCommand(..)
@@ -283,17 +288,17 @@ resolveComputerUseEnabled options stdinTty =
 -- @--no-yolo@ is set. Interactive sessions prompt on mutating tools, unless
 -- project settings already enabled auto-approve (and @--no-yolo@ was not set).
 resolveApprovalPolicy :: CliOptions -> Bool -> Bool -> ApprovalPolicy
-resolveApprovalPolicy options isTty projectAutoApprove
-    | options.optYolo == Explicit True = ApproveAll
-    | options.optManagedDenyMutations = DenyMutating
-    | isJust options.optManagedTurnFile && options.optYolo == Explicit False =
-        PromptMutating
-    | options.optYolo == Explicit False && not isTty = DenyMutating
-    | not isTty && isOneShot options = ApproveAll
-    | not isTty = DenyMutating
-    | options.optYolo == Explicit False = PromptMutating
-    | projectAutoApprove = ApproveAll
-    | otherwise = PromptMutating
+resolveApprovalPolicy options isTty projectAutoApprove =
+    resolveApproval ApprovalInputs
+        { approvalYolo = case options.optYolo of
+            Inherit -> Nothing
+            Explicit enabled -> Just enabled
+        , approvalDenyMutations = options.optManagedDenyMutations
+        , approvalManagedTurn = isJust options.optManagedTurnFile
+        , approvalOneShot = isOneShot options
+        , approvalInteractive = isTty
+        , approvalProjectAutoApprove = projectAutoApprove
+        }
 
 -- | Preserve a parent's policy in a background turn without borrowing stdin.
 applyBackgroundApproval :: ApprovalPolicy -> CliOptions -> CliOptions
@@ -797,28 +802,6 @@ parseMotionMode raw = case Text.toLower (Text.pack raw) of
     "reduced" -> Right MotionReduced
     "off" -> Right MotionOff
     _ -> Left ("--motion expects full, reduced, or off (got " <> raw <> ")")
-
-reasoningEfforts :: [ReasoningEffort]
-reasoningEfforts = ReasoningEffort.reasoningEfforts
-
--- | Efforts exposed by the active model-facing protocol. Grok accepts
--- @xhigh@ but rejects the OpenAI-only @max@ value.
-reasoningEffortsForDialect :: DialectId -> [ReasoningEffort]
-reasoningEffortsForDialect = \case
-    GrokBuildDialect -> filter (/= EffortMax) reasoningEfforts
-    _ -> reasoningEfforts
-
--- | Replace an effort unsupported by the active model-facing protocol with
--- its closest supported value. This also cleans up resumed sessions and
--- provider switches that inherited an effort from another dialect.
-normalizeReasoningEffortForDialect
-    :: DialectId
-    -> ReasoningEffort
-    -> ReasoningEffort
-normalizeReasoningEffortForDialect dialect effort
-    | effort `elem` reasoningEffortsForDialect dialect = effort
-    | dialect == GrokBuildDialect = EffortHigh
-    | otherwise = effort
 
 parseEffort :: Text -> Either String ReasoningEffort
 parseEffort = either (Left . Text.unpack) Right . parseReasoningEffort

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Model.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Model.hs
@@ -9,14 +9,14 @@ module Agent.CLI.Runtime.Orchestration.Tools.Model
 import Agent.Accounts.Auth (LoadedAuth(..), isGatewayLoadedAuth)
 import Agent.Runtime.Config (HarnessConfig)
 import Agent.Runtime.GatewayClient (cachedGatewayModels, gatewayCredentialIdentity)
-import Agent.CLI.GatewayModels (modelOptionsForGatewayModels, selectGatewayModelOption)
-import Agent.Runtime.ModelConfig (ResponsesConnection(..), builtinConnectionId)
-import Agent.Runtime.Models
-    ( ModelOption(..), ModelTarget(..), defaultModelFor, rawModelOption
-    , resolveConfiguredModel, resolvePersistedDialect )
+import Agent.Runtime.Startup.Gateway (modelOptionsForGatewayModels, selectGatewayModelOption)
+import Agent.Runtime.ModelConfig (ResponsesConnection(..))
+import Agent.Runtime.Models (ModelOption(..), ModelTarget(..))
+import Agent.Runtime.Startup.Model
+import Agent.Runtime.Startup.Policy
+    ( NativeApprovalMode(..), resolveNativeApproval, claudeBypassEnabled )
 import Agent.CLI.Options
-    ( ApprovalPolicy(..), CliOptions(..), Override(..), defaultEffortFor
-    , normalizeReasoningEffortForDialect, resolveApprovalPolicy )
+    ( ApprovalPolicy, CliOptions(..), Override(..), resolveApprovalPolicy )
 import Agent.CLI.Project (ProjectModel(..), ProjectSettings(..))
 import Agent.CLI.Runtime.Orchestration.Tools.Request
 import Agent.CLI.Runtime.Orchestration.Types
@@ -28,11 +28,11 @@ import Agent.CLI.Startup.Auth (markStartupStage, startupDie)
 import Agent.Dialect (Dialect, DialectId, dialectForId)
 import qualified Agent.OpenRouter as OpenRouter
 import Agent.Provider (Provider(..))
-import Agent.ReasoningEffort (parseReasoningEffort, reasoningEffortText)
+import Agent.ReasoningEffort (reasoningEffortText)
 import Agent.Responses.GenericClient (GenericClientOptions(..))
 import Control.Monad (when)
 import Data.IORef (readIORef)
-import Data.Maybe (fromMaybe, isJust, catMaybes)
+import Data.Maybe (isJust, catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -157,49 +157,31 @@ resolveToolModel AgentToolsRequest
     } =
     ToolModelRuntime{..}
   where
-    toolProvider = loaded.loadedProvider
-    fallbackModel =
-        defaultModelFor catalog toolProvider
-    unrestrictedModel =
-        fromMaybe
-            (maybe fallbackModel (.targetModelId) targetHint)
-            options.optModel
-    toolModel =
-        maybe
-            unrestrictedModel
-            (.modelTarget.targetModelId)
-            gatewaySelection
-    rawTarget = (rawModelOption toolProvider toolModel).modelTarget
-    inferredTarget0 =
-        maybe
-            (fromMaybe rawTarget targetHint)
-            (.modelTarget)
-            gatewaySelection
-    toolTransportModel = case customResponses of
-        Just _ ->
-            \name ->
-                case resolveConfiguredModel catalog name of
-                    Just option
-                        | option.modelTarget.targetConnectionId
-                            == inferredTarget0.targetConnectionId ->
-                            option.modelTarget.targetWireModelId
-                    _
-                        | name == toolModel ->
-                            inferredTarget0.targetWireModelId
-                        | otherwise -> name
-        _ -> case toolProvider of
-            OpenRouterProvider -> OpenRouter.mapModel openRouterOptions
-            _ -> id
-    toolInferredTarget =
-        inferredTarget0
-            { targetWireModelId =
-                if inferredTarget0.targetConnectionId
-                    == builtinConnectionId OpenRouterProvider
-                    && inferredTarget0.targetWireModelId
-                        == inferredTarget0.targetModelId
-                    then toolTransportModel toolModel
-                    else inferredTarget0.targetWireModelId
-            }
+    resolved = resolveStartupModel ModelStartupInputs
+        { startupProvider = loaded.loadedProvider
+        , startupCatalog = catalog
+        , startupRequestedModel = options.optModel
+        , startupTargetHint = targetHint
+        , startupGatewaySelection = gatewaySelection
+        , startupTransitionTarget = transitionTarget
+        , startupResumedModel = toResumedModel . fst <$> resumed
+        , startupRememberedTarget = (.projectModelTarget) <$> projectSettings.settingsLastModel
+        , startupRequestedEffort = options.optEffort
+        , startupCustomResponses = isJust customResponses
+        , startupOpenRouterMap = OpenRouter.mapModel openRouterOptions
+        }
+    toResumedModel meta = ResumedModel
+        { resumedProvider = meta.metaProvider
+        , resumedConnection = meta.metaConnection
+        , resumedModel = meta.metaModel
+        , resumedDialect = meta.metaDialect
+        , resumedTransportModel = meta.metaTransportModel
+        , resumedEffort = meta.metaEffort
+        }
+    toolProvider = resolved.resolvedProvider
+    toolModel = resolved.resolvedModel
+    toolTransportModel = resolved.resolvedTransportModel
+    toolInferredTarget = resolved.resolvedTarget
     toolCustomGenericOptions = do
         (_, responses) <- customResponses
         pure GenericClientOptions
@@ -209,86 +191,27 @@ resolveToolModel AgentToolsRequest
             , requestTimeoutSeconds =
                 responses.responsesRequestTimeoutSeconds
             }
-    persistedTarget = case fst <$> resumed of
-        Just meta ->
-            Just
-                ( meta.metaDialect
-                , meta.metaTransportModel
-                )
-        Nothing -> do
-            remembered <- projectSettings.settingsLastModel
-            let target = remembered.projectModelTarget
-            if target.targetProvider == toolProvider
-                then Just
-                    ( target.targetDialect
-                    , Just target.targetWireModelId
-                    )
-                else Nothing
-    resolvedPersistedTarget =
-        (\(storedDialect, storedTransportModel) ->
-            resolvePersistedDialect
-                storedDialect
-                storedTransportModel
-                toolInferredTarget)
-            <$> persistedTarget
-    mappedTargetChanged = maybe False snd resolvedPersistedTarget
-    toolDialectId = case gatewaySelection of
-        Just selected -> selected.modelTarget.targetDialect
-        Nothing -> case transitionTarget of
-            Just target -> target.targetDialect
-            Nothing -> case options.optModel of
-                Just _ -> toolInferredTarget.targetDialect
-                Nothing
-                    | mappedTargetChanged -> toolInferredTarget.targetDialect
-                    | otherwise ->
-                        maybe
-                            toolInferredTarget.targetDialect
-                            fst
-                            resolvedPersistedTarget
+    toolDialectId = resolved.resolvedDialect
     toolDialect = dialectForId toolDialectId
-    toolResumeTargetChanged = case fst <$> resumed of
-        Just meta ->
-            toolProvider /= meta.metaProvider
-                || toolInferredTarget.targetConnectionId /= meta.metaConnection
-                || toolModel /= meta.metaModel
-                || mappedTargetChanged
-                || toolDialectId /= meta.metaDialect
-        Nothing -> False
-    toolRefreshDialectContext = case fst <$> resumed of
-        Just meta -> toolDialectId /= meta.metaDialect
-        Nothing -> False
+    toolResumeTargetChanged = resolved.resolvedResumeTargetChanged
+    toolRefreshDialectContext = resolved.resolvedRefreshDialectContext
     toolLegacySubagentTarget =
         sessionLegacySubagentTarget . fst <$> resumed
-    effort =
-        normalizeReasoningEffortForDialect toolDialectId $
-            fromMaybe
-                (maybe
-                    (defaultEffortFor toolProvider)
-                    (either
-                        (const (defaultEffortFor toolProvider))
-                        id
-                        . parseReasoningEffort
-                        . (.metaEffort))
-                    (fst <$> resumed))
-                options.optEffort
-    toolEffortText = reasoningEffortText effort
-    toolPolicy = case startup.startupNativeHooks of
-        Just hooks -> case hooks.nativeInteractionMode of
-            NativeYolo -> ApproveAll
-            NativeAsk -> PromptMutating
-            NativePlan -> PromptMutating
+    toolEffortText = reasoningEffortText resolved.resolvedEffort
+    nativeApproval = (\hooks ->
+        ( case hooks.nativeInteractionMode of
+            NativeYolo -> NativeApprovalYolo
+            NativeAsk -> NativeApprovalAsk
+            NativePlan -> NativeApprovalPlan
+        , isJust hooks.nativeRegisterInteractionMode
+        )) <$> startup.startupNativeHooks
+    toolPolicy = case nativeApproval of
+        Just (mode, _) -> resolveNativeApproval mode
         Nothing ->
             resolveApprovalPolicy options isTty
                 projectSettings.settingsAutoApprove
-    toolClaudeBypassEnabled =
-        case startup.startupNativeHooks of
-            Just hooks ->
-                -- A live native mode must always pass through the host's
-                -- mutable approval policy, even when initially in Yolo.
-                case hooks.nativeRegisterInteractionMode of
-                    Just _ -> False
-                    Nothing -> hooks.nativeInteractionMode == NativeYolo
-            Nothing ->
-                options.optYolo /= Explicit False
-                    && (options.optYolo == Explicit True
-                        || projectSettings.settingsAutoApprove)
+    toolClaudeBypassEnabled = claudeBypassEnabled nativeApproval
+        (case options.optYolo of
+            Inherit -> Nothing
+            Explicit enabled -> Just enabled)
+        projectSettings.settingsAutoApprove

--- a/packages/agent-runtime/agent-runtime.cabal
+++ b/packages/agent-runtime/agent-runtime.cabal
@@ -111,6 +111,9 @@ library
                     , Agent.Runtime.SessionOwner
                     , Agent.Runtime.SessionState
                     , Agent.Runtime.StartupPolicy
+                    , Agent.Runtime.Startup.Model
+                    , Agent.Runtime.Startup.Policy
+                    , Agent.Runtime.Startup.Gateway
                     , Agent.Runtime.TurnEngine
                     , Agent.Runtime.TurnExecution
                     , Agent.Runtime.TurnState
@@ -255,6 +258,9 @@ test-suite agent-runtime-test
                     , Agent.Runtime.SessionSpec.Persistence
                     , Agent.Runtime.SessionSpec.ResponseItems
                     , Agent.Runtime.StartupPolicySpec
+                    , Agent.Runtime.Startup.ModelSpec
+                    , Agent.Runtime.Startup.PolicySpec
+                    , Agent.Runtime.Startup.GatewaySpec
                     , Agent.Runtime.ConversationStoreSpec
                     , Agent.Runtime.ConversationSessionSpec
                     , Agent.Runtime.TurnEngineSpec

--- a/packages/agent-runtime/src/Agent/Runtime/Startup/Gateway.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Startup/Gateway.hs
@@ -1,0 +1,89 @@
+-- | Pure credential-scoped gateway catalog projection and selection.
+module Agent.Runtime.Startup.Gateway
+    ( modelOptionsForGatewayModels
+    , modelOptionsForGatewayState
+    , selectGatewayModelOption
+    ) where
+
+import Agent.Runtime.GatewayClient (GatewayModel(..), GatewayModelProvider(..))
+import Agent.Runtime.ModelConfig (ModelCatalog)
+import Agent.Runtime.Models
+    ( ModelOption(modelTarget)
+    , ModelTarget(targetProvider, targetModelId)
+    , gatewayModelOptions
+    , modelCatalog
+    , resolveModelOptionById
+    )
+import Agent.Provider
+    ( Provider (ClaudeCodeProvider, OpenAIProvider, XAIProvider) )
+import Data.List (find, nubBy)
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import Data.Text qualified as Text
+
+-- | Saved targets supply an alias preference, never provider identity: older
+-- gateway sessions recorded Grok aliases as OpenAI targets.
+selectGatewayModelOption
+    :: [ModelOption]
+    -> Maybe Text
+    -> Maybe Provider
+    -> [ModelTarget]
+    -> Either Text ModelOption
+selectGatewayModelOption options requestedModel requestedProvider targetHints =
+    case requestedModel of
+        Just modelId ->
+            case resolveModelOptionById options modelId of
+                Nothing ->
+                    Left
+                        ("Model " <> modelId
+                            <> " is not offered by the organization gateway.")
+                Just option
+                    | matchesProvider option -> Right option
+                    | otherwise ->
+                        Left
+                            "The selected gateway model does not use the requested provider."
+        Nothing ->
+            case find matchesProvider (preferredOptions <> options) of
+                Just option -> Right option
+                Nothing ->
+                    Left
+                        (case requestedProvider of
+                            Just _ ->
+                                "The organization gateway does not offer any models for the requested provider."
+                            Nothing ->
+                                "The organization gateway does not offer any models.")
+  where
+    preferredOptions =
+        mapMaybe
+            (resolveModelOptionById options . (.targetModelId))
+            targetHints
+    matchesProvider option =
+        maybe True (== option.modelTarget.targetProvider) requestedProvider
+
+modelOptionsForGatewayModels
+    :: ModelCatalog
+    -> [GatewayModel]
+    -> [ModelOption]
+modelOptionsForGatewayModels catalog models =
+    concatMap modelOptions $
+        nubBy (\first second -> first.gatewayModelId == second.gatewayModelId)
+            (filter (publicAlias . (.gatewayModelId)) models)
+  where
+    modelOptions model =
+        gatewayModelOptions catalog
+            (case model.gatewayModelProvider of
+                GatewayOpenAIProvider -> OpenAIProvider
+                GatewayXAIProvider -> XAIProvider
+                GatewayAnthropicProvider -> ClaudeCodeProvider)
+            [model.gatewayModelId]
+    publicAlias modelId =
+        not ("router-" `Text.isPrefixOf` modelId)
+            && modelId /= "traumimmo-translation"
+
+modelOptionsForGatewayState
+    :: ModelCatalog
+    -> Maybe [GatewayModel]
+    -> [ModelOption]
+modelOptionsForGatewayState catalog = \case
+    Nothing -> modelCatalog catalog
+    Just models -> modelOptionsForGatewayModels catalog models

--- a/packages/agent-runtime/src/Agent/Runtime/Startup/Model.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Startup/Model.hs
@@ -1,0 +1,128 @@
+-- | Pure model/dialect/effort resolution after the host has loaded its inputs.
+-- No terminal, credential loading, or mutable session state enters this boundary.
+module Agent.Runtime.Startup.Model
+    ( ModelStartupInputs(..)
+    , ResumedModel(..)
+    , ResolvedModel(..)
+    , resolveStartupModel
+    ) where
+
+import Agent.Dialect (DialectId)
+import Agent.Provider (Provider(..))
+import Agent.ReasoningEffort (ReasoningEffort, parseReasoningEffort)
+import Agent.Runtime.ModelConfig (ModelCatalog, builtinConnectionId)
+import Agent.Runtime.Models
+    ( ModelOption(..), ModelTarget(..), defaultModelFor, rawModelOption
+    , resolveConfiguredModel, resolvePersistedDialect )
+import Agent.Runtime.Options (defaultEffortFor)
+import Agent.Runtime.Startup.Policy (normalizeReasoningEffortForDialect)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+
+-- | Only the persisted fields that participate in startup resolution.
+data ResumedModel = ResumedModel
+    { resumedProvider :: Provider
+    , resumedConnection :: Text
+    , resumedModel :: Text
+    , resumedDialect :: DialectId
+    , resumedTransportModel :: Maybe Text
+    , resumedEffort :: Text
+    }
+
+data ModelStartupInputs = ModelStartupInputs
+    { startupProvider :: Provider
+    , startupCatalog :: ModelCatalog
+    , startupRequestedModel :: Maybe Text
+    -- | Already resolved by the host's authentication/connection selection.
+    , startupTargetHint :: Maybe ModelTarget
+    -- | An authoritative, admitted gateway selection overrides local hints.
+    , startupGatewaySelection :: Maybe ModelOption
+    , startupTransitionTarget :: Maybe ModelTarget
+    , startupResumedModel :: Maybe ResumedModel
+    , startupRememberedTarget :: Maybe ModelTarget
+    , startupRequestedEffort :: Maybe ReasoningEffort
+    , startupCustomResponses :: Bool
+    , startupOpenRouterMap :: Text -> Text
+    }
+
+data ResolvedModel = ResolvedModel
+    { resolvedProvider :: Provider
+    , resolvedModel :: Text
+    , resolvedTransportModel :: Text -> Text
+    , resolvedTarget :: ModelTarget
+    , resolvedDialect :: DialectId
+    , resolvedResumeTargetChanged :: Bool
+    , resolvedRefreshDialectContext :: Bool
+    , resolvedEffort :: ReasoningEffort
+    }
+
+resolveStartupModel :: ModelStartupInputs -> ResolvedModel
+resolveStartupModel ModelStartupInputs{..} = ResolvedModel{..}
+  where
+    resolvedProvider = startupProvider
+    fallbackModel = defaultModelFor startupCatalog startupProvider
+    unrestrictedModel = fromMaybe
+        (maybe fallbackModel (.targetModelId) startupTargetHint)
+        startupRequestedModel
+    resolvedModel = maybe unrestrictedModel (.modelTarget.targetModelId)
+        startupGatewaySelection
+    rawTarget = (rawModelOption startupProvider resolvedModel).modelTarget
+    inferredTarget = maybe (fromMaybe rawTarget startupTargetHint) (.modelTarget)
+        startupGatewaySelection
+    resolvedTransportModel
+        | startupCustomResponses = \name ->
+            case resolveConfiguredModel startupCatalog name of
+                Just option
+                    | option.modelTarget.targetConnectionId == inferredTarget.targetConnectionId ->
+                        option.modelTarget.targetWireModelId
+                _
+                    | name == resolvedModel -> inferredTarget.targetWireModelId
+                    | otherwise -> name
+        | startupProvider == OpenRouterProvider = startupOpenRouterMap
+        | otherwise = id
+    resolvedTarget = inferredTarget
+        { targetWireModelId =
+            if inferredTarget.targetConnectionId == builtinConnectionId OpenRouterProvider
+                && inferredTarget.targetWireModelId == inferredTarget.targetModelId
+                then resolvedTransportModel resolvedModel
+                else inferredTarget.targetWireModelId
+        }
+    persistedTarget = case startupResumedModel of
+        Just resumed -> Just (resumed.resumedDialect, resumed.resumedTransportModel)
+        Nothing -> do
+            target <- startupRememberedTarget
+            if target.targetProvider == startupProvider
+                then Just (target.targetDialect, Just target.targetWireModelId)
+                else Nothing
+    resolvedPersistedTarget =
+        (\(storedDialect, storedTransportModel) ->
+            resolvePersistedDialect storedDialect storedTransportModel resolvedTarget)
+            <$> persistedTarget
+    mappedTargetChanged = maybe False snd resolvedPersistedTarget
+    resolvedDialect = case startupGatewaySelection of
+        Just selected -> selected.modelTarget.targetDialect
+        Nothing -> case startupTransitionTarget of
+            Just target -> target.targetDialect
+            Nothing -> case startupRequestedModel of
+                Just _ -> resolvedTarget.targetDialect
+                Nothing
+                    | mappedTargetChanged -> resolvedTarget.targetDialect
+                    | otherwise -> maybe resolvedTarget.targetDialect fst resolvedPersistedTarget
+    resolvedResumeTargetChanged = case startupResumedModel of
+        Just resumed ->
+            startupProvider /= resumed.resumedProvider
+                || resolvedTarget.targetConnectionId /= resumed.resumedConnection
+                || resolvedModel /= resumed.resumedModel
+                || mappedTargetChanged
+                || resolvedDialect /= resumed.resumedDialect
+        Nothing -> False
+    resolvedRefreshDialectContext = case startupResumedModel of
+        Just resumed -> resolvedDialect /= resumed.resumedDialect
+        Nothing -> False
+    resolvedEffort = normalizeReasoningEffortForDialect resolvedDialect $
+        fromMaybe
+            (maybe (defaultEffortFor startupProvider)
+                (either (const (defaultEffortFor startupProvider)) id
+                    . parseReasoningEffort . (.resumedEffort))
+                startupResumedModel)
+            startupRequestedEffort

--- a/packages/agent-runtime/src/Agent/Runtime/Startup/Policy.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Startup/Policy.hs
@@ -1,0 +1,82 @@
+-- | Frontend-neutral approval and reasoning-effort policy.
+module Agent.Runtime.Startup.Policy
+    ( ApprovalInputs(..)
+    , NativeApprovalMode(..)
+    , resolveApproval
+    , resolveNativeApproval
+    , claudeBypassEnabled
+    , reasoningEfforts
+    , reasoningEffortsForDialect
+    , normalizeReasoningEffortForDialect
+    ) where
+
+import Agent.Dialect (DialectId(..))
+import Agent.ReasoningEffort (ReasoningEffort(..), reasoningEfforts)
+import Agent.Runtime.Options (ApprovalPolicy(..))
+
+data ApprovalInputs = ApprovalInputs
+    { approvalYolo :: Maybe Bool
+    , approvalDenyMutations :: Bool
+    , approvalManagedTurn :: Bool
+    , approvalOneShot :: Bool
+    , approvalInteractive :: Bool
+    , approvalProjectAutoApprove :: Bool
+    } deriving (Eq, Show)
+
+-- | Explicit approval remains authoritative. A managed turn with an explicit
+-- prompt policy can use its host approval channel without borrowing stdin.
+resolveApproval :: ApprovalInputs -> ApprovalPolicy
+resolveApproval inputs
+    | inputs.approvalYolo == Just True = ApproveAll
+    | inputs.approvalDenyMutations = DenyMutating
+    | inputs.approvalManagedTurn && inputs.approvalYolo == Just False =
+        PromptMutating
+    | inputs.approvalYolo == Just False && not inputs.approvalInteractive =
+        DenyMutating
+    | not inputs.approvalInteractive && inputs.approvalOneShot = ApproveAll
+    | not inputs.approvalInteractive = DenyMutating
+    | inputs.approvalYolo == Just False = PromptMutating
+    | inputs.approvalProjectAutoApprove = ApproveAll
+    | otherwise = PromptMutating
+
+data NativeApprovalMode
+    = NativeApprovalYolo
+    | NativeApprovalAsk
+    | NativeApprovalPlan
+    deriving (Eq, Show)
+
+resolveNativeApproval :: NativeApprovalMode -> ApprovalPolicy
+resolveNativeApproval = \case
+    NativeApprovalYolo -> ApproveAll
+    NativeApprovalAsk -> PromptMutating
+    NativeApprovalPlan -> PromptMutating
+
+-- | A live native policy must continue through the host's mutable approval
+-- channel, even when its initial mode is Yolo. The tuple flag indicates that
+-- the host supports live policy changes.
+claudeBypassEnabled
+    :: Maybe (NativeApprovalMode, Bool)
+    -> Maybe Bool
+    -> Bool
+    -> Bool
+claudeBypassEnabled native yolo projectAutoApprove =
+    case native of
+        Just (mode, mutable) -> not mutable && mode == NativeApprovalYolo
+        Nothing -> yolo /= Just False && (yolo == Just True || projectAutoApprove)
+
+-- | Efforts exposed by the active model-facing protocol. Grok accepts
+-- @xhigh@ but rejects the OpenAI-only @max@ value.
+reasoningEffortsForDialect :: DialectId -> [ReasoningEffort]
+reasoningEffortsForDialect = \case
+    GrokBuildDialect -> filter (/= EffortMax) reasoningEfforts
+    _ -> reasoningEfforts
+
+-- | Normalize inherited effort when resuming or switching providers.
+normalizeReasoningEffortForDialect
+    :: DialectId
+    -> ReasoningEffort
+    -> ReasoningEffort
+normalizeReasoningEffortForDialect dialect effort
+    | effort `elem` reasoningEffortsForDialect dialect = effort
+    | dialect == GrokBuildDialect = EffortHigh
+    | otherwise = effort

--- a/packages/agent-runtime/test/Agent/Runtime/Startup/GatewaySpec.hs
+++ b/packages/agent-runtime/test/Agent/Runtime/Startup/GatewaySpec.hs
@@ -1,0 +1,39 @@
+module Agent.Runtime.Startup.GatewaySpec (spec) where
+
+import Agent.Provider (Provider(..))
+import Agent.Runtime.Models (ModelOption(..), ModelTarget(..), rawModelOption)
+import Agent.Runtime.Startup.Gateway
+import Test.Hspec
+
+spec :: Spec
+spec = describe "startup gateway selection" do
+    it "rejects a requested alias outside the admitted catalog" do
+        selectGatewayModelOption offered (Just "private") Nothing []
+            `shouldBe` Left "Model private is not offered by the organization gateway."
+    it "rejects an explicit alias routed through another provider" do
+        selectGatewayModelOption offered (Just "grok") (Just OpenAIProvider) []
+            `shouldBe` Left "The selected gateway model does not use the requested provider."
+    it "uses explicit selection before saved hints" do
+        selectGatewayModelOption offered (Just "openai") Nothing [grok.modelTarget]
+            `shouldBe` Right openai
+    it "treats a legacy saved provider as a hint, not routing authority" do
+        let legacy = grok.modelTarget{targetProvider = OpenAIProvider}
+        selectGatewayModelOption offered Nothing (Just XAIProvider) [legacy]
+            `shouldBe` Right grok
+    it "skips unavailable and provider-incompatible saved hints" do
+        selectGatewayModelOption offered Nothing (Just OpenAIProvider)
+            [(rawModelOption OpenAIProvider "removed").modelTarget, grok.modelTarget]
+            `shouldBe` Right openai
+    it "preserves hint ordering among available aliases" do
+        selectGatewayModelOption offered Nothing Nothing [grok.modelTarget, openai.modelTarget]
+            `shouldBe` Right grok
+    it "does not fall back to an unrequested provider" do
+        selectGatewayModelOption offered Nothing (Just GeminiProvider) []
+            `shouldBe` Left "The organization gateway does not offer any models for the requested provider."
+    it "fails closed on an empty gateway catalog" do
+        selectGatewayModelOption [] Nothing Nothing []
+            `shouldBe` Left "The organization gateway does not offer any models."
+  where
+    openai = rawModelOption OpenAIProvider "openai"
+    grok = rawModelOption XAIProvider "grok"
+    offered = [openai, grok]

--- a/packages/agent-runtime/test/Agent/Runtime/Startup/ModelSpec.hs
+++ b/packages/agent-runtime/test/Agent/Runtime/Startup/ModelSpec.hs
@@ -1,0 +1,146 @@
+module Agent.Runtime.Startup.ModelSpec (spec) where
+
+import Agent.Dialect (DialectId(..))
+import Agent.Provider (Provider(..))
+import Agent.ReasoningEffort (ReasoningEffort(..))
+import Agent.Runtime.ModelConfig
+    ( ModelCatalog, decodeModelConfig, mergeModelConfigs, packagedModelCatalogPath, builtinConnectionId )
+import Agent.Runtime.Models (ModelOption(..), ModelTarget(..), defaultModelFor, rawModelOption)
+import Agent.Runtime.Startup.Model
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text as Text
+import Test.Hspec
+
+spec :: Spec
+spec = describe "startup model resolution" do
+    catalog <- runIO do
+        path <- packagedModelCatalogPath
+        bytes <- LBS.readFile path
+        either (fail . Text.unpack) pure (decodeModelConfig "models.default.json" bytes)
+    let inputs = defaults catalog
+        base = (rawModelOption OpenAIProvider "selected").modelTarget
+        resumed = ResumedModel OpenAIProvider (builtinConnectionId OpenAIProvider)
+            "selected" CodexDialect (Just "selected") "high"
+        resuming = inputs{startupTargetHint = Just base, startupResumedModel = Just resumed}
+    it "uses the catalog default without an explicit model or hint" do
+        (resolveStartupModel inputs).resolvedModel `shouldBe` defaultModelFor catalog OpenAIProvider
+    it "uses a resolved target hint before the catalog default" do
+        (resolveStartupModel inputs{startupTargetHint = Just base}).resolvedModel `shouldBe` "selected"
+    it "uses an explicit model before the target hint" do
+        (resolveStartupModel inputs{startupRequestedModel = Just "explicit", startupTargetHint = Just base}).resolvedModel
+            `shouldBe` "explicit"
+    it "uses the admitted gateway target and dialect before local overrides" do
+        let gateway = (rawModelOption OpenAIProvider "gateway")
+                {modelTarget = base{targetModelId = "gateway", targetWireModelId = "gateway", targetDialect = GenericResponsesDialect}}
+            result = resolveStartupModel resuming
+                { startupRequestedModel = Just "explicit"
+                , startupGatewaySelection = Just gateway
+                , startupTransitionTarget = Just base
+                }
+        result.resolvedModel `shouldBe` "gateway"
+        result.resolvedTarget `shouldBe` gateway.modelTarget
+        result.resolvedDialect `shouldBe` GenericResponsesDialect
+    it "retains persisted dialect and effort when resuming an unchanged target" do
+        let result = resolveStartupModel resuming
+        result.resolvedDialect `shouldBe` CodexDialect
+        result.resolvedEffort `shouldBe` EffortHigh
+        result.resolvedResumeTargetChanged `shouldBe` False
+        result.resolvedRefreshDialectContext `shouldBe` False
+    it "prefers a transition dialect over persisted dialect" do
+        let result = resolveStartupModel resuming
+                {startupTransitionTarget = Just base{targetDialect = GenericResponsesDialect}}
+        result.resolvedDialect `shouldBe` GenericResponsesDialect
+        result.resolvedResumeTargetChanged `shouldBe` True
+        result.resolvedRefreshDialectContext `shouldBe` True
+    it "invalidates a resumed target when its wire mapping changes" do
+        let result = resolveStartupModel resuming
+                {startupTargetHint = Just base{targetWireModelId = "new-wire", targetDialect = GenericResponsesDialect}}
+        result.resolvedDialect `shouldBe` GenericResponsesDialect
+        result.resolvedResumeTargetChanged `shouldBe` True
+        result.resolvedRefreshDialectContext `shouldBe` True
+    it "invalidates a connection change without unnecessarily refreshing dialect context" do
+        let result = resolveStartupModel resuming
+                {startupTargetHint = Just base{targetConnectionId = "other"}}
+        result.resolvedResumeTargetChanged `shouldBe` True
+        result.resolvedRefreshDialectContext `shouldBe` False
+    it "only inherits a remembered project's dialect for the same provider" do
+        let remembered = base{targetDialect = GenericResponsesDialect}
+            result target = resolveStartupModel inputs
+                {startupTargetHint = Just base, startupRememberedTarget = Just target}
+        (result remembered).resolvedDialect `shouldBe` GenericResponsesDialect
+        (result remembered{targetProvider = XAIProvider}).resolvedDialect `shouldBe` CodexDialect
+    it "an explicit selection replaces the remembered dialect" do
+        (resolveStartupModel resuming
+            { startupRequestedModel = Just "selected"
+            , startupResumedModel = Just resumed{resumedDialect = GenericResponsesDialect}
+            }).resolvedDialect `shouldBe` CodexDialect
+    it "an invalid saved effort falls back to the active provider default" do
+        (resolveStartupModel resuming
+            {startupResumedModel = Just resumed{resumedEffort = "invalid"}}).resolvedEffort
+            `shouldBe` EffortMedium
+    it "explicit effort overrides valid resumed effort" do
+        (resolveStartupModel resuming{startupRequestedEffort = Just EffortLow}).resolvedEffort
+            `shouldBe` EffortLow
+    mapM_ (\(provider, expected) ->
+        it ("invalid saved effort uses the new default after switching to " <> show provider) do
+            let result = resolveStartupModel inputs
+                    { startupProvider = provider
+                    , startupTargetHint = Just (rawModelOption provider "switched").modelTarget
+                    , startupResumedModel = Just resumed{resumedEffort = "invalid"}
+                    }
+            result.resolvedEffort `shouldBe` expected
+            result.resolvedResumeTargetChanged `shouldBe` True)
+        [(ClaudeCodeProvider, EffortXHigh), (XAIProvider, EffortHigh)]
+    it "resumed dialect wins over a remembered project dialect" do
+        (resolveStartupModel resuming
+            {startupRememberedTarget = Just base{targetDialect = GenericResponsesDialect}}).resolvedDialect
+            `shouldBe` CodexDialect
+    it "normalizes an explicitly inherited max effort for Grok" do
+        (resolveStartupModel inputs
+            { startupProvider = XAIProvider
+            , startupRequestedEffort = Just EffortMax
+            , startupTargetHint = Just (rawModelOption XAIProvider "grok").modelTarget{targetDialect = GrokBuildDialect}
+            }).resolvedEffort `shouldBe` EffortHigh
+    it "maps built-in OpenRouter wire targets without changing their public model id" do
+        let target = (rawModelOption OpenRouterProvider "alias").modelTarget
+            result = resolveStartupModel inputs
+                {startupProvider = OpenRouterProvider, startupTargetHint = Just target, startupOpenRouterMap = const "wire"}
+        result.resolvedModel `shouldBe` "alias"
+        result.resolvedTarget.targetWireModelId `shouldBe` "wire"
+        result.resolvedTransportModel "child" `shouldBe` "wire"
+    it "preserves an already resolved OpenRouter wire target" do
+        let target = (rawModelOption OpenRouterProvider "alias").modelTarget{targetWireModelId = "pinned"}
+        (resolveStartupModel inputs
+            {startupProvider = OpenRouterProvider, startupTargetHint = Just target, startupOpenRouterMap = const "changed"}
+            ).resolvedTarget.targetWireModelId `shouldBe` "pinned"
+    it "custom response mappings retain unknown child names and the selected exact wire id" do
+        let target = base{targetConnectionId = "custom", targetWireModelId = "exact-wire"}
+            result = resolveStartupModel inputs{startupTargetHint = Just target, startupCustomResponses = True}
+        result.resolvedTransportModel "selected" `shouldBe` "exact-wire"
+        result.resolvedTransportModel "unknown-child" `shouldBe` "unknown-child"
+    it "maps configured children only within the selected custom connection" do
+        path <- packagedModelCatalogPath
+        bytes <- LBS.readFile path
+        let overlay = "{\"version\":1,\"connections\":{\"custom\":{\"api\":\"responses\",\"base_url\":\"http://localhost:8000/v1\",\"api_key_optional\":true},\"other\":{\"api\":\"responses\",\"base_url\":\"http://localhost:8001/v1\",\"api_key_optional\":true}},\"models\":[{\"id\":\"child\",\"connection\":\"custom\",\"model\":\"child-wire\",\"dialect\":\"generic-responses\"},{\"id\":\"foreign\",\"connection\":\"other\",\"model\":\"foreign-wire\",\"dialect\":\"generic-responses\"}]}"
+        customCatalog <- either (fail . Text.unpack) pure
+            (mergeModelConfigs ("defaults.json", bytes) (Just ("custom.json", overlay)))
+        let target = base{targetConnectionId = "custom", targetWireModelId = "exact-wire"}
+            result = resolveStartupModel inputs
+                {startupCatalog = customCatalog, startupTargetHint = Just target, startupCustomResponses = True}
+        result.resolvedTransportModel "child" `shouldBe` "child-wire"
+        result.resolvedTransportModel "foreign" `shouldBe` "foreign"
+
+defaults :: ModelCatalog -> ModelStartupInputs
+defaults catalog = ModelStartupInputs
+    { startupProvider = OpenAIProvider
+    , startupCatalog = catalog
+    , startupRequestedModel = Nothing
+    , startupTargetHint = Nothing
+    , startupGatewaySelection = Nothing
+    , startupTransitionTarget = Nothing
+    , startupResumedModel = Nothing
+    , startupRememberedTarget = Nothing
+    , startupRequestedEffort = Nothing
+    , startupCustomResponses = False
+    , startupOpenRouterMap = id
+    }

--- a/packages/agent-runtime/test/Agent/Runtime/Startup/PolicySpec.hs
+++ b/packages/agent-runtime/test/Agent/Runtime/Startup/PolicySpec.hs
@@ -1,0 +1,48 @@
+module Agent.Runtime.Startup.PolicySpec (spec) where
+
+import Agent.Runtime.Options (ApprovalPolicy(..))
+import Agent.Runtime.Startup.Policy
+import Test.Hspec
+
+spec :: Spec
+spec = describe "startup approval policy" do
+    mapM_ (\(label, inputs, expected) ->
+        it label $ resolveApproval inputs `shouldBe` expected)
+        [ ("prompts in an interactive session", defaults, PromptMutating)
+        , ("inherits project approval interactively",
+            defaults{approvalProjectAutoApprove = True}, ApproveAll)
+        , ("explicit opt-out overrides project approval",
+            defaults{approvalYolo = Just False, approvalProjectAutoApprove = True}, PromptMutating)
+        , ("denies an unattended interactive session",
+            defaults{approvalInteractive = False, approvalProjectAutoApprove = True}, DenyMutating)
+        , ("auto-approves unattended one-shot work",
+            defaults{approvalInteractive = False, approvalOneShot = True}, ApproveAll)
+        , ("explicit opt-out denies unattended one-shot work",
+            defaults{approvalYolo = Just False, approvalInteractive = False, approvalOneShot = True}, DenyMutating)
+        , ("managed prompt policy uses the host instead of stdin",
+            defaults{approvalYolo = Just False, approvalManagedTurn = True, approvalInteractive = False}, PromptMutating)
+        , ("managed deny wins over the managed prompt exception",
+            defaults{approvalYolo = Just False, approvalManagedTurn = True, approvalDenyMutations = True}, DenyMutating)
+        , ("explicit yolo retains precedence over managed deny",
+            defaults{approvalYolo = Just True, approvalDenyMutations = True}, ApproveAll)
+        ]
+    mapM_ (\(mode, expected) -> it ("resolves native " <> show mode) do
+        resolveNativeApproval mode `shouldBe` expected
+        claudeBypassEnabled (Just (mode, True)) (Just True) True `shouldBe` False
+        claudeBypassEnabled (Just (mode, False)) (Just False) False
+            `shouldBe` (mode == NativeApprovalYolo))
+        [(NativeApprovalYolo, ApproveAll), (NativeApprovalAsk, PromptMutating), (NativeApprovalPlan, PromptMutating)]
+    it "only bypasses Claude approval when inherited or explicit yolo allows it" do
+        map (\(override, project) -> claudeBypassEnabled Nothing override project)
+            [(Nothing, False), (Nothing, True), (Just False, True), (Just True, False)]
+            `shouldBe` [False, True, False, True]
+
+defaults :: ApprovalInputs
+defaults = ApprovalInputs
+    { approvalYolo = Nothing
+    , approvalDenyMutations = False
+    , approvalManagedTurn = False
+    , approvalOneShot = False
+    , approvalInteractive = True
+    , approvalProjectAutoApprove = False
+    }

--- a/packages/agent-runtime/test/Spec.hs
+++ b/packages/agent-runtime/test/Spec.hs
@@ -7,6 +7,9 @@ import qualified Agent.Runtime.Tools.StartupSpec as ToolStartup
 import qualified Agent.Runtime.ProviderRuntimeSpec as ProviderRuntime
 import qualified Agent.Runtime.CompactionSpec as Compaction
 import qualified Agent.Runtime.StartupPolicySpec as StartupPolicy
+import qualified Agent.Runtime.Startup.ModelSpec as StartupModel
+import qualified Agent.Runtime.Startup.PolicySpec as StartupApproval
+import qualified Agent.Runtime.Startup.GatewaySpec as StartupGateway
 import qualified Agent.Runtime.ConversationStoreSpec as ConversationStore
 import qualified Agent.Runtime.ConversationSessionSpec as ConversationSession
 import qualified Agent.Runtime.TurnEngineSpec as TurnEngine
@@ -43,6 +46,9 @@ main = hspec do
     ProviderRuntime.spec
     Compaction.spec
     StartupPolicy.spec
+    StartupModel.spec
+    StartupApproval.spec
+    StartupGateway.spec
     ConversationStore.spec
     ConversationSession.spec
     TurnEngine.spec

--- a/scripts/check-package-boundaries.sh
+++ b/scripts/check-package-boundaries.sh
@@ -165,6 +165,9 @@ required_files=(
   packages/agent-runtime/src/Agent/Runtime/Tools/Dialects.hs
   packages/agent-runtime/src/Agent/Runtime/Tools/Resources.hs
   packages/agent-runtime/src/Agent/Runtime/Tools/Startup.hs
+  packages/agent-runtime/src/Agent/Runtime/Startup/Model.hs
+  packages/agent-runtime/src/Agent/Runtime/Startup/Policy.hs
+  packages/agent-runtime/src/Agent/Runtime/Startup/Gateway.hs
   packages/agent-runtime/test/Agent/Runtime/Tools/ResourcesSpec.hs
   packages/agent-runtime/test/Agent/Runtime/Tools/StartupSpec.hs
   packages/agent-runtime/src/Agent/Runtime/Providers.hs


### PR DESCRIPTION
## Summary
- Move pure model, dialect, effort, approval, and gateway-selection rules into agent-runtime.
- Keep credential loading and UI/IO adapters in agent-cli; preserve existing behavior and public CLI exports.
- Add 41 regression cases and update package boundaries and architecture documentation. No new Cabal package or dependency.

## Validation
- All 759 library modules load in GHCi.
- 49 focused runtime tests pass.
- 1,202 CLI options, gateway, and native-runtime compatibility tests pass.
- Nix package-boundary check passes.
- Regenerated runtime package.nix (unchanged); git diff --check passes.