### PR TITLE
Increase managed PostgreSQL connection limit to 1024

### DIFF
--- a/packages/agent-store/src/Agent/Store/Postgres/Config.hs
+++ b/packages/agent-store/src/Agent/Store/Postgres/Config.hs
@@ -70,7 +70,7 @@ defaultManagedPostgresConfig stateDirectory binDirectory =
         , postgresPort = 55432
         , postgresDatabase = "haskell_agent"
         , postgresOwnerRole = "ha_owner"
-        , postgresMaxConnections = 32
+        , postgresMaxConnections = 1024
         }
   where
     root = stateDirectory </> "postgres"

--- a/packages/agent-store/test/Agent/Store/Postgres/ConfigSpec.hs
+++ b/packages/agent-store/test/Agent/Store/Postgres/ConfigSpec.hs
@@ -11,6 +11,12 @@ import Agent.Store.Postgres.Config
 spec :: Spec
 spec = do
     describe "defaultManagedPostgresConfig" do
+        it "allows 1024 connections in the generated server configuration" do
+            let config = defaultManagedPostgresConfig "/agent-state" ""
+            config.postgresMaxConnections `shouldBe` 1024
+            Text.lines (postgresqlConf config)
+                `shouldContain` ["max_connections = 1024"]
+
         it "keeps all cluster state below the agent state directory" do
             let config = defaultManagedPostgresConfig "/tmp/agent" "/pg/bin"
             config.postgresPaths.postgresDataDirectory


### PR DESCRIPTION
## Summary
- Raise the managed PostgreSQL default from 32 to 1024 connections to provide capacity for concurrent agent sessions and their pools.
- Add a regression test for both the configuration value and generated postgresql.conf.
- Leave lifecycle behavior unchanged: running clusters are not restarted. The new setting is written when an updated runtime next starts a stopped cluster.

## Validation
- ConfigSpec via GHCi inside nix develop: 4 examples, 0 failures.
- git diff --check passed.
- No running application or PostgreSQL instance was restarted or reconfigured.

## Rollout
The macOS application must consume the updated public runtime through its pinned flake input in a subsequent update. Existing running clusters retain their current limit until a later PostgreSQL restart. The larger limit increases shared-memory requirements; actual connections consume additional memory and processes.