### PR TITLE
Add macOS JavaScriptCore code-mode experiment

### DIFF
--- a/packages/agent-tools/benchmark/javascriptcore/Comparison.hs
+++ b/packages/agent-tools/benchmark/javascriptcore/Comparison.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import qualified Agent.Tools.CodeMode.Host as Bun
+import Control.DeepSeq (force)
+import Control.Exception.Safe (bracket)
+import Control.Exception (evaluate)
+import Control.Monad (forM, forM_, replicateM_, unless)
+import Data.Aeson (Value(..), eitherDecodeStrict', encode)
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString.Lazy as Lazy
+import Data.List (sort)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Vector as Vector
+import GHC.Clock (getMonotonicTimeNSec)
+import qualified JavaScriptCorePrototype as JavaScriptCore
+import System.Environment (getArgs)
+import Text.Printf (printf)
+import Text.Read (readMaybe)
+
+-- Compare a deliberately limited prototype with the actual production Bun host.
+-- This is not a feature-equivalent backend or an end-to-end application benchmark.
+main :: IO ()
+main = do
+    arguments <- getArgs
+    (worker, cells, samples) <- case arguments of
+        [path, count, repetitions]
+            | Just count' <- readMaybe count, count' > 0
+            , Just repetitions' <- (readMaybe repetitions :: Maybe Int), repetitions' > 0 ->
+                pure (path, count', repetitions')
+        _ -> fail "usage: javascriptcore-comparison WORKER_PATH CELLS SAMPLES"
+    let config = Bun.defaultCodeModeConfig worker (\_ value -> pure (Right value))
+    bracket (Bun.newCodeModeHost config) Bun.closeCodeModeHost $ \host ->
+        JavaScriptCore.withRuntime $ \runtime -> do
+            let runBun source = do
+                    result <- Bun.execCodeCell host (Text.pack source) ["echo", "reject"] 3000
+                    finishBun host result
+                runNative source = do
+                    result <- JavaScriptCore.executeCellWith runtime echoPayload source
+                    either fail pure result
+            forM_ [(0, 16), (1, 16), (10, 16), (100, 16), (1, 4096), (10, 4096)] $ \(calls, bytes) -> do
+                let source = workload calls bytes
+                    expected = [if calls == 0 then "ok" else show (calls * bytes)]
+                    checked run = run source >>= \actual -> do
+                        unless (actual == expected) $ fail ("unexpected output: " <> show actual)
+                        evaluate (force actual) >> pure ()
+                _ <- evaluate (force source)
+                replicateM_ 5 (checked runBun >> checked runNative)
+                pairs <- forM [1..samples] $ \index ->
+                    if odd index then do
+                        baseline <- measure cells (checked runBun)
+                        native <- measure cells (checked runNative)
+                        pure (baseline, native)
+                    else do
+                        native <- measure cells (checked runNative)
+                        baseline <- measure cells (checked runBun)
+                        pure (baseline, native)
+                printf "calls=%d bytes=%d cells=%d samples=%d bun_ms=%.4f javascriptcore_ms=%.4f\n"
+                    calls bytes cells samples (median (map fst pairs)) (median (map snd pairs))
+echoPayload :: String -> IO (Either String String)
+echoPayload payload = pure $ case eitherDecodeStrict' (Text.encodeUtf8 (Text.pack payload)) of
+    Left message -> Left message
+    Right value -> Right (Text.unpack (Text.decodeUtf8 (Lazy.toStrict (encode (value :: Value)))))
+
+workload :: Int -> Int -> String
+workload 0 _ = "text('ok');"
+workload calls bytes =
+    "const payload = 'x'.repeat(" <> show bytes <> "); let total = 0; "
+    <> "for (let index = 0; index < " <> show calls <> "; index++) { "
+    <> "const result = await tools.echo({payload}); total += result.payload.length; } text(total);"
+
+finishBun :: Bun.CodeModeHost -> Either Bun.CodeModeError Bun.CodeModeResult -> IO [String]
+finishBun host result = case result of
+    Right Bun.CodeModeRunning{Bun.cellId = identifier} ->
+        Bun.waitCodeCell host identifier 3000 >>= finishBun host
+    Right Bun.CodeModeFinished{Bun.cellValue = value} -> case value of
+        Object object | Just (Array content) <- KeyMap.lookup "content" object ->
+            mapM extractText (Vector.toList content)
+        _ -> fail ("unexpected Bun result: " <> show value)
+    _ -> fail ("Bun execution failed: " <> show result)
+  where
+    extractText (Object item) | Just (String value) <- KeyMap.lookup "text" item = pure (Text.unpack value)
+    extractText value = fail ("unexpected content: " <> show value)
+
+measure :: Int -> IO () -> IO Double
+measure cells action = do
+    started <- getMonotonicTimeNSec
+    replicateM_ cells action
+    finished <- getMonotonicTimeNSec
+    pure (fromIntegral (finished - started) / 1e6 / fromIntegral cells)
+
+median :: [Double] -> Double
+median values = sort values !! (length values `div` 2)

--- a/packages/agent-tools/benchmark/javascriptcore/JavaScriptCorePrototype.hs
+++ b/packages/agent-tools/benchmark/javascriptcore/JavaScriptCorePrototype.hs
@@ -1,0 +1,182 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | Experimental, trusted-input-only code-mode evaluator. Not a sandbox.
+-- All JavaScriptCore activity stays on the bound thread owning the runtime.
+-- No public execution timeout API is used: never run untrusted/CPU-bound input.
+module JavaScriptCorePrototype
+    ( Runtime, withRuntime, executeCell, executeCellWith ) where
+
+import Control.Concurrent (runInBoundThread)
+import Control.Exception.Safe (SomeException, bracket, catch, finally, try, displayException)
+import Control.Monad (void, when)
+import Data.IORef
+import qualified Data.Sequence as Sequence
+import qualified Data.ByteString as BS
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Foreign hiding (void)
+import Foreign.C
+
+type Reference = Ptr ()
+type Callback = Reference -> Reference -> Reference -> CSize -> Ptr Reference
+    -> Ptr Reference -> IO Reference
+
+foreign import ccall safe "JSContextGroupCreate" createGroup :: IO Reference
+foreign import ccall safe "JSContextGroupRelease" releaseGroup :: Reference -> IO ()
+foreign import ccall safe "JSGlobalContextCreateInGroup" createContext :: Reference -> Reference -> IO Reference
+foreign import ccall safe "JSGlobalContextRelease" releaseContext :: Reference -> IO ()
+foreign import ccall unsafe "JSContextGetGlobalObject" globalObject :: Reference -> IO Reference
+foreign import ccall unsafe "JSStringCreateWithCharacters" createString :: Ptr Word16 -> CSize -> IO Reference
+foreign import ccall unsafe "JSStringRelease" releaseString :: Reference -> IO ()
+foreign import ccall unsafe "JSStringGetMaximumUTF8CStringSize" stringCapacity :: Reference -> IO CSize
+foreign import ccall unsafe "JSStringGetUTF8CString" copyString :: Reference -> CString -> CSize -> IO CSize
+foreign import ccall safe "JSValueToStringCopy" valueString :: Reference -> Reference -> Ptr Reference -> IO Reference
+foreign import ccall unsafe "JSValueMakeString" makeString :: Reference -> Reference -> IO Reference
+foreign import ccall unsafe "JSValueMakeUndefined" makeUndefined :: Reference -> IO Reference
+foreign import ccall unsafe "JSValueProtect" protectValue :: Reference -> Reference -> IO ()
+foreign import ccall unsafe "JSValueUnprotect" unprotectValue :: Reference -> Reference -> IO ()
+foreign import ccall unsafe "JSObjectMakeFunctionWithCallback" makeFunction :: Reference -> Reference -> FunPtr Callback -> IO Reference
+foreign import ccall safe "JSObjectSetProperty" setProperty :: Reference -> Reference -> Reference -> Reference -> CUInt -> Ptr Reference -> IO ()
+foreign import ccall safe "JSEvaluateScript" evaluateScript :: Reference -> Reference -> Reference -> Reference -> CInt -> Ptr Reference -> IO Reference
+foreign import ccall safe "JSObjectCallAsFunction" callFunction :: Reference -> Reference -> Reference -> CSize -> Ptr Reference -> Ptr Reference -> IO Reference
+foreign import ccall "wrapper" wrapCallback :: Callback -> IO (FunPtr Callback)
+
+data Runtime = Runtime Reference (FunPtr Callback) (IORef Callback)
+
+-- | Caller must not use the runtime from another thread or retain it afterward.
+withRuntime :: (Runtime -> IO a) -> IO a
+withRuntime action = runInBoundThread $ do
+    dispatch <- newIORef (\context _ _ _ _ _ -> makeUndefined context)
+    let callback context function object count arguments exception = do
+            current <- readIORef dispatch
+            current context function object count arguments exception
+    bracket (wrapCallback callback) freeHaskellFunPtr $ \function ->
+        bracket createGroup releaseGroup $ \group ->
+            action (Runtime group function dispatch)
+
+withString :: String -> (Reference -> IO a) -> IO a
+withString value action =
+    BS.useAsCStringLen (Text.encodeUtf16LE (Text.pack value)) $ \(bytes, size) ->
+        bracket (createString (castPtr bytes) (fromIntegral (size `div` 2))) releaseString action
+
+readString :: Reference -> IO String
+readString value = do
+    capacity <- stringCapacity value
+    allocaBytes (fromIntegral capacity) $ \buffer -> do
+        count <- copyString value buffer capacity
+        bytes <- BS.packCStringLen (buffer, max 0 (fromIntegral count - 1))
+        pure (Text.unpack (Text.decodeUtf8 bytes))
+
+readValue :: Reference -> Reference -> IO String
+readValue context value =
+    bracket (valueString context value nullPtr)
+        (\string -> when (string /= nullPtr) (releaseString string)) $ \string ->
+        if string == nullPtr then pure "<unprintable JavaScript value>" else readString string
+
+checked :: Reference -> (Ptr Reference -> IO a) -> IO a
+checked context action = alloca $ \exception -> do
+    poke exception nullPtr
+    result <- action exception
+    failure <- peek exception
+    when (failure /= nullPtr) $ readValue context failure >>= ioError . userError
+    pure result
+
+evaluate :: Reference -> String -> IO ()
+evaluate context source = withString source $ \script ->
+    void (checked context (evaluateScript context script nullPtr nullPtr 1))
+
+data Pending = Pending Reference Reference String
+
+executeCell :: Runtime -> String -> IO (Either String [String])
+executeCell runtime = executeCellWith runtime (pure . Right)
+
+-- | Tool handler consumes/returns JSON payloads, not request envelopes.
+-- Pending Promise functions are protected until handled or cell cleanup.
+-- Handlers run after evaluation returns, not inside a JavaScript callback.
+executeCellWith :: Runtime -> (String -> IO (Either String String)) -> String
+    -> IO (Either String [String])
+executeCellWith (Runtime group function currentCallback) handler source = do
+    outcome <- try $ bracket (createContext group nullPtr) releaseContext $ \context -> do
+        output <- newIORef []
+        completed <- newIORef Nothing
+        pending <- newIORef Sequence.empty
+        callbackFailure <- newIORef Nothing
+        let releasePending (Pending resolve reject _) =
+                unprotectValue context resolve >> unprotectValue context reject
+            cleanup = readIORef pending >>= mapM_ releasePending
+            dispatch arguments = case arguments of
+                [operation, value, resolve, reject] -> do
+                    name <- readValue context operation
+                    case name of
+                        "tool" -> do
+                            payload <- readValue context value
+                            protectValue context resolve
+                            protectValue context reject
+                            modifyIORef' pending (Sequence.|> Pending resolve reject payload)
+                        _ -> ioError (userError "invalid native operation")
+                [operation, value] -> do
+                    name <- readValue context operation
+                    case name of
+                        "text" -> readValue context value >>= \text -> modifyIORef' output (text :)
+                        "done" -> writeIORef completed (Just (Right ()))
+                        "error" -> readValue context value >>= writeIORef completed . Just . Left
+                        _ -> ioError (userError "invalid native operation")
+                _ -> ioError (userError "invalid native argument count")
+            callback _ _ _ count arguments _ = do
+                (peekArray (fromIntegral count) arguments >>= dispatch)
+                    `catch` \(failure :: SomeException) ->
+                        writeIORef callbackFailure (Just (displayException failure))
+                makeUndefined context
+            resolvePending entry@(Pending resolve reject payload) =
+                (do
+                    response <- handler payload
+                    let (continuation, text) = either (\err -> (reject, err)) (\value -> (resolve, value)) response
+                    withString text $ \string -> do
+                        value <- makeString context string
+                        withArray [value] $ \arguments ->
+                            void (checked context (callFunction context continuation nullPtr 1 arguments)))
+                `finally` releasePending entry
+            drain = do
+                failure <- readIORef callbackFailure
+                case failure of
+                    Just message -> pure (Left message)
+                    Nothing -> do
+                        state <- readIORef completed
+                        case state of
+                            Just (Left message) -> pure (Left message)
+                            Just (Right ()) -> Right . reverse <$> readIORef output
+                            Nothing -> do
+                                -- Remove one request at a time so exceptions leave
+                                -- every remaining protected value owned by cleanup.
+                                next <- atomicModifyIORef' pending $ \entries -> case Sequence.viewl entries of
+                                    Sequence.EmptyL -> (Sequence.empty, Nothing)
+                                    first Sequence.:< rest -> (rest, Just first)
+                                case next of
+                                    Nothing -> pure (Left "execution suspended without a pending tool request")
+                                    Just entry -> resolvePending entry >> drain
+        -- The runtime owns the trampoline until its context group is released.
+        -- Only the active cell's closure is retained between callback entries.
+        bracket
+            (writeIORef currentCallback callback)
+            (\() -> writeIORef currentCallback (\ctx _ _ _ _ _ -> makeUndefined ctx))
+            $ \() ->
+            (do
+                global <- globalObject context
+                withString "__native" $ \name -> do
+                    native <- makeFunction context name function
+                    checked context (setProperty context global name native 0)
+                evaluate context (bootstrap <> "\n(async () => {\n\"use strict\";\n" <> source
+                    <> "\n})().then(() => __native('done', ''), error => __native('error', String(error)));")
+                drain)
+            `finally` cleanup
+    pure $ either (Left . displayException) id (outcome :: Either SomeException (Either String [String]))
+
+bootstrap :: String
+bootstrap = unlines
+    [ "globalThis.text = value => __native('text', typeof value === 'string' ? value : JSON.stringify(value));"
+    , "globalThis.tools = Object.freeze({"
+    , "  echo: value => new Promise((resolve, reject) =>"
+    , "    __native('tool', JSON.stringify(value), result => resolve(JSON.parse(result)), reject)),"
+    , "  reject: value => Promise.reject(new Error(String(value)))"
+    , "});"
+    ]

--- a/packages/agent-tools/benchmark/javascriptcore/JavaScriptCoreTests.hs
+++ b/packages/agent-tools/benchmark/javascriptcore/JavaScriptCoreTests.hs
@@ -1,0 +1,46 @@
+module Main (main) where
+
+import Control.Monad (unless)
+import Control.Concurrent (threadDelay)
+import Data.List (isInfixOf)
+import JavaScriptCorePrototype
+
+main :: IO ()
+main = withRuntime $ \runtime -> do
+    assertEqual "text" (Right ["ok"]) =<< executeCell runtime "text('ok');"
+    assertEqual "await" (Right ["{\"answer\":42}"]) =<<
+        executeCell runtime "text(await tools.echo({answer: 42}));"
+    assertEqual "concurrent" (Right ["[1,2,3]"]) =<<
+        executeCell runtime "text(await Promise.all([1,2,3].map(value => tools.echo(value))));"
+    assertEqual "unicode" (Right ["Grüße 日本語 😀"]) =<<
+        executeCell runtime "text(await tools.echo('Grüße 日本語 😀'));"
+    assertEqual "embedded null" (Right ["a\0b"]) =<<
+        executeCell runtime "text(await tools.echo('a\\u0000b'));"
+    assertEqual "state initial" (Right []) =<<
+        executeCell runtime "globalThis.previousCell = 42;"
+    assertEqual "fresh state" (Right ["undefined"]) =<<
+        executeCell runtime "text(typeof globalThis.previousCell);"
+    assertFailure "JavaScript rejection" "refused" =<<
+        executeCell runtime "await tools.reject('refused');"
+    assertFailure "native rejection" "native refused" =<<
+        executeCellWith runtime (\_ -> pure (Left "native refused")) "await tools.echo({});"
+    assertEqual "deferred native completion" (Right ["42"]) =<<
+        executeCellWith runtime (\payload -> threadDelay 1000 >> pure (Right payload))
+            "text(await tools.echo(42));"
+    assertFailure "handler exception" "handler failure" =<<
+        executeCellWith runtime (\_ -> fail "handler failure")
+            "await Promise.all([tools.echo(1), tools.echo(2)]);"
+    assertFailure "syntax" "SyntaxError" =<< executeCell runtime "const = ;"
+    assertFailure "unresolved promise" "suspended" =<<
+        executeCell runtime "await new Promise(() => {});"
+    assertEqual "recovery" (Right ["ok"]) =<< executeCell runtime "text('ok');"
+    putStrLn "JavaScriptCore prototype: 14 checks passed."
+
+assertEqual :: (Eq a, Show a) => String -> a -> a -> IO ()
+assertEqual label expected actual =
+    unless (expected == actual) (fail (label <> ": expected " <> show expected <> ", got " <> show actual))
+
+assertFailure :: String -> String -> Either String a -> IO ()
+assertFailure label fragment actual = case actual of
+    Left message | fragment `isInfixOf` message -> pure ()
+    _ -> fail (label <> ": expected failure containing " <> fragment)

--- a/packages/agent-tools/benchmark/javascriptcore/README.md
+++ b/packages/agent-tools/benchmark/javascriptcore/README.md
@@ -1,0 +1,95 @@
+# macOS JavaScriptCore experiment
+
+Standalone, trusted-input-only prototype. **Not wired into production code mode.**
+It links Apple's system JavaScriptCore framework through Haskell's C FFI; no Bun
+process is involved in the native path.
+
+## How it works
+
+One bound Haskell thread owns a reusable JSContextGroup and callback trampoline.
+Each cell gets a fresh global context. An async-function wrapper permits `await`.
+`tools.echo` creates a Promise, calls into Haskell, and queues protected resolver
+references. Once evaluation returns, Haskell services the queue and resolves or
+rejects each Promise through the C API. JavaScriptCore runs the continuation.
+Payloads remain JSON, but there are no pipes, RPC envelopes or process switches.
+Context cleanup releases pending references; the trampoline outlives the group.
+
+## Reproduce
+
+On macOS, from the repository root:
+
+```sh
+bash packages/agent-tools/benchmark/javascriptcore/run.sh
+```
+
+The script uses the existing Nix flake, builds the actual agent-tools library and
+comparison executable with `-O2`, runs the semantic checks, and benchmarks twice
+with `+RTS -N4`. Build artifacts and results go beneath `$TMPDIR`. The framework
+comes from macOS, so its version is not pinned by Nix.
+
+For interactive validation (not performance measurements):
+
+```sh
+mkdir -p "$TMPDIR/javascriptcore-ghci"
+nix develop -c ghci -ignore-dot-ghci -framework JavaScriptCore \
+  -stubdir "$TMPDIR/javascriptcore-ghci" \
+  -ipackages/agent-tools/benchmark/javascriptcore \
+  packages/agent-tools/benchmark/javascriptcore/JavaScriptCoreTests.hs
+# :main
+```
+
+Tests cover output, awaited callbacks, queued Promise.all calls, delayed native
+completion, Unicode and embedded NUL, fresh globals, JavaScript/native rejection,
+syntax errors, unresolved Promises, native exceptions with pending siblings, and
+recovery afterward. These are semantic smoke tests, not a security audit.
+
+## Measurement scope
+
+Comparison.hs runs the same source through the actual pooled Bun Host and this
+prototype, checks/forces outputs, and uses an echo handler with JSON decoding and
+encoding on both paths. Runtime startup is excluded; fresh cell/context setup,
+execution, callbacks, output handling and cleanup are included. Each reported
+number is the median of seven sample averages, each averaging 30 cells, after five
+warmups per workload/backend. Backend order alternates between samples.
+
+This is **not feature-equivalent** and not an end-to-end application measurement:
+only two tool names are advertised to Bun and native defaults to echo/reject.
+The native prototype has a fixed echo/reject catalog, not production tool dispatch.
+Large tool catalogs, approvals, real network tools, database persistence, concurrent
+cells and CPU/memory usage are not measured. Do not attribute the entire difference
+to IPC or extrapolate directly to the application's reported 20 ms overhead.
+
+## Results (2026-09-12)
+
+Apple M3 Max, macOS 26.6.1 (25G76), system JavaScriptCore bundle version 21624,
+GHC 9.10.3, Bun 1.4.0. Repository base: 434b6bcbc71afebc9636b9156635c41c2bc32f89.
+All 14 semantic checks passed. Two independent benchmark runs:
+
+| Calls/cell | Payload bytes | Bun ms/cell, runs 1 / 2 | JSC ms/cell, runs 1 / 2 |
+|---:|---:|---:|---:|
+| 0 | — | 0.1908 / 0.2366 | 0.0584 / 0.0769 |
+| 1 | 16 | 0.2738 / 0.2679 | 0.0758 / 0.0864 |
+| 10 | 16 | 0.7891 / 0.8621 | 0.1386 / 0.1413 |
+| 100 | 16 | 6.0652 / 6.4684 | 0.6216 / 0.5931 |
+| 1 | 4096 | 0.3095 / 0.2956 | 0.2593 / 0.2709 |
+| 10 | 4096 | 1.0577 / 1.1085 | 1.6572 / 1.7069 |
+
+Embedding is promising for small calls, but this prototype loses on repeated large
+payloads. Its String/Text/JSON conversions remain unoptimized. These timings do not
+reproduce a 20 ms warm empty-cell cost; trace the real application before deciding
+which overhead to remove. Earlier exploratory runs showed substantial timing
+variation, so treat these as local microbenchmarks, not latency guarantees.
+
+## Before production
+
+- Hard cancellation and memory limits: an infinite JS loop can hang this process;
+  engine crashes/OOM are no longer isolated in a disposable Bun worker. Do not run
+  arbitrary model-generated code here. Consider a small isolated JSC helper.
+- Full host API: tool allowlists/dispatch, approval lifecycle, output limits,
+  media, store/load, timers, yield/wait, exit and cancellation semantics.
+- Module semantics: async-function wrapping is not ES-module evaluation and differs
+  for imports/exports, return and top-level bindings.
+- Thread-safe scheduling: runtime is single-owner and non-reentrant; queued native
+  handlers are serviced serially, not concurrently.
+- Validate resource lifetimes under cancellation and long-running workloads, engine
+  version differences, signed app/JIT behavior and a non-macOS fallback.

--- a/packages/agent-tools/benchmark/javascriptcore/run.sh
+++ b/packages/agent-tools/benchmark/javascriptcore/run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Run from the repository root on macOS: bash packages/agent-tools/benchmark/javascriptcore/run.sh
+set -euo pipefail
+: "${TMPDIR:?TMPDIR must be set}"
+bench=packages/agent-tools/benchmark/javascriptcore
+out=$(mktemp -d "$TMPDIR/javascriptcore.XXXXXX")
+export CODE_MODE_BENCH_OUT="$out"
+nix develop -c bash -euo pipefail -c '
+bench=packages/agent-tools/benchmark/javascriptcore
+out=$CODE_MODE_BENCH_OUT
+mkdir -p "$out/tests" "$out/comparison"
+ghc -O2 -threaded -rtsopts -Wall -framework JavaScriptCore -i"$bench" \
+  "$bench/JavaScriptCoreTests.hs" -outputdir "$out/tests" -stubdir "$out/tests" -o "$out/tests/run"
+"$out/tests/run" +RTS -N4
+cabal build agent-tools:lib:agent-tools --enable-optimization=2
+cabal exec -- ghc -O2 -threaded -rtsopts -package agent-tools -framework JavaScriptCore \
+  -i"$bench" "$bench/Comparison.hs" -outputdir "$out/comparison" -stubdir "$out/comparison" -o "$out/compare"
+for run in 1 2; do
+  "$out/compare" "$PWD/packages/agent-tools/data/code-mode/worker.mjs" 30 7 +RTS -N4 | tee "$out/results-$run.txt"
+done
+'
+printf 'Artifacts: %s\n' "$out"


### PR DESCRIPTION
## Summary

- Add a standalone macOS JavaScriptCore C-FFI experiment with fresh per-cell contexts and Promise-based Haskell callbacks.
- Compare against the actual pooled Bun code-mode host using optimized, warmed, output-checked microbenchmarks.
- Document methodology, measured results, and missing production safety/compatibility requirements.

**This does not switch production code mode or agent-cli to JavaScriptCore. The native prototype is for trusted inputs only.**

## Results

Two local runs on an M3 Max: empty cells take 0.058–0.077 ms with JSC versus 0.191–0.237 ms with Bun; 100 small callbacks take 0.593–0.622 ms versus 6.065–6.468 ms. Repeated 4 KiB callbacks are slower with this prototype (1.657–1.707 ms versus 1.058–1.109 ms). These are not full CLI latency measurements or evidence that all differences are IPC overhead.

## Validation

- `bash packages/agent-tools/benchmark/javascriptcore/run.sh`: passed all 14 semantic checks and both benchmark runs.
- `nix build .#agent-cli --no-link --print-out-paths`: passed, including a rebuild at the exact PR commit. A subsequent read-only smoke attempt could not launch because the unrooted store output was no longer present.
- All nine GitHub CI checks passed for `e3b9a8d4ba721a45648953508e6a42187496ef9e`.
- tmux CLI smoke test: created a C Hello World program, edited it to accept an optional name, and added tests for the default and named greetings. This exercises the existing Bun backend, not the standalone JSC prototype.
- The CLI's compile step was blocked by scratch-directory sandbox access and an unavailable escalation prompt. Independently compiled its generated program with `-std=c11 -Wall -Wextra -Werror` in its Nix dev shell and ran its test script successfully: `Hello, world!` and `Hello, Ada!`. This is not a fully passing end-to-end CLI build test.
