### PR TITLE
Move session resource preparation into agent-runtime

### DIFF
--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -159,9 +159,22 @@ unwind. Shutdown order remains activities, code mode, session lock, computer
 use, LSP, web fetch, MCP, coding tools, scratch storage.
 
 This is a bounded extraction, not the complete session entry point. Concrete
-MCP/scratch setup, host-specific tool groups, terminal hooks, and session launch
+MCP setup, host-specific tool groups, terminal hooks, and session launch
 still live in CLI orchestration. Server still depends on `agent-cli` until
 those remaining composition boundaries move. No new Cabal package is needed.
+
+## Implemented: shared session resource preparation
+
+`Agent.Runtime.Session.Preparation` owns deferred persistence creation and
+resumed-session retargeting through a typed `PersistenceRequest`.
+`Agent.Runtime.Session.Resources` restores task plans and image history,
+allocates scratch storage, and owns temporary-directory leases and cleanup.
+Partial acquisition failures and cancellation unwind the same resource scope.
+
+CLI supplies resume notices, fullscreen history wiring, external-session tool
+construction, and a repository worktree lease hook. CLI options are translated
+at the adapter boundary; the runtime request contains no terminal or CLI types.
+Stale-resource housekeeping remains in the host composition layer.
 
 ## Remaining: move session composition and ownership out of the CLI
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Scratch.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Scratch.hs
@@ -18,14 +18,14 @@ import Agent.CLI.Runtime.Orchestration.Tools.Collaboration
 import Agent.CLI.Runtime.Orchestration.Tools.Model
 import Agent.CLI.Runtime.Orchestration.Tools.Request
 import Agent.CLI.Runtime.Orchestration.Types (AgentProcessRuntime(..), NativeRunCapabilities(..))
-import Agent.CLI.Runtime.Persistence (preparePersistence)
+import Agent.CLI.Runtime.Persistence (persistenceRequest, announceResumedSession)
 import Agent.Runtime.Session
     ( Persistence, SessionTempCleanupReport(..)
-    , acquireSessionTempLease, allocateSessionTemp, cleanupPendingPersistence
     , cleanupStaleSessionTemps, defaultSessionTempKeepCount
-    , loadCurrentTaskPlan, persistenceTempDir, releaseSessionTempLease
-    , removeSessionTemp, taskPlanHooksForPersistence )
-import Agent.Runtime.Session.History (foldSessionItems)
+    )
+import Agent.Runtime.Session.Resources
+    ( SessionResourcesRequest(..), SessionResourceHooks(..)
+    , SessionResources(..), SessionResourceError(..), prepareSessionResources )
 import Agent.CLI.Session.Runtime.Types (StartupRuntime(..))
 import Agent.CLI.Session.Selection (loadPrompt, reservedSessionId)
 import Agent.CLI.Startup.Auth (startupDie)
@@ -35,16 +35,13 @@ import Agent.CLI.Worktree
     ( WorktreeCleanupReport(..), acquireWorktreeLease, gcWorktreesWithActivity
     , releaseWorktreeLease, worktreeRoot )
 import Agent.CLI.Worktree.Provenance (loadWorktreeActivity)
-import Agent.OpenAI.ImageGeneration
-    ( ImageGenerationHistory, newImageGenerationHistory, recordImageGenerationResponseItems )
+import Agent.OpenAI.ImageGeneration (ImageGenerationHistory)
 import Agent.OsPath (unsafeToFilePath)
-import Agent.ResourceScope (allocateResource, closeResourceScope, newResourceScope)
 import Agent.Store.Postgres (trustedPool)
-import Agent.Tools.TaskPlan (TaskPlanEnv, newTaskPlanEnv)
-import Agent.Tools.Types
-    ( AppTool, ToolEnv(toolOutputMemoryStore), setToolSessionTmp, clearMemoryOutputArtifacts )
+import Agent.Tools.TaskPlan (TaskPlanEnv)
+import Agent.Tools.Types (AppTool)
 import Control.Concurrent.Async (concurrently)
-import Control.Exception.Safe (SomeException, bracketOnError, try)
+import Control.Exception.Safe (SomeException, catch, try)
 import Control.Monad (forM_)
 import Data.IORef (writeIORef)
 import Data.Maybe (isNothing)
@@ -86,93 +83,53 @@ prepareScratchRuntime AgentToolsRequest
     , toolEffortText = effortText
     } CollaborationRuntime
     { collaborationPersistSlotRef = persistSlotRef
-    } = bracketOnError newResourceScope closeResourceScope \scratchScope -> do
+    } = do
     scratchPromptRequest <- loadPrompt options
     let promptText =
             fmap (\request -> request.managedTurnText) scratchPromptRequest
