### PR TITLE
Move collaboration startup policy and ownership into agent-runtime

### DIFF
--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -186,6 +186,17 @@ elicitation, integration endpoint discovery, and stale-resource housekeeping.
 Protocol and transport implementations remain in `agent-mcp`; no new package is
 introduced for this session-integration layer.
 
+## Implemented: shared collaboration startup
+
+`Agent.Runtime.Collaboration` owns child-model policy, live gateway child-target
+resolution, concurrency-limit precedence, and scoped subagent registry ownership.
+Teardown interrupts active children before the host snapshots their state and
+closes the registry even if snapshotting fails. Gateway resolution reads the
+current host-supplied catalog and fails closed when that catalog is unavailable.
+The CLI retains credential loading, transcript persistence callbacks, worktree
+creation, and notification presentation. This session-integration layer remains
+in `agent-runtime`, without a new Cabal package or frontend dependencies.
+
 ## Remaining: move session composition and ownership out of the CLI
 
 ### Conversation-state ownership

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Collaboration.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools/Collaboration.hs
@@ -8,9 +8,10 @@ module Agent.CLI.Runtime.Orchestration.Tools.Collaboration
 
 import Agent.Accounts.Auth (LoadedAuth(..), hasOpenAiAuth, loadAuth)
 import Agent.Runtime.Config (HarnessConfig(..))
+import Agent.Runtime.Collaboration
 import Agent.Runtime.GatewayClient (cachedGatewayModels)
 import Agent.CLI.GatewayModels (modelOptionsForGatewayModels)
-import Agent.Runtime.Models (ModelOption(..), ModelTarget(..), resolveModelOptionById)
+import Agent.Runtime.Models (ModelOption, ModelTarget(..))
 import Agent.CLI.Options (CliOptions(..))
 import Agent.CLI.PendingInputs
     ( PendingInputs, PendingNoticeKind(..), enqueuePendingInput
@@ -28,29 +29,24 @@ import Agent.CLI.Subagents.Runtime
     , prepareCollaborationSpawn, restoreAgentFromDisk )
 import Agent.CLI.Subagents.Runtime.Types (SubagentSession, SubagentStoreRoot)
 import Agent.CLI.Worktree (createManagedWorktree, removeWorktree)
-import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs, grokRootChildModels)
-import Agent.Loop (TurnInput(..), LoopError(..))
+import Agent.GrokBuild.Dialect.Task (GrokSubagentSpecs)
+import Agent.Loop (TurnInput(..))
 import Agent.Provider (Provider(..), TokenProvider, tokenProviderBillingMode)
 import Agent.Responses.Types (ResponseItem)
-import Agent.ResourceScope (logSlowCleanup)
 import Agent.Subagents
-    ( RootTurnId, SubagentId, SubagentRegistry, SubagentConfig(..)
-    , closeSubagentRegistry, defaultMaxConcurrent, defaultSubagentConfig
-    , formatCompletionNotice, interruptActiveSubagents, newSubagentRegistry
+    ( RootTurnId, SubagentId, SubagentRegistry
+    , formatCompletionNotice
     , setSubagentOnComplete, setSubagentOnSettled )
 import Agent.Subagents.TaskPath (taskPathRoot)
 import Agent.Tools.MultiAgents
     ( CollaborationModelTarget(..), MultiAgentContext(..), SubagentWorktree(..) )
-import Control.Applicative ((<|>))
-import Control.Exception.Safe (finally)
 import Control.Monad.IO.Class (liftIO)
-import Data.Acquire (Acquire, mkAcquire)
+import Data.Acquire (Acquire)
 import Data.IORef (IORef, newIORef, readIORef)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isJust, isNothing)
+import Data.Maybe (isJust)
 import Data.Text (Text)
-import qualified Data.Text as Text
 import System.OsPath (OsPath)
 
 data CollaborationRuntime = CollaborationRuntime
@@ -119,87 +115,44 @@ acquireCollaborationRuntime AgentToolsRequest
         liftIO $ newIORef (Nothing :: Maybe (IO [ResponseItem]))
     collaborationPendingNotices <- liftIO newPendingInputs
     collaborationAgentTypes <- liftIO $ newIORef Map.empty
