### PR TITLE
Correct Ghostty SSH link instructions

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Terminal.hs
+++ b/packages/agent-cli/src/Agent/CLI/Terminal.hs
@@ -145,7 +145,7 @@ isSshSession =
 
 remoteLinkInstructions :: Text
 remoteLinkInstructions =
-    "Over SSH, use your terminal's Open Link action (usually Cmd-click on macOS or Ctrl-click on Linux/Windows) to open this URL on your local computer."
+    "Over SSH, use your terminal's Open Link action to open this URL on your local computer. In Ghostty on macOS, use Cmd+Shift+click."
 
 formatTerminalCapabilities :: TerminalCapabilities -> Text
 formatTerminalCapabilities capabilities =

--- a/packages/agent-cli/test/Agent/CLI/TerminalSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TerminalSpec.hs
@@ -25,6 +25,11 @@ spec = do
                     setEnv name ""
                 isSshSession `shouldReturn` False
 
+    describe "remote link instructions" do
+        it "explains Ghostty's mouse-capture bypass shortcut" do
+            remoteLinkInstructions `shouldSatisfy` Text.isInfixOf "Cmd+Shift+click"
+            remoteLinkInstructions `shouldSatisfy` Text.isInfixOf "Ghostty on macOS"
+
     describe "terminal protocol encoders" do
         it "reports an escaped working directory" do
             osc7WorkingDirectory "/tmp/a b"


### PR DESCRIPTION
## Summary
- Correct the SSH link notice to recommend **Cmd+Shift+click** in Ghostty on macOS, rather than Cmd-click.
- Keep generic terminal Open Link guidance for other terminals.
- Add regression coverage for the Ghostty shortcut wording. Link handling itself is unchanged.

## Validation
- Focused `TerminalSpec` under GHCi via `nix develop`: **16 examples, 0 failures**.
- Live fullscreen TUI fixture under GHCi in tmux: captured and inspected the revised notice, wrapped shortcut, URL, and input prompt. This checks display, not the native browser-opening gesture.
- `git diff --check` passed.
