### PR TITLE
Optimize printable ASCII terminal rendering

### DIFF
--- a/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
+++ b/packages/agent-cli/test/Agent/CLI/WorktreeSpec.hs
@@ -1148,9 +1148,7 @@ withTempGitRepo :: (OsPath -> IO a) -> IO a
 withTempGitRepo action =
     withTempDir "agent-git-" \dir -> do
         _ <- git dir ["init"]
-        _ <- git dir ["config", "user.email", "test@example.com"]
-        _ <- git dir ["config", "user.name", "Test"]
-        _ <- git dir ["config", "commit.gpgsign", "false"]
+        configureGit dir
         writeFile (toFilePath (dir </> fromFilePath "README")) "hello\n"
         _ <- git dir ["add", "README"]
         _ <- git dir ["commit", "-m", "init"]
@@ -1188,6 +1186,11 @@ withTempRemoteRepo action =
 
 configureGit :: OsPath -> IO ()
 configureGit repo = do
+    -- Background maintenance can remove lock files while the fixture's
+    -- recursive cleanup is traversing them. These short-lived repositories
+    -- do not need automatic maintenance or garbage collection.
+    _ <- git repo ["config", "maintenance.auto", "false"]
+    _ <- git repo ["config", "gc.auto", "0"]
     _ <- git repo ["config", "user.email", "test@example.com"]
     _ <- git repo ["config", "user.name", "Test"]
     _ <- git repo ["config", "commit.gpgsign", "false"]

--- a/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ServerTurnSpec.hs
@@ -573,7 +573,14 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
     withServerTurnOwnerActionFence pool instanceOne \_ -> do
         reserveServerSessionMutation pool protectedMutation
             `shouldReturn` Right ServerSessionMutationReserved
+        timeout 100000 (waitForServerTurnOwnerDisconnect pool instanceOne)
+            `shouldReturn` Nothing
         abandonServerTurnOwnerLease ownerOne
+        -- Closing the client socket does not acknowledge PostgreSQL backend
+        -- teardown. Wait for its liveness lock to disappear before asserting
+        -- admission rejection; the separate action fence remains held.
+        timeout 5000000 (waitForServerTurnOwnerDisconnect pool instanceOne)
+            `shouldReturn` Just (Right ())
         reserveServerTurn pool interruptedRequest
             `shouldReturn` Right ServerTurnOwnerUnavailable
         reserveServerSessionMutation pool mutation
@@ -720,6 +727,25 @@ exerciseTurnStoreWithOwners pool ownerOne ownerTwo = do
     listed `shouldSatisfy` \case
         Right turns -> length turns == 3
         Left _ -> False
+
+waitForServerTurnOwnerDisconnect :: StorePool -> Text -> IO (Either StoreError ())
+waitForServerTurnOwnerDisconnect pool instanceId =
+    withSession pool (Session.statement instanceId ownerDisconnectedStatement)
+        >>= \case
+            Left err -> pure (Left err)
+            Right True -> pure (Right ())
+            Right False -> do
+                threadDelay 10000
+                waitForServerTurnOwnerDisconnect pool instanceId
+  where
+    -- This standalone statement releases the probe lock at transaction end.
+    ownerDisconnectedStatement :: Statement Text Bool
+    ownerDisconnectedStatement =
+        Statement.preparable
+            "SELECT pg_try_advisory_xact_lock(hashtextextended(\
+            \ 'haskell-agent:server-turn-owner:' || $1::text, 0))"
+            (Encoders.param (Encoders.nonNullable Encoders.text))
+            (Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool)))
 
 waitForInterruptedTurn ::
     StorePool ->

