### PR TITLE
Stream fullscreen Markdown parsing across message deltas

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/TUI/App/History.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/History.hs
@@ -378,6 +378,7 @@ truncateUiBlocks count ui =
             Map.filter (`Map.member` indices) ui.uiShellProcesses
     in ui
         { uiBlocks = blocks
+        , uiStreamingMarkdown = Nothing
         , uiSelectedBlock =
             selectedIndex >>= \index ->
                 (.blockId) <$> Seq.lookup index blocks

--- a/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/App/Mailbox.hs
@@ -10,6 +10,7 @@ import Agent.CLI.Dictation ( DictationControl(..)
     )
 import Agent.CLI.Secret (sanitizeSecretPromptText)
 import Agent.CLI.Artifact (fencedCodeBlock)
+import Agent.TUI.Markdown.Stream (markdownStreamRetainedBytes)
 import Agent.CLI.Input ( ReplLine(..)
     , readReplHistory
     , terminalTextWidth
@@ -868,6 +869,9 @@ uiStateLogicalBytes ui =
             0
             ui.uiBlocks
         , logicalTextBytes ui.uiDraft
+        , maybe 0
+            (fromInteger . min (toInteger (maxBound :: Int)) . markdownStreamRetainedBytes . snd)
+            ui.uiStreamingMarkdown
         , logicalTextsBytes ui.uiQueuedInputs
         , logicalTextBytes ui.uiActivity
         , promptStateLogicalBytes ui.uiPrompt

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -55,7 +55,7 @@ import Agent.TUI.Markdown
       diffWidgetWithSyntaxHighlighting,
       markdownWidgetWithLinks,
       markdownWidgetWithStreamingCache,
-      markdownWidgetWithParsedStreamingCache,
+      markdownWidgetWithMarkdownStreamingCache,
       markdownWidgetWithSyntaxHighlightingAndLinks )
 import Agent.TUI.Model
     ( blockCodeLanguage,
@@ -214,7 +214,7 @@ drawBlock state target ui block =
             | block.blockState == BlockStreaming
             , Just (ident, parsed) <- ui.uiStreamingMarkdown
             , ident == block.blockId =
-                markdownWidgetWithParsedStreamingCache
+                markdownWidgetWithMarkdownStreamingCache
                     state.appSyntaxHighlighter
                     MarkdownLink
                     cacheProse

--- a/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/Render/Blocks.hs
@@ -55,6 +55,7 @@ import Agent.TUI.Markdown
       diffWidgetWithSyntaxHighlighting,
       markdownWidgetWithLinks,
       markdownWidgetWithStreamingCache,
+      markdownWidgetWithParsedStreamingCache,
       markdownWidgetWithSyntaxHighlightingAndLinks )
 import Agent.TUI.Model
     ( blockCodeLanguage,
@@ -69,7 +70,8 @@ import Agent.TUI.Model
       RetryCountdown(retryCountdownBlockId),
       UiBlock(blockId, blockTimestamp, blockTitle, blockKind, blockState,
               blockDetail, blockExpanded, blockBody),
-      UiState(uiRetryCountdown, uiSelectedBlock, uiFocus, uiInspectionGroups) )
+      UiState(uiRetryCountdown, uiSelectedBlock, uiFocus, uiInspectionGroups,
+              uiStreamingMarkdown) )
 import Agent.TUI.Motion
     ( foregroundIndicator,
       nativeProgressAnimationEnabled,
@@ -208,21 +210,28 @@ drawBlock state target ui block =
             txt (if highlighted then "❯ " else "  ")
         -- Completed/history blocks already have a whole-block cache. Avoid
         -- paying for cold prose-section cache entries when no appends remain.
-        assistantMarkdown =
-            if block.blockState == BlockStreaming
-                then markdownWidgetWithStreamingCache
+        assistantMarkdown cacheCode codeHeader body
+            | block.blockState == BlockStreaming
+            , Just (ident, parsed) <- ui.uiStreamingMarkdown
+            , ident == block.blockId =
+                markdownWidgetWithParsedStreamingCache
                     state.appSyntaxHighlighter
                     MarkdownLink
-                    (\chunkIndex sectionIndex ->
-                        cached
-                            (MarkdownProseCache
-                                target
-                                block.blockId
-                                chunkIndex
-                                sectionIndex))
-                else markdownWidgetWithSyntaxHighlightingAndLinks
+                    cacheProse
+                    cacheCode codeHeader parsed
+            | block.blockState == BlockStreaming =
+                markdownWidgetWithStreamingCache
                     state.appSyntaxHighlighter
                     MarkdownLink
+                    cacheProse
+                    cacheCode codeHeader body
+            | otherwise =
+                markdownWidgetWithSyntaxHighlightingAndLinks
+                    state.appSyntaxHighlighter
+                    MarkdownLink
+                    cacheCode codeHeader body
+        cacheProse chunkIndex sectionIndex =
+            cached (MarkdownProseCache target block.blockId chunkIndex sectionIndex)
         content = case block.blockKind of
             BlockUser ->
                 withAttr Theme.userAttr $

--- a/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
+++ b/packages/agent-cli/src/Agent/CLI/TUI/SessionHistory.hs
@@ -416,7 +416,8 @@ hasDisplayAssistant =
 completeProjectedStreams :: UiState -> UiState
 completeProjectedStreams state =
     state
-        { uiBlocks =
+        { uiStreamingMarkdown = Nothing
+        , uiBlocks =
             fmap
                 (\block ->
                     if block.blockState == BlockStreaming

--- a/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/TUIBridgeSpec.hs
@@ -23,6 +23,7 @@ import Agent.CLI.TUI.App
     , setFullscreenSessionActions
     )
 import Agent.CLI.TUI.Bridge
+import Agent.CLI.TUIAppSpec.AgentFixtures (childEntry)
 import Agent.CLI.TUI.ImagePreview (TuiImagePreview(..))
 import Agent.CLI.TUI.Types
     ( AppEvent(..)
@@ -36,6 +37,11 @@ import Agent.CLI.TUI.Types
     , SyntaxHighlighterState(..)
     )
 import Agent.TUI.Model
+import Agent.TUI.Markdown.Stream
+    ( emptyMarkdownStreamState
+    , feedMarkdownStream
+    , markdownStreamRetainedBytes
+    )
 import Agent.TUI.Presentation
     ( TodoDisplayLine(..)
     , TodoDisplayStatus(..)
@@ -380,6 +386,69 @@ spec = describe "fullscreen TUI bridge" do
                 }
         appEventLogicalBytes (AppAgentSnapshot AgentRoot [entry])
             `shouldSatisfy` (>= 4 * 1024 * 1024)
+
+    describe "retained Markdown snapshot accounting" do
+        let content = Text.replicate 4096 "界"
+            snapshot conversation =
+                AppAgentSnapshot AgentRoot
+                    [(childEntry 1){agentConversation = conversation}]
+        mapM_ (\(label, source) ->
+            it ("charges parser storage for " <> label) do
+                let conversation = reduceUi (UiLoop (TextDelta source)) initialUiState
+                    withoutParser = conversation{uiStreamingMarkdown = Nothing}
+                    additional = appEventLogicalBytes (snapshot conversation)
+                        - appEventLogicalBytes (snapshot withoutParser)
+                additional `shouldSatisfy` (>= 4 * Text.length content)
+                case conversation.uiStreamingMarkdown of
+                    Nothing -> expectationFailure "expected retained streaming parser"
+                    Just (_, parser) ->
+                        toInteger additional `shouldBe` markdownStreamRetainedBytes parser)
+            [ ("pending prose", content)
+            , ("completed prose", content <> "\n\n")
+            , ("pending inline markup", "**" <> content)
+            , ("completed inline markup", "**" <> content <> "**\n\n")
+            , ("table header candidates", "| " <> content <> " |\n")
+            , ("active tables", "| heading |\n| --- |\n| " <> content <> " |\n")
+            , ("completed tables", "| heading |\n| --- |\n| " <> content <> " |\n\n")
+            , ("open code fences", "```haskell\n" <> content <> "\n")
+            , ("closed code fences", "```haskell\n" <> content <> "\n```\n")
+            ]
+
+        it "charges retained parser storage even when its block is absent" do
+            let parser = feedMarkdownStream emptyMarkdownStreamState content
+                conversation = initialUiState{uiStreamingMarkdown = Just (BlockId 999, parser)}
+            appEventLogicalBytes (snapshot conversation)
+                - appEventLogicalBytes (snapshot initialUiState)
+                `shouldBe` fromInteger (markdownStreamRetainedBytes parser)
+
+        it "releases the parser charge when the conversation is cleared" do
+            let conversation = reduceUi (UiLoop (TextDelta content)) initialUiState
+                cleared = reduceUi UiConversationCleared conversation
+            cleared.uiStreamingMarkdown `shouldBe` Nothing
+            appEventLogicalBytes (snapshot cleared)
+                `shouldBe` appEventLogicalBytes (snapshot cleared{uiStreamingMarkdown = Nothing})
+
+        it "backpressures snapshots whose parser storage exceeds the remaining budget" do
+            runtime <- newBridgeTestRuntime
+            -- The old block-only accounting would admit both events (< 16 MiB).
+            -- The pending line and inline scanner make the second exceed it.
+            let body = Text.replicate (1024 * 1024) "x"
+                conversation = reduceUi (UiLoop (TextDelta body)) initialUiState
+                event = snapshot conversation
+                preceding = AppSetWindowTitle body
+                budget = 16 * 1024 * 1024
+            appEventLogicalBytes preceding
+                + appEventLogicalBytes (snapshot conversation{uiStreamingMarkdown = Nothing})
+                `shouldSatisfy` (< budget)
+            appEventLogicalBytes preceding + appEventLogicalBytes event
+                `shouldSatisfy` (> budget)
+            enqueueAppEvent runtime preceding
+            withAsync (enqueueAppEvent runtime event) \publishing -> do
+                timeout 100000 (wait publishing) `shouldReturn` Nothing
+                let AppEventMailbox stateRef = runtime.runtimeMailbox
+                state <- readTVarIO stateRef
+                state.mailboxPendingCount `shouldBe` 1
+                state.mailboxPendingBytes `shouldBe` appEventLogicalBytes preceding
 
     it "accounts provider-controlled snapshot target identifiers" do
         let target = AgentNative (Text.replicate (1024 * 1024) "x")

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -128,6 +128,7 @@ benchmark fullscreen-markdown-bench
     build-depends:    agent-core
                     , agent-json
                     , agent-syntax
+                    , agent-tools
                     , aeson
                     , aeson-pretty
                     , base

--- a/packages/agent-tui/agent-tui.cabal
+++ b/packages/agent-tui/agent-tui.cabal
@@ -42,6 +42,7 @@ library
                     , Agent.TUI.Markdown
                     , Agent.TUI.Markdown.Block
                     , Agent.TUI.Markdown.Inline
+                    , Agent.TUI.Markdown.Stream
                     , Agent.TUI.Motion
                     , Agent.TUI.Model
                     , Agent.TUI.Presentation
@@ -78,6 +79,7 @@ test-suite agent-tui-test
                     , Agent.TUI.FencedCodeSpec
                     , Agent.TUI.Markdown.BlockSpec
                     , Agent.TUI.Markdown.InlineSpec
+                    , Agent.TUI.Markdown.InlineStreamSpec
                     , Agent.TUI.MarkdownSpec
                     , Agent.TUI.MotionSpec
                     , Agent.TUI.ModelSpec
@@ -121,6 +123,7 @@ benchmark fullscreen-markdown-bench
                     , Agent.TUI.Markdown
                     , Agent.TUI.Markdown.Block
                     , Agent.TUI.Markdown.Inline
+                    , Agent.TUI.Markdown.Stream
                     , Agent.TUI.Motion
                     , Agent.TUI.Presentation
                     , Agent.TUI.TextWidth

--- a/packages/agent-tui/benchmark/FullscreenMarkdown.hs
+++ b/packages/agent-tui/benchmark/FullscreenMarkdown.hs
@@ -5,6 +5,7 @@
 module Main (main) where
 
 import qualified Agent.TUI.Markdown as Markdown
+import Agent.TUI.FencedCode (FenceStreamState, emptyFenceStreamState, feedFenceStream)
 import qualified Agent.TUI.Theme as Theme
 import Brick
 import Control.Exception (evaluate) -- safe-exceptions does not export evaluate.
@@ -32,7 +33,10 @@ data Name = Transcript | Code !Int | Prose !Int !Int | Link !Text
 
 data Sample = Sample !Double !Double !Double
 
-type Renderer = Bool -> Text -> Widget Name
+-- The historical modes remain available so earlier benchmark reports can be
+-- reproduced. "current" is the baseline for retained-parser measurements.
+data Renderer = LegacyRenderer | SectionCacheRenderer | IncrementalRenderer
+    deriving (Eq)
 
 -- This is the pre-optimization production path: append the strict body, parse
 -- the complete Markdown every frame, and cache only closed fenced-code bodies.
@@ -45,9 +49,25 @@ optimized = Markdown.markdownWidgetWithStreamingCache
     Nothing Link (\chunk section -> cached (Prose chunk section))
     (\index -> cached (Code index)) (\_ _ -> emptyWidget)
 
-oldRenderer, newRenderer :: Renderer
-oldRenderer _ = baseline
-newRenderer streaming = if streaming then optimized else baseline
+prepareFrame
+    :: Renderer
+    -> FenceStreamState
+    -> Bool
+    -> Text
+    -> Text
+    -> (FenceStreamState, Widget Name)
+prepareFrame renderer parser streaming body delta
+    | not streaming = (emptyFenceStreamState, baseline body)
+    | renderer == LegacyRenderer = (parser, baseline body)
+    | renderer == SectionCacheRenderer = (parser, optimized body)
+    | otherwise =
+        let !nextParser = feedFenceStream parser delta
+        in ( nextParser
+           , Markdown.markdownWidgetWithParsedStreamingCache
+                Nothing Link (\chunk section -> cached (Prose chunk section))
+                (\index -> cached (Code index)) (\_ _ -> emptyWidget)
+                nextParser
+           )
 
 main :: IO ()
 main = do
@@ -56,9 +76,11 @@ main = do
     getArgs >>= \case
         [mode, scenario, countArg, chunkArg, samplesArg] -> do
             renderer <- case mode of
-                "old" -> pure oldRenderer
-                "new" -> pure newRenderer
-                _ -> die "mode must be old or new"
+                "old" -> pure LegacyRenderer
+                "new" -> pure SectionCacheRenderer
+                "current" -> pure SectionCacheRenderer
+                "incremental" -> pure IncrementalRenderer
+                _ -> die "mode must be old, new, current, or incremental"
             unless (scenario `elem`
                 ["prose", "prose-lines", "fence", "open-fence", "table", "open-table", "mixed", "resize",
                  "history-prose", "history-mixed"])
@@ -69,8 +91,8 @@ main = do
             let input = frameInput scenario count chunkSize 0
             case [(index, old, new) |
                     (index, (old, new)) <- zip [0 :: Int ..]
-                        (zip (frames oldRenderer (scenario == "resize") input)
-                            (frames newRenderer (scenario == "resize") input)),
+                        (zip (frames SectionCacheRenderer (scenario == "resize") input)
+                            (frames renderer (scenario == "resize") input)),
                     old /= new] of
                 [] -> pure ()
                 (index, old, new) : _ ->
@@ -84,7 +106,7 @@ main = do
                 (median [wall | Sample wall _ _ <- results])
                 (median [cpu | Sample _ cpu _ <- results])
                 (median [bytes | Sample _ _ bytes <- results])
-        _ -> die "usage: fullscreen-markdown-bench old|new SCENARIO COUNT CHUNK_CHARS SAMPLES"
+        _ -> die "usage: fullscreen-markdown-bench old|new|current|incremental SCENARIO COUNT CHUNK_CHARS SAMPLES"
   where
     positive raw = case reads raw of
         [(n, "")] | n > 0 -> pure n
@@ -113,43 +135,45 @@ measure renderer resize input = do
 
 {-# NOINLINE run #-}
 run :: Renderer -> Bool -> [(Bool, Text)] -> Int
-run renderer resize = go "" emptyRenderState 0 (0 :: Int)
+run renderer resize = go "" emptyFenceStreamState emptyRenderState 0 (0 :: Int)
   where
-    go !_ !_ !total !_ [] = total
-    go !body !state !total !frame ((streaming, delta) : rest) =
+    go !_ !_ !_ !total !_ [] = total
+    go !body !parser !state !total !frame ((streaming, delta) : rest) =
         let !nextBody = body <> delta
+            (!nextParser, markdown) = prepareFrame renderer parser streaming nextBody delta
             width = if resize && (frame `div` 50) `mod` 2 == 1 then 40 else 80
             region = (width, 30)
             stateBefore =
                 if resize && frame `mod` 50 == 0 then emptyRenderState else state
             widget = viewport Transcript Vertical $
-                vBox [renderer streaming nextBody, visible (txt " ")]
+                vBox [markdown, visible (txt " ")]
             (nextState, picture, _, extents) =
                 renderFinal Theme.terminalDefault [widget] region
                     (const Nothing) stateBefore
             !checksum = foldl' (foldl' spanChecksum) 0
                 (displayOpsForPic picture region)
                 + foldl' (\n extent -> n + length (show extent)) 0 extents
-        in go nextBody nextState (total + checksum) (frame + 1) rest
+        in go nextBody nextParser nextState (total + checksum) (frame + 1) rest
 
 -- Equality checking deliberately stays outside the measurement. Compare the
 -- complete display operations (including styles/URLs) and click extents.
 frames :: Renderer -> Bool -> [(Bool, Text)] -> [([[(Char, V.Attr)]], [String])]
-frames renderer resize = go "" emptyRenderState (0 :: Int)
+frames renderer resize = go "" emptyFenceStreamState emptyRenderState (0 :: Int)
   where
-    go _ _ _ [] = []
-    go body state frame ((streaming, delta) : rest) =
+    go _ _ _ _ [] = []
+    go body parser state frame ((streaming, delta) : rest) =
         let nextBody = body <> delta
+            (nextParser, markdown) = prepareFrame renderer parser streaming nextBody delta
             width = if resize && (frame `div` 50) `mod` 2 == 1 then 40 else 80
             region = (width, 30)
             before = if resize && frame `mod` 50 == 0 then emptyRenderState else state
             widget = viewport Transcript Vertical $
-                vBox [renderer streaming nextBody, visible (txt " ")]
+                vBox [markdown, visible (txt " ")]
             (nextState, picture, _, extents) =
                 renderFinal Theme.terminalDefault [widget] region (const Nothing) before
         in ( map (concatMap spanCells . toList) (toList (displayOpsForPic picture region))
             , sort (map show extents))
-            : go nextBody nextState (frame + 1) rest
+            : go nextBody nextParser nextState (frame + 1) rest
 
 -- Span segmentation depends on image composition and is not observable.
 -- SpanOp's Show instance also omits text, so compare explicit payloads.

--- a/packages/agent-tui/benchmark/FullscreenMarkdown.hs
+++ b/packages/agent-tui/benchmark/FullscreenMarkdown.hs
@@ -6,6 +6,8 @@ module Main (main) where
 
 import qualified Agent.TUI.Markdown as Markdown
 import Agent.TUI.FencedCode (FenceStreamState, emptyFenceStreamState, feedFenceStream)
+import Agent.TUI.Markdown.Stream (MarkdownStreamState, emptyMarkdownStreamState, feedMarkdownStream)
+import qualified Agent.TUI.Markdown.Inline as Inline
 import qualified Agent.TUI.Theme as Theme
 import Brick
 import Control.Exception (evaluate) -- safe-exceptions does not export evaluate.
@@ -34,9 +36,15 @@ data Name = Transcript | Code !Int | Prose !Int !Int | Link !Text
 data Sample = Sample !Double !Double !Double
 
 -- The historical modes remain available so earlier benchmark reports can be
--- reproduced. "current" is the baseline for retained-parser measurements.
-data Renderer = LegacyRenderer | SectionCacheRenderer | IncrementalRenderer
+-- reproduced. "incremental" is the PR #1278 fence-only parser baseline.
+data Renderer = LegacyRenderer | SectionCacheRenderer | IncrementalRenderer | StreamingRenderer
+    | BaselineInlineParser | StreamingInlineParser
     deriving (Eq)
+
+data ParserState = ParserState !FenceStreamState !MarkdownStreamState
+
+emptyParserState :: ParserState
+emptyParserState = ParserState emptyFenceStreamState emptyMarkdownStreamState
 
 -- This is the pre-optimization production path: append the strict body, parse
 -- the complete Markdown every frame, and cache only closed fenced-code bodies.
@@ -51,19 +59,27 @@ optimized = Markdown.markdownWidgetWithStreamingCache
 
 prepareFrame
     :: Renderer
-    -> FenceStreamState
+    -> ParserState
     -> Bool
     -> Text
     -> Text
-    -> (FenceStreamState, Widget Name)
-prepareFrame renderer parser streaming body delta
-    | not streaming = (emptyFenceStreamState, baseline body)
+    -> (ParserState, Widget Name)
+prepareFrame renderer parser@(ParserState fences markdown) streaming body delta
+    | not streaming = (emptyParserState, baseline body)
     | renderer == LegacyRenderer = (parser, baseline body)
     | renderer == SectionCacheRenderer = (parser, optimized body)
-    | otherwise =
-        let !nextParser = feedFenceStream parser delta
-        in ( nextParser
+    | renderer == IncrementalRenderer =
+        let !nextParser = feedFenceStream fences delta
+        in ( ParserState nextParser markdown
            , Markdown.markdownWidgetWithParsedStreamingCache
+                Nothing Link (\chunk section -> cached (Prose chunk section))
+                (\index -> cached (Code index)) (\_ _ -> emptyWidget)
+                nextParser
+           )
+    | otherwise =
+        let !nextParser = feedMarkdownStream markdown delta
+        in ( ParserState fences nextParser
+           , Markdown.markdownWidgetWithMarkdownStreamingCache
                 Nothing Link (\chunk section -> cached (Prose chunk section))
                 (\index -> cached (Code index)) (\_ _ -> emptyWidget)
                 nextParser
@@ -80,24 +96,30 @@ main = do
                 "new" -> pure SectionCacheRenderer
                 "current" -> pure SectionCacheRenderer
                 "incremental" -> pure IncrementalRenderer
-                _ -> die "mode must be old, new, current, or incremental"
+                "streaming" -> pure StreamingRenderer
+                "baseline-inline" -> pure BaselineInlineParser
+                "streaming-inline" -> pure StreamingInlineParser
+                _ -> die "unknown renderer or parser mode"
             unless (scenario `elem`
                 ["prose", "prose-lines", "fence", "open-fence", "table", "open-table", "mixed", "resize",
-                 "history-prose", "history-mixed"])
+                 "history-prose", "history-mixed", "long-line", "incomplete",
+                 "unmatched-code", "unmatched-link"])
                 (die "unknown scenario")
             count <- positive countArg
             chunkSize <- positive chunkArg
             samples <- positive samplesArg
             let input = frameInput scenario count chunkSize 0
-            case [(index, old, new) |
+            if renderer `elem` [BaselineInlineParser, StreamingInlineParser]
+                then verifyInlineFrames input
+                else case [(index, old, new) |
                     (index, (old, new)) <- zip [0 :: Int ..]
                         (zip (frames SectionCacheRenderer (scenario == "resize") input)
                             (frames renderer (scenario == "resize") input)),
                     old /= new] of
-                [] -> pure ()
-                (index, old, new) : _ ->
-                    die ("old/new per-frame display or click targets differ at "
-                        <> show index <> "\nOLD: " <> show old <> "\nNEW: " <> show new)
+                    [] -> pure ()
+                    (index, old, new) : _ ->
+                        die ("old/new per-frame display or click targets differ at "
+                            <> show index <> "\nOLD: " <> show old <> "\nNEW: " <> show new)
             results <- forM [1 .. samples] \sample ->
                 measure renderer (scenario == "resize")
                     (frameInput scenario count chunkSize sample)
@@ -106,7 +128,7 @@ main = do
                 (median [wall | Sample wall _ _ <- results])
                 (median [cpu | Sample _ cpu _ <- results])
                 (median [bytes | Sample _ _ bytes <- results])
-        _ -> die "usage: fullscreen-markdown-bench old|new|current|incremental SCENARIO COUNT CHUNK_CHARS SAMPLES"
+        _ -> die "usage: fullscreen-markdown-bench old|new|current|incremental|streaming|baseline-inline|streaming-inline SCENARIO COUNT CHUNK_CHARS SAMPLES"
   where
     positive raw = case reads raw of
         [(n, "")] | n > 0 -> pure n
@@ -135,7 +157,9 @@ measure renderer resize input = do
 
 {-# NOINLINE run #-}
 run :: Renderer -> Bool -> [(Bool, Text)] -> Int
-run renderer resize = go "" emptyFenceStreamState emptyRenderState 0 (0 :: Int)
+run BaselineInlineParser _ = runInline False
+run StreamingInlineParser _ = runInline True
+run renderer resize = go "" emptyParserState emptyRenderState 0 (0 :: Int)
   where
     go !_ !_ !_ !total !_ [] = total
     go !body !parser !state !total !frame ((streaming, delta) : rest) =
@@ -155,10 +179,45 @@ run renderer resize = go "" emptyFenceStreamState emptyRenderState 0 (0 :: Int)
                 + foldl' (\n extent -> n + length (show extent)) 0 extents
         in go nextBody nextParser nextState (total + checksum) (frame + 1) rest
 
+-- Diagnostics force the complete syntax tree, not just its rendered text.
+-- They are not a substitute for the full-render acceptance measurements.
+runInline :: Bool -> [(Bool, Text)] -> Int
+runInline retained = go "" Inline.emptyInlineStreamState 0
+  where
+    go !_ !_ !total [] = total
+    go !body !parser !total ((streaming, delta) : rest) =
+        let !nextBody = body <> delta
+            !nextParser = if retained && streaming
+                then Inline.feedInlineStream parser delta else parser
+            nodes = if retained && streaming
+                then Inline.inlineStreamSnapshot nextParser
+                else Inline.parseInline nextBody
+            !checksum = inlineChecksum nodes
+        in go nextBody nextParser (total + checksum) rest
+
+inlineChecksum :: [Inline.Inline] -> Int
+inlineChecksum = foldl' (\total node -> total * 33 + case node of
+    Inline.InlineText value -> textChecksum value
+    Inline.InlineCode value -> 1 + textChecksum value
+    Inline.InlineStrong children -> 2 + inlineChecksum children
+    Inline.InlineEmphasis children -> 3 + inlineChecksum children
+    Inline.InlineLink url children -> 4 + textChecksum url + inlineChecksum children) 0
+
+verifyInlineFrames :: [(Bool, Text)] -> IO ()
+verifyInlineFrames = go "" Inline.emptyInlineStreamState (0 :: Int)
+  where
+    go _ _ _ [] = pure ()
+    go body parser index ((_, delta) : rest) = do
+        let nextBody = body <> delta
+            nextParser = Inline.feedInlineStream parser delta
+        unless (Inline.parseInline nextBody == Inline.inlineStreamSnapshot nextParser)
+            (die ("inline per-frame syntax differs at " <> show index))
+        go nextBody nextParser (index + 1) rest
+
 -- Equality checking deliberately stays outside the measurement. Compare the
 -- complete display operations (including styles/URLs) and click extents.
 frames :: Renderer -> Bool -> [(Bool, Text)] -> [([[(Char, V.Attr)]], [String])]
-frames renderer resize = go "" emptyFenceStreamState emptyRenderState (0 :: Int)
+frames renderer resize = go "" emptyParserState emptyRenderState (0 :: Int)
   where
     go _ _ _ _ [] = []
     go body parser state frame ((streaming, delta) : rest) =
@@ -221,6 +280,10 @@ workload scenario count nonce =
     "# Response " <> Text.pack (show nonce) <> "\n\n" <> case scenario of
         "prose" -> Text.replicate count (prose <> "\n")
         "prose-lines" -> Text.replicate count prose
+        "long-line" -> Text.replicate count (Text.stripEnd prose <> " ")
+        "incomplete" -> "**unfinished [label (with nesting) " <> Text.replicate count "plain text and `code` "
+        "unmatched-code" -> "`" <> Text.replicate count "unfinished code "
+        "unmatched-link" -> "[label](https://example.com/" <> Text.replicate count "nested(segment)/"
         "fence" -> fence count <> prose
         "open-fence" -> "```haskell\n" <> Text.replicate count code
         "table" -> table count <> "\n" <> prose

--- a/packages/agent-tui/benchmark/FullscreenMarkdown.md
+++ b/packages/agent-tui/benchmark/FullscreenMarkdown.md
@@ -239,3 +239,207 @@ unfinished-section parsing/layout, open-code-body flattening, and Brick image
 composition still revisit growing state. The benchmark includes those costs
 and excludes event-loop cache retirement, terminal I/O, and syntax highlighting
 just as the original comparison does.
+
+## Retained Markdown syntax
+
+`streaming` retains block and inline syntax using `MarkdownStreamState`.
+Compare it with `incremental`, the fence-only retained parser from PR #1278,
+not the older `current` section-cache implementation. All historical modes
+remain runnable. Both implementations append the strict message body, feed
+the new delta inside the measured interval, render every frame through Brick,
+and perform the final non-streaming render. Before measurement, every frame
+is checked against the independent section-cache renderer for display text,
+attributes, and click extents.
+
+```sh
+nix develop
+cabal build --offline agent-tui:bench:fullscreen-markdown-bench
+bin=$(cabal list-bin agent-tui:bench:fullscreen-markdown-bench)
+for mode in incremental streaming; do
+  "$bin" "$mode" prose-lines 100 64 7 +RTS -T
+  "$bin" "$mode" mixed 100 64 7 +RTS -T
+  "$bin" "$mode" long-line 100 64 7 +RTS -T
+  "$bin" "$mode" incomplete 100 64 7 +RTS -T
+done
+```
+
+`prose-lines` has completed prose lines without blank paragraph boundaries.
+`long-line` repeats the same styled prose on one line. `incomplete` keeps an
+unclosed emphasis/link prefix before a growing line containing code spans:
+this tests the ambiguous-suffix boundary rather than only complete syntax.
+Counts represent repeated workload units; chunk sizes are Unicode characters.
+
+`unmatched-code` and `unmatched-link` retain an unclosed inline code span or
+link destination. `baseline-inline` and `streaming-inline` are parser-only
+diagnostics using these same input deltas, retaining the strict body append
+and forcing a checksum of the entire syntax tree after each delta. They check
+every prefix against `parseInline` before measurement. These modes omit Brick
+layout and cannot establish a fullscreen performance improvement.
+
+```sh
+for mode in baseline-inline streaming-inline; do
+  "$bin" "$mode" long-line 100 64 7 +RTS -T
+  "$bin" "$mode" unmatched-code 100 64 7 +RTS -T
+  "$bin" "$mode" unmatched-link 100 64 7 +RTS -T
+done
+```
+
+Streaming snapshots retain literal fallback for unresolved syntax. An
+ambiguous suffix may grow without bound and still requires reparsing in the
+snapshot; resumable feed state does not make total per-frame work linear.
+
+### Retained-syntax measurements
+
+#### Final validation
+
+Same machine, GHC 9.10.3 and `-O2` settings as below; count 100,
+64-character deltas, 21 samples (`prose`: 31), `+RTS -T`.
+The first four baselines use the saved executable from `eab8603f9` to avoid
+shared-renderer baseline drift. The two newly added workloads use the retained
+`incremental` mode in the current executable. Every invocation passed the
+per-frame picture/style/click-extent equivalence check.
+
+| Workload | Wall baseline → streaming ms | CPU ms | Allocated MB |
+| --- | --- | --- | --- |
+| prose | 39.059 → 39.446 | 38.977 → 39.376 | 289.913 → 290.684 |
+| prose-lines | 334.944 → 305.146 | 334.040 → 304.453 | 1942.843 → 1745.893 |
+| mixed | 328.451 → 324.783 | 326.804 → 324.169 | 1730.266 → 1698.266 |
+| table | 112.123 → 84.699 | 111.998 → 84.591 | 615.623 → 393.293 |
+| long-line | 377.901 → 350.799 | 377.288 → 350.240 | 1926.716 → 1782.735 |
+| incomplete | 42.496 → 28.336 | 42.475 → 28.320 | 376.868 → 191.140 |
+
+Continuous prose uses 8.9% less CPU and 10.1% less allocation; tables use
+24.5% less CPU and 36.1% less allocation. The incomplete-markup fixture uses
+33.3% less CPU and 49.3% less allocation. Mixed content is effectively flat
+in CPU, with 1.8% less allocation. Short-paragraph CPU is about 1% higher:
+a reversed-order repeat measured baseline 38.894 ms versus streaming 39.252 ms.
+The always-on short-inline scanner was redesigned to use batch parsing up to
+128 characters, but retained block bookkeeping still has a small cost here.
+No short-paragraph or universal no-regression claim is made.
+
+Run the final workload checks with the executable setup above:
+
+```sh
+for scenario in prose prose-lines mixed table long-line incomplete; do
+  for mode in incremental streaming; do
+    "$bin" "$mode" "$scenario" 100 64 21 +RTS -T
+  done
+done
+```
+
+For an independent pre-change comparison, build the benchmark at `eab8603f9`
+and substitute that executable for `incremental` on the first four workloads.
+It does not contain the `long-line` or `incomplete` scenarios.
+
+#### Earlier implementation matrix
+
+The matrix below records the initial retained-syntax implementation, before
+the final line-boundary reuse, ordinary-prose classification fast path, and
+batch fallback for inline bodies of at most 128 characters.
+See the final validation measurements above for the final implementation.
+
+Measured on Apple M3 Max/macOS arm64, GHC 9.10.3, benchmark source modules
+compiled with `-O2`, default single-thread RTS and `+RTS -T`. Values are medians
+of seven samples; allocation is decimal MB. Every measured invocation passed
+per-frame equivalence. Arrows below mean `incremental` → `streaming`.
+
+| Workload | Count | Chunk | Wall ms | CPU ms | Allocated MB |
+| --- | ---: | ---: | --- | --- | --- |
+| prose-lines | 50 | 64 | 84.321 → 75.739 | 84.160 → 75.697 | 545.071 → 494.085 |
+| prose-lines | 100 | 64 | 313.519 → 282.306 | 313.285 → 282.030 | 1953.380 → 1745.974 |
+| prose-lines | 200 | 64 | 1204.561 → 1097.227 | 1203.494 → 1096.521 | 7210.924 → 6381.328 |
+| long-line | 50 | 64 | 89.415 → 82.331 | 89.382 → 82.263 | 536.251 → 500.571 |
+| long-line | 100 | 64 | 360.264 → 328.410 | 358.983 → 328.519 | 1927.189 → 1783.086 |
+| long-line | 200 | 64 | 1542.112 → 1345.816 | 1538.568 → 1343.593 | 7090.156 → 6515.806 |
+| incomplete | 50 | 64 | 10.924 → 7.744 | 10.920 → 7.743 | 103.815 → 55.992 |
+| incomplete | 100 | 64 | 40.947 → 27.692 | 40.970 → 27.621 | 377.097 → 190.438 |
+| incomplete | 200 | 64 | 155.441 → 101.926 | 155.094 → 101.970 | 1336.197 → 637.899 |
+| table | 50 | 64 | 32.552 → 24.726 | 32.560 → 24.728 | 191.924 → 130.524 |
+| table | 100 | 64 | 106.152 → 79.446 | 106.179 → 79.446 | 623.395 → 394.360 |
+| table | 200 | 64 | 414.956 → 311.894 | 414.089 → 311.217 | 2223.239 → 1339.749 |
+| mixed | 50 | 64 | 110.534 → 108.319 | 110.306 → 108.247 | 666.624 → 646.548 |
+| mixed | 100 | 64 | 312.356 → 303.641 | 311.897 → 303.213 | 1733.480 → 1698.171 |
+| mixed | 200 | 64 | 1090.264 → 1102.583 | 1089.308 → 1101.596 | 5057.506 → 5008.271 |
+| mixed | 50 | 16 | 326.345 → 323.434 | 326.233 → 323.118 | 2226.845 → 2175.469 |
+| mixed | 50 | 256 | 54.669 → 54.108 | 54.615 → 54.068 | 276.460 → 264.041 |
+| mixed, single delta | 50 | 100000 | 35.408 → 34.323 | 35.420 → 34.327 | 148.015 → 137.870 |
+| open-table | 100 | 64 | 107.445 → 81.793 | 107.467 → 81.748 | 620.438 → 391.393 |
+| resize | 100 | 64 | 455.271 → 442.004 | 454.392 → 436.445 | 2291.299 → 2094.601 |
+
+The main benefit is retained syntax in growing prose and tables, not a large
+additional speedup for already-cached mixed messages. The initial implementation
+regressed incomplete syntax and long lines; avoiding repeated block-prefix scans
+and reusing literal-fallback syntax removed those large regressions.
+
+Boundary and representative workloads were repeated with 21 samples, reversing
+implementation order except the 200-group mixed repeat:
+
+| Workload | Count | Chunk | Wall ms | CPU ms | Allocated MB |
+| --- | ---: | ---: | --- | --- | --- |
+| unmatched-code | 100 | 64 | 10.272 → 10.671 | 10.238 → 10.618 | 67.803 → 67.882 |
+| unmatched-link | 100 | 64 | 20.675 → 20.554 | 20.657 → 20.534 | 186.227 → 186.236 |
+| prose | 100 | 64 | 37.857 → 38.513 | 37.681 → 38.494 | 290.392 → 290.412 |
+| prose | 5 | 64 | 1.206 → 1.354 | 1.207 → 1.347 | 8.802 → 8.759 |
+| fence | 100 | 64 | 27.906 → 27.751 | 27.899 → 27.740 | 184.906 → 184.955 |
+| open-fence | 100 | 64 | 28.732 → 28.192 | 28.624 → 28.167 | 189.363 → 189.414 |
+| history-mixed | 100 | 64 | 38.257 → 37.731 | 38.198 → 37.723 | 156.579 → 156.579 |
+| mixed | 100 | 64 | 313.333 → 307.255 | 313.259 → 306.531 | 1733.938 → 1698.514 |
+| mixed | 200 | 64 | 1088.515 → 1075.271 | 1087.332 → 1074.837 | 5057.604 → 5008.369 |
+
+The mixed-200 apparent slowdown reversed on repeat. Small prose and unmatched
+code still show overhead, so these measurements do not support a universal
+no-regression claim. The five-paragraph difference is 0.140 ms per complete
+stream, not per frame.
+
+Three further interleaved subprocess pairs on unchanged sources did not
+consistently reproduce the small-boundary slowdowns: prose-5/64/51 CPU was
+1.286 → 1.285, 1.272 → 1.321, and 1.271 → 1.275 ms; unmatched-code-100/64/21
+was 10.587 → 10.372, 10.592 → 10.622, and 10.402 → 10.280 ms.
+These sub-millisecond differences are sensitive to process/run conditions;
+no speedup is claimed for these boundaries.
+
+A saved executable built from PR #1278 independently checked baseline drift.
+For mixed-100/64/21 it measured wall 317.523 ms, CPU 313.470 ms and 1730.266 MB,
+versus streaming wall 310.250 ms, CPU 309.687 ms and 1698.514 MB. Its prose-lines
+and table allocation totals were 1943.327 and 616.585 MB (100/64/7), slightly
+below the in-tree baseline; the major prose/table gains remain.
+
+Parser-only diagnostics (100/64/7) illustrate why parser timings alone are
+insufficient:
+
+| Workload | Wall baseline → streaming ms | CPU ms | Allocated MB |
+| --- | --- | --- | --- |
+| long-line | 27.048 → 2.152 | 27.038 → 2.163 | 155.719 → 12.234 |
+| incomplete | 13.470 → 1.558 | 13.457 → 1.558 | 207.310 → 20.528 |
+| prose-lines | 16.973 → 2.460 | 16.975 → 2.466 | 168.021 → 15.881 |
+| unmatched-code | 0.112 → 0.087 | 0.112 → 0.088 | 0.721 → 0.699 |
+| unmatched-link | 0.321 → 0.331 | 0.321 → 0.331 | 3.143 → 3.123 |
+
+Separate `100 64 1 +RTS -T -s` subprocesses reported maximum residency:
+prose-lines 1.276 → 1.433 MB, mixed 16.707 → 20.255 MB, long-line
+1.767 → 1.809 MB. **These include the untimed equivalence pass**, which runs
+both the oracle and selected renderer; they are whole-harness peaks, not
+isolated parser-state sizes. Reduced allocation does not imply lower residency:
+retained syntax occupies additional live memory.
+
+Reproduce the matrix with the build and `bin` setup above:
+
+```sh
+for count in 50 100 200; do
+  for scenario in prose-lines mixed long-line incomplete table; do
+    for mode in incremental streaming; do
+      "$bin" "$mode" "$scenario" "$count" 64 7 +RTS -T
+    done
+  done
+done
+for scenario in unmatched-code unmatched-link prose fence open-fence history-mixed mixed; do
+  for mode in streaming incremental; do
+    "$bin" "$mode" "$scenario" 100 64 21 +RTS -T
+  done
+done
+for scenario in prose-lines mixed long-line; do
+  for mode in incremental streaming; do
+    "$bin" "$mode" "$scenario" 100 64 1 +RTS -T -s
+  done
+done
+```

--- a/packages/agent-tui/benchmark/FullscreenMarkdown.md
+++ b/packages/agent-tui/benchmark/FullscreenMarkdown.md
@@ -1,5 +1,9 @@
 # Fullscreen streaming Markdown benchmark
 
+The original section-cache comparison is retained below. For the subsequent
+retained-parser comparison, use `current` versus `incremental` and see
+[Retained parser](#retained-parser).
+
 `FullscreenMarkdown.hs` retains the pre-optimization production path as
 `baseline`: strict `Text` append followed by whole-message Markdown rendering,
 with Brick's existing closed-code-body cache. `optimized` additionally caches
@@ -151,3 +155,87 @@ and benchmark source are unchanged: the timings above include the final
 completed-message render, but exclude that targeted event-loop cleanup.
 The harness retains its prose entries until the sample ends, so these results
 do not measure production cache residency after completion.
+
+## Retained parser
+
+`current` is the existing streaming-section-cache renderer (also available as
+the historical `new` mode). `incremental` additionally retains
+`FenceStreamState`, feeds each new delta inside the measured interval, and
+renders its parsed sections. Both retain the strict body append and perform
+the same final completed-message render. Cold history bypasses the parser.
+The measurement therefore includes parser maintenance rather than moving
+that work outside the timed region.
+
+```sh
+nix develop
+cabal build --offline agent-tui:bench:fullscreen-markdown-bench
+bin=$(cabal list-bin agent-tui:bench:fullscreen-markdown-bench)
+"$bin" current mixed 100 64 7 +RTS -T
+"$bin" incremental mixed 100 64 7 +RTS -T
+```
+
+The incremental mode compares every frame with the existing section-cache
+renderer before measurement, including normalized display text, attributes,
+and click extents. The benchmark's parser, renderer, and support modules use
+`-O2`; shared dependency libraries use Cabal's normal optimization settings.
+The original `old` and `new` modes remain available.
+
+### Measurements, 2026-09-12
+
+GHC 9.10.3, Apple M3 Max (arm64 macOS), single-threaded RTS with `+RTS -T`,
+default allocation area, seven samples per row. Time covers all frames,
+including completion; allocation is decimal MB.
+
+| Workload | Count | Chunk | Wall current → incremental (ms) | CPU current → incremental (ms) | Allocated current → incremental (MB) |
+| --- | ---: | ---: | --- | --- | --- |
+| prose | 20 | 64 | 5.981 → 5.715 | 5.976 → 5.696 | 44.665 → 44.346 |
+| prose | 50 | 64 | 17.551 → 17.636 | 17.527 → 17.571 | 131.987 → 130.015 |
+| prose | 100 | 64 | 41.656 → 43.949 | 41.628 → 43.759 | 298.150 → 290.413 |
+| prose | 200 | 64 | 108.097 → 93.691 | 107.713 → 93.662 | 719.611 → 688.701 |
+| mixed | 50 | 64 | 128.041 → 115.699 | 127.752 → 115.640 | 719.094 → 664.796 |
+| mixed | 100 | 64 | 381.505 → 335.819 | 379.783 → 335.283 | 1947.231 → 1729.814 |
+| prose-lines | 50 | 64 | 86.942 → 86.585 | 86.849 → 86.514 | 543.395 → 542.492 |
+| fence | 100 | 64 | 28.643 → 28.926 | 28.611 → 28.891 | 186.993 → 184.940 |
+| open-fence | 100 | 64 | 30.257 → 29.397 | 30.217 → 29.384 | 191.361 → 189.400 |
+| table | 100 | 64 | 113.322 → 114.826 | 112.837 → 114.611 | 617.845 → 616.585 |
+| open-table | 100 | 64 | 115.089 → 112.165 | 114.499 → 112.063 | 614.829 → 613.633 |
+| resize | 50 | 64 | 165.758 → 155.165 | 165.556 → 154.723 | 859.159 → 804.829 |
+| mixed | 50 | 16 | 381.735 → 347.581 | 381.236 → 347.086 | 2440.845 → 2223.372 |
+| mixed | 50 | 256 | 59.804 → 55.980 | 59.752 → 55.949 | 288.679 → 275.052 |
+| mixed (repeat) | 50 | 64 | 124.231 → 112.191 | 123.943 → 112.118 | 719.094 → 664.796 |
+| history-prose | 50 | 64 | 2.515 → 2.489 | 2.515 → 2.483 | 15.754 → 15.754 |
+| history-mixed | 50 | 64 | 18.660 → 18.729 | 18.649 → 18.702 | 78.135 → 78.135 |
+
+The mixed 50-group repeat retains a 9.5% CPU reduction and 7.6% allocation
+reduction. The 100-group mixed case reduces CPU 11.7% and allocation 11.2%.
+This is an incremental improvement over section caching, not the much larger
+historical gain from introducing section caching itself.
+
+The small apparent regressions were repeated in reverse implementation order
+with 21 samples. The initial 100-paragraph slowdown did not reproduce; a
+growing table remains effectively unchanged. Sample-specific headings have
+different digit lengths in the 21-sample run, so allocation totals are not
+identical to the seven-sample run.
+
+| Repeated workload | Count | Chunk | Wall current → incremental (ms) | CPU current → incremental (ms) | Allocated current → incremental (MB) |
+| --- | ---: | ---: | --- | --- | --- |
+| prose | 100 | 64 | 39.375 → 38.301 | 39.361 → 38.281 | 297.649 → 289.913 |
+| fence | 100 | 64 | 28.475 → 27.805 | 28.453 → 27.801 | 186.946 → 184.894 |
+| table | 100 | 64 | 111.675 → 111.497 | 111.346 → 111.397 | 616.883 → 615.623 |
+| prose | 50 | 64 | 16.808 → 16.719 | 16.799 → 16.709 | 131.739 → 129.768 |
+| mixed | 100 | 64 | 358.745 → 317.702 | 358.045 → 317.055 | 1947.665 → 1730.266 |
+| prose, single delta | 50 | 100000 | 5.317 → 5.300 | 5.318 → 5.306 | 31.840 → 31.816 |
+| mixed, single delta | 50 | 100000 | 36.632 → 36.900 | 36.606 → 36.856 | 146.890 → 146.739 |
+
+Every incremental run passed per-frame equivalence. The representative
+100-group mixed improvement remains 11.4% CPU and 11.2% allocation on repeat.
+No speedup is claimed for growing tables, small prose messages, cold history,
+or the single-delta boundary. Their CPU differences are small and inconsistent
+between runs.
+
+This change removes rediscovery of completed fences and prose-section
+boundaries. It does not make total streaming work linear: strict body append,
+unfinished-section parsing/layout, open-code-body flattening, and Brick image
+composition still revisit growing state. The benchmark includes those costs
+and excludes event-loop cache retirement, terminal I/O, and syntax highlighting
+just as the original comparison does.

--- a/packages/agent-tui/package.nix
+++ b/packages/agent-tui/package.nix
@@ -15,8 +15,8 @@ mkDerivation {
     QuickCheck text vty
   ];
   benchmarkHaskellDepends = [
-    aeson aeson-pretty agent-core agent-json agent-syntax base brick
-    bytestring containers deepseq safe-exceptions text vty
+    aeson aeson-pretty agent-core agent-json agent-syntax agent-tools
+    base brick bytestring containers deepseq safe-exceptions text vty
   ];
   description = "Retained terminal UI for the universal agent harness";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-tui/src/Agent/TUI/FencedCode.hs
+++ b/packages/agent-tui/src/Agent/TUI/FencedCode.hs
@@ -15,6 +15,10 @@ module Agent.TUI.FencedCode
     , emptyFenceStreamState
     , feedFenceStream
     , fenceStreamSections
+    , FenceSectionLayout(..)
+    , feedFenceStreamWithProse
+    , fenceStreamPendingProse
+    , fenceStreamLayout
     ) where
 
 import Control.Applicative ((<|>))
@@ -171,6 +175,64 @@ feedFenceStream state input =
                 let line = SourceLine (state.streamPendingLine <> fragment) "\n"
                     next = consumeStreamLine state{streamPendingLine = ""} line
                 in feedFenceStream next (Text.drop 1 suffix)
+
+-- | Structural events for a downstream prose parser. Only newline-complete
+-- prose lines are committed; the final line remains a reversible preview.
+feedFenceStreamWithProse
+    :: FenceStreamState -> Text -> (FenceStreamState, [(Int, Int, Text)])
+feedFenceStreamWithProse state input =
+    case Text.breakOn "\n" input of
+        (fragment, suffix)
+            | Text.null suffix ->
+                (state{streamPendingLine = state.streamPendingLine <> fragment}, [])
+            | otherwise ->
+                let source = state.streamPendingLine <> fragment
+                    line = SourceLine source "\n"
+                    -- A prose line leaves the parser outside a fence. Reuse
+                    -- the transition's decision instead of running contextual
+                    -- opener recognition twice for every completed line.
+                    events = case (state.streamOpener, next.streamOpener) of
+                        (Nothing, Nothing) ->
+                            [(state.streamChunkIndex, state.streamSectionIndex, source)]
+                        _ -> []
+                    next = consumeStreamLine state{streamPendingLine = ""} line
+                    (final, remaining) = feedFenceStreamWithProse next (Text.drop 1 suffix)
+                in (final, events <> remaining)
+
+fenceStreamPendingProse :: FenceStreamState -> Maybe (Int, Int, Text)
+fenceStreamPendingProse state
+    | Nothing <- state.streamOpener
+    , not (Text.null state.streamPendingLine)
+    , Nothing <- fenceOpenerInContext state.streamPrevious state.streamPendingLine =
+        Just (state.streamChunkIndex, state.streamSectionIndex, state.streamPendingLine)
+    | otherwise = Nothing
+
+-- | A view that does not flatten the growing prose section. Source-bearing
+-- snapshots remain available for callers that actually require source text.
+data FenceSectionLayout
+    = FenceProseLayout !Int !Int !Bool
+    | FenceCodeLayout !Int !FencedBlock
+    deriving (Eq, Show)
+
+fenceStreamLayout :: FenceStreamState -> [FenceSectionLayout]
+fenceStreamLayout state =
+    let preview
+            | Text.null state.streamPendingLine = state
+            | otherwise = consumeStreamLine state{streamPendingLine = ""}
+                (SourceLine state.streamPendingLine "")
+        completed = map sectionLayout (toList preview.streamSections)
+        active = case preview.streamOpener of
+            Just opener ->
+                [FenceCodeLayout preview.streamChunkIndex (streamBlock preview opener False)]
+            Nothing
+                | not (null preview.streamLines) ->
+                    [FenceProseLayout preview.streamChunkIndex preview.streamSectionIndex False]
+                | otherwise -> []
+    in completed <> active
+  where
+    sectionLayout (FenceProseSection chunk section stable _) =
+        FenceProseLayout chunk section stable
+    sectionLayout (FenceCodeSection chunk block) = FenceCodeLayout chunk block
 
 consumeStreamLine :: FenceStreamState -> SourceLine -> FenceStreamState
 consumeStreamLine state line =

--- a/packages/agent-tui/src/Agent/TUI/FencedCode.hs
+++ b/packages/agent-tui/src/Agent/TUI/FencedCode.hs
@@ -10,10 +10,18 @@ module Agent.TUI.FencedCode
     , isFenceCloser
     , fenceChunks
     , fencedBlocks
+    , FenceStreamState
+    , FenceSection(..)
+    , emptyFenceStreamState
+    , feedFenceStream
+    , fenceStreamSections
     ) where
 
 import Control.Applicative ((<|>))
 import Data.Char (isSpace)
+import Data.Foldable (toList)
+import Data.Sequence (Seq, (|>))
+import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -124,6 +132,135 @@ data ContextualFence = ContextualFence
     , openContainerIndent :: !Int
     , openIndent :: !Int
     }
+    deriving (Eq, Show)
+
+-- | Completed prose sections retain the renderer's fence-chunk and section
+-- indices. Only an empty, newline-terminated line makes prose cacheable.
+data FenceSection
+    = FenceProseSection !Int !Int !Bool !Text
+    | FenceCodeSection !Int !FencedBlock
+    deriving (Eq, Show)
+
+-- | Append-only parser state. A partial final line is never committed: even a
+-- seemingly complete closing fence can become ordinary code when more arrives.
+-- Rendering previews that line without changing the retained parser state.
+data FenceStreamState = FenceStreamState
+    { streamSections :: !(Seq FenceSection)
+    , streamPrevious :: ![SourceLine]
+    , streamPendingLine :: !Text
+    , streamOpener :: !(Maybe ContextualFence)
+    , streamLines :: ![Text]
+    , streamChunkIndex :: !Int
+    , streamCodeIndex :: !Int
+    , streamSectionIndex :: !Int
+    , streamHasProse :: !Bool
+    }
+    deriving (Eq, Show)
+
+emptyFenceStreamState :: FenceStreamState
+emptyFenceStreamState =
+    FenceStreamState Seq.empty [] "" Nothing [] 1 1 1 False
+
+feedFenceStream :: FenceStreamState -> Text -> FenceStreamState
+feedFenceStream state input =
+    case Text.breakOn "\n" input of
+        (fragment, suffix)
+            | Text.null suffix ->
+                state{streamPendingLine = state.streamPendingLine <> fragment}
+            | otherwise ->
+                let line = SourceLine (state.streamPendingLine <> fragment) "\n"
+                    next = consumeStreamLine state{streamPendingLine = ""} line
+                in feedFenceStream next (Text.drop 1 suffix)
+
+consumeStreamLine :: FenceStreamState -> SourceLine -> FenceStreamState
+consumeStreamLine state line =
+    (consume state){streamPrevious = retainContext line state.streamPrevious}
+  where
+    consume current = case current.streamOpener of
+        Just opener
+            | isContextualFenceCloser opener line.lineText ->
+                current
+                    { streamSections = current.streamSections
+                        |> FenceCodeSection current.streamChunkIndex
+                            (streamBlock current opener True)
+                    , streamOpener = Nothing
+                    , streamLines = []
+                    , streamChunkIndex = current.streamChunkIndex + 1
+                    , streamCodeIndex = current.streamCodeIndex + 1
+                    }
+            | otherwise ->
+                current{streamLines =
+                    (stripBodyIndent opener.openIndent line.lineText
+                        <> line.lineEnding) : current.streamLines}
+        Nothing -> case fenceOpenerInContext current.streamPrevious line.lineText of
+            Just opener ->
+                current
+                    { streamSections = appendProseTail current
+                    , streamOpener = Just opener
+                    , streamLines = []
+                    , streamChunkIndex = current.streamChunkIndex
+                        + if current.streamHasProse then 1 else 0
+                    , streamSectionIndex = 1
+                    , streamHasProse = False
+                    }
+            Nothing
+                | Text.null line.lineText
+                , line.lineEnding == "\n"
+                , not (null current.streamLines) ->
+                    current
+                        { streamSections = current.streamSections
+                            |> FenceProseSection current.streamChunkIndex
+                                current.streamSectionIndex True
+                                (Text.concat (reverse ("\n" : current.streamLines)))
+                        , streamLines = []
+                        , streamSectionIndex = current.streamSectionIndex + 1
+                        , streamHasProse = True
+                        }
+                | otherwise ->
+                    current
+                        { streamLines = sourceLineText line : current.streamLines
+                        , streamHasProse = True
+                        }
+
+-- The contextual lookup stops at a non-list, non-blank, unindented line.
+-- Earlier source can no longer influence any future fence, so do not retain it.
+retainContext :: SourceLine -> [SourceLine] -> [SourceLine]
+retainContext line previous
+    | leadingSpaceCount line.lineText == 0
+    , not (Text.null (Text.strip line.lineText))
+    , Nothing <- listItemContentIndent line.lineText = []
+    | otherwise = line : previous
+
+appendProseTail :: FenceStreamState -> Seq FenceSection
+appendProseTail state
+    | null state.streamLines = state.streamSections
+    | otherwise = state.streamSections
+        |> FenceProseSection state.streamChunkIndex state.streamSectionIndex
+            False (Text.concat (reverse state.streamLines))
+
+streamBlock :: FenceStreamState -> ContextualFence -> Bool -> FencedBlock
+streamBlock state opener closed = FencedBlock
+    { fencedIndex = state.streamCodeIndex
+    , fencedMarker = opener.openMarker
+    , fencedInfo = opener.openInfo
+    , fencedBody = Text.concat (reverse state.streamLines)
+    , fencedClosed = closed
+    }
+
+-- | Snapshot with the same interpretation as 'fenceChunks' on the source seen
+-- so far, but without rescanning completed lines or completed prose sections.
+fenceStreamSections :: FenceStreamState -> [FenceSection]
+fenceStreamSections state =
+    let preview
+            | Text.null state.streamPendingLine = state
+            | otherwise = consumeStreamLine
+                state{streamPendingLine = ""}
+                (SourceLine state.streamPendingLine "")
+    in toList $ case preview.streamOpener of
+        Nothing -> appendProseTail preview
+        Just opener -> preview.streamSections
+            |> FenceCodeSection preview.streamChunkIndex
+                (streamBlock preview opener False)
 
 fenceOpenerInContext :: [SourceLine] -> Text -> Maybe ContextualFence
 fenceOpenerInContext previous line =
@@ -248,6 +385,7 @@ data SourceLine = SourceLine
     { lineText :: !Text
     , lineEnding :: !Text
     }
+    deriving (Eq, Show)
 
 sourceLines :: Text -> [SourceLine]
 sourceLines input

--- a/packages/agent-tui/src/Agent/TUI/FencedCode.hs
+++ b/packages/agent-tui/src/Agent/TUI/FencedCode.hs
@@ -19,6 +19,7 @@ module Agent.TUI.FencedCode
     , feedFenceStreamWithProse
     , fenceStreamPendingProse
     , fenceStreamLayout
+    , fenceStreamRetainedBytes
     ) where
 
 import Control.Applicative ((<|>))
@@ -144,6 +145,26 @@ data FenceSection
     = FenceProseSection !Int !Int !Bool !Text
     | FenceCodeSection !Int !FencedBlock
     deriving (Eq, Show)
+
+-- | Logical retained size, including source context and unfinished sections.
+-- Count shared text conservatively and never construct a rendering snapshot.
+-- Integer arithmetic lets callers saturate at their own accounting limit.
+-- This is a logical estimate, not exact heap residency: Text slices may share
+-- backing arrays, and their complete allocation sizes are not inspected.
+fenceStreamRetainedBytes :: FenceStreamState -> Integer
+fenceStreamRetainedBytes state =
+    256
+        + foldl' (\size section -> size + sectionBytes section) 0 state.streamSections
+        + foldl' (\size line -> size + 128 + textBytes line.lineText + textBytes line.lineEnding)
+            0 state.streamPrevious
+        + textBytes state.streamPendingLine
+        + maybe 0 (\opener -> 128 + textBytes opener.openInfo) state.streamOpener
+        + foldl' (\size text -> size + textBytes text) 0 state.streamLines
+  where
+    textBytes text = 64 + 4 * toInteger (Text.length text)
+    sectionBytes (FenceProseSection _ _ _ text) = 128 + textBytes text
+    sectionBytes (FenceCodeSection _ block) =
+        128 + textBytes block.fencedInfo + textBytes block.fencedBody
 
 -- | Append-only parser state. A partial final line is never committed: even a
 -- seemingly complete closing fence can become ordinary code when more arrives.

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -18,6 +18,7 @@ module Agent.TUI.Markdown
     , markdownWidgetWithSyntaxHighlightingAndLinks
     , markdownWidgetWithStreamingCache
     , markdownWidgetWithParsedStreamingCache
+    , markdownWidgetWithMarkdownStreamingCache
     , markdownStreamingCacheSections
     , parseInline
     ) where
@@ -36,6 +37,7 @@ import Agent.TUI.Markdown.Inline
     , parseInline
     )
 import qualified Agent.TUI.Markdown.Block as Block
+import qualified Agent.TUI.Markdown.Stream as Stream
 import Agent.Syntax
     ( HighlightedLine
     , SyntaxHighlighter
@@ -62,6 +64,7 @@ import qualified Brick.Types as B
 import Control.Applicative ((<|>))
 import Data.Bits ((.|.))
 import Data.Char (isDigit, isSpace)
+import Data.Foldable (toList)
 import qualified Data.List as List
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
@@ -244,6 +247,48 @@ markdownWidgetWithParsedStreamingCache highlighter linkName cacheProse cacheCode
                         vBox (renderLines (Just linkName) (Text.lines prose))
             ]
         | otherwise = renderLines (Just linkName) (Text.lines prose)
+
+-- | Render retained syntax, including inline trees and table-cell measurements.
+-- Only immutable prose sections enter Brick's cache; the active suffix remains
+-- uncached and can be reinterpreted as additional Markdown arrives.
+markdownWidgetWithMarkdownStreamingCache
+    :: Ord n
+    => Maybe SyntaxHighlighter
+    -> (Text -> n)
+    -> (Int -> Int -> Widget n -> Widget n)
+    -> (Int -> Widget n -> Widget n)
+    -> (Int -> Text -> Widget n)
+    -> Stream.MarkdownStreamState
+    -> Widget n
+markdownWidgetWithMarkdownStreamingCache highlighter linkName cacheProse cacheCode codeHeader =
+    vBox . concatMap renderSection . Stream.markdownStreamSnapshot
+  where
+    renderSection (Stream.MarkdownCodeSection _ block) =
+        renderChunk highlighter (Just linkName) cacheCode codeHeader (FenceBlock block)
+    renderSection (Stream.MarkdownProseSection chunk index stable whitespace blocks)
+        | stable =
+            [cacheProse chunk index $
+                B.Widget (if whitespace then B.Fixed else B.Greedy) B.Fixed $
+                    B.render (vBox (map renderBlock (toList blocks)))]
+        | otherwise = map renderBlock (toList blocks)
+    renderBlock (Stream.MarkdownTable alignments rows) =
+        let cells = toList rows
+        in tableInlineRowsWidget (Just linkName) alignments
+            (map (map (.cellInlines)) cells)
+            (map (map (\cell -> (cell.cellNaturalWidth, cell.cellMinimumWidth))) cells)
+    renderBlock (Stream.MarkdownLine kind inlines) =
+        let inline = inlineWidgetWithAttr (Just linkName)
+        in case kind of
+            Stream.ProseLine -> inline Theme.assistantAttr inlines
+            Stream.HeadingLine -> padTop (Pad 1) (inline Theme.headingAttr inlines)
+            Stream.BulletLine indent -> hBox
+                [txt indent, withAttr Theme.headingAttr (txt "• "), inline Theme.assistantAttr inlines]
+            Stream.OrderedLine indent number -> hBox
+                [txt indent, withAttr Theme.headingAttr (txt (number <> ". ")), inline Theme.assistantAttr inlines]
+            Stream.QuoteLine -> hBox
+                [withAttr Theme.mutedAttr (txt "│ "), inline Theme.mutedAttr inlines]
+            Stream.BlankLine -> txt " "
+            Stream.ThematicLine -> withAttr Theme.mutedAttr (vLimit 1 (fill '─'))
 
 -- | Render a standalone code body with the same width bounding and optional
 -- syntax highlighting used by fenced Markdown blocks.
@@ -1295,7 +1340,20 @@ tableRowsWidget
     -> [[Text]]
     -> [Text]
     -> Widget n
-tableRowsWidget linkName table rows headerCells =
+tableRowsWidget linkName table rows _ =
+    tableInlineRowsWidget linkName table.tableAlignments
+        (map (map parseInline) rows)
+        (map (map (\cell -> (cellDisplayWidth cell, cellMinimumWidth cell))) rows)
+
+tableInlineRowsWidget
+    :: Ord n
+    => Maybe (Text -> n)
+    -> [Block.TableAlignment]
+    -> [[[Inline]]]
+    -> [[(Int, Int)]]
+    -> Widget n
+tableInlineRowsWidget _ _ [] _ = emptyWidget
+tableInlineRowsWidget linkName alignments rows@(headerCells : _) measurements =
     B.Widget B.Greedy B.Fixed do
         context <- B.getContext
         borderAttr <- B.lookupAttrName Theme.borderAttr
@@ -1308,8 +1366,7 @@ tableRowsWidget linkName table rows headerCells =
                         (resolveInline
                             (if rowIndex == 0
                                 then Theme.strongAttr
-                                else Theme.assistantAttr)
-                            . parseInline)
+                                else Theme.assistantAttr))
                         cells)
                 (zip [0 :: Int ..] normalizedRows)
         let availableWidth = max 1 context.availWidth
@@ -1346,13 +1403,13 @@ tableRowsWidget linkName table rows headerCells =
                                 renderTableRow
                                     linkName
                                     borderAttr headerAttr horizontalPadding
-                                    table.tableAlignments widths header
+                                    alignments widths header
                                     : map
                                         (renderTableRow
                                             linkName
                                             borderAttr bodyAttr
                                             horizontalPadding
-                                            table.tableAlignments widths)
+                                            alignments widths)
                                         body
                         in top
                             : (List.intersperse divider logicalRows
@@ -1366,14 +1423,14 @@ tableRowsWidget linkName table rows headerCells =
   where
     columnCount = length headerCells
     normalizedRows =
-        [ take columnCount (cells <> repeat "")
+        [ take columnCount (cells <> repeat [])
         | cells <- rows
         ]
     naturalWidths =
         [ maximum
             (1
-                : [ cellDisplayWidth cell
-                  | row <- normalizedRows
+                : [ fst cell
+                  | row <- measurements
                   , cell <- take 1 (drop columnIndex row)
                   ])
         | columnIndex <- [0 .. columnCount - 1]
@@ -1381,8 +1438,8 @@ tableRowsWidget linkName table rows headerCells =
     minimumWidths =
         [ maximum
             (1
-                : [ cellMinimumWidth cell
-                  | row <- normalizedRows
+                : [ snd cell
+                  | row <- measurements
                   , cell <- take 1 (drop columnIndex row)
                   ])
         | columnIndex <- [0 .. columnCount - 1]

--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -17,6 +17,7 @@ module Agent.TUI.Markdown
     , markdownWidgetWithSyntaxHighlighting
     , markdownWidgetWithSyntaxHighlightingAndLinks
     , markdownWidgetWithStreamingCache
+    , markdownWidgetWithParsedStreamingCache
     , markdownStreamingCacheSections
     , parseInline
     ) where
@@ -25,6 +26,9 @@ import Agent.TUI.FencedCode
     ( FenceChunk(..)
     , FencedBlock(..)
     , fenceChunks
+    , FenceStreamState
+    , FenceSection(..)
+    , fenceStreamSections
     )
 import Agent.TUI.Markdown.Inline
     ( Inline(..)
@@ -213,6 +217,33 @@ markdownStreamingCacheSections input =
     | (chunkIndex, FenceText prose) <- zip [1 ..] (fenceChunks input)
     , sectionIndex <- [1 .. Text.count "\n\n" prose]
     ]
+
+-- | Render retained block boundaries. Feed the state on source deltas, not on
+-- redraws; width and interaction changes affect layout caches, not parsing.
+markdownWidgetWithParsedStreamingCache
+    :: Ord n
+    => Maybe SyntaxHighlighter
+    -> (Text -> n)
+    -> (Int -> Int -> Widget n -> Widget n)
+    -> (Int -> Widget n -> Widget n)
+    -> (Int -> Text -> Widget n)
+    -> FenceStreamState
+    -> Widget n
+markdownWidgetWithParsedStreamingCache highlighter linkName cacheProse cacheCode codeHeader =
+    vBox . concatMap renderSection . fenceStreamSections
+  where
+    renderSection (FenceCodeSection _ block) =
+        renderChunk highlighter (Just linkName) cacheCode codeHeader (FenceBlock block)
+    renderSection (FenceProseSection chunkIndex sectionIndex stable prose)
+        | stable =
+            [ cacheProse chunkIndex sectionIndex $
+                B.Widget
+                    (if Text.all isSpace prose then B.Fixed else B.Greedy)
+                    B.Fixed $
+                    B.render $
+                        vBox (renderLines (Just linkName) (Text.lines prose))
+            ]
+        | otherwise = renderLines (Just linkName) (Text.lines prose)
 
 -- | Render a standalone code body with the same width bounding and optional
 -- syntax highlighting used by fenced Markdown blocks.

--- a/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
@@ -3,6 +3,11 @@ module Agent.TUI.Markdown.Inline
     ( Inline(..)
     , inlinePlainText
     , parseInline
+    , InlineStreamState
+    , emptyInlineStreamState
+    , feedInlineStream
+    , inlineStreamSnapshot
+    , finishInlineStream
     ) where
 
 import Control.Applicative ((<|>))
@@ -13,6 +18,9 @@ import Data.Char
     , isSpace
     )
 import qualified Data.List as List
+import Data.Foldable (toList)
+import Data.Sequence (Seq, (|>))
+import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -32,6 +40,254 @@ parseInline =
         . List.intersperse [InlineText "\n"]
         . map (parseSequence Nothing Nothing)
         . Text.splitOn "\n"
+
+-- | Parsed syntax is retained independently of display width. Only the suffix
+-- whose interpretation can change remains source text. In particular, an
+-- unmatched opener can keep an arbitrarily long suffix provisional.
+--
+-- Pending scanners resume code runs, links, and URL boundaries during feeds;
+-- they do not make repeated snapshots linear in the total input size.
+data InlineStreamState = InlineStreamState
+    !(Seq Inline)
+    !(Maybe Char)
+    !PendingInline
+    deriving (Eq, Show)
+
+data PendingInline = PendingInline !(Seq Text) !PendingScan
+    deriving (Eq, Show)
+
+-- These states locate a syntax boundary, not a provisional presentation. A
+-- snapshot still renders malformed constructs with the batch parser's literal
+-- fallback. Keeping this distinction avoids committing a provisional closer.
+data PendingScan
+    = ScanGeneral
+    | ScanCodeOpening !Int
+    | ScanCodeLiteral !Int
+    | ScanCodeBody !Int !Int
+    | ScanLinkLabel !Int !Bool !Bool
+    | ScanLinkDestination !Int !Bool
+    | ScanBareUrl
+    | ScanStyleOpening !Char !Int
+    | ScanUnclosedStyle !Char !Int
+    | ScanStyleBody
+    | ScanReconsider
+    deriving (Eq, Show)
+
+emptyInlineStreamState :: InlineStreamState
+emptyInlineStreamState = InlineStreamState Seq.empty Nothing emptyPendingInline
+
+emptyPendingInline :: PendingInline
+emptyPendingInline = PendingInline Seq.empty ScanGeneral
+
+pendingInlineText :: PendingInline -> Text
+pendingInlineText (PendingInline chunks _) = Text.concat (toList chunks)
+
+-- | Append a delta. Newlines terminate all inline constructs, so even malformed
+-- syntax becomes permanent at a line boundary. Empty deltas are identities.
+feedInlineStream :: InlineStreamState -> Text -> InlineStreamState
+feedInlineStream state delta
+    | Text.null delta = state
+feedInlineStream (InlineStreamState committed previous pending) delta =
+    commitLines committed previous pending delta
+  where
+    commitLines nodes preceding provisional source =
+        let (lineDelta, remainder) = Text.breakOn "\n" source
+        in if Text.null remainder
+            then appendInlinePending nodes preceding provisional lineDelta
+            else
+                let line = pendingInlineText provisional <> lineDelta
+                    parsed = parseSequence Nothing preceding line
+                    completed = (nodes <> Seq.fromList parsed) |> InlineText "\n"
+                in commitLines completed Nothing emptyPendingInline (Text.drop 1 remainder)
+
+appendInlinePending :: Seq Inline -> Maybe Char -> PendingInline -> Text -> InlineStreamState
+appendInlinePending committed previous (PendingInline chunks scanner) delta
+    | Seq.null chunks = retainInlinePrefix committed previous delta
+    | otherwise =
+        let scanner' = Text.foldl' advancePendingScan scanner delta
+            chunks' = if Text.null delta then chunks else chunks |> delta
+            pending = PendingInline chunks' scanner'
+        in case scanner' of
+            ScanGeneral -> retainInlinePrefix committed previous (pendingInlineText pending)
+            ScanReconsider -> retainInlinePrefix committed previous (pendingInlineText pending)
+            _ -> InlineStreamState committed previous pending
+
+retainPendingInline :: Seq Inline -> Maybe Char -> Text -> InlineStreamState
+retainPendingInline committed previous source =
+    let scanner = case Text.uncons source of
+            Just ('`', _) -> Text.foldl' advancePendingScan (ScanCodeOpening 0) source
+            Just ('[', rest) -> Text.foldl' advancePendingScan (ScanLinkLabel 0 False False) rest
+            Just (marker, _) | marker == '*' || marker == '_' ->
+                case Text.foldl' advancePendingScan (ScanStyleOpening marker 0) source of
+                    ScanReconsider -> case Text.unsnoc source of
+                        Just (_, last_) | last_ == '*' || last_ == '_' -> ScanReconsider
+                        _ -> ScanStyleBody
+                    scanned -> scanned
+            _ | "http://" `Text.isPrefixOf` source || "https://" `Text.isPrefixOf` source ->
+                    Text.foldl' advancePendingScan ScanBareUrl source
+              | otherwise -> ScanGeneral
+    in InlineStreamState committed previous
+        (PendingInline (Seq.singleton source) scanner)
+
+advancePendingScan :: PendingScan -> Char -> PendingScan
+advancePendingScan scanner character = case scanner of
+    ScanCodeOpening count
+        | character == '`' -> ScanCodeOpening (count + 1)
+        | literalCodeCharacter character -> ScanCodeLiteral count
+        | otherwise -> ScanCodeBody count 0
+    ScanCodeLiteral count
+        | character == '`' -> ScanCodeBody count 1
+        | literalCodeCharacter character -> ScanCodeLiteral count
+        | otherwise -> ScanCodeBody count 0
+    ScanCodeBody openingCount closingCount
+        | character == '`' -> ScanCodeBody openingCount (closingCount + 1)
+        | closingCount == openingCount -> ScanReconsider
+        | otherwise -> ScanCodeBody openingCount 0
+    ScanLinkLabel depth escaped bracketPending
+        | escaped && isAsciiPunctuation character -> ScanLinkLabel depth False False
+        | escaped -> advancePendingScan (ScanLinkLabel depth False False) character
+        | bracketPending && character == '(' -> ScanLinkDestination 0 False
+        | bracketPending -> advancePendingScan (ScanLinkLabel depth False False) character
+        | character == '\\' -> ScanLinkLabel depth True False
+        | character == '[' -> ScanLinkLabel (depth + 1) False False
+        | character == ']' && depth > 0 -> ScanLinkLabel (depth - 1) False False
+        | character == ']' -> ScanLinkLabel depth False True
+        | otherwise -> ScanLinkLabel depth False False
+    ScanLinkDestination depth escaped
+        | escaped && isAsciiPunctuation character -> ScanLinkDestination depth False
+        | escaped -> advancePendingScan (ScanLinkDestination depth False) character
+        | character == '\\' -> ScanLinkDestination depth True
+        | character == '(' -> ScanLinkDestination (depth + 1) False
+        | character == ')' && depth == 0 -> ScanReconsider
+        | character == ')' -> ScanLinkDestination (depth - 1) False
+        | otherwise -> ScanLinkDestination depth False
+    ScanBareUrl
+        | isSpace character || isControl character -> ScanReconsider
+        | otherwise -> ScanBareUrl
+    ScanStyleOpening marker count
+        | character == marker -> ScanStyleOpening marker (count + 1)
+        | otherwise -> ScanUnclosedStyle marker count
+    ScanUnclosedStyle marker count
+        | character == marker -> ScanReconsider
+        | otherwise -> ScanUnclosedStyle marker count
+    ScanStyleBody
+        | Text.any (== character) "\\`[*_" -> ScanReconsider
+        | otherwise -> ScanStyleBody
+    ScanGeneral -> ScanGeneral
+    ScanReconsider -> ScanReconsider
+
+-- Without another tick or any inline markup (including a URL's colon), a
+-- pending code opener and its body can only render as one literal text node.
+literalCodeCharacter :: Char -> Bool
+literalCodeCharacter character = not (Text.any (== character) "\\`[*_:")
+
+-- | Preview literal fallbacks without committing them. This reparses the
+-- unresolved suffix to preserve the batch parser's interpretation of malformed
+-- and nested syntax. A long unfinished construct therefore still has growing
+-- snapshot cost. Adjacent source chunks are concatenated together once rather
+-- than through repeated strict appends.
+inlineStreamSnapshot :: InlineStreamState -> [Inline]
+inlineStreamSnapshot (InlineStreamState committed previous pending) =
+    coalesceStreamText
+        (toList committed <> pendingInlineSnapshot previous pending)
+
+pendingInlineSnapshot :: Maybe Char -> PendingInline -> [Inline]
+pendingInlineSnapshot previous pending@(PendingInline _ scanner) =
+    let source = pendingInlineText pending
+    in case scanner of
+        ScanCodeOpening _ -> [InlineText source]
+        ScanCodeLiteral _ -> [InlineText source]
+        ScanStyleOpening _ count | count <= 2 -> [InlineText source]
+        -- No matching marker exists after the initial one/two-character run.
+        -- Longer runs can close themselves (e.g. "***"), so must fall back.
+        -- Both strong and
+        -- emphasis searches must fail, even when other nested syntax exists.
+        -- Skip those searches, but still parse the remainder's literal fallback.
+        ScanUnclosedStyle marker count | count <= 2 ->
+            InlineText (Text.take count source)
+                : parseSequence Nothing (Just marker) (Text.drop count source)
+        _ -> parseSequence Nothing previous source
+
+finishInlineStream :: InlineStreamState -> [Inline]
+finishInlineStream = inlineStreamSnapshot
+
+retainInlinePrefix :: Seq Inline -> Maybe Char -> Text -> InlineStreamState
+retainInlinePrefix committed previous source
+    | Text.null source = InlineStreamState committed previous emptyPendingInline
+    | Just (escaped, rest) <- escapedPunctuation source =
+        continue (InlineText (Text.singleton escaped)) (Just escaped) rest
+    | Just (code, rest) <- codeSpan source
+    , not (Text.null rest) =
+        continue (InlineCode code) (lastCharacter code <|> previous) rest
+    | Just (url, label, rest) <- linkSpan source =
+        let node = InlineLink url (parseInline label)
+        in continue node (lastCharacter (inlinePlainText [node]) <|> previous) rest
+    | maybe True (not . isWordCharacter) previous
+    , Just (url, rest) <- bareUrlSpan source
+    , Text.any (\character -> isSpace character || isControl character) rest =
+        continue (InlineLink url [InlineText url]) (lastCharacter url <|> previous) rest
+    | Just (node, rest) <- stableSimpleStyle previous source =
+        continue node (lastCharacter (inlinePlainText [node]) <|> previous) rest
+    | otherwise =
+        let (plain, remainder) = takePlain Nothing source
+            retainedLength = Text.length plain - partialSchemeLength plain
+            (stable, provisional) = Text.splitAt retainedLength plain
+        in if Text.null stable
+            then retainPendingInline committed previous source
+            else retainInlinePrefix
+                (committed |> InlineText stable)
+                (lastCharacter stable <|> previous)
+                (provisional <> remainder)
+  where
+    continue node preceding rest =
+        retainInlinePrefix (committed |> node) preceding rest
+
+-- A completed simple style is stable once both delimiter runs and right-hand
+-- context are known. Nested syntax is kept provisional: a presently unmatched
+-- code/link opener inside a style can later swallow its apparent closer.
+stableSimpleStyle :: Maybe Char -> Text -> Maybe (Inline, Text)
+stableSimpleStyle previous source = do
+    (marker, constructor) <-
+        List.find (\(marker, _) -> marker `Text.isPrefixOf` source)
+            [("**", InlineStrong), ("__", InlineStrong),
+             ("*", InlineEmphasis), ("_", InlineEmphasis)]
+    afterOpen <- Text.stripPrefix marker source
+    if canOpen marker previous afterOpen
+        then do
+            let (body, atClosing) = Text.break isAmbiguous afterOpen
+            rest <- Text.stripPrefix marker atClosing
+            (following, _) <- Text.uncons rest
+            if not (Text.null body)
+                && canClose marker (lastCharacter body) rest
+                && following /= Text.head marker
+                then Just (constructor (parseInline body), rest)
+                else Nothing
+        else Nothing
+  where
+    isAmbiguous character = Text.any (== character) "\\`[*_"
+
+partialSchemeLength :: Text -> Int
+partialSchemeLength source =
+    maximum
+        (0 :
+            [ count
+            | scheme <- ["http://", "https://"]
+            , count <- [1 .. Text.length scheme - 1]
+            , Text.take count scheme `Text.isSuffixOf` source
+            ])
+
+coalesceStreamText :: [Inline] -> [Inline]
+coalesceStreamText [] = []
+coalesceStreamText (InlineText first : rest) =
+    let (texts, remaining) = span isText rest
+    in InlineText (Text.concat (first : map textContent texts))
+        : coalesceStreamText remaining
+  where
+    isText (InlineText _) = True
+    isText _ = False
+    textContent (InlineText value) = value
+    textContent _ = ""
+coalesceStreamText (node : rest) = node : coalesceStreamText rest
 
 -- | Text displayed by either renderer, including the visible destination
 -- appended to links whose label differs from their destination.

--- a/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown/Inline.hs
@@ -8,6 +8,8 @@ module Agent.TUI.Markdown.Inline
     , feedInlineStream
     , inlineStreamSnapshot
     , finishInlineStream
+    , inlineRetainedBytes
+    , inlineStreamRetainedBytes
     ) where
 
 import Control.Applicative ((<|>))
@@ -75,6 +77,28 @@ data PendingScan
 
 emptyInlineStreamState :: InlineStreamState
 emptyInlineStreamState = InlineStreamState Seq.empty Nothing emptyPendingInline
+
+-- | Conservative logical storage charge for syntax, including nested labels.
+-- Text slices are charged separately even when their storage may be shared;
+-- this is a logical estimate rather than exact heap residency.
+inlineRetainedBytes :: Inline -> Integer
+inlineRetainedBytes node = 64 + case node of
+    InlineText text -> textBytes text
+    InlineCode text -> textBytes text
+    InlineStrong children -> childrenBytes children
+    InlineEmphasis children -> childrenBytes children
+    InlineLink destination children ->
+        textBytes destination + childrenBytes children
+  where
+    textBytes text = 64 + 4 * toInteger (Text.length text)
+    childrenBytes = foldl' (\size child -> size + inlineRetainedBytes child) 0
+
+-- | Count the retained scanner state directly, without parsing its suffix.
+inlineStreamRetainedBytes :: InlineStreamState -> Integer
+inlineStreamRetainedBytes (InlineStreamState committed _ (PendingInline chunks _)) =
+    192
+        + foldl' (\size node -> size + inlineRetainedBytes node) 0 committed
+        + foldl' (\size text -> size + 64 + 4 * toInteger (Text.length text)) 0 chunks
 
 emptyPendingInline :: PendingInline
 emptyPendingInline = PendingInline Seq.empty ScanGeneral

--- a/packages/agent-tui/src/Agent/TUI/Markdown/Stream.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown/Stream.hs
@@ -7,6 +7,7 @@ module Agent.TUI.Markdown.Stream
     , feedMarkdownStream
     , markdownStreamSnapshot
     , finishMarkdownStream
+    , markdownStreamRetainedBytes
     , MarkdownSection(..)
     , MarkdownBlock(..)
     , MarkdownLineKind(..)
@@ -78,6 +79,43 @@ data MarkdownStreamState = MarkdownStreamState
 
 emptyMarkdownStreamState :: MarkdownStreamState
 emptyMarkdownStreamState = MarkdownStreamState emptyFenceStreamState Map.empty Nothing
+
+-- | Logical retained storage for mailbox admission. Include both source and
+-- syntax, even if some Text storage is shared. Inspect retained fields rather
+-- than snapshots: rendering can allocate or reparse provisional syntax.
+-- This remains valid when the associated UI block is missing or stale.
+-- The charge is a logical estimate, not an exact measurement of heap residency
+-- or the backing arrays shared by Text slices.
+markdownStreamRetainedBytes :: MarkdownStreamState -> Integer
+markdownStreamRetainedBytes state =
+    128
+        + fenceStreamRetainedBytes state.fenceParser
+        + Map.foldl' (\size prose -> size + proseBytes prose) 0 state.proseParsers
+        + maybe 0 pendingBytes state.pendingInline
+  where
+    textBytes text = 64 + 4 * toInteger (Text.length text)
+    kindBytes (BulletLine marker) = textBytes marker
+    kindBytes (OrderedLine marker spacing) = textBytes marker + textBytes spacing
+    kindBytes _ = 0
+    blockBytes (MarkdownLine kind inlines) =
+        128 + kindBytes kind + inlinesBytes inlines
+    blockBytes (MarkdownTable alignments rows) = 128 + tableBytes alignments rows
+    tableBytes alignments rows =
+        64 * toInteger (length alignments)
+            + foldl' (\size cells ->
+                size + 64 + foldl' (\rowSize cell -> rowSize + cellBytes cell) 0 cells) 0 rows
+    inlinesBytes = foldl' (\size node -> size + inlineRetainedBytes node) 0
+    cellBytes :: MarkdownCell -> Integer
+    cellBytes cell = 128 + inlinesBytes cell.cellInlines
+    proseBytes :: ProseState -> Integer
+    proseBytes prose =
+        192 + foldl' (\size block -> size + blockBytes block) 0 prose.completedBlocks
+            + maybe 0 (\(source, node) -> textBytes source + blockBytes node) prose.candidateHeader
+            + maybe 0 (uncurry tableBytes) prose.activeTable
+    pendingBytes :: PendingInline -> Integer
+    pendingBytes pending =
+        128 + kindBytes pending.pendingKind + textBytes pending.pendingBody
+            + maybe 0 inlineStreamRetainedBytes pending.pendingParser
 
 emptyProseState :: ProseState
 emptyProseState = ProseState Seq.empty Nothing Nothing True

--- a/packages/agent-tui/src/Agent/TUI/Markdown/Stream.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown/Stream.hs
@@ -1,0 +1,235 @@
+-- | Width-independent, append-only Markdown syntax. Completed lines and table
+-- cells are parsed once. The last line and a possible table header remain
+-- provisional because later input can change their interpretation.
+module Agent.TUI.Markdown.Stream
+    ( MarkdownStreamState
+    , emptyMarkdownStreamState
+    , feedMarkdownStream
+    , markdownStreamSnapshot
+    , finishMarkdownStream
+    , MarkdownSection(..)
+    , MarkdownBlock(..)
+    , MarkdownLineKind(..)
+    , MarkdownCell(..)
+    ) where
+
+import Agent.TUI.FencedCode
+import qualified Agent.TUI.Markdown.Block as Block
+import Agent.TUI.Markdown.Inline
+import Agent.TUI.TextWidth (displayTerminalText, graphemeCellWidth, graphemeClusters)
+import Data.Char (isSpace)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
+import Data.Sequence (Seq, (|>))
+import qualified Data.Sequence as Seq
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+data MarkdownLineKind
+    = ProseLine
+    | HeadingLine
+    | BulletLine !Text
+    | OrderedLine !Text !Text
+    | QuoteLine
+    | BlankLine
+    | ThematicLine
+    deriving (Eq, Show)
+
+data MarkdownCell = MarkdownCell
+    { cellInlines :: ![Inline]
+    , cellNaturalWidth :: !Int
+    , cellMinimumWidth :: !Int
+    }
+    deriving (Eq, Show)
+
+data MarkdownBlock
+    = MarkdownLine !MarkdownLineKind ![Inline]
+    | MarkdownTable ![Block.TableAlignment] !(Seq [MarkdownCell])
+    deriving (Eq, Show)
+
+data MarkdownSection
+    = MarkdownProseSection !Int !Int !Bool !Bool !(Seq MarkdownBlock)
+    | MarkdownCodeSection !Int !FencedBlock
+    deriving (Eq, Show)
+
+data ProseState = ProseState
+    { completedBlocks :: !(Seq MarkdownBlock)
+    , candidateHeader :: !(Maybe (Text, MarkdownBlock))
+    , activeTable :: !(Maybe ([Block.TableAlignment], Seq [MarkdownCell]))
+    , allWhitespace :: !Bool
+    }
+    deriving (Eq, Show)
+
+data PendingInline = PendingInline
+    { pendingKey :: !(Int, Int)
+    , pendingKind :: !MarkdownLineKind
+    , pendingBody :: !Text
+    , pendingParser :: !(Maybe InlineStreamState)
+    }
+    deriving (Eq, Show)
+
+data MarkdownStreamState = MarkdownStreamState
+    { fenceParser :: !FenceStreamState
+    , proseParsers :: !(Map (Int, Int) ProseState)
+    , pendingInline :: !(Maybe PendingInline)
+    }
+    deriving (Eq, Show)
+
+emptyMarkdownStreamState :: MarkdownStreamState
+emptyMarkdownStreamState = MarkdownStreamState emptyFenceStreamState Map.empty Nothing
+
+emptyProseState :: ProseState
+emptyProseState = ProseState Seq.empty Nothing Nothing True
+
+feedMarkdownStream :: MarkdownStreamState -> Text -> MarkdownStreamState
+feedMarkdownStream state input
+    | Text.null input = state
+    | otherwise =
+        let (fences, lines_) = feedFenceStreamWithProse state.fenceParser input
+            prose = case lines_ of
+                [] -> state.proseParsers
+                first : rest -> foldl' (consumeLine Nothing)
+                    (consumeLine state.pendingInline state.proseParsers first) rest
+            pending = case fenceStreamPendingProse fences of
+                Nothing -> Nothing
+                Just (chunk, section, source) ->
+                    let (kind, body) = lineParts source
+                        key = (chunk, section)
+                        -- For short lines, constructing resumable scanner state
+                        -- costs more than the batch parse. Retain block syntax
+                        -- either way, and start the inline scanner once useful.
+                        parser = if Text.compareLength body 128 /= GT
+                            then Nothing
+                            else Just $ case state.pendingInline of
+                                -- Prose bodies are the complete source line: when
+                                -- no newline arrived, the input is exactly its
+                                -- suffix. Avoid comparing the growing old prefix.
+                                Just previous
+                                    | Just previousParser <- previous.pendingParser
+                                    , previous.pendingKey == key
+                                    , previous.pendingKind == ProseLine
+                                    , kind == ProseLine
+                                    , not (Text.any (== '\n') input) ->
+                                        feedInlineStream previousParser input
+                                Just previous
+                                    | Just previousParser <- previous.pendingParser
+                                    , null lines_
+                                    , previous.pendingKey == key
+                                    , Just delta <- Text.stripPrefix previous.pendingBody body ->
+                                        feedInlineStream previousParser delta
+                                _ -> feedInlineStream emptyInlineStreamState body
+                    in Just (PendingInline key kind body parser)
+        in MarkdownStreamState fences prose pending
+  where
+    -- Only the first completed line can extend the previous inline parser.
+    -- Reclassification or a changed body prefix falls back to the batch oracle.
+    consumeLine :: Maybe PendingInline -> Map (Int, Int) ProseState
+        -> (Int, Int, Text) -> Map (Int, Int) ProseState
+    consumeLine previous parsers (chunk, section, source) =
+        let (kind, body) = lineParts source
+            inlines = case previous of
+                Just pending
+                    | Just parser <- pending.pendingParser
+                    , pending.pendingKey == (chunk, section)
+                    , pending.pendingKind == kind
+                    , Just delta <- Text.stripPrefix pending.pendingBody body ->
+                        inlineStreamSnapshot (feedInlineStream parser delta)
+                _ -> parseInline body
+        in Map.alter
+            (Just . appendLine source (MarkdownLine kind inlines) . fromMaybe emptyProseState)
+            (chunk, section) parsers
+
+markdownStreamSnapshot :: MarkdownStreamState -> [MarkdownSection]
+markdownStreamSnapshot state = map section (fenceStreamLayout state.fenceParser)
+  where
+    pendingProse = fenceStreamPendingProse state.fenceParser
+    section (FenceCodeLayout chunk block) = MarkdownCodeSection chunk block
+    section (FenceProseLayout chunk index stable) =
+        let key = (chunk, index)
+            committed = Map.findWithDefault emptyProseState key state.proseParsers
+            preview = case pendingProse of
+                Just (pendingChunk, pendingIndex, source)
+                    | key == (pendingChunk, pendingIndex) ->
+                        let node = case state.pendingInline of
+                                Just pending | pending.pendingKey == key ->
+                                    MarkdownLine pending.pendingKind
+                                        (maybe (parseInline pending.pendingBody) inlineStreamSnapshot pending.pendingParser)
+                                _ -> parseLine source
+                        in appendLine source node committed
+                _ -> committed
+        in MarkdownProseSection chunk index stable preview.allWhitespace (proseBlocks preview)
+
+-- | Finishing accepts the current literal fallback for incomplete syntax. It
+-- does not append a synthetic newline or change the interpretation of fences.
+finishMarkdownStream :: MarkdownStreamState -> [MarkdownSection]
+finishMarkdownStream = markdownStreamSnapshot
+
+proseBlocks :: ProseState -> Seq MarkdownBlock
+proseBlocks state = case state.activeTable of
+    Just (alignments, rows) -> state.completedBlocks |> MarkdownTable alignments rows
+    Nothing -> case state.candidateHeader of
+        Just (_, node) -> state.completedBlocks |> node
+        Nothing -> state.completedBlocks
+
+appendLine :: Text -> MarkdownBlock -> ProseState -> ProseState
+appendLine source node initial =
+    append initial{allWhitespace = initial.allWhitespace && Text.all isSpace source}
+  where
+    append state = case state.activeTable of
+        Just (alignments, rows)
+            | Text.any (== '|') source
+            , Just cells <- Block.splitTableRow source ->
+                state{activeTable = Just (alignments, rows |> map parseCell cells)}
+            | otherwise ->
+                append state
+                    { completedBlocks = state.completedBlocks |> MarkdownTable alignments rows
+                    , activeTable = Nothing
+                    }
+        Nothing -> case state.candidateHeader of
+            Just (header, headerNode)
+                | Just (table, _) <- Block.takeTableRows [header, source] ->
+                    state
+                        { candidateHeader = Nothing
+                        , activeTable = Just
+                            (table.tableAlignments, Seq.fromList (map (map parseCell) table.tableRows))
+                        }
+                | otherwise ->
+                    append state
+                        { completedBlocks = state.completedBlocks |> headerNode
+                        , candidateHeader = Nothing
+                        }
+            Nothing
+                | Text.any (== '|') source
+                , Just _ <- Block.splitTableRow source ->
+                    state{candidateHeader = Just (source, node)}
+                | otherwise ->
+                    state{completedBlocks = state.completedBlocks |> node}
+
+parseLine :: Text -> MarkdownBlock
+parseLine source =
+    let (kind, body) = lineParts source
+    in MarkdownLine kind (parseInline body)
+
+lineParts :: Text -> (MarkdownLineKind, Text)
+lineParts source
+    -- An ASCII letter at column zero cannot later become a block marker.
+    -- Avoid running every block recognizer on the common prose path.
+    | Just (first, _) <- Text.uncons source
+    , (first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z') = (ProseLine, source)
+    | Just (_, body) <- Block.headingPartsWith (== ' ') source = (HeadingLine, body)
+    | Just (indent, body) <- Block.bulletPartsWith (== ' ') source = (BulletLine indent, body)
+    | Just (indent, number, body) <- Block.orderedParts source = (OrderedLine indent number, body)
+    | Just quote <- Block.blockQuoteRemainder source = (QuoteLine, fromMaybe quote (Text.stripPrefix " " quote))
+    | Text.null (Text.strip source) = (BlankLine, "")
+    | Just (marker, _) <- Text.uncons (Text.stripStart source)
+    , marker `elem` ['-', '*', '_']
+    , Block.isThematicBreak source = (ThematicLine, "")
+    | otherwise = (ProseLine, source)
+
+parseCell :: Text -> MarkdownCell
+parseCell source =
+    let inlines = parseInline source
+        widths = map graphemeCellWidth
+            (graphemeClusters (displayTerminalText (inlinePlainText inlines)))
+    in MarkdownCell inlines (sum widths) (maximum (1 : widths))

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -63,6 +63,7 @@ import Agent.TUI.Model.ToolResult
 import Agent.TUI.Model.State
 import Agent.TUI.Model.Timing
 import Agent.TUI.Model.Types
+import Agent.TUI.FencedCode (emptyFenceStreamState, feedFenceStream)
 import Agent.TUI.Motion
     ( completionStatusDurationMillis )
 import Agent.Loop
@@ -289,6 +290,7 @@ clearConversation :: UiState -> UiState
 clearConversation state =
     state
         { uiBlocks = Seq.empty
+        , uiStreamingMarkdown = Nothing
         , uiSelectedBlock = Nothing
         , uiSelectedBlockIndex = Nothing
         , uiBlockIndices = Map.empty
@@ -333,6 +335,7 @@ restartTurn :: UiState -> UiState
 restartTurn state =
     state
         { uiBlocks = blocks
+        , uiStreamingMarkdown = Nothing
         , uiSelectedBlock = (.blockId) . snd <$> selected
         , uiSelectedBlockIndex = fst <$> selected
         , uiBlockIndices =
@@ -384,6 +387,7 @@ snapshotGenerationRate usage state =
     in state
         { uiGenerating = False
         , uiGenerationMillis = generationMillis
+        , uiStreamingMarkdown = Nothing
         , uiLastTokensPerSecond =
             generationTokensPerSecond
                 usage.outputTokens
@@ -551,6 +555,16 @@ appendOrExtend kind title delta streamState state =
                     { uiBlocks =
                         rest Seq.|> block
                             { blockBody = block.blockBody <> delta }
+                    , uiStreamingMarkdown =
+                        if kind == BlockAssistant
+                            then
+                                let previous = case state.uiStreamingMarkdown of
+                                        Just (ident, parsed)
+                                            | ident == block.blockId -> parsed
+                                        _ -> feedFenceStream emptyFenceStreamState block.blockBody
+                                    parsed = feedFenceStream previous delta
+                                in parsed `seq` Just (block.blockId, parsed)
+                            else Nothing
                     }
         _ ->
             appendBlock kind title delta "" streamState Nothing state
@@ -1086,6 +1100,7 @@ discardResponseAttempt state =
             retainShellProcesses blocks state.uiShellProcesses
     in state
         { uiBlocks = blocks
+        , uiStreamingMarkdown = Nothing
         , uiSelectedBlock = (.blockId) . snd <$> selected
         , uiSelectedBlockIndex = fst <$> selected
         , uiBlockIndices =
@@ -1176,6 +1191,7 @@ finalizeTurn terminalState state =
     in state
         { uiBlocks = blocks
         , uiRunning = False
+        , uiStreamingMarkdown = Nothing
         , uiGenerating = False
         , uiGenerationMillis = generationMillis
         , uiLastTokensPerSecond =
@@ -1224,7 +1240,8 @@ transientNotice kind text = UiNotice
 finalizeStreams :: UiState -> UiState
 finalizeStreams state =
     state
-        { uiBlocks =
+        { uiStreamingMarkdown = Nothing
+        , uiBlocks =
             fmap
                 (\block ->
                     if block.blockState == BlockStreaming

--- a/packages/agent-tui/src/Agent/TUI/Model.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model.hs
@@ -63,7 +63,7 @@ import Agent.TUI.Model.ToolResult
 import Agent.TUI.Model.State
 import Agent.TUI.Model.Timing
 import Agent.TUI.Model.Types
-import Agent.TUI.FencedCode (emptyFenceStreamState, feedFenceStream)
+import Agent.TUI.Markdown.Stream (emptyMarkdownStreamState, feedMarkdownStream)
 import Agent.TUI.Motion
     ( completionStatusDurationMillis )
 import Agent.Loop
@@ -561,8 +561,8 @@ appendOrExtend kind title delta streamState state =
                                 let previous = case state.uiStreamingMarkdown of
                                         Just (ident, parsed)
                                             | ident == block.blockId -> parsed
-                                        _ -> feedFenceStream emptyFenceStreamState block.blockBody
-                                    parsed = feedFenceStream previous delta
+                                        _ -> feedMarkdownStream emptyMarkdownStreamState block.blockBody
+                                    parsed = feedMarkdownStream previous delta
                                 in parsed `seq` Just (block.blockId, parsed)
                             else Nothing
                     }

--- a/packages/agent-tui/src/Agent/TUI/Model/Block.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Block.hs
@@ -5,6 +5,7 @@ module Agent.TUI.Model.Block
     ) where
 
 import Agent.TUI.Model.Types
+import Agent.TUI.FencedCode (emptyFenceStreamState, feedFenceStream)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
@@ -42,6 +43,11 @@ appendBlock kind title body detail blockState callId state =
             }
     in prepared
         { uiBlocks = prepared.uiBlocks Seq.|> block
+        , uiStreamingMarkdown =
+            if kind == BlockAssistant && blockState == BlockStreaming
+                then let parsed = feedFenceStream emptyFenceStreamState body
+                     in parsed `seq` Just (ident, parsed)
+                else Nothing
         , uiNextBlockId = prepared.uiNextBlockId + 1
         , uiSelectedBlock = Just ident
         , uiSelectedBlockIndex = Just index

--- a/packages/agent-tui/src/Agent/TUI/Model/Block.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Block.hs
@@ -5,7 +5,7 @@ module Agent.TUI.Model.Block
     ) where
 
 import Agent.TUI.Model.Types
-import Agent.TUI.FencedCode (emptyFenceStreamState, feedFenceStream)
+import Agent.TUI.Markdown.Stream (emptyMarkdownStreamState, feedMarkdownStream)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 import Data.Text (Text)
@@ -45,7 +45,7 @@ appendBlock kind title body detail blockState callId state =
         { uiBlocks = prepared.uiBlocks Seq.|> block
         , uiStreamingMarkdown =
             if kind == BlockAssistant && blockState == BlockStreaming
-                then let parsed = feedFenceStream emptyFenceStreamState body
+                then let parsed = feedMarkdownStream emptyMarkdownStreamState body
                      in parsed `seq` Just (ident, parsed)
                 else Nothing
         , uiNextBlockId = prepared.uiNextBlockId + 1

--- a/packages/agent-tui/src/Agent/TUI/Model/State.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/State.hs
@@ -18,6 +18,7 @@ import qualified Data.Sequence as Seq
 initialUiState :: UiState
 initialUiState = UiState
     { uiBlocks = Seq.empty
+    , uiStreamingMarkdown = Nothing
     , uiNextBlockId = 1
     , uiDraft = ""
     , uiCursor = 0

--- a/packages/agent-tui/src/Agent/TUI/Model/Types.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Types.hs
@@ -20,7 +20,7 @@ module Agent.TUI.Model.Types
 import Agent.Loop (LoopEvent, TokenUsage)
 import Agent.ToolDispatch (ToolCall)
 import Agent.TUI.Presentation (TodoDisplayLine)
-import Agent.TUI.FencedCode (FenceStreamState)
+import Agent.TUI.Markdown.Stream (MarkdownStreamState)
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import Data.Text (Text)
@@ -142,7 +142,7 @@ data UiState = UiState
     { uiBlocks :: !(Seq UiBlock)
     -- | Parser state for the most recently extended assistant block. Other
     -- blocks use the ordinary renderer; no parser state is retained in history.
-    , uiStreamingMarkdown :: !(Maybe (BlockId, FenceStreamState))
+    , uiStreamingMarkdown :: !(Maybe (BlockId, MarkdownStreamState))
     , uiNextBlockId :: !Int
     , uiDraft :: !Text
     , uiCursor :: !Int

--- a/packages/agent-tui/src/Agent/TUI/Model/Types.hs
+++ b/packages/agent-tui/src/Agent/TUI/Model/Types.hs
@@ -20,6 +20,7 @@ module Agent.TUI.Model.Types
 import Agent.Loop (LoopEvent, TokenUsage)
 import Agent.ToolDispatch (ToolCall)
 import Agent.TUI.Presentation (TodoDisplayLine)
+import Agent.TUI.FencedCode (FenceStreamState)
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import Data.Text (Text)
@@ -139,6 +140,9 @@ data PromptState = PromptState
 
 data UiState = UiState
     { uiBlocks :: !(Seq UiBlock)
+    -- | Parser state for the most recently extended assistant block. Other
+    -- blocks use the ordinary renderer; no parser state is retained in history.
+    , uiStreamingMarkdown :: !(Maybe (BlockId, FenceStreamState))
     , uiNextBlockId :: !Int
     , uiDraft :: !Text
     , uiCursor :: !Int

--- a/packages/agent-tui/test/Agent/TUI/FencedCodeSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/FencedCodeSpec.hs
@@ -1,10 +1,50 @@
 module Agent.TUI.FencedCodeSpec (spec) where
 
 import Agent.TUI.FencedCode
+import Control.Monad (forM_)
+import Data.Text (Text)
+import qualified Data.Text as Text
 import Test.Hspec
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (elements, forAll, listOf, withMaxSuccess)
 
 spec :: Spec
 spec = describe "fencedBlocks" do
+    prop "preserves full-parser sections across generated fragment sequences" $
+        withMaxSuccess 1000 $ forAll
+            (listOf (elements
+                [ "text", "\n", "\n\n", " ", "    ", "- item\n", "  - inner\n"
+                , "```", "~~~", "`", "~", "hs", " trailing", "\r\n", "\r"
+                , "| x |", "中", "  continuation\n", "1. item\n"
+                ])) \fragments ->
+                let prefixes = scanl (<>) "" fragments
+                    states = scanl feedFenceStream emptyFenceStreamState fragments
+                in map fenceStreamSections states == map referenceSections prefixes
+
+    it "matches full parsing at every character boundary and arbitrary feed split" do
+        let documents =
+                [ "\n\n\n\nfirst **strong**\n\nsecond\n\n\n"
+                , "before\n```hs\none\n```\nbetween\n~~~sh\ntwo\n"
+                , "- outer\n  - inner\n\n    ```hs\n    x\n    ```\n\n  ~~~\n  y\n  ~~~\n"
+                , "````hs\n```\na\n````` trailing\n`````\n"
+                , "    ```ignored\nx\n   ~~~ diff\n-old\n+new\n  ~~~   \n"
+                , "| a | b |\n|---|---|\n| 中 | é |\n\nend"
+                , "```hs\r\nx\r\n```\r\n\r\nend"
+                , "- list\n  continuation\n\n    ```\n    body\n    ```\n"
+                ]
+        forM_ documents \document -> do
+            let fragments = map Text.singleton (Text.unpack document)
+                states = scanl feedFenceStream emptyFenceStreamState fragments
+                prefixes = scanl (<>) "" fragments
+            forM_ (zip prefixes states) \(prefix, state) ->
+                fenceStreamSections state `shouldBe` referenceSections prefix
+            forM_ [0 .. Text.length document] \offset ->
+                fenceStreamSections
+                    (feedFenceStream
+                        (feedFenceStream emptyFenceStreamState (Text.take offset document))
+                        (Text.drop offset document))
+                    `shouldBe` referenceSections document
+
     it "returns prose and fences in source order for rendering" do
         let chunks =
                 fenceChunks
@@ -110,3 +150,17 @@ spec = describe "fencedBlocks" do
 
     it "rejects backticks in a backtick fence info string" do
         fenceOpener "```lang`bad" `shouldBe` Nothing
+
+referenceSections :: Text -> [FenceSection]
+referenceSections = concatMap splitChunk . zip [1 ..] . fenceChunks
+  where
+    splitChunk (index, FenceBlock block) = [FenceCodeSection index block]
+    splitChunk (index, FenceText prose) = splitProse index 1 prose
+    splitProse index section prose
+        | Text.null prose = []
+        | otherwise = case Text.breakOn "\n\n" prose of
+            (_, suffix) | Text.null suffix ->
+                [FenceProseSection index section False prose]
+            (prefix, suffix) ->
+                FenceProseSection index section True (prefix <> "\n\n")
+                    : splitProse index (section + 1) (Text.drop 2 suffix)

--- a/packages/agent-tui/test/Agent/TUI/Markdown/InlineStreamSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/Markdown/InlineStreamSpec.hs
@@ -1,0 +1,69 @@
+module Agent.TUI.Markdown.InlineStreamSpec (spec) where
+
+import Agent.TUI.Markdown.Inline
+import Control.Monad (forM_)
+import qualified Data.Text as Text
+import Test.Hspec
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (elements, forAll, listOf, resize, withMaxSuccess)
+
+spec :: Spec
+spec = describe "streaming inline Markdown" do
+    prop "matches the batch parser for every generated fragment prefix" $
+        withMaxSuccess 2000 $ forAll
+            (resize 30 (listOf (elements
+                [ "plain", " ", "\n", "\r", "\r\n", "*", "**", "***"
+                , "_", "__", "`", "``", "\\", "[", "]", "(", ")"
+                , "http", "https://", "://", "h", "ttp://", "a.test"
+                , ".", "!", ",", "中", "é", "\\*", "[label](url)"
+                , "*simple* ", "**strong** ", "_emphasis_ ", "__strong__ "
+                ]))) \fragments ->
+                    map inlineStreamSnapshot
+                        (scanl feedInlineStream emptyInlineStreamState fragments)
+                        == map parseInline (scanl (<>) "" fragments)
+
+    it "preserves all character prefixes and binary partitions" do
+        let documents =
+                [ "before **strong** after *emphasis* tail"
+                , "before __strong__ after _emphasis_word"
+                , "***nested **strong** emphasis***"
+                , "*a ` apparent* closer` end"
+                , "*a [apparent* closer](url) end"
+                , "escaped \\* text \\\\*style*"
+                , "a `code`` not a closer` following"
+                , "[nested [label]](https://example.test/a(b)c) tail"
+                , "[label](url\\)part) [unfinished"
+                , "https://example.test/a(b)). next http://a.test."
+                , "wordhttp://example.test https://x.test/中"
+                , "plain h\nhttp://example.test\r\n*unfinished\nnext"
+                , "_a_ https://example.test/path_(next)."
+                , "**unfinished [label (with nesting) plain text and `code` "
+                , "`literal http://example.test *style*` done"
+                , "***literal ___literal"
+                ]
+        forM_ documents \document -> do
+            let fragments = Text.foldr (\character rest -> Text.singleton character : rest) [] document
+            forM_ (zip
+                (scanl (<>) "" fragments)
+                (scanl feedInlineStream emptyInlineStreamState fragments)) \(prefix, state) ->
+                    inlineStreamSnapshot state `shouldBe` parseInline prefix
+            forM_ [0 .. Text.length document] \offset -> do
+                let state = feedInlineStream
+                        (feedInlineStream emptyInlineStreamState (Text.take offset document))
+                        (Text.drop offset document)
+                finishInlineStream state `shouldBe` parseInline document
+                feedInlineStream state "" `shouldBe` state
+
+    it "resumes long pending constructs and resolves split closing syntax" do
+        forM_
+            [ (["``"], ["`", "`", "x", "``", " tail"])
+            , (["[outer ["], ["]", "]", "(", "path(", "x", ")", "\\", ")", ")", " tail"])
+            , (["[label](path("], [")", "\\", ")", ")", " tail"])
+            , (["https://"], [".", ")", " ", "tail"])
+            , (["**"], ["*", "*", " ", "tail"])
+            ] \(opening, closing) -> do
+                let fragments = opening <> replicate 64 "ordinarytext" <> closing
+                    prefixes = scanl (<>) "" fragments
+                    states = scanl feedInlineStream emptyInlineStreamState fragments
+                forM_ (zip prefixes states) \(prefix, state) ->
+                    inlineStreamSnapshot state `shouldBe` parseInline prefix

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -1,5 +1,6 @@
 module Agent.TUI.MarkdownSpec (spec) where
 
+import Agent.TUI.FencedCode (emptyFenceStreamState, feedFenceStream)
 import Agent.TUI.Markdown
 import Agent.Syntax
     ( SyntaxClass(SyntaxComment)
@@ -1192,19 +1193,25 @@ checkStreamingPicturesAtHeight height width =
     checkStreamingFrames . map ((width, height),)
 
 checkStreamingFrames :: [((Int, Int), Text.Text)] -> Expectation
-checkStreamingFrames = go Nothing emptyRenderState
+checkStreamingFrames frames =
+    go False Nothing "" emptyFenceStreamState emptyRenderState frames
+        >> go True Nothing "" emptyFenceStreamState emptyRenderState frames
   where
-    go _ _ [] = pure ()
-    go previousRegion previous ((region, input) : rest) = do
+    go _ _ _ _ _ [] = pure ()
+    go incremental previousRegion previousInput parser previous ((region, input) : rest) = do
         let baseline = markdownWidgetWithLinks id input
+            nextParser = case Text.stripPrefix previousInput input of
+                Just delta -> feedFenceStream parser delta
+                Nothing -> feedFenceStream emptyFenceStreamState input
+            proseCache chunk section = cached (Text.pack (show (chunk, section)))
             streaming =
-                markdownWidgetWithStreamingCache
-                    Nothing
-                    id
-                    (\chunk section -> cached (Text.pack (show (chunk, section))))
-                    (\_ widget -> widget)
-                    (\_ _ -> txt "")
-                    input
+                if incremental
+                    then markdownWidgetWithParsedStreamingCache
+                        Nothing id proseCache (\_ widget -> widget)
+                        (\_ _ -> txt "") nextParser
+                    else markdownWidgetWithStreamingCache
+                        Nothing id proseCache (\_ widget -> widget)
+                        (\_ _ -> txt "") input
             (next, actual, _, actualExtents) =
                 renderFinal Theme.terminalDefault [streaming] region
                     (const Nothing)
@@ -1228,7 +1235,7 @@ checkStreamingFrames = go Nothing emptyRenderState
         rows actual `shouldBe` rows expected
         sortOn id (map extentKey actualExtents)
             `shouldBe` sortOn id (map extentKey expectedExtents)
-        go (Just region) next rest
+        go incremental (Just region) input nextParser next rest
 
 spanRowText :: [SpanOp] -> Text.Text
 spanRowText =

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -1,7 +1,13 @@
 module Agent.TUI.MarkdownSpec (spec) where
 
-import Agent.TUI.FencedCode (emptyFenceStreamState, feedFenceStream)
+import Agent.TUI.FencedCode
+    ( FenceSection(..)
+    , emptyFenceStreamState
+    , feedFenceStream
+    , fenceStreamSections
+    )
 import Agent.TUI.Markdown
+import Agent.TUI.Markdown.Stream
 import Agent.Syntax
     ( SyntaxClass(SyntaxComment)
     , SyntaxSpan(syntaxClass)
@@ -44,6 +50,7 @@ import Graphics.Vty.PictureToSpans (displayOpsForPic)
 import Graphics.Vty.Span (SpanOp(..))
 import System.Environment (lookupEnv)
 import Test.Hspec
+import Test.QuickCheck (elements, forAll, ioProperty, listOf, resize)
 
 spec :: Spec
 spec = describe "fullscreen Markdown rendering" do
@@ -56,10 +63,57 @@ spec = describe "fullscreen Markdown rendering" do
                 , "a\n\n\n\n界 👩\x200d💻\n\n---\n\n> quote\n\n"
                 , "| potential | table |\n\n| -- | -- |\n"
                 , "before\n\n```hs`not a fence\n\n[link](https://example.com)\n\nTail"
+                , "# heading\r\n> quote\r\n\n| A | B |\r\n| :- | -: |\r\n| 界 | `a|b` |\r\n"
+                , "**outer *inner*** [nested [label]](https://example.com/a(b)) https://example.com/x)."
+                , "| A | B |\n| --- | --- |\n| escaped \\| pipe | `unfinished | code` |\n"
+                , "```hs\nvalue\n```suffix\n```\n> quote\n1. item\n\n"
+                , Text.replicate 120 "a" <> " **bold** [docs](https://example.com)\r\nnext\n"
+                , "> " <> Text.replicate 125 "界" <> " *unfinished then closed*\n\n"
                 ]
         forM_ [12, 40, 80] \width ->
             forM_ inputs \input ->
                 checkStreamingPictures width (Text.inits input)
+
+    it "preserves rendering with randomized Markdown chunk partitions" $
+        forAll (resize 35 (listOf (elements
+            ["text", "*", "**", "_", "`", "```", "~", "|", "---", ":",
+             "[", "]", "(", ")", "\\", " ", "\n", "\r", "界", "https://x.y"]))) \chunks ->
+            ioProperty do
+                checkStreamingPictures 28 (scanl (<>) "" chunks)
+                pure True
+
+    it "preserves pending line classification transitions and Unicode prose deltas" do
+        forM_
+            [ "   界e\x301 👩\x200d💻 **bold**"
+            , "***not a rule***\n---not a rule\n___not a rule"
+            , "# heading 界\n##  heading\n-  bullet\n1. ordered\n> quote"
+            , " \t\n***\n#\n# heading\nplain 界 **more**\r\nnext"
+            ] \source ->
+                checkStreamingPictures 24 (Text.inits source)
+
+    it "preserves final syntax across every binary split and empty delta" do
+        let source = "| A | B |\n| --- | --- |\n| **one** | `two|three` |\n\n```hs\nx\n```suffix\n```\nTail"
+            expected = finishMarkdownStream (feedMarkdownStream emptyMarkdownStreamState source)
+        forM_ [0 .. Text.length source] \index -> do
+            let (prefix, suffix) = Text.splitAt index source
+                state = feedMarkdownStream
+                    (feedMarkdownStream
+                        (feedMarkdownStream emptyMarkdownStreamState prefix) "") suffix
+            finishMarkdownStream state `shouldBe` expected
+
+    it "retains fence metadata and prose cache indices at every prefix" do
+        let source = "- item\n\n    ```hs\n    value\n    ```suffix\n    ```\n\n| A | B |\n| - | - |\n\n~~~\ncode\n~~~"
+            deltas = Text.chunksOf 1 source
+            fences = scanl feedFenceStream emptyFenceStreamState deltas
+            markdown = scanl feedMarkdownStream emptyMarkdownStreamState deltas
+            fenceMetadata = map \case
+                FenceProseSection chunk section stable _ -> Left (chunk, section, stable)
+                FenceCodeSection chunk block -> Right (chunk, block)
+            markdownMetadata = map \case
+                MarkdownProseSection chunk section stable _ _ -> Left (chunk, section, stable)
+                MarkdownCodeSection chunk block -> Right (chunk, block)
+        map (markdownMetadata . markdownStreamSnapshot) markdown
+            `shouldBe` map (fenceMetadata . fenceStreamSections) fences
 
     it "keeps unterminated blank-looking lines live" do
         checkStreamingPictures 30
@@ -1194,22 +1248,28 @@ checkStreamingPicturesAtHeight height width =
 
 checkStreamingFrames :: [((Int, Int), Text.Text)] -> Expectation
 checkStreamingFrames frames =
-    go False Nothing "" emptyFenceStreamState emptyRenderState frames
-        >> go True Nothing "" emptyFenceStreamState emptyRenderState frames
+    forM_ [0 :: Int, 1, 2] \mode ->
+        go mode Nothing "" emptyFenceStreamState emptyMarkdownStreamState emptyRenderState frames
   where
-    go _ _ _ _ _ [] = pure ()
-    go incremental previousRegion previousInput parser previous ((region, input) : rest) = do
+    go _ _ _ _ _ _ [] = pure ()
+    go mode previousRegion previousInput parser syntaxParser previous ((region, input) : rest) = do
         let baseline = markdownWidgetWithLinks id input
             nextParser = case Text.stripPrefix previousInput input of
                 Just delta -> feedFenceStream parser delta
                 Nothing -> feedFenceStream emptyFenceStreamState input
+            nextSyntaxParser = case Text.stripPrefix previousInput input of
+                Just delta -> feedMarkdownStream syntaxParser delta
+                Nothing -> feedMarkdownStream emptyMarkdownStreamState input
             proseCache chunk section = cached (Text.pack (show (chunk, section)))
             streaming =
-                if incremental
-                    then markdownWidgetWithParsedStreamingCache
+                case mode of
+                    2 -> markdownWidgetWithMarkdownStreamingCache
+                        Nothing id proseCache (\_ widget -> widget)
+                        (\_ _ -> txt "") nextSyntaxParser
+                    1 -> markdownWidgetWithParsedStreamingCache
                         Nothing id proseCache (\_ widget -> widget)
                         (\_ _ -> txt "") nextParser
-                    else markdownWidgetWithStreamingCache
+                    _ -> markdownWidgetWithStreamingCache
                         Nothing id proseCache (\_ widget -> widget)
                         (\_ _ -> txt "") input
             (next, actual, _, actualExtents) =
@@ -1235,7 +1295,7 @@ checkStreamingFrames frames =
         rows actual `shouldBe` rows expected
         sortOn id (map extentKey actualExtents)
             `shouldBe` sortOn id (map extentKey expectedExtents)
-        go incremental (Just region) input nextParser next rest
+        go mode (Just region) input nextParser nextSyntaxParser next rest
 
 spanRowText :: [SpanOp] -> Text.Text
 spanRowText =

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1,7 +1,7 @@
 module Agent.TUI.ModelSpec (spec) where
 
 import Agent.TUI.Model
-import Agent.TUI.FencedCode (emptyFenceStreamState, feedFenceStream, fenceStreamSections)
+import Agent.TUI.Markdown.Stream (emptyMarkdownStreamState, feedMarkdownStream, markdownStreamSnapshot)
 import Agent.TUI.Presentation
     ( TodoDisplayLine(..)
     , TodoDisplayStatus(..)
@@ -32,9 +32,9 @@ spec = describe "fullscreen UI reducer" do
     it "retains incremental assistant parsing across deltas and releases it at completion" do
         let fragments = ["First paragraph.\n", "\n```haskell\n", "value = 1\n", "```\n"]
             streaming = foldl' (flip (reduceUi . UiLoop . TextDelta)) initialUiState fragments
-            expected = feedFenceStream emptyFenceStreamState (Text.concat fragments)
-        fmap (fenceStreamSections . snd) streaming.uiStreamingMarkdown
-            `shouldBe` Just (fenceStreamSections expected)
+            expected = feedMarkdownStream emptyMarkdownStreamState (Text.concat fragments)
+        fmap (markdownStreamSnapshot . snd) streaming.uiStreamingMarkdown
+            `shouldBe` Just (markdownStreamSnapshot expected)
         fmap fst streaming.uiStreamingMarkdown `shouldBe` streaming.uiSelectedBlock
         let completed = reduceUi (UiLoop (TurnFinished (emptyTurnOutput "r1" [] Nothing))) streaming
         completed.uiStreamingMarkdown `shouldBe` Nothing
@@ -52,9 +52,26 @@ spec = describe "fullscreen UI reducer" do
     it "reconstructs missing assistant parser state before extending an existing block" do
         let first = reduceUi (UiLoop (TextDelta "paragraph\n\n```\n")) initialUiState
             recovered = reduceUi (UiLoop (TextDelta "body\n```")) first{uiStreamingMarkdown = Nothing}
-            expected = feedFenceStream emptyFenceStreamState "paragraph\n\n```\nbody\n```"
-        fmap (fenceStreamSections . snd) recovered.uiStreamingMarkdown
-            `shouldBe` Just (fenceStreamSections expected)
+            expected = feedMarkdownStream emptyMarkdownStreamState "paragraph\n\n```\nbody\n```"
+        fmap (markdownStreamSnapshot . snd) recovered.uiStreamingMarkdown
+            `shouldBe` Just (markdownStreamSnapshot expected)
+
+    it "retains the same syntax at every reducer prefix, including empty deltas" do
+        let fragments = ["A **", "bold", "** [label](https://example.com", ")\n", "", "| A | B |\n", "| -", "-- | --- |\n", "| λ | `x|y` |"]
+            states = tail (scanl (flip (reduceUi . UiLoop . TextDelta)) initialUiState fragments)
+            sources = tail (scanl (<>) "" fragments)
+        map (fmap (markdownStreamSnapshot . snd) . (.uiStreamingMarkdown)) states
+            `shouldBe` map (Just . markdownStreamSnapshot . feedMarkdownStream emptyMarkdownStreamState) sources
+
+    it "does not reuse parser state belonging to another assistant block" do
+        let old = reduceUi (UiLoop (TextDelta "Unrelated **syntax")) initialUiState
+            submitted = reduceUi (UiUserSubmitted "next") old
+            current = reduceUi (UiLoop (TextDelta "Current `code")) submitted
+            stale = current{uiStreamingMarkdown = old.uiStreamingMarkdown}
+            recovered = reduceUi (UiLoop (TextDelta "` text")) stale
+            expected = feedMarkdownStream emptyMarkdownStreamState "Current `code` text"
+        fmap (markdownStreamSnapshot . snd) recovered.uiStreamingMarkdown
+            `shouldBe` Just (markdownStreamSnapshot expected)
 
     it "updates background work without changing the draft or adding transcript blocks" do
         let draft = reduceUi (UiSetDraft "follow-up message" 4) initialUiState

--- a/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/ModelSpec.hs
@@ -1,6 +1,7 @@
 module Agent.TUI.ModelSpec (spec) where
 
 import Agent.TUI.Model
+import Agent.TUI.FencedCode (emptyFenceStreamState, feedFenceStream, fenceStreamSections)
 import Agent.TUI.Presentation
     ( TodoDisplayLine(..)
     , TodoDisplayStatus(..)
@@ -28,6 +29,33 @@ import Test.Hspec
 
 spec :: Spec
 spec = describe "fullscreen UI reducer" do
+    it "retains incremental assistant parsing across deltas and releases it at completion" do
+        let fragments = ["First paragraph.\n", "\n```haskell\n", "value = 1\n", "```\n"]
+            streaming = foldl' (flip (reduceUi . UiLoop . TextDelta)) initialUiState fragments
+            expected = feedFenceStream emptyFenceStreamState (Text.concat fragments)
+        fmap (fenceStreamSections . snd) streaming.uiStreamingMarkdown
+            `shouldBe` Just (fenceStreamSections expected)
+        fmap fst streaming.uiStreamingMarkdown `shouldBe` streaming.uiSelectedBlock
+        let completed = reduceUi (UiLoop (TurnFinished (emptyTurnOutput "r1" [] Nothing))) streaming
+        completed.uiStreamingMarkdown `shouldBe` Nothing
+
+    it "discards streaming parsing on cancellation, restart, clear, and non-assistant blocks" do
+        let streaming = reduceUi (UiLoop (TextDelta "paragraph\n\n```\npartial")) initialUiState
+        map (\event -> (reduceUi event streaming).uiStreamingMarkdown)
+            [ UiTurnEnded BlockCancelled
+            , UiTurnEnded BlockFailed
+            , UiTurnRestarted
+            , UiConversationCleared
+            , UiUserSubmitted "next question"
+            ] `shouldBe` replicate 5 Nothing
+
+    it "reconstructs missing assistant parser state before extending an existing block" do
+        let first = reduceUi (UiLoop (TextDelta "paragraph\n\n```\n")) initialUiState
+            recovered = reduceUi (UiLoop (TextDelta "body\n```")) first{uiStreamingMarkdown = Nothing}
+            expected = feedFenceStream emptyFenceStreamState "paragraph\n\n```\nbody\n```"
+        fmap (fenceStreamSections . snd) recovered.uiStreamingMarkdown
+            `shouldBe` Just (fenceStreamSections expected)
+
     it "updates background work without changing the draft or adding transcript blocks" do
         let draft = reduceUi (UiSetDraft "follow-up message" 4) initialUiState
             active = reduceUi (UiSetBackgroundTaskStatus ["1 background task"]) draft


### PR DESCRIPTION
## Summary

Adapt our in-tree Markdown parser to consume streamed deltas, rather than replacing it with a different Markdown dialect.

- Retain fence state, completed prose blocks, inline syntax, and parsed table cells with width measurements.
- Resume scanning long pending inline constructs; retain ambiguous suffixes provisionally so every prefix preserves the batch parser's rendering. Short inline bodies (up to 128 characters) use batch parsing to avoid scanner setup overhead.
- Feed the active assistant block directly from `TextDelta`; clear state across completion, cancellation, history replacement, and other block lifecycle changes. Historical messages continue using the ordinary renderer.
- Keep stable Brick cache boundaries, code highlighting, Unicode layout, and clickable links unchanged.

## Validation

- Focused GHCi suite: 178 examples, including generated inline/fence prefix properties and rendered picture/style/click-extent equivalence across chunk boundaries, widths, tables, CRLF and incomplete syntax.
- Multi-package CLI/TUI GHCi reload: 258 modules.
- Live tmux fullscreen smoke: streamed bold/links, nested fenced code, Unicode table, terminal resize and scrollback.
- Optimized benchmark with fully forced Brick output; every benchmark checks frame equivalence before measuring. Cabal2nix output unchanged.

## Performance

Apple M3 Max/macOS arm64, GHC 9.10.3, benchmark modules `-O2`, single-thread RTS, count 100, 64-character deltas, medians of 21 samples (short prose: 31), `+RTS -T`. Compared with the earlier fence-only implementation, not the original uncached parser.

| Workload | CPU baseline → streaming (ms) | Allocated MB |
| --- | --- | --- |
| Continuous prose | 334.040 → 304.453 | 1942.843 → 1745.893 |
| Tables | 111.998 → 84.591 | 615.623 → 393.293 |
| Long styled line | 377.288 → 350.240 | 1926.716 → 1782.735 |
| Incomplete markup | 42.475 → 28.320 | 376.868 → 191.140 |
| Mixed | 326.804 → 324.169 | 1730.266 → 1698.266 |
| Short paragraphs | 38.977 → 39.376 | 289.913 → 290.684 |

Continuous prose saves 8.9% CPU; tables 24.5%; incomplete markup 33.3%. Short paragraphs remain about 1% slower despite removing always-on short-inline scanning; no universal speedup/no-regression claim. Retained syntax costs live memory. Ambiguous suffix snapshots and growing layout can still revisit input, so this does not make the whole rendering pipeline linear.

Reproduce after `nix develop`:

```sh
cabal build --offline agent-tui:bench:fullscreen-markdown-bench
bin=$(cabal list-bin agent-tui:bench:fullscreen-markdown-bench)
for scenario in prose prose-lines mixed table long-line incomplete; do
  for mode in incremental streaming; do
    "$bin" "$mode" "$scenario" 100 64 21 +RTS -T
  done
done
```

Prose/prose-lines/mixed/table results above use a saved executable from `eab8603f9` for an independent baseline; new long-line/incomplete workloads use the preserved in-tree `incremental` mode. [Benchmark documentation](packages/agent-tui/benchmark/FullscreenMarkdown.md) includes wall times, repeated runs, 50/100/200 scaling and memory boundaries.
