### PR TITLE
Extract shared MCP startup configuration and lifecycle

### DIFF
--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -159,7 +159,7 @@ unwind. Shutdown order remains activities, code mode, session lock, computer
 use, LSP, web fetch, MCP, coding tools, scratch storage.
 
 This is a bounded extraction, not the complete session entry point. Concrete
-MCP setup, host-specific tool groups, terminal hooks, and session launch
+host-specific tool groups, terminal hooks, and session launch
 still live in CLI orchestration. Server still depends on `agent-cli` until
 those remaining composition boundaries move. No new Cabal package is needed.
 
@@ -175,6 +175,16 @@ CLI supplies resume notices, fullscreen history wiring, external-session tool
 construction, and a repository worktree lease hook. CLI options are translated
 at the adapter boundary; the runtime request contains no terminal or CLI types.
 Stale-resource housekeeping remains in the host composition layer.
+
+## Implemented: shared MCP startup
+
+`Agent.Runtime.Mcp.Startup` maps harness configuration into MCP server
+configuration and owns blocking/progressive fleet acquisition and lease cleanup.
+Host hooks are cleared when startup fails or is cancelled and after lease release.
+The CLI adapter retains progress rendering, pending notices, interactive
+elicitation, integration endpoint discovery, and stale-resource housekeeping.
+Protocol and transport implementations remain in `agent-mcp`; no new package is
+introduced for this session-integration layer.
 
 ## Remaining: move session composition and ownership out of the CLI
 

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs
@@ -4,13 +4,10 @@ module Agent.CLI.Runtime.Orchestration.Tools.Mcp
     , acquireMcpRuntime
     ) where
 
-import Agent.Runtime.Config
-    ( HarnessConfig(..), McpServerConfig(..)
-    , mcpServersForRuntime, useProgressiveMcp, mcpUsesConnectionCredentials )
+import Agent.Runtime.Mcp.Startup
 import Agent.CLI.FileUri (fileUri)
 import Agent.CLI.IntegrationGateway (integrationEndpointServers)
 import Agent.CLI.McpElicitation (cliMcpElicitation)
-import Agent.Runtime.McpOAuthStore (mcpOAuthStorePath)
 import Agent.CLI.McpStatus
     ( formatMcpInstructionsNotice, formatMcpModelNoticeFor
     , formatMcpProgress, summarizeMcpStatuses )
@@ -33,11 +30,9 @@ import qualified Agent.MCP as MCP
 import Agent.OsPath (unsafeToFilePath)
 import Agent.TUI.Model (UiEvent(..))
 import Agent.Tools.Types (withToolHumanInputWait)
-import Control.Exception.Safe
-    ( SomeException, bracketOnError, finally, onException, try )
+import Control.Exception.Safe (catch)
 import Control.Monad (forM_, unless, when)
 import Data.IORef (atomicModifyIORef', newIORef, readIORef, writeIORef)
-import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as Text
 
@@ -60,55 +55,14 @@ mcpConfiguration AgentToolsRequest
     } ToolStartup
     { toolNativeCapabilities = nativeCapabilities
     , toolHarnessConfig = harnessConfig
-    } =
-    ( serverConfigs
-    , useProgressiveMcp
-        harnessConfig.configMcpInitStrategy
-        (isOneShot options)
-    )
-  where
-    serverConfigs =
-        [ MCP.McpServerConfig
-            { MCP.mcpServerName = label
-            , MCP.mcpServerConnection = fmap (\identifier -> MCP.McpConnectionIdentity
-                identifier config.mcpConnectionGeneration config.mcpDisplayName)
-                (if mcpUsesConnectionCredentials config then config.mcpConnectionId else Nothing)
-            , MCP.mcpServerUrl = config.mcpUrl
-            , MCP.mcpServerCommand = Text.unpack config.mcpCommand
-            , MCP.mcpServerArgs = map Text.unpack config.mcpArgs
-            , MCP.mcpServerCwd =
-                Just $
-                    maybe (unsafeToFilePath cwd) Text.unpack config.mcpCwd
-            , MCP.mcpServerEnv =
-                [ (Text.unpack name, Text.unpack value)
-                | (name, value) <- Map.toAscList config.mcpEnv
-                ] <> case (mcpUsesConnectionCredentials config, config.mcpUrl) of
-                    (False, Just url)
-                        | Map.notMember
-                            "MCP_OAUTH_TOKEN_FILE"
-                            config.mcpEnv ->
-                            [ ( "MCP_OAUTH_TOKEN_FILE"
-                              , unsafeToFilePath
-                                    (mcpOAuthStorePath home url)
-                              )
-                            ]
-                    _ -> []
-            , MCP.mcpServerStartupTimeoutSeconds =
-                config.mcpStartupTimeoutSeconds
-            , MCP.mcpServerRequestTimeoutSeconds =
-                config.mcpRequestTimeoutSeconds
-            , MCP.mcpServerProtocol = config.mcpProtocol
-            , MCP.mcpServerRootsEnabled = config.mcpRoots
-            , MCP.mcpServerSamplingEnabled = config.mcpSampling
-            , MCP.mcpServerLogLevel = config.mcpLogLevel
-            , MCP.mcpServerExcludedTools = []
-            }
-        | (label, config) <-
-            mcpServersForRuntime
-                nativeCapabilities.nativeMcpTools
-                nativeCapabilities.nativeHostExtensions
-                harnessConfig
-        ]
+    } = resolveMcpConfiguration McpConfigurationRequest
+        { mcpConfigCwd = cwd
+        , mcpConfigHome = home
+        , mcpConfigHarness = harnessConfig
+        , mcpConfigToolsEnabled = nativeCapabilities.nativeMcpTools
+        , mcpConfigHostExtensions = nativeCapabilities.nativeHostExtensions
+        , mcpConfigOneShot = isOneShot options
+        }
 
 acquireMcpRuntime
     :: AgentToolsRequest windowTitleResult
