### PR TITLE
Extract shared startup context preparation into runtime

### DIFF
--- a/docs/session-engine.md
+++ b/docs/session-engine.md
@@ -197,6 +197,16 @@ The CLI retains credential loading, transcript persistence callbacks, worktree
 creation, and notification presentation. This session-integration layer remains
 in `agent-runtime`, without a new Cabal package or frontend dependencies.
 
+## Implemented: shared startup context preparation
+
+`Agent.Runtime.Startup.Context` owns transcript-derived initial-context and
+snapshot eligibility, instruction discovery, and startup skill-catalog assembly.
+Context preloading preserves host workspace restrictions and dialect refresh
+semantics, and overlaps independent reads with structured concurrency. The host
+supplies learned-skill storage access and remote catalog loading; terminal notices
+and context installation remain in CLI. Existing CLI entry points delegate or
+reexport for compatibility. This extraction adds no Cabal package.
+
 ## Remaining: move session composition and ownership out of the CLI
 
 ### Conversation-state ownership

--- a/packages/agent-cli/src/Agent/CLI/Resume.hs
+++ b/packages/agent-cli/src/Agent/CLI/Resume.hs
@@ -53,10 +53,11 @@ import Agent.Runtime.Session
     , loadSessionMeta
     , loadSessionResumeStats
     )
-import Agent.Runtime.Session.History (foldSessionItems)
+import Agent.Runtime.Startup.Context
+    ( SessionInitialContext(..), resolveSessionInitialContext
+    , resumeNeedsGeneratedContext )
 import Agent.Runtime.Session.Types (TranscriptEffect(..))
 import Agent.CLI.Style (roleMuted, rolePrompt, roleSuccess)
-import Agent.OpenAI.Compaction (hasReloadedGeneratedContextItems)
 import Agent.CLI.TextLayout
     ( SplitPaneFrame(..)
     , clampSelectionIndex
@@ -72,7 +73,7 @@ import Control.Monad.Trans.Except (ExceptT(..), runExceptT)
 import Data.Char (isAlphaNum)
 import Data.Containers.ListUtils (nubOrd)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -87,46 +88,6 @@ data ResumeSourceFilter
     = ResumeAll
     | ResumeProvider !Text
     deriving (Eq, Show)
-
--- | Transcript-derived context requirements that can be resolved before
--- provider prompt construction. Keeping this decision pure allows startup
--- context reads to overlap independent tool acquisition without changing
--- resume semantics.
-data SessionInitialContext = SessionInitialContext
-    { initialContextItems :: [ResponseItem]
-    , initialContextResumeNeedsFresh :: Bool
-    , initialContextPrevious :: Maybe Text
-    , initialContextNeeded :: Bool
-    , initialContextMayRestoreSnapshot :: Bool
-    }
-    deriving (Eq, Show)
-
-resolveSessionInitialContext
-    :: Bool
-    -> Bool
-    -> Maybe (SessionMeta, [SessionTurn])
-    -> SessionInitialContext
-resolveSessionInitialContext hasTransition resumeTargetChanged resumed =
-    SessionInitialContext{..}
-  where
-    initialTurns = maybe [] snd resumed
-    initialContextItems = maybe [] (foldSessionItems . snd) resumed
-    initialContextResumeNeedsFresh =
-        resumeNeedsGeneratedContext initialTurns
-    initialContextPrevious
-        | hasTransition || resumeTargetChanged = Nothing
-        | otherwise =
-            resumed >>= \(meta, _) -> meta.metaLastResponseId
-    initialContextNeeded =
-        initialContextResumeNeedsFresh
-            || (null initialTurns && initialContextPrevious == Nothing)
-    initialContextMayRestoreSnapshot =
-        case resumed of
-            Just (meta, turns) ->
-                null turns
-                    && initialContextPrevious == Nothing
-                    && isJust meta.metaPromptSnapshot
-            Nothing -> False
 
 data ResumeEntry = ResumeEntry
     { resumeId :: !Text
@@ -170,24 +131,6 @@ data ResumeState = ResumeState
     , resumeIndex :: !Int
     }
     deriving (Eq, Show)
-
--- | Reinstall generated project and skill context after the newest durable
--- transcript-replacement boundary until a later persisted turn proves that
--- the regenerated context was consumed. This also repairs sessions compacted
--- by older clients that did not reload generated context.
-resumeNeedsGeneratedContext :: [SessionTurn] -> Bool
-resumeNeedsGeneratedContext turns =
-    case break isContextBoundary (reverse turns) of
-        (_, []) -> False
-        (newerTurns, _boundary : _) ->
-            null newerTurns
-                || not
-                    (any
-                        (hasReloadedGeneratedContextItems . (.turnItems))
-                        newerTurns)
-  where
-    isContextBoundary turn =
-        turn.turnEffect /= TranscriptAppend
 
 -- | Build picker entries from already loaded sessions.
 resumeEntriesFrom :: [(SessionMeta, [SessionTurn])] -> [ResumeEntry]

--- a/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
+++ b/packages/agent-cli/src/Agent/CLI/Runtime/Orchestration/Tools.hs
@@ -53,7 +53,7 @@ import Agent.Runtime.ModelConfig (builtinConnectionId)
 import Agent.Runtime.Models (ModelTarget(targetConnectionId, targetWireModelId))
 import Agent.CLI.Options
     ( isOneShot, resolveComputerUseEnabled
-    , CliOptions(optGhci, optBash, optSkills)
+    , CliOptions(optGhci, optBash, optSkills, optAgentsMd)
     )
 import Agent.CLI.Plan (resumedPlanNeedsApproval)
 import Agent.CLI.Runtime.Orchestration.Background
@@ -67,12 +67,10 @@ import Agent.CLI.Runtime.Orchestration.Types
     , nativeLoadsHostWorkspaceContext
     , nativePreparedDiscovery
     )