-    (_, scratchPersistence) <-
-        allocateResource scratchScope
-            (preparePersistence
+        request = SessionResourcesRequest
+            { resourcePersistenceRequest = persistenceRequest
                 (trustedPool startup.startupDatabaseStore)
-                startup
-                options
-                root
-                inferredTarget { targetDialect = dialectId }
-                gatewayIdentity
-                (isNothing transition)
-                cwd
-                effortText
-                promptText
-                resumed)
-            cleanupPendingPersistence
-    writeIORef persistSlotRef scratchPersistence
-    initialTaskPlan <-
-        loadCurrentTaskPlan scratchPersistence >>= \case
-            Left err ->
-                startupDie startup
-                    ("Failed to load current task plan: " <> err)
-            Right plan -> pure plan
-    scratchTaskPlan <-
-        newTaskPlanEnv
-            initialTaskPlan
-            (taskPlanHooksForPersistence scratchPersistence)
-    forM_ fullscreen \runtime ->
-        reservedSessionId scratchPersistence >>= \case
-            Nothing ->
-                clearFullscreenHistorySource runtime
-            Just sessionId ->
-                setFullscreenHistorySource
-                    runtime
-                    sessionId
-                    (loadFullscreenHistoryPage
-                        (trustedPool startup.startupDatabaseStore)
-                        root
-                        sessionId)
-                    (emptyFullscreenHistoryPage
-                        (HistoryGeneration 0))
-    scratchSessionTmp <-
-        persistenceTempDir scratchPersistence >>= \case
-            Just tempDir -> pure tempDir
-            Nothing -> do
-                (_, (_, tempDir)) <-
-                    allocateResource scratchScope
-                        (allocateSessionTemp root)
-                        (\(sessionId, _) -> do
-                            _ <- removeSessionTemp root sessionId
-                            pure ())
-                pure tempDir
-    setToolSessionTmp baseToolEnv (Just scratchSessionTmp)
-    _ <- allocateResource scratchScope
-        (pure ())
-        (\() -> clearMemoryOutputArtifacts baseToolEnv.toolOutputMemoryStore)
-    scratchImageGenerationHistory <- newImageGenerationHistory
-    forM_ resumed \(_, turns) ->
-        recordImageGenerationResponseItems
-            scratchImageGenerationHistory
-            (foldSessionItems turns)
-    scratchExternalSessionTools <-
-        if options.optSkills
-            && nativeCapabilities.nativeHostExtensions
-            then do
-                env <-
-                    defaultExternalSessionEnv
-                        baseToolEnv
-                        (unsafeToFilePath cwd)
-                        (unsafeToFilePath scratchSessionTmp)
-                        (unsafeToFilePath home)
-                pure [externalSessionTool env]
-            else pure []
-    _ <- allocateResource scratchScope
-        (acquireWorktreeLease (worktreeRoot home) cwd >>= \case
-            Left err -> startupDie startup err
-            Right lease -> pure lease)
-        (mapM_ releaseWorktreeLease)
-    _ <- allocateResource scratchScope
-        (acquireSessionTempLease root scratchSessionTmp >>= \case
-            Left err -> startupDie startup err
-            Right lease -> pure lease)
-        (mapM_ releaseSessionTempLease)
-    let scratchCleanup = closeResourceScope scratchScope
+                options root inferredTarget { targetDialect = dialectId }
+                gatewayIdentity (isNothing transition) cwd effortText promptText resumed
+            , resourceToolEnv = baseToolEnv
+            , resourceResumedTurns = maybe [] snd resumed
+            }
+        hooks = SessionResourceHooks
+            { resourcePersistenceReady = \persistence -> do
+                forM_ resumed \(meta, _) -> announceResumedSession startup meta
+                writeIORef persistSlotRef persistence
+            , resourceTaskPlanReady = \persistence ->
+                forM_ fullscreen \runtime ->
+                    reservedSessionId persistence >>= \case
+                        Nothing -> clearFullscreenHistorySource runtime
+                        Just sessionId ->
+                            setFullscreenHistorySource runtime sessionId
+                                (loadFullscreenHistoryPage
+                                    (trustedPool startup.startupDatabaseStore) root sessionId)
+                                (emptyFullscreenHistoryPage (HistoryGeneration 0))
+            , resourcePrepareHost = \sessionTmp ->
+                if options.optSkills && nativeCapabilities.nativeHostExtensions
+                    then do
+                        env <- defaultExternalSessionEnv baseToolEnv
+                            (unsafeToFilePath cwd)
+                            (unsafeToFilePath sessionTmp)
+                            (unsafeToFilePath home)
+                        pure [externalSessionTool env]
+                    else pure []
+            , resourceAcquireWorktreeLease =
+                acquireWorktreeLease (worktreeRoot home) cwd >>= \case
+                    Left err -> startupDie startup err
+                    Right lease -> pure (mapM_ releaseWorktreeLease lease)
+            }
+    resources <- prepareSessionResources request hooks
+        `catch` \(SessionResourceError err) -> startupDie startup err
+    let scratchPersistence = resources.resourcePersistence
+        scratchTaskPlan = resources.resourceTaskPlan
+        scratchSessionTmp = resources.resourceSessionTmp
+        scratchImageGenerationHistory = resources.resourceImageGenerationHistory
+        scratchExternalSessionTools = resources.resourceHost
+        scratchCleanup = resources.resourceCleanup
     pure ScratchRuntime{..}
 
 startStaleResourceCleanup

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Persistence.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Persistence.hs
@@ -1,148 +1,53 @@
+-- | CLI policy and presentation adapters for shared persistence preparation.
 module Agent.CLI.Runtime.Persistence
