### PR TITLE
Benchmark transcript index Map and IntMap representations

### DIFF
--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -13,6 +13,7 @@ build-type:         Simple
 extra-source-files: README.md
                   , benchmark/FullscreenMarkdown.md
                   , benchmark/TerminalText.md
+                  , benchmark/TranscriptIndex.md
 
 common common-options
     default-language: GHC2021
@@ -96,6 +97,17 @@ test-suite agent-tui-test
                     , QuickCheck >= 2.14 && < 2.16
                     , text
                     , vty
+
+benchmark transcript-index-bench
+    import:           common-options
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmark
+    main-is:          TranscriptIndex.hs
+    ghc-options:      -O2 -rtsopts -threaded
+    build-depends:    base
+                    , containers
+                    , deepseq
+                    , safe-exceptions
 
 benchmark terminal-text-bench
     import:           common-options

--- a/packages/agent-tui/benchmark/TranscriptIndex.hs
+++ b/packages/agent-tui/benchmark/TranscriptIndex.hs
@@ -1,0 +1,243 @@
+{-# LANGUAGE BangPatterns #-}
+module Main (main) where
+
+import Control.DeepSeq (NFData(..), force)
+import Control.Exception (evaluate) -- safe-exceptions does not export evaluate.
+import Control.Exception.Safe (bracket)
+import Control.Monad (foldM, forM, forM_, unless)
+import Data.Coerce (coerce)
+import Data.IORef (IORef, newIORef, readIORef)
+import qualified Data.IntMap.Strict as IntMap
+import Data.List (sort)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Foreign.StablePtr (freeStablePtr, newStablePtr)
+import GHC.Clock (getMonotonicTimeNSec)
+import GHC.Stats
+import System.CPUTime (getCPUTime)
+import System.Environment (getArgs)
+import System.Exit (die)
+import System.IO (BufferMode(LineBuffering), hSetBuffering, stdout)
+import System.Mem (performGC)
+import Text.Printf (printf)
+import Text.Read (readMaybe)
+
+-- Same representation as production BlockId, without importing the UI stack.
+newtype BlockId = BlockId Int deriving (Eq, Ord)
+instance NFData BlockId where rnf (BlockId value) = value `seq` ()
+
+data Measurement = Measurement !Double !Double !Integer !Int
+
+main :: IO ()
+main = do
+    hSetBuffering stdout LineBuffering
+    enabled <- getRTSStatsEnabled
+    unless enabled (die "RTS statistics required: +RTS -T")
+    arguments <- getArgs
+    let (dimensions, requestedShape) = splitAt 3 arguments
+    (size, repetitions, samples) <- case dimensions of
+        [a, b, c]
+            | Just n <- readMaybe a, n > 0
+            , Just r <- readMaybe b, r > 0
+            , Just s <- readMaybe c, s > 0 -> pure (n, r, s :: Int)
+        _ -> die "usage: transcript-index-bench SIZE REPETITIONS SAMPLES [SHAPE] +RTS -T"
+    printf "# size=%d repetitions=%d samples=%d\n" size repetitions samples
+    putStrLn "workload,implementation,median_cpu_ms,median_elapsed_ms,median_allocated_bytes,checksum"
+    let positive = [(i + 4096, i) | i <- [0 .. size - 1]]
+        negative = [(-i - 4096, i) | i <- [0 .. size - 1]]
+        mixed = [(if even i then i + 4096 else -i - 4096, i) | i <- [0 .. size - 1]]
+        paged = zip (concat (reverse (pages (map fst negative)))) [0 ..]
+        sparse = [(if even i then (i + 4096) * 104729 else -(i + 4096) * 104729, i)
+                 | i <- [0 .. size - 1]]
+        shapes = [("positive", positive), ("negative", negative), ("mixed", mixed),
+                  ("paged", paged), ("sparse", sparse)]
+    selected <- case requestedShape of
+        [] -> pure shapes
+        [name] | name `elem` map fst shapes -> pure (filter ((== name) . fst) shapes)
+        _ -> die "shape must be positive, negative, mixed, paged, or sparse"
+    forM_ selected $ \(label, input) -> do
+        _ <- evaluate (force input)
+        source <- newIORef input
+        let old = mapBuild input
+            new = intBuild input
+        _ <- evaluate (force (old, new))
+        unless ([(key, value) | (BlockId key, value) <- Map.toAscList old]
+                == IntMap.toAscList new) (die "index equivalence failure")
+        unless (all (\(key, _) -> Map.notMember (BlockId key) old)
+                (freshEntries size input)) (die "appended identifiers overlap the input")
+        oldReference <- newIORef old
+        newReference <- newIORef new
+        let queries = map fst input <> [0, minBound, maxBound]
+        _ <- evaluate (force queries)
+        queryReference <- newIORef queries
+        forM_
+            [ ("rebuild", runRepeated repetitions source mapRebuild,
+                           runRepeated repetitions source intRebuild)
+            , ("append", runRepeated repetitions source mapAppend,
+                          runRepeated repetitions source intAppend)
+            , ("lookup", runRepeated repetitions queryReference
+                    (\keys -> readIORef oldReference >>= \index -> evaluate (mapLookup index keys)),
+                         runRepeated repetitions queryReference
+                    (\keys -> readIORef newReference >>= \index -> evaluate (intLookup index keys)))
+            , ("retract", runRepeated repetitions oldReference (mapRetract size),
+                           runRepeated repetitions newReference (intRetract size))
+            , ("lifecycle", runRepeated repetitions source (mapLifecycle size),
+                             runRepeated repetitions source (intLifecycle size))
+            ] $ \(workload, baseline, candidate) -> do
+                results <- forM [1 .. samples] $ \sample ->
+                    if odd sample
+                        then do a <- measure baseline; b <- measure candidate; pure (a, b)
+                        else do b <- measure candidate; a <- measure baseline; pure (a, b)
+                let original = map fst results
+                    replacement = map snd results
+                unless (map resultChecksum original == map resultChecksum replacement)
+                    (die ("checksum mismatch: " <> workload))
+                report (label <> "-" <> workload) "map" original
+                report (label <> "-" <> workload) "intmap" replacement
+        oldSizes <- forM [1 .. samples] $ \_ -> retainedBytes source mapBuild
+        newSizes <- forM [1 .. samples] $ \_ -> retainedBytes source intBuild
+        printf "# retained,%s,map,%d\n" label (median oldSizes)
+        printf "# retained,%s,intmap,%d\n" label (median newSizes)
+
+-- Newly loaded older pages receive lower IDs and are prepended. IDs descend
+-- inside each 64-block fixture page but not across the retained window.
+pages :: [a] -> [[a]]
+pages [] = []
+pages input = let (page, remaining) = splitAt 64 input in page : pages remaining
+
+{-# NOINLINE mapBuild #-}
+mapBuild :: [(Int, Int)] -> Map.Map BlockId Int
+mapBuild = Map.fromList . coerce
+
+{-# NOINLINE intBuild #-}
+intBuild :: [(Int, Int)] -> IntMap.IntMap Int
+intBuild = IntMap.fromList
+
+mapChecksum :: Map.Map BlockId Int -> Int
+mapChecksum = Map.foldlWithKey' (\total (BlockId key) value -> total + key + value) 0
+
+intChecksum :: IntMap.IntMap Int -> Int
+intChecksum = IntMap.foldlWithKey' (\total key value -> total + key + value) 0
+
+{-# NOINLINE mapRebuild #-}
+mapRebuild :: [(Int, Int)] -> IO Int
+mapRebuild input = evaluate (mapChecksum (mapBuild input))
+
+{-# NOINLINE intRebuild #-}
+intRebuild :: [(Int, Int)] -> IO Int
+intRebuild input = evaluate (intChecksum (intBuild input))
+
+{-# NOINLINE mapAppend #-}
+mapAppend :: [(Int, Int)] -> IO Int
+mapAppend input = evaluate $ mapChecksum $
+    foldl' (\index (key, value) -> Map.insert (BlockId key) value index) Map.empty input
+
+{-# NOINLINE intAppend #-}
+intAppend :: [(Int, Int)] -> IO Int
+intAppend input = evaluate $ intChecksum $
+    foldl' (\index (key, value) -> IntMap.insert key value index) IntMap.empty input
+
+{-# NOINLINE mapLookup #-}
+mapLookup :: Map.Map BlockId Int -> [Int] -> Int
+mapLookup index = foldl' (\total key -> total + fromMaybe (-1) (Map.lookup (BlockId key) index)) 0
+
+{-# NOINLINE intLookup #-}
+intLookup :: IntMap.IntMap Int -> [Int] -> Int
+intLookup index = foldl' (\total key -> total + fromMaybe (-1) (IntMap.lookup key index)) 0
+
+-- Mirrors abort/retraction filtering by transcript position.
+{-# NOINLINE mapRetract #-}
+mapRetract :: Int -> Map.Map BlockId Int -> IO Int
+mapRetract size index = evaluate (mapChecksum (Map.filter (< size `div` 2) index))
+
+{-# NOINLINE intRetract #-}
+intRetract :: Int -> IntMap.IntMap Int -> IO Int
+intRetract size index = evaluate (intChecksum (IntMap.filter (< size `div` 2) index))
+
+freshEntries :: Int -> [(Int, Int)] -> [(Int, Int)]
+freshEntries size input =
+    let offset = 1 + foldl' (\largest (key, _) -> max largest (abs key)) 0 input
+    in [(key + signum key * offset, value + size) | (key, value) <- take 20 input]
+
+-- Build a window, append fresh entries, navigate, retract its second half, then
+-- rebuild after removing a middle block (the existing deletion path).
+{-# NOINLINE mapLifecycle #-}
+mapLifecycle :: Int -> [(Int, Int)] -> IO Int
+mapLifecycle size input = evaluate $
+    let initial = mapBuild input
+        added = foldl' (\index (key, value) -> Map.insert (BlockId key) value index)
+            initial (freshEntries size input)
+        navigation = mapLookup added (map fst input)
+        retracted = Map.filter (< size `div` 2) added
+        remaining = [(key, position) | (position, (key, _)) <-
+            zip [0 ..] (filter ((/= size `div` 4) . snd) (take (size `div` 2) input))]
+        rebuilt = mapBuild remaining
+    in mapChecksum initial + mapChecksum added + navigation
+        + mapChecksum retracted + mapChecksum rebuilt
+
+{-# NOINLINE intLifecycle #-}
+intLifecycle :: Int -> [(Int, Int)] -> IO Int
+intLifecycle size input = evaluate $
+    let initial = intBuild input
+        added = foldl' (\index (key, value) -> IntMap.insert key value index)
+            initial (freshEntries size input)
+        navigation = intLookup added (map fst input)
+        retracted = IntMap.filter (< size `div` 2) added
+        remaining = [(key, position) | (position, (key, _)) <-
+            zip [0 ..] (filter ((/= size `div` 4) . snd) (take (size `div` 2) input))]
+        rebuilt = intBuild remaining
+    in intChecksum initial + intChecksum added + navigation
+        + intChecksum retracted + intChecksum rebuilt
+
+{-# NOINLINE runRepeated #-}
+runRepeated :: Int -> IORef input -> (input -> IO Int) -> IO Int
+runRepeated repetitions reference action =
+    foldM (\ !total _ -> do
+        input <- readIORef reference
+        result <- action input
+        pure $! total + result) 0 [1 .. repetitions]
+
+measure :: IO Int -> IO Measurement
+measure action = do
+    performGC
+    before <- getRTSStats
+    cpuStart <- getCPUTime
+    wallStart <- getMonotonicTimeNSec
+    result <- action >>= evaluate
+    wallEnd <- getMonotonicTimeNSec
+    cpuEnd <- getCPUTime
+    performGC
+    after <- getRTSStats
+    pure (Measurement (fromIntegral (cpuEnd - cpuStart) / 1e9)
+        (fromIntegral (wallEnd - wallStart) / 1e6)
+        (toInteger (allocated_bytes after) - toInteger (allocated_bytes before)) result)
+
+retainedBytes :: NFData result => IORef input -> (input -> result) -> IO Integer
+retainedBytes reference build = do
+    performGC
+    before <- getRTSStats
+    input <- readIORef reference
+    result <- evaluate (force (build input))
+    bracket (newStablePtr result) freeStablePtr $ \_ -> do
+        performGC
+        after <- getRTSStats
+        pure (toInteger (gcdetails_live_bytes (gc after)) - toInteger (gcdetails_live_bytes (gc before)))
+
+resultChecksum :: Measurement -> Int
+resultChecksum (Measurement _ _ _ result) = result
+
+report :: String -> String -> [Measurement] -> IO ()
+report workload implementation measurements = do
+    let checksums = map resultChecksum measurements
+    expected <- case checksums of
+        [] -> die "empty measurement list"
+        first : _ -> pure first
+    unless (all (== expected) checksums) (die "unstable checksum")
+    printf "%s,%s,%.6f,%.6f,%d,%d\n" workload implementation
+        (median [cpu | Measurement cpu _ _ _ <- measurements])
+        (median [wall | Measurement _ wall _ _ <- measurements])
+        (median [bytes | Measurement _ _ bytes _ <- measurements])
+        expected
+
+median :: Ord a => [a] -> a
+median values = sort values !! (length values `div` 2)

--- a/packages/agent-tui/benchmark/TranscriptIndex.md
+++ b/packages/agent-tui/benchmark/TranscriptIndex.md
@@ -1,0 +1,187 @@
+# Transcript index benchmark
+
+`TranscriptIndex.hs` compares the existing `Map BlockId value` representation
+with `IntMap value` (a Patricia trie). The benchmark isolates index maintenance;
+it does not measure terminal rendering, text layout, database reads, or total
+application memory. Values are shared, already evaluated `Int` payloads.
+
+## Workloads
+
+- `positive`: increasing positive identifiers, as in the live transcript.
+- `negative`: decreasing negative identifiers, as within one reconstructed page.
+- `mixed`: alternating signs, exercising signed ordering and non-monotone input.
+- `paged`: decreasing negative identifiers within 64-block fixture pages, with
+  the pages reversed. This models older pages allocated later and prepended:
+  the retained history is not globally ordered by identifier. Payload positions
+  are reassigned to match the resulting transcript order.
+- `sparse`: alternating signs with 104,729 between successive identifier
+  magnitudes, exercising a non-dense trie. This is a stress shape rather than
+  the allocator's usual consecutive identifiers.
+
+Identifiers begin outside GHC's small-integer cache. Each shape measures:
+
+- `rebuild`: the existing `fromList` construction, including its ascending-input
+  optimization in `Map`, followed by complete result consumption.
+- `append`: repeated individual inserts from an empty index, followed by complete
+  result consumption.
+- `lookup`: every resident identifier and three misses in an already built index.
+- `retract`: filter an already built index by retained transcript position,
+  keeping its first half, followed by result consumption.
+- `lifecycle`: construction, up to twenty fresh insertions, navigation over the
+  input identifiers, retention of the original first half, and reconstruction
+  after removing one middle entry from those survivors. Fresh identifiers keep
+  their signs and lie beyond the input's maximum magnitude; the untimed
+  validation asserts they do not overwrite existing entries.
+  This is a composite **index** workload, not a replay of the complete UI reducer.
+
+The standalone `BlockId` has the same newtype representation as production.
+`coerce` lets the baseline consume the fixture without a conversion-list cost.
+No sorting or specialized ascending constructor is added to either candidate.
+An `IORef` read per repetition and non-inlined workload entry points prevent a
+repeated pure result from being shared across iterations. Checksums fully consume
+the indexes. Ascending association lists and all paired workload checksums must
+agree before a run is accepted.
+
+Timing includes workload-triggered garbage collections, but excludes the explicit
+collections surrounding each sample. The final collection refreshes RTS allocation
+statistics to include the unfinished nursery. Seven samples alternate baseline
+and candidate execution order; each output column reports its median independently.
+The retained measurement is an incremental live-heap delta with a stable pointer
+keeping the new index alive. It excludes shared input payloads and includes a
+small measurement-bookkeeping overhead; it is not process RSS.
+
+## Reproduction
+
+Measured on Apple M3 Max, arm64 macOS, GHC 9.10.3, `-O2 -threaded`, one runtime
+capability, default allocation area, RTS statistics enabled.
+
+From the repository root:
+
+```sh
+mkdir -p "$TMPDIR/transcript-index-benchmark"
+nix develop -c sh -c '
+  directory="$1"
+  ghc -O2 -Wall -rtsopts -threaded \
+    packages/agent-tui/benchmark/TranscriptIndex.hs \
+    -outputdir "$directory" -o "$directory/transcript-index-bench"
+  for size in 10 100 1200 5000; do
+    repetitions=$((1200000 / size))
+    "$directory/transcript-index-bench" "$size" "$repetitions" 7 +RTS -T -N1
+  done
+  "$directory/transcript-index-bench" 1200 1000 7 +RTS -T -N1
+' sh "$TMPDIR/transcript-index-benchmark"
+```
+
+The 1,200-entry case corresponds to the configured history-window block budget,
+not an assertion that typical sessions fill it. The 5,000-entry case is a stress
+case beyond that budget, not the ordinary retained window.
+An optional fourth positional argument selects a single shape, for example
+`1200 1000 7 paged +RTS -T -N1`.
+
+## Results (2026-09-12)
+
+At 1,200 entries, 1,000 repetitions per sample. Times are microseconds **per
+repetition**, bytes are allocated **per repetition**. Each cell is
+`Map / IntMap`. A lookup repetition visits all 1,200 keys plus three misses;
+these are not individual-lookup timings.
+
+| Identifier shape / operation | CPU µs | Elapsed µs | Allocated bytes |
+|---|---:|---:|---:|
+| Positive rebuild | 16.262 / 23.033 | 16.278 / 23.064 | 86,313 / 265,713 |
+| Positive append | 102.903 / 22.522 | 104.418 / 22.650 | 810,673 / 265,713 |
+| Positive lookup | 23.113 / 19.943 | 23.103 / 19.934 | 19,321 / 121 |
+| Positive retract | 11.028 / 11.827 | 11.039 / 11.841 | 609 / 43,337 |
+| Positive lifecycle | 84.545 / 94.319 | 85.145 / 94.375 | 365,369 / 637,817 |
+| Negative rebuild | 98.109 / 25.373 | 98.278 / 25.521 | 810,673 / 313,393 |
+| Negative append | 92.954 / 23.008 | 92.999 / 23.078 | 810,673 / 313,393 |
+| Negative lookup | 21.643 / 20.882 | 21.655 / 20.934 | 19,321 / 121 |
+| Negative retract | 10.952 / 11.850 | 10.959 / 11.848 | 609 / 43,337 |
+| Negative lifecycle | 201.760 / 98.529 | 202.361 / 98.621 | 1,412,993 / 709,697 |
+| Mixed rebuild | 97.882 / 26.775 | 98.238 / 26.788 | 781,873 / 289,673 |
+| Mixed append | 96.158 / 26.213 | 96.407 / 26.255 | 781,873 / 289,673 |
+| Mixed lookup | 22.604 / 19.963 | 22.633 / 19.963 | 19,321 / 121 |
+| Mixed retract | 11.602 / 11.651 | 11.609 / 11.655 | 849 / 43,337 |
+| Mixed lifecycle | 212.683 / 101.422 | 214.206 / 102.059 | 1,369,553 / 674,097 |
+
+Lifecycle scaling, again `Map / IntMap` and per repetition:
+
+| Entries | Repetitions | Positive CPU µs | Positive allocated bytes | Negative CPU µs | Negative allocated bytes |
+|---:|---:|---:|---:|---:|---:|
+| 10 | 120,000 | 1.146 / 0.829 | 8,000 / 6,416 | 1.259 / 0.857 | 9,640 / 6,776 |
+| 100 | 12,000 | 7.364 / 6.675 | 42,728 / 48,816 | 12.084 / 6.926 | 92,864 / 54,416 |
+| 1,200 | 1,000 | 84.545 / 94.319 | 365,369 / 637,817 | 201.760 / 98.529 | 1,412,993 / 709,697 |
+| 5,000 | 240 | 419.179 / 465.508 | 1,478,429 / 2,945,781 | 1,138.175 / 477.854 | 6,939,989 / 3,209,221 |
+
+The independent 1,200-entry repeat returned positive lifecycle CPU
+83.044 / 92.566 µs and negative lifecycle 195.849 / 95.256 µs, with
+identical allocation figures. The positive-rebuild regression persisted
+(16.169 / 22.622 µs).
+
+Retained incremental heap at 1,200 entries was:
+
+| Shape | Map bytes | IntMap bytes |
+|---|---:|---:|
+| Positive | 58,896 | 78,056 |
+| Negative | 78,080 | 78,056 |
+| Mixed | 78,080 | 78,056 |
+
+These figures do **not** establish a retained-memory reduction for the trie.
+The practically equal negative/mixed measurements should not be presented as
+a 24-byte improvement; that difference is below the useful precision of this
+measurement.
+
+### Page ordering and sparse identifiers
+
+The same seven-sample 1,200-entry run includes `paged` and `sparse` shapes.
+All checksum comparisons passed. Units and `Map / IntMap` convention match the
+table above.
+
+| Shape / operation | CPU µs | Elapsed µs | Allocated bytes |
+|---|---:|---:|---:|
+| Paged rebuild | 103.320 / 36.191 | 103.379 / 36.599 | 815,569 / 390,913 |
+| Paged append | 103.009 / 34.869 | 103.101 / 34.886 | 815,569 / 390,913 |
+| Paged lookup | 22.113 / 20.575 | 22.124 / 20.560 | 19,321 / 121 |
+| Paged retract | 11.175 / 11.648 | 11.178 / 11.653 | 993 / 43,337 |
+| Paged lifecycle | 216.558 / 112.249 | 217.259 / 112.709 | 1,418,993 / 816,457 |
+| Sparse rebuild | 96.588 / 28.462 | 96.689 / 28.503 | 781,873 / 307,633 |
+| Sparse append | 96.328 / 27.982 | 96.412 / 27.979 | 781,873 / 307,633 |
+| Sparse lookup | 22.202 / 20.264 | 22.224 / 20.364 | 19,321 / 121 |
+| Sparse retract | 11.873 / 11.794 | 11.867 / 11.806 | 849 / 43,337 |
+| Sparse lifecycle | 207.704 / 102.799 | 208.111 / 102.871 | 1,369,553 / 702,617 |
+
+Both additional shapes retained 78,080 / 78,056 bytes, again effectively equal.
+The paged result is the stronger basis for a history-index candidate than the
+single descending-run result: rebuild CPU drops 65% and allocation drops 52%;
+the composite index workload improves 48% in CPU and 42% in allocation.
+The independent repeat returned paged rebuild 101.970 / 34.538 µs and paged
+lifecycle 214.073 / 110.623 µs, with identical allocations.
+
+Paged lifecycle scaling:
+
+| Entries | CPU µs (Map / IntMap) | Elapsed µs (Map / IntMap) | Allocated bytes (Map / IntMap) |
+|---:|---:|---:|---:|
+| 10 | 1.265 / 0.859 | 1.266 / 0.860 | 9,640 / 6,776 |
+| 100 | 12.433 / 7.468 | 12.459 / 7.474 | 92,912 / 57,936 |
+| 1,200 | 216.558 / 112.249 | 217.259 / 112.709 | 1,418,993 / 816,457 |
+| 5,000 | 1,160.692 / 575.525 | 1,161.325 / 575.625 | 6,993,941 / 3,683,381 |
+
+## Interpretation
+
+Do not replace the live transcript index wholesale. Although incremental
+insertion improves substantially, ascending `Map.fromList` construction is
+already efficient. The positive composite workload regresses at 1,200 and
+5,000 entries. `Map.filter` also shares unchanged subtrees in this workload;
+the `IntMap` candidate allocates substantially more while retaining the first
+half. Faster insertion alone would hide those costs.
+
+The history-block lookup index remains a narrower candidate because its negative
+identifiers descend within pages, missing the ascending `Map.fromList` fast path.
+However, the measurements do not demonstrate a retained-memory improvement or
+an application-level benefit. Keep this as a benchmark result rather than
+shipping a broad transcript-index substitution. Any future history-only change
+needs validation in the actual history-page maintenance path.
+
+This benchmark does not establish that a trie is superior to every alternative.
+An order-aware `Map` constructor could also improve construction if its ordering
+and uniqueness preconditions can be established safely; history IDs are not
+globally descending once pages are combined.


### PR DESCRIPTION
## Summary
- Add a reproducible baseline-versus-Patricia-trie benchmark for transcript index construction, insertion, lookup, filtering, and composite maintenance.
- Cover positive, negative, mixed, paged, and sparse identifiers at 10, 100, 1,200, and 5,000 entries, seven samples each, with an independent 1,200-entry repeat.
- Keep production unchanged: live-index maintenance regresses; history-only application performance remains unproven.

## Measurements
Apple M3 Max, arm64 macOS, GHC 9.10.3, optimized -O2 -threaded build inside nix develop, +RTS -T -N1. Median per operation at 1,200 entries (Map → IntMap):

| Workload | CPU | Elapsed | Allocated bytes |
|---|---:|---:|---:|
| Paged rebuild | 103.320 → 36.191 µs | 103.379 → 36.599 µs | 815,569 → 390,913 |
| Paged composite maintenance | 216.558 → 112.249 µs | 217.259 → 112.709 µs | 1,418,993 → 816,457 |
| Live composite maintenance | 84.545 → 94.319 µs | See report | 365,369 → 637,817 |

Retained index heap: live 58,896 → 78,056 bytes; paged 78,080 → 78,056 bytes (effectively unchanged, not a meaningful saving). These are index microbenchmarks, not total application speed or RSS.

Full reproduction command, workload dimensions, elapsed results, scaling and repeat measurements are in packages/agent-tui/benchmark/TranscriptIndex.md. Standalone executable invocation: transcript-index-bench 1200 1000 7 paged +RTS -T -N1 (optimized build instructions in report).

## Validation
- Warning-free optimized benchmark compilation; association-list equivalence, fresh-ID disjointness and paired checksums pass throughout the matrix.
- 89 focused model examples passed in GHCi, including three 500-case properties. All-source loading used temporary extension-only adapters for conflicting package FieldSelectors settings, not behavior stubs. Normal offline Cabal test entry was blocked by a missing Hermes source checkout.
- GHCi signed boundary/duplicate-key lookup equivalence passed.
- Regenerated package.nix using cabal2nix; no generated dependency change.
- git diff --check passed.
- No production or CLI UI changes; no new TTY behavior to smoke-test.