### PR TITLE
Simplify LSP document synchronization with ExceptT

### DIFF
--- a/packages/agent-cli/src/Agent/CLI/Lsp.hs
+++ b/packages/agent-cli/src/Agent/CLI/Lsp.hs
@@ -77,6 +77,7 @@ import Control.Monad
     , void
     , when
     )
+import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except
     ( ExceptT(..)
     , runExceptT
@@ -608,75 +609,59 @@ synchronizeDocument
     -> FilePath
     -> Text
     -> IO (Either Text ())
-synchronizeDocument client path uri = do
-    contentResult <- tryAny (BS.readFile path)
-    case contentResult of
-        Left exception ->
-            pure . Left $
-                "lsp could not read file contents: "
-                    <> exceptionText exception
-        Right bytes
-            | BS.length bytes > maxLspDocumentBytes ->
-                pure . Left $
-                    "lsp document exceeds "
-                        <> Text.pack (show maxLspDocumentBytes)
-                        <> " bytes"
-            | otherwise -> do
-                versions <-
-                    readIORef client.clientDocumentVersions
-                let previous = Map.lookup path versions
-                    version = maybe 1 (+ 1) previous
-                    content =
-                        Text.decodeUtf8With lenientDecode bytes
-                    extension =
-                        Text.pack (FilePath.takeExtension path)
-                    languageId =
-                        Map.findWithDefault
-                            ""
-                            extension
-                            client.clientConfig.lspExtensionToLanguage
-                    notification =
-                        case previous of
-                            Nothing ->
-                                ( "textDocument/didOpen"
-                                , Aeson.object
-                                    [ "textDocument" .= Aeson.object
-                                        [ "uri" .= uri
-                                        , "languageId" .= languageId
-                                        , "version" .= version
-                                        , "text" .= content
-                                        ]
-                                    ]
-                                )
-                            Just _ ->
-                                ( "textDocument/didChange"
-                                , Aeson.object
-                                    [ "textDocument" .= Aeson.object
-                                        [ "uri" .= uri
-                                        , "version" .= version
-                                        ]
-                                    , "contentChanges" .=
-                                        [ Aeson.object
-                                            ["text" .= content]
-                                        ]
-                                    ]
-                                )
-                sent <-
-                    uncurry
-                        (sendNotificationWithin
-                            client
-                            requestTimeoutMilliseconds)
-                        notification
-                case sent of
-                    Left err ->
-                        pure . Left $
-                            "failed to synchronize file with LSP server: "
-                                <> err
-                    Right () -> do
-                        writeIORef
-                            client.clientDocumentVersions
-                            (Map.insert path version versions)
-                        pure (Right ())
+synchronizeDocument client path uri = runExceptT do
+    bytes <- withExceptT
+        (\exception -> "lsp could not read file contents: " <> exceptionText exception)
+        (ExceptT (tryAny (BS.readFile path)))
+    when (BS.length bytes > maxLspDocumentBytes) $
+        throwE $
+            "lsp document exceeds "
+                <> Text.pack (show maxLspDocumentBytes)
+                <> " bytes"
+    versions <- liftIO (readIORef client.clientDocumentVersions)
+    let previous = Map.lookup path versions
+        version = maybe 1 (+ 1) previous
+        content = Text.decodeUtf8With lenientDecode bytes
+        extension = Text.pack (FilePath.takeExtension path)
+        languageId =
+            Map.findWithDefault
+                ""
+                extension
+                client.clientConfig.lspExtensionToLanguage
+        notification =
+            case previous of
+                Nothing ->
+                    ( "textDocument/didOpen"
+                    , Aeson.object
+                        [ "textDocument" .= Aeson.object
+                            [ "uri" .= uri
+                            , "languageId" .= languageId
+                            , "version" .= version
+                            , "text" .= content
+                            ]
+                        ]
+                    )
+                Just _ ->
+                    ( "textDocument/didChange"
+                    , Aeson.object
+                        [ "textDocument" .= Aeson.object
+                            [ "uri" .= uri
+                            , "version" .= version
+                            ]
+                        , "contentChanges" .=
+                            [ Aeson.object ["text" .= content]
+                            ]
+                        ]
+                    )
+    withExceptT ("failed to synchronize file with LSP server: " <>) $
+        ExceptT $
+            uncurry
+                (sendNotificationWithin client requestTimeoutMilliseconds)
+                notification
+    liftIO $
+        writeIORef
+            client.clientDocumentVersions
+            (Map.insert path version versions)
 
 requestTimeoutMilliseconds :: Int
 requestTimeoutMilliseconds = 30000

--- a/packages/agent-cli/test/Agent/CLI/WebLspSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WebLspSpec.hs
@@ -224,6 +224,12 @@ spec = describe "web_fetch and LSP runtime support" do
                     unsupported.output `shouldSatisfy`
                         Text.isInfixOf
                             "No initialized LSP server is configured for .txt"
+                    original <- BS.readFile source
+                    BS.writeFile source (BS.replicate (5 * 1024 * 1024 + 1) 120)
+                    oversized <- callLsp tool (fileRequest "hover")
+                    oversized.output `shouldSatisfy`
+                        Text.isInfixOf "lsp document exceeds 5242880 bytes"
+                    BS.writeFile source original
                     definition <- callLsp tool
                         (fileRequest "goToDefinition")
                     definition.output `shouldSatisfy`
@@ -255,6 +261,23 @@ spec = describe "web_fetch and LSP runtime support" do
                         Text.isInfixOf "- Global"
                     closeLspRuntime runtime
                     requests <- Text.pack <$> readFile trace
+                    let documentNotifications =
+                            filter
+                                (\line ->
+                                    Text.isInfixOf "\"method\":\"textDocument/didOpen\"" line
+                                        || Text.isInfixOf "\"method\":\"textDocument/didChange\"" line)
+                                (Text.lines requests)
+                    length documentNotifications `shouldBe` 5
+                    case documentNotifications of
+                        first : rest -> do
+                            first `shouldSatisfy` Text.isInfixOf "\"method\":\"textDocument/didOpen\""
+                            first `shouldSatisfy` Text.isInfixOf "\"version\":1"
+                            mapM_
+                                (\(version, notification) ->
+                                    notification `shouldSatisfy`
+                                        Text.isInfixOf ("\"version\":" <> Text.pack (show version)))
+                                (zip [2 :: Int ..] rest)
+                        [] -> expectationFailure "expected document synchronization notifications"
                     mapM_
                         (\method ->
                             requests `shouldSatisfy`


### PR DESCRIPTION
## Summary
- Flatten document read, size validation, notification sending, and version update with ExceptT.
- Preserve error messages and update document versions only after successful synchronization.
- Extend mock LSP coverage to reject oversized documents, retry successfully, and verify notification counts and versions.

## Validation
- Actual Cabal test component via GHCi: cabal repl agent-cli:test:agent-cli-test, then :main --match "web_fetch and LSP runtime support".
- 105 modules loaded; 10 examples, 0 failures.
- git diff --check passed.