-    let maxConcurrentAgents =
-            fromMaybe defaultMaxConcurrent $
-                options.optMaxConcurrentAgents
-                    <|> projectSettings.settingsMaxConcurrentAgents
-                    <|> harnessConfig.configMaxConcurrentAgents
-        finalizeRegistry registry = logSlowCleanup "collaboration agents" $
-            -- Persistence needs the interrupted agents' final state, but a
-            -- failed snapshot must never leave their supervisors alive while
-            -- the session releases dependent tool resources.
-            (do
-                interruptActiveSubagents registry
-                flushAllSubagentSnapshots
-                    collaborationSubagentStoreRoot
-                    registry
-                    collaborationSubagentSessions
-                    collaborationAgentTypes)
-                `finally` closeSubagentRegistry registry
-    collaborationRegistry <- mkAcquire
-        (newSubagentRegistry
-            defaultSubagentConfig { maxConcurrent = maxConcurrentAgents }
-            cwd
-            (\_ _ _ _ -> pure $ Left LoopNoResponseId)
-            (\_ _ -> pure ()))
-        finalizeRegistry
+    collaborationRegistry <- acquireCollaborationRegistry
+        (resolveMaxConcurrentAgents
+            options.optMaxConcurrentAgents
+            projectSettings.settingsMaxConcurrentAgents
+            harnessConfig.configMaxConcurrentAgents)
+        cwd
+        (\registry ->
+            flushAllSubagentSnapshots
+                collaborationSubagentStoreRoot
+                registry
+                collaborationSubagentSessions
+                collaborationAgentTypes)
     collaborationRootTurnRef <- liftIO $ newIORef (Nothing :: Maybe RootTurnId)
     collaborationOpenAiChild <- liftIO $
-        if not nativeCapabilities.nativeCollaboration
-            || isJust gatewayAllowedChildModels
-            then pure Nothing
-            else case provider of
-                XAIProvider -> do
-                    available <- hasOpenAiAuth
-                    if not available
-                        then pure Nothing
-                        else loadAuth (Just OpenAIProvider) >>= \case
-                            Left _ -> pure Nothing
-                            Right openaiLoaded ->
-                                pure (Just openaiLoaded.loadedTokenProvider)
-                _ -> pure Nothing
-    let collaborationAllowedChildModels =
-            case gatewayAllowedChildModels of
-                Just modelIds -> Just modelIds
-                Nothing -> case provider of
-                    XAIProvider ->
-                        Just
-                            (grokRootChildModels
-                                (isJust collaborationOpenAiChild))
-                    _ -> Nothing
-        collaborationChildModelAllowed
-            | Just resolve <- collaborationGatewayChildModelOption =
-                Just \modelId -> isJust <$> resolve modelId
-            | otherwise = Nothing
-        collaborationResolveChildModel
-            | Just resolve <- collaborationGatewayChildModelOption =
-                Just \modelId ->
-                    fmap toCollaborationTarget <$> resolve modelId
-            | otherwise = Nothing
-        toCollaborationTarget option =
-            let target = option.modelTarget
-            in CollaborationModelTarget
-                { collaborationTargetProvider = target.targetProvider
-                , collaborationTargetConnection = target.targetConnectionId
-                , collaborationTargetEffectiveModel =
-                    target.targetWireModelId
-                , collaborationTargetDialect = target.targetDialect
-                }
-        collaborationGatewayChildModelOption
-            | isNothing gatewayAllowedChildModels = Nothing
-            | otherwise =
-                Just \requested ->
-                    readIORef gatewayModelsRef >>= \case
-                        Nothing -> pure Nothing
-                        Just access ->
-                            cachedGatewayModels access >>= \case
-                                Nothing -> pure Nothing
-                                Just models ->
-                                    pure
-                                        (resolveModelOptionById
-                                            (modelOptionsForGatewayModels
-                                                catalog models)
-                                            (Text.strip requested))
+        if shouldLoadOpenAiChild nativeCapabilities.nativeCollaboration
+            gatewayAllowedChildModels provider
+            then do
+                available <- hasOpenAiAuth
+                if not available
+                    then pure Nothing
+                    else loadAuth (Just OpenAIProvider) >>= \case
+                        Left _ -> pure Nothing
+                        Right openaiLoaded ->
+                            pure (Just openaiLoaded.loadedTokenProvider)
+            else pure Nothing
+    let childModels = resolveCollaborationModels
+            provider
+            gatewayAllowedChildModels
+            (isJust collaborationOpenAiChild)
+            (readIORef gatewayModelsRef >>= \case
+                Nothing -> pure Nothing
+                Just access ->
+                    fmap (modelOptionsForGatewayModels catalog)
+                        <$> cachedGatewayModels access)
+        collaborationAllowedChildModels = childModels.childAllowedModels
+        collaborationChildModelAllowed = childModels.childModelAllowed
+        collaborationResolveChildModel = childModels.childResolveModel
+        collaborationGatewayChildModelOption = childModels.childGatewayModelOption
         sendToRoot message = do
             enqueuePendingInput
                 collaborationPendingNotices