@@ -144,36 +98,40 @@ acquireMcpRuntime request@AgentToolsRequest
             [(integrationsMcpConfig name, server) | (name, server) <- localServers]
         -- Include the in-memory name in the reported configuration too: callers
         -- use this list to decide whether MCP tools exist at all.
-        runtimeMcpServerConfigs = configuredServers <> remoteServers
-            <> map fst inMemoryServers
-        transportServers = configuredServers <> remoteServers
+        mcpRequest = McpStartupRequest
+            { mcpStartupTransportServers = configuredServers <> remoteServers
+            , mcpStartupInMemoryServers = inMemoryServers
+            , mcpStartupProgressive = configuredProgressive
+            }
+        runtimeMcpServerConfigs = startupServerConfigs mcpRequest
         runtimeProgressiveMcp = configuredProgressive
     startStaleResourceCleanup request sessionTmp
     mcpStatusPhaseRef <- newIORef (Nothing :: Maybe Bool)
     mcpFleetRef <- newIORef (Nothing :: Maybe MCP.McpFleet)
-    writeIORef processRuntime.processMcpElicitation
-        (if isOneShot options || not isTty
-            then Nothing
-            else Just \elicitation ->
-                withToolHumanInputWait baseToolEnv $
-                    cliMcpElicitation stdinControl uiRuntimeRef elicitation)
-    writeIORef processRuntime.processMcpRoots $
-        Just \_serverName ->
-            pure
-                [ MCP.McpRoot
-                    { MCP.rootUri = fileUri (unsafeToFilePath request.cwd)
-                    , MCP.rootName = Nothing
-                    }
-                ]
-    writeIORef processRuntime.processMcpSampling $
-        if any
-            (\MCP.McpServerConfig
-                { MCP.mcpServerSamplingEnabled = samplingEnabled
-                } -> samplingEnabled)
-            runtimeMcpServerConfigs
-            then Just \_ ->
-                pure (Left "MCP sampling is unavailable until the model session is ready")
-            else Nothing
+    let installMcpHostHooks = do
+            writeIORef processRuntime.processMcpElicitation
+                (if isOneShot options || not isTty
+                    then Nothing
+                    else Just \elicitation ->
+                        withToolHumanInputWait baseToolEnv $
+                            cliMcpElicitation stdinControl uiRuntimeRef elicitation)
+            writeIORef processRuntime.processMcpRoots $
+                Just \_serverName ->
+                    pure
+                        [ MCP.McpRoot
+                            { MCP.rootUri = fileUri (unsafeToFilePath request.cwd)
+                            , MCP.rootName = Nothing
+                            }
+                        ]
+            writeIORef processRuntime.processMcpSampling $
+                if any
+                    (\MCP.McpServerConfig
+                        { MCP.mcpServerSamplingEnabled = samplingEnabled
+                        } -> samplingEnabled)
+                    runtimeMcpServerConfigs
+                    then Just \_ ->
+                        pure (Left "MCP sampling is unavailable until the model session is ready")
+                    else Nothing
     let clearMcpHostHooks = do
             writeIORef processRuntime.processMcpElicitation Nothing
             writeIORef processRuntime.processMcpRoots Nothing
@@ -227,64 +185,12 @@ acquireMcpRuntime request@AgentToolsRequest
                         "Loading tools: "
                             <> Text.intercalate ", " names
                             <> "…")
