### PR TITLE
Distinguish fullscreen link URLs from titles

### DIFF
--- a/packages/agent-tui/src/Agent/TUI/Markdown.hs
+++ b/packages/agent-tui/src/Agent/TUI/Markdown.hs
@@ -1597,14 +1597,19 @@ resolveInline plainAttr = fmap concat . traverse (go emptyContext)
             suffix <-
                 if Text.null url || inlinePlainText children == url
                     then pure []
-                    else one Theme.linkAttr linkContext (" (" <> url <> ")")
+                    else oneWithAttr Theme.dimAttr linkContext (" (" <> url <> ")")
             pure (label <> suffix)
 
-    one baseName context text = do
-        base <- B.lookupAttrName $
-            case context.inlineUrl of
+    one baseName context text =
+        oneWithAttr
+            (case context.inlineUrl of
                 Just _ -> Theme.linkAttr
-                Nothing -> baseName
+                Nothing -> baseName)
+            context
+            text
+
+    oneWithAttr attributeName context text = do
+        base <- B.lookupAttrName attributeName
         let addedStyle =
                 (if context.inlineStrong then V.bold else 0)
                     .|. (if context.inlineEmphasis then V.italic else 0)

--- a/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/MarkdownSpec.hs
@@ -102,7 +102,7 @@ spec = describe "fullscreen Markdown rendering" do
                 renderFinal Theme.terminalDefault [widget True] (40, 20)
                     (const Nothing) warm
         V.imageHeight (V.picImage picture) `shouldSatisfy` (> 0)
-        map extentName extents `shouldBe` ["https://example.com"]
+        map extentName extents `shouldBe` replicate 2 "https://example.com"
 
     it "parses strong, emphasis, code, and links" do
         parseInline
@@ -125,6 +125,22 @@ spec = describe "fullscreen Markdown rendering" do
             rendered = show (renderWidget Nothing [widget] (40, 3))
         rendered `shouldSatisfy`
             isInfixOf "attrURL = SetTo \"https://example.com\""
+
+    it "renders a muted URL suffix without the link title's underline" do
+        let url = "https://example.com"
+            widget :: Widget ()
+            widget = markdownWidget ("[Example](" <> url <> ") after")
+            (_, picture, _, _) =
+                renderFinal Theme.terminalDefault [widget] (80, 3)
+                    (const Nothing) emptyRenderState
+            spans = concatMap toList (toList (displayOpsForPic picture (80, 3)))
+            attributeFor value = spanAttr <$> find (hasText value) spans
+        attributeFor "Example" `shouldBe`
+            Just (attrMapLookup Theme.linkAttr Theme.terminalDefault `V.withURL` url)
+        attributeFor " (https://example.com)" `shouldBe`
+            Just (attrMapLookup Theme.dimAttr Theme.terminalDefault `V.withURL` url)
+        attributeFor " after" `shouldSatisfy`
+            maybe False ((/= V.SetTo url) . V.attrURL)
 
     it "renders bare URLs with native terminal hyperlink metadata" do
         let url = "https://github.com/digitallyinduced/haskell-agent/pull/339"
@@ -149,7 +165,10 @@ spec = describe "fullscreen Markdown rendering" do
                 , extentSize extent
                 ))
             extents
-            `shouldContain` [(url, Location (5, 0), (31, 1))]
+            `shouldContain`
+                [ (url, Location (5, 0), (4, 1))
+                , (url, Location (9, 0), (27, 1))
+                ]
 
     it "registers a click target for every wrapped link fragment" do
         let url = "https://example.com/abcdefgh"


### PR DESCRIPTION
## Summary
- Render displayed URL suffixes in muted gray while keeping link titles blue and underlined.
- Preserve clickable targets for both parts and update rendering/cache regression tests.

## Validation
- 67 Markdown Hspec examples passed under GHCi.
- Live fullscreen agent smoke-tested in tmux: distinct title/URL colors, hyperlink targets preserved, and normal composer interaction.
- git diff --check passed.