### PR TITLE
Isolate tool execution behind an opaque ToolScope

### DIFF
--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -87,7 +87,7 @@ library
                     , Agent.Loop.EventPump
                     , Agent.Loop.Input
                     , Agent.Loop.Internal
-                    , Agent.Loop.ToolManager
+                    , Agent.Loop.ToolExecution
                     , Agent.Loop.VisibleState
                     , Agent.Loop.Output
                     , Agent.Loop.TokenUsage

--- a/packages/agent-core/agent-core.cabal
+++ b/packages/agent-core/agent-core.cabal
@@ -87,6 +87,7 @@ library
                     , Agent.Loop.EventPump
                     , Agent.Loop.Input
                     , Agent.Loop.Internal
+                    , Agent.Loop.ToolManager
                     , Agent.Loop.VisibleState
                     , Agent.Loop.Output
                     , Agent.Loop.TokenUsage

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -26,61 +26,22 @@ import Agent.Loop.Input
 import Agent.Loop.InputItems (turnInputsToItems)
 import Agent.Loop.Output
 import Agent.Loop.TokenUsage
+import qualified Agent.Loop.ToolManager as ToolManager
 import Agent.Loop.VisibleState
 import Agent.Responses.Types
 import Agent.Telemetry (TurnTelemetry)
 import Agent.ToolDispatch
     ( ToolCall(..)
-    , ToolCallMode(..)
-    , ToolOutcome(..)
     , ToolCallResult(..)
     , ToolDispatchConfig(..)
-    , toolCallMode
-    , withToolCallResultMode
     )
-import Agent.Tools.Scheduling
-    ( ToolSchedulingPlan(..)
-    , schedulingPlansConflict
-    )
-import Agent.Tools.Types
-    ( ToolRegistry
-    , ToolApproval(..)
-    , dispatchApprovedRegisteredToolCall
-    , toolSupportsAsync
-    , toolSchedulingPlanFor
-    )
+import Agent.Tools.Types (ToolRegistry, ToolApproval)
 import Control.Concurrent.Async