-        acquireMcpLease =
-            try @_ @SomeException
-                (if null inMemoryServers
-                    then
-                        if runtimeProgressiveMcp
-                            then
-                                MCP.acquireMcpFleetProgressive
-                                    mcpSupervisor
-                                    reportProgressiveMcp
-                                    runtimeMcpServerConfigs
-                            else
-                                MCP.acquireMcpFleetWithProgress
-                                    mcpSupervisor
-                                    reportBlockingMcp
-                                    runtimeMcpServerConfigs
-                    else
-                        if runtimeProgressiveMcp
-                            then
-                                MCP.acquireMcpFleetProgressiveWithInMemory
-                                    mcpSupervisor
-                                    reportProgressiveMcp
-                                    transportServers
-                                    inMemoryServers
-                            else
-                                MCP.acquireMcpFleetWithInMemory
-                                    mcpSupervisor
-                                    reportBlockingMcp
-                                    transportServers
-                                    inMemoryServers)
-                >>= \case
-                    Left exception ->
-                        startupDie startup
-                            ("Failed to initialize MCP tools: "
-                                <> Text.pack (show exception))
-                    Right lease -> pure lease
-    bracketOnError
-        (acquireMcpLease `onException` clearMcpHostHooks)
-        (\lease ->
-            MCP.releaseMcpFleetLease lease
-                `finally` clearMcpHostHooks)
-        \runtimeMcpLease -> finishRuntime runtimeMcpLease.mcpLeaseFleet
-            (MCP.releaseMcpFleetLease runtimeMcpLease
-                `finally` clearMcpHostHooks)
-
-integrationsMcpConfig :: Text -> MCP.McpServerConfig
-integrationsMcpConfig serverName = MCP.McpServerConfig
-    { MCP.mcpServerName = serverName
-    , MCP.mcpServerUrl = Nothing
-    , MCP.mcpServerCommand = ""
-    , MCP.mcpServerArgs = []
-    , MCP.mcpServerCwd = Nothing
-    , MCP.mcpServerEnv = []
-    , MCP.mcpServerStartupTimeoutSeconds = 10
-    , MCP.mcpServerRequestTimeoutSeconds = 60
-    , MCP.mcpServerProtocol = MCP.McpProtocolModern
-    , MCP.mcpServerRootsEnabled = False
-    , MCP.mcpServerSamplingEnabled = False
-    , MCP.mcpServerLogLevel = Nothing
-    , MCP.mcpServerExcludedTools = []
-    , MCP.mcpServerConnection = Nothing
-    }
+    acquireMcpStartup mcpSupervisor mcpRequest McpStartupHooks
+        { mcpInstallHostHooks = installMcpHostHooks
+        , mcpClearHostHooks = clearMcpHostHooks
+        , mcpReportBlocking = reportBlockingMcp
+        , mcpReportProgressive = reportProgressiveMcp
+        } finishRuntime
+        `catch` \(McpStartupError exception) ->
+            startupDie startup
+                ("Failed to initialize MCP tools: " <> Text.pack (show exception))

--- a/packages/agent-runtime/agent-runtime.cabal
+++ b/packages/agent-runtime/agent-runtime.cabal
@@ -79,6 +79,7 @@ library
                     , Agent.Runtime.McpConnectionRuntime
                     , Agent.Runtime.McpOAuth
                     , Agent.Runtime.McpOAuthStore
+                    , Agent.Runtime.Mcp.Startup
                     , Agent.Runtime.ModelConfig
                     , Agent.Runtime.Models
                     , Agent.Runtime.NativeProcess
@@ -229,6 +230,7 @@ test-suite agent-runtime-test
     main-is:          Spec.hs
     ghc-options:      -threaded
     other-modules:    Agent.Runtime.RequestSpec
+                    , Agent.Runtime.Mcp.StartupSpec
                     , Agent.Runtime.Tools.DialectsSpec
                     , Agent.Runtime.Tools.ResourcesSpec
                     , Agent.Runtime.Tools.StartupSpec
@@ -274,6 +276,7 @@ test-suite agent-runtime-test
                     , agent-accounts
                     , agent-connectivity
                     , agent-core
+                    , agent-mcp
                     , agent-tools
                     , agent-json
                     , agent-openai

--- a/packages/agent-runtime/package.nix
+++ b/packages/agent-runtime/package.nix
@@ -29,11 +29,11 @@ mkDerivation {
   ];
   testHaskellDepends = [
     aeson agent-accounts agent-connectivity agent-core agent-json
-    agent-openai agent-openrouter agent-responses agent-responses-types
-    agent-store agent-tools agent-xai async base bytestring containers
-    directory filelock filepath hspec http-client http-types network
-    QuickCheck resourcet safe-exceptions stm text time transformers
-    unix wai warp
+    agent-mcp agent-openai agent-openrouter agent-responses
+    agent-responses-types agent-store agent-tools agent-xai async base
+    bytestring containers directory filelock filepath hspec http-client
+    http-types network QuickCheck resourcet safe-exceptions stm text
+    time transformers unix wai warp
   ];
   description = "Frontend-independent conversation and turn lifecycle";
   license = lib.meta.getLicenseFromSpdxId "MIT";