--- a/packages/agent-tui/benchmark/FullscreenMarkdown.hs
+++ b/packages/agent-tui/benchmark/FullscreenMarkdown.hs
@@ -10,7 +10,8 @@ import Agent.TUI.Markdown.Stream (MarkdownStreamState, emptyMarkdownStreamState,
 import qualified Agent.TUI.Markdown.Inline as Inline
 import qualified Agent.TUI.Theme as Theme
 import Brick
-import Control.Exception (evaluate) -- safe-exceptions does not export evaluate.
+-- This standalone benchmark uses base's bracket solely for stable-pointer cleanup.
+import Control.Exception (bracket, evaluate)
 import Control.Monad (forM, unless)
 import Data.Char (ord)
 import Data.Foldable (toList)
@@ -19,11 +20,13 @@ import Data.List (sort)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LazyText
+import Data.Word (Word64)
 import qualified Graphics.Vty as V
 import Graphics.Vty.PictureToSpans (displayOpsForPic)
 import Graphics.Vty.Span (SpanOp(..))
 import GHC.Clock (getMonotonicTimeNSec)
-import GHC.Stats (RTSStats(..), getRTSStats, getRTSStatsEnabled)
+import Foreign.StablePtr (newStablePtr, freeStablePtr)
+import GHC.Stats (RTSStats(..), GCDetails(..), getRTSStats, getRTSStatsEnabled)
 import System.CPUTime (getCPUTime)
 import System.Environment (getArgs)
 import System.Exit (die)
@@ -38,7 +41,7 @@ data Sample = Sample !Double !Double !Double
 -- The historical modes remain available so earlier benchmark reports can be
 -- reproduced. "incremental" is the PR #1278 fence-only parser baseline.
 data Renderer = LegacyRenderer | SectionCacheRenderer | IncrementalRenderer | StreamingRenderer
-    | BaselineInlineParser | StreamingInlineParser
+    | BaselineInlineParser | StreamingInlineParser | RetainedRenderer
     deriving (Eq)
 
 data ParserState = ParserState !FenceStreamState !MarkdownStreamState
@@ -97,6 +100,7 @@ main = do
                 "current" -> pure SectionCacheRenderer
                 "incremental" -> pure IncrementalRenderer
                 "streaming" -> pure StreamingRenderer
+                "retained" -> pure RetainedRenderer
                 "baseline-inline" -> pure BaselineInlineParser
                 "streaming-inline" -> pure StreamingInlineParser
                 _ -> die "unknown renderer or parser mode"
@@ -120,15 +124,23 @@ main = do
                     (index, old, new) : _ ->
                         die ("old/new per-frame display or click targets differ at "
                             <> show index <> "\nOLD: " <> show old <> "\nNEW: " <> show new)
-            results <- forM [1 .. samples] \sample ->
-                measure renderer (scenario == "resize")
-                    (frameInput scenario count chunkSize sample)
-            printf "%s,%s,%d,%d,%d,%.6f,%.6f,%.0f\n"
-                mode scenario count chunkSize samples
-                (median [wall | Sample wall _ _ <- results])
-                (median [cpu | Sample _ cpu _ <- results])
-                (median [bytes | Sample _ _ bytes <- results])
-        _ -> die "usage: fullscreen-markdown-bench old|new|current|incremental|streaming|baseline-inline|streaming-inline SCENARIO COUNT CHUNK_CHARS SAMPLES"
+            if renderer == RetainedRenderer
+                then do
+                    results <- forM [1 .. samples] \sample ->
+                        measureRetained (scenario == "resize")
+                            (frameInput scenario count chunkSize sample)
+                    printf "%s,%s,%d,%d,%d,%d\n"
+                        mode scenario count chunkSize samples (median results)
+                else do
+                    results <- forM [1 .. samples] \sample ->
+                        measure renderer (scenario == "resize")
+                            (frameInput scenario count chunkSize sample)
+                    printf "%s,%s,%d,%d,%d,%.6f,%.6f,%.0f\n"
+                        mode scenario count chunkSize samples
+                        (median [wall | Sample wall _ _ <- results])
+                        (median [cpu | Sample _ cpu _ <- results])
+                        (median [bytes | Sample _ _ bytes <- results])
+        _ -> die "usage: fullscreen-markdown-bench old|new|current|incremental|streaming|retained|baseline-inline|streaming-inline SCENARIO COUNT CHUNK_CHARS SAMPLES"
   where
     positive raw = case reads raw of
         [(n, "")] | n > 0 -> pure n
@@ -159,10 +171,29 @@ measure renderer resize input = do
 run :: Renderer -> Bool -> [(Bool, Text)] -> Int
 run BaselineInlineParser _ = runInline False
 run StreamingInlineParser _ = runInline True
-run renderer resize = go "" emptyParserState emptyRenderState 0 (0 :: Int)
+run renderer resize = \input ->
+    case runRendered renderer resize input of
+        (checksum, _, _, _) -> checksum
+
+-- The normal timing runner discards its output. This diagnostic instead pins
+-- the final body, Brick image cache, and picture across a major GC, without
+-- retaining the input frame list. Its final CSV field is total live heap bytes,
+-- not allocated bytes or peak RSS. Compare separately built helper variants.
+measureRetained :: Bool -> [(Bool, Text)] -> IO Word64
+measureRetained resize input = do
+    result <- evaluate (runRendered StreamingRenderer resize input)
+    bracket (newStablePtr result) freeStablePtr \_ -> do
+        performGC
+        stats <- getRTSStats
+        pure stats.gc.gcdetails_live_bytes
+
+{-# NOINLINE runRendered #-}
+runRendered :: Renderer -> Bool -> [(Bool, Text)] -> (Int, Text, RenderState Name, V.Picture)
+runRendered renderer resize =
+    go "" emptyParserState emptyRenderState (V.picForImage V.emptyImage) 0 (0 :: Int)
   where
-    go !_ !_ !_ !total !_ [] = total
-    go !body !parser !state !total !frame ((streaming, delta) : rest) =
+    go !body !_ !state !picture !total !_ [] = (total, body, state, picture)
+    go !body !parser !state !_ !total !frame ((streaming, delta) : rest) =
         let !nextBody = body <> delta
             (!nextParser, markdown) = prepareFrame renderer parser streaming nextBody delta
             width = if resize && (frame `div` 50) `mod` 2 == 1 then 40 else 80
@@ -177,7 +208,7 @@ run renderer resize = go "" emptyParserState emptyRenderState 0 (0 :: Int)
             !checksum = foldl' (foldl' spanChecksum) 0
                 (displayOpsForPic picture region)
                 + foldl' (\n extent -> n + length (show extent)) 0 extents
-        in go nextBody nextParser nextState (total + checksum) (frame + 1) rest
+        in go nextBody nextParser nextState picture (total + checksum) (frame + 1) rest
 
 -- Diagnostics force the complete syntax tree, not just its rendered text.
 -- They are not a substitute for the full-render acceptance measurements.

--- a/packages/agent-tui/benchmark/FullscreenMarkdown.hs
+++ b/packages/agent-tui/benchmark/FullscreenMarkdown.hs
@@ -103,7 +103,7 @@ main = do
             unless (scenario `elem`
                 ["prose", "prose-lines", "fence", "open-fence", "table", "open-table", "mixed", "resize",
                  "history-prose", "history-mixed", "long-line", "incomplete",
-                 "unmatched-code", "unmatched-link"])
+                 "unmatched-code", "unmatched-link", "unicode-prose", "unicode-tail"])
                 (die "unknown scenario")
             count <- positive countArg
             chunkSize <- positive chunkArg