-import Agent.CLI.Resume
-    ( SessionInitialContext
-        ( initialContextMayRestoreSnapshot
-        , initialContextNeeded
-        )
-    , resolveSessionInitialContext
+import Agent.Runtime.Startup.Context
+    ( SessionInitialContext, ContextPreloadPolicy(..)
+    , resolveSessionInitialContext, preloadInitialContext, preloadAgentsContext
+    , assembleInitialSkills
     )
 import Agent.CLI.Session.Workspace (WorkspaceContext(..))
 import Agent.CLI.Runtime.Orchestration.Session ( AgentSessionRequest(..)
@@ -99,8 +97,7 @@ import Agent.Runtime.SessionLock
       sessionLockFilePath,
       sessionLockPath )
 import Agent.CLI.Startup.Auth (startupDie)
-import Agent.CLI.StartupContext ( preloadAgentsContext )
-import Agent.CLI.Skills (loadMcpSkillsCatalog, mergeSkillCatalogs)
+import Agent.CLI.Skills (loadMcpSkillsCatalog)
 import Agent.CLI.WebFetch
     ( WebFetchRuntime
     , closeWebFetchRuntime
@@ -141,7 +138,6 @@ import Agent.Tools.Types
     , ToolEnv(..)
     , appToolsFromGroups
     )
-import Control.Concurrent.Async ( concurrently )
 import Control.Exception.Safe
     ( SomeException, mask_, throwIO, try )
 import Control.Monad ( forM_, when, void )
@@ -257,14 +253,11 @@ runAgentTools request = withSessionResourceScopes \resources -> do
         (reportStartupWarning request.startup)
         lspStartup.lspStartupWarnings
     installCollaborationCallbacks request collaborationRuntime
-    remoteInitialSkills <-
-        if request.options.optSkills
-            then loadMcpSkillsCatalog mcpRuntime.runtimeMcpFleet
-            else pure (SkillCatalog [] [])
-    let initialSkills =
-            mergeSkillCatalogs
-                localToolRuntime.localInitialSkills
-                remoteInitialSkills
+    initialSkills <-
+        assembleInitialSkills
+            request.options.optSkills
+            localToolRuntime.localInitialSkills
+            (loadMcpSkillsCatalog mcpRuntime.runtimeMcpFleet)
     sessionControlRuntime <-
         newSessionControlRuntime
             request
@@ -437,7 +430,17 @@ prepareInitialContextPreload AgentToolsRequest
     , toolRefreshDialectContext = refreshDialectContext
     } = do
     (preloadedAgentsContext, preloadedLearnedSkills) <-