--- a/packages/agent-runtime/agent-runtime.cabal
+++ b/packages/agent-runtime/agent-runtime.cabal
@@ -61,6 +61,7 @@ library
                     , Agent.Runtime.AgentSnapshot
                     , Agent.Runtime.Browser
                     , Agent.Runtime.Config
+                    , Agent.Runtime.Collaboration
                     , Agent.Runtime.Compaction
                     , Agent.Runtime.Compaction.Provider
                     , Agent.Runtime.Compaction.Projection
@@ -230,6 +231,7 @@ test-suite agent-runtime-test
     main-is:          Spec.hs
     ghc-options:      -threaded
     other-modules:    Agent.Runtime.RequestSpec
+                    , Agent.Runtime.CollaborationSpec
                     , Agent.Runtime.Mcp.StartupSpec
                     , Agent.Runtime.Tools.DialectsSpec
                     , Agent.Runtime.Tools.ResourcesSpec

--- a/packages/agent-runtime/src/Agent/Runtime/Collaboration.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Collaboration.hs
@@ -1,0 +1,101 @@
+-- | Frontend-neutral collaboration startup policy and registry ownership.
+-- Hosts supply their live admitted model catalog and persistence callback;
+-- neither terminal interaction nor worktree management belongs here.
+module Agent.Runtime.Collaboration
+    ( CollaborationModels(..)
+    , resolveMaxConcurrentAgents
+    , shouldLoadOpenAiChild
+    , resolveCollaborationModels
+    , acquireCollaborationRegistry
+    ) where
+
+import Agent.GrokBuild.Dialect.Task (grokRootChildModels)
+import Agent.Loop (LoopError(..))
+import Agent.Provider (Provider(..))
+import Agent.ResourceScope (logSlowCleanup)
+import Agent.Runtime.Models
+    ( ModelOption(..), ModelTarget(..), resolveModelOptionById )
+import Agent.Subagents
+    ( SubagentConfig(..), SubagentRegistry, closeSubagentRegistry
+    , defaultMaxConcurrent, defaultSubagentConfig, interruptActiveSubagents
+    , newSubagentRegistry )
+import Agent.Tools.MultiAgents (CollaborationModelTarget(..))
+import Control.Applicative ((<|>))
+import Control.Exception.Safe (finally)
+import Data.Acquire (Acquire, mkAcquire)
+import Data.Maybe (fromMaybe, isJust, isNothing)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import System.OsPath (OsPath)
+
+resolveMaxConcurrentAgents :: Maybe Int -> Maybe Int -> Maybe Int -> Int
+resolveMaxConcurrentAgents explicit project harness =
+    fromMaybe defaultMaxConcurrent (explicit <|> project <|> harness)
+
+-- | Gateway sessions must never load local credentials to extend admission.
+shouldLoadOpenAiChild :: Bool -> Maybe [Text] -> Provider -> Bool
+shouldLoadOpenAiChild enabled gatewayModels provider =
+    enabled && isNothing gatewayModels && provider == XAIProvider
+
+data CollaborationModels = CollaborationModels
+    { childAllowedModels :: Maybe [Text]
+    , childModelAllowed :: Maybe (Text -> IO Bool)
+    , childResolveModel :: Maybe (Text -> IO (Maybe CollaborationModelTarget))
+    , childGatewayModelOption :: Maybe (Text -> IO (Maybe ModelOption))
+    }
+
+-- | Keep gateway resolution live: the advertised startup list is not a
+-- substitute for the currently admitted catalog. An unavailable catalog
+-- fails closed rather than falling back to local provider routing.
+resolveCollaborationModels
+    :: Provider
+    -> Maybe [Text]
+    -> Bool
+    -> IO (Maybe [ModelOption])
+    -> CollaborationModels
+resolveCollaborationModels provider gatewayModels hasOpenAiChild loadCatalog =
+    CollaborationModels{..}
+  where
+    childAllowedModels = case gatewayModels of
+        Just modelIds -> Just modelIds
+        Nothing -> case provider of
+            XAIProvider -> Just (grokRootChildModels hasOpenAiChild)
+            _ -> Nothing
+    childGatewayModelOption
+        | isNothing gatewayModels = Nothing
+        | otherwise = Just \requested ->
+            loadCatalog >>= \case
+                Nothing -> pure Nothing
+                Just models ->
+                    pure (resolveModelOptionById models (Text.strip requested))
+    childModelAllowed = fmap (\resolve modelId -> isJust <$> resolve modelId)
+        childGatewayModelOption
+    childResolveModel = fmap
+        (\resolve modelId -> fmap toTarget <$> resolve modelId)
+        childGatewayModelOption
+    toTarget option =
+        let target = option.modelTarget
+        in CollaborationModelTarget
+            { collaborationTargetProvider = target.targetProvider
+            , collaborationTargetConnection = target.targetConnectionId
+            , collaborationTargetEffectiveModel = target.targetWireModelId
+            , collaborationTargetDialect = target.targetDialect
+            }
+
+-- | Register ownership before later initialization. Snapshot interrupted
+-- agents while their registry remains available, then always close and join
+-- its supervisors, even if persistence fails or the owner is cancelled.
+acquireCollaborationRegistry
+    :: Int
+    -> OsPath
+    -> (SubagentRegistry -> IO ())
+    -> Acquire SubagentRegistry
+acquireCollaborationRegistry concurrency cwd snapshot = mkAcquire
+    (newSubagentRegistry
+        defaultSubagentConfig { maxConcurrent = concurrency }
+        cwd
+        (\_ _ _ _ -> pure $ Left LoopNoResponseId)
+        (\_ _ -> pure ()))
+    (\registry -> logSlowCleanup "collaboration agents" $
+        (interruptActiveSubagents registry >> snapshot registry)
+            `finally` closeSubagentRegistry registry)