@@ -280,6 +280,8 @@ workload scenario count nonce =
     "# Response " <> Text.pack (show nonce) <> "\n\n" <> case scenario of
         "prose" -> Text.replicate count (prose <> "\n")
         "prose-lines" -> Text.replicate count prose
+        "unicode-prose" -> Text.replicate count unicodeProse
+        "unicode-tail" -> Text.replicate count unicodeTail
         "long-line" -> Text.replicate count (Text.stripEnd prose <> " ")
         "incomplete" -> "**unfinished [label (with nesting) " <> Text.replicate count "plain text and `code` "
         "unmatched-code" -> "`" <> Text.replicate count "unfinished code "
@@ -291,6 +293,14 @@ workload scenario count nonce =
         _ -> Text.replicate count (prose <> "\n" <> fence 3 <> table 3 <> "\n")
   where
     prose = "A **bold** explanation with `inline code` and [docs](https://example.com).\n"
+    -- No blank separators: completed lines remain in the active prose section.
+    unicodeProse =
+        "説明 **重要** cafe\x0301 with `変数` and [資料](https://example.com) "
+            <> "\x1f469\x200d\x1f4bb \x1f1e9\x1f1ea.\n"
+    -- The final non-ASCII character rejects a whole-span ASCII fast path only
+    -- after scanning a long prefix. Keep the prefix free of inline delimiters.
+    unicodeTail =
+        Text.replicate 16 "A representative line of ordinary source text. " <> "界\n"
     code = "value = map (+ 1) [1, 2, 3]\n"
     row = "| item | **some value** |\n"
     fence n = "```haskell\n" <> Text.replicate n code <> "```\n"

--- a/packages/agent-tui/benchmark/FullscreenMarkdown.hs
+++ b/packages/agent-tui/benchmark/FullscreenMarkdown.hs
@@ -12,7 +12,7 @@ import qualified Agent.TUI.Theme as Theme
 import Brick
 -- This standalone benchmark uses base's bracket solely for stable-pointer cleanup.
 import Control.Exception (bracket, evaluate)
-import Control.Monad (forM, unless)
+import Control.Monad (forM, unless, when)
 import Data.Char (ord)
 import Data.Foldable (toList)
 import Data.IORef (newIORef, readIORef)
@@ -28,8 +28,8 @@ import GHC.Clock (getMonotonicTimeNSec)
 import Foreign.StablePtr (newStablePtr, freeStablePtr)
 import GHC.Stats (RTSStats(..), GCDetails(..), getRTSStats, getRTSStatsEnabled)
 import System.CPUTime (getCPUTime)
-import System.Environment (getArgs)
-import System.Exit (die)
+import System.Environment (getArgs, lookupEnv)
+import System.Exit (die, exitSuccess)
 import System.Mem (performGC)
 import Text.Printf (printf)
 
@@ -90,6 +90,10 @@ prepareFrame renderer parser@(ParserState fences markdown) streaming body delta
 
 main :: IO ()
 main = do
+    -- Separate processes are required when attributing process-wide peak RSS.
+    phase <- lookupEnv "MARKDOWN_BENCH_PHASE"
+    unless (phase `elem` [Nothing, Just "verify", Just "measure"])
+        (die "MARKDOWN_BENCH_PHASE must be verify or measure")
     enabled <- getRTSStatsEnabled
     unless enabled (die "run with +RTS -T")
     getArgs >>= \case
@@ -113,7 +117,8 @@ main = do
             chunkSize <- positive chunkArg
             samples <- positive samplesArg
             let input = frameInput scenario count chunkSize 0