-    ( Async
-    , race
+    ( race
     , waitCatch
     , withAsync
     )
 import Control.Concurrent.MVar (modifyMVar, modifyMVar_, newMVar, withMVar)
-import Control.Concurrent.STM
-    ( STM
-    , TMVar
-    , TQueue
-    , TVar
-    , atomically
-    , check
-    , modifyTVar'
-    , newEmptyTMVar
-    , newEmptyTMVarIO
-    , newTQueueIO
-    , newTVar
-    , newTVarIO
-    , putTMVar
-    , readTMVar
-    , readTQueue
-    , readTVar
-    , retry
-    , throwSTM
-    , tryPutTMVar
-    , tryReadTMVar
-    , tryReadTQueue
-    , writeTQueue
-    , writeTVar
-    )
 import qualified Control.Exception as Exception
 import Control.Exception.Safe
     ( SomeException
@@ -94,12 +55,8 @@ import Control.Monad (when)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as LBS
 import Data.IORef (IORef, atomicModifyIORef', atomicWriteIORef, modifyIORef', newIORef, readIORef, writeIORef)
-import qualified Data.IntMap.Strict as IntMap
-import Data.IntMap.Strict (IntMap)
 import qualified Data.Map.Strict as Map
-import Data.Map.Strict (Map)
 import Data.Maybe (catMaybes, fromMaybe)
-import Data.List (sortOn)
 import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -310,7 +267,7 @@ exceptionSummary =
 data LoopRuntime = LoopRuntime
     { loopRuntimeConfig :: LoopConfig
     , loopRuntimeEventPump :: LoopEventPump
-    , loopRuntimeAsyncToolManager :: AsyncToolManager
+    , loopRuntimeAsyncToolManager :: ToolManager.ToolManager
     , loopRuntimeState :: IORef LoopState
     , loopRuntimeVisibleStateRef :: IORef VisibleLoopState
     , loopRuntimeProviderTelemetryRef :: IORef [TurnTelemetry]
@@ -356,7 +313,7 @@ initializeLoopRuntime config0 initialState previousResponseId firstInputs = do
     eventPump <- newEventPump config0.loopOnEvent
     -- Allocate only STM state here; the manager's workers remain scoped to
     -- runLoopWithEventPump.
-    manager <- newAsyncToolManager
+    manager <- ToolManager.newToolManager
     eventAdmissionLock <- newMVar ()
     visibleStateRef <- newIORef emptyVisibleLoopState
     providerTelemetryRef <- newIORef []
@@ -532,9 +489,9 @@ submitLoopTurn runtime state = do
                                 Nothing
                         committed <-
                             config.loopBackendState.commitBackendState candidate
-                        acknowledgeManagedTools
+                        ToolManager.acknowledgeManagedTools
                             (asyncToolManager runtime)
-                            state.pending.inputs
+                            [result | CompletedTool result <- state.pending.inputs]
                             (catMaybes (map snd items))
                         recordCheckpoint runtime committed
                         setPendingInputs runtime []
@@ -584,7 +541,7 @@ submitLoopTurn runtime state = do
                             withMVar recovery \case
                                 RecoveryClosed -> pure ()
                                 RecoveryOpen{} ->
-                                    admitAsyncToolCall
+                                    ToolManager.admitAsyncToolCall
                                         (asyncToolManager runtime)
                                         call
                         , onRecoveryCheckpoint = checkpoint
@@ -624,9 +581,9 @@ submitLoopTurn runtime state = do
                             committed <-
                                 config.loopBackendState.commitBackendState
                                     backendState
-                            acknowledgeManagedTools
+                            ToolManager.acknowledgeManagedTools
                                 (asyncToolManager runtime)
-                                state.pending.inputs
+                                [result | CompletedTool result <- state.pending.inputs]
                                 backendOutput.toolCalls
                             recordCheckpoint runtime committed
                             pure
@@ -705,7 +662,7 @@ completeLoopTurn runtime turn = do
     clearSteeringAcknowledgement runtime
     race
         (waitCancel config.loopCancel)
-        (runManagedToolCalls (asyncToolManager runtime) turn.toolCalls)
+        (ToolManager.runManagedToolCalls (asyncToolManager runtime) turn.toolCalls)
         >>= \case
             Left () ->
                 -- Leaving the enclosing manager scope cancels and joins
@@ -756,8 +713,8 @@ runLoopWithEventPump runtime =
                     unexpectedLoopExecution runtime exception
         execution <-
             withAsync
-                (runAsyncToolManager
-                    runtime.loopRuntimeConfig
+                (ToolManager.runToolManager
+                    (toolManagerConfig runtime.loopRuntimeConfig)
                     manager)
                 \managerWorker -> do
                     raced <-
@@ -766,7 +723,7 @@ runLoopWithEventPump runtime =
                                 (waitEventPumpFailure
                                     eventWorker
                                     runtime.loopRuntimeEventPump)
-                                (waitAsyncToolManagerFailure
+                                (ToolManager.waitToolManagerFailure
                                     managerWorker
                                     manager))
                             (runLoopState runtime)
@@ -778,8 +735,7 @@ runLoopWithEventPump runtime =
                         Left (Right exception) ->
                             handleManagerFailure exception
                         Right completed ->
-                            atomically
-                                (tryReadTMVar manager.asyncToolFailure)
+                            ToolManager.readToolManagerFailure manager
                                 >>= maybe
                                     (pure completed)
                                     handleManagerFailure
@@ -797,36 +753,15 @@ runLoopWithEventPump runtime =
                     failure
             Right () -> pure recovered
 
--- | A tool result is acknowledged only when the response consuming it commits,
--- not when a waiter drains it. Keep that fact across history compaction.
-acknowledgeManagedTools :: AsyncToolManager -> [TurnInput] -> [ToolCall] -> IO ()
-acknowledgeManagedTools manager inputs calls = atomically do
-    modifyTVar' manager.asyncToolAcknowledged $
-        Set.union (Set.fromList [result.callId | CompletedTool result <- inputs])
-    modifyTVar' manager.asyncToolCommittedCalls $
-        Map.union (Map.fromList [(call.callId, call) | call <- calls])
-
 recoverManagedTools
     :: LoopRuntime
-    -> AsyncToolManager
+    -> ToolManager.ToolManager
     -> LoopExecution
     -> IO LoopExecution
 recoverManagedTools runtime manager execution = do
-    (records, acknowledged, committedCalls) <- atomically do
-        calls <- readTVar manager.asyncToolCalls
-        records <- traverse
-            (\record -> do
-                result <- readTVar record.managedTrustedResult
-                pure (record, result))
-            (sortOn (.managedAdmissionSequence) (Map.elems calls))
-        acknowledged <- readTVar manager.asyncToolAcknowledged
-        committedCalls <- readTVar manager.asyncToolCommittedCalls
-        pure (records, acknowledged, committedCalls)
-    let unacknowledged =
-            [ (record.managedCall, result)
-            | (record, result) <- records
-            , Set.notMember record.managedCall.callId acknowledged
-            ]
+    evidence <- ToolManager.readToolRecoveryEvidence manager
+    let unacknowledged = evidence.unacknowledgedTools
+        committedCalls = evidence.committedTools
         retainedCallIds = Set.fromList (concatMap retainedCallId execution.executionState)
         canonical call =
             Map.lookup call.callId committedCalls == Just call
@@ -954,370 +889,14 @@ handleLoopEventFailure unexpected = \case
     EventPumpAsyncFailure exception ->
         Exception.throwIO exception
 
-data AsyncToolManager = AsyncToolManager
-    { asyncToolRequests :: !(TQueue ManagedToolCall)
-    , asyncToolCalls :: !(TVar (Map Text ManagedToolCall))
-    , asyncToolScheduled :: !(TVar (IntMap ToolSchedulingPlan))
-    , asyncToolOutstanding :: !(TVar Int)
-    , asyncToolCompleted :: !(TQueue ToolCallResult)
-    , asyncToolFailure :: !(TMVar SomeException)
-    , asyncToolAcknowledged :: !(TVar (Set.Set Text))
-    , asyncToolCommittedCalls :: !(TVar (Map Text ToolCall))
-    }
-
-data ManagedToolCall = ManagedToolCall
-    { managedCall :: !ToolCall
-    , managedResult :: !(TMVar (Maybe ToolCallResult))
-    -- Recorded by the worker before event delivery; unlike managedResult,
-    -- this does not release scheduling barriers or normal result waiters.
-    , managedTrustedResult :: !(TVar (Maybe ToolCallResult))
-    , managedAdmissionSequence :: !Int
-    }
-
-data AsyncToolCallConflict = AsyncToolCallConflict !Text
-
-instance Show AsyncToolCallConflict where
-    show (AsyncToolCallConflict message) = Text.unpack message
-
-instance Exception.Exception AsyncToolCallConflict
-
-newAsyncToolManager :: IO AsyncToolManager
-newAsyncToolManager =
-    AsyncToolManager
-        <$> newTQueueIO
-        <*> newTVarIO Map.empty
-        <*> newTVarIO IntMap.empty
-        <*> newTVarIO 0
-        <*> newTQueueIO
-        <*> newEmptyTMVarIO
-        <*> newTVarIO Set.empty
-        <*> newTVarIO Map.empty
-
-asyncToolManager :: LoopRuntime -> AsyncToolManager
+asyncToolManager :: LoopRuntime -> ToolManager.ToolManager
 asyncToolManager runtime = runtime.loopRuntimeAsyncToolManager
 
-admitAsyncToolCall :: AsyncToolManager -> ToolCall -> IO ()
-admitAsyncToolCall manager call
-    | toolCallMode call /= AsyncToolCall =
-        atomically $
-            throwSTM $
-                AsyncToolCallConflict
-                    ("Backend announced a non-async tool call: " <> call.callId)
-    | otherwise = do
-        _ <- atomically (admitManagedToolCall manager call)
-        pure ()
-
-admitBlockingToolCall
-    :: AsyncToolManager
-    -> ToolCall
-    -> IO (TMVar (Maybe ToolCallResult))
-admitBlockingToolCall manager call =
-    atomically (admitManagedToolCall manager call)
-
-admitManagedToolCall
-    :: AsyncToolManager
-    -> ToolCall
-    -> STM (TMVar (Maybe ToolCallResult))
-admitManagedToolCall manager call = do
-    calls <- readTVar manager.asyncToolCalls
-    case Map.lookup call.callId calls of
-        Just existing
-            | existing.managedCall == call ->
-                pure existing.managedResult
-            | otherwise ->
-                throwSTM $
-                    AsyncToolCallConflict
-                        ("Conflicting tool calls reused call_id " <> call.callId)
-        Nothing -> do
-            result <- newEmptyTMVar
-            trustedResult <- newTVar Nothing
-            -- The registry retains every admitted call for deduplication and
-            -- recovery, so its size is also the next admission sequence.
-            let record = ManagedToolCall
-                    { managedCall = call
-                    , managedResult = result
-                    , managedTrustedResult = trustedResult
-                    , managedAdmissionSequence = Map.size calls
-                    }
-            writeTVar
-                manager.asyncToolCalls
-                (Map.insert call.callId record calls)
-            when (toolCallMode call == AsyncToolCall) $
-                modifyTVar' manager.asyncToolOutstanding (+ 1)
-            writeTQueue manager.asyncToolRequests record
-            pure result
-
-runManagedToolCalls
-    :: AsyncToolManager
-    -> [ToolCall]
-    -> IO [ToolCallResult]
-runManagedToolCalls manager calls = do
-    blocking <- catMaybes <$> traverse admit calls
-    blockingResults <-
-        catMaybes <$> traverse (atomically . readTMVar) blocking
-    completedAsync <- atomically do
-        ready <- takeAsyncToolCompletions manager
-        admitted <- readTVar manager.asyncToolCalls
-        committed <- readTVar manager.asyncToolCommittedCalls
-        -- A restarted provider stream may omit a call that already executed.
-        -- Keep its trusted evidence for host-attributed recovery, but never
-        -- submit an unmatched native tool result on the normal path.
-        let canonical =
-                [ result
-                | result <- ready
-                , Just record <- [Map.lookup result.callId admitted]
-                , Map.lookup result.callId committed == Just record.managedCall
-                ]
-        outstanding <- readTVar manager.asyncToolOutstanding
-        -- An orphan-only batch is not the end of the turn while other
-        -- asynchronous tools are still running. Retry also restores the queue.
-        if null canonical && outstanding > 0
-            then retry
-            else pure canonical
-    pure (blockingResults <> completedAsync)
-  where
-    admit call =
-        case toolCallMode call of
-            AsyncToolCall ->
-                admitAsyncToolCall manager call >> pure Nothing
-            BlockingToolCall ->
-                Just <$> admitBlockingToolCall manager call
-
-takeAsyncToolCompletions
-    :: AsyncToolManager
-    -> STM [ToolCallResult]
-takeAsyncToolCompletions manager = do
-    ready <- drainTQueue manager.asyncToolCompleted
-    case ready of
-        _ : _ -> pure ready
-        [] -> do
-            outstanding <- readTVar manager.asyncToolOutstanding
-            if outstanding == 0
-                then pure []
-                else do
-                    first <- readTQueue manager.asyncToolCompleted
-                    rest <- drainTQueue manager.asyncToolCompleted
-                    pure (first : rest)
-
-drainTQueue :: TQueue value -> STM [value]
-drainTQueue queue =
-    tryReadTQueue queue >>= \case
-        Nothing -> pure []
-        Just value -> (value :) <$> drainTQueue queue
-
-runAsyncToolManager :: LoopConfig -> AsyncToolManager -> IO ()
-runAsyncToolManager config manager = do
-    request <- atomically (readTQueue manager.asyncToolRequests)
-    cancelledBefore <- isCancelled config.loopCancel
-    if cancelledBefore
-        then completeCancelledRequest request
-        else
-            race
-                (waitCancel config.loopCancel)
-                (do
-                    prepared <-
-                        prepareManagedToolCall
-                            config
-                            request.managedCall
-                    plan <- schedulingPlanForPrepared config prepared
-                    pure (prepared, plan))
-                >>= \case
-                    Left () ->
-                        completeCancelledRequest request
-                    Right (prepared, plan) -> do
-                        cancelledAfter <- isCancelled config.loopCancel
-                        if cancelledAfter
-                            then completeCancelledRequest request
-                            else do
-                                atomically $
-                                    modifyTVar'
-                                        manager.asyncToolScheduled
-                                        (IntMap.insert
-                                            request.managedAdmissionSequence
-                                            plan)
-                                withAsync
-                                    (runManagedToolWorker
-                                        config
-                                        manager
-                                        request
-                                        prepared
-                                        plan)
-                                    \worker ->
-                                        withAsync
-                                            (waitCatch worker
-                                                >>= completeManagedToolRequest
-                                                    manager
-                                                    request)
-                                            \_monitor ->
-                                                runAsyncToolManager
-                                                    config
-                                                    manager
-  where
-    -- Approval and scheduling are allowed to perform IO. Complete cancelled
-    -- requests so blocking result waiters cannot be stranded.
-    completeCancelledRequest request = do
-        completeManagedToolRequest manager request (Right Nothing)
-        runAsyncToolManager config manager
-
-prepareManagedToolCall :: LoopConfig -> ToolCall -> IO PreparedToolCall
-prepareManagedToolCall config call
-    | toolCallMode call == AsyncToolCall
-        && not (toolSupportsAsync config.loopTools call) =
-            pure $
-                PreparedToolCall call $
-                    ToolApprovalDenied
-                        ("Tool " <> call.name
-                            <> " does not support asynchronous execution.")
-    | otherwise =
-        prepareToolCall config call
-
-runManagedToolWorker
-    :: LoopConfig
-    -> AsyncToolManager
-    -> ManagedToolCall
-    -> PreparedToolCall
-    -> ToolSchedulingPlan
-    -> IO (Maybe ToolCallResult)
-runManagedToolWorker config manager request prepared plan = do
-    atomically do
-        scheduled <- readTVar manager.asyncToolScheduled
-        check $
-            not $
-                IntMap.foldrWithKey
-                    (\sequenceNumber earlierPlan conflicts ->
-                        conflicts
-                            || ( sequenceNumber < request.managedAdmissionSequence
-                                && schedulingPlansConflict earlierPlan plan
-                               ))
-                    False
-                    scheduled
-    race
-        (waitCancel config.loopCancel)
-        (runPreparedToolCallWithCompletion
-            (atomically . writeTVar request.managedTrustedResult . Just)
-            config
-            prepared)
-        >>= \case
-            Left () -> pure Nothing
-            Right result -> pure result
-
-completeManagedToolRequest
-    :: AsyncToolManager
-    -> ManagedToolCall
-    -> Either SomeException (Maybe ToolCallResult)
-    -> IO ()
-completeManagedToolRequest manager request outcome =
-    atomically do
-        modifyTVar'
-            manager.asyncToolScheduled
-            (IntMap.delete request.managedAdmissionSequence)
-        let call = request.managedCall
-        case outcome of
-            Left exception -> do
-                -- Do not publish a synthetic empty completion for a crashed
-                -- worker. Keeping any waiter blocked makes the manager-failure
-                -- branch of the enclosing structured race authoritative.
-                _ <- tryPutTMVar manager.asyncToolFailure exception
-                pure ()
-            Right result -> do
-                putTMVar request.managedResult result
-                when (toolCallMode call == AsyncToolCall) do
-                    modifyTVar'
-                        manager.asyncToolOutstanding
-                        (\count -> count - 1)
-                    case result of
-                        Nothing -> pure ()
-                        Just completed ->
-                            writeTQueue
-                                manager.asyncToolCompleted
-                                completed
-
-waitAsyncToolManagerFailure
-    :: Async ()
-    -> AsyncToolManager
-    -> IO SomeException
-waitAsyncToolManagerFailure managerWorker manager =
-    race
-        (waitCatch managerWorker)
-        (atomically (readTMVar manager.asyncToolFailure))
-        >>= \case
-            Left (Left exception) -> pure exception
-            Left (Right ()) ->
-                pure $
-                    Exception.toException $
-                        AsyncToolCallConflict
-                            "Async tool manager stopped unexpectedly."
-            Right exception -> pure exception
-
-data PreparedToolCall =
-    PreparedToolCall !ToolCall !ToolApproval
-
-schedulingPlanForPrepared
-    :: LoopConfig
-    -> PreparedToolCall
-    -> IO ToolSchedulingPlan
-schedulingPlanForPrepared config (PreparedToolCall call approval) =
-    case approval of
-        ToolApprovalGranted ->
-            toolSchedulingPlanFor config.loopTools call
-        ToolApprovalDenied{} ->
-            pure ToolUnconstrained
-        ToolApprovalRejected ->
-            pure ToolUnconstrained
-
--- | Approval may touch interactive or otherwise order-sensitive state, so it
--- is prepared serially even when the resulting handlers may run concurrently.
-prepareToolCall :: LoopConfig -> ToolCall -> IO PreparedToolCall
-prepareToolCall config call = do
-    approval <- tryAny (config.loopApprove call)
-    pure $
-        PreparedToolCall call $
-            case approval of
-                Left exception ->
-                    ToolApprovalDenied
-                        ("Tool " <> call.name
-                            <> " could not be prepared: "
-                            <> exceptionSummary exception)
-                Right decision -> decision
-
-runPreparedToolCallWithCompletion
-    :: (ToolCallResult -> IO ())
-    -> LoopConfig
-    -> PreparedToolCall
-    -> IO (Maybe ToolCallResult)
-runPreparedToolCallWithCompletion completed config (PreparedToolCall call approval) = do
-    cancelled <- isCancelled config.loopCancel
-    if cancelled
-        then pure Nothing
-        else do
-            config.loopOnEvent (ToolStarted call)
-            result <- case approval of
-                ToolApprovalDenied denial ->
-                    pure (deniedResult denial)
-                ToolApprovalRejected ->
-                    pure (deniedResult "Tool call rejected by user.")
-                ToolApprovalGranted ->
-                    dispatchApprovedRegisteredToolCall
-                        config.loopDispatch
-                            { toolDispatchOnOutput = \progressCall output ->
-                                config.loopDispatch.toolDispatchOnOutput progressCall output
-                                    >> config.loopOnEvent
-                                        (ToolOutputUpdated progressCall.callId output)
-                            }
-                        config.loopTools
-                        call
-            -- The trusted result must survive cancellation or a failing event
-            -- consumer after the tool has returned. The manager's monitor is
-            -- not authoritative: its own scope can be cancelled first.
-            completed result
-            config.loopOnEvent (ToolFinished result)
-            pure (Just result)
-  where
-    deniedResult message = ToolCallResult
-        { callId = call.callId
-        , output = message
-        , callKind = call.callKind
-        , toolResultMode = toolCallMode call
-        , toolResultImages = []
-        , toolResultOutcome = Just ToolDenied
-        }
+toolManagerConfig :: LoopConfig -> ToolManager.ToolManagerConfig
+toolManagerConfig config = ToolManager.ToolManagerConfig
+    { tools = config.loopTools
+    , dispatch = config.loopDispatch
+    , approve = config.loopApprove
+    , cancel = config.loopCancel
+    , onEvent = config.loopOnEvent
+    }

--- a/packages/agent-core/src/Agent/Loop/Internal.hs
+++ b/packages/agent-core/src/Agent/Loop/Internal.hs
@@ -26,7 +26,7 @@ import Agent.Loop.Input
 import Agent.Loop.InputItems (turnInputsToItems)
 import Agent.Loop.Output
 import Agent.Loop.TokenUsage
-import qualified Agent.Loop.ToolManager as ToolManager
+import qualified Agent.Loop.ToolExecution as ToolExecution
 import Agent.Loop.VisibleState
 import Agent.Responses.Types
 import Agent.Telemetry (TurnTelemetry)
@@ -267,7 +267,7 @@ exceptionSummary =
 data LoopRuntime = LoopRuntime
     { loopRuntimeConfig :: LoopConfig
     , loopRuntimeEventPump :: LoopEventPump
-    , loopRuntimeAsyncToolManager :: ToolManager.ToolManager
+    , loopRuntimeToolScope :: ToolExecution.ToolScope
     , loopRuntimeState :: IORef LoopState
     , loopRuntimeVisibleStateRef :: IORef VisibleLoopState
     , loopRuntimeProviderTelemetryRef :: IORef [TurnTelemetry]
@@ -311,9 +311,9 @@ initializeLoopRuntime
     -> IO LoopRuntime
 initializeLoopRuntime config0 initialState previousResponseId firstInputs = do
     eventPump <- newEventPump config0.loopOnEvent
-    -- Allocate only STM state here; the manager's workers remain scoped to
+    -- Allocate only STM state here; tool workers remain scoped to
     -- runLoopWithEventPump.
-    manager <- ToolManager.newToolManager
+    scope <- ToolExecution.newToolScope
     eventAdmissionLock <- newMVar ()
     visibleStateRef <- newIORef emptyVisibleLoopState
     providerTelemetryRef <- newIORef []
@@ -342,7 +342,7 @@ initializeLoopRuntime config0 initialState previousResponseId firstInputs = do
     pure LoopRuntime
         { loopRuntimeConfig = config
         , loopRuntimeEventPump = eventPump
-        , loopRuntimeAsyncToolManager = manager
+        , loopRuntimeToolScope = scope
         , loopRuntimeState = stateRef
         , loopRuntimeVisibleStateRef = visibleStateRef
         , loopRuntimeProviderTelemetryRef = providerTelemetryRef
@@ -489,8 +489,8 @@ submitLoopTurn runtime state = do
                                 Nothing
                         committed <-
                             config.loopBackendState.commitBackendState candidate
-                        ToolManager.acknowledgeManagedTools
-                            (asyncToolManager runtime)
+                        ToolExecution.acknowledgeTools
+                            (toolScope runtime)
                             [result | CompletedTool result <- state.pending.inputs]
                             (catMaybes (map snd items))
                         recordCheckpoint runtime committed
@@ -541,8 +541,8 @@ submitLoopTurn runtime state = do
                             withMVar recovery \case
                                 RecoveryClosed -> pure ()
                                 RecoveryOpen{} ->
-                                    ToolManager.admitAsyncToolCall
-                                        (asyncToolManager runtime)
+                                    ToolExecution.admitAsyncToolCall
+                                        (toolScope runtime)
                                         call
                         , onRecoveryCheckpoint = checkpoint
                         , onCompletedResponseItem = completedItem
@@ -581,8 +581,8 @@ submitLoopTurn runtime state = do
                             committed <-
                                 config.loopBackendState.commitBackendState
                                     backendState
-                            ToolManager.acknowledgeManagedTools
-                                (asyncToolManager runtime)
+                            ToolExecution.acknowledgeTools
+                                (toolScope runtime)
                                 [result | CompletedTool result <- state.pending.inputs]
                                 backendOutput.toolCalls
                             recordCheckpoint runtime committed
@@ -662,10 +662,10 @@ completeLoopTurn runtime turn = do
     clearSteeringAcknowledgement runtime
     race
         (waitCancel config.loopCancel)
-        (ToolManager.runManagedToolCalls (asyncToolManager runtime) turn.toolCalls)
+        (ToolExecution.runToolCalls (toolScope runtime) turn.toolCalls)
         >>= \case
             Left () ->
-                -- Leaving the enclosing manager scope cancels and joins
+                -- Leaving the enclosing tool scope cancels and joins
                 -- unfinished handlers and approval callbacks.
                 finishLoopExecution runtime (Left (LoopCancelled []))
             Right results -> do
@@ -705,27 +705,26 @@ runLoopWithEventPump
     -> IO LoopExecution
 runLoopWithEventPump runtime =
     withAsync (runEventPump runtime.loopRuntimeEventPump) \eventWorker -> do
-        let manager = asyncToolManager runtime
-            handleManagerFailure exception
+        let scope = toolScope runtime
+            handleToolFailure exception
                 | isAsyncException exception =
                     Exception.throwIO exception
                 | otherwise =
                     unexpectedLoopExecution runtime exception
         execution <-
-            withAsync
-                (ToolManager.runToolManager
-                    (toolManagerConfig runtime.loopRuntimeConfig)
-                    manager)
-                \managerWorker -> do
+            ToolExecution.withToolScope
+                (toolExecutionConfig runtime.loopRuntimeConfig)
+                scope
+                \scheduler -> do
                     raced <-
                         race
                             (race
                                 (waitEventPumpFailure
                                     eventWorker
                                     runtime.loopRuntimeEventPump)
-                                (ToolManager.waitToolManagerFailure
-                                    managerWorker
-                                    manager))
+                                (ToolExecution.waitToolFailure
+                                    scheduler
+                                    scope))
                             (runLoopState runtime)
                     case raced of
                         Left (Left failure) ->
@@ -733,16 +732,16 @@ runLoopWithEventPump runtime =
                                 (unexpectedLoopExecution runtime)
                                 failure
                         Left (Right exception) ->
-                            handleManagerFailure exception
+                            handleToolFailure exception
                         Right completed ->
-                            ToolManager.readToolManagerFailure manager
+                            ToolExecution.readToolFailure scope
                                 >>= maybe
                                     (pure completed)
-                                    handleManagerFailure
-        -- Only inspect outcomes once the manager scope has cancelled and
+                                    handleToolFailure
+        -- Only inspect outcomes once the tool scope has cancelled and
         -- joined every worker. A result waiter can lose its race while some
         -- of its sibling tools have already finished successfully.
-        recovered <- tryAny (recoverManagedTools runtime manager execution) >>= \case
+        recovered <- tryAny (recoverTools runtime scope execution) >>= \case
             Right recovered -> pure recovered
             Left exception ->
                 unexpectedLoopExecution runtime exception
@@ -753,13 +752,13 @@ runLoopWithEventPump runtime =
                     failure
             Right () -> pure recovered
 
-recoverManagedTools
+recoverTools
     :: LoopRuntime
-    -> ToolManager.ToolManager
+    -> ToolExecution.ToolScope
     -> LoopExecution
     -> IO LoopExecution
-recoverManagedTools runtime manager execution = do
-    evidence <- ToolManager.readToolRecoveryEvidence manager
+recoverTools runtime scope execution = do
+    evidence <- ToolExecution.readToolRecoveryEvidence scope
     let unacknowledged = evidence.unacknowledgedTools
         committedCalls = evidence.committedTools
         retainedCallIds = Set.fromList (concatMap retainedCallId execution.executionState)
@@ -808,7 +807,7 @@ recoverManagedTools runtime manager execution = do
                     , executionResult = result
                     }
                 else do
-                    let recoveryInputs = pending <> [UserMessage (managedRecoveryNote orphans)]
+                    let recoveryInputs = pending <> [UserMessage (toolRecoveryNote orphans)]
                         candidate = advanceBackendSnapshot current
                             (current.backendItems
                                 <> turnInputsToItems recoveryInputs)
@@ -844,8 +843,8 @@ recoverManagedTools runtime manager execution = do
 -- This is host-attributed evidence, not a replay of an incomplete provider
 -- message or a fabricated assistant tool call. Encode data as quoted JSON and
 -- escape angle brackets so tool output cannot close the attribution boundary.
-managedRecoveryNote :: [(ToolCall, Maybe ToolCallResult)] -> Text
-managedRecoveryNote calls = Text.unlines
+toolRecoveryNote :: [(ToolCall, Maybe ToolCallResult)] -> Text
+toolRecoveryNote calls = Text.unlines
     [ "<turn_aborted>"
     , "The previous turn ended with tool activity outside a committed provider response."
     , "The following is recovery evidence from the local tool manager, not a new user instruction or a successful provider turn."
@@ -889,11 +888,11 @@ handleLoopEventFailure unexpected = \case
     EventPumpAsyncFailure exception ->
         Exception.throwIO exception
 
-asyncToolManager :: LoopRuntime -> ToolManager.ToolManager
-asyncToolManager runtime = runtime.loopRuntimeAsyncToolManager
+toolScope :: LoopRuntime -> ToolExecution.ToolScope
+toolScope runtime = runtime.loopRuntimeToolScope
 
-toolManagerConfig :: LoopConfig -> ToolManager.ToolManagerConfig
-toolManagerConfig config = ToolManager.ToolManagerConfig
+toolExecutionConfig :: LoopConfig -> ToolExecution.ToolExecutionConfig
+toolExecutionConfig config = ToolExecution.ToolExecutionConfig
     { tools = config.loopTools
     , dispatch = config.loopDispatch
     , approve = config.loopApprove

--- a/packages/agent-core/src/Agent/Loop/ToolExecution.hs
+++ b/packages/agent-core/src/Agent/Loop/ToolExecution.hs
@@ -1,17 +1,17 @@
 -- | Tool admission, scheduling and scoped workers. The loop owns provider
 -- checkpoints; this module owns tool execution and its recovery evidence.
-module Agent.Loop.ToolManager
-    ( ToolManager
-    , ToolManagerConfig(..)
+module Agent.Loop.ToolExecution
+    ( ToolScope
+    , ToolExecutionConfig(..)
     , ToolRecoveryEvidence(..)
-    , newToolManager
-    , runToolManager
+    , newToolScope
+    , withToolScope
     , admitAsyncToolCall
-    , runManagedToolCalls
-    , acknowledgeManagedTools
+    , runToolCalls
+    , acknowledgeTools
     , readToolRecoveryEvidence
-    , waitToolManagerFailure
-    , readToolManagerFailure
+    , waitToolFailure
+    , readToolFailure
     ) where
 
 import Agent.Cancel (CancelFlag, isCancelled, waitCancel)
@@ -65,7 +65,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 
 -- | Only tool-execution dependencies; no provider or conversation state.
-data ToolManagerConfig = ToolManagerConfig
+data ToolExecutionConfig = ToolExecutionConfig
     { tools :: !ToolRegistry
     , dispatch :: !ToolDispatchConfig
     , approve :: !(ToolCall -> IO ToolApproval)
@@ -73,15 +73,15 @@ data ToolManagerConfig = ToolManagerConfig
     , onEvent :: !(LoopEvent -> IO ())
     }
 
--- | Immutable, atomic snapshot, read after the manager and its workers join.
+-- | Immutable, atomic snapshot, read after the scope's workers join.
 data ToolRecoveryEvidence = ToolRecoveryEvidence
     { unacknowledgedTools :: ![(ToolCall, Maybe ToolCallResult)]
     , committedTools :: !(Map Text ToolCall)
     }
 
-data ToolManager = ToolManager
-    { asyncToolRequests :: !(TQueue ManagedToolCall)
-    , asyncToolCalls :: !(TVar (Map Text ManagedToolCall))
+data ToolScope = ToolScope
+    { asyncToolRequests :: !(TQueue AdmittedToolCall)
+    , asyncToolCalls :: !(TVar (Map Text AdmittedToolCall))
     , asyncToolScheduled :: !(TVar (IntMap ToolSchedulingPlan))
     , asyncToolOutstanding :: !(TVar Int)
     , asyncToolCompleted :: !(TQueue ToolCallResult)
@@ -90,13 +90,13 @@ data ToolManager = ToolManager
     , asyncToolCommittedCalls :: !(TVar (Map Text ToolCall))
     }
 
-data ManagedToolCall = ManagedToolCall
-    { managedCall :: !ToolCall
-    , managedResult :: !(TMVar (Maybe ToolCallResult))
-    -- Recorded by the worker before event delivery; unlike managedResult,
+data AdmittedToolCall = AdmittedToolCall
+    { admittedCall :: !ToolCall
+    , admittedResult :: !(TMVar (Maybe ToolCallResult))
+    -- Recorded by the worker before event delivery; unlike admittedResult,
     -- this does not release scheduling barriers or normal result waiters.
-    , managedTrustedResult :: !(TVar (Maybe ToolCallResult))
-    , managedAdmissionSequence :: !Int
+    , admittedTrustedResult :: !(TVar (Maybe ToolCallResult))
+    , admissionSequence :: !Int
     }
 
 data AsyncToolCallConflict = AsyncToolCallConflict !Text
@@ -106,10 +106,10 @@ instance Show AsyncToolCallConflict where
 
 instance Exception.Exception AsyncToolCallConflict
 
--- | Allocate state only. All workers are scoped to 'runToolManager'.
-newToolManager :: IO ToolManager
-newToolManager =
-    ToolManager
+-- | Allocate state only. All workers are scoped to 'withToolScope'.
+newToolScope :: IO ToolScope
+newToolScope =
+    ToolScope
         <$> newTQueueIO
         <*> newTVarIO Map.empty
         <*> newTVarIO IntMap.empty
@@ -121,60 +121,60 @@ newToolManager =
 
 -- | A result is acknowledged only when the response consuming it commits,
 -- not when a waiter drains it. Keep that fact across history compaction.
-acknowledgeManagedTools :: ToolManager -> [ToolCallResult] -> [ToolCall] -> IO ()
-acknowledgeManagedTools manager results calls = atomically do
-    modifyTVar' manager.asyncToolAcknowledged $
+acknowledgeTools :: ToolScope -> [ToolCallResult] -> [ToolCall] -> IO ()
+acknowledgeTools scope results calls = atomically do
+    modifyTVar' scope.asyncToolAcknowledged $
         Set.union (Set.fromList [result.callId | result <- results])
-    modifyTVar' manager.asyncToolCommittedCalls $
+    modifyTVar' scope.asyncToolCommittedCalls $
         Map.union (Map.fromList [(call.callId, call) | call <- calls])
 
-readToolRecoveryEvidence :: ToolManager -> IO ToolRecoveryEvidence
-readToolRecoveryEvidence manager = atomically do
-    calls <- readTVar manager.asyncToolCalls
+readToolRecoveryEvidence :: ToolScope -> IO ToolRecoveryEvidence
+readToolRecoveryEvidence scope = atomically do
+    calls <- readTVar scope.asyncToolCalls
     records <- traverse
         (\record -> do
-            result <- readTVar record.managedTrustedResult
-            pure (record.managedCall, result))
-        (sortOn (.managedAdmissionSequence) (Map.elems calls))
-    acknowledged <- readTVar manager.asyncToolAcknowledged
-    committedTools <- readTVar manager.asyncToolCommittedCalls
+            result <- readTVar record.admittedTrustedResult
+            pure (record.admittedCall, result))
+        (sortOn (.admissionSequence) (Map.elems calls))
+    acknowledged <- readTVar scope.asyncToolAcknowledged
+    committedTools <- readTVar scope.asyncToolCommittedCalls
     pure ToolRecoveryEvidence
         { unacknowledgedTools =
             [(call, result) | (call, result) <- records, Set.notMember call.callId acknowledged]
         , committedTools
         }
 
-readToolManagerFailure :: ToolManager -> IO (Maybe SomeException)
-readToolManagerFailure manager = atomically (tryReadTMVar manager.asyncToolFailure)
+readToolFailure :: ToolScope -> IO (Maybe SomeException)
+readToolFailure scope = atomically (tryReadTMVar scope.asyncToolFailure)
 
-admitAsyncToolCall :: ToolManager -> ToolCall -> IO ()
-admitAsyncToolCall manager call
+admitAsyncToolCall :: ToolScope -> ToolCall -> IO ()
+admitAsyncToolCall scope call
     | toolCallMode call /= AsyncToolCall =
         atomically $
             throwSTM $
                 AsyncToolCallConflict
                     ("Backend announced a non-async tool call: " <> call.callId)
     | otherwise = do
-        _ <- atomically (admitManagedToolCall manager call)
+        _ <- atomically (admitToolCall scope call)
         pure ()
 
 admitBlockingToolCall
-    :: ToolManager
+    :: ToolScope
     -> ToolCall
     -> IO (TMVar (Maybe ToolCallResult))
-admitBlockingToolCall manager call =
-    atomically (admitManagedToolCall manager call)
+admitBlockingToolCall scope call =
+    atomically (admitToolCall scope call)
 
-admitManagedToolCall
-    :: ToolManager
+admitToolCall
+    :: ToolScope
     -> ToolCall
     -> STM (TMVar (Maybe ToolCallResult))
-admitManagedToolCall manager call = do
-    calls <- readTVar manager.asyncToolCalls
+admitToolCall scope call = do
+    calls <- readTVar scope.asyncToolCalls
     case Map.lookup call.callId calls of
         Just existing
-            | existing.managedCall == call ->
-                pure existing.managedResult
+            | existing.admittedCall == call ->
+                pure existing.admittedResult
             | otherwise ->
                 throwSTM $
                     AsyncToolCallConflict
@@ -184,29 +184,29 @@ admitManagedToolCall manager call = do
             trustedResult <- newTVar Nothing
             -- The registry retains every admitted call for deduplication and
             -- recovery, so its size is also the next admission sequence.
-            let record = ManagedToolCall
-                    { managedCall = call
-                    , managedResult = result
-                    , managedTrustedResult = trustedResult
-                    , managedAdmissionSequence = Map.size calls
+            let record = AdmittedToolCall
+                    { admittedCall = call
+                    , admittedResult = result
+                    , admittedTrustedResult = trustedResult
+                    , admissionSequence = Map.size calls
                     }
             writeTVar
-                manager.asyncToolCalls
+                scope.asyncToolCalls
                 (Map.insert call.callId record calls)
             when (toolCallMode call == AsyncToolCall) $
-                modifyTVar' manager.asyncToolOutstanding (+ 1)
-            writeTQueue manager.asyncToolRequests record
+                modifyTVar' scope.asyncToolOutstanding (+ 1)
+            writeTQueue scope.asyncToolRequests record
             pure result
 
-runManagedToolCalls :: ToolManager -> [ToolCall] -> IO [ToolCallResult]
-runManagedToolCalls manager calls = do
+runToolCalls :: ToolScope -> [ToolCall] -> IO [ToolCallResult]
+runToolCalls scope calls = do
     blocking <- catMaybes <$> traverse admit calls
     blockingResults <-
         catMaybes <$> traverse (atomically . readTMVar) blocking
     completedAsync <- atomically do
-        ready <- takeAsyncToolCompletions manager
-        admitted <- readTVar manager.asyncToolCalls
-        committed <- readTVar manager.asyncToolCommittedCalls
+        ready <- takeAsyncToolCompletions scope
+        admitted <- readTVar scope.asyncToolCalls
+        committed <- readTVar scope.asyncToolCommittedCalls
         -- A restarted provider stream may omit a call that already executed.
         -- Keep its trusted evidence for host-attributed recovery, but never
         -- submit an unmatched native tool result on the normal path.
@@ -214,9 +214,9 @@ runManagedToolCalls manager calls = do
                 [ result
                 | result <- ready
                 , Just record <- [Map.lookup result.callId admitted]
-                , Map.lookup result.callId committed == Just record.managedCall
+                , Map.lookup result.callId committed == Just record.admittedCall
                 ]
-        outstanding <- readTVar manager.asyncToolOutstanding
+        outstanding <- readTVar scope.asyncToolOutstanding
         -- An orphan-only batch is not the end of the turn while other
         -- asynchronous tools are still running. Retry also restores the queue.
         if null canonical && outstanding > 0
@@ -227,22 +227,22 @@ runManagedToolCalls manager calls = do
     admit call =
         case toolCallMode call of
             AsyncToolCall ->
-                admitAsyncToolCall manager call >> pure Nothing
+                admitAsyncToolCall scope call >> pure Nothing
             BlockingToolCall ->
-                Just <$> admitBlockingToolCall manager call
+                Just <$> admitBlockingToolCall scope call
 
-takeAsyncToolCompletions :: ToolManager -> STM [ToolCallResult]
-takeAsyncToolCompletions manager = do
-    ready <- drainTQueue manager.asyncToolCompleted
+takeAsyncToolCompletions :: ToolScope -> STM [ToolCallResult]
+takeAsyncToolCompletions scope = do
+    ready <- drainTQueue scope.asyncToolCompleted
     case ready of
         _ : _ -> pure ready
         [] -> do
-            outstanding <- readTVar manager.asyncToolOutstanding
+            outstanding <- readTVar scope.asyncToolOutstanding
             if outstanding == 0
                 then pure []
                 else do
-                    first <- readTQueue manager.asyncToolCompleted
-                    rest <- drainTQueue manager.asyncToolCompleted
+                    first <- readTQueue scope.asyncToolCompleted
+                    rest <- drainTQueue scope.asyncToolCompleted
                     pure (first : rest)
 
 drainTQueue :: TQueue value -> STM [value]
@@ -251,9 +251,14 @@ drainTQueue queue =
         Nothing -> pure []
         Just value -> (value :) <$> drainTQueue queue
 
-runToolManager :: ToolManagerConfig -> ToolManager -> IO ()
-runToolManager config manager = do
-    request <- atomically (readTQueue manager.asyncToolRequests)
+-- | Run the scheduler and its children for the duration of the callback.
+-- Recovery evidence remains available after every worker has been joined.
+withToolScope :: ToolExecutionConfig -> ToolScope -> (Async () -> IO a) -> IO a
+withToolScope config scope = withAsync (runToolScheduler config scope)
+
+runToolScheduler :: ToolExecutionConfig -> ToolScope -> IO ()
+runToolScheduler config scope = do
+    request <- atomically (readTQueue scope.asyncToolRequests)
     cancelledBefore <- isCancelled config.cancel
     if cancelledBefore
         then completeCancelledRequest request
@@ -262,7 +267,7 @@ runToolManager config manager = do
                 (waitCancel config.cancel)
                 (do
                     prepared <-
-                        prepareManagedToolCall config request.managedCall
+                        prepareAdmittedToolCall config request.admittedCall
                     plan <- schedulingPlanForPrepared config prepared
                     pure (prepared, plan))
                 >>= \case
@@ -275,29 +280,29 @@ runToolManager config manager = do
                             else do
                                 atomically $
                                     modifyTVar'
-                                        manager.asyncToolScheduled
+                                        scope.asyncToolScheduled
                                         (IntMap.insert
-                                            request.managedAdmissionSequence
+                                            request.admissionSequence
                                             plan)
                                 withAsync
-                                    (runManagedToolWorker
-                                        config manager request prepared plan)
+                                    (runToolWorker
+                                        config scope request prepared plan)
                                     \worker ->
                                         withAsync
                                             (waitCatch worker
-                                                >>= completeManagedToolRequest
-                                                    manager request)
+                                                >>= completeToolRequest
+                                                    scope request)
                                             \_monitor ->
-                                                runToolManager config manager
+                                                runToolScheduler config scope
   where
     -- Approval and scheduling are allowed to perform IO. Complete cancelled
     -- requests so blocking result waiters cannot be stranded.
     completeCancelledRequest request = do
-        completeManagedToolRequest manager request (Right Nothing)
-        runToolManager config manager
+        completeToolRequest scope request (Right Nothing)
+        runToolScheduler config scope
 
-prepareManagedToolCall :: ToolManagerConfig -> ToolCall -> IO PreparedToolCall
-prepareManagedToolCall config call
+prepareAdmittedToolCall :: ToolExecutionConfig -> ToolCall -> IO PreparedToolCall
+prepareAdmittedToolCall config call
     | toolCallMode call == AsyncToolCall
         && not (toolSupportsAsync config.tools call) =
             pure $
@@ -308,22 +313,22 @@ prepareManagedToolCall config call
     | otherwise =
         prepareToolCall config call
 
-runManagedToolWorker
-    :: ToolManagerConfig
-    -> ToolManager
-    -> ManagedToolCall
+runToolWorker
+    :: ToolExecutionConfig
+    -> ToolScope
+    -> AdmittedToolCall
     -> PreparedToolCall
     -> ToolSchedulingPlan
     -> IO (Maybe ToolCallResult)
-runManagedToolWorker config manager request prepared plan = do
+runToolWorker config scope request prepared plan = do
     atomically do
-        scheduled <- readTVar manager.asyncToolScheduled
+        scheduled <- readTVar scope.asyncToolScheduled
         check $
             not $
                 IntMap.foldrWithKey
                     (\sequenceNumber earlierPlan conflicts ->
                         conflicts
-                            || ( sequenceNumber < request.managedAdmissionSequence
+                            || ( sequenceNumber < request.admissionSequence
                                 && schedulingPlansConflict earlierPlan plan
                                ))
                     False
@@ -331,60 +336,60 @@ runManagedToolWorker config manager request prepared plan = do
     race
         (waitCancel config.cancel)
         (runPreparedToolCallWithCompletion
-            (atomically . writeTVar request.managedTrustedResult . Just)
+            (atomically . writeTVar request.admittedTrustedResult . Just)
             config
             prepared)
         >>= \case
             Left () -> pure Nothing
             Right result -> pure result
 
-completeManagedToolRequest
-    :: ToolManager
-    -> ManagedToolCall
+completeToolRequest
+    :: ToolScope
+    -> AdmittedToolCall
     -> Either SomeException (Maybe ToolCallResult)
     -> IO ()
-completeManagedToolRequest manager request outcome =
+completeToolRequest scope request outcome =
     atomically do
         modifyTVar'
-            manager.asyncToolScheduled
-            (IntMap.delete request.managedAdmissionSequence)
-        let call = request.managedCall
+            scope.asyncToolScheduled
+            (IntMap.delete request.admissionSequence)
+        let call = request.admittedCall
         case outcome of
             Left exception -> do
                 -- Do not publish a synthetic empty completion for a crashed
-                -- worker. Keeping any waiter blocked makes the manager-failure
+                -- worker. Keeping any waiter blocked makes the tool-failure
                 -- branch of the enclosing structured race authoritative.
-                _ <- tryPutTMVar manager.asyncToolFailure exception
+                _ <- tryPutTMVar scope.asyncToolFailure exception
                 pure ()
             Right result -> do
-                putTMVar request.managedResult result
+                putTMVar request.admittedResult result
                 when (toolCallMode call == AsyncToolCall) do
                     modifyTVar'
-                        manager.asyncToolOutstanding
+                        scope.asyncToolOutstanding
                         (\count -> count - 1)
                     case result of
                         Nothing -> pure ()
                         Just completed ->
-                            writeTQueue manager.asyncToolCompleted completed
+                            writeTQueue scope.asyncToolCompleted completed
 
-waitToolManagerFailure :: Async () -> ToolManager -> IO SomeException
-waitToolManagerFailure managerWorker manager =
+waitToolFailure :: Async () -> ToolScope -> IO SomeException
+waitToolFailure scheduler scope =
     race
-        (waitCatch managerWorker)
-        (atomically (readTMVar manager.asyncToolFailure))
+        (waitCatch scheduler)
+        (atomically (readTMVar scope.asyncToolFailure))
         >>= \case
             Left (Left exception) -> pure exception
             Left (Right ()) ->
                 pure $
                     Exception.toException $
                         AsyncToolCallConflict
-                            "Async tool manager stopped unexpectedly."
+                            "Tool scheduler stopped unexpectedly."
             Right exception -> pure exception
 
 data PreparedToolCall = PreparedToolCall !ToolCall !ToolApproval
 
 schedulingPlanForPrepared
-    :: ToolManagerConfig
+    :: ToolExecutionConfig
     -> PreparedToolCall
     -> IO ToolSchedulingPlan
 schedulingPlanForPrepared config (PreparedToolCall call approval) =
@@ -398,7 +403,7 @@ schedulingPlanForPrepared config (PreparedToolCall call approval) =
 
 -- | Approval may touch interactive or otherwise order-sensitive state, so it
 -- is prepared serially even when the resulting handlers may run concurrently.
-prepareToolCall :: ToolManagerConfig -> ToolCall -> IO PreparedToolCall
+prepareToolCall :: ToolExecutionConfig -> ToolCall -> IO PreparedToolCall
 prepareToolCall config call = do
     approval <- tryAny (config.approve call)
     pure $
@@ -413,7 +418,7 @@ prepareToolCall config call = do
 
 runPreparedToolCallWithCompletion
     :: (ToolCallResult -> IO ())
-    -> ToolManagerConfig
+    -> ToolExecutionConfig
     -> PreparedToolCall
     -> IO (Maybe ToolCallResult)
 runPreparedToolCallWithCompletion completed config (PreparedToolCall call approval) = do
@@ -438,7 +443,7 @@ runPreparedToolCallWithCompletion completed config (PreparedToolCall call approv
                         config.tools
                         call
             -- The trusted result must survive cancellation or a failing event
-            -- consumer after the tool has returned. The manager's monitor is
+            -- consumer after the tool has returned. The worker's monitor is
             -- not authoritative: its own scope can be cancelled first.
             completed result
             config.onEvent (ToolFinished result)

--- a/packages/agent-core/src/Agent/Loop/ToolManager.hs
+++ b/packages/agent-core/src/Agent/Loop/ToolManager.hs
@@ -1,0 +1,461 @@
+-- | Tool admission, scheduling and scoped workers. The loop owns provider
+-- checkpoints; this module owns tool execution and its recovery evidence.
+module Agent.Loop.ToolManager
+    ( ToolManager
+    , ToolManagerConfig(..)
+    , ToolRecoveryEvidence(..)
+    , newToolManager
+    , runToolManager
+    , admitAsyncToolCall
+    , runManagedToolCalls
+    , acknowledgeManagedTools
+    , readToolRecoveryEvidence
+    , waitToolManagerFailure
+    , readToolManagerFailure
+    ) where
+
+import Agent.Cancel (CancelFlag, isCancelled, waitCancel)
+import Agent.Loop.Output (LoopEvent(..))
+import Agent.ToolDispatch
+    ( ToolCall(..), ToolCallMode(..), ToolCallResult(..), ToolOutcome(..)
+    , ToolDispatchConfig(..), toolCallMode
+    )
+import Agent.Tools.Scheduling (ToolSchedulingPlan(..), schedulingPlansConflict)
+import Agent.Tools.Types
+    ( ToolRegistry, ToolApproval(..), dispatchApprovedRegisteredToolCall
+    , toolSupportsAsync, toolSchedulingPlanFor
+    )
+import Control.Concurrent.Async (Async, race, waitCatch, withAsync)
+import Control.Concurrent.STM
+    ( STM
+    , TMVar
+    , TQueue
+    , TVar
+    , atomically
+    , check
+    , modifyTVar'
+    , newEmptyTMVar
+    , newEmptyTMVarIO
+    , newTQueueIO
+    , newTVar
+    , newTVarIO
+    , putTMVar
+    , readTMVar
+    , readTQueue
+    , readTVar
+    , retry
+    , throwSTM
+    , tryPutTMVar
+    , tryReadTMVar
+    , tryReadTQueue
+    , writeTQueue
+    , writeTVar
+    )
+import qualified Control.Exception.Safe as Exception
+import Control.Exception.Safe (SomeException, displayException, tryAny)
+import Control.Monad (when)
+import Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IntMap
+import Data.List (sortOn)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (catMaybes)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | Only tool-execution dependencies; no provider or conversation state.
+data ToolManagerConfig = ToolManagerConfig
+    { tools :: !ToolRegistry
+    , dispatch :: !ToolDispatchConfig
+    , approve :: !(ToolCall -> IO ToolApproval)
+    , cancel :: !CancelFlag
+    , onEvent :: !(LoopEvent -> IO ())
+    }
+
+-- | Immutable, atomic snapshot, read after the manager and its workers join.
+data ToolRecoveryEvidence = ToolRecoveryEvidence
+    { unacknowledgedTools :: ![(ToolCall, Maybe ToolCallResult)]
+    , committedTools :: !(Map Text ToolCall)
+    }
+
+data ToolManager = ToolManager
+    { asyncToolRequests :: !(TQueue ManagedToolCall)
+    , asyncToolCalls :: !(TVar (Map Text ManagedToolCall))
+    , asyncToolScheduled :: !(TVar (IntMap ToolSchedulingPlan))
+    , asyncToolOutstanding :: !(TVar Int)
+    , asyncToolCompleted :: !(TQueue ToolCallResult)
+    , asyncToolFailure :: !(TMVar SomeException)
+    , asyncToolAcknowledged :: !(TVar (Set.Set Text))
+    , asyncToolCommittedCalls :: !(TVar (Map Text ToolCall))
+    }
+
+data ManagedToolCall = ManagedToolCall
+    { managedCall :: !ToolCall
+    , managedResult :: !(TMVar (Maybe ToolCallResult))
+    -- Recorded by the worker before event delivery; unlike managedResult,
+    -- this does not release scheduling barriers or normal result waiters.
+    , managedTrustedResult :: !(TVar (Maybe ToolCallResult))
+    , managedAdmissionSequence :: !Int
+    }
+
+data AsyncToolCallConflict = AsyncToolCallConflict !Text
+
+instance Show AsyncToolCallConflict where
+    show (AsyncToolCallConflict message) = Text.unpack message
+
+instance Exception.Exception AsyncToolCallConflict
+
+-- | Allocate state only. All workers are scoped to 'runToolManager'.
+newToolManager :: IO ToolManager
+newToolManager =
+    ToolManager
+        <$> newTQueueIO
+        <*> newTVarIO Map.empty
+        <*> newTVarIO IntMap.empty
+        <*> newTVarIO 0
+        <*> newTQueueIO
+        <*> newEmptyTMVarIO
+        <*> newTVarIO Set.empty
+        <*> newTVarIO Map.empty
+
+-- | A result is acknowledged only when the response consuming it commits,
+-- not when a waiter drains it. Keep that fact across history compaction.
+acknowledgeManagedTools :: ToolManager -> [ToolCallResult] -> [ToolCall] -> IO ()
+acknowledgeManagedTools manager results calls = atomically do
+    modifyTVar' manager.asyncToolAcknowledged $
+        Set.union (Set.fromList [result.callId | result <- results])
+    modifyTVar' manager.asyncToolCommittedCalls $
+        Map.union (Map.fromList [(call.callId, call) | call <- calls])
+
+readToolRecoveryEvidence :: ToolManager -> IO ToolRecoveryEvidence
+readToolRecoveryEvidence manager = atomically do
+    calls <- readTVar manager.asyncToolCalls
+    records <- traverse
+        (\record -> do
+            result <- readTVar record.managedTrustedResult
+            pure (record.managedCall, result))
+        (sortOn (.managedAdmissionSequence) (Map.elems calls))
+    acknowledged <- readTVar manager.asyncToolAcknowledged
+    committedTools <- readTVar manager.asyncToolCommittedCalls
+    pure ToolRecoveryEvidence
+        { unacknowledgedTools =
+            [(call, result) | (call, result) <- records, Set.notMember call.callId acknowledged]
+        , committedTools
+        }
+
+readToolManagerFailure :: ToolManager -> IO (Maybe SomeException)
+readToolManagerFailure manager = atomically (tryReadTMVar manager.asyncToolFailure)
+
+admitAsyncToolCall :: ToolManager -> ToolCall -> IO ()
+admitAsyncToolCall manager call
+    | toolCallMode call /= AsyncToolCall =
+        atomically $
+            throwSTM $
+                AsyncToolCallConflict
+                    ("Backend announced a non-async tool call: " <> call.callId)
+    | otherwise = do
+        _ <- atomically (admitManagedToolCall manager call)
+        pure ()
+
+admitBlockingToolCall
+    :: ToolManager
+    -> ToolCall
+    -> IO (TMVar (Maybe ToolCallResult))
+admitBlockingToolCall manager call =
+    atomically (admitManagedToolCall manager call)
+
+admitManagedToolCall
+    :: ToolManager
+    -> ToolCall
+    -> STM (TMVar (Maybe ToolCallResult))
+admitManagedToolCall manager call = do
+    calls <- readTVar manager.asyncToolCalls
+    case Map.lookup call.callId calls of
+        Just existing
+            | existing.managedCall == call ->
+                pure existing.managedResult
+            | otherwise ->
+                throwSTM $
+                    AsyncToolCallConflict
+                        ("Conflicting tool calls reused call_id " <> call.callId)
+        Nothing -> do
+            result <- newEmptyTMVar
+            trustedResult <- newTVar Nothing
+            -- The registry retains every admitted call for deduplication and
+            -- recovery, so its size is also the next admission sequence.
+            let record = ManagedToolCall
+                    { managedCall = call
+                    , managedResult = result
+                    , managedTrustedResult = trustedResult
+                    , managedAdmissionSequence = Map.size calls
+                    }
+            writeTVar
+                manager.asyncToolCalls
+                (Map.insert call.callId record calls)
+            when (toolCallMode call == AsyncToolCall) $
+                modifyTVar' manager.asyncToolOutstanding (+ 1)
+            writeTQueue manager.asyncToolRequests record
+            pure result
+
+runManagedToolCalls :: ToolManager -> [ToolCall] -> IO [ToolCallResult]
+runManagedToolCalls manager calls = do
+    blocking <- catMaybes <$> traverse admit calls
+    blockingResults <-
+        catMaybes <$> traverse (atomically . readTMVar) blocking
+    completedAsync <- atomically do
+        ready <- takeAsyncToolCompletions manager
+        admitted <- readTVar manager.asyncToolCalls
+        committed <- readTVar manager.asyncToolCommittedCalls
+        -- A restarted provider stream may omit a call that already executed.
+        -- Keep its trusted evidence for host-attributed recovery, but never
+        -- submit an unmatched native tool result on the normal path.
+        let canonical =
+                [ result
+                | result <- ready
+                , Just record <- [Map.lookup result.callId admitted]
+                , Map.lookup result.callId committed == Just record.managedCall
+                ]
+        outstanding <- readTVar manager.asyncToolOutstanding
+        -- An orphan-only batch is not the end of the turn while other
+        -- asynchronous tools are still running. Retry also restores the queue.
+        if null canonical && outstanding > 0
+            then retry
+            else pure canonical
+    pure (blockingResults <> completedAsync)
+  where
+    admit call =
+        case toolCallMode call of
+            AsyncToolCall ->
+                admitAsyncToolCall manager call >> pure Nothing
+            BlockingToolCall ->
+                Just <$> admitBlockingToolCall manager call
+
+takeAsyncToolCompletions :: ToolManager -> STM [ToolCallResult]
+takeAsyncToolCompletions manager = do
+    ready <- drainTQueue manager.asyncToolCompleted
+    case ready of
+        _ : _ -> pure ready
+        [] -> do
+            outstanding <- readTVar manager.asyncToolOutstanding
+            if outstanding == 0
+                then pure []
+                else do
+                    first <- readTQueue manager.asyncToolCompleted
+                    rest <- drainTQueue manager.asyncToolCompleted
+                    pure (first : rest)
+
+drainTQueue :: TQueue value -> STM [value]
+drainTQueue queue =
+    tryReadTQueue queue >>= \case
+        Nothing -> pure []
+        Just value -> (value :) <$> drainTQueue queue
+
+runToolManager :: ToolManagerConfig -> ToolManager -> IO ()
+runToolManager config manager = do
+    request <- atomically (readTQueue manager.asyncToolRequests)
+    cancelledBefore <- isCancelled config.cancel
+    if cancelledBefore
+        then completeCancelledRequest request
+        else
+            race
+                (waitCancel config.cancel)
+                (do
+                    prepared <-
+                        prepareManagedToolCall config request.managedCall
+                    plan <- schedulingPlanForPrepared config prepared
+                    pure (prepared, plan))
+                >>= \case
+                    Left () ->
+                        completeCancelledRequest request
+                    Right (prepared, plan) -> do
+                        cancelledAfter <- isCancelled config.cancel
+                        if cancelledAfter
+                            then completeCancelledRequest request
+                            else do
+                                atomically $
+                                    modifyTVar'
+                                        manager.asyncToolScheduled
+                                        (IntMap.insert
+                                            request.managedAdmissionSequence
+                                            plan)
+                                withAsync
+                                    (runManagedToolWorker
+                                        config manager request prepared plan)
+                                    \worker ->
+                                        withAsync
+                                            (waitCatch worker
+                                                >>= completeManagedToolRequest
+                                                    manager request)
+                                            \_monitor ->
+                                                runToolManager config manager
+  where
+    -- Approval and scheduling are allowed to perform IO. Complete cancelled
+    -- requests so blocking result waiters cannot be stranded.
+    completeCancelledRequest request = do
+        completeManagedToolRequest manager request (Right Nothing)
+        runToolManager config manager
+
+prepareManagedToolCall :: ToolManagerConfig -> ToolCall -> IO PreparedToolCall
+prepareManagedToolCall config call
+    | toolCallMode call == AsyncToolCall
+        && not (toolSupportsAsync config.tools call) =
+            pure $
+                PreparedToolCall call $
+                    ToolApprovalDenied
+                        ("Tool " <> call.name
+                            <> " does not support asynchronous execution.")
+    | otherwise =
+        prepareToolCall config call
+
+runManagedToolWorker
+    :: ToolManagerConfig
+    -> ToolManager
+    -> ManagedToolCall
+    -> PreparedToolCall
+    -> ToolSchedulingPlan
+    -> IO (Maybe ToolCallResult)
+runManagedToolWorker config manager request prepared plan = do
+    atomically do
+        scheduled <- readTVar manager.asyncToolScheduled
+        check $
+            not $
+                IntMap.foldrWithKey
+                    (\sequenceNumber earlierPlan conflicts ->
+                        conflicts
+                            || ( sequenceNumber < request.managedAdmissionSequence
+                                && schedulingPlansConflict earlierPlan plan
+                               ))
+                    False
+                    scheduled
+    race
+        (waitCancel config.cancel)
+        (runPreparedToolCallWithCompletion
+            (atomically . writeTVar request.managedTrustedResult . Just)
+            config
+            prepared)
+        >>= \case
+            Left () -> pure Nothing
+            Right result -> pure result
+
+completeManagedToolRequest
+    :: ToolManager
+    -> ManagedToolCall
+    -> Either SomeException (Maybe ToolCallResult)
+    -> IO ()
+completeManagedToolRequest manager request outcome =
+    atomically do
+        modifyTVar'
+            manager.asyncToolScheduled
+            (IntMap.delete request.managedAdmissionSequence)
+        let call = request.managedCall
+        case outcome of
+            Left exception -> do
+                -- Do not publish a synthetic empty completion for a crashed
+                -- worker. Keeping any waiter blocked makes the manager-failure
+                -- branch of the enclosing structured race authoritative.
+                _ <- tryPutTMVar manager.asyncToolFailure exception
+                pure ()
+            Right result -> do
+                putTMVar request.managedResult result
+                when (toolCallMode call == AsyncToolCall) do
+                    modifyTVar'
+                        manager.asyncToolOutstanding
+                        (\count -> count - 1)
+                    case result of
+                        Nothing -> pure ()
+                        Just completed ->
+                            writeTQueue manager.asyncToolCompleted completed
+
+waitToolManagerFailure :: Async () -> ToolManager -> IO SomeException
+waitToolManagerFailure managerWorker manager =
+    race
+        (waitCatch managerWorker)
+        (atomically (readTMVar manager.asyncToolFailure))
+        >>= \case
+            Left (Left exception) -> pure exception
+            Left (Right ()) ->
+                pure $
+                    Exception.toException $
+                        AsyncToolCallConflict
+                            "Async tool manager stopped unexpectedly."
+            Right exception -> pure exception
+
+data PreparedToolCall = PreparedToolCall !ToolCall !ToolApproval
+
+schedulingPlanForPrepared
+    :: ToolManagerConfig
+    -> PreparedToolCall
+    -> IO ToolSchedulingPlan
+schedulingPlanForPrepared config (PreparedToolCall call approval) =
+    case approval of
+        ToolApprovalGranted ->
+            toolSchedulingPlanFor config.tools call
+        ToolApprovalDenied{} ->
+            pure ToolUnconstrained
+        ToolApprovalRejected ->
+            pure ToolUnconstrained
+
+-- | Approval may touch interactive or otherwise order-sensitive state, so it
+-- is prepared serially even when the resulting handlers may run concurrently.
+prepareToolCall :: ToolManagerConfig -> ToolCall -> IO PreparedToolCall
+prepareToolCall config call = do
+    approval <- tryAny (config.approve call)
+    pure $
+        PreparedToolCall call $
+            case approval of
+                Left exception ->
+                    ToolApprovalDenied
+                        ("Tool " <> call.name
+                            <> " could not be prepared: "
+                            <> exceptionSummary exception)
+                Right decision -> decision
+
+runPreparedToolCallWithCompletion
+    :: (ToolCallResult -> IO ())
+    -> ToolManagerConfig
+    -> PreparedToolCall
+    -> IO (Maybe ToolCallResult)
+runPreparedToolCallWithCompletion completed config (PreparedToolCall call approval) = do
+    cancelled <- isCancelled config.cancel
+    if cancelled
+        then pure Nothing
+        else do
+            config.onEvent (ToolStarted call)
+            result <- case approval of
+                ToolApprovalDenied denial ->
+                    pure (deniedResult denial)
+                ToolApprovalRejected ->
+                    pure (deniedResult "Tool call rejected by user.")
+                ToolApprovalGranted ->
+                    dispatchApprovedRegisteredToolCall
+                        config.dispatch
+                            { toolDispatchOnOutput = \progressCall output ->
+                                config.dispatch.toolDispatchOnOutput progressCall output
+                                    >> config.onEvent
+                                        (ToolOutputUpdated progressCall.callId output)
+                            }
+                        config.tools
+                        call
+            -- The trusted result must survive cancellation or a failing event
+            -- consumer after the tool has returned. The manager's monitor is
+            -- not authoritative: its own scope can be cancelled first.
+            completed result
+            config.onEvent (ToolFinished result)
+            pure (Just result)
+  where
+    deniedResult message = ToolCallResult
+        { callId = call.callId
+        , output = message
+        , callKind = call.callKind
+        , toolResultMode = toolCallMode call
+        , toolResultImages = []
+        , toolResultOutcome = Just ToolDenied
+        }
+
+exceptionSummary :: SomeException -> Text
+exceptionSummary =
+    fst
+        . Text.breakOn "\nHasCallStack backtrace:"
+        . Text.pack
+        . displayException

--- a/packages/agent-core/test/Agent/LoopSpec.hs
+++ b/packages/agent-core/test/Agent/LoopSpec.hs
@@ -1332,6 +1332,59 @@ spec = describe "runLoop" do
                 })
         readIORef invocations `shouldReturn` ["first", "second", "third"]
 
+    it "deduplicates a blocking call replayed by a later response" do
+        invocations <- newIORef (0 :: Int)
+        approvals <- newIORef (0 :: Int)
+        submissions <- newIORef []
+        let call = functionToolCall "replayed" "once" "{}"
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1" [call] Nothing
+            , Right $ emptyTurnOutput "resp-2" [call] Nothing
+            , Right $ emptyTurnOutput "resp-3" [] (Just "done")
+            ]
+        config <- testConfig backend
+        result <- runLoop config
+            { loopTools = registryFromHandlers
+                [noArgsTool "once" do
+                    modifyIORef' invocations (+ 1)
+                    pure (Right "ran once")]
+            , loopApprove = \_ -> do
+                modifyIORef' approvals (+ 1)
+                pure ToolApprovalGranted
+            } Nothing "go"
+        result `shouldSatisfy` \case
+            Right output -> output.finalText == Just "done"
+            _ -> False
+        readIORef invocations `shouldReturn` 1
+        readIORef approvals `shouldReturn` 1
+        seen <- readIORef submissions
+        case seen of
+            [_, (_, [CompletedTool first]), (_, [CompletedTool replayed])] ->
+                replayed `shouldBe` first
+            other -> expectationFailure ("unexpected submissions: " <> show other)
+
+    it "rejects a conflicting blocking call without approving it" do
+        approvals <- newIORef ([] :: [Text])
+        submissions <- newIORef []
+        backend <- scriptedBackend submissions
+            [ Right $ emptyTurnOutput "resp-1"
+                [ functionToolCall "duplicate" "first" "{}"
+                , functionToolCall "duplicate" "second" "{}"
+                ] Nothing
+            ]
+        config <- testConfig backend
+        result <- runLoop config
+            { loopApprove = \call -> do
+                modifyIORef' approvals (call.name :)
+                pure ToolApprovalGranted
+            } Nothing "go"
+        result `shouldSatisfy` \case
+            Left (LoopUnexpected message) ->
+                "Conflicting tool calls reused call_id duplicate"
+                    `Text.isInfixOf` message
+            _ -> False
+        readIORef approvals >>= (`shouldSatisfy` all (/= "second"))
+
     it "fails closed when an async call_id is reused for a different call" do
         firstInvocations <- newIORef (0 :: Int)
         secondInvocations <- newIORef (0 :: Int)


### PR DESCRIPTION
## Summary
Extract tool admission, scheduling, and scoped workers into the hidden `Agent.Loop.ToolExecution` module. Ordinary functions operate on an opaque `ToolScope`, with five explicit execution dependencies rather than the full `LoopConfig`.

`withToolScope`, `runToolCalls`, and `acknowledgeTools` describe the operations directly. Provider checkpoints and recovery policy stay in the loop; recovery evidence is read only after workers have joined. Approval ordering, deduplication, cancellation, and commit acknowledgement semantics are preserved.

## Validation
- GHCi loop suite: **120 examples, 0 failures**, including blocking-call deduplication and conflicting-call regressions.
- Verified successful module loading without compiler errors using the single test component and `--disable-multi-repl`.
- Regenerated `package.nix`; output unchanged.
- `git diff --check` passes.