-        concurrently preloadAgents preloadLearnedSkills
+        preloadInitialContext
+            ContextPreloadPolicy
+                { contextLoadsHostWorkspace = loadsHostWorkspaceContext
+                , contextRefreshDialect = refreshDialectContext
+                }
+            contextRequirements
+            (preloadAgentsContext options.optAgentsMd dialect home cwd)
+            (successfulLearnedSkillsPreload
+                <$> loadApplicableLearnedSkillsForStore
+                    startup.startupDatabaseStore
+                    databaseScopes)
     pure (contextRequirements, InitialContextPreload{..})
   where
     contextRequirements =
@@ -452,23 +455,6 @@ prepareInitialContextPreload AgentToolsRequest
                 . (.nativeWorkspaceDiscovery)
             )
             startup.startupNativeHooks
-    preloadAgents
-        | loadsHostWorkspaceContext
-            && ( contextRequirements.initialContextNeeded
-                || refreshDialectContext
-               ) =
-            if refreshDialectContext
-                || not contextRequirements.initialContextMayRestoreSnapshot
-                then preloadAgentsContext options dialect home cwd
-                else pure Nothing
-        | otherwise = pure Nothing
-    preloadLearnedSkills
-        | contextRequirements.initialContextNeeded =
-            successfulLearnedSkillsPreload
-                <$> loadApplicableLearnedSkillsForStore
-                    startup.startupDatabaseStore
-                    databaseScopes
-        | otherwise = pure Nothing
 
 newSessionControlRuntime
     :: AgentToolsRequest windowTitleResult

--- a/packages/agent-cli/src/Agent/CLI/Skills.hs
+++ b/packages/agent-cli/src/Agent/CLI/Skills.hs
@@ -45,6 +45,7 @@ import Agent.MCP.Types
     )
 import Agent.OsPath (toText, unsafeToFilePath)
 import Agent.Skills
+import Agent.Runtime.Startup.Context (mergeSkillCatalogs)
 import Agent.Tools.Types (ToolEnv, setToolSkillRoots)
 import Crypto.Hash (Digest, SHA256, hash)
 import Data.Aeson qualified as Aeson
@@ -156,12 +157,6 @@ loadMcpSkillsCatalog fleet = do
             registration.mcpSkillEntry.mcpSkillUri
             (entryResourceUris registration.mcpSkillEntry)
             value
-
-mergeSkillCatalogs :: SkillCatalog -> SkillCatalog -> SkillCatalog
-mergeSkillCatalogs local remote =
-    SkillCatalog
-        (local.catalogSkills <> remote.catalogSkills)
-        (local.catalogWarnings <> remote.catalogWarnings)
 
 -- | Resolve local content immediately or fetch and verify an MCP skill on
 -- demand. Remote instructions are never trusted merely because they appeared

--- a/packages/agent-cli/src/Agent/CLI/StartupContext.hs
+++ b/packages/agent-cli/src/Agent/CLI/StartupContext.hs
@@ -8,8 +8,9 @@ module Agent.CLI.StartupContext
 
 import Agent.Runtime.Tools.Dialects
     ( formatAgentsMdForDialect
-    , globalAgentsHomeDir
     )
+import Agent.Runtime.Startup.Context (agentsDiscoverOptions)
+import qualified Agent.Runtime.Startup.Context as Context
 import Agent.CLI.Options (CliOptions(..))
 import Agent.CLI.Render (putTextLn)
 import Agent.CLI.Style
@@ -26,10 +27,8 @@ import Agent.CLI.TUI.App
 import Agent.Dialect (Dialect)
 import Agent.OsPath (toText)
 import Agent.ProjectInstructions