-            if renderer `elem` [BaselineInlineParser, StreamingInlineParser]
+            if phase == Just "measure" then pure ()
+            else if renderer `elem` [BaselineInlineParser, StreamingInlineParser]
                 then verifyInlineFrames input
                 else case [(index, old, new) |
                     (index, (old, new)) <- zip [0 :: Int ..]
@@ -124,6 +129,7 @@ main = do
                     (index, old, new) : _ ->
                         die ("old/new per-frame display or click targets differ at "
                             <> show index <> "\nOLD: " <> show old <> "\nNEW: " <> show new)
+            when (phase == Just "verify") exitSuccess
             if renderer == RetainedRenderer
                 then do
                     results <- forM [1 .. samples] \sample ->

--- a/packages/agent-tui/benchmark/MarkdownAsciiResults.md
+++ b/packages/agent-tui/benchmark/MarkdownAsciiResults.md
@@ -124,9 +124,56 @@ Peak RSS is a separate metric. Three fresh process runs with macOS
 `/usr/bin/time -l` around that retained command (including parity checks) gave
 median RSS of 62,390,272 → 49,790,976 bytes for `history-prose 1000`, but
 134,922,240 → 148,553,728 bytes for `history-mixed 500` (about 10% higher).
-Thus copying fixes source-buffer retention, but these results do **not** establish
-a general peak-memory improvement. The mixed-history peak remains a limitation;
-allocation reductions must not be presented as reductions in process memory.
+These initial figures include the correctness checker and are superseded for
+rendering attribution by the isolated investigation below. Allocation reductions
+must not be presented as reductions in process memory.
+
+### Isolated peak-memory investigation
+
+The parity checker renders both implementations and expands their pictures into
+per-character comparisons. Its memory contributes to process-wide peak RSS even
+though it is outside the timing interval. The benchmark now supports separate
+processes for verification and measurement (default behavior is unchanged):
+
+```sh
+MARKDOWN_BENCH_PHASE=verify "$BENCH" retained history-mixed 500 64 3 +RTS -T
+# Only measure after verification succeeds, for each comparison binary.
+MARKDOWN_BENCH_PHASE=measure /usr/bin/time -l \
+  "$BENCH" retained history-mixed 500 64 3 +RTS -T -s
+```
+
+Both binaries use the same updated harness; baseline disables only the ASCII
+guard. Three fresh measurement processes gave median peak RSS of **85,442,560 →
+87,572,480 bytes (+2.5%)**, rather than the earlier combined-process 10%.
+RTS maximum live heap was slightly lower, **26,888,152 → 26,780,304 bytes**,
+while runtime memory in use rose from **65 to 67 MiB**. Final live heap remained
+identical. This points to allocation/GC scheduling and heap reservation rather
+than extra retained source buffers; it does not prove every source of RSS.
+
+Additional isolated runs (three retained samples per process):
+
+| Mixed-history count | Baseline peak RSS bytes | Copy peak RSS bytes | Final live bytes, both |
+| ---: | ---: | ---: | ---: |
+| 100 | 37,191,680 | 35,127,296 | 1,035,376 |
+| 250 | 57,114,624 | 58,163,200 | 2,494,120 |
+| 500 | 85,426,176 | 87,539,712 | 4,925,392 |
+| 1000 | 152,551,424 | 154,697,728 | 9,787,888 |
+
+Single-sample controls also showed about 2 MiB more RSS at counts 500/1000.
+Here count means repeated workload sections in **one completed body**, not
+separate chat messages. The phase harness adds a small fixed live-heap overhead
+relative to the earlier table, identically for both binaries.
+
+A new combined-process control gave 146,276,352 → 148,422,656 bytes. Even
+harness changes can move GC thresholds, so the historical 10% cannot be treated
+as a stable production effect or attributed solely to the parity checker.
+
+An attempted single-pass table-width measurement reduced allocation in the
+isolated 500-count run from 1,660,190,376 to 1,513,814,376 bytes, but increased
+peak RSS to 89,636,864 bytes (69 MiB runtime memory). It was rejected and reverted.
+No GC tuning or unsafe identity-return shortcut is included. The remaining
+roughly 2 MiB peak overhead is **not eliminated**; the production implementation
+is unchanged by this investigation.
 
 ## Performance boundary
 

--- a/packages/agent-tui/benchmark/MarkdownAsciiResults.md
+++ b/packages/agent-tui/benchmark/MarkdownAsciiResults.md
@@ -1,5 +1,11 @@
 # Printable ASCII rendering benchmark
 
+The candidate copies printable ASCII with `Text.copy`, avoiding grapheme
+reconstruction without retaining the source buffer behind a rendered slice.
+This replaces the original identity fast path after review identified its
+ownership regression, already documented in [`TerminalText.md`](TerminalText.md).
+The timings below are for the corrected copying implementation.
+
 Measured on 2026-09-12 with GHC 9.10.3 on aarch64 macOS, inside `nix develop`.
 The benchmark component uses `-O2`; allocation statistics use `+RTS -T`.
 Results are medians of seven samples, with 64-character streaming chunks and
@@ -8,8 +14,12 @@ workload repetition counts of 5, 25, and 100.
 The baseline is the saved benchmark executable built from master
 `7e6cf643f7b12882117dc25c5807d619934f0a23`. The candidate adds only the
 printable-ASCII guard to `displayTerminalText`: text consisting entirely of
-characters from space through tilde is returned unchanged; other text uses
+characters from space through tilde is copied; other text uses
 the existing grapheme-aware sanitization.
+
+These timing executables were saved before the retained-heap diagnostic
+refactor in `FullscreenMarkdown.hs`; both use the same original timing harness.
+The baseline also includes the Unicode fixtures, with the original text helper.
 
 Both executables use **streaming** mode. Comparing historical renderer modes
 within the candidate executable would not isolate this change: they share
@@ -52,39 +62,39 @@ bytes accumulated across all frames in one sample, not retained heap size.
 
 | Scenario | Count | Elapsed ms | CPU ms | Allocated bytes |
 | --- | ---: | ---: | ---: | ---: |
-| prose | 5 | 1.387 → 0.966 | 1.388 → 0.966 | 9,492,144 → 7,736,592 |
-| prose-lines | 5 | 1.915 → 1.251 | 1.915 → 1.259 | 12,664,096 → 8,885,848 |
-| mixed | 5 | 7.733 → 7.193 | 7.727 → 7.171 | 46,417,240 → 41,615,496 |
-| table | 5 | 1.219 → 0.991 | 1.218 → 0.993 | 7,983,080 → 7,041,520 |
-| long-line | 5 | 1.830 → 1.312 | 1.831 → 1.303 | 12,228,648 → 8,409,944 |
-| prose | 25 | 8.763 → 7.620 | 8.761 → 7.628 | 67,184,744 → 58,401,504 |
-| prose-lines | 25 | 25.303 → 15.269 | 25.276 → 15.247 | 159,109,960 → 100,200,768 |
-| mixed | 25 | 51.543 → 45.032 | 51.550 → 45.006 | 282,479,408 → 258,345,376 |
-| table | 25 | 7.882 → 6.621 | 7.866 → 6.617 | 46,555,440 → 41,018,256 |
-| long-line | 25 | 25.973 → 15.430 | 25.926 → 15.441 | 157,084,480 → 97,495,888 |
-| prose | 100 | 51.640 → 42.554 | 51.452 → 42.528 | 350,065,736 → 314,622,872 |
-| prose-lines | 100 | 344.014 → 197.819 | 342.838 → 197.274 | 1,876,583,512 → 1,012,810,920 |
-| mixed | 100 | 348.442 → 330.386 | 347.903 → 329.957 | 1,787,271,336 → 1,691,153,224 |
-| table | 100 | 88.548 → 76.825 | 88.419 → 76.708 | 393,368,952 → 336,104,856 |
-| long-line | 100 | 429.143 → 242.258 | 426.021 → 240.437 | 1,925,557,328 → 1,051,619,064 |
+| prose | 5 | 1.280 → 1.081 | 1.280 → 1.077 | 9,492,144 → 7,743,408 |
+| prose-lines | 5 | 1.727 → 1.271 | 1.727 → 1.271 | 12,664,096 → 8,900,320 |
+| mixed | 5 | 7.501 → 6.535 | 7.509 → 6.550 | 46,417,240 → 41,635,016 |
+| table | 5 | 1.126 → 1.004 | 1.126 → 1.006 | 7,983,080 → 7,045,920 |
+| long-line | 5 | 1.711 → 1.357 | 1.711 → 1.341 | 12,228,648 → 8,423,632 |
+| prose | 25 | 8.683 → 7.561 | 8.674 → 7.537 | 67,184,744 → 58,435,608 |
+| prose-lines | 25 | 23.863 → 14.885 | 23.811 → 14.748 | 159,109,960 → 100,426,024 |
+| mixed | 25 | 48.375 → 44.703 | 48.301 → 44.643 | 282,479,408 → 258,442,024 |
+| table | 25 | 7.377 → 6.587 | 7.370 → 6.579 | 46,555,440 → 41,044,920 |
+| long-line | 25 | 23.728 → 14.775 | 23.721 → 14.757 | 157,084,480 → 97,707,344 |
+| prose | 100 | 46.085 → 40.373 | 46.014 → 40.196 | 350,065,736 → 314,760,296 |
+| prose-lines | 100 | 321.568 → 191.620 | 321.019 → 191.202 | 1,876,583,512 → 1,016,108,080 |
+| mixed | 100 | 333.364 → 317.798 | 332.970 → 317.196 | 1,787,271,336 → 1,691,537,352 |
+| table | 100 | 85.143 → 73.646 | 84.853 → 73.542 | 393,368,952 → 336,381,720 |
+| long-line | 100 | 379.203 → 219.822 | 378.096 → 219.664 | 1,925,557,328 → 1,054,709,344 |
 
 ## Repeat and Unicode fallback checks
 
 An eleven-sample repeat, running the candidate first, measured `prose-lines 100`
-at 321.512 → 191.132 ms elapsed, 321.283 → 190.796 ms CPU, and
-1,876,583,512 → 1,012,810,920 allocated bytes. This confirms roughly 41% less
+at 313.839 → 182.705 ms elapsed, 313.476 → 182.691 ms CPU, and
+1,876,583,512 → 1,016,108,080 allocated bytes. This confirms roughly 42% less
 rendering time and 46% less allocation for that workload.
 
-The following eleven-sample checks use the same settings and both executables
+The following seven-sample checks use the same settings and both executables
 include the new Unicode fixtures; the baseline has only the ASCII guard removed.
-Run each executable with `streaming SCENARIO COUNT 64 11 +RTS -T`.
+Run each executable with `streaming SCENARIO COUNT 64 7 +RTS -T`.
 
 | Scenario | Count | Elapsed ms | CPU ms | Allocated bytes |
 | --- | ---: | ---: | ---: | ---: |
-| unicode-prose | 5 | 1.479 → 1.370 | 1.480 → 1.362 | 10,591,592 → 8,848,968 |
-| unicode-prose | 20 | 13.692 → 11.274 | 13.691 → 11.261 | 88,227,648 → 69,932,704 |
-| unicode-tail | 5 | 49.587 → 33.303 | 49.558 → 33.296 | 316,450,776 → 202,878,872 |
-| unicode-tail | 20 | 700.619 → 503.677 | 698.833 → 502.191 | 4,525,057,240 → 3,028,550,184 |
+| unicode-prose | 5 | 1.577 → 1.293 | 1.572 → 1.295 | 10,591,592 → 8,853,736 |
+| unicode-prose | 20 | 13.345 → 11.085 | 13.347 → 11.064 | 88,227,648 → 69,982,592 |
+| unicode-tail | 5 | 49.898 → 32.706 | 49.871 → 32.671 | 316,450,776 → 203,041,448 |
+| unicode-tail | 20 | 696.118 → 504.058 | 694.904 → 503.574 | 4,525,057,240 → 3,030,715,032 |
 
 `unicode-prose` includes CJK, combining accents, emoji ZWJ sequences and flags.
 `unicode-tail` ends each long ASCII line with CJK, exercising a failed guard
@@ -92,6 +102,31 @@ after a long prefix. Both still contain printable ASCII spans that benefit from
 the guard, especially after wrapping. These full-render results show no observed
 regression for the fixtures; they do not imply the Unicode fallback itself is
 faster or that its extra guard scan is free.
+
+## Retained heap and peak RSS
+
+The new `retained SCENARIO COUNT 64 3 +RTS -T` mode pins the final body,
+Brick render state/image cache, and picture across a major GC. Both comparison
+binaries include this diagnostic; the baseline disables only the ASCII guard.
+Median total live heap bytes match exactly in all seven fixtures:
+
+| Scenario | Count | Baseline bytes | Copy bytes |
+| --- | ---: | ---: | ---: |
+| history-prose | 100 | 307,680 | 307,680 |
+| history-prose | 1000 | 2,542,496 | 2,542,496 |
+| history-mixed | 100 | 1,035,280 | 1,035,280 |
+| history-mixed | 500 | 4,925,296 | 4,925,296 |
+| prose | 50 | 591,544 | 591,544 |
+| mixed | 20 | 1,185,320 | 1,185,320 |
+| resize | 20 | 1,203,688 | 1,203,688 |
+
+Peak RSS is a separate metric. Three fresh process runs with macOS
+`/usr/bin/time -l` around that retained command (including parity checks) gave
+median RSS of 62,390,272 → 49,790,976 bytes for `history-prose 1000`, but
+134,922,240 → 148,553,728 bytes for `history-mixed 500` (about 10% higher).
+Thus copying fixes source-buffer retention, but these results do **not** establish
+a general peak-memory improvement. The mixed-history peak remains a limitation;
+allocation reductions must not be presented as reductions in process memory.
 
 ## Performance boundary
 
@@ -109,6 +144,10 @@ The focused `Agent.TUI.TextWidthSpec` and `Agent.TUI.MarkdownSpec` suites passed
 in GHCi: 88 examples, zero failures. Coverage includes the entire printable
 ASCII range, controls before and after ASCII, combining marks, keycaps, emoji
 ZWJ sequences, and existing rendering/layout parity checks.
+
+After adding the deterministic backing-array ownership regression test, the
+text-width suite was rerun: 18 examples, zero failures. It verifies that a
+seven-byte slice of a larger buffer renders into its own seven-byte array.
 
 A live tmux smoke test streamed seven-character deltas through the fullscreen
 TUI, including bold/link prose, fenced code, and a Unicode table. Resizing from

--- a/packages/agent-tui/benchmark/MarkdownAsciiResults.md
+++ b/packages/agent-tui/benchmark/MarkdownAsciiResults.md
@@ -1,0 +1,116 @@
+# Printable ASCII rendering benchmark
+
+Measured on 2026-09-12 with GHC 9.10.3 on aarch64 macOS, inside `nix develop`.
+The benchmark component uses `-O2`; allocation statistics use `+RTS -T`.
+Results are medians of seven samples, with 64-character streaming chunks and
+workload repetition counts of 5, 25, and 100.
+
+The baseline is the saved benchmark executable built from master
+`7e6cf643f7b12882117dc25c5807d619934f0a23`. The candidate adds only the
+printable-ASCII guard to `displayTerminalText`: text consisting entirely of
+characters from space through tilde is returned unchanged; other text uses
+the existing grapheme-aware sanitization.
+
+Both executables use **streaming** mode. Comparing historical renderer modes
+within the candidate executable would not isolate this change: they share
+the modified text helper.
+
+## Procedure
+
+Build and save the baseline executable before applying the guard, then rebuild
+the candidate with the same command:
+
+```sh
+nix develop -c cabal build --offline agent-tui:bench:fullscreen-markdown-bench
+nix develop -c cabal list-bin agent-tui:bench:fullscreen-markdown-bench
+```
+
+Set `BASELINE` and `CANDIDATE` to the respective executable paths and run:
+
+```sh
+nix develop -c sh -c '
+  for count in 5 25 100; do
+    for scenario in prose prose-lines mixed table long-line; do
+      "$BASELINE" streaming "$scenario" "$count" 64 7 +RTS -T
+      "$CANDIDATE" streaming "$scenario" "$count" 64 7 +RTS -T
+    done
+  done
+'
+```
+
+This measures the full Brick rendering path, not parser time or widget
+construction alone. Each frame retains Brick's image cache, renders an
+80-by-30 viewport, and consumes Vty display spans and clickable extents.
+Input construction is outside the measured interval. The workload includes
+the final non-streaming frame. The benchmark also checks per-frame display
+and click-target equivalence against its historical section-cache renderer.
+
+## Results
+
+Each cell is **baseline → candidate**. Times are milliseconds; allocation is
+bytes accumulated across all frames in one sample, not retained heap size.
+
+| Scenario | Count | Elapsed ms | CPU ms | Allocated bytes |
+| --- | ---: | ---: | ---: | ---: |
+| prose | 5 | 1.387 → 0.966 | 1.388 → 0.966 | 9,492,144 → 7,736,592 |
+| prose-lines | 5 | 1.915 → 1.251 | 1.915 → 1.259 | 12,664,096 → 8,885,848 |
+| mixed | 5 | 7.733 → 7.193 | 7.727 → 7.171 | 46,417,240 → 41,615,496 |
+| table | 5 | 1.219 → 0.991 | 1.218 → 0.993 | 7,983,080 → 7,041,520 |
+| long-line | 5 | 1.830 → 1.312 | 1.831 → 1.303 | 12,228,648 → 8,409,944 |
+| prose | 25 | 8.763 → 7.620 | 8.761 → 7.628 | 67,184,744 → 58,401,504 |
+| prose-lines | 25 | 25.303 → 15.269 | 25.276 → 15.247 | 159,109,960 → 100,200,768 |
+| mixed | 25 | 51.543 → 45.032 | 51.550 → 45.006 | 282,479,408 → 258,345,376 |
+| table | 25 | 7.882 → 6.621 | 7.866 → 6.617 | 46,555,440 → 41,018,256 |
+| long-line | 25 | 25.973 → 15.430 | 25.926 → 15.441 | 157,084,480 → 97,495,888 |
+| prose | 100 | 51.640 → 42.554 | 51.452 → 42.528 | 350,065,736 → 314,622,872 |
+| prose-lines | 100 | 344.014 → 197.819 | 342.838 → 197.274 | 1,876,583,512 → 1,012,810,920 |
+| mixed | 100 | 348.442 → 330.386 | 347.903 → 329.957 | 1,787,271,336 → 1,691,153,224 |
+| table | 100 | 88.548 → 76.825 | 88.419 → 76.708 | 393,368,952 → 336,104,856 |
+| long-line | 100 | 429.143 → 242.258 | 426.021 → 240.437 | 1,925,557,328 → 1,051,619,064 |
+
+## Repeat and Unicode fallback checks
+
+An eleven-sample repeat, running the candidate first, measured `prose-lines 100`
+at 321.512 → 191.132 ms elapsed, 321.283 → 190.796 ms CPU, and
+1,876,583,512 → 1,012,810,920 allocated bytes. This confirms roughly 41% less
+rendering time and 46% less allocation for that workload.
+
+The following eleven-sample checks use the same settings and both executables
+include the new Unicode fixtures; the baseline has only the ASCII guard removed.
+Run each executable with `streaming SCENARIO COUNT 64 11 +RTS -T`.
+
+| Scenario | Count | Elapsed ms | CPU ms | Allocated bytes |
+| --- | ---: | ---: | ---: | ---: |
+| unicode-prose | 5 | 1.479 → 1.370 | 1.480 → 1.362 | 10,591,592 → 8,848,968 |
+| unicode-prose | 20 | 13.692 → 11.274 | 13.691 → 11.261 | 88,227,648 → 69,932,704 |
+| unicode-tail | 5 | 49.587 → 33.303 | 49.558 → 33.296 | 316,450,776 → 202,878,872 |
+| unicode-tail | 20 | 700.619 → 503.677 | 698.833 → 502.191 | 4,525,057,240 → 3,028,550,184 |
+
+`unicode-prose` includes CJK, combining accents, emoji ZWJ sequences and flags.
+`unicode-tail` ends each long ASCII line with CJK, exercising a failed guard
+after a long prefix. Both still contain printable ASCII spans that benefit from
+the guard, especially after wrapping. These full-render results show no observed
+regression for the fixtures; they do not imply the Unicode fallback itself is
+faster or that its extra guard scan is free.
+
+## Performance boundary
+
+The main table uses ASCII-source Markdown workloads. No Unicode-path speedup is claimed:
+non-ASCII and control-containing text still requires the general path.
+The change removes unnecessary segmentation and reconstruction for printable
+ASCII; it does not change streaming parser state or introduce image caches.
+Completed lines within a growing prose section are still rendered again until
+the section becomes stable, so this is a constant-factor improvement rather
+than a change to that rendering complexity.
+
+## Correctness validation
+
+The focused `Agent.TUI.TextWidthSpec` and `Agent.TUI.MarkdownSpec` suites passed
+in GHCi: 88 examples, zero failures. Coverage includes the entire printable
+ASCII range, controls before and after ASCII, combining marks, keycaps, emoji
+ZWJ sequences, and existing rendering/layout parity checks.
+
+A live tmux smoke test streamed seven-character deltas through the fullscreen
+TUI, including bold/link prose, fenced code, and a Unicode table. Resizing from
+110×35 to 55×28 preserved wrapping and alignment; PageUp/PageDown navigated
+history and returned to the final text correctly.

--- a/packages/agent-tui/src/Agent/TUI/TextWidth.hs
+++ b/packages/agent-tui/src/Agent/TUI/TextWidth.hs
@@ -72,7 +72,9 @@ displayTerminalChar char
 displayTerminalText :: Text -> Text
 displayTerminalText text
     -- Printable ASCII needs neither sanitization nor grapheme reconstruction.
-    | Text.all (\character -> character >= ' ' && character <= '~') text = text
+    -- Rendered slices outlive their source frame in Brick's image cache. Copy
+    -- them so a short span cannot retain the entire source backing array.
+    | Text.all (\character -> character >= ' ' && character <= '~') text = Text.copy text
     | otherwise = Text.concat (map displayTerminalCluster (graphemeClusters text))
   where
     -- ZWJ and emoji tag characters are terminal formatting controls when

--- a/packages/agent-tui/src/Agent/TUI/TextWidth.hs
+++ b/packages/agent-tui/src/Agent/TUI/TextWidth.hs
@@ -70,8 +70,10 @@ displayTerminalChar char
     code = ord char
 
 displayTerminalText :: Text -> Text
-displayTerminalText =
-    Text.concat . map displayTerminalCluster . graphemeClusters
+displayTerminalText text
+    -- Printable ASCII needs neither sanitization nor grapheme reconstruction.
+    | Text.all (\character -> character >= ' ' && character <= '~') text = text
+    | otherwise = Text.concat (map displayTerminalCluster (graphemeClusters text))
   where
     -- ZWJ and emoji tag characters are terminal formatting controls when
     -- they occur on their own, but are required source characters inside a

--- a/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
@@ -8,11 +8,35 @@ import Test.QuickCheck (elements, forAll, listOf, property)
 
 spec :: Spec
 spec = describe "terminal character width" do
+    it "preserves empty text and the complete printable ASCII range" do
+        displayTerminalText "" `shouldBe` ""
+        let printableAscii = Text.pack [' ' .. '~']
+        displayTerminalText printableAscii `shouldBe` printableAscii
+
     it "preserves arbitrary printable ASCII and structural newlines" $
         property $
             forAll (listOf (elements ('\n' : [' ' .. '~']))) \characters ->
                 let text = Text.pack characters
                 in displayTerminalText text == text
+
+    it "sanitizes controls before and after printable ASCII" do
+        let printableAscii = Text.pack [' ' .. '~']
+        displayTerminalText ("\ESC\t\r\DEL" <> printableAscii)
+            `shouldBe` ("␛⇥↵␡" <> printableAscii)
+        displayTerminalText (printableAscii <> "\ESC\t\r\DEL")
+            `shouldBe` (printableAscii <> "␛⇥↵␡")
+
+    it "preserves grapheme handling between printable ASCII runs" do
+        let womanTechnologist =
+                Text.pack ['\x1f469', '\x200d', '\x1f4bb']
+        displayTerminalText "prefix e\x0301 suffix"
+            `shouldBe` "prefix e\x0301 suffix"
+        displayTerminalText "prefix 1\xfe0f\x20e3 suffix"
+            `shouldBe` "prefix １ suffix"
+        displayTerminalText ("prefix " <> womanTechnologist <> " suffix")
+            `shouldBe` ("prefix " <> womanTechnologist <> " suffix")
+        displayTerminalText "prefix \x200d suffix"
+            `shouldBe` "prefix � suffix"
 
     it "does not bypass sanitization after a long ASCII prefix" do
         let prefix = Text.replicate 1000 "source code "

--- a/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
+++ b/packages/agent-tui/test/Agent/TUI/TextWidthSpec.hs
@@ -1,10 +1,17 @@
+{-# LANGUAGE MagicHash #-}
 module Agent.TUI.TextWidthSpec (spec) where
 
 import Agent.TUI.TextWidth
 import qualified Data.Text as Text
+import Data.Array.Byte (ByteArray (..))
+import GHC.Exts (Int (I#), sizeofByteArray#)
+import qualified Data.Text.Internal as TextInternal
 import qualified Graphics.Vty as V
 import Test.Hspec
 import Test.QuickCheck (elements, forAll, listOf, property)
+
+sizeofByteArray :: ByteArray -> Int
+sizeofByteArray (ByteArray array) = I# (sizeofByteArray# array)
 
 spec :: Spec
 spec = describe "terminal character width" do
@@ -12,6 +19,21 @@ spec = describe "terminal character width" do
         displayTerminalText "" `shouldBe` ""
         let printableAscii = Text.pack [' ' .. '~']
         displayTerminalText printableAscii `shouldBe` printableAscii
+
+    it "detaches printable ASCII slices from a larger source buffer" do
+        let source = Text.replicate 4096 "x" <> "visible" <> Text.replicate 4096 "y"
+            slice = Text.take 7 (Text.drop 4096 source)
+            TextInternal.Text sourceArray sourceOffset _ = slice
+            rendered@(TextInternal.Text renderedArray renderedOffset renderedLength) =
+                displayTerminalText slice
+        -- Check the fixture really is a nonzero-offset slice, then inspect
+        -- ownership directly instead of relying on nondeterministic GC timing.
+        sourceOffset `shouldSatisfy` (> 0)
+        sizeofByteArray sourceArray `shouldSatisfy` (> 7)
+        rendered `shouldBe` "visible"
+        renderedOffset `shouldBe` 0
+        renderedLength `shouldBe` 7
+        sizeofByteArray renderedArray `shouldBe` renderedLength
 
     it "preserves arbitrary printable ASCII and structural newlines" $
         property $


### PR DESCRIPTION
## Summary

Avoid grapheme reconstruction for printable ASCII during fullscreen Markdown rendering, preserving the text ownership boundary with `Text.copy`.

- Keep Unicode/control sanitization unchanged.
- Add ASCII, Unicode fallback, and backing-array ownership tests.
- Add retained-heap diagnostics and separate verification/measurement processes for peak RSS attribution.

## Validation and memory investigation

- Focused Markdown/text-width tests and full-render parity checks passed in prior validation.
- Large prose-lines: about 40% less elapsed time and 46% less allocation.
- Retained heap matches baseline across the tested workloads.
- The earlier 10% mixed-history RSS result included correctness-checker and harness effects. Isolated rendering gives **85,442,560 → 87,572,480 bytes (+2.5%)**, with slightly lower peak live heap but **65 → 67 MiB runtime reservation**.
- Additional counts 100/250/500/1000 and single-sample controls were measured. This is not a general peak-memory improvement; **roughly 2 MiB overhead remains at large sizes**.
- A single-pass table-width experiment reduced allocation but worsened RSS and was reverted. No production changes from that experiment or GC tuning are included.
- Prior live tmux streaming, Unicode, resize, and scrolling smoke test passed.

Full methodology and results: [MarkdownAsciiResults.md](packages/agent-tui/benchmark/MarkdownAsciiResults.md).