--- a/packages/agent-runtime/src/Agent/Runtime/Mcp/Startup.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Mcp/Startup.hs
@@ -1,0 +1,137 @@
+-- | Frontend-neutral MCP configuration and ownership during session startup.
+module Agent.Runtime.Mcp.Startup
+    ( McpConfigurationRequest(..)
+    , resolveMcpConfiguration
+    , McpStartupRequest(..)
+    , McpStartupHooks(..)
+    , McpStartupError(..)
+    , startupServerConfigs
+    , integrationsMcpConfig
+    , acquireMcpStartup
+    ) where
+
+import qualified Agent.MCP as MCP
+import Agent.OsPath (unsafeToFilePath)
+import Agent.Runtime.Config
+    ( HarnessConfig(..), McpServerConfig(..)
+    , mcpServersForRuntime, mcpUsesConnectionCredentials, useProgressiveMcp )
+import Agent.Runtime.McpOAuthStore (mcpOAuthStorePath)
+import Control.Exception.Safe (Exception, SomeException, bracketOnError, finally, onException, throwIO, try)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.OsPath (OsPath)
+
+data McpConfigurationRequest = McpConfigurationRequest
+    { mcpConfigCwd :: OsPath
+    , mcpConfigHome :: OsPath
+    , mcpConfigHarness :: HarnessConfig
+    , mcpConfigToolsEnabled :: Bool
+    , mcpConfigHostExtensions :: Bool
+    , mcpConfigOneShot :: Bool
+    }
+
+newtype McpStartupError = McpStartupError SomeException
+    deriving (Show)
+
+instance Exception McpStartupError
+
+resolveMcpConfiguration :: McpConfigurationRequest -> ([MCP.McpServerConfig], Bool)
+resolveMcpConfiguration McpConfigurationRequest{..} =
+    ( map configure
+        (mcpServersForRuntime mcpConfigToolsEnabled mcpConfigHostExtensions mcpConfigHarness)
+    , useProgressiveMcp mcpConfigHarness.configMcpInitStrategy mcpConfigOneShot
+    )
+  where
+    configure (label, config) = MCP.McpServerConfig
+        { MCP.mcpServerName = label
+        , MCP.mcpServerConnection = fmap (\identifier -> MCP.McpConnectionIdentity
+            identifier config.mcpConnectionGeneration config.mcpDisplayName)
+            (if mcpUsesConnectionCredentials config then config.mcpConnectionId else Nothing)
+        , MCP.mcpServerUrl = config.mcpUrl
+        , MCP.mcpServerCommand = Text.unpack config.mcpCommand
+        , MCP.mcpServerArgs = map Text.unpack config.mcpArgs
+        , MCP.mcpServerCwd = Just (maybe (unsafeToFilePath mcpConfigCwd) Text.unpack config.mcpCwd)
+        , MCP.mcpServerEnv =
+            [(Text.unpack name, Text.unpack value) | (name, value) <- Map.toAscList config.mcpEnv]
+                <> case (mcpUsesConnectionCredentials config, config.mcpUrl) of
+                    (False, Just url)
+                        | Map.notMember "MCP_OAUTH_TOKEN_FILE" config.mcpEnv ->
+                            [("MCP_OAUTH_TOKEN_FILE", unsafeToFilePath (mcpOAuthStorePath mcpConfigHome url))]
+                    _ -> []
+        , MCP.mcpServerStartupTimeoutSeconds = config.mcpStartupTimeoutSeconds
+        , MCP.mcpServerRequestTimeoutSeconds = config.mcpRequestTimeoutSeconds
+        , MCP.mcpServerProtocol = config.mcpProtocol
+        , MCP.mcpServerRootsEnabled = config.mcpRoots
+        , MCP.mcpServerSamplingEnabled = config.mcpSampling
+        , MCP.mcpServerLogLevel = config.mcpLogLevel
+        , MCP.mcpServerExcludedTools = []
+        }
+
+data McpStartupRequest = McpStartupRequest
+    { mcpStartupTransportServers :: [MCP.McpServerConfig]
+    , mcpStartupInMemoryServers :: [(MCP.McpServerConfig, MCP.McpToolServer)]
+    , mcpStartupProgressive :: Bool
+    }
+
+-- | Hosts supply presentation and install their session-specific protocol
+-- callbacks. Clearing must tolerate partially completed installation.
+data McpStartupHooks = McpStartupHooks
+    { mcpInstallHostHooks :: IO ()
+    , mcpClearHostHooks :: IO ()
+    , mcpReportBlocking :: [Text] -> IO ()
+    , mcpReportProgressive :: [MCP.McpServerStatus] -> IO ()
+    }
+
+startupServerConfigs :: McpStartupRequest -> [MCP.McpServerConfig]
+startupServerConfigs request =
+    request.mcpStartupTransportServers <> map fst request.mcpStartupInMemoryServers
+
+-- | The successful continuation transfers cleanup to the enclosing session
+-- scope. If acquisition or that continuation fails (including cancellation),
+-- release the lease before clearing hooks used by its workers.
+acquireMcpStartup
+    :: MCP.McpSupervisor
+    -> McpStartupRequest
+    -> McpStartupHooks
+    -> (MCP.McpFleet -> IO () -> IO a)
+    -> IO a
+acquireMcpStartup supervisor request hooks finish =
+    bracketOnError
+        ((hooks.mcpInstallHostHooks >> acquireLease)
+            `onException` hooks.mcpClearHostHooks)
+        release
+        (\lease -> finish lease.mcpLeaseFleet (release lease))
+  where
+    acquireLease = try (acquire request hooks) >>= either (throwIO . McpStartupError) pure
+    release lease =
+        MCP.releaseMcpFleetLease lease `finally` hooks.mcpClearHostHooks
+    acquire McpStartupRequest{..} McpStartupHooks{..}
+        | null mcpStartupInMemoryServers =
+            if mcpStartupProgressive
+                then MCP.acquireMcpFleetProgressive supervisor mcpReportProgressive mcpStartupTransportServers
+                else MCP.acquireMcpFleetWithProgress supervisor mcpReportBlocking mcpStartupTransportServers
+        | mcpStartupProgressive =
+            MCP.acquireMcpFleetProgressiveWithInMemory supervisor mcpReportProgressive
+                mcpStartupTransportServers mcpStartupInMemoryServers
+        | otherwise =
+            MCP.acquireMcpFleetWithInMemory supervisor mcpReportBlocking
+                mcpStartupTransportServers mcpStartupInMemoryServers
+
+integrationsMcpConfig :: Text -> MCP.McpServerConfig
+integrationsMcpConfig serverName = MCP.McpServerConfig
+    { MCP.mcpServerName = serverName
+    , MCP.mcpServerUrl = Nothing
+    , MCP.mcpServerCommand = ""
+    , MCP.mcpServerArgs = []
+    , MCP.mcpServerCwd = Nothing
+    , MCP.mcpServerEnv = []
+    , MCP.mcpServerStartupTimeoutSeconds = 10
+    , MCP.mcpServerRequestTimeoutSeconds = 60
+    , MCP.mcpServerProtocol = MCP.McpProtocolModern
+    , MCP.mcpServerRootsEnabled = False
+    , MCP.mcpServerSamplingEnabled = False
+    , MCP.mcpServerLogLevel = Nothing
+    , MCP.mcpServerExcludedTools = []
+    , MCP.mcpServerConnection = Nothing
+    }