--- a/packages/agent-runtime/test/Agent/Runtime/CollaborationSpec.hs
+++ b/packages/agent-runtime/test/Agent/Runtime/CollaborationSpec.hs
@@ -1,0 +1,211 @@
+module Agent.Runtime.CollaborationSpec (spec) where
+
+import Agent.Dialect (DialectId(..))
+import Agent.Provider (Provider(..))
+import Agent.Runtime.Collaboration
+import Agent.Runtime.Models (ModelOption(..), ModelTarget(..))
+import Agent.Subagents
+    ( SubagentId, SubagentRegistry, SubagentStatus(..), defaultMaxConcurrent
+    , getStatus, setSubagentRunner, spawnSubagent )
+import Agent.Tools.MultiAgents (CollaborationModelTarget(..))
+import Control.Concurrent.Async (cancel, withAsync)
+import Control.Concurrent.MVar
+    ( MVar, newEmptyMVar, putMVar, readMVar )
+import Control.Exception.Safe (finally, throwIO, tryAny)
+import qualified Data.Acquire as Acquire
+import Data.Either (isLeft)
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
+import Data.Maybe (isJust, isNothing)
+import Data.Text (Text)
+import System.OsPath (OsPath, unsafeEncodeUtf)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "collaboration startup" do
+    it "prefers explicit concurrency over project, harness, and default settings" do
+        resolveMaxConcurrentAgents (Just 2) (Just 3) (Just 4) `shouldBe` 2
+        resolveMaxConcurrentAgents Nothing (Just 3) (Just 4) `shouldBe` 3
+        resolveMaxConcurrentAgents Nothing Nothing (Just 4) `shouldBe` 4
+        resolveMaxConcurrentAgents Nothing Nothing Nothing
+            `shouldBe` defaultMaxConcurrent
+
+    it "only loads supplemental OpenAI credentials for enabled local Grok collaboration" do
+        shouldLoadOpenAiChild True Nothing XAIProvider `shouldBe` True
+        shouldLoadOpenAiChild False Nothing XAIProvider `shouldBe` False
+        shouldLoadOpenAiChild True (Just []) XAIProvider `shouldBe` False
+        shouldLoadOpenAiChild True (Just ["admitted"]) XAIProvider `shouldBe` False
+        shouldLoadOpenAiChild True Nothing OpenAIProvider `shouldBe` False
+
+    it "keeps local non-Grok models unrestricted without consulting gateway state" do
+        let policy = resolveCollaborationModels OpenAIProvider Nothing False
+                (expectationFailure "local policy read gateway catalog" >> pure Nothing)
+        policy.childAllowedModels `shouldBe` Nothing
+        isNothing policy.childModelAllowed `shouldBe` True
+        isNothing policy.childResolveModel `shouldBe` True
+        isNothing policy.childGatewayModelOption `shouldBe` True
+
+    it "preserves the Grok child list and only adds the supplemental model when available" do
+        let policy available =
+                resolveCollaborationModels XAIProvider Nothing available (pure Nothing)
+        (policy False).childAllowedModels `shouldBe` Just ["grok-4.6", "grok-4.5"]
+        (policy True).childAllowedModels
+            `shouldBe` Just ["grok-4.6", "grok-4.5", "gpt-5.6-luna"]
+
+    it "uses gateway child restrictions instead of extending the Grok list" do
+        let policy = resolveCollaborationModels XAIProvider (Just ["admitted"]) True
+                (pure (Just [model]))
+        policy.childAllowedModels `shouldBe` Just ["admitted"]
+        allowed <- requireCallback policy.childModelAllowed
+        allowed "gpt-5.6-luna" `shouldReturn` False
+        allowed "admitted" `shouldReturn` True
+
+    it "fails closed when the live gateway catalog is unavailable or has no matching model" do
+        catalog <- newIORef Nothing
+        let policy = gatewayPolicy catalog
+        allowed <- requireCallback policy.childModelAllowed
+        resolve <- requireCallback policy.childResolveModel
+        allowed "admitted" `shouldReturn` False
+        resolve "admitted" `shouldReturn` Nothing
+        writeIORef catalog (Just [])
+        allowed "admitted" `shouldReturn` False
+        resolve "admitted" `shouldReturn` Nothing
+
+    it "resolves the exact admitted connection, wire model, and dialect after trimming input" do
+        catalog <- newIORef (Just [model])
+        let policy = gatewayPolicy catalog
+        resolve <- requireCallback policy.childResolveModel
+        option <- requireCallback policy.childGatewayModelOption
+        resolve "  admitted\n" `shouldReturn` Just CollaborationModelTarget
+            { collaborationTargetProvider = OpenRouterProvider
+            , collaborationTargetConnection = "gateway-custom"
+            , collaborationTargetEffectiveModel = "upstream/exact-wire"
+            , collaborationTargetDialect = CodexDialect
+            }
+        option "admitted" `shouldReturn` Just model
+
+    it "rechecks catalog changes instead of retaining a stale admission or wire target" do
+        catalog <- newIORef (Just [model])
+        let policy = gatewayPolicy catalog
+        allowed <- requireCallback policy.childModelAllowed
+        resolve <- requireCallback policy.childResolveModel
+        allowed "admitted" `shouldReturn` True
+        let changed = model
+                { modelTarget = model.modelTarget
+                    { targetWireModelId = "upstream/replaced-wire" }
+                }
+        writeIORef catalog (Just [changed])
+        fmap (fmap (.collaborationTargetEffectiveModel)) (resolve "admitted")
+            `shouldReturn` Just "upstream/replaced-wire"
+        writeIORef catalog Nothing
+        allowed "admitted" `shouldReturn` False
+        resolve "admitted" `shouldReturn` Nothing
+
+    it "interrupts and joins active children before snapshots, then closes the registry" do
+        events <- newIORef []
+        childSlot <- newEmptyMVar
+        let snapshot registry = do
+                child <- readMVar childSlot
+                getStatus registry child `shouldReturn` Interrupted
+                record events "snapshot"
+        result <- timeout 2000000 $
+            Acquire.with (acquireCollaborationRegistry 1 cwd snapshot) \registry -> do
+                child <- startBlockedChild registry events
+                putMVar childSlot child
+                pure (registry, child)
+        (registry, child) <- requireResult result
+        readIORef events `shouldReturn` ["child stopped", "snapshot"]
+        getStatus registry child `shouldReturn` Closed
+        spawnSubagent registry Nothing 0 "late" Nothing
+            `shouldReturn` Left "Subagent registry is closed."
+
+    it "closes supervisors and rejects new work even when snapshot persistence fails" do
+        events <- newIORef []
+        registrySlot <- newEmptyMVar
+        result <- timeout 2000000 $ tryAny $
+            Acquire.with
+                (acquireCollaborationRegistry 1 cwd \_ -> do
+                    record events "snapshot"
+                    throwIO (userError "snapshot failed"))
+                \registry -> do
+                    child <- startBlockedChild registry events
+                    putMVar registrySlot (registry, child)
+        -- Resource wrappers may suppress finalizer errors; the contract here
+        -- is that failing persistence cannot leave child supervisors alive.
+        result `shouldSatisfy` isJust
+        (registry, child) <- readMVar registrySlot
+        readIORef events `shouldReturn` ["child stopped", "snapshot"]
+        getStatus registry child `shouldReturn` Closed
+        spawnSubagent registry Nothing 0 "late" Nothing
+            `shouldReturn` Left "Subagent registry is closed."
+
+    it "releases collaboration ownership when its session owner is cancelled" do
+        events <- newIORef []
+        registrySlot <- newEmptyMVar
+        blocked <- newEmptyMVar
+        let owner = Acquire.with
+                (acquireCollaborationRegistry 1 cwd (\_ -> record events "snapshot"))
+                \registry -> do
+                    child <- startBlockedChild registry events
+                    putMVar registrySlot (registry, child)
+                    readMVar blocked :: IO ()
+        result <- timeout 2000000 $ withAsync owner \worker -> do
+            (registry, child) <- readMVar registrySlot
+            cancel worker
+            getStatus registry child `shouldReturn` Closed
+            spawnSubagent registry Nothing 0 "late" Nothing
+                `shouldReturn` Left "Subagent registry is closed."
+        result `shouldBe` Just ()
+        readIORef events `shouldReturn` ["child stopped", "snapshot"]
+
+    it "applies the configured concurrency limit to the acquired registry" do
+        events <- newIORef []
+        result <- timeout 2000000 $
+            Acquire.with (acquireCollaborationRegistry 1 cwd (const (pure ()))) \registry -> do
+                _ <- startBlockedChild registry events
+                second <- spawnSubagent registry Nothing 0 "second" Nothing
+                second `shouldSatisfy` isLeft
+        result `shouldBe` Just ()
+        readIORef events `shouldReturn` ["child stopped"]
+
+model :: ModelOption
+model = ModelOption
+    { modelTarget = ModelTarget
+        { targetProvider = OpenRouterProvider
+        , targetConnectionId = "gateway-custom"
+        , targetModelId = "admitted"
+        , targetWireModelId = "upstream/exact-wire"
+        , targetDialect = CodexDialect
+        }
+    , modelContextWindow = Nothing
+    , modelLabel = Nothing
+    , modelFallbackPriority = Nothing
+    }
+
+gatewayPolicy :: IORef (Maybe [ModelOption]) -> CollaborationModels
+gatewayPolicy catalog =
+    resolveCollaborationModels XAIProvider (Just ["admitted"]) False (readIORef catalog)
+
+cwd :: OsPath
+cwd = unsafeEncodeUtf "/workspace"
+
+requireCallback :: Maybe a -> IO a
+requireCallback = maybe (fail "expected gateway callback") pure
+
+requireResult :: Maybe a -> IO a
+requireResult = maybe (fail "collaboration lifecycle timed out") pure
+
+record :: IORef [Text] -> Text -> IO ()
+record ref event = atomicModifyIORef' ref (\events -> (events <> [event], ()))
+
+startBlockedChild :: SubagentRegistry -> IORef [Text] -> IO SubagentId
+startBlockedChild registry events = do
+    started <- newEmptyMVar
+    blocked <- newEmptyMVar :: IO (MVar ())
+    setSubagentRunner registry \_ _ _ _ ->
+        (putMVar started () >> readMVar blocked >> fail "unreachable child result")
+            `finally` record events "child stopped"
+    child <- spawnSubagent registry Nothing 0 "work" Nothing >>= either
+        (fail . show) pure
+    readMVar started
+    pure child

