### PR TITLE
Reduce Markdown table parsing allocation with strict Text

### DIFF
--- a/packages/agent-cli/STRING_AUDIT.md
+++ b/packages/agent-cli/STRING_AUDIT.md
@@ -12,13 +12,19 @@ handling. NUL splitting operates on Text and converts individual paths to
 `benchmark/GitOutput.md` for the isolated representation benchmark; this is
 not a measurement of whole-process memory or Git execution time.
 
+Markdown table rows now scan strict Text chunks rather than unpacking rows and
+packing each backtick-lookahead suffix. Completed cells are copied to avoid
+retaining a large source row through a small cell. Escape parity, Unicode
+whitespace, and the existing closing-backtick run rule are unchanged. See
+`../agent-tui/benchmark/MarkdownTable.md` for measurements and validation.
+This targets temporary parsing allocation, not retained conversation size.
+
 ## Prioritized follow-up
 
 | Priority | Module | Finding and acceptance criteria |
 | --- | --- | --- |
 | High | `agent-tui/src/Agent/TUI/TextWidth.hs` | `graphemeClusters` unpacks entire input, constructs character lists, then packs clusters; width checks also unpack. Benchmark Text traversal/slices in actual rendering and cursor workloads; preserve combining marks, flags, ZWJ, modifiers and terminal-width compatibility. |
 | Medium | `agent-cli/src/Agent/CLI/Clipboard/{MacOS,Linux}.hs` | Process capture passes potentially large clipboard content through String. Prefer byte capture with explicit decoding and Text results. Preserve subprocess cleanup, errors, and paste behavior. |
-| Medium | `agent-tui/src/Agent/TUI/Markdown/Block.hs` | `splitTableRow` unpacks each row and constructs reversed character lists. Benchmark a Text scanner/builder; preserve escaped pipes and code spans. |
 | Medium | `agent-store/src/Agent/Store/Postgres/Custom/Sql.hs` | `splitTopLevelStatements` unpacks complete SQL batches and constructs character-list statements. Separate parser change with equivalence tests for dollar quotes, escaping and nested comments. |
 | Lower | `agent-grok-build-dialect/src/Agent/GrokBuild/Dialect/Shell.hs` | Quote and ampersand scanning unpacks command text. Security-sensitive: preserve parser decisions before considering performance. |
 | Lower | `agent-mcp/src/Agent/MCP/Types.hs` | Arguments/environment retained as `[String]` and `[(String,String)]`. Text storage could defer conversion until process creation, but no significant memory contribution has been established. |
@@ -39,9 +45,9 @@ Further review identified these compatibility boundaries:
 - TextWidth predicates can migrate before segmentation. Preserve exactly two
   regional indicators for flags and character-count cursor offsets, not UTF-8
   byte offsets. Benchmark complete rendering/cursor consumers, not only helpers.
-- Markdown table scanning repeatedly packs the remaining suffix when looking
-  for closing backticks. Preserve escape parity and the existing closing-run
-  length rule while replacing this with Text traversal.
+- Markdown table scanning preserves escape parity and accepts closing backtick
+  runs at least as long as the opening run. Repeated suffix searches remain for
+  unmatched runs; the Text replacement is not a worst-case linear-time parser.
 - Clipboard byte capture must not silently change locale-based strict decoding
   into lenient UTF-8. Preserve backend fallback order and first-error selection.
 

--- a/packages/agent-tui/benchmark/MarkdownTable.hs
+++ b/packages/agent-tui/benchmark/MarkdownTable.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- Build twice, overriding only Markdown/Block.hs with the recorded baseline.
+module Main (main) where
+
+import qualified Agent.TUI.Markdown as Markdown
+import qualified Agent.TUI.Markdown.Block as Block
+import qualified Agent.TUI.Theme as Theme
+import Brick
+import Control.Exception (evaluate)
+import Control.Monad (forM, unless)
+import Data.Char (ord)
+import Data.IORef (newIORef, readIORef)
+import Data.List (foldl', sort)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LazyText
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+import Graphics.Vty.PictureToSpans (displayOpsForPic)
+import Graphics.Vty.Span (SpanOp(..))
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.Mem (performGC)
+import Text.Printf (printf)
+
+main :: IO ()
+main = do
+    enabled <- getRTSStatsEnabled
+    unless enabled (die "use +RTS -T")
+    getArgs >>= \case
+        [mode, kind, sizeArg, repeatsArg, samplesArg] -> do
+            unless (mode `elem` ["split", "render"]) (die "expected split or render")
+            unless (kind `elem` ["plain", "mixed", "unicode", "escaped", "prose"]) (die "unknown kind")
+            size <- positive sizeArg
+            repeats <- positive repeatsArg
+            samples <- positive samplesArg
+            results <- forM [1..samples] $ \nonce -> do
+                let input = [workload mode kind size (nonce * repeats + i) | i <- [1..repeats]]
+                _ <- evaluate (foldl' (\s t -> s + checksum t) 0 input)
+                ref <- newIORef input
+                performGC
+                before <- getRTSStats
+                cpu <- getCPUTime
+                wall <- getMonotonicTimeNSec
+                fresh <- readIORef ref
+                !result <- evaluate (consume mode fresh)
+                wallEnd <- getMonotonicTimeNSec
+                cpuEnd <- getCPUTime
+                performGC
+                after <- getRTSStats
+                pure (fromIntegral (wallEnd-wall)/1e6 :: Double,
+                      fromIntegral (cpuEnd-cpu)/1e9 :: Double,
+                      fromIntegral (allocated_bytes after-allocated_bytes before) :: Double,
+                      result)
+            printf "%s,%s,%d,%d,%d,%.6f,%.6f,%.0f,%d\n"
+                mode kind size repeats samples
+                (median [w | (w,_,_,_) <- results])
+                (median [c | (_,c,_,_) <- results])
+                (median [a | (_,_,a,_) <- results])
+                (sum [s | (_,_,_,s) <- results])
+        _ -> die "usage: MarkdownTable split|render plain|mixed|unicode|escaped|prose SIZE REPEATS SAMPLES"
+  where
+    positive s = case reads s of
+        [(n,"")] | n > 0 -> pure n
+        _ -> die "expected positive integer"
+    median xs = sort xs !! (length xs `div` 2)
+
+{-# NOINLINE consume #-}
+consume :: String -> [Text] -> Int
+consume mode = foldl' (\s t -> s + one t) 0
+  where
+    one = if mode == "split"
+        then maybe 0 (foldl' (\s t -> s + checksum t) 0) . Block.splitTableRow
+        else renderChecksum
+
+checksum :: Text -> Int
+checksum = Text.foldl' (\s c -> s * 33 + ord c) 5381
+
+renderChecksum :: Text -> Int
+renderChecksum body =
+    let widget :: Widget Text
+        widget = viewport "body" Vertical $ vBox
+            [Markdown.markdownWidgetWithSyntaxHighlightingAndLinks
+                Nothing id (\_ w -> w) (\_ _ -> emptyWidget) body,
+             visible (txt " ")]
+        (_, picture, _, extents) =
+            renderFinal Theme.terminalDefault [widget] (80,30) (const Nothing) emptyState
+    in foldl' (foldl' spanChecksum) 0 (displayOpsForPic picture (80,30))
+        + foldl' (\s e -> s + length (show e)) 0 extents
+  where
+    spanChecksum s = \case
+        TextSpan{textSpanText, textSpanAttr} ->
+            LazyText.foldl' (\n c -> n * 33 + ord c) s textSpanText + length (show textSpanAttr)
+        Skip n -> s + n
+        RowEnd n -> s + n
+    emptyState = read
+        "RS {viewportMap = fromList [], rsScrollRequests = [], \
+        \observedNames = fromList [], renderCache = fromList [], \
+        \clickableNames = [], requestedVisibleNames_ = fromList [], \
+        \reportedExtents = fromList []}"
+
+workload :: String -> String -> Int -> Int -> Text
+workload mode kind size nonce
+    | kind == "prose" = "# Answer " <> Text.pack (show nonce) <> "\n\n"
+        <> Text.replicate size "An ordinary **Markdown** paragraph with `code` and 日本語.\n\n"
+    | mode == "split" = "| " <> Text.pack (show nonce) <> " " <> Text.replicate size cell <> " | end |"
+    | otherwise = "# Table " <> Text.pack (show nonce) <> "\n\n"
+        <> "| Name | Value |\n| :--- | ---: |\n"
+        <> Text.replicate size ("| entry | " <> cell <> " |\n")
+        <> "\nA **complete** answer with [docs](https://example.com).\n"
+  where
+    cell = case kind of
+        "plain" -> "ordinary words "
+        "mixed" -> "**bold** `a|b` and ``c|d`` "
+        "unicode" -> "日本語 café 🙂 é "
+        _ -> "a\\|b \\\\| c `x\\|y` "

--- a/packages/agent-tui/benchmark/MarkdownTable.md
+++ b/packages/agent-tui/benchmark/MarkdownTable.md
@@ -1,0 +1,180 @@
+# Markdown table parser benchmark
+
+`MarkdownTable.hs` measures isolated row splitting and complete cold Markdown
+rendering. Preserve the exact baseline using its recorded Git object, not a
+second implementation rewritten to resemble the old algorithm.
+
+## Reproduce
+
+From the repository root, enter `nix develop`, then:
+
+```sh
+root="$TMPDIR/table-bench"
+mkdir -p "$root/old/Agent/TUI/Markdown" "$root/old-obj" "$root/new-obj"
+git show 434b6bcbc71afebc9636b9156635c41c2bc32f89:packages/agent-tui/src/Agent/TUI/Markdown/Block.hs \
+  > "$root/old/Agent/TUI/Markdown/Block.hs"
+for version in old new; do
+  ghc -O2 -rtsopts -XGHC2021 -XOverloadedStrings \
+    -XLambdaCase -XBlockArguments -XDerivingStrategies -XRecordWildCards \
+    -XDuplicateRecordFields -XOverloadedRecordDot -XNoFieldSelectors \
+    -i"$root/$version" -ipackages/agent-tui/src \
+    -ipackages/agent-syntax/src -ipackages/agent-core/src \
+    -ipackages/agent-json/src -ipackages/agent-responses-types/src -ipackages/agent-tools/src \
+    -outputdir "$root/$version-obj" \
+    packages/agent-tui/benchmark/MarkdownTable.hs -o "$root/$version-bin"
+done
+"$root/old-bin" split mixed 100 1000 7 +RTS -T
+"$root/new-bin" split mixed 100 1000 7 +RTS -T
+"$root/old-bin" render mixed 100 20 7 +RTS -T
+"$root/new-bin" render mixed 100 20 7 +RTS -T
+```
+
+Only `Block.hs` is overridden; all rendering and support code is otherwise
+identical and compiled with `-O2`. No production source is overwritten.
+Arguments: stage, kind, size, repetitions per sample, samples.
+CSV columns: stage, kind, size, repetitions, samples, median elapsed ms,
+median CPU ms, median allocated bytes, checksum.
+
+`split` grows a row by repeating a cell fragment `size` times; `render`
+grows a complete two-column table to `size` body rows, with a heading and
+following Markdown paragraph. Kinds include ordinary ASCII, inline formatting
+and different-width backtick spans, Unicode including combining and astral
+characters, and escaped pipes/backslashes. The escaped workload deliberately
+includes an unescaped pipe after a paired backslash.
+The `prose` kind is a non-table rendering control: a heading followed by
+`size` paragraphs containing ordinary words, bold, code, and Japanese text.
+
+Each sample uses unique, pre-forced input, an IORef read in the timed region,
+and a `NOINLINE` consumer. Splitting forces every resulting cell character;
+rendering parses the entire message, performs Brick layout/image composition
+in an 80×30 tail-following viewport, and consumes actual Vty span text,
+attributes, and click extents. It does not merely force widget WHNF.
+Syntax highlighting and caches are disabled. Rendering is completed-message
+rendering, not streaming cache performance.
+
+GC before timing is excluded. GC after timing accounts for the unfinished
+nursery in allocation totals. Default single-threaded RTS/allocation area.
+Compare checksums between the separately compiled binaries as a workload
+sanity check; the correctness suite provides stronger semantic checks.
+
+Peak RSS must be collected from separate processes (on macOS,
+`/usr/bin/time -l "$root/new-bin" render mixed 1000 20 1 +RTS -T`;
+on Linux use `/usr/bin/time -v`). Repeat each version and take the median.
+RSS includes the executable, runtime, inputs, and rendering; it is not an
+allocation count or a GC live-heap estimate.
+
+## Results
+
+Apple M3 Max, macOS, Nix GHC 9.10.3, settings above. Seven samples per
+invocation; allocations below are decimal MB. All old/new checksums matched.
+`split` uses 100 repetitions; `render` uses 20. Sizes 10/100/1000 were
+run for every kind, sequentially, with old/new adjacent.
+
+| Stage/kind | Size | Elapsed old → new (ms) | CPU old → new (ms) | Allocated old → new (MB) |
+| --- | ---: | --- | --- | --- |
+| split/plain | 10 | 0.196 → 0.046 | 0.196 → 0.046 | 2.094 → 0.125 |
+| split/plain | 100 | 1.977 → 0.368 | 1.978 → 0.367 | 18.657 → 0.260 |
+| split/plain | 1000 | 22.847 → 3.591 | 22.826 → 3.591 | 183.529 → 1.610 |
+| split/mixed | 10 | 1.632 → 0.355 | 1.619 → 0.356 | 5.478 → 2.594 |
+| split/mixed | 100 | 128.145 → 3.592 | 128.008 → 3.490 | 126.556 → 24.896 |
+| split/mixed | 1000 | 8946.497 → 45.269 | 8927.939 → 45.172 | 8264.894 → 247.916 |
+| split/unicode | 10 | 0.220 → 0.066 | 0.221 → 0.067 | 2.027 → 0.135 |
+| split/unicode | 100 | 2.186 → 0.438 | 2.200 → 0.438 | 17.868 → 0.360 |
+| split/unicode | 1000 | 24.878 → 4.491 | 24.774 → 4.491 | 174.808 → 2.610 |
+| split/escaped | 10 | 0.718 → 0.306 | 0.718 → 0.305 | 3.523 → 2.820 |
+| split/escaped | 100 | 39.419 → 3.450 | 39.259 → 3.449 | 56.169 → 27.156 |
+| split/escaped | 1000 | 3128.399 → 44.845 | 3123.387 → 44.774 | 2886.478 → 270.516 |
+| render/plain | 10 | 11.734 → 12.160 | 11.702 → 12.156 | 77.494 → 76.384 |
+| render/plain | 100 | 100.091 → 97.347 | 100.014 → 97.291 | 487.183 → 476.842 |
+| render/plain | 1000 | 1057.269 → 1052.240 | 1056.299 → 1051.277 | 4577.598 → 4474.955 |
+| render/mixed | 10 | 17.233 → 16.934 | 17.223 → 16.918 | 106.131 → 104.908 |
+| render/mixed | 100 | 149.724 → 147.213 | 149.616 → 146.849 | 687.726 → 676.265 |
+| render/mixed | 1000 | 1509.193 → 1491.047 | 1503.759 → 1488.999 | 6480.729 → 6366.886 |
+| render/unicode | 10 | 12.313 → 12.610 | 12.068 → 12.454 | 75.866 → 74.801 |
+| render/unicode | 100 | 101.756 → 101.458 | 101.670 → 101.369 | 470.885 → 460.992 |
+| render/unicode | 1000 | 1074.639 → 1056.525 | 1071.066 → 1051.105 | 4414.600 → 4316.437 |
+| render/escaped | 10 | 10.593 → 10.565 | 10.600 → 10.546 | 68.615 → 67.987 |
+| render/escaped | 100 | 82.151 → 82.585 | 82.128 → 82.529 | 398.438 → 392.929 |
+| render/escaped | 1000 | 918.848 → 920.093 | 917.599 → 918.314 | 3690.139 → 3635.816 |
+
+The large isolated speedups are **not** whole-render speedups. Ordinary
+short-cell tables spend most of their time in the unchanged inline renderer
+and Brick layout. Their allocation reductions are only about 1–2%, and
+timing differences are small enough to require repeat measurements.
+
+### Stability and apparent regressions
+
+Short isolated rows were also checked at size 1, 10,000 repetitions and seven
+samples (old/new adjacent). Checksums matched; there was no short-row slowdown.
+
+| Split kind | Elapsed old → new (ms) | CPU old → new (ms) | Allocated old → new (MB) |
+| --- | --- | --- | --- |
+| plain | 4.220 → 1.601 | 4.215 → 1.601 | 45.521 → 11.041 |
+| mixed | 9.276 → 4.463 | 9.281 → 4.470 | 72.481 → 36.241 |
+| unicode | 4.385 → 1.941 | 4.381 → 1.937 | 44.321 → 11.121 |
+| escaped | 6.474 → 4.684 | 6.469 → 4.677 | 58.401 → 38.561 |
+
+The initial short plain/Unicode renders appeared 2–4% slower. Retesting all
+four kinds at 10/100 rows with 100 repetitions, seven samples, and three fresh
+invocations per version (new then old, adjacent) did not reproduce that
+regression. The table is the median of those three invocation medians.
+
+| Render kind | Rows | Elapsed old → new (ms) | CPU old → new (ms) | Allocated old → new (MB) |
+| --- | ---: | --- | --- | --- |
+| plain | 10 | 59.632 → 58.455 | 59.290 → 58.098 | 387.467 → 381.914 |
+| plain | 100 | 478.589 → 476.835 | 477.620 → 474.790 | 2435.911 → 2384.206 |
+| unicode | 10 | 61.442 → 61.414 | 61.353 → 61.385 | 379.327 → 373.998 |
+| unicode | 100 | 505.852 → 504.824 | 505.199 → 503.995 | 2354.420 → 2304.956 |
+| escaped | 10 | 53.141 → 52.278 | 52.978 → 52.230 | 343.068 → 339.932 |
+| escaped | 100 | 412.313 → 411.379 | 411.296 → 410.505 | 1992.187 → 1964.642 |
+| mixed | 10 | 84.018 → 83.576 | 83.902 → 83.388 | 530.648 → 524.536 |
+| mixed | 100 | 732.434 → 723.863 | 730.718 → 722.556 | 3438.626 → 3381.321 |
+
+No material repeatable full-render regression was observed. Do not claim a
+meaningful full-render speedup for Unicode or escaped short-cell tables:
+these measurements are effectively flat. The supported benefit is faster,
+lower-allocation splitting, particularly eliminating repeated suffix conversion
+to Text during backtick lookahead, without moving cost into rendering. Suffix
+searches remain; this is not a worst-case linear-time parser.
+
+### Non-table control
+
+`render prose SIZE 20 7 +RTS -T`, three fresh invocations per version,
+old/new adjacent. Medians of invocation medians; all checksums matched.
+
+| Paragraphs | Elapsed old → new (ms) | CPU old → new (ms) | Allocated old → new (MB) |
+| ---: | --- | --- | --- |
+| 10 | 7.808 → 7.784 | 7.801 → 7.743 | 54.980 → 53.957 |
+| 100 | 73.625 → 71.514 | 73.617 → 71.463 | 394.658 → 384.621 |
+| 1000 | 758.593 → 751.993 | 757.602 → 751.232 | 3767.561 → 3667.380 |
+
+No repeatable regression: the first 100-paragraph pair was 68.238 → 71.257
+ms, but the next two were 73.934 → 71.514 and 73.625 → 71.771 ms.
+Treat small timing differences conservatively, not as a reliable prose speedup.
+
+### Peak RSS
+
+Five fresh processes per version, alternating old/new, running
+`render mixed 1000 20 1 +RTS -T` under macOS `/usr/bin/time -l`:
+median peak RSS **63,422,464 → 62,390,272 bytes** (60.48 → 59.50 MiB).
+Old range 63,422,464–63,455,232 bytes; all five new values were 62,390,272.
+This modest whole-process change is consistent with the small full-render
+allocation reduction, not the much larger isolated long-row improvement.
+
+For isolated splitting, three fresh processes per version, alternating
+old/new, running `split mixed 1000 100 1 +RTS -T` gave median peak RSS
+**35,586,048 → 28,262,400 bytes** (33.94 → 26.95 MiB). All old values
+were 35,586,048; new range 28,262,400–28,295,168 bytes.
+
+## Validation and limitations
+
+- Block, inline, and Markdown renderer suites: 92 examples, zero failures.
+- Differential comparison with the original parser: 166,501 generated rows,
+  zero mismatches, including 3,000 longer rows.
+- Direct source CLI Markdown rendering in tmux passed at widths 100 and 24,
+  including escaped pipes, code spans, Unicode, alignment, and wrapping.
+- Full-agent smoke testing was blocked by the existing GStreamer/pkg-config
+  dependency failure. The source renderer was tested directly instead.
+- Pathological unmatched-backtick performance was not measured separately.
+- This change reduces temporary parsing overhead; it does not establish a
+  reduction in idle agent memory or retained conversation size.

--- a/packages/agent-tui/src/Agent/TUI/Markdown/Block.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown/Block.hs
@@ -130,74 +130,74 @@ splitTableRow raw =
     let stripped = Text.strip raw
         content = fromMaybe stripped (Text.stripPrefix "|" stripped)
         (cells, delimiterCount) =
-            scan Nothing [] [] 0 False (Text.unpack content)
+            scan Nothing [] [] 0 False content
     in if delimiterCount >= 1 then Just cells else Nothing
   where
     scan
         :: Maybe Int
-        -> String
+        -> [Text]
         -> [Text]
         -> Int
         -> Bool
-        -> String
+        -> Text
         -> ([Text], Int)
-    scan _ current cells delimiterCount trailingDelimiter [] =
-        let allCells = reverse (finishCell current : cells)
-            withoutOuterBorder
-                | trailingDelimiter = dropLast allCells
-                | otherwise = allCells
-        in (withoutOuterBorder, delimiterCount)
-    scan codeRun current cells delimiterCount _ ('\\' : rest) =
-        let (slashes, afterSlashes) = span (== '\\') rest
-            slashCount = 1 + length slashes
-            literalSlashes =
-                replicate
-                    (if startsWithPipe afterSlashes
-                        then slashCount `div` 2
-                        else slashCount)
-                    '\\'
-            current' = literalSlashes <> current
-        in case afterSlashes of
-            '|' : afterPipe
-                | odd slashCount ->
-                    scan codeRun ('|' : current') cells
-                        delimiterCount False afterPipe
+    scan codeRun current cells delimiterCount trailingDelimiter remaining =
+        case Text.uncons remaining of
+            Nothing ->
+                let allCells
+                        | trailingDelimiter = cells
+                        | otherwise = finishCell current : cells
+                in (reverse allCells, delimiterCount)
+            Just ('\\', _) ->
+                let (slashes, afterSlashes) = Text.span (== '\\') remaining
+                    slashCount = Text.length slashes
+                    literalSlashes
+                        | startsWith (== '|') afterSlashes =
+                            Text.take (slashCount `div` 2) slashes
+                        | otherwise = slashes
+                    current' = literalSlashes : current
+                in case Text.uncons afterSlashes of
+                    Just ('|', afterPipe)
+                        | odd slashCount ->
+                            scan codeRun ("|" : current') cells
+                                delimiterCount False afterPipe
+                        | codeRun == Nothing ->
+                            splitCell codeRun current' cells delimiterCount afterPipe
+                    _ ->
+                        scan codeRun current' cells
+                            delimiterCount False afterSlashes
+            Just ('`', _) ->
+                let (ticks, afterTicks) = Text.span (== '`') remaining
+                    tickCount = Text.length ticks
+                    nextCodeRun = case codeRun of
+                        Just openCount
+                            | tickCount >= openCount -> Nothing
+                        Just openCount -> Just openCount
+                        Nothing
+                            | hasClosingRun tickCount afterTicks -> Just tickCount
+                        Nothing -> Nothing
+                in scan nextCodeRun (ticks : current) cells
+                    delimiterCount False afterTicks
+            Just ('|', rest)
                 | codeRun == Nothing ->
-                    splitCell codeRun current' cells delimiterCount afterPipe
+                    splitCell codeRun current cells delimiterCount rest
+                | otherwise ->
+                    scan codeRun ("|" : current) cells delimiterCount False rest
             _ ->
-                scan codeRun current' cells
-                    delimiterCount False afterSlashes
-    scan codeRun current cells delimiterCount _ ('`' : rest) =
-        let (ticks, afterTicks) = span (== '`') rest
-            tickCount = 1 + length ticks
-            marker = replicate tickCount '`'
-            nextCodeRun = case codeRun of
-                Just openCount
-                    | tickCount >= openCount -> Nothing
-                Just openCount -> Just openCount
-                Nothing
-                    | hasClosingRun tickCount afterTicks -> Just tickCount
-                Nothing -> Nothing
-        in scan nextCodeRun (marker <> current) cells
-            delimiterCount False afterTicks
-    scan Nothing current cells delimiterCount _ ('|' : rest) =
-        splitCell Nothing current cells delimiterCount rest
-    scan codeRun current cells delimiterCount _ (character : rest) =
-        scan codeRun (character : current) cells
-            delimiterCount False rest
+                let (plain, rest) = Text.break isSpecial remaining
+                in scan codeRun (plain : current) cells delimiterCount False rest
 
     splitCell codeRun current cells delimiterCount rest =
         scan codeRun [] (finishCell current : cells)
             (delimiterCount + 1) True rest
 
-    finishCell = Text.strip . Text.pack . reverse
-    startsWithPipe ('|' : _) = True
-    startsWithPipe _ = False
+    -- Accumulate slices, not characters or repeated strict Text appends. Copy
+    -- the finished cell so a small retained cell cannot retain the whole row.
+    finishCell = Text.copy . Text.strip . Text.concat . reverse
+    isSpecial character =
+        character == '\\' || character == '`' || character == '|'
     hasClosingRun count =
-        Text.isInfixOf (Text.replicate count "`") . Text.pack
-    dropLast values = case reverse values of
-        _ : rest -> reverse rest
-        [] -> []
+        Text.isInfixOf (Text.replicate count "`")
 
 startsWith :: (Char -> Bool) -> Text -> Bool
 startsWith predicate text = case Text.uncons text of

--- a/packages/agent-tui/test/Agent/TUI/Markdown/BlockSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/Markdown/BlockSpec.hs
@@ -1,6 +1,7 @@
 module Agent.TUI.Markdown.BlockSpec (spec) where
 
 import Agent.TUI.Markdown.Block
+import Control.Monad (forM_)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Test.Hspec
@@ -17,6 +18,51 @@ import Test.QuickCheck
 
 spec :: Spec
 spec = describe "Markdown block parsing" do
+    describe "pipe table row compatibility" do
+        it "distinguishes opening borders, trailing borders, and empty cells" do
+            forM_
+                [ ("", Nothing)
+                , ("|", Nothing)
+                , ("| lone", Nothing)
+                , ("lone |", Just ["lone"])
+                , ("| lone |", Just ["lone"])
+                , ("||", Just [""])
+                , ("|||", Just ["", ""])
+                , ("a || b |", Just ["a", "", "b"])
+                ] \(input, expected) ->
+                    splitTableRow input `shouldBe` expected
+
+        it "halves backslashes before pipes and escapes only odd runs" do
+            forM_ [0 .. 8] \count -> do
+                let slashes = Text.replicate count "\\"
+                    literal = Text.replicate (count `div` 2) "\\"
+                    expected
+                        | odd count = ["a" <> literal <> "|b", "c"]
+                        | otherwise = ["a" <> literal, "b", "c"]
+                splitTableRow ("a" <> slashes <> "|b|c")
+                    `shouldBe` Just expected
+                splitTableRow ("`a" <> slashes <> "|b`|c")
+                    `shouldBe` Just ["`a" <> literal <> "|b`", "c"]
+                splitTableRow ("a" <> slashes <> "x|c")
+                    `shouldBe` Just ["a" <> slashes <> "x", "c"]
+
+        it "keeps matching code pipes but splits unmatched backtick spans" do
+            forM_
+                [ ("`a|b`|c", ["`a|b`", "c"])
+                , ("``a|b```|c", ["``a|b```", "c"])
+                , ("``a`|b``|c", ["``a`|b``", "c"])
+                , ("``a|b`|c", ["``a", "b`", "c"])
+                , ("`a|b", ["`a", "b"])
+                , ("`a\\`|b", ["`a\\`", "b"])
+                ] \(input, expected) ->
+                    splitTableRow input `shouldBe` Just expected
+
+        it "strips Unicode whitespace without dropping Unicode cell content" do
+            splitTableRow "\x2003| \x00a0界\x2003 | 👩\x200d💻 \x202f|\x2003"
+                `shouldBe` Just ["界", "👩\x200d💻"]
+            splitTableRow "界|\x2003|\x00a0"
+                `shouldBe` Just ["界", ""]
+
     it "parses heading levels and requires following whitespace" do
         headingParts "  ### Title  " `shouldBe` Just (3, "Title")
         headingParts "###Title" `shouldBe` Nothing


### PR DESCRIPTION
## Summary
- Scan Markdown table rows as strict Text chunks instead of character lists; eliminate repeated suffix packing during backtick lookahead.
- Copy completed cells so small retained cells do not retain entire source rows.
- Preserve escape parity, Unicode whitespace, empty cells, borders, and closing-backtick rules.
- Include compatibility tests, a reproducible old/new benchmark, and the table-specific String audit update. Unrelated local TextWidth work is excluded.

## Performance
Nix GHC 9.10.3, optimized -O2 builds, +RTS -T, Apple M3 Max/macOS. Seven samples per invocation with forced results, sizes 10/100/1000, repeated representative cases, and a prose-only control.
- Isolated mixed row (100 fragments, 100 repetitions): elapsed 128.145 -> 3.592 ms; CPU 128.008 -> 3.490 ms; allocation 126.556 -> 24.896 MB.
- Isolated mixed row (1000 fragments): allocation 8264.894 -> 247.916 MB. This is not a whole-renderer speedup claim.
- Full rendering: approximately 1–2% less allocation, no repeatable timing regression. Mixed 1000-row renderer median peak RSS: 60.48 -> 59.50 MiB across five fresh processes per version.
- Exact build/run commands, baseline Git object, complete workload matrix, repeat measurements, and limitations: packages/agent-tui/benchmark/MarkdownTable.md.
- Repeated suffix searches remain; this is not a worst-case linear-time parser or an idle-memory reduction claim.

## Validation
- GHCi block, inline, and Markdown suites: 92 examples, zero failures.
- Differential comparison against original parser: 166,501 rows, zero mismatches (including 3,000 longer rows).
- Direct source CLI Markdown rendering in tmux passed at widths 100 and 24, including escaped pipes, code spans, Unicode, alignment, and wrapping.
- Full live-agent tmux validation was blocked by the existing GStreamer/pkg-config development dependency failure. The user approved opening this PR with that limitation documented; direct renderer validation is not presented as a full-agent test.
- git diff --check passed.