-    ( preparePersistence
+    ( persistenceRequest
+    , announceResumedSession
     , shouldPersist
     ) where
 
-import Agent.Runtime.Models (ModelTarget(..))
+import Agent.Runtime.Models (ModelTarget)
 import Agent.CLI.Options (CliOptions(..), isOneShot)
 import Agent.CLI.Render (putTextLn)
-import Agent.Runtime.Session
-    ( Persistence(..)
-    , SessionCreate(..)
-    , SessionHandle(..)
-    , SessionMeta(..)
-    , SessionTurn
-    , newActivePersistence
-    , newPendingPersistence
-    , sessionLegacySubagentTarget
-    , sessionTempDirForId
-    , sessionTitleFromPrompt
-    , writeSessionMeta
-    )
+import Agent.Runtime.Session (SessionMeta(..), SessionTurn)
+import Agent.Runtime.Session.Preparation (PersistenceRequest(..))
 import Agent.CLI.Session.Runtime.Types (StartupRuntime(..))
 import Agent.CLI.Style (glyphSession, roleMuted)
 import Agent.CLI.Terminal (resolveColor)
-import Agent.CLI.TUI.App
-    ( emitUiEvent
-    )
-import Agent.OsPath (fromText)
+import Agent.CLI.TUI.App (emitUiEvent)
 import Agent.Store.Postgres.Connection (StorePool)
 import Agent.TUI.Model (UiEvent(..))
-import Control.Monad (when)
-import Data.Maybe (isNothing)
 import Data.Text (Text)
-import qualified Data.Text as Text
-import Data.Time.Clock (getCurrentTime)
-import System.OsPath
-    ( OsPath
-    , unsafeEncodeUtf
-    , (</>)
-    )
+import System.OsPath (OsPath)
 
-preparePersistence
-    :: StorePool
-    -> StartupRuntime
-    -> CliOptions
-    -> OsPath
-    -> ModelTarget
-    -> Maybe Text
-    -> Bool
-    -> OsPath
-    -> Text
-    -> Maybe Text
-    -> Maybe (SessionMeta, [SessionTurn])
-    -> IO Persistence
-preparePersistence
-        sessionPool startup options root target
-        gatewayIdentity retargetResumed cwd effort prompt resumed =
-    case resumed of
-        Just (meta, _) -> do
-            now <- getCurrentTime
-            let targetChanged =
-                    retargetResumed
-                        && ( target.targetProvider /= meta.metaProvider
-                            || target.targetConnectionId /= meta.metaConnection
-                            || target.targetModelId /= meta.metaModel
-                            || maybe
-                                False
-                                (/= target.targetWireModelId)
-                                meta.metaTransportModel
-                            || target.targetDialect /= meta.metaDialect
-                           )
-                metadataChanged =
-                    retargetResumed
-                        && ( targetChanged
-                            || meta.metaGatewayIdentity /= gatewayIdentity
-                            || meta.metaTransportModel
-                                /= Just target.targetWireModelId
-                            || isNothing meta.metaLegacySubagentTarget
-                           )
-                activeMeta
-                    | metadataChanged =
-                        meta
-                            { metaProvider = target.targetProvider
-                            , metaConnection = target.targetConnectionId
-                            , metaGatewayIdentity = gatewayIdentity
-                            , metaModel = target.targetModelId
-                            , metaTransportModel =
-                                Just target.targetWireModelId
-                            , metaDialect = target.targetDialect
-                            , metaLegacySubagentTarget =
-                                Just (sessionLegacySubagentTarget meta)
-                            , metaLastResponseId =
-                                if targetChanged
-                                    then Nothing
-                                    else meta.metaLastResponseId
-                            , metaUpdatedAt = now
-                            }
-                    | otherwise = meta
-            let handle = SessionHandle
-                    { sessionPool = sessionPool
-                    , sessionDir = root </> fromText activeMeta.metaId
-                    , sessionTempDir =
-                        either
-                            (error . Text.unpack)
-                            id
-                            (sessionTempDirForId root activeMeta.metaId)
-                    , sessionMetaPath =
-                        root
-                            </> fromText activeMeta.metaId
-                            </> unsafeEncodeUtf "meta.json"
-                    , sessionTranscriptPath =
-                        root
-                            </> fromText activeMeta.metaId
-                            </> unsafeEncodeUtf "transcript.jsonl"
-                    , sessionMeta = activeMeta
-                    }
-            when metadataChanged $
-                writeSessionMeta
-                    handle.sessionPool
-                    handle.sessionMetaPath
-                    activeMeta
-            let message = "session: " <> activeMeta.metaId <> " (resumed)"
-            case startup.startupFullscreen of
-                Nothing -> do
-                    color <- resolveColor startup.startupStderr
-                    putTextLn startup.startupStderr
-                        (roleMuted color (glyphSession <> message))
-                Just runtime ->
-                    emitUiEvent runtime (UiSystemMessage message)
-            newActivePersistence handle
-        Nothing
-            | shouldPersist options ->
-                -- Defer directory creation until the first successful turn so
-                -- an abandoned REPL does not leave empty session folders.
-                newPendingPersistence SessionCreate
-                    { createPool = sessionPool
-                    , createRoot = root
-                    , createTarget = target
-                    , createGatewayIdentity = gatewayIdentity
-                    , createCwd = cwd
-                    , createEffort = effort
-                    , createTitleHint = sessionTitleFromPrompt <$> prompt
-                    , createTitleIsManual = False
-                    }
-            | otherwise -> pure PersistenceDisabled
+persistenceRequest
+    :: StorePool -> CliOptions -> OsPath -> ModelTarget -> Maybe Text -> Bool
+    -> OsPath -> Text -> Maybe Text -> Maybe (SessionMeta, [SessionTurn])
+    -> PersistenceRequest
+persistenceRequest pool options root target gatewayIdentity retargetResumed
+        cwd effort prompt resumed =
+    PersistenceRequest
+        { persistencePool = pool
+        , persistenceRoot = root
+        , persistenceTarget = target
+        , persistenceGatewayIdentity = gatewayIdentity
+        , persistenceRetargetResumed = retargetResumed
+        , persistenceCwd = cwd
+        , persistenceEffort = effort
+        , persistencePrompt = prompt
+        , persistenceResumed = fst <$> resumed
+        , persistenceEnabled = shouldPersist options
+        }
+
+announceResumedSession :: StartupRuntime -> SessionMeta -> IO ()
+announceResumedSession startup meta = do
+    let message = "session: " <> meta.metaId <> " (resumed)"
+    case startup.startupFullscreen of
+        Nothing -> do
+            color <- resolveColor startup.startupStderr
+            putTextLn startup.startupStderr
+                (roleMuted color (glyphSession <> message))
+        Just runtime ->
+            emitUiEvent runtime (UiSystemMessage message)
 
 shouldPersist :: CliOptions -> Bool
 shouldPersist options = not (isOneShot options) || options.optSaveSession

--- a/packages/agent-runtime/agent-runtime.cabal
+++ b/packages/agent-runtime/agent-runtime.cabal
@@ -94,6 +94,8 @@ library
                     , Agent.Runtime.Session.Activity
                     , Agent.Runtime.Session.Codec
                     , Agent.Runtime.Session.History
+                    , Agent.Runtime.Session.Preparation
+                    , Agent.Runtime.Session.Resources
                     , Agent.Runtime.Session.Inbox
                     , Agent.Runtime.Session.Observation
                     , Agent.Runtime.Session.PullRequest
@@ -252,6 +254,8 @@ test-suite agent-runtime-test
                     , Agent.Runtime.TurnRecordSpec
                     , Agent.Runtime.SessionThreadsSpec
                     , Agent.Runtime.SessionSpec
+                    , Agent.Runtime.Session.ResourcesSpec
+                    , Agent.Runtime.Session.PreparationSpec
                     , Agent.Runtime.SessionSpec.Compatibility
                     , Agent.Runtime.SessionSpec.Fixtures
                     , Agent.Runtime.SessionSpec.JsonCodec

--- a/packages/agent-runtime/src/Agent/Runtime/Session/Preparation.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Session/Preparation.hs
@@ -1,0 +1,126 @@
+-- | Frontend-neutral creation and retargeting of session persistence.
+module Agent.Runtime.Session.Preparation
+    ( PersistenceRequest(..)
+    , prepareSessionPersistence
+    ) where
+
+import Agent.Runtime.Models (ModelTarget(..))
+import Agent.Runtime.Session
+    ( Persistence(..), SessionCreate(..), SessionHandle(..), SessionMeta(..)
+    , newActivePersistence, newPendingPersistence, sessionLegacySubagentTarget
+    , sessionTempDirForId, sessionTitleFromPrompt, writeSessionMeta )
+import Agent.OsPath (fromText)
+import Agent.Store.Postgres.Connection (StorePool)
+import Control.Monad (when)
+import Data.Maybe (isNothing)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time.Clock (getCurrentTime)
+import System.OsPath (OsPath, unsafeEncodeUtf, (</>))
+
+data PersistenceRequest = PersistenceRequest
+    { persistencePool :: StorePool
+    , persistenceRoot :: OsPath
+    , persistenceTarget :: ModelTarget
+    , persistenceGatewayIdentity :: Maybe Text
+    , persistenceRetargetResumed :: Bool
+    , persistenceCwd :: OsPath
+    , persistenceEffort :: Text
+    , persistencePrompt :: Maybe Text
+    , persistenceResumed :: Maybe SessionMeta
+    , persistenceEnabled :: Bool
+    }
+
+prepareSessionPersistence :: PersistenceRequest -> IO Persistence
+prepareSessionPersistence PersistenceRequest
+    { persistencePool = sessionPool
+    , persistenceRoot = root
+    , persistenceTarget = target
+    , persistenceGatewayIdentity = gatewayIdentity
+    , persistenceRetargetResumed = retargetResumed
+    , persistenceCwd = cwd
+    , persistenceEffort = effort
+    , persistencePrompt = prompt
+    , persistenceResumed = resumed
+    , persistenceEnabled = enabled
+    } =
+    case resumed of
+        Just meta -> do
+            now <- getCurrentTime
+            let targetChanged =
+                    retargetResumed
+                        && ( target.targetProvider /= meta.metaProvider
+                            || target.targetConnectionId /= meta.metaConnection
+                            || target.targetModelId /= meta.metaModel
+                            || maybe
+                                False
+                                (/= target.targetWireModelId)
+                                meta.metaTransportModel
+                            || target.targetDialect /= meta.metaDialect
+                           )
+                metadataChanged =
+                    retargetResumed
+                        && ( targetChanged
+                            || meta.metaGatewayIdentity /= gatewayIdentity
+                            || meta.metaTransportModel
+                                /= Just target.targetWireModelId
+                            || isNothing meta.metaLegacySubagentTarget
+                           )
+                activeMeta
+                    | metadataChanged =
+                        meta
+                            { metaProvider = target.targetProvider
+                            , metaConnection = target.targetConnectionId
+                            , metaGatewayIdentity = gatewayIdentity
+                            , metaModel = target.targetModelId
+                            , metaTransportModel =
+                                Just target.targetWireModelId
+                            , metaDialect = target.targetDialect
+                            , metaLegacySubagentTarget =
+                                Just (sessionLegacySubagentTarget meta)
+                            , metaLastResponseId =
+                                if targetChanged
+                                    then Nothing
+                                    else meta.metaLastResponseId
+                            , metaUpdatedAt = now
+                            }
+                    | otherwise = meta
+            let handle = SessionHandle
+                    { sessionPool = sessionPool
+                    , sessionDir = root </> fromText activeMeta.metaId
+                    , sessionTempDir =
+                        either
+                            (error . Text.unpack)
+                            id
+                            (sessionTempDirForId root activeMeta.metaId)
+                    , sessionMetaPath =
+                        root
+                            </> fromText activeMeta.metaId
+                            </> unsafeEncodeUtf "meta.json"
+                    , sessionTranscriptPath =
+                        root
+                            </> fromText activeMeta.metaId
+                            </> unsafeEncodeUtf "transcript.jsonl"
+                    , sessionMeta = activeMeta
+                    }
+            when metadataChanged $
+                writeSessionMeta
+                    handle.sessionPool
+                    handle.sessionMetaPath
+                    activeMeta
+            newActivePersistence handle
+        Nothing
+            | enabled ->
+                -- Defer directory creation until the first successful turn so
+                -- an abandoned REPL does not leave empty session folders.
+                newPendingPersistence SessionCreate
+                    { createPool = sessionPool
+                    , createRoot = root
+                    , createTarget = target
+                    , createGatewayIdentity = gatewayIdentity
+                    , createCwd = cwd
+                    , createEffort = effort
+                    , createTitleHint = sessionTitleFromPrompt <$> prompt
+                    , createTitleIsManual = False
+                    }
+            | otherwise -> pure PersistenceDisabled

--- a/packages/agent-runtime/src/Agent/Runtime/Session/Resources.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Session/Resources.hs
@@ -1,0 +1,103 @@
+-- | Session-owned persistence, task plans, scratch storage, and leases.
+-- Frontends adapt presentation and repository-specific worktree ownership at
+-- the hooks below; acquisition and reverse-order cleanup stay together here.
+module Agent.Runtime.Session.Resources
+    ( SessionResourcesRequest(..)
+    , SessionResourceHooks(..)
+    , SessionResources(..)
+    , SessionResourceError(..)
+    , prepareSessionResources
+    ) where
+
+import Agent.OpenAI.ImageGeneration
+    ( ImageGenerationHistory, newImageGenerationHistory, recordImageGenerationResponseItems )
+import Agent.ResourceScope (allocateResource, closeResourceScope, newResourceScope)
+import Agent.Runtime.Session
+    ( Persistence, SessionTurn
+    , acquireSessionTempLease, allocateSessionTemp, cleanupPendingPersistence
+    , loadCurrentTaskPlan, persistenceTempDir, releaseSessionTempLease
+    , removeSessionTemp, taskPlanHooksForPersistence )
+import Agent.Runtime.Session.History (foldSessionItems)
+import Agent.Runtime.Session.Preparation (PersistenceRequest(..), prepareSessionPersistence)
+import Agent.Tools.TaskPlan (TaskPlanEnv, newTaskPlanEnv)
+import Agent.Tools.Types
+    ( ToolEnv(toolOutputMemoryStore), setToolSessionTmp, clearMemoryOutputArtifacts )
+import Control.Exception.Safe (Exception, bracketOnError, throwIO)
+import Data.Text (Text)
+import System.OsPath (OsPath)
+
+data SessionResourcesRequest = SessionResourcesRequest
+    { resourcePersistenceRequest :: PersistenceRequest
+    , resourceToolEnv :: ToolEnv
+    , resourceResumedTurns :: [SessionTurn]
+    }
+
+-- | Hooks run synchronously within the acquisition scope. Host preparation
+-- must not retain unowned resources; the worktree acquisition returns its
+-- finalizer, which is registered atomically with acquisition.
+data SessionResourceHooks host = SessionResourceHooks
+    { resourcePersistenceReady :: Persistence -> IO ()
+    , resourceTaskPlanReady :: Persistence -> IO ()
+    , resourcePrepareHost :: OsPath -> IO host
+    , resourceAcquireWorktreeLease :: IO (IO ())
+    }
+
+data SessionResources host = SessionResources
+    { resourcePersistence :: Persistence
+    , resourceTaskPlan :: TaskPlanEnv
+    , resourceSessionTmp :: OsPath
+    , resourceImageGenerationHistory :: ImageGenerationHistory
+    , resourceHost :: host
+    , resourceCleanup :: IO ()
+    }
+
+newtype SessionResourceError = SessionResourceError Text
+    deriving (Show)
+
+instance Exception SessionResourceError
+
+-- | The caller must transfer the returned cleanup to its enclosing resource
+-- owner. Partial startup failures and cancellation release completed resources.
+prepareSessionResources
+    :: SessionResourcesRequest
+    -> SessionResourceHooks host
+    -> IO (SessionResources host)
+prepareSessionResources SessionResourcesRequest{..} hooks =
+    bracketOnError newResourceScope closeResourceScope \scope -> do
+        (_, resourcePersistence) <- allocateResource scope
+            (prepareSessionPersistence resourcePersistenceRequest)
+            cleanupPendingPersistence
+        hooks.resourcePersistenceReady resourcePersistence
+        initialTaskPlan <- loadCurrentTaskPlan resourcePersistence >>= \case
+            Left err -> throwIO (SessionResourceError ("Failed to load current task plan: " <> err))
+            Right plan -> pure plan
+        resourceTaskPlan <- newTaskPlanEnv initialTaskPlan
+            (taskPlanHooksForPersistence resourcePersistence)
+        hooks.resourceTaskPlanReady resourcePersistence
+        resourceSessionTmp <- persistenceTempDir resourcePersistence >>= \case
+            Just tempDir -> pure tempDir
+            Nothing -> do
+                (_, (_, tempDir)) <- allocateResource scope
+                    (allocateSessionTemp root)
+                    (\(sessionId, _) -> do
+                        _ <- removeSessionTemp root sessionId
+                        pure ())
+                pure tempDir
+        setToolSessionTmp resourceToolEnv (Just resourceSessionTmp)
+        _ <- allocateResource scope
+            (pure ())
+            (\() -> clearMemoryOutputArtifacts resourceToolEnv.toolOutputMemoryStore)
+        resourceImageGenerationHistory <- newImageGenerationHistory
+        recordImageGenerationResponseItems resourceImageGenerationHistory
+            (foldSessionItems resourceResumedTurns)
+        resourceHost <- hooks.resourcePrepareHost resourceSessionTmp
+        _ <- allocateResource scope hooks.resourceAcquireWorktreeLease id
+        _ <- allocateResource scope
+            (acquireSessionTempLease root resourceSessionTmp >>= \case
+                Left err -> throwIO (SessionResourceError err)
+                Right lease -> pure lease)
+            (mapM_ releaseSessionTempLease)
+        let resourceCleanup = closeResourceScope scope
+        pure SessionResources{..}
+  where
+    root = resourcePersistenceRequest.persistenceRoot

--- a/packages/agent-runtime/test/Agent/Runtime/Session/PreparationSpec.hs
+++ b/packages/agent-runtime/test/Agent/Runtime/Session/PreparationSpec.hs
@@ -1,0 +1,120 @@
+module Agent.Runtime.Session.PreparationSpec (spec) where
+
+import Agent.Runtime.Models (ModelTarget(..))
+import Agent.Runtime.Session
+import Agent.Runtime.Session.Preparation
+import Agent.Runtime.SessionSpec.Fixtures
+    ( testCreate, testMeta, withTempSessionRoot, withTempStore, toFilePath )
+import Agent.Store.Postgres (trustedPool)
+import Agent.Store.Postgres.Connection (StorePool)
+import Control.Exception.Safe (bracket)
+import Data.IORef (readIORef)
+import qualified System.Directory as Directory
+import System.OsPath (OsPath)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "session persistence preparation" do
+    it "keeps disabled sessions independent of a database" $
+        withTempSessionRoot \root -> do
+            result <- prepareSessionPersistence (request unusedPool root)
+                { persistenceEnabled = False }
+            case result of
+                PersistenceDisabled -> pure ()
+                _ -> expectationFailure "expected disabled persistence"
+
+    it "reserves scratch but defers materialization for new sessions" $
+        withTempStore \store root ->
+            bracket
+                (prepareSessionPersistence (request (trustedPool store) root))
+                cleanupPendingPersistence
+                \persistence -> do
+                    state <- persistenceState persistence
+                    case state of
+                        PersistencePending create _ temp -> do
+                            create.createTarget `shouldBe` (testCreate (trustedPool store) root).createTarget
+                            create.createTitleHint `shouldBe` Just "first prompt"
+                            create.createTitleIsManual `shouldBe` False
+                            Directory.doesDirectoryExist (toFilePath temp) `shouldReturn` True
+                        _ -> expectationFailure "new session materialized during preparation"
+
+    it "retains an unchanged resumed session even when new persistence is disabled" $
+        withTempStore \store root -> do
+            let meta = (testMeta "unchanged") { metaLastResponseId = Just "response" }
+            persistence <- prepareSessionPersistence (request (trustedPool store) root)
+                { persistenceEnabled = False
+                , persistenceResumed = Just meta
+                }
+            handle <- activeHandle persistence
+            handle.sessionMeta `shouldBe` meta
+
+    it "does not retarget a resumed session during a pending transition" $
+        withTempStore \store root -> do
+            let meta = (testMeta "transition") { metaLastResponseId = Just "response" }
+                initial = request (trustedPool store) root
+            persistence <- prepareSessionPersistence initial
+                { persistenceResumed = Just meta
+                , persistenceRetargetResumed = False
+                , persistenceTarget = initial.persistenceTarget
+                    { targetModelId = "replacement", targetWireModelId = "replacement-wire" }
+                }
+            handle <- activeHandle persistence
+            handle.sessionMeta `shouldBe` meta
+
+    it "clears response continuation for a changed wire target but retains legacy child routing" $
+        withTempStore \store root -> do
+            original <- createSession (testCreate (trustedPool store) root)
+            let meta = original.sessionMeta { metaLastResponseId = Just "response" }
+                initial = request (trustedPool store) root
+            persistence <- prepareSessionPersistence initial
+                { persistenceResumed = Just meta
+                , persistenceTarget = initial.persistenceTarget { targetWireModelId = "replacement-wire" }
+                }
+            handle <- activeHandle persistence
+            handle.sessionMeta.metaLastResponseId `shouldBe` Nothing
+            handle.sessionMeta.metaTransportModel `shouldBe` Just "replacement-wire"
+            handle.sessionMeta.metaLegacySubagentTarget
+                `shouldBe` Just (sessionLegacySubagentTarget meta)
+            handle.sessionMeta.metaId `shouldBe` meta.metaId
+
+    it "backfills missing transport metadata without discarding response continuation" $
+        withTempStore \store root -> do
+            original <- createSession (testCreate (trustedPool store) root)
+            let meta = original.sessionMeta
+                    { metaLastResponseId = Just "response"
+                    , metaTransportModel = Nothing
+                    , metaLegacySubagentTarget = Nothing
+                    }
+            persistence <- prepareSessionPersistence (request (trustedPool store) root)
+                { persistenceResumed = Just meta }
+            handle <- activeHandle persistence
+            handle.sessionMeta.metaLastResponseId `shouldBe` Just "response"
+            handle.sessionMeta.metaTransportModel `shouldBe` Just "grok-4"
+            handle.sessionMeta.metaLegacySubagentTarget
+                `shouldBe` Just (sessionLegacySubagentTarget meta)
+
+request :: StorePool -> OsPath -> PersistenceRequest
+request pool root = PersistenceRequest
+    { persistencePool = pool
+    , persistenceRoot = root
+    , persistenceTarget = (testCreate pool root).createTarget
+    , persistenceGatewayIdentity = Nothing
+    , persistenceRetargetResumed = True
+    , persistenceCwd = root
+    , persistenceEffort = "low"
+    , persistencePrompt = Just "first prompt"
+    , persistenceResumed = Nothing
+    , persistenceEnabled = True
+    }
+
+unusedPool :: StorePool
+unusedPool = error "preparation unexpectedly used database"
+
+persistenceState :: Persistence -> IO PersistenceState
+persistenceState (PersistenceEnabled slot) = readIORef slot
+persistenceState PersistenceDisabled = fail "expected enabled persistence"
+
+activeHandle :: Persistence -> IO SessionHandle
+activeHandle persistence = persistenceState persistence >>= \case
+    PersistenceActive handle -> pure handle
+    _ -> fail "expected active persistence"

--- a/packages/agent-runtime/test/Agent/Runtime/Session/ResourcesSpec.hs
+++ b/packages/agent-runtime/test/Agent/Runtime/Session/ResourcesSpec.hs
@@ -1,0 +1,167 @@
+module Agent.Runtime.Session.ResourcesSpec (spec) where
+
+import Agent.Runtime.Session (SessionCreate(..), Persistence(..))
+import Agent.Runtime.Session.Preparation (PersistenceRequest(..))
+import Agent.Runtime.Session.Resources
+import Agent.Runtime.SessionSpec.Fixtures (testCreate, toFilePath, withTempSessionRoot)
+import Agent.Tools.TaskPlan (readTaskPlan)
+import Agent.Tools.Types
+    ( ToolEnv(..), defaultToolEnv
+    , insertMemoryOutputArtifact, lookupMemoryOutputArtifact )
+import Control.Concurrent.Async (cancel, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
+import Control.Exception.Safe (bracket, finally, throwIO, tryAny)
+import Data.Either (isLeft)
+import Data.IORef (IORef, newIORef, readIORef, modifyIORef', writeIORef)
+import Data.Maybe (isJust)
+import Data.Text (Text)
+import qualified System.Directory as Directory
+import System.OsPath (OsPath)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "session resource preparation" do
+    it "owns scratch storage without enabling persistence and closes it once" $
+        withRequest \request -> do
+            released <- newIORef (0 :: Int)
+            let hooks = emptyHooks
+                    { resourceAcquireWorktreeLease =
+                        pure (modifyIORef' released (+ 1))
+                    }
+            bracket (prepareSessionResources request hooks) (.resourceCleanup) \resources -> do
+                case resources.resourcePersistence of
+                    PersistenceDisabled -> pure ()
+                    _ -> expectationFailure "expected disabled persistence"
+                readTaskPlan resources.resourceTaskPlan `shouldReturn` Nothing
+                readIORef request.resourceToolEnv.toolSessionTmp
+                    `shouldReturn` Just resources.resourceSessionTmp
+                Directory.doesDirectoryExist (toFilePath resources.resourceSessionTmp)
+                    `shouldReturn` True
+                resources.resourceCleanup
+                resources.resourceCleanup
+                readIORef released `shouldReturn` 1
+                Directory.doesDirectoryExist (toFilePath resources.resourceSessionTmp)
+                    `shouldReturn` False
+
+    it "releases worktree ownership before clearing artifacts and deleting scratch" $
+        withRequest \request -> do
+            pathRef <- newIORef Nothing
+            handle <- newIORef Nothing
+            let hooks = emptyHooks
+                    { resourcePrepareHost = \path -> do
+                        writeIORef pathRef (Just path)
+                        retainArtifact request.resourceToolEnv handle
+                    , resourceAcquireWorktreeLease = pure do
+                        readIORef pathRef >>= mapM_ \path ->
+                            Directory.doesDirectoryExist (toFilePath path) `shouldReturn` True
+                        artifactPresent request.resourceToolEnv handle `shouldReturn` True
+                    }
+            bracket (prepareSessionResources request hooks) (.resourceCleanup) \resources -> do
+                resources.resourceCleanup
+                artifactPresent request.resourceToolEnv handle `shouldReturn` False
+                Directory.doesDirectoryExist (toFilePath resources.resourceSessionTmp)
+                    `shouldReturn` False
+
+    it "cleans completed acquisitions after a later host acquisition fails" $
+        withRequest \request -> do
+            pathRef <- newIORef Nothing
+            handle <- newIORef Nothing
+            let hooks = emptyHooks
+                    { resourcePrepareHost = \path -> do
+                        writeIORef pathRef (Just path)
+                        retainArtifact request.resourceToolEnv handle
+                    , resourceAcquireWorktreeLease = throwIO (userError "worktree lease failed")
+                    }
+            result <- tryAny (prepareSessionResources request hooks)
+            fmap (const ()) result `shouldSatisfy` isLeft
+            path <- readIORef pathRef
+            path `shouldSatisfy` isJust
+            mapM_ (\value -> Directory.doesDirectoryExist (toFilePath value) `shouldReturn` False) path
+            artifactPresent request.resourceToolEnv handle `shouldReturn` False
+
+    it "joins a cancelled acquisition before deleting its scratch directory" $
+        withRequest \request -> do
+            started <- newEmptyMVar
+            blocked <- newEmptyMVar
+            stopped <- newIORef False
+            handle <- newIORef Nothing
+            let hooks = emptyHooks
+                    { resourcePrepareHost = \path ->
+                        (retainArtifact request.resourceToolEnv handle
+                            >> putMVar started path >> takeMVar blocked)
+                            `finally` do
+                                Directory.doesDirectoryExist (toFilePath path) `shouldReturn` True
+                                modifyIORef' stopped (const True)
+                    }
+            result <- timeout 2000000 $
+                withAsync (prepareSessionResources request hooks) \worker -> do
+                    path <- takeMVar started
+                    cancel worker
+                    readIORef stopped `shouldReturn` True
+                    Directory.doesDirectoryExist (toFilePath path) `shouldReturn` False
+            result `shouldBe` Just ()
+            artifactPresent request.resourceToolEnv handle `shouldReturn` False
+
+    it "continues scratch cleanup when a worktree finalizer fails" $
+        withRequest \request -> do
+            handle <- newIORef Nothing
+            released <- newIORef False
+            let hooks = emptyHooks
+                    { resourcePrepareHost = const (retainArtifact request.resourceToolEnv handle)
+                    , resourceAcquireWorktreeLease =
+                        pure (writeIORef released True >> throwIO (userError "worktree release failed"))
+                    }
+            resources <- prepareSessionResources request hooks
+            -- Preserve ResourceScope's best-effort cleanup contract.
+            resources.resourceCleanup
+            readIORef released `shouldReturn` True
+            Directory.doesDirectoryExist (toFilePath resources.resourceSessionTmp)
+                `shouldReturn` False
+            artifactPresent request.resourceToolEnv handle `shouldReturn` False
+            resources.resourceCleanup
+
+emptyHooks :: SessionResourceHooks ()
+emptyHooks = SessionResourceHooks
+    { resourcePersistenceReady = const (pure ())
+    , resourceTaskPlanReady = const (pure ())
+    , resourcePrepareHost = const (pure ())
+    , resourceAcquireWorktreeLease = pure (pure ())
+    }
+
+withRequest :: (SessionResourcesRequest -> IO a) -> IO a
+withRequest action = withTempSessionRoot \root -> do
+    env <- defaultToolEnv root
+    action SessionResourcesRequest
+        { resourcePersistenceRequest = disabledPersistence root
+        , resourceToolEnv = env
+        , resourceResumedTurns = []
+        }
+
+disabledPersistence :: OsPath -> PersistenceRequest
+disabledPersistence root = PersistenceRequest
+    { persistencePool = unusedPool
+    , persistenceRoot = root
+    , persistenceTarget = (testCreate unusedPool root).createTarget
+    , persistenceGatewayIdentity = Nothing
+    , persistenceRetargetResumed = False
+    , persistenceCwd = root
+    , persistenceEffort = "low"
+    , persistencePrompt = Nothing
+    , persistenceResumed = Nothing
+    , persistenceEnabled = False
+    }
+  where
+    unusedPool = error "disabled session resource preparation must not access the database"
+
+retainArtifact :: ToolEnv -> IORef (Maybe Text) -> IO ()
+retainArtifact env reference = do
+    result <- insertMemoryOutputArtifact env.toolOutputMemoryStore 4096 "retained" 8
+    case result of
+        Just handle -> writeIORef reference (Just handle)
+        Nothing -> expectationFailure "could not retain fixture artifact"
+
+artifactPresent :: ToolEnv -> IORef (Maybe Text) -> IO Bool
+artifactPresent env reference = readIORef reference >>= \case
+    Nothing -> expectationFailure "artifact fixture was never retained" >> pure False
+    Just handle -> isJust <$> lookupMemoryOutputArtifact env.toolOutputMemoryStore handle

--- a/packages/agent-runtime/test/Spec.hs
+++ b/packages/agent-runtime/test/Spec.hs
@@ -34,6 +34,8 @@ import qualified Agent.Runtime.ModelConfigSpec as ModelConfigSpec
 import qualified Agent.Runtime.ModelsSpec as ModelsSpec
 import qualified Agent.Runtime.NativeProcessSpec as NativeProcessSpec
 import qualified Agent.Runtime.SessionSpec as SessionSpec
+import qualified Agent.Runtime.Session.ResourcesSpec as SessionResources
+import qualified Agent.Runtime.Session.PreparationSpec as SessionPreparation
 import qualified Agent.Runtime.TurnStateSpec as TurnStateSpec
 import Test.Hspec
 
@@ -114,4 +116,6 @@ main = hspec do
     ModelsSpec.spec
     NativeProcessSpec.spec
     SessionSpec.spec
+    SessionResources.spec
+    SessionPreparation.spec
     TurnStateSpec.spec

--- a/scripts/check-package-boundaries.sh
+++ b/scripts/check-package-boundaries.sh
@@ -162,6 +162,9 @@ for registration in \
 done
 
 required_files=(
+  packages/agent-runtime/src/Agent/Runtime/Session/Preparation.hs
+  packages/agent-runtime/src/Agent/Runtime/Session/Resources.hs
+  packages/agent-runtime/test/Agent/Runtime/Session/ResourcesSpec.hs
   packages/agent-runtime/src/Agent/Runtime/Tools/Dialects.hs
   packages/agent-runtime/src/Agent/Runtime/Tools/Resources.hs
   packages/agent-runtime/src/Agent/Runtime/Tools/Startup.hs


### PR DESCRIPTION
## Summary
Move session persistence and resource preparation from CLI orchestration into agent-runtime through typed requests and narrow host hooks.

- Share task-plan restoration, scratch storage, image history restoration, and lease ownership.
- Keep presentation, history wiring, external-session adapters, and repository-specific worktree hooks in the CLI.
- Preserve resumed-session metadata and continuation rules, cancellation cleanup, and teardown ordering.
- Add 11 regression tests and extend package-boundary enforcement.

## Validation
- All 766 library modules loaded successfully in GHCi.
- 11 focused runtime regression tests passed.
- Nix package-boundary check passed.
- Generated runtime package dependencies remain unchanged.