--- a/packages/agent-runtime/test/Spec.hs
+++ b/packages/agent-runtime/test/Spec.hs
@@ -5,6 +5,7 @@ import qualified Agent.Runtime.Tools.ResourcesSpec as ToolResources
 import qualified Agent.Runtime.Tools.DialectsSpec as ToolDialects
 import qualified Agent.Runtime.Tools.StartupSpec as ToolStartup
 import qualified Agent.Runtime.Mcp.StartupSpec as McpStartup
+import qualified Agent.Runtime.CollaborationSpec as Collaboration
 import qualified Agent.Runtime.ProviderRuntimeSpec as ProviderRuntime
 import qualified Agent.Runtime.CompactionSpec as Compaction
 import qualified Agent.Runtime.StartupPolicySpec as StartupPolicy
@@ -46,6 +47,7 @@ main = hspec do
     ToolResources.spec
     ToolStartup.spec
     McpStartup.spec
+    Collaboration.spec
     Request.spec
     ProviderRuntime.spec
     Compaction.spec

--- a/scripts/check-package-boundaries.sh
+++ b/scripts/check-package-boundaries.sh
@@ -27,6 +27,10 @@ if [[ -e "$cli/src/Agent/CLI/Dialects.hs" \
 fi
 
 python3 "$root/scripts/check-package-graph.py" "$root"
+if rg --line-number '\b(newSubagentRegistry|closeSubagentRegistry|interruptActiveSubagents|grokRootChildModels|resolveModelOptionById)\b' \
+    "$cli/src/Agent/CLI/Runtime/Orchestration/Tools/Collaboration.hs"; then
+  fail "collaboration startup policy and registry ownership must remain in agent-runtime"
+fi
 if rg --line-number 'MCP\.(acquireMcpFleet|releaseMcpFleetLease)' \
     "$cli/src/Agent/CLI/Runtime/Orchestration/Tools/Mcp.hs"; then
   fail "MCP startup lease ownership must remain in agent-runtime"
@@ -167,6 +171,8 @@ done
 
 required_files=(
   packages/agent-runtime/src/Agent/Runtime/Mcp/Startup.hs
+  packages/agent-runtime/src/Agent/Runtime/Collaboration.hs
+  packages/agent-runtime/test/Agent/Runtime/CollaborationSpec.hs
   packages/agent-runtime/test/Agent/Runtime/Mcp/StartupSpec.hs
   packages/agent-runtime/src/Agent/Runtime/Session/Preparation.hs
   packages/agent-runtime/src/Agent/Runtime/Session/Resources.hs


### PR DESCRIPTION
Move child-model policy, live gateway target resolution, concurrency-limit precedence, and scoped subagent registry ownership into Agent.Runtime.Collaboration. Keep credential loading, snapshots, worktree callbacks, and notifications in the CLI adapter.

Preserve interrupt-before-snapshot teardown and unconditional registry closure, including failed snapshots and cancellation. Add regression tests, documentation, and package-boundary checks. No new packages or dependencies.

Validation:
- All 768 library modules load in GHCi.
- 12 collaboration startup tests pass.
- Nix package-boundary check passes.