--- a/packages/agent-runtime/test/Agent/Runtime/Mcp/StartupSpec.hs
+++ b/packages/agent-runtime/test/Agent/Runtime/Mcp/StartupSpec.hs
@@ -1,0 +1,323 @@
+module Agent.Runtime.Mcp.StartupSpec (spec) where
+
+import qualified Agent.MCP as MCP
+import qualified System.OsPath as OsPath
+import qualified Agent.MCP.Types as MCP
+import Agent.Runtime.Config
+import Agent.Runtime.Mcp.Startup
+import Agent.Runtime.McpOAuthStore (mcpOAuthStorePath)
+import Agent.OsPath (unsafeToFilePath)
+import Control.Concurrent.Async (cancel, poll, wait, withAsync)
+import Control.Concurrent.MVar
+import Control.Exception.Safe (bracket, finally)
+import Control.Monad (forM_)
+import Data.IORef
+import qualified Data.Map.Strict as Map
+import Data.Maybe (isNothing)
+import Data.Text (Text)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "MCP startup" do
+    it "maps transport configuration and preserves explicit capability settings" do
+        let configured = testConfig
+                { mcpCwd = Just "/workspace/override"
+                , mcpEnv = Map.fromList [("B", "two"), ("A", "one")]
+                , mcpRoots = True
+                , mcpSampling = True
+                , mcpLogLevel = Just MCP.McpLogWarning
+                , mcpStartupTimeoutSeconds = 12
+                , mcpRequestTimeoutSeconds = 34
+                }
+            (servers, _) = resolveMcpConfiguration (configuration [("test", configured)])
+        case servers of
+            [server] -> do
+                server.mcpServerName `shouldBe` "test"
+                server.mcpServerCommand `shouldBe` "test-server"
+                server.mcpServerArgs `shouldBe` ["--test"]
+                server.mcpServerCwd `shouldBe` Just "/workspace/override"
+                server.mcpServerEnv `shouldBe` [("A", "one"), ("B", "two")]
+                server.mcpServerRootsEnabled `shouldBe` True
+                server.mcpServerSamplingEnabled `shouldBe` True
+                server.mcpServerLogLevel `shouldBe` Just MCP.McpLogWarning
+                server.mcpServerStartupTimeoutSeconds `shouldBe` 12
+                server.mcpServerRequestTimeoutSeconds `shouldBe` 34
+                server.mcpServerProtocol `shouldBe` MCP.McpProtocolModern
+            _ -> expectationFailure "expected one mapped MCP server"
+
+    it "filters disabled and host-command servers without disabling remote MCP" do
+        let request = (configuration
+                [ ("command", testConfig)
+                , ("disabled", testConfig { mcpEnabled = False })
+                , ("remote", testConfig { mcpUrl = Just "https://example.test/mcp" })
+                ]) { mcpConfigHostExtensions = False }
+        map (.mcpServerName) (fst (resolveMcpConfiguration request))
+            `shouldBe` ["remote"]
+        null (fst (resolveMcpConfiguration request { mcpConfigToolsEnabled = False }))
+            `shouldBe` True
+
+    it "keeps connection credentials separate from legacy OAuth token files" do
+        let url = "https://example.test/mcp"
+            remote = testConfig { mcpUrl = Just url }
+            connection = remote
+                { mcpConnectionId = Just "connection"
+                , mcpConnectionGeneration = Just "generation"
+                , mcpDisplayName = Just "Display"
+                }
+            request = configuration
+                [ ("connection", connection)
+                , ("explicit", remote { mcpEnv = Map.singleton "MCP_OAUTH_TOKEN_FILE" "/custom/token" })
+                , ("legacy", remote)
+                ]
+        case fst (resolveMcpConfiguration request) of
+            [protected, explicit, legacy] -> do
+                protected.mcpServerConnection `shouldBe`
+                    Just (MCP.McpConnectionIdentity "connection" (Just "generation") (Just "Display"))
+                lookup "MCP_OAUTH_TOKEN_FILE" protected.mcpServerEnv `shouldBe` Nothing
+                lookup "MCP_OAUTH_TOKEN_FILE" explicit.mcpServerEnv `shouldBe` Just "/custom/token"
+                lookup "MCP_OAUTH_TOKEN_FILE" legacy.mcpServerEnv `shouldBe`
+                    Just (unsafeToFilePath (mcpOAuthStorePath request.mcpConfigHome url))
+                legacy.mcpServerCwd `shouldBe` Just "/workspace"
+            _ -> expectationFailure "expected three mapped remote MCP servers"
+
+    it "resolves interactive and one-shot initialization policy" do
+        forM_ [(McpInitAuto, False, True), (McpInitAuto, True, False),
+               (McpInitProgressive, True, True), (McpInitBlocking, False, False)] $
+            \(strategy, oneShot, expected) -> do
+                let request = (configuration [])
+                        { mcpConfigHarness = defaultHarnessConfig { configMcpInitStrategy = strategy }
+                        , mcpConfigOneShot = oneShot
+                        }
+                snd (resolveMcpConfiguration request) `shouldBe` expected
+
+    it "reports in-memory endpoints in the complete configuration" do
+        let request = (memoryRequest False testServer)
+                { mcpStartupTransportServers = [integrationsMcpConfig "remote"] }
+        map (.mcpServerName) (startupServerConfigs request) `shouldBe` ["remote", "memory"]
+
+    it "waits for the catalog in blocking mode and releases only the session lease" $ within $
+        bracket MCP.newMcpSupervisor MCP.closeMcpSupervisor \supervisor -> do
+            started <- newEmptyMVar
+            unblock <- newEmptyMVar
+            live <- newIORef False
+            reports <- newIORef ([] :: [[Text]])
+            let endpoint = testServer
+                    { MCP.toolServerListTools =
+                        putMVar started () >> takeMVar unblock >> pure (Right [])
+                    }
+                hooks = quietHooks
+                    { mcpInstallHostHooks = writeIORef live True
+                    , mcpClearHostHooks = writeIORef live False
+                    , mcpReportBlocking = \names -> atomicModifyIORef' reports (\values -> (values <> [names], ()))
+                    , mcpReportProgressive = \_ -> expectationFailure "blocking startup used progressive reports"
+                    }
+            withAsync
+                (acquireMcpStartup supervisor (memoryRequest False endpoint) hooks
+                    \fleet close -> pure (fleet, close)) \worker -> do
+                takeMVar started
+                isNothing <$> poll worker `shouldReturn` True
+                readIORef live `shouldReturn` True
+                putMVar unblock ()
+                (fleet, close) <- wait worker
+                readIORef reports >>= (`shouldSatisfy` any (elem "memory"))
+                MCP.mcpFleetInstructions fleet `shouldReturn` [("memory", "Test instructions")]
+                leaseCount supervisor `shouldReturn` 1
+                close
+                leaseCount supervisor `shouldReturn` 0
+                readIORef live `shouldReturn` False
+                -- A session lease does not own the process-wide fleet itself.
+                MCP.mcpFleetInstructions fleet `shouldReturn` [("memory", "Test instructions")]
+
+    it "returns a progressive fleet before its in-memory catalog settles" $ within $
+        bracket MCP.newMcpSupervisor MCP.closeMcpSupervisor \supervisor -> do
+            started <- newEmptyMVar
+            unblock <- newEmptyMVar
+            reported <- newEmptyMVar
+            let endpoint = testServer
+                    { MCP.toolServerListTools =
+                        putMVar started () >> takeMVar unblock >> pure (Right [])
+                    }
+                hooks = quietHooks
+                    { mcpReportBlocking = \_ -> expectationFailure "progressive startup used blocking reports"
+                    , mcpReportProgressive = \statuses ->
+                        if any (\status -> status.mcpStatusName == "memory") statuses
+                            then do
+                                _ <- tryPutMVar reported ()
+                                pure ()
+                            else pure ()
+                    }
+            close <- acquireMcpStartup supervisor (memoryRequest True endpoint) hooks
+                \_ release -> pure release
+            takeMVar started
+            takeMVar reported
+            leaseCount supervisor `shouldReturn` 1
+            putMVar unblock ()
+            close
+            leaseCount supervisor `shouldReturn` 0
+
+    it "supports progressive acquisition without in-memory endpoints" $ within $
+        bracket MCP.newMcpSupervisor MCP.closeMcpSupervisor \supervisor -> do
+            let request = emptyRequest { mcpStartupProgressive = True }
+                hooks = quietHooks
+                    { mcpReportBlocking = \_ -> expectationFailure "progressive startup used blocking reports" }
+            close <- acquireMcpStartup supervisor request hooks
+                \fleet release -> do
+                    MCP.mcpFleetStatuses fleet `shouldReturn` []
+                    pure release
+            state <- readMVar supervisor.supervisorState
+            map (.supervisorEntryProgressive) state.supervisorEntries `shouldBe` [True]
+            close
+            leaseCount supervisor `shouldReturn` 0
+
+    it "clears partially installed hooks when hook installation fails" $
+        bracket MCP.newMcpSupervisor MCP.closeMcpSupervisor \supervisor -> do
+            live <- newIORef False
+            let hooks = quietHooks
+                    { mcpInstallHostHooks = writeIORef live True >> ioError (userError "install failed")
+                    , mcpClearHostHooks = writeIORef live False
+                    }
+            acquireMcpStartup supervisor emptyRequest hooks (\_ _ -> pure ())
+                `shouldThrow` anyIOException
+            readIORef live `shouldReturn` False
+            leaseCount supervisor `shouldReturn` 0
+
+    it "clears hooks when fleet acquisition fails" $
+        bracket MCP.newMcpSupervisor MCP.closeMcpSupervisor \supervisor -> do
+            MCP.closeMcpSupervisor supervisor
+            live <- newIORef False
+            let hooks = quietHooks
+                    { mcpInstallHostHooks = writeIORef live True
+                    , mcpClearHostHooks = writeIORef live False
+                    }
+            acquireMcpStartup supervisor emptyRequest hooks (\_ _ -> pure ())
+                `shouldThrow` (\(McpStartupError _) -> True)
+            readIORef live `shouldReturn` False
+
+    it "releases the lease before clearing hooks when completion fails" $
+        bracket MCP.newMcpSupervisor MCP.closeMcpSupervisor \supervisor -> do
+            cleared <- newIORef False
+            let hooks = quietHooks
+                    { mcpClearHostHooks = do
+                        leaseCount supervisor `shouldReturn` 0
+                        writeIORef cleared True
+                    }
+            acquireMcpStartup supervisor emptyRequest hooks
+                (\_ _ -> ioError (userError "completion failed") :: IO ())
+                `shouldThrow` anyIOException
+            readIORef cleared `shouldReturn` True
+
+    it "joins a cancelled blocking acquisition before clearing its host hooks" $ within $
+        bracket MCP.newMcpSupervisor MCP.closeMcpSupervisor \supervisor -> do
+            started <- newEmptyMVar
+            blocked <- newEmptyMVar
+            stopped <- newEmptyMVar
+            cleared <- newIORef False
+            let endpoint = testServer
+                    { MCP.toolServerListTools =
+                        (putMVar started () >> takeMVar blocked >> pure (Right []))
+                            `finally` putMVar stopped ()
+                    }
+                hooks = quietHooks
+                    { mcpClearHostHooks = do
+                        tryReadMVar stopped `shouldReturn` Just ()
+                        writeIORef cleared True
+                    }
+            withAsync
+                (acquireMcpStartup supervisor (memoryRequest False endpoint) hooks
+                    (\_ _ -> pure ())) \worker -> do
+                takeMVar started
+                cancel worker
+            readIORef cleared `shouldReturn` True
+            leaseCount supervisor `shouldReturn` 0
+
+    it "releases an acquired lease when its completion callback is cancelled" $ within $
+        bracket MCP.newMcpSupervisor MCP.closeMcpSupervisor \supervisor -> do
+            started <- newEmptyMVar
+            blocked <- newEmptyMVar
+            cleared <- newIORef False
+            let hooks = quietHooks
+                    { mcpClearHostHooks = do
+                        leaseCount supervisor `shouldReturn` 0
+                        writeIORef cleared True
+                    }
+            withAsync
+                (acquireMcpStartup supervisor emptyRequest hooks
+                    (\_ _ -> putMVar started () >> takeMVar blocked :: IO ())) \worker -> do
+                takeMVar started
+                leaseCount supervisor `shouldReturn` 1
+                cancel worker
+            readIORef cleared `shouldReturn` True
+
+configuration :: [(Text, McpServerConfig)] -> McpConfigurationRequest
+configuration servers = McpConfigurationRequest
+    { mcpConfigCwd = either (error . show) id (OsPath.encodeUtf "/workspace")
+    , mcpConfigHome = either (error . show) id (OsPath.encodeUtf "/home/test")
+    , mcpConfigHarness = defaultHarnessConfig { configMcpServers = Map.fromList servers }
+    , mcpConfigToolsEnabled = True
+    , mcpConfigHostExtensions = True
+    , mcpConfigOneShot = False
+    }
+
+quietHooks :: McpStartupHooks
+quietHooks = McpStartupHooks
+    { mcpInstallHostHooks = pure ()
+    , mcpClearHostHooks = pure ()
+    , mcpReportBlocking = const (pure ())
+    , mcpReportProgressive = const (pure ())
+    }
+
+emptyRequest :: McpStartupRequest
+emptyRequest = McpStartupRequest [] [] False
+
+memoryRequest :: Bool -> MCP.McpToolServer -> McpStartupRequest
+memoryRequest progressive endpoint =
+    McpStartupRequest [] [(integrationsMcpConfig "memory", endpoint)] progressive
+
+testConfig :: McpServerConfig
+testConfig = McpServerConfig
+    { mcpEnabled = True
+    , mcpUrl = Nothing
+    , mcpConnectionId = Nothing
+    , mcpConnectionCredentials = Nothing
+    , mcpConnectionGeneration = Nothing
+    , mcpDisplayName = Nothing
+    , mcpCommand = "test-server"
+    , mcpArgs = ["--test"]
+    , mcpCwd = Nothing
+    , mcpEnv = Map.empty
+    , mcpStartupTimeoutSeconds = 30
+    , mcpRequestTimeoutSeconds = 60
+    , mcpOAuth = Nothing
+    , mcpProtocol = MCP.McpProtocolModern
+    , mcpRoots = False
+    , mcpSampling = False
+    , mcpLogLevel = Nothing
+    }
+
+testServer :: MCP.McpToolServer
+testServer = MCP.McpToolServer
+    { toolServerInitialize = pure MCP.McpServerInfo
+        { serverInfoEra = MCP.McpEraModern
+        , serverInfoProtocolVersion = "2026-07-28"
+        , serverInfoName = Just "test"
+        , serverInfoVersion = Just "1"
+        , serverInfoTitle = Nothing
+        , serverInfoIcons = []
+        , serverInfoInstructions = Just "Test instructions"
+        , serverInfoCapabilities = MCP.emptyServerCapabilities
+            { MCP.capabilityTools = Just (MCP.McpListCapability False) }
+        }
+    , toolServerListTools = pure (Right [])
+    , toolServerCallTool = \_ -> error "no test tools"
+    , toolServerSubscribe = \_ -> pure (pure ())
+    }
+
+leaseCount :: MCP.McpSupervisor -> IO Int
+leaseCount supervisor = do
+    state <- readMVar supervisor.supervisorState
+    pure (sum (map (.supervisorEntryLeases) state.supervisorEntries))
+
+within :: IO () -> IO ()
+within action =
+    timeout 5000000 action `shouldReturn` Just ()