-    ( DiscoverOptions(..)
-    , InstructionWarning(..)
+    ( InstructionWarning(..)
     , LoadedAgentsMd
-    , defaultDiscoverOptions
     , discoverProjectInstructions
     , loadedInstructionFiles
     , loadedInstructionWarnings
@@ -96,12 +95,7 @@ preloadAgentsContext
     -> OsPath
     -> OsPath
     -> IO (Maybe LoadedAgentsMd)
-preloadAgentsContext options dialect home cwd
-    | not options.optAgentsMd = pure Nothing
-    | otherwise =
-        Just <$> discoverProjectInstructions
-            (agentsDiscoverOptions dialect home)
-            cwd
+preloadAgentsContext options = Context.preloadAgentsContext options.optAgentsMd
 
 -- | Finalize generated context from an optional startup preload. A preload
 -- that becomes unnecessary because persisted history is reusable is discarded
@@ -153,14 +147,6 @@ loadAgentsContextWithPreload
                                 emitUiEvent runtime (UiSystemMessage message)
                 newIORef
                     (Just (text <> maybe "" ("\n\n" <>) extraContext))
-
-agentsDiscoverOptions :: Dialect -> OsPath -> DiscoverOptions
-agentsDiscoverOptions dialect home =
-    DiscoverOptions
-        { discoverMaxBytes = defaultDiscoverOptions.discoverMaxBytes
-        , discoverGlobalDir = Just (globalAgentsHomeDir dialect home)
-        , discoverRootMarkers = defaultDiscoverOptions.discoverRootMarkers
-        }
 
 reportInstructionWarning
     :: Handle

--- a/packages/agent-runtime/agent-runtime.cabal
+++ b/packages/agent-runtime/agent-runtime.cabal
@@ -115,6 +115,7 @@ library
                     , Agent.Runtime.SessionOwner
                     , Agent.Runtime.SessionState
                     , Agent.Runtime.StartupPolicy
+                    , Agent.Runtime.Startup.Context
                     , Agent.Runtime.Startup.Model
                     , Agent.Runtime.Startup.Policy
                     , Agent.Runtime.Startup.Gateway
@@ -266,6 +267,7 @@ test-suite agent-runtime-test
                     , Agent.Runtime.SessionSpec.Persistence
                     , Agent.Runtime.SessionSpec.ResponseItems
                     , Agent.Runtime.StartupPolicySpec
+                    , Agent.Runtime.Startup.ContextSpec
                     , Agent.Runtime.Startup.ModelSpec
                     , Agent.Runtime.Startup.PolicySpec
                     , Agent.Runtime.Startup.GatewaySpec

--- a/packages/agent-runtime/src/Agent/Runtime/Startup/Context.hs
+++ b/packages/agent-runtime/src/Agent/Runtime/Startup/Context.hs
@@ -1,0 +1,134 @@
+-- | Frontend-neutral startup context policy and quiet discovery. Presentation
+-- and installation happen later, after persisted context has been considered.
+module Agent.Runtime.Startup.Context
+    ( SessionInitialContext(..)
+    , resolveSessionInitialContext
+    , resumeNeedsGeneratedContext
+    , ContextPreloadPolicy(..)
+    , preloadInitialContext
+    , preloadAgentsContext
+    , agentsDiscoverOptions
+    , assembleInitialSkills
+    , mergeSkillCatalogs
+    ) where
+
+import Agent.Dialect (Dialect)
+import Agent.OpenAI.Compaction (hasReloadedGeneratedContextItems)
+import Agent.ProjectInstructions
+    ( DiscoverOptions(..), LoadedAgentsMd, defaultDiscoverOptions
+    , discoverProjectInstructions )
+import Agent.Responses.Types (ResponseItem)
+import Agent.Runtime.Session (SessionMeta(..), SessionTurn(..))
+import Agent.Runtime.Session.History (foldSessionItems)
+import Agent.Runtime.Session.Types (TranscriptEffect(..))
+import Agent.Runtime.Tools.Dialects (globalAgentsHomeDir)
+import Agent.Skills (SkillCatalog(..))
+import Control.Concurrent.Async (concurrently)
+import Data.Maybe (isJust)
+import Data.Text (Text)
+import System.OsPath (OsPath)
+
+data SessionInitialContext = SessionInitialContext
+    { initialContextItems :: [ResponseItem]
+    , initialContextResumeNeedsFresh :: Bool
+    , initialContextPrevious :: Maybe Text
+    , initialContextNeeded :: Bool
+    , initialContextMayRestoreSnapshot :: Bool
+    }
+    deriving (Eq, Show)
+
+resolveSessionInitialContext
+    :: Bool
+    -- ^ A session transition is pending.
+    -> Bool
+    -- ^ The resumed provider/connection/wire target changed.
+    -> Maybe (SessionMeta, [SessionTurn])
+    -> SessionInitialContext
+resolveSessionInitialContext hasTransition resumeTargetChanged resumed =
+    SessionInitialContext{..}
+  where
+    initialTurns = maybe [] snd resumed
+    initialContextItems = maybe [] (foldSessionItems . snd) resumed
+    initialContextResumeNeedsFresh = resumeNeedsGeneratedContext initialTurns
+    initialContextPrevious
+        | hasTransition || resumeTargetChanged = Nothing
+        | otherwise = resumed >>= \(meta, _) -> meta.metaLastResponseId
+    initialContextNeeded =
+        initialContextResumeNeedsFresh
+            || (null initialTurns && initialContextPrevious == Nothing)
+    initialContextMayRestoreSnapshot =
+        case resumed of
+            Just (meta, turns) ->
+                null turns
+                    && initialContextPrevious == Nothing
+                    && isJust meta.metaPromptSnapshot
+            Nothing -> False
+
+-- | Reload after the newest durable transcript replacement until a later
+-- persisted turn proves generated context was consumed.
+resumeNeedsGeneratedContext :: [SessionTurn] -> Bool
+resumeNeedsGeneratedContext turns =
+    case break isContextBoundary (reverse turns) of
+        (_, []) -> False
+        (newerTurns, _boundary : _) ->
+            null newerTurns
+                || not
+                    (any
+                        (hasReloadedGeneratedContextItems . (.turnItems))
+                        newerTurns)
+  where
+    isContextBoundary turn = turn.turnEffect /= TranscriptAppend
+
+data ContextPreloadPolicy = ContextPreloadPolicy
+    { contextLoadsHostWorkspace :: Bool
+    , contextRefreshDialect :: Bool
+    }
+    deriving (Eq, Show)
+
+-- | Overlap quiet reads, skipping filesystem discovery when a snapshot may
+-- satisfy startup. Learned skills remain independent of workspace permission.
+-- Structured concurrency joins either reader on failure or cancellation.
+preloadInitialContext
+    :: ContextPreloadPolicy
+    -> SessionInitialContext
+    -> IO (Maybe agents)
+    -> IO (Maybe skills)
+    -> IO (Maybe agents, Maybe skills)
+preloadInitialContext policy requirements loadAgents loadLearnedSkills =
+    concurrently preloadAgents preloadLearnedSkills
+  where
+    preloadAgents
+        | policy.contextLoadsHostWorkspace
+            && (requirements.initialContextNeeded || policy.contextRefreshDialect)
+            && (policy.contextRefreshDialect
+                || not requirements.initialContextMayRestoreSnapshot) =
+            loadAgents
+        | otherwise = pure Nothing
+    preloadLearnedSkills
+        | requirements.initialContextNeeded = loadLearnedSkills
+        | otherwise = pure Nothing
+
+preloadAgentsContext
+    :: Bool -> Dialect -> OsPath -> OsPath -> IO (Maybe LoadedAgentsMd)
+preloadAgentsContext enabled dialect home cwd
+    | not enabled = pure Nothing
+    | otherwise =
+        Just <$> discoverProjectInstructions (agentsDiscoverOptions dialect home) cwd
+
+agentsDiscoverOptions :: Dialect -> OsPath -> DiscoverOptions
+agentsDiscoverOptions dialect home =
+    DiscoverOptions
+        { discoverMaxBytes = defaultDiscoverOptions.discoverMaxBytes
+        , discoverGlobalDir = Just (globalAgentsHomeDir dialect home)
+        , discoverRootMarkers = defaultDiscoverOptions.discoverRootMarkers
+        }
+
+assembleInitialSkills :: Bool -> SkillCatalog -> IO SkillCatalog -> IO SkillCatalog
+assembleInitialSkills enabled local loadRemote =
+    mergeSkillCatalogs local <$> if enabled then loadRemote else pure (SkillCatalog [] [])
+
+mergeSkillCatalogs :: SkillCatalog -> SkillCatalog -> SkillCatalog
+mergeSkillCatalogs local remote =
+    SkillCatalog
+        (local.catalogSkills <> remote.catalogSkills)
+        (local.catalogWarnings <> remote.catalogWarnings)

--- a/packages/agent-runtime/test/Agent/Runtime/Startup/ContextSpec.hs
+++ b/packages/agent-runtime/test/Agent/Runtime/Startup/ContextSpec.hs
@@ -1,0 +1,184 @@
+module Agent.Runtime.Startup.ContextSpec (spec) where
+
+import Agent.Runtime.Session
+import Agent.Runtime.SessionSpec.Fixtures
+    ( fixedTime, testMeta, testPromptSnapshot )
+import Agent.Runtime.Startup.Context
+import Agent.Loop (TurnInput(..))
+import Agent.Responses.LoopBackend (turnInputsToItems)
+import Agent.Skills (SkillCatalog(..), SkillWarning(..))
+import Control.Concurrent.Async (cancel, withAsync)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, readMVar, takeMVar)
+import Control.Exception.Safe (finally, throwIO, tryAny)
+import Data.Either (isLeft)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.Text (Text)
+import System.OsPath (unsafeEncodeUtf)
+import System.Timeout (timeout)
+import Test.Hspec
+
+spec :: Spec
+spec = describe "startup context preparation" do
+    it "requests generated context for a fresh session" do
+        let context = resolveSessionInitialContext False False Nothing
+        context.initialContextItems `shouldBe` []
+        context.initialContextPrevious `shouldBe` Nothing
+        context.initialContextNeeded `shouldBe` True
+        context.initialContextMayRestoreSnapshot `shouldBe` False
+
+    it "retains existing transcript and response continuation on a compatible resume" do
+        let context = resolveSessionInitialContext False False
+                (Just (continuedMeta, [sampleTurn]))
+        context.initialContextItems `shouldBe` turnInputsToItems [UserMessage "hello"]
+        context.initialContextPrevious `shouldBe` Just "response-1"
+        context.initialContextNeeded `shouldBe` False
+        context.initialContextMayRestoreSnapshot `shouldBe` False
+
+    it "drops continuation but keeps transcript context on a target change" do
+        let context = resolveSessionInitialContext False True
+                (Just (continuedMeta, [sampleTurn]))
+        context.initialContextItems `shouldBe` turnInputsToItems [UserMessage "hello"]
+        context.initialContextPrevious `shouldBe` Nothing
+        context.initialContextNeeded `shouldBe` False
+
+    it "drops continuation on a pending transition and regenerates an empty session" do
+        let context = resolveSessionInitialContext True False
+                (Just (continuedMeta, []))
+        context.initialContextPrevious `shouldBe` Nothing
+        context.initialContextNeeded `shouldBe` True
+
+    it "regenerates context after a transcript reset rather than restoring an old snapshot" do
+        let context = resolveSessionInitialContext False False
+                (Just (snapshotMeta, [sampleTurn { turnEffect = TranscriptReset }]))
+        context.initialContextResumeNeedsFresh `shouldBe` True
+        context.initialContextNeeded `shouldBe` True
+        context.initialContextMayRestoreSnapshot `shouldBe` False
+
+    it "permits snapshot restore only for an empty transcript without continuation" do
+        let context = resolveSessionInitialContext False False (Just (snapshotMeta, []))
+            continued = resolveSessionInitialContext False False
+                (Just (snapshotMeta { metaLastResponseId = Just "response-1" }, []))
+        context.initialContextNeeded `shouldBe` True
+        context.initialContextMayRestoreSnapshot `shouldBe` True
+        continued.initialContextNeeded `shouldBe` False
+        continued.initialContextMayRestoreSnapshot `shouldBe` False
+
+    it "overlaps instruction and learned-skill reads while preserving their results" do
+        agentsStarted <- newEmptyMVar
+        skillsStarted <- newEmptyMVar
+        result <- timeout 2000000 $
+            preloadInitialContext (ContextPreloadPolicy True False) freshContext
+                (putMVar agentsStarted () >> takeMVar skillsStarted >> pure (Just "agents"))
+                (putMVar skillsStarted () >> takeMVar agentsStarted >> pure (Just "skills"))
+        result `shouldBe` Just (Just ("agents" :: Text), Just ("skills" :: Text))
+
+    it "never discovers host instructions for restricted native hosts, even on dialect refresh" do
+        preloadInitialContext (ContextPreloadPolicy False True) freshContext
+            forbiddenRead (pure (Just "skills"))
+            `shouldReturn` (Nothing :: Maybe Text, Just ("skills" :: Text))
+
+    it "skips both quiet reads when compatible resumed context is reusable" do
+        let context = resolveSessionInitialContext False False
+                (Just (continuedMeta, [sampleTurn]))
+        preloadInitialContext (ContextPreloadPolicy True False) context
+            forbiddenRead forbiddenRead
+            `shouldReturn` (Nothing :: Maybe Text, Nothing :: Maybe Text)
+
+    it "defers instruction discovery for possible snapshot restore but still loads learned skills" do
+        let context = resolveSessionInitialContext False False (Just (snapshotMeta, []))
+        preloadInitialContext (ContextPreloadPolicy True False) context
+            forbiddenRead (pure (Just "skills"))
+            `shouldReturn` (Nothing :: Maybe Text, Just ("skills" :: Text))
+
+    it "refreshes dialect instructions even when the old snapshot could otherwise be restored" do
+        let context = resolveSessionInitialContext False False (Just (snapshotMeta, []))
+        preloadInitialContext (ContextPreloadPolicy True True) context
+            (pure (Just "new dialect")) (pure (Just "skills"))
+            `shouldReturn` (Just ("new dialect" :: Text), Just ("skills" :: Text))
+
+    it "refreshes dialect instructions without reloading learned skills for a retained transcript" do
+        let context = resolveSessionInitialContext False False
+                (Just (continuedMeta, [sampleTurn]))
+        preloadInitialContext (ContextPreloadPolicy True True) context
+            (pure (Just "new dialect")) forbiddenRead
+            `shouldReturn` (Just ("new dialect" :: Text), Nothing :: Maybe Text)
+
+    it "does not inspect discovery inputs when project instructions are disabled" do
+        preloadAgentsContext False
+            (error "disabled dialect evaluated")
+            (error "disabled home evaluated")
+            (error "disabled cwd evaluated")
+            `shouldReturn` Nothing
+
+    it "joins the instruction reader before propagating a learned-skill failure" do
+        started <- newEmptyMVar
+        blocked <- newEmptyMVar
+        stopped <- newIORef False
+        result <- timeout 2000000 $ tryAny $
+            preloadInitialContext (ContextPreloadPolicy True False) freshContext
+                ((putMVar started () >> takeMVar blocked :: IO (Maybe Text))
+                    `finally` writeIORef stopped True)
+                (takeMVar started >> throwIO (userError "learned skills failed") :: IO (Maybe Text))
+        result `shouldSatisfy` maybe False isLeft
+        readIORef stopped `shouldReturn` True
+
+    it "joins both quiet readers when startup is cancelled" do
+        agentsStarted <- newEmptyMVar
+        skillsStarted <- newEmptyMVar
+        blocked <- newEmptyMVar
+        agentsStopped <- newIORef False
+        skillsStopped <- newIORef False
+        let reader started stopped =
+                (putMVar started () >> readMVar blocked :: IO (Maybe Text))
+                    `finally` writeIORef stopped True
+        result <- timeout 2000000 $
+            withAsync
+                (preloadInitialContext (ContextPreloadPolicy True False) freshContext
+                    (reader agentsStarted agentsStopped)
+                    (reader skillsStarted skillsStopped))
+                \worker -> do
+                    takeMVar agentsStarted
+                    takeMVar skillsStarted
+                    cancel worker
+        result `shouldBe` Just ()
+        readIORef agentsStopped `shouldReturn` True
+        readIORef skillsStopped `shouldReturn` True
+
+    it "retains local catalog warnings before remote warnings" do
+        let localWarning = SkillWarning (unsafeEncodeUtf "local") "local warning"
+            remoteWarning = SkillWarning (unsafeEncodeUtf "remote") "remote warning"
+        assembleInitialSkills True
+            (SkillCatalog [] [localWarning])
+            (pure (SkillCatalog [] [remoteWarning]))
+            `shouldReturn` SkillCatalog [] [localWarning, remoteWarning]
+
+    it "does not query remote skills when skills are disabled" do
+        let local = SkillCatalog [] [SkillWarning (unsafeEncodeUtf "local") "retained"]
+        assembleInitialSkills False local forbiddenRead `shouldReturn` local
+
+freshContext :: SessionInitialContext
+freshContext = resolveSessionInitialContext False False Nothing
+
+forbiddenRead :: IO a
+forbiddenRead = throwIO (userError "unexpected context read")
+
+continuedMeta :: SessionMeta
+continuedMeta = (testMeta "context") { metaLastResponseId = Just "response-1" }
+
+snapshotMeta :: SessionMeta
+snapshotMeta = (testMeta "context")
+    { metaPromptSnapshot = Just (testPromptSnapshot "context") }
+
+sampleTurn :: SessionTurn
+sampleTurn = SessionTurn
+    { turnAt = fixedTime
+    , turnUserText = "hello"
+    , turnAssistantText = Nothing
+    , turnError = Nothing
+    , turnResponseId = Nothing
+    , turnItems = turnInputsToItems [UserMessage "hello"]
+    , turnDisplayItems = []
+    , turnUsage = Nothing
+    , turnEffect = TranscriptAppend
+    , turnProviderTelemetry = []
+    }

--- a/packages/agent-runtime/test/Spec.hs
+++ b/packages/agent-runtime/test/Spec.hs
@@ -9,6 +9,7 @@ import qualified Agent.Runtime.CollaborationSpec as Collaboration
 import qualified Agent.Runtime.ProviderRuntimeSpec as ProviderRuntime
 import qualified Agent.Runtime.CompactionSpec as Compaction
 import qualified Agent.Runtime.StartupPolicySpec as StartupPolicy
+import qualified Agent.Runtime.Startup.ContextSpec as StartupContext
 import qualified Agent.Runtime.Startup.ModelSpec as StartupModel
 import qualified Agent.Runtime.Startup.PolicySpec as StartupApproval
 import qualified Agent.Runtime.Startup.GatewaySpec as StartupGateway
@@ -48,6 +49,7 @@ main = hspec do
     ToolStartup.spec
     McpStartup.spec
     Collaboration.spec
+    StartupContext.spec
     Request.spec
     ProviderRuntime.spec
     Compaction.spec

--- a/scripts/check-package-boundaries.sh
+++ b/scripts/check-package-boundaries.sh
@@ -27,6 +27,10 @@ if [[ -e "$cli/src/Agent/CLI/Dialects.hs" \
 fi
 
 python3 "$root/scripts/check-package-graph.py" "$root"
+if rg --line-number '^(data SessionInitialContext|resolveSessionInitialContext[^:]|agentsDiscoverOptions[^:]|mergeSkillCatalogs[^:])' \
+    "$cli/src/Agent/CLI/Resume.hs" "$cli/src/Agent/CLI/StartupContext.hs" "$cli/src/Agent/CLI/Skills.hs"; then
+  fail "startup context policy and catalog assembly must remain in agent-runtime"
+fi
 if rg --line-number '\b(newSubagentRegistry|closeSubagentRegistry|interruptActiveSubagents|grokRootChildModels|resolveModelOptionById)\b' \
     "$cli/src/Agent/CLI/Runtime/Orchestration/Tools/Collaboration.hs"; then
   fail "collaboration startup policy and registry ownership must remain in agent-runtime"
@@ -170,6 +174,8 @@ for registration in \
 done
 
 required_files=(
+  packages/agent-runtime/src/Agent/Runtime/Startup/Context.hs
+  packages/agent-runtime/test/Agent/Runtime/Startup/ContextSpec.hs
   packages/agent-runtime/src/Agent/Runtime/Mcp/Startup.hs
   packages/agent-runtime/src/Agent/Runtime/Collaboration.hs
   packages/agent-runtime/test/Agent/Runtime/CollaborationSpec.hs


### PR DESCRIPTION
## Summary
- Move resume context policy, quiet instruction discovery, concurrent preloading, and skill catalog assembly into Agent.Runtime.Startup.Context.
- Keep CLI presentation and storage callbacks in frontend adapters; preserve snapshot reuse and restricted-host behavior.
- Add 17 regression cases, architecture documentation, and package-boundary guards. No new Cabal package or dependency.

## Validation
- All 769 library modules loaded successfully in multi-package GHCi.
- Runtime startup context tests: 17 examples, 0 failures.
- Nix package-boundary check passed.
- Regenerated runtime package.nix with cabal2nix; no changes required.
- git diff --check passed.