--- a/packages/agent-runtime/test/Spec.hs
+++ b/packages/agent-runtime/test/Spec.hs
@@ -4,6 +4,7 @@ import qualified Agent.Runtime.RequestSpec as Request
 import qualified Agent.Runtime.Tools.ResourcesSpec as ToolResources
 import qualified Agent.Runtime.Tools.DialectsSpec as ToolDialects
 import qualified Agent.Runtime.Tools.StartupSpec as ToolStartup
+import qualified Agent.Runtime.Mcp.StartupSpec as McpStartup
 import qualified Agent.Runtime.ProviderRuntimeSpec as ProviderRuntime
 import qualified Agent.Runtime.CompactionSpec as Compaction
 import qualified Agent.Runtime.StartupPolicySpec as StartupPolicy
@@ -44,6 +45,7 @@ main = hspec do
     ToolDialects.spec
     ToolResources.spec
     ToolStartup.spec
+    McpStartup.spec
     Request.spec
     ProviderRuntime.spec
     Compaction.spec

--- a/scripts/check-package-boundaries.sh
+++ b/scripts/check-package-boundaries.sh
@@ -27,6 +27,10 @@ if [[ -e "$cli/src/Agent/CLI/Dialects.hs" \
 fi
 
 python3 "$root/scripts/check-package-graph.py" "$root"
+if rg --line-number 'MCP\.(acquireMcpFleet|releaseMcpFleetLease)' \
+    "$cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs"; then
+  fail "MCP startup lease ownership must remain in agent-runtime"
+fi
 [[ ! -e "$root/packages/agent-cli-runtime/agent-cli-runtime.cabal" ]] \
   || fail "agent-cli-runtime must be replaced by agent-runtime"
 
@@ -162,6 +166,8 @@ for registration in \
 done
 
 required_files=(
+  packages/agent-runtime/src/Agent/Runtime/Mcp/Startup.hs
+  packages/agent-runtime/test/Agent/Runtime/Mcp/StartupSpec.hs
   packages/agent-runtime/src/Agent/Runtime/Session/Preparation.hs
   packages/agent-runtime/src/Agent/Runtime/Session/Resources.hs
   packages/agent-runtime/test/Agent/Runtime/Session/ResourcesSpec.hs


### PR DESCRIPTION
## Summary

MCP startup configuration and resource ownership still lived in CLI orchestration, preventing other frontends from reusing that lifecycle.

- Move configuration mapping, blocking/progressive acquisition, and lease/hook cleanup into `Agent.Runtime.Mcp.Startup`.
- Keep progress rendering, interactive elicitation, integration discovery, and housekeeping in the CLI adapter.
- Cover real supervisor/in-memory startup, failure, and cancellation with 13 regression tests.
- Extend the package-boundary guard and document ownership. No new Cabal package.

## Validation

- GHCi `all:libs`: 767 modules loaded.
- Runtime MCP startup tests: 13 examples, 0 failures.
- Nix package-boundary check passed.
- Regenerated runtime Nix test dependencies with cabal2